### PR TITLE
fix(db): add invitation acceptance identity migration

### DIFF
--- a/packages/db/migrations/20260712220000000_invite_accept_identity.sql
+++ b/packages/db/migrations/20260712220000000_invite_accept_identity.sql
@@ -1,0 +1,36 @@
+-- Up Migration
+--
+-- Add kortix.account_invitations.accepted_by_user_id (uuid, nullable).
+--
+-- The Drizzle schema (packages/db/src/schema/kortix.ts) gained this column and
+-- the API began selecting it — every SELECT against account_invitations now
+-- projects `accepted_by_user_id` (Drizzle's `select()` reads the full row),
+-- e.g. GET /v1/accounts/:id/invites, GET /v1/account-invites/:id, and the
+-- accept/decline handlers. On accept, accounts/invites.ts stamps
+-- `accepted_by_user_id = <userId>` alongside `accepted_at` so a re-entry by a
+-- different identity can be detected and rejected (409).
+--
+-- The schema change was committed (and a Drizzle-generated SQL file landed in
+-- packages/db/drizzle/) but the corresponding node-pg-migrate migration in
+-- packages/db/migrations/ — the ONLY directory the deploy runner applies — was
+-- never created. So every environment that ships this code has a kortix.ts that
+-- references a column the database does not have, and every invite-listing /
+-- invite-accept call 500s with `column "accepted_by_user_id" does not exist`
+-- (Better Stack error 97669531…; first seen 2026-07-04, 171 occurrences / 5
+-- users as of 2026-07-12).
+--
+-- This is the missing migration. `ADD COLUMN IF NOT EXISTS` makes it a no-op on
+-- fresh builds (the baseline will eventually carry the column too) and a
+-- targeted backfill on every already-deployed environment — the same pattern
+-- used by 20260622154500000_reconcile_faked_baseline_drift.sql to close
+-- code-references-column-prod-lacks drift. The column is nullable: pre-existing
+-- accepted invites simply have no recorded acceptor, which the accept handler
+-- already tolerates (`if (alreadyAccepted && invite.acceptedByUserId …)`).
+
+ALTER TABLE kortix.account_invitations
+  ADD COLUMN IF NOT EXISTS accepted_by_user_id uuid;
+
+-- Down Migration
+--
+-- Forward-only: dropping the column would re-introduce the 500s the deployable
+-- code depends on it not raising. Leave it in place on every environment.

--- a/packages/db/scripts/invite-accept-identity-migration.integration.test.ts
+++ b/packages/db/scripts/invite-accept-identity-migration.integration.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+
+/**
+ * Regression test for Better Stack error 97669531…
+ * (https://errors.betterstack.com/team/t502678/errors/97669531…).
+ *
+ * Symptom: GET /v1/accounts/:id/invites (and every other Drizzle `select()`
+ * against kortix.account_invitations) 500'd in prod with
+ *   column "accepted_by_user_id" does not exist
+ * because the Drizzle schema gained `acceptedByUserId` and the API began
+ * projecting it, but the node-pg-migrate migration that actually adds the
+ * column to deployed databases was never created — only an orphaned
+ * Drizzle-generated SQL file landed in packages/db/drizzle/, which the deploy
+ * runner does not apply.
+ *
+ * This test stands up a real PostgreSQL, builds account_invitations in its
+ * PRE-migration shape (matching the committed baseline), applies the fix
+ * migration, and asserts:
+ *   1. the `accepted_by_user_id` column now exists, and
+ *   2. the exact failing SELECT from the error (the Drizzle-generated query for
+ *      GET /v1/accounts/:id/invites) succeeds instead of raising 42703.
+ *
+ * Docker is required; the suite is skipped when docker is unavailable (same
+ * gate pattern as runtime-identity-migration.integration.test.ts).
+ */
+
+const dockerAvailable =
+  Bun.spawnSync(['docker', 'version'], { stdout: 'ignore', stderr: 'ignore' }).exitCode === 0;
+
+const container = `kortix-invite-accept-${crypto.randomUUID().slice(0, 8)}`;
+
+function dockerPsql(sql: string, allowFailure = false) {
+  const result = Bun.spawnSync(
+    [
+      'docker',
+      'exec',
+      '-i',
+      container,
+      'psql',
+      '-U',
+      'postgres',
+      '-d',
+      'testdb',
+      '-v',
+      'ON_ERROR_STOP=1',
+    ],
+    { stdin: Buffer.from(sql), stdout: 'pipe', stderr: 'pipe' },
+  );
+  const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+  if (!allowFailure && result.exitCode !== 0) throw new Error(output);
+  return { exitCode: result.exitCode, output };
+}
+
+// PRE-migration shape of kortix.account_invitations, taken from the committed
+// baseline (20260621094136410_baseline.sql). Crucially: NO accepted_by_user_id.
+// This is the exact state prod was in when the 500s fired.
+const PRE_MIGRATION_SCHEMA = `
+  CREATE SCHEMA kortix;
+  CREATE TYPE kortix.account_role AS ENUM ('owner', 'admin', 'member');
+  CREATE TABLE kortix.accounts (
+    account_id uuid PRIMARY KEY
+  );
+  CREATE TABLE kortix.account_invitations (
+    invite_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id uuid NOT NULL REFERENCES kortix.accounts(account_id) ON DELETE CASCADE,
+    email varchar(255) NOT NULL,
+    invited_by uuid,
+    initial_role kortix.account_role NOT NULL DEFAULT 'member',
+    accepted_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL DEFAULT (now() + '14 days'::interval),
+    bootstrap_grants jsonb
+  );
+`;
+
+describe.skipIf(!dockerAvailable)('invite_accept_identity migration — real PostgreSQL', () => {
+  beforeAll(async () => {
+    const started = Bun.spawnSync([
+      'docker',
+      'run',
+      '--rm',
+      '-d',
+      '--name',
+      container,
+      '-e',
+      'POSTGRES_PASSWORD=test',
+      '-e',
+      'POSTGRES_DB=testdb',
+      'postgres:16-alpine',
+    ]);
+    if (started.exitCode !== 0) throw new Error(started.stderr.toString());
+
+    let ready = false;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const probe = Bun.spawnSync(
+        ['docker', 'exec', container, 'psql', '-U', 'postgres', '-d', 'testdb', '-c', 'SELECT 1'],
+        { stdout: 'ignore', stderr: 'ignore' },
+      );
+      if (probe.exitCode === 0) {
+        ready = true;
+        break;
+      }
+      await Bun.sleep(250);
+    }
+    if (!ready) throw new Error('Disposable PostgreSQL did not become ready');
+
+    // Sanity: confirm the PRE-migration schema really lacks the column, i.e.
+    // that this test is set up to reproduce the prod failure mode. The exact
+    // failing SELECT from the error must 42703 BEFORE the migration runs.
+    dockerPsql(PRE_MIGRATION_SCHEMA);
+    const pre = dockerPsql(
+      `\\set VERBOSITY verbose\nSELECT accepted_by_user_id FROM kortix.account_invitations LIMIT 1;`,
+      true,
+    );
+    expect(pre.exitCode).not.toBe(0);
+    expect(pre.output).toContain('42703'); // undefined_column
+    expect(pre.output).toContain('accepted_by_user_id');
+  }, 30_000);
+
+  afterAll(() => {
+    Bun.spawnSync(['docker', 'rm', '-f', container], { stdout: 'ignore', stderr: 'ignore' });
+  });
+
+  test('adds the accepted_by_user_id column', async () => {
+    const migration = await Bun.file(
+      resolve(import.meta.dir, '..', 'migrations', '20260712220000000_invite_accept_identity.sql'),
+    ).text();
+    // Apply only the Up portion (everything before the "-- Down Migration"
+    // marker), as node-pg-migrate would.
+    const up = migration.split(/^\s*--\s*Down\s+Migration/im)[0] ?? migration;
+    dockerPsql(up);
+
+    const col = dockerPsql(
+      `SELECT data_type FROM information_schema.columns
+        WHERE table_schema='kortix' AND table_name='account_invitations'
+          AND column_name='accepted_by_user_id';`,
+    );
+    expect(col.output.trim()).toBe('uuid');
+  });
+
+  test('the exact failing GET /v1/accounts/:id/invites SELECT now succeeds', () => {
+    dockerPsql(`
+      INSERT INTO kortix.accounts(account_id) VALUES
+        ('4c66e49f-142f-4cad-af2c-eb24743fc809');
+      INSERT INTO kortix.account_invitations
+        (account_id, email, initial_role, expires_at)
+      VALUES
+        ('4c66e49f-142f-4cad-af2c-eb24743fc809', 'invitee@example.test', 'member',
+         now() + interval '7 days');
+    `);
+
+    // This is the verbatim query Drizzle emits for GET /v1/accounts/:id/invites
+    // (members.ts: db.select().from(accountInvitations).where(...)). Before the
+    // migration it raised `column "accepted_by_user_id" does not exist`.
+    const result = dockerPsql(`
+      SELECT invite_id, account_id, email, invited_by, initial_role,
+             bootstrap_grants, accepted_at, accepted_by_user_id,
+             created_at, expires_at
+        FROM kortix.account_invitations
+       WHERE account_id = '4c66e49f-142f-4cad-af2c-eb24743fc809'
+         AND accepted_at IS NULL
+         AND expires_at > now();
+    `);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('invitee@example.test');
+    // The column is nullable; a never-accepted invite reads as NULL, not an
+    // error — which is what the accept handler's
+    // `if (alreadyAccepted && invite.acceptedByUserId …)` guard depends on.
+    expect(result.output).toContain('|');
+  });
+
+  test('accept stamps accepted_by_user_id, and a different identity is rejected', () => {
+    // Mirrors the accept handler's stamp + the 409 guard in accounts/invites.ts.
+    dockerPsql(`
+      UPDATE kortix.account_invitations
+         SET accepted_at = now(), accepted_by_user_id = '00000000-0000-4000-a000-0000000000aa'
+       WHERE email = 'invitee@example.test';
+    `);
+    const row = dockerPsql(
+      `SELECT accepted_by_user_id FROM kortix.account_invitations
+        WHERE email = 'invitee@example.test';`,
+    );
+    expect(row.output).toContain('00000000-0000-4000-a000-0000000000aa');
+  });
+
+  test('the migration is idempotent (re-applying is a no-op)', async () => {
+    const migration = await Bun.file(
+      resolve(import.meta.dir, '..', 'migrations', '20260712220000000_invite_accept_identity.sql'),
+    ).text();
+    const up = migration.split(/^\s*--\s*Down\s+Migration/im)[0] ?? migration;
+    // ADD COLUMN IF NOT EXISTS → second application must not error and must not
+    // duplicate the column.
+    expect(() => dockerPsql(up)).not.toThrow();
+    const cols = dockerPsql(
+      `SELECT count(*) FROM information_schema.columns
+        WHERE table_schema='kortix' AND table_name='account_invitations'
+          AND column_name='accepted_by_user_id';`,
+    );
+    expect(cols.output.trim()).toBe('1');
+  });
+});

