### PR TITLE
fix(runtime): preserve sandbox identity during recovery

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -37,6 +37,12 @@ let providerStatusAfterStart: string | null = null;
 let providerStartError: Error | null = null;
 let providerStartGate: Promise<void> | null = null;
 let releaseProviderStart: (() => void) | null = null;
+let providerRecoveryCalls = 0;
+let providerRecoveryEnabled = false;
+let providerRecoveryStatus: 'running' | 'recovering' | 'unavailable' = 'unavailable';
+let providerRecoveryGate: Promise<void> | null = null;
+let releaseProviderRecovery: (() => void) | null = null;
+let computeReopenCalls = 0;
 let opencodeEnsureReason: 'unchanged' | 'healed' | 'not_ready' | 'unreachable' = 'unchanged';
 let activeSessionCount = 0;
 let sessionRow: typeof projectSessions.$inferSelect | null;
@@ -85,6 +91,12 @@ function resetState() {
   providerStartError = null;
   providerStartGate = null;
   releaseProviderStart = null;
+  providerRecoveryCalls = 0;
+  providerRecoveryEnabled = false;
+  providerRecoveryStatus = 'unavailable';
+  providerRecoveryGate = null;
+  releaseProviderRecovery = null;
+  computeReopenCalls = 0;
   opencodeEnsureReason = 'unchanged';
   activeSessionCount = 0;
   lastProvisionInput = null;
@@ -293,6 +305,15 @@ mock.module('../platform/providers', () => ({
     },
     stop: async () => undefined,
     remove: async () => undefined,
+    ...(providerRecoveryEnabled
+      ? {
+          recoverInPlace: async () => {
+            providerRecoveryCalls += 1;
+            if (providerRecoveryGate) await providerRecoveryGate;
+            return providerRecoveryStatus;
+          },
+        }
+      : {}),
   }),
 }));
 
