### PR TITLE
feat(session): local CLI attach commands in the Terminal panel

### DIFF
--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -322,7 +322,11 @@ export const SessionLayout = memo(function SessionLayout({
     <div className="relative h-full w-full">
       {terminalActivated && (
         <div className={cn('absolute inset-0', !showTerminal && 'hidden')}>
-          <SessionTerminalPanel sessionId={sessionId} hidden={!showTerminal} />
+          <SessionTerminalPanel
+            sessionId={sessionId}
+            projectSessionId={projectSessionId ?? undefined}
+            hidden={!showTerminal}
+          />
         </div>
       )}
       {browserActivated && (

--- a/apps/web/src/features/session/session-terminal-connect-bar.tsx
+++ b/apps/web/src/features/session/session-terminal-connect-bar.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Check, ChevronRight, Copy, Laptop } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * A slim strip that lives at the top of the session Terminal panel and tells the
+ * user how to attach their *local* OpenCode TUI to this session's sandbox with
+ * the Kortix CLI. Deliberately NOT its own tab — it rides along with the live
+ * terminal so "how do I get a shell into this from my machine?" is answered
+ * right where a shell already lives.
+ *
+ * Collapsed, it shows just the one command that matters (`kortix sessions
+ * connect <id>`) with a copy button. Expanded, it adds the one-time install
+ * step and a one-line explainer.
+ */
+export function SessionTerminalConnectBar({ projectSessionId }: { projectSessionId: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const connectCmd = `kortix sessions connect ${projectSessionId}`;
+  const installCmd = 'npm i -g @kortix/cli';
+
+  return (
+    <div className="shrink-0 border-b border-white/10 bg-[#15151d] text-[13px]">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-white/60 transition-colors hover:text-white/80"
+        aria-expanded={expanded}
+      >
+        <Laptop className="h-3.5 w-3.5 shrink-0" />
+        <span className="shrink-0 font-medium">Connect from your machine</span>
+        <span className="min-w-0 flex-1 truncate font-mono text-white/35">{connectCmd}</span>
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 transition-transform',
+            expanded && 'rotate-90',
+          )}
+        />
+      </button>
+
+      {expanded && (
+        <div className="space-y-2.5 px-3 pb-3 pt-0.5">
+          <p className="text-xs leading-relaxed text-white/45">
+            Attach your local OpenCode TUI straight to this session&apos;s sandbox. The CLI opens a
+            local proxy, injects your Kortix token, then runs{' '}
+            <span className="font-mono text-white/60">opencode attach</span>.
+          </p>
+          <CommandRow label="1. Install the CLI (once)" command={installCmd} />
+          <CommandRow label="2. Attach to this session" command={connectCmd} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CommandRow({ label, command }: { label: string; command: string }) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(command);
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 1500);
+  }, [command]);
+
+  useEffect(() => () => void (timer.current && clearTimeout(timer.current)), []);
+
+  return (
+    <div className="space-y-1">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-white/35">{label}</div>
+      <div className="flex items-center gap-2 rounded-md border border-white/10 bg-black/40 px-2.5 py-1.5">
+        <code className="min-w-0 flex-1 truncate font-mono text-white/80">{command}</code>
+        <button
+          type="button"
+          onClick={copy}
+          className="shrink-0 rounded p-1 text-white/40 transition-colors hover:bg-white/10 hover:text-white/80"
+          aria-label={copied ? 'Copied' : 'Copy command'}
+        >
+          {copied ? (
+            <Check className="text-kortix-green h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/session/session-terminal-panel.tsx
+++ b/apps/web/src/features/session/session-terminal-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { SessionTerminalConnectBar } from '@/features/session/session-terminal-connect-bar';
 import { useCreatePty, useOpenCodePtyList, type Pty } from '@/hooks/opencode/use-opencode-pty';
 import { useOpenCodeRuntimeReady } from '@/hooks/opencode/use-opencode-sessions';
 import { useKortixComputerStore } from '@/stores/kortix-computer-store';
@@ -38,9 +39,11 @@ const PTY_ENV = { TERM: 'xterm-256color', COLORTERM: 'truecolor' } as const;
  */
 export function SessionTerminalPanel({
   sessionId,
+  projectSessionId,
   hidden,
 }: {
   sessionId: string;
+  projectSessionId?: string;
   hidden?: boolean;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -110,30 +113,23 @@ export function SessionTerminalPanel({
   }, [currentSandboxId, runtimeReady, isLoading, pty, terminalPtyId, ensurePty]);
 
   // Sandbox mode — shared SSH terminal into the sandbox.
+  let content: React.ReactNode;
   if (currentSandboxId) {
-    return (
-      <div className="h-full w-full bg-[#0f0f14]">
-        <SSHTerminal sandboxId={currentSandboxId} className="h-full" />
-      </div>
-    );
-  }
-
-  // Waiting for the sandbox runtime, or spinning up / loading the PTY list.
-  if (!runtimeReady || isLoading || (!pty && (createPty.isPending || ensuringRef.current))) {
-    return (
-      <div className="flex h-full w-full flex-col items-center justify-center bg-[#0f0f14]">
+    content = <SSHTerminal sandboxId={currentSandboxId} className="h-full" />;
+  } else if (!runtimeReady || isLoading || (!pty && (createPty.isPending || ensuringRef.current))) {
+    // Waiting for the sandbox runtime, or spinning up / loading the PTY list.
+    content = (
+      <div className="flex h-full w-full flex-col items-center justify-center">
         <CircleDashed className="text-muted-foreground h-4 w-4 animate-spin" />
         <span className="text-muted-foreground mt-2 text-xs">
           {tI18nHardcoded.raw('autoFeaturesSessionSessionTerminalPanelJsxTextConnecting80303e70')}
         </span>
       </div>
     );
-  }
-
-  // No PTY and not (re)spawning — offer to start one.
-  if (!pty) {
-    return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-[#0f0f14]">
+  } else if (!pty) {
+    // No PTY and not (re)spawning — offer to start one.
+    content = (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3">
         <Terminal className="text-muted-foreground/30 h-8 w-8" />
         <Button variant="outline" size="sm" onClick={ensurePty} className="gap-1.5">
           <Plus className="h-3.5 w-3.5" />
@@ -141,16 +137,21 @@ export function SessionTerminalPanel({
         </Button>
       </div>
     );
-  }
-
-  return (
-    <div className="relative h-full w-full bg-[#0f0f14]">
+  } else {
+    content = (
       <PtyTerminal
         pty={pty}
         serverUrl={serverUrl}
         hidden={hidden}
         className="absolute inset-0 h-full w-full"
       />
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col bg-[#0f0f14]">
+      {projectSessionId && <SessionTerminalConnectBar projectSessionId={projectSessionId} />}
+      <div className="relative min-h-0 flex-1">{content}</div>
     </div>
   );
 }


### PR DESCRIPTION
Adds a collapsible **Connect from your machine** strip at the top of the session **Terminal** tab — no new tab, it rides along with the live terminal.

- Collapsed: one line showing `kortix sessions connect <session-id>` (pre-filled with this session's id) + copy.
- Expanded: short explainer + two copy-able command rows — `npm i -g @kortix/cli` (install once) and `kortix sessions connect <session-id>` (attach).
- Renders above every terminal state (sandbox SSH / PTY / loading / spawn), styled to match the `#0f0f14` terminal.

Command verified against the existing CLI (`apps/cli/src/commands/sessions-connect.ts`), which resolves the id via `/projects/{projectId}/sessions/{sessionId}` — i.e. the Kortix `projectSessionId` threaded through here.

Files:
- new `session-terminal-connect-bar.tsx`
- `session-terminal-panel.tsx` — takes `projectSessionId`, early-return branches folded into one `content` var so the bar sits above all states
- `session-layout.tsx` — passes `projectSessionId`

Typecheck clean.