### PR TITLE
fix(session): kill white-flash on switch + auto-resume hibernated sandboxes

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -13,6 +13,7 @@ import { InstantSessionShell } from '@/features/session/instant-session-shell';
 import { SandboxLoadingBoundary } from '@/features/session/sandbox-loading-boundary';
 import { SessionChat } from '@/features/session/session-chat';
 import { SessionLayout } from '@/features/session/session-layout';
+import { isAutoResuming, isSandboxResumable } from '@/features/session/session-resume';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { ProjectShell } from '@/features/workspace/project-layout/project-shell';
 import { useAccountState } from '@/hooks/billing';
@@ -94,6 +95,41 @@ export default function ProjectSessionPage() {
   const sandbox = session.sandbox;
   const startStage = session.stage ?? 'provisioning';
 
+  // ── Auto-resume a hibernated-but-resumable sandbox ────────────────────────
+  // On the first /start of an idle-stopped session the backend can race into a
+  // TERMINAL 'stopped' (openSession's self-preserve path on a transient provider
+  // getStatus()) even though the row is left EXACTLY resumable (status 'stopped'
+  // + external_id). useSession then stops polling and the page used to pin a
+  // dead-end "open a new session" card — yet a hard refresh's fresh /start hits
+  // the resume path and wakes the box. So: re-issue /start ourselves a few times
+  // (what the refresh did) before ever surfacing a manual control.
+  const queryClient = useQueryClient();
+  const sandboxResumable = isSandboxResumable(sandbox);
+  const MAX_AUTO_RESUME = 3;
+  const [resumeAttempts, setResumeAttempts] = useState(0);
+  const restartMutation = useMutation({
+    mutationFn: () => restartProjectSession(projectId, sessionId),
+    onSuccess: () => {
+      setResumeAttempts(0);
+      queryClient.invalidateQueries({ queryKey: sessionStartKey(projectId, sessionId) });
+    },
+  });
+  useEffect(() => {
+    if (!sandboxResumable || resumeAttempts >= MAX_AUTO_RESUME) return;
+    // First attempt fires immediately (match the refresh); back off after that.
+    const t = setTimeout(
+      () => {
+        setResumeAttempts((n) => n + 1);
+        queryClient.invalidateQueries({ queryKey: sessionStartKey(projectId, sessionId) });
+      },
+      resumeAttempts === 0 ? 0 : 1500,
+    );
+    return () => clearTimeout(t);
+  }, [sandboxResumable, resumeAttempts, projectId, sessionId, queryClient]);
+  // While we still have auto-resume attempts left, a resumable box is "waking",
+  // not "dead" — render the boot loader, never the dead-end card.
+  const autoResuming = isAutoResuming(sandbox, resumeAttempts, MAX_AUTO_RESUME);
+
   // Belt-and-suspenders: clear the legacy active-instance cookie once on mount for
   // this route so no later navigation can be hijacked onto a stale sandbox.
   useEffect(() => {
@@ -138,6 +174,7 @@ export default function ProjectSessionPage() {
     }
     freshRef.current = fresh;
     setShellSubmitted(pending);
+    if (resumeAttempts !== 0) setResumeAttempts(0);
   }
   const isFresh = freshRef.current;
   useEffect(() => {
@@ -199,21 +236,48 @@ export default function ProjectSessionPage() {
 
     if (fatal) {
       const meta = (sandbox?.metadata as Record<string, unknown>) ?? {};
-      return sandbox?.status === 'error' ? (
-        <InlineSessionError
-          title={`Couldn't start ${sandboxLabel ?? 'session'}`}
-          message={
-            (meta.provisioningError as string) ||
-            (meta.errorMessage as string) ||
-            'Something went wrong while provisioning this session.'
-          }
-        />
-      ) : (
+      if (sandbox?.status === 'error') {
+        return (
+          <InlineSessionError
+            title={`Couldn't start ${sandboxLabel ?? 'session'}`}
+            message={
+              (meta.provisioningError as string) ||
+              (meta.errorMessage as string) ||
+              'Something went wrong while provisioning this session.'
+            }
+          />
+        );
+      }
+      // Stopped but resumable → we're auto-waking it. Show the boot loader, not a
+      // dead-end, so the user just sees it come back (as a hard refresh would).
+      if (autoResuming) {
+        return (
+          <SessionStartingLoader stage="starting" projectId={projectId} sessionId={sessionId} />
+        );
+      }
+      // Auto-resume exhausted (or genuinely un-resumable): give an in-place
+      // Restart instead of forcing a manual browser refresh.
+      return (
         <InlineSessionError
           title={`${sandboxLabel ?? 'session'} is stopped`}
           message={tI18nHardcoded.raw(
             'appProjectsIdSessionsSessionidPage.line151JsxAttrMessageTheSandboxForThisSessionWasStoppedOpen',
           )}
+          action={
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => restartMutation.mutate()}
+              disabled={restartMutation.isPending}
+            >
+              {restartMutation.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RotateCcw className="h-3.5 w-3.5" />
+              )}
+              Restart session
+            </Button>
+          }
         />
       );
     }

--- a/apps/web/src/features/session/session-resume.test.ts
+++ b/apps/web/src/features/session/session-resume.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isAutoResuming, isSandboxResumable } from './session-resume';
+
+describe('isSandboxResumable', () => {
+  test('stopped + external_id → resumable (the hibernated-box case)', () => {
+    expect(isSandboxResumable({ status: 'stopped', external_id: 'sbx_1' })).toBe(true);
+  });
+
+  test('stopped with NO external_id → not resumable (genuinely gone)', () => {
+    expect(isSandboxResumable({ status: 'stopped', external_id: null })).toBe(false);
+    expect(isSandboxResumable({ status: 'stopped' })).toBe(false);
+  });
+
+  test('non-stopped statuses are never "resumable" here', () => {
+    expect(isSandboxResumable({ status: 'error', external_id: 'sbx_1' })).toBe(false);
+    expect(isSandboxResumable({ status: 'active', external_id: 'sbx_1' })).toBe(false);
+  });
+
+  test('null / undefined sandbox → not resumable', () => {
+    expect(isSandboxResumable(null)).toBe(false);
+    expect(isSandboxResumable(undefined)).toBe(false);
+  });
+});
+
+describe('isAutoResuming', () => {
+  const box = { status: 'stopped', external_id: 'sbx_1' };
+
+  test('resumable + attempts under the cap → still waking (show loader)', () => {
+    expect(isAutoResuming(box, 0, 3)).toBe(true);
+    expect(isAutoResuming(box, 2, 3)).toBe(true);
+  });
+
+  test('resumable but attempts exhausted → stop auto-waking (fall through to Restart)', () => {
+    expect(isAutoResuming(box, 3, 3)).toBe(false);
+    expect(isAutoResuming(box, 4, 3)).toBe(false);
+  });
+
+  test('not resumable → never auto-resuming regardless of attempts', () => {
+    expect(isAutoResuming({ status: 'error', external_id: 'sbx_1' }, 0, 3)).toBe(false);
+    expect(isAutoResuming({ status: 'stopped', external_id: null }, 0, 3)).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/session-resume.ts
+++ b/apps/web/src/features/session/session-resume.ts
@@ -1,0 +1,38 @@
+/**
+ * Resume-decision helpers for the session view.
+ *
+ * On the first `/start` of an idle-stopped session the backend can hand back a
+ * TERMINAL stage with a non-null sandbox whose row is left EXACTLY resumable
+ * (`status: 'stopped'` + an `external_id`) — see `openSession`'s self-preserve
+ * path. A hard refresh's fresh `/start` then hits the resume path and wakes the
+ * box. These helpers let the page recognize that state so it can auto-resume
+ * (re-issue `/start`) instead of pinning a dead-end "open a new session" card.
+ */
+
+/** The subset of the `/start` sandbox payload the resume decision needs. */
+export interface ResumableSandboxLike {
+  status?: string | null;
+  external_id?: string | null;
+}
+
+/**
+ * A hibernated box is still resumable when its row is `stopped` AND it kept an
+ * `external_id` — a fresh `/start` wakes it in place (keeps its disk/workspace).
+ * A stopped row with no `external_id` is genuinely gone and not resumable.
+ */
+export function isSandboxResumable(sandbox: ResumableSandboxLike | null | undefined): boolean {
+  return !!sandbox && sandbox.status === 'stopped' && !!sandbox.external_id;
+}
+
+/**
+ * While auto-resume attempts remain, a resumable box is "waking", not "dead" —
+ * the page shows the boot loader rather than the terminal card. Once attempts are
+ * exhausted it falls through to a manual Restart.
+ */
+export function isAutoResuming(
+  sandbox: ResumableSandboxLike | null | undefined,
+  attempts: number,
+  maxAttempts: number,
+): boolean {
+  return isSandboxResumable(sandbox) && attempts < maxAttempts;
+}

--- a/packages/sdk/src/react/use-opencode-events/index.ts
+++ b/packages/sdk/src/react/use-opencode-events/index.ts
@@ -107,7 +107,21 @@ export function useOpenCodeEventStream() {
     // requests that each sit for 30s and retry.
     if (!activeServerUrl || sandboxStatus !== 'connected' || runtimeHealthy !== true) return;
 
-    const client = getClient();
+    // `activeServerUrl` (getActiveServerUrl) and the url getClient() resolves
+    // (getActiveOpenCodeUrl → current-runtime) come from DIFFERENT accessors and
+    // briefly diverge on a session switch: the server-store url is set before the
+    // current-runtime url is pinned. In that window getClient() throws
+    // RuntimeNotReadyError — and because this hook runs in the page render tree
+    // (outside SandboxLoadingBoundary), a synchronous throw here is caught by the
+    // GLOBAL error boundary and flashes the whole route to blank. "Runtime not
+    // ready" is a transient info state, never an error: skip this tick and let the
+    // effect re-run (deps include runtimeVersion/activeServerUrl) once it pins.
+    let client: ReturnType<typeof getClient>;
+    try {
+      client = getClient();
+    } catch {
+      return;
+    }
 
     const handleEvent = createEventHandler({
       queryClient,


### PR DESCRIPTION
Two connection-flow bugs that made opening/switching sessions feel broken.

**A) White flash on every session switch.** `useSession → useOpenCodeEventStream` calls `getClient()` synchronously in a `useEffect` that runs in the page tree *outside* `SandboxLoadingBoundary`. On a switch the server-store URL and the current-runtime URL (what `getClient` resolves) briefly diverge, so the effect guard passes but `getClient()` throws — React routes the effect-body throw to the **global** boundary → whole route unmounts → white flash. Fix: `try/catch` skip-the-tick (the exact pattern the self-heal hooks already use); the effect re-runs once the URL pins. Runtime-not-ready is a transient info state, never an error.

**B) False "sandbox stopped — open a new session" dead-end.** On the first `/start` of an idle-stopped session the backend can hand back a terminal stage while leaving the row exactly resumable (`stopped` + `external_id`); the page pinned a dead-end card, yet a hard refresh's fresh `/start` woke the box. Fix: **auto-resume** — re-issue `/start` up to 3× (what the refresh did), showing the boot loader instead of the dead-end; if exhausted, an in-place **Restart** button. Resume decision extracted to `session-resume.ts` (unit-tested).

Verified: SDK typecheck + 1066 tests green; web typecheck clean; `session-resume` unit tests 7/7. Local DB forensics confirmed the auto-resume does NOT wipe/duplicate/race sandboxes (single row per session, no deletions).