### PR TITLE
fix(session): wrap long unbroken tokens in messages instead of overflowing the page

### DIFF
--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -13,13 +13,6 @@ import {
   normalizeClassName,
   prepareMarkdownForKatex,
 } from '@/components/markdown/katex-markdown';
-import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
-import { parseSetupLinkHref } from '@/components/setup-links/util';
-import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
-import { isMermaidCode } from '@/lib/mermaid-utils';
-import { toast } from '@/lib/toast';
-import { cn } from '@/lib/utils';
-import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
 import {
   isInternalUrl,
   languageLabel,
@@ -27,6 +20,13 @@ import {
   looksLikeUrl,
   normalizeLanguage,
 } from '@/components/markdown/unified-markdown-utils';
+import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
+import { parseSetupLinkHref } from '@/components/setup-links/util';
+import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
+import { isMermaidCode } from '@/lib/mermaid-utils';
+import { toast } from '@/lib/toast';
+import { cn } from '@/lib/utils';
+import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
 import { useFilePreviewStore } from '@/stores/file-preview-store';
 import { getActivePanelSessionId, openFileInSessionPanel } from '@/stores/session-browser-store';
 import { autoLinkUrls } from '@kortix/shared';
@@ -328,7 +328,7 @@ function KaTeXBlock({ math }: { math: string }) {
 
 // ─── Inline code ─────────────────────────────────────────────────────────────
 const INLINE_CODE =
-  'rounded-sm border bg-muted px-1.5 py-[0.1rem] font-mono text-[0.9rem] text-foreground/95 dark:bg-card';
+  'rounded-sm border bg-muted px-1.5 py-[0.1rem] font-mono text-[0.9rem] text-foreground/95 [overflow-wrap:anywhere] dark:bg-card';
 
 // Inline code that becomes a link (URLs) or opens a file preview (absolute paths).
 function ClickableInlineCode({ children }: { children: React.ReactNode }) {
@@ -454,7 +454,7 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
         ),
 
         p: ({ children }: { children?: React.ReactNode }) => (
-          <div className="text-foreground/95 my-4 leading-relaxed font-medium first:mt-0 last:mb-0 [&:has(img)]:my-0">
+          <div className="text-foreground/95 my-4 leading-relaxed font-medium [overflow-wrap:anywhere] first:mt-0 last:mb-0 [&:has(img)]:my-0">
             {wrapChildrenWithPaths(children)}
           </div>
         ),
@@ -470,7 +470,7 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           </ol>
         ),
         li: ({ children }: { children?: React.ReactNode }) => (
-          <li className="text-foreground/95 leading-relaxed font-medium">
+          <li className="text-foreground/95 leading-relaxed font-medium [overflow-wrap:anywhere]">
             {wrapChildrenWithPaths(children)}
           </li>
         ),
@@ -696,7 +696,11 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
 
     return (
       <div
-        className={cn('kortix-markdown text-[15px]', isStreaming && 'streaming-active', className)}
+        className={cn(
+          'kortix-markdown max-w-full min-w-0 text-[15px] [overflow-wrap:anywhere]',
+          isStreaming && 'streaming-active',
+          className,
+        )}
         data-streaming={isStreaming ? 'true' : 'false'}
       >
         <Streamdown

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -3,8 +3,8 @@
 import { UnifiedMarkdown } from '@/components/markdown/unified-markdown';
 import { SandboxImage } from '@/features/session/sandbox-image';
 import { SessionApprovalPrompt } from '@/features/session/session-approval-prompt';
-import { SessionPermissionPrompt } from '@/features/session/session-permission-prompt';
 import { isPendingAction, useSessionAudit } from '@/features/session/session-audit-shared';
+import { SessionPermissionPrompt } from '@/features/session/session-permission-prompt';
 import { useSessionWallpaperLayer } from '@/features/session/session-wallpaper-layer';
 import {
   AlertTriangle,
@@ -115,21 +115,6 @@ import { useAutoScroll } from '@/hooks/use-auto-scroll';
 import { useModelPricingLookup } from '@/lib/model-pricing';
 import { getClient } from '@/lib/opencode-sdk';
 import {
-  abandonOptimisticSend,
-  applyOptimisticAbort,
-  beginOptimisticSend,
-  classifySendError,
-  clearStartStash,
-  type KortixSendError,
-  readStartStash,
-  replayStartStash,
-  sendAndRecover,
-  usePermissionSelfHeal,
-  useQuestionSelfHeal,
-  useProjectConfig,
-  writeForkDraft,
-} from '@kortix/sdk/react';
-import {
   type AgentRefLike,
   type FileRefLike,
   buildAgentRefsBlock,
@@ -155,6 +140,21 @@ import { useSyncStore } from '@/stores/opencode-sync-store';
 import { usePendingFilesStore } from '@/stores/pending-files-store';
 import { useSessionBrowserStore } from '@/stores/session-browser-store';
 import { openTabAndNavigate, useTabStore } from '@/stores/tab-store';
+import {
+  type KortixSendError,
+  abandonOptimisticSend,
+  applyOptimisticAbort,
+  beginOptimisticSend,
+  classifySendError,
+  clearStartStash,
+  readStartStash,
+  replayStartStash,
+  sendAndRecover,
+  usePermissionSelfHeal,
+  useProjectConfig,
+  useQuestionSelfHeal,
+  writeForkDraft,
+} from '@kortix/sdk/react';
 // Shared UI primitives (framework-agnostic, reusable on mobile)
 import {
   type AgentPart,
@@ -3386,7 +3386,7 @@ function SessionTurn({
                 // the dedicated response section to avoid duplicate output.
                 if (!hasSteps) return null;
                 return (
-                  <div key={part.id} className="text-sm">
+                  <div key={part.id} className="min-w-0 text-sm">
                     <ThrottledMarkdown content={part.text} isStreaming={working} />
                   </div>
                 );
@@ -3481,7 +3481,7 @@ function SessionTurn({
       {/* Inline content: text and answered questions rendered in natural order.
 			    Works both during streaming and after completion. */}
       {working && !hasSteps && !shouldUseInlineContent && response && (
-        <div className="text-sm">
+        <div className="min-w-0 text-sm">
           <ThrottledMarkdown content={response} isStreaming />
         </div>
       )}
@@ -3503,7 +3503,7 @@ function SessionTurn({
                 const isStreaming = idx === lastTextIdx;
                 const text = isStreaming ? item.part.text! : item.part.text!.trim();
                 return (
-                  <div key={item.id} className="text-sm">
+                  <div key={item.id} className="min-w-0 text-sm">
                     {isStreaming ? (
                       <ThrottledMarkdown content={text} isStreaming />
                     ) : (


### PR DESCRIPTION
## Problem

A long unbroken string (e.g. a base64 token with no spaces) in a chat message had nowhere to break, so it forced the message column wider than the viewport — which let the entire session page scroll sideways/vertically off-screen.

Only **links** and **fenced code blocks** had overflow protection in the markdown renderer. Plain paragraph text, list items, and inline code had no `overflow-wrap` rule at all.

## Fix

Fixed at the single source of truth — `UnifiedMarkdown`, which every message path (streaming, settled, inline, `SandboxUrlDetector`) flows through:

- **Root wrapper**: `min-w-0 max-w-full [overflow-wrap:anywhere]`. `overflow-wrap` is inherited, so every descendant text node wraps; `min-w-0` lets the container shrink inside flex/grid ancestors instead of blowing out the layout.
- **Paragraphs, list items, inline code**: explicit `[overflow-wrap:anywhere]` as belt-and-suspenders.
- **Assistant message containers** in `session-chat.tsx` (3 spots): `min-w-0`.

Used `overflow-wrap:anywhere` (not `break-words`) deliberately — `anywhere` also shrinks the element's min-content size, which is what stops a flex/grid item from expanding the layout.

Fenced code blocks are untouched — they already scroll internally (`overflow-auto`), the correct behavior for code. Only free-flowing prose and inline tokens now wrap.

## Testing

- CSS-class-only changes; `tsc` clean on both files, Prettier-formatted.
- Long tokens now wrap onto the next line instead of pushing the page sideways.