### PR TITLE
fix(sandbox-proxy): auto-resume a stopped box on active OpenCode access + flip session status on ready

### DIFF
--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -165,6 +165,41 @@ export async function resumeStoppedSandbox(row: {
   return true;
 }
 
+/**
+ * Resume a stopped box addressed by its provider `external_id` (the id in proxy
+ * URLs, `/v1/p/<externalId>/<port>`). Fetches the full row — crucially including
+ * `metadata`, which {@link resumeStoppedSandbox} rewrites — so the sandbox-proxy
+ * data path can wake a hibernated box the SAME way `/start` does when a real user
+ * actively hits the OpenCode runtime. Idempotent: the conditional stopped→active
+ * lock inside `resumeStoppedSandbox` de-dupes the concurrent session.list retries,
+ * so at most one provider start is kicked. Returns true when THIS call won the
+ * resume (false if it wasn't stopped, isn't resumable, or a concurrent call won).
+ */
+export async function resumeStoppedSandboxByExternalId(externalId: string): Promise<boolean> {
+  const [row] = await db
+    .select({
+      sandboxId: sessionSandboxes.sandboxId,
+      sessionId: sessionSandboxes.sessionId,
+      accountId: sessionSandboxes.accountId,
+      provider: sessionSandboxes.provider,
+      externalId: sessionSandboxes.externalId,
+      status: sessionSandboxes.status,
+      metadata: sessionSandboxes.metadata,
+    })
+    .from(sessionSandboxes)
+    .where(eq(sessionSandboxes.externalId, externalId))
+    .limit(1);
+  if (!row || row.status !== 'stopped' || !row.externalId) return false;
+  return resumeStoppedSandbox({
+    sandboxId: row.sandboxId,
+    sessionId: row.sessionId,
+    accountId: row.accountId,
+    provider: row.provider,
+    externalId: row.externalId,
+    metadata: row.metadata,
+  });
+}
+
 // ── Pre-resume on presence ───────────────────────────────────────────────────
 // Throttle pre-resume per project so portal activity doesn't re-kick on every
 // request. The resume itself is idempotent (resumeStoppedSandbox only acts on a

--- a/apps/api/src/sandbox-proxy/routes/preview.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+
+import { shouldAutoResumeStoppedSandbox } from './preview';
+
+// The data-path proxy may only wake a stopped box on ACTIVE user traffic to the
+// OpenCode daemon (port 8000, principal). Everything else must still 503 so we
+// never resurrect an idle-quiesced box on passive asset/preview traffic.
+describe('shouldAutoResumeStoppedSandbox', () => {
+  test('stopped + daemon port 8000 + principal → resume', () => {
+    expect(shouldAutoResumeStoppedSandbox('stopped', 8000, 'principal')).toBe(true);
+  });
+
+  test('a non-daemon (passive/asset/preview) port never resumes', () => {
+    expect(shouldAutoResumeStoppedSandbox('stopped', 4096, 'principal')).toBe(false);
+    expect(shouldAutoResumeStoppedSandbox('stopped', 3000, 'principal')).toBe(false);
+    expect(shouldAutoResumeStoppedSandbox('stopped', 443, 'principal')).toBe(false);
+  });
+
+  test('non-user (service / share) access never resumes', () => {
+    expect(shouldAutoResumeStoppedSandbox('stopped', 8000, 'service')).toBe(false);
+    expect(shouldAutoResumeStoppedSandbox('stopped', 8000, 'share')).toBe(false);
+    expect(shouldAutoResumeStoppedSandbox('stopped', 8000, '')).toBe(false);
+  });
+
+  test('only a STOPPED record is a resume candidate (error/archived/active are not)', () => {
+    expect(shouldAutoResumeStoppedSandbox('error', 8000, 'principal')).toBe(false);
+    expect(shouldAutoResumeStoppedSandbox('archived', 8000, 'principal')).toBe(false);
+    expect(shouldAutoResumeStoppedSandbox('active', 8000, 'principal')).toBe(false);
+    expect(shouldAutoResumeStoppedSandbox('provisioning', 8000, 'principal')).toBe(false);
+  });
+});

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -3,6 +3,7 @@ import { HTTPException } from 'hono/http-exception';
 import { config } from '../../config';
 import { getTraceHeaders } from '../../lib/request-context';
 import { syncSandboxEnvForPrompt } from '../../projects/lib/sandbox-env-sync';
+import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
 import { canAccessPreviewSandbox, canAccessSandboxSession } from '../../shared/preview-ownership';
 import { KORTIX_USER_CONTEXT_HEADER } from '../../shared/kortix-user-context';
 import {
@@ -352,6 +353,22 @@ function principalUserId(access: PreviewProxyAccess): string {
 // reachability, never the auth/control surface.
 const OPENCODE_INTERNAL_PORT = 4096;
 const SANDBOX_AGENT_PORT = 8000;
+
+/**
+ * Should the data-path proxy WAKE a stopped box instead of 503ing it? Only when a
+ * real user (principal) is actively hitting the OpenCode daemon (port 8000) — never
+ * on passive asset/preview traffic or non-user (service) access. That gate is what
+ * lets the runtime path auto-resume like `/start` WITHOUT fighting the reaper's
+ * idle-quiesce "don't resurrect on passive traffic" policy. Pure + exported so the
+ * gate is unit-tested without provisioning a sandbox.
+ */
+export function shouldAutoResumeStoppedSandbox(
+  status: string,
+  upstreamPort: number,
+  accessKind: string,
+): boolean {
+  return status === 'stopped' && upstreamPort === SANDBOX_AGENT_PORT && accessKind === 'principal';
+}
 function effectiveUpstreamPort(provider: string | null | undefined, addressedPort: number): number {
   return provider === 'platinum' && addressedPort === OPENCODE_INTERNAL_PORT
     ? SANDBOX_AGENT_PORT
@@ -382,7 +399,7 @@ export async function forwardToSandbox(
   // 1. One row fetch — enforces the v1 session-sandbox contract, ownership, and
   // active state, and yields the service key for upstream auth. (Previously two
   // separate queries for the same row.)
-  const record = await loadSandbox(sandboxId);
+  let record = await loadSandbox(sandboxId);
   if (!record) {
     return jsonProxyError({ error: 'sandbox not found' }, 404, origin);
   }
@@ -429,13 +446,35 @@ export async function forwardToSandbox(
     return jsonProxyError({ error: 'not found' }, 404, origin);
   }
   if (record.status !== 'active') {
-    return portUnreachableResponse({
-      port,
-      status: 503,
-      origin,
-      incomingHeaders,
-      reason: `sandbox not ready (status: ${record.status})`,
-    });
+    // A stopped-but-resumable box hit by a REAL USER on the OpenCode data path
+    // (port 8000, principal) should wake in place — the same resume `/start` does —
+    // rather than dead-end with a manual-Restart card. This closes the stale-ready
+    // gap: /start settles 'ready', the reaper idle-stops the box, and the client's
+    // next runtime call used to 503 forever. resumeStoppedSandboxByExternalId is
+    // idempotent, clears the reaper's idle-quiesce marker, and its DB conditional
+    // lock de-dupes the concurrent session.list retries (one provider start). Gated
+    // so passive asset/preview traffic still 503s — we don't fight idle-quiesce.
+    if (shouldAutoResumeStoppedSandbox(record.status, upstreamPort, access.kind)) {
+      const resumeExternalId = record.externalId;
+      await resumeStoppedSandboxByExternalId(resumeExternalId).catch((err) => {
+        console.warn(`[sandbox-proxy] auto-resume failed for ${resumeExternalId}:`, err);
+        return false;
+      });
+      // Re-read: the resume flips the row → 'active' (this call or a concurrent
+      // one). The box boots in the background; the wake/retry loop below tolerates
+      // the gap and forwards once it's up (and subsequent client retries recover).
+      const resumed = await loadSandbox(sandboxId);
+      if (resumed) record = resumed;
+    }
+    if (record.status !== 'active') {
+      return portUnreachableResponse({
+        port,
+        status: 503,
+        origin,
+        incomingHeaders,
+        reason: `sandbox not ready (status: ${record.status})`,
+      });
+    }
   }
   const serviceKey = record.serviceKey;
 

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -125,8 +125,15 @@ export default function ProjectSessionPage() {
   }, []);
 
   useEffect(() => {
-    if (session.switched && sandbox) sessionMark(sandbox.session_id, 'server-switched');
-  }, [session.switched, sandbox]);
+    if (session.switched && sandbox) {
+      sessionMark(sandbox.session_id, 'server-switched');
+      // The sidebar's session-list status ('running' vs 'stopped') is a SEPARATE
+      // query that /start never touches, so opening a session left the dot stale
+      // until a manual refresh. Refresh the list once the runtime switches in so
+      // the status flips to running on its own.
+      queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+    }
+  }, [session.switched, sandbox, queryClient, projectId]);
 
   // The moment we know there's no plan, pop the one Team plan modal.
   const billingGatedRef = useRef(false);


### PR DESCRIPTION
## The bug
Opening idle-stopped sessions (esp. **platinum trigger-run boxes** that idle-stop right after their turn) shows **"OpenCode failed to load / sandbox not ready (status: stopped)"** with a manual-only Restart — recoverable only by refresh.

## Root cause (traced against prod DB + code + logs)
A **stale-ready cache**: `/start` settles `ready` and stops polling (`use-session.ts:286-290`); the **reaper idle-stops** the box afterward (`sandbox-reaper.ts:571` → `status='stopped'`); the client has no liveness re-check, so its next proxied OpenCode call (`session.list`) hits `preview.ts`'s `record.status !== 'active'` guard — which returned **503 with no resume attempt**, unlike `/start` which resumes in place. The prior `0.9.106` fix covered the `/start` path but not this proxy-503 path.

## Fix (backend, frontend-agnostic)
When a **real user actively hits the OpenCode daemon** (port 8000, principal) and the box is **stopped-but-resumable** (`external_id` present), the proxy now resumes it via a new `resumeStoppedSandboxByExternalId` — the **same in-place resume `/start` uses** (clears the reaper's idle-quiesce marker; the DB conditional lock de-dupes concurrent `session.list` retries → one provider start) — then falls into the existing wake/retry loop. **Tightly gated** (`shouldAutoResumeStoppedSandbox`, unit-tested): passive asset/preview traffic and non-user access still 503, so we never resurrect an idle-quiesced box on passive traffic. Fixes web, mobile, and the refactored UI at once.

## Also (smaller)
Session status stuck `stopped` in the sidebar until refresh → now invalidates the session-list query when the runtime switches in, so the dot flips to running on its own.

## Verified
`shouldAutoResumeStoppedSandbox` unit test 4/4; API + web typecheck clean for touched files. Prod DB confirmed both reported sessions are platinum `stopped` + `external_id` (resumable).