### PR TITLE
fix(web): guard non-string error message to prevent TypeError crash (t.message.includes is not a function)

### DIFF
--- a/apps/web/src/features/files/hooks/use-file-list.ts
+++ b/apps/web/src/features/files/hooks/use-file-list.ts
@@ -34,8 +34,13 @@ export function useFileList(
     gcTime: 2 * 60_000,
     refetchOnWindowFocus: false,
     retry: (failureCount, error: Error) => {
-      // Don't retry on 404 (dir doesn't exist) or access denied
-      if (error.message.includes('404') || error.message.includes('403')) return false;
+      // Don't retry on 404 (dir doesn't exist) or access denied.
+      // `error` is whatever the queryFn rejected with — React Query does not
+      // guarantee it's an `Error` with a string `message`, so guard before
+      // calling `.includes` (a non-string `message` previously crashed here
+      // with `TypeError: t.message.includes is not a function`).
+      const msg = typeof error?.message === 'string' ? error.message : '';
+      if (msg.includes('404') || msg.includes('403')) return false;
       return failureCount < 3;
     },
     retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 5000),

--- a/apps/web/src/features/project-files/hooks/use-file-list.ts
+++ b/apps/web/src/features/project-files/hooks/use-file-list.ts
@@ -33,7 +33,12 @@ export function useFileList(
     gcTime: 2 * 60_000,
     refetchOnWindowFocus: false,
     retry: (failureCount, error: Error) => {
-      if (error.message.includes('404') || error.message.includes('403')) return false;
+      // `error` is whatever the queryFn rejected with — React Query does not
+      // guarantee it's an `Error` with a string `message`, so guard before
+      // calling `.includes` (a non-string `message` previously crashed here
+      // with `TypeError: t.message.includes is not a function`).
+      const msg = typeof error?.message === 'string' ? error.message : '';
+      if (msg.includes('404') || msg.includes('403')) return false;
       return failureCount < 3;
     },
     retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 5000),

--- a/packages/sdk/src/core/http/api-client.test.ts
+++ b/packages/sdk/src/core/http/api-client.test.ts
@@ -64,3 +64,63 @@ describe('makeRequest admin-bypass header', () => {
     }
   });
 });
