### PR TITLE
fix(sessions): verify provider restart state

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -33,6 +33,7 @@ let branchCreateCalls = 0;
 let sandboxProvisionCalls = 0;
 let providerStartCalls = 0;
 let providerStatus = 'stopped';
+let providerStatusAfterStart: string | null = null;
 let providerStartError: Error | null = null;
 let providerStartGate: Promise<void> | null = null;
 let releaseProviderStart: (() => void) | null = null;
@@ -80,6 +81,7 @@ function resetState() {
   sandboxProvisionCalls = 0;
   providerStartCalls = 0;
   providerStatus = 'stopped';
+  providerStatusAfterStart = null;
   providerStartError = null;
   providerStartGate = null;
   releaseProviderStart = null;
@@ -286,6 +288,7 @@ mock.module('../platform/providers', () => ({
     start: async () => {
       providerStartCalls += 1;
       if (providerStartError) throw providerStartError;
+      if (providerStatusAfterStart) providerStatus = providerStatusAfterStart;
       if (providerStartGate) await providerStartGate;
     },
     stop: async () => undefined,
@@ -1797,6 +1800,46 @@ describe('project session API contract', () => {
       lastRuntimeRecovery: {
         externalId: 'box-missing-on-start',
         reason: 'restart_missing_runtime',
+      },
+    });
+  });
+
+  test('restart self-heals when provider accepts start but then reports removed', async () => {
+    const app = createApp();
+    sessionRow = { ...sessionRow!, status: 'running', opencodeSessionId: 'ses_root_existing' };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'box-accepted-start-then-removed',
+        baseUrl: null,
+        status: 'active',
+        config: {},
+        metadata: {},
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-02T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z'),
+      },
+    ];
+    providerStatus = 'unknown';
+    providerStatusAfterStart = 'removed';
+
+    const res = await app.request(
+      `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`,
+      { method: 'POST' },
+    );
+    expect(res.status).toBe(202);
+    await flushUntil(() => sandboxProvisionCalls === 1);
+    expect(providerStartCalls).toBe(1);
+    expect(sandboxProvisionCalls).toBe(1);
+    expect(sessionRow?.status).toBe('provisioning');
+    expect(sessionRow?.metadata).toMatchObject({
+      lastRuntimeRecovery: {
+        externalId: 'box-accepted-start-then-removed',
+        reason: 'restart_post_start_removed',
       },
     });
   });

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -237,6 +237,28 @@ export async function restartSession(input: {
       try {
         await provider.stop(externalId).catch(() => {});
         await provider.start(externalId);
+        // A provider may acknowledge start before discovering that the backing
+        // runtime is gone (observed live with Platinum: POST start succeeded,
+        // the next GET returned removed). Never mark the DB running from command
+        // acceptance alone; verify provider truth first.
+        let verifiedStatus = await provider.getStatus(externalId).catch(() => 'unknown' as const);
+        for (let attempt = 1; verifiedStatus !== 'running' && verifiedStatus !== 'removed' && attempt < 15; attempt += 1) {
+          await Bun.sleep(1_000);
+          verifiedStatus = await provider.getStatus(externalId).catch(() => 'unknown' as const);
+        }
+        if (verifiedStatus === 'removed') {
+          const retired = await retireConfirmedMissingRuntime(
+            existingSandbox,
+            'restart_post_start_removed',
+          ).catch(() => false);
+          if (retired) await provisionReplacementRuntime();
+          return;
+        }
+        if (verifiedStatus !== 'running') {
+          throw new Error(
+            `Sandbox ${externalId} did not reach running after restart (provider status: ${verifiedStatus})`,
+          );
+        }
         await db
           .update(sessionSandboxes)
           .set({ status: 'active', updatedAt: new Date() })


### PR DESCRIPTION
## Live finding
After #4451 deployed, the original incident sandbox reproduced a second provider contract failure: Platinum accepted POST start, but GET status immediately afterward remained removed. The restart worker trusted command acceptance and marked the dead runtime running.

## Fix
- verify provider state after restart before writing running/active
- allow up to 15 seconds for legitimate transitional states
- if post-start state is removed, retire the missing runtime and provision replacement compute under the same logical session

## Verification
- `pnpm --filter kortix-api exec dotenvx run -- bun test ./src/__tests__/e2e-project-session-contract.test.ts` (34 pass)
- `pnpm --filter kortix-api typecheck`
- live dev reproduction against session `d49046ed-5486-467b-b194-6a54fdfe610d`