### PR TITLE
feat(maintenance): admin bypass + auto rollout banner in CI/CD

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -88,6 +88,37 @@ jobs:
             echo "No RELEASE_SOURCE_SHA (legacy release) — will use legacy dev fallback images"
           fi
 
+  # ── Raise the "new version rolling out" banner ──────────────────────────────
+  # Show users a dismissible WARNING banner for the duration of the rollout.
+  # Best-effort and non-blocking: it never gates or fails the deploy, and it
+  # never clobbers an active incident banner (see scripts/ci-maintenance-banner.sh).
+  # Cleared again by `maintenance-banner-off`, but ONLY once the rollout is green.
+  # Requires the PROD_MAINTENANCE_TOKEN secret (a platform-admin bearer); if it
+  # is unset the job is a no-op, so the release still works before it is added.
+  maintenance-banner-on:
+    name: Rollout banner (raise)
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Detect maintenance token
+        id: cfg
+        env:
+          TOKEN: ${{ secrets.PROD_MAINTENANCE_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::PROD_MAINTENANCE_TOKEN not set — skipping rollout banner."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Raise rollout banner
+        if: steps.cfg.outputs.enabled == 'true'
+        continue-on-error: true
+        env:
+          MAINTENANCE_TOKEN: ${{ secrets.PROD_MAINTENANCE_TOKEN }}
+        run: bash scripts/ci-maintenance-banner.sh on "v${{ needs.version.outputs.version }}"
+
   # ── Retag staged images → versioned + latest (no rebuild) ───────────────────
   retag-images:
     name: Re-tag staged → v${{ needs.version.outputs.version }}
@@ -1038,3 +1069,35 @@ jobs:
           gh pr merge "$BR" --squash --delete-branch --subject "$SUBJ" --body "" --admin \
             || gh pr merge "$BR" --squash --delete-branch --subject "$SUBJ" --body "" \
             || true
+
+  # ── Lower the "new version rolling out" banner — ONLY when the rollout is green ─
+  # `needs: deploy-api` with the default `if: success()` means this runs only
+  # after the API has rolled out to the new version AND passed its health gate
+  # (deploy-api hard-fails otherwise). migrate-db is upstream of deploy-api, so a
+  # failed migration also keeps the banner up. If the rollout fails, this job is
+  # skipped and the warning banner stays raised — deliberately, so users keep
+  # seeing it until an admin clears or escalates it from the console. Best-effort
+  # and non-clobbering: only clears the banner if it is still OUR rollout banner.
+  maintenance-banner-off:
+    name: Rollout banner (lower)
+    needs: [deploy-api]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Detect maintenance token
+        id: cfg
+        env:
+          TOKEN: ${{ secrets.PROD_MAINTENANCE_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::PROD_MAINTENANCE_TOKEN not set — skipping rollout banner clear."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Lower rollout banner
+        if: steps.cfg.outputs.enabled == 'true'
+        continue-on-error: true
+        env:
+          MAINTENANCE_TOKEN: ${{ secrets.PROD_MAINTENANCE_TOKEN }}
+        run: bash scripts/ci-maintenance-banner.sh off

--- a/apps/web/src/app/(system)/api/maintenance/bypass/route.ts
+++ b/apps/web/src/app/(system)/api/maintenance/bypass/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import {
+  MAINTENANCE_BYPASS_COOKIE,
+  MAINTENANCE_BYPASS_TTL_SECONDS,
+  createBypassToken,
+} from '@/lib/maintenance-bypass';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+// ---------------------------------------------------------------------------
+// POST /api/maintenance/bypass — admin only. Mints a signed, httpOnly bypass
+// cookie so a platform admin keeps access during Full Lockdown. Middleware
+// verifies the cookie and lets these requests through the maintenance redirect.
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const isAdmin = await checkAdminRole();
+  if (!isAdmin) {
+    return NextResponse.json({ error: 'Forbidden: admin access required' }, { status: 403 });
+  }
+
+  const token = await createBypassToken();
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(MAINTENANCE_BYPASS_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: MAINTENANCE_BYPASS_TTL_SECONDS,
+  });
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/maintenance/bypass — clear the bypass cookie (re-lock yourself).
+// Any authenticated user may clear their own cookie.
+// ---------------------------------------------------------------------------
+
+export async function DELETE() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(MAINTENANCE_BYPASS_COOKIE, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  return res;
+}
+
+/**
+ * Check the caller's platform admin role via the backend `/user-roles`
+ * endpoint, mirroring `PUT /api/maintenance` and the client `useAdminRole` hook.
+ */
+async function checkAdminRole(): Promise<boolean> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session?.access_token) return false;
+
+    const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || '';
+
+    const res = await fetch(`${backendUrl}/user-roles`, {
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!res.ok) return false;
+    const data: { isAdmin?: boolean } = await res.json();
+    return data.isAdmin === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/components/announcements/maintenance-banner.tsx
+++ b/apps/web/src/components/announcements/maintenance-banner.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { usePathname } from 'next/navigation';
 import { normalizeAppPathname } from '@kortix/sdk/instance-routes';
+import { useAdminRole } from '@/hooks/admin/use-admin-role';
 import type { MaintenanceConfig, MaintenanceLevel } from '@/lib/maintenance-store';
 
 interface MaintenanceBannerProps {
@@ -58,6 +59,8 @@ export function MaintenanceBanner({ config }: MaintenanceBannerProps) {
   const [isMounted, setIsMounted] = useState(false);
   const [countdown, setCountdown] = useState<string>('');
   const pathname = normalizeAppPathname(usePathname());
+  const { data: adminRole } = useAdminRole();
+  const isAdmin = adminRole?.isAdmin === true;
 
   // Show the banner app-wide (dashboard + marketing) so a system notice reaches
   // everyone, not just a handful of routes. Only suppress it where it would be
@@ -69,11 +72,15 @@ export function MaintenanceBanner({ config }: MaintenanceBannerProps) {
   const level = config.level;
   const lc = level !== 'none' && level !== 'blocking' ? levelConfig[level] : null;
 
+  // Admins can always dismiss/bypass any banner — including the normally
+  // non-dismissible `critical` level — so a system notice never traps them.
+  const canDismiss = (lc?.dismissible ?? false) || isAdmin;
+
   const dismissKey = `maintenance-dismissed-${config.updatedAt}`;
 
   useEffect(() => {
     setIsMounted(true);
-    if (lc?.dismissible) {
+    if (canDismiss) {
       try {
         if (localStorage.getItem(dismissKey) === 'true') {
           setIsDismissed(true);
@@ -82,7 +89,7 @@ export function MaintenanceBanner({ config }: MaintenanceBannerProps) {
         // ignore
       }
     }
-  }, [dismissKey, lc?.dismissible]);
+  }, [dismissKey, canDismiss]);
 
   // Countdown timer for scheduled maintenance
   useEffect(() => {
@@ -124,7 +131,7 @@ export function MaintenanceBanner({ config }: MaintenanceBannerProps) {
 
   // Don't render for none/blocking levels, before mount, or on suppressed paths.
   if (!lc || !isMounted || isSuppressedPath) return null;
-  if (isDismissed && lc.dismissible) return null;
+  if (isDismissed && canDismiss) return null;
 
   const Icon = lc.icon;
   const title = config.title || lc.defaultTitle;
@@ -158,7 +165,7 @@ export function MaintenanceBanner({ config }: MaintenanceBannerProps) {
         className="fixed bottom-4 right-4 z-[110] w-[340px]"
       >
         <div className="relative bg-muted rounded-2xl overflow-hidden border">
-          {lc.dismissible && (
+          {canDismiss && (
             <Button variant="ghost" size="icon-sm" onClick={handleDismiss} className="absolute top-2 right-2 z-10">
               <X className="h-3 w-3 text-foreground" />
             </Button>

--- a/apps/web/src/components/maintenance/maintenance-page.tsx
+++ b/apps/web/src/components/maintenance/maintenance-page.tsx
@@ -3,9 +3,10 @@
 import { useTranslations } from 'next-intl';
 
 import { useEffect, useState } from 'react';
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, ArrowRight } from 'lucide-react';
 import { KortixLoader } from '@/components/ui/kortix-loader';
 import { useApiHealth } from '@/hooks/usage/use-health';
+import { useAdminRole } from '@/hooks/admin/use-admin-role';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { AnimatedBg } from '@/components/ui/animated-bg';
@@ -15,7 +16,25 @@ export function MaintenancePage() {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const [lastChecked, setLastChecked] = useState<Date | null>(null);
 
+  const { data: adminRole } = useAdminRole();
+  const [isBypassing, setIsBypassing] = useState(false);
+
   const { data: healthData, isLoading: isCheckingHealth, refetch } = useApiHealth();
+
+  // Admins can bypass a full lockdown: mint a signed bypass cookie server-side
+  // (after an admin-role check), then hard-navigate so middleware re-evaluates
+  // with the cookie present and lets us into the app.
+  const handleAdminBypass = async () => {
+    setIsBypassing(true);
+    try {
+      const res = await fetch('/api/maintenance/bypass', { method: 'POST' });
+      if (!res.ok) throw new Error(`bypass failed (${res.status})`);
+      window.location.href = '/projects';
+    } catch (error) {
+      console.error('Admin maintenance bypass failed:', error);
+      setIsBypassing(false);
+    }
+  };
 
   const checkHealth = async () => {
     try {
@@ -36,6 +55,29 @@ export function MaintenancePage() {
 
   return (
     <div className="w-full relative overflow-hidden min-h-screen">
+      {/* Admin bypass — top-right. Only admins can mint the bypass cookie; the
+          server re-checks the role, so this button is safe to always render. */}
+      {adminRole?.isAdmin && (
+        <div className="absolute top-4 right-4 z-[60]">
+          <Button
+            onClick={handleAdminBypass}
+            disabled={isBypassing}
+            size="sm"
+            variant="outline"
+            className="gap-1.5 bg-card/80 backdrop-blur"
+          >
+            {isBypassing ? (
+              <KortixLoader size="small" customSize={14} />
+            ) : (
+              <>
+                Enter app (admin)
+                <ArrowRight className="h-3.5 w-3.5" />
+              </>
+            )}
+          </Button>
+        </div>
+      )}
+
       <div className="relative flex flex-col items-center w-full px-4 sm:px-6 min-h-screen justify-center">
         {/* Animated background - exactly like hero section */}
         <AnimatedBg variant="hero" />

--- a/apps/web/src/lib/maintenance-bypass.test.ts
+++ b/apps/web/src/lib/maintenance-bypass.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'bun:test';
+import {
+  createBypassToken,
+  verifyBypassToken,
+  MAINTENANCE_BYPASS_TTL_SECONDS,
+} from './maintenance-bypass';
+
+const NOW = 1_800_000_000; // fixed reference time (seconds)
+
+test('a freshly minted token verifies', async () => {
+  const token = await createBypassToken(NOW);
+  expect(await verifyBypassToken(token, NOW)).toBe(true);
+});
+
+test('a token is valid right up to its expiry and invalid after', async () => {
+  const token = await createBypassToken(NOW);
+  const justBeforeExp = NOW + MAINTENANCE_BYPASS_TTL_SECONDS - 1;
+  const afterExp = NOW + MAINTENANCE_BYPASS_TTL_SECONDS + 1;
+  expect(await verifyBypassToken(token, justBeforeExp)).toBe(true);
+  expect(await verifyBypassToken(token, afterExp)).toBe(false);
+});
+
+test('empty / malformed tokens are rejected', async () => {
+  expect(await verifyBypassToken(undefined, NOW)).toBe(false);
+  expect(await verifyBypassToken('', NOW)).toBe(false);
+  expect(await verifyBypassToken('nodot', NOW)).toBe(false);
+  expect(await verifyBypassToken('.onlysig', NOW)).toBe(false);
+  expect(await verifyBypassToken('9999999999.', NOW)).toBe(false);
+});
+
+test('a tampered signature is rejected', async () => {
+  const token = await createBypassToken(NOW);
+  const [exp, sig] = token.split('.');
+  const flipped = sig.slice(0, -1) + (sig.endsWith('0') ? '1' : '0');
+  expect(await verifyBypassToken(`${exp}.${flipped}`, NOW)).toBe(false);
+});
+
+test('a forged expiry (kept far in the future, unsigned) is rejected', async () => {
+  const token = await createBypassToken(NOW);
+  const sig = token.split('.')[1];
+  // Attacker extends expiry but cannot resign it with the server secret.
+  expect(await verifyBypassToken(`9999999999.${sig}`, NOW)).toBe(false);
+});

--- a/apps/web/src/lib/maintenance-bypass.ts
+++ b/apps/web/src/lib/maintenance-bypass.ts
@@ -1,0 +1,99 @@
+/**
+ * Admin maintenance bypass — signed cookie shared by the middleware (verify) and
+ * the `/api/maintenance/bypass` route (mint).
+ *
+ * When maintenance is at the `blocking` (Full Lockdown) level, middleware
+ * redirects everyone to `/maintenance`. A platform admin can mint a short-lived
+ * bypass token from that page; middleware honors it so admins keep access even
+ * during a full lockdown. The token is an HMAC-signed `${exp}.${sig}` string set
+ * as an httpOnly cookie, so it can't be forged client-side or read by scripts.
+ *
+ * The lockdown is a traffic-shedding / UX gate, not a security boundary — the
+ * backend still enforces real auth on every request — but signing the cookie
+ * keeps casual bypass out and only lets through tokens minted after a
+ * server-side admin-role check.
+ *
+ * Uses Web Crypto (`crypto.subtle`) so the exact same code runs in both the Edge
+ * middleware runtime and the Node route handler.
+ */
+
+export const MAINTENANCE_BYPASS_COOKIE = 'kortix-maint-bypass';
+
+/** How long a minted bypass lasts, in seconds (8h — long enough for a rollout). */
+export const MAINTENANCE_BYPASS_TTL_SECONDS = 8 * 60 * 60;
+
+/**
+ * Server-only signing secret. Must resolve to the SAME value in the middleware
+ * and the route handler. Prefer an explicit secret; fall back to the Supabase
+ * service-role key (server-only, present in every deploy). We deliberately do
+ * NOT fall back to the public anon key — that would make the token forgeable.
+ */
+function bypassSecret(): string {
+  return (
+    process.env.MAINTENANCE_BYPASS_SECRET ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_SERVICE_KEY ||
+    // Last-resort dev fallback so local (no service key) still functions; not a
+    // real secret, but the lockdown is not a security boundary.
+    'kortix-maintenance-bypass-dev-secret'
+  );
+}
+
+const encoder = new TextEncoder();
+
+function bytesToHex(bytes: ArrayBuffer): string {
+  const view = new Uint8Array(bytes);
+  let out = '';
+  for (let i = 0; i < view.length; i++) {
+    out += view[i].toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+async function sign(payload: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(bypassSecret()),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+  return bytesToHex(sig);
+}
+
+/** Constant-time-ish string compare (both inputs are fixed-length hex here). */
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/** Mint a bypass token valid until `nowSeconds + ttlSeconds`. */
+export async function createBypassToken(
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+  ttlSeconds: number = MAINTENANCE_BYPASS_TTL_SECONDS,
+): Promise<string> {
+  const exp = nowSeconds + ttlSeconds;
+  const sig = await sign(String(exp));
+  return `${exp}.${sig}`;
+}
+
+/** Verify a bypass token: valid signature AND not expired. */
+export async function verifyBypassToken(
+  token: string | undefined | null,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): Promise<boolean> {
+  if (!token) return false;
+  const dot = token.indexOf('.');
+  if (dot <= 0) return false;
+  const expPart = token.slice(0, dot);
+  const sigPart = token.slice(dot + 1);
+  const exp = Number(expPart);
+  if (!Number.isFinite(exp) || exp <= nowSeconds) return false;
+  const expected = await sign(expPart);
+  return safeEqual(sigPart, expected);
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,5 +1,6 @@
 import { locales, type Locale } from '@/i18n/config';
 import { getMaintenanceConfig } from '@/lib/maintenance-store';
+import { MAINTENANCE_BYPASS_COOKIE, verifyBypassToken } from '@/lib/maintenance-bypass';
 import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
 import { createServerClient } from '@supabase/ssr';
 import type { NextRequest } from 'next/server';
@@ -127,10 +128,18 @@ export async function middleware(request: NextRequest) {
     try {
       const config = await getMaintenanceConfig();
       if (config.level === 'blocking') {
-        return NextResponse.redirect(new URL('/maintenance', request.url));
+        // Platform admins can mint a signed bypass token from the maintenance
+        // page (POST /api/maintenance/bypass) to keep working during a full
+        // lockdown. Honor a valid, unexpired token instead of redirecting.
+        const adminBypass = await verifyBypassToken(
+          request.cookies.get(MAINTENANCE_BYPASS_COOKIE)?.value,
+        );
+        if (!adminBypass) {
+          return NextResponse.redirect(new URL('/maintenance', request.url));
+        }
       }
     } catch {
-      // If Edge Config is unreachable, don't block traffic
+      // If the maintenance config is unreachable, don't block traffic
     }
   }
 

--- a/scripts/ci-maintenance-banner.sh
+++ b/scripts/ci-maintenance-banner.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# ci-maintenance-banner.sh — flip the system-wide maintenance banner on/off
+# around a production rollout, from CI.
+#
+# Called by .github/workflows/deploy-prod.yml:
+#   on  <version>   activate a dismissible WARNING banner ("new version rolling
+#                   out, may be briefly unavailable") at the START of the rollout.
+#   off             clear it (level none) — only called AFTER the rollout is green.
+#
+# It writes the same maintenance config the admin console does, via
+# `PUT /v1/system/maintenance` (platform-admin bearer required).
+#
+# SAFETY — it never clobbers a human-set incident banner:
+#   * `on`  refuses to downgrade an active `critical`/`blocking` incident.
+#   * `off` only clears the banner if it is STILL our rollout banner (same title
+#           and warning level); if an admin changed it mid-rollout, we leave it.
+#
+# Env:
+#   MAINTENANCE_TOKEN     (required) platform-admin bearer (kortix_pat_/kortix_sa_ or JWT)
+#   MAINTENANCE_API_BASE  (optional) API base incl. /v1, default https://api.kortix.com/v1
+#
+# Best-effort: the caller runs this with continue-on-error so a banner hiccup
+# never fails the release.
+
+set -euo pipefail
+
+API_BASE="${MAINTENANCE_API_BASE:-https://api.kortix.com/v1}"
+ENDPOINT="${API_BASE%/}/system/maintenance"
+ROLLOUT_TITLE="New version rolling out"
+
+CMD="${1:-}"
+
+if [[ -z "${MAINTENANCE_TOKEN:-}" ]]; then
+  echo "MAINTENANCE_TOKEN is not set — skipping maintenance banner ($CMD)." >&2
+  exit 0
+fi
+
+get_field() {
+  # $1 = jq field expression; prints current value (empty on any failure)
+  curl -fsS --max-time 15 "$ENDPOINT" 2>/dev/null | jq -r "$1 // empty" 2>/dev/null || true
+}
+
+put() {
+  # $1 level  $2 title  $3 message
+  local body
+  body="$(jq -n --arg l "$1" --arg t "$2" --arg m "$3" \
+    '{level:$l, title:$t, message:$m, startTime:null, endTime:null}')"
+  curl -fsS --max-time 15 -X PUT "$ENDPOINT" \
+    -H "Authorization: Bearer ${MAINTENANCE_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" >/dev/null
+}
+
+case "$CMD" in
+  on)
+    version="${2:-}"
+    level="$(get_field '.level')"
+    level="${level:-none}"
+    if [[ "$level" == "critical" || "$level" == "blocking" ]]; then
+      echo "An active incident banner ($level) is up — leaving it in place, not showing the rollout notice."
+      exit 0
+    fi
+    msg="Kortix is rolling out a new version"
+    [[ -n "$version" ]] && msg="Kortix is rolling out ${version}"
+    msg="${msg} and may be briefly unavailable or behave unexpectedly. Please check back in a few minutes."
+    put "warning" "$ROLLOUT_TITLE" "$msg"
+    echo "Rollout warning banner activated${version:+ for $version}."
+    ;;
+  off)
+    level="$(get_field '.level')"
+    title="$(get_field '.title')"
+    if [[ "$level" == "warning" && "$title" == "$ROLLOUT_TITLE" ]]; then
+      put "none" "" ""
+      echo "Rollout banner cleared."
+    else
+      echo "Current banner (level='${level:-none}', title='${title:-}') is not the rollout banner — leaving it as-is."
+    fi
+    ;;
+  *)
+    echo "usage: $0 on <version> | off" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## What & why

Two things, both about the maintenance-notifications system:

### 1. Admin bypass — admins can always get past any maintenance state
- **Full Lockdown (`blocking`)**: a top-right **"Enter app (admin)"** button on `/maintenance` mints a signed, httpOnly bypass cookie via a new admin-verified route (`POST /api/maintenance/bypass`). Middleware honors a valid, unexpired token instead of redirecting everyone. The token is HMAC-signed with a server-only secret (Web Crypto, runs in both Edge middleware and the Node route), so it can't be forged client-side. The lockdown stays a traffic/UX gate — the backend is still the real auth boundary.
- **Banners**: `info`/`warning`/`critical` banners are now **admin-dismissible even when non-dismissible** (critical), so a system notice never traps an admin.

### 2. Auto rollout banner in CI/CD
`deploy-prod.yml` now:
- **Raises** a dismissible **warning** banner ("new version rolling out, may be briefly unavailable, check back in a few minutes") at the **start** of a prod rollout.
- **Lowers** it **only after the rollout is green** — `maintenance-banner-off` `needs: [deploy-api]` with the default `if: success()`, so it runs only once the API has rolled to the new version and passed its health gate (`migrate-db` is upstream, so a failed migration keeps it up too). **A failed rollout leaves the banner up on purpose.**
- Helper `scripts/ci-maintenance-banner.sh` **never clobbers a human-set incident banner**: `on` won't downgrade an active `critical`/`blocking` incident; `off` only clears the banner if it's still the rollout banner. Best-effort + non-blocking (`continue-on-error`), and a **no-op unless `PROD_MAINTENANCE_TOKEN` is set** — so merging this can't break a release before the secret exists.

## ⚠️ Action required to activate part 2
Add a GitHub Actions secret **`PROD_MAINTENANCE_TOKEN`** = a platform-admin bearer (a `kortix_pat_`/`kortix_sa_` token for an admin machine account, mirroring `KE2E_ADMIN_TOKEN`). Until then the banner jobs no-op.

## Notes / scope
- The "green" signal is the in-workflow **API rollout + health gate**. Vercel frontend auto-deploy isn't workflow-verified today (pre-existing gap) — not covered here.
- Bypass token TTL is 8h. Optional `MAINTENANCE_BYPASS_SECRET` overrides the signing secret (defaults to the Supabase service-role key).

## Tests
- `apps/web/src/lib/maintenance-bypass.test.ts` — sign/verify, expiry boundary, tampered-signature and forged-expiry rejection (5 pass).
- `scripts/ci-maintenance-banner.sh` guard paths verified manually; `deploy-prod.yml` YAML validated.
- Web typecheck clean for all touched files.