--- a/packages/db/scripts/invite-accept-identity-migration.integration.test.ts
+++ b/packages/db/scripts/invite-accept-identity-migration.integration.test.ts
@@ -44,6 +44,8 @@ function dockerPsql(sql: string, allowFailure = false) {
       'testdb',
       '-v',
       'ON_ERROR_STOP=1',
+      '-t',
+      '-A',
     ],
     { stdin: Buffer.from(sql), stdout: 'pipe', stderr: 'pipe' },
   );
@@ -170,8 +172,9 @@ describe.skipIf(!dockerAvailable)('invite_accept_identity migration — real Pos
     expect(result.output).toContain('|');
   });
 
-  test('accept stamps accepted_by_user_id, and a different identity is rejected', () => {
-    // Mirrors the accept handler's stamp + the 409 guard in accounts/invites.ts.
+  test('accept stamps accepted_by_user_id', () => {
+    // Mirrors the accept handler's persisted identity stamp. The API-level 409
+    // guard for a different identity is covered by the accounts contract tests.
     dockerPsql(`
       UPDATE kortix.account_invitations
          SET accepted_at = now(), accepted_by_user_id = '00000000-0000-4000-a000-0000000000aa'


### PR DESCRIPTION
## Root cause
Production API queries project account_invitations.accepted_by_user_id, but the production database never received the forward migration for that nullable UUID column. Better Stack pattern 97669531 has 171 occurrences across 5 users.

Better Stack: https://errors.betterstack.com/team/t502678/errors/97669531f829fc2692be56523b1b8e3062ecaac181538abee44480c8798154c0?s=2346961

## Fix
- add the idempotent, forward-only accepted_by_user_id migration
- add a real PostgreSQL integration contract covering pre-migration 42703, exact select, identity stamp, and reapply
- preserve the API contract that rejects a different accepting identity with 409

## Verification
- PostgreSQL migration integration: 4 pass, 0 fail
- migration lint: 44 pass
- @kortix/db typecheck: pass
- accounts API contract: 7 pass, 61 assertions
- git diff --check: pass