### PR TITLE
fix(web,api): stop transient runtime-not-ready throw from crashing every session switch + harden review inbox

### DIFF
--- a/apps/api/src/projects/review-items.test.ts
+++ b/apps/api/src/projects/review-items.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+
+import { collectInboxItems, type InboxSources } from './review-items';
+
+// review_items row factory (only the fields serializeReviewItem touches).
+function nativeRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    reviewItemId: 'ri_1',
+    accountId: 'acc_1',
+    projectId: 'proj_1',
+    originSessionId: null,
+    kind: 'output',
+    status: 'needs_you',
+    risk: 'none',
+    source: 'agent',
+    title: 'Native item',
+    summary: '',
+    detail: {},
+    agent: '',
+    createdBy: 'user_1',
+    actedBy: null,
+    actedAt: null,
+    feedback: null,
+    metadata: {},
+    createdAt: new Date('2026-07-12T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-12T00:00:00.000Z'),
+    ...over,
+  } as unknown as Awaited<ReturnType<InboxSources['native']>>[number];
+}
+
+const throwing = (label: string) => async () => {
+  throw new Error(`boom: ${label} source unavailable (simulated schema drift)`);
+};
+
+describe('collectInboxItems fault isolation', () => {
+  test('one failing source degrades to empty — the whole inbox does NOT throw', async () => {
+    const sources: InboxSources = {
+      native: async () => [nativeRow()],
+      changeRequests: throwing('change_requests'),
+      executorApprovals: throwing('executor_executions'),
+    };
+
+    const items = await collectInboxItems(sources);
+
+    // The native source survives; the two broken sources contribute nothing.
+    expect(items).toHaveLength(1);
+    expect(items[0].review_item_id).toBe('ri_1');
+  });
+
+  test('ALL sources failing yields an empty inbox, never a rejection', async () => {
+    const sources: InboxSources = {
+      native: throwing('native'),
+      changeRequests: throwing('change_requests'),
+      executorApprovals: throwing('executor_executions'),
+    };
+
+    // The point of the fix: this must resolve to [], not reject → the route
+    // returns 200 { review_items: [] } instead of 500.
+    await expect(collectInboxItems(sources)).resolves.toEqual([]);
+  });
+
+  test('a single un-serializable row is skipped, the rest of the source survives', async () => {
+    const sources: InboxSources = {
+      native: async () => [
+        nativeRow({ reviewItemId: 'ri_ok' }),
+        // createdAt=null makes serializeReviewItem throw on .toISOString()
+        nativeRow({ reviewItemId: 'ri_bad', createdAt: null }),
+        nativeRow({ reviewItemId: 'ri_ok2' }),
+      ],
+      changeRequests: async () => [],
+      executorApprovals: async () => [],
+    };
+
+    const items = await collectInboxItems(sources);
+    const ids = items.map((i) => i.review_item_id).sort();
+    expect(ids).toEqual(['ri_ok', 'ri_ok2']);
+  });
+
+  test('segment + kind filters still apply over the surviving items', async () => {
+    const sources: InboxSources = {
+      native: async () => [
+        nativeRow({ reviewItemId: 'ri_needs', status: 'needs_you', kind: 'output' }),
+        nativeRow({ reviewItemId: 'ri_done', status: 'done', kind: 'output' }),
+        nativeRow({ reviewItemId: 'ri_decision', status: 'needs_you', kind: 'decision' }),
+      ],
+      changeRequests: async () => [],
+      executorApprovals: async () => [],
+    };
+
+    const needsYou = await collectInboxItems(sources, { segment: 'needs_you' });
+    expect(needsYou.map((i) => i.review_item_id).sort()).toEqual(['ri_decision', 'ri_needs']);
+
+    const outputs = await collectInboxItems(sources, { segment: 'needs_you', kind: 'output' });
+    expect(outputs.map((i) => i.review_item_id)).toEqual(['ri_needs']);
+  });
+});

--- a/apps/api/src/projects/review-items.ts
+++ b/apps/api/src/projects/review-items.ts
@@ -10,10 +10,13 @@
 
 import { changeRequests, executorExecutions, reviewItems } from '@kortix/db';
 import { and, desc, eq, inArray } from 'drizzle-orm';
+import { captureException } from '../lib/sentry';
 import { db } from '../shared/db';
 import { changeRequestToReviewItem, executorExecutionToReviewItem } from './review-adapters';
 
 type ReviewItemRow = typeof reviewItems.$inferSelect;
+type ChangeRequestRow = typeof changeRequests.$inferSelect;
+type ExecutorExecutionRow = typeof executorExecutions.$inferSelect;
 
 export type ReviewSegment = 'needs_you' | 'waiting' | 'done';
 export type ReviewVerdict = 'approve' | 'reject' | 'changes' | 'answer' | 'dismiss';
@@ -99,31 +102,72 @@ export async function listReviewItems(
 }
 
 /**
+ * One inbox source (native items, change requests, executor approvals). Each is
+ * fetched INDEPENDENTLY and folded in memory — there is no SQL join.
+ */
+export interface InboxSources {
+  native: () => Promise<ReviewItemRow[]>;
+  changeRequests: () => Promise<ChangeRequestRow[]>;
+  executorApprovals: () => Promise<ExecutorExecutionRow[]>;
+}
+
+/**
+ * Run one inbox source, degrading a failure to an empty contribution.
+ *
+ * This endpoint is POLLED by the sidebar (every 8–20s) and the Review Center, so
+ * one flaky source must NEVER 500 the whole inbox. The recurring real-world cause
+ * is schema/enum drift on a DB the API code has outrun (e.g. `review_items` not
+ * yet migrated, or an `executor_execution_status` value the deployed enum lacks):
+ * that throws a Postgres error which — unguarded — took the entire response down.
+ * We surface the failure to Sentry (so the drift is still visible and fixable) but
+ * return `[]` for that source and keep serving the sources that DO work.
+ */
+async function safeSource<T>(label: string, run: () => Promise<T[]>): Promise<T[]> {
+  try {
+    return await run();
+  } catch (error) {
+    console.error(`[review-items] inbox source "${label}" failed; degrading to empty`, error);
+    captureException(error, { reviewInboxSource: label });
+    return [];
+  }
+}
+
+/** Map rows to DTOs, skipping (not throwing on) any single row that fails to serialize. */
+function safeMap<T, R>(label: string, rows: T[], fn: (row: T) => R): R[] {
+  const out: R[] = [];
+  for (const row of rows) {
+    try {
+      out.push(fn(row));
+    } catch (error) {
+      console.error(`[review-items] failed to serialize a "${label}" row; skipping`, error);
+      captureException(error, { reviewInboxSource: label, phase: 'serialize' });
+    }
+  }
+  return out;
+}
+
+/**
  * The full inbox read model: native review items UNIONed with adapted sources
  * (Change Requests now; executor/tunnel approvals next), filtered to a segment /
  * kind and sorted newest-first. Returns already-serialized DTOs.
+ *
+ * Every source and every row is fault-isolated (see {@link safeSource} /
+ * {@link safeMap}) so a partial failure degrades to a partial (or empty) inbox
+ * rather than a 500. Pure over its injected `sources` — unit-testable without a DB.
  */
-export async function listInboxItems(
-  projectId: string,
+export async function collectInboxItems(
+  sources: InboxSources,
   opts: { segment?: ReviewSegment; kind?: ReviewItemRow['kind'] } = {},
 ) {
   const [nativeRows, crRows, execRows] = await Promise.all([
-    db.select().from(reviewItems).where(eq(reviewItems.projectId, projectId)),
-    db.select().from(changeRequests).where(eq(changeRequests.projectId, projectId)),
-    db
-      .select()
-      .from(executorExecutions)
-      .where(
-        and(
-          eq(executorExecutions.projectId, projectId),
-          eq(executorExecutions.status, 'pending_approval'),
-        ),
-      ),
+    safeSource('native', sources.native),
+    safeSource('change_requests', sources.changeRequests),
+    safeSource('executor_executions', sources.executorApprovals),
   ]);
   const items = [
-    ...nativeRows.map(serializeReviewItem),
-    ...crRows.map(changeRequestToReviewItem),
-    ...execRows.map(executorExecutionToReviewItem),
+    ...safeMap('native', nativeRows, serializeReviewItem),
+    ...safeMap('change_requests', crRows, changeRequestToReviewItem),
+    ...safeMap('executor_executions', execRows, executorExecutionToReviewItem),
   ];
   const segmentStatuses = opts.segment ? statusesForSegment(opts.segment) : null;
   return items
@@ -133,6 +177,31 @@ export async function listInboxItems(
         (!opts.kind || i.kind === opts.kind),
     )
     .sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+}
+
+export async function listInboxItems(
+  projectId: string,
+  opts: { segment?: ReviewSegment; kind?: ReviewItemRow['kind'] } = {},
+) {
+  return collectInboxItems(
+    {
+      native: () =>
+        db.select().from(reviewItems).where(eq(reviewItems.projectId, projectId)),
+      changeRequests: () =>
+        db.select().from(changeRequests).where(eq(changeRequests.projectId, projectId)),
+      executorApprovals: () =>
+        db
+          .select()
+          .from(executorExecutions)
+          .where(
+            and(
+              eq(executorExecutions.projectId, projectId),
+              eq(executorExecutions.status, 'pending_approval'),
+            ),
+          ),
+    },
+    opts,
+  );
 }
 
 export interface InsertReviewItemInput {

--- a/apps/web/src/app/error.test.ts
+++ b/apps/web/src/app/error.test.ts
@@ -1,8 +1,23 @@
 import { expect, test } from 'bun:test';
 
-test('global error boundary never renders or reloads a session-starting screen', async () => {
+// The global boundary must degrade a TRANSIENT runtime-not-ready throw (which
+// fires on every session switch before the runtime URL pins, and self-heals in a
+// second or two) to a silent auto-retry — never the hard "Something went wrong"
+// crash. This reverses the previous expectation, which pushed all handling to
+// SandboxLoadingBoundary; that proved insufficient because the throw reaches this
+// boundary from callers OUTSIDE the session subtree (and from stale bundles).
+test('global error boundary auto-retries transient runtime-not-ready errors', async () => {
   const source = await Bun.file(import.meta.dir + '/error.tsx').text();
+  // It must recognize the transient class and soft-reset via Next's `reset()`.
+  expect(source).toContain('isRuntimeNotReadyError');
+  expect(source).toContain('reset()');
+  // It must NOT hard-reload the page for the transient case (jarring loop) — the
+  // full reload stays reserved for the manual "Try again" on a genuine crash.
   expect(source).not.toContain('Starting your session');
-  expect(source).not.toContain('isRuntimeNotReadyError');
-  expect(source).not.toContain('setTimeout');
+});
+
+test('a genuine crash still shows the recoverable error card', async () => {
+  const source = await Bun.file(import.meta.dir + '/error.tsx').text();
+  expect(source).toContain('autoAppErrorJsxTextSomethingWentWrong493afd7e');
+  expect(source).toContain('window.location.reload()');
 });

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -7,12 +7,31 @@ import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useEffect } from 'react';
 
+/**
+ * Transient "the sandbox/opencode runtime URL isn't pinned yet" throw. It fires
+ * during provisioning and — critically — for a beat on every SESSION SWITCH,
+ * before the new session's runtime URL resolves, and it ALWAYS self-heals within
+ * a second or two. `SandboxLoadingBoundary` catches it inside the session
+ * subtree, but a caller mounted OUTSIDE that subtree (a shell/layout component,
+ * or a stale-bundle race) lets it reach this global boundary. Such a transient
+ * error must NEVER present as the hard "Something went wrong" crash — degrade it
+ * to a silent auto-retry here too. Match on message text (the throw is a plain
+ * `RuntimeNotReadyError`, but sibling env/pty guards reuse the same wording).
+ */
+function isRuntimeNotReadyError(error: Error): boolean {
+  const m = error?.message ?? '';
+  return /server url not ready|sandbox is still loading|opencode not ready/i.test(m);
+}
+
 export default function Error({
   error,
+  reset,
 }: {
   error: Error & { digest?: string; statusCode?: number };
+  reset: () => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const runtimeNotReady = isRuntimeNotReadyError(error);
 
   const handleReset = () => {
     try {
@@ -22,10 +41,35 @@ export default function Error({
     }
   };
 
+  // Transient runtime-not-ready: soft-reset the segment on a short interval so it
+  // re-renders and picks up the runtime URL the moment it pins — no hard reload,
+  // no crash card. Mirrors SandboxLoadingBoundary's belt-and-suspenders retry.
   useEffect(() => {
+    if (!runtimeNotReady) return;
+    const t = setInterval(() => reset(), 800);
+    return () => clearInterval(t);
+  }, [runtimeNotReady, reset]);
+
+  // Only genuine crashes are worth logging / reporting. A transient
+  // runtime-not-ready race is expected background noise during a session switch.
+  useEffect(() => {
+    if (runtimeNotReady) return;
     console.error('[Kortix Home Error]', error);
     Sentry.captureException(error);
-  }, [error]);
+  }, [error, runtimeNotReady]);
+
+  if (runtimeNotReady) {
+    // A calm, minimal loader — the route re-mounts as soon as the URL lands.
+    return (
+      <div
+        className="bg-background flex min-h-screen items-center justify-center"
+        role="status"
+        aria-label="Loading session"
+      >
+        <KortixHyperLogo size={34} startOnView={false} animateOnHover={false} />
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">


### PR DESCRIPTION
## What & why

Two independent user-facing failures on the session view, both fixed here.

### 1. "Something went wrong" crash on every session switch (the loud one)
A transient `RuntimeNotReadyError` from `getClient()` — thrown in the ~1s window before the new session's runtime URL pins, and **always self-healing** — was escaping to the global boundary `app/error.tsx` (`[Kortix Home Error]`) from a caller mounted **outside** the session subtree's `SandboxLoadingBoundary`. It rendered the hard glitch-crash screen even though the session loads fine a beat later. Users hit it on **every session switch**.

**Fix:** `app/error.tsx` now recognizes the transient runtime-not-ready class and degrades it to a **silent auto-retry** (soft `reset()` on a short interval, calm loader, no Sentry noise) — the same belt-and-suspenders `SandboxLoadingBoundary` already applies one level in. Genuine crashes still show the recoverable "Something went wrong" card with Home / Try again.

This deliberately reverses `error.test.ts`'s prior "never handle this in the global boundary" expectation — that architecture proved insufficient because the throw reaches this boundary from callers outside the session subtree (and from stale deployed bundles). Rationale is in the test + code comments.

### 2. `GET /projects/:id/review/items` 500 storm
`listInboxItems` ran three DB reads in one `Promise.all` with **zero error handling**, so any one failing (this repo's recurring prod schema/enum drift) 500'd the whole inbox — and the sidebar + Review Center poll it every 8–20s.

**Fix:** each inbox source and each row serialization is now fault-isolated (`collectInboxItems` / `safeSource` / `safeMap`): a failure degrades to an empty contribution and is reported to Sentry, never a 500. The endpoint always returns 200 with whatever sources succeed. Extracted a DB-free, injectable core so it's unit-tested without a live DB.

## Tests
- `apps/web/src/app/error.test.ts` — rewritten to assert the transient case auto-retries and genuine crashes still render the card. (pass)
- `apps/api/src/projects/review-items.test.ts` — new: one/all sources failing degrades to partial/empty instead of throwing; bad rows skipped; segment/kind filters still apply. (4 pass)
- Web + API typecheck clean for touched files.

## Not covered here (separate prod-infra symptom)
The "OpenCode failed to load / sandbox not ready (status: stopped)" inline card + failing Restart are downstream of prod sandboxes actually being stopped and the known stuck-session/orphan-row restart bug — a data/infra issue, not this code path.
