### PR TITLE
fix(api): stop Sentry-capturing the expected request-deadline 503 (BS 29af03…)

### DIFF
--- a/apps/api/src/__tests__/unit-request-deadline.test.ts
+++ b/apps/api/src/__tests__/unit-request-deadline.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it, beforeAll } from 'bun:test';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-
 // DEADLINE_MS is read from env at module load, and static imports are hoisted
 // above top-level code — so we must set the env var and then *dynamically*
 // import the middleware, otherwise it captures the default 28s budget.
 let requestDeadline: typeof import('../middleware/request-deadline').requestDeadline;
+let isRequestDeadlineHTTPException: typeof import('../middleware/request-deadline').isRequestDeadlineHTTPException;
+let RequestDeadlineHTTPException: typeof import('../middleware/request-deadline').RequestDeadlineHTTPException;
 
 beforeAll(async () => {
   process.env.REQUEST_DEADLINE_MS = '50';
-  ({ requestDeadline } = await import('../middleware/request-deadline'));
+  const mod = await import('../middleware/request-deadline');
+  requestDeadline = mod.requestDeadline;
+  isRequestDeadlineHTTPException = mod.isRequestDeadlineHTTPException;
+  RequestDeadlineHTTPException = mod.RequestDeadlineHTTPException;
 });
 
 function makeApp() {
@@ -96,5 +100,54 @@ describe('requestDeadline', () => {
     expect(post.status).toBe(200);
     const get = await makeApp().request('/v1/projects');
     expect(get.status).toBe(503);
+  });
+});
+
+describe('requestDeadline Sentry classification', () => {
+  // Regression for Better Stack pattern 29af03… "Request exceeded the 25s
+  // server processing deadline": the deadline 503 must be identifiable so the
+  // global onError can skip captureException (it's an expected, retryable
+  // degradation, not a crash) while still surfacing as a 503 response.
+  it('throws a RequestDeadlineHTTPException (identifiable, not a bare HTTPException)', async () => {
+    const app = makeApp();
+    const res = await app.request('/v1/projects/x/change-requests');
+    expect(res.status).toBe(503);
+    // The handler in makeApp returns the raw HTTPException; pull it out via a
+    // spy that captures the thrown error before it is serialized.
+    let thrown: unknown;
+    const app2 = new Hono();
+    app2.use('/v1/*', (c, next) => requestDeadline(c, next));
+    app2.get('/v1/projects/x/change-requests', async (c) => {
+      await new Promise((r) => setTimeout(r, 500));
+      return c.json({ ok: true });
+    });
+    app2.onError((err, c) => {
+      thrown = err;
+      if (err instanceof HTTPException) return c.json({ error: err.message }, err.status);
+      return c.json({ error: String(err) }, 500);
+    });
+    await app2.request('/v1/projects/x/change-requests');
+    expect(isRequestDeadlineHTTPException(thrown)).toBe(true);
+    expect(thrown).toBeInstanceOf(RequestDeadlineHTTPException);
+    expect(thrown).toBeInstanceOf(HTTPException);
+    expect((thrown as HTTPException).status).toBe(503);
+  });
+
+  it('isRequestDeadlineHTTPException is false for an unrelated 503 HTTPException', () => {
+    const other = new HTTPException(503, { message: 'sandbox waking up' });
+    expect(isRequestDeadlineHTTPException(other)).toBe(false);
+  });
+
+  it('isRequestDeadlineHTTPException is false for non-errors', () => {
+    expect(isRequestDeadlineHTTPException(null)).toBe(false);
+    expect(isRequestDeadlineHTTPException(undefined)).toBe(false);
+    expect(isRequestDeadlineHTTPException(new Error('boom'))).toBe(false);
+  });
+
+  it('the deadline message reflects the configured budget', () => {
+    const err = new RequestDeadlineHTTPException();
+    // REQUEST_DEADLINE_MS=50 → Math.round(50/1000) = 0s; just assert shape + 503.
+    expect(err.status).toBe(503);
+    expect(err.message).toContain('server processing deadline');
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,7 +32,7 @@ import { platformApp } from './platform';
 import { sandboxProxyApp } from './sandbox-proxy';
 import { setupApp } from './setup';
 import { supabaseAuth, combinedAuth } from './middleware/auth';
-import { requestDeadline } from './middleware/request-deadline';
+import { requestDeadline, isRequestDeadlineHTTPException } from './middleware/request-deadline';
 // Statically imported (NOT await import() in the handlers): on a long-running
 // `bun --hot` dev process, dynamic import() can wedge permanently after enough
 // hot reloads — the promise never settles, the handler hangs, and Bun's
@@ -738,8 +738,14 @@ app.onError((err, c) => {
   }
 
   if (err instanceof HTTPException) {
-    // Only capture 5xx HTTP exceptions to Sentry (4xx are expected)
-    if (err.status >= 500) {
+    // Only capture 5xx HTTP exceptions to Sentry (4xx are expected). The
+    // request-deadline 503 is an EXPECTED, typed, retryable degradation (the
+    // deadline net bounding a slow request) — already logged + metriced
+    // per-route and returned with Retry-After. Capturing it to Sentry produced
+    // the recurring Better Stack pattern `29af03…` "Request exceeded the 25s
+    // server processing deadline" (the system working as designed), so classify
+    // it out. See middleware/request-deadline.ts.
+    if (err.status >= 500 && !isRequestDeadlineHTTPException(err)) {
       captureException(err, { method, path, status: err.status });
     }
     appLogger.error(`${method} ${path} -> ${err.status} [HTTPException]`, {

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -124,13 +124,34 @@ export function isExempt(c: Context): boolean {
 }
 
 // Built once — duration is constant for the process lifetime.
-const bounded = timeout(
-  Math.max(DEADLINE_MS, 1),
-  () =>
-    new HTTPException(503, {
+const bounded = timeout(Math.max(DEADLINE_MS, 1), () => new RequestDeadlineHTTPException());
+
+/**
+ * Dedicated HTTPException subclass for the request-deadline 503.
+ *
+ * The deadline 503 is an *expected, typed, retryable* degradation — the net is
+ * doing its job (bounding a slow downstream / pool-saturated request) and the
+ * global onError adds `Retry-After: 10`. It is already recorded per-route in
+ * metrics and as a structured warn log, so reporting it to Sentry/Better Stack
+ * as an error is pure noise (it was the Better Stack pattern
+ * `29af03…` "Request exceeded the 25s server processing deadline"). The global
+ * Sentry `ignoreErrors: ['HTTPException']` filter does NOT catch it because the
+ * exception *message* is the deadline string, not the literal "HTTPException".
+ *
+ * Exposing a typed guard lets `onError` classify it out of `captureException`
+ * without brittle string-matching, while keeping the 503 response + log intact.
+ */
+export class RequestDeadlineHTTPException extends HTTPException {
+  constructor() {
+    super(503, {
       message: `Request exceeded the ${Math.round(DEADLINE_MS / 1000)}s server processing deadline`,
-    }),
-);
+    });
+  }
+}
+
+export function isRequestDeadlineHTTPException(err: unknown): boolean {
+  return err instanceof RequestDeadlineHTTPException;
+}
 
 export async function requestDeadline(c: Context, next: Next): Promise<void | Response> {
   if (!ENABLED || isExempt(c)) {


### PR DESCRIPTION
## Root cause (one line)

The prod Better Stack pattern `29af03ddb5b62244abffb6b781a70d493f690d90d5a99acb7f6d777fe905b2b9` — *"Request exceeded the 25s server processing deadline..."* — is the **request-deadline 503** being Sentry-captured as an error, even though it is an **expected, typed, retryable** degradation the system returns by design.

## Evidence

- **Better Stack error:** https://errors.betterstack.com/team/t502678/errors/29af03ddb5b62244abffb6b781a70d493f690d90d5a99acb7f6d777fe905b2b9?s=2346961
  - application_id=**2346961** (Kortix API prod), env=prod, count=4, users=1, last seen 2026-07-11 14:10:06 UTC.
- **Source of the message (exactly one site in the repo):** `apps/api/src/middleware/request-deadline.ts:147`
  ```ts
  new HTTPException(503, { message: `Request exceeded the ${Math.round(DEADLINE_MS / 1000)}s server processing deadline` })
  ```
  `grep -rn "server processing deadline"` → only this file. `DEADLINE_MS` defaults to `25_000` (env `REQUEST_DEADLINE_MS`).
- **Why it reaches Better Stack:** `apps/api/src/index.ts` `app.onError` does `if (err.status >= 500) captureException(err, …)` for every `HTTPException`. The Sentry `ignoreErrors: ['HTTPException']` list (`apps/api/src/lib/sentry.ts`) does **not** catch it — that filter matches on exception *message/type*, and this exception's message is the deadline string, not the literal `"HTTPException"`. So the 503 slips through to Better Stack Errors as pattern `29af03…`.
- **It is a controlled response, not a crash:** `onError` adds `Retry-After: 10` for 503s and returns `{error, message, status:503}`. The deadline net is defense-in-depth (see the module docstring) bounding slow downstream / pool-saturated requests; the prior broad June saturation (618 occurrences) has subsided to residual 4.
- **Already observable elsewhere:** the 503 is recorded per-route in metrics (`recordHttpRequest` in the entry middleware) and as a structured `warn` log (`Request completed: … 503 …`), so ops still see the signal — just not as a Sentry error.

## What the fix does (telemetry classification — no runtime behavior change)

- Introduces a typed `RequestDeadlineHTTPException extends HTTPException` + `isRequestDeadlineHTTPException(err)` guard in `middleware/request-deadline.ts` (replaces the anonymous factory).
- In `app.onError`, skips `captureException` when `isRequestDeadlineHTTPException(err)` — the 503 response, `Retry-After`, structured log, and per-route metric are all unchanged.

This is the "telemetry classification" mitigation from the playbook: the deadline 503 is the system working as designed, not a bug to investigate. Route-agnostic and safe — no exemption list or timeout budget is touched.

## Relation to frontend timeout mirrors

The June 21 ledger noted frontend timeout `ApiError` mirrors on `/accounts`, `/projects`, `sandbox-health`, `change-requests` cluster with this API pattern. Those mirrors are frontend-side `fetch` timeouts/aborts that fire when an API request exceeds the client's own deadline. With this change the API returns a clean, fast 503 (well under the client's 30s abort) instead of hanging, and stops emitting the Sentry event — so the API-side pattern drops to zero. The frontend mirrors are expected to continue resolving as the prior `#3531/#3537/#3538` fixes finish promoting (a frontend-side noise classification, not chased here).

## Tests

Added to `apps/api/src/__tests__/unit-request-deadline.test.ts` (Sentry-classification regression block):
- the middleware throws an identifiable `RequestDeadlineHTTPException` (instanceof both the subclass and `HTTPException`, status 503);
- `isRequestDeadlineHTTPException` is `false` for an unrelated 503 `HTTPException` and for non-errors;
- the deadline message reflects the configured budget.

## Verification

```
$ bun test apps/api/src/__tests__/unit-request-deadline.test.ts apps/api/src/middleware/request-deadline.test.ts
24 pass, 0 fail, 33 expect() calls
$ (cd apps/api && node node_modules/typescript/bin/tsc --noEmit)   # exit 0, clean
```

## Confirmation after merge/promote

The Better Stack error `29af03…` should drop to **zero new occurrences** once this reaches prod (the 503 is no longer `captureException`'d). The underlying signal remains visible in the per-route `http_request_duration_seconds` metric (status=503) and the structured `Request completed: … 503 …` warn log.
