### PR TITLE
fix(web): guard non-string command templates

### DIFF
--- a/apps/mobile/components/session/SessionTurn.tsx
+++ b/apps/mobile/components/session/SessionTurn.tsx
@@ -3496,7 +3496,10 @@ function detectCommandFromText(
   const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   for (const cmd of commands) {
-    if (!cmd.template) continue;
+    // `template` is typed as string but can arrive non-string from MCP/skill
+    // command sources; guard before `.trim()` to avoid a TypeError crash.
+    // Canonical implementation: apps/web/src/features/session/detect-command.ts.
+    if (typeof cmd.template !== 'string') continue;
     const tpl = cmd.template.trim();
 
     // Large templates — fast exact/prefix match

--- a/apps/web/src/features/session/detect-command.test.ts
+++ b/apps/web/src/features/session/detect-command.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Command } from '@kortix/sdk/react';
+
+import { detectCommandFromText } from './detect-command';
+
+// Build a Command with an arbitrary (possibly non-string) `template`, bypassing
+// the SDK's `template: string` type — the opencode API / MCP / skill command
+// sources have been observed returning non-string templates in production
+// (Better Stack error: "TypeError: e.template.trim is not a function").
+function cmd(name: string, template: unknown, extra: Partial<Command> = {}): Command {
+  return { name, template: template as string, hints: [], ...extra } as Command;
+}
+
+describe('detectCommandFromText', () => {
+  test('matches a normal string template by its prefix', () => {
+    const commands = [cmd('build', 'build the project now please $ARGUMENTS')];
+    expect(detectCommandFromText('build the project now please --force', commands)).toEqual({
+      name: 'build',
+      args: '--force',
+    });
+  });
+
+  test('returns undefined when no command matches', () => {
+    const commands = [cmd('build', 'build the project now please $ARGUMENTS')];
+    expect(detectCommandFromText('something completely unrelated', commands)).toBeUndefined();
+  });
+
+  test('returns undefined for empty input', () => {
+    expect(
+      detectCommandFromText('', [cmd('build', 'build the project now please $ARGUMENTS')]),
+    ).toBeUndefined();
+    expect(detectCommandFromText('text')).toBeUndefined();
+  });
+
+  // Regression for Better Stack error "TypeError: e.template.trim is not a
+  // function" — the API can return a non-string `template` (object/number/null
+  // but truthy). The old guard `if (!cmd.template) continue` let non-string
+  // truthy values through and `.trim()` threw, crashing the render.
+  test('does NOT throw when a command has a non-string template (object/number)', () => {
+    const commands: Command[] = [
+      cmd('broken-object', { path: 'onboarding.md' }),
+      cmd('broken-number', 42),
+      cmd('broken-array', ['a', 'b']),
+      cmd('broken-bool', true),
+      cmd('good', 'build the project now please $ARGUMENTS'),
+    ];
+
+    // Must not throw — non-string templates are skipped, the good one still matches.
+    const result = detectCommandFromText('build the project now please --force', commands);
+    expect(result).toEqual({ name: 'good', args: '--force' });
+  });
+
+  test('returns undefined (without throwing) when every command has a non-string template', () => {
+    const commands: Command[] = [
+      cmd('broken-object', { path: 'onboarding.md' }),
+      cmd('broken-number', 42),
+    ];
+    expect(detectCommandFromText('build the project now please', commands)).toBeUndefined();
+  });
+
+  test('skips null/undefined templates without throwing', () => {
+    const commands: Command[] = [
+      cmd('null-template', null),
+      cmd('undefined-template', undefined),
+      cmd('good', 'build the project now please $ARGUMENTS'),
+    ];
+    expect(detectCommandFromText('build the project now please', commands)).toEqual({
+      name: 'good',
+      args: undefined,
+    });
+  });
+});

--- a/apps/web/src/features/session/detect-command.ts
+++ b/apps/web/src/features/session/detect-command.ts
@@ -1,0 +1,119 @@
+import type { Command } from '@kortix/sdk/react';
+
+/**
+ * Detect if user message text matches a known command template.
+ * Returns the command name + extracted args, or undefined if no match.
+ * Works by splitting each command template at its first placeholder
+ * ($1 or $ARGUMENTS) and checking if the message text starts with that prefix.
+ *
+ * Extracted into its own (React-free) module so it can be unit-tested directly.
+ */
+export function detectCommandFromText(
+  rawText: string,
+  commands?: Command[],
+): { name: string; args?: string } | undefined {
+  if (!commands || !rawText) return undefined;
+
+  const trimmedRawText = rawText.trim();
+  const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  for (const cmd of commands) {
+    // The opencode API (and MCP/skill-sourced commands) can return a `template`
+    // that is not a string (e.g. an object/number). The SDK types it as string,
+    // but the runtime value sometimes disagrees — calling `.trim()` on it throws
+    // `TypeError: e.template.trim is not a function` (Sentry: template.trim).
+    // Skip any command whose template isn't a usable string so detection degrades
+    // gracefully instead of crashing the render. Empty/whitespace-only templates
+    // are skipped later by the `prefix.length < 20` guard, matching prior behavior.
+    if (typeof cmd.template !== 'string') continue;
+    const tpl = cmd.template.trim();
+
+    // For large templates (e.g. onboarding.md), skip regex entirely and do a
+    // fast exact-match: strip the trailing $ARGUMENTS placeholder and check
+    // if rawText matches the body. This handles commands whose template is the
+    // full file content (which opencode sends verbatim as the user message).
+    if (tpl.length > 2000) {
+      // Strip trailing $ARGUMENTS (with optional surrounding whitespace/newlines)
+      const tplBody = tpl.replace(/\s*\$ARGUMENTS\s*$/, '').trimEnd();
+      // Fast check: does rawText equal the template body exactly?
+      if (tplBody.length > 0 && trimmedRawText === tplBody) {
+        return { name: cmd.name, args: undefined };
+      }
+      // Also handle the case where $ARGUMENTS is at the end and the user
+      // provided some text after the template body.
+      if (tplBody.length > 0 && trimmedRawText.startsWith(tplBody)) {
+        const after = trimmedRawText.slice(tplBody.length).trim();
+        return {
+          name: cmd.name,
+          args: after.length > 0 && after.length < 200 ? after : undefined,
+        };
+      }
+      continue;
+    }
+
+    // Find the first placeholder position ($1, $2, ..., $ARGUMENTS)
+    const placeholderMatch = tpl.match(/\$(\d+|\bARGUMENTS\b)/);
+    // Use the text before the first placeholder as the prefix to match
+    const prefix = placeholderMatch
+      ? tpl.slice(0, placeholderMatch.index).trimEnd()
+      : tpl.trimEnd();
+
+    // Require a meaningful prefix (at least 20 chars) to avoid false positives
+    if (prefix.length < 20) continue;
+
+    if (trimmedRawText.startsWith(prefix)) {
+      // Extract the user's arguments: text after the template prefix (approximate)
+      // For templates ending with the placeholder, the args are what comes after the prefix
+      let args: string | undefined;
+      if (placeholderMatch) {
+        const afterPrefix = trimmedRawText.slice(prefix.length).trim();
+        // The args are at the end; try to extract the last meaningful section
+        const lastNewlineBlock = afterPrefix.split('\n\n').pop()?.trim();
+        if (lastNewlineBlock && lastNewlineBlock.length < 200) {
+          args = lastNewlineBlock;
+        }
+      }
+      return { name: cmd.name, args };
+    }
+
+    // Fallback: robust full-template match where placeholders are wildcards.
+    // This handles commands whose template begins with a placeholder.
+    const placeholderRegex = /\$(\d+|\bARGUMENTS\b)/g;
+    const placeholderOrder: string[] = [];
+    let regexSource = '^';
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = placeholderRegex.exec(tpl)) !== null) {
+      regexSource += escapeRegExp(tpl.slice(lastIndex, match.index));
+      regexSource += '([\\s\\S]*?)';
+      placeholderOrder.push(match[1]);
+      lastIndex = match.index + match[0].length;
+    }
+
+    regexSource += escapeRegExp(tpl.slice(lastIndex));
+    regexSource += '$';
+
+    let fullTemplateMatch: RegExpMatchArray | null;
+    try {
+      fullTemplateMatch = trimmedRawText.match(new RegExp(regexSource));
+    } catch {
+      // Regex too large or invalid — skip this command template
+      continue;
+    }
+    if (!fullTemplateMatch) continue;
+
+    let args: string | undefined;
+    const captures = fullTemplateMatch.slice(1).map((value) => value?.trim() ?? '');
+    const argumentsIndex = placeholderOrder.findIndex((name) => name.toUpperCase() === 'ARGUMENTS');
+    const bestCapture =
+      (argumentsIndex >= 0 ? captures[argumentsIndex] : undefined) ||
+      captures.find((value) => value.length > 0);
+    if (bestCapture && bestCapture.length < 200) {
+      args = bestCapture;
+    }
+
+    return { name: cmd.name, args };
+  }
+  return undefined;
+}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -2,6 +2,7 @@
 
 import { UnifiedMarkdown } from '@/components/markdown/unified-markdown';
 import { SandboxImage } from '@/features/session/sandbox-image';
