### PR TITLE
fix(acp): wait for sandbox daemon readiness

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1507,6 +1507,47 @@ describe('project session API contract', () => {
     expect(sandboxProvisionCalls).toBe(0);
   });
 
+  test('dashboard start keeps polling while a provider-running ACP daemon is not reachable yet', async () => {
+    const app = createApp();
+    sessionRow = { ...sessionRow!, status: 'running' };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'daytona',
+        externalId: 'box-acp-booting',
+        baseUrl: null,
+        status: 'active',
+        config: {},
+        metadata: { initStatus: 'ready' },
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-02T00:00:00Z'),
+        updatedAt: new Date('2026-01-02T00:00:00Z'),
+      },
+    ];
+    providerStatus = 'running';
+    inspectedRuntime = null;
+
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      stage: 'starting',
+      retriable: true,
+      reason: 'acp_starting',
+      runtime_protocol: 'acp',
+      runtime_id: null,
+      runtime_url: '/p/box-acp-booting/8000',
+      sandbox: { external_id: 'box-acp-booting', status: 'active' },
+    });
+    expect(providerStartCalls).toBe(0);
+    expect(sandboxProvisionCalls).toBe(0);
+  });
+
   test('dashboard start preserves a sandbox that stayed stopped after wake grace', async () => {
     const app = createApp();
     sessionRow = {

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -816,6 +816,22 @@ export async function openSession(args: {
   // Box is provider-running. Inspect the daemon-owned runtime mode. Every
   // supported harness, including OpenCode, is ready only through ACP.
   const runtimeHealth = await inspectSandboxRuntime(runningExternalId, loaded.userId);
+  if (!runtimeHealth) {
+    return {
+      stage: 'starting',
+      agent_name: visible.row.agentName ?? 'default',
+      retriable: true,
+      sandbox: serializeSandboxRow(row),
+      runtime_protocol: 'acp',
+      runtime_id: null,
+      runtime_session_id:
+        typeof visible.row.metadata?.acp_session_id === 'string'
+          ? visible.row.metadata.acp_session_id
+          : null,
+      runtime_url: sessionRuntimeUrlPath(runningExternalId),
+      reason: 'acp_starting',
+    };
+  }
   if (runtimeHealth?.runtime === 'acp') {
     const ready = runtimeHealth.runtimeReady && !!runtimeHealth.acpServerId;
     return {


### PR DESCRIPTION
## Summary
- treat a provider-running but not-yet-reachable sandbox daemon as ACP starting
- keep polling instead of terminally classifying the runtime as non-ACP
- cover the fast cached-snapshot race in the session API contract

## Verification
- `pnpm --filter kortix-api typecheck`
- `dotenvx run -- bun test ./src/__tests__/e2e-project-session-contract.test.ts` (41 pass)
- reproduced on dev with fresh Claude, Codex, OpenCode, and Pi sessions: all hit the same premature `non_acp_runtime` race immediately after provisioning