### PR TITLE
fix(gateway): standardize all error exits

### DIFF
--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -1,4 +1,4 @@
-import { createGateway } from '@kortix/llm-gateway';
+import { createGateway, gatewayErrorResponse } from '@kortix/llm-gateway';
 import { pickAutoModel } from '@kortix/llm-catalog';
 import { Hono } from 'hono';
 import { createApiClient } from './clients/api-client';
@@ -168,6 +168,7 @@ export function buildServer(): GatewayServer {
   const chatCompletions = async (c: {
     req: { header: (k: string) => string | undefined; text: () => Promise<string> };
   }) => {
+    const requestId = `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
     try {
       const res = await gateway.chatCompletions({
         authorization: c.req.header('authorization'),
@@ -178,9 +179,10 @@ export function buildServer(): GatewayServer {
     } catch (err) {
       console.error('[gateway] request failed', err);
       recordOutcome(503);
-      return new Response(JSON.stringify({ error: 'Gateway unavailable', code: 'gateway_error' }), {
-        status: 503,
-        headers: { 'content-type': 'application/json' },
+      return gatewayErrorResponse(503, {
+        message: 'Gateway unavailable', code: 'gateway_error', provider: '',
+        requestedModel: '', resolvedModel: '', requestId,
+        suggestion: 'Retry the request. If the error continues, switch to another model.',
       });
     }
   };

--- a/packages/llm-gateway/src/create-gateway.ts
+++ b/packages/llm-gateway/src/create-gateway.ts
@@ -6,6 +6,7 @@ import {
   handleChatCompletions,
 } from './pipeline';
 import { CircuitBreaker } from './resilience';
+import { gatewayErrorResponse } from './pipeline/error-response';
 
 export function createGateway(
   hooks: GatewayHooks,
@@ -61,20 +62,33 @@ export function createGateway(
   };
 
   const listModels = async (authorization: string | undefined): Promise<Response> => {
+    const requestId = `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
     const token = bearer(authorization);
-    if (!token) return jsonResponse({ error: 'Missing bearer token' }, 401);
-    const principal = await hooks.authenticate(token);
-    if (!principal) return jsonResponse({ error: 'Invalid token' }, 401);
-    if (!hooks.listModels) return jsonResponse({ models: {} });
+    if (!token) return gatewayErrorResponse(401, {
+      message: 'Missing bearer token', code: 'missing_token', provider: '',
+      requestedModel: '', resolvedModel: '', requestId,
+      suggestion: 'Sign in again or provide a valid API token, then retry.',
+    });
     try {
+      const principal = await hooks.authenticate(token);
+      if (!principal) return gatewayErrorResponse(401, {
+        message: 'Invalid token', code: 'invalid_token', provider: '',
+        requestedModel: '', resolvedModel: '', requestId,
+        suggestion: 'Sign in again or provide a valid API token, then retry.',
+      });
+      if (!hooks.listModels) return jsonResponse({ models: {} });
       const models = await hooks.listModels(principal);
       logger.info(
         `[gateway] models ${Object.keys(models).length} for acct=${principal.accountId.slice(0, 8)}`,
       );
       return jsonResponse({ models });
     } catch (err) {
-      logger.error('[gateway] listModels failed', err);
-      return jsonResponse({ error: 'models unavailable', code: 'models_error' }, 502);
+      logger.error('[gateway] model catalog request failed', err);
+      return gatewayErrorResponse(502, {
+        message: 'Model catalog unavailable', code: 'models_error', provider: '',
+        requestedModel: '', resolvedModel: '', requestId,
+        suggestion: 'Retry the request. If the error continues, reconnect the provider.',
+      });
     }
   };
 

--- a/packages/llm-gateway/src/index.ts
+++ b/packages/llm-gateway/src/index.ts
@@ -1,5 +1,7 @@
 export { createGateway } from './create-gateway';
 export type { ChatCompletionRequest, GatewayDeps } from './pipeline';
+export { gatewayErrorBody, gatewayErrorResponse } from './pipeline/error-response';
+export type { GatewayErrorContext } from './pipeline/error-response';
 
 export { callUpstream } from './http';
 export type { CallUpstreamOptions, FetchImpl } from './http';

--- a/packages/llm-gateway/src/pipeline/error-response.ts
+++ b/packages/llm-gateway/src/pipeline/error-response.ts
@@ -39,3 +39,10 @@ export function gatewayErrorBody(context: GatewayErrorContext): Record<string, u
     suggestion: context.suggestion,
   };
 }
