### PR TITLE
fix(web): guard malformed markdown prefetch links

### DIFF
--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -22,6 +22,7 @@ import { cn } from '@/lib/utils';
 import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
 import {
   isInternalUrl,
+  isLinkSafeHref,
   languageLabel,
   looksLikeFilePath,
   looksLikeUrl,
@@ -340,13 +341,32 @@ function ClickableInlineCode({ children }: { children: React.ReactNode }) {
   const isAbsolute = text.startsWith('/');
 
   if (isUrl) {
+    const href = proxyUrl(text) ?? text;
+    const linkClass = cn(INLINE_CODE, 'hover:text-kortix-blue cursor-pointer transition-colors');
+
+    // A malformed absolute URL (e.g. `http://:`) must not reach next/link —
+    // its prefetch path throws `Cannot prefetch '...'` (see isLinkSafeHref).
+    if (!isLinkSafeHref(href)) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={`Open ${text} in a new tab`}
+          className={linkClass}
+        >
+          {children}
+        </a>
+      );
+    }
+
     return (
       <Link
-        href={proxyUrl(text) ?? text}
+        href={href}
         target="_blank"
         rel="noopener noreferrer"
         title={`Open ${text} in a new tab`}
-        className={cn(INLINE_CODE, 'hover:text-kortix-blue cursor-pointer transition-colors')}
+        className={linkClass}
       >
         {children}
       </Link>
@@ -496,6 +516,21 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
             'transition-colors hover:decoration-kortix-blue',
             '[overflow-wrap:anywhere]',
           );
+
+          // A malformed absolute href (e.g. `http://:` from an unsubstituted
+          // `${HOST}:${PORT}` template in content) must not reach next/link —
+          // its prefetch path throws `Cannot prefetch '...'` (see isLinkSafeHref).
+          if (!isLinkSafeHref(resolvedHref)) {
+            return (
+              <a
+                href={resolvedHref}
+                className={linkClass}
+                {...(isExternal && !isHash ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              >
+                {children}
+              </a>
+            );
+          }
 
           return (
             <Link

--- a/apps/web/src/components/markdown/unified-markdown-utils.test.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   isInternalUrl,
+  isLinkSafeHref,
   languageLabel,
   looksLikeFilePath,
   looksLikeUrl,
@@ -69,6 +70,47 @@ describe('looksLikeUrl', () => {
   test('rejects paths and prose', () => {
     expect(looksLikeUrl('/etc/hosts')).toBe(false);
     expect(looksLikeUrl('just text')).toBe(false);
+  });
+
+  // Regression: `http://:` (an empty host/port template like
+  // `http://${HOST}:${PORT}` that leaked unsubstituted from content) matches
+  // the `://\S+` shape, so looksLikeUrl happily returns true. The guard that
+  // keeps it out of next/link lives in isLinkSafeHref below.
+  test('matches the malformed http://: shape (guarded downstream)', () => {
+    expect(looksLikeUrl('http://:')).toBe(true);
+  });
+});
+
+describe('isLinkSafeHref', () => {
+  test('rejects malformed absolute URLs that crash next/link prefetch', () => {
+    // The exact production signature: `Cannot prefetch 'http://:' because it
+    // cannot be converted to a URL.` — `new URL('http://:')` throws.
+    expect(isLinkSafeHref('http://:')).toBe(false);
+    expect(isLinkSafeHref('https://:')).toBe(false);
+    expect(isLinkSafeHref('http://')).toBe(false);
+    // An unsubstituted `http://${HOST}:${PORT}` template rendered with an
+    // empty host collapses to this shape.
+    expect(isLinkSafeHref('http://:8080')).toBe(false);
+  });
+
+  test('accepts valid absolute URLs (external is fine — prefetch short-circuits)', () => {
+    expect(isLinkSafeHref('https://kortix.ai/x')).toBe(true);
+    expect(isLinkSafeHref('http://localhost:3000')).toBe(true);
+    // `mailto:` has no `//` and `new URL('mailto:...')` parses fine, so it is
+    // safe to hand to next/link (no prefetch throw).
+    expect(isLinkSafeHref('mailto:hi@kortix.ai')).toBe(true);
+  });
+
+  test('accepts internal hrefs that next/link always handles', () => {
+    expect(isLinkSafeHref('/dashboard')).toBe(true);
+    expect(isLinkSafeHref('#section')).toBe(true);
+    expect(isLinkSafeHref('?q=1')).toBe(true);
+    expect(isLinkSafeHref('relative/path')).toBe(true);
+  });
+
+  test('rejects empty / undefined', () => {
+    expect(isLinkSafeHref('')).toBe(false);
+    expect(isLinkSafeHref(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/markdown/unified-markdown-utils.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.ts
@@ -11,6 +11,43 @@ export function isInternalUrl(href: string | undefined): boolean {
   return href.startsWith('/') || href.startsWith('#');
 }
 
+/**
+ * Can this href be handed to `next/link` without crashing the prefetch path?
+ *
+ * Next.js' app-router `createPrefetchURL` (in `app-router.tsx`) does
+ * `new URL(addBasePath(href), window.location.href)` and, on failure, throws
+ * `Cannot prefetch '<href>' because it cannot be converted to a URL.` — which
+ * fires whenever a `<Link>` carrying a malformed absolute href scrolls into
+ * view (segment-cache `pingVisibleLinks`). A valid external URL is fine
+ * (`isExternalURL` short-circuits prefetch); only URLs that fail `new URL()`
+ * blow up, e.g. `http://:` (an empty host/port template like
+ * `http://${HOST}:${PORT}` that leaked unsubstituted from content).
+ *
+ * Internal (`/`, `#`, `?`) and bare-relative hrefs are always safe. We only
+ * reject protocol-prefixed hrefs that don't parse, so the renderer can fall
+ * back to a plain `<a>` and never feed garbage to `next/link`.
+ */
+export function isLinkSafeHref(href: string | undefined): boolean {
+  if (!href) return false;
+  // Root-relative, hash, and query links are always safe for next/link.
+  if (href.startsWith('/') || href.startsWith('#') || href.startsWith('?')) {
+    return true;
+  }
+  // Protocol-prefixed URLs must parse, or next/link's prefetch throws on
+  // `new URL()` failure when the link enters the viewport.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(href)) {
+    try {
+      new URL(href);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  // Bare-relative paths are resolved against the current URL by next/link —
+  // `new URL(..., window.location.href)` always succeeds for them.
+  return true;
+}
+
 /** Normalise a fenced-code language hint to a Shiki grammar id. */
 export function normalizeLanguage(lang: string): string {
   const map: Record<string, string> = {

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/markdown/katex-markdown';
 import {
   isInternalUrl,
+  isLinkSafeHref,
   languageLabel,
   looksLikeFilePath,
   looksLikeUrl,
@@ -340,13 +341,32 @@ function ClickableInlineCode({ children }: { children: React.ReactNode }) {
   const isAbsolute = text.startsWith('/');
 
   if (isUrl) {
+    const href = proxyUrl(text) ?? text;
+    const linkClass = cn(INLINE_CODE, 'hover:text-kortix-blue cursor-pointer transition-colors');
+
+    // A malformed absolute URL (e.g. `http://:`) must not reach next/link —
+    // its prefetch path throws `Cannot prefetch '...'` (see isLinkSafeHref).
+    if (!isLinkSafeHref(href)) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={`Open ${text} in a new tab`}
+          className={linkClass}
+        >
+          {children}
+        </a>
+      );
+    }
+
     return (
       <Link
-        href={proxyUrl(text) ?? text}
+        href={href}
         target="_blank"
         rel="noopener noreferrer"
         title={`Open ${text} in a new tab`}
-        className={cn(INLINE_CODE, 'hover:text-kortix-blue cursor-pointer transition-colors')}
+        className={linkClass}
       >
         {children}
       </Link>
@@ -495,6 +515,21 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
             'transition-colors hover:decoration-kortix-blue',
             '[overflow-wrap:anywhere]',
           );
+
+          // A malformed absolute href (e.g. `http://:` from an unsubstituted
+          // `${HOST}:${PORT}` template in content) must not reach next/link —
+          // its prefetch path throws `Cannot prefetch '...'` (see isLinkSafeHref).
+          if (!isLinkSafeHref(resolvedHref)) {
+            return (
+              <a
+                href={resolvedHref}
+                className={linkClass}
+                {...(isExternal && !isHash ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              >
+                {children}
+              </a>
+            );
+          }
 
           return (
             <Link


### PR DESCRIPTION
## Root cause
Content-derived malformed absolute links such as http://: were passed to Next Link. When visible-link prefetch ran, Next failed URL construction and threw Better Stack pattern 70d3564c.

Better Stack: https://errors.betterstack.com/team/t502678/errors/70d3564c89bd221da58fb6b3009f28160aed9ae5ad9cd029f907aa73e6c53f60?s=2346967

## Fix
- validate protocol-prefixed hrefs before handing them to Next Link
- fall back to a plain anchor for malformed values
- apply the guard to both unified and docs markdown renderers
- add exact http://: regression coverage

## Verification
- markdown utility suite: 17 pass
- web TypeScript touched-file check: pass; only unrelated generated-content baseline errors before generation
- git diff --check: pass