### PR TITLE
fix(web): suppress exact browser image-load noise

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -68,10 +68,10 @@ if (SENTRY_DSN) {
       'MetaMask extension not found',
       'Looks like your website URL has changed',
       'CookieYes account',
-      // Browser-native <img> / next/image load failures (broken/expired URLs,
-      // ad-blockers, offline, CSP). Never thrown by our code; image components
-      // already degrade gracefully via onError handlers. See browser-error-noise.ts.
-      'Failed to load image',
+      // Browser-native <img> / next/image load failures. Anchor this so real
+      // viewer errors such as "Failed to load image for duotone processing"
+      // remain reportable. See browser-error-noise.ts.
+      /^(?:Error: )?Failed to load image$/,
       // Injected scripts / extensions / scanner bots monkey-patching the native
       // (read-only) Promise prototype, e.g. `promise.then = ...`. Always external.
       "Cannot assign to read only property 'then' of object '#<Promise>'",

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -68,6 +68,10 @@ if (SENTRY_DSN) {
       'MetaMask extension not found',
       'Looks like your website URL has changed',
       'CookieYes account',
+      // Browser-native <img> / next/image load failures (broken/expired URLs,
+      // ad-blockers, offline, CSP). Never thrown by our code; image components
+      // already degrade gracefully via onError handlers. See browser-error-noise.ts.
+      'Failed to load image',
       // Injected scripts / extensions / scanner bots monkey-patching the native
       // (read-only) Promise prototype, e.g. `promise.then = ...`. Always external.
       "Cannot assign to read only property 'then' of object '#<Promise>'",

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -274,3 +274,81 @@ test('does NOT suppress a genuine runtime/server error that is not the transient
     false,
   )
 })
