### PR TITLE
fix(llm-gateway): restore API typecheck

### DIFF
--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -184,7 +184,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
     const open = lastError instanceof CircuitOpenError;
     const status = open ? 503 : 502;
     const errorCode = open ? 'upstream_unavailable' : 'upstream_unreachable';
-    const lastDescriptor = candidates.findLast((candidate) => candidate.provider === tried.at(-1));
+    const lastDescriptor = [...candidates].reverse().find((candidate) => candidate.provider === tried.at(-1));
     const upstreamError = lastError instanceof UpstreamHttpError
       ? parseUpstreamBody(lastError.body)
       : { message: errorMessage(lastError) };

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -301,6 +301,28 @@ describe("gateway.chatCompletions", () => {
     });
   });
 
+  test("reports the last attempted descriptor when every upstream fails", async () => {
+    const candidates: UpstreamDescriptor[] = [
+      { ...managed, provider: "first", resolvedModel: "first/model" },
+      { ...managed, provider: "last", resolvedModel: "last/model" },
+    ];
+    const { hooks } = makeHooks({ resolveUpstream: async () => candidates });
+    const res = await createGateway(
+      hooks,
+      { retry: { ...fastRetry, maxAttempts: 1 } },
+      { fetchImpl: async () => new Response("boom", { status: 500 }) },
+    ).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x"}',
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      provider: "last",
+      resolved_model: "last/model",
+    });
+  });
+
   test("returns 503 once the provider circuit opens", async () => {
     const fetchImpl: FetchImpl = async () =>
       new Response("boom", { status: 500 });

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -360,7 +360,7 @@ export async function handleChatCompletions(
       const message = lastErrorFrame
         ? lastErrorFrame.message
         : 'All upstream candidates returned an empty completion';
-      const failedDescriptor = candidates.findLast((candidate) =>
+      const failedDescriptor = [...candidates].reverse().find((candidate) =>
         emptyProviders.has(candidate.provider),
       );
       emit({


### PR DESCRIPTION
Replace `Array.findLast` with an ES2022-compatible reverse/find lookup so the API typecheck works with the repository tsconfig.

Verification:
- `pnpm --filter kortix-api typecheck`
- `bun test packages/llm-gateway/src/pipeline` — 44 pass, 0 fail