### PR TITLE
Harden pentest findings and keep Strix manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ pnpm-debug.log*
 coverage/
 .nyc_output/
 test-results/
+strix_runs/
 
 # Temporary files
 *.tmp

--- a/.strix/instructions/ci-source.md
+++ b/.strix/instructions/ci-source.md
@@ -1,0 +1,13 @@
+# Kortix pull-request security review
+
+Perform an authorized, source-aware security review of the checked-out Kortix
+repository. In pull requests, prioritize the diff from `origin/main` and follow
+reachable data flow into surrounding code. Do not contact production services
+or any target outside the mounted repository.
+
+Focus on authentication, authorization, tenant isolation, untrusted input to
+commands/queries/templates/URLs, SSRF, unsafe files and archives, secret leakage,
+cryptographic misuse, CORS/CSRF, webhook verification, runtime proxy boundaries,
+mass assignment, dependency risk, and business-logic regressions. Do not execute
+destructive operations or print secret values. Report only findings with a
+concrete reachable path, impact, CWE, source location, and practical fix.

--- a/.strix/instructions/deep-api.md
+++ b/.strix/instructions/deep-api.md
@@ -1,0 +1,25 @@
+# Kortix API penetration-test rules of engagement
+
+This is an authorized security assessment of the local Kortix source tree and
+the API origin explicitly passed on the Strix command line. Keep all network
+activity strictly within that origin. Source code mounted at `/workspace` is in
+scope for white-box analysis. Instructions never add another network target.
+
+Test the complete reachable API attack surface, prioritizing authentication and
+JWT handling, authorization and cross-tenant IDOR/BOLA, session/runtime proxy
+boundaries, SSRF, command and template injection, SQL/NoSQL injection, unsafe
+file handling, mass assignment, CORS/CSRF, request smuggling, rate-limit bypass,
+secrets or sensitive-data exposure, webhook/trigger validation, billing and
+business-logic abuse, and LLM prompt-injection paths that cross a trust boundary.
+
+Use safe, minimal proofs of concept. Do not perform denial of service, load or
+stress testing, password guessing, persistence, destructive writes, deletion,
+payment capture, contacting third parties, cloud-account mutation, sandbox
+escape, or accessing data belonging to real users. Never print or retain secret
+values. Redact tokens, cookies, credentials, personal data, and private keys in
+all artifacts. Stop a proof immediately once exploitability is established.
+
+Treat source-only suspicions as hypotheses. Report a vulnerability only after a
+reachable path and concrete security impact are demonstrated. Include the exact
+endpoint or source location, safe reproduction steps, CWE, CVSS rationale, and
+the smallest practical remediation.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NPM := npm --prefix $(TESTS)
 .DEFAULT_GOAL := help
 .PHONY: help install fast all ci-pr ci-main ci-nightly ci-release \
         lint typecheck unit integration api api-coverage contract smoke e2e visual a11y \
-        performance security security-dast pentest migration infra chaos mutation \
+        performance security security-dast pentest strix migration infra chaos mutation \
         coverage gates report portal-up portal-down clean
 
 help: ## Show this help
@@ -71,6 +71,8 @@ security-dast: ## Dynamic security scan + API fuzz (needs TARGET_URL)
 	$(NPM) run test:security:dast
 pentest: ## Enterprise black-box pentest probes (needs PENTEST_TARGET_URL)
 	$(NPM) run test:pentest
+strix: ## OSS agentic source/pentest scan (needs LLM_API_KEY)
+	bash $(TESTS)/security/strix/run.sh
 migration: ## Database migration tests (throwaway Postgres)
 	$(NPM) run test:migration
 infra: ## Infrastructure / IaC tests (tflint/checkov/kubeconform)

