### PR TITLE
fix(api): harden pentest auth and billing findings

### DIFF
--- a/apps/api/src/__tests__/billing/webhooks.test.ts
+++ b/apps/api/src/__tests__/billing/webhooks.test.ts
@@ -221,6 +221,30 @@ describe('checkout.session.completed', () => {
     expect(diffDays).toBeGreaterThan(25);
     expect(diffDays).toBeLessThan(35);
   });
+
+  test('subscription.created then checkout.completed share one activation idempotency key', async () => {
+    mockRegistry.getCreditAccount = async () => null;
+
+    const subscription = createMockStripeSubscription({ id: 'sub_race_123' });
+    mockRegistry.stripeClient.subscriptions.retrieve = async () => subscription;
+
+    const subscriptionEvent = createMockStripeEvent('customer.subscription.created', subscription);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => subscriptionEvent;
+    await processStripeWebhook(JSON.stringify(subscriptionEvent), 'sig');
+
+    const checkout = createMockStripeCheckoutSession({
+      id: 'cs_race_123',
+      subscription: 'sub_race_123',
+    });
+    const checkoutEvent = createMockStripeEvent('checkout.session.completed', checkout);
+    mockRegistry.stripeClient.webhooks.constructEvent = () => checkoutEvent;
+    await processStripeWebhook(JSON.stringify(checkoutEvent), 'sig');
+
+    expect(resetExpiringCreditsCalls.length).toBe(1);
+    expect(grantCreditsCalls.length).toBe(1);
+    expect(resetExpiringCreditsCalls[0][3]).toBe('subscription_activation:sub_race_123');
+    expect(grantCreditsCalls[0][5]).toBe('subscription_activation:sub_race_123');
+  });
 });
 
 describe('subscription changes', () => {

--- a/apps/api/src/__tests__/e2e-api-key-create-scope.ts
+++ b/apps/api/src/__tests__/e2e-api-key-create-scope.ts
@@ -59,8 +59,19 @@ async function main() {
   dim('projA', projA);
   if (projB) dim('projB', projB);
 
+  const foreignRes = await db.execute<{ project_id: string; account_id: string }>(sql`
+    select project_id, account_id
+    from kortix.projects
+    where account_id <> ${owner.account_id}
+    order by created_at desc
+    limit 1
+  `);
+  const foreignRows = (foreignRes as unknown as { rows?: Array<{ project_id: string; account_id: string }> }).rows
+    ?? (foreignRes as unknown as Array<{ project_id: string; account_id: string }>);
+  const foreignProject = foreignRows[0] ?? null;
+
   // 3. CREATE a project-scoped key via the API — the new capability.
-  const created = await call<{ secret_key: string; project_id: string | null }>(
+  const created = await call<{ secret_key: string; token_id: string; project_id: string | null }>(
     admin.secretKey, '/accounts/tokens',
     { method: 'POST', body: JSON.stringify({ name: 'e2e-create-scope-key', project_id: projA }) },
   );
@@ -84,9 +95,55 @@ async function main() {
   if (enumr.status !== 403) die(`scoped key enumerating projects should 403, got ${enumr.status}`);
   ok('scoped key cannot enumerate projects → 403');
 
+  if (projB) {
+    const createdB = await call<{ token_id: string; secret_key: string; project_id: string | null }>(
+      admin.secretKey,
+      '/accounts/tokens',
+      { method: 'POST', body: JSON.stringify({ name: 'e2e-create-scope-key-b', project_id: projB }) },
+    );
+    if (createdB.status !== 201) die(`create projB token → ${createdB.status} ${JSON.stringify(createdB.body)}`);
+    const wrongProjectRevoke = await call<Record<string, unknown>>(
+      admin.secretKey,
+      `/projects/${projA}/cli-token/${createdB.body.token_id}`,
+      { method: 'DELETE' },
+    );
+    if (wrongProjectRevoke.status !== 404) {
+      die(
+        `revoking projB token through projA route should 404, got ${wrongProjectRevoke.status}: ${JSON.stringify(wrongProjectRevoke.body)}`,
+      );
+    }
+    ok('DELETE /projects/<projA>/cli-token/<projB-token> → 404');
+    const rightProjectRevoke = await call<Record<string, unknown>>(
+      admin.secretKey,
+      `/projects/${projB}/cli-token/${createdB.body.token_id}`,
+      { method: 'DELETE' },
+    );
+    if (rightProjectRevoke.status !== 200) {
+      die(
+        `revoking projB token through projB route should 200, got ${rightProjectRevoke.status}: ${JSON.stringify(rightProjectRevoke.body)}`,
+      );
+    }
+    ok('DELETE /projects/<projB>/cli-token/<projB-token> → 200');
+  }
+
+  if (foreignProject) {
+    dim('foreign', `${foreignProject.project_id} (${foreignProject.account_id})`);
+    const foreignCreate = await call<Record<string, unknown>>(
+      admin.secretKey,
+      '/accounts/tokens',
+      { method: 'POST', body: JSON.stringify({ name: 'e2e-foreign-scope-denied', project_id: foreignProject.project_id }) },
+    );
+    if (foreignCreate.status !== 403) {
+      die(`foreign project scope mint should 403, got ${foreignCreate.status}: ${JSON.stringify(foreignCreate.body)}`);
+    }
+    ok('POST /accounts/tokens rejects a project_id from a different account → 403');
+  } else {
+    dim('foreign', 'skipped (no second account project available)');
+  }
+
   // 5. Clean up.
   await db.execute(sql`
-    delete from kortix.account_tokens where name in ('e2e-create-scope-admin', 'e2e-create-scope-key')
+    delete from kortix.account_tokens where name in ('e2e-create-scope-admin', 'e2e-create-scope-key', 'e2e-create-scope-key-b', 'e2e-foreign-scope-denied')
   `);
 
   process.stdout.write('\n  \x1b[0;32mAll create-scope checks passed.\x1b[0m\n\n');

--- a/apps/api/src/__tests__/e2e-billing-routes.test.ts
+++ b/apps/api/src/__tests__/e2e-billing-routes.test.ts
@@ -38,6 +38,7 @@ let mockDeletionRequestResult: any = null;
 let mockDeletionCancelResult: any = null;
 let mockDeletionDeleteResult: any = null;
 let mockDeletionError: Error | null = null;
+let mockAccountDeleteAllowed = true;
 
 // ─── Register mocks ──────────────────────────────────────────────────────────
 
@@ -55,6 +56,17 @@ mock.module('../middleware/auth', () => ({
 mock.module('../shared/resolve-account', () => ({
   resolveAccountId: async () => TEST_USER_ID,
   resolveScopedAccountId: async () => TEST_USER_ID,
+}));
+
+mock.module('../iam', () => ({
+  ACCOUNT_ACTIONS: {
+    ACCOUNT_DELETE: 'account.delete',
+  },
+  assertAuthorized: async (_userId: string, _accountId: string, action: string) => {
+    if (action === 'account.delete' && !mockAccountDeleteAllowed) {
+      throw new HTTPException(403, { message: "You don't have permission to delete accounts." });
+    }
+  },
 }));
 
 // Credits service mock
@@ -236,6 +248,7 @@ beforeEach(() => {
   mockDeletionCancelResult = null;
   mockDeletionDeleteResult = null;
   mockDeletionError = null;
+  mockAccountDeleteAllowed = true;
 });
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -446,6 +459,18 @@ describe('Billing: account deletion', () => {
     expect(body.has_pending_deletion).toBe(false);
   });
 
+  test('GET /v1/billing/account/deletion-status requires account delete permission', async () => {
+    mockAccountDeleteAllowed = false;
+    const app = createBillingTestApp();
+    const res = await app.request('/v1/billing/account/deletion-status', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer test_token' },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.message).toContain("don't have permission");
+  });
+
   test('GET /v1/billing/account/deletion-status returns pending deletion', async () => {
     mockDeletionStatus = {
       has_pending_deletion: true,
@@ -481,6 +506,17 @@ describe('Billing: account deletion', () => {
     expect(body.grace_period_days).toBe(14);
   });
 
+  test('POST /v1/billing/account/request-deletion requires account delete permission', async () => {
+    mockAccountDeleteAllowed = false;
+    const app = createBillingTestApp();
+    const res = await app.request('/v1/billing/account/request-deletion', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test_token' },
+      body: JSON.stringify({ reason: 'not owner' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
   test('POST /v1/billing/account/request-deletion works without reason', async () => {
     const app = createBillingTestApp();
     const res = await app.request('/v1/billing/account/request-deletion', {
@@ -513,6 +549,16 @@ describe('Billing: account deletion', () => {
     expect(body.success).toBe(true);
   });
 
+  test('POST /v1/billing/account/cancel-deletion requires account delete permission', async () => {
+    mockAccountDeleteAllowed = false;
+    const app = createBillingTestApp();
+    const res = await app.request('/v1/billing/account/cancel-deletion', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test_token' },
+    });
+    expect(res.status).toBe(403);
+  });
+
   test('POST /v1/billing/account/cancel-deletion returns error when nothing to cancel', async () => {
     mockDeletionError = new BillingError('No active deletion request found', 400);
     const app = createBillingTestApp();
@@ -533,5 +579,15 @@ describe('Billing: account deletion', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.message).toBe('Account deleted');
+  });
+
+  test('DELETE /v1/billing/account/delete-immediately requires account delete permission', async () => {
+    mockAccountDeleteAllowed = false;
+    const app = createBillingTestApp();
+    const res = await app.request('/v1/billing/account/delete-immediately', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer test_token' },
+    });
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/api/src/__tests__/e2e-project-scoped-tokens.ts
+++ b/apps/api/src/__tests__/e2e-project-scoped-tokens.ts
@@ -98,9 +98,21 @@ async function main() {
     die(`Need ≥ 2 projects on account ${m.account_id} for the cross-project test. Have ${projectRows.length}.`);
   }
   const [projA, projB] = projectRows;
+  const foreignProjects = await db.execute<ProjectRow>(sql`
+    select project_id, account_id, name
+    from kortix.projects
+    where account_id <> ${m.account_id}
+    order by created_at desc
+    limit 1
+  `);
+  const foreignProjectRows =
+    (foreignProjects as unknown as { rows?: ProjectRow[] }).rows
+    ?? (foreignProjects as unknown as ProjectRow[]);
+  const foreignProject = foreignProjectRows[0] ?? null;
   dim('user', m.user_id);
   dim('projA', `${projA.project_id} (${projA.name})`);
   dim('projB', `${projB.project_id} (${projB.name})`);
+  if (foreignProject) dim('foreign', `${foreignProject.project_id} (${foreignProject.name})`);
 
   // ── 2. Mint a project-scoped token for projA via direct DB insert ───
   const { publicKey, secretKey } = generateAccountTokenPair();
@@ -176,6 +188,31 @@ async function main() {
     die(`projA token → /executor/projects/<projB>/catalog should 403, got ${crossProjectCatalog.status}: ${JSON.stringify(crossProjectCatalog.body)}`);
   }
   ok('token cannot use Executor gateway routes for a different project → 403');
+
+  // ── 8b. Defense-in-depth: forged foreign project scope is rejected ───
+  if (foreignProject) {
+    const forged = generateAccountTokenPair();
+    const forgedHash = hashSecretKey(forged.secretKey);
+    await db.execute(sql`
+      insert into kortix.account_tokens
+        (account_id, user_id, project_id, name, public_key, secret_key_hash)
+      values
+        (${m.account_id}, ${m.user_id}, ${foreignProject.project_id}, 'e2e-forged-foreign-scope', ${forged.publicKey}, ${forgedHash})
+    `);
+    try {
+      const forgedCatalog = await callApi(forged.secretKey, `/executor/projects/${foreignProject.project_id}/catalog`);
+      if (forgedCatalog.status !== 403) {
+        die(`foreign-scoped forged token → /executor/projects/<foreign>/catalog should 403, got ${forgedCatalog.status}: ${JSON.stringify(forgedCatalog.body)}`);
+      }
+      ok('forged token row with a foreign project_id cannot use Executor gateway routes → 403');
+    } finally {
+      await db.execute(sql`
+        delete from kortix.account_tokens where secret_key_hash = ${forgedHash}
+      `);
+    }
+  } else {
+    dim('foreign', 'executor forged-scope check skipped (no second account project available)');
+  }
 
   // ── 9. Revoke + verify 401 ───────────────────────────────────────────
   await db.execute(sql`

--- a/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
@@ -154,6 +154,19 @@ describe('HTTP enforcement — project read-leaf gates (agent-grant fold now rea
   }
 });
 
+describe('HTTP enforcement — gateway playground spend gate', () => {
+  test('agent granted an UNRELATED capability → 403 before upstream dispatch', async () => {
+    const secret = await mintToken({ agent: 'scoped-bot', kortixCli: ['project.trigger.fire'], connectors: [] });
+    const res = await postReq(`/v1/projects/${PROJECT}/gateway/playground`, secret, {
+      prompt: 'hello',
+      models: ['not-a-real-model'],
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json().catch(() => ({}));
+    expect(JSON.stringify(body)).toContain(PROJECT_ACTIONS.PROJECT_GATEWAY_SPEND_READ);
+  });
+});
+
 describe('HTTP enforcement — editor-tier read gates (file.read / secret.read moved off member)', () => {
   for (const c of EDITOR_TIER_READ_CASES) {
     describe(c.name, () => {

--- a/apps/api/src/accounts/core/tokens.ts
+++ b/apps/api/src/accounts/core/tokens.ts
@@ -11,6 +11,7 @@ import {
   revokeAccountToken,
 } from '../../repositories/account-tokens';
 import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
+import { loadProjectForUser } from '../../projects/lib/access';
 import {
   accountsRouter,
   accountDisplayName,
@@ -134,6 +135,8 @@ accountsRouter.openapi(
     return c.json({ error: (err as Error).message }, 403);
   }
 
+  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.TOKEN_READ);
+
   const tokens = await listAccountTokens(accountId);
   return c.json(
     tokens.map((t) => ({
@@ -212,6 +215,13 @@ accountsRouter.openapi(
     typeof body.project_id === 'string' && body.project_id.trim()
       ? body.project_id.trim()
       : undefined;
+
+  if (projectId) {
+    const loaded = await loadProjectForUser(c, projectId, 'manage');
+    if (!loaded?.row || loaded.row.accountId !== accountId) {
+      return c.json({ error: 'Project not found in account' }, 403);
+    }
+  }
 
   let created;
   try {

--- a/apps/api/src/billing/routes/account-deletion.ts
+++ b/apps/api/src/billing/routes/account-deletion.ts
@@ -8,12 +8,14 @@ import {
 } from '../services/account-deletion';
 import { resolveAccountId } from '../../shared/resolve-account';
 import { makeOpenApiApp, json, auth } from '../../openapi';
+import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
 
 export const accountDeletionRouter = makeOpenApiApp<AppEnv>();
 
 async function resolveDeletionContext(c: any) {
   const userId = c.get('userId') as string;
   const accountId = await resolveAccountId(userId);
+  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_DELETE);
   return { userId, accountId };
 }
 

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -106,7 +106,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   }
 
   if (session.mode === 'subscription') {
-    await handleSubscriptionCheckout(session, accountId);
+    await withAccountLock(accountId, () => handleSubscriptionCheckout(session, accountId));
   }
 }
 
@@ -220,7 +220,7 @@ async function handleSubscriptionCheckout(session: Stripe.Checkout.Session, acco
       'tier_grant',
       creditDesc,
       true,
-      session.id,
+      `subscription_activation:${subscriptionId}`,
     );
   }
 
@@ -379,7 +379,7 @@ async function syncSubscriptionState(accountId: string, subscription: Stripe.Sub
         accountId,
         credits,
         `Recovered Stripe subscription: ${credits} credits`,
-        `legacy_sync:${subscription.id}`,
+        `subscription_activation:${subscription.id}`,
       );
     }
   }

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -626,8 +626,18 @@ async function resolveProjectPrincipal(
 
   if (tokenProjectId) {
     // Project-scoped (session) token: enforceTokenProjectScope already guaranteed
-    // tokenProjectId === the URL project at the auth layer. Re-check defensively.
+    // tokenProjectId === the URL project at the auth layer. Re-check defensively,
+    // then bind the token account to the actual project account. This prevents a
+    // PAT row from one account from being labeled with another account's project
+    // id and then used on the project-explicit Executor gateway.
     if (tokenProjectId !== projectId) return null;
+    const [project] = await db
+      .select({ accountId: projects.accountId })
+      .from(projects)
+      .where(eq(projects.projectId, projectId))
+      .limit(1);
+    if (!project || !accountId || project.accountId !== accountId) return null;
+    accountId = project.accountId;
   } else {
     // User token (PAT/JWT, no pinned project): verify project access. Throws 403
     // if the user isn't a member — treat that as an unauthorized principal.

--- a/apps/api/src/projects/routes/gateway.ts
+++ b/apps/api/src/projects/routes/gateway.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, sql } from 'drizzle-orm';
 import { createRoute, z } from '@hono/zod-openapi';
 import { gatewayBudgets, gatewayRequestLogs, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
-import { callUpstream, type AuthedPrincipal } from '@kortix/llm-gateway';
+import { calculateCost, callUpstream, type AuthedPrincipal } from '@kortix/llm-gateway';
 import { resolveCandidates } from '../../llm-gateway/resolution/resolve-candidates';
 import { db } from '../../shared/db';
 import { auth, errors, json } from '../../openapi';
@@ -12,6 +12,11 @@ import { assertProjectCapability, loadProjectForUser, lookupEmailsByUserIds } fr
 import { projectsApp } from '../lib/app';
 import { UUID_V4_REGEX } from '../lib/serializers';
 import { createGatewayKey, listGatewayKeys, revokeGatewayKey } from '../../llm-gateway/gateway-keys';
+import {
+  assertGatewayBudget,
+  persistGatewayTrace,
+  recordGatewayUsage,
+} from '../../llm-gateway/hooks';
 import { publicGatewayBaseUrl } from '../../llm-gateway/public-url';
 import { config } from '../../config';
 
@@ -799,6 +804,13 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_GATEWAY_SPEND_READ,
+    );
 
     const body = await c.req.json();
     const prompt = typeof body.prompt === 'string' ? body.prompt : '';
@@ -812,26 +824,80 @@ projectsApp.openapi(
       accountId: loaded.row.accountId,
       projectId,
     };
+    await assertGatewayBudget(principal);
 
     const results = await Promise.all(
       models.map(async (model) => {
+        const requestId = crypto.randomUUID();
+        const request = {
+          model,
+          messages: [{ role: 'user', content: prompt }],
+          stream: false,
+          max_tokens: 512,
+        };
         try {
           const candidates = await resolveCandidates(principal, model);
           if (candidates.length === 0) {
             return { model, ok: false, error: 'No upstream configured for this model' };
           }
+          const descriptor = candidates[0]!;
           const start = Date.now();
-          const res = await callUpstream(
-            {
-              model,
-              messages: [{ role: 'user', content: prompt }],
-              stream: false,
-              max_tokens: 512,
-            },
-            candidates[0]!,
-          );
+          const res = await callUpstream(request, descriptor);
           const latencyMs = Date.now() - start;
           const data = (await res.json()) as any;
+          const usage = data?.usage ?? {};
+          const promptTokens = Number(usage.prompt_tokens ?? usage.input_tokens ?? 0) || 0;
+          const completionTokens = Number(usage.completion_tokens ?? usage.output_tokens ?? 0) || 0;
+          const cachedTokens = Number(usage.cached_tokens ?? 0) || 0;
+          const resolvedModel = String(data?.model ?? descriptor.resolvedModel ?? model);
+          const { upstreamCost, finalCost } = calculateCost(
+            resolvedModel,
+            { promptTokens, completionTokens, cachedTokens },
+            descriptor.billingMode === 'none' ? 0 : descriptor.markup,
+            typeof usage.cost === 'number' ? usage.cost : undefined,
+            descriptor.pricing,
+          );
+          await persistGatewayTrace({
+            requestId,
+            startedAt: new Date(start).toISOString(),
+            accountId: principal.accountId,
+            actorUserId: principal.userId,
+            projectId,
+            requestedModel: model,
+            resolvedModel,
+            provider: descriptor.provider,
+            billingMode: descriptor.billingMode,
+            streaming: false,
+            status: res.status,
+            ok: res.ok,
+            errorMessage: res.ok ? undefined : data?.error?.message ?? data?.message ?? `HTTP ${res.status}`,
+            latencyMs,
+            attempts: 1,
+            candidatesTried: [descriptor.provider],
+            usage: { promptTokens, completionTokens, cachedTokens },
+            upstreamCost,
+            finalCost,
+            request,
+            response: data,
+            metadata: { surface: 'gateway_playground' },
+          });
+          if (promptTokens + completionTokens > 0) {
+            await recordGatewayUsage({
+              promptTokens,
+              completionTokens,
+              cachedTokens,
+              accountId: principal.accountId,
+              actorUserId: principal.userId,
+              projectId,
+              provider: descriptor.provider,
+              model: resolvedModel,
+              upstreamCost,
+              finalCost,
+              billingMode: descriptor.billingMode,
+              streaming: false,
+              requestId,
+            });
+          }
           if (!res.ok) {
             return {
               model,
@@ -845,8 +911,8 @@ projectsApp.openapi(
             ok: true,
             latency_ms: latencyMs,
             output: data?.choices?.[0]?.message?.content ?? '',
-            input_tokens: data?.usage?.prompt_tokens ?? 0,
-            output_tokens: data?.usage?.completion_tokens ?? 0,
+            input_tokens: promptTokens,
+            output_tokens: completionTokens,
           };
         } catch (err) {
           return { model, ok: false, error: err instanceof Error ? err.message : 'Request failed' };

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -198,7 +198,7 @@ projectsApp.openapi(
   if (getAgentGrant(c)) {
     return c.json({ error: 'Agent-session tokens cannot manage project tokens' }, 403);
   }
-  const ok = await revokeAccountToken(tokenId, loaded.row.accountId);
+  const ok = await revokeAccountToken(tokenId, loaded.row.accountId, projectId);
   if (!ok) return c.json({ error: 'token not found or already revoked' }, 404);
   return c.json({ ok: true });
 },

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1327,6 +1327,13 @@ projectsApp.openapi(
     } else {
       const loaded = await loadProjectForUser(c, projectId, 'read');
       if (!loaded) return c.json({ error: 'Not found' }, 404);
+      await assertProjectCapability(
+        c,
+        loaded.userId,
+        loaded.row.accountId,
+        projectId,
+        PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+      );
     }
 
     let body: {

--- a/apps/api/src/repositories/account-tokens.ts
+++ b/apps/api/src/repositories/account-tokens.ts
@@ -217,17 +217,18 @@ export async function listAccountTokens(
 export async function revokeAccountToken(
   tokenId: string,
   accountId: string,
+  projectId?: string | null,
 ): Promise<boolean> {
+  const filter = and(
+    eq(accountTokens.tokenId, tokenId),
+    eq(accountTokens.accountId, accountId),
+    eq(accountTokens.status, 'active'),
+    projectId ? eq(accountTokens.projectId, projectId) : undefined,
+  );
   const result = await db
     .update(accountTokens)
     .set({ status: 'revoked', revokedAt: new Date() })
-    .where(
-      and(
-        eq(accountTokens.tokenId, tokenId),
-        eq(accountTokens.accountId, accountId),
-        eq(accountTokens.status, 'active'),
-      ),
-    )
+    .where(filter)
     .returning({ tokenId: accountTokens.tokenId });
 
   return result.length > 0;

--- a/apps/api/src/tunnel/core/rate-limiter.ts
+++ b/apps/api/src/tunnel/core/rate-limiter.ts
@@ -21,6 +21,9 @@ class TunnelRateLimiter {
     deviceAuthCreateGlobal: { limit: 100, windowMs: 60_000 },
     deviceAuthCreate: { limit: 5, windowMs: 60_000 },
     deviceAuthPoll: { limit: 30, windowMs: 60_000 },
+    deviceAuthInfo: { limit: 30, windowMs: 60_000 },
+    deviceAuthApprove: { limit: 10, windowMs: 60_000 },
+    deviceAuthDeny: { limit: 10, windowMs: 60_000 },
   };
 
   check(endpoint: string, key: string): { allowed: boolean; retryAfterMs?: number } {

--- a/apps/api/src/tunnel/routes/device-auth.ts
+++ b/apps/api/src/tunnel/routes/device-auth.ts
@@ -53,6 +53,12 @@ function clientRateLimitKey(c: any): string {
   return forwarded || realIp || cfIp || 'unknown';
 }
 
+function checkDeviceAuthResolutionRateLimit(c: any, endpoint: string) {
+  const userId = (c.get('userId') as string | undefined) ?? 'anonymous';
+  const key = `${userId}:${clientRateLimitKey(c)}`;
+  return tunnelRateLimiter.check(endpoint, key);
+}
+
 /**
  * Public router — mounted BEFORE auth middleware.
  * Handles create + poll (unauthenticated, used by CLI).
@@ -237,6 +243,10 @@ export function createDeviceAuthRouter() {
     }),
     async (c: any) => {
       requireUserCredential(c);
+      const rl = checkDeviceAuthResolutionRateLimit(c, 'deviceAuthInfo');
+      if (!rl.allowed) {
+        return c.json({ error: 'Too many requests', retryAfterMs: rl.retryAfterMs }, 429);
+      }
       const code = c.req.param('code');
 
       const [row] = await db
@@ -294,6 +304,10 @@ export function createDeviceAuthRouter() {
     }),
     async (c: any) => {
       requireUserCredential(c);
+      const rl = checkDeviceAuthResolutionRateLimit(c, 'deviceAuthApprove');
+      if (!rl.allowed) {
+        return c.json({ error: 'Too many requests', retryAfterMs: rl.retryAfterMs }, 429);
+      }
       const userId = c.get('userId') as string;
       const accountId = await resolveAccountId(userId);
       const code = c.req.param('code');
@@ -383,6 +397,10 @@ export function createDeviceAuthRouter() {
     }),
     async (c: any) => {
       requireUserCredential(c);
+      const rl = checkDeviceAuthResolutionRateLimit(c, 'deviceAuthDeny');
+      if (!rl.allowed) {
+        return c.json({ error: 'Too many requests', retryAfterMs: rl.retryAfterMs }, 429);
+      }
       const code = c.req.param('code');
 
       const [updated] = await db

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -159,7 +159,7 @@
   "files": ["dist", "src", "README.md"],
   "scripts": {
     "typecheck": "tsc --noEmit && tsc --noEmit -p examples/tsconfig.json",
-    "test": "bun test src",
+    "test": "bun test --isolate src",
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths",
     "build:bundles": "pnpm run build && tsup",
     "prepublishOnly": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths && tsup",

--- a/packages/sdk/src/core/http/config.test.ts
+++ b/packages/sdk/src/core/http/config.test.ts
@@ -1,34 +1,18 @@
-import { test, expect, beforeEach, afterEach } from 'bun:test';
+import { test, expect } from 'bun:test';
 import {
   configureKortix,
   platformConfig,
   isConfigured,
-  __setConfigResolver,
-  __getConfigResolver,
 } from './config';
+import { runWithKortix } from '../../platform/config-node';
 
-// This file deliberately never imports `./config-node` (the `@kortix/sdk/server`
-// AsyncLocalStorage layer) — it exercises the plain browser/single-config path
-// that every host without a registered resolver still gets: `platformConfig()`
-// falls back to the process-global `current` set by `configureKortix()`, exactly
-// as before the per-request isolation layer existed.
-//
-// `bun test src` runs every test file in one process, sharing `config.ts`'s
-// module state — if some OTHER file in the same run imports `config-node.ts`
-// (registering the real AsyncLocalStorage resolver as an import-time side
-// effect), that registration is process-global too. Save + restore whatever
-// resolver was active before each test here, so this file's "no resolver"
-// experiments never permanently clobber another file's registration.
-let savedResolver: ReturnType<typeof __getConfigResolver>;
-beforeEach(() => {
-  savedResolver = __getConfigResolver();
-  __setConfigResolver(null);
-});
-afterEach(() => {
-  __setConfigResolver(savedResolver);
-});
+// `bun test src` runs SDK test files in one process. Do not mutate the internal
+// config resolver here: `@kortix/sdk/server` installs the real AsyncLocalStorage
+// resolver as a process-global import-time side effect, and clearing it from
+// this file can race other async tests. These assertions exercise the fallback
+// and scoped paths through the public-ish Node helper instead.
 
-test('with no resolver registered, platformConfig() reads the process-global set by configureKortix()', () => {
+test('with no active scoped config, platformConfig() reads the process-global set by configureKortix()', () => {
   configureKortix({ backendUrl: 'http://global.local', getToken: async () => 'global-tok' });
   expect(platformConfig().backendUrl).toBe('http://global.local');
   expect(isConfigured()).toBe(true);
@@ -41,11 +25,14 @@ test('configureKortix(config, { global: false }) does not touch the process-glob
   expect(platformConfig().backendUrl).toBe('http://one.local');
 });
 
-test('a registered resolver takes priority over the process-global config', () => {
+test('an active scoped resolver takes priority over the process-global config', async () => {
   configureKortix({ backendUrl: 'http://global.local', getToken: async () => 'global-tok' });
-  __setConfigResolver(() => ({ backendUrl: 'http://scoped.local', getToken: async () => 'scoped-tok' }));
-  expect(platformConfig().backendUrl).toBe('http://scoped.local');
+  await runWithKortix(
+    { backendUrl: 'http://scoped.local', getToken: async () => 'scoped-tok' },
+    async () => {
+      expect(platformConfig().backendUrl).toBe('http://scoped.local');
+    },
+  );
 
-  __setConfigResolver(() => undefined);
   expect(platformConfig().backendUrl).toBe('http://global.local');
 });


### PR DESCRIPTION
## Summary
- bind project-scoped PAT creation and Executor project principals to the real project account
- require token-read IAM for account token listing and account-delete IAM for account deletion workflows
- scope project CLI-token revocation to the URL project
- require connector/write for Slack bind-thread and add device-auth resolution rate limits
- gate gateway playground with gateway spend permission, budget checks, usage events, and traces
- make Stripe subscription checkout/recovery grants share one subscription activation idempotency key

## Verification
- pnpm --filter kortix-api typecheck
- bun test apps/api/src/__tests__/e2e-billing-routes.test.ts -t "Billing: account deletion"
- bun test apps/api/src/__tests__/billing/webhooks.test.ts
- KORTIX_URL=http://localhost:8008 dotenvx run --ignore=MISSING_ENV_FILE -f apps/api/.env.local -f apps/api/.env -- bun test apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts -t "gateway playground"
- KORTIX_URL=http://localhost:8008 KORTIX_API_URL=http://localhost:8008 dotenvx run --ignore=MISSING_ENV_FILE -f apps/api/.env.local -f apps/api/.env -- bun run apps/api/src/__tests__/e2e-api-key-create-scope.ts
- KORTIX_URL=http://localhost:8008 KORTIX_API_URL=http://localhost:8008 dotenvx run --ignore=MISSING_ENV_FILE -f apps/api/.env.local -f apps/api/.env -- bun run apps/api/src/__tests__/e2e-project-scoped-tokens.ts

## Notes
Weekly pentest cloud session 99b9dead-6c5c-4d3c-b18b-56f37490dd53 completed 25 native OpenCode subagent tasks and covered all 450 dev OpenAPI operations. This PR fixes the two confirmed HIGH findings plus several bounded medium/low findings from that run.