### PR TITLE
chore(release): promote latest main to staging

### DIFF
--- a/apps/web/src/components/projects/project-onboarding-wizard.tsx
+++ b/apps/web/src/components/projects/project-onboarding-wizard.tsx
@@ -55,10 +55,10 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { DemoQualifierModal } from '@/features/contact/demo-qualifier-modal';
 import { useAuth } from '@/features/providers/auth-provider';
+import { flattenModels } from '@/features/session/session-chat-input';
 import { useModelConnectionGate } from '@/features/session/use-model-connection-gate';
 import { useSlackInstall, useSlackMode } from '@/hooks/channels/use-channels-installations';
 import { useToolConnect } from '@/hooks/connectors/use-tool-connect';
-import { providerListHasModels } from '@/hooks/opencode/provider-selection';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import { useProjectOnboarding } from '@/hooks/projects/use-project-onboarding';
 import { usePersonalContactTier } from '@/hooks/use-show-personal-contact';
@@ -279,7 +279,7 @@ function StepPrimaryAction({
   const slackInstall = useSlackInstall(stepId === 'slack' ? projectId : null);
   const slackConnected = !!slackInstall.data;
   const modelProviders = useOpenCodeProviders();
-  const hasModels = providerListHasModels(modelProviders.data);
+  const { hasSelectableModels } = useModelConnectionGate(flattenModels(modelProviders.data));
 
   if (stepId === 'slack') {
     return (
@@ -314,7 +314,7 @@ function StepPrimaryAction({
   if (stepId === 'model') {
     return (
       <div className="flex items-center gap-3">
-        {!hasModels && (
+        {!hasSelectableModels && (
           <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={onNext}>
             Skip
           </Button>
@@ -725,8 +725,9 @@ function SlackGlyph() {
 
 function ModelStep() {
   const { data: providers, isLoading } = useOpenCodeProviders();
-  const hasModels = providerListHasModels(providers);
-  const { openConnectProvider, openUpgrade, modal } = useModelConnectionGate();
+  const { openConnectProvider, openUpgrade, modal, hasSelectableModels } = useModelConnectionGate(
+    flattenModels(providers),
+  );
 
   return (
     <div className="flex flex-col gap-5">
@@ -746,7 +747,7 @@ function ModelStep() {
           <Loader2 className="size-4 animate-spin" />
           Checking your connected models…
         </div>
-      ) : hasModels ? (
+      ) : hasSelectableModels ? (
         <InfoBanner tone="success" icon={Check} title="You're connected 🎉">
           A model is ready to go — switch it anytime from the chat composer.
         </InfoBanner>

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -52,6 +52,7 @@ import {
 } from './model-availability';
 import { ModelConnectionGate } from './model-connection-gate';
 import { type ModelDefaultControls, ModelSelector } from './model-selector';
+import { useModelConnectionGate } from './use-model-connection-gate';
 import { VoiceRecorder } from './voice-recorder';
 
 import {
@@ -1675,12 +1676,17 @@ export function SessionChatInput({
     selectedModel,
     lockForQuestion,
   });
-  // Stricter than modelUnavailable: true only once we're confident the catalog
-  // is genuinely empty (not mid-fetch) — this is when the whole input gets
-  // replaced with the "connect a model" teaching moment, not just the send
-  // button being disabled.
+  // Stricter than modelUnavailable: true only once we're confident NOTHING is
+  // usable (not mid-fetch) — this is when the whole input gets replaced with
+  // the "connect a model" teaching moment, not just the send button being
+  // disabled. Deliberately NOT `models.length === 0` — the gateway bakes its
+  // whole catalog into every project regardless of plan or connected keys, so
+  // the raw list is basically never empty even for a brand-new, unpaid,
+  // no-BYOK account. `hasSelectableModels` accounts for free-tier gating and
+  // which providers are actually connected.
+  const { hasSelectableModels } = useModelConnectionGate(models);
   const noModelsConnected =
-    modelRequired && !lockForQuestion && !modelsLoading && models.length === 0;
+    modelRequired && !lockForQuestion && !modelsLoading && !hasSelectableModels;
   const canSubmit = text.trim().length > 0 || attachedFiles.length > 0;
   const submitDisabled = disabled || modelUnavailable || lockForApproval;
 

--- a/apps/web/src/features/session/use-model-connection-gate.tsx
+++ b/apps/web/src/features/session/use-model-connection-gate.tsx
@@ -2,9 +2,12 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { ProjectProviderModal } from '@/features/workspace/customize/sections/llm-provider/llm-provider-modal';
+import { accountStateSelectors, useAccountState } from '@/hooks/billing';
+import { connectedGatewayProviderIdsFromSecretNames } from '@/hooks/opencode/provider-selection';
+import { hasUsableModel } from '@/hooks/opencode/use-model-store';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useProjectCan } from '@/lib/use-project-can';
@@ -12,7 +15,8 @@ import { useCustomizeStore } from '@/stores/customize-store';
 import type { ProviderModalTab } from '@/stores/provider-modal-store';
 import { useProviderModalStore } from '@/stores/provider-modal-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
-import { getProjectDetail } from '@kortix/sdk/projects-client';
+import { getProjectDetail, listProjectSecrets } from '@kortix/sdk/projects-client';
+import type { FlatModel } from './session-chat-input';
 
 /**
  * Shared "connect a model" routing — where clicking Upgrade / Connect provider
@@ -20,8 +24,15 @@ import { getProjectDetail } from '@kortix/sdk/projects-client';
  * the LLM gateway on, project without it, or no project at all). Extracted from
  * `ModelSelector` so any surface (the picker's empty state, the chat input's
  * full-block gate, onboarding) opens the exact same dialogs.
+ *
+ * Also computes `hasSelectableModels` — pass the caller's flattened model list
+ * (default `[]` for callers that only need the routing actions). This is
+ * deliberately NOT `models.length > 0` or a raw provider-connected check: the
+ * gateway bakes its whole catalog into every project regardless of plan or
+ * connected keys, so the raw list is basically never empty. See
+ * `hasUsableModel` for the actual entitlement check.
  */
-export function useModelConnectionGate() {
+export function useModelConnectionGate(models: FlatModel[] = []) {
   const openProviderModal = useProviderModalStore((s) => s.openProviderModal);
   const openCustomize = useCustomizeStore((s) => s.openCustomize);
   const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
@@ -44,6 +55,38 @@ export function useModelConnectionGate() {
   const [projectModalOpen, setProjectModalOpen] = useState(false);
   const [projectModalTab, setProjectModalTab] = useState<'connected' | 'catalog' | 'models'>(
     'catalog',
+  );
+
+  // Same entitlement inputs ModelSelector uses: which BYOK providers are
+  // connected (from project secrets), and whether the account is on free
+  // tier (hides Kortix-managed models — they paywall server-side otherwise).
+  const baseModels = useMemo(
+    () => (llmGatewayEnabled ? models : models.filter((m) => m.providerID !== 'kortix')),
+    [models, llmGatewayEnabled],
+  );
+  const secretsQuery = useQuery({
+    queryKey: ['project-secrets', projectId],
+    queryFn: () => listProjectSecrets(projectId as string),
+    enabled: !!projectId && llmGatewayEnabled,
+    staleTime: 10_000,
+  });
+  const connectedProviderIds = useMemo(() => {
+    if (!llmGatewayEnabled) return new Set<string>();
+    const data = secretsQuery.data;
+    const items = Array.isArray(data) ? data : (data?.items ?? []);
+    const secretNames = new Set(items.map((secret: { name: string }) => secret.name));
+    return connectedGatewayProviderIdsFromSecretNames(secretNames);
+  }, [llmGatewayEnabled, secretsQuery.data]);
+  const { data: accountState } = useAccountState();
+  const freeTier = useMemo(() => {
+    const tierKey = accountStateSelectors.tierKey(accountState).toLowerCase();
+    const hasActiveSubscription = !!accountState?.subscription?.subscription_id;
+    return (tierKey === 'free' || tierKey === 'none') && !hasActiveSubscription;
+  }, [accountState]);
+  const hasSelectableModels = useMemo(
+    () =>
+      hasUsableModel(baseModels, { connectedProviderIds, freeTier: llmGatewayEnabled && freeTier }),
+    [baseModels, connectedProviderIds, llmGatewayEnabled, freeTier],
   );
 
   const openConnectProvider = useCallback(
@@ -83,5 +126,5 @@ export function useModelConnectionGate() {
     />
   ) : null;
 
-  return { openConnectProvider, openUpgrade, modal };
+  return { openConnectProvider, openUpgrade, modal, hasSelectableModels };
 }

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-aa3a0962"
+  tag: "dev-8bbda732"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/packages/sdk/src/react/use-model-store.ts
+++ b/packages/sdk/src/react/use-model-store.ts
@@ -207,6 +207,39 @@ function subProviderOf(modelID: string): string {
   return slash === -1 ? modelID : modelID.slice(0, slash);
 }
 
+/**
+ * True when at least one model in `allModels` is actually usable right now —
+ * i.e. would work if sent, not merely present in the catalog. The gateway
+ * bakes its ENTIRE routable catalog into every project regardless of plan or
+ * connected keys (`providers.connected` always includes `kortix`), so raw
+ * catalog presence (`providerListHasModels`, `models.length`) is never a
+ * reliable "nothing is connected" signal — it's true even for a brand-new,
+ * unpaid, no-BYOK account. This mirrors the entitlement half of `isVisible`
+ * (managed models gated by `!freeTier`, BYOK-under-gateway models gated by
+ * their sub-provider being connected) without its display-curation half
+ * (the "latest per family" / flagship-only default view) — a model can be
+ * fully usable while `isVisible` still hides it by default.
+ */
+export function hasUsableModel(
+  allModels: FlatModel[],
+  opts: { connectedProviderIds?: Set<string>; freeTier?: boolean },
+): boolean {
+  const connectedProviderIds = opts.connectedProviderIds;
+  const freeTier = opts.freeTier ?? false;
+  return allModels.some((m) => {
+    if (m.providerID !== MANAGED_GATEWAY_PROVIDER_ID) {
+      // Native/direct provider models: flattenModels only includes models
+      // from CONNECTED providers, so presence here already means usable.
+      return true;
+    }
+    if (MANAGED_MODEL_IDS.has(m.modelID)) return !freeTier;
+    const sub = subProviderOf(m.modelID);
+    return sub === SUBSCRIPTION_PROVIDER_ID
+      ? (connectedProviderIds?.has(SUBSCRIPTION_PROVIDER_ID) ?? false)
+      : (connectedProviderIds?.has(sub) ?? false);
+  });
+}
+
 export function isDefaultVisible(model: ModelKey): boolean {
   return DEFAULT_VISIBLE_MODEL_IDS.has(model.modelID);
 }


### PR DESCRIPTION
## Summary

Full promotion of the current `main` head to `staging` for end-to-end validation.

- Source SHA: `e811a05f86e30a478cf1e54538c183b983bc146d`
- Includes all changes merged after PR #4468
- Staging only; no production promotion