### PR TITLE
Fix CLI sandbox OpenCode proxy targeting

### DIFF
--- a/apps/cli/src/__tests__/cli-blackbox.test.ts
+++ b/apps/cli/src/__tests__/cli-blackbox.test.ts
@@ -204,8 +204,46 @@ function startCliE2eServer() {
           updated_at: '2026-01-02T00:00:00.000Z',
         });
       }
-      if (url.pathname === '/v1/p/ext-sess-connect/4096/session/ses_oc' && req.method === 'GET') {
+      if (url.pathname === '/v1/projects/proj_e2e/sessions/sess_stale' && req.method === 'GET') {
+        return Response.json({
+          session_id: 'sess_stale',
+          account_id: 'account_1',
+          project_id: 'proj_e2e',
+          branch_name: 'session-sess_stale',
+          base_ref: 'main',
+          sandbox_provider: 'daytona',
+          sandbox_id: 'row-sandbox-id',
+          sandbox_url: `${url.origin}/v1/p/ext-sess-stale/8000`,
+          opencode_session_id: 'ses_stale',
+          name: 'Stale pin target',
+          custom_name: null,
+          agent_name: 'default',
+          status: 'running',
+          error: null,
+          metadata: {},
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-02T00:00:00.000Z',
+        });
+      }
+      if (url.pathname === '/v1/projects/proj_e2e/sessions/sess_stale' && req.method === 'PATCH') {
+        return Response.json({
+          session_id: 'sess_stale',
+          opencode_session_id: entry.body && typeof entry.body === 'object'
+            ? (entry.body as { opencode_session_id?: string }).opencode_session_id
+            : null,
+        });
+      }
+      if (url.pathname === '/v1/p/ext-sess-connect/8000/session/ses_oc' && req.method === 'GET') {
         return Response.json({ id: 'ses_oc', title: 'Connected through proxy' });
+      }
+      if (url.pathname === '/v1/p/ext-sess-stale/8000/session/ses_stale' && req.method === 'GET') {
+        return Response.json({ error: 'Session not found: ses_stale' }, { status: 404 });
+      }
+      if (url.pathname === '/v1/p/ext-sess-stale/8000/session' && req.method === 'GET') {
+        return Response.json([{ id: 'ses_live', title: 'Live root' }]);
+      }
+      if (url.pathname === '/v1/p/ext-sess-stale/8000/session/ses_live' && req.method === 'GET') {
+        return Response.json({ id: 'ses_live', title: 'Live root' });
       }
 
       if (url.pathname === '/v1/marketplace/items' && req.method === 'GET') {
@@ -327,8 +365,61 @@ console.log(JSON.stringify({ cmd, args, body }));
     ]);
     expect(requests.map((r) => [r.method, r.path, r.authorization])).toContainEqual([
       'GET',
-      '/v1/p/ext-sess-connect/4096/session/ses_oc',
+      '/v1/p/ext-sess-connect/8000/session/ses_oc',
       'Bearer tok_blackbox',
+    ]);
+  }, 15_000);
+
+  test('sessions connect heals a stale opencode session pin before attaching', async () => {
+    const apiBase = startCliE2eServer();
+    const configFile = writeConfig(apiBase);
+    const fakeOpenCode = join(tmp, 'fake-opencode-stale');
+    writeFileSync(
+      fakeOpenCode,
+      `#!/usr/bin/env bun
+const [,, cmd, url, ...args] = process.argv;
+if (cmd !== 'attach') process.exit(11);
+const res = await fetch(new URL('/session/ses_live', url));
+if (!res.ok) {
+  console.error(await res.text());
+  process.exit(13);
+}
+const body = await res.json();
+console.log(JSON.stringify({ cmd, args, body }));
+`,
+      'utf8',
+    );
+    chmodSync(fakeOpenCode, 0o755);
+
+    const result = await runCli(
+      ['sessions', 'connect', 'sess_stale', '--project', 'proj_e2e', '--', '--mini'],
+      tmp,
+      { KORTIX_CONFIG_FILE: configFile, KORTIX_OPENCODE_BIN: fakeOpenCode },
+    );
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      cmd: 'attach',
+      args: ['--session', 'ses_live', '--mini'],
+      body: { id: 'ses_live', title: 'Live root' },
+    });
+    expect(requests.map((r) => [r.method, r.path, r.authorization, r.body])).toContainEqual([
+      'GET',
+      '/v1/p/ext-sess-stale/8000/session/ses_stale',
+      'Bearer tok_blackbox',
+      undefined,
+    ]);
+    expect(requests.map((r) => [r.method, r.path, r.authorization, r.body])).toContainEqual([
+      'GET',
+      '/v1/p/ext-sess-stale/8000/session',
+      'Bearer tok_blackbox',
+      undefined,
+    ]);
+    expect(requests.map((r) => [r.method, r.path, r.authorization, r.body])).toContainEqual([
+      'PATCH',
+      '/v1/projects/proj_e2e/sessions/sess_stale',
+      'Bearer tok_blackbox',
+      { opencode_session_id: 'ses_live' },
     ]);
   }, 15_000);
 

