### PR TITLE
fix(sandbox-proxy): strip preview cookies upstream

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -931,6 +931,30 @@ describe('Preview proxy: forwarding', () => {
     expect(mockFetchCalls[0].headers['x-request-id']).toMatch(/^[a-z0-9]+-[a-z0-9]+$/);
   });
 
+  test('does not forward the preview session credential cookie upstream', async () => {
+    mockFetchResponses = [{ status: 200, body: 'OK' }];
+    const app = createProxyTestApp();
+    await app.request(`/v1/p/${TEST_SANDBOX_ID}/${TEST_PORT}/`, {
+      headers: {
+        Cookie: '__preview_session=eyJhbGciOiJIUzI1NiJ9.secret-token',
+        Authorization: 'Bearer test',
+      },
+    });
+    expect(mockFetchCalls[0].headers['cookie']).toBeUndefined();
+  });
+
+  test('does not forward arbitrary caller cookies upstream', async () => {
+    mockFetchResponses = [{ status: 200, body: 'OK' }];
+    const app = createProxyTestApp();
+    await app.request(`/v1/p/${TEST_SANDBOX_ID}/${TEST_PORT}/`, {
+      headers: {
+        Cookie: 'tracking=abc; __preview_session=secret; prefs=dark',
+        Authorization: 'Bearer test',
+      },
+    });
+    expect(mockFetchCalls[0].headers['cookie']).toBeUndefined();
+  });
+
   test('does NOT inject preview token when null', async () => {
     mockPreviewToken = null;
     mockFetchResponses = [{ status: 200, body: 'OK' }];

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -24,9 +24,12 @@ const preview = new Hono<{ Variables: { userId: string; userEmail: string } }>()
 // Hop-by-hop + caller-controlled headers we never forward upstream. Auth is
 // replaced with the sandbox service key, trace headers are regenerated, and
 // Accept-Encoding is forced to identity (raw byte passthrough).
+// Cookies may contain the caller's raw __preview_session credential and must
+// never reach arbitrary user-controlled apps running inside the sandbox.
 const STRIP_FORWARD_HEADERS = new Set([
   'host',
   'authorization',
+  'cookie',
   'traceparent',
   'x-request-id',
   'accept-encoding',


### PR DESCRIPTION
## Security fix

Prevents the authenticated preview proxy from forwarding caller cookies, including the raw `__preview_session` bearer credential, into arbitrary user-controlled sandbox applications.

## Verification

- `cd apps/api && bun test src/__tests__/e2e-preview-proxy.test.ts` — 52 pass, 0 fail
- Regression tests were proven red with the strip removed and green with it restored.
- `git diff --check` — pass
- `pnpm exec tsc --noEmit` currently hits four unrelated baseline errors in `packages/llm-gateway/src/pipeline/{failover,handler}.ts` (`Array.findLast` lib target).
- File-wide Biome currently reports pre-existing diagnostics in both touched legacy files; no unrelated formatting was changed.