### PR TITLE
fix(web): drop expected billing-gate 402 from Sentry noise

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -59,6 +59,19 @@ if (SENTRY_DSN) {
       'Server URL not ready',
       'sandbox is still loading',
       'opencode not ready',
+      // Expected billing-gate HTTP 402 outcomes (insufficient credits / no
+      // account / subscription required — the exact strings emitted by
+      // `apps/api/src/billing/services/billing-gate.ts:assertBillingActive`).
+      // They are user-facing business states handled by a top-up toast / upgrade
+      // dialog (`error-handler.tsx`), but the SDK's `ApiError` can leak to
+      // Sentry through capture paths that bypass `handleApiError`'s 402 guard
+      // (route/system-fault boundaries, `<ClientErrorBoundary>`, and the Sentry
+      // SDK's own `onunhandledrejection`). Drop them at the SDK level too so an
+      // expected billing state never pages Better Stack. Real `ApiError`s keep
+      // reporting — only these exact strings are matched.
+      'Out of credits. Top up to continue.',
+      'No credit account found. Complete account setup first.',
+      'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
       // External Safari / WebView video probing noise
       'webkitPresentationMode',
       "null is not an object (evaluating 'document.querySelector('video').webkitPresentationMode')",

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -68,10 +68,10 @@ if (SENTRY_DSN) {
       // (route/system-fault boundaries, `<ClientErrorBoundary>`, and the Sentry
       // SDK's own `onunhandledrejection`). Drop them at the SDK level too so an
       // expected billing state never pages Better Stack. Real `ApiError`s keep
-      // reporting — only these exact strings are matched.
-      'Out of credits. Top up to continue.',
-      'No credit account found. Complete account setup first.',
-      'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
+      // reporting — these regexes are exact after optional canonical wrappers.
+      /^(?:Unhandled promise rejection: )?(?:ApiError: )?Out of credits\. Top up to continue\.$/,
+      /^(?:Unhandled promise rejection: )?(?:ApiError: )?No credit account found\. Complete account setup first\.$/,
+      /^(?:Unhandled promise rejection: )?(?:ApiError: )?Subscribe to activate your seat\. \$20\/teammate per month includes wallet credits for compute and LLM usage\.$/,
       // External Safari / WebView video probing noise
       'webkitPresentationMode',
       "null is not an object (evaluating 'document.querySelector('video').webkitPresentationMode')",

--- a/apps/web/src/app/sentry-ignore-errors.test.ts
+++ b/apps/web/src/app/sentry-ignore-errors.test.ts
@@ -22,3 +22,14 @@ test('sentry.client.config ignores the transient runtime-not-ready markers', asy
   // classifies runtime-not-ready via shouldIgnoreSentryNoiseEvent).
   expect(source).toContain('shouldIgnoreSentryNoiseEvent');
 });
+
+test('sentry.client.config anchors expected billing-gate 402 markers', async () => {
+  const source = await Bun.file(`${import.meta.dir}/../../sentry.client.config.ts`).text();
+  expect(source).toContain(
+    '/^(?:Unhandled promise rejection: )?(?:ApiError: )?Out of credits\\. Top up to continue\\.$/',
+  );
+  // Guard against reintroducing a bare string entry: Sentry treats string
+  // ignoreErrors values as contains-matches, which would hide longer real
+  // errors that merely mention the billing-gate phrase.
+  expect(source).not.toContain("'Out of credits. Top up to continue.'");
+});

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -454,3 +454,30 @@ test('does NOT suppress an unrelated message that merely mentions "credits"', ()
     false,
   )
 })
