### PR TITLE
release: complete staging health verification

### DIFF
--- a/apps/api/src/__tests__/e2e-health.test.ts
+++ b/apps/api/src/__tests__/e2e-health.test.ts
@@ -20,6 +20,8 @@ describe('Health & System endpoints', () => {
     expect(body.status).toBe('ok');
     expect(body.service).toBe('kortix-api');
     expect(body.timestamp).toBeDefined();
+    expect(body.environment).toBe('dev');
+    expect(body.version).toBe('dev');
   });
 
   // ─── GET /v1/health ─────────────────────────────────────────────────────
@@ -30,8 +32,10 @@ describe('Health & System endpoints', () => {
 
     const body = await res.json();
     expect(body.status).toBe('ok');
-    expect(body.service).toBe('kortix');
+    expect(body.service).toBe('kortix-api');
     expect(body.timestamp).toBeDefined();
+    expect(body.environment).toBe('dev');
+    expect(body.version).toBe('dev');
   });
 
   // ─── GET /v1/system/status ──────────────────────────────────────────────

--- a/apps/api/src/__tests__/helpers.ts
+++ b/apps/api/src/__tests__/helpers.ts
@@ -39,14 +39,18 @@ export function createTestApp(opts: TestAppOptions = {}) {
       status: 'ok',
       service: 'kortix-api',
       timestamp: new Date().toISOString(),
+      environment: 'dev',
+      version: 'dev',
     }),
   );
 
   app.get('/v1/health', (c) =>
     c.json({
       status: 'ok',
-      service: 'kortix',
+      service: 'kortix-api',
       timestamp: new Date().toISOString(),
+      environment: 'dev',
+      version: 'dev',
     }),
   );
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -350,6 +350,8 @@ const HealthSchema = z
     status: z.string(),
     service: z.string(),
     timestamp: z.string(),
+    environment: z.string(),
+    version: z.string(),
   })
   .openapi('Health');
 
@@ -358,6 +360,8 @@ const healthHandler = (c: any) =>
     status: 'ok',
     service: 'kortix-api',
     timestamp: new Date().toISOString(),
+    environment: config.INTERNAL_KORTIX_ENV,
+    version: API_VERSION,
   });
 
 app.openapi(

--- a/apps/web/src/components/projects/project-onboarding-wizard.tsx
+++ b/apps/web/src/components/projects/project-onboarding-wizard.tsx
@@ -14,7 +14,11 @@
  *                                and flip to a confirmed ✓ the moment it lands.
  *                                Gated (can't "Continue" until connected) with a
  *                                quiet "Skip for now" escape hatch.
- *   4. You're all set          — recap + into the product.
+ *   4. Connect a model         — upgrade to a Kortix plan or bring your own API
+ *                                key. Not hard-gated (the chat composer enforces
+ *                                it later if skipped) — same shared actions as
+ *                                the composer's own gate, see model-connection-gate.
+ *   5. You're all set          — recap + into the product.
  *
  * Self-gates: only renders while the project's onboarding status is 'pending'
  * (no `metadata.onboarding_completed_at`). Heavy deps (the Pipedream browser
@@ -25,12 +29,14 @@
  * to be generated for these strings before this ships beyond local testing.
  */
 
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ArrowLeft,
   ArrowRight,
   Check,
   ChevronDown,
+  CreditCard,
+  KeyRound,
   Loader2,
   Plus,
   Search,
@@ -49,17 +55,16 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { DemoQualifierModal } from '@/features/contact/demo-qualifier-modal';
 import { useAuth } from '@/features/providers/auth-provider';
+import { useModelConnectionGate } from '@/features/session/use-model-connection-gate';
 import { useSlackInstall, useSlackMode } from '@/hooks/channels/use-channels-installations';
+import { useToolConnect } from '@/hooks/connectors/use-tool-connect';
+import { providerListHasModels } from '@/hooks/opencode/provider-selection';
+import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import { useProjectOnboarding } from '@/hooks/projects/use-project-onboarding';
 import { usePersonalContactTier } from '@/hooks/use-show-personal-contact';
-import {
-  listConnectors,
-  listPipedreamApps,
-  type PipedreamApp,
-} from '@kortix/sdk/projects-client';
-import { useToolConnect } from '@/hooks/connectors/use-tool-connect';
 import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
+import { listConnectors, listPipedreamApps, type PipedreamApp } from '@kortix/sdk/projects-client';
 
 const CAL_LINK = 'team/kortix/demo';
 const CAL_NAMESPACE = 'kortix-onboarding-wizard';
@@ -84,7 +89,7 @@ const CustomConnectorForm = lazy(() =>
   })),
 );
 
-type StepId = 'welcome' | 'tools' | 'slack' | 'done';
+type StepId = 'welcome' | 'tools' | 'slack' | 'model' | 'done';
 
 // ─── Shell ────────────────────────────────────────────────────────────────────
 