--- a/apps/cli/src/__tests__/sessions-approvals.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions-approvals.e2e.test.ts
@@ -72,21 +72,21 @@ describe('sessions pending/approve/answer', () => {
         if (req.method === 'GET' && url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}`) {
           return Response.json(sessionRow());
         }
-        if (req.method === 'GET' && url.pathname === `/v1/p/${PROXY_ID}/4096/permission`) {
+        if (req.method === 'GET' && url.pathname === `/v1/p/${PROXY_ID}/8000/permission`) {
           return Response.json(pendingPermissions);
         }
-        if (req.method === 'GET' && url.pathname === `/v1/p/${PROXY_ID}/4096/question`) {
+        if (req.method === 'GET' && url.pathname === `/v1/p/${PROXY_ID}/8000/question`) {
           return Response.json(pendingQuestions);
         }
         const permReply = url.pathname.match(
-          new RegExp(`^/v1/p/${PROXY_ID}/4096/permission/([^/]+)/reply$`),
+          new RegExp(`^/v1/p/${PROXY_ID}/8000/permission/([^/]+)/reply$`),
         );
         if (req.method === 'POST' && permReply) {
           permissionReplies.push({ id: permReply[1], body: await req.json() });
           return Response.json(true);
         }
         const qReply = url.pathname.match(
-          new RegExp(`^/v1/p/${PROXY_ID}/4096/question/([^/]+)/(reply|reject)$`),
+          new RegExp(`^/v1/p/${PROXY_ID}/8000/question/([^/]+)/(reply|reject)$`),
         );
         if (req.method === 'POST' && qReply) {
           questionReplies.push({

--- a/apps/cli/src/api/sandbox-proxy.ts
+++ b/apps/cli/src/api/sandbox-proxy.ts
@@ -2,11 +2,17 @@ import type { Auth } from './auth.ts';
 import { ApiError } from './client.ts';
 
 /**
- * The OpenCode HTTP API listens on this port inside every sandbox.
- * The Kortix API exposes it at /v1/p/{sandboxId}/4096/* with the same
- * Bearer-token auth the rest of the CLI uses.
+ * The sandbox daemon exposes OpenCode and PTY helpers on this port. Older CLI
+ * builds talked to OpenCode's internal 4096 port directly, but live sessions are
+ * proxied through the daemon URL returned by the API:
+ *
+ *   https://<host>/v1/p/<external-id>/8000
+ *
+ * Keep this as a fallback only; when a session has `sandbox_url`, callers
+ * should parse the external id and runtime port from that URL.
  */
-export const OPENCODE_PORT = 4096;
+export const DEFAULT_SANDBOX_RUNTIME_PORT = 8000;
+export const OPENCODE_PORT = DEFAULT_SANDBOX_RUNTIME_PORT;
 
 interface RequestOpts {
   apiBase: string;
@@ -39,7 +45,7 @@ function joinProxyUrl(opts: RequestOpts): string {
 
 /**
  * Make an HTTP call against a sandbox service through the Kortix proxy.
- * Used for talking to OpenCode (port 4096) from the CLI.
+ * Used for talking to OpenCode through the sandbox daemon from the CLI.
  */
 export async function sandboxRequest<T>(opts: RequestOpts): Promise<T> {
   const url = joinProxyUrl(opts);
@@ -99,8 +105,17 @@ export async function sandboxRequest<T>(opts: RequestOpts): Promise<T> {
  *  daemon port, same proxy, same auth as everything else, just a different
  *  path than OpenCode's own (now-unused-by-the-CLI) `/pty`. */
 export function kortixPtyWsUrl(auth: Auth, sandboxId: string, ptyId: string): string {
+  return kortixPtyWsUrlForPort(auth, sandboxId, DEFAULT_SANDBOX_RUNTIME_PORT, ptyId);
+}
+
+export function kortixPtyWsUrlForPort(
+  auth: Auth,
+  sandboxId: string,
+  port: number,
+  ptyId: string,
+): string {
   const base = auth.api_base.replace(/\/+$/, '').replace(/\/v1$/, '');
-  const httpBase = `${base}/v1/p/${encodeURIComponent(sandboxId)}/${OPENCODE_PORT}`;
+  const httpBase = `${base}/v1/p/${encodeURIComponent(sandboxId)}/${port}`;
   const wsBase = httpBase.replace(/^http:/i, 'ws:').replace(/^https:/i, 'wss:');
   return `${wsBase}/kortix/pty/${encodeURIComponent(ptyId)}/connect?token=${encodeURIComponent(auth.token)}`;
 }
@@ -108,6 +123,7 @@ export function kortixPtyWsUrl(auth: Auth, sandboxId: string, ptyId: string): st
 export interface SandboxOpencodeOpts {
   auth: Auth;
   sandboxId: string;
+  port?: number;
 }
 
 /**
@@ -120,7 +136,7 @@ export function opencodeClient(opts: SandboxOpencodeOpts) {
     apiBase: auth.api_base,
     token: auth.token,
     sandboxId,
-    port: OPENCODE_PORT,
+    port: opts.port ?? DEFAULT_SANDBOX_RUNTIME_PORT,
   };
   return {
     listSessions: () =>

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { ApiError } from '../api/client.ts';
 import { loadAuth, loadAuthForHost } from '../api/auth.ts';
 import { hasEnvTokenHost } from '../api/config.ts';
-import { opencodeClient } from '../api/sandbox-proxy.ts';
+import { DEFAULT_SANDBOX_RUNTIME_PORT, opencodeClient } from '../api/sandbox-proxy.ts';
 import { loadLink } from '../project-link.ts';
 import {
   resolveProjectContext,
@@ -173,7 +173,16 @@ export async function runDoctor(argv: string[]): Promise<number> {
     );
 
     // ── 6. Open an opencode session + send a prompt ──────────────────────
-    const oc = opencodeClient({ auth, sandboxId: running.sandbox_id! });
+    const sandboxTarget = opencodeTargetFromSession(running);
+    if (!sandboxTarget) {
+      process.stdout.write(`${status.err('running session has no reachable sandbox target')}\n`);
+      return 1;
+    }
+    const oc = opencodeClient({
+      auth,
+      sandboxId: sandboxTarget.sandboxId,
+      port: sandboxTarget.port,
+    });
     let ocSid: string;
     try {
       const created = await oc.createSession({ title: 'kortix doctor' });
@@ -222,6 +231,25 @@ export async function runDoctor(argv: string[]): Promise<number> {
   }
   process.stdout.write(`${status.ok('all checks passed')}\n\n`);
   return 0;
+}
+
+function opencodeTargetFromSession(session: { sandbox_id?: string | null; sandbox_url?: string | null }): {
+  sandboxId: string;
+  port: number;
+} | null {
+  if (session.sandbox_url) {
+    const match = session.sandbox_url.match(/\/p\/([^/]+)\/(\d+)(?:\/|$)/);
+    if (match?.[1]) {
+      const port = Number(match[2]);
+      return {
+        sandboxId: match[1],
+        port: Number.isInteger(port) && port > 0 ? port : DEFAULT_SANDBOX_RUNTIME_PORT,
+      };
+    }
+  }
+  return session.sandbox_id
+    ? { sandboxId: session.sandbox_id, port: DEFAULT_SANDBOX_RUNTIME_PORT }
+    : null;
 }
 
 function parseFlags(argv: string[]): DoctorFlags {

--- a/apps/cli/src/commands/sessions-chat.ts
+++ b/apps/cli/src/commands/sessions-chat.ts
@@ -32,6 +32,8 @@ export interface ResolvedSession {
   oc: ReturnType<typeof opencodeClient>;
   /** The sandbox's external/provider id — the `/v1/p/{proxyId}/…` proxy key. */
   proxyId: string;
+  /** Sandbox daemon/runtime port parsed from sandbox_url. */
+  runtimePort: number;
   /** The OpenCode session id INSIDE the sandbox. May need creating. */
   opencodeSessionId: string | null;
   /** Kortix-side API client (for PATCH/save-back). */
@@ -78,14 +80,14 @@ export async function loadSessionForChat(
     );
     return null;
   }
-  // The OpenCode proxy is keyed by the sandbox's *external* (provider) id,
-  // which only ever appears inside sandbox_url:
+  // The OpenCode proxy is keyed by the sandbox's *external* (provider) id and
+  // runtime daemon port, which appear inside sandbox_url:
   //   https://<host>/v1/p/<external-id>/8000
   // `sandbox_id` is the Kortix row id and the proxy rejects it ("sandbox not
   // found"). The external id is also ephemeral — it changes on every restart —
   // so we always derive it fresh from the just-fetched session row.
-  const proxyId = proxyIdFromSession(session);
-  if (!proxyId) {
+  const proxyTarget = proxyTargetFromSession(session);
+  if (!proxyTarget) {
     process.stderr.write(
       `${status.err('Session has no reachable sandbox yet — provisioning may not be done.')}\n` +
         `  ${C.dim}Check \`kortix sessions info ${session.session_id}\`.${C.reset}\n`,
@@ -95,12 +97,17 @@ export async function loadSessionForChat(
 
   // Same auth `locateSessionAnywhere` resolved the session with, so the
   // sandbox proxy auth header matches the host the session actually lives on.
-  const oc = opencodeClient({ auth, sandboxId: proxyId });
+  const oc = opencodeClient({
+    auth,
+    sandboxId: proxyTarget.proxyId,
+    port: proxyTarget.runtimePort,
+  });
   return {
     session,
     auth,
     oc,
-    proxyId,
+    proxyId: proxyTarget.proxyId,
+    runtimePort: proxyTarget.runtimePort,
     opencodeSessionId: session.opencode_session_id,
     ctx,
   };
@@ -113,7 +120,20 @@ export async function loadSessionForChat(
  * stay glued to the same conversation.
  */
 export async function ensureOpencodeSession(r: ResolvedSession): Promise<string | null> {
-  if (r.opencodeSessionId) return r.opencodeSessionId;
+  if (r.opencodeSessionId) {
+    try {
+      await r.oc.getSession(r.opencodeSessionId);
+      return r.opencodeSessionId;
+    } catch (err) {
+      // A restarted sandbox can leave the DB pin pointing at an OpenCode root
+      // that no longer exists. Heal below by adopting the live root instead of
+      // surfacing "Session not found" to every chat/log/connect command.
+      if (!(err instanceof ApiError) || err.status !== 404) {
+        surfaceApiError(err);
+        return null;
+      }
+    }
+  }
 
   // First try to discover an existing session inside the sandbox.
   try {
@@ -232,12 +252,26 @@ export function prompt(label: string): Promise<string> {
  * only appears embedded in sandbox_url. Falls back to sandbox_id for older
  * servers that surface no URL (proxy will then error clearly).
  */
-function proxyIdFromSession(session: ProjectSession): string | null {
+export function proxyIdFromSession(session: ProjectSession): string | null {
+  return proxyTargetFromSession(session)?.proxyId ?? session.sandbox_id ?? null;
+}
+
+export function runtimePortFromSession(session: ProjectSession): number {
+  return proxyTargetFromSession(session)?.runtimePort ?? 8000;
+}
+
+function proxyTargetFromSession(session: ProjectSession): { proxyId: string; runtimePort: number } | null {
   if (session.sandbox_url) {
-    const m = session.sandbox_url.match(/\/p\/([^/]+)\//);
-    if (m?.[1]) return m[1];
+    const m = session.sandbox_url.match(/\/p\/([^/]+)\/(\d+)(?:\/|$)/);
+    if (m?.[1]) {
+      const parsedPort = Number(m[2]);
+      return {
+        proxyId: m[1],
+        runtimePort: Number.isInteger(parsedPort) && parsedPort > 0 ? parsedPort : 8000,
+      };
+    }
   }
-  return session.sandbox_id || null;
+  return session.sandbox_id ? { proxyId: session.sandbox_id, runtimePort: 8000 } : null;
 }
 
 const CHAT_HELP = help`Usage: kortix sessions chat [<session-id>] [options]
@@ -810,7 +844,7 @@ async function fetchSessionActivity(
 ): Promise<SessionActivity | null> {
   const proxyId = proxyIdFromSession(s);
   if (!proxyId) return null;
-  const oc = opencodeClient({ auth, sandboxId: proxyId });
+  const oc = opencodeClient({ auth, sandboxId: proxyId, port: runtimePortFromSession(s) });
   try {
     let ocId = s.opencode_session_id;
     if (!ocId) {

--- a/apps/cli/src/commands/sessions-connect.ts
+++ b/apps/cli/src/commands/sessions-connect.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'node:child_process';
 
-import { OPENCODE_PORT } from '../api/sandbox-proxy.ts';
 import { takeFlagValue } from '../command-helpers.ts';
 import { C, help, status } from '../style.ts';
 import {
@@ -81,6 +80,7 @@ export async function runSessionsConnect(argv: string[]): Promise<number> {
       apiBase: resolved.auth.api_base,
       token: resolved.auth.token,
       sandboxId: resolved.proxyId,
+      runtimePort: resolved.runtimePort,
       port: proxyPort,
     });
   } catch (err) {
@@ -121,6 +121,7 @@ interface StartOpenCodeProxyOpts {
   apiBase: string;
   token: string;
   sandboxId: string;
+  runtimePort: number;
   port?: number;
 }
 
@@ -134,10 +135,10 @@ interface ProxyWsData {
 /**
  * Expose the sandbox OpenCode API on localhost so `opencode attach` can use its
  * normal SDK client. The remote API requires Kortix Bearer auth and lives behind
- * `/v1/p/{sandbox}/{4096}`; this proxy hides both details from OpenCode.
+ * `/v1/p/{sandbox}/{runtimePort}`; this proxy hides both details from OpenCode.
  */
 export function startOpenCodeProxy(opts: StartOpenCodeProxyOpts): RunningOpenCodeProxy {
-  const baseHttp = buildProxyBase(opts.apiBase, opts.sandboxId);
+  const baseHttp = buildProxyBase(opts.apiBase, opts.sandboxId, opts.runtimePort);
   const baseWs = baseHttp.replace(/^http:/i, 'ws:').replace(/^https:/i, 'wss:');
 
   const server = Bun.serve<ProxyWsData>({
@@ -245,9 +246,9 @@ async function forwardOpenCodeHttp(
   });
 }
 
-function buildProxyBase(apiBase: string, sandboxId: string): string {
+function buildProxyBase(apiBase: string, sandboxId: string, runtimePort: number): string {
   const base = apiBase.replace(/\/+$/, '').replace(/\/v1$/, '');
-  return `${base}/v1/p/${encodeURIComponent(sandboxId)}/${OPENCODE_PORT}`;
+  return `${base}/v1/p/${encodeURIComponent(sandboxId)}/${runtimePort}`;
 }
 
 function buildAttachArgs(

--- a/apps/cli/src/commands/sessions-shell.ts
+++ b/apps/cli/src/commands/sessions-shell.ts
@@ -1,4 +1,4 @@
-import { kortixPtyWsUrl, type OpencodePty } from '../api/sandbox-proxy.ts';
+import { kortixPtyWsUrlForPort, type OpencodePty } from '../api/sandbox-proxy.ts';
 import { takeFlagBool, takeFlagValue } from '../command-helpers.ts';
 import { C, help, status } from '../style.ts';
 import { loadSessionForChat, resolveRunningSessionId, type ResolvedSession } from './sessions-chat.ts';
@@ -115,7 +115,7 @@ function createPty(resolved: ResolvedSession): Promise<OpencodePty> {
 /** Put the local terminal in raw mode, pipe bytes to/from the remote PTY's
  *  WebSocket, and forward local resizes. Returns once the connection ends. */
 function runPtySession(resolved: ResolvedSession, pty: OpencodePty): Promise<number> {
-  const wsUrl = kortixPtyWsUrl(resolved.auth, resolved.proxyId, pty.id);
+  const wsUrl = kortixPtyWsUrlForPort(resolved.auth, resolved.proxyId, resolved.runtimePort, pty.id);
   const ws = new WebSocket(wsUrl);
   ws.binaryType = 'arraybuffer';
 


### PR DESCRIPTION
## Summary
- derive the sandbox external id and runtime daemon port from session sandbox_url for chat/log/connect/shell/doctor
- heal stale opencode_session_id pins by adopting the live sandbox root when the stored id 404s
- update CLI tests to cover daemon port 8000 and stale-pin recovery

## Verification
- bun test apps/cli/src/__tests__/cli-blackbox.test.ts apps/cli/src/__tests__/sessions-approvals.e2e.test.ts
- pnpm --filter @kortix/cli typecheck
- git diff --check
- live check: bun apps/cli/src/index.ts sessions log e41db43e-5e93-4820-a914-5638706378a1 --project fda4e35e-046d-4659-9a33-4bf99ff50592 --limit 40 read the live session via /8000 and no longer returned 502/Session not found