### PR TITLE
fix(runtime): preserve session sandbox identity

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -36,6 +36,8 @@ let sandboxProvisionCalls = 0;
 let providerStartCalls = 0;
 let providerStatus = 'stopped';
 let providerStartError: Error | null = null;
+let providerStartGate: Promise<void> | null = null;
+let releaseProviderStart: (() => void) | null = null;
 let opencodeEnsureReason: 'unchanged' | 'healed' | 'not_ready' | 'unreachable' =
   'unchanged';
 let activeSessionCount = 0;
@@ -81,6 +83,8 @@ function resetState() {
   providerStartCalls = 0;
   providerStatus = 'stopped';
   providerStartError = null;
+  providerStartGate = null;
+  releaseProviderStart = null;
   opencodeEnsureReason = 'unchanged';
   activeSessionCount = 0;
   lastProvisionInput = null;
@@ -175,6 +179,7 @@ mock.module('../projects/git', () => ({
   getFileAtRef: async () => null,
   resolveCommitSha: async () => 'a'.repeat(40),
   resolveBranchTip: async () => 'a'.repeat(40),
+  resolveBranchAheadState: async () => ({ ahead: 0, behind: 0 }),
   getBranchDiff: async () => ({ files: [], diff: '' }),
   getDiffBetweenShas: async () => ({ files: [], diff: '' }),
   previewMerge: async () => ({ canMerge: true, conflicts: [] }),
@@ -283,6 +288,7 @@ mock.module('../platform/providers', () => ({
     start: async () => {
       providerStartCalls += 1;
       if (providerStartError) throw providerStartError;
+      if (providerStartGate) await providerStartGate;
     },
     stop: async () => undefined,
     remove: async () => undefined,
@@ -303,6 +309,14 @@ mock.module('../projects/opencode-mapping', () => ({
     reason: opencodeEnsureReason,
     sessions: [],
   }),
+}));
+
+mock.module('../billing/services/compute-metering', () => ({
+  reopenComputeForSandbox: async () => undefined,
+  endComputeSession: async () => undefined,
+  pauseComputeSession: async () => undefined,
+  startComputeSession: async () => undefined,
+  tickRunningComputeCharges: async () => undefined,
 }));
 
 // Session create runs the billing gate. Return a billing-active account so the
@@ -533,6 +547,7 @@ mock.module('../shared/db', () => ({
           };
           return [sessionRow];
         },
+        onConflictDoNothing: async () => [],
         onConflictDoUpdate: ({
           set,
         }: {
@@ -713,6 +728,34 @@ mock.module('../shared/db', () => ({
               return resolve(rows);
             } catch (err) {
               return reject?.(err);
+            }
+          },
+          catch: async (reject: (reason: unknown) => unknown) => {
+            try {
+              if (table === projectSessions) {
+                if (!sessionRow) return [];
+                sessionRow = {
+                  ...sessionRow,
+                  ...updates,
+                  updatedAt:
+                    updates.updatedAt ?? new Date('2026-01-02T00:00:00Z'),
+                };
+                return [sessionRow];
+              }
+              if (table === sessionSandboxes) {
+                const row = sessionSandboxRows[0];
+                if (!row) return [];
+                sessionSandboxRows[0] = {
+                  ...row,
+                  ...updates,
+                  updatedAt:
+                    updates.updatedAt ?? new Date('2026-01-02T00:00:00Z'),
+                };
+                return [sessionSandboxRows[0]];
+              }
+              return [];
+            } catch (err) {
+              return reject(err);
             }
           },
         }),
@@ -1424,7 +1467,7 @@ describe('project session API contract', () => {
     expect(sandboxProvisionCalls).toBe(0);
   });
 
-  test('dashboard start retires a sandbox that stayed stopped after wake grace', async () => {
+  test('dashboard start preserves a sandbox that stayed stopped after wake grace', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1462,19 +1505,19 @@ describe('project session API contract', () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      stage: 'provisioning',
-      retriable: true,
-      sandbox: null,
-      reason: 'runtime_wake_timeout',
+      stage: 'failed',
+      retriable: false,
+      reason: 'runtime_identity_unavailable',
+      sandbox: { external_id: 'box-stuck-stopped', status: 'stopped' },
     });
 
-    await flushUntil(() => sandboxProvisionCalls === 1);
     expect(providerStartCalls).toBe(0);
-    expect(sessionSandboxRows).toHaveLength(0);
-    expect(lastProvisionInput?.sandboxId).toBe(SESSION_ID);
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]?.externalId).toBe('box-stuck-stopped');
   });
 
-  test('dashboard start retires an old active row whose provider status stays unknown', async () => {
+  test('dashboard start preserves an old active row whose provider status stays unknown', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1510,16 +1553,16 @@ describe('project session API contract', () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      stage: 'provisioning',
-      retriable: true,
-      sandbox: null,
-      reason: 'runtime_status_unknown_timeout',
+      stage: 'failed',
+      retriable: false,
+      reason: 'runtime_identity_unavailable',
+      sandbox: { external_id: 'box-status-unknown', status: 'stopped' },
     });
 
-    await flushUntil(() => sandboxProvisionCalls === 1);
     expect(providerStartCalls).toBe(0);
-    expect(sessionSandboxRows).toHaveLength(0);
-    expect(lastProvisionInput?.sandboxId).toBe(SESSION_ID);
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]?.externalId).toBe('box-status-unknown');
   });
 
   test('dashboard start gives a freshly-created active runtime grace when provider status is removed', async () => {
@@ -1575,7 +1618,61 @@ describe('project session API contract', () => {
     ).toEqual(expect.any(String));
   });
 
-  test('dashboard start retires a provider-removed sandbox and reallocates through the canonical runtime path', async () => {
+  test('concurrent archived resume + transient removed status keeps the original identity fenced', async () => {
+    const app = createApp();
+    sessionRow = {
+      ...sessionRow!,
+      sandboxProvider: 'daytona',
+      status: 'stopped',
+      opencodeSessionId: 'ses_root_existing',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'daytona',
+        externalId: 'box-original-archived',
+        baseUrl: null,
+        status: 'stopped',
+        config: {},
+        metadata: {
+          initStatus: 'ready',
+          initSucceededAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+        },
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-02T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z'),
+      },
+    ];
+    providerStatus = 'removed';
+    providerStartGate = new Promise<void>((resolve) => {
+      releaseProviderStart = resolve;
+    });
+
+    const res = await app.request(
+      `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`,
+      { method: 'POST' },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      stage: 'starting',
+      retriable: true,
+      reason: 'runtime_removed_checking',
+    });
+    expect(providerStartCalls).toBe(1);
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]?.externalId).toBe('box-original-archived');
+    expect(sessionSandboxRows[0]?.status).toBe('active');
+    expect(
+      (sessionSandboxRows[0]?.metadata as Record<string, unknown>).runtimeWakeStartedAt,
+    ).toEqual(expect.any(String));
+    releaseProviderStart?.();
+  });
+
+  test('dashboard start preserves a provider-removed sandbox and never reallocates', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1613,27 +1710,20 @@ describe('project session API contract', () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      stage: 'provisioning',
+      stage: 'failed',
       agent_name: 'default',
-      retriable: true,
-      sandbox: null,
-      reason: 'runtime_removed',
+      retriable: false,
+      reason: 'runtime_identity_unavailable',
+      sandbox: { external_id: 'box-deleted', status: 'stopped' },
     });
 
-    await flushUntil(() => sandboxProvisionCalls === 1);
     expect(providerStartCalls).toBe(0);
-    expect(sandboxProvisionCalls).toBe(1);
-    expect(sessionSandboxRows).toHaveLength(0);
-    expect(lastProvisionInput?.sandboxId).toBe(SESSION_ID);
-    expect(
-      lastProvisionInput?.extraEnvVars?.KORTIX_INITIAL_PROMPT,
-    ).toBeUndefined();
-    expect(lastProvisionInput?.extraEnvVars?.KORTIX_OPENCODE_MODEL).toBe(
-      'anthropic/claude-sonnet-4-6',
-    );
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]?.externalId).toBe('box-deleted');
   });
 
