### PR TITLE
fix(health): restore staging deployment identity fields

### DIFF
--- a/apps/api/src/__tests__/e2e-health.test.ts
+++ b/apps/api/src/__tests__/e2e-health.test.ts
@@ -20,6 +20,8 @@ describe('Health & System endpoints', () => {
     expect(body.status).toBe('ok');
     expect(body.service).toBe('kortix-api');
     expect(body.timestamp).toBeDefined();
+    expect(body.environment).toBe('dev');
+    expect(body.version).toBe('dev');
   });
 
   // ─── GET /v1/health ─────────────────────────────────────────────────────
@@ -30,8 +32,10 @@ describe('Health & System endpoints', () => {
 
     const body = await res.json();
     expect(body.status).toBe('ok');
-    expect(body.service).toBe('kortix');
+    expect(body.service).toBe('kortix-api');
     expect(body.timestamp).toBeDefined();
+    expect(body.environment).toBe('dev');
+    expect(body.version).toBe('dev');
   });
 
   // ─── GET /v1/system/status ──────────────────────────────────────────────

--- a/apps/api/src/__tests__/helpers.ts
+++ b/apps/api/src/__tests__/helpers.ts
@@ -39,14 +39,18 @@ export function createTestApp(opts: TestAppOptions = {}) {
       status: 'ok',
       service: 'kortix-api',
       timestamp: new Date().toISOString(),
+      environment: 'dev',
+      version: 'dev',
     }),
   );
 
   app.get('/v1/health', (c) =>
     c.json({
       status: 'ok',
-      service: 'kortix',
+      service: 'kortix-api',
       timestamp: new Date().toISOString(),
+      environment: 'dev',
+      version: 'dev',
     }),
   );
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -350,6 +350,8 @@ const HealthSchema = z
     status: z.string(),
     service: z.string(),
     timestamp: z.string(),
+    environment: z.string(),
+    version: z.string(),
   })
   .openapi('Health');
 
@@ -358,6 +360,8 @@ const healthHandler = (c: any) =>
     status: 'ok',
     service: 'kortix-api',
     timestamp: new Date().toISOString(),
+    environment: config.INTERNAL_KORTIX_ENV,
+    version: API_VERSION,
   });
 
 app.openapi(


### PR DESCRIPTION
Restores `environment` and `version` on `/health` and `/v1/health`, which the staging deploy verifier and ke2e contract require. The omission left an otherwise healthy staging rollout stuck until timeout.\n\nVerified:\n- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/e2e-health.test.ts`\n- `pnpm --filter kortix-api typecheck`\n- `git diff --check`