+
+export function gatewayErrorResponse(status: number, context: GatewayErrorContext): Response {
+  return new Response(JSON.stringify(gatewayErrorBody(context)), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -60,6 +60,32 @@ function okFetch(data: unknown): FetchImpl {
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 5));
 
+function expectErrorContract(body: any, code: string): void {
+  expect(typeof body.message).toBe("string");
+  expect(body.message === "").toBe(false);
+  expect(typeof body.suggestion).toBe("string");
+  expect(body.suggestion === "").toBe(false);
+  expect(body).toMatchObject({
+    message: expect.any(String),
+    code,
+    provider: expect.any(String),
+    requested_model: expect.any(String),
+    resolved_model: expect.any(String),
+    request_id: expect.stringMatching(/^req_/),
+    suggestion: expect.any(String),
+    error: {
+      message: expect.any(String),
+      type: code,
+      code: expect.anything(),
+      provider: expect.any(String),
+      requested_model: expect.any(String),
+      resolved_model: expect.any(String),
+      request_id: expect.stringMatching(/^req_/),
+      suggestion: expect.any(String),
+    },
+  });
+}
+
 describe("gateway.chatCompletions", () => {
   test("401 without a bearer token, still traced", async () => {
     const { hooks, traces } = makeHooks();
@@ -879,5 +905,128 @@ describe("gateway.chatCompletions — request size guard", () => {
     });
 
     expect(res.status).toBe(200);
+  });
+});
+
+describe("gateway error envelope contract", () => {
+  test("all pre-dispatch rejection classes use the complete error envelope", async () => {
+    const cases: Array<{ code: string; run: () => Promise<Response> }> = [
+      {
+        code: "missing_token",
+        run: async () => createGateway(makeHooks().hooks).chatCompletions({
+          authorization: undefined, rawBody: "{}",
+        }),
+      },
+      {
+        code: "invalid_token",
+        run: async () => createGateway(makeHooks().hooks).chatCompletions({
+          authorization: "Bearer bad", rawBody: "{}",
+        }),
+      },
+      {
+        code: "subscription_required",
+        run: async () => createGateway(makeHooks({
+          assertBillingActive: async () => { throw new Error("inactive"); },
+        }).hooks).chatCompletions({ authorization: "Bearer good", rawBody: "{}" }),
+      },
+      {
+        code: "budget_exceeded",
+        run: async () => createGateway(makeHooks({
+          authorize: async () => ({ ok: false, status: 402, errorCode: "budget_exceeded", principal }),
+        }).hooks).chatCompletions({ authorization: "Bearer good", rawBody: "{}" }),
+      },
+      {
+        code: "invalid_json",
+        run: async () => createGateway(makeHooks().hooks).chatCompletions({
+          authorization: "Bearer good", rawBody: "not-json",
+        }),
+      },
+      {
+        code: "request_too_large",
+        run: async () => createGateway(makeHooks().hooks, { maxRequestBytes: 2 }).chatCompletions({
+          authorization: "Bearer good", rawBody: "{}x",
+        }),
+      },
+      {
+        code: "model_unavailable",
+        run: async () => createGateway(makeHooks({ resolveUpstream: async () => [] }).hooks)
+          .chatCompletions({ authorization: "Bearer good", rawBody: '{"model":"missing"}' }),
+      },
+    ];
+
+    for (const entry of cases) {
+      const response = await entry.run();
+      expectErrorContract(await response.json(), entry.code);
+    }
+  });
+
+  test("model catalog authentication and failure exits use the complete error envelope", async () => {
+    const gateway = createGateway(makeHooks({
+      listModels: async () => { throw new Error("catalog database detail"); },
+    }).hooks, {}, { logger: { info: () => {}, warn: () => {}, error: () => {} } });
+    const cases = [
+      { response: await gateway.listModels(undefined), code: "missing_token" },
+      { response: await gateway.listModels("Bearer bad"), code: "invalid_token" },
+      { response: await gateway.listModels("Bearer good"), code: "models_error" },
+    ];
+    for (const entry of cases) expectErrorContract(await entry.response.json(), entry.code);
+  });
+
+  test("model catalog catches authentication infrastructure failures", async () => {
+    const gateway = createGateway(makeHooks({
+      authenticate: async () => { throw new Error("auth database unavailable"); },
+    }).hooks, {}, { logger: { info: () => {}, warn: () => {}, error: () => {} } });
+    const response = await gateway.listModels("Bearer good");
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.message).toBe("Model catalog unavailable");
+    expectErrorContract(body, "models_error");
+  });
+
+  test("a reader failure before first content preserves the actual upstream error", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      pull() { throw new Error("provider socket reset"); },
+    });
+    const res = await createGateway(makeHooks().hooks, { retry: fastRetry }, {
+      fetchImpl: async () => new Response(stream, { status: 200 }),
+    }).chatCompletions({
+      authorization: "Bearer good", rawBody: '{"model":"x","stream":true}',
+    });
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.message).toBe("provider socket reset");
+    expectErrorContract(body, "upstream_error");
+  });
+
+  test("a reader failure after content emits a complete SSE error envelope and settles as failed", async () => {
+    const { hooks, traces } = makeHooks();
+    let pull = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pull += 1;
+        if (pull === 1) {
+          controller.enqueue(new TextEncoder().encode(
+            'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+          ));
+          return;
+        }
+        throw new Error("provider stream disconnected");
+      },
+    });
+    const res = await createGateway(hooks, { retry: fastRetry }, {
+      fetchImpl: async () => new Response(stream, { status: 200 }),
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    }).chatCompletions({
+      authorization: "Bearer good", rawBody: '{"model":"x","stream":true}',
+    });
+    expect(res.status).toBe(200);
+    const output = await new Response(res.body).text();
+    const errorLine = output.split("\n").find((line) => line.startsWith("data: {") && line.includes('"error"'));
+    expect(errorLine).toBeDefined();
+    const body = JSON.parse(errorLine!.slice(6));
+    expect(body.message).toBe("provider stream disconnected");
+    expectErrorContract(body, "upstream_stream_error");
+    await flush();
+    expect(traces.at(-1)).toMatchObject({ ok: false, errorCode: "upstream_stream_error" });
   });
 });

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -17,7 +17,7 @@ import {
   extractUsageFromJson,
   jsonHasContent,
 } from '../usage';
