### PR TITLE
fix(runtime): keep active sandbox turns alive

### DIFF
--- a/apps/api/src/projects/execution-lease.test.ts
+++ b/apps/api/src/projects/execution-lease.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { executionLeaseUntilOf, hasActiveExecutionLease } from './execution-lease';
+
+describe('execution lease policy', () => {
+  const now = new Date('2026-07-11T20:00:00.000Z');
+  test('vetoes stop only while the lease is live', () => {
+    expect(hasActiveExecutionLease({ executionLeaseUntil: '2026-07-11T20:00:01.000Z' }, now)).toBe(
+      true,
+    );
+    expect(hasActiveExecutionLease({ executionLeaseUntil: '2026-07-11T20:00:00.000Z' }, now)).toBe(
+      false,
+    );
+  });
+  test('fails closed on malformed or missing timestamps', () => {
+    expect(executionLeaseUntilOf({ executionLeaseUntil: 'bad' })).toBeNull();
+    expect(hasActiveExecutionLease(null, now)).toBe(false);
+  });
+});

--- a/apps/api/src/projects/execution-lease.ts
+++ b/apps/api/src/projects/execution-lease.ts
@@ -1,0 +1,165 @@
+import { sessionSandboxes } from '@kortix/db';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { type ProviderName, getProvider } from '../platform/providers';
+import { db } from '../shared/db';
+
+export const DEFAULT_EXECUTION_LEASE_SECONDS = 120;
+export const MIN_EXECUTION_LEASE_SECONDS = 30;
+export const MAX_EXECUTION_LEASE_SECONDS = 300;
+const PROVIDER_TOUCH_TIMEOUT_MS = 5_000;
+
+export interface ExecutionLeaseTarget {
+  sandboxId: string;
+  sessionId: string;
+  projectId: string;
+}
+
+export interface ExecutionKeepAliveEndpoint {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function keepAliveEndpoint(url: string, headers: Record<string, string>): ExecutionKeepAliveEndpoint {
+  const safeHeaders = Object.fromEntries(
+    Object.entries(headers).filter(([name]) => name.toLowerCase() !== 'authorization'),
+  );
+  return { url: url.replace(/\/$/, ''), headers: safeHeaders };
+}
+
+function clampLeaseSeconds(requested?: number): number {
+  if (!Number.isFinite(requested)) return DEFAULT_EXECUTION_LEASE_SECONDS;
+  return Math.max(
+    MIN_EXECUTION_LEASE_SECONDS,
+    Math.min(MAX_EXECUTION_LEASE_SECONDS, Math.floor(requested as number)),
+  );
+}
+
+export function executionLeaseUntilOf(metadata: Record<string, unknown> | null): Date | null {
+  const raw = metadata?.executionLeaseUntil;
+  if (typeof raw !== 'string') return null;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function hasActiveExecutionLease(
+  metadata: Record<string, unknown> | null,
+  now = new Date(),
+): boolean {
+  const until = executionLeaseUntilOf(metadata);
+  return until !== null && until.getTime() > now.getTime();
+}
+
+async function loadLeaseSandbox(target: ExecutionLeaseTarget) {
+  const [row] = await db
+    .select({ provider: sessionSandboxes.provider, externalId: sessionSandboxes.externalId })
+    .from(sessionSandboxes)
+    .where(
+      and(
+        eq(sessionSandboxes.sandboxId, target.sandboxId),
+        eq(sessionSandboxes.sessionId, target.sessionId),
+        eq(sessionSandboxes.projectId, target.projectId),
+        inArray(sessionSandboxes.status, ['provisioning', 'active']),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export async function discoverExecutionKeepAliveEndpoint(
+  target: ExecutionLeaseTarget,
+): Promise<ExecutionKeepAliveEndpoint | null> {
+  const row = await loadLeaseSandbox(target);
+  if (!row?.externalId) return null;
+  const endpoint = await getProvider(row.provider as ProviderName).resolveEndpoint(row.externalId);
+  return keepAliveEndpoint(endpoint.url, endpoint.headers);
+}
+
+async function touchProvider(
+  provider: ProviderName,
+  externalId: string,
+): Promise<ExecutionKeepAliveEndpoint | null> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const endpoint = await getProvider(provider).resolveEndpoint(externalId);
+      const keepAlive = keepAliveEndpoint(endpoint.url, endpoint.headers);
+      const response = await fetch(`${keepAlive.url}/kortix/health`, {
+        headers: endpoint.headers,
+        signal: AbortSignal.timeout(PROVIDER_TOUCH_TIMEOUT_MS),
+      });
+      if (response.ok || response.status === 503) return keepAlive;
+    } catch {
+      /* the next heartbeat retries; the DB lease remains authoritative */
+    }
+  }
+  return null;
+}
+
+export async function renewExecutionLease(
+  target: ExecutionLeaseTarget,
+  requestedTtlSeconds?: number,
+  now = new Date(),
+): Promise<{
+  ok: boolean;
+  leaseUntil: string | null;
+  providerUrl: string | null;
+  providerHeaders: Record<string, string> | null;
+}> {
+  const leaseUntil = new Date(
+    now.getTime() + clampLeaseSeconds(requestedTtlSeconds) * 1_000,
+  ).toISOString();
+  const patch = JSON.stringify({
+    executionLeaseUntil: leaseUntil,
+    lastTurnAt: now.toISOString(),
+    idleObservedAt: null,
+  });
+  const [row] = await db
+    .update(sessionSandboxes)
+    .set({
+      metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${patch}::jsonb`,
+      lastUsedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(sessionSandboxes.sandboxId, target.sandboxId),
+        eq(sessionSandboxes.sessionId, target.sessionId),
+        eq(sessionSandboxes.projectId, target.projectId),
+        inArray(sessionSandboxes.status, ['provisioning', 'active']),
+      ),
+    )
+    .returning({ provider: sessionSandboxes.provider, externalId: sessionSandboxes.externalId });
+  if (!row) {
+    return { ok: false, leaseUntil: null, providerUrl: null, providerHeaders: null };
+  }
+  const providerEndpoint = row.externalId
+    ? await touchProvider(row.provider as ProviderName, row.externalId)
+    : null;
+  return {
+    ok: true,
+    leaseUntil,
+    providerUrl: providerEndpoint?.url ?? null,
+    providerHeaders: providerEndpoint?.headers ?? null,
+  };
+}
+
+export async function releaseExecutionLease(
+  target: ExecutionLeaseTarget,
+  now = new Date(),
+): Promise<boolean> {
+  const patch = JSON.stringify({ executionLeaseUntil: null });
+  const rows = await db
+    .update(sessionSandboxes)
+    .set({
+      metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${patch}::jsonb`,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(sessionSandboxes.sandboxId, target.sandboxId),
+        eq(sessionSandboxes.sessionId, target.sessionId),
+        eq(sessionSandboxes.projectId, target.projectId),
+      ),
+    )
+    .returning({ sandboxId: sessionSandboxes.sandboxId });
+  return rows.length > 0;
+}

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -74,6 +74,7 @@ import {
   sessionSandboxes,
 } from "@kortix/db";
 import { and, eq, inArray } from "drizzle-orm";
+import { discoverExecutionKeepAliveEndpoint, releaseExecutionLease, renewExecutionLease } from "../execution-lease";
 import { loadProjectForUser, assertProjectCapability } from "../lib/access";
 import {
   bindChatThread,
@@ -1022,6 +1023,7 @@ projectsApp.openapi(
     // in-sandbox agent CLI) and the session sandbox's own service credential.
     // Each is scoped back to this projectId before a turn event is accepted.
     const authType = (c as any).get("authType") as string | undefined;
+    let authenticatedSandboxId: string | null = null;
     if (authType === "apiKey" && (c as any).get("apiKeyType") === "sandbox") {
       const accountId = (c as any).get("accountId") as string | undefined;
       const sandboxId = (c as any).get("sandboxId") as string | undefined;
@@ -1029,7 +1031,7 @@ projectsApp.openapi(
         return c.json({ error: "turn-stream requires a sandbox token" }, 403);
       }
       const [sandbox] = await db
-        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .select({ sandboxId: sessionSandboxes.sandboxId, sessionId: sessionSandboxes.sessionId })
         .from(sessionSandboxes)
         .where(
           and(
@@ -1046,6 +1048,7 @@ projectsApp.openapi(
           403,
         );
       }
+      authenticatedSandboxId = sandbox.sandboxId;
     } else {
       const loaded = await loadProjectForUser(c, projectId, "read");
       if (!loaded) return c.json({ error: "Not found" }, 404);
@@ -1068,6 +1071,7 @@ projectsApp.openapi(
       error_status?: number;
       error_retryable?: boolean;
       error_provider?: string;
+      lease_ttl_seconds?: number;
     };
     try {
       body = (await c.req.json()) as typeof body;
@@ -1077,6 +1081,13 @@ projectsApp.openapi(
     const sessionId = body.session_id?.trim();
     if (!sessionId) {
       return c.json({ error: "session_id is required" }, 400);
+    }
+
+    if (authenticatedSandboxId) {
+      const [ownedSession] = await db.select({ sessionId: sessionSandboxes.sessionId }).from(sessionSandboxes).where(and(
+        eq(sessionSandboxes.sandboxId, authenticatedSandboxId), eq(sessionSandboxes.sessionId, sessionId), eq(sessionSandboxes.projectId, projectId),
+      )).limit(1);
+      if (!ownedSession) return c.json({ error: "sandbox token is not scoped to this session" }, 403);
     }
 
     // session_id is caller-supplied — scope it back to :projectId so a caller
@@ -1094,6 +1105,28 @@ projectsApp.openapi(
       .limit(1);
     if (!turnStreamSession) {
       return c.json({ error: "Not found" }, 404);
+    }
+
+    if (body.kind === "execution_heartbeat" || body.kind === "execution_lease_release" || body.kind === "execution_lease_discover") {
+      if (!authenticatedSandboxId) return c.json({ error: "execution lease requires a sandbox token" }, 403);
+      const target = { sandboxId: authenticatedSandboxId, sessionId, projectId };
+      if (body.kind === "execution_lease_release") return c.json({ ok: await releaseExecutionLease(target) });
+      if (body.kind === "execution_lease_discover") {
+        const provider = await discoverExecutionKeepAliveEndpoint(target);
+        return c.json({
+          ok: provider !== null,
+          provider_url: provider?.url ?? null,
+          provider_headers: provider?.headers ?? null,
+        });
+      }
+      const result = await renewExecutionLease(target, body.lease_ttl_seconds);
+      return c.json({
+        ok: result.ok,
+        lease_until: result.leaseUntil,
+        provider_url: result.providerUrl,
+        provider_headers: result.providerHeaders,
+        provider_touched: result.providerUrl !== null,
+      });
     }
 
     // `end` / `turn_end` carry no text — the sandbox observed the opencode turn

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -283,6 +283,13 @@ describe('reapAndReconcileSandboxes', () => {
     expect(sbUpdate?.updates.status).toBeUndefined();
   });
 
+  test('active execution lease vetoes stop before the busy probe', async () => {
+    candidates = [candidate({ metadata: { executionLeaseUntil: new Date(NOW.getTime() + 60_000).toISOString(), idleObservedAt: new Date(NOW.getTime() - TTL).toISOString() } })];
+    statusByExternal['ext-1'] = 'running'; busyByExternal['ext-1'] = 'idle';
+    const r = await reapAndReconcileSandboxes(NOW);
+    expect(r.busyVetoed).toBe(1); expect(r.stopped).toBe(0); expect(stops).toEqual([]); expect(updateCalls).toEqual([]);
+  });
+
   test('first idle observation arms the countdown instead of stopping', async () => {
     candidates = [candidate()];
     statusByExternal['ext-1'] = 'running';

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -40,6 +40,7 @@ import { pauseComputeSession } from '../billing/services/compute-metering';
 import { probeSandboxBusy } from './sandbox-busy-probe';
 import { ACTIVE_SESSION_STATUSES } from './lib/session-status';
 import { config } from '../config';
+import { hasActiveExecutionLease } from './execution-lease';
 import { preserveEstablishedRuntime } from './runtime-identity';
 
 export const REAP_BATCH_SIZE = 100;
@@ -314,6 +315,10 @@ export async function reapAndReconcileSandboxes(now = new Date()): Promise<ReapR
         const providerStatus: SandboxStatus = await getProvider(row.provider).getStatus(row.externalId);
 
         if (providerStatus === 'running') {
+          if (hasActiveExecutionLease(row.metadata, now)) {
+            result.busyVetoed += 1;
+            continue;
+          }
           let fallbackLastMeaningful: Date | null = null;
           if (lastUsageBySession !== null) {
             const base = lastMeaningfulAt(row);

--- a/apps/kortix-sandbox-agent-server/src/__tests__/execution-lease.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/execution-lease.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { type ExecutionLeaseContext, ExecutionLeaseReporter } from '../execution-lease';
+
+const context: ExecutionLeaseContext = {
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  token: 'kortix_sb_test',
+  apiRoot: 'https://api.test/v1',
+};
+const response = (body: unknown) =>
+  new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
+
+describe('ExecutionLeaseReporter', () => {
+  test('touches both provider and API while busy', async () => {
+    const calls: Array<{ url: string; kind?: string; headers?: RequestInit['headers'] }> = [];
+    const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const body = init?.body ? (JSON.parse(String(init.body)) as { kind?: string }) : {};
+      calls.push({ url, kind: body.kind, headers: init?.headers });
+      return url.startsWith('https://api.test/')
+        ? response({
+            provider_url: 'https://edge.test',
+            provider_headers: { 'X-Daytona-Preview-Token': 'preview-secret', Authorization: 'drop-me' },
+          })
+        : response({ status: 'ok' });
+    }) as typeof fetch;
+    const reporter = new ExecutionLeaseReporter(context, { fetchFn, heartbeatIntervalMs: 5 });
+    reporter.discover();
+    reporter.markBusy('root');
+    await reporter.settled();
+    await Bun.sleep(12);
+    reporter.markInactive('root');
+    await reporter.settled();
+    expect(calls.some((call) => call.kind === 'execution_heartbeat')).toBe(true);
+    expect(calls.some((call) => call.kind === 'execution_lease_release')).toBe(true);
+    const direct = calls.find((call) => call.url === 'https://edge.test/kortix/health');
+    expect(direct).toBeDefined();
+    expect(direct?.headers).toMatchObject({
+      'X-Daytona-Preview-Token': 'preview-secret',
+      Authorization: 'Bearer kortix_sb_test',
+    });
+  });
+  test('holds the lease until every root/subagent is inactive', async () => {
+    const kinds: string[] = [];
+    const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(String(init.body)) as { kind?: string }) : {};
+      if (body.kind) kinds.push(body.kind);
+      return response({ ok: true });
+    }) as typeof fetch;
+    const reporter = new ExecutionLeaseReporter(context, { fetchFn, heartbeatIntervalMs: 60_000 });
+    reporter.markBusy('root');
+    reporter.markBusy('child');
+    reporter.markInactive('root');
+    await reporter.settled();
+    expect(kinds).toEqual(['execution_heartbeat']);
+    reporter.markInactive('child');
+    await reporter.settled();
+    expect(kinds).toEqual(['execution_heartbeat', 'execution_lease_release']);
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-events-dispatch.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-events-dispatch.test.ts
@@ -80,4 +80,9 @@ describe('dispatch — session.error flattening', () => {
     )
     expect(id).toBe('ses_root')
   })
+  test('session.status dispatches busy state for execution leasing', () => {
+    const seen: Array<[string, string]> = []
+    dispatch({ type: 'session.status', properties: { sessionID: 'root', status: { type: 'busy' } } }, { onSessionStatus: (id, status) => seen.push([id, status]) })
+    expect(seen).toEqual([['root', 'busy']])
+  })
 })

--- a/apps/kortix-sandbox-agent-server/src/execution-lease.ts
+++ b/apps/kortix-sandbox-agent-server/src/execution-lease.ts
@@ -1,0 +1,145 @@
+import { logger } from './logger';
+
+export const EXECUTION_HEARTBEAT_INTERVAL_MS = 20_000;
+export const EXECUTION_LEASE_TTL_SECONDS = 120;
+export interface ExecutionLeaseContext {
+  projectId: string;
+  sessionId: string;
+  token: string;
+  apiRoot: string;
+}
+export interface ExecutionLeaseReporterOptions {
+  fetchFn?: typeof fetch;
+  heartbeatIntervalMs?: number;
+  leaseTtlSeconds?: number;
+}
+
+export function executionLeaseContextFromEnv(): ExecutionLeaseContext | null {
+  const projectId = process.env.KORTIX_PROJECT_ID?.trim();
+  const sessionId = process.env.KORTIX_SESSION_ID?.trim();
+  const token = (process.env.KORTIX_SANDBOX_TOKEN || process.env.KORTIX_TOKEN || '').trim();
+  const apiUrl = process.env.KORTIX_API_URL?.replace(/\/$/, '');
+  if (!projectId || !sessionId || !token || !apiUrl) return null;
+  return { projectId, sessionId, token, apiRoot: apiUrl.endsWith('/v1') ? apiUrl : `${apiUrl}/v1` };
+}
+
+export class ExecutionLeaseReporter {
+  private readonly busySessions = new Set<string>();
+  private readonly fetchFn: typeof fetch;
+  private readonly heartbeatIntervalMs: number;
+  private readonly leaseTtlSeconds: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private providerUrl: string | null = null;
+  private providerHeaders: Record<string, string> = {};
+  private queue: Promise<void> = Promise.resolve();
+  constructor(
+    private readonly context: ExecutionLeaseContext,
+    options: ExecutionLeaseReporterOptions = {},
+  ) {
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? EXECUTION_HEARTBEAT_INTERVAL_MS;
+    this.leaseTtlSeconds = options.leaseTtlSeconds ?? EXECUTION_LEASE_TTL_SECONDS;
+  }
+  discover(): void {
+    this.enqueue('execution_lease_discover');
+  }
+  markBusy(sessionId: string): void {
+    if (!sessionId) return;
+    const wasIdle = this.busySessions.size === 0;
+    this.busySessions.add(sessionId);
+    if (!wasIdle) return;
+    this.enqueue('execution_heartbeat');
+    this.timer = setInterval(() => this.enqueue('execution_heartbeat'), this.heartbeatIntervalMs);
+  }
+  markInactive(sessionId: string): void {
+    if (!sessionId) return;
+    this.busySessions.delete(sessionId);
+    if (this.busySessions.size > 0) return;
+    this.clearTimer();
+    this.enqueue('execution_lease_release');
+  }
+  replaceBusySessions(sessionIds: string[]): void {
+    const wasBusy = this.busySessions.size > 0;
+    this.busySessions.clear();
+    for (const id of sessionIds.filter(Boolean)) this.busySessions.add(id);
+    if (!wasBusy && this.busySessions.size > 0) {
+      this.enqueue('execution_heartbeat');
+      this.timer = setInterval(() => this.enqueue('execution_heartbeat'), this.heartbeatIntervalMs);
+    } else if (wasBusy && this.busySessions.size === 0) {
+      this.clearTimer();
+      this.enqueue('execution_lease_release');
+    }
+  }
+  close(): void {
+    this.clearTimer();
+    if (this.busySessions.size > 0) {
+      this.busySessions.clear();
+      this.enqueue('execution_lease_release');
+    }
+  }
+  async settled(): Promise<void> {
+    await this.queue;
+  }
+  private clearTimer(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+  private enqueue(
+    kind: 'execution_heartbeat' | 'execution_lease_release' | 'execution_lease_discover',
+  ): void {
+    this.queue = this.queue
+      .then(() => this.send(kind))
+      .catch((err) =>
+        logger.warn('[execution-lease] reporter failed', { err: (err as Error).message }),
+      );
+  }
+  private async send(
+    kind: 'execution_heartbeat' | 'execution_lease_release' | 'execution_lease_discover',
+  ): Promise<void> {
+    if (kind === 'execution_heartbeat' && this.providerUrl) {
+      try {
+        await this.fetchFn(`${this.providerUrl}/kortix/health`, {
+          headers: {
+            ...this.providerHeaders,
+            Authorization: `Bearer ${this.context.token}`,
+          },
+          signal: AbortSignal.timeout(10_000),
+        });
+      } catch (err) {
+        logger.warn('[execution-lease] direct provider touch failed', {
+          err: (err as Error).message,
+        });
+      }
+    }
+    const response = await this.fetchFn(
+      `${this.context.apiRoot}/projects/${encodeURIComponent(this.context.projectId)}/turn-stream`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.context.token}`,
+        },
+        body: JSON.stringify({
+          session_id: this.context.sessionId,
+          kind,
+          lease_ttl_seconds: this.leaseTtlSeconds,
+        }),
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) throw new Error(`${kind} returned ${response.status}`);
+    const body = (await response.json().catch(() => ({}))) as {
+      provider_url?: unknown;
+      provider_headers?: unknown;
+    };
+    if (typeof body.provider_url === 'string' && body.provider_url.startsWith('https://'))
+      this.providerUrl = body.provider_url.replace(/\/$/, '');
+    if (body.provider_headers && typeof body.provider_headers === 'object' && !Array.isArray(body.provider_headers)) {
+      this.providerHeaders = Object.fromEntries(
+        Object.entries(body.provider_headers as Record<string, unknown>).filter(
+          ([name, value]) => name.toLowerCase() !== 'authorization' && typeof value === 'string',
+        ),
+      ) as Record<string, string>;
+    }
+  }
+}

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -32,6 +32,7 @@ import {
 import type { SandboxBootState } from './routes/health'
 import { installShutdownHandlers } from './shutdown'
 import { startStaticWebServer } from './static-web'
+import { ExecutionLeaseReporter, executionLeaseContextFromEnv } from './execution-lease'
 
 // Pin file for the opencode session created from KORTIX_INITIAL_PROMPT.
 // Webhook follow-ups (e.g. Slack thread replies) read this to deliver new
@@ -325,17 +326,26 @@ async function startSessionRuntime(
   bootState: SandboxBootState,
   bootMark: (label: string) => void,
 ): Promise<void> {
+  const leaseContext = executionLeaseContextFromEnv()
+  const executionLease = leaseContext ? new ExecutionLeaseReporter(leaseContext) : null
+  executionLease?.discover()
+  const onSessionStatus = (opencodeSessionId: string, status: string) => {
+    if (status === 'busy' || status === 'retry') executionLease?.markBusy(opencodeSessionId)
+    else if (status === 'idle') executionLease?.markInactive(opencodeSessionId)
+  }
   const onQuestionAsked = (req: QuestionRequest) => {
     void relayQuestionToApi(req, cfg).catch((err) =>
       logger.warn('[opencode-events] question relay failed', { err: (err as Error).message }),
     )
   }
   const onSessionIdle = (opencodeSessionId: string) => {
+    executionLease?.markInactive(opencodeSessionId)
     void relayTurnEndToApi(opencodeSessionId, 'idle', opencode, cfg).catch((err) =>
       logger.warn('[opencode-events] turn-end relay failed', { err: (err as Error).message }),
     )
   }
   const onSessionError = (opencodeSessionId: string, error?: OpencodeTurnError) => {
+    executionLease?.markInactive(opencodeSessionId)
     void relayTurnEndToApi(opencodeSessionId, 'error', opencode, cfg, error).catch((err) =>
       logger.warn('[opencode-events] turn-end relay failed', { err: (err as Error).message }),
     )
@@ -348,11 +358,15 @@ async function startSessionRuntime(
   // and this reconcile collapse to a single finalize; a reconnect after the turn
   // relayed is a no-op.
   const onConnected = () => {
+    executionLease?.discover()
+    void reconcileExecutionLease(opencode, cfg, executionLease).catch((err) =>
+      logger.warn('[execution-lease] status reconcile failed', { err: (err as Error).message }),
+    )
     void reconcileFinishedFirstTurn(opencode, cfg).catch((err) =>
       logger.warn('[opencode-events] connect reconcile failed', { err: (err as Error).message }),
     )
   }
-  const eventHandlers = { onQuestionAsked, onSessionIdle, onSessionError, onConnected }
+  const eventHandlers = { onQuestionAsked, onSessionIdle, onSessionError, onSessionStatus, onConnected }
   let loopStarted = false
   if (bootState.initialOpenCodeSessionRequired) {
     // SUBSCRIBE BEFORE PROMPT: start the /event loop first and hand its
@@ -384,6 +398,18 @@ async function startSessionRuntime(
   } else {
     logger.warn('[boot] opencode did not become ready within deadline; supervisor still retrying', { opencodePid: opencode.getPid() })
   }
+}
+
+async function reconcileExecutionLease(opencode: Opencode, cfg: Config, reporter: ExecutionLeaseReporter | null): Promise<void> {
+  if (!reporter) return
+  const response = await fetch(`${opencode.getInternalUrl()}/session/status?directory=${encodeURIComponent(cfg.workspace)}`, { signal: AbortSignal.timeout(10_000) })
+  if (!response.ok) throw new Error(`/session/status returned ${response.status}`)
+  const statuses = (await response.json()) as Record<string, { type?: string } | string>
+  const busy = Object.entries(statuses).filter(([, status]) => {
+    const type = typeof status === 'string' ? status : status?.type
+    return type === 'busy' || type === 'retry'
+  }).map(([sessionId]) => sessionId)
+  reporter.replaceBusySessions(busy)
 }
 
 // Read KEY=VALUE lines from the per-session env file into process.env. Platinum

--- a/apps/kortix-sandbox-agent-server/src/opencode-events.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-events.ts
@@ -42,6 +42,7 @@ type OpencodeEventHandlers = {
   // filtering down to the root turn.
   onSessionIdle?: (sessionID: string) => void
   onSessionError?: (sessionID: string, error?: OpencodeTurnError) => void
+  onSessionStatus?: (sessionID: string, status: string) => void
   // Fired every time the /event SSE (re)subscribes successfully. Used to
   // reconcile a turn that finished BEFORE the subscription was live: a fast
   // boot could reach session.idle inside the gap between prompt_async and the
@@ -169,6 +170,12 @@ export function flattenOpencodeError(e: {
 // Exported for unit testing — maps a raw opencode SSE event to a handler call,
 // including flattening session.error's nested error into OpencodeTurnError.
 export function dispatch(event: { type?: string; properties?: unknown }, handlers: OpencodeEventHandlers): void {
+  if (event.type === 'session.status' && handlers.onSessionStatus) {
+    const props = event.properties as { sessionID?: string; status?: { type?: string } | string } | undefined
+    const status = typeof props?.status === 'string' ? props.status : props?.status?.type
+    if (props?.sessionID && status) handlers.onSessionStatus(props.sessionID, status)
+    return
+  }
   if (event.type === 'question.asked' && handlers.onQuestionAsked) {
     const req = event.properties as QuestionRequest
     if (req?.id && req?.sessionID && Array.isArray(req.questions)) {

--- a/apps/web/content/docs/reference/session-runtime.mdx
+++ b/apps/web/content/docs/reference/session-runtime.mdx
@@ -22,6 +22,12 @@ A session row (`project_sessions`) carries a `status`. The enum defines `queued`
 
 Concurrent-session caps are enforced per account; exceeding your tier returns `429`.
 
+## Active-turn protection
+
+While any OpenCode root or subagent session is `busy` or `retrying`, the sandbox daemon renews a short execution lease with the API every 20 seconds. The lease vetoes the idle reaper, and each renewal touches the provider edge so the provider's native inactivity timer cannot hibernate the VM during a long tool-only phase. The daemon also caches that provider edge and continues the busy-only keep-alive if the Kortix API is temporarily unavailable. `session.idle` and `session.error` release the lease.
+
+An open dashboard, preview, SSE connection, or health poll does **not** create an execution lease. Passive tabs therefore cannot keep genuinely idle compute alive.
+
 ## Branch model
 
 - The session branch is **named after the session id** (a UUID). `KORTIX_SESSION_ID` and `KORTIX_BRANCH_NAME` are the same value.
@@ -65,7 +71,7 @@ Injected at boot, alongside your project's [secrets](/docs/reference/secrets) (w
 | `KORTIX_PROJECT_AUTO_CLONE` | `1` — tells the daemon to clone the repo on boot. |
 | `KORTIX_PROJECT_SECRET_NAMES` | Comma-separated names of the project's secrets. |
 | `KORTIX_PROJECT_SECRETS_REVISION` | Revision marker for the secret set. |
-| `KORTIX_SANDBOX_TOKEN` | The sandbox **service key** — the daemon's own identity. It signs and validates its own control-surface requests with it (HMAC key for `X-Kortix-User-Context`) and is the bearer for the sandbox-identity routes (clone-credential / turn-stream / turn-question). It is *not* a project API token, and the `kortix` CLI does not read it — the project-scoped API routes reject it. `KORTIX_TOKEN` is injected with the same value as a back-compat alias for daemons baked before the rename to `KORTIX_SANDBOX_TOKEN`; a planned Phase 2 will drop the `KORTIX_TOKEN`/`KORTIX_EXECUTOR_TOKEN` aliases and repurpose `KORTIX_TOKEN` to mean the session token instead, so don't depend on `KORTIX_TOKEN` continuing to carry the sandbox identity long-term. |
+| `KORTIX_SANDBOX_TOKEN` | The sandbox **service key** — the daemon's own identity. It signs and validates its own control-surface requests with it (HMAC key for `X-Kortix-User-Context`) and is the bearer for the sandbox-identity routes (clone-credential / turn-stream, including execution leases / turn-question). It is *not* a project API token, and the `kortix` CLI does not read it — the project-scoped API routes reject it. `KORTIX_TOKEN` is injected with the same value as a back-compat alias for daemons baked before the rename to `KORTIX_SANDBOX_TOKEN`; a planned Phase 2 will drop the `KORTIX_TOKEN`/`KORTIX_EXECUTOR_TOKEN` aliases and repurpose `KORTIX_TOKEN` to mean the session token instead, so don't depend on `KORTIX_TOKEN` continuing to carry the sandbox identity long-term. |
 | `KORTIX_CLI_TOKEN` | The project-scoped PAT the in-sandbox `kortix` CLI authenticates with (same value as `KORTIX_EXECUTOR_TOKEN`). |
 | `KORTIX_EXECUTOR_TOKEN` | The same project-scoped PAT — acts as the launching user, scoped to the project. Also backs the `kortix-executor` MCP gateway. |
 | `KORTIX_BOOTSTRAP_OPENCODE_SESSION` | `1` — always set. The sandbox daemon owns OpenCode root creation on every cold boot; this tells it to create/open the OpenCode root at boot, and the API adopts whatever root the daemon creates rather than racing to create its own. |

--- a/apps/web/src/features/files/hooks/server-health-state.test.ts
+++ b/apps/web/src/features/files/hooks/server-health-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { fileServerHealthState } from './server-health-state';
+
+describe('fileServerHealthState', () => {
+  test('keeps Files available while daemon is connected but runtime readiness is false', () => {
+    expect(fileServerHealthState('connected', false, '1.2.3')).toEqual({
+      healthy: true,
+      version: '1.2.3',
+    });
+  });
+  test('reports a truly unreachable daemon as unhealthy', () => {
+    expect(fileServerHealthState('unreachable', false, null)).toEqual({
+      healthy: false,
+      version: '',
+    });
+  });
+  test('keeps initial unresolved state loading', () => {
+    expect(fileServerHealthState('connecting', null, null)).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/files/hooks/server-health-state.ts
+++ b/apps/web/src/features/files/hooks/server-health-state.ts
@@ -1,0 +1,11 @@
+import type { ServerHealth } from '@/features/file-browser/types';
+import type { SandboxConnectionStatus } from '@kortix/sdk/sandbox-connection-store';
+
+export function fileServerHealthState(
+  status: SandboxConnectionStatus,
+  runtimeHealthy: boolean | null,
+  version: string | null,
+): ServerHealth | undefined {
+  if (status === 'connecting' && runtimeHealthy === null) return undefined;
+  return { healthy: status === 'connected', version: version ?? '' };
+}

--- a/apps/web/src/features/files/hooks/use-server-health.ts
+++ b/apps/web/src/features/files/hooks/use-server-health.ts
@@ -2,9 +2,10 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getClient } from '@/lib/opencode-sdk';
-import { useSandboxConnectionStore } from '@kortix/sdk/sandbox-connection-store';
+import { requestRuntimeReconnect, useSandboxConnectionStore } from '@kortix/sdk/sandbox-connection-store';
 import { opencodeKeys } from '@/hooks/opencode/use-opencode-sessions';
 import type { ServerHealth, OpenCodeProjectInfo } from '@/features/file-browser/types';
+import { fileServerHealthState } from './server-health-state';
 
 /**
  * Check if the active OpenCode server is reachable and healthy.
@@ -19,13 +20,12 @@ import type { ServerHealth, OpenCodeProjectInfo } from '@/features/file-browser/
  */
 export function useServerHealth(options?: { enabled?: boolean }) {
   const status = useSandboxConnectionStore((s) => s.status);
-  const healthy = useSandboxConnectionStore((s) => s.healthy);
+  const runtimeHealthy = useSandboxConnectionStore((s) => s.healthy);
   const version = useSandboxConnectionStore((s) => s.openCodeVersion);
 
   // Return a shape compatible with the old UseQueryResult<ServerHealth>
   // so consumers don't need to change their destructuring pattern.
-  const data: ServerHealth | undefined =
-    healthy !== null ? { healthy, version: version ?? '' } : undefined;
+  const data: ServerHealth | undefined = fileServerHealthState(status, runtimeHealthy, version);
 
   return {
     data,
@@ -33,8 +33,7 @@ export function useServerHealth(options?: { enabled?: boolean }) {
     isError: status === 'unreachable',
     error: status === 'unreachable' ? new Error('Server unreachable') : null,
     refetch: async () => {
-      // No-op — the health check polling loop handles this automatically.
-      // Kept for backward compatibility with consumers that call refetch().
+      requestRuntimeReconnect();
       return { data } as any;
     },
   };

--- a/packages/sdk/src/react/use-runtime-reconnect.test.ts
+++ b/packages/sdk/src/react/use-runtime-reconnect.test.ts
@@ -15,6 +15,7 @@ import {
 } from './use-runtime-reconnect';
 import {
   incrementSandboxFail,
+  requestRuntimeReconnect,
   resetSandboxFail,
   useSandboxConnectionStore,
 } from '../state/sandbox-connection-store';
@@ -36,6 +37,14 @@ describe('computeFailureStatus — first connection', () => {
 
   test('stays unreachable past the threshold', () => {
     expect(computeFailureStatus(FAIL_THRESHOLD_FIRST + 3, false, false)).toBe('unreachable');
+  });
+});
+
+describe('manual runtime reconnect', () => {
+  test('clears stale unreachable state and emits an immediate-retry signal', () => {
+    useSandboxConnectionStore.setState({ status: 'unreachable', healthy: false, failCount: 7, runtimeError: 'stale', disconnectedAt: 123, manualRetryNonce: 4 });
+    requestRuntimeReconnect();
+    expect(useSandboxConnectionStore.getState()).toMatchObject({ status: 'connecting', healthy: null, failCount: 0, runtimeError: null, manualRetryNonce: 5 });
   });
 });
 

--- a/packages/sdk/src/react/use-runtime-reconnect.ts
+++ b/packages/sdk/src/react/use-runtime-reconnect.ts
@@ -156,11 +156,15 @@ export function nextPollDelay(status: SandboxConnectionStatus, healthy: boolean 
  * functions, since the repo has no harness to render-test a hook directly.
  */
 export function useRuntimeReconnect() {
+  const manualRetryNonce = useSandboxConnectionStore((state) => state.manualRetryNonce);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const isMountRef = useRef(true);
 
   useEffect(() => {
+    // Reading the generation inside the effect makes the dependency explicit:
+    // each manual retry tears down the in-flight probe and starts a fresh one.
+    void manualRetryNonce;
     const isFirstMount = isMountRef.current;
     isMountRef.current = false;
 
@@ -286,5 +290,5 @@ export function useRuntimeReconnect() {
       abortRef.current?.abort();
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, []);
+  }, [manualRetryNonce]);
 }

--- a/packages/sdk/src/state/sandbox-connection-store.ts
+++ b/packages/sdk/src/state/sandbox-connection-store.ts
@@ -36,6 +36,7 @@ interface SandboxConnectionStore {
 	runtimeError: string | null;
 	recoveryPhase: SandboxRecoveryPhase;
 	restartRequestedAt: number | null;
+	manualRetryNonce: number;
 }
 
 // ── Persist wasConnected across hard refreshes via sessionStorage ──
@@ -117,7 +118,15 @@ export const useSandboxConnectionStore = create<SandboxConnectionStore>(() => ({
 	runtimeError: null,
 	recoveryPhase: "idle",
 	restartRequestedAt: null,
+	manualRetryNonce: 0,
 }));
+
+export function requestRuntimeReconnect() {
+	useSandboxConnectionStore.setState((state) => ({
+		status: "connecting", healthy: null, failCount: 0, runtimeError: null,
+		disconnectedAt: state.disconnectedAt ?? Date.now(), manualRetryNonce: state.manualRetryNonce + 1,
+	}));
+}
 
 // ── Static actions (stable references, no re-render loops) ──
 
@@ -228,6 +237,7 @@ export function resetForServerSwitch() {
 			runtimeError: null,
 			recoveryPhase: "idle",
 			restartRequestedAt: null,
+			manualRetryNonce: 0,
 		});
 		saveWasConnected(true);
 		return;
@@ -249,6 +259,7 @@ export function resetForServerSwitch() {
 			runtimeError: null,
 			recoveryPhase: "idle",
 			restartRequestedAt: null,
+			manualRetryNonce: 0,
 		});
 		saveWasConnected(true);
 		return;
@@ -267,6 +278,7 @@ export function resetForServerSwitch() {
 		runtimeError: null,
 		recoveryPhase: "idle",
 		restartRequestedAt: null,
+		manualRetryNonce: 0,
 	});
 	saveWasConnected(false);
 }


### PR DESCRIPTION
## What changed

- add a busy-only execution lease renewed by the sandbox daemon every 20s while any OpenCode root/subagent is busy or retrying
- touch and cache the provider edge (including provider preview headers) so native auto-stop cannot kill a long tool phase, including during a temporary Kortix API outage
- make the reaper veto auto-stop while an execution lease is live
- bind sandbox turn-stream credentials to the exact session
- make Files use daemon reachability instead of global runtime readiness, and make Retry immediately restart the SDK probe
- document the busy-only lease contract

## Verification

- real Daytona turn: 95-second bash tool call completed with `LEASE_OK`; `session_sandboxes.executionLeaseUntil` renewed every ~20s and cleared after idle
- real reaper: forced `idleObservedAt` and `last_used_at` 20 minutes stale during a busy turn; `reapAndReconcileSandboxes()` returned `busyVetoed: 1`, `stopped: 0`; daemon and OpenCode stayed healthy; turn completed `REAPER_OK`
- real sandbox-authenticated lease discovery route returned HTTP 200 with HTTPS provider endpoint and no Authorization header disclosure
- API: 43 targeted tests passed; `pnpm typecheck` passed
- sandbox agent: 8 targeted tests passed; `bun tsc --noEmit` passed; Linux x64 binary rebuilt
- SDK: 20 targeted tests passed; package typecheck passed
- web Files state: 3 tests passed; ESLint passed on touched files
- `git diff --check` passed

## Cleanup

The live E2E project, sessions, sandbox rows, and test user were deleted after verification.