### PR TITLE
fix(sdk): record hasUsableModel in the public surface snapshots

### DIFF
--- a/packages/sdk/src/public-surface.snapshot.json
+++ b/packages/sdk/src/public-surface.snapshot.json
@@ -578,6 +578,7 @@
     "getSendRetryDelayMs",
     "hasActiveNonQuestionTool",
     "hasRunningQuestionTool",
+    "hasUsableModel",
     "isBillingError",
     "isDefaultVisible",
     "isImmediateOfflineSignal",

--- a/packages/sdk/src/public-type-surface.snapshot.json
+++ b/packages/sdk/src/public-type-surface.snapshot.json
@@ -2491,6 +2491,7 @@
     "getSendRetryDelayMs",
     "hasActiveNonQuestionTool",
     "hasRunningQuestionTool",
+    "hasUsableModel",
     "isBillingError",
     "isDefaultVisible",
     "isImmediateOfflineSignal",


### PR DESCRIPTION
## Summary

`hasUsableModel` was exported from `packages/sdk/src/react/use-model-store.ts` without regenerating the SDK export-surface snapshots, so `bun unit tests (packages + apps)` fails on `main` and on every open PR (CI tests the merge with current main). This regenerates both snapshots; the diff is exactly the one intended new export, added to the value-level and type-level surface.

## Test plan
- `bun test src/public-surface.test.ts src/public-type-surface.test.ts` in `packages/sdk`: 2 pass after regeneration (both failed before)
- Snapshot diff reviewed: only `hasUsableModel` added, nothing removed