+
+// Reproduces Better Stack error 1426e718... (38 occurrences) and b04a2106...
+// (6 occurrences), Kortix Frontend (prod), application_id 2346967: a browser-
+// native image load failure raised through window.onerror. The app already
+// degrades gracefully via onError handlers, so the exact message is noise.
+test('suppresses the "Failed to load image" browser noise via runtime guard', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Error: Failed to load image',
+      filename: 'app:///_next/static/chunks/main.js',
+    }),
+    true,
+  )
+})
+
+test('suppresses the bare "Failed to load image" Sentry exception', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://app.kortix.com/projects' },
+      exception: {
+        values: [
+          {
+            value: 'Failed to load image',
+            stacktrace: {
+              frames: [{ filename: 'app:///_next/static/chunks/main.js' }],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a real application error that merely mentions images', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://app.kortix.com/projects' },
+      exception: {
+        values: [
+          {
+            value: 'TypeError: Cannot read properties of undefined (reading src)',
+            stacktrace: { frames: [{ filename: 'app:///_next/static/chunks/app.js' }] },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress an actionable pptx image-processing failure', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://app.kortix.com/projects' },
+      exception: {
+        values: [
+          {
+            value: 'Failed to load image for colour change processing',
+            stacktrace: {
+              frames: [{ filename: 'app:///_next/static/chunks/pptx-viewer.js' }],
+            },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a same-worded server exception without a browser frame', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: 'Failed to load image' }] },
+    }),
+    false,
+  )
+})

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -12,17 +12,6 @@ const KNOWN_BROWSER_NOISE_MESSAGES = [
   // tech-detection crawlers hitting the marketing site.
   "Cannot assign to read only property 'then' of object '#<Promise>'",
   'Cannot assign to read only property',
-  // Browser-native <img> / next/image load failures. The browser emits this
-  // (or "Error: Failed to load image") through window.onerror/Sentry when an
-  // image resource fails to load for reasons outside the app: broken/expired
-  // CDN or S3 signed URLs, ad-blockers blocking image hosts, CSP, offline, or
-  // prefetch failures. It is never thrown by our own code (verified: the string
-  // does not appear anywhere in the repo), and the image components already
-  // degrade gracefully (image-renderer.tsx / show-content-renderer.tsx attach
-  // onError handlers that hide the broken <img>). Suppress the noise class so
-  // it stops paging Better Stack. Better Stack patterns 1426e718... (38) and
-  // b04a2106... (6), Kortix Frontend (prod), application_id 2346967.
-  'Failed to load image',
 ] as const;
 
 const KNOWN_TEST_NOISE_MESSAGES = [
@@ -78,6 +67,17 @@ function containsKnownPattern(message: string, patterns: readonly string[]): boo
 
 function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value : '';
+}
+
+function isBareImageLoadNoiseMessage(message: unknown): boolean {
+  const normalized = normalizeString(message);
+  return normalized === 'Failed to load image' || normalized === 'Error: Failed to load image';
+}
+
+function isBrowserBundleSource(filename: unknown): boolean {
+  const normalized = normalizeString(filename);
+  return normalized.startsWith('app:///_next/static/')
+    || /^https?:\/\/[^/]+\/_next\/static\//.test(normalized);
 }
 
 function extractMessage(value: unknown): string {
@@ -141,6 +141,14 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Browser-native <img> / next/image load failures can surface as this exact
+  // message through window.onerror. Keep this exact: pptx-react-viewer throws
+  // actionable errors such as "Failed to load image for colour change
+  // processing", which must still reach error tracking.
+  if (isBareImageLoadNoiseMessage(message)) {
+    return true;
+  }
+
   if (isKnownTestNoiseMessage(message)) {
     return true;
   }
@@ -173,6 +181,15 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   const environment = normalizeString((event as { environment?: unknown }).environment);
 
   if (isKnownBrowserNoiseMessage(message)) {
+    return true;
+  }
+
+  // This helper is also used by the server and edge Sentry configs. Require a
+  // browser bundle frame here so a same-worded server exception is not hidden.
+  // The client config additionally has an anchored ignoreErrors regex for
+  // frame-less browser events.
+  if (isBareImageLoadNoiseMessage(message)
+    && frames.some((frame) => isBrowserBundleSource(frame.filename))) {
     return true;
   }
 

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -12,6 +12,17 @@ const KNOWN_BROWSER_NOISE_MESSAGES = [
   // tech-detection crawlers hitting the marketing site.
   "Cannot assign to read only property 'then' of object '#<Promise>'",
   'Cannot assign to read only property',
+  // Browser-native <img> / next/image load failures. The browser emits this
+  // (or "Error: Failed to load image") through window.onerror/Sentry when an
+  // image resource fails to load for reasons outside the app: broken/expired
+  // CDN or S3 signed URLs, ad-blockers blocking image hosts, CSP, offline, or
+  // prefetch failures. It is never thrown by our own code (verified: the string
+  // does not appear anywhere in the repo), and the image components already
+  // degrade gracefully (image-renderer.tsx / show-content-renderer.tsx attach
+  // onError handlers that hide the broken <img>). Suppress the noise class so
+  // it stops paging Better Stack. Better Stack patterns 1426e718... (38) and
+  // b04a2106... (6), Kortix Frontend (prod), application_id 2346967.
+  'Failed to load image',
 ] as const;
 
 const KNOWN_TEST_NOISE_MESSAGES = [


### PR DESCRIPTION
## Root cause
Better Stack Frontend prod patterns 1426e718 and b04a2106 report the browser-native bare message Failed to load image. The app does not throw that exact error, and image components already degrade through onError.

## Fix
- suppress only exact Failed to load image / Error: Failed to load image browser events
- scope the shared Sentry helper to browser Next.js frames
- anchor the client ignoreErrors expression
- preserve real PPTX and server failures containing longer image-load messages

Better Stack: https://errors.betterstack.com/team/t502678/errors/1426e718ac5b470f13b7e039c7da6b6f00c7446e510a760334e9647fb3fb34bd?s=2346967

## Verification
- focused browser-error-noise suite: 17 pass, 0 fail
- web TypeScript check: pass
- targeted Biome lint: pass
- git diff --check: pass