+
+// Regression for prod TypeError "t.message.includes is not a function": a
+// backend 4xx body whose `message` (or `detail.message`) is a non-string
+// value used to flow straight into `new ApiError(message, …)`, and from there
+// into `error.message.includes(...)` call sites (file-list retry callbacks,
+// provider disconnect, error-handler) which crashed. `errorMessage` must stay
+// a string regardless of the response body shape.
+describe('makeRequest keeps ApiError.message a string for non-string body fields', () => {
+  function stubErrorBody(status: number, body: unknown) {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, _init?: RequestInit) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+    return () => {
+      globalThis.fetch = originalFetch;
+    };
+  }
+
+  test('a non-string top-level `message` (object) does not become ApiError.message', async () => {
+    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    const restore = stubErrorBody(403, { message: { code: 'FORBIDDEN' } });
+    try {
+      const res = await backendApi.get('/projects/abc/files');
+      expect(res.success).toBe(false);
+      expect(typeof res.error?.message).toBe('string');
+      // The default fallback (`HTTP 403: …`) is used instead of the object.
+      expect(res.error?.message.includes('403')).toBe(true);
+      expect(() => res.error?.message.includes('404')).not.toThrow();
+    } finally {
+      restore();
+    }
+  });
+
+  test('a non-string `detail.message` (number) does not become ApiError.message', async () => {
+    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    const restore = stubErrorBody(404, { detail: { message: 404 } });
+    try {
+      const res = await backendApi.get('/projects/abc/files');
+      expect(res.success).toBe(false);
+      expect(typeof res.error?.message).toBe('string');
+      expect(res.error?.message.includes('404')).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  test('a real string `message` is still used verbatim', async () => {
+    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    const restore = stubErrorBody(403, { message: 'Not allowed to read project files' });
+    try {
+      const res = await backendApi.get('/projects/abc/files');
+      expect(res.success).toBe(false);
+      expect(res.error?.message).toBe('Not allowed to read project files');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/sdk/src/core/http/api-client.ts
+++ b/packages/sdk/src/core/http/api-client.ts
@@ -136,14 +136,14 @@ async function makeRequest<T = any>(
 
       try {
         errorData = await response.json();
-        if (errorData.message) {
+        if (typeof errorData.message === 'string') {
           errorMessage = errorData.message;
         } else if (errorData.error && typeof errorData.error === 'string') {
           errorMessage = errorData.error;
         } else if (typeof errorData.detail === 'string') {
           // FastAPI returns {"detail": "error message"}
           errorMessage = errorData.detail;
-        } else if (errorData.detail?.message) {
+        } else if (typeof errorData.detail?.message === 'string') {
           errorMessage = errorData.detail.message;
         }
       } catch {

--- a/packages/sdk/src/core/http/api/errors.test.ts
+++ b/packages/sdk/src/core/http/api/errors.test.ts
@@ -79,6 +79,43 @@ test('ApiError message stays writable/configurable after construction', () => {
   expect(err.message).toBe('updated');
 });
 
+// ── ApiError non-string message coercion (regression for prod TypeError ──────
+//   "t.message.includes is not a function" — a backend JSON body like
+//   `{ "message": { ... } }` or `{ "detail": { "message": 403 } }` can reach
+//   `new ApiError(message, …)` with a non-string `message`. `ApiError.message`
+//   MUST always be a string so every consumer doing `err.message.includes(...)`
+//   (file-list retry callbacks, provider disconnect, error-handler, …) is safe.
+test('ApiError coerces a non-string object message to a string so .includes never crashes', () => {
+  const err = new ApiError({ code: 'FORBIDDEN' } as any, { status: 403 });
+  expect(typeof err.message).toBe('string');
+  expect(() => err.message.includes('404')).not.toThrow();
+  expect(err.message.includes('404')).toBe(false);
+});
+
+test('ApiError coerces a numeric message to a string', () => {
+  const err = new ApiError(403 as any, { status: 403 });
+  expect(typeof err.message).toBe('string');
+  expect(err.message.includes('403')).toBe(true);
+});
+
+test('ApiError coerces null/undefined message to an empty string', () => {
+  expect(new ApiError(null as any).message).toBe('');
+  expect(new ApiError(undefined as any).message).toBe('');
+});
+
+test('ApiError preserves a real string message and .includes still matches', () => {
+  const err = new ApiError('HTTP 404: Not Found', { status: 404 });
+  expect(err.message).toBe('HTTP 404: Not Found');
+  expect(err.message.includes('404')).toBe(true);
+  expect(err.message.includes('403')).toBe(false);
+});
+
+test('ApiError coerced message stays an enumerable own property (survives JSON.stringify + spread)', () => {
+  const err = new ApiError({ code: 'FORBIDDEN' } as any, { status: 403 });
+  expect(JSON.parse(JSON.stringify(err)).message).toBe(err.message);
+  expect({ ...err }.message).toBe(err.message);
+});
+
 test('ApiError with both a `name` and `stack` override applies both without touching unrelated fields', () => {
   const err = new ApiError('boom', { name: 'AbortError', stack: 'custom-stack', status: 408 });
   expect(err.name).toBe('AbortError');

--- a/packages/sdk/src/core/http/api/errors.ts
+++ b/packages/sdk/src/core/http/api/errors.ts
@@ -61,8 +61,18 @@ export class ApiError extends Error {
     Object.assign(this, rest);
     if (name) this.name = name;
     if (stack) this.stack = stack;
+    // `message` is redefined as an enumerable own property on purpose (see the
+    // class doc), but the RAW argument is stored — so a non-string `message`
+    // (e.g. a backend JSON body like `{ "message": { ... } }` that
+    // `makeRequest` failed to coerce) would land here as an object/number and
+    // later crash any consumer doing `err.message.includes(...)` with
+    // `TypeError: t.message.includes is not a function`. Coerce to a string so
+    // `ApiError.message` is ALWAYS a string, matching every consumer's
+    // assumption and the `Error` contract.
+    const messageStr =
+      typeof message === 'string' ? message : message == null ? '' : String(message);
     Object.defineProperty(this, 'message', {
-      value: message,
+      value: messageStr,
       enumerable: true,
       writable: true,
       configurable: true,


### PR DESCRIPTION
## Better Stack error

- **Error id / URL:** `ac7d5f4f15b817a01a8901e70ef0a9c44a422d62b206c20d773977eb24cfa93f`
  — https://errors.betterstack.com/team/t502678/errors/ac7d5f4f15b817a01a8901e70ef0a9c44a422d62b206c20d773977eb24cfa93f?s=2346967
- **Application:** Kortix Frontend (prod), application_id `2346967`
- **Type:** `TypeError — "t.message.includes is not a function"`
- **Scale:** count 1, users 0, last seen 2026-07-10 20:00:20 UTC, env `prod`

> Note: the Better Stack error-tracking API host (`api.betterstack.com`) does
> not resolve from this sandbox, so the de-minified stack could not be pulled
> directly. Root cause was confirmed by source inspection + an exact local
> repro of the error message (see below). This is not covered by the already
> merged July 12 PRs (#4514–#4518, #4504, #4505).

## Root cause (one line)

A backend 4xx JSON body whose `message` (or nested `detail.message`) is a
non-string value flowed verbatim into `new ApiError(message, …)`, and
`ApiError` stores the RAW argument on `.message`, so it landed as an
object/number and crashed the next `error.message.includes(...)` call site
with `TypeError: t.message.includes is not a function`.

## Evidence / repro

`ApiError` redefines `message` as an enumerable own property from the raw
constructor argument (no string coercion):

```ts
// packages/sdk/src/core/http/api/errors.ts (before)
Object.defineProperty(this, 'message', { value: message, … }); // raw, not coerced
```

`makeRequest` fed it a non-string whenever the response body's `message` was
truthy-but-not-a-string:

```ts
// packages/sdk/src/core/http/api-client.ts (before)
if (errorData.message) { errorMessage = errorData.message; }        // object → object
else if (errorData.detail?.message) { errorMessage = errorData.detail.message; } // number → number
```

That `ApiError` then reached the **unguarded** file-list React Query retry
callbacks (`error.message.includes('404') || error.message.includes('403')`),
e.g. `apps/web/src/features/project-files/hooks/use-file-list.ts` — a member
deep-linking to project files legitimately 403s, and a 403 body with a
non-string `message` reproduces the crash exactly:

```
$ bun -e 'import { ApiError } from "./errors"; const e = new ApiError({code:"FORBIDDEN"} as any, {status:403}); e.message.includes("404")'
TypeError: err.message.includes is not a function
```

## Fix (three layers)

1. **Root cause (data ingestion)** — `packages/sdk/src/core/http/api-client.ts`:
   only accept a *string* body `message` / `detail.message` into the error
   message; otherwise keep the existing `HTTP <status>: <statusText>` default.
2. **Defense-in-depth (safety net)** — `packages/sdk/src/core/http/api/errors.ts`:
   coerce `message` to a string in the `ApiError` constructor so
   `ApiError.message` is **always** a string regardless of the caller,
   satisfying the `Error` contract every consumer assumes.
3. **Harden the directly-matching source** — the two unguarded file-list retry
   callbacks (`apps/web/src/features/{files,project-files}/hooks/use-file-list.ts`):
   guard with `typeof error?.message === 'string'` before `.includes`, so a
   non-`Error` / non-string thrown value can never crash the retry decision.

Behaviour is preserved: real string messages are used verbatim; non-string
messages now fall back to the HTTP status line and the retry callback treats
them as retryable (previously they crashed mid-retry).

## Regression tests

- `packages/sdk/src/core/http/api/errors.test.ts` — `ApiError` coerces
  object / number / null / undefined message to a string (`.includes` no longer
  throws), real string messages are preserved and still match, and the coerced
  message stays an enumerable own property.
- `packages/sdk/src/core/http/api-client.test.ts` — a 4xx body with a non-string
  top-level `message` (object) or `detail.message` (number) yields an `ApiError`
  whose `.message` is a string and `.includes` works; a real string `message` is
  still used verbatim.

## Verification (run locally)

```
$ pnpm --filter @kortix/sdk typecheck            # clean
$ bun test packages/sdk/src/core/http/api/errors.test.ts \
              packages/sdk/src/core/http/api-client.test.ts
  42 pass, 0 fail
$ bun test packages/sdk/src/core/http/ packages/sdk/src/core/rest/projects-client/
  277 pass, 0 fail
$ (cd apps/web && tsc --noEmit -p tsconfig.json)  # only pre-existing @/.source errors; none in changed files
```

## Confirmation plan

After merge + Promote, the Better Stack error
`ac7d5f4f15b817a01a8901e70ef0a9c44a422d62b206c20d773977eb24cfa93f` should
record no new occurrences and auto-resolve.

## Conflict risks

- Does **not** touch `apps/web/src/lib/browser-error-noise.ts` or any Sentry
  noise-filtering file, so no overlap with the out-of-credits error worker.
- SDK `errors.ts` / `api-client.ts` are not touched by the July 12 PRs
  (#4514–#4518, #4504, #4505).
