### PR TITLE
fix(session): 'healthy is not defined' crash on session start

### DIFF
--- a/apps/web/src/features/files/hooks/use-server-health.ts
+++ b/apps/web/src/features/files/hooks/use-server-health.ts
@@ -29,7 +29,7 @@ export function useServerHealth(options?: { enabled?: boolean }) {
 
   return {
     data,
-    isLoading: status === 'connecting' && healthy === null,
+    isLoading: status === 'connecting' && runtimeHealthy === null,
     isError: status === 'unreachable',
     error: status === 'unreachable' ? new Error('Server unreachable') : null,
     refetch: async () => {


### PR DESCRIPTION
## Bug

Starting a new session crashed the connecting screen with:

> Something went wrong — `healthy is not defined`

## Cause

`useServerHealth` (`apps/web/src/features/files/hooks/use-server-health.ts`) referenced a bare `healthy` that was never declared — the store selector is bound to `runtimeHealthy` (line 23):

```ts
const runtimeHealthy = useSandboxConnectionStore((s) => s.healthy);
...
isLoading: status === 'connecting' && healthy === null,   // ❌ ReferenceError
```

It only threw when `status === 'connecting'` (short-circuit `&&`) — i.e. precisely while a new session is spinning up — so the connecting screen white-screened. (Next's build type-check doesn't hard-fail on this, which is why it deployed.)

## Fix

One line: `healthy` → `runtimeHealthy`.

Verified no sibling copies of the typo elsewhere (the `connecting-screen.tsx` uses of `healthy` are correctly bound to a store selector).