### PR TITLE
fix(sandbox-proxy): route Platinum opencode(4096) HTTP through the :8000 agent (fixes opencode attach 502)

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -559,6 +559,36 @@ describe('Preview proxy: forwarding', () => {
     expect(mockFetchCalls).toHaveLength(1);
   });
 
+  test('routes Platinum opencode(4096) HTTP through the in-box agent on 8000', async () => {
+    // opencode binds 127.0.0.1:4096 (loopback-only); Platinum's edge dials the
+    // guest eth0 IP, so :4096 is unreachable → 502. The proxy must resolve the
+    // agent's :8000 preview link (it bridges to localhost:4096 in-box). This is
+    // what makes `kortix sessions connect` / `opencode attach` work on Platinum.
+    // Distinct id so the module-level previewLinkCache can't collide with the
+    // PTY test above (which caches a non-preview.* URL for the same id:8000 key).
+    mockDbSandbox = { ...mockDbSandbox, provider: 'platinum' };
+    mockFetchResponses = [{ status: 200, body: '{"sessions":[]}' }];
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/platinum-oc-http/4096/session`, {
+      headers: { Authorization: 'Bearer test' },
+    });
+    expect(res.status).toBe(200);
+    // opencode's loopback-only 4096 is unreachable from the Platinum edge, so the
+    // proxy must resolve the agent's :8000 preview link instead of :4096.
+    expect(mockResolvedPreviewPorts).toEqual([8000]);
+  });
+
+  test('keeps Daytona opencode(4096) HTTP on the direct port 4096', async () => {
+    // provider defaults to 'daytona' — reaches opencode's 4096 directly, no reroute.
+    mockFetchResponses = [{ status: 200, body: '{"sessions":[]}' }];
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/daytona-oc-http/4096/session`, {
+      headers: { Authorization: 'Bearer test' },
+    });
+    expect(res.status).toBe(200);
+    expect(mockResolvedPreviewPorts).toEqual([4096]);
+  });
+
   test('syncs latest project secrets before forwarding prompt_async', async () => {
     mockFetchResponses = [
       { status: 200, body: '{"ok":true,"changed":true,"revision":"rev"}' },

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -335,6 +335,26 @@ function principalUserId(access: PreviewProxyAccess): string {
   return access.kind === 'principal' ? access.userId : '';
 }
 
+// opencode's HTTP/SSE + PTY server binds 127.0.0.1:4096 (loopback-only). Daytona
+// (a container) reaches it directly; Platinum (a microVM) has its edge dial the
+// guest's eth0 IP, so :4096 is unreachable → 502 ("upstream-unreachable"). This
+// is what breaks `kortix sessions connect` / `opencode attach` on Platinum.
+//
+// The sandbox agent on :8000 (binds 0.0.0.0, reachable) already reverse-proxies
+// every path to opencode's localhost:4096 in-box. So for Platinum we route
+// opencode(4096) traffic through :8000 — the same bridge the /pty/ WebSocket
+// already uses. The 8000-keyed guards below (session-visibility gate, /kortix/env
+// block) key on the EFFECTIVE upstream port so rerouted opencode traffic is
+// subject to the SAME protection as a direct :8000 request — the reroute changes
+// reachability, never the auth/control surface.
+const OPENCODE_INTERNAL_PORT = 4096;
+const SANDBOX_AGENT_PORT = 8000;
+function effectiveUpstreamPort(provider: string | null | undefined, addressedPort: number): number {
+  return provider === 'platinum' && addressedPort === OPENCODE_INTERNAL_PORT
+    ? SANDBOX_AGENT_PORT
+    : addressedPort;
+}
+
 export async function forwardToSandbox(
   sandboxId: string,
   port: number,
@@ -372,13 +392,23 @@ export async function forwardToSandbox(
       message: `Not authorized to access this sandbox, userId: ${userId}, sandboxId: ${sandboxId}`,
     });
   }
+  // Effective upstream port: Platinum opencode(4096) → the in-box agent on 8000.
+  // The 8000-keyed AUTH/CONTROL guards below (session-visibility gate + /kortix/env
+  // block) key on THIS, so rerouted opencode is gated exactly like a direct :8000
+  // request (sandbox ownership is already enforced unconditionally above). NOTE:
+  // redirectPrefix/X-Forwarded-Prefix and shouldSyncProjectEnvBeforeProxy stay on
+  // the client-addressed `port` ON PURPOSE — the prefix must reflect the URL the
+  // client actually used (/4096), and env-sync-before-prompt must behave identically
+  // to Daytona, which likewise skips it on the direct 4096 opencode path.
+  const upstreamPort = effectiveUpstreamPort(record.provider, port);
+
   // The daemon port serves the session's OpenCode conversation + owner-synced
   // secrets; gate it on SESSION visibility (mirrors loadVisibleSession on the
   // REST side), not just account membership — closes the window where a member
   // whose access was revoked/downgraded replays captured ids on the data path.
   if (
     access.kind === 'principal' &&
-    port === 8000 &&
+    upstreamPort === 8000 &&
     !(await canAccessSandboxSession({
       sessionId: record.sessionId,
       projectId: record.projectId,
@@ -392,7 +422,7 @@ export async function forwardToSandbox(
   // live secret env. The API reaches it server-to-server (postEnvToDaemon),
   // never through this user-facing proxy — block it so an account member can't
   // inject arbitrary env into a sandbox by POSTing /v1/p/<id>/8000/kortix/env.
-  if (port === 8000 && /^\/kortix\/env(?:$|[/?#])/.test(remainingPath)) {
+  if (upstreamPort === 8000 && /^\/kortix\/env(?:$|[/?#])/.test(remainingPath)) {
     return jsonProxyError({ error: 'not found' }, 404, origin);
   }
   if (record.status !== 'active') {
@@ -432,7 +462,7 @@ export async function forwardToSandbox(
     const budgetRemainingMs = PROXY_RETRY_BUDGET_MS - (Date.now() - proxyStartedAt);
     if (budgetRemainingMs <= 500) break; // out of budget → friendly page below
     try {
-      const { url: previewUrl, token: previewToken } = await resolvePreviewLink(record, port);
+      const { url: previewUrl, token: previewToken } = await resolvePreviewLink(record, upstreamPort);
       const targetUrl = previewUrl.replace(/\/$/, '') + remainingPath + queryString;
 
       if (shouldSyncProjectEnvBeforeProxy(port, method, remainingPath)) {


### PR DESCRIPTION
## Problem
`kortix sessions connect` / `opencode attach` works on Daytona sandboxes but **502s on Platinum** (Cloudflare 502 from api-eks).

## Root cause
opencode binds `127.0.0.1:4096` (loopback-only). Daytona is a **container** — its port proxy runs in-namespace, so `localhost:4096` is reachable. Platinum is a **microVM** — its edge dials the guest's eth0 IP, so a loopback-only port is unreachable → the edge returns 502.

The CLI (`apps/cli/.../sessions-connect.ts`) proxies opencode's HTTP/SSE to `/v1/p/{id}/4096/*`. On Platinum that 502s. The existing Platinum `/pty/`→8000 override only covered the **web terminal's WebSocket**, not `opencode attach`'s HTTP/SSE API.

## Fix
Route Platinum opencode(`4096`) HTTP through the in-box **sandbox agent on `:8000`** (binds `0.0.0.0`; already reverse-proxies every path to `localhost:4096` — the same bridge `/pty/` already uses). In `forwardToSandbox`:
- `effectiveUpstreamPort(provider, port)` → `8000` for Platinum `4096`, else unchanged.
- The 8000-keyed guards (session-visibility gate, `/kortix/env` block) + `resolvePreviewLink` key on the **effective** upstream port → rerouted opencode is gated **exactly like a direct `:8000` request** (sandbox ownership is already enforced unconditionally above).
- `redirectPrefix` + `shouldSyncProjectEnvBeforeProxy` intentionally stay on the client-addressed port → preserves Daytona parity.

Zero behavior change for Daytona / non-4096 ports / direct-8000 (there `upstreamPort === port`).

## Security
Ran an adversarial review (security/correctness/regression). The two "block" flags (env-sync + redirectPrefix keying) were adjudicated **false positives**: the session gate fires on `upstreamPort===8000`, sandbox ownership is unconditional, and env-sync is a secrets-*push* gated by both — keying those on the addressed port is deliberate (parity + correct client-facing prefix). Rationale is in the code comment.

## Tests
Added e2e coverage: Platinum opencode(4096) HTTP resolves the `:8000` preview link; Daytona stays on `:4096`. Full preview suite green (50/50), typecheck clean.

## Verify on dev
Deploy to dev → `kortix sessions connect <platinum-session-id>` → opencode attach loads with no 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)