@@ -104,7 +109,7 @@ export function ProjectOnboardingWizard({ projectId }: { projectId: string }) {
   const [calOpen, setCalOpen] = useState(false);
   const [index, setIndex] = useState(0);
 
-  const steps = useMemo<StepId[]>(() => ['welcome', 'tools', 'slack', 'done'], []);
+  const steps = useMemo<StepId[]>(() => ['welcome', 'tools', 'slack', 'model', 'done'], []);
   const stepId = steps[index] ?? 'welcome';
 
   // `?onboarding-reset` reopens the wizard from the top (clears completion flag).
@@ -134,7 +139,8 @@ export function ProjectOnboardingWizard({ projectId }: { projectId: string }) {
     ...Q,
   });
   const connectedSlugs = useMemo(
-    () => new Set((connectors.data?.connectors ?? []).filter((c) => c.secretSet).map((c) => c.slug)),
+    () =>
+      new Set((connectors.data?.connectors ?? []).filter((c) => c.secretSet).map((c) => c.slug)),
     [connectors.data],
   );
   const refreshConnectors = useCallback(() => {
@@ -167,7 +173,9 @@ export function ProjectOnboardingWizard({ projectId }: { projectId: string }) {
         <div className="relative flex items-center px-5 py-4 md:px-8">
           <div className="flex items-center gap-2.5">
             <KortixAsterisk index={0} />
-            <span className="text-foreground text-sm font-semibold tracking-tight">Set up your project</span>
+            <span className="text-foreground text-sm font-semibold tracking-tight">
+              Set up your project
+            </span>
           </div>
           <div className="absolute left-1/2 hidden -translate-x-1/2 items-center gap-1.5 md:flex">
             {steps.map((s, i) => (
@@ -175,7 +183,11 @@ export function ProjectOnboardingWizard({ projectId }: { projectId: string }) {
                 key={s}
                 className={cn(
                   'h-1 rounded-full transition-all duration-300',
-                  i < index ? 'bg-foreground/60 w-8' : i === index ? 'bg-foreground w-8' : 'bg-foreground/15 w-8',
+                  i < index
+                    ? 'bg-foreground/60 w-8'
+                    : i === index
+                      ? 'bg-foreground w-8'
+                      : 'bg-foreground/15 w-8',
                 )}
               />
             ))}
@@ -208,11 +220,9 @@ export function ProjectOnboardingWizard({ projectId }: { projectId: string }) {
                   />
                 )}
                 {stepId === 'slack' && <SlackStep projectId={projectId} />}
+                {stepId === 'model' && <ModelStep />}
                 {stepId === 'done' && (
-                  <DoneStep
-                    connectedCount={connectedSlugs.size}
-                    onStart={complete}
-                  />
+                  <DoneStep connectedCount={connectedSlugs.size} onStart={complete} />
                 )}
               </motion.div>
             </AnimatePresence>
@@ -268,6 +278,8 @@ function StepPrimaryAction({
 }) {
   const slackInstall = useSlackInstall(stepId === 'slack' ? projectId : null);
   const slackConnected = !!slackInstall.data;
+  const modelProviders = useOpenCodeProviders();
+  const hasModels = providerListHasModels(modelProviders.data);
 
   if (stepId === 'slack') {
     return (
@@ -291,6 +303,22 @@ function StepPrimaryAction({
         <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={onNext}>
           Skip
         </Button>
+        <Button size="sm" className="gap-1.5" onClick={onNext}>
+          Continue
+          <ArrowRight className="size-4" />
+        </Button>
+      </div>
+    );
+  }
+
+  if (stepId === 'model') {
+    return (
+      <div className="flex items-center gap-3">
+        {!hasModels && (
+          <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={onNext}>
+            Skip
+          </Button>
+        )}
         <Button size="sm" className="gap-1.5" onClick={onNext}>
           Continue
           <ArrowRight className="size-4" />
@@ -329,8 +357,9 @@ function WelcomeStep({
             Let&apos;s get your command center set up
           </h1>
           <p className="text-muted-foreground max-w-lg text-[15px] leading-7">
-            I&apos;m Marko, founder of Kortix. Book a quick 20-minute call and we&apos;ll set up your
-            company&apos;s AI command center together — or jump straight in and connect your tools below.
+            I&apos;m Marko, founder of Kortix. Book a quick 20-minute call and we&apos;ll set up
+            your company&apos;s AI command center together — or jump straight in and connect your
+            tools below.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-3">
@@ -402,8 +431,8 @@ function ToolsStep({
           Connect your tools
         </h1>
         <p className="text-muted-foreground max-w-lg text-[15px] leading-7">
-          Pick the apps you live in and authorize them right here. Your agent can read, write, and act
-          across everything you connect — Gmail, Notion, Salesforce, and 3,000+ more.
+          Pick the apps you live in and authorize them right here. Your agent can read, write, and
+          act across everything you connect — Gmail, Notion, Salesforce, and 3,000+ more.
         </p>
       </div>
 
@@ -599,8 +628,8 @@ function SlackStep({ projectId }: { projectId: string }) {
           Install Kortix into Slack
         </h1>
         <p className="text-muted-foreground max-w-lg text-[15px] leading-7">
-          This is where most teams actually use Kortix. Install the app and you can @mention your agent,
-          kick off tasks, and get results right inside Slack.
+          This is where most teams actually use Kortix. Install the app and you can @mention your
+          agent, kick off tasks, and get results right inside Slack.
         </p>
       </div>
 
@@ -622,8 +651,8 @@ function SlackStep({ projectId }: { projectId: string }) {
                 Waiting for you to approve in Slack…
               </div>
               <p className="text-muted-foreground max-w-sm text-xs leading-5">
-                Approve the install in the window that opened. We&apos;ll detect it automatically — no
-                need to come back and click anything.
+                Approve the install in the window that opened. We&apos;ll detect it automatically —
+                no need to come back and click anything.
               </p>
               <Button variant="ghost" size="sm" className="mt-1" onClick={openInstall}>
                 Reopen Slack install
@@ -658,15 +687,15 @@ function SlackStep({ projectId }: { projectId: string }) {
             className="text-muted-foreground h-8 gap-1.5 px-0"
             onClick={() => setCustomOpen((o) => !o)}
           >
-            <ChevronDown className={cn('size-3.5 transition-transform', customOpen && 'rotate-180')} />
+            <ChevronDown
+              className={cn('size-3.5 transition-transform', customOpen && 'rotate-180')}
+            />
             <SlidersHorizontal className="size-3.5" />
             Use a custom Slack app instead
           </Button>
           {customOpen && (
             <div className="mt-3">
-              <Suspense
-                fallback={<Skeleton className="h-24 w-full rounded-2xl" />}
-              >
+              <Suspense fallback={<Skeleton className="h-24 w-full rounded-2xl" />}>
                 <SlackConnectForm projectId={projectId} onConnected={() => install.refetch()} />
               </Suspense>
             </div>
@@ -692,7 +721,65 @@ function SlackGlyph() {
   );
 }
 
-// ─── Step 4: Done ──────────────────────────────────────────────────────────────
+// ─── Step 4: Connect a model ────────────────────────────────────────────────────
+
+function ModelStep() {
+  const { data: providers, isLoading } = useOpenCodeProviders();
+  const hasModels = providerListHasModels(providers);
+  const { openConnectProvider, openUpgrade, modal } = useModelConnectionGate();
+
+  return (
+    <div className="flex flex-col gap-5">
+      {modal}
+      <div className="space-y-2">
+        <h1 className="text-foreground text-[26px] leading-tight font-semibold tracking-tight">
+          Connect a model
+        </h1>
+        <p className="text-muted-foreground max-w-lg text-[15px] leading-7">
+          Your agent needs an LLM to think with. Upgrade to a Kortix plan for instant access, or
+          bring your own API key from Anthropic, OpenAI, or any other provider.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="border-border/60 bg-card text-muted-foreground flex items-center justify-center gap-2 rounded-2xl border px-6 py-10 text-sm">
+          <Loader2 className="size-4 animate-spin" />
+          Checking your connected models…
+        </div>
+      ) : hasModels ? (
+        <InfoBanner tone="success" icon={Check} title="You're connected 🎉">
+          A model is ready to go — switch it anytime from the chat composer.
+        </InfoBanner>
+      ) : (
+        <div className="border-border/60 bg-card flex flex-col items-center gap-4 rounded-2xl border px-6 py-10 text-center">
+          <span className="border-border/60 bg-background flex size-14 items-center justify-center rounded-2xl border">
+            <KeyRound className="text-muted-foreground size-6" />
+          </span>
+          <p className="text-muted-foreground max-w-sm text-sm leading-6">
+            Pick whichever is faster for you right now — both take under a minute.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Button size="lg" className="gap-2" onClick={openUpgrade}>
+              <CreditCard className="size-4" />
+              Upgrade
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              className="gap-2"
+              onClick={() => openConnectProvider('providers')}
+            >
+              <KeyRound className="size-4" />
+              Bring your own key
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Step 5: Done ──────────────────────────────────────────────────────────────
 
 function DoneStep({ connectedCount, onStart }: { connectedCount: number; onStart: () => void }) {
   return (
@@ -709,8 +796,8 @@ function DoneStep({ connectedCount, onStart }: { connectedCount: number; onStart
           {connectedCount > 0
             ? ` with ${connectedCount} ${connectedCount === 1 ? 'tool' : 'tools'} connected`
             : ''}
-          . Describe a task in the composer and your agent gets to work — it can research, write, and
-          act across everything you&apos;ve connected.
+          . Describe a task in the composer and your agent gets to work — it can research, write,
+          and act across everything you&apos;ve connected.
         </p>
       </div>
       <Button size="lg" className="gap-1.5" onClick={onStart}>

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -5,13 +5,13 @@ import type { ReactNode } from 'react';
 import { type AttachedFile, SessionChatInput } from '@/features/session/session-chat-input';
 import { useOpenCodeConfig } from '@/hooks/opencode/use-opencode-config';
 import { type ModelKey, useOpenCodeLocal } from '@/hooks/opencode/use-opencode-local';
-import { useProjectConfig } from '@kortix/sdk/react';
 import {
   type Command,
   useOpenCodeAgents,
   useOpenCodeCommands,
   useOpenCodeProviders,
 } from '@/hooks/opencode/use-opencode-sessions';
+import { useProjectConfig } from '@kortix/sdk/react';
 
 export interface ComposerOptions {
   agent?: string;
@@ -70,7 +70,7 @@ export function ComposerChatInput({
   boundAgentName?: string | null;
 }) {
   const { data: agents } = useOpenCodeAgents({ projectId });
-  const { data: providers } = useOpenCodeProviders();
+  const { data: providers, isLoading: providersLoading } = useOpenCodeProviders();
   const { data: commands } = useOpenCodeCommands();
   const { data: config } = useOpenCodeConfig();
   const projectConfig = useProjectConfig(projectId);
@@ -122,6 +122,7 @@ export function ComposerChatInput({
       selectedModel={local.model.currentKey ?? null}
       onModelChange={(m) => local.model.set(m ?? undefined, { recent: true })}
       modelRequired
+      modelsLoading={providersLoading}
       variants={local.model.variant.list}
       selectedVariant={local.model.variant.current ?? null}
       onVariantChange={(v) => local.model.variant.set(v ?? undefined)}

--- a/apps/web/src/features/session/model-connection-gate.tsx
+++ b/apps/web/src/features/session/model-connection-gate.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { CreditCard, KeyRound } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/features/layout/section/empty-state';
+import { useModelConnectionGate } from './use-model-connection-gate';
+
+/**
+ * The single "no model connected" teaching moment — an icon, a plain-English
+ * explanation, and the two ways out: upgrade to a Kortix plan, or bring an API
+ * key from any provider. Shared by the chat input's full-block gate and the
+ * project onboarding wizard so the copy and actions never drift apart.
+ */
+export function ModelConnectionGate({
+  size = 'default',
+  className,
+}: {
+  size?: 'sm' | 'default';
+  className?: string;
+}) {
+  const { openConnectProvider, openUpgrade, modal } = useModelConnectionGate();
+
+  return (
+    <>
+      {modal}
+      <EmptyState
+        className={className}
+        icon={KeyRound}
+        size={size}
+        title="Connect a model to start chatting"
+        description="This session needs an LLM connected before it can respond. Upgrade for instant access to Kortix's managed models, or bring your own API key from any provider."
+        action={
+          <Button type="button" size="sm" onClick={openUpgrade}>
+            <CreditCard className="size-3.5" />
+            Upgrade
+          </Button>
+        }
+        secondaryAction={
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => openConnectProvider('providers')}
+          >
+            <KeyRound className="size-3.5" />
+            Bring your own key
+          </Button>
+        }
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -33,25 +33,21 @@ import {
   PROVIDER_LABELS,
   ProviderLogo,
 } from '@/features/providers/provider-branding';
-import { ProjectProviderModal } from '@/features/workspace/customize/sections/llm-provider/llm-provider-modal';
 import { accountStateSelectors, useAccountState } from '@/hooks/billing';
 import { connectedGatewayProviderIdsFromSecretNames } from '@/hooks/opencode/provider-selection';
 import { useModelStore } from '@/hooks/opencode/use-model-store';
 import type { ProviderListResponse } from '@/hooks/opencode/use-opencode-sessions';
-import { featureFlags } from '@kortix/sdk/feature-flags';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
-import { PROJECT_ACTIONS } from '@/lib/project-actions';
-import { useProjectCan } from '@/lib/use-project-can';
-import { getProjectDetail, listProjectSecrets } from '@kortix/sdk/projects-client';
-import { useCustomizeStore } from '@/stores/customize-store';
 import type { ProviderModalTab } from '@/stores/provider-modal-store';
 import { useProviderModalStore } from '@/stores/provider-modal-store';
-import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { AUTO_MODEL_ID, DEFAULT_MANAGED_MODEL_IDS } from '@kortix/llm-catalog';
+import { featureFlags } from '@kortix/sdk/feature-flags';
+import { getProjectDetail, listProjectSecrets } from '@kortix/sdk/projects-client';
 import { useQuery } from '@tanstack/react-query';
 import { AutoModelToggle } from './auto-model-toggle';
 import { shouldShowFreeTag } from './model-tags';
 import type { FlatModel } from './session-chat-input';
+import { useModelConnectionGate } from './use-model-connection-gate';
 
 // Re-export for consumers
 export { ConnectProviderContent } from '@/features/providers/connect-provider-content';
@@ -143,14 +139,14 @@ export function ModelSelector({
   // When AUTO is on, the manual provider list is hidden by default. This reveals
   // it (so the user can switch to a specific model) without turning AUTO off yet.
   const [expandManual, setExpandManual] = useState(false);
-  const openProviderModal = useProviderModalStore((s) => s.openProviderModal);
-  const openCustomize = useCustomizeStore((s) => s.openCustomize);
-  const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
+  // Where Upgrade / Connect provider should route, given the current route
+  // context — shared with the chat input's full-block gate and onboarding so
+  // they all open the exact same dialogs.
+  const { openConnectProvider, openUpgrade, modal: connectionModal } = useModelConnectionGate();
 
-  // When mounted under /projects/[id]/..., route the action buttons to the
-  // per-project provider modal so credentials land in `project_secrets`. On
-  // every other route (instance dashboard, /milano, /berlin, etc.) we keep
-  // the legacy GlobalProviderModal that writes to the active sandbox.
+  // When mounted under /projects/[id]/..., route model filtering to the
+  // per-project gateway catalog. On every other route (instance dashboard,
+  // /milano, /berlin, etc.) we filter to native (non-gateway) models.
   const params = useParams<{ id?: string }>();
   const projectId = typeof params?.id === 'string' ? params.id : null;
   const projectDetailQuery = useQuery({
@@ -160,20 +156,9 @@ export function ModelSelector({
     staleTime: 30_000,
   });
   const llmGatewayEnabled = isLlmGatewayEnabled(projectDetailQuery.data?.project);
-  // The legacy (non-gateway) provider modal lets you connect/disconnect
-  // providers — all writes. Gate them so a read-only member sees the catalog
-  // but no mutating controls (fails safe to read-only until the probe resolves).
-  const canWriteProviders =
-    useProjectCan(projectId ?? undefined, PROJECT_ACTIONS.PROJECT_WRITE, {
-      accountId: projectDetailQuery.data?.project.account_id,
-    }).allowed === true;
   const baseModels = useMemo(() => {
     return llmGatewayEnabled ? models : models.filter((m) => m.providerID !== 'kortix');
   }, [models, llmGatewayEnabled]);
-  const [projectModalOpen, setProjectModalOpen] = useState(false);
-  const [projectModalTab, setProjectModalTab] = useState<'connected' | 'catalog' | 'models'>(
-    'catalog',
-  );
 
   // Track project secrets whenever we're in a project (not only while the picker
   // is open) so connecting/disconnecting a provider flips model visibility live —
@@ -319,43 +304,19 @@ export function ModelSelector({
   const handleOpenProviderModal = useCallback(
     (tab: ProviderModalTab) => {
       setOpen(false);
-      if (projectId) {
-        if (llmGatewayEnabled) {
-          // Plus → "Add provider" (the core surface); the sliders / manage-models
-          // button → "Models". Both land on LLM → Providers, never Files.
-          openCustomize('llm-providers', {
-            llmProvidersTab: tab === 'models' ? 'models' : 'catalog',
-          });
-        } else {
-          setProjectModalTab(tab === 'providers' ? 'catalog' : tab);
-          setProjectModalOpen(true);
-        }
-        return;
-      }
-      openProviderModal(tab);
+      openConnectProvider(tab);
     },
-    [projectId, llmGatewayEnabled, openProviderModal, openCustomize],
+    [openConnectProvider],
   );
 
   const handleUpgrade = useCallback(() => {
     setOpen(false);
-    openUpgradeDialog({
-      reason: 'subscription_required',
-      accountId: projectDetailQuery.data?.project.account_id,
-    });
-  }, [openUpgradeDialog, projectDetailQuery.data?.project.account_id]);
+    openUpgrade();
+  }, [openUpgrade]);
 
   return (
     <>
-      {projectId && (
-        <ProjectProviderModal
-          projectId={projectId}
-          open={projectModalOpen}
-          onOpenChange={setProjectModalOpen}
-          defaultTab={projectModalTab}
-          canWrite={canWriteProviders}
-        />
-      )}
+      {connectionModal}
       <CommandPopover open={open} onOpenChange={setOpen}>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -25,7 +25,6 @@ import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import { normalizeAppPathname } from '@kortix/sdk/instance-routes';
 
-import { resolveComposerResetOnSend } from './composer-reset';
 import {
   ArrowUp,
   ArrowUpLeft,
@@ -45,11 +44,13 @@ import { AnimatePresence, motion } from 'motion/react';
 import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { extractClipboardFiles } from './clipboard-files';
+import { resolveComposerResetOnSend } from './composer-reset';
 import {
   NO_MODEL_AVAILABLE_ACTION_MESSAGE,
   NO_MODEL_AVAILABLE_MESSAGE,
   isModelRequiredButUnavailable,
 } from './model-availability';
+import { ModelConnectionGate } from './model-connection-gate';
 import { type ModelDefaultControls, ModelSelector } from './model-selector';
 import { VoiceRecorder } from './voice-recorder';
 
@@ -1153,6 +1154,10 @@ export interface SessionChatInputProps {
   clearOnSend?: boolean;
   /** If true, a concrete model must be selected before a chat/command send. */
   modelRequired?: boolean;
+  /** True while the provider/model catalog is still being fetched — suppresses
+   *  the full-block "connect a model" gate so it doesn't flash for accounts
+   *  that do have models but are mid-load (e.g. sandbox still warming up). */
+  modelsLoading?: boolean;
   /** Auto-focus the textarea on mount (default: true on desktop) */
   autoFocus?: boolean;
   placeholder?: string;
@@ -1231,6 +1236,7 @@ export function SessionChatInput({
   disabled = false,
   clearOnSend = true,
   modelRequired = false,
+  modelsLoading = false,
   autoFocus,
   placeholder = 'Ask anything...',
   prefill = null,
@@ -1669,6 +1675,12 @@ export function SessionChatInput({
     selectedModel,
     lockForQuestion,
   });
+  // Stricter than modelUnavailable: true only once we're confident the catalog
+  // is genuinely empty (not mid-fetch) — this is when the whole input gets
+  // replaced with the "connect a model" teaching moment, not just the send
+  // button being disabled.
+  const noModelsConnected =
+    modelRequired && !lockForQuestion && !modelsLoading && models.length === 0;
   const canSubmit = text.trim().length > 0 || attachedFiles.length > 0;
   const submitDisabled = disabled || modelUnavailable || lockForApproval;
 
@@ -2152,267 +2164,281 @@ export function SessionChatInput({
             </div>
           )}
 
-          <div className="flex max-h-[320px] translate-y-0 flex-col gap-1 px-3.5 opacity-100">
-            <div className="relative w-full">
-              {/* Sending while the agent is busy already works — Enter (or the
+          {noModelsConnected ? (
+            <div className="px-3.5 pt-3 pb-4">
+              <ModelConnectionGate size="sm" />
+            </div>
+          ) : (
+            <>
+              <div className="flex max-h-[320px] translate-y-0 flex-col gap-1 px-3.5 opacity-100">
+                <div className="relative w-full">
+                  {/* Sending while the agent is busy already works — Enter (or the
                   send button) posts straight to the server, which queues it
                   per-session. No separate "Add to queue" affordance needed. */}
-              {text.trim().length === 0 && !stagedCommand && (
-                <div
-                  aria-hidden
-                  className="text-muted-foreground pointer-events-none absolute top-4 left-0.5 h-6 w-[calc(100%-0.5rem)] overflow-hidden text-base sm:text-sm"
-                >
-                  {lockForApproval ? (
-                    <div className="absolute inset-0 text-amber-600 dark:text-amber-400">
-                      Approve or deny the action above to continue…
-                    </div>
-                  ) : lockForQuestion ? (
-                    <div className="absolute inset-0">
-                      {questionButtonLabel ? 'Or type your own answer...' : 'Type your answer...'}
-                    </div>
-                  ) : (
-                    <AnimatePresence mode="wait" initial={false}>
-                      <motion.div
-                        key={`${placeholderIndex}:${placeholderVariants[placeholderIndex]}`}
-                        className="absolute inset-0"
-                        initial={{ opacity: 0, y: 8 }}
-                        animate={{
-                          opacity: 1,
-                          y: 0,
-                          transition: { duration: 0.42, ease: [0.22, 1, 0.36, 1] },
-                        }}
-                        exit={{
-                          opacity: 0,
-                          y: -8,
-                          transition: { duration: 0.48, ease: [0.2, 0, 0.1, 1] },
-                        }}
-                      >
-                        {placeholderVariants[placeholderIndex]}
-                      </motion.div>
-                    </AnimatePresence>
-                  )}
-                </div>
-              )}
-              {text.trim().length === 0 && stagedCommand && (
-                <div
-                  aria-hidden
-                  className="text-muted-foreground/50 pointer-events-none absolute top-4 left-0.5 text-base sm:text-sm"
-                >
-                  {tHardcodedUi.raw(
-                    'componentsSessionSessionChatInput.line2185JsxTextEnterDetailsAndPressEnterOrPressEsc',
-                  )}
-                </div>
-              )}
-              {/* Highlight overlay — mirrors textarea text with colored mention spans */}
-              {highlightSegments && (
-                <div
-                  ref={highlightRef}
-                  aria-hidden
-                  className="text-foreground pointer-events-none absolute inset-0 px-0.5 pt-4 pb-6 text-base leading-normal break-words whitespace-pre-wrap sm:text-sm"
-                >
-                  {highlightSegments.map((seg, i) => (
-                    <span
-                      key={i}
-                      className={cn(
-                        (seg.kind === 'file' || seg.kind === 'agent' || seg.kind === 'session') &&
-                          'border-foreground/40 text-foreground/80 border-b font-medium',
-                      )}
+                  {text.trim().length === 0 && !stagedCommand && (
+                    <div
+                      aria-hidden
+                      className="text-muted-foreground pointer-events-none absolute top-4 left-0.5 h-6 w-[calc(100%-0.5rem)] overflow-hidden text-base sm:text-sm"
                     >
-                      {seg.text}
-                    </span>
-                  ))}
-                </div>
-              )}
-              <textarea
-                ref={textareaRef}
-                value={text}
-                onChange={handleInput}
-                onKeyDown={handleKeyDown}
-                onPaste={handlePaste}
-                onScroll={() => {
-                  if (highlightRef.current && textareaRef.current) {
-                    highlightRef.current.scrollTop = textareaRef.current.scrollTop;
-                  }
-                }}
-                placeholder=""
-                rows={1}
-                disabled={disabled || lockForApproval}
-                className={cn(
-                  'placeholder:text-muted-foreground relative max-h-[200px] min-h-[72px] w-full resize-none overflow-y-auto rounded-[24px] border-none bg-transparent px-0.5 pt-4 pb-6 text-base shadow-none outline-none focus-visible:ring-0 disabled:opacity-50 sm:text-sm',
-                  highlightSegments && 'caret-foreground text-transparent',
-                )}
-                autoFocus={shouldAutoFocus}
-              />
-            </div>
-          </div>
-
-          {/* Bottom toolbar */}
-          <div className="mb-1.5 flex items-center justify-between gap-1 overflow-visible pr-1.5 pl-2">
-            {/* LEFT: Attach + Agent + Model + Variant */}
-            <div className="flex min-w-0 items-center gap-0 overflow-visible">
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept={tHardcodedUi.raw(
-                  'componentsSessionSessionChatInput.line2237JsxAttrAcceptImagePdfTxtMdJsonCsvXmlYaml',
-                )}
-                multiple
-                className="hidden"
-                onChange={handleFileSelect}
-              />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors"
-                  >
-                    <Paperclip className="h-4 w-4" strokeWidth={2} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p>
-                    {tHardcodedUi.raw(
-                      'componentsSessionSessionChatInput.line2252JsxTextAttachFiles',
-                    )}
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-
-              {primaryAgents.length > 0 && (onAgentChange || agentSelectorLocked) && (
-                <AgentSelector
-                  agents={primaryAgents}
-                  selectedAgent={selectedAgent}
-                  onSelect={onAgentChange ?? (() => {})}
-                  disabled={agentSelectorLocked}
-                />
-              )}
-              {(models.length > 0 || modelRequired) && onModelChange && (
-                <ModelSelector
-                  models={models}
-                  selectedModel={selectedModel}
-                  onSelect={onModelChange}
-                  providers={providers}
-                  defaultControls={modelDefaultControls}
-                />
-              )}
-              {variants.length > 0 && onVariantChange && (
-                <VariantSelector
-                  variants={variants}
-                  selectedVariant={selectedVariant}
-                  onSelect={onVariantChange}
-                />
-              )}
-            </div>
-
-            {/* RIGHT: TokenProgress + Voice + Submit/Stop */}
-            <div className="flex shrink-0 items-center gap-0">
-              <TokenProgress
-                messages={messages}
-                models={models}
-                selectedModel={selectedModel}
-                onContextClick={onContextClick}
-              />
-
-              {toolbarSlot}
-
-              <VoiceRecorder
-                onTranscription={handleTranscription}
-                disabled={submitDisabled || isBusy}
-              />
-
-              {isSending && !lockForQuestion && (
-                <Button size="sm" disabled className="h-8 w-8 flex-shrink-0 rounded-full p-0">
-                  <Loader2 className="size-4 animate-spin" />
-                </Button>
-              )}
-              {!isSending && isBusy && (onStop || stopDisabled) && !lockForQuestion && (
-                <div className="relative flex items-center">
-                  {/* ESC hint — matches Kortix tooltip styling (bg-primary rounded-2xl) */}
-                  {escCount > 0 && (
-                    <div className="animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2 pointer-events-none absolute right-1/2 bottom-full mb-2 translate-x-1/2 duration-150">
-                      <div className="bg-primary text-primary-foreground flex items-center gap-1.5 rounded-2xl px-3 py-1.5 text-xs whitespace-nowrap">
-                        <kbd className="bg-background/20 text-primary-foreground inline-flex h-5 min-w-5 items-center justify-center rounded-sm px-1 font-sans text-xs font-medium">
-                          ESC
-                        </kbd>
-                        <span>{escCount === 1 ? '×2 to stop' : '×1 to stop'}</span>
-                      </div>
-                      {/* Arrow matching TooltipContent */}
-                      <div className="-mt-px flex justify-center">
-                        <div className="bg-primary size-2.5 -translate-y-[calc(50%_-_2px)] rotate-45 rounded-[2px]" />
-                      </div>
+                      {lockForApproval ? (
+                        <div className="absolute inset-0 text-amber-600 dark:text-amber-400">
+                          Approve or deny the action above to continue…
+                        </div>
+                      ) : lockForQuestion ? (
+                        <div className="absolute inset-0">
+                          {questionButtonLabel
+                            ? 'Or type your own answer...'
+                            : 'Type your answer...'}
+                        </div>
+                      ) : (
+                        <AnimatePresence mode="wait" initial={false}>
+                          <motion.div
+                            key={`${placeholderIndex}:${placeholderVariants[placeholderIndex]}`}
+                            className="absolute inset-0"
+                            initial={{ opacity: 0, y: 8 }}
+                            animate={{
+                              opacity: 1,
+                              y: 0,
+                              transition: { duration: 0.42, ease: [0.22, 1, 0.36, 1] },
+                            }}
+                            exit={{
+                              opacity: 0,
+                              y: -8,
+                              transition: { duration: 0.48, ease: [0.2, 0, 0.1, 1] },
+                            }}
+                          >
+                            {placeholderVariants[placeholderIndex]}
+                          </motion.div>
+                        </AnimatePresence>
+                      )}
                     </div>
                   )}
+                  {text.trim().length === 0 && stagedCommand && (
+                    <div
+                      aria-hidden
+                      className="text-muted-foreground/50 pointer-events-none absolute top-4 left-0.5 text-base sm:text-sm"
+                    >
+                      {tHardcodedUi.raw(
+                        'componentsSessionSessionChatInput.line2185JsxTextEnterDetailsAndPressEnterOrPressEsc',
+                      )}
+                    </div>
+                  )}
+                  {/* Highlight overlay — mirrors textarea text with colored mention spans */}
+                  {highlightSegments && (
+                    <div
+                      ref={highlightRef}
+                      aria-hidden
+                      className="text-foreground pointer-events-none absolute inset-0 px-0.5 pt-4 pb-6 text-base leading-normal break-words whitespace-pre-wrap sm:text-sm"
+                    >
+                      {highlightSegments.map((seg, i) => (
+                        <span
+                          key={i}
+                          className={cn(
+                            (seg.kind === 'file' ||
+                              seg.kind === 'agent' ||
+                              seg.kind === 'session') &&
+                              'border-foreground/40 text-foreground/80 border-b font-medium',
+                          )}
+                        >
+                          {seg.text}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  <textarea
+                    ref={textareaRef}
+                    value={text}
+                    onChange={handleInput}
+                    onKeyDown={handleKeyDown}
+                    onPaste={handlePaste}
+                    onScroll={() => {
+                      if (highlightRef.current && textareaRef.current) {
+                        highlightRef.current.scrollTop = textareaRef.current.scrollTop;
+                      }
+                    }}
+                    placeholder=""
+                    rows={1}
+                    disabled={disabled || lockForApproval}
+                    className={cn(
+                      'placeholder:text-muted-foreground relative max-h-[200px] min-h-[72px] w-full resize-none overflow-y-auto rounded-[24px] border-none bg-transparent px-0.5 pt-4 pb-6 text-base shadow-none outline-none focus-visible:ring-0 disabled:opacity-50 sm:text-sm',
+                      highlightSegments && 'caret-foreground text-transparent',
+                    )}
+                    autoFocus={shouldAutoFocus}
+                  />
+                </div>
+              </div>
+
+              {/* Bottom toolbar */}
+              <div className="mb-1.5 flex items-center justify-between gap-1 overflow-visible pr-1.5 pl-2">
+                {/* LEFT: Attach + Agent + Model + Variant */}
+                <div className="flex min-w-0 items-center gap-0 overflow-visible">
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept={tHardcodedUi.raw(
+                      'componentsSessionSessionChatInput.line2237JsxAttrAcceptImagePdfTxtMdJsonCsvXmlYaml',
+                    )}
+                    multiple
+                    className="hidden"
+                    onChange={handleFileSelect}
+                  />
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button
-                        size="sm"
-                        onClick={onStop}
-                        disabled={stopDisabled || !onStop}
-                        className="h-8 w-8 flex-shrink-0 rounded-full p-0"
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors"
                       >
-                        <div className="h-3 w-3 rounded-[3px] bg-current" />
-                      </Button>
+                        <Paperclip className="h-4 w-4" strokeWidth={2} />
+                      </button>
                     </TooltipTrigger>
                     <TooltipContent side="top">
                       <p>
-                        Stop{' '}
-                        <kbd className="bg-background/20 text-primary-foreground ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-sm px-1 font-sans text-xs font-medium">
-                          ESC
-                        </kbd>{' '}
-                        ×3
+                        {tHardcodedUi.raw(
+                          'componentsSessionSessionChatInput.line2252JsxTextAttachFiles',
+                        )}
                       </p>
                     </TooltipContent>
                   </Tooltip>
-                </div>
-              )}
-              {!isSending && (!isBusy || lockForQuestion) && (
-                <div className="opacity-100">
-                  {lockForQuestion && questionButtonLabel && !text.trim() ? (
-                    <Button
-                      size="sm"
-                      disabled={!questionCanAct || disabled}
-                      onClick={handleSubmit}
-                      className="h-8 flex-shrink-0 rounded-full px-3.5 text-xs font-medium"
-                    >
-                      {questionButtonLabel}
-                    </Button>
-                  ) : (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="inline-flex rounded-full">
-                          <Button
-                            size="sm"
-                            disabled={
-                              lockForQuestion
-                                ? (!canSubmit && !questionCanAct) || disabled
-                                : !canSubmit || submitDisabled
-                            }
-                            onClick={handleSubmit}
-                            aria-label={
-                              modelUnavailable ? NO_MODEL_AVAILABLE_ACTION_MESSAGE : 'Send message'
-                            }
-                            className="h-8 w-8 flex-shrink-0 rounded-full p-0"
-                          >
-                            {disabled ? (
-                              <div className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                            ) : (
-                              <ArrowUp className="size-4" />
-                            )}
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      {modelUnavailable && (
-                        <TooltipContent side="top" className="max-w-[260px] text-xs">
-                          <p>{NO_MODEL_AVAILABLE_ACTION_MESSAGE}</p>
-                        </TooltipContent>
-                      )}
-                    </Tooltip>
+
+                  {primaryAgents.length > 0 && (onAgentChange || agentSelectorLocked) && (
+                    <AgentSelector
+                      agents={primaryAgents}
+                      selectedAgent={selectedAgent}
+                      onSelect={onAgentChange ?? (() => {})}
+                      disabled={agentSelectorLocked}
+                    />
+                  )}
+                  {(models.length > 0 || modelRequired) && onModelChange && (
+                    <ModelSelector
+                      models={models}
+                      selectedModel={selectedModel}
+                      onSelect={onModelChange}
+                      providers={providers}
+                      defaultControls={modelDefaultControls}
+                    />
+                  )}
+                  {variants.length > 0 && onVariantChange && (
+                    <VariantSelector
+                      variants={variants}
+                      selectedVariant={selectedVariant}
+                      onSelect={onVariantChange}
+                    />
                   )}
                 </div>
-              )}
-            </div>
-          </div>
+
+                {/* RIGHT: TokenProgress + Voice + Submit/Stop */}
+                <div className="flex shrink-0 items-center gap-0">
+                  <TokenProgress
+                    messages={messages}
+                    models={models}
+                    selectedModel={selectedModel}
+                    onContextClick={onContextClick}
+                  />
+
+                  {toolbarSlot}
+
+                  <VoiceRecorder
+                    onTranscription={handleTranscription}
+                    disabled={submitDisabled || isBusy}
+                  />
+
+                  {isSending && !lockForQuestion && (
+                    <Button size="sm" disabled className="h-8 w-8 flex-shrink-0 rounded-full p-0">
+                      <Loader2 className="size-4 animate-spin" />
+                    </Button>
+                  )}
+                  {!isSending && isBusy && (onStop || stopDisabled) && !lockForQuestion && (
+                    <div className="relative flex items-center">
+                      {/* ESC hint — matches Kortix tooltip styling (bg-primary rounded-2xl) */}
+                      {escCount > 0 && (
+                        <div className="animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2 pointer-events-none absolute right-1/2 bottom-full mb-2 translate-x-1/2 duration-150">
+                          <div className="bg-primary text-primary-foreground flex items-center gap-1.5 rounded-2xl px-3 py-1.5 text-xs whitespace-nowrap">
+                            <kbd className="bg-background/20 text-primary-foreground inline-flex h-5 min-w-5 items-center justify-center rounded-sm px-1 font-sans text-xs font-medium">
+                              ESC
+                            </kbd>
+                            <span>{escCount === 1 ? '×2 to stop' : '×1 to stop'}</span>
+                          </div>
+                          {/* Arrow matching TooltipContent */}
+                          <div className="-mt-px flex justify-center">
+                            <div className="bg-primary size-2.5 -translate-y-[calc(50%_-_2px)] rotate-45 rounded-[2px]" />
+                          </div>
+                        </div>
+                      )}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            size="sm"
+                            onClick={onStop}
+                            disabled={stopDisabled || !onStop}
+                            className="h-8 w-8 flex-shrink-0 rounded-full p-0"
+                          >
+                            <div className="h-3 w-3 rounded-[3px] bg-current" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">
+                          <p>
+                            Stop{' '}
+                            <kbd className="bg-background/20 text-primary-foreground ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-sm px-1 font-sans text-xs font-medium">
+                              ESC
+                            </kbd>{' '}
+                            ×3
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )}
+                  {!isSending && (!isBusy || lockForQuestion) && (
+                    <div className="opacity-100">
+                      {lockForQuestion && questionButtonLabel && !text.trim() ? (
+                        <Button
+                          size="sm"
+                          disabled={!questionCanAct || disabled}
+                          onClick={handleSubmit}
+                          className="h-8 flex-shrink-0 rounded-full px-3.5 text-xs font-medium"
+                        >
+                          {questionButtonLabel}
+                        </Button>
+                      ) : (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex rounded-full">
+                              <Button
+                                size="sm"
+                                disabled={
+                                  lockForQuestion
+                                    ? (!canSubmit && !questionCanAct) || disabled
+                                    : !canSubmit || submitDisabled
+                                }
+                                onClick={handleSubmit}
+                                aria-label={
+                                  modelUnavailable
+                                    ? NO_MODEL_AVAILABLE_ACTION_MESSAGE
+                                    : 'Send message'
+                                }
+                                className="h-8 w-8 flex-shrink-0 rounded-full p-0"
+                              >
+                                {disabled ? (
+                                  <div className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                                ) : (
+                                  <ArrowUp className="size-4" />
+                                )}
+                              </Button>
+                            </span>
+                          </TooltipTrigger>
+                          {modelUnavailable && (
+                            <TooltipContent side="top" className="max-w-[260px] text-xs">
+                              <p>{NO_MODEL_AVAILABLE_ACTION_MESSAGE}</p>
+                            </TooltipContent>
+                          )}
+                        </Tooltip>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -1223,7 +1223,6 @@ function NotificationTurn({ turn }: { turn: Turn }) {
 // Edit Part Dialog — inline editing for text parts
 // ============================================================================
 
-
 // ============================================================================
 // User Message Row
 // ============================================================================
@@ -3561,7 +3560,7 @@ export function SessionChat({
   );
   const hasPendingApproval = (approvalAudit?.actions ?? []).some(isPendingAction);
   const { data: commands } = useOpenCodeCommands();
-  const { data: providers } = useOpenCodeProviders();
+  const { data: providers, isLoading: providersLoading } = useOpenCodeProviders();
   const { data: allSessions } = useOpenCodeSessions();
   const { data: config } = useOpenCodeConfig();
   const projectConfig = useProjectConfig(projectId);
@@ -5398,6 +5397,7 @@ export function SessionChat({
           onFileSearch={handleFileSearch}
           providers={providers}
           modelRequired
+          modelsLoading={providersLoading}
           threadContext={threadContext}
           onContextClick={() => setContextModalOpen(true)}
           replyTo={replyTo}

--- a/apps/web/src/features/session/use-model-connection-gate.tsx
+++ b/apps/web/src/features/session/use-model-connection-gate.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+import { useCallback, useState } from 'react';
+
+import { ProjectProviderModal } from '@/features/workspace/customize/sections/llm-provider/llm-provider-modal';
+import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
+import { PROJECT_ACTIONS } from '@/lib/project-actions';
+import { useProjectCan } from '@/lib/use-project-can';
+import { useCustomizeStore } from '@/stores/customize-store';
+import type { ProviderModalTab } from '@/stores/provider-modal-store';
+import { useProviderModalStore } from '@/stores/provider-modal-store';
+import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
+import { getProjectDetail } from '@kortix/sdk/projects-client';
+
+/**
+ * Shared "connect a model" routing — where clicking Upgrade / Connect provider
+ * should actually take the user, given the current route context (project with
+ * the LLM gateway on, project without it, or no project at all). Extracted from
+ * `ModelSelector` so any surface (the picker's empty state, the chat input's
+ * full-block gate, onboarding) opens the exact same dialogs.
+ */
+export function useModelConnectionGate() {
+  const openProviderModal = useProviderModalStore((s) => s.openProviderModal);
+  const openCustomize = useCustomizeStore((s) => s.openCustomize);
+  const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
+
+  const params = useParams<{ id?: string }>();
+  const projectId = typeof params?.id === 'string' ? params.id : null;
+
+  const projectDetailQuery = useQuery({
+    queryKey: ['project-detail', projectId],
+    queryFn: () => getProjectDetail(projectId as string),
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+  const llmGatewayEnabled = isLlmGatewayEnabled(projectDetailQuery.data?.project);
+  const canWriteProviders =
+    useProjectCan(projectId ?? undefined, PROJECT_ACTIONS.PROJECT_WRITE, {
+      accountId: projectDetailQuery.data?.project.account_id,
+    }).allowed === true;
+
+  const [projectModalOpen, setProjectModalOpen] = useState(false);
+  const [projectModalTab, setProjectModalTab] = useState<'connected' | 'catalog' | 'models'>(
+    'catalog',
+  );
+
+  const openConnectProvider = useCallback(
+    (tab: ProviderModalTab = 'providers') => {
+      if (projectId) {
+        if (llmGatewayEnabled) {
+          // Plus → "Add provider" (the core surface); the sliders / manage-models
+          // button → "Models". Both land on LLM → Providers, never Files.
+          openCustomize('llm-providers', {
+            llmProvidersTab: tab === 'models' ? 'models' : 'catalog',
+          });
+        } else {
+          setProjectModalTab(tab === 'providers' ? 'catalog' : tab);
+          setProjectModalOpen(true);
+        }
+        return;
+      }
+      openProviderModal(tab);
+    },
+    [projectId, llmGatewayEnabled, openProviderModal, openCustomize],
+  );
+
+  const openUpgrade = useCallback(() => {
+    openUpgradeDialog({
+      reason: 'subscription_required',
+      accountId: projectDetailQuery.data?.project.account_id,
+    });
+  }, [openUpgradeDialog, projectDetailQuery.data?.project.account_id]);
+
+  const modal = projectId ? (
+    <ProjectProviderModal
+      projectId={projectId}
+      open={projectModalOpen}
+      onOpenChange={setProjectModalOpen}
+      defaultTab={projectModalTab}
+      canWrite={canWriteProviders}
+    />
+  ) : null;
+
+  return { openConnectProvider, openUpgrade, modal };
+}

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-25260b0b"
+  tag: "dev-aa3a0962"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
Follow-up full main → staging promotion after #4462. Includes #4465, restoring `environment` and `version` on both health endpoints so the staging deployment verifier and ke2e health contract can prove the deployed artifact.\n\nThe session identity guard migration from #4462 is already applied to staging and live negative checks block unauthorized identity update/delete.