### PR TITLE
fix(web): show deterministic session switching state

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -27,6 +27,10 @@ import { finishSessionTiming, sessionMark } from '@/lib/session-timing';
 import { cn } from '@/lib/utils';
 import { useSandboxConnectionStore } from '@kortix/sdk/sandbox-connection-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
+import {
+  shouldShowSessionSwitchLoading,
+  useSessionSwitchStore,
+} from '@/stores/session-switch-store';
 import { clearSessionFresh, isSessionFresh } from '@kortix/sdk/fresh-sessions';
 import { setActiveInstanceCookie } from '@kortix/sdk/instance-routes';
 import { formatOpenCodeRuntimeError } from '@kortix/sdk/opencode-errors';
@@ -94,6 +98,8 @@ export default function ProjectSessionPage() {
   });
   const sandbox = session.sandbox;
   const startStage = session.stage ?? 'provisioning';
+  const switchingToSessionId = useSessionSwitchStore((state) => state.targetSessionId);
+  const completeSessionSwitch = useSessionSwitchStore((state) => state.completeSwitch);
 
   // ── Auto-resume a hibernated-but-resumable sandbox ────────────────────────
   // On the first /start of an idle-stopped session the backend can race into a
@@ -195,6 +201,25 @@ export default function ProjectSessionPage() {
     !!user &&
     !!sandbox &&
     (sandbox.status === 'error' || sandbox.status === 'stopped');
+  const sessionSwitchLoading = shouldShowSessionSwitchLoading(
+    switchingToSessionId,
+    sessionId,
+    session.switched,
+  );
+  useEffect(() => {
+    if (switchingToSessionId !== sessionId) return;
+    if (session.switched || session.startError || fatal || gated) {
+      completeSessionSwitch(sessionId);
+    }
+  }, [
+    switchingToSessionId,
+    sessionId,
+    session.switched,
+    session.startError,
+    fatal,
+    gated,
+    completeSessionSwitch,
+  ]);
   // The chat subtree mounts once useSession reports the runtime is switched in.
   const canMountChat = session.switched;
   // For a fresh session, hold the real chat until the user actually sends their
@@ -203,6 +228,16 @@ export default function ProjectSessionPage() {
 
   const sandboxLabel = sandbox ? `session ${sandbox.sandbox_id.slice(0, 8)}` : undefined;
   const inner = (() => {
+    if (sessionSwitchLoading) {
+      return (
+        <SessionStartingLoader
+          stage={switchingToSessionId === sessionId ? startStage : 'starting'}
+          projectId={projectId}
+          sessionId={switchingToSessionId ?? sessionId}
+        />
+      );
+    }
+
     if (gated) {
       return (
         <InlineSessionError

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -42,6 +42,10 @@ import {
   type ProjectSessionStatus,
 } from '@kortix/sdk/projects-client';
 import { cn } from '@/lib/utils';
+import {
+  shouldBeginSessionSwitch,
+  useSessionSwitchStore,
+} from '@/stores/session-switch-store';
 import { Icon as IconMynauiType, Pencil, Share, TrashSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNowStrict } from 'date-fns';
@@ -103,6 +107,9 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const activeOpenCodeSessionId = searchParams.get('oc');
+  const activeSessionId = pathname?.match(/\/sessions\/([^/?]+)/)?.[1] ?? null;
+  const switchingToSessionId = useSessionSwitchStore((state) => state.targetSessionId);
+  const beginSessionSwitch = useSessionSwitchStore((state) => state.beginSwitch);
   const queryClient = useQueryClient();
   const [sessionToDelete, setSessionToDelete] = useState<{ id: string; label: string } | null>(
     null,
@@ -209,13 +216,29 @@ export function ProjectSessionList({ projectId, filter = 'all' }: ProjectSession
         {visibleSessions.map((session) => {
           const href = `/projects/${session.project_id}/sessions/${session.session_id}`;
           const isActive = pathname?.includes(`/sessions/${session.session_id}`);
+          const isSwitchTarget = switchingToSessionId === session.session_id;
           const children = directSubsessions(session);
           return (
             <div key={session.session_id} className="space-y-px">
               <ProjectSessionRow
                 session={session}
                 href={href}
-                isActive={!!isActive && !activeOpenCodeSessionId}
+                isActive={
+                  (!!isActive && !activeOpenCodeSessionId && !switchingToSessionId) ||
+                  isSwitchTarget
+                }
+                isSwitching={isSwitchTarget}
+                onNavigate={(event) => {
+                  if (
+                    shouldBeginSessionSwitch(
+                      event,
+                      session.session_id,
+                      activeSessionId,
+                    )
+                  ) {
+                    beginSessionSwitch(session.session_id);
+                  }
+                }}
                 displayTitle={getSessionDisplayTitle(session)}
                 childCount={children.length}
                 reviewCount={reviewSummary.needsYouBySession[session.session_id] ?? 0}
@@ -285,6 +308,8 @@ interface ProjectSessionRowProps {
   session: ProjectSession;
   href: string;
   isActive: boolean;
+  isSwitching: boolean;
+  onNavigate: (event: React.MouseEvent<HTMLAnchorElement>) => void;
   displayTitle: string;
   onDelete: (sessionId: string, label: string) => void;
   onShare: (session: ProjectSession) => void;
@@ -302,6 +327,8 @@ function ProjectSessionRow({
   session,
   href,
   isActive,
+  isSwitching,
+  onNavigate,
   displayTitle,
   onDelete,
   onShare,
@@ -342,8 +369,17 @@ function ProjectSessionRow({
             : 'text-muted-foreground hover:text-sidebar-foreground',
         )}
       >
-        <Link href={href} className="flex min-w-0 flex-1 items-center gap-2 self-stretch">
-          <SessionStatusDot status={session.status} reviewCount={reviewCount} />
+        <Link
+          href={href}
+          onClick={onNavigate}
+          aria-busy={isSwitching || undefined}
+          className="flex min-w-0 flex-1 items-center gap-2 self-stretch"
+        >
+          {isSwitching ? (
+            <Loading className="text-kortix-green size-3 shrink-0" />
+          ) : (
+            <SessionStatusDot status={session.status} reviewCount={reviewCount} />
+          )}
 
           <span
             title={displayTitle}

--- a/apps/web/src/stores/session-switch-store.test.ts
+++ b/apps/web/src/stores/session-switch-store.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  shouldBeginSessionSwitch,
+  shouldShowSessionSwitchLoading,
+  useSessionSwitchStore,
+} from './session-switch-store';
+
+describe('shouldBeginSessionSwitch', () => {
+  test('starts a switch for an unmodified primary click on another session', () => {
+    expect(
+      shouldBeginSessionSwitch(
+        { button: 0, metaKey: false, ctrlKey: false, shiftKey: false, altKey: false },
+        'session-b',
+        'session-a',
+      ),
+    ).toBe(true);
+  });
+
+  test('does not hijack same-session, modified, or middle-button navigation', () => {
+    expect(
+      shouldBeginSessionSwitch(
+        { button: 0, metaKey: false, ctrlKey: false, shiftKey: false, altKey: false },
+        'session-a',
+        'session-a',
+      ),
+    ).toBe(false);
+    expect(
+      shouldBeginSessionSwitch(
+        { button: 0, metaKey: true, ctrlKey: false, shiftKey: false, altKey: false },
+        'session-b',
+        'session-a',
+      ),
+    ).toBe(false);
+    expect(
+      shouldBeginSessionSwitch(
+        { button: 1, metaKey: false, ctrlKey: false, shiftKey: false, altKey: false },
+        'session-b',
+        'session-a',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('session switch state', () => {
+  beforeEach(() => useSessionSwitchStore.setState({ targetSessionId: null }));
+
+  test('keeps the newest target when an older rapid switch finishes later', () => {
+    const state = useSessionSwitchStore.getState();
+    state.beginSwitch('session-b');
+    useSessionSwitchStore.getState().beginSwitch('session-c');
+
+    useSessionSwitchStore.getState().completeSwitch('session-b');
+    expect(useSessionSwitchStore.getState().targetSessionId).toBe('session-c');
+
+    useSessionSwitchStore.getState().completeSwitch('session-c');
+    expect(useSessionSwitchStore.getState().targetSessionId).toBeNull();
+  });
+});
+
+describe('shouldShowSessionSwitchLoading', () => {
+  test('covers both the route transition and the target runtime boot', () => {
+    expect(shouldShowSessionSwitchLoading('session-b', 'session-a', false)).toBe(true);
+    expect(shouldShowSessionSwitchLoading('session-b', 'session-b', false)).toBe(true);
+    expect(shouldShowSessionSwitchLoading('session-b', 'session-b', true)).toBe(false);
+  });
+
+  test('does not affect ordinary session boot when no click switch is pending', () => {
+    expect(shouldShowSessionSwitchLoading(null, 'session-b', false)).toBe(false);
+  });
+});

--- a/apps/web/src/stores/session-switch-store.ts
+++ b/apps/web/src/stores/session-switch-store.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { create } from 'zustand';
+
+interface SessionSwitchClickLike {
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+/** Preserve browser-native new-tab/window behavior and ignore the active row. */
+export function shouldBeginSessionSwitch(
+  event: SessionSwitchClickLike,
+  targetSessionId: string,
+  activeSessionId: string | null,
+): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey &&
+    targetSessionId !== activeSessionId
+  );
+}
+
+/** A click switch spans both Next navigation and the target runtime becoming ready. */
+export function shouldShowSessionSwitchLoading(
+  targetSessionId: string | null,
+  renderedSessionId: string,
+  targetReady: boolean,
+): boolean {
+  if (!targetSessionId) return false;
+  return targetSessionId !== renderedSessionId || !targetReady;
+}
+
+interface SessionSwitchState {
+  targetSessionId: string | null;
+  beginSwitch: (sessionId: string) => void;
+  completeSwitch: (sessionId: string) => void;
+  cancelSwitch: () => void;
+}
+
+/**
+ * Cross-route client state for project-session navigation. Completion is compare-
+ * and-clear so a slow older route can never clear a newer rapid-click target.
+ */
+export const useSessionSwitchStore = create<SessionSwitchState>((set) => ({
+  targetSessionId: null,
+  beginSwitch: (sessionId) => set({ targetSessionId: sessionId }),
+  completeSwitch: (sessionId) =>
+    set((state) =>
+      state.targetSessionId === sessionId ? { targetSessionId: null } : state,
+    ),
+  cancelSwitch: () => set({ targetSessionId: null }),
+}));


### PR DESCRIPTION
## What changed
- mark the clicked session row active and busy immediately
- keep the existing Kortix Computer loader visible across route navigation and target runtime readiness
- make completion compare-and-clear so rapid session clicks cannot race
- preserve modified and middle-click browser behavior

## Verification
- bun tests: 36 passed, 0 failed
- touched-file ESLint: clean
- frontend TypeScript: clean
- Next production build: clean with NODE_OPTIONS=--max-old-space-size=8192
- authenticated Chromium: clicked a second session, observed aria-busy immediately, exact target URL, loader during a delayed real start response, and pending state clearing after settlement