-import { gatewayErrorBody } from './error-response';
+import { gatewayErrorBody, gatewayErrorResponse } from './error-response';
 import { runFailover } from './failover';
 import { type StreamProbeResult, probeStream, relayStream } from './streaming';
 import { createTraceEmitter } from './trace';
@@ -173,7 +173,11 @@ export async function handleChatCompletions(
   if (!token) {
     step('reject_no_token');
     emit({ status: 401, ok: false, errorCode: 'missing_token' });
-    return json({ error: 'Missing bearer token' }, 401);
+    return gatewayErrorResponse(401, {
+      message: 'Missing bearer token', code: 'missing_token', provider: '',
+      requestedModel: '', resolvedModel: '', requestId,
+      suggestion: 'Sign in again or provide a valid API token, then retry.',
+    });
   }
 
   // Pre-dispatch gate: authenticate + billing + budget. When the host provides a
@@ -192,7 +196,12 @@ export async function handleChatCompletions(
       errorMessage: gate.message,
     });
     const message = gate.message ?? 'Unauthorized';
-    return json({ error: message, message, code: gate.errorCode }, gate.status);
+    return gatewayErrorResponse(gate.status, {
+      message, code: gate.errorCode, provider: '', requestedModel: '', resolvedModel: '', requestId,
+      suggestion: gate.status === 401
+        ? 'Sign in again or provide a valid API token, then retry.'
+        : 'Check account billing and budget settings, or use another available model.',
+    });
   }
   const principal = gate.principal;
   step('authenticated', {
@@ -218,13 +227,11 @@ export async function handleChatCompletions(
       errorCode: 'request_too_large',
       errorMessage: `Request body ${req.rawBody.length} bytes exceeds limit ${config.maxRequestBytes}`,
     });
-    return json(
-      {
-        error: `Request body of ${req.rawBody.length} bytes exceeds the ${config.maxRequestBytes}-byte limit`,
-        code: 'request_too_large',
-      },
-      413,
-    );
+    return gatewayErrorResponse(413, {
+      message: `Request body of ${req.rawBody.length} bytes exceeds the ${config.maxRequestBytes}-byte limit`,
+      code: 'request_too_large', provider: '', requestedModel: '', resolvedModel: '', requestId,
+      suggestion: 'Start a new session or reduce the conversation and attachment size, then retry.',
+    });
   }
 
   let body: Record<string, unknown>;
