### PR TITLE
fix(file-viewer): contain the PPTX mobile Slides/Notes drawer to the panel

### DIFF
--- a/apps/web/src/components/file-renderers/pptx-renderer.tsx
+++ b/apps/web/src/components/file-renderers/pptx-renderer.tsx
@@ -164,7 +164,7 @@ export function PptxRenderer({
   return (
     <div
       data-pptx-minimal=""
-      className={cn('flex h-full w-full flex-col overflow-hidden bg-background', className)}
+      className={cn('relative flex h-full w-full flex-col overflow-hidden bg-background', className)}
     >
       <I18nextProvider i18n={getPptxI18n()}>
         <PowerPointViewer

--- a/apps/web/src/components/file-renderers/pptx-viewer.css
+++ b/apps/web/src/components/file-renderers/pptx-viewer.css
@@ -130,6 +130,25 @@
   display: none !important;
 }
 
+/* The mobile "Slides"/"Notes" sheets are `position: fixed` full-viewport modals.
+   That's right on a real phone, but here the viewer often lives in a narrow
+   desktop panel — a fixed modal would cover the whole app. The sheet is rendered
+   inside our wrapper (made a positioning context via `relative` above), so
+   anchoring it there with `absolute` turns it into a bottom sheet bounded by the
+   viewer panel. Present mode is a fixed, non-modal layer and is unaffected. */
+[data-pptx-minimal] [role='dialog'][aria-modal='true'] {
+  position: absolute !important;
+}
+
+/* That sheet reuses the desktop slides <aside>; stretched to the full sheet
+   width its fixed-size thumbnails leave dead space. Cap + center the list so it
+   reads as an intentional column of slides. */
+[data-pptx-minimal] [role='dialog'][aria-modal='true'] aside {
+  max-width: 320px;
+  margin-inline: auto;
+  border-inline: 0 !important;
+}
+
 /* ── Drive-grid thumbnail ──────────────────────────────────────────────────
  * The file grid renders this same viewer scaled down as a preview. There we
  * want just the first slide — drop all chrome (desktop control strip + slides


### PR DESCRIPTION
When the PPTX viewer sits in a narrow (**<768px**) container — e.g. a session side panel — the library switches to its **phone layout** (this is container-width based, not viewport). That layout's "Slides"/"Notes" sheets are `position: fixed` full-viewport modals, so tapping **Slides** covered the *entire app* with a cramped, left-aligned thumbnail list.

## Fix (CSS-only, 2 files)
The sheet is rendered **inside** our viewer wrapper, so:
- Make the wrapper a positioning context (`relative`) and override the sheet from `fixed` → `absolute` → it becomes a bottom sheet **bounded by the viewer panel**, not the window.
- Cap + center the reused slides `<aside>` so the thumbnails read as an intentional column instead of a strip with dead space.

**Present mode** uses a `fixed`, *non-modal* layer (verified), so it's untouched and still goes fullscreen. Panels ≥768px keep the desktop layout.

## Verification (Playwright, 1600px viewport)
- Narrow (638px) panel: Slides sheet now `absolute`, geometry == the panel (was full 1600px viewport). ✅
- Present from a wide panel: still a `fixed` 1600×900 fullscreen layer. ✅
- Thumbnails centered in a 320px column. ✅