### PR TITLE
fix: make session uploads recoverable

### DIFF
--- a/apps/api/src/__tests__/unit-preview-retry-budget.test.ts
+++ b/apps/api/src/__tests__/unit-preview-retry-budget.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  PROXY_ATTEMPT_TIMEOUT_MS,
+  PROXY_RETRY_BUDGET_MS,
+  proxyAttemptTimeoutMs,
+} from '../sandbox-proxy/preview-retry-budget';
+
+describe('preview proxy retry budget', () => {
+  test('allows a sandbox file upload to use the remaining proxy budget', () => {
+    expect(
+      proxyAttemptTimeoutMs(PROXY_RETRY_BUDGET_MS, {
+        method: 'POST',
+        path: '/file/upload',
+      }),
+    ).toBe(PROXY_RETRY_BUDGET_MS - 500);
+  });
+
+  test('keeps the short connect timeout for ordinary sandbox requests', () => {
+    expect(
+      proxyAttemptTimeoutMs(PROXY_RETRY_BUDGET_MS, {
+        method: 'GET',
+        path: '/kortix/health',
+      }),
+    ).toBe(PROXY_ATTEMPT_TIMEOUT_MS);
+  });
+});

--- a/apps/api/src/sandbox-proxy/preview-retry-budget.ts
+++ b/apps/api/src/sandbox-proxy/preview-retry-budget.ts
@@ -9,6 +9,20 @@ export const PROXY_ATTEMPT_TIMEOUT_MS = 15_000;
 
 // Per-attempt upstream fetch timeout, shrunk to whatever budget remains so the
 // retry loop can never run past PROXY_RETRY_BUDGET_MS even if an attempt hangs.