+import { detectCommandFromText } from '@/features/session/detect-command';
 import { SessionApprovalPrompt } from '@/features/session/session-approval-prompt';
 import { isPendingAction, useSessionAudit } from '@/features/session/session-audit-shared';
 import { SessionPermissionPrompt } from '@/features/session/session-permission-prompt';
@@ -1226,115 +1227,6 @@ function NotificationTurn({ turn }: { turn: Turn }) {
 // ============================================================================
 // User Message Row
 // ============================================================================
-
-/**
- * Detect if user message text matches a known command template.
- * Returns the command name + extracted args, or undefined if no match.
- * Works by splitting each command template at its first placeholder ($1 or $ARGUMENTS)
- * and checking if the message text starts with that prefix.
- */
-function detectCommandFromText(
-  rawText: string,
-  commands?: Command[],
-): { name: string; args?: string } | undefined {
-  if (!commands || !rawText) return undefined;
-
-  const trimmedRawText = rawText.trim();
-  const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-  for (const cmd of commands) {
-    if (!cmd.template) continue;
-    const tpl = cmd.template.trim();
-
-    // For large templates (e.g. onboarding.md), skip regex entirely and do a
-    // fast exact-match: strip the trailing $ARGUMENTS placeholder and check
-    // if rawText matches the body. This handles commands whose template is the
-    // full file content (which opencode sends verbatim as the user message).
-    if (tpl.length > 2000) {
-      // Strip trailing $ARGUMENTS (with optional surrounding whitespace/newlines)
-      const tplBody = tpl.replace(/\s*\$ARGUMENTS\s*$/, '').trimEnd();
-      // Fast check: does rawText equal the template body exactly?
-      if (tplBody.length > 0 && trimmedRawText === tplBody) {
-        return { name: cmd.name, args: undefined };
-      }
-      // Also handle the case where $ARGUMENTS is at the end and the user
-      // provided some text after the template body.
-      if (tplBody.length > 0 && trimmedRawText.startsWith(tplBody)) {
-        const after = trimmedRawText.slice(tplBody.length).trim();
-        return {
-          name: cmd.name,
-          args: after.length > 0 && after.length < 200 ? after : undefined,
-        };
-      }
-      continue;
-    }
-
-    // Find the first placeholder position ($1, $2, ..., $ARGUMENTS)
-    const placeholderMatch = tpl.match(/\$(\d+|\bARGUMENTS\b)/);
-    // Use the text before the first placeholder as the prefix to match
-    const prefix = placeholderMatch
-      ? tpl.slice(0, placeholderMatch.index).trimEnd()
-      : tpl.trimEnd();
-
-    // Require a meaningful prefix (at least 20 chars) to avoid false positives
-    if (prefix.length < 20) continue;
-
-    if (trimmedRawText.startsWith(prefix)) {
-      // Extract the user's arguments: text after the template prefix (approximate)
-      // For templates ending with the placeholder, the args are what comes after the prefix
-      let args: string | undefined;
-      if (placeholderMatch) {
-        const afterPrefix = trimmedRawText.slice(prefix.length).trim();
-        // The args are at the end; try to extract the last meaningful section
-        const lastNewlineBlock = afterPrefix.split('\n\n').pop()?.trim();
-        if (lastNewlineBlock && lastNewlineBlock.length < 200) {
-          args = lastNewlineBlock;
-        }
-      }
-      return { name: cmd.name, args };
-    }
-
-    // Fallback: robust full-template match where placeholders are wildcards.
-    // This handles commands whose template begins with a placeholder.
-    const placeholderRegex = /\$(\d+|\bARGUMENTS\b)/g;
-    const placeholderOrder: string[] = [];
-    let regexSource = '^';
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-
-    while ((match = placeholderRegex.exec(tpl)) !== null) {
-      regexSource += escapeRegExp(tpl.slice(lastIndex, match.index));
-      regexSource += '([\\s\\S]*?)';
-      placeholderOrder.push(match[1]);
-      lastIndex = match.index + match[0].length;
-    }
-
-    regexSource += escapeRegExp(tpl.slice(lastIndex));
-    regexSource += '$';
-
-    let fullTemplateMatch: RegExpMatchArray | null;
-    try {
-      fullTemplateMatch = trimmedRawText.match(new RegExp(regexSource));
-    } catch {
-      // Regex too large or invalid — skip this command template
-      continue;
-    }
-    if (!fullTemplateMatch) continue;
-
-    let args: string | undefined;
-    const captures = fullTemplateMatch.slice(1).map((value) => value?.trim() ?? '');
-    const argumentsIndex = placeholderOrder.findIndex((name) => name.toUpperCase() === 'ARGUMENTS');
-    const bestCapture =
-      (argumentsIndex >= 0 ? captures[argumentsIndex] : undefined) ||
-      captures.find((value) => value.length > 0);
-    if (bestCapture && bestCapture.length < 200) {
-      args = bestCapture;
-    }
-
-    return { name: cmd.name, args };
-  }
-  return undefined;
-}
 
 function UserMessageRow({
   message,


### PR DESCRIPTION
## Root cause
A runtime command source violated the SDK type and supplied a truthy non-string template. Session rendering called template.trim unconditionally, producing Better Stack TypeError patterns 4efb3dc3, 9ca5739b, and 5de308bb.

## Fix
- extract command detection into a focused helper
- require template to be a string before trimming
- mirror the guard in mobile session rendering
- add null and non-string regressions

## Verification
- focused regression: 6 pass
- complete web session suite: 88 pass
- full web TypeScript check: pass after generated content types
- targeted web ESLint: pass
- git diff --check: pass