### PR TITLE
fix(sessions): recover provider-lost runtimes safely

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -409,6 +409,9 @@ mock.module('../shared/supabase', () => ({
 mock.module('../shared/db', () => ({
   hasDatabase: () => true,
   db: {
+    transaction: async function <T>(fn: (tx: any) => Promise<T>): Promise<T> {
+      return fn(this);
+    },
     execute: async () => [],
     select: (fields?: Record<string, unknown>) => ({
       from: (table: unknown) => ({
@@ -1693,7 +1696,7 @@ describe('project session API contract', () => {
     releaseProviderStart?.();
   });
 
-  test('dashboard start preserves a provider-removed sandbox and never reallocates', async () => {
+  test('dashboard start retires a provider-confirmed missing sandbox and reallocates once', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1731,17 +1734,26 @@ describe('project session API contract', () => {
     );
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      stage: 'failed',
+      stage: 'provisioning',
       agent_name: 'default',
-      retriable: false,
-      reason: 'runtime_identity_unavailable',
-      sandbox: { external_id: 'box-deleted', status: 'stopped' },
+      retriable: true,
+      reason: 'runtime_recovery_provisioning',
+      sandbox: null,
     });
 
     expect(providerStartCalls).toBe(0);
-    expect(sandboxProvisionCalls).toBe(0);
-    expect(sessionSandboxRows).toHaveLength(1);
-    expect(sessionSandboxRows[0]?.externalId).toBe('box-deleted');
+    await flushUntil(() => sandboxProvisionCalls === 1);
+    expect(sandboxProvisionCalls).toBe(1);
+    expect(sessionSandboxRows).toHaveLength(0);
+    expect(sessionRow?.status).toBe('provisioning');
+    expect(sessionRow?.opencodeSessionId).toBeNull();
+    expect(sessionRow?.metadata).toMatchObject({
+      lastRuntimeRecovery: {
+        externalId: 'box-deleted',
+        reason: 'runtime_removed',
+        opencodeSessionId: 'ses_root_existing',
+      },
+    });
   });
 
   test('dashboard start preserves a running sandbox whose OpenCode runtime never becomes reachable', async () => {
@@ -1797,7 +1809,7 @@ describe('project session API contract', () => {
     expect(sessionSandboxRows[0]?.externalId).toBe('box-opencode-dead');
   });
 
-  test('restart of a provider-removed sandbox refuses replacement and preserves identity', async () => {
+  test('restart of a provider-removed sandbox provisions a replacement', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1828,19 +1840,63 @@ describe('project session API contract', () => {
       `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`,
       { method: 'POST' },
     );
-    expect(res.status).toBe(409);
+    expect(res.status).toBe(202);
     expect(await res.json()).toMatchObject({
-      code: 'SESSION_RUNTIME_IDENTITY_UNAVAILABLE',
+      ok: true,
       session_id: SESSION_ID,
-      external_id: 'box-deleted',
-      reason: 'runtime_identity_unavailable',
+      status: 'provisioning',
+      reason: 'runtime_recovery_provisioning',
     });
 
     expect(providerStartCalls).toBe(0);
-    expect(sandboxProvisionCalls).toBe(0);
-    expect(sessionRow?.status).toBe('stopped');
-    expect(sessionSandboxRows).toHaveLength(1);
-    expect(sessionSandboxRows[0]?.externalId).toBe('box-deleted');
+    await flushUntil(() => sandboxProvisionCalls === 1);
+    expect(sandboxProvisionCalls).toBe(1);
+    expect(sessionRow?.status).toBe('provisioning');
+    expect(sessionSandboxRows).toHaveLength(0);
+  });
+
+  test('restart self-heals when provider status is uncertain but start returns not-found', async () => {
+    const app = createApp();
+    sessionRow = {
+      ...sessionRow!,
+      status: 'running',
+      opencodeSessionId: 'ses_root_existing',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'daytona',
+        externalId: 'box-missing-on-start',
+        baseUrl: null,
+        status: 'active',
+        config: {},
+        metadata: {},
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-02T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z'),
+      },
+    ];
+    providerStatus = 'unknown';
+    providerStartError = Object.assign(new Error('sandbox not found'), { status: 404 });
+
+    const res = await app.request(
+      `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`,
+      { method: 'POST' },
+    );
+    expect(res.status).toBe(202);
+    await flushUntil(() => sandboxProvisionCalls === 1);
+    expect(providerStartCalls).toBe(1);
+    expect(sandboxProvisionCalls).toBe(1);
+    expect(sessionRow?.status).toBe('provisioning');
+    expect(sessionRow?.metadata).toMatchObject({
+      lastRuntimeRecovery: {
+        externalId: 'box-missing-on-start',
+        reason: 'restart_missing_runtime',
+      },
+    });
   });
 
   test('dashboard start recovery of an already-bootstrapped session provisions without replaying the initial prompt', async () => {

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -53,11 +53,17 @@ let updateCalls: Array<{
   sql: string;
   params: unknown[];
 }> = [];
-let scenario: { archiveBeforeFinish: boolean; projectSessionStatusAtCheck: string } = {
+let scenario: {
+  archiveBeforeFinish: boolean;
+  projectSessionStatusAtCheck: string;
+  projectSessionMetadataAtCheck: Record<string, unknown>;
+} = {
   archiveBeforeFinish: false,
   projectSessionStatusAtCheck: 'provisioning',
+  projectSessionMetadataAtCheck: {},
 };
 let removedIds: string[] = [];
+let stoppedIds: string[] = [];
 let onRemoved: (() => void) | null = null;
 let computeSessionsOpened: Array<{ sandboxId: string; accountId: string }> = [];
 let onComputeOpened: (() => void) | null = null;
@@ -110,7 +116,10 @@ mock.module('../../shared/db', () => ({
         where: (_cond: unknown) => ({
           limit: async (_n: number) => {
             if (table === projectSessions) {
-              return [{ status: scenario.projectSessionStatusAtCheck }];
+              return [{
+                status: scenario.projectSessionStatusAtCheck,
+                metadata: scenario.projectSessionMetadataAtCheck,
+              }];
             }
             return [];
           },
@@ -150,7 +159,9 @@ mock.module('../providers', () => ({
       onRemoved?.();
     },
     start: async () => {},
-    stop: async () => {},
+    stop: async (externalId: string) => {
+      stoppedIds.push(externalId);
+    },
     getStatus: async () => 'running',
     resolveEndpoint: async () => ({ url: '', headers: {} }),
     resolveProxyEndpoint: async () => ({ url: '', headers: {} }),
@@ -228,8 +239,13 @@ function waitFor(setResolver: (resolve: () => void) => void, timeoutMs = 2000): 
 
 beforeEach(() => {
   updateCalls = [];
-  scenario = { archiveBeforeFinish: false, projectSessionStatusAtCheck: 'provisioning' };
+  scenario = {
+    archiveBeforeFinish: false,
+    projectSessionStatusAtCheck: 'provisioning',
+    projectSessionMetadataAtCheck: {},
+  };
   removedIds = [];
+  stoppedIds = [];
   onRemoved = null;
   computeSessionsOpened = [];
   onComputeOpened = null;
@@ -325,5 +341,21 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(flipCall).toBeUndefined();
 
     expect(recordedEvents.some((e) => e.outcome === 'stopped')).toBe(true);
+  });
+
+  test('manual stop racing provider create stops and preserves the sandbox instead of removing it', async () => {
+    scenario.projectSessionStatusAtCheck = 'stopped';
+    const eventRecorded = waitFor((resolve) => { onProviderEvent = resolve; });
+    await provisionSessionSandbox(baseOpts());
+    await eventRecorded;
+
+    expect(removedIds).toEqual([]);
+    expect(stoppedIds).toEqual([EXTERNAL_ID]);
+    expect(computeSessionsOpened).toEqual([]);
+    const preserved = updateCalls.find(
+      (c) => c.table === sessionSandboxes && c.updates.status === 'stopped',
+    );
+    expect(preserved?.updates.externalId).toBe(EXTERNAL_ID);
+    expect(preserved?.updates.metadata).toMatchObject({ stoppedDuringProvisioning: true });
   });
 });

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -460,13 +460,15 @@ export async function provisionSessionSandbox(opts: {
       const timeline = tl.summary();
 
       const [currentSession] = await db
-        .select({ status: projectSessions.status })
+        .select({ status: projectSessions.status, metadata: projectSessions.metadata })
         .from(projectSessions)
         .where(eq(projectSessions.sessionId, sandbox.sandboxId))
         .limit(1);
-      if (currentSession?.status === 'stopped') {
-        // The session was explicitly deleted while this box was still being
-        // created — deletion is the one case where we remove the provider box.
+      const currentSessionMetadata =
+        (currentSession?.metadata as Record<string, unknown> | null) ?? {};
+      if (typeof currentSessionMetadata.deletedAt === 'string') {
+        // Only an explicit deletion authorizes provider removal. A normal stop
+        // uses the same status and must never be mistaken for deletion.
         await provider.remove(result.externalId).catch((err) => {
           console.warn(`[session-sandbox] failed to remove deleted session sandbox ${result.externalId}:`, err);
         });
@@ -495,6 +497,48 @@ export async function provisionSessionSandbox(opts: {
         recordProviderEvent({
           provider: providerName, kind: 'provision', outcome: 'stopped',
           totalMs: stopTl.totalMs, marks: stopTl.marks, attempts,
+          sessionId: sandbox.sandboxId, accountId,
+        });
+        return;
+      }
+
+      if (currentSession?.status === 'stopped') {
+        // A manual stop or idle reconciliation won while provider.create was
+        // in flight. Preserve the disk/identity and power it down.
+        await provider.stop(result.externalId).catch((err) => {
+          console.warn(
+            `[session-sandbox] failed to stop concurrently-paused sandbox ${result.externalId}:`,
+            err,
+          );
+        });
+        await db
+          .update(sessionSandboxes)
+          .set({
+            externalId: result.externalId,
+            baseUrl: result.baseUrl || null,
+            status: 'stopped',
+            metadata: {
+              ...buildSandboxInitSuccessMetadata(
+                sandbox.metadata as Record<string, unknown> | null,
+                {
+                  ...result.metadata,
+                  provisionTimeline: timeline,
+                  daytonaSandboxId: result.externalId,
+                },
+                attempts,
+              ),
+              stoppedDuringProvisioning: true,
+              stoppedAt: new Date().toISOString(),
+            },
+            updatedAt: new Date(),
+          })
+          .where(eq(sessionSandboxes.sandboxId, sandbox.sandboxId));
+        tl.mark('row-stopped-during-provision');
+        tl.log({ provider: providerName, attempts, stoppedDuringProvisioning: true });
+        const stoppedTl = tl.summary();
+        recordProviderEvent({
+          provider: providerName, kind: 'provision', outcome: 'stopped',
+          totalMs: stoppedTl.totalMs, marks: stoppedTl.marks, attempts,
           sessionId: sandbox.sandboxId, accountId,
         });
         return;

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -22,6 +22,7 @@ import {
 import { ensureOpencodeSessionPin } from '../opencode-mapping';
 import {
   preserveEstablishedRuntime,
+  retireConfirmedMissingRuntime,
   retireUnmaterializedRuntime,
   RUNTIME_IDENTITY_UNAVAILABLE,
 } from '../runtime-identity';
@@ -606,6 +607,33 @@ async function preserveEstablishedRuntimeOnOpen(
   };
 }
 
+async function recoverConfirmedMissingRuntimeOnOpen(
+  loaded: { row: ProjectRow; userId: string },
+  visible: {
+    row: {
+      sandboxProvider: string;
+      baseRef: string | null;
+      agentName: string | null;
+      metadata?: Record<string, unknown> | null;
+    };
+  },
+  projectId: string,
+  sessionId: string,
+  row: typeof sessionSandboxes.$inferSelect,
+  reason: string,
+): Promise<SessionStartResult> {
+  const retired = await retireConfirmedMissingRuntime(row, reason);
+  if (retired) await allocateRuntimeOnOpen(loaded, visible.row, projectId, sessionId);
+  return {
+    stage: 'provisioning',
+    agent_name: visible.row.agentName ?? 'default',
+    retriable: true,
+    sandbox: null,
+    opencode_session_id: null,
+    reason: retired ? 'runtime_recovery_provisioning' : 'runtime_recovery_in_progress',
+  };
+}
+
 /**
  * THE authoritative session-open path — the single call the dashboard uses to
  * bring a session's runtime up. Idempotent: provisions a missing sandbox,
@@ -755,7 +783,7 @@ export async function openSession(args: {
         reason: 'runtime_removed_checking',
       };
     }
-    return preserveEstablishedRuntimeOnOpen(
+    return recoverConfirmedMissingRuntimeOnOpen(
       loaded,
       visible,
       projectId,

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -1,5 +1,5 @@
 import { projectSessions, sessionSandboxes } from '@kortix/db';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 
 import { endComputeSession } from '../billing/services/compute-metering';
 import { db } from '../shared/db';
@@ -103,5 +103,103 @@ export async function retireUnmaterializedRuntime(
         isNull(sessionSandboxes.externalId),
       ),
     );
+  return true;
+}
+
+/**
+ * Detach a provider-confirmed missing runtime so the same logical session can
+ * provision replacement compute. This never calls provider.remove(): the
+ * provider already says the object is gone. A guarded project-session update
+ * prevents duplicate recovery and refuses to revive explicit deletions.
+ */
+export async function retireConfirmedMissingRuntime(
+  row: RuntimeIdentityRow,
+  reason: string,
+  now = new Date(),
+): Promise<boolean> {
+  if (!row.externalId) {
+    throw new Error(
+      `Cannot retire sandbox ${row.sandboxId} as provider-missing without an external_id`,
+    );
+  }
+  const externalId = row.externalId;
+
+  const retired = await db.transaction(async (tx) => {
+    const [session] = await tx
+      .select({
+        metadata: projectSessions.metadata,
+        opencodeSessionId: projectSessions.opencodeSessionId,
+      })
+      .from(projectSessions)
+      .where(eq(projectSessions.sessionId, row.sessionId))
+      .limit(1);
+    if (!session) return false;
+
+    const sessionMetadata = {
+      ...((session.metadata as Record<string, unknown> | null) ?? {}),
+    };
+    if (typeof sessionMetadata.deletedAt === 'string') return false;
+
+    const previousRecoveries = Array.isArray(sessionMetadata.runtimeRecoveries)
+      ? sessionMetadata.runtimeRecoveries.slice(-9)
+      : [];
+    const recovery = {
+      externalId,
+      detectedAt: now.toISOString(),
+      reason,
+      opencodeSessionId: session.opencodeSessionId ?? null,
+    };
+    const [won] = await tx
+      .update(projectSessions)
+      .set({
+        status: 'provisioning',
+        error: null,
+        sandboxUrl: null,
+        opencodeSessionId: null,
+        metadata: {
+          ...sessionMetadata,
+          runtimeRecoveries: [...previousRecoveries, recovery],
+          lastRuntimeRecovery: recovery,
+        },
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(projectSessions.sessionId, row.sessionId),
+          sql`(${projectSessions.metadata}->>'deletedAt') is null`,
+          sql`exists (
+            select 1 from ${sessionSandboxes} current_runtime
+            where current_runtime.session_id = ${row.sessionId}
+              and current_runtime.external_id = ${externalId}
+          )`,
+        ),
+      )
+      .returning({ sessionId: projectSessions.sessionId });
+    if (!won) return false;
+
+    await tx
+      .delete(sessionSandboxes)
+      .where(
+        and(
+          eq(sessionSandboxes.sandboxId, row.sandboxId),
+          eq(sessionSandboxes.externalId, externalId),
+        ),
+      );
+    return true;
+  });
+
+  if (!retired) return false;
+  await endComputeSession(row.sandboxId).catch((err) =>
+    console.warn(
+      `[runtime-identity] failed to close compute for provider-missing ${row.sandboxId}/${externalId}:`,
+      err,
+    ),
+  );
+  console.error('[runtime-identity] retired provider-confirmed missing sandbox', {
+    sessionId: row.sessionId,
+    sandboxId: row.sandboxId,
+    externalId,
+    reason,
+  });
   return true;
 }

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -15,10 +15,8 @@ import {
   isMissingRuntimeError,
 } from '../routes/shared';
 import {
-  preserveEstablishedRuntime,
+  retireConfirmedMissingRuntime,
   retireUnmaterializedRuntime,
-  RUNTIME_IDENTITY_UNAVAILABLE,
-  RUNTIME_IDENTITY_ERROR,
 } from '../runtime-identity';
 
 export async function deleteSession(input: {
@@ -205,15 +203,18 @@ export async function restartSession(input: {
     const provider = getProvider(existingSandbox.provider as SandboxProviderName);
     const providerStatus = await provider.getStatus(externalId).catch(() => 'unknown' as const);
     if (providerStatus === 'removed') {
-      await preserveEstablishedRuntime(existingSandbox, 'restart_removed_runtime');
+      const retired = await retireConfirmedMissingRuntime(
+        existingSandbox,
+        'restart_removed_runtime',
+      );
+      if (retired) await provisionReplacementRuntime();
       return {
-        status: 409,
+        status: 202,
         body: {
-          error: RUNTIME_IDENTITY_ERROR,
-          code: 'SESSION_RUNTIME_IDENTITY_UNAVAILABLE',
+          ok: true,
           session_id: sessionId,
-          external_id: externalId,
-          reason: RUNTIME_IDENTITY_UNAVAILABLE,
+          status: 'provisioning',
+          reason: retired ? 'runtime_recovery_provisioning' : 'runtime_recovery_in_progress',
         },
       };
     }
@@ -247,7 +248,11 @@ export async function restartSession(input: {
       } catch (err) {
         console.warn(`[projects] restart-in-place failed for ${sessionId}:`, err);
         if (isMissingRuntimeError(err)) {
-          await preserveEstablishedRuntime(existingSandbox, 'restart_missing_runtime').catch(() => {});
+          const retired = await retireConfirmedMissingRuntime(
+            existingSandbox,
+            'restart_missing_runtime',
+          ).catch(() => false);
+          if (retired) await provisionReplacementRuntime();
           return;
         }
         await db

--- a/apps/web/src/app/error.test.ts
+++ b/apps/web/src/app/error.test.ts
@@ -1,35 +1,8 @@
 import { expect, test } from 'bun:test';
 
-import { isRuntimeNotReadyError } from './error';
-
-test('matches the existing sandbox/opencode boot-race messages', () => {
-  expect(isRuntimeNotReadyError(new Error('Server URL not ready — sandbox is still loading'))).toBe(true);
-  expect(isRuntimeNotReadyError(new Error('opencode not ready'))).toBe(true);
-});
-
-// Regression: the SDK's per-session runtime errors weren't recognized as
-// transient boot races, so they fell through to the hard crash screen instead
-// of the "Starting your session…" loader.
-test('matches SessionNotReadyError\'s message', () => {
-  expect(
-    isRuntimeNotReadyError(
-      new Error(
-        'Session runtime not ready — call `await session.ensureReady()` before calling `health`.',
-      ),
-    ),
-  ).toBe(true);
-});
-
-test('matches the "no auth token provider configured" message', () => {
-  expect(
-    isRuntimeNotReadyError(
-      new Error(
-        '[opencode-sdk] No auth token provider configured — call configureKortix()/createKortix() before talking to a sandbox runtime.',
-      ),
-    ),
-  ).toBe(true);
-});
-
-test('does not match an unrelated error', () => {
-  expect(isRuntimeNotReadyError(new Error('Something else went wrong'))).toBe(false);
+test('global error boundary never renders or reloads a session-starting screen', async () => {
+  const source = await Bun.file(import.meta.dir + '/error.tsx').text();
+  expect(source).not.toContain('Starting your session');
+  expect(source).not.toContain('isRuntimeNotReadyError');
+  expect(source).not.toContain('setTimeout');
 });

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -7,24 +7,12 @@ import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useEffect } from 'react';
 
-/** Transient errors thrown while a session's sandbox/opencode runtime is still
- *  booting — a stray `getClient()` before the runtime URL is pinned. These are
- *  NOT real failures; they clear within a couple seconds. Exported for
- *  `error.test.ts`. */
-export function isRuntimeNotReadyError(error: Error): boolean {
-  const m = error?.message ?? '';
-  return /server url not ready|sandbox is still loading|opencode not ready|session runtime not ready|no auth token provider configured/i.test(
-    m,
-  );
-}
-
 export default function Error({
   error,
 }: {
   error: Error & { digest?: string; statusCode?: number };
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
-  const transient = isRuntimeNotReadyError(error);
 
   const handleReset = () => {
     try {
@@ -35,33 +23,9 @@ export default function Error({
   };
 
   useEffect(() => {
-    if (transient) return; // boot races aren't real errors — don't log/report
     console.error('[Kortix Home Error]', error);
     Sentry.captureException(error);
-  }, [error, transient]);
-
-  // Auto-recover from the sandbox-still-loading race: give the runtime a moment to
-  // pin its URL, then hard-reload (the manual "Try again" path, which reliably
-  // recovers) — so the user sees a brief loader instead of a hard crash.
-  useEffect(() => {
-    if (!transient) return;
-    const t = setTimeout(() => {
-      if (typeof window !== 'undefined') window.location.reload();
-    }, 2000);
-    return () => clearTimeout(t);
-  }, [transient]);
-
-  if (transient) {
-    return (
-      <div className="flex min-h-screen items-center justify-center p-4">
-        <div className="flex flex-col items-center justify-center gap-4 text-center">
-          <KortixHyperLogo size={50} />
-          <span className="border-muted-foreground/30 border-t-foreground size-5 animate-spin rounded-full border-2" />
-          <p className="text-base-500 text-sm">Starting your session…</p>
-        </div>
-      </div>
-    );
-  }
+  }, [error]);
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- replace a provider-confirmed missing runtime under the same logical session instead of permanently bricking it
- preserve prior external/OpenCode identity in bounded recovery metadata and prevent duplicate/concurrent recovery
- distinguish explicit deletion from ordinary stopped state so a provisioning/stop race never calls provider remove
- remove the global Starting your session auto-reload error boundary

## Verification
- `pnpm --filter kortix-api exec dotenvx run -- bun test ./src/__tests__/e2e-project-session-contract.test.ts` (33 pass)
- `pnpm --filter kortix-api exec dotenvx run -- bun test ./src/platform/services/session-sandbox.test.ts` (4 pass)
- `pnpm --filter kortix-api exec dotenvx run -- bun test ./src/projects/sandbox-reaper.test.ts` (41 pass)
- `pnpm --filter kortix-api exec dotenvx run -- bun test ./src/projects/session-lifecycle/__tests__/continue-session-deleted-guard.test.ts` (2 pass)
- `pnpm --filter kortix-api typecheck`
- `cd apps/web && bun test ./src/app/error.test.ts`
- `cd apps/web && pnpm exec eslint src/app/error.tsx src/app/error.test.ts`
- real local HTTP: `GET localhost:19808/v1/health` 200; unauthenticated recovery route rejects with 401

## Incident
Dev session d49046ed-5486-467b-b194-6a54fdfe610d was permanently stopped after Platinum returned 404 for sbx_01KX9N5ER3055G4V5ZQ9P8BT0D. This change makes that provider-loss class self-healing without treating uncertain health failures as data loss.