-export function proxyAttemptTimeoutMs(budgetRemainingMs: number): number {
+export function proxyAttemptTimeoutMs(
+  budgetRemainingMs: number,
+  request?: { method: string; path: string },
+): number {
+  // Upload handlers cannot return response headers until the multipart body has
+  // been received and written. Treating that whole interval as a connection
+  // stall aborts every sufficiently large upload at 15s, then retries the same
+  // body until the outer 50s budget is exhausted. Give an upload the remaining
+  // request budget; the outer budget still keeps us below the ALB idle timeout.
+  if (
+    request?.method.toUpperCase() === 'POST' &&
+    /^\/file\/upload(?:$|[/?#])/.test(request.path)
+  ) {
+    return Math.max(1_000, budgetRemainingMs - 500);
+  }
   return Math.max(1_000, Math.min(PROXY_ATTEMPT_TIMEOUT_MS, budgetRemainingMs));
 }

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -579,8 +579,11 @@ export async function forwardToSandbox(
       // a stream) so aborting only kills the in-flight attempt, never truncates
       // an upload mid-stream.
       //
-      // CRITICAL: the timeout bounds ONLY the connect/header phase — the timer
-      // is cleared the moment `fetch` resolves. The previous
+      // CRITICAL: for ordinary requests the timeout bounds ONLY the
+      // connect/header phase — the timer is cleared the moment `fetch` resolves.
+      // Multipart uploads are the exception: their handler cannot return
+      // headers until the body is written, so they receive the remaining outer
+      // proxy budget instead of the generic 15s cutoff. The previous
       // `AbortSignal.timeout(...)` bounded the ENTIRE fetch lifecycle, which
       // severed every streaming response body at ~15s: the `/global/event` SSE
       // stream (each open session tab then reconnected ~250ms later, forever —
@@ -593,7 +596,7 @@ export async function forwardToSandbox(
           attemptController.abort(
             new DOMException('proxy attempt connect timeout', 'TimeoutError'),
           ),
-        proxyAttemptTimeoutMs(budgetRemainingMs),
+        proxyAttemptTimeoutMs(budgetRemainingMs, { method, path: remainingPath }),
       );
       let upstream: Response;
       try {

--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -61,7 +61,12 @@ export function ComposerChatInput({
   clearOnSend?: boolean;
   autoFocus?: boolean;
   placeholder?: string;
-  prefill?: { text: string; id: number } | null;
+  prefill?: {
+    text: string;
+    id: number;
+    files?: AttachedFile[];
+    mode?: 'replace' | 'merge';
+  } | null;
   inputSlot?: ReactNode;
   toolbarSlot?: ReactNode;
   /** Extra classes for the input card (e.g. the project-home radius override). */

--- a/apps/web/src/features/session/composer-draft-recovery.test.ts
+++ b/apps/web/src/features/session/composer-draft-recovery.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { AttachedFile, TrackedMention } from './session-chat-input';
+import {
+  mergeFailedSubmissionFiles,
+  mergeFailedSubmissionMentions,
+  mergeFailedSubmissionText,
+} from './composer-draft-recovery';
+
+function localFile(name: string, localUrl: string): Extract<AttachedFile, { kind: 'local' }> {
+  return {
+    kind: 'local',
+    file: new File(['draft'], name, { type: 'text/plain' }),
+    localUrl,
+    isImage: false,
+  };
+}
+
+describe('failed composer submission recovery', () => {
+  test('restores the submitted prompt when the composer is still empty', () => {
+    expect(mergeFailedSubmissionText('', 'twenty minutes of work')).toBe(
+      'twenty minutes of work',
+    );
+  });
+
+  test('preserves text typed while the failed request was in flight', () => {
+    expect(mergeFailedSubmissionText('new follow-up', 'original prompt')).toBe(
+      'original prompt\n\nnew follow-up',
+    );
+  });
+
+  test('restores sent files ahead of newly attached files without duplicates', () => {
+    const sent = localFile('offer.pdf', 'blob:offer');
+    const addedWhileSending = localFile('notes.txt', 'blob:notes');
+    expect(mergeFailedSubmissionFiles([addedWhileSending], [sent])).toEqual([
+      sent,
+      addedWhileSending,
+    ]);
+    expect(mergeFailedSubmissionFiles([sent], [sent])).toEqual([sent]);
+  });
+
+  test('restores mentions without dropping mentions added while sending', () => {
+    const sent: TrackedMention = { kind: 'session', label: 'Research', value: 'ses_1' };
+    const added: TrackedMention = { kind: 'agent', label: 'Analyst' };
+    expect(mergeFailedSubmissionMentions([added], [sent])).toEqual([sent, added]);
+  });
+});

--- a/apps/web/src/features/session/composer-draft-recovery.ts
+++ b/apps/web/src/features/session/composer-draft-recovery.ts
@@ -1,0 +1,43 @@
+import type { AttachedFile, TrackedMention } from './session-chat-input';
+
+export function mergeFailedSubmissionText(current: string, submitted: string): string {
+  if (!current) return submitted;
+  if (!submitted || current === submitted) return current;
+  return `${submitted}\n\n${current}`;
+}
+
+function attachedFileKey(file: AttachedFile): string {
+  return file.kind === 'local'
+    ? `local:${file.localUrl}`
+    : `remote:${file.url}:${file.filename}`;
+}
+
+export function mergeFailedSubmissionFiles(
+  current: AttachedFile[],
+  submitted: AttachedFile[],
+): AttachedFile[] {
+  const seen = new Set<string>();
+  return [...submitted, ...current].filter((file) => {
+    const key = attachedFileKey(file);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function mentionKey(mention: TrackedMention): string {
+  return `${mention.kind}:${mention.value ?? ''}:${mention.label}`;
+}
+
+export function mergeFailedSubmissionMentions(
+  current: TrackedMention[],
+  submitted: TrackedMention[],
+): TrackedMention[] {
+  const seen = new Set<string>();
+  return [...submitted, ...current].filter((mention) => {
+    const key = mentionKey(mention);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -46,6 +46,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { extractClipboardFiles } from './clipboard-files';
 import { resolveComposerResetOnSend } from './composer-reset';
 import {
+  mergeFailedSubmissionFiles,
+  mergeFailedSubmissionMentions,
+  mergeFailedSubmissionText,
+} from './composer-draft-recovery';
+import {
   NO_MODEL_AVAILABLE_ACTION_MESSAGE,
   NO_MODEL_AVAILABLE_MESSAGE,
   isModelRequiredButUnavailable,
@@ -1162,8 +1167,15 @@ export interface SessionChatInputProps {
   /** Auto-focus the textarea on mount (default: true on desktop) */
   autoFocus?: boolean;
   placeholder?: string;
-  /** Imperative draft prefill used by parent composers for starter prompts. */
-  prefill?: { text: string; id: number } | null;
+  /** Imperative draft prefill used by parent composers for starter prompts or
+   * failed first-turn recovery. Recovery merges instead of overwriting any
+   * draft the user typed while the request was in flight. */
+  prefill?: {
+    text: string;
+    id: number;
+    files?: AttachedFile[];
+    mode?: 'replace' | 'merge';
+  } | null;
 
   /** Callback to search files via SDK for @ mentions */
   onFileSearch?: (query: string) => Promise<string[]>;
@@ -1324,9 +1336,24 @@ export function SessionChatInput({
   const fileResultsCache = useRef<Set<string>>(new Set());
 
   const savedTextBeforeQuestionRef = useRef('');
+  const prefillId = prefill?.id;
+  const prefillText = prefill?.text ?? '';
+  const prefillFiles = prefill?.files;
+  const prefillMode = prefill?.mode;
   useEffect(() => {
-    if (!prefill?.text) return;
-    setText(prefill.text);
+    if (prefillId === undefined || (!prefillText && !prefillFiles?.length)) return;
+    setText((current) =>
+      prefillMode === 'merge'
+        ? mergeFailedSubmissionText(current, prefillText)
+        : prefillText,
+    );
+    if (prefillFiles?.length) {
+      setAttachedFiles((current) =>
+        prefillMode === 'merge'
+          ? mergeFailedSubmissionFiles(current, prefillFiles)
+          : [...prefillFiles],
+      );
+    }
     setStagedCommand(null);
     setSlashFilter(null);
     setMentionQuery(null);
@@ -1335,14 +1362,14 @@ export function SessionChatInput({
       const ta = textareaRef.current;
       if (!ta) return;
       ta.focus();
-      ta.setSelectionRange(prefill.text.length, prefill.text.length);
+      ta.setSelectionRange(prefillText.length, prefillText.length);
       ta.style.height = 'auto';
       ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
       if (highlightRef.current) {
         highlightRef.current.style.height = ta.style.height;
       }
     });
-  }, [prefill?.id, prefill?.text]);
+  }, [prefillId, prefillText, prefillFiles, prefillMode]);
 
   useEffect(() => {
     if (lockForQuestion) {
@@ -1768,7 +1795,6 @@ export function SessionChatInput({
       setSlashFilter(null);
       setMentionQuery(null);
       setMentions([]);
-      for (const url of reset.urlsToRevoke) URL.revokeObjectURL(url);
       setAttachedFiles([]);
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
@@ -1790,12 +1816,21 @@ export function SessionChatInput({
     // without queuing — this path is only reached when no queue is wired up.
     try {
       await onSend(trimmed, filesToSend, mentionsToSend);
+      for (const url of reset.urlsToRevoke) URL.revokeObjectURL(url);
     } catch {
-      // Restore the text so the user can retry. The failure itself is surfaced
-      // by the persistent typed banner (commandError → TurnErrorDisplay) set in
-      // handleSend's catch — a toast here would double-display it. (No-op when
-      // clearOnSend is false: the text was never cleared.)
-      if (clearOnSend) setText(trimmed);
+      // Restore the entire submitted draft, not just its text. Object URLs stay
+      // alive until success, so local files remain retryable. Merge with any
+      // text/files/mentions added while the request was in flight instead of
+      // overwriting newer work.
+      if (clearOnSend) {
+        setText((current) => mergeFailedSubmissionText(current, trimmed));
+        setAttachedFiles((current) =>
+          mergeFailedSubmissionFiles(current, filesToSend ?? []),
+        );
+        setMentions((current) =>
+          mergeFailedSubmissionMentions(current, mentionsToSend ?? []),
+        );
+      }
     }
   }, [
     text,

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -3628,6 +3628,11 @@ export function SessionChat({
     description?: string;
   } | null>(null);
   const [commandError, setCommandError] = useState<KortixSendError | null>(null);
+  const [failedStartDraft, setFailedStartDraft] = useState<{
+    text: string;
+    files: AttachedFile[];
+    id: number;
+  } | null>(null);
   // Map of user message IDs → command info, so UserMessageRow can render
   // a compact command pill instead of the raw expanded template text.
   const commandMessagesRef = useRef<Map<string, { name: string; args?: string }>>(new Map());
@@ -3758,14 +3763,21 @@ export function SessionChat({
           },
         };
       },
-      onFailure: (_stash, _err, classified) => {
+      onFailure: (stash, _err, classified) => {
         setPendingSendInFlight(false);
         setPendingSendMessageId(null);
         setOptimisticPrompt(null);
         setPollingActive(false);
         setCommandError(classified);
         usePendingFilesStore.getState().setPendingFiles(filesToRestoreOnFailure);
-        pendingPromptHandled.current = false;
+        // replayStartStash restores durable sessionStorage itself. Rehydrate the
+        // visible composer too, so the user can retry immediately without a
+        // reload and without losing either the prompt or local File objects.
+        setFailedStartDraft({
+          text: stash.prompt,
+          files: filesToRestoreOnFailure,
+          id: Date.now(),
+        });
       },
     });
 
@@ -5357,7 +5369,22 @@ export function SessionChat({
         <SessionChatInput
           onSend={async (text, files, mentions) => {
             await handleSend(text, files, mentions);
+            if (failedStartDraft) {
+              clearStartStash(sessionId);
+              usePendingFilesStore.getState().consumePendingFiles();
+              setFailedStartDraft(null);
+            }
           }}
+          prefill={
+            failedStartDraft
+              ? {
+                  text: failedStartDraft.text,
+                  files: failedStartDraft.files,
+                  id: failedStartDraft.id,
+                  mode: 'merge',
+                }
+              : null
+          }
           isBusy={isBusy}
           queuedMessages={queuedMessages}
           onQueueMessage={handleQueueMessage}


### PR DESCRIPTION
## What changed
- stop applying the generic 15s proxy header timeout to multipart sandbox uploads; uploads receive the remaining bounded proxy budget
- keep composer object URLs alive until send success and restore text, attachments, and mentions on failure
- rehydrate a failed first-turn start stash into the visible composer so cold-session upload failures never erase the draft

## Production incident evidence
Session `878c9572-e539-43cd-91dc-0834944194b8` created/started normally. `POST /file/upload` repeatedly hit `proxy attempt connect timeout` and returned 502 after ~50s while the target file remained 404. The proxy was aborting multipart handlers at the generic 15s response-header deadline.

## Verification
- `bun test ./apps/api/src/__tests__/unit-preview-retry-budget.test.ts ./apps/api/src/__tests__/e2e-preview-proxy.test.ts ./apps/web/src/features/session/composer-draft-recovery.test.ts ./apps/web/src/features/session/composer-reset.test.ts ./apps/web/src/features/session/uploaded-file-refs.test.ts` (69 pass)
- API `pnpm exec tsc --noEmit`
- touched web ESLint clean; touched-file TypeScript filter clean
- real local stack + live cloud sandbox file-upload smoke: upload 200, exact bytes/size read back, collision, nested path, rename, delete all passed