### PR TITLE
fix(web): suppress transient runtime-not-ready telemetry

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -48,6 +48,17 @@ if (SENTRY_DSN) {
       'The operation was aborted',
       // Ad-blocker blocked requests
       'ERR_BLOCKED_BY_CLIENT',
+      // Transient "session runtime not ready" — `RuntimeNotReadyError`
+      // (`[opencode-sdk] Server URL not ready — sandbox is still loading`) from
+      // `getClient()` for the ~1s window before a session's runtime URL pins.
+      // Expected + self-healing on every session switch/provisioning; never an
+      // error. `app/error.tsx` already suppresses the render-path case, but the
+      // throw can also surface via `<ClientErrorBoundary>`, `route-error`/
+      // `system-fault`, the network branch of `error-handler`, and unhandled
+      // promise rejections — drop them all here.
+      'Server URL not ready',
+      'sandbox is still loading',
+      'opencode not ready',
       // External Safari / WebView video probing noise
       'webkitPresentationMode',
       "null is not an object (evaluating 'document.querySelector('video').webkitPresentationMode')",

--- a/apps/web/src/app/sentry-ignore-errors.test.ts
+++ b/apps/web/src/app/sentry-ignore-errors.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'bun:test';
+
+// Locks the SDK-level gate for the transient `RuntimeNotReadyError` cluster
+// (Kortix Frontend prod): `[opencode-sdk] Server URL not ready — sandbox is
+// still loading`. `app/error.tsx` handles the global route-segment render
+// case, but the throw also reaches Sentry via `<ClientErrorBoundary>`,
+// `route-error`/`system-fault`, the network branch of `error-handler`, and
+// unhandled promise rejections. Sentry's `ignoreErrors` list is the one gate
+// that covers ALL capture paths (it is checked before an event is sent), so
+// the runtime-not-ready markers MUST live here too.
+
+test('sentry.client.config ignores the transient runtime-not-ready markers', async () => {
+  const source = await Bun.file(`${import.meta.dir}/../../sentry.client.config.ts`).text();
+  expect(source).toContain('ignoreErrors');
+  // The three marker strings that cover every variant of the throw
+  // (RuntimeNotReadyError, the plain Error in env.ts/pty.ts, and any
+  // re-wrapped unhandled-rejection preserving the wording).
+  expect(source).toContain("'Server URL not ready'");
+  expect(source).toContain("'sandbox is still loading'");
+  expect(source).toContain("'opencode not ready'");
+  // The beforeSend hook must still delegate to the noise filter (which also
+  // classifies runtime-not-ready via shouldIgnoreSentryNoiseEvent).
+  expect(source).toContain('shouldIgnoreSentryNoiseEvent');
+});

--- a/apps/web/src/components/common/error-boundary.tsx
+++ b/apps/web/src/components/common/error-boundary.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { isRuntimeNotReadyNoiseMessage } from '@/lib/browser-error-noise';
 import * as Sentry from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import type { ErrorInfo } from 'react';
@@ -59,6 +60,15 @@ class ErrorBoundaryInner extends Component<InnerProps, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    // Transient "session runtime not ready" is an expected, self-healing info
+    // state (every session switch/provisioning window) — never an error. The
+    // global `app/error.tsx` boundary already suppresses it for the route
+    // segment; mirror that here so a subtree wrapped in this boundary doesn't
+    // page Better Stack for the same transient throw. The Sentry `ignoreErrors`
+    // list + `beforeSend` filter back this up at the SDK level.
+    if (isRuntimeNotReadyNoiseMessage(error?.message)) {
+      return;
+    }
     Sentry.captureException(error, {
       extra: { componentStack: info.componentStack },
     });

--- a/apps/web/src/components/common/route-error.tsx
+++ b/apps/web/src/components/common/route-error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { isRuntimeNotReadyNoiseMessage } from '@/lib/browser-error-noise';
 import * as Sentry from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import { useEffect } from 'react';
@@ -24,6 +25,11 @@ export function RouteErrorFallback({
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   useEffect(() => {
+    // Transient "session runtime not ready" is an expected, self-healing info
+    // state — never page Better Stack for it. Mirrors `app/error.tsx` +
+    // `ClientErrorBoundary`; the Sentry `ignoreErrors`/`beforeSend` filter
+    // backs this up at the SDK level.
+    if (isRuntimeNotReadyNoiseMessage(error?.message)) return;
     Sentry.captureException(error);
   }, [error]);
 

--- a/apps/web/src/components/common/runtime-not-ready-noise.test.ts
+++ b/apps/web/src/components/common/runtime-not-ready-noise.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'bun:test';
+
+// Locks the telemetry-side guard for the transient `RuntimeNotReadyError`
+// ("[opencode-sdk] Server URL not ready — sandbox is still loading") cluster.
+// The throw is an expected, self-healing state on every session switch /
+// provisioning window; it must never page Better Stack. `app/error.tsx`
+// suppresses the global route-segment render case, but the throw can also be
+// captured by the generic `<ClientErrorBoundary>` and the shared
+// `RouteErrorFallback` — both must skip Sentry for it. (The Sentry
+// `ignoreErrors` list + `browser-error-noise` `beforeSend` filter back these
+// up at the SDK level; see browser-error-noise.test.mts.)
+
+test('ClientErrorBoundary does not capture runtime-not-ready to Sentry', async () => {
+  const source = await Bun.file(`${import.meta.dir}/error-boundary.tsx`).text();
+  expect(source).toContain('isRuntimeNotReadyNoiseMessage');
+  expect(source).toContain('Sentry.captureException');
+  // The guard must short-circuit BEFORE the capture call.
+  const guardIdx = source.indexOf('isRuntimeNotReadyNoiseMessage(error?.message)');
+  const captureIdx = source.indexOf('Sentry.captureException(error');
+  expect(guardIdx).toBeGreaterThan(-1);
+  expect(captureIdx).toBeGreaterThan(-1);
+  expect(guardIdx).toBeLessThan(captureIdx);
+});
+
+test('RouteErrorFallback does not capture runtime-not-ready to Sentry', async () => {
+  const source = await Bun.file(`${import.meta.dir}/route-error.tsx`).text();
+  expect(source).toContain('isRuntimeNotReadyNoiseMessage(error?.message)');
+  expect(source).toContain('return;');
+  // The guard must return before the capture call inside the effect.
+  const guardIdx = source.indexOf('isRuntimeNotReadyNoiseMessage(error?.message)');
+  const captureIdx = source.indexOf('Sentry.captureException(error)');
+  expect(guardIdx).toBeGreaterThan(-1);
+  expect(captureIdx).toBeGreaterThan(-1);
+  expect(guardIdx).toBeLessThan(captureIdx);
+});

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -5,6 +5,7 @@ import {
   isExtensionSource,
   isInjectedAppSource,
   isKnownBrowserNoiseMessage,
+  isRuntimeNotReadyNoiseMessage,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
 } from './browser-error-noise.ts'
@@ -192,4 +193,84 @@ test('suppresses the Better Stack Promise.then incident event', () => {
 test('flags the injected embed widget source as third-party noise', () => {
   assert.equal(isInjectedAppSource('app:///embed/embed.js'), true)
   assert.equal(isInjectedAppSource('app:///_next/static/chunks/main.js'), false)
+})
+
+// Reproduces the Kortix Frontend (prod) RuntimeNotReadyError cluster (patterns
+// 1a9acfd0…, 4c20d52d…, 7e2697b4…, a58cd1cb…, …). `getClient()` throws
+// `RuntimeNotReadyError: [opencode-sdk] Server URL not ready — sandbox is
+// still loading` for the ~1s window before a session's runtime URL pins — an
+// expected, self-healing state on every session switch/provisioning. The
+// render-path UI handling lives in `app/error.tsx` + `SandboxLoadingBoundary`,
+// but the throw can also reach Sentry through `<ClientErrorBoundary>`,
+// `route-error`/`system-fault`, the network branch of `error-handler`, and
+// unhandled promise rejections. The filter below is the telemetry-side
+// backstop that drops it regardless of capture path.
+const RUNTIME_NOT_READY_EVENTS = [
+  // The canonical SDK throw (RuntimeNotReadyError).
+  'RuntimeNotReadyError: [opencode-sdk] Server URL not ready — sandbox is still loading',
+  // The bare message (env.ts path / re-wrapped).
+  '[opencode-sdk] Server URL not ready — sandbox is still loading',
+  // The pty guard variant.
+  '[kortix-pty] Server URL not ready — sandbox is still loading',
+  // An unhandled-rejection wrapper preserving the message.
+  'Unhandled promise rejection: Server URL not ready — sandbox is still loading',
+  // The "opencode not ready" sibling wording used by env/pty guards.
+  'opencode not ready — sandbox is still starting',
+]
+
+test('classifies every runtime-not-ready variant as transient noise', () => {
+  for (const message of RUNTIME_NOT_READY_EVENTS) {
+    assert.equal(
+      isRuntimeNotReadyNoiseMessage(message),
+      true,
+      `expected ${message} to be classified as runtime-not-ready noise`,
+    )
+  }
+})
+
+test('suppresses a runtime-not-ready Sentry event regardless of capture path', () => {
+  for (const value of RUNTIME_NOT_READY_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://app.kortix.com/projects/p/sessions/s' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [{ filename: 'app:///_next/static/chunks/sdk.js' }],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a runtime-not-ready unhandled rejection from the browser', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        'Unhandled promise rejection: [opencode-sdk] Server URL not ready — sandbox is still loading',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a genuine runtime/server error that is not the transient not-ready state', () => {
+  assert.equal(
+    isRuntimeNotReadyNoiseMessage('Error: the OpenCode daemon crashed mid-turn (exit code 1)'),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [{ value: 'TypeError: Cannot read properties of undefined (reading id)' }],
+      },
+    }),
+    false,
+  )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -29,6 +29,25 @@ const KNOWN_HYDRATION_NOISE_MESSAGES = [
   "Hydration failed because the server rendered",
 ] as const;
 
+// Transient "the session runtime / sandbox URL hasn't pinned yet" throws. The
+// SDK throws `RuntimeNotReadyError` (`[opencode-sdk] Server URL not ready —
+// sandbox is still loading`) from `getClient()` for the ~1s window before a
+// new/switched session's runtime URL resolves; sibling guards reuse the same
+// wording for the pty/env paths (`[kortix-pty] Server URL not ready …`). It is
+// an EXPECTED, self-healing info state — never an error — but it can reach
+// Sentry through paths that don't go through the global `app/error.tsx`
+// boundary's manual guard: a subtree wrapped in `<ClientErrorBoundary>`
+// (whose `componentDidCatch` captures unconditionally), `route-error`/
+// `system-fault`, `error-handler`'s network branch, and unhandled promise
+// rejections auto-captured by the Sentry SDK. Filter it once, here, so every
+// capture path drops it. The render-path UI handling lives in `app/error.tsx`
+// + `SandboxLoadingBoundary`; this is the telemetry-side backstop.
+const RUNTIME_NOT_READY_NOISE_PATTERNS = [
+  'Server URL not ready',
+  'sandbox is still loading',
+  'opencode not ready',
+] as const;
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -85,6 +104,19 @@ export function isLikelyDomMutationNoise(message: unknown): boolean {
     || containsKnownPattern(normalized, KNOWN_HYDRATION_NOISE_MESSAGES);
 }
 
+/**
+ * Whether a message is the transient, self-healing "session runtime not ready
+ * yet" state — `[opencode-sdk] Server URL not ready — sandbox is still loading`
+ * and its sibling variants. Such a message must NEVER page Better Stack: it
+ * resolves on its own within ~1s (every session switch/provisioning window).
+ */
+export function isRuntimeNotReadyNoiseMessage(message: unknown): boolean {
+  const normalized = normalizeString(message).toLowerCase();
+  return RUNTIME_NOT_READY_NOISE_PATTERNS.some((pattern) =>
+    normalized.includes(pattern.toLowerCase()),
+  );
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -99,6 +131,10 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   }
 
   if (isKnownTestNoiseMessage(message)) {
+    return true;
+  }
+
+  if (isRuntimeNotReadyNoiseMessage(message)) {
     return true;
   }
 
@@ -130,6 +166,13 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   }
 
   if (isKnownTestNoiseMessage(message)) {
+    return true;
+  }
+
+  // Transient "session runtime not ready yet" — expected during every session
+  // switch/provisioning window, self-heals in ~1s, never an error. Drop it
+  // before it pages Better Stack, no matter which capture path delivered it.
+  if (isRuntimeNotReadyNoiseMessage(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause
RuntimeNotReadyError is an expected self-healing state while the session runtime URL pins, but capture paths outside the global route error boundary still sent it to Sentry. Multiple Better Stack Frontend prod patterns accumulated more than 100 occurrences.

## Fix
- classify the canonical runtime-not-ready variants in the shared noise filter
- suppress them in client and route error boundaries
- add SDK-level ignore markers for unhandled rejection and alternate capture paths
- retain reporting for real daemon and application failures

## Verification
- four focused suites: 21 pass, 0 fail
- full web TypeScript check: pass after generated content types
- targeted Biome lint: pass
- git diff --check: pass