### PR TITLE
fix(sessions): reclaim missing runtime identity safely

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1652,7 +1652,15 @@ describe('project session API contract', () => {
     expect(providerStartCalls).toBe(0);
     await flushUntil(() => sandboxProvisionCalls === 1);
     expect(sandboxProvisionCalls).toBe(1);
-    expect(sessionSandboxRows).toHaveLength(0);
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]).toMatchObject({
+      externalId: null,
+      status: 'provisioning',
+      metadata: {
+        retiredExternalId: 'box-deleted',
+        identityRecoveryAuthorizedAt: expect.any(String),
+      },
+    });
     expect(sessionRow?.status).toBe('provisioning');
     expect(sessionRow?.opencodeSessionId).toBeNull();
     expect(sessionRow?.metadata).toMatchObject({
@@ -1757,7 +1765,15 @@ describe('project session API contract', () => {
     await flushUntil(() => sandboxProvisionCalls === 1);
     expect(sandboxProvisionCalls).toBe(1);
     expect(sessionRow?.status).toBe('provisioning');
-    expect(sessionSandboxRows).toHaveLength(0);
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]).toMatchObject({
+      externalId: null,
+      status: 'provisioning',
+      metadata: {
+        retiredExternalId: 'box-deleted',
+        identityRecoveryAuthorizedAt: expect.any(String),
+      },
+    });
   });
 
   test('restart self-heals when provider status is uncertain but start returns not-found', async () => {

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -69,6 +69,7 @@ let computeSessionsOpened: Array<{ sandboxId: string; accountId: string }> = [];
 let onComputeOpened: (() => void) | null = null;
 let recordedEvents: Array<{ outcome: string }> = [];
 let identityConflict = false;
+let recoveryPlaceholder = false;
 let providerCreateCalls = 0;
 
 function compile(condition: unknown): { sql: string; params: unknown[] } {
@@ -135,6 +136,29 @@ mock.module('../../shared/db', () => ({
             table === sessionSandboxes && 'externalId' in updates && 'config' in updates;
           if (isSessionSandboxesFinish) {
             return updateResult(scenario.archiveBeforeFinish ? [] : [{ sandboxId: SANDBOX_ID }]);
+          }
+          const isRecoveryClaim =
+            table === sessionSandboxes &&
+            updates.provider === 'daytona' &&
+            updates.status === 'provisioning' &&
+            'config' in updates;
+          if (isRecoveryClaim) {
+            return updateResult(
+              recoveryPlaceholder
+                ? [{
+                    sandboxId: SANDBOX_ID,
+                    sessionId: SANDBOX_ID,
+                    accountId: ACCOUNT_ID,
+                    projectId: PROJECT_ID,
+                    provider: 'daytona',
+                    externalId: null,
+                    status: 'provisioning',
+                    baseUrl: null,
+                    config: {},
+                    metadata: { identityRecoveryAuthorizedAt: new Date().toISOString() },
+                  }]
+                : [],
+            );
           }
           return updateResult([{ ok: true }]);
         },
@@ -252,6 +276,7 @@ beforeEach(() => {
   recordedEvents = [];
   onProviderEvent = null;
   identityConflict = false;
+  recoveryPlaceholder = false;
   providerCreateCalls = 0;
 });
 
@@ -281,6 +306,19 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(removedIds).toEqual([]);
     expect(computeSessionsOpened).toEqual([]);
     expect(recordedEvents).toEqual([]);
+  });
+
+  test('provider-loss placeholder is reclaimed without inserting a second logical row', async () => {
+    identityConflict = true;
+    recoveryPlaceholder = true;
+    const opened = waitFor((resolve) => { onComputeOpened = resolve; });
+
+    await provisionSessionSandbox(baseOpts());
+    await opened;
+
+    expect(providerCreateCalls).toBe(1);
+    expect(removedIds).toEqual([]);
+    expect(computeSessionsOpened).toHaveLength(1);
   });
 
   test('nothing raced it: flips to running, guarded WHERE clauses are the expected shape, opens compute metering', async () => {

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -12,7 +12,7 @@
  * path in sandbox-cloud.ts.
  */
 
-import { and, eq, inArray, ne } from 'drizzle-orm';
+import { and, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { db } from '../../shared/db';
 import { PROVISIONING_SESSION_STATUSES } from '../../projects/lib/session-status';
@@ -247,8 +247,8 @@ export async function provisionSessionSandbox(opts: {
   // (~100ms each on a warm DB), now ~one round-trip total.
   const sandboxName = `session-${sandboxId.slice(0, 8)}`;
   const llmGatewayEnabled = projectLlmGatewayEnabled(opts.projectMetadata);
-  const [sandboxRows, sandboxKey, executorToken, gatewayEntitled] = await Promise.all([
-    db
+  const createOrClaimSandboxRow = async () => {
+    const inserted = await db
       .insert(sessionSandboxes)
       .values({
         sandboxId,
@@ -269,7 +269,35 @@ export async function provisionSessionSandbox(opts: {
         },
       })
       .onConflictDoNothing({ target: sessionSandboxes.sessionId })
-      .returning(),
+      .returning();
+    if (inserted.length > 0) return inserted;
+
+    // Provider-confirmed loss keeps the durable logical row because DB-level
+    // identity guards and child records intentionally forbid deleting it. The
+    // recovery transaction resets external_id to NULL and stamps an explicit
+    // authorization marker; only that exact placeholder may be claimed here.
+    return db
+      .update(sessionSandboxes)
+      .set({
+        provider: providerName,
+        status: 'provisioning',
+        baseUrl: null,
+        config: {},
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(sessionSandboxes.sandboxId, sandboxId),
+          isNull(sessionSandboxes.externalId),
+          eq(sessionSandboxes.status, 'provisioning'),
+          sql`coalesce(${sessionSandboxes.metadata}->>'identityRecoveryAuthorizedAt', '') <> ''`,
+        ),
+      )
+      .returning();
+  };
+
+  const [sandboxRows, sandboxKey, executorToken, gatewayEntitled] = await Promise.all([
+    createOrClaimSandboxRow(),
     createApiKey({
       sandboxId,
       accountId,

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -177,14 +177,30 @@ export async function retireConfirmedMissingRuntime(
       .returning({ sessionId: projectSessions.sessionId });
     if (!won) return false;
 
-    await tx
-      .delete(sessionSandboxes)
+    const runtimeMetadata = {
+      ...((row.metadata as Record<string, unknown> | null) ?? {}),
+      identityRecoveryAuthorizedAt: now.toISOString(),
+      retiredExternalId: externalId,
+      runtimeRecoveryReason: reason,
+    };
+    const [reset] = await tx
+      .update(sessionSandboxes)
+      .set({
+        externalId: null,
+        baseUrl: null,
+        status: 'provisioning',
+        config: {},
+        metadata: runtimeMetadata,
+        updatedAt: now,
+      })
       .where(
         and(
           eq(sessionSandboxes.sandboxId, row.sandboxId),
           eq(sessionSandboxes.externalId, externalId),
         ),
-      );
+      )
+      .returning({ sandboxId: sessionSandboxes.sandboxId });
+    if (!reset) throw new Error(`Failed to reset provider-missing runtime ${row.sandboxId}`);
     return true;
   });
 

--- a/packages/db/migrations/20260712200000000_allow_missing_runtime_recovery.sql
+++ b/packages/db/migrations/20260712200000000_allow_missing_runtime_recovery.sql
@@ -1,0 +1,51 @@
+-- Provider-confirmed loss is the one safe exception to immutable runtime
+-- identity: the original object no longer exists, so keep the logical sandbox
+-- row and reset only its provider attachment for replacement provisioning.
+CREATE OR REPLACE FUNCTION kortix.guard_session_sandbox_identity()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  session_deleted boolean;
+  recovery_authorized boolean;
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.external_id IS NOT NULL THEN
+    recovery_authorized :=
+      coalesce(NEW.metadata->>'identityRecoveryAuthorizedAt', '') <> ''
+      AND NEW.external_id IS NULL
+      AND NEW.provider = OLD.provider
+      AND NEW.status = 'provisioning';
+
+    IF (NEW.external_id IS DISTINCT FROM OLD.external_id
+        OR NEW.provider IS DISTINCT FROM OLD.provider)
+       AND NOT recovery_authorized THEN
+      RAISE EXCEPTION
+        'established session sandbox identity is immutable (session %, provider %, external_id %)',
+        OLD.session_id, OLD.provider, OLD.external_id
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' AND OLD.external_id IS NOT NULL THEN
+    SELECT coalesce((metadata->>'deletedAt') IS NOT NULL, false)
+      INTO session_deleted
+      FROM kortix.project_sessions
+     WHERE session_id = OLD.session_id;
+
+    IF NOT coalesce(session_deleted, false)
+       AND coalesce(OLD.metadata->>'identityDeletionAuthorizedAt', '') = '' THEN
+      RAISE EXCEPTION
+        'refusing to delete established session sandbox identity (session %, provider %, external_id %)',
+        OLD.session_id, OLD.provider, OLD.external_id
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Live finding
The deployed recovery path hit the DB identity trigger: established session_sandboxes rows cannot be deleted or reassigned, so recovery returned 500 before allocating replacement compute.

## Fix
- add a narrow DB-trigger exception only for provider-confirmed loss: same provider, external_id reset to NULL, status provisioning, explicit authorization marker
- keep the durable logical sandbox row and all child/audit records
- reclaim only that authorized placeholder in provisionSessionSandbox; ordinary row conflicts still fail closed
- preserve retired external ID and recovery reason in metadata

## Verification
- session sandbox lifecycle suite: 5 pass
- project session HTTP contract: 34 pass
- API typecheck passed
- migration lint passed
- migration applied successfully against local shared Supabase
- live dev reproduction captured the previous 23514 identity-trigger failure on session d49046ed-5486-467b-b194-6a54fdfe610d