--- a/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
+++ b/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
@@ -47,9 +47,16 @@ interface InMemorySession {
 
 let sessions: InMemorySession[] = [];
 let debitCalls: { accountId: string; amount: number; description: string; ledgerType: string }[] = [];
+let simulateUniqueViolationOnInsert = false;
 
 mock.module('../../billing/repositories/compute-sessions', () => ({
   insertComputeSession: async (data: any) => {
+    if (simulateUniqueViolationOnInsert) {
+      simulateUniqueViolationOnInsert = false;
+      const err = new Error('duplicate open compute session') as Error & { code?: string };
+      err.code = '23505';
+      throw err;
+    }
     const row: InMemorySession = {
       id: `cs_${sessions.length + 1}`,
       accountId: data.accountId,
@@ -123,6 +130,7 @@ const SPEC = { cpuCores: 2, memoryGb: 4, diskGb: 20, gpuCount: 0 };
 beforeEach(() => {
   sessions = [];
   debitCalls = [];
+  simulateUniqueViolationOnInsert = false;
   resetMockRegistry();
   // Default to a per-seat account so metering engages.
   mockRegistry.getCreditAccount = async () =>
@@ -222,6 +230,41 @@ describe('compute metering — per-seat happy path', () => {
     });
     expect(first).toBe(second);
     expect(sessions.length).toBe(1);
+  });
+
+  test('start recovers from database unique-open-session races by returning the winning row', async () => {
+    const winner: InMemorySession = {
+      id: 'cs_winner',
+      accountId: 'acc_test_123',
+      sandboxId: 'sb_race',
+      sessionId: null,
+      actorUserId: null,
+      cpuCores: SPEC.cpuCores,
+      memoryGb: SPEC.memoryGb,
+      diskGb: SPEC.diskGb,
+      gpuCount: SPEC.gpuCount,
+      state: 'active',
+      startedAt: new Date().toISOString(),
+      endedAt: null,
+      lastBilledAt: new Date().toISOString(),
+      costUsd: '0',
+      ledgerId: null,
+      metadata: {},
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    simulateUniqueViolationOnInsert = true;
+    queueMicrotask(() => sessions.push(winner));
+
+    const id = await startComputeSession({
+      sandboxId: 'sb_race',
+      accountId: 'acc_test_123',
+      spec: SPEC,
+    });
+
+    expect(id).toBe('cs_winner');
+    expect(sessions.filter((s) => s.sandboxId === 'sb_race')).toHaveLength(1);
   });
 
   test('pause is a safe no-op when no open session exists', async () => {

--- a/apps/api/src/__tests__/billing/mocks.ts
+++ b/apps/api/src/__tests__/billing/mocks.ts
@@ -135,6 +135,7 @@ export function registerGlobalMocks() {
   mock.module('../../billing/services/webhook-concurrency', () => ({
     recordWebhookEvent: async () =>
       mockRegistry.recordWebhookEvent ? mockRegistry.recordWebhookEvent() : true,
+    forgetWebhookEvent: async () => undefined,
     withAccountLock: async (_accountId: string, fn: () => Promise<any>) => fn(),
   }));
 
@@ -420,6 +421,7 @@ export function createMockStripeClient(overrides: Record<string, any> = {}) {
 export function createMockRevenueCatEvent(type: string, overrides: Record<string, any> = {}) {
   return {
     event: {
+      id: overrides.id ?? `evt_rc_${type.toLowerCase()}`,
       type,
       app_user_id: overrides.app_user_id ?? 'acc_test_123',
       product_id: overrides.product_id ?? 'kortix_pro_monthly',

--- a/apps/api/src/__tests__/billing/webhooks.test.ts
+++ b/apps/api/src/__tests__/billing/webhooks.test.ts
@@ -463,6 +463,30 @@ describe('RevenueCat', () => {
     expect(result.event_type).toBe('INITIAL_PURCHASE');
   });
 
+  test('duplicate RevenueCat event IDs are idempotent and do not grant twice', async () => {
+    const seen = new Set<string>();
+    mockRegistry.recordWebhookEvent = async (...args: any[]) => {
+      const key = String(args[0]);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    };
+
+    const body = createMockRevenueCatEvent('INITIAL_PURCHASE', {
+      id: 'rc_evt_duplicate_1',
+      event_id: 'rc_evt_duplicate_1',
+      product_id: 'kortix_plus_monthly',
+    });
+
+    const first = await processRevenueCatWebhook(body);
+    const second = await processRevenueCatWebhook(body);
+
+    expect((first as any).skipped).toBeUndefined();
+    expect((second as any).deduped).toBe(true);
+    expect(upsertCreditAccountCalls.length).toBe(1);
+    expect(grantCreditsCalls.length).toBe(2);
+  });
+
   test('RENEWAL: resets expiring credits', async () => {
     // Default mock has tier from getCreditAccount, which has tier_6_50
     const body = createMockRevenueCatEvent('RENEWAL');

--- a/apps/api/src/__tests__/e2e-accounts-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-accounts-contract.test.ts
@@ -36,6 +36,7 @@ interface InviteRow {
   invitedBy: string | null;
   initialRole: AccountRole;
   acceptedAt: Date | null;
+  acceptedByUserId?: string | null;
   createdAt: Date;
   expiresAt: Date;
 }
@@ -223,6 +224,7 @@ function upsertInvite(values: any, set?: Record<string, unknown>) {
     existing.expiresAt = (set?.expiresAt ?? values.expiresAt) as Date;
     existing.invitedBy = (set?.invitedBy ?? values.invitedBy) as string;
     existing.acceptedAt = (set?.acceptedAt ?? null) as Date | null;
+    existing.acceptedByUserId = (set?.acceptedByUserId ?? null) as string | null;
     return existing;
   }
   const invite: InviteRow = {
@@ -232,6 +234,7 @@ function upsertInvite(values: any, set?: Record<string, unknown>) {
     invitedBy: values.invitedBy ?? null,
     initialRole: values.initialRole ?? 'member',
     acceptedAt: values.acceptedAt ?? null,
+    acceptedByUserId: values.acceptedByUserId ?? null,
     createdAt: baseDate,
     expiresAt: values.expiresAt,
   };
@@ -321,6 +324,7 @@ mock.module('../shared/resolve-account', () => ({
 }));
 
 mock.module('../shared/db', () => ({
+  hasDatabase: () => true,
   db: {
     select: (fields?: Record<string, unknown>) => ({
       from: (table: unknown) => ({
@@ -739,6 +743,7 @@ describe('accounts API contract', () => {
     });
     expect(membership(INVITEE_ID, ACCOUNT_ID)?.accountRole).toBe('member');
     expect(inviteRows[0]?.acceptedAt).toBeInstanceOf(Date);
+    expect(inviteRows[0]?.acceptedByUserId).toBe(INVITEE_ID);
 
     const again = await app.request(`/v1/account-invites/${INVITE_ID}/accept`, { method: 'POST' });
     expect(again.status).toBe(200);
@@ -747,6 +752,14 @@ describe('accounts API contract', () => {
       account_role: 'member',
       already_accepted: true,
       bootstrap_grants_applied: [],
+    });
+
+    currentUserId = MEMBER_ID;
+    currentUserEmail = 'invitee@example.test';
+    const otherIdentity = await app.request(`/v1/account-invites/${INVITE_ID}/accept`, { method: 'POST' });
+    expect(otherIdentity.status).toBe(409);
+    expect(await otherIdentity.json()).toEqual({
+      error: 'Invite has already been accepted by another account.',
     });
 
     inviteRows[0] = {

--- a/apps/api/src/__tests__/e2e-projects-provision.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-provision.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { mockIamEngineAllowAll, mockIamMembershipSyncNoop } from './helpers/iam-mocks';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { accountMembers, projectMembers, projects } from '@kortix/db';
+import { accountMembers, projectGitConnections, projectMembers, projects } from '@kortix/db';
 
 process.env.KORTIX_DEFAULT_MARKETPLACES = '';
 
@@ -28,6 +28,8 @@ let seedFilePaths: string[];
 let seedBaseFilePaths: string[];
 let seedFilesByPath: Map<string, string>;
 let canonicalMembership: boolean;
+let managedPat: string | null;
+let provisionedInitialToken: string | null;
 
 function setTestAuth(userId = USER_ID, userEmail = 'ship@example.test') {
   (globalThis as any)[TEST_AUTH_KEY] = { userId, userEmail };
@@ -71,7 +73,7 @@ const stubBackend = {
       installationId: INSTALL_ID,
       credentialRef: null,
       defaultBranch: input.defaultBranch,
-      initialToken: PUSH_TOKEN,
+      initialToken: provisionedInitialToken,
     };
   },
   deleteRepo: async () => { backendCalls.push('deleteRepo'); },
@@ -90,7 +92,7 @@ mock.module('../projects/git-backends', () => ({
   getDefaultManagedBackend: () => stubBackend,
   githubBackend: stubBackend,
   managedGithubInstallId: () => INSTALL_ID,
-  managedGithubToken: () => null,
+  managedGithubToken: () => managedPat,
 }));
 
 // Stub the Freestyle *deployments* provider (kept feature, unrelated to managed
@@ -157,6 +159,7 @@ mock.module('../projects/git', () => ({
   diffStat: async () => ({ files: [], additions: 0, deletions: 0 }),
   getFileAtRef: async () => null,
   getMergeBase: async () => 'a'.repeat(40),
+  resolveBranchAheadState: async () => ({ ahead: false, commitsAhead: 0 }),
 }));
 
 mock.module("../snapshots/builder", () => ({
@@ -213,6 +216,26 @@ function projectRowFrom(values: any) {
   };
 }
 
+function existingProjectRow() {
+  return projectRowFrom({
+    accountId: ACCOUNT_ID,
+    name: 'Existing Managed Project',
+    repoUrl: `https://github.com/${REPO_OWNER}/existing-managed.git`,
+    defaultBranch: 'main',
+    manifestPath: 'kortix.yaml',
+    status: 'active',
+    metadata: {
+      git: {
+        url: `https://github.com/${REPO_OWNER}/existing-managed.git`,
+        provider: 'github',
+        managed: true,
+        auth: { method: 'github_app', installation_id: INSTALL_ID },
+        owner: REPO_OWNER,
+      },
+    },
+  });
+}
+
 mock.module('../shared/db', () => ({
   hasDatabase: true,
   db: {
@@ -231,6 +254,36 @@ mock.module('../shared/db', () => ({
                   return [{ accountId: ACCOUNT_ID, accountRole: 'owner' }];
                 }
                 return [];
+              }
+              if (table === projectMembers) {
+                return [{ projectRole: 'manager' }];
+              }
+              if (table === projects) {
+                return [existingProjectRow()];
+              }
+              if (table === projectGitConnections) {
+                return [{
+                  accountId: ACCOUNT_ID,
+                  projectId: PROJECT_ID,
+                  provider: 'github',
+                  repoUrl: `https://github.com/${REPO_OWNER}/existing-managed.git`,
+                  upstreamUrl: `https://github.com/${REPO_OWNER}/existing-managed.git`,
+                  managed: true,
+                  repoOwner: REPO_OWNER,
+                  repoName: 'existing-managed',
+                  externalRepoId: EXTERNAL_REPO_ID,
+                  defaultBranch: 'main',
+                  authMethod: 'github_app',
+                  installationId: INSTALL_ID,
+                  credentialRef: null,
+                  permissions: {},
+                  visibility: 'private',
+                  webhookId: null,
+                  status: 'connected',
+                  metadata: {},
+                  createdAt: new Date('2026-01-01T00:00:00Z'),
+                  updatedAt: new Date('2026-01-01T00:00:00Z'),
+                }];
               }
               return [];
             },
@@ -293,6 +346,8 @@ describe('POST /v1/projects/provision (managed git)', () => {
     canonicalMembership = true;
     backendCalls.length = 0;
     backendConfigured = true;
+    managedPat = null;
+    provisionedInitialToken = PUSH_TOKEN;
   });
 
   test('provisions a managed repo + scoped token and registers the project', async () => {
@@ -343,6 +398,36 @@ describe('POST /v1/projects/provision (managed git)', () => {
 
     // Provisioned the repo through the backend seam (no seeding without flag).
     expect(backendCalls).toEqual(['createRepo']);
+  });
+
+  test('does not return the server-global managed GitHub PAT as a provision push token', async () => {
+    provisionedInitialToken = null;
+    managedPat = 'server-global-ghp-token';
+
+    const app = createApp();
+    const res = await app.request('/v1/projects/provision', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ account_id: ACCOUNT_ID, name: 'PAT Fallback Project' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.push_token).toBeNull();
+  });
+
+  test('git-token fails closed when managed GitHub auth resolves to server-global PAT fallback', async () => {
+    managedPat = 'server-global-ghp-token';
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/git-token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.text()).toContain('repo-scoped installation token');
   });
 
   test('rejects an explicit account the caller has no membership in', async () => {

--- a/apps/api/src/__tests__/e2e-router.test.ts
+++ b/apps/api/src/__tests__/e2e-router.test.ts
@@ -231,7 +231,7 @@ describe('Router: health', () => {
     expect(body.status).toBe('ok');
     expect(body.service).toBe('kortix-router');
     expect(body.timestamp).toBeDefined();
-    expect(body.billing_enabled).toBeDefined();
+    expect(body.billing_enabled).toBeUndefined();
   });
 });
 

--- a/apps/api/src/__tests__/unit-billing-cron-auth.test.ts
+++ b/apps/api/src/__tests__/unit-billing-cron-auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+mock.module('../config', () => ({
+  config: {
+    KORTIX_BILLING_INTERNAL_ENABLED: false,
+    INTERNAL_SERVICE_KEY: 'internal-test-key',
+  },
+}));
+
+const { billingApp } = await import('../billing');
+
+describe('billing cron route auth', () => {
+  test('rejects ordinary authenticated users before rotation code can run', async () => {
+    const res = await billingApp.request('/cron/yearly-rotation', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer user-jwt' },
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Internal cron authentication required' });
+  });
+
+  test('allows the internal service key for scheduler callers', async () => {
+    const res = await billingApp.request('/cron/free-tier-rotation', {
+      method: 'POST',
+      headers: { 'X-Kortix-Internal-Key': 'internal-test-key' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ skipped: true, reason: 'billing disabled' });
+  });
+});

--- a/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
+++ b/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
@@ -30,6 +30,7 @@ mock.module('../repositories/account-tokens', () => ({
 }));
 
 mock.module('../shared/jwt-verify', () => ({
+  decodeSupabaseJwtPayload: () => null,
   verifySupabaseJwt: async () => ({ ok: false }),
 }));
 

--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -50,6 +50,8 @@ const {
   resetEmailSessionLifecycleForTest,
   setEmailSessionLifecycleForTest,
 } = await import("../channels/email/session");
+const { emailWebhookApp } = await import("../channels/email/app");
+await import("../channels/email/routes");
 
 const event: AgentMailMessageReceivedEvent = {
   type: "event",
@@ -128,6 +130,38 @@ describe("AgentMail webhook verification", () => {
         svixSignature: `v1,${sig}`,
       }),
     ).toBe(false);
+  });
+
+  test("webhook route fails closed when signing is missing or invalid", async () => {
+    const originalSecret = config.AGENTMAIL_WEBHOOK_SECRET;
+    const rawBody = JSON.stringify(event);
+    try {
+      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
+        undefined;
+      const missingSecret = await emailWebhookApp.request("/agentmail", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: rawBody,
+      });
+      expect(missingSecret.status).toBe(503);
+
+      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
+        `whsec_${Buffer.from("test-signing-key").toString("base64")}`;
+      const invalidSignature = await emailWebhookApp.request("/agentmail", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "svix-id": "msg_123",
+          "svix-timestamp": String(Math.floor(Date.now() / 1000)),
+          "svix-signature": "v1,not-valid",
+        },
+        body: rawBody,
+      });
+      expect(invalidSignature.status).toBe(401);
+    } finally {
+      (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
+        originalSecret;
+    }
   });
 });
 

--- a/apps/api/src/__tests__/unit-git-proxy-parse.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-parse.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   extractToken,
+  isValidGitProxyProjectId,
   normalizeProjectId,
   scopeForService,
 } from '../git-proxy/parse';
@@ -13,6 +14,16 @@ describe('normalizeProjectId', () => {
     expect(normalizeProjectId('abc-123.git')).toBe('abc-123');
     expect(normalizeProjectId('abc-123')).toBe('abc-123');
     expect(normalizeProjectId('abc.GIT')).toBe('abc');
+  });
+});
+
+describe('isValidGitProxyProjectId', () => {
+  test('accepts UUID project ids with optional .git and rejects malformed path tokens', () => {
+    expect(isValidGitProxyProjectId('11111111-1111-4111-8111-111111111111')).toBe(true);
+    expect(isValidGitProxyProjectId('11111111-1111-4111-8111-111111111111.git')).toBe(true);
+    expect(isValidGitProxyProjectId('not-a-project')).toBe(false);
+    expect(isValidGitProxyProjectId('../11111111-1111-4111-8111-111111111111')).toBe(false);
+    expect(isValidGitProxyProjectId('11111111-1111-4111-8111-111111111111/refs')).toBe(false);
   });
 });
 

--- a/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
@@ -48,6 +48,7 @@ mock.module('../repositories/service-accounts', () => ({
 }));
 
 mock.module('../shared/jwt-verify', () => ({
+  decodeSupabaseJwtPayload: () => null,
   verifySupabaseJwt: async (t: string) => {
     if (t === 'jwt-owner') return { ok: true, userId: 'user-owner' };
     if (t === 'jwt-other') return { ok: true, userId: 'user-other' };
@@ -73,9 +74,15 @@ mock.module('../shared/preview-ownership', () => ({
     if (userId && allowedUsers.has(userId)) return true;
     return false;
   },
+  resolvePreviewUserContext: async (_previewSandboxId: string, userId?: string) =>
+    userId && allowedUsers.has(userId)
+      ? { userId, sandboxId: SANDBOX_ID, sandboxRole: 'member', scopes: ['*'] }
+      : null,
+  canAccessSandboxSession: async () => true,
 }));
 
 const { authenticatePreviewPrincipal, extractPreviewToken } = await import('../sandbox-proxy/preview-auth');
+const { previewSubdomainAuthCacheKeyForTest } = await import('../sandbox-proxy/subdomain');
 
 beforeEach(() => {
   allowedAccounts = new Set(['acct-owner']);
@@ -166,5 +173,27 @@ describe('extractPreviewToken', () => {
   test('returns null when no credential is present', () => {
     const req = new Request(u);
     expect(extractPreviewToken(req, new URL(req.url))).toBeNull();
+  });
+});
+
+describe('preview subdomain auth cache key', () => {
+  test('binds cached auth to client IP and user-agent, not only sandbox/port', () => {
+    const a = new Request('http://p3000-sbx.localhost/x', {
+      headers: { 'x-forwarded-for': '198.51.100.10', 'user-agent': 'browser-a' },
+    });
+    const b = new Request('http://p3000-sbx.localhost/x', {
+      headers: { 'x-forwarded-for': '198.51.100.11', 'user-agent': 'browser-a' },
+    });
+    const c = new Request('http://p3000-sbx.localhost/x', {
+      headers: { 'x-forwarded-for': '198.51.100.10', 'user-agent': 'browser-b' },
+    });
+
+    expect(previewSubdomainAuthCacheKeyForTest('sbx', 3000, a)).toBe('p3000-sbx|198.51.100.10|browser-a');
+    expect(previewSubdomainAuthCacheKeyForTest('sbx', 3000, b)).not.toBe(
+      previewSubdomainAuthCacheKeyForTest('sbx', 3000, a),
+    );
+    expect(previewSubdomainAuthCacheKeyForTest('sbx', 3000, c)).not.toBe(
+      previewSubdomainAuthCacheKeyForTest('sbx', 3000, a),
+    );
   });
 });

--- a/apps/api/src/__tests__/unit-preview-auth.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth.test.ts
@@ -74,6 +74,7 @@ mock.module('../repositories/account-tokens', () => ({
 }));
 
 mock.module('../shared/jwt-verify', () => ({
+  decodeSupabaseJwtPayload: () => null,
   verifySupabaseJwt: async (token: string) => {
     if (token === 'jwt-owner') {
       return { ok: true, userId: 'user-owner', email: 'owner@kortix.dev' };
@@ -155,6 +156,12 @@ describe('preview auth ownership', () => {
       headers: { Cookie: '__preview_session=kortix_owner' },
     });
     expect(res.status).toBe(200);
+  });
+
+  test('rejects query-string bearer tokens on ordinary HTTP preview routes', async () => {
+    const app = createApp();
+    const res = await app.request('/v1/p/8c70e5be-2f95-45ae-bd8d-5d07b65c631b/8000/session/status?token=kortix_owner');
+    expect(res.status).toBe(401);
   });
 
   test('rejects non-owner kortix token', async () => {

--- a/apps/api/src/__tests__/unit-public-session-share.test.ts
+++ b/apps/api/src/__tests__/unit-public-session-share.test.ts
@@ -17,6 +17,11 @@ mock.module('../shared/db', () => ({
   db: {
     select: () => ({
       from: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            limit: async () => shareRow ? [shareRow] : [],
+          }),
+        }),
         innerJoin: () => ({
           where: () => ({
             limit: async () => shareRow ? [shareRow] : [],
@@ -140,7 +145,7 @@ describe('public session preview shares', () => {
     expect(fetchUrls.at(-1)).toBe('https://preview.test/open?path=%2Fworkspace%2Fapp%2Findex.html');
   });
 
-  test('proxies file share asset requests under the same public prefix', async () => {
+  test('rejects file share subpaths instead of exposing the static file server', async () => {
     shareRow = {
       ...shareRow,
       resourceType: 'file',
@@ -150,8 +155,36 @@ describe('public session preview shares', () => {
     };
 
     const res = await app().request(`/v1/p/public-share/${SHARE_TOKEN}/file/abs/workspace/app/style.css`);
+    expect(res.status).toBe(403);
+    expect(fetchUrls.length).toBe(0);
+  });
+
+  test('does not let caller query params override the shared file path', async () => {
+    shareRow = {
+      ...shareRow,
+      resourceType: 'file',
+      label: 'index.html',
+      port: null,
+      filePath: '/workspace/app/index.html',
+    };
+
+    const res = await app().request(`/v1/p/public-share/${SHARE_TOKEN}/file/open?path=/workspace/secret.env`);
     expect(res.status).toBe(200);
-    expect(fetchUrls.at(-1)).toBe('https://preview.test/abs/workspace/app/style.css');
+    expect(fetchUrls.at(-1)).toBe('https://preview.test/open?path=%2Fworkspace%2Fapp%2Findex.html');
+  });
+
+  test('rejects static file server port as a preview share target', async () => {
+    shareRow = {
+      ...shareRow,
+      resourceType: 'preview',
+      port: 3211,
+    };
+
+    const meta = await app().request(`/v1/p/public-share/${SHARE_TOKEN}`);
+    expect(meta.status).toBe(403);
+
+    const res = await app().request(`/v1/p/public-share/${SHARE_TOKEN}/3211/`);
+    expect(res.status).toBe(403);
   });
 
   test('keeps file shares read-only', async () => {

--- a/apps/api/src/__tests__/unit-telegram-webhook-auth.test.ts
+++ b/apps/api/src/__tests__/unit-telegram-webhook-auth.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  isKnownTelegramSenderForTest,
+  telegramRequireUserIdentityForTest,
+} from '../channels/telegram-webhook';
+
+const originalRequireIdentity = process.env.TELEGRAM_REQUIRE_USER_IDENTITY;
+
+afterEach(() => {
+  if (originalRequireIdentity === undefined) {
+    delete process.env.TELEGRAM_REQUIRE_USER_IDENTITY;
+  } else {
+    process.env.TELEGRAM_REQUIRE_USER_IDENTITY = originalRequireIdentity;
+  }
+});
+
+describe('Telegram webhook sender binding', () => {
+  test('requires bound sender identity by default', () => {
+    delete process.env.TELEGRAM_REQUIRE_USER_IDENTITY;
+    expect(telegramRequireUserIdentityForTest()).toBe(true);
+  });
+
+  test('allows explicit temporary legacy opt-out', () => {
+    process.env.TELEGRAM_REQUIRE_USER_IDENTITY = 'false';
+    expect(telegramRequireUserIdentityForTest()).toBe(false);
+  });
+
+  test('accepts only configured Telegram sender IDs', () => {
+    const project = { metadata: { telegram: { allowedUserIds: ['12345'] } } };
+
+    expect(
+      isKnownTelegramSenderForTest(project, {
+        message_id: 1,
+        chat: { id: 1, type: 'private' },
+        from: { id: 12345 },
+        text: 'run',
+      }),
+    ).toBe(true);
+
+    expect(
+      isKnownTelegramSenderForTest(project, {
+        message_id: 1,
+        chat: { id: 1, type: 'private' },
+        from: { id: 99999 },
+        text: 'run',
+      }),
+    ).toBe(false);
+  });
+
+  test('fails closed when no allowlist or sender identity is present', () => {
+    expect(
+      isKnownTelegramSenderForTest(
+        { metadata: {} },
+        { message_id: 1, chat: { id: 1, type: 'private' }, from: { id: 12345 } },
+      ),
+    ).toBe(false);
+    expect(
+      isKnownTelegramSenderForTest(
+        { metadata: { telegram: { allowedUserIds: ['12345'] } } },
+        { message_id: 1, chat: { id: 1, type: 'private' } },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/unit-tunnel-auth.test.ts
+++ b/apps/api/src/__tests__/unit-tunnel-auth.test.ts
@@ -4,15 +4,17 @@
  * Locks the regression that killed the cloud agent: the sandbox authenticates
  * with an `apiKey` (KORTIX_TOKEN), so it MUST be able to READ connections + RPC
  * (getTunnelReadContext), while tunnel MANAGEMENT stays user-credential-only
- * (getTunnelOwnerContext → requireUserCredential rejects apiKey).
+ * (getTunnelOwnerContext -> requireUserCredential rejects non-human tokens).
  */
 import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import {
   requireUserCredential,
   getTunnelReadContext,
   getTunnelOwnerContext,
 } from '../tunnel/routes/auth';
+import { createConnectionsRouter } from '../tunnel/routes/connections';
 
 /** Minimal stand-in for a Hono context: only `c.get(key)` is used here. */
 function fakeCtx(values: Record<string, unknown>) {
@@ -23,19 +25,21 @@ const ACCOUNT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const USER = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
 
 describe('requireUserCredential', () => {
-  test('rejects apiKey auth with 403', () => {
-    let status = 0;
-    try {
-      requireUserCredential(fakeCtx({ authType: 'apiKey' }));
-    } catch (err) {
-      if (err instanceof HTTPException) status = err.status;
-    }
-    expect(status).toBe(403);
-  });
-
-  for (const authType of ['pat', 'supabase', 'jwt', 'service_account']) {
+  for (const authType of ['pat', 'supabase']) {
     test(`allows ${authType}`, () => {
       expect(() => requireUserCredential(fakeCtx({ authType }))).not.toThrow();
+    });
+  }
+
+  for (const authType of ['apiKey', 'service_account', 'jwt', 'unknown', undefined]) {
+    test(`rejects ${authType ?? 'missing'} auth with 403`, () => {
+      let status = 0;
+      try {
+        requireUserCredential(fakeCtx({ authType }));
+      } catch (err) {
+        if (err instanceof HTTPException) status = err.status;
+      }
+      expect(status).toBe(403);
     });
   }
 });
@@ -81,11 +85,46 @@ describe('getTunnelOwnerContext — management stays user-only', () => {
     expect(status).toBe(403);
   });
 
+  test('service_account is rejected with 403 (cannot manage)', async () => {
+    let status = 0;
+    try {
+      await getTunnelOwnerContext(fakeCtx({ authType: 'service_account', accountId: ACCOUNT }));
+    } catch (err) {
+      if (err instanceof HTTPException) status = err.status;
+    }
+    expect(status).toBe(403);
+  });
+
   test('a user credential is accepted', async () => {
     const ctx = await getTunnelOwnerContext(
       fakeCtx({ authType: 'supabase', userId: USER, accountId: ACCOUNT }),
     );
     expect(ctx.accountId).toBe(ACCOUNT);
     expect(ctx.ownerClause).toBeDefined();
+  });
+});
+
+describe('tunnel management routes', () => {
+  test('service accounts cannot create tunnel connections over HTTP', async () => {
+    const app = new Hono();
+    app.use('/connections', async (c, next) => {
+      c.set('authType' as never, 'service_account' as never);
+      c.set('accountId' as never, ACCOUNT as never);
+      c.set('userId' as never, 'service-account-id' as never);
+      await next();
+    });
+    app.route('/connections', createConnectionsRouter());
+
+    const res = await app.request('/connections', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'SA-owned tunnel',
+        capabilities: ['filesystem'],
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('User credentials are required');
   });
 });

--- a/apps/api/src/accounts/index.ts
+++ b/apps/api/src/accounts/index.ts
@@ -12,12 +12,22 @@ import { auditRouter } from './audit';
 import { registerTokenRoutes } from './core/tokens';
 import { registerAccountRoutes } from './core/accounts';
 import { registerMemberRoutes } from './core/members';
+import { resolveAccountId } from '../shared/resolve-account';
 
 accountsRouter.use('/*', supabaseAuth);
 // Enforce per-account session policies (max lifetime / idle timeout /
 // force-logout) on every authenticated, account-scoped request. No-op
 // on routes without an :accountId param.
-accountsRouter.use('/*', accountSessionGate());
+accountsRouter.use('/*', async (c, next) => {
+  if (!c.req.param('accountId') && !c.get('accountId') && c.get('authType') === 'supabase') {
+    const userId = c.get('userId') as string | undefined;
+    const sessionId = c.get('sessionId') as string | undefined;
+    if (userId && sessionId) {
+      c.set('accountId', await resolveAccountId(userId));
+    }
+  }
+  return accountSessionGate()(c, next);
+});
 
 // Mount IAM routes (groups/policies/roles/super-admin/effective). Sub-router
 // declares its own paths under /:accountId/iam/*, so mounting at '/' here is

--- a/apps/api/src/accounts/invites.ts
+++ b/apps/api/src/accounts/invites.ts
@@ -300,6 +300,9 @@ accountInvitesRouter.openapi(
   }
 
   const alreadyAccepted = !!invite.acceptedAt;
+  if (alreadyAccepted && invite.acceptedByUserId && invite.acceptedByUserId !== userId) {
+    return c.json({ error: 'Invite has already been accepted by another account.' }, 409);
+  }
 
   // Only block a *fresh* accept on expiry. An already-accepted invite stays
   // redeemable for the addressed user so re-entry can heal a grant that was
@@ -327,7 +330,7 @@ accountInvitesRouter.openapi(
   if (!alreadyAccepted) {
     await db
       .update(accountInvitations)
-      .set({ acceptedAt: new Date() })
+      .set({ acceptedAt: new Date(), acceptedByUserId: userId })
       .where(
         and(
           eq(accountInvitations.inviteId, invite.inviteId),

--- a/apps/api/src/billing/index.ts
+++ b/apps/api/src/billing/index.ts
@@ -1,9 +1,10 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { AUTO_TOPUP_DEFAULT_AMOUNT, AUTO_TOPUP_DEFAULT_THRESHOLD } from '@kortix/shared';
+import { timingSafeEqual } from 'node:crypto';
 import type { Context } from 'hono';
 import { config } from '../config';
 import { supabaseAuth } from '../middleware/auth';
-import { json, makeOpenApiApp } from '../openapi';
+import { errors, json, makeOpenApiApp } from '../openapi';
 import type { AppEnv } from '../types';
 
 import { accountDeletionRouter } from './routes/account-deletion';
@@ -26,6 +27,9 @@ billingApp.use('*', async (c, next) => {
   if (c.req.path.includes('/webhook')) {
     return next();
   }
+  if (c.req.path.includes('/cron/')) {
+    return next();
+  }
   return supabaseAuth(c, next);
 });
 
@@ -37,7 +41,7 @@ billingApp.route('/account-state', accountStateRouter);
 // never hit Stripe, never get blocked by credits, never see subscription UI.
 // Account-state (above) already returns the "Local (Unlimited)" mock.
 billingApp.use('*', async (c, next) => {
-  if (c.req.path.includes('/account-state') || c.req.path.includes('/webhooks')) {
+  if (c.req.path.includes('/account-state') || c.req.path.includes('/webhooks') || c.req.path.includes('/cron/')) {
     return next();
   }
   if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
@@ -64,6 +68,27 @@ accountDeletionApp.use('*', async (c, next) => {
 });
 accountDeletionApp.route('/', accountDeletionRouter);
 
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const aa = Buffer.from(a);
+  const bb = Buffer.from(b);
+  return aa.length === bb.length && timingSafeEqual(aa, bb);
+}
+
+function requireInternalCronAuth(c: Context<AppEnv>): Response | null {
+  const authHeader = c.req.header('Authorization');
+  const bearer = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  const header = c.req.header('X-Kortix-Internal-Key') ?? '';
+  const expected = config.INTERNAL_SERVICE_KEY;
+  const ok =
+    (bearer && timingSafeStringEqual(bearer, expected)) ||
+    (header && timingSafeStringEqual(header, expected));
+
+  if (!ok) {
+    return c.json({ error: 'Internal cron authentication required' }, 401);
+  }
+  return null;
+}
+
 // Yearly credit rotation cron endpoint
 billingApp.openapi(
   createRoute({
@@ -73,9 +98,12 @@ billingApp.openapi(
     summary: 'Run the yearly credit rotation (cron)',
     responses: {
       200: json(z.record(z.string(), z.any()), 'Rotation result'),
+      ...errors(401),
     },
   }),
   async (c: Context<AppEnv>) => {
+    const authError = requireInternalCronAuth(c);
+    if (authError) return authError as any;
     if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
       return c.json({ skipped: true, reason: 'billing disabled' });
     }
@@ -94,9 +122,12 @@ billingApp.openapi(
     summary: 'Run the free-tier monthly credit rotation (cron)',
     responses: {
       200: json(z.record(z.string(), z.any()), 'Rotation result'),
+      ...errors(401),
     },
   }),
   async (c: Context<AppEnv>) => {
+    const authError = requireInternalCronAuth(c);
+    if (authError) return authError as any;
     if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
       return c.json({ skipped: true, reason: 'billing disabled' });
     }

--- a/apps/api/src/billing/services/compute-metering.ts
+++ b/apps/api/src/billing/services/compute-metering.ts
@@ -91,8 +91,11 @@ export async function startComputeSession(opts: StartComputeOpts): Promise<strin
     gpuCount: opts.spec.gpuCount ?? 0,
     state: 'active',
     metadata: (opts.metadata ?? {}) as Record<string, unknown>,
+  }).catch(async (err) => {
+    if ((err as { code?: string })?.code !== '23505') throw err;
+    return getOpenComputeSession(opts.sandboxId);
   });
-  return row.id;
+  return row?.id ?? null;
 }
 
 /**

--- a/apps/api/src/billing/services/webhook-concurrency.ts
+++ b/apps/api/src/billing/services/webhook-concurrency.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { stripeWebhookEventsProcessed } from '@kortix/db';
 import { db } from '../../shared/db';
 
@@ -9,6 +9,10 @@ export async function recordWebhookEvent(eventId: string, eventType: string): Pr
     .onConflictDoNothing({ target: stripeWebhookEventsProcessed.eventId })
     .returning({ eventId: stripeWebhookEventsProcessed.eventId });
   return inserted.length > 0;
+}
+
+export async function forgetWebhookEvent(eventId: string): Promise<void> {
+  await db.delete(stripeWebhookEventsProcessed).where(eq(stripeWebhookEventsProcessed.eventId, eventId));
 }
 
 function accountLockKey(accountId: string): bigint {

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 import { getStripe } from '../../shared/stripe';
-import { recordWebhookEvent, withAccountLock } from './webhook-concurrency';
+import { forgetWebhookEvent, recordWebhookEvent, withAccountLock } from './webhook-concurrency';
 import { config } from '../../config';
 import { WebhookError } from '../../errors';
 import {
@@ -49,38 +49,45 @@ export async function processStripeWebhook(rawBody: string, signature: string) {
 
   console.log(`[Webhook] Processing ${event.type} (${event.id})`);
 
-  switch (event.type) {
-    case 'checkout.session.completed':
-      await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
-      break;
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+        break;
 
-    case 'customer.subscription.created':
-    case 'customer.subscription.updated':
-      await handleSubscriptionChange(event.data.object as Stripe.Subscription);
-      break;
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+        await handleSubscriptionChange(event.data.object as Stripe.Subscription);
+        break;
 
-    case 'customer.subscription.deleted':
-      await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
-      break;
+      case 'customer.subscription.deleted':
+        await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
+        break;
 
-    case 'invoice.paid':
-      await handleInvoicePaid(event.data.object as Stripe.Invoice);
-      break;
+      case 'invoice.paid':
+        await handleInvoicePaid(event.data.object as Stripe.Invoice);
+        break;
 
-    case 'invoice.payment_failed':
-      await handleInvoiceFailed(event.data.object as Stripe.Invoice);
-      break;
+      case 'invoice.payment_failed':
+        await handleInvoiceFailed(event.data.object as Stripe.Invoice);
+        break;
 
-    case 'subscription_schedule.completed':
-      await handleScheduleCompleted(event.data.object as any);
-      break;
+      case 'subscription_schedule.completed':
+        await handleScheduleCompleted(event.data.object as any);
+        break;
 
-    case 'subscription_schedule.released':
-      console.log(`[Webhook] Schedule released: ${(event.data.object as any).id}`);
-      break;
+      case 'subscription_schedule.released':
+        console.log(`[Webhook] Schedule released: ${(event.data.object as any).id}`);
+        break;
 
-    default:
-      console.log(`[Webhook] Unhandled event type: ${event.type}`);
+      default:
+        console.log(`[Webhook] Unhandled event type: ${event.type}`);
+    }
+  } catch (err) {
+    await forgetWebhookEvent(event.id).catch((cleanupErr) => {
+      console.error(`[Webhook] Failed to clear failed event marker ${event.id}:`, cleanupErr);
+    });
+    throw err;
   }
 
   return { received: true, event_type: event.type };
@@ -626,8 +633,16 @@ export async function processRevenueCatWebhook(body: any) {
   if (!event) throw new WebhookError('Missing event in RevenueCat webhook');
 
   const eventType = event.type;
+  const eventId = event.id ?? event.event_id;
+  if (!eventId) throw new WebhookError('Missing event id');
   const appUserId = event.app_user_id;
   if (!appUserId) throw new WebhookError('Missing app_user_id');
+
+  const dedupeKey = `revenuecat:${eventId}`;
+  if (!(await recordWebhookEvent(dedupeKey, eventType))) {
+    console.log(`[RevenueCat] Skipping duplicate ${eventType} (${eventId})`);
+    return { received: true, event_type: eventType, deduped: true };
+  }
 
   if (isRevenueCatAnonymous(appUserId)) {
     console.log(`[RevenueCat] Skipping anonymous user: ${appUserId}`);

--- a/apps/api/src/channels/email/routes.ts
+++ b/apps/api/src/channels/email/routes.ts
@@ -37,19 +37,17 @@ emailWebhookApp.openapi(
     const secret = projectId
       ? await loadAgentMailWebhookSecretForInbox(projectId, event.message.inbox_id)
       : config.AGENTMAIL_WEBHOOK_SECRET;
-    if (!secret && process.env.NODE_ENV === 'production') {
+    if (!secret) {
       return c.json({ error: 'AgentMail webhook signing is not configured' }, 503);
     }
-    if (secret) {
-      const ok = verifyAgentMailSignature({
-        rawBody,
-        secret,
-        svixId: c.req.header('svix-id') ?? '',
-        svixTimestamp: c.req.header('svix-timestamp') ?? '',
-        svixSignature: c.req.header('svix-signature') ?? '',
-      });
-      if (!ok) return c.json({ error: 'Invalid signature' }, 401);
-    }
+    const ok = verifyAgentMailSignature({
+      rawBody,
+      secret,
+      svixId: c.req.header('svix-id') ?? '',
+      svixTimestamp: c.req.header('svix-timestamp') ?? '',
+      svixSignature: c.req.header('svix-signature') ?? '',
+    });
+    if (!ok) return c.json({ error: 'Invalid signature' }, 401);
 
     void dispatchAgentMailEvent(event).catch((err) => {
       console.error('[email-webhook] handler failed', err);

--- a/apps/api/src/channels/telegram-webhook.ts
+++ b/apps/api/src/channels/telegram-webhook.ts
@@ -60,14 +60,15 @@ telegramWebhookApp.openapi(
 
 // Gate for the Telegram equivalent of Slack's SLACK_REQUIRE_USER_IDENTITY: the
 // webhook otherwise runs every agent turn AS THE ACCOUNT OWNER for whoever can
-// message the bot, with no sender check. Defaults OFF (current behavior — every
-// project chatting via Telegram today keeps working unchanged); an operator
-// turns it on only after wiring an allowlist (see isKnownTelegramSender below).
+// message the bot, with no sender check. Defaults ON: a webhook secret proves
+// the request came from Telegram, but not that this sender may run this project
+// as the automation actor. Operators may temporarily set
+// TELEGRAM_REQUIRE_USER_IDENTITY=false only while migrating legacy projects to
+// metadata.telegram.allowedUserIds.
 // Read live (not module-scope) so it's cheap to flip per-request in tests.
-function telegramRequireUserIdentity(): boolean {
-  return ['true', '1', 'yes', 'on'].includes(
-    (process.env.TELEGRAM_REQUIRE_USER_IDENTITY ?? '').trim().toLowerCase(),
-  );
+export function telegramRequireUserIdentityForTest(): boolean {
+  const raw = (process.env.TELEGRAM_REQUIRE_USER_IDENTITY ?? 'true').trim().toLowerCase();
+  return !['false', '0', 'no', 'off'].includes(raw);
 }
 
 // "Bound identity" here is a per-project allowlist of Telegram user ids, stored
@@ -76,7 +77,7 @@ function telegramRequireUserIdentity(): boolean {
 // this yet — see risk note in the PR. Until one exists, enabling the flag
 // rejects every sender for a project with no allowlist configured, which is
 // the safe direction to fail in.
-function isKnownTelegramSender(
+export function isKnownTelegramSenderForTest(
   project: { metadata: unknown },
   message: TelegramMessage,
 ): boolean {
@@ -103,7 +104,7 @@ async function spawnAgentTurn(
     .limit(1);
   if (!project) return;
 
-  if (telegramRequireUserIdentity() && !isKnownTelegramSender(project, message)) {
+  if (telegramRequireUserIdentityForTest() && !isKnownTelegramSenderForTest(project, message)) {
     console.warn(
       '[telegram-webhook] rejecting unbound sender for project',
       projectId,

--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -28,6 +28,7 @@ import {
   FORWARD_REQUEST_HEADERS,
   STRIP_RESPONSE_HEADERS,
   extractToken,
+  isValidGitProxyProjectId,
   normalizeProjectId,
   scopeForService,
 } from './parse';
@@ -69,6 +70,14 @@ const projectParam = z.object({
 function unauthorized(c: any, message: string) {
   c.header('WWW-Authenticate', 'Basic realm="Kortix Git"');
   return c.text(message, 401);
+}
+
+function validProjectIdOrResponse(c: any, raw: string): string | Response {
+  const projectId = normalizeProjectId(raw);
+  if (!isValidGitProxyProjectId(raw)) {
+    return c.text('invalid project identifier', 400);
+  }
+  return projectId;
 }
 
 async function authorize(c: any, projectId: string, scope: GitScope): Promise<GitProxyAuth> {
@@ -178,7 +187,8 @@ gitProxyApp.openapi(
     responses: gitResponses,
   }),
   async (c) => {
-    const projectId = normalizeProjectId(c.req.param('project'));
+    const projectId = validProjectIdOrResponse(c, c.req.param('project'));
+    if (projectId instanceof Response) return projectId;
     const scope = scopeForService(c.req.query('service'));
     return forward(c, projectId, scope, '/info/refs');
   },
@@ -195,7 +205,8 @@ gitProxyApp.openapi(
     responses: gitResponses,
   }),
   async (c) => {
-    const projectId = normalizeProjectId(c.req.param('project'));
+    const projectId = validProjectIdOrResponse(c, c.req.param('project'));
+    if (projectId instanceof Response) return projectId;
     return forward(c, projectId, 'read', '/git-upload-pack');
   },
 );
@@ -211,7 +222,8 @@ gitProxyApp.openapi(
     responses: gitResponses,
   }),
   async (c) => {
-    const projectId = normalizeProjectId(c.req.param('project'));
+    const projectId = validProjectIdOrResponse(c, c.req.param('project'));
+    if (projectId instanceof Response) return projectId;
     return forward(c, projectId, 'write', '/git-receive-pack');
   },
 );

--- a/apps/api/src/git-proxy/parse.ts
+++ b/apps/api/src/git-proxy/parse.ts
@@ -9,6 +9,11 @@ export function normalizeProjectId(raw: string): string {
   return raw.replace(/\.git$/i, '');
 }
 
+/** Git proxy project ids must be UUIDs after optional `.git` suffix stripping. */
+export function isValidGitProxyProjectId(raw: string): boolean {
+  return /^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(normalizeProjectId(raw));
+}
+
 /** Extract the bare token from a git `Authorization` header (Basic or Bearer). */
 export function extractToken(header: string | undefined): string | null {
   if (!header) return null;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { getRequestContext, runWithContext, setContextField } from './lib/request-context';
 import { getRequestUrl } from './lib/request-url';
 
+import { timingSafeEqual } from 'node:crypto';
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
 import { mountOpenApiDocs, json, errors, auth } from './openapi';
 import { cors } from 'hono/cors';
@@ -348,18 +349,7 @@ const HealthSchema = z
   .object({
     status: z.string(),
     service: z.string(),
-    version: z.string(),
-    commit: z.string(),
-    environment: z.string(),
-    instance: z.string(),
-    started_at: z.string(),
-    uptime_seconds: z.number(),
-    memory_mb: z.number(),
     timestamp: z.string(),
-    billing_enabled: z.boolean(),
-    tunnel: z.any(),
-    leader: z.boolean(),
-    trigger_scheduler: z.any(),
   })
   .openapi('Health');
 
@@ -367,25 +357,7 @@ const healthHandler = (c: any) =>
   c.json({
     status: 'ok',
     service: 'kortix-api',
-    version: API_VERSION,
-    commit: API_COMMIT,
-    environment: config.INTERNAL_KORTIX_ENV,
-    instance: API_INSTANCE,
-    started_at: STARTED_AT,
-    uptime_seconds: Math.round(process.uptime()),
-    // Resident memory (MB) for this pod — a quick leak/OOM-risk signal against
-    // the container's memory limit, without needing metrics-server/dashboards.
-    memory_mb: Math.round(process.memoryUsage().rss / 1024 / 1024),
     timestamp: new Date().toISOString(),
-    billing_enabled: config.KORTIX_BILLING_INTERNAL_ENABLED,
-    tunnel: getTunnelServiceStatus(),
-    leader: isLeader(),
-    // The leader pod's trigger-sweep heartbeat: when it last ran, how long it
-    // took, and what it did. On a non-leader pod the fields are null (the sweep
-    // only runs on the leader) — so "all pods null" = no leader = no triggers.
-    // `stale` is true when we're the leader but the sweep has frozen (started
-    // and not completed within the stale window) — the signal to alert on.
-    trigger_scheduler: { ...getTriggerSchedulerHealth(), stale: schedulerSweepIsStale(isLeader()) },
   });
 
 app.openapi(
@@ -444,7 +416,23 @@ const livenessHandler = (c: any) => {
 app.get('/health/live', livenessHandler);
 app.get('/v1/health/live', livenessHandler);
 
+function hasInternalObservabilityAuth(c: any): boolean {
+  const authHeader = c.req.header('Authorization');
+  const bearer = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  const header = c.req.header('X-Kortix-Internal-Key') ?? '';
+  const expected = config.INTERNAL_SERVICE_KEY;
+  const safeEq = (a: string, b: string) => {
+    const aa = Buffer.from(a);
+    const bb = Buffer.from(b);
+    return aa.length === bb.length && timingSafeEqual(aa, bb);
+  };
+  return (!!bearer && safeEq(bearer, expected)) || (!!header && safeEq(header, expected));
+}
+
 app.get('/metrics', (c) => {
+  if (!hasInternalObservabilityAuth(c)) {
+    return c.text('unauthorized\n', 401);
+  }
   if (!metricsEnabled()) return c.text('metrics disabled\n', 404);
   c.header('content-type', 'text/plain; version=0.0.4; charset=utf-8');
   return c.body(renderMetrics());

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -6,7 +6,7 @@ import { validateServiceAccountToken } from '../repositories/service-accounts';
 import { isKortixToken, isAccountToken, isServiceAccountToken } from '../shared/crypto';
 import { canAccessPreviewSandbox } from '../shared/preview-ownership';
 import { getSupabase } from '../shared/supabase';
-import { verifySupabaseJwt } from '../shared/jwt-verify';
+import { decodeSupabaseJwtPayload, verifySupabaseJwt } from '../shared/jwt-verify';
 import { setSentryUser } from '../lib/sentry';
 import { setContextField } from '../lib/request-context';
 import { syncSsoMembership } from '../iam/sso-sync';
@@ -306,6 +306,12 @@ export async function supabaseAuth(c: Context, next: Next) {
     c.set('userId', user.id);
     c.set('userEmail', user.email || '');
     c.set('authType', 'supabase');
+    const payload = decodeSupabaseJwtPayload(token);
+    if (payload?.aal) c.set('mfaAal', payload.aal);
+    if (payload?.session_id) c.set('sessionId', payload.session_id);
+    if (typeof payload?.iat === 'number') {
+      c.set('sessionIat', payload.iat);
+    }
     setSentryUser({ id: user.id, email: user.email || undefined });
     setContextField('userId', user.id);
     setContextField('userEmail', user.email || '');
@@ -318,7 +324,12 @@ export async function supabaseAuth(c: Context, next: Next) {
     // SAML JIT on the network-verify path too (a token whose kid isn't in the
     // cached JWKS lands here, NOT the local path) — `user.app_metadata` is the
     // authoritative record straight from Supabase.
-    await jitSyncSso(user.id, user.email || '', user as unknown as Record<string, unknown>);
+    await jitSyncSso(
+      user.id,
+      user.email || '',
+      (payload as unknown as Record<string, unknown> | null) ??
+        (user as unknown as Record<string, unknown>),
+    );
     await next();
   } catch (err) {
     if (err instanceof HTTPException) throw err;
@@ -375,16 +386,14 @@ export async function combinedAuth(c: Context, next: Next) {
   }
 
   if (!token) {
-    // Last resort: check query param for preview proxy routes and SSE endpoints.
-    // Browser WebSocket API can't set custom headers, so PTY terminals
-    // and other WS clients pass the token as ?token=<jwt>.
-    // EventSource (SSE) also can't set headers, so provision-stream uses this.
+    // Last resort: query tokens are allowed only for legacy EventSource
+    // provision-stream. Browser WebSocket preview auth is handled by the Bun
+    // upgrade path (ws-proxy.ts), not this HTTP middleware. Do not accept
+    // ?token= on ordinary preview HTTP routes: it leaks bearer material into
+    // URLs, logs, history, and Referer headers.
     const url = new URL(c.req.url);
     const queryToken = url.searchParams.get('token');
-    if (queryToken && (
-      c.req.path.startsWith('/v1/p/') ||
-      c.req.path.includes('/provision-stream')
-    )) {
+    if (queryToken && c.req.path.includes('/provision-stream')) {
       token = queryToken;
     }
   }
@@ -600,6 +609,12 @@ export async function combinedAuth(c: Context, next: Next) {
     c.set('userId', user.id);
     c.set('userEmail', user.email || '');
     c.set('authType', 'supabase');
+    const payload = decodeSupabaseJwtPayload(token);
+    if (payload?.aal) c.set('mfaAal', payload.aal);
+    if (payload?.session_id) c.set('sessionId', payload.session_id);
+    if (typeof payload?.iat === 'number') {
+      c.set('sessionIat', payload.iat);
+    }
     setSentryUser({ id: user.id, email: user.email || undefined });
     setContextField('userId', user.id);
     setContextField('userEmail', user.email || '');
@@ -611,7 +626,12 @@ export async function combinedAuth(c: Context, next: Next) {
       metadata: { verify_path: 'network' },
     });
     // SAML JIT — combinedAuth network-verify path.
-    await jitSyncSso(user.id, user.email || '', user as unknown as Record<string, unknown>);
+    await jitSyncSso(
+      user.id,
+      user.email || '',
+      (payload as unknown as Record<string, unknown> | null) ??
+        (user as unknown as Record<string, unknown>),
+    );
     await next();
   } catch (err) {
     if (err instanceof HTTPException) throw err;

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -489,9 +489,14 @@ projectsApp.openapi(
 
   // Resolve a push credential for seeding / the CLI's first push. The managed
   // GitHub backend mints an installation token.
-  let pushToken = provisioned.initialToken;
-  if (!pushToken) {
-    pushToken = (await resolveProjectGitAuth(row)).auth?.token ?? null;
+  let internalPushToken = provisioned.initialToken;
+  let exportablePushToken = provisioned.initialToken;
+  if (!internalPushToken) {
+    const resolved = await resolveProjectGitAuth(row);
+    internalPushToken = resolved.auth?.token ?? null;
+    exportablePushToken = resolved.authSource === 'pat'
+      ? null
+      : resolved.auth?.token ?? null;
   }
 
   // Seed the starter into the empty repo when the caller has no local working
@@ -505,7 +510,7 @@ projectsApp.openapi(
   if (seedStarter) {
     const connRef = buildConnectionRef(row, getProjectGitRemote(row, await getProjectGitConnection(row.projectId)));
     try {
-      if (!pushToken) throw new Error('no push credential resolved for seeding');
+      if (!internalPushToken) throw new Error('no push credential resolved for seeding');
       const seed = await buildProjectSeedFiles({
         projectName: name,
         repoFullName: repoSlug,
@@ -522,7 +527,7 @@ projectsApp.openapi(
         // root) — the single biggest spawn-latency win. The per-project name
         // customization is applied in-sandbox at fork (not committed to the
         // shared remote root) so the warm reuse is never broken by a divergent tip.
-        await backend.seedFiles(connRef, pushToken, seed.files, {
+        await backend.seedFiles(connRef, internalPushToken, seed.files, {
           branch: provisioned.defaultBranch,
           message: 'chore: scaffold Kortix project',
           baseFiles: seed.baseFiles,
@@ -530,7 +535,7 @@ projectsApp.openapi(
       } else {
         await seedRepoViaGitPush({
           upstreamUrl: connRef.upstreamUrl,
-          token: pushToken,
+          token: internalPushToken,
           files: seed.files,
           branch: provisioned.defaultBranch,
           commitMessage: 'chore: scaffold Kortix project',
@@ -552,7 +557,7 @@ projectsApp.openapi(
         repoUrl: row.repoUrl,
         defaultBranch: row.defaultBranch,
         manifestPath: row.manifestPath,
-        gitAuthToken: pushToken,
+        gitAuthToken: internalPushToken,
       },
       { accountId: scope.accountId, source: 'project-create' },
     );
@@ -561,7 +566,7 @@ projectsApp.openapi(
   return c.json(
     {
       ...serializeProject(row, { projectRole: 'manager', effectiveRole: 'manager' }),
-      push_token: pushToken,
+      push_token: exportablePushToken,
       repo_id: provisioned.externalRepoId,
       seeded,
     },
@@ -612,6 +617,12 @@ projectsApp.openapi(
   const gitAuth = await resolveProjectGitAuth(loaded.row);
   if (!gitAuth.auth?.token) {
     return c.json({ error: 'Managed git is not configured / unavailable for this project' }, 503);
+  }
+  if (gitAuth.authSource === 'pat') {
+    return c.json(
+      { error: 'Managed git push token export requires a repo-scoped installation token' },
+      503,
+    );
   }
   const upstream = await resolveProjectUpstream(loaded.row, 'write');
 

--- a/apps/api/src/router/index.ts
+++ b/apps/api/src/router/index.ts
@@ -23,7 +23,6 @@ router.openapi(
           status: z.string(),
           service: z.string(),
           timestamp: z.string(),
-          billing_enabled: z.boolean(),
         }),
         'Router health status',
       ),
@@ -34,7 +33,6 @@ router.openapi(
       status: 'ok',
       service: 'kortix-router',
       timestamp: new Date().toISOString(),
-      billing_enabled: config.KORTIX_BILLING_INTERNAL_ENABLED,
     });
   },
 );

--- a/apps/api/src/sandbox-proxy/routes/public-share.ts
+++ b/apps/api/src/sandbox-proxy/routes/public-share.ts
@@ -208,13 +208,16 @@ async function forwardFileShare(c: any, args: {
   const file = assertFileShare(args.share);
   if (!file.ok) return c.json({ error: 'Not authorized for this file' }, 403);
 
-  const isFileEntry = args.remainingPath === '/';
+  const isFileEntry = args.remainingPath === '/' || args.remainingPath === '/open';
+  if (!isFileEntry) {
+    return c.json({ error: 'Not authorized for this file path' }, 403);
+  }
   return forwardPublicShare(c, {
     token: args.token,
     share: args.share,
     port: STATIC_FILE_SHARE_PORT,
-    remainingPath: isFileEntry ? '/open' : args.remainingPath,
-    queryString: isFileEntry ? fileOpenQuery(file.filePath) : args.queryString,
+    remainingPath: '/open',
+    queryString: fileOpenQuery(file.filePath),
     redirectPrefix: `/v1/p/public-share/${args.token}/file`,
   });
 }

--- a/apps/api/src/sandbox-proxy/subdomain.ts
+++ b/apps/api/src/sandbox-proxy/subdomain.ts
@@ -54,22 +54,37 @@ const authedSubdomains = new Map<string, AuthState>();
 const AUTH_SESSION_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const PUBLIC_SHARE_SESSION_TTL_MS = 15 * 60 * 1000;
 
-function key(sandboxId: string, port: number): string {
-  return `p${port}-${sandboxId}`;
+function clientKey(req: Request): string {
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    req.headers.get('x-real-ip')?.trim() ||
+    req.headers.get('cf-connecting-ip')?.trim() ||
+    'unknown';
+  const ua = req.headers.get('user-agent') || 'unknown';
+  return `${ip}|${ua}`;
 }
 
-function getAuthedSubdomain(sandboxId: string, port: number): AuthState | null {
-  const entry = authedSubdomains.get(key(sandboxId, port));
+export function previewSubdomainAuthCacheKeyForTest(sandboxId: string, port: number, req: Request): string {
+  return `p${port}-${sandboxId}|${clientKey(req)}`;
+}
+
+function key(sandboxId: string, port: number, req: Request): string {
+  return previewSubdomainAuthCacheKeyForTest(sandboxId, port, req);
+}
+
+function getAuthedSubdomain(sandboxId: string, port: number, req: Request): AuthState | null {
+  const cacheKey = key(sandboxId, port, req);
+  const entry = authedSubdomains.get(cacheKey);
   if (!entry) return null;
   if (Date.now() > entry.expiresAt) {
-    authedSubdomains.delete(key(sandboxId, port));
+    authedSubdomains.delete(cacheKey);
     return null;
   }
   return entry;
 }
 
-function markAuthedSubdomain(sandboxId: string, port: number, userId: string): void {
-  authedSubdomains.set(key(sandboxId, port), {
+function markAuthedSubdomain(sandboxId: string, port: number, req: Request, userId: string): void {
+  authedSubdomains.set(key(sandboxId, port, req), {
     kind: 'principal',
     userId,
     expiresAt: Date.now() + AUTH_SESSION_TTL_MS,
@@ -80,7 +95,7 @@ function markPublicShareSubdomain(sandboxId: string, port: number, share: {
   shareId: string;
   mode: string;
   expiresAt: Date | null;
-}): AuthState {
+}, req: Request): AuthState {
   const expiresAt = Math.min(
     Date.now() + PUBLIC_SHARE_SESSION_TTL_MS,
     share.expiresAt?.getTime() ?? Number.POSITIVE_INFINITY,
@@ -91,7 +106,7 @@ function markPublicShareSubdomain(sandboxId: string, port: number, share: {
     mode: share.mode,
     expiresAt,
   };
-  authedSubdomains.set(key(sandboxId, port), state);
+  authedSubdomains.set(key(sandboxId, port, req), state);
   return state;
 }
 
@@ -99,6 +114,7 @@ async function authenticatePublicShareSubdomain(
   token: string | null,
   sandboxId: string,
   port: number,
+  req: Request,
 ): Promise<AuthState | null> {
   if (!token) return null;
   const resolved = await resolvePublicShare(token);
@@ -115,7 +131,7 @@ async function authenticatePublicShareSubdomain(
   }
 
   void touchPublicShare(share.shareId).catch(() => {});
-  return markPublicShareSubdomain(sandboxId, port, share);
+  return markPublicShareSubdomain(sandboxId, port, share, req);
 }
 
 // Periodic cleanup of expired entries — keeps the map from growing
@@ -164,7 +180,7 @@ export async function handleSubdomainRequest(
     });
   }
 
-  let authed = getAuthedSubdomain(sandboxId, port);
+  let authed = getAuthedSubdomain(sandboxId, port, req);
 
   // Not authed yet — first honor a public share token, then fall back to normal
   // logged-in preview auth. Public shares deliberately use the same transparent
@@ -175,6 +191,7 @@ export async function handleSubdomainRequest(
       url.searchParams.get('public_share'),
       sandboxId,
       port,
+      req,
     );
   }
   if (!authed) {
@@ -193,7 +210,7 @@ export async function handleSubdomainRequest(
         },
       );
     }
-    markAuthedSubdomain(sandboxId, port, validatedUserId);
+    markAuthedSubdomain(sandboxId, port, req, validatedUserId);
     authed = { kind: 'principal', userId: validatedUserId, expiresAt: Date.now() + AUTH_SESSION_TTL_MS };
   }
 

--- a/apps/api/src/shared/jwt-verify.ts
+++ b/apps/api/src/shared/jwt-verify.ts
@@ -109,6 +109,16 @@ interface JwtPayload {
   user_metadata?: Record<string, unknown>;
 }
 
+export function decodeSupabaseJwtPayload(token: string): JwtPayload | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    return JSON.parse(new TextDecoder().decode(base64urlToBytes(parts[1]))) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
 interface JwtHeader {
   alg: string;
   kid?: string;

--- a/apps/api/src/shared/session-public-shares.ts
+++ b/apps/api/src/shared/session-public-shares.ts
@@ -6,7 +6,7 @@ import { db } from './db';
 export type PublicShareResourceType = 'preview' | 'file';
 
 export const STATIC_FILE_SHARE_PORT = 3211;
-export const PUBLIC_SHARE_BLOCKED_PORTS = new Set([22, 4096, 8000]);
+export const PUBLIC_SHARE_BLOCKED_PORTS = new Set([22, 4096, 8000, STATIC_FILE_SHARE_PORT]);
 
 export const DEFAULT_PREVIEW_CANDIDATES = [
   { id: 'web', label: 'App preview', port: 3000, path: '/', source: 'default' },

--- a/apps/api/src/tunnel/routes/auth.ts
+++ b/apps/api/src/tunnel/routes/auth.ts
@@ -15,12 +15,14 @@ import { resolveAccountId } from '../../shared/resolve-account';
  *   • MANAGE (getTunnelOwnerContext) — create/delete/rename connections, grant/
  *     revoke permissions, approve device-auth, rotate tokens. These mutate the
  *     security posture of a real machine, so they require a USER credential
- *     (interactive session / PAT), never a long-lived sandbox apiKey.
+ *     (interactive session / PAT), never a long-lived non-human principal
+ *     like a sandbox apiKey or service-account bearer.
  */
 
-/** Reject sandbox/apiKey credentials — used to fence off tunnel management. */
+/** Allow only human credentials — used to fence off tunnel management. */
 export function requireUserCredential(c: any): void {
-  if (c.get('authType') === 'apiKey') {
+  const authType = c.get('authType');
+  if (authType !== 'supabase' && authType !== 'pat') {
     throw new HTTPException(403, {
       message: 'User credentials are required for tunnel management',
     });
@@ -54,7 +56,7 @@ export async function getTunnelReadContext(c: any) {
 
 /**
  * Resolve the account + ownership clause for tunnel MANAGEMENT. Same as the
- * read context, but first rejects apiKey credentials.
+ * read context, but first rejects non-human credentials.
  */
 export async function getTunnelOwnerContext(c: any) {
   requireUserCredential(c);

--- a/apps/api/src/tunnel/routes/device-auth.ts
+++ b/apps/api/src/tunnel/routes/device-auth.ts
@@ -46,6 +46,13 @@ const DEFAULT_PERMISSION_SCOPES: Record<string, Record<string, unknown>[]> = {
 /** Permissive device-auth request row shape, as persisted + serialized. */
 const DeviceAuthRowSchema = z.record(z.string(), z.any());
 
+function clientRateLimitKey(c: any): string {
+  const forwarded = c.req.header('x-forwarded-for')?.split(',')[0]?.trim();
+  const realIp = c.req.header('x-real-ip')?.trim();
+  const cfIp = c.req.header('cf-connecting-ip')?.trim();
+  return forwarded || realIp || cfIp || 'unknown';
+}
+
 /**
  * Public router — mounted BEFORE auth middleware.
  * Handles create + poll (unauthenticated, used by CLI).
@@ -85,7 +92,7 @@ export function createDeviceAuthPublicRouter() {
       },
     }),
     async (c: any) => {
-      const ip = 'public-device-auth-create';
+      const ip = clientRateLimitKey(c);
       const globalRl = tunnelRateLimiter.check('deviceAuthCreateGlobal', 'global');
       if (!globalRl.allowed) {
         return c.json({ error: 'Too many requests', retryAfterMs: globalRl.retryAfterMs }, 429);

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -80,7 +80,7 @@ export interface AuthVariables {
   userId: string;
   userEmail: string;
   accountId?: string;
-  authType?: 'supabase' | 'pat' | 'apiKey';
+  authType?: 'supabase' | 'pat' | 'apiKey' | 'service_account';
   apiKeyType?: 'user' | 'sandbox';
   keyId?: string;
   sandboxId?: string;

--- a/packages/agent-tunnel/src/agent/agent.ts
+++ b/packages/agent-tunnel/src/agent/agent.ts
@@ -267,7 +267,8 @@ export class TunnelAgent {
     const { id, method, params = {} } = request;
 
     const permissionId = params.permissionId as string | undefined;
-    if (!this.permissionGuard.checkPermission(permissionId)) {
+    const permission = this.permissionGuard.getPermission(permissionId);
+    if (!permission) {
       this.sendSignedError(id, -32000, `Permission denied: ${permissionId ? 'invalid or expired permission' : 'no permissionId provided'}`);
       return;
     }
@@ -279,7 +280,10 @@ export class TunnelAgent {
     }
 
     try {
-      const result = await handler(params);
+      const result = await handler({
+        ...params,
+        __permission: permission,
+      });
       this.sendSignedResult(id, result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/agent-tunnel/src/agent/capabilities/filesystem.ts
+++ b/packages/agent-tunnel/src/agent/capabilities/filesystem.ts
@@ -10,6 +10,41 @@ import { join, dirname } from 'path';
 import type { Capability, RpcHandler } from './index';
 import { validatePath, validateWritePath } from '../security/path-validator';
 import type { TunnelConfig } from '../config';
+import type { LocalPermission } from '../security/permission-guard';
+
+function permissionFilesystemScope(params: Record<string, unknown>): {
+  paths?: string[];
+  allowedPaths?: string[];
+  blockedPaths?: string[];
+  operations?: string[];
+  maxFileSize?: number;
+} {
+  const permission = params.__permission as LocalPermission | undefined;
+  if (permission?.capability !== 'filesystem') {
+    throw new Error('Permission denied: filesystem permission required');
+  }
+  return (permission.scope ?? {}) as {
+    paths?: string[];
+    blockedPaths?: string[];
+    excludePatterns?: string[];
+    operations?: string[];
+    maxFileSize?: number;
+  };
+}
+
+function effectiveAllowedPaths(config: TunnelConfig, params: Record<string, unknown>): string[] {
+  const scope = permissionFilesystemScope(params);
+  const scoped = Array.isArray(scope.paths)
+    ? scope.paths.filter((p: unknown): p is string => typeof p === 'string' && p.trim().length > 0)
+    : [];
+  return scoped.length > 0 ? scoped : config.allowedPaths;
+}
+
+function effectiveBlockedPaths(config: TunnelConfig, params: Record<string, unknown>): string[] {
+  const scope = permissionFilesystemScope(params);
+  const scoped = Array.isArray(scope.blockedPaths) ? scope.blockedPaths.filter((p): p is string => typeof p === 'string' && p.trim().length > 0) : [];
+  return [...config.blockedPaths, ...scoped];
+}
 
 export function createFilesystemCapability(config: TunnelConfig): Capability {
   const methods = new Map<string, RpcHandler>();
@@ -18,11 +53,13 @@ export function createFilesystemCapability(config: TunnelConfig): Capability {
     const path = params.path as string;
     const encoding = (params.encoding as BufferEncoding) || 'utf-8';
 
-    validatePath(path, config.allowedPaths, config.blockedPaths);
+    validatePath(path, effectiveAllowedPaths(config, params), effectiveBlockedPaths(config, params));
 
     const stats = await stat(path);
-    if (stats.size > config.maxFileSize) {
-      throw new Error(`File exceeds max size (${stats.size} > ${config.maxFileSize})`);
+    const scope = permissionFilesystemScope(params);
+    const maxFileSize = Math.min(config.maxFileSize, typeof scope.maxFileSize === 'number' ? scope.maxFileSize : config.maxFileSize);
+    if (stats.size > maxFileSize) {
+      throw new Error(`File exceeds max size (${stats.size} > ${maxFileSize})`);
     }
 
     const content = await readFile(path, { encoding });
@@ -40,17 +77,19 @@ export function createFilesystemCapability(config: TunnelConfig): Capability {
     const content = params.content as string;
     const encoding = (params.encoding as BufferEncoding) || 'utf-8';
 
-    validateWritePath(path, config.allowedPaths, config.blockedPaths);
+    validateWritePath(path, effectiveAllowedPaths(config, params), effectiveBlockedPaths(config, params));
 
-    if (content.length > config.maxFileSize) {
-      throw new Error(`Content exceeds max size (${content.length} > ${config.maxFileSize})`);
+    const scope = permissionFilesystemScope(params);
+    const maxFileSize = Math.min(config.maxFileSize, typeof scope.maxFileSize === 'number' ? scope.maxFileSize : config.maxFileSize);
+    if (content.length > maxFileSize) {
+      throw new Error(`Content exceeds max size (${content.length} > ${maxFileSize})`);
     }
 
     await mkdir(dirname(path), { recursive: true });
-    validateWritePath(path, config.allowedPaths, config.blockedPaths);
+    validateWritePath(path, effectiveAllowedPaths(config, params), effectiveBlockedPaths(config, params));
 
     await writeFile(path, content, { encoding });
-    validatePath(path, config.allowedPaths, config.blockedPaths);
+    validatePath(path, effectiveAllowedPaths(config, params), effectiveBlockedPaths(config, params));
     const stats = await stat(path);
 
     return {
@@ -64,7 +103,7 @@ export function createFilesystemCapability(config: TunnelConfig): Capability {
     const path = params.path as string;
     const recursive = params.recursive as boolean || false;
 
-    validatePath(path, config.allowedPaths, config.blockedPaths);
+    validatePath(path, effectiveAllowedPaths(config, params), effectiveBlockedPaths(config, params));
 
     const entries = await readdir(path, { withFileTypes: true });
 
@@ -102,7 +141,7 @@ export function createFilesystemCapability(config: TunnelConfig): Capability {
   methods.set('fs.stat', async (params) => {
     const path = params.path as string;
 
-    validatePath(path, config.allowedPaths, config.blockedPaths);
+    validatePath(path, effectiveAllowedPaths(config, params), effectiveBlockedPaths(config, params));
 
     const stats = await stat(path);
 
@@ -121,7 +160,7 @@ export function createFilesystemCapability(config: TunnelConfig): Capability {
   methods.set('fs.delete', async (params) => {
     const path = params.path as string;
 
-    validatePath(path, config.allowedPaths, config.blockedPaths);
+    validatePath(path, effectiveAllowedPaths(config, params), effectiveBlockedPaths(config, params));
 
     await unlink(path);
 

--- a/packages/agent-tunnel/src/agent/security/permission-guard.ts
+++ b/packages/agent-tunnel/src/agent/security/permission-guard.ts
@@ -36,26 +36,30 @@ export class PermissionGuard {
   }
 
   checkPermission(permissionId: string | undefined): boolean {
+    return !!this.getPermission(permissionId);
+  }
+
+  getPermission(permissionId: string | undefined): LocalPermission | null {
     if (!permissionId) {
-      return false;
+      return null;
     }
 
     const perm = this.permissions.get(permissionId);
     if (!perm) {
       // After sync, unknown permission = deny (fail-closed).
       // Before sync, also deny — we have no basis to allow.
-      return false;
+      return null;
     }
 
     if (perm.expiresAt) {
       const expiry = new Date(perm.expiresAt).getTime();
       if (isNaN(expiry) || expiry < Date.now()) {
         this.permissions.delete(permissionId);
-        return false;
+        return null;
       }
     }
 
-    return true;
+    return perm;
   }
 
   clear(): void {

--- a/packages/db/drizzle/20260711120000_compute_single_open_session.sql
+++ b/packages/db/drizzle/20260711120000_compute_single_open_session.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_sandbox_compute_sessions_one_open"
+ON "kortix"."sandbox_compute_sessions" USING btree ("sandbox_id")
+WHERE "ended_at" IS NULL;

--- a/packages/db/drizzle/20260711120500_invite_accept_identity.sql
+++ b/packages/db/drizzle/20260711120500_invite_accept_identity.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "kortix"."account_invitations"
+ADD COLUMN IF NOT EXISTS "accepted_by_user_id" uuid;

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -221,6 +221,7 @@ export const accountInvitations = kortixSchema.table(
       >
     >(),
     acceptedAt: timestamp('accepted_at', { withTimezone: true }),
+    acceptedByUserId: uuid('accepted_by_user_id'),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true })
       .default(sql`now() + interval '14 days'`)
@@ -1991,6 +1992,9 @@ export const sandboxComputeSessions = kortixSchema.table(
   (table) => [
     index('idx_sandbox_compute_sessions_account_time').on(table.accountId, table.startedAt),
     index('idx_sandbox_compute_sessions_open')
+      .on(table.sandboxId)
+      .where(sql`${table.endedAt} IS NULL`),
+    uniqueIndex('uniq_sandbox_compute_sessions_one_open')
       .on(table.sandboxId)
       .where(sql`${table.endedAt} IS NULL`),
     index('idx_sandbox_compute_sessions_last_billed')

--- a/tests/security/README.md
+++ b/tests/security/README.md
@@ -24,6 +24,7 @@ tests/security/run.sh --sast --deps
 | Container | [`container/`](container/) | Trivy image (Apache-2.0) | `aquasec/trivy:0.58.0` | No (builds `apps/*/Dockerfile`) | `trivy-image-{api,web,sandbox}.sarif` |
 | DAST | [`dast/`](dast/) | OWASP ZAP baseline + Schemathesis (Apache-2.0 / MIT) | `ghcr.io/zaproxy/zaproxy:2.16.0`, `schemathesis/schemathesis:3.39.5` | **Yes — `TARGET_URL`** | `zap-baseline.{html,json}`, `schemathesis-junit.xml` |
 | Automated pentest | [`../pentest/`](../pentest/) | Kortix black-box adversarial probes | Bun | **Yes — `PENTEST_TARGET_URL`** | `pentest/junit.xml`, `pentest/results.json` |
+| Agentic pentest | [`strix/`](strix/) | Strix OSS (Apache-2.0) | Local CLI + pinned sandbox | Optional dev/staging target | `strix_runs/*/{findings.sarif,penetration_test_report.md}` |
 
 Static vs dynamic: the first four lanes are **static** and safe to run anywhere
 (including CI on every PR). The **DAST** lane is dynamic — it sends live,
@@ -74,7 +75,8 @@ For compliance, use three layers:
 
 1. Deterministic static gates here (`make security`).
 2. Dynamic automated gates against staging (`make security-dast` and `make pentest`).
-3. Independent manual/external penetration test reports with remediation evidence.
+3. Source-aware Strix OSS scans (`make strix`) with safe, validated proofs of concept.
+4. Independent manual/external penetration test reports with remediation evidence.
 
 The automated lanes are release/nightly controls. They are not a replacement for human-led
 penetration testing, but they provide recurring evidence that known attack classes stay fixed.

--- a/tests/security/strix/README.md
+++ b/tests/security/strix/README.md
@@ -1,0 +1,46 @@
+# Strix OSS agentic penetration testing
+
+This lane runs the Apache-2.0 `usestrix/strix` CLI and its local Docker sandbox.
+It does not use Strix Cloud. Strix performs source-aware analysis and optional
+low-impact dynamic validation against an explicitly allowed development target.
+
+## Prerequisites
+
+- Docker
+- `strix-agent==1.0.4`
+- `openai-agents==0.18.2` injected into the Strix tool environment
+- `LLM_API_KEY` for the configured provider
+
+Strix 1.0.4 pins `openai-agents==0.14.6`, whose LiteLLM adapter fails during
+warm-up because it omits `cache_write_tokens`. Version 0.18.2 fixes that runtime
+failure. OpenRouter is routed through the OpenAI-compatible endpoint so Strix's
+local cost estimator enforces `--max-budget-usd`; its LiteLLM OpenRouter route
+currently records `$0.00` and cannot enforce the cap.
+
+## Local run
+
+```bash
+uv tool install --force strix-agent==1.0.4
+uv pip install --python "$(uv tool dir)/strix-agent/bin/python" openai-agents==0.18.2
+
+export LLM_API_KEY="..."
+STRIX_SCAN_MODE=quick \
+STRIX_SCOPE_MODE=diff \
+STRIX_MAX_BUDGET_USD=5 \
+bash tests/security/strix/run.sh
+```
+
+For an authorized staging assessment:
+
+```bash
+STRIX_SCAN_MODE=standard \
+STRIX_SCOPE_MODE=full \
+STRIX_TARGET_URL=https://staging-api.kortix.com \
+STRIX_INSTRUCTION_FILE=.strix/instructions/deep-api.md \
+STRIX_MAX_BUDGET_USD=25 \
+bash tests/security/strix/run.sh
+```
+
+The committed runner refuses production and unknown remote targets. Reports are
+written under ignored `strix_runs/` directories. Exit code `0` means no finding,
+`1` means execution failed, and `2` means vulnerabilities were found.

--- a/tests/security/strix/run.sh
+++ b/tests/security/strix/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+STRIX_BIN="${STRIX_BIN:-strix}"
+SCAN_MODE="${STRIX_SCAN_MODE:-quick}"
+SCOPE_MODE="${STRIX_SCOPE_MODE:-auto}"
+MAX_BUDGET_USD="${STRIX_MAX_BUDGET_USD:-5}"
+TARGET_URL="${STRIX_TARGET_URL:-}"
+INSTRUCTION_FILE="${STRIX_INSTRUCTION_FILE:-${ROOT_DIR}/.strix/instructions/ci-source.md}"
+
+if ! command -v "${STRIX_BIN}" >/dev/null 2>&1; then
+  echo "[strix] missing CLI: ${STRIX_BIN}" >&2
+  exit 1
+fi
+
+if [[ -z "${LLM_API_KEY:-}" ]]; then
+  echo "[strix] LLM_API_KEY is required" >&2
+  exit 1
+fi
+
+case "${SCAN_MODE}" in
+  quick | standard | deep) ;;
+  *)
+    echo "[strix] invalid STRIX_SCAN_MODE: ${SCAN_MODE}" >&2
+    exit 1
+    ;;
+esac
+
+case "${SCOPE_MODE}" in
+  auto | diff | full) ;;
+  *)
+    echo "[strix] invalid STRIX_SCOPE_MODE: ${SCOPE_MODE}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -n "${TARGET_URL}" ]]; then
+  case "${TARGET_URL}" in
+    https://staging-api.kortix.com | https://dev-api.kortix.com | http://localhost:* | http://127.0.0.1:*) ;;
+    *)
+      echo "[strix] refusing non-development target: ${TARGET_URL}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+export STRIX_LLM="${STRIX_LLM:-openai/openai/gpt-5.4}"
+export LLM_API_BASE="${LLM_API_BASE:-https://openrouter.ai/api/v1}"
+export STRIX_TELEMETRY="${STRIX_TELEMETRY:-0}"
+export STRIX_IMAGE="${STRIX_IMAGE:-ghcr.io/usestrix/strix-sandbox@sha256:478e0b37ec83b2ba8c6e159593cb46d5dc9b624a45d6a9bb606851b83058d284}"
+
+args=(
+  --non-interactive
+  --mount "${ROOT_DIR}"
+  --scan-mode "${SCAN_MODE}"
+  --scope-mode "${SCOPE_MODE}"
+  --instruction-file "${INSTRUCTION_FILE}"
+  --max-budget-usd "${MAX_BUDGET_USD}"
+)
+
+if [[ "${SCOPE_MODE}" == "diff" ]]; then
+  args+=(--diff-base "${STRIX_DIFF_BASE:-origin/main}")
+fi
+
+if [[ -n "${TARGET_URL}" ]]; then
+  args+=(--target "${TARGET_URL}")
+fi
+
+echo "[strix] mode=${SCAN_MODE} scope=${SCOPE_MODE} target=${TARGET_URL:-source-only} budget=\$${MAX_BUDGET_USD}"
+cd "${ROOT_DIR}"
+exec "${STRIX_BIN}" "${args[@]}"


### PR DESCRIPTION
## Summary

- Remove the automatic Strix GitHub Actions workflow so Strix does not run on PRs/schedules and incur cloud/LLM cost by default.
- Keep the OSS/local Strix harness, instructions, Makefile target, and ignored run outputs for explicit manual use only.
- Remediate the reported Strix pentest findings across critical, high, medium, and low severities with focused regressions.

## Security fixes

1. Critical/high
   - `/v1/projects/{projectId}/git-token`: fail closed instead of returning server-global/human GitHub PAT fallback credentials.
   - `/v1/billing/cron/yearly-rotation`, `/v1/billing/cron/free-tier-rotation`: require internal service-key auth, not ordinary user auth.
   - Service-account tunnel management: restrict mutating tunnel management APIs to human credentials (`supabase`, `pat`) while preserving read/agent paths.
   - Supabase session bypass: preserve JWT session claims on Supabase network fallback and run session policy gates on account-agnostic account routes.
   - Public file share: block arbitrary static-server subpaths and prevent caller query params from overriding the stored shared file path.
   - Preview `?token=` leakage: reject query bearer tokens on ordinary HTTP preview routes; keep query tokens only for provision-stream/WS-specific paths.
   - Compute metering race: add partial unique DB constraint for one open compute session per sandbox and recover from unique races by returning the winning row.

2. Medium
   - Tunnel filesystem symlink/scope bypass: enforce realpath-aware filesystem permission scope inside the local agent, not only at API permission issuance time.
   - AgentMail webhook: require Svix signing secret and valid signature; fail closed when signing is missing.
   - Public device auth create: rate-limit by client IP plus global bucket instead of one shared public bucket.
   - Observability metadata: keep health minimal and require internal auth for `/metrics`; remove `billing_enabled` from router health.

3. Low/source concerns
   - Git smart-HTTP proxy: reject malformed project identifiers with 400 before auth/upstream resolution.
   - Account invite reaccept: stamp `accepted_by_user_id` and reject a later accept by a different identity sharing the same email.
   - Telegram webhook: require bound sender identity by default via `metadata.telegram.allowedUserIds`, with explicit env opt-out for temporary legacy migration.
   - Preview share port 3211: block the static file server port as a public preview target.
   - Preview subdomain auth cache: bind cache entries to sandbox/port plus client IP and user-agent.
   - Stripe webhook partial commits: clear failed event markers so failed handlers can retry.
   - RevenueCat webhook replay: require event IDs and dedupe by `revenuecat:<event_id>`.

## Verification

- `pnpm --filter kortix-api exec tsc --noEmit --pretty false`
- `pnpm --filter @kortix/agent-tunnel exec tsc --noEmit --pretty false`
- `pnpm --filter agent-tunnel test -- --runInBand`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/e2e-projects-provision.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-tunnel-auth.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-combined-auth-sa.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-billing-cron-auth.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-public-session-share.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-preview-auth.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-preview-auth-principal.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/billing/e2e-compute-metering.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/billing/webhooks.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-email-channel.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-git-proxy-parse.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/e2e-accounts-contract.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/e2e-router.test.ts`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-telegram-webhook-auth.test.ts`
- `git diff --check`

## Notes

- Live HTTP probes were not rerun after this final amend because no local API listener was running on `localhost:8008`; the focused Hono/service regressions above exercise the changed handlers directly.
- The already-disclosed GitHub PAT must still be revoked/rotated in GitHub and the production secret store. This PR prevents future disclosure but cannot invalidate a token already returned by production.
- Strix is now manual/local only. Do not add a scheduled or PR Strix workflow unless cost controls are explicitly approved.