@@ -233,7 +240,11 @@ export async function handleChatCompletions(
   } catch {
     step('invalid_json');
     emit({ ...id, status: 400, ok: false, errorCode: 'invalid_json' });
-    return json({ error: 'Invalid JSON body' }, 400);
+    return gatewayErrorResponse(400, {
+      message: 'Invalid JSON body', code: 'invalid_json', provider: '',
+      requestedModel: '', resolvedModel: '', requestId,
+      suggestion: 'Correct the request body and retry.',
+    });
   }
 
   const requestedModel = typeof body.model === 'string' ? body.model : '';
@@ -282,10 +293,11 @@ export async function handleChatCompletions(
       request: capture(body),
       metadata,
     });
-    return json(
-      { error: `No upstream configured for model "${routedModel}"`, code: 'model_unavailable' },
-      400,
-    );
+    return gatewayErrorResponse(400, {
+      message: `No upstream configured for model "${routedModel}"`, code: 'model_unavailable',
+      provider: '', requestedModel, resolvedModel: routedModel, requestId,
+      suggestion: 'Choose another model or connect the required provider, then retry.',
+    });
   }
 
   const streaming = body.stream === true;
@@ -460,6 +472,18 @@ export async function handleChatCompletions(
       emptyProviders.add(chosen.provider);
       continue;
     }
+    if (probe.readError) {
+      lastErrorFrame = probe.readError;
+      logger.warn(
+        `[llm-gateway] upstream stream read failed during probe from ${chosen.provider} ${requestId}: "${probe.readError.message}"`,
+      );
+      step('upstream_stream_error', {
+        provider: chosen.provider,
+        message: probe.readError.message,
+      });
+      emptyProviders.add(chosen.provider);
+      continue;
+    }
     await registerEmptyCompletion(chosen.provider, { streaming: true });
   }
 