-  test('dashboard start retires a running sandbox whose OpenCode runtime never becomes reachable', async () => {
+  test('dashboard start preserves a running sandbox whose OpenCode runtime never becomes reachable', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1674,19 +1764,19 @@ describe('project session API contract', () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      stage: 'provisioning',
-      retriable: true,
-      sandbox: null,
-      reason: 'runtime_unreachable_timeout',
+      stage: 'failed',
+      retriable: false,
+      reason: 'runtime_identity_unavailable',
+      sandbox: { external_id: 'box-opencode-dead', status: 'stopped' },
     });
 
-    await flushUntil(() => sandboxProvisionCalls === 1);
     expect(providerStartCalls).toBe(0);
-    expect(sessionSandboxRows).toHaveLength(0);
-    expect(lastProvisionInput?.sandboxId).toBe(SESSION_ID);
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]?.externalId).toBe('box-opencode-dead');
   });
 
-  test('restart of a provider-removed sandbox provisions a replacement instead of leaving the session stopped', async () => {
+  test('restart of a provider-removed sandbox refuses replacement and preserves identity', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1717,19 +1807,19 @@ describe('project session API contract', () => {
       `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`,
       { method: 'POST' },
     );
-    expect(res.status).toBe(202);
+    expect(res.status).toBe(409);
     expect(await res.json()).toMatchObject({
-      ok: true,
+      code: 'SESSION_RUNTIME_IDENTITY_UNAVAILABLE',
       session_id: SESSION_ID,
-      status: 'provisioning',
-      reason: 'runtime_removed',
+      external_id: 'box-deleted',
+      reason: 'runtime_identity_unavailable',
     });
 
-    await flushUntil(() => sandboxProvisionCalls === 1);
     expect(providerStartCalls).toBe(0);
-    expect(sandboxProvisionCalls).toBe(1);
-    expect(sessionRow?.status).toBe('provisioning');
-    expect(sessionSandboxRows).toHaveLength(0);
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionRow?.status).toBe('stopped');
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]?.externalId).toBe('box-deleted');
   });
 
   test('dashboard start recovery of an already-bootstrapped session provisions without replaying the initial prompt', async () => {

--- a/apps/api/src/admin/index.ts
+++ b/apps/api/src/admin/index.ts
@@ -632,29 +632,18 @@ adminApp.openapi(
     if (!sess) return c.json({ error: 'session not found' }, 404);
     const [proj] = await db.select().from(projects).where(eq(projects.projectId, sess.projectId)).limit(1);
     if (!proj) return c.json({ error: 'project not found' }, 404);
-    const oldProvider = sb.provider; const oldExternalId = sb.externalId;
-    const { getProvider } = await import('../platform/providers');
-    // Data migration is via the session git branch (KORTIX_BRANCH_NAME=sessionId):
-    // the target re-clones it, so only *committed* work crosses over. Flush the
-    // old box's working tree to the branch first (best-effort, only while it's
-    // still active) so uncommitted changes survive the move. Same daemon contract
-    // as the /commit-push route — resolveEndpoint injects the service Bearer.
-    if (oldExternalId && sb.status === 'active') {
-      try {
-        const ep = await getProvider(oldProvider as any).resolveEndpoint(oldExternalId);
-        const res = await fetch(`${ep.url.replace(/\/$/, '')}/kortix/git/commit-push`, {
-          method: 'POST', headers: ep.headers,
-          body: JSON.stringify({ message: `chore: flush before migrate ${oldProvider}→${target}` }),
-          signal: AbortSignal.timeout(30_000),
-        });
-        console.log(`[migrate] flush ${sessionId} ${oldProvider}: ${res.status}`);
-      } catch (e: any) {
-        console.warn('[migrate] pre-teardown commit-push failed (committed work still migrates):', e?.message ?? e);
-      }
+    const oldProvider = sb.provider;
+    if (sb.externalId) {
+      return c.json({
+        error: 'A materialized session sandbox cannot be replaced or migrated in place because it may contain uncommitted data.',
+        code: 'SESSION_RUNTIME_IDENTITY_IMMUTABLE',
+        sessionId,
+        provider: oldProvider,
+        externalId: sb.externalId,
+      }, 409);
     }
-    if (oldExternalId) {
-      getProvider(oldProvider as any).remove(oldExternalId).catch((e: any) => console.warn('[migrate] old remove failed:', e?.message ?? e));
-    }
+    // A placeholder that never acquired an external provider object contains no
+    // user data and can safely be reassigned.
     await db.delete(sessionSandboxes).where(eq(sessionSandboxes.sessionId, sessionId));
     const { allocateRuntimeOnOpen } = await import('../projects/routes/shared');
     await allocateRuntimeOnOpen(

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -62,6 +62,8 @@ let onRemoved: (() => void) | null = null;
 let computeSessionsOpened: Array<{ sandboxId: string; accountId: string }> = [];
 let onComputeOpened: (() => void) | null = null;
 let recordedEvents: Array<{ outcome: string }> = [];
+let identityConflict = false;
+let providerCreateCalls = 0;
 
 function compile(condition: unknown): { sql: string; params: unknown[] } {
   try {
@@ -95,9 +97,13 @@ mock.module('../../config', () => ({
 mock.module('../../shared/db', () => ({
   db: {
     insert: (table: unknown) => ({
-      values: (v: Record<string, unknown>) => ({
-        returning: async () => [{ ...v }],
-      }),
+      values: (v: Record<string, unknown>) => {
+        const result = {
+          returning: async () => (identityConflict && table === sessionSandboxes ? [] : [{ ...v }]),
+          onConflictDoNothing: () => result,
+        };
+        return result;
+      },
     }),
     select: (_proj: unknown) => ({
       from: (table: unknown) => ({
@@ -131,11 +137,14 @@ mock.module('../../shared/db', () => ({
 mock.module('../providers', () => ({
   getProvider: (_name: string) => ({
     provisioning: { async: true, stages: [{ id: 'boot', progress: 50, message: 'Booting…' }] },
-    create: async (_opts: unknown) => ({
-      externalId: EXTERNAL_ID,
-      baseUrl: 'https://sandbox.test',
-      metadata: {},
-    }),
+    create: async (_opts: unknown) => {
+      providerCreateCalls += 1;
+      return {
+        externalId: EXTERNAL_ID,
+        baseUrl: 'https://sandbox.test',
+        metadata: {},
+      };
+    },
     remove: async (externalId: string) => {
       removedIds.push(externalId);
       onRemoved?.();
@@ -226,6 +235,8 @@ beforeEach(() => {
   onComputeOpened = null;
   recordedEvents = [];
   onProviderEvent = null;
+  identityConflict = false;
+  providerCreateCalls = 0;
 });
 
 function baseOpts() {
@@ -243,6 +254,19 @@ function baseOpts() {
 }
 
 describe('provisionSessionSandbox — mid-provision delete race', () => {
+  test('authoritative row conflict fails closed before a second provider sandbox can be created', async () => {
+    identityConflict = true;
+
+    await expect(provisionSessionSandbox(baseOpts())).rejects.toMatchObject({
+      name: 'RuntimeIdentityConflictError',
+    });
+
+    expect(providerCreateCalls).toBe(0);
+    expect(removedIds).toEqual([]);
+    expect(computeSessionsOpened).toEqual([]);
+    expect(recordedEvents).toEqual([]);
+  });
+
   test('nothing raced it: flips to running, guarded WHERE clauses are the expected shape, opens compute metering', async () => {
     const opened = waitFor((resolve) => {
       onComputeOpened = resolve;

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -50,6 +50,7 @@ import { accountEntitledToLlmGateway } from '../../shared/account-limits';
 import { readManifest } from '../../projects/triggers';
 import { resolveAgentGrant } from '../../projects/agents';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
+import { RuntimeIdentityConflictError } from '../../projects/runtime-identity-error';
 
 // Fallback spec for sandboxes that don't declare `sandbox:` in kortix.yaml.
 // Mirrors the platform default sandbox size (2 vCPU / 4 GB / 20 GB).
@@ -267,6 +268,7 @@ export async function provisionSessionSandbox(opts: {
           healthStatus: 'unknown',
         },
       })
+      .onConflictDoNothing({ target: sessionSandboxes.sessionId })
       .returning(),
     createApiKey({
       sandboxId,
@@ -295,6 +297,7 @@ export async function provisionSessionSandbox(opts: {
       : Promise.resolve(false),
   ]);
   const [sandbox] = sandboxRows;
+  if (!sandbox) throw new RuntimeIdentityConflictError(sandboxId);
   tl.mark('row+tokens');
 
   const kortixOrigin = config.KORTIX_URL.replace(/\/+$/, '');

--- a/apps/api/src/projects/lib/session-runtime-allocator.ts
+++ b/apps/api/src/projects/lib/session-runtime-allocator.ts
@@ -6,6 +6,7 @@ import { provisionSessionSandbox } from '../../platform/services/session-sandbox
 import { db } from '../../shared/db';
 import type { SandboxProviderName } from '../../config';
 import type { ProjectRow } from './serializers';
+import { RuntimeIdentityConflictError } from '../runtime-identity-error';
 
 type RuntimeProject = Pick<ProjectRow, 'repoUrl' | 'defaultBranch' | 'manifestPath' | 'metadata'>;
 
@@ -88,6 +89,10 @@ async function allocateSessionRuntimeAsync(input: AllocateSessionRuntimeInput): 
       session_start_timeline: sessionStartTimeline,
     }).catch(() => {});
   } catch (err) {
+    if (err instanceof RuntimeIdentityConflictError) {
+      console.warn(`[runtime-identity] refused duplicate allocation for ${input.sessionId}`);
+      return;
+    }
     const message = (err as Error)?.message || 'Sandbox provisioning failed';
     console.error(`[projects] Failed to allocate runtime for session ${input.sessionId}:`, err);
     try {

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -1,7 +1,4 @@
-import {
-  endComputeSession,
-  reopenComputeForSandbox,
-} from '../../billing/services/compute-metering';
+import { reopenComputeForSandbox } from '../../billing/services/compute-metering';
 import { config, type SandboxProviderName } from '../../config';
 import type { ProjectSessionSandbox, SessionStartResult } from '@kortix/api-contract';
 import { auth, json } from '../../openapi';
@@ -23,6 +20,11 @@ import {
   sandboxCallbackUnreachableReason,
 } from '../lib/sessions';
 import { ensureOpencodeSessionPin } from '../opencode-mapping';
+import {
+  preserveEstablishedRuntime,
+  retireUnmaterializedRuntime,
+  RUNTIME_IDENTITY_UNAVAILABLE,
+} from '../runtime-identity';
 
 /**
  * Resume a hibernated (status='stopped') session sandbox IN PLACE instead of
@@ -48,6 +50,7 @@ export async function resumeStoppedSandbox(row: {
   accountId: string;
   provider: string;
   externalId: string | null;
+  metadata?: Record<string, unknown> | null;
 }): Promise<boolean> {
   if (!row.externalId) return false;
   if (
@@ -59,6 +62,26 @@ export async function resumeStoppedSandbox(row: {
 
   const externalId = row.externalId;
   const now = new Date();
+  const runtimeWakeId = crypto.randomUUID();
+  const wakeMetadata = { ...(row.metadata ?? {}) };
+  for (const key of [
+    'idleQuiesced',
+    'idleQuiescedAt',
+    'idleObservedAt',
+    'runtimeIdentityState',
+    'runtimeUnavailableReason',
+    'runtimeUnavailableAt',
+    'preservedExternalId',
+    'needsReprovision',
+    'runtimeWakeError',
+    'runtimeWakeFailedAt',
+  ]) delete wakeMetadata[key];
+  Object.assign(wakeMetadata, {
+    lastTurnAt: now.toISOString(),
+    runtimeWakeStartedAt: now.toISOString(),
+    runtimeWakeId,
+    runtimeWakeProviderStatus: 'starting',
+  });
   // Conditional update = the lock: only the request that flips stopped→active
   // proceeds to start the VM. Concurrent polls see `active` and just return it.
   const [won] = await db
@@ -70,7 +93,7 @@ export async function resumeStoppedSandbox(row: {
       // countdown (idleObservedAt — a stale pre-stop stamp would shut the box
       // down on the very next pass), and stamps lastTurnAt so the resume opens
       // a FRESH idle window for the unreachable-box fallback clock too.
-      metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'idleQuiesced' - 'idleQuiescedAt' - 'idleObservedAt') || ${JSON.stringify({ lastTurnAt: now.toISOString() })}::jsonb`,
+      metadata: wakeMetadata,
     })
     .where(
       and(
@@ -101,29 +124,53 @@ export async function resumeStoppedSandbox(row: {
   );
 
   const provider = getProvider(row.provider as SandboxProviderName);
-  void provider.start(externalId).catch(async (err) => {
-    console.warn(
-      `[projects] failed to resume sandbox ${externalId} for session ${row.sessionId}:`,
-      err,
-    );
-    if (isMissingRuntimeError(err)) {
-      await retireSessionSandboxRow(
-        { sandboxId: row.sandboxId, externalId },
-        'resume_missing_runtime',
-      ).catch(() => {});
-      return;
-    }
-    // Revert so a later open retries the resume instead of spinning the health
-    // poll against a VM that never came up.
+  void provider.start(externalId).then(async () => {
     await db
       .update(sessionSandboxes)
-      .set({ status: 'stopped', updatedAt: new Date() })
+      .set({
+        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'runtimeWakeStartedAt' - 'runtimeWakeId' - 'runtimeWakeProviderStatus' - 'runtimeWakeError' - 'runtimeWakeFailedAt'`,
+        updatedAt: new Date(),
+      })
       .where(
         and(
           eq(sessionSandboxes.sandboxId, row.sandboxId),
           eq(sessionSandboxes.externalId, externalId),
+          sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
         ),
       )
+      .catch((err) =>
+        console.warn(
+          `[runtime-identity] failed to clear wake fence for ${row.sessionId}:`,
+          err,
+        ),
+      );
+  }).catch(async (err) => {
+    console.warn(
+      `[projects] failed to resume sandbox ${externalId} for session ${row.sessionId}:`,
+      err,
+    );
+    // Never retire or replace an established identity based on a provider
+    // start error. Revert this exact fenced wake so a later explicit open can
+    // retry the original sandbox in place.
+    await db
+      .update(sessionSandboxes)
+      .set({
+        status: 'stopped',
+        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify({ runtimeWakeError: isMissingRuntimeError(err) ? 'missing' : 'start_failed', runtimeWakeFailedAt: new Date().toISOString() })}::jsonb`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(sessionSandboxes.sandboxId, row.sandboxId),
+          eq(sessionSandboxes.externalId, externalId),
+          sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
+        ),
+      )
+      .catch(() => {});
+    await db
+      .update(projectSessions)
+      .set({ status: 'stopped', updatedAt: new Date() })
+      .where(eq(projectSessions.sessionId, row.sessionId))
       .catch(() => {});
   });
   return true;
@@ -157,7 +204,7 @@ export async function selectPreResumeTargets(
   projectId: string,
   userId: string,
   limit: number,
-): Promise<Array<{ sandboxId: string; sessionId: string; accountId: string; provider: string; externalId: string | null }>> {
+): Promise<Array<{ sandboxId: string; sessionId: string; accountId: string; provider: string; externalId: string | null; metadata: Record<string, unknown> | null }>> {
   return db
     .select({
       sandboxId: sessionSandboxes.sandboxId,
@@ -165,6 +212,7 @@ export async function selectPreResumeTargets(
       accountId: sessionSandboxes.accountId,
       provider: sessionSandboxes.provider,
       externalId: sessionSandboxes.externalId,
+      metadata: sessionSandboxes.metadata,
     })
     .from(sessionSandboxes)
     .innerJoin(projectSessions, eq(projectSessions.sessionId, sessionSandboxes.sessionId))
@@ -361,7 +409,7 @@ function staleRuntimeWakeReason(
 
   // Existing bad rows predate runtimeWakeStartedAt. If the provider status is
   // unknown long after provider create succeeded, stop returning retriable
-  // "starting" forever and replace the runtime on this open.
+  // "starting" forever and surface the preserved identity as unavailable.
   const initSucceededAtMs = parseTimestampMs(metadata.initSucceededAt);
   if (
     !wakeStartedAtMs &&
@@ -499,35 +547,6 @@ export function isMissingRuntimeError(error: unknown): boolean {
   );
 }
 
-export async function retireSessionSandboxRow(
-  row: Pick<typeof sessionSandboxes.$inferSelect, 'sandboxId' | 'externalId'>,
-  reason: string,
-): Promise<void> {
-  await endComputeSession(row.sandboxId).catch((err) =>
-    console.warn(
-      `[projects] failed to close compute session while retiring sandbox ${row.sandboxId} (${reason}):`,
-      err,
-    ),
-  );
-  if (row.externalId) {
-    await db
-      .delete(sessionSandboxes)
-      .where(
-        and(
-          eq(sessionSandboxes.sandboxId, row.sandboxId),
-          eq(sessionSandboxes.externalId, row.externalId),
-        ),
-      );
-    return;
-  }
-  console.warn(
-    `[projects] retiring session sandbox ${row.sandboxId} without external_id (${reason})`,
-  );
-  await db
-    .delete(sessionSandboxes)
-    .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-}
-
 export function serializeSandboxRow(
   row: typeof sessionSandboxes.$inferSelect,
 ): ProjectSessionSandbox {
@@ -548,7 +567,7 @@ export function serializeSandboxRow(
   };
 }
 
-async function replaceStaleRuntimeOnOpen(
+async function preserveEstablishedRuntimeOnOpen(
   loaded: { row: ProjectRow; userId: string },
   visible: {
     row: {
@@ -563,20 +582,27 @@ async function replaceStaleRuntimeOnOpen(
   row: typeof sessionSandboxes.$inferSelect,
   reason: string,
 ): Promise<SessionStartResult> {
-  await retireSessionSandboxRow(row, reason).catch((err) =>
-    console.warn(
-      `[projects] failed to retire stale runtime ${row.externalId} for session ${sessionId}:`,
-      err,
-    ),
-  );
-  await allocateRuntimeOnOpen(loaded, visible.row, projectId, sessionId);
+  if (!row.externalId) {
+    await retireUnmaterializedRuntime(row, reason);
+    await allocateRuntimeOnOpen(loaded, visible.row, projectId, sessionId);
+    return {
+      stage: 'provisioning',
+      agent_name: visible.row.agentName ?? 'default',
+      retriable: true,
+      sandbox: null,
+      opencode_session_id: null,
+      reason,
+    };
+  }
+  const preserved = await preserveEstablishedRuntime(row, reason);
   return {
-    stage: 'provisioning',
+    stage: 'failed',
     agent_name: visible.row.agentName ?? 'default',
-    retriable: true,
-    sandbox: null,
+    retriable: false,
+    sandbox: preserved ? serializeSandboxRow(preserved) : serializeSandboxRow(row),
     opencode_session_id: null,
-    reason,
+    runtime_url: sessionRuntimeUrlPath(row.externalId),
+    reason: RUNTIME_IDENTITY_UNAVAILABLE,
   };
 }
 
@@ -626,19 +652,13 @@ export async function openSession(args: {
       row.provider,
     )
   ) {
-    // A box the reaper idle-stopped with `needsReprovision` cannot be safely
-    // resumed in place (Platinum's stop→resume wedges the guest — the CH
-    // resume-freeze). Replace it with a fresh box on open instead. This is an
-    // EXPLICIT open, so it clears the idle state by re-provisioning.
-    if ((row.metadata as Record<string, unknown> | null)?.needsReprovision) {
-      return replaceStaleRuntimeOnOpen(loaded, visible, projectId, sessionId, row, 'reprovision_on_open');
-    }
     await resumeStoppedSandbox({
       sandboxId: row.sandboxId,
       sessionId: row.sessionId,
       accountId: row.accountId,
       provider: row.provider,
       externalId: row.externalId,
+      metadata: row.metadata as Record<string, unknown> | null,
     });
     const [resumed] = await db
       .select()
@@ -662,11 +682,17 @@ export async function openSession(args: {
       };
     }
     if (visible.row.status !== 'provisioning') {
-      if (row)
-        await db
-          .delete(sessionSandboxes)
-          .where(eq(sessionSandboxes.sandboxId, sessionId))
-          .catch(() => {});
+      if (row?.externalId) {
+        return preserveEstablishedRuntimeOnOpen(
+          loaded,
+          visible,
+          projectId,
+          sessionId,
+          row,
+          'non_usable_established_runtime',
+        );
+      }
+      if (row) await retireUnmaterializedRuntime(row, 'non_usable_unmaterialized_runtime');
       await allocateRuntimeOnOpen(loaded, visible.row, projectId, sessionId);
     }
     return {
@@ -680,7 +706,7 @@ export async function openSession(args: {
 
   const staleProvisioning = row ? staleProvisioningReason(row) : null;
   if (row && staleProvisioning) {
-    return replaceStaleRuntimeOnOpen(
+    return preserveEstablishedRuntimeOnOpen(
       loaded,
       visible,
       projectId,
@@ -729,7 +755,7 @@ export async function openSession(args: {
         reason: 'runtime_removed_checking',
       };
     }
-    return replaceStaleRuntimeOnOpen(
+    return preserveEstablishedRuntimeOnOpen(
       loaded,
       visible,
       projectId,
@@ -742,7 +768,7 @@ export async function openSession(args: {
   if (providerStatus !== 'running') {
     const staleWake = staleRuntimeWakeReason(row, providerStatus);
     if (staleWake) {
-      return replaceStaleRuntimeOnOpen(
+      return preserveEstablishedRuntimeOnOpen(
         loaded,
         visible,
         projectId,
@@ -759,20 +785,7 @@ export async function openSession(args: {
         err,
       );
       if (isMissingRuntimeError(err)) {
-        await retireSessionSandboxRow(row, 'wake_missing_runtime').catch(
-          () => {},
-        );
-        await allocateRuntimeOnOpen(
-          loaded,
-          visible.row,
-          projectId,
-          sessionId,
-        ).catch((allocErr) =>
-          console.warn(
-            `[start] failed to reallocate missing runtime for session ${sessionId}:`,
-            allocErr,
-          ),
-        );
+        await preserveEstablishedRuntime(row, 'wake_missing_runtime').catch(() => {});
       }
     });
     return {
@@ -807,7 +820,7 @@ export async function openSession(args: {
   if (booting) {
     const staleBoot = staleOpencodeReadyReason(row, ensured.reason);
     if (staleBoot) {
-      return replaceStaleRuntimeOnOpen(
+      return preserveEstablishedRuntimeOnOpen(
         loaded,
         visible,
         projectId,

--- a/apps/api/src/projects/runtime-identity-error.ts
+++ b/apps/api/src/projects/runtime-identity-error.ts
@@ -1,0 +1,6 @@
+export class RuntimeIdentityConflictError extends Error {
+  constructor(sessionId: string) {
+    super(`Session ${sessionId} already has an authoritative runtime identity`);
+    this.name = 'RuntimeIdentityConflictError';
+  }
+}

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -1,0 +1,107 @@
+import { projectSessions, sessionSandboxes } from '@kortix/db';
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { endComputeSession } from '../billing/services/compute-metering';
+import { db } from '../shared/db';
+
+export const RUNTIME_IDENTITY_UNAVAILABLE = 'runtime_identity_unavailable';
+export const RUNTIME_IDENTITY_ERROR =
+  'The original sandbox is unavailable. Its identity was preserved and no replacement sandbox was created.';
+
+type RuntimeIdentityRow = Pick<
+  typeof sessionSandboxes.$inferSelect,
+  'sandboxId' | 'sessionId' | 'externalId' | 'metadata'
+>;
+
+/**
+ * Mark an established runtime unavailable without ever changing its identity.
+ *
+ * An external_id means the sandbox may contain user-authored, uncommitted data.
+ * It is therefore an immutable identity boundary: provider 404s, transitional
+ * states, health timeouts, and restart failures may stop the session, but may
+ * never delete this row or attach a fresh provider object to the same session.
+ */
+export async function preserveEstablishedRuntime(
+  row: RuntimeIdentityRow,
+  reason: string,
+  now = new Date(),
+): Promise<typeof sessionSandboxes.$inferSelect | null> {
+  if (!row.externalId) {
+    throw new Error(
+      `Cannot preserve sandbox ${row.sandboxId} as established without an external_id`,
+    );
+  }
+
+  await endComputeSession(row.sandboxId).catch((err) =>
+    console.warn(
+      `[runtime-identity] failed to close compute for ${row.sandboxId} while preserving ${row.externalId}:`,
+      err,
+    ),
+  );
+
+  const metadata = { ...((row.metadata as Record<string, unknown> | null) ?? {}) };
+  delete metadata.needsReprovision;
+  Object.assign(metadata, {
+    runtimeIdentityState: 'unavailable',
+    runtimeUnavailableReason: reason,
+    runtimeUnavailableAt: now.toISOString(),
+    preservedExternalId: row.externalId,
+  });
+
+  const [preserved] = await db
+    .update(sessionSandboxes)
+    .set({ status: 'stopped', metadata, updatedAt: now })
+    .where(
+      and(
+        eq(sessionSandboxes.sandboxId, row.sandboxId),
+        eq(sessionSandboxes.externalId, row.externalId),
+      ),
+    )
+    .returning();
+
+  if (!preserved) return null;
+
+  await db
+    .update(projectSessions)
+    .set({ status: 'stopped', error: RUNTIME_IDENTITY_ERROR, updatedAt: now })
+    .where(eq(projectSessions.sessionId, row.sessionId));
+
+  console.error('[runtime-identity] preserved unavailable sandbox identity', {
+    sessionId: row.sessionId,
+    sandboxId: row.sandboxId,
+    externalId: row.externalId,
+    reason,
+  });
+  return preserved;
+}
+
+/**
+ * Delete only a provisioning placeholder that never acquired provider state.
+ * This guard makes accidental use against a data-bearing sandbox fail closed.
+ */
+export async function retireUnmaterializedRuntime(
+  row: Pick<typeof sessionSandboxes.$inferSelect, 'sandboxId' | 'externalId'>,
+  reason: string,
+): Promise<boolean> {
+  if (row.externalId) {
+    throw new Error(
+      `Refusing to retire established sandbox ${row.sandboxId}/${row.externalId} (${reason})`,
+    );
+  }
+
+  await endComputeSession(row.sandboxId).catch((err) =>
+    console.warn(
+      `[runtime-identity] failed to close compute for unmaterialized sandbox ${row.sandboxId} (${reason}):`,
+      err,
+    ),
+  );
+  await db
+    .delete(sessionSandboxes)
+    .where(
+      and(
+        eq(sessionSandboxes.sandboxId, row.sandboxId),
+        isNull(sessionSandboxes.externalId),
+      ),
+    );
+  return true;
+}

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -208,18 +208,13 @@ describe('triggerAutoStopTtlMs', () => {
 describe('buildIdleStopMetadata', () => {
   const nowIso = '2026-06-21T12:00:00.000Z';
   test('idle stop quiesces so passive traffic cannot resurrect', () => {
-    const m = buildIdleStopMetadata({ quiesce: true, reprovision: false, nowIso });
+    const m = buildIdleStopMetadata({ quiesce: true, nowIso });
     expect(m.idleQuiesced).toBe(true);
     expect(m.idleQuiescedAt).toBe(nowIso);
     expect(m.needsReprovision).toBeUndefined();
   });
-  test('Platinum idle stop also flags reprovision', () => {
-    const m = buildIdleStopMetadata({ quiesce: true, reprovision: true, nowIso });
-    expect(m.idleQuiesced).toBe(true);
-    expect(m.needsReprovision).toBe(true);
-  });
   test('no flags → empty patch (nothing merged)', () => {
-    expect(buildIdleStopMetadata({ quiesce: false, reprovision: false, nowIso })).toEqual({});
+    expect(buildIdleStopMetadata({ quiesce: false, nowIso })).toEqual({});
   });
 });
 
@@ -345,7 +340,7 @@ describe('reapAndReconcileSandboxes', () => {
     expect(r.skipped).toBe(1);
   });
 
-  test('Platinum idle stop flags reprovision (resume is broken)', async () => {
+  test('Platinum idle stop preserves the same runtime for in-place resume', async () => {
     candidates = [candidate({ provider: 'platinum', externalId: 'ext-p', sandboxId: 'sb-p' })];
     statusByExternal['ext-p'] = 'running';
 
@@ -353,8 +348,6 @@ describe('reapAndReconcileSandboxes', () => {
 
     expect(r.stopped).toBe(1);
     expect(stops).toEqual(['ext-p']);
-    // The stop wrote a metadata merge (the reprovision flag content is covered by
-    // the buildIdleStopMetadata unit test below — the SQL object isn't introspectable).
     const sbUpdate = updateCalls.find((c) => c.table === sessionSandboxes);
     expect(sbUpdate?.updates.metadata).toBeDefined();
   });
@@ -422,7 +415,7 @@ describe('reapAndReconcileSandboxes', () => {
     ).toBe(false);
   });
 
-  test('provider-removed → reconcile to STOPPED (not archived) + needsReprovision, so it can reopen', async () => {
+  test('provider-removed preserves the established external identity', async () => {
     candidates = [candidate()];
     statusByExternal['ext-1'] = 'removed';
 
@@ -431,9 +424,11 @@ describe('reapAndReconcileSandboxes', () => {
     expect(r.reconciled).toBe(1);
     expect(endedCompute).toEqual(['sb-1']);
     const sbUpdate = updateCalls.find((c) => c.table === sessionSandboxes);
-    // MUST be 'stopped' — openSession only reprovisions a stopped+needsReprovision row.
     expect(sbUpdate?.updates.status).toBe('stopped');
-    expect(sbUpdate?.updates.metadata).toBeDefined();
+    expect(sbUpdate?.updates.metadata).toMatchObject({
+      runtimeIdentityState: 'unavailable',
+      preservedExternalId: 'ext-1',
+    });
     expect(stops).toEqual([]); // never poke a removed box
   });
 

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -36,10 +36,11 @@ import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../shared/db';
 import { getProvider, type ProviderName, type SandboxStatus } from '../platform/providers';
 import { invalidateProviderCache } from '../sandbox-proxy';
-import { pauseComputeSession, endComputeSession } from '../billing/services/compute-metering';
+import { pauseComputeSession } from '../billing/services/compute-metering';
 import { probeSandboxBusy } from './sandbox-busy-probe';
 import { ACTIVE_SESSION_STATUSES } from './lib/session-status';
 import { config } from '../config';
+import { preserveEstablishedRuntime } from './runtime-identity';
 
 export const REAP_BATCH_SIZE = 100;
 const REAP_CONCURRENCY = 6;
@@ -107,8 +108,8 @@ export type ReconcileAction = 'none' | 'reconcile-stopped' | 'reconcile-removed'
  * could kill a healthy box or fight a wake.
  */
 export function decideReconcile(providerStatus: SandboxStatus): ReconcileAction {
-  // The external box is gone — finalize billing and mark our row so the next
-  // open reprovisions instead of trying to resume a box that no longer exists.
+  // The provider currently reports the external box gone. Preserve its identity
+  // and stop billing; a later explicit open may retry that same sandbox.
   if (providerStatus === 'removed') return 'reconcile-removed';
   // Provider already stopped/archived it (its own auto-stop, an admin, or a
   // webhook we missed) but our row still says active — reconcile + close billing.
@@ -159,16 +160,14 @@ function mergeMetadata(patch: Record<string, unknown>) {
 /**
  * The metadata patch written when the reaper stops a box. `quiesce` marks an
  * idle-stop so passive traffic can't resurrect it (only an explicit open / new
- * turn clears it); `reprovision` flags that the next open must REPROVISION
- * rather than resume (Platinum's broken stop→resume). Pure so it is unit-tested.
+ * turn clears it). Stopping never authorizes replacing a data-bearing runtime.
  */
-export function buildIdleStopMetadata(opts: { quiesce: boolean; reprovision: boolean; nowIso: string }): Record<string, unknown> {
+export function buildIdleStopMetadata(opts: { quiesce: boolean; nowIso: string }): Record<string, unknown> {
   const meta: Record<string, unknown> = {};
   if (opts.quiesce) {
     meta.idleQuiesced = true;
     meta.idleQuiescedAt = opts.nowIso;
   }
-  if (opts.reprovision) meta.needsReprovision = true;
   return meta;
 }
 
@@ -182,13 +181,13 @@ interface ReapCandidate {
   createdAt: Date;
 }
 
-async function reconcileRowToStopped(row: ReapCandidate, now: Date, quiesce: boolean, reprovision: boolean): Promise<void> {
+async function reconcileRowToStopped(row: ReapCandidate, now: Date, quiesce: boolean): Promise<void> {
   // Close billing FIRST (computes the wall-clock delta against the still-active
   // metering row), then flip status, so the final window is billed correctly.
   await pauseComputeSession(row.sandboxId).catch((err) =>
     console.warn(`[reaper] pauseComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
   );
-  const meta = buildIdleStopMetadata({ quiesce, reprovision, nowIso: now.toISOString() });
+  const meta = buildIdleStopMetadata({ quiesce, nowIso: now.toISOString() });
   await db
     .update(sessionSandboxes)
     .set({
@@ -267,7 +266,7 @@ async function reapRunningBox(
     }
     // Already stopped/gone on the provider side is success — reconcile.
   }
-  await reconcileRowToStopped(row, now, /* quiesce */ true, /* reprovision */ row.provider === 'platinum');
+  await reconcileRowToStopped(row, now, /* quiesce */ true);
   return 'stopped';
 }
 
@@ -341,27 +340,15 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
             // (or a webhook/reaper stop) must NOT be resurrected by passive /v1/p
             // traffic (markSandboxUsed heals unflagged stopped rows). It comes
             // back only on an explicit open / real turn, which clears the flag.
-            await reconcileRowToStopped(row, now, /* quiesce */ true, false);
+            await reconcileRowToStopped(row, now, /* quiesce */ true);
             result.reconciled += 1;
             result.billingClosed += 1;
             break;
           case 'reconcile-removed':
-            await endComputeSession(row.sandboxId).catch((err) =>
-              console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
-            );
-            // Status MUST be 'stopped' (not 'archived'): openSession only honors
-            // `needsReprovision` in its `row.status === 'stopped'` branch. An
-            // 'archived' row would fall through to a terminal 'stopped' result and
-            // NEVER reprovision — stranding the session. 'stopped' + the marker
-            // makes the next open reprovision a fresh box.
-            await db
-              .update(sessionSandboxes)
-              .set({ status: 'stopped', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
-              .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-            await db
-              .update(projectSessions)
-              .set({ status: 'stopped', updatedAt: now })
-              .where(eq(projectSessions.sessionId, row.sessionId));
+            // A provider 404 can be a transient archive/restore observation.
+            // Preserve the established identity; never turn this signal into a
+            // fresh, empty sandbox for the same session.
+            await preserveEstablishedRuntime(row, 'provider_reported_removed', now);
             invalidateProviderCache(row.externalId);
             result.reconciled += 1;
             result.billingClosed += 1;
@@ -491,7 +478,7 @@ const STUCK_SESSION_BATCH = 200;
  *   - NO in-flight turn (unfinalized chat_turn_stream), and
  *   - NO LLM usage within the TTL window.
  * For each it settles + closes any lingering billing window (DB-only) and flips
- * the session to `stopped` — resumable: the next open reprovisions a fresh box.
+ * the session to `stopped` — resumable in place without changing identity.
  * Idempotent; the status guard on UPDATE avoids racing a concurrent real open.
  */
 export async function reconcileStuckActiveSessions(
@@ -576,7 +563,7 @@ export async function reconcileSandboxStoppedByExternalId(externalId: string, no
   // explicit open / real turn.
   await db
     .update(sessionSandboxes)
-    .set({ status: 'stopped', updatedAt: now, metadata: mergeMetadata(buildIdleStopMetadata({ quiesce: true, reprovision: false, nowIso: now.toISOString() })) })
+    .set({ status: 'stopped', updatedAt: now, metadata: mergeMetadata(buildIdleStopMetadata({ quiesce: true, nowIso: now.toISOString() })) })
     .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
   await db.update(projectSessions).set({ status: 'stopped', updatedAt: now }).where(eq(projectSessions.sessionId, row.sessionId));
   invalidateProviderCache(externalId);
@@ -585,26 +572,24 @@ export async function reconcileSandboxStoppedByExternalId(externalId: string, no
 
 /**
  * The provider reports the box destroyed/deleted/lost — finalize billing and
- * flag the row so the next open reprovisions a fresh box. Keyed by external id;
- * idempotent. Shared by webhook ingress + reaper.
+ * preserve the original mapping. Keyed by external id; idempotent. Shared by
+ * webhook ingress + reaper.
  */
 export async function reconcileSandboxRemovedByExternalId(externalId: string, now = new Date()): Promise<boolean> {
   const [row] = await db
-    .select({ sandboxId: sessionSandboxes.sandboxId, sessionId: sessionSandboxes.sessionId, status: sessionSandboxes.status })
+    .select({
+      sandboxId: sessionSandboxes.sandboxId,
+      sessionId: sessionSandboxes.sessionId,
+      externalId: sessionSandboxes.externalId,
+      metadata: sessionSandboxes.metadata,
+      status: sessionSandboxes.status,
+    })
     .from(sessionSandboxes)
     .where(eq(sessionSandboxes.externalId, externalId))
     .limit(1);
   if (!row) return false;
-  await endComputeSession(row.sandboxId).catch((err) =>
-    console.warn(`[reaper] endComputeSession failed for ${row.sandboxId}:`, err instanceof Error ? err.message : err),
-  );
-  // 'stopped' (not 'archived') + needsReprovision so openSession's stopped-branch
-  // reprovisions a fresh box on the next open (an archived row would strand it).
-  await db
-    .update(sessionSandboxes)
-    .set({ status: 'stopped', updatedAt: now, metadata: mergeMetadata({ needsReprovision: true }) })
-    .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
-  await db.update(projectSessions).set({ status: 'stopped', updatedAt: now }).where(eq(projectSessions.sessionId, row.sessionId));
+  if (!row.externalId) return false;
+  await preserveEstablishedRuntime(row, 'provider_webhook_removed', now);
   invalidateProviderCache(externalId);
   return true;
 }

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -13,8 +13,13 @@ import {
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import {
   isMissingRuntimeError,
-  retireSessionSandboxRow,
 } from '../routes/shared';
+import {
+  preserveEstablishedRuntime,
+  retireUnmaterializedRuntime,
+  RUNTIME_IDENTITY_UNAVAILABLE,
+  RUNTIME_IDENTITY_ERROR,
+} from '../runtime-identity';
 
 export async function deleteSession(input: {
   projectId: string;
@@ -200,16 +205,16 @@ export async function restartSession(input: {
     const provider = getProvider(existingSandbox.provider as SandboxProviderName);
     const providerStatus = await provider.getStatus(externalId).catch(() => 'unknown' as const);
     if (providerStatus === 'removed') {
-      await retireSessionSandboxRow(existingSandbox, 'restart_removed_runtime').catch((err) =>
-        console.warn(
-          `[projects] failed to retire removed runtime ${externalId} for session ${sessionId}:`,
-          err,
-        ),
-      );
-      await provisionReplacementRuntime();
+      await preserveEstablishedRuntime(existingSandbox, 'restart_removed_runtime');
       return {
-        status: 202,
-        body: { ok: true, session_id: sessionId, status: 'provisioning', reason: 'runtime_removed' },
+        status: 409,
+        body: {
+          error: RUNTIME_IDENTITY_ERROR,
+          code: 'SESSION_RUNTIME_IDENTITY_UNAVAILABLE',
+          session_id: sessionId,
+          external_id: externalId,
+          reason: RUNTIME_IDENTITY_UNAVAILABLE,
+        },
       };
     }
 
@@ -242,13 +247,7 @@ export async function restartSession(input: {
       } catch (err) {
         console.warn(`[projects] restart-in-place failed for ${sessionId}:`, err);
         if (isMissingRuntimeError(err)) {
-          await retireSessionSandboxRow(existingSandbox, 'restart_missing_runtime').catch(() => {});
-          await provisionReplacementRuntime().catch((allocErr) =>
-            console.warn(
-              `[projects] failed to reallocate missing runtime for session ${sessionId}:`,
-              allocErr,
-            ),
-          );
+          await preserveEstablishedRuntime(existingSandbox, 'restart_missing_runtime').catch(() => {});
           return;
         }
         await db
@@ -277,7 +276,7 @@ export async function restartSession(input: {
     // provision failed before an externalId was assigned) — there's nothing to
     // stop/start, and leaving it in place would collide with the fresh insert
     // provisionReplacementRuntime() is about to do on the same sandboxId PK.
-    await retireSessionSandboxRow(existingSandbox, 'restart_never_provisioned').catch((err) =>
+    await retireUnmaterializedRuntime(existingSandbox, 'restart_never_provisioned').catch((err) =>
       console.warn(
         `[projects] failed to retire never-provisioned sandbox row for session ${sessionId}:`,
         err,

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -23,15 +23,17 @@ SDK resolves for you.
 await s.get();                 // session detail
 await s.update({ /* … */ });   // rename, settings
 await s.start();               // provision + boot the runtime
-await s.restart();             // restart the runtime (may re-provision a new sandbox)
+await s.restart();             // restart the same runtime in place
 await s.stop();                // stop the runtime without deleting the session
 await s.commit();              // commit the agent's work
 await s.setSharing(intent);    // sharing / visibility
 await s.delete();
 ```
 
-`restart()` and `delete()` both forget this handle's cached runtime (a restart
-may land on a different sandbox); `stop()` does the same without deleting the
+`restart()` preserves the session's established sandbox identity and refreshes
+the handle's cached readiness state. If the original provider object is
+unavailable, restart fails explicitly instead of attaching an empty replacement.
+`delete()` removes the runtime; `stop()` clears readiness without deleting the
 session itself.
 
 ### Previews & public shares

--- a/packages/db/migrations/20260711210000000_session_sandbox_identity_immutability.sql
+++ b/packages/db/migrations/20260711210000000_session_sandbox_identity_immutability.sql
@@ -1,0 +1,53 @@
+-- A materialized session sandbox may contain user-authored, uncommitted data.
+-- Its provider identity is immutable for the lifetime of the session. Runtime
+-- health checks may stop or flag it, but may never swap in an empty sandbox.
+
+CREATE OR REPLACE FUNCTION kortix.guard_session_sandbox_identity()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  session_deleted boolean;
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.external_id IS NOT NULL THEN
+    IF NEW.external_id IS DISTINCT FROM OLD.external_id
+       OR NEW.provider IS DISTINCT FROM OLD.provider THEN
+      RAISE EXCEPTION
+        'established session sandbox identity is immutable (session %, provider %, external_id %)',
+        OLD.session_id, OLD.provider, OLD.external_id
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' AND OLD.external_id IS NOT NULL THEN
+    SELECT coalesce((metadata->>'deletedAt') IS NOT NULL, false)
+      INTO session_deleted
+      FROM kortix.project_sessions
+     WHERE session_id = OLD.session_id;
+
+    IF NOT coalesce(session_deleted, false)
+       AND coalesce(OLD.metadata->>'identityDeletionAuthorizedAt', '') = '' THEN
+      RAISE EXCEPTION
+        'refusing to delete established session sandbox identity (session %, provider %, external_id %)',
+        OLD.session_id, OLD.provider, OLD.external_id
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_session_sandbox_identity_immutable
+  ON kortix.session_sandboxes;
+
+CREATE TRIGGER trg_session_sandbox_identity_immutable
+BEFORE UPDATE OF external_id, provider OR DELETE
+ON kortix.session_sandboxes
+FOR EACH ROW
+EXECUTE FUNCTION kortix.guard_session_sandbox_identity();

--- a/packages/sdk/src/kortix.ts
+++ b/packages/sdk/src/kortix.ts
@@ -737,8 +737,8 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
       start: (...a: DropFirst2<Parameters<typeof P.startProjectSession>>) =>
         P.startProjectSession(projectId, sessionId, ...a),
       restart: () => {
-        // Restart may re-provision a DIFFERENT sandbox — a stale cached/
-        // registered runtime would route subsequent calls at a dead box.
+        // Restart preserves the established sandbox identity, but readiness
+        // and the proxy connection must still be resolved again after reboot.
         forgetReady();
         return P.restartProjectSession(projectId, sessionId);
       },

--- a/packages/sdk/src/state/session-runtime-registry.ts
+++ b/packages/sdk/src/state/session-runtime-registry.ts
@@ -96,9 +96,9 @@ export function setSessionRuntime(
 }
 
 /**
- * Drop a session's registry entry (restart/delete). A restart may re-provision
- * a different sandbox, so a stale entry would route subsequent calls at a dead
- * box — every handle must re-resolve via `ensureReady()`/`startProjectSession`.
+ * Drop a session's registry entry (restart/delete). Restart preserves the
+ * established sandbox identity, but every handle must still re-resolve
+ * readiness via `ensureReady()`/`startProjectSession` after the reboot.
  */
 export function clearSessionRuntime(projectId: string, sessionId: string): void {
   registry.delete(registryKey(projectId, sessionId));


### PR DESCRIPTION
## Incident

Session `b3746ba0-746a-4343-8bf3-5a33cfeaebcb` was remapped from Daytona sandbox `271ae596-43b2-437b-832f-fbc56795be58` to a new empty sandbox `cb3a513a-f257-426c-a6f6-23fa17302d9d`. Concurrent archived-resume and `/start` checks let one request begin restoring the original object while another interpreted Daytona's transitional `removed` status as permanent, deleted the authoritative DB mapping, and provisioned a replacement.

## Fix

- Treat any `session_sandboxes.external_id` as a permanent data-bearing identity.
- Fence stopped-runtime wakes before contacting the provider and clear only the winning wake transition.
- Preserve and explicitly flag established identities on provider `removed`/`unknown`, wake failure, OpenCode timeout, webhook, reaper, and restart paths.
- Permit retirement/reprovision only for placeholders where `external_id IS NULL`.
- Use the unique session row as allocation ownership so a competing allocation fails before creating a second provider sandbox.
- Reject admin provider migration for materialized sessions.
- Add a DB trigger that rejects established external ID/provider changes and unauthorized deletion.
- Return `409 SESSION_RUNTIME_IDENTITY_UNAVAILABLE` when restart cannot reach the preserved runtime.

## Verification

- `bun test src/platform/services/session-sandbox.test.ts` — 3 passed
- `dotenvx run -- bun test src/__tests__/e2e-project-session-contract.test.ts` — 27 passed
- `bun test src/projects/sandbox-reaper.test.ts` — 40 passed
- `pnpm --filter kortix-api typecheck` — passed
- `pnpm --filter @kortix/sdk typecheck` — passed
- `pnpm --filter @kortix/db migrate:lint` — 38 migrations passed (pre-existing destructive-operation warnings only)
- `git diff --check origin/main...HEAD` — passed
- Disposable PostgreSQL: established external ID replacement, provider change, and unauthorized deletion all rejected.
- Isolated Supabase/API black-box: authenticated `/start` preserved the original external ID with zero provider provisioning events; `/restart` returned `409 SESSION_RUNTIME_IDENTITY_UNAVAILABLE`, still with zero provisioning events.

## Release note

Merging to `main` deploys dev only. Production remains protected until the normal staging -> prod promotion applies the migration and rollout.