### PR TITLE
fix(llm-gateway): preserve actionable upstream errors

### DIFF
--- a/packages/llm-gateway/src/pipeline/error-response.ts
+++ b/packages/llm-gateway/src/pipeline/error-response.ts
@@ -1,0 +1,41 @@
+export interface GatewayErrorContext {
+  message: string;
+  code: string;
+  upstreamCode?: string | number;
+  upstreamStatus?: number;
+  provider: string;
+  requestedModel: string;
+  resolvedModel: string;
+  requestId: string;
+  suggestion: string;
+}
+
+// OpenAI-compatible clients read `error.message`; generic HTTP clients commonly
+// read top-level `message`/`code`. Keep both so no client has to fall back to the
+// unhelpful HTTP status text (for example, "Bad Gateway").
+export function gatewayErrorBody(context: GatewayErrorContext): Record<string, unknown> {
+  const details = {
+    message: context.message,
+    type: context.code,
+    code: context.upstreamCode ?? context.code,
+    ...(context.upstreamStatus !== undefined ? { upstream_status: context.upstreamStatus } : {}),
+    provider: context.provider,
+    requested_model: context.requestedModel,
+    resolved_model: context.resolvedModel,
+    request_id: context.requestId,
+    suggestion: context.suggestion,
+  };
+
+  return {
+    error: details,
+    message: context.message,
+    code: context.code,
+    ...(context.upstreamCode ? { upstream_code: context.upstreamCode } : {}),
+    ...(context.upstreamStatus !== undefined ? { upstream_status: context.upstreamStatus } : {}),
+    provider: context.provider,
+    requested_model: context.requestedModel,
+    resolved_model: context.resolvedModel,
+    request_id: context.requestId,
+    suggestion: context.suggestion,
+  };
+}

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -1,7 +1,8 @@
-import { CircuitOpenError, UpstreamHttpError } from '../errors';
-import { CircuitBreaker } from '../resilience';
-import { callUpstream, type FetchImpl } from '../http';
 import type { GatewayConfig, GatewayLogger, UpstreamDescriptor } from '../domain';
+import { CircuitOpenError, UpstreamHttpError } from '../errors';
+import { type FetchImpl, callUpstream } from '../http';
+import type { CircuitBreaker } from '../resilience';
+import { gatewayErrorBody } from './error-response';
 import type { TraceEmitter, TraceFields } from './trace';
 
 // 4xx statuses that mean "this upstream won't serve you right now" rather than
@@ -18,6 +19,45 @@ function json(data: unknown, status = 200): Response {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function parseUpstreamBody(body: string): { message: string; code?: string } {
+  if (!body) return { message: 'Upstream request failed' };
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    const nested = parsed.error;
+    if (typeof nested === 'string') {
+      return { message: nested, code: typeof parsed.code === 'string' ? parsed.code : undefined };
+    }
+    if (nested && typeof nested === 'object') {
+      const error = nested as Record<string, unknown>;
+      return {
+        message: typeof error.message === 'string' ? error.message : body,
+        code:
+          typeof error.code === 'string'
+            ? error.code
+            : typeof error.type === 'string'
+              ? error.type
+              : undefined,
+      };
+    }
+    return {
+      message: typeof parsed.message === 'string' ? parsed.message : body,
+      code: typeof parsed.code === 'string' ? parsed.code : undefined,
+    };
+  } catch {
+    return { message: body };
+  }
+}
+
+function suggestionFor(status: number): string {
+  if (status === 401 || status === 402 || status === 403) {
+    return 'Check the provider credentials, billing, and model access, or switch to another model.';
+  }
+  if (status === 429) {
+    return 'Retry after a short wait, or switch to another model.';
+  }
+  return 'Retry the request. If the error continues, switch to another model.';
 }
 
 export interface FailoverContext {
@@ -115,13 +155,27 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
           continue;
         }
         debug('upstream_client_error_return', { provider: descriptor.provider, status: err.status });
+        const upstreamError = parseUpstreamBody(err.body);
         emit({
           ...trace, resolvedModel: descriptor.resolvedModel, provider: descriptor.provider,
           billingMode: descriptor.billingMode, status: err.status, ok: false,
-          errorCode: 'upstream_client_error', errorMessage: err.body, attempts, candidatesTried: tried,
+          errorCode: 'upstream_client_error', errorMessage: upstreamError.message, attempts, candidatesTried: tried,
           request: capturedRequest,
         });
-        return { kind: 'response', response: json({ error: err.body || `Upstream error ${err.status}` }, err.status) };
+        return {
+          kind: 'response',
+          response: json(gatewayErrorBody({
+            message: upstreamError.message,
+            code: 'upstream_client_error',
+            upstreamCode: upstreamError.code,
+            upstreamStatus: err.status,
+            provider: descriptor.provider,
+            requestedModel: trace.requestedModel ?? '',
+            resolvedModel: descriptor.resolvedModel ?? trace.requestedModel ?? '',
+            requestId,
+            suggestion: suggestionFor(err.status),
+          }), err.status),
+        };
       }
     }
   }
@@ -130,13 +184,31 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
     const open = lastError instanceof CircuitOpenError;
     const status = open ? 503 : 502;
     const errorCode = open ? 'upstream_unavailable' : 'upstream_unreachable';
-    debug('all_upstreams_exhausted', { circuitOpen: open, status, tried, attempts, error: errorMessage(lastError) });
+    const lastDescriptor = candidates.findLast((candidate) => candidate.provider === tried.at(-1));
+    const upstreamError = lastError instanceof UpstreamHttpError
+      ? parseUpstreamBody(lastError.body)
+      : { message: errorMessage(lastError) };
+    debug('all_upstreams_exhausted', { circuitOpen: open, status, tried, attempts, error: upstreamError.message });
     emit({
       ...trace, provider: tried[tried.length - 1] ?? '', status, ok: false,
-      errorCode, errorMessage: errorMessage(lastError), attempts, candidatesTried: tried,
+      resolvedModel: lastDescriptor?.resolvedModel,
+      errorCode, errorMessage: upstreamError.message, attempts, candidatesTried: tried,
       request: capturedRequest,
     });
-    return { kind: 'response', response: json({ error: 'All upstreams unavailable', code: errorCode }, status) };
+    return {
+      kind: 'response',
+      response: json(gatewayErrorBody({
+        message: upstreamError.message || 'All upstreams unavailable',
+        code: errorCode,
+        upstreamCode: upstreamError.code,
+        upstreamStatus: lastError instanceof UpstreamHttpError ? lastError.status : undefined,
+        provider: lastDescriptor?.provider ?? tried.at(-1) ?? '',
+        requestedModel: trace.requestedModel ?? '',
+        resolvedModel: lastDescriptor?.resolvedModel ?? trace.requestedModel ?? '',
+        requestId,
+        suggestion: suggestionFor(lastError instanceof UpstreamHttpError ? lastError.status : status),
+      }), status),
+    };
   }
 
   return { kind: 'success', value: { upstream, chosen, tried, attempts } };

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -258,6 +258,22 @@ describe("gateway.chatCompletions", () => {
       rawBody: '{"model":"x"}',
     });
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      message: "bad request",
+      code: "upstream_client_error",
+      upstream_status: 400,
+      provider: "a",
+      requested_model: "x",
+      resolved_model: "x",
+    });
+    expect(body.request_id).toMatch(/^req_/);
+    expect(body.suggestion).toContain("switch to another model");
+    expect(body.error).toMatchObject({
+      message: "bad request",
+      type: "upstream_client_error",
+      provider: "a",
+    });
     expect(bCalled).toBe(false);
   });
 
@@ -274,7 +290,15 @@ describe("gateway.chatCompletions", () => {
       rawBody: '{"model":"x"}',
     });
     expect(res.status).toBe(502);
-    expect((await res.json()).code).toBe("upstream_unreachable");
+    expect(await res.json()).toMatchObject({
+      message: "boom",
+      code: "upstream_unreachable",
+      upstream_status: 500,
+      provider: "openrouter",
+      requested_model: "x",
+      resolved_model: "x",
+      suggestion: "Retry the request. If the error continues, switch to another model.",
+    });
   });
 
   test("returns 503 once the provider circuit opens", async () => {
@@ -776,8 +800,19 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     expect(res.status).toBe(502);
     const body = await res.json();
     expect(body.code).toBe("upstream_error");
-    expect(body.error).toBe("Overloaded");
+    expect(body.message).toBe("Overloaded");
+    expect(body.error).toMatchObject({
+      message: "Overloaded",
+      type: "upstream_error",
+      code: "overloaded_error",
+      provider: "openrouter",
+    });
     expect(body.upstream_code).toBe("overloaded_error");
+    expect(body.provider).toBe("openrouter");
+    expect(body.requested_model).toBe("x");
+    expect(body.resolved_model).toBe("x");
+    expect(body.request_id).toMatch(/^req_/);
+    expect(body.suggestion).toContain("switch to another model");
     expect(calls).toBe(1); // the error candidate is excluded at once, not retried 3×
     await flush();
     expect(usage).toHaveLength(0);

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -17,6 +17,7 @@ import {
   extractUsageFromJson,
   jsonHasContent,
 } from '../usage';
+import { gatewayErrorBody } from './error-response';
 import { runFailover } from './failover';
 import { type StreamProbeResult, probeStream, relayStream } from './streaming';
 import { createTraceEmitter } from './trace';
@@ -359,6 +360,9 @@ export async function handleChatCompletions(
       const message = lastErrorFrame
         ? lastErrorFrame.message
         : 'All upstream candidates returned an empty completion';
+      const failedDescriptor = candidates.findLast((candidate) =>
+        emptyProviders.has(candidate.provider),
+      );
       emit({
         ...id,
         requestedModel,
@@ -373,11 +377,16 @@ export async function handleChatCompletions(
         metadata,
       });
       return json(
-        {
-          error: message,
+        gatewayErrorBody({
+          message,
           code: errorCode,
-          ...(lastErrorFrame?.code !== undefined ? { upstream_code: lastErrorFrame.code } : {}),
-        },
+          upstreamCode: lastErrorFrame?.code,
+          provider: failedDescriptor?.provider ?? tried.at(-1) ?? '',
+          requestedModel,
+          resolvedModel: failedDescriptor?.resolvedModel ?? routedModel,
+          requestId,
+          suggestion: 'Retry the request. If the error continues, switch to another model.',
+        }),
         502,
       );
     }


### PR DESCRIPTION
## Summary
- return OpenAI-compatible `error.message/type/code` so OpenCode does not collapse 502s to `Bad Gateway`
- include provider, requested/resolved model, upstream status/code, request ID, and recovery suggestion
- preserve the real nested upstream message for HTTP and mid-stream SSE failures

## Production evidence
Session `3f9e28d7-669b-41a9-aedd-e2ac5dbf88b0` sent `codex/gpt-5.5` for 121 requests after previously sending `glm-5.2`. Fifteen Codex requests failed with an upstream 200 SSE error frame whose only message was `Upstream stream error`; the old non-standard 502 body made OpenCode display only `Bad Gateway`.

## Verification
- `pnpm --filter @kortix/llm-gateway test` (132 pass)
- `pnpm --filter @kortix/llm-gateway typecheck`
- `git diff --check`