### PR TITLE
fix(web): render nothing for transient runtime-not-ready (info, not an error)

### DIFF
--- a/apps/web/src/app/error.test.ts
+++ b/apps/web/src/app/error.test.ts
@@ -1,18 +1,21 @@
 import { expect, test } from 'bun:test';
 
-// The global boundary must degrade a TRANSIENT runtime-not-ready throw (which
-// fires on every session switch before the runtime URL pins, and self-heals in a
-// second or two) to a silent auto-retry — never the hard "Something went wrong"
-// crash. This reverses the previous expectation, which pushed all handling to
-// SandboxLoadingBoundary; that proved insufficient because the throw reaches this
-// boundary from callers OUTSIDE the session subtree (and from stale bundles).
-test('global error boundary auto-retries transient runtime-not-ready errors', async () => {
+// "Sandbox still loading" is a transient INFO state, never an error. If it ever
+// reaches this global boundary it must render NOTHING — no logo, no card, no
+// message — and silently soft-reset until the runtime URL pins and the real page
+// renders in place. The only trace is a console.debug. This reverses the earlier
+// "push all handling to SandboxLoadingBoundary" stance, which proved insufficient
+// because the throw reaches this boundary from outside the session subtree.
+test('global boundary renders NOTHING for a transient runtime-not-ready state', async () => {
   const source = await Bun.file(import.meta.dir + '/error.tsx').text();
-  // It must recognize the transient class and soft-reset via Next's `reset()`.
   expect(source).toContain('isRuntimeNotReadyError');
+  // Recognized → soft-reset via Next's reset(), and render nothing.
   expect(source).toContain('reset()');
-  // It must NOT hard-reload the page for the transient case (jarring loop) — the
-  // full reload stays reserved for the manual "Try again" on a genuine crash.
+  expect(source).toContain('return null;');
+  // Logged as info (console.debug), never surfaced or Sentry-reported as an error.
+  expect(source).toContain('console.debug');
+  // No visible UI whatsoever for the transient case.
+  expect(source).not.toContain('aria-label="Loading session"');
   expect(source).not.toContain('Starting your session');
 });
 

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -51,24 +51,25 @@ export default function Error({
   }, [runtimeNotReady, reset]);
 
   // Only genuine crashes are worth logging / reporting. A transient
-  // runtime-not-ready race is expected background noise during a session switch.
+  // runtime-not-ready race is expected background noise during a session switch —
+  // it is an info state, not an error, so it goes to the console and nowhere else.
   useEffect(() => {
-    if (runtimeNotReady) return;
+    if (runtimeNotReady) {
+      console.debug('[runtime] not ready yet (sandbox still loading) — retrying', error?.message);
+      return;
+    }
     console.error('[Kortix Home Error]', error);
     Sentry.captureException(error);
   }, [error, runtimeNotReady]);
 
   if (runtimeNotReady) {
-    // A calm, minimal loader — the route re-mounts as soon as the URL lands.
-    return (
-      <div
-        className="bg-background flex min-h-screen items-center justify-center"
-        role="status"
-        aria-label="Loading session"
-      >
-        <KortixHyperLogo size={34} startOnView={false} animateOnHover={false} />
-      </div>
-    );
+    // Render NOTHING. "Sandbox still loading" is a transient info state, never an
+    // error UI — no logo, no card, no message. We silently soft-reset (above) until
+    // the runtime URL pins, at which point the real page renders in place. The only
+    // trace is the console.debug. This is the last-ditch backstop; the session
+    // subtree's own gating + SandboxLoadingBoundary normally prevent the throw from
+    // ever reaching here at all.
+    return null;
   }
 
   return (


### PR DESCRIPTION
Follow-up to #4483. The transient "sandbox still loading" state is an INFO state, not an error — on every session switch it self-heals in ~1s. The global boundary now renders NOTHING for it (no logo, no card, console.debug only) and silently soft-resets until the real page renders in place. Genuine crashes still show the recoverable card and remain the only Sentry-reported case. Test locks the invisible behavior.