### PR TITLE
feat(web): redesign the template install wizard (two-column + logos + stepper)

### DIFF
--- a/apps/web/src/components/use-cases/template-install-dialog.tsx
+++ b/apps/web/src/components/use-cases/template-install-dialog.tsx
@@ -8,8 +8,9 @@ import {
   upsertProjectSecret,
   type KortixProject,
 } from '@kortix/sdk/projects-client';
-import { Bot, Check, Clock, KeyRound, Loader2, Plug, Puzzle, Sparkles } from 'lucide-react';
+import { Bot, Check, Clock, KeyRound, Loader2, LogIn, Plug, Puzzle, Sparkles } from 'lucide-react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -31,6 +32,7 @@ import {
   StepperTitle,
   StepperTrigger,
 } from '@/components/ui/stepper';
+import { useAuth } from '@/features/providers/auth-provider';
 import { useToolConnect } from '@/hooks/connectors/use-tool-connect';
 import {
   getTemplate,
@@ -143,6 +145,10 @@ function TemplateInstallDialog({
   const [live, setLive] = useState(false);
   const [activating, setActivating] = useState(false);
 
+  const { user, isLoading: authLoading } = useAuth();
+  const pathname = usePathname();
+  const signInHref = `/auth?returnUrl=${encodeURIComponent(pathname ?? '/')}`;
+
   const connect = useToolConnect(projectId, () => {});
 
   useEffect(() => {
@@ -165,6 +171,11 @@ function TemplateInstallDialog({
         setInputs(seed);
       })
       .catch((e: Error) => setError(e.message));
+    if (!user) {
+      setProjects([]);
+      setProjectId('');
+      return;
+    }
     listProjectsForAccount()
       .then((list) => {
         const active = (list ?? []).filter((p) => p.status === 'active');
@@ -172,7 +183,7 @@ function TemplateInstallDialog({
         setProjectId((prev) => prev || active[0]?.project_id || '');
       })
       .catch(() => setProjects([]));
-  }, [open, templateId]);
+  }, [open, templateId, user]);
 
   const previewConnectors = detail?.requirements.filter((r) => r.kind === 'connector') ?? [];
   const previewSecrets = detail?.requirements.filter((r) => r.kind === 'secret') ?? [];
@@ -295,9 +306,16 @@ function TemplateInstallDialog({
                 <p className="text-muted-foreground font-mono text-[11px] tracking-wider uppercase">
                   Set up automation
                 </p>
-                <h2 className="text-foreground mt-1 text-lg leading-snug font-medium text-balance">
-                  {detail?.title ?? 'Loading…'}
-                </h2>
+                {detail ? (
+                  <h2 className="text-foreground mt-1 text-lg leading-snug font-medium text-balance">
+                    {detail.title}
+                  </h2>
+                ) : (
+                  <div className="mt-2 space-y-1.5">
+                    <div className="bg-foreground/10 h-4 w-4/5 animate-pulse rounded" />
+                    <div className="bg-foreground/10 h-4 w-2/5 animate-pulse rounded" />
+                  </div>
+                )}
               </div>
             </div>
 
@@ -306,6 +324,13 @@ function TemplateInstallDialog({
                 What it sets up
               </p>
               <ul className="space-y-1.5">
+                {!detail &&
+                  [0, 1, 2].map((i) => (
+                    <li key={i} className="flex items-center gap-2.5">
+                      <span className="bg-foreground/10 size-6 shrink-0 animate-pulse rounded" />
+                      <span className="bg-foreground/10 h-3.5 w-28 animate-pulse rounded" />
+                    </li>
+                  ))}
                 {agents.map((a) => (
                   <CoverItem key={a.name} icon={<Bot className="size-3.5" />} label={`Agent · ${a.name}`} />
                 ))}
@@ -332,7 +357,7 @@ function TemplateInstallDialog({
 
           {/* ── Right: working area ──────────────────────────────────────── */}
           <div className="flex min-h-[540px] flex-col">
-            <div className="border-border/60 border-b px-6 py-4">
+            <div className="border-border/60 border-b py-4 pr-14 pl-6">
               <Stepper value={step} count={STEPS.length} className="w-full">
                 {STEPS.map((s, i) => (
                   <StepperItem key={s} step={i} completed={live && i === 3} className="not-last:flex-1">
@@ -342,7 +367,7 @@ function TemplateInstallDialog({
                       </StepperIndicator>
                       <StepperTitle className="hidden text-xs sm:block">{s}</StepperTitle>
                     </StepperTrigger>
-                    <StepperSeparator />
+                    {i < STEPS.length - 1 && <StepperSeparator />}
                   </StepperItem>
                 ))}
               </Stepper>
@@ -359,13 +384,39 @@ function TemplateInstallDialog({
               {detail && step === 0 && (
                 <div className="space-y-5">
                   <p className="text-muted-foreground text-sm leading-relaxed">{detail.description}</p>
-                  <div className="space-y-1.5">
-                    <Label className="text-sm">Install into</Label>
-                    {projects.length === 0 ? (
-                      <p className="text-muted-foreground text-sm">
-                        Sign in and create a project to install this template.
+
+                  {authLoading ? (
+                    <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                      <Loader2 className="size-4 animate-spin" /> Checking your account…
+                    </div>
+                  ) : !user ? (
+                    <div className="border-border/60 bg-muted/30 flex flex-col items-center gap-3 rounded-xl border border-dashed px-6 py-8 text-center">
+                      <span className="bg-foreground text-background flex size-11 items-center justify-center rounded-xl">
+                        <LogIn className="size-5" />
+                      </span>
+                      <div>
+                        <p className="text-foreground text-sm font-medium">
+                          Sign in to install this automation
+                        </p>
+                        <p className="text-muted-foreground mx-auto mt-1 max-w-xs text-xs leading-relaxed">
+                          You&apos;re previewing everything it sets up. Sign in to pick a project and
+                          install — we&apos;ll bring you right back here.
+                        </p>
+                      </div>
+                    </div>
+                  ) : projects.length === 0 ? (
+                    <div className="border-border/60 bg-muted/30 rounded-xl border px-4 py-4">
+                      <p className="text-foreground text-sm font-medium">No projects yet</p>
+                      <p className="text-muted-foreground mt-0.5 text-xs">
+                        Create a project first, then come back to install this template into it.
                       </p>
-                    ) : (
+                      <Button asChild size="sm" variant="outline" className="mt-3">
+                        <Link href="/projects">Go to projects</Link>
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="space-y-1.5">
+                      <Label className="text-sm">Install into</Label>
                       <Select value={projectId} onValueChange={setProjectId}>
                         <SelectTrigger className="w-full">
                           <SelectValue placeholder="Choose a project" />
@@ -378,11 +429,11 @@ function TemplateInstallDialog({
                           ))}
                         </SelectContent>
                       </Select>
-                    )}
-                    <p className="text-muted-foreground text-xs">
-                      Nothing runs yet — you&apos;ll connect accounts and turn it on at the end.
-                    </p>
-                  </div>
+                      <p className="text-muted-foreground text-xs">
+                        Nothing runs yet — you&apos;ll connect accounts and turn it on at the end.
+                      </p>
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -603,11 +654,22 @@ function TemplateInstallDialog({
                   >
                     Back
                   </Button>
-                  {step === 0 && (
-                    <Button size="sm" disabled={!detail || !projectId} onClick={() => setStep(1)}>
-                      Continue
-                    </Button>
-                  )}
+                  {step === 0 &&
+                    (authLoading ? (
+                      <Button size="sm" disabled>
+                        Continue
+                      </Button>
+                    ) : !user ? (
+                      <Button asChild size="sm" disabled={!detail}>
+                        <Link href={signInHref}>
+                          <LogIn className="size-4" /> Sign in to continue
+                        </Link>
+                      </Button>
+                    ) : (
+                      <Button size="sm" disabled={!detail || !projectId} onClick={() => setStep(1)}>
+                        Continue
+                      </Button>
+                    ))}
                   {step === 1 && (
                     <Button size="sm" disabled={!projectId || missingInput || installing} onClick={runInstall}>
                       {installing ? (

--- a/apps/web/src/components/use-cases/template-install-dialog.tsx
+++ b/apps/web/src/components/use-cases/template-install-dialog.tsx
@@ -1,20 +1,36 @@
 'use client';
 
+/* eslint-disable @next/next/no-img-element */
+
 import {
   listProjectsForAccount,
   updateProjectTrigger,
   upsertProjectSecret,
   type KortixProject,
 } from '@kortix/sdk/projects-client';
-import { Bot, Check, Clock, Hash, KeyRound, Loader2, Plug, Puzzle, Sparkles } from 'lucide-react';
+import { Bot, Check, Clock, KeyRound, Loader2, Plug, Puzzle, Sparkles } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Stepper,
+  StepperIndicator,
+  StepperItem,
+  StepperSeparator,
+  StepperTitle,
+  StepperTrigger,
+} from '@/components/ui/stepper';
 import { useToolConnect } from '@/hooks/connectors/use-tool-connect';
 import {
   getTemplate,
@@ -25,6 +41,51 @@ import {
 import { cn } from '@/lib/utils';
 
 const STEPS = ['Review', 'Configure', 'Connect', 'Go live'] as const;
+
+// ── brand logos via the public Simple Icons CDN (cdn.simpleicons.org/<slug>) ──
+const LOGO_ALIAS: Record<string, string> = { gh: 'github' };
+
+function brandFor(name: string): string | null {
+  const n = name.toLowerCase();
+  if (n.includes('github') || n.startsWith('gh_') || n.startsWith('gh-')) return 'github';
+  if (n.includes('stripe')) return 'stripe';
+  if (n.includes('slack')) return 'slack';
+  if (n.includes('linear')) return 'linear';
+  if (n.includes('gmail')) return 'gmail';
+  if (n.includes('google')) return 'google';
+  if (n.includes('notion')) return 'notion';
+  if (n.includes('openai')) return 'openai';
+  if (n.includes('hubspot')) return 'hubspot';
+  return null;
+}
+
+function Logo({ slug, className }: { slug: string; className?: string }) {
+  const [err, setErr] = useState(false);
+  const brand = LOGO_ALIAS[slug] ?? slug;
+  if (err) return <Plug className={cn('text-muted-foreground size-5', className)} />;
+  return (
+    <img
+      src={`https://cdn.simpleicons.org/${encodeURIComponent(brand)}`}
+      alt=""
+      className={cn('size-5 object-contain', className)}
+      onError={() => setErr(true)}
+    />
+  );
+}
+
+/** White chip holding a brand logo — the connector/app tile. */
+function LogoTile({ slug, className }: { slug: string; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'ring-border/70 flex size-9 items-center justify-center rounded-lg bg-white shadow-sm ring-1',
+        className,
+      )}
+    >
+      <Logo slug={slug} />
+    </span>
+  );
+}
 
 export function UseTemplateButton({
   templateId,
@@ -118,9 +179,21 @@ function TemplateInstallDialog({
   const previewChannels = detail?.requirements.filter((r) => r.kind === 'channel') ?? [];
   const agents = detail?.installs.filter((i) => i.type === 'registry:agent') ?? [];
   const skills = detail?.installs.filter((i) => i.type === 'registry:skill') ?? [];
+  const hasSchedule = detail?.inputs.some((i) => i.type === 'cron') ?? false;
   const requiredInputs = detail?.inputs.filter((i) => i.required !== false) ?? [];
   const missingInput = requiredInputs.some((i) => !inputs[i.key]?.trim());
   const selectedProject = projects.find((p) => p.project_id === projectId);
+
+  // Brand logos for the cover — connectors, channels, and apps inferred from secrets.
+  const appSlugs = Array.from(
+    new Set(
+      [
+        ...previewConnectors.map((c) => c.key),
+        ...previewChannels.map((c) => c.key),
+        ...previewSecrets.map((s) => brandFor(s.key)),
+      ].filter(Boolean) as string[],
+    ),
+  ).slice(0, 4);
 
   const installConnectors = installed?.requirements.filter((r) => r.kind === 'connector') ?? [];
   const installSecrets = installed?.requirements.filter((r) => r.kind === 'secret') ?? [];
@@ -192,393 +265,384 @@ function TemplateInstallDialog({
     }
   }
 
+  const busyGuard = connect.isPending || installing || activating;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="gap-0 overflow-hidden p-0 sm:max-w-xl"
-        onInteractOutside={(e) => {
-          if (connect.isPending || installing) e.preventDefault();
-        }}
-        onEscapeKeyDown={(e) => {
-          if (connect.isPending || installing) e.preventDefault();
-        }}
+        className="max-h-[92vh] gap-0 overflow-hidden p-0 sm:max-w-3xl"
+        onInteractOutside={(e) => busyGuard && e.preventDefault()}
+        onEscapeKeyDown={(e) => busyGuard && e.preventDefault()}
       >
         <DialogTitle className="sr-only">
           Set up {detail?.title ?? 'automation'} from a template
         </DialogTitle>
-        <div className="border-border/60 flex items-center gap-3 border-b px-6 py-4">
-          <div className="bg-foreground text-background flex size-9 items-center justify-center rounded-lg">
-            <Sparkles className="size-4.5" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-muted-foreground font-mono text-[11px] tracking-wider uppercase">
-              Set up automation
-            </p>
-            <p className="text-foreground truncate text-sm font-medium">
-              {detail?.title ?? 'Loading…'}
-            </p>
-          </div>
-        </div>
 
-        <div className="border-border/60 flex items-center gap-1 border-b px-6 py-3">
-          {STEPS.map((s, i) => (
-            <div key={s} className="flex items-center gap-1">
-              <div
-                className={cn(
-                  'flex items-center gap-2 rounded-full px-2.5 py-1 text-xs',
-                  i === step
-                    ? 'bg-foreground text-background'
-                    : i < step
-                      ? 'text-foreground'
-                      : 'text-muted-foreground',
-                )}
-              >
-                <span className="font-mono tabular-nums">{i + 1}</span>
-                <span className="hidden sm:inline">{s}</span>
+        <div className="grid sm:grid-cols-[300px_1fr]">
+          {/* ── Left: cover ──────────────────────────────────────────────── */}
+          <aside className="from-muted/60 via-background to-primary/[0.08] border-border/60 relative hidden flex-col gap-6 border-r bg-gradient-to-br p-6 sm:flex">
+            <div className="absolute inset-0 bg-[url('/grain-texture.png')] bg-repeat opacity-[0.08]" />
+            <div className="relative flex flex-col gap-5">
+              <div className="flex items-center -space-x-2">
+                <span className="bg-foreground ring-background flex size-9 items-center justify-center rounded-lg ring-4">
+                  <Sparkles className="text-background size-4.5" />
+                </span>
+                {appSlugs.map((slug) => (
+                  <LogoTile key={slug} slug={slug} className="ring-background ring-4" />
+                ))}
               </div>
-              {i < STEPS.length - 1 && <div className="bg-border h-px w-3" />}
+              <div>
+                <p className="text-muted-foreground font-mono text-[11px] tracking-wider uppercase">
+                  Set up automation
+                </p>
+                <h2 className="text-foreground mt-1 text-lg leading-snug font-medium text-balance">
+                  {detail?.title ?? 'Loading…'}
+                </h2>
+              </div>
             </div>
-          ))}
-        </div>
 
-        <div className="min-h-[320px] px-6 py-5">
-          {error && <p className="text-destructive mb-3 text-sm">{error}</p>}
-          {!detail && !error && (
-            <div className="text-muted-foreground flex h-[280px] items-center justify-center gap-2 text-sm">
-              <Loader2 className="size-4 animate-spin" /> Loading template…
-            </div>
-          )}
-
-          {detail && step === 0 && (
-            <div className="space-y-4">
-              <p className="text-muted-foreground text-sm leading-relaxed">{detail.description}</p>
-              <p className="text-muted-foreground font-mono text-[11px] tracking-wider uppercase">
-                This sets up
+            <div className="relative">
+              <p className="text-muted-foreground mb-2.5 font-mono text-[11px] tracking-wider uppercase">
+                What it sets up
               </p>
-              <ul className="space-y-2">
+              <ul className="space-y-1.5">
                 {agents.map((a) => (
-                  <SetupRow key={a.name} icon={<Bot className="size-4" />} label={`Agent · ${a.name}`} tag="New" />
+                  <CoverItem key={a.name} icon={<Bot className="size-3.5" />} label={`Agent · ${a.name}`} />
                 ))}
                 {previewConnectors.map((c) => (
-                  <SetupRow key={c.key} icon={<Plug className="size-4" />} label={c.label} tag="Connect" />
+                  <CoverItem key={c.key} icon={<Logo slug={c.key} className="size-3.5" />} label={c.label} />
                 ))}
                 {previewChannels.map((c) => (
-                  <SetupRow
-                    key={c.key}
-                    icon={<Hash className="size-4" />}
-                    label={`${c.label} channel`}
-                    tag="Optional"
-                  />
+                  <CoverItem key={c.key} icon={<Logo slug={c.key} className="size-3.5" />} label={`${c.label} channel`} />
                 ))}
-                {detail.inputs.some((i) => i.type === 'cron') && (
-                  <SetupRow icon={<Clock className="size-4" />} label="Schedule" tag="New" />
-                )}
+                {hasSchedule && <CoverItem icon={<Clock className="size-3.5" />} label="Schedule" />}
                 {previewSecrets.map((s) => (
-                  <SetupRow key={s.key} icon={<KeyRound className="size-4" />} label={s.label} tag="You provide" tone="req" />
+                  <CoverItem key={s.key} icon={<KeyRound className="size-3.5" />} label={s.label} />
                 ))}
                 {skills.map((s) => (
-                  <SetupRow key={s.name} icon={<Puzzle className="size-4" />} label={`Skill · ${s.name}`} tag="New" />
+                  <CoverItem key={s.name} icon={<Puzzle className="size-3.5" />} label={`Skill · ${s.name}`} />
                 ))}
               </ul>
-              <div className="pt-1">
-                <p className="text-muted-foreground mb-2 font-mono text-[11px] tracking-wider uppercase">
-                  Install into
-                </p>
-                {projects.length === 0 ? (
-                  <p className="text-muted-foreground text-sm">
-                    Sign in and create a project to install this template.
-                  </p>
-                ) : (
-                  <select
-                    value={projectId}
-                    onChange={(e) => setProjectId(e.target.value)}
-                    className="border-input bg-background text-foreground focus-visible:ring-ring w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-1 focus-visible:outline-none"
-                  >
-                    {projects.map((p) => (
-                      <option key={p.project_id} value={p.project_id}>
-                        {p.name}
-                      </option>
-                    ))}
-                  </select>
-                )}
-              </div>
             </div>
-          )}
 
-          {detail && step === 1 && (
-            <div className="space-y-5">
-              <p className="text-muted-foreground text-sm">
-                Set the template's options. You can change these any time later.
-              </p>
-              {detail.inputs.map((inp) => (
-                <div key={inp.key} className="space-y-1.5">
-                  <Label htmlFor={inp.key} className="text-sm">
-                    {inp.label}
-                  </Label>
-                  <Input
-                    id={inp.key}
-                    value={inputs[inp.key] ?? ''}
-                    placeholder={inp.default}
-                    onChange={(e) => setInputs((p) => ({ ...p, [inp.key]: e.target.value }))}
-                  />
-                  {inp.help && <p className="text-muted-foreground text-xs">{inp.help}</p>}
+            <p className="text-muted-foreground/80 relative mt-auto text-xs leading-relaxed">
+              Guarded by default — sensitive steps stop at an approval gate before they run.
+            </p>
+          </aside>
+
+          {/* ── Right: working area ──────────────────────────────────────── */}
+          <div className="flex min-h-[540px] flex-col">
+            <div className="border-border/60 border-b px-6 py-4">
+              <Stepper value={step} count={STEPS.length} className="w-full">
+                {STEPS.map((s, i) => (
+                  <StepperItem key={s} step={i} completed={live && i === 3} className="not-last:flex-1">
+                    <StepperTrigger className="gap-2" tabIndex={-1}>
+                      <StepperIndicator>
+                        {i < step || (live && i === 3) ? <Check className="size-3.5" /> : i + 1}
+                      </StepperIndicator>
+                      <StepperTitle className="hidden text-xs sm:block">{s}</StepperTitle>
+                    </StepperTrigger>
+                    <StepperSeparator />
+                  </StepperItem>
+                ))}
+              </Stepper>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-6 py-5">
+              {error && <p className="text-destructive mb-3 text-sm">{error}</p>}
+              {!detail && !error && (
+                <div className="text-muted-foreground flex h-[320px] items-center justify-center gap-2 text-sm">
+                  <Loader2 className="size-4 animate-spin" /> Loading template…
                 </div>
-              ))}
-            </div>
-          )}
+              )}
 
-          {detail && step === 2 && installed && (
-            <div className="space-y-3">
-              <p className="text-muted-foreground text-sm">
-                Committed to your project. Now connect the accounts and add the key — brokered
-                server-side, so a raw token never reaches the agent.
-              </p>
-              {installConnectors.map((c) => {
-                const done = connectedSlugs.has(c.key);
-                const busy = connect.isPending && connect.variables === c.key;
-                return (
-                  <div
-                    key={c.key}
-                    className={cn(
-                      'border-border/60 flex items-center gap-3 rounded-xl border px-4 py-3',
-                      done && 'border-emerald-500/40 bg-emerald-500/[0.04]',
-                    )}
-                  >
-                    <Plug className="text-muted-foreground size-4" />
-                    <div className="min-w-0 flex-1">
-                      <p className="text-foreground text-sm font-medium capitalize">{c.label}</p>
-                      {c.provider && <p className="text-muted-foreground text-xs">via {c.provider}</p>}
-                    </div>
-                    {done ? (
-                      <span className="flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                        <Check className="size-3.5" /> Connected
-                      </span>
+              {detail && step === 0 && (
+                <div className="space-y-5">
+                  <p className="text-muted-foreground text-sm leading-relaxed">{detail.description}</p>
+                  <div className="space-y-1.5">
+                    <Label className="text-sm">Install into</Label>
+                    {projects.length === 0 ? (
+                      <p className="text-muted-foreground text-sm">
+                        Sign in and create a project to install this template.
+                      </p>
                     ) : (
-                      <Button size="sm" variant="outline" disabled={busy} onClick={() => handleConnect(c.key)}>
-                        {busy ? <Loader2 className="size-3.5 animate-spin" /> : 'Connect'}
-                      </Button>
+                      <Select value={projectId} onValueChange={setProjectId}>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Choose a project" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {projects.map((p) => (
+                            <SelectItem key={p.project_id} value={p.project_id}>
+                              {p.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     )}
-                  </div>
-                );
-              })}
-              {installSecrets.map((s) => {
-                const done = savedSecrets.has(s.key);
-                return (
-                  <div
-                    key={s.key}
-                    className={cn(
-                      'border-border/60 rounded-xl border px-4 py-3',
-                      done && 'border-emerald-500/40 bg-emerald-500/[0.04]',
-                    )}
-                  >
-                    <div className="flex items-center gap-3">
-                      <KeyRound className="text-muted-foreground size-4" />
-                      <p className="text-foreground flex-1 text-sm font-medium">{s.label}</p>
-                      {done && (
-                        <span className="flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                          <Check className="size-3.5" /> Saved
-                        </span>
-                      )}
-                    </div>
-                    {!done && (
-                      <div className="mt-2.5 flex gap-2">
-                        <Input
-                          type="password"
-                          placeholder={`Paste ${s.key}`}
-                          value={secretValues[s.key] ?? ''}
-                          onChange={(e) =>
-                            setSecretValues((p) => ({ ...p, [s.key]: e.target.value }))
-                          }
-                        />
-                        <Button
-                          size="sm"
-                          disabled={savingSecret === s.key || !secretValues[s.key]?.trim()}
-                          onClick={() => saveSecret(s.key)}
-                        >
-                          {savingSecret === s.key ? (
-                            <Loader2 className="size-3.5 animate-spin" />
-                          ) : (
-                            'Save'
-                          )}
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-              {installChannels.map((c) => (
-                <div
-                  key={c.key}
-                  className="border-border/60 flex items-center gap-3 rounded-xl border border-dashed px-4 py-3"
-                >
-                  <Hash className="text-muted-foreground size-4" />
-                  <div className="min-w-0 flex-1">
-                    <p className="text-foreground text-sm font-medium">{c.label}</p>
                     <p className="text-muted-foreground text-xs">
-                      Optional — connect from Settings → Channels any time
+                      Nothing runs yet — you&apos;ll connect accounts and turn it on at the end.
                     </p>
                   </div>
-                  <Button asChild size="sm" variant="outline">
-                    <Link href={`/projects/${installed.projectId}`}>Open</Link>
-                  </Button>
                 </div>
-              ))}
-            </div>
-          )}
-
-          {detail && step === 3 && installed && !live && (
-            <div className="space-y-4">
-              <p className="text-muted-foreground text-sm">
-                Here's what will run once you turn it on.
-              </p>
-              <div className="border-border/60 divide-border/60 divide-y rounded-xl border text-sm">
-                <RecapRow k="Automation" v={detail.title} />
-                {detail.inputs.map((inp) => (
-                  <RecapRow key={inp.key} k={inp.label} v={inputs[inp.key] || inp.default || '—'} />
-                ))}
-                <RecapRow
-                  k="Connected"
-                  v={
-                    installConnectors
-                      .filter((c) => connectedSlugs.has(c.key))
-                      .map((c) => c.label)
-                      .join(' · ') || 'none yet'
-                  }
-                />
-              </div>
-              {(!allConnected || !allSecretsSaved) && (
-                <p className="text-muted-foreground text-xs">
-                  You can turn it on now and finish connecting later — runs will wait on anything
-                  that isn't connected yet.
-                </p>
               )}
-              <div className="bg-muted/40 border-border/60 rounded-xl border p-3">
-                <p className="text-foreground text-xs font-medium">Guarded by default</p>
-                <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
-                  Sensitive steps stop at an approval gate before they run. You review, then it goes.
-                </p>
-              </div>
-            </div>
-          )}
 
-          {detail && step === 3 && installed && live && (
-            <div className="flex h-[280px] flex-col items-center justify-center text-center">
-              <div className="mb-4 flex size-14 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
-                <Check className="size-7" />
-              </div>
-              <p className="text-foreground text-base font-medium">It's live</p>
-              <p className="text-muted-foreground mx-auto mt-1.5 max-w-xs text-sm leading-relaxed">
-                The schedule is on. It makes its first run at the next scheduled time — watch it land
-                in your project.
-              </p>
-            </div>
-          )}
-        </div>
+              {detail && step === 1 && (
+                <div className="space-y-5">
+                  <p className="text-muted-foreground text-sm">
+                    Set the template&apos;s options. You can change these any time later.
+                  </p>
+                  {detail.inputs.map((inp) => (
+                    <div key={inp.key} className="space-y-1.5">
+                      <Label htmlFor={inp.key} className="text-sm">
+                        {inp.label}
+                      </Label>
+                      <Input
+                        id={inp.key}
+                        value={inputs[inp.key] ?? ''}
+                        placeholder={inp.default}
+                        onChange={(e) => setInputs((p) => ({ ...p, [inp.key]: e.target.value }))}
+                      />
+                      {inp.help && <p className="text-muted-foreground text-xs">{inp.help}</p>}
+                    </div>
+                  ))}
+                </div>
+              )}
 
-        <div className="border-border/60 flex items-center justify-between gap-2 border-t px-6 py-4">
-          {step === 3 && installed ? (
-            live ? (
-              <>
-                <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
-                  Close
-                </Button>
-                <Button asChild size="sm">
-                  <Link href={`/projects/${installed.projectId}`}>Open project</Link>
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={activating}
-                  onClick={() => onOpenChange(false)}
-                >
-                  Not now
-                </Button>
-                <Button
-                  size="sm"
-                  disabled={activating || installed.triggerSlugs.length === 0}
-                  onClick={activate}
-                >
-                  {activating ? (
-                    <>
-                      <Loader2 className="size-4 animate-spin" /> Turning on…
-                    </>
-                  ) : (
-                    <>
-                      <Sparkles className="size-4" /> Turn it on
-                    </>
+              {detail && step === 2 && installed && (
+                <div className="space-y-3">
+                  <p className="text-muted-foreground text-sm">
+                    Committed to your project. Connect the accounts and add the key — brokered
+                    server-side, so a raw token never reaches the agent.
+                  </p>
+                  {installConnectors.map((c) => {
+                    const done = connectedSlugs.has(c.key);
+                    const busy = connect.isPending && connect.variables === c.key;
+                    return (
+                      <div
+                        key={c.key}
+                        className={cn(
+                          'border-border/60 flex items-center gap-3 rounded-xl border px-4 py-3',
+                          done && 'border-kortix-green/40 bg-kortix-green/[0.05]',
+                        )}
+                      >
+                        <LogoTile slug={c.key} />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-foreground text-sm font-medium capitalize">{c.label}</p>
+                          {c.provider && (
+                            <p className="text-muted-foreground text-xs">via {c.provider}</p>
+                          )}
+                        </div>
+                        {done ? (
+                          <span className="text-kortix-green flex items-center gap-1 text-xs font-medium">
+                            <Check className="size-3.5" /> Connected
+                          </span>
+                        ) : (
+                          <Button size="sm" variant="outline" disabled={busy} onClick={() => handleConnect(c.key)}>
+                            {busy ? <Loader2 className="size-3.5 animate-spin" /> : 'Connect'}
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {installSecrets.map((s) => {
+                    const done = savedSecrets.has(s.key);
+                    const brand = brandFor(s.key);
+                    return (
+                      <div
+                        key={s.key}
+                        className={cn(
+                          'border-border/60 rounded-xl border px-4 py-3',
+                          done && 'border-kortix-green/40 bg-kortix-green/[0.05]',
+                        )}
+                      >
+                        <div className="flex items-center gap-3">
+                          {brand ? (
+                            <LogoTile slug={brand} />
+                          ) : (
+                            <span className="bg-muted flex size-9 items-center justify-center rounded-lg">
+                              <KeyRound className="text-muted-foreground size-4" />
+                            </span>
+                          )}
+                          <p className="text-foreground flex-1 text-sm font-medium">{s.label}</p>
+                          {done && (
+                            <span className="text-kortix-green flex items-center gap-1 text-xs font-medium">
+                              <Check className="size-3.5" /> Saved
+                            </span>
+                          )}
+                        </div>
+                        {!done && (
+                          <div className="mt-2.5 flex gap-2">
+                            <Input
+                              type="password"
+                              placeholder={`Paste ${s.key}`}
+                              value={secretValues[s.key] ?? ''}
+                              onChange={(e) =>
+                                setSecretValues((p) => ({ ...p, [s.key]: e.target.value }))
+                              }
+                            />
+                            <Button
+                              size="sm"
+                              disabled={savingSecret === s.key || !secretValues[s.key]?.trim()}
+                              onClick={() => saveSecret(s.key)}
+                            >
+                              {savingSecret === s.key ? (
+                                <Loader2 className="size-3.5 animate-spin" />
+                              ) : (
+                                'Save'
+                              )}
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {installChannels.map((c) => (
+                    <div
+                      key={c.key}
+                      className="border-border/60 flex items-center gap-3 rounded-xl border border-dashed px-4 py-3"
+                    >
+                      <LogoTile slug={c.key} />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-foreground text-sm font-medium capitalize">{c.label}</p>
+                        <p className="text-muted-foreground text-xs">
+                          Optional — connect from Settings → Channels any time
+                        </p>
+                      </div>
+                      <Button asChild size="sm" variant="outline">
+                        <Link href={`/projects/${installed.projectId}`}>Open</Link>
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {detail && step === 3 && installed && !live && (
+                <div className="space-y-4">
+                  <p className="text-muted-foreground text-sm">
+                    Here&apos;s what will run once you turn it on.
+                  </p>
+                  <div className="border-border/60 divide-border/60 divide-y rounded-xl border text-sm">
+                    <RecapRow k="Automation" v={detail.title} />
+                    {detail.inputs.map((inp) => (
+                      <RecapRow key={inp.key} k={inp.label} v={inputs[inp.key] || inp.default || '—'} />
+                    ))}
+                    <RecapRow
+                      k="Connected"
+                      v={
+                        installConnectors
+                          .filter((c) => connectedSlugs.has(c.key))
+                          .map((c) => c.label)
+                          .join(' · ') || 'none yet'
+                      }
+                    />
+                  </div>
+                  {(!allConnected || !allSecretsSaved) && (
+                    <p className="text-muted-foreground text-xs">
+                      You can turn it on now and finish connecting later — runs wait on anything
+                      that isn&apos;t connected yet.
+                    </p>
                   )}
-                </Button>
-              </>
-            )
-          ) : (
-            <>
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={step === 0 || installing || step >= 2}
-                onClick={() => setStep((s) => Math.max(0, s - 1))}
-              >
-                Back
-              </Button>
-              {step === 0 && (
-                <Button size="sm" disabled={!detail || !projectId} onClick={() => setStep(1)}>
-                  Continue
-                </Button>
+                </div>
               )}
-              {step === 1 && (
-                <Button size="sm" disabled={!projectId || missingInput || installing} onClick={runInstall}>
-                  {installing ? (
-                    <>
-                      <Loader2 className="size-4 animate-spin" /> Installing…
-                    </>
-                  ) : (
-                    <>
-                      <Check className="size-4" /> Install into {selectedProject?.name ?? 'project'}
-                    </>
+
+              {detail && step === 3 && installed && live && (
+                <div className="flex h-[320px] flex-col items-center justify-center text-center">
+                  <div className="bg-kortix-green/10 text-kortix-green mb-4 flex size-14 items-center justify-center rounded-2xl">
+                    <Check className="size-7" />
+                  </div>
+                  <p className="text-foreground text-base font-medium">It&apos;s live</p>
+                  <p className="text-muted-foreground mx-auto mt-1.5 max-w-xs text-sm leading-relaxed">
+                    The schedule is on. It makes its first run at the next scheduled time — watch it
+                    land in your project.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* ── Footer ────────────────────────────────────────────────── */}
+            <div className="border-border/60 flex items-center justify-between gap-2 border-t px-6 py-4">
+              {step === 3 && installed ? (
+                live ? (
+                  <>
+                    <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+                      Close
+                    </Button>
+                    <Button asChild size="sm">
+                      <Link href={`/projects/${installed.projectId}`}>Open project</Link>
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button variant="ghost" size="sm" disabled={activating} onClick={() => onOpenChange(false)}>
+                      Not now
+                    </Button>
+                    <Button
+                      size="sm"
+                      disabled={activating || installed.triggerSlugs.length === 0}
+                      onClick={activate}
+                    >
+                      {activating ? (
+                        <>
+                          <Loader2 className="size-4 animate-spin" /> Turning on…
+                        </>
+                      ) : (
+                        <>
+                          <Sparkles className="size-4" /> Turn it on
+                        </>
+                      )}
+                    </Button>
+                  </>
+                )
+              ) : (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={step === 0 || installing || step >= 2}
+                    onClick={() => setStep((s) => Math.max(0, s - 1))}
+                  >
+                    Back
+                  </Button>
+                  {step === 0 && (
+                    <Button size="sm" disabled={!detail || !projectId} onClick={() => setStep(1)}>
+                      Continue
+                    </Button>
                   )}
-                </Button>
+                  {step === 1 && (
+                    <Button size="sm" disabled={!projectId || missingInput || installing} onClick={runInstall}>
+                      {installing ? (
+                        <>
+                          <Loader2 className="size-4 animate-spin" /> Installing…
+                        </>
+                      ) : (
+                        <>
+                          <Check className="size-4" /> Install into {selectedProject?.name ?? 'project'}
+                        </>
+                      )}
+                    </Button>
+                  )}
+                  {step === 2 && (
+                    <Button size="sm" onClick={() => setStep(3)}>
+                      {allConnected && allSecretsSaved ? 'Finish' : 'Finish later'}
+                    </Button>
+                  )}
+                </>
               )}
-              {step === 2 && (
-                <Button size="sm" onClick={() => setStep(3)}>
-                  {allConnected && allSecretsSaved ? 'Finish' : 'Finish later'}
-                </Button>
-              )}
-            </>
-          )}
+            </div>
+          </div>
         </div>
       </DialogContent>
     </Dialog>
   );
 }
 
-function SetupRow({
-  icon,
-  label,
-  tag,
-  tone = 'new',
-}: {
-  icon: React.ReactNode;
-  label: string;
-  tag: string;
-  tone?: 'new' | 'reuse' | 'req';
-}) {
+function CoverItem({ icon, label }: { icon: React.ReactNode; label: string }) {
   return (
-    <li className="border-border/60 flex items-center gap-3 rounded-lg border px-3 py-2.5">
-      <span className="text-muted-foreground">{icon}</span>
-      <span className="text-foreground flex-1 text-sm font-medium">{label}</span>
-      <Badge
-        variant="outline"
-        className={cn(
-          'font-mono text-[10px] tracking-wider uppercase',
-          tone === 'reuse' && 'border-emerald-500/40 text-emerald-600 dark:text-emerald-400',
-          tone === 'req' && 'border-amber-500/40 text-amber-600 dark:text-amber-400',
-        )}
-      >
-        {tag}
-      </Badge>
+    <li className="flex items-center gap-2.5">
+      <span className="text-muted-foreground flex size-6 shrink-0 items-center justify-center">
+        {icon}
+      </span>
+      <span className="text-foreground/90 truncate text-[13px]">{label}</span>
     </li>
   );
 }

--- a/apps/web/src/lib/templates-client.ts
+++ b/apps/web/src/lib/templates-client.ts
@@ -1,7 +1,22 @@
-export { getTemplate, installTemplate } from '@kortix/sdk/projects-client';
+import { getEnv } from '@/lib/env-config';
+
+export { installTemplate } from '@kortix/sdk/projects-client';
 export type {
   TemplateDetail,
   TemplateInput,
   TemplateRequirement,
   TemplateInstallResult,
 } from '@kortix/sdk/projects-client';
+
+import type { TemplateDetail } from '@kortix/sdk/projects-client';
+
+function apiBase(): string {
+  return getEnv().BACKEND_URL || '/v1';
+}
+
+/** Public preview — no auth, so the wizard's Review/Configure work signed-out. */
+export async function getTemplate(id: string): Promise<TemplateDetail> {
+  const res = await fetch(`${apiBase()}/templates/${encodeURIComponent(id)}`);
+  if (!res.ok) throw new Error(`Template "${id}" not found`);
+  return (await res.json()) as TemplateDetail;
+}


### PR DESCRIPTION
Redesign the "Use this template" install wizard.

## Changes
- **Two-column layout** — a **cover panel on the left** (brand gradient + grain, an app-logo cluster with the Kortix mark, the template title, and a "what it sets up" list) and the wizard working area on the right.
- **Real brand logos** — via the public **Simple Icons CDN** (`cdn.simpleicons.org/<slug>`), on the connect rows, the secret rows (inferred from the key name, e.g. `GH_TOKEN` → GitHub), and the cover cluster. Falls back to a plug icon on load error. Plain `<img>` (the host isn't in `next/image` remotePatterns).
- **Proper `Stepper`** (`@/components/ui/stepper`) for Review → Configure → Connect → Go live, replacing the hand-rolled pills.
- **shadcn `Select`** for the project picker, replacing the native `<select>`.
- Connected/live states use the **`kortix-green`** token.

All install / connect / activate logic is unchanged — only the presentation.

Behind `KORTIX_TEMPLATES_ENABLED`.