@@ -591,6 +615,12 @@ export async function handleChatCompletions(
     requestId,
     logger,
     settle,
+    errorContext: {
+      provider: finalDescriptor.provider,
+      requestedModel,
+      resolvedModel: finalDescriptor.resolvedModel ?? requestedModel,
+      requestId,
+    },
   });
 
   return new Response(readable, {

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -5,6 +5,7 @@ import {
   sseErrorFrame,
   sseHasContent,
 } from '../usage';
+import { gatewayErrorBody } from './error-response';
 
 export interface StreamRelayOptions {
   /** Fresh upstream body — mutually exclusive with `primed`. */
@@ -19,6 +20,12 @@ export interface StreamRelayOptions {
     response: unknown,
     streamError?: SseErrorFrame | null,
   ) => Promise<void>;
+  errorContext?: {
+    provider: string;
+    requestedModel: string;
+    resolvedModel: string;
+    requestId: string;
+  };
   /** Keep-alive interval in ms (overridable for tests). */
   heartbeatMs?: number;
 }
@@ -49,6 +56,7 @@ export interface StreamProbeResult {
   // "empty stop" hiccup that same-candidate retries target. The caller surfaces
   // this real error instead of retrying into a generic empty-completion.
   errorFrame?: SseErrorFrame | null;
+  readError?: SseErrorFrame | null;
   reader: ReadableStreamDefaultReader<Uint8Array>;
   chunks: Uint8Array[];
 }
@@ -73,12 +81,12 @@ export async function probeStream(body: ReadableStream<Uint8Array>): Promise<Str
     let value: Uint8Array | undefined;
     try {
       ({ done, value } = await reader.read());
-    } catch {
-      // A read error mid-probe is not this function's concern to report — whatever
-      // content/error (if any) arrived before it is all there is to judge on.
+    } catch (err) {
+      const message = boundedErrorMessage(err);
       return {
         hasContent: sseHasContent(buffer),
         errorFrame: sseErrorFrame(buffer),
+        readError: { message, code: 'upstream_stream_error' },
         reader,
         chunks,
       };
@@ -100,6 +108,11 @@ export async function probeStream(body: ReadableStream<Uint8Array>): Promise<Str
     const errorFrame = sseErrorFrame(buffer);
     if (errorFrame) return { hasContent: false, errorFrame, reader, chunks };
   }
+}
+
+function boundedErrorMessage(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return (message || 'Upstream stream failed').slice(0, 2_000);
 }
 
 export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array> {
@@ -185,12 +198,27 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
         await writeChunk(value);
       }
     } catch (err) {
+      const message = boundedErrorMessage(err);
       logger.warn(`[llm-gateway] stream read error ${requestId}:`, err);
       debug('stream_error', {
-        error: err instanceof Error ? err.message : String(err),
+        error: message,
         bytes,
         chunks,
       });
+      // Once headers are committed, SSE is the only remaining error channel.
+      // Emit the standard shape opencode understands instead of silently closing.
+      if (downstreamAlive) {
+        const frame = `data: ${JSON.stringify(gatewayErrorBody({
+          message,
+          code: 'upstream_stream_error',
+          provider: opts.errorContext?.provider ?? '',
+          requestedModel: opts.errorContext?.requestedModel ?? '',
+          resolvedModel: opts.errorContext?.resolvedModel ?? '',
+          requestId: opts.errorContext?.requestId ?? requestId,
+          suggestion: 'Retry the request. If the error continues, switch to another model.',
+        }))}\n\n`;
+        await writeChunk(new TextEncoder().encode(frame));
+      }
     } finally {
       try {
         await writer.close();


### PR DESCRIPTION
## Summary
- return the canonical OpenAI-compatible error envelope from every gateway-owned HTTP rejection and model-catalog failure
- preserve upstream reader exceptions before first content instead of degrading them to `empty_completion`
- emit a canonical actionable SSE error frame when an upstream reader fails after response headers are committed
- keep unexpected internal failures safe while correlating them with a request ID

## Production incident
The affected prod session explicitly switched from GLM to `codex/gpt-5.5` before the failures. The gateway did not substitute the model. Codex then returned HTTP 200 streams containing `Upstream stream error`; the old response shape was discarded by the OpenAI-compatible client and surfaced only as `Bad Gateway`.

## Verification
- `pnpm --filter @kortix/llm-gateway test` (137 pass)
- `pnpm --filter @kortix/llm-gateway typecheck`
- `pnpm --filter @kortix/llm-gateway-server test` (13 pass)
- `pnpm --filter @kortix/llm-gateway-server typecheck`
- `git diff --check`