### PR TITLE
feat(review): per-session review indicators + one coherent needs_you count

### DIFF
--- a/apps/web/src/features/review-center/hooks/use-review-session-summary.test.ts
+++ b/apps/web/src/features/review-center/hooks/use-review-session-summary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { ApiReviewItem } from '@kortix/sdk/projects-client';
+
+import { summarizeReviewSessions } from './use-review-session-summary';
+
+function makeItem(overrides: Partial<ApiReviewItem> = {}): ApiReviewItem {
+  return {
+    review_item_id: 'ri1',
+    account_id: 'a1',
+    project_id: 'p1',
+    origin_session_id: 's1',
+    kind: 'output',
+    status: 'needs_you',
+    risk: 'none',
+    source: 'agent',
+    title: 'Output',
+    summary: '',
+    detail: {},
+    agent: '',
+    created_by: 'u1',
+    acted_by: null,
+    acted_at: null,
+    feedback: null,
+    metadata: {},
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('summarizeReviewSessions', () => {
+  test('empty list → zero total, no sessions', () => {
+    expect(summarizeReviewSessions([])).toEqual({ totalNeedsYou: 0, needsYouBySession: {} });
+  });
+
+  test('counts only needs_you items', () => {
+    const summary = summarizeReviewSessions([
+      makeItem({ review_item_id: 'a', status: 'needs_you' }),
+      makeItem({ review_item_id: 'b', status: 'approved' }),
+      makeItem({ review_item_id: 'c', status: 'waiting' }),
+      makeItem({ review_item_id: 'd', status: 'needs_you' }),
+    ]);
+    expect(summary.totalNeedsYou).toBe(2);
+  });
+
+  test('groups needs_you by origin session', () => {
+    const summary = summarizeReviewSessions([
+      makeItem({ review_item_id: 'a', origin_session_id: 's1' }),
+      makeItem({ review_item_id: 'b', origin_session_id: 's1' }),
+      makeItem({ review_item_id: 'c', origin_session_id: 's2' }),
+    ]);
+    expect(summary.needsYouBySession).toEqual({ s1: 2, s2: 1 });
+    expect(summary.totalNeedsYou).toBe(3);
+  });
+
+  test('sessionless needs_you items count toward the total but not any session', () => {
+    const summary = summarizeReviewSessions([
+      makeItem({ review_item_id: 'a', origin_session_id: null }),
+      makeItem({ review_item_id: 'b', origin_session_id: 's1' }),
+    ]);
+    expect(summary.totalNeedsYou).toBe(2);
+    expect(summary.needsYouBySession).toEqual({ s1: 1 });
+  });
+
+  test('a resolved item stops attributing to its session', () => {
+    const summary = summarizeReviewSessions([
+      makeItem({ review_item_id: 'a', origin_session_id: 's1', status: 'approved' }),
+    ]);
+    expect(summary.needsYouBySession.s1).toBeUndefined();
+    expect(summary.totalNeedsYou).toBe(0);
+  });
+});

--- a/apps/web/src/features/review-center/hooks/use-review-session-summary.ts
+++ b/apps/web/src/features/review-center/hooks/use-review-session-summary.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { listReviewItems, type ApiReviewItem } from '@kortix/sdk/projects-client';
+import { useQuery } from '@tanstack/react-query';
+
+import { reviewKeys } from './use-review-items';
+
+/**
+ * The one derived view the sidebar needs from the review inbox: how many items
+ * are awaiting the human (`needs_you`) in total, and how that breaks down per
+ * originating session. Both the aggregate "Review" badge and the per-session row
+ * indicators read from this SAME shape (and the same query cache), so the number
+ * on the pill always equals the sum of the dots — one coherent system.
+ */
+export interface ReviewSessionSummary {
+  /** Total items awaiting the human across the project (matches the rail badge). */
+  totalNeedsYou: number;
+  /**
+   * `needs_you` count keyed by `origin_session_id`. Sessions with nothing pending
+   * are absent (0), so a row lights up iff its id is present with a positive count.
+   */
+  needsYouBySession: Record<string, number>;
+}
+
+const EMPTY_SUMMARY: ReviewSessionSummary = { totalNeedsYou: 0, needsYouBySession: {} };
+
+/**
+ * Fold the flat inbox list into the `needs_you`-by-session summary. Items with no
+ * originating session still count toward the total (they belong in the inbox) but
+ * can't be attributed to a row. Pure + exported for unit tests.
+ */
+export function summarizeReviewSessions(items: readonly ApiReviewItem[]): ReviewSessionSummary {
+  const needsYouBySession: Record<string, number> = {};
+  let totalNeedsYou = 0;
+  for (const item of items) {
+    if (item.status !== 'needs_you') continue;
+    totalNeedsYou += 1;
+    const sessionId = item.origin_session_id;
+    if (sessionId) {
+      needsYouBySession[sessionId] = (needsYouBySession[sessionId] ?? 0) + 1;
+    }
+  }
+  return { totalNeedsYou, needsYouBySession };
+}
+
+/**
+ * Per-session review state for the project sidebar. Reads the unified inbox via
+ * the shared `['review-center', projectId, 'list']` query key (deduping with the
+ * Review Center view and the Customize rail badge), and derives the summary
+ * client-side. Gate the caller on the `review_center` flag — pass
+ * `{ enabled: false }` to keep the poll (and the surface) dark when it's off.
+ */
+export function useReviewSessionSummary(
+  projectId: string,
+  options?: { enabled?: boolean },
+): ReviewSessionSummary {
+  const enabled = Boolean(projectId) && options?.enabled !== false;
+  const { data } = useQuery<{ review_items: ApiReviewItem[] }, Error, ReviewSessionSummary>({
+    queryKey: reviewKeys.list(projectId),
+    queryFn: () => listReviewItems(projectId),
+    enabled,
+    staleTime: 5_000,
+    // Slower than the open inbox's 8s poll — the sidebar only needs the count to
+    // feel live, not instant. When disabled the query never runs, so no poll.
+    refetchInterval: enabled ? 20_000 : false,
+    refetchOnWindowFocus: false,
+    // `select` transforms per-observer without touching the shared cache entry, so
+    // the Review Center view still reads the raw `{ review_items }` off the same key.
+    select: (result) => summarizeReviewSessions(result.review_items),
+  });
+  return data ?? EMPTY_SUMMARY;
+}

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -25,8 +25,9 @@ import { CUSTOMIZE_SECTION_GATE_ACTIONS, isCustomizeSectionVisible } from '@/lib
 import { useProjectCans } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import { hasOpenFloatingLayer, hasOpenNestedDialog } from '@/lib/z-stack';
+import { useReviewSessionSummary } from '@/features/review-center/hooks/use-review-session-summary';
 import { useCustomizeStore } from '@/stores/customize-store';
-import { getProjectDetail, listReviewItems } from '@kortix/sdk/projects-client';
+import { getProjectDetail } from '@kortix/sdk/projects-client';
 import { AlarmClock, ArrowLeft, ChatMessages, Command, Sparkles } from '@mynaui/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import {
@@ -204,19 +205,12 @@ export function CustomizPanel({ projectId }: { projectId: string }) {
     ? detectManifestVersion(detail.data.config.manifest_raw) === 1
     : false;
 
-  // "Needs you" count for the Review rail badge. Shares the review inbox's query
-  // key so the badge and the section stay in sync; only fetched when the panel is
-  // open and the flag is on.
-  const reviewItemsQuery = useQuery({
-    queryKey: ['review-center', projectId, 'list'],
-    queryFn: () => listReviewItems(projectId),
-    enabled: open && reviewEnabled && !!projectId,
-    staleTime: 5_000,
-    refetchInterval: open && reviewEnabled ? 15_000 : false,
-  });
-  const reviewNeedsYou = (reviewItemsQuery.data?.review_items ?? []).filter(
-    (i) => i.status === 'needs_you',
-  ).length;
+  // "Needs you" count for the Review rail badge — the SAME shared inbox summary the
+  // sidebar "Review" pill and the per-session row dots read (one query key, one
+  // derivation), so the badge, the pill, and the dots can never drift apart.
+  const reviewNeedsYou = useReviewSessionSummary(projectId, {
+    enabled: reviewEnabled,
+  }).totalNeedsYou;
 
   const groups = useMemo(
     // Compose flag-gating with IAM visibility: an item shows only if it passes

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-change-requests-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-change-requests-nav.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import { ArrowRight, FileDiff } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
@@ -12,8 +11,9 @@ import type { ChangeRequest } from '@/features/project-files/api/change-requests
 import { ChangeRequestDetailDialog } from '@/features/project-files/components/change-request-detail-dialog';
 import { ProjectFilesProvider } from '@/features/project-files/context';
 import { useChangeRequests } from '@/features/project-files/hooks/use-change-requests';
+import { useReviewSessionSummary } from '@/features/review-center/hooks/use-review-session-summary';
+import { useReviewCenterEnabled } from '@/hooks/projects/use-review-center-enabled';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { getProjectDetail } from '@kortix/sdk/projects-client';
 import { useCustomizeStore } from '@/stores/customize-store';
 
 interface CrController {
@@ -122,18 +122,19 @@ function NavItemInner({ projectId }: { projectId: string }) {
   // When the Review Center is enabled for this project, this pill becomes the
   // single entry point into the unified inbox (Customize → Review) — change
   // requests, approvals and agent outputs all live in one place — instead of
-  // opening a single CR's detail dialog.
-  const detail = useQuery({
-    queryKey: ['project-detail', projectId],
-    queryFn: () => getProjectDetail(projectId),
-    enabled: !!projectId,
-    staleTime: 60_000,
-  });
-  const reviewEnabled = detail.data?.project?.experimental?.review_center ?? false;
+  // opening a single CR's detail dialog. Its badge then counts the SAME unified
+  // "needs_you" set the per-session row dots and the Customize rail read, so the
+  // pill, the dots, and the rail always agree on one number.
+  const reviewEnabled = useReviewCenterEnabled(projectId);
+  const reviewSummary = useReviewSessionSummary(projectId, { enabled: reviewEnabled });
 
-  if (c.count === 0) return null;
+  // Flag on → the unified inbox's "awaiting you" count (open CRs are a subset of
+  // needs_you, so this never hides a change request); flag off → legacy open-CR count.
+  const count = reviewEnabled ? reviewSummary.totalNeedsYou : c.count;
 
-  const label = reviewEnabled ? 'Review' : c.count === 1 ? 'Review change' : 'Review changes';
+  if (count === 0) return null;
+
+  const label = reviewEnabled ? 'Review' : count === 1 ? 'Review change' : 'Review changes';
   const baseRef = c.crs[0]?.base_ref ?? '';
 
   const menuButton = (
@@ -150,7 +151,7 @@ function NavItemInner({ projectId }: { projectId: string }) {
     >
       <FileDiff />
       <span>{label}</span>
-      <span className="ml-auto pr-1 text-xs tabular-nums">{c.count}</span>
+      <span className="ml-auto pr-1 text-xs tabular-nums">{count}</span>
     </SidebarMenuButton>
   );
 

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -31,6 +31,8 @@ import {
   shouldPollProjectSessions,
   sortSessionsByCreatedAt,
 } from '@/features/workspace/project-sidebar/project-session-list-helpers';
+import { useReviewSessionSummary } from '@/features/review-center/hooks/use-review-session-summary';
+import { useReviewCenterEnabled } from '@/hooks/projects/use-review-center-enabled';
 import { Icon } from '@/features/icon/icon';
 import {
   listProjectSessions,
@@ -116,6 +118,13 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
       shouldPollProjectSessions(query.state.data as ProjectSession[] | undefined) ? 5_000 : false,
     refetchOnWindowFocus: false,
   });
+
+  // Review Center is one coherent system: the per-session row indicators, the
+  // footer "Review" pill, and the Customize rail all read the SAME inbox summary
+  // and gate on the SAME flag. When the flag is off the summary query never runs,
+  // so no indicators render and nothing polls.
+  const reviewEnabled = useReviewCenterEnabled(projectId);
+  const reviewSummary = useReviewSessionSummary(projectId, { enabled: reviewEnabled });
 
   const restartMutation = useMutation({
     mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
@@ -209,6 +218,7 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
                 isActive={!!isActive && !activeOpenCodeSessionId}
                 displayTitle={getSessionDisplayTitle(session)}
                 childCount={children.length}
+                reviewCount={reviewSummary.needsYouBySession[session.session_id] ?? 0}
                 onDelete={(id, label) => setSessionToDelete({ id, label })}
                 onShare={(s) => setSessionToShare(s)}
                 onRename={(id, name) => setSessionToRename({ id, name })}
@@ -284,6 +294,8 @@ interface ProjectSessionRowProps {
   onStop: (sessionId: string, label: string) => void;
   isStopping: boolean;
   childCount?: number;
+  /** How many review items from this session are awaiting the human (`needs_you`). */
+  reviewCount?: number;
 }
 
 function ProjectSessionRow({
@@ -299,6 +311,7 @@ function ProjectSessionRow({
   onStop,
   isStopping,
   childCount = 0,
+  reviewCount = 0,
 }: ProjectSessionRowProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const [menuOpen, setMenuOpen] = useState(false);
@@ -330,7 +343,7 @@ function ProjectSessionRow({
         )}
       >
         <Link href={href} className="flex min-w-0 flex-1 items-center gap-2 self-stretch">
-          <SessionStatusDot status={session.status} />
+          <SessionStatusDot status={session.status} reviewCount={reviewCount} />
 
           <span
             title={displayTitle}
@@ -487,11 +500,33 @@ function ProjectSubsessionRow({
   );
 }
 
-function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
+function SessionStatusDot({
+  status,
+  reviewCount = 0,
+}: {
+  status: ProjectSessionStatus;
+  reviewCount?: number;
+}) {
   const isProvisioning = status === 'queued' || status === 'branching' || status === 'provisioning';
+  // A session with items awaiting the human reads as "finished — your turn": a
+  // solid accent ring + filled center in Kortix green, overriding the run-status
+  // dot because "awaiting you" is the more actionable signal. This is the same
+  // needs_you state the footer "Review" pill counts, so the dots always sum to it.
+  const reviewPending = reviewCount > 0;
 
   return (
-    <Hint side="right" label={<span className="text-xs capitalize">{status}</span>}>
+    <Hint
+      side="right"
+      label={
+        reviewPending ? (
+          <span className="text-xs">
+            {reviewCount} awaiting your review
+          </span>
+        ) : (
+          <span className="text-xs capitalize">{status}</span>
+        )
+      }
+    >
       <div className="flex size-4 shrink-0 items-center justify-center">
         <svg
           height="16"
@@ -499,19 +534,21 @@ function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
           width="16"
           strokeLinejoin="round"
           style={{
-            color: isProvisioning
-              ? 'var(--kortix-yellow)'
-              : status === 'running'
-                ? 'var(--kortix-green)'
-                : status === 'stopped'
-                  ? 'var(--muted-foreground)'
-                  : status === 'completed'
-                    ? 'var(--kortix-green)'
-                    : 'var(--kortix-red)',
+            color: reviewPending
+              ? 'var(--kortix-green)'
+              : isProvisioning
+                ? 'var(--kortix-yellow)'
+                : status === 'running'
+                  ? 'var(--kortix-green)'
+                  : status === 'stopped'
+                    ? 'var(--muted-foreground)'
+                    : status === 'completed'
+                      ? 'var(--kortix-green)'
+                      : 'var(--kortix-red)',
           }}
           className={cn(
             'relative flex shrink-0 items-center justify-center',
-            isProvisioning && 'animate-spin',
+            !reviewPending && isProvisioning && 'animate-spin',
           )}
         >
           <circle
@@ -521,10 +558,10 @@ function SessionStatusDot({ status }: { status: ProjectSessionStatus }) {
             stroke="currentColor"
             fill="none"
             strokeWidth="1.5"
-            strokeDasharray="3 3.4"
+            strokeDasharray={reviewPending ? undefined : '3 3.4'}
           ></circle>
-          {(isProvisioning || status === 'failed') && (
-            <circle cx="8" cy="8" r="4" fill="currentColor" />
+          {(reviewPending || isProvisioning || status === 'failed') && (
+            <circle cx="8" cy="8" r={reviewPending ? 3.2 : 4} fill="currentColor" />
           )}
         </svg>
       </div>

--- a/apps/web/src/hooks/projects/use-review-center-enabled.ts
+++ b/apps/web/src/hooks/projects/use-review-center-enabled.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { getProjectDetail } from '@kortix/sdk/projects-client';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * The single on/off switch for the Review Center surface, read from the server's
+ * per-project experimental flags (`review_center`). Every review-related surface —
+ * the sidebar "Review" pill, the per-session row indicators, and the Customize
+ * rail — gates off this one hook so they light up (and go dark) together. Reads
+ * the shared `['project-detail', projectId]` cache entry, so it adds no extra
+ * fetch alongside the detail query the sidebar already runs.
+ */
+export function useReviewCenterEnabled(projectId: string): boolean {
+  const { data } = useQuery({
+    queryKey: ['project-detail', projectId],
+    queryFn: () => getProjectDetail(projectId),
+    enabled: !!projectId,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+  return data?.project?.experimental?.review_center ?? false;
+}


### PR DESCRIPTION
## What & why

The Review Center is now **one coherent system** across the sidebar. Today you can see a "Review 2" badge but not *which* sessions produced those pending items. This surfaces per-session review state so a glance at the sidebar tells you which sessions have finished and are **awaiting your approval/review** — and makes the aggregate count, the footer pill, and the per-row dots all agree on one number.

Both `change_requests` and `review_items` already carry `origin_session_id` and are unioned into one inbox by `listInboxItems()`, where `needs_you` = open CRs + pending executor approvals + submitted outputs/decisions/batches. So this is a **pure surfacing change — no backend, no migration**: the endpoint already returns `origin_session_id`; we just associate and render it.

Everything is gated behind the existing `review_center` experimental flag (one switch — dark together when off).

## Changes

- **`useReviewSessionSummary`** (new) — reads the shared `['review-center', projectId, 'list']` query key and derives `{ totalNeedsYou, needsYouBySession }` via a pure, unit-tested `summarizeReviewSessions()` grouped by `origin_session_id`. Single source of truth for every review surface.
- **`useReviewCenterEnabled`** (new) — the one `review_center` flag switch, reusing the shared `['project-detail', projectId]` cache. Every review surface gates off this.
- **Per-session rows** (`project-session-list.tsx`) — `SessionStatusDot` renders a solid accent-green ring + filled center (the "finished → your turn" look) with an "N awaiting your review" tooltip when the session has `needs_you` items.
- **Footer "Review" pill** (`project-change-requests-nav.tsx`) — with the flag on, its badge counts the unified `totalNeedsYou` instead of just open CRs. Open CRs are a subset of `needs_you`, so nothing is ever hidden.
- **Customize rail badge** (`customize-panel.tsx`) — moved onto the same shared hook, dropping its duplicate inline query.

**Result:** footer badge = rail badge = sum of the row dots, all from one query.

## Behavior when the flag is off

Unchanged — the legacy open-CR pill remains, and no per-session dots render (the summary query never runs). The coherent-system behavior is the `review_center` experience.

## Testing

- ✅ Unit tests (`use-review-session-summary.test.ts`): 5/5 — filtering to `needs_you`, grouping by session, sessionless items counting toward total only, resolved items dropping out.
- ✅ `tsc --noEmit`: clean across all touched files.
- ✅ ESLint: clean on all 6 files.