+
+test('does NOT suppress a longer real error containing the billing-gate phrase', () => {
+  for (const value of [
+    'Failed to retry run: Out of credits. Top up to continue.',
+    'Out of credits. Top up to continue. Database reconciliation failed',
+    'ApiError: Out of credits. Top up to continue. while starting sandbox',
+    'Unhandled promise rejection: Something else: Out of credits. Top up to continue.',
+  ]) {
+    assert.equal(
+      isExpectedBillingGateMessage(value),
+      false,
+      `expected longer message "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected longer Sentry event "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message: value }),
+      false,
+      `expected longer runtime error "${value}" to keep reporting`,
+    )
+  }
+})

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  isExpectedBillingGateMessage,
   isExtensionSource,
   isInjectedAppSource,
   isKnownBrowserNoiseMessage,
@@ -348,6 +349,107 @@ test('does NOT suppress a same-worded server exception without a browser frame',
   assert.equal(
     shouldIgnoreSentryBrowserNoise({
       exception: { values: [{ value: 'Failed to load image' }] },
+    }),
+    false,
+  )
+})
+
+// Reproduces Better Stack error 140195488...4f7255 (4 occurrences) + sibling
+// 50c1919a...0bf1cd (2 occurrences), Kortix Frontend (prod), application_id
+// 2346967: an `ApiError` with message "Out of credits. Top up to continue."
+// (the exact body the API billing gate emits for an `insufficient_credits`
+// HTTP 402 — apps/api/src/billing/services/billing-gate.ts:assertBillingActive).
+//
+// `apps/web/src/lib/error-handler.tsx:handleApiError` already routes a
+// structured 402 `insufficient_credits` to a top-up toast and intentionally
+// only reports 5xx/network/timeout to Sentry. But the SDK's `ApiError` can
+// reach Sentry through capture paths that bypass that guard —
+// `route-error`/`system-fault`/`app/error`/`<ClientErrorBoundary>`'s
+// unconditional `Sentry.captureException`, and the Sentry SDK's own
+// `onunhandledrejection` auto-capture. An expected, user-facing billing state
+// must never page Better Stack; drop it at the telemetry gate regardless of
+// which capture path delivered it. The exact messages are the only strings the
+// billing gate emits for a 402 — real `ApiError`s ("Internal server error",
+// "HTTP 500: …", etc.) keep reporting.
+const BILLING_GATE_EXPECTED_EVENTS = [
+  // The assigned error + sibling share this exact message.
+  'Out of credits. Top up to continue.',
+  // An unhandled-rejection wrapper preserving the message.
+  'Unhandled promise rejection: ApiError: Out of credits. Top up to continue.',
+  // The other two billing-gate 402 reasons — same expected business state,
+  // same leak paths, same fix (prevents the next noise pattern).
+  'No credit account found. Complete account setup first.',
+  'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
+]
+
+test('classifies every billing-gate 402 message as an expected business state', () => {
+  for (const message of BILLING_GATE_EXPECTED_EVENTS) {
+    assert.equal(
+      isExpectedBillingGateMessage(message),
+      true,
+      `expected ${message} to be classified as an expected billing-gate message`,
+    )
+  }
+})
+
+test('suppresses a billing-gate 402 Sentry event regardless of capture path', () => {
+  for (const value of BILLING_GATE_EXPECTED_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://app.kortix.com/projects/p/sessions/s' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [{ filename: 'app:///_next/static/chunks/sdk.js' }],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a billing-gate 402 unhandled rejection from the browser', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Unhandled promise rejection: Out of credits. Top up to continue.',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a real ApiError / internal server error', () => {
+  for (const value of [
+    'Internal server error',
+    'HTTP 500: Internal Server Error',
+    'TypeError: Cannot read properties of undefined (reading id)',
+  ]) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message: value }),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress an unrelated message that merely mentions "credits"', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [{ value: 'Failed to deduct credits for the run' }],
+      },
     }),
     false,
   )

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -61,7 +61,8 @@ const RUNTIME_NOT_READY_NOISE_PATTERNS = [
 // Sentry SDK's own `onunhandledrejection`), so the exact billing-gate strings
 // are dropped here at the telemetry gate regardless of which path delivered
 // them. Real `ApiError`s ("Internal server error", "HTTP 500: …", …) keep
-// reporting — these exact strings are the only messages the billing gate emits.
+// reporting — only exact matches for these messages (plus the explicit
+// canonical wrappers below) are suppressed.
 const BILLING_GATE_EXPECTED_MESSAGES = [
   // `insufficient_credits` — wallet ran dry on an active plan.
   'Out of credits. Top up to continue.',
@@ -157,14 +158,17 @@ export function isRuntimeNotReadyNoiseMessage(message: unknown): boolean {
  * states already handled by a top-up toast or upgrade dialog in
  * `error-handler.tsx`; they must NEVER page Better Stack, but the SDK's
  * `ApiError` can leak to Sentry through capture paths that bypass
- * `handleApiError`'s 402 guard. Match is anchored on the exact strings the
- * billing gate emits, so a real `ApiError` ("Internal server error", …) is
- * never matched.
+ * `handleApiError`'s 402 guard. Match is exact after trimming, with only the
+ * canonical browser/Sentry wrappers we explicitly support, so a longer real
+ * `ApiError` that merely contains the billing phrase is never matched.
  */
 export function isExpectedBillingGateMessage(message: unknown): boolean {
-  const normalized = normalizeString(message);
-  return BILLING_GATE_EXPECTED_MESSAGES.some((expected) =>
-    normalized.includes(expected),
+  const normalized = normalizeString(message).trim();
+  return BILLING_GATE_EXPECTED_MESSAGES.some(
+    (expected) => normalized === expected
+      || normalized === `ApiError: ${expected}`
+      || normalized === `Unhandled promise rejection: ${expected}`
+      || normalized === `Unhandled promise rejection: ApiError: ${expected}`,
   );
 }
 

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -48,6 +48,29 @@ const RUNTIME_NOT_READY_NOISE_PATTERNS = [
   'opencode not ready',
 ] as const;
 
+// Expected billing-gate HTTP 402 messages. The API billing gate
+// (`apps/api/src/billing/services/billing-gate.ts:assertBillingActive`) throws
+// a 402 carrying one of these exact strings in the response body
+// (`{ error: <message>, code, balance, account_id }`); the SDK surfaces them as
+// an `ApiError` (message === the body's `error` field). They are EXPECTED,
+// user-facing business states — `apps/web/src/lib/error-handler.tsx:handleApiError`
+// already routes a structured 402 to a top-up toast / upgrade dialog and
+// intentionally only reports 5xx/network/timeout to Sentry. But the `ApiError`
+// can leak through capture paths that bypass that guard
+// (`route-error`/`system-fault`/`app/error`/`<ClientErrorBoundary>` and the
+// Sentry SDK's own `onunhandledrejection`), so the exact billing-gate strings
+// are dropped here at the telemetry gate regardless of which path delivered
+// them. Real `ApiError`s ("Internal server error", "HTTP 500: …", …) keep
+// reporting — these exact strings are the only messages the billing gate emits.
+const BILLING_GATE_EXPECTED_MESSAGES = [
+  // `insufficient_credits` — wallet ran dry on an active plan.
+  'Out of credits. Top up to continue.',
+  // `no_account` — no credit account found.
+  'No credit account found. Complete account setup first.',
+  // `subscription_required` — per-seat account with no active subscription.
+  'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
+] as const;
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -128,6 +151,23 @@ export function isRuntimeNotReadyNoiseMessage(message: unknown): boolean {
   );
 }
 
+/**
+ * Whether a message is an EXPECTED billing-gate HTTP 402 outcome (insufficient
+ * credits / no account / subscription required). These are user-facing business
+ * states already handled by a top-up toast or upgrade dialog in
+ * `error-handler.tsx`; they must NEVER page Better Stack, but the SDK's
+ * `ApiError` can leak to Sentry through capture paths that bypass
+ * `handleApiError`'s 402 guard. Match is anchored on the exact strings the
+ * billing gate emits, so a real `ApiError` ("Internal server error", …) is
+ * never matched.
+ */
+export function isExpectedBillingGateMessage(message: unknown): boolean {
+  const normalized = normalizeString(message);
+  return BILLING_GATE_EXPECTED_MESSAGES.some((expected) =>
+    normalized.includes(expected),
+  );
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -154,6 +194,14 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   }
 
   if (isRuntimeNotReadyNoiseMessage(message)) {
+    return true;
+  }
+
+  // Expected billing-gate 402 outcomes are user-facing business states handled
+  // by a toast/upgrade dialog — never page Better Stack for them, even when the
+  // SDK's `ApiError` reaches window.onerror / unhandledrejection before
+  // `handleApiError` can gate it.
+  if (isExpectedBillingGateMessage(message)) {
     return true;
   }
 
@@ -201,6 +249,18 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // switch/provisioning window, self-heals in ~1s, never an error. Drop it
   // before it pages Better Stack, no matter which capture path delivered it.
   if (isRuntimeNotReadyNoiseMessage(message)) {
+    return true;
+  }
+
+  // Expected billing-gate 402 outcomes (insufficient credits / no account /
+  // subscription required) are user-facing business states handled by a toast
+  // or upgrade dialog. The SDK's `ApiError` can leak to Sentry through capture
+  // paths that bypass `handleApiError`'s 402 guard (route/system-fault
+  // boundaries, `<ClientErrorBoundary>`, and the Sentry SDK's own
+  // `onunhandledrejection`); drop them here so an expected billing state never
+  // pages Better Stack. Real `ApiError`s are never matched — only the exact
+  // strings the billing gate emits are.
+  if (isExpectedBillingGateMessage(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause (one line)

The API billing gate's expected HTTP 402 (`"Out of credits. Top up to continue."`) was leaking into Better Stack as an `ApiError` because the SDK's `ApiError` reaches Sentry through capture paths that bypass `error-handler.tsx`'s intentional 402 guard.

## Better Stack error

- **Error:** `140195488b0eb14c96090586946052b4f6ccaec6d74b21130d7800b33c4f7255`
- **URL:** https://errors.betterstack.com/team/t502678/errors/140195488b0eb14c96090586946052b4f6ccaec6d74b21130d7800b33c4f7255?s=2346967
- **App:** Kortix Frontend (prod), application_id `2346967`
- **Type/message:** `ApiError` — "Out of credits. Top up to continue." — count 4, users 0, last seen 2026-07-12 03:57:03 UTC, env prod
- **Sibling (same message, same root cause):** `50c1919af7d226222f81daf668dc8edb2a10e397264b9523ca5780ebfc0bf1cd` — count 2, last 2026-07-09 18:28:04 UTC

## Evidence

**API source** — `apps/api/src/billing/services/billing-gate.ts:68` emits the exact message for the `insufficient_credits` reason, and `assertBillingActive` (line 72) throws it as an `HTTPException(402)` with body `{ error: <message>, code, balance, account_id }`:

```ts
// billing-gate.ts:64-69
return {
  ok: false,
  reason: "insufficient_credits",
  balance,
  message: "Out of credits. Top up to continue.",
};
```

**SDK surfacing** — `packages/sdk/src/core/http/api-client.ts:139-159` reads the 402 body's `error` field into an `ApiError` whose `message === "Out of credits. Top up to continue."` and `name === 'ApiError'` (`packages/sdk/src/core/http/api/errors.ts:46-71`).

**Frontend handler already does the right thing — but only on its own path.** `apps/web/src/lib/error-handler.tsx:handleApiError`:
- line 167 — only reports `status >= 500 || code === 'TIMEOUT' || code === 'NETWORK_ERROR'` to Sentry; a 402 is intentionally **not** reported.
- lines 224-245 — routes a structured 402 `insufficient_credits` to a top-up warning toast and `return`s.

**The leak:** the SDK's `ApiError` can reach Sentry through capture paths that bypass `handleApiError`'s 402 guard. Several boundaries capture unconditionally (or only guard the unrelated runtime-not-ready noise):
- `apps/web/src/components/common/route-error.tsx:33` — `Sentry.captureException(error)` (guards only `isRuntimeNotReadyNoiseMessage`)
- `apps/web/src/components/common/system-fault.tsx:56-59` — `Sentry.captureException(error, …)`
- `apps/web/src/app/error.tsx:62` — `Sentry.captureException(error)`
- `apps/web/src/components/common/error-boundary.tsx:72` — `Sentry.captureException(error, …)`
- the Sentry SDK's own `onunhandledrejection` auto-capture (when a call site's promise rejects with the `ApiError` without routing through `handleApiError`)

So an **expected, user-facing billing state** (the wallet ran dry) was paging Better Stack — pure telemetry noise, not a product defect.

## Fix

Suppress the billing gate's exact expected 402 messages at the telemetry gate, following the established `RuntimeNotReadyError` noise pattern (#4516). Match is anchored on the exact strings emitted by `billing-gate.ts:assertBillingActive`, so **real `ApiError`s keep reporting** ("Internal server error", "HTTP 500: …", etc. are never matched).

1. **`apps/web/src/lib/browser-error-noise.ts`** — new `isExpectedBillingGateMessage()` helper + `BILLING_GATE_EXPECTED_MESSAGES` constant (the three exact 402 strings: `insufficient_credits` / `no_account` / `subscription_required`), wired into:
   - `shouldIgnoreBrowserRuntimeNoise` — covers `window.onerror`, `onunhandledrejection` (`BrowserNoiseGuard`), and `system-fault`'s capture guard.
   - `shouldIgnoreSentryBrowserNoise` — covers `beforeSend` in all three Sentry configs (client/server/edge), so it drops regardless of which capture path delivered the event.
2. **`apps/web/sentry.client.config.ts`** — add the same three exact strings to `ignoreErrors` (frame-less auto-captured events), mirroring the runtime-not-ready precedent.

Including the `no_account` / `subscription_required` siblings prevents the next identical noise pattern (same root cause, same leak paths) without suppressing any real error.

## Regression tests

`apps/web/src/lib/browser-error-noise.test.mts` — 5 new tests (26 total, all pass):
- `classifies every billing-gate 402 message as an expected business state`
- `suppresses a billing-gate 402 Sentry event regardless of capture path`
- `suppresses a billing-gate 402 unhandled rejection from the browser`
- `does NOT suppress a real ApiError / internal server error`
- `does NOT suppress an unrelated message that merely mentions "credits"`

## Verification

```sh
cd apps/web
node --experimental-strip-types --test src/lib/browser-error-noise.test.mts
# => 26 pass / 0 fail

# scoped tsc --noEmit on the changed source files (against the workspace tsconfig.base.json)
# => exit 0 (browser-error-noise.ts + sentry.{client,server,edge}.config.ts)
```

- ✅ `node --test` suite: 26/26 green (5 new regression tests).
- ✅ Scoped `tsc --noEmit` on changed source files: exit 0.
- Note: the repo-wide `pnpm --filter ./apps/web build` (the CI `Frontend build` gate) could not be run end-to-end in this sandbox because the install pulls the mobile/expo workspace deps and exceeds the sandbox tmpfs. The changed files are type-clean against the project tsconfig and the unit suite is green; CI will run the full build.
- Biome formatting warnings exist but are pre-existing on `main` (the original files emit the same warnings) and biome is not part of the PR gate (`ci.yml`), so they are not a blocker.

## Confirmation after merge/promote

Once this reaches prod, the Better Stack error `140195488…` (and sibling `50c1919a…`) should drop to **zero new occurrences** — the exact `ApiError` "Out of credits. Top up to continue." message is dropped at the Sentry `beforeSend` / `ignoreErrors` / runtime-noise gate before it can page. Real 5xx `ApiError`s continue to report unchanged.