@@ -313,7 +334,9 @@ mock.module('../projects/opencode-mapping', () => ({
 }));
 
 mock.module('../billing/services/compute-metering', () => ({
-  reopenComputeForSandbox: async () => undefined,
+  reopenComputeForSandbox: async () => {
+    computeReopenCalls += 1;
+  },
   endComputeSession: async () => undefined,
   pauseComputeSession: async () => undefined,
   startComputeSession: async () => undefined,
@@ -381,7 +404,11 @@ mock.module('../deployments/providers/freestyle', () => ({
 mock.module('../shared/account-limits', () => ({
   resolveAccountTier: async () => 'free',
   maxConcurrentSessionsForTier: () => 1,
-  resolveAccountSessionLimit: async () => ({ tier: 'free', limit: 1, source: 'tier' }),
+  resolveAccountSessionLimit: async () => ({
+    tier: 'free',
+    limit: 1,
+    source: 'tier',
+  }),
   sessionLlmPolicyForTier: () => ({ limit: 60, windowMs: 60_000 }),
   maxProjectsForAccount: async () => 100,
   accountEntitledToLlmGateway: async () => true,
@@ -664,6 +691,12 @@ mock.module('../shared/db', () => ({
           returning: async () => {
             if (table === projectSessions) {
               if (!sessionRow) return [];
+              if (
+                typeof (sessionRow.metadata as Record<string, unknown> | null)?.deletedAt ===
+                  'string' &&
+                !('metadata' in updates)
+              )
+                return [];
               sessionRow = {
                 ...sessionRow,
                 ...updates,
@@ -1605,11 +1638,11 @@ describe('project session API contract', () => {
     releaseProviderStart?.();
   });
 
-  test('dashboard start retires a provider-confirmed missing sandbox and reallocates once', async () => {
+  test('dashboard start never replaces a provider-removed established sandbox', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
-      sandboxProvider: 'daytona',
+      sandboxProvider: 'platinum',
       status: 'running',
       opencodeSessionId: 'ses_root_existing',
       metadata: {
@@ -1624,7 +1657,7 @@ describe('project session API contract', () => {
         sessionId: SESSION_ID,
         accountId: ACCOUNT_ID,
         projectId: PROJECT_ID,
-        provider: 'daytona',
+        provider: 'platinum',
         externalId: 'box-deleted',
         baseUrl: null,
         status: 'active',
@@ -1636,40 +1669,211 @@ describe('project session API contract', () => {
       },
     ];
     providerStatus = 'removed';
+    providerRecoveryEnabled = true;
 
     const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
       method: 'POST',
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      stage: 'provisioning',
+      stage: 'failed',
       agent_name: 'default',
-      retriable: true,
-      reason: 'runtime_recovery_provisioning',
-      sandbox: null,
+      retriable: false,
+      reason: 'runtime_identity_unavailable',
+      sandbox: { external_id: 'box-deleted', status: 'stopped' },
     });
 
     expect(providerStartCalls).toBe(0);
-    await flushUntil(() => sandboxProvisionCalls === 1);
-    expect(sandboxProvisionCalls).toBe(1);
+    expect(providerRecoveryCalls).toBe(1);
+    expect(sandboxProvisionCalls).toBe(0);
     expect(sessionSandboxRows).toHaveLength(1);
     expect(sessionSandboxRows[0]).toMatchObject({
-      externalId: null,
-      status: 'provisioning',
+      externalId: 'box-deleted',
+      status: 'stopped',
       metadata: {
-        retiredExternalId: 'box-deleted',
-        identityRecoveryAuthorizedAt: expect.any(String),
+        preservedExternalId: 'box-deleted',
+        runtimeIdentityState: 'unavailable',
       },
     });
-    expect(sessionRow?.status).toBe('provisioning');
-    expect(sessionRow?.opencodeSessionId).toBeNull();
-    expect(sessionRow?.metadata).toMatchObject({
-      lastRuntimeRecovery: {
-        externalId: 'box-deleted',
-        reason: 'runtime_removed',
+    expect(sessionRow?.status).toBe('stopped');
+    expect(sessionRow?.opencodeSessionId).toBe('ses_root_existing');
+  });
+
+  test('dashboard start restores a provider-removed sandbox in place without provisioning', async () => {
+    const app = createApp();
+    sessionRow = {
+      ...sessionRow!,
+      status: 'stopped',
+      opencodeSessionId: 'ses_root_existing',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'box-restorable',
+        status: 'stopped',
+        baseUrl: 'https://box-restorable.test',
+        config: {},
+        metadata: { providerStatusObservedAt: '2026-01-01T00:00:00.000Z' },
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+    providerStatus = 'removed';
+    providerRecoveryEnabled = true;
+    providerRecoveryStatus = 'recovering';
+
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      stage: 'starting',
+      reason: 'runtime_restoring_in_place',
+      sandbox: { external_id: 'box-restorable' },
+      opencode_session_id: 'ses_root_existing',
+    });
+    expect(providerRecoveryCalls).toBe(1);
+    expect(providerStartCalls).toBe(0);
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows[0]?.externalId).toBe('box-restorable');
+    expect(sessionSandboxRows[0]?.status).toBe('provisioning');
+    expect(computeReopenCalls).toBe(0);
+
+    providerStatus = 'running';
+    const ready = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
+      method: 'POST',
+    });
+    expect(ready.status).toBe(200);
+    expect(await ready.json()).toMatchObject({
+      stage: 'ready',
+      sandbox: { external_id: 'box-restorable', status: 'active' },
+      opencode_session_id: 'ses_root_existing',
+    });
+    expect(providerRecoveryCalls).toBe(1);
+    expect(sessionSandboxRows[0]?.status).toBe('active');
+    expect(sessionRow?.status).toBe('running');
+    expect(computeReopenCalls).toBe(1);
+  });
+
+  test('concurrent dashboard starts issue exactly one same-id provider recovery', async () => {
+    const app = createApp();
+    sessionRow = {
+      ...sessionRow!,
+      status: 'running',
+      opencodeSessionId: 'ses_root_existing',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'box-single-flight',
+        status: 'active',
+        baseUrl: 'https://box-single-flight.test',
+        config: {},
+        metadata: {},
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+    providerStatus = 'removed';
+    providerRecoveryEnabled = true;
+    providerRecoveryStatus = 'recovering';
+    providerRecoveryGate = new Promise<void>((resolve) => {
+      releaseProviderRecovery = resolve;
+    });
+
+    const first = app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
+      method: 'POST',
+    });
+    await flushUntil(() => providerRecoveryCalls === 1);
+    const second = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
+      method: 'POST',
+    });
+
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({
+      stage: 'starting',
+      reason: 'runtime_recovery_in_progress',
+      sandbox: { external_id: 'box-single-flight' },
+    });
+    expect(providerRecoveryCalls).toBe(1);
+    expect(sandboxProvisionCalls).toBe(0);
+
+    releaseProviderRecovery?.();
+    expect(await (await first).json()).toMatchObject({
+      stage: 'starting',
+      reason: 'runtime_restoring_in_place',
+    });
+    expect(providerRecoveryCalls).toBe(1);
+  });
+
+  test('explicit deletion winning during recovery prevents status and billing resurrection', async () => {
+    const app = createApp();
+    sessionRow = {
+      ...sessionRow!,
+      status: 'running',
         opencodeSessionId: 'ses_root_existing',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'box-delete-race',
+        status: 'active',
+        baseUrl: 'https://box-delete-race.test',
+        config: {},
+        metadata: {},
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
       },
+    ];
+    providerStatus = 'removed';
+    providerRecoveryEnabled = true;
+    providerRecoveryStatus = 'running';
+    providerRecoveryGate = new Promise<void>((resolve) => {
+      releaseProviderRecovery = resolve;
     });
+
+    const request = app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
+      method: 'POST',
+    });
+    await flushUntil(() => providerRecoveryCalls === 1);
+    sessionRow = {
+      ...sessionRow!,
+      status: 'stopped',
+      metadata: {
+        ...(sessionRow?.metadata ?? {}),
+        deletedAt: new Date().toISOString(),
+      },
+    };
+    sessionSandboxRows[0] = { ...sessionSandboxRows[0]!, status: 'archived' };
+    releaseProviderRecovery?.();
+
+    const res = await request;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      stage: 'stopped',
+      retriable: false,
+      reason: 'runtime_recovery_cancelled',
+    });
+    expect(sessionRow?.status).toBe('stopped');
+    expect(sessionSandboxRows[0]?.status).toBe('archived');
+    expect(computeReopenCalls).toBe(0);
+    expect(sandboxProvisionCalls).toBe(0);
   });
 
   test('dashboard start preserves a running sandbox whose OpenCode runtime never becomes reachable', async () => {
@@ -1722,11 +1926,11 @@ describe('project session API contract', () => {
     expect(sessionSandboxRows[0]?.externalId).toBe('box-opencode-dead');
   });
 
-  test('restart of a provider-removed sandbox provisions a replacement', async () => {
+  test('restart of a provider-removed sandbox refuses replacement and preserves identity', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
-      sandboxProvider: 'daytona',
+      sandboxProvider: 'platinum',
       status: 'running',
       opencodeSessionId: 'ses_root_existing',
     };
@@ -1736,7 +1940,7 @@ describe('project session API contract', () => {
         sessionId: SESSION_ID,
         accountId: ACCOUNT_ID,
         projectId: PROJECT_ID,
-        provider: 'daytona',
+        provider: 'platinum',
         externalId: 'box-deleted',
         baseUrl: null,
         status: 'active',
@@ -1748,35 +1952,87 @@ describe('project session API contract', () => {
       },
     ];
     providerStatus = 'removed';
+    providerRecoveryEnabled = true;
 
-    const res = await app.request(
-      `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`,
-      { method: 'POST' },
-    );
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`, {
+      method: 'POST',
+    });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      code: 'SESSION_RUNTIME_IDENTITY_UNAVAILABLE',
+      session_id: SESSION_ID,
+      external_id: 'box-deleted',
+      reason: 'runtime_identity_unavailable',
+    });
+
+    expect(providerStartCalls).toBe(0);
+    expect(providerRecoveryCalls).toBe(1);
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionRow?.status).toBe('stopped');
+    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sessionSandboxRows[0]).toMatchObject({
+      externalId: 'box-deleted',
+      status: 'stopped',
+      metadata: {
+        preservedExternalId: 'box-deleted',
+        runtimeIdentityState: 'unavailable',
+      },
+    });
+  });
+
+  test('restart restores a provider-removed sandbox in place without provisioning', async () => {
+    const app = createApp();
+    sessionRow = {
+      ...sessionRow!,
+      status: 'stopped',
+      opencodeSessionId: 'ses_root_existing',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'box-restart-restorable',
+        status: 'stopped',
+        baseUrl: 'https://box-restart-restorable.test',
+        config: {},
+        metadata: {},
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+    providerStatus = 'removed';
+    providerRecoveryEnabled = true;
+    providerRecoveryStatus = 'recovering';
+
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`, {
+      method: 'POST',
+    });
+
     expect(res.status).toBe(202);
     expect(await res.json()).toMatchObject({
       ok: true,
       session_id: SESSION_ID,
       status: 'provisioning',
-      reason: 'runtime_recovery_provisioning',
+      reason: 'runtime_restoring_in_place',
     });
-
+    expect(providerRecoveryCalls).toBe(1);
     expect(providerStartCalls).toBe(0);
-    await flushUntil(() => sandboxProvisionCalls === 1);
-    expect(sandboxProvisionCalls).toBe(1);
-    expect(sessionRow?.status).toBe('provisioning');
-    expect(sessionSandboxRows).toHaveLength(1);
+    expect(sandboxProvisionCalls).toBe(0);
     expect(sessionSandboxRows[0]).toMatchObject({
-      externalId: null,
+      externalId: 'box-restart-restorable',
       status: 'provisioning',
-      metadata: {
-        retiredExternalId: 'box-deleted',
-        identityRecoveryAuthorizedAt: expect.any(String),
-      },
+    });
+    expect(sessionRow).toMatchObject({
+      status: 'provisioning',
+      opencodeSessionId: 'ses_root_existing',
     });
   });
 
-  test('restart self-heals when provider status is uncertain but start returns not-found', async () => {
+  test('restart preserves identity when provider status is uncertain and start returns not-found', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -1801,28 +2057,31 @@ describe('project session API contract', () => {
       },
     ];
     providerStatus = 'unknown';
-    providerStartError = Object.assign(new Error('sandbox not found'), { status: 404 });
+    providerStartError = Object.assign(new Error('sandbox not found'), {
+      status: 404,
+    });
 
-    const res = await app.request(
-      `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`,
-      { method: 'POST' },
-    );
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`, {
+      method: 'POST',
+    });
     expect(res.status).toBe(202);
-    await flushUntil(() => sandboxProvisionCalls === 1);
+    await flushUntil(() => sessionRow?.status === 'stopped');
     expect(providerStartCalls).toBe(1);
-    expect(sandboxProvisionCalls).toBe(1);
-    expect(sessionRow?.status).toBe('provisioning');
-    expect(sessionRow?.metadata).toMatchObject({
-      lastRuntimeRecovery: {
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows[0]).toMatchObject({
         externalId: 'box-missing-on-start',
-        reason: 'restart_missing_runtime',
-      },
+      status: 'stopped',
+      metadata: { preservedExternalId: 'box-missing-on-start' },
     });
   });
 
-  test('restart self-heals when provider accepts start but then reports removed', async () => {
+  test('restart preserves identity when provider accepts start but then reports removed', async () => {
     const app = createApp();
-    sessionRow = { ...sessionRow!, status: 'running', opencodeSessionId: 'ses_root_existing' };
+    sessionRow = {
+      ...sessionRow!,
+      status: 'running',
+      opencodeSessionId: 'ses_root_existing',
+    };
     sessionSandboxRows = [
       {
         sandboxId: SESSION_ID,
@@ -1843,20 +2102,17 @@ describe('project session API contract', () => {
     providerStatus = 'unknown';
     providerStatusAfterStart = 'removed';
 
-    const res = await app.request(
-      `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`,
-      { method: 'POST' },
-    );
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`, {
+      method: 'POST',
+    });
     expect(res.status).toBe(202);
-    await flushUntil(() => sandboxProvisionCalls === 1);
+    await flushUntil(() => sessionRow?.status === 'stopped');
     expect(providerStartCalls).toBe(1);
-    expect(sandboxProvisionCalls).toBe(1);
-    expect(sessionRow?.status).toBe('provisioning');
-    expect(sessionRow?.metadata).toMatchObject({
-      lastRuntimeRecovery: {
+    expect(sandboxProvisionCalls).toBe(0);
+    expect(sessionSandboxRows[0]).toMatchObject({
         externalId: 'box-accepted-start-then-removed',
-        reason: 'restart_post_start_removed',
-      },
+      status: 'stopped',
+      metadata: { preservedExternalId: 'box-accepted-start-then-removed' },
     });
   });
 
@@ -2124,7 +2380,11 @@ describe('project session API contract', () => {
       updatedAt: new Date('2026-01-02T00:00:00Z'),
       },
     ];
-    sessionRow = { ...sessionRow!, status: 'running', opencodeSessionId: 'ses_existing' };
+    sessionRow = {
+      ...sessionRow!,
+      status: 'running',
+      opencodeSessionId: 'ses_existing',
+    };
     sessionSandboxRows = [];
 
     const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
@@ -2147,7 +2407,11 @@ describe('project session API contract', () => {
       updatedAt: new Date('2026-01-02T00:00:00Z'),
       },
     ];
-    sessionRow = { ...sessionRow!, status: 'running', opencodeSessionId: 'ses_existing' };
+    sessionRow = {
+      ...sessionRow!,
+      status: 'running',
+      opencodeSessionId: 'ses_existing',
+    };
     sessionSandboxRows = [];
 
     const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/restart`, {

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -59,6 +59,7 @@ export interface ProvisionResult {
 }
 
 export type SandboxStatus = 'running' | 'stopped' | 'removed' | 'unknown';
+export type InPlaceRecoveryStatus = 'running' | 'recovering' | 'unavailable';
 
 export interface ResolvedEndpoint {
   url: string;
@@ -94,6 +95,13 @@ export interface SandboxProvider {
   stop(externalId: string): Promise<void>;
   remove(externalId: string): Promise<void>;
   getStatus(externalId: string): Promise<SandboxStatus>;
+  /**
+   * Recover the SAME provider object when provider state looks terminal.
+   * Implementations may restore a provider-native disk backup, but must never
+   * create or return a different external identity. Callers fail closed when
+   * this capability is absent or returns unavailable.
+   */
+  recoverInPlace?(externalId: string): Promise<InPlaceRecoveryStatus>;
   resolveEndpoint(externalId: string): Promise<ResolvedEndpoint>;
   /**
    * Resolve a reachable upstream URL for an arbitrary port — the data path the

--- a/apps/api/src/platform/providers/platinum-status.test.ts
+++ b/apps/api/src/platform/providers/platinum-status.test.ts
@@ -20,7 +20,7 @@ mock.module('../sandbox-frontend-url', () => ({
 }));
 
 let fetchStatus = 404;
-let fetchBody = { error: 'not found', code: 'not_found' };
+let fetchBody: Record<string, unknown> = { error: 'not found', code: 'not_found' };
 
 beforeEach(() => {
   fetchStatus = 404;
@@ -47,4 +47,45 @@ test('getStatus() preserves transitional Platinum failures as unknown', async ()
   const provider = new PlatinumProvider();
 
   await expect(provider.getStatus('sbx_starting')).resolves.toBe('unknown');
+});
+
+test('recoverInPlace() restores a terminal sandbox backup without changing identity', async () => {
+  const calls: Array<{ url: string; method: string }> = [];
+  globalThis.fetch = (async (input, init) => {
+    calls.push({ url: String(input), method: String(init?.method ?? 'GET') });
+    if (String(input).endsWith('/restore-from-backup')) {
+      return new Response(JSON.stringify({ id: 'sbx_data', state: 'restoring' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(
+      JSON.stringify({ id: 'sbx_data', state: 'failed-start', backup_state: 'completed' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as typeof fetch;
+
+  const { PlatinumProvider } = await import('./platinum');
+  const provider = new PlatinumProvider();
+
+  await expect(provider.recoverInPlace('sbx_data')).resolves.toBe('recovering');
+  expect(calls).toContainEqual({
+    url: 'https://platinum.example.test/v1/sandboxes/sbx_data/restore-from-backup',
+    method: 'POST',
+  });
+  expect(calls.some((call) => call.url.includes('/v1/sandboxes?'))).toBe(false);
+});
+
+test('recoverInPlace() refuses to create a replacement for an unbacked terminal sandbox', async () => {
+  fetchStatus = 200;
+  fetchBody = {
+    id: 'sbx_unbacked',
+    state: 'failed-start',
+    backupState: 'none',
+  };
+
+  const { PlatinumProvider } = await import('./platinum');
+  const provider = new PlatinumProvider();
+
+  await expect(provider.recoverInPlace('sbx_unbacked')).resolves.toBe('unavailable');
 });

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -25,6 +25,7 @@ import type {
   ResolvedEndpoint,
   ProvisioningTraits,
   ProvisioningStatus,
+  InPlaceRecoveryStatus,
 } from './index';
 import { providerAutoStopBackstopMinutes } from './index';
 
@@ -33,6 +34,8 @@ const AGENT_PORT = 8000;
 interface PlatinumSandbox {
   id: string;
   state?: string;
+  backupState?: string | null;
+  backup_state?: string | null;
 }
 type PlatinumExposedPort = { port: number; url: string; token?: string; public: boolean };
 
@@ -236,6 +239,40 @@ export class PlatinumProvider implements SandboxProvider {
       if (isMissingSandboxError(err)) return 'removed';
       return 'unknown';
     }
+  }
+
+  async recoverInPlace(externalId: string): Promise<InPlaceRecoveryStatus> {
+    let sandbox: PlatinumSandbox;
+    try {
+      sandbox = await platinumJson<PlatinumSandbox>(`/v1/sandboxes/${externalId}`);
+    } catch (err) {
+      return isMissingSandboxError(err) ? 'unavailable' : 'recovering';
+    }
+
+    const state = String(sandbox.state ?? '').toLowerCase();
+    if (state === 'running') return 'running';
+
+    if (state === 'stopped' || state === 'stopping' || state.includes('archiv')) {
+      await this.start(externalId);
+      return 'recovering';
+    }
+
+    // A terminal VM state is not proof of data loss. Platinum continuously
+    // backs up data-bearing disks and can restore that backup onto a healthy
+    // host while retaining the exact sandbox id.
+    if (
+      ['failed-start', 'lost', 'deleted'].includes(state) &&
+      String(sandbox.backupState ?? sandbox.backup_state ?? '').toLowerCase() === 'completed'
+    ) {
+      await platinumJson(`/v1/sandboxes/${externalId}/restore-from-backup`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(120_000),
+      });
+      return 'recovering';
+    }
+
+    if (['failed-start', 'lost', 'deleted'].includes(state)) return 'unavailable';
+    return 'recovering';
   }
 
   async resolvePreviewLink(externalId: string, port: number): Promise<{ url: string; token: string | null }> {

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -143,8 +143,10 @@ mock.module('../../shared/db', () => ({
             updates.status === 'provisioning' &&
             'config' in updates;
           if (isRecoveryClaim) {
+            const claimed = recoveryPlaceholder;
+            recoveryPlaceholder = false;
             return updateResult(
-              recoveryPlaceholder
+              claimed
                 ? [{
                     sandboxId: SANDBOX_ID,
                     sessionId: SANDBOX_ID,
@@ -318,6 +320,26 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
 
     expect(providerCreateCalls).toBe(1);
     expect(removedIds).toEqual([]);
+    expect(computeSessionsOpened).toHaveLength(1);
+  });
+
+  test('legacy recovery placeholder authorization is single-use under concurrent allocation', async () => {
+    identityConflict = true;
+    recoveryPlaceholder = true;
+    const opened = waitFor((resolve) => { onComputeOpened = resolve; });
+
+    const results = await Promise.allSettled([
+      provisionSessionSandbox(baseOpts()),
+      provisionSessionSandbox(baseOpts()),
+    ]);
+    await opened;
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(results.find((result) => result.status === 'rejected')).toMatchObject({
+      reason: { name: 'RuntimeIdentityConflictError' },
+    });
+    expect(providerCreateCalls).toBe(1);
     expect(computeSessionsOpened).toHaveLength(1);
   });
 

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -283,6 +283,11 @@ export async function provisionSessionSandbox(opts: {
         status: 'provisioning',
         baseUrl: null,
         config: {},
+        // Legacy recovery placeholders may still exist while this release rolls
+        // out. Consume their authorization marker atomically so at most one
+        // allocator can claim the row and call provider.create(). New code never
+        // creates this marker because established identities are fail-closed.
+        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'identityRecoveryAuthorizedAt'`,
         updatedAt: new Date(),
       })
       .where(

--- a/apps/api/src/projects/maintenance.test.ts
+++ b/apps/api/src/projects/maintenance.test.ts
@@ -26,6 +26,7 @@ mock.module('../shared/db', () => ({
 }));
 mock.module('./git', () => ({ deleteRemoteSessionBranch: async () => false }));
 mock.module('../billing/services/compute-metering', () => ({
+  reopenComputeForSandbox: async () => undefined,
   tickRunningComputeCharges: async () => ({ settled: 0 }),
 }));
 mock.module('../snapshots/builder', () => ({

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -10,19 +10,15 @@ import { rehydrateSessionChat } from '../legacy-migration-rehydrate';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
 import { resolveProjectGitAuth } from '../lib/git';
-import {
-  ProjectRow,
-  serializeSessionSandboxConfig,
-} from '../lib/serializers';
+import { ProjectRow, serializeSessionSandboxConfig } from '../lib/serializers';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
-import {
-  buildSessionSandboxEnvVars,
-  sandboxCallbackUnreachableReason,
-} from '../lib/sessions';
+import { buildSessionSandboxEnvVars, sandboxCallbackUnreachableReason } from '../lib/sessions';
 import { ensureOpencodeSessionPin } from '../opencode-mapping';
 import {
+  claimInPlaceRuntimeRecovery,
+  finalizeRecoveredRuntimeIfRunning,
+  markInPlaceRuntimeRecoveryAccepted,
   preserveEstablishedRuntime,
-  retireConfirmedMissingRuntime,
   retireUnmaterializedRuntime,
   RUNTIME_IDENTITY_UNAVAILABLE,
 } from '../runtime-identity';
@@ -54,12 +50,7 @@ export async function resumeStoppedSandbox(row: {
   metadata?: Record<string, unknown> | null;
 }): Promise<boolean> {
   if (!row.externalId) return false;
-  if (
-    !(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(
-      row.provider,
-    )
-  )
-    return false;
+  if (!(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(row.provider)) return false;
 
   const externalId = row.externalId;
   const now = new Date();
@@ -76,7 +67,8 @@ export async function resumeStoppedSandbox(row: {
     'needsReprovision',
     'runtimeWakeError',
     'runtimeWakeFailedAt',
-  ]) delete wakeMetadata[key];
+  ])
+    delete wakeMetadata[key];
   Object.assign(wakeMetadata, {
     lastTurnAt: now.toISOString(),
     runtimeWakeStartedAt: now.toISOString(),
@@ -97,10 +89,7 @@ export async function resumeStoppedSandbox(row: {
       metadata: wakeMetadata,
     })
     .where(
-      and(
-        eq(sessionSandboxes.sandboxId, row.sandboxId),
-        eq(sessionSandboxes.status, 'stopped'),
-      ),
+      and(eq(sessionSandboxes.sandboxId, row.sandboxId), eq(sessionSandboxes.status, 'stopped')),
     )
     .returning();
   if (!won) return false;
@@ -116,16 +105,14 @@ export async function resumeStoppedSandbox(row: {
       ),
     );
 
-  void reopenComputeForSandbox(
-    row.sandboxId,
-    row.accountId,
-    row.sessionId,
-  ).catch((err) =>
+  void reopenComputeForSandbox(row.sandboxId, row.accountId, row.sessionId).catch((err) =>
     console.warn(`[projects] compute reopen failed for ${row.sandboxId}:`, err),
   );
 
   const provider = getProvider(row.provider as SandboxProviderName);
-  void provider.start(externalId).then(async () => {
+  void provider
+    .start(externalId)
+    .then(async () => {
     await db
       .update(sessionSandboxes)
       .set({
@@ -140,12 +127,10 @@ export async function resumeStoppedSandbox(row: {
         ),
       )
       .catch((err) =>
-        console.warn(
-          `[runtime-identity] failed to clear wake fence for ${row.sessionId}:`,
-          err,
-        ),
+          console.warn(`[runtime-identity] failed to clear wake fence for ${row.sessionId}:`, err),
       );
-  }).catch(async (err) => {
+    })
+    .catch(async (err) => {
     console.warn(
       `[projects] failed to resume sandbox ${externalId} for session ${row.sessionId}:`,
       err,
@@ -205,7 +190,16 @@ export async function selectPreResumeTargets(
   projectId: string,
   userId: string,
   limit: number,
-): Promise<Array<{ sandboxId: string; sessionId: string; accountId: string; provider: string; externalId: string | null; metadata: Record<string, unknown> | null }>> {
+): Promise<
+  Array<{
+    sandboxId: string;
+    sessionId: string;
+    accountId: string;
+    provider: string;
+    externalId: string | null;
+    metadata: Record<string, unknown> | null;
+  }>
+> {
   return db
     .select({
       sandboxId: sessionSandboxes.sandboxId,
@@ -217,12 +211,14 @@ export async function selectPreResumeTargets(
     })
     .from(sessionSandboxes)
     .innerJoin(projectSessions, eq(projectSessions.sessionId, sessionSandboxes.sessionId))
-    .where(and(
+    .where(
+      and(
       eq(sessionSandboxes.projectId, projectId),
       eq(sessionSandboxes.status, 'stopped'),
       isNotNull(sessionSandboxes.externalId),
       eq(projectSessions.createdBy, userId),
-    ))
+      ),
+    )
     .orderBy(desc(sessionSandboxes.lastUsedAt))
     .limit(Math.max(1, limit));
 }
@@ -234,16 +230,24 @@ export function preResumeRecentStoppedSessions(projectId: string, userId?: strin
   preResumeThrottle.set(projectId, nowMs);
   void (async () => {
     try {
-      const rows = await selectPreResumeTargets(projectId, userId, config.KORTIX_PRERESUME_MAX_PER_PROJECT);
+      const rows = await selectPreResumeTargets(
+        projectId,
+        userId,
+        config.KORTIX_PRERESUME_MAX_PER_PROJECT,
+      );
       let kicked = 0;
       for (const row of rows) {
         const won = await resumeStoppedSandbox(row).catch((err) => {
-          console.warn(`[pre-resume] resume ${row.sandboxId.slice(0, 8)} failed:`, err instanceof Error ? err.message : err);
+          console.warn(
+            `[pre-resume] resume ${row.sandboxId.slice(0, 8)} failed:`,
+            err instanceof Error ? err.message : err,
+          );
           return false;
         });
         if (won) kicked++;
       }
-      if (kicked) console.log(`[pre-resume] kicked ${kicked} resume(s) for project ${projectId.slice(0, 8)}`);
+      if (kicked)
+        console.log(`[pre-resume] kicked ${kicked} resume(s) for project ${projectId.slice(0, 8)}`);
     } catch (err) {
       console.warn('[pre-resume] failed:', err instanceof Error ? err.message : err);
       preResumeThrottle.delete(projectId); // let the next presence retry
@@ -263,12 +267,7 @@ export async function allocateRuntimeOnOpen(
   sessionId: string,
 ): Promise<void> {
   const providerName = session.sandboxProvider as SandboxProviderName;
-  if (
-    !(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(
-      providerName,
-    )
-  )
-    return;
+  if (!(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(providerName)) return;
   if (sandboxCallbackUnreachableReason()) return;
   await db
     .update(projectSessions)
@@ -282,9 +281,7 @@ export async function allocateRuntimeOnOpen(
     }
   ).metadata?.legacy_migration?.source_sandbox_id;
   const opencodeModel =
-    typeof session.metadata?.opencode_model === 'string'
-      ? session.metadata.opencode_model
-      : null;
+    typeof session.metadata?.opencode_model === 'string' ? session.metadata.opencode_model : null;
   const runtimeMetadata = { opened_at: new Date().toISOString() };
   const sessionMetadata = { ...(session.metadata ?? {}), ...runtimeMetadata };
 
@@ -313,8 +310,7 @@ export async function allocateRuntimeOnOpen(
         manifestPath: loaded.row.manifestPath,
         llmGatewayEnabled: projectLlmGatewayEnabled(loaded.row.metadata),
       }),
-    resolveGitAuthToken: async () =>
-      (await resolveProjectGitAuth(loaded.row)).auth?.token ?? null,
+    resolveGitAuthToken: async () => (await resolveProjectGitAuth(loaded.row)).auth?.token ?? null,
     beforeActive:
       typeof legacySandboxId === 'string'
         ? (externalId) =>
@@ -331,7 +327,10 @@ export async function allocateRuntimeOnOpen(
 // The stage/result wire types live in @kortix/api-contract (the shared wire
 // contract); re-exported here for the existing import sites.
 
-export type { SessionStartResult, SessionStartStage } from '@kortix/api-contract';
+export type {
+  SessionStartResult,
+  SessionStartStage,
+} from '@kortix/api-contract';
 
 /**
  * The relative proxy path a client uses for all OpenCode (port 8000) traffic for
@@ -375,8 +374,7 @@ function staleProvisioningReason(
   }
 
   if (initStatus === 'provisioning' || initStatus === 'retrying') {
-    const initUpdatedAtMs =
-      parseTimestampMs(metadata.initUpdatedAt) ?? rowUpdatedAtMs;
+    const initUpdatedAtMs = parseTimestampMs(metadata.initUpdatedAt) ?? rowUpdatedAtMs;
     return nowMs - initUpdatedAtMs > STALE_STARTED_PROVISIONING_MS
       ? 'stale_provisioning_lost'
       : null;
@@ -385,9 +383,7 @@ function staleProvisioningReason(
   return null;
 }
 
-function sandboxMetadata(
-  row: typeof sessionSandboxes.$inferSelect,
-): Record<string, unknown> {
+function sandboxMetadata(row: typeof sessionSandboxes.$inferSelect): Record<string, unknown> {
   return row.metadata && typeof row.metadata === 'object'
     ? (row.metadata as Record<string, unknown>)
     : {};
@@ -403,9 +399,7 @@ function staleRuntimeWakeReason(
   const metadata = sandboxMetadata(row);
   const wakeStartedAtMs = parseTimestampMs(metadata.runtimeWakeStartedAt);
   if (wakeStartedAtMs && nowMs - wakeStartedAtMs > STALE_RUNTIME_WAKE_MS) {
-    return providerStatus === 'stopped'
-      ? 'runtime_wake_timeout'
-      : 'runtime_status_unknown_timeout';
+    return providerStatus === 'stopped' ? 'runtime_wake_timeout' : 'runtime_status_unknown_timeout';
   }
 
   // Existing bad rows predate runtimeWakeStartedAt. If the provider status is
@@ -430,16 +424,9 @@ function staleOpencodeReadyReason(
 ): string | null {
   if (reason !== 'not_ready' && reason !== 'unreachable') return null;
   const metadata = sandboxMetadata(row);
-  const readyWaitStartedAtMs = parseTimestampMs(
-    metadata.opencodeReadyWaitStartedAt,
-  );
-  if (
-    readyWaitStartedAtMs &&
-    nowMs - readyWaitStartedAtMs > STALE_OPENCODE_READY_MS
-  ) {
-    return reason === 'not_ready'
-      ? 'runtime_not_ready_timeout'
-      : 'runtime_unreachable_timeout';
+  const readyWaitStartedAtMs = parseTimestampMs(metadata.opencodeReadyWaitStartedAt);
+  if (readyWaitStartedAtMs && nowMs - readyWaitStartedAtMs > STALE_OPENCODE_READY_MS) {
+    return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
   }
 
   const initSucceededAtMs = parseTimestampMs(metadata.initSucceededAt);
@@ -448,9 +435,7 @@ function staleOpencodeReadyReason(
     initSucceededAtMs &&
     nowMs - initSucceededAtMs > STALE_OPENCODE_READY_MS
   ) {
-    return reason === 'not_ready'
-      ? 'runtime_not_ready_timeout'
-      : 'runtime_unreachable_timeout';
+    return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
   }
   return null;
 }
@@ -461,12 +446,8 @@ function removedRuntimeStillInGrace(
 ): boolean {
   const metadata = sandboxMetadata(row);
   const graceStartedAtMs =
-    parseTimestampMs(metadata.runtimeWakeStartedAt) ??
-    parseTimestampMs(metadata.initSucceededAt);
-  return (
-    graceStartedAtMs != null &&
-    nowMs - graceStartedAtMs <= STALE_RUNTIME_WAKE_MS
-  );
+    parseTimestampMs(metadata.runtimeWakeStartedAt) ?? parseTimestampMs(metadata.initSucceededAt);
+  return graceStartedAtMs != null && nowMs - graceStartedAtMs <= STALE_RUNTIME_WAKE_MS;
 }
 
 async function markRuntimeWakeStarted(
@@ -488,10 +469,7 @@ async function markRuntimeWakeStarted(
       })
       .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
   } catch (err) {
-    console.warn(
-      `[start] failed to mark runtime wake for ${row.sandboxId}:`,
-      err,
-    );
+    console.warn(`[start] failed to mark runtime wake for ${row.sandboxId}:`, err);
   }
 }
 
@@ -514,10 +492,7 @@ async function markOpencodeReadyWaitStarted(
       })
       .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
   } catch (err) {
-    console.warn(
-      `[start] failed to mark OpenCode wait for ${row.sandboxId}:`,
-      err,
-    );
+    console.warn(`[start] failed to mark OpenCode wait for ${row.sandboxId}:`, err);
   }
 }
 
@@ -607,33 +582,6 @@ async function preserveEstablishedRuntimeOnOpen(
   };
 }
 
-async function recoverConfirmedMissingRuntimeOnOpen(
-  loaded: { row: ProjectRow; userId: string },
-  visible: {
-    row: {
-      sandboxProvider: string;
-      baseRef: string | null;
-      agentName: string | null;
-      metadata?: Record<string, unknown> | null;
-    };
-  },
-  projectId: string,
-  sessionId: string,
-  row: typeof sessionSandboxes.$inferSelect,
-  reason: string,
-): Promise<SessionStartResult> {
-  const retired = await retireConfirmedMissingRuntime(row, reason);
-  if (retired) await allocateRuntimeOnOpen(loaded, visible.row, projectId, sessionId);
-  return {
-    stage: 'provisioning',
-    agent_name: visible.row.agentName ?? 'default',
-    retriable: true,
-    sandbox: null,
-    opencode_session_id: null,
-    reason: retired ? 'runtime_recovery_provisioning' : 'runtime_recovery_in_progress',
-  };
-}
-
 /**
  * THE authoritative session-open path — the single call the dashboard uses to
  * bring a session's runtime up. Idempotent: provisions a missing sandbox,
@@ -671,15 +619,21 @@ export async function openSession(args: {
     )
     .limit(1);
 
-  // Resume a hibernated box in place (keeps its disk/workspace).
+  // Resume a hibernated box in place (keeps its disk/workspace). Check provider
+  // truth first: a terminal Platinum VM may need backup restoration, and sending
+  // a normal start before that restore creates a second provider-side race.
+  let stoppedProviderStatus: SandboxStatus | null = null;
   if (
     row &&
     row.status === 'stopped' &&
     row.externalId &&
-    (config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(
-      row.provider,
-    )
+    (config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(row.provider)
   ) {
+    const provider = getProvider(row.provider as SandboxProviderName);
+    stoppedProviderStatus = await provider
+      .getStatus(row.externalId)
+      .catch(() => 'unknown' as const);
+    if (stoppedProviderStatus !== 'removed' || !provider.recoverInPlace) {
     await resumeStoppedSandbox({
       sandboxId: row.sandboxId,
       sessionId: row.sessionId,
@@ -695,10 +649,14 @@ export async function openSession(args: {
       .limit(1);
     if (resumed) row = resumed;
   }
+  }
 
   // No usable box → provision on open (or report a terminal state).
   const usable =
-    row && (row.status === 'provisioning' || row.status === 'active');
+    row &&
+    (row.status === 'provisioning' ||
+      row.status === 'active' ||
+      (row.status === 'stopped' && row.externalId && stoppedProviderStatus === 'removed'));
   if (!usable) {
     if (['failed', 'stopped', 'completed'].includes(visible.row.status)) {
       return {
@@ -744,8 +702,29 @@ export async function openSession(args: {
     );
   }
 
+  // A same-id restore already owns the provider operation. Concurrent polls
+  // must observe that lease without issuing another restore request.
+  if (
+    row.status === 'provisioning' &&
+    row.externalId &&
+    sandboxMetadata(row).runtimeIdentityState === 'recovery_claimed'
+  ) {
+    return {
+      stage: 'starting',
+      agent_name: visible.row.agentName ?? 'default',
+      retriable: true,
+      sandbox: serializeSandboxRow(row),
+      opencode_session_id: visible.row.opencodeSessionId,
+      runtime_url: sessionRuntimeUrlPath(row.externalId),
+      reason: 'runtime_recovery_in_progress',
+    };
+  }
+
   // Still provisioning, or active but external_id not yet written.
-  if (row.status === 'provisioning' || !row.externalId) {
+  if (
+    (row.status === 'provisioning' && sandboxMetadata(row).runtimeIdentityState !== 'recovering') ||
+    !row.externalId
+  ) {
     return {
       stage: 'provisioning',
       agent_name: visible.row.agentName ?? 'default',
@@ -765,7 +744,7 @@ export async function openSession(args: {
   const provider = getProvider(row.provider as SandboxProviderName);
   let providerStatus: SandboxStatus;
   try {
-    providerStatus = await provider.getStatus(row.externalId);
+    providerStatus = stoppedProviderStatus ?? (await provider.getStatus(row.externalId));
   } catch {
     providerStatus = 'unknown';
   }
@@ -783,17 +762,67 @@ export async function openSession(args: {
         reason: 'runtime_removed_checking',
       };
     }
-    return recoverConfirmedMissingRuntimeOnOpen(
+    const claim = await claimInPlaceRuntimeRecovery(row);
+    if (!claim) {
+      return {
+        stage: 'starting',
+        agent_name: visible.row.agentName ?? 'default',
+        retriable: true,
+        sandbox: serializeSandboxRow(row),
+        opencode_session_id: visible.row.opencodeSessionId,
+        runtime_url: sessionRuntimeUrlPath(row.externalId),
+        reason: 'runtime_recovery_in_progress',
+      };
+    }
+    const recovery = await provider.recoverInPlace?.(row.externalId).catch((err) => {
+      console.warn(`[start] in-place recovery failed for ${row.externalId}:`, err);
+      return 'unavailable' as const;
+    });
+    if (recovery === 'running' || recovery === 'recovering') {
+      const recoveringRow = await markInPlaceRuntimeRecoveryAccepted(claim, recovery);
+      if (!recoveringRow) {
+        return {
+          stage: 'stopped',
+          agent_name: visible.row.agentName ?? 'default',
+          retriable: false,
+          sandbox: null,
+          opencode_session_id: null,
+          reason: 'runtime_recovery_cancelled',
+        };
+      }
+      return {
+        stage: 'starting',
+        agent_name: visible.row.agentName ?? 'default',
+        retriable: true,
+        sandbox: serializeSandboxRow(recoveringRow),
+        opencode_session_id: visible.row.opencodeSessionId,
+        runtime_url: sessionRuntimeUrlPath(row.externalId),
+        reason:
+          recovery === 'running' ? 'runtime_recovered_in_place' : 'runtime_restoring_in_place',
+      };
+    }
+    return preserveEstablishedRuntimeOnOpen(
       loaded,
       visible,
       projectId,
       sessionId,
-      row,
+      claim.row,
       'runtime_removed',
     );
   }
 
   if (providerStatus !== 'running') {
+    if (sandboxMetadata(row).runtimeIdentityState === 'recovering') {
+      return {
+        stage: 'starting',
+        agent_name: visible.row.agentName ?? 'default',
+        retriable: true,
+        sandbox: serializeSandboxRow(row),
+        opencode_session_id: visible.row.opencodeSessionId,
+        runtime_url: sessionRuntimeUrlPath(row.externalId),
+        reason: 'runtime_restoring_in_place',
+      };
+    }
     const staleWake = staleRuntimeWakeReason(row, providerStatus);
     if (staleWake) {
       return preserveEstablishedRuntimeOnOpen(
@@ -808,10 +837,7 @@ export async function openSession(args: {
     await markRuntimeWakeStarted(row, providerStatus);
     // Idle auto-stop: kick the start in the background; the client keeps polling.
     void provider.start(row.externalId).catch(async (err) => {
-      console.warn(
-        `[start] failed to wake sandbox ${row.externalId} (session ${sessionId}):`,
-        err,
-      );
+      console.warn(`[start] failed to wake sandbox ${row.externalId} (session ${sessionId}):`, err);
       if (isMissingRuntimeError(err)) {
         await preserveEstablishedRuntime(row, 'wake_missing_runtime').catch(() => {});
       }
@@ -823,11 +849,27 @@ export async function openSession(args: {
       sandbox: null,
       opencode_session_id: null,
       runtime_url: sessionRuntimeUrlPath(row.externalId),
-      reason:
-        providerStatus === 'stopped'
-          ? 'runtime_waking'
-          : 'runtime_status_unknown',
+      reason: providerStatus === 'stopped' ? 'runtime_waking' : 'runtime_status_unknown',
     };
+  }
+
+  if (sandboxMetadata(row).runtimeIdentityState === 'recovering') {
+    const finalized = await finalizeRecoveredRuntimeIfRunning(row);
+    if (!finalized) {
+      return {
+        stage: 'stopped',
+        agent_name: visible.row.agentName ?? 'default',
+        retriable: false,
+        sandbox: null,
+        opencode_session_id: null,
+        reason: 'runtime_recovery_cancelled',
+    };
+  }
+    row = finalized;
+  }
+  const runningExternalId = row.externalId;
+  if (!runningExternalId) {
+    throw new Error(`Provider-running sandbox ${row.sandboxId} has no external_id`);
   }
 
   // Box is provider-running. Resolve OpenCode readiness + the canonical pin
@@ -839,12 +881,11 @@ export async function openSession(args: {
     projectId,
     sessionId,
     accountId,
-    externalId: row.externalId,
+    externalId: runningExternalId,
     userId: loaded.userId,
     currentPin: visible.row.opencodeSessionId ?? null,
   });
-  const booting =
-    ensured.reason === 'not_ready' || ensured.reason === 'unreachable';
+  const booting = ensured.reason === 'not_ready' || ensured.reason === 'unreachable';
   if (booting) {
     const staleBoot = staleOpencodeReadyReason(row, ensured.reason);
     if (staleBoot) {
@@ -865,7 +906,7 @@ export async function openSession(args: {
     retriable: booting,
     sandbox: serializeSandboxRow(row),
     opencode_session_id: ensured.pin,
-    runtime_url: sessionRuntimeUrlPath(row.externalId),
+    runtime_url: sessionRuntimeUrlPath(runningExternalId),
     reason: ensured.reason,
   };
 }

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -1,7 +1,7 @@
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, eq, isNull, sql } from 'drizzle-orm';
 
-import { endComputeSession } from '../billing/services/compute-metering';
+import { endComputeSession, reopenComputeForSandbox } from '../billing/services/compute-metering';
 import { db } from '../shared/db';
 
 export const RUNTIME_IDENTITY_UNAVAILABLE = 'runtime_identity_unavailable';
@@ -12,6 +12,150 @@ type RuntimeIdentityRow = Pick<
   typeof sessionSandboxes.$inferSelect,
   'sandboxId' | 'sessionId' | 'externalId' | 'metadata'
 >;
+
+type RecoverableRuntimeIdentityRow = typeof sessionSandboxes.$inferSelect;
+
+const RECOVERY_LEASE_MS = 10 * 60 * 1000;
+
+class RuntimeIdentityCasLostError extends Error {}
+
+function sessionIsNotDeleted() {
+  return sql`coalesce(${projectSessions.metadata}->>'deletedAt', '') = ''`;
+}
+
+export type RuntimeRecoveryClaim = {
+  row: RecoverableRuntimeIdentityRow & { externalId: string };
+  leaseId: string;
+};
+
+/** Acquire the single-flight fence before issuing any provider recovery call. */
+export async function claimInPlaceRuntimeRecovery(
+  row: RecoverableRuntimeIdentityRow,
+  now = new Date(),
+): Promise<RuntimeRecoveryClaim | null> {
+  if (!row.externalId) return null;
+  const externalId = row.externalId;
+  const currentMetadata = (row.metadata as Record<string, unknown> | null) ?? {};
+  const currentExpiry = Number(currentMetadata.runtimeRecoveryLeaseExpiresAtMs ?? 0);
+  if (Number.isFinite(currentExpiry) && currentExpiry > now.getTime()) return null;
+
+  const leaseId = crypto.randomUUID();
+  const metadata = {
+    ...currentMetadata,
+    runtimeIdentityState: 'recovery_claimed',
+    runtimeRecoveryLeaseId: leaseId,
+    runtimeRecoveryLeaseAt: now.toISOString(),
+    runtimeRecoveryLeaseExpiresAtMs: now.getTime() + RECOVERY_LEASE_MS,
+    preservedExternalId: externalId,
+  };
+
+  try {
+    const claimed = await db.transaction(async (tx) => {
+      const [liveSession] = await tx
+        .update(projectSessions)
+        .set({ status: 'provisioning', error: null, updatedAt: now })
+        .where(and(eq(projectSessions.sessionId, row.sessionId), sessionIsNotDeleted()))
+        .returning({ sessionId: projectSessions.sessionId });
+      if (!liveSession) return null;
+
+      const [claimedRow] = await tx
+        .update(sessionSandboxes)
+        .set({ status: 'provisioning', metadata, updatedAt: now })
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, row.sandboxId),
+            eq(sessionSandboxes.externalId, externalId),
+            sql`CASE WHEN jsonb_typeof(${sessionSandboxes.metadata}->'runtimeRecoveryLeaseExpiresAtMs') = 'number' THEN (${sessionSandboxes.metadata}->>'runtimeRecoveryLeaseExpiresAtMs')::numeric ELSE 0 END < ${now.getTime()}`,
+          ),
+        )
+        .returning();
+      if (!claimedRow) throw new RuntimeIdentityCasLostError();
+      return claimedRow;
+    });
+    return claimed ? { row: { ...claimed, externalId }, leaseId } : null;
+  } catch (err) {
+    if (err instanceof RuntimeIdentityCasLostError) return null;
+    throw err;
+  }
+}
+
+/** Persist provider acceptance only if this request still owns the recovery fence. */
+export async function markInPlaceRuntimeRecoveryAccepted(
+  claim: RuntimeRecoveryClaim,
+  recovery: 'running' | 'recovering',
+  now = new Date(),
+): Promise<RecoverableRuntimeIdentityRow | null> {
+  const metadata: Record<string, unknown> = {
+    ...((claim.row.metadata as Record<string, unknown> | null) ?? {}),
+    runtimeIdentityState: recovery === 'running' ? 'recovered' : 'recovering',
+    runtimeRecoveryStartedAt: now.toISOString(),
+    preservedExternalId: claim.row.externalId,
+  };
+  delete metadata.runtimeUnavailableReason;
+  delete metadata.runtimeUnavailableAt;
+  if (recovery === 'running') {
+    delete metadata.runtimeRecoveryLeaseId;
+    delete metadata.runtimeRecoveryLeaseAt;
+    delete metadata.runtimeRecoveryLeaseExpiresAtMs;
+  }
+
+  try {
+    const updated = await db.transaction(async (tx) => {
+      const [liveSession] = await tx
+        .update(projectSessions)
+        .set({
+          status: recovery === 'running' ? 'running' : 'provisioning',
+          error: null,
+          updatedAt: now,
+        })
+        .where(and(eq(projectSessions.sessionId, claim.row.sessionId), sessionIsNotDeleted()))
+        .returning({ sessionId: projectSessions.sessionId });
+      if (!liveSession) return null;
+
+      const [updatedRow] = await tx
+        .update(sessionSandboxes)
+        .set({
+          status: recovery === 'running' ? 'active' : 'provisioning',
+          metadata,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, claim.row.sandboxId),
+            eq(sessionSandboxes.externalId, claim.row.externalId),
+            sql`${sessionSandboxes.metadata}->>'runtimeRecoveryLeaseId' = ${claim.leaseId}`,
+          ),
+        )
+        .returning();
+      if (!updatedRow) throw new RuntimeIdentityCasLostError();
+      return updatedRow;
+    });
+    if (updated && recovery === 'running') {
+      void reopenComputeForSandbox(updated.sandboxId, updated.accountId, updated.sessionId).catch(
+        (err) =>
+          console.warn(`[runtime-identity] compute reopen failed for ${updated.sandboxId}:`, err),
+      );
+    }
+    return updated;
+  } catch (err) {
+    if (err instanceof RuntimeIdentityCasLostError) return null;
+    throw err;
+  }
+}
+
+export async function finalizeRecoveredRuntimeIfRunning(
+  row: RecoverableRuntimeIdentityRow,
+): Promise<RecoverableRuntimeIdentityRow | null> {
+  const metadata = (row.metadata as Record<string, unknown> | null) ?? {};
+  const leaseId =
+    typeof metadata.runtimeRecoveryLeaseId === 'string' ? metadata.runtimeRecoveryLeaseId : null;
+  if (!leaseId || metadata.runtimeIdentityState !== 'recovering') return row;
+  if (!row.externalId) return null;
+  return markInPlaceRuntimeRecoveryAccepted(
+    { row: { ...row, externalId: row.externalId }, leaseId },
+    'running',
+  );
+}
 
 /**
  * Mark an established runtime unavailable without ever changing its identity.
@@ -31,6 +175,7 @@ export async function preserveEstablishedRuntime(
       `Cannot preserve sandbox ${row.sandboxId} as established without an external_id`,
     );
   }
+  const externalId = row.externalId;
 
   await endComputeSession(row.sandboxId).catch((err) =>
     console.warn(
@@ -39,32 +184,51 @@ export async function preserveEstablishedRuntime(
     ),
   );
 
-  const metadata = { ...((row.metadata as Record<string, unknown> | null) ?? {}) };
+  const metadata = {
+    ...((row.metadata as Record<string, unknown> | null) ?? {}),
+  };
   delete metadata.needsReprovision;
+  delete metadata.runtimeRecoveryLeaseId;
+  delete metadata.runtimeRecoveryLeaseAt;
+  delete metadata.runtimeRecoveryLeaseExpiresAtMs;
   Object.assign(metadata, {
     runtimeIdentityState: 'unavailable',
     runtimeUnavailableReason: reason,
     runtimeUnavailableAt: now.toISOString(),
-    preservedExternalId: row.externalId,
+    preservedExternalId: externalId,
   });
 
-  const [preserved] = await db
+  let preserved: typeof sessionSandboxes.$inferSelect | null = null;
+  try {
+    preserved = await db.transaction(async (tx) => {
+      const [liveSession] = await tx
+        .update(projectSessions)
+        .set({
+          status: 'stopped',
+          error: RUNTIME_IDENTITY_ERROR,
+          updatedAt: now,
+        })
+        .where(and(eq(projectSessions.sessionId, row.sessionId), sessionIsNotDeleted()))
+        .returning({ sessionId: projectSessions.sessionId });
+      if (!liveSession) return null;
+      const [preservedRow] = await tx
     .update(sessionSandboxes)
     .set({ status: 'stopped', metadata, updatedAt: now })
     .where(
       and(
         eq(sessionSandboxes.sandboxId, row.sandboxId),
-        eq(sessionSandboxes.externalId, row.externalId),
+            eq(sessionSandboxes.externalId, externalId),
       ),
     )
     .returning();
+      if (!preservedRow) throw new RuntimeIdentityCasLostError();
+      return preservedRow;
+    });
+  } catch (err) {
+    if (!(err instanceof RuntimeIdentityCasLostError)) throw err;
+  }
 
   if (!preserved) return null;
-
-  await db
-    .update(projectSessions)
-    .set({ status: 'stopped', error: RUNTIME_IDENTITY_ERROR, updatedAt: now })
-    .where(eq(projectSessions.sessionId, row.sessionId));
 
   console.error('[runtime-identity] preserved unavailable sandbox identity', {
     sessionId: row.sessionId,
@@ -97,125 +261,6 @@ export async function retireUnmaterializedRuntime(
   );
   await db
     .delete(sessionSandboxes)
-    .where(
-      and(
-        eq(sessionSandboxes.sandboxId, row.sandboxId),
-        isNull(sessionSandboxes.externalId),
-      ),
-    );
-  return true;
-}
-
-/**
- * Detach a provider-confirmed missing runtime so the same logical session can
- * provision replacement compute. This never calls provider.remove(): the
- * provider already says the object is gone. A guarded project-session update
- * prevents duplicate recovery and refuses to revive explicit deletions.
- */
-export async function retireConfirmedMissingRuntime(
-  row: RuntimeIdentityRow,
-  reason: string,
-  now = new Date(),
-): Promise<boolean> {
-  if (!row.externalId) {
-    throw new Error(
-      `Cannot retire sandbox ${row.sandboxId} as provider-missing without an external_id`,
-    );
-  }
-  const externalId = row.externalId;
-
-  const retired = await db.transaction(async (tx) => {
-    const [session] = await tx
-      .select({
-        metadata: projectSessions.metadata,
-        opencodeSessionId: projectSessions.opencodeSessionId,
-      })
-      .from(projectSessions)
-      .where(eq(projectSessions.sessionId, row.sessionId))
-      .limit(1);
-    if (!session) return false;
-
-    const sessionMetadata = {
-      ...((session.metadata as Record<string, unknown> | null) ?? {}),
-    };
-    if (typeof sessionMetadata.deletedAt === 'string') return false;
-
-    const previousRecoveries = Array.isArray(sessionMetadata.runtimeRecoveries)
-      ? sessionMetadata.runtimeRecoveries.slice(-9)
-      : [];
-    const recovery = {
-      externalId,
-      detectedAt: now.toISOString(),
-      reason,
-      opencodeSessionId: session.opencodeSessionId ?? null,
-    };
-    const [won] = await tx
-      .update(projectSessions)
-      .set({
-        status: 'provisioning',
-        error: null,
-        sandboxUrl: null,
-        opencodeSessionId: null,
-        metadata: {
-          ...sessionMetadata,
-          runtimeRecoveries: [...previousRecoveries, recovery],
-          lastRuntimeRecovery: recovery,
-        },
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(projectSessions.sessionId, row.sessionId),
-          sql`(${projectSessions.metadata}->>'deletedAt') is null`,
-          sql`exists (
-            select 1 from ${sessionSandboxes} current_runtime
-            where current_runtime.session_id = ${row.sessionId}
-              and current_runtime.external_id = ${externalId}
-          )`,
-        ),
-      )
-      .returning({ sessionId: projectSessions.sessionId });
-    if (!won) return false;
-
-    const runtimeMetadata = {
-      ...((row.metadata as Record<string, unknown> | null) ?? {}),
-      identityRecoveryAuthorizedAt: now.toISOString(),
-      retiredExternalId: externalId,
-      runtimeRecoveryReason: reason,
-    };
-    const [reset] = await tx
-      .update(sessionSandboxes)
-      .set({
-        externalId: null,
-        baseUrl: null,
-        status: 'provisioning',
-        config: {},
-        metadata: runtimeMetadata,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(sessionSandboxes.sandboxId, row.sandboxId),
-          eq(sessionSandboxes.externalId, externalId),
-        ),
-      )
-      .returning({ sandboxId: sessionSandboxes.sandboxId });
-    if (!reset) throw new Error(`Failed to reset provider-missing runtime ${row.sandboxId}`);
-    return true;
-  });
-
-  if (!retired) return false;
-  await endComputeSession(row.sandboxId).catch((err) =>
-    console.warn(
-      `[runtime-identity] failed to close compute for provider-missing ${row.sandboxId}/${externalId}:`,
-      err,
-    ),
-  );
-  console.error('[runtime-identity] retired provider-confirmed missing sandbox', {
-    sessionId: row.sessionId,
-    sandboxId: row.sandboxId,
-    externalId,
-    reason,
-  });
+    .where(and(eq(sessionSandboxes.sandboxId, row.sandboxId), isNull(sessionSandboxes.externalId)));
   return true;
 }

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -40,6 +40,9 @@ mock.module('./sandbox-busy-probe', () => ({
 
 mock.module('../shared/db', () => ({
   db: {
+    transaction: async function <T>(fn: (tx: any) => Promise<T>): Promise<T> {
+      return fn(this);
+    },
     select: () => ({
       from: (table: unknown) => ({
         where: () =>
@@ -96,6 +99,7 @@ mock.module('../sandbox-proxy', () => ({
 }));
 
 mock.module('../billing/services/compute-metering', () => ({
+  reopenComputeForSandbox: async () => undefined,
   pauseComputeSession: async (sandboxId: string) => {
     pausedCompute.push(sandboxId);
   },

--- a/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/stop.test.ts
@@ -13,6 +13,7 @@ mock.module('../../../config', () => ({
 }));
 
 mock.module('../../../shared/db', () => ({
+  hasDatabase: () => true,
   db: {
     select: () => ({
       from: (table: unknown) => ({
@@ -41,6 +42,7 @@ mock.module('../../../platform/providers', () => ({
 }));
 
 mock.module('../../../billing/services/compute-metering', () => ({
+  reopenComputeForSandbox: async () => undefined,
   pauseComputeSession: async (sandboxId: string) => {
     pausedCompute.push(sandboxId);
   },

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -6,17 +6,16 @@ import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
 import { withProjectGitAuth } from '../lib/git';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
-import {
-  buildSessionSandboxEnvVars,
-  sandboxCallbackUnreachableReason,
-} from '../lib/sessions';
+import { buildSessionSandboxEnvVars, sandboxCallbackUnreachableReason } from '../lib/sessions';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
+import { isMissingRuntimeError } from '../routes/shared';
 import {
-  isMissingRuntimeError,
-} from '../routes/shared';
-import {
-  retireConfirmedMissingRuntime,
+  claimInPlaceRuntimeRecovery,
+  markInPlaceRuntimeRecoveryAccepted,
+  preserveEstablishedRuntime,
   retireUnmaterializedRuntime,
+  RUNTIME_IDENTITY_ERROR,
+  RUNTIME_IDENTITY_UNAVAILABLE,
 } from '../runtime-identity';
 
 export async function deleteSession(input: {
@@ -73,7 +72,9 @@ export async function deleteSession(input: {
           initStatus: sandbox.status === 'active' ? 'ready' : 'failed',
           ...(sandbox.status === 'active'
             ? {}
-            : { lastInitError: 'Session was stopped before sandbox initialization completed' }),
+            : {
+                lastInitError: 'Session was stopped before sandbox initialization completed',
+              }),
         },
         updatedAt: new Date(),
       })
@@ -128,12 +129,18 @@ export async function restartSession(input: {
   const { loaded, session, projectId, sessionId } = input;
   const providerName = session.sandboxProvider as SandboxProviderName;
   if (!(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(providerName)) {
-    return { status: 400, body: { error: `Restart is not supported for provider ${providerName}` } };
+    return {
+      status: 400,
+      body: { error: `Restart is not supported for provider ${providerName}` },
+    };
   }
 
   const restartUnreachable = sandboxCallbackUnreachableReason();
   if (restartUnreachable) {
-    return { status: 503, body: { error: restartUnreachable, code: 'KORTIX_URL_UNREACHABLE' } };
+    return {
+      status: 503,
+      body: { error: restartUnreachable, code: 'KORTIX_URL_UNREACHABLE' },
+    };
   }
 
   const [existingSandbox] = await db
@@ -203,18 +210,55 @@ export async function restartSession(input: {
     const provider = getProvider(existingSandbox.provider as SandboxProviderName);
     const providerStatus = await provider.getStatus(externalId).catch(() => 'unknown' as const);
     if (providerStatus === 'removed') {
-      const retired = await retireConfirmedMissingRuntime(
-        existingSandbox,
-        'restart_removed_runtime',
-      );
-      if (retired) await provisionReplacementRuntime();
+      const claim = await claimInPlaceRuntimeRecovery(existingSandbox);
+      if (!claim) {
+        return {
+          status: 202,
+          body: {
+            ok: true,
+            session_id: sessionId,
+            status: 'provisioning',
+            reason: 'runtime_recovery_in_progress',
+          },
+        };
+      }
+      const recovery = await provider
+        .recoverInPlace?.(externalId)
+        .catch(() => 'unavailable' as const);
+      if (recovery === 'running' || recovery === 'recovering') {
+        const accepted = await markInPlaceRuntimeRecoveryAccepted(claim, recovery);
+        if (!accepted) {
+          return {
+            status: 409,
+            body: {
+              error: RUNTIME_IDENTITY_ERROR,
+              code: 'SESSION_RUNTIME_RECOVERY_CANCELLED',
+              session_id: sessionId,
+              external_id: externalId,
+              reason: 'runtime_recovery_cancelled',
+            },
+          };
+        }
       return {
         status: 202,
         body: {
           ok: true,
           session_id: sessionId,
           status: 'provisioning',
-          reason: retired ? 'runtime_recovery_provisioning' : 'runtime_recovery_in_progress',
+            reason:
+              recovery === 'running' ? 'runtime_recovered_in_place' : 'runtime_restoring_in_place',
+          },
+        };
+      }
+      await preserveEstablishedRuntime(claim.row, 'restart_removed_runtime');
+      return {
+        status: 409,
+        body: {
+          error: RUNTIME_IDENTITY_ERROR,
+          code: 'SESSION_RUNTIME_IDENTITY_UNAVAILABLE',
+          session_id: sessionId,
+          external_id: externalId,
+          reason: RUNTIME_IDENTITY_UNAVAILABLE,
         },
       };
     }
@@ -242,16 +286,27 @@ export async function restartSession(input: {
         // the next GET returned removed). Never mark the DB running from command
         // acceptance alone; verify provider truth first.
         let verifiedStatus = await provider.getStatus(externalId).catch(() => 'unknown' as const);
-        for (let attempt = 1; verifiedStatus !== 'running' && verifiedStatus !== 'removed' && attempt < 15; attempt += 1) {
+        for (
+          let attempt = 1;
+          verifiedStatus !== 'running' && verifiedStatus !== 'removed' && attempt < 15;
+          attempt += 1
+        ) {
           await Bun.sleep(1_000);
           verifiedStatus = await provider.getStatus(externalId).catch(() => 'unknown' as const);
         }
         if (verifiedStatus === 'removed') {
-          const retired = await retireConfirmedMissingRuntime(
-            existingSandbox,
-            'restart_post_start_removed',
-          ).catch(() => false);
-          if (retired) await provisionReplacementRuntime();
+          const claim = await claimInPlaceRuntimeRecovery(existingSandbox);
+          if (!claim) return;
+          const recovery = await provider
+            .recoverInPlace?.(externalId)
+            .catch(() => 'unavailable' as const);
+          if (recovery === 'running' || recovery === 'recovering') {
+            await markInPlaceRuntimeRecoveryAccepted(claim, recovery).catch(() => null);
+          } else {
+            await preserveEstablishedRuntime(claim.row, 'restart_post_start_removed').catch(
+              () => null,
+            );
+          }
           return;
         }
         if (verifiedStatus !== 'running') {
@@ -270,11 +325,18 @@ export async function restartSession(input: {
       } catch (err) {
         console.warn(`[projects] restart-in-place failed for ${sessionId}:`, err);
         if (isMissingRuntimeError(err)) {
-          const retired = await retireConfirmedMissingRuntime(
-            existingSandbox,
-            'restart_missing_runtime',
-          ).catch(() => false);
-          if (retired) await provisionReplacementRuntime();
+          const claim = await claimInPlaceRuntimeRecovery(existingSandbox);
+          if (!claim) return;
+          const recovery = await provider
+            .recoverInPlace?.(externalId)
+            .catch(() => 'unavailable' as const);
+          if (recovery === 'running' || recovery === 'recovering') {
+            await markInPlaceRuntimeRecoveryAccepted(claim, recovery).catch(() => null);
+          } else {
+            await preserveEstablishedRuntime(claim.row, 'restart_missing_runtime').catch(
+              () => null,
+            );
+          }
           return;
         }
         await db
@@ -295,7 +357,10 @@ export async function restartSession(input: {
       }
     })();
 
-    return { status: 202, body: { ok: true, session_id: sessionId, status: 'provisioning' } };
+    return {
+      status: 202,
+      body: { ok: true, session_id: sessionId, status: 'provisioning' },
+    };
   }
 
   if (existingSandbox) {
@@ -312,5 +377,8 @@ export async function restartSession(input: {
   }
 
   await provisionReplacementRuntime();
-  return { status: 202, body: { ok: true, session_id: sessionId, status: 'provisioning' } };
+  return {
+    status: 202,
+    body: { ok: true, session_id: sessionId, status: 'provisioning' },
+  };
 }

--- a/packages/db/migrations/20260712210000000_revoke_automatic_runtime_identity_recovery.sql
+++ b/packages/db/migrations/20260712210000000_revoke_automatic_runtime_identity_recovery.sql
@@ -1,0 +1,47 @@
+-- An established sandbox identity is never automatically detachable.
+--
+-- The previous provider-loss recovery exception trusted an application-written
+-- metadata marker and allowed external_id to be reset to NULL. A provider 404
+-- or terminal-looking state is not proof that the user's disk is irrecoverable:
+-- Platinum can retain a complete backup even when a VM reports failed-start.
+-- Recovery must therefore revive the same external_id or fail closed.
+
+CREATE OR REPLACE FUNCTION kortix.guard_session_sandbox_identity()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  session_deleted boolean;
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.external_id IS NOT NULL THEN
+    IF NEW.external_id IS DISTINCT FROM OLD.external_id
+       OR NEW.provider IS DISTINCT FROM OLD.provider THEN
+      RAISE EXCEPTION
+        'established session sandbox identity is immutable (session %, provider %, external_id %)',
+        OLD.session_id, OLD.provider, OLD.external_id
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' AND OLD.external_id IS NOT NULL THEN
+    SELECT coalesce((metadata->>'deletedAt') IS NOT NULL, false)
+      INTO session_deleted
+      FROM kortix.project_sessions
+     WHERE session_id = OLD.session_id;
+
+    IF NOT coalesce(session_deleted, false) THEN
+      RAISE EXCEPTION
+        'refusing to delete established session sandbox identity (session %, provider %, external_id %)',
+        OLD.session_id, OLD.provider, OLD.external_id
+        USING ERRCODE = '23514';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/packages/db/scripts/runtime-identity-migration.integration.test.ts
+++ b/packages/db/scripts/runtime-identity-migration.integration.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+
+const dockerAvailable =
+  Bun.spawnSync(['docker', 'version'], {
+    stdout: 'ignore',
+    stderr: 'ignore',
+  }).exitCode === 0;
+
+const container = `kortix-runtime-identity-${crypto.randomUUID().slice(0, 8)}`;
+
+function dockerPsql(sql: string, allowFailure = false) {
+  const result = Bun.spawnSync(
+    [
+      'docker',
+      'exec',
+      '-i',
+      container,
+      'psql',
+      '-U',
+      'postgres',
+      '-d',
+      'testdb',
+      '-v',
+      'ON_ERROR_STOP=1',
+    ],
+    { stdin: Buffer.from(sql), stdout: 'pipe', stderr: 'pipe' },
+  );
+  const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+  if (!allowFailure && result.exitCode !== 0) throw new Error(output);
+  return { exitCode: result.exitCode, output };
+}
+
+describe.skipIf(!dockerAvailable)('runtime identity migration — real PostgreSQL', () => {
+  beforeAll(async () => {
+    const started = Bun.spawnSync([
+      'docker',
+      'run',
+      '--rm',
+      '-d',
+      '--name',
+      container,
+      '-e',
+      'POSTGRES_PASSWORD=test',
+      '-e',
+      'POSTGRES_DB=testdb',
+      'postgres:16-alpine',
+    ]);
+    if (started.exitCode !== 0) throw new Error(started.stderr.toString());
+
+    let ready = false;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const probe = Bun.spawnSync(
+        ['docker', 'exec', container, 'psql', '-U', 'postgres', '-d', 'testdb', '-c', 'SELECT 1'],
+        { stdout: 'ignore', stderr: 'ignore' },
+      );
+      if (probe.exitCode === 0) {
+        ready = true;
+        break;
+      }
+      await Bun.sleep(250);
+    }
+    if (!ready) throw new Error('Disposable PostgreSQL did not become ready');
+
+    const migrationDir = resolve(import.meta.dir, '..', 'migrations');
+    const migrations = await Promise.all(
+      [
+        '20260711210000000_session_sandbox_identity_immutability.sql',
+        '20260712200000000_allow_missing_runtime_recovery.sql',
+        '20260712210000000_revoke_automatic_runtime_identity_recovery.sql',
+      ].map((name) => Bun.file(resolve(migrationDir, name)).text()),
+    );
+
+    dockerPsql(`
+      CREATE SCHEMA kortix;
+      CREATE TABLE kortix.project_sessions (
+        session_id uuid PRIMARY KEY,
+        metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+      );
+      CREATE TABLE kortix.session_sandboxes (
+        session_id uuid NOT NULL,
+        external_id text,
+        provider text NOT NULL,
+        status text NOT NULL,
+        metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+      );
+      ${migrations.join('\n')}
+      INSERT INTO kortix.project_sessions(session_id) VALUES
+        ('00000000-0000-4000-a000-000000000001'),
+        ('00000000-0000-4000-a000-000000000002');
+      INSERT INTO kortix.session_sandboxes(session_id, external_id, provider, status, metadata) VALUES
+        ('00000000-0000-4000-a000-000000000001', 'sbx_original', 'platinum', 'active', '{}'),
+        ('00000000-0000-4000-a000-000000000002', NULL, 'platinum', 'provisioning', '{}');
+    `);
+  }, 30_000);
+
+  afterAll(() => {
+    Bun.spawnSync(['docker', 'rm', '-f', container], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+  });
+
+  test('blocks direct replacement and provider swaps', () => {
+    for (const statement of [
+      `UPDATE kortix.session_sandboxes SET external_id = 'sbx_replacement' WHERE session_id = '00000000-0000-4000-a000-000000000001'`,
+      `UPDATE kortix.session_sandboxes SET provider = 'daytona' WHERE session_id = '00000000-0000-4000-a000-000000000001'`,
+      `UPDATE kortix.session_sandboxes SET external_id = NULL, status = 'provisioning', metadata = '{"identityRecoveryAuthorizedAt":"stale"}' WHERE session_id = '00000000-0000-4000-a000-000000000001'`,
+    ]) {
+      const result = dockerPsql(`\\set VERBOSITY verbose\n${statement};`, true);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('23514');
+    }
+  });
+
+  test('blocks stale deletion markers and allows only explicit session deletion', () => {
+    dockerPsql(`
+      UPDATE kortix.session_sandboxes
+         SET metadata = '{"identityDeletionAuthorizedAt":"stale"}'
+       WHERE session_id = '00000000-0000-4000-a000-000000000001';
+    `);
+    const blocked = dockerPsql(
+      `
+      \\set VERBOSITY verbose
+      DELETE FROM kortix.session_sandboxes
+       WHERE session_id = '00000000-0000-4000-a000-000000000001';
+    `,
+      true,
+    );
+    expect(blocked.exitCode).not.toBe(0);
+    expect(blocked.output).toContain('23514');
+
+    dockerPsql(`
+      UPDATE kortix.project_sessions
+         SET metadata = '{"deletedAt":"2026-07-12T00:00:00Z"}'
+       WHERE session_id = '00000000-0000-4000-a000-000000000001';
+      DELETE FROM kortix.session_sandboxes
+       WHERE session_id = '00000000-0000-4000-a000-000000000001';
+      DELETE FROM kortix.session_sandboxes
+       WHERE session_id = '00000000-0000-4000-a000-000000000002';
+    `);
+    expect(dockerPsql('SELECT count(*) FROM kortix.session_sandboxes;').output).toContain('0');
+  });
+});


### PR DESCRIPTION
## What changed
- makes established session sandbox provider identity fail-closed across start, restart, provider removal, wake failures, and reaper reconciliation
- restores Platinum terminal VMs from completed backups under the same external ID; never provisions a replacement into that session
- adds a 10-minute database CAS lease so concurrent opens issue exactly one provider recovery operation
- prevents recovery from resurrecting status or billing after explicit session deletion
- revokes the metadata-based external_id reset and stale deletion-marker bypass in PostgreSQL
- atomically consumes legacy recovery placeholders exactly once

## Verification
- API typecheck: pass
- project session contract: 38 pass, 0 fail
- Platinum provider recovery: 4 pass, 0 fail
- allocator concurrency: 6 pass, 0 fail
- sandbox reaper: 41 pass, 0 fail
- maintenance: 6 pass, 0 fail
- stop lifecycle: 6 pass, 0 fail
- DB package: 91 pass, 0 fail, including real PostgreSQL migration ordering and trigger behavior
- migration lint: 43 files pass; only 4 pre-existing destructive-operation warnings
- real local authenticated HTTP start against real DB/provider lookup: HTTP 200, runtime_identity_unavailable, external identity unchanged, stopped, zero replacement provision events

## Adversarial cases covered
- immediate provider removed
- start accepted then removed
- start returns not found
- backed terminal Platinum VM same-ID restore
- unbacked terminal VM fail-closed
- concurrent restore callers single-flight
- explicit deletion racing restore completion
- stale recovery and deletion authorization markers
- concurrent legacy placeholder claims

## Known baseline
The monolithic API test command currently fails on origin/main-independent test-process mock leakage in auth-sso-sync and subsequent environment validation. All touched suites were run in isolated Bun processes and are green.