### PR TITLE
fix(web): suppress stale-deploy webpack-runtime 'call' TypeError noise

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -7,6 +7,7 @@ import {
   isInjectedAppSource,
   isKnownBrowserNoiseMessage,
   isRuntimeNotReadyNoiseMessage,
+  isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
@@ -522,4 +523,139 @@ test('does NOT suppress a real null-access error on a non-storage method', () =>
     }),
     false,
   )
+})
+
+// Reproduces Better Stack error 83e0c2af...189c3b17 (Kortix Frontend prod,
+// application_id 2346967) + siblings 5d02255f…, e77f06d4…, 1cb3009d… — all
+// `TypeError: Cannot read properties of undefined (reading 'call')`, count 1,
+// 0 identified users, last_seen 2026-07-12 08:44 UTC. The raw stack's throwing
+// frame (last frame, Sentry oldest-first ordering) is the Next.js webpack
+// runtime chunk `webpack-<hash>.js` function `c` (= `__webpack_require__`), and
+// the webpack runtime chunk carries a *different* Vercel `?dpl=` deployment id
+// than the app chunks in the same stack — the stale-deploy-chunk signature:
+// a long-lived tab holds app chunks/module ids from one deploy while the
+// runtime chunk is served from another, so `__webpack_modules__[moduleId]` is
+// `undefined` and `.call(...)` throws. One-off, self-heals on reload; not an
+// app defect. Suppressed ONLY when the throwing frame is the runtime chunk, so
+// a real app `.call` TypeError (which throws inside an app chunk, not the
+// runtime) still reports.
+const WEBPACK_RUNTIME_FRAME = {
+  filename:
+    'app:///_next/static/chunks/webpack-35676c5ce2292e1c.js?dpl=dpl_CTqmc8S7CG7w9gkCs2ySzURsbhxm',
+  function: 'c',
+}
+const APP_CHUNK_FRAME = {
+  filename:
+    'app:///_next/static/chunks/app/(app)/projects/[id]/not-found-c7f03e853940d826.js?dpl=dpl_GnR22QKUwZLPkRykUCM8KBxZmy8o',
+  function: '81761',
+}
+
+test('suppresses the stale-deploy webpack-runtime call TypeError (assigned pattern)', () => {
+  // The exact frame chain from the raw 83e0c2af… event: webpack `c` recurses
+  // through app chunks, and the throwing frame (last) is the runtime `c`.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects' },
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of undefined (reading 'call')",
+            stacktrace: {
+              frames: [
+                WEBPACK_RUNTIME_FRAME,
+                APP_CHUNK_FRAME,
+                WEBPACK_RUNTIME_FRAME,
+                {
+                  filename:
+                    'app:///_next/static/chunks/65820-89cc54263b2034da.js?dpl=dpl_GnR22QKUwZLPkRykUCM8KBxZmy8o',
+                  function: '65820',
+                },
+                WEBPACK_RUNTIME_FRAME,
+                {
+                  filename:
+                    'app:///_next/static/chunks/27594-5ca3ed0a68bbd353.js?dpl=dpl_GnR22QKUwZLPkRykUCM8KBxZmy8o',
+                  function: '36735',
+                },
+                WEBPACK_RUNTIME_FRAME,
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses a minimal stale-webpack-runtime call event', () => {
+  assert.equal(
+    isStaleWebpackRuntimeCallNoise({
+      message: "Cannot read properties of undefined (reading 'call')",
+      frames: [APP_CHUNK_FRAME, WEBPACK_RUNTIME_FRAME],
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the same message when the throwing frame is an app chunk', () => {
+  // A real app TypeError calling `.call(...)` on an `undefined` value throws
+  // inside the app chunk, not the runtime — keep reporting it.
+  assert.equal(
+    isStaleWebpackRuntimeCallNoise({
+      message: "Cannot read properties of undefined (reading 'call')",
+      frames: [WEBPACK_RUNTIME_FRAME, APP_CHUNK_FRAME],
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: "Cannot read properties of undefined (reading 'call')",
+            stacktrace: { frames: [WEBPACK_RUNTIME_FRAME, APP_CHUNK_FRAME] },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress the webpack-call message when there are no frames', () => {
+  // Can't confirm the runtime scope — keep reporting rather than guess.
+  assert.equal(
+    isStaleWebpackRuntimeCallNoise({
+      message: "Cannot read properties of undefined (reading 'call')",
+      frames: [],
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [{ value: "Cannot read properties of undefined (reading 'call')" }],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a same-shaped message reading a different property', () => {
+  // `reading id` / `reading src` are the existing real-app TypeError fixtures;
+  // the exact-message match must not catch them.
+  for (const value of [
+    'Cannot read properties of undefined (reading id)',
+    'Cannot read properties of undefined (reading src)',
+    'TypeError: Cannot read properties of undefined (reading call)',
+  ]) {
+    assert.equal(
+      isStaleWebpackRuntimeCallNoise({
+        message: value,
+        frames: [WEBPACK_RUNTIME_FRAME],
+      }),
+      false,
+      `expected "${value}" to keep reporting`,
+    )
+  }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -92,6 +92,31 @@ const BILLING_GATE_EXPECTED_MESSAGES = [
   'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
 ] as const;
 
+// Stale Next.js webpack runtime chunk after a deploy. A long-lived tab (or
+// cached HTML) holds app chunks from one Vercel deployment (`?dpl=dpl_…`) while
+// the webpack runtime chunk is served from a different deployment, so
+// `__webpack_require__(moduleId)` (minified to function `c`) looks up a module
+// id that isn't registered in this runtime's `__webpack_modules__` map →
+// `undefined` → `__webpack_modules__[moduleId].call(...)` throws
+// `TypeError: Cannot read properties of undefined (reading 'call')`. It is a
+// one-off, self-healing-on-reload browser state (single occurrence, 0
+// identified users across the four sibling patterns 83e0c2af…/5d02255f…/
+// e77f06d4…/1cb3009d…, all last_seen 2026-07-12 08:44 UTC), not an app defect.
+// Suppress ONLY when the throwing frame (Sentry's oldest-first stack ordering
+// → last frame) is the Next.js webpack runtime chunk, so a genuine app
+// TypeError with the same message text — e.g. calling `.call(...)` on an
+// `undefined` value inside app code — still reports normally.
+const STALE_WEBPACK_RUNTIME_CALL_MESSAGE =
+  "Cannot read properties of undefined (reading 'call')";
+
+function isWebpackRuntimeChunkFilename(filename: unknown): boolean {
+  const normalized = normalizeString(filename);
+  return (
+    /^app:\/\/\/_next\/static\/chunks\/webpack-[^/]*\.js/.test(normalized)
+    || /^https?:\/\/[^/]+\/_next\/static\/chunks\/webpack-[^/]*\.js/.test(normalized)
+  );
+}
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -202,6 +227,31 @@ export function isExpectedBillingGateMessage(message: unknown): boolean {
       || normalized === `Unhandled promise rejection: ${expected}`
       || normalized === `Unhandled promise rejection: ApiError: ${expected}`,
   );
+}
+
+/**
+ * Whether a Sentry exception is the stale-deploy webpack-runtime
+ * `… (reading 'call')` TypeError. Requires BOTH the exact webpack
+ * module-loader message AND the throwing frame (the last stack frame, per
+ * Sentry's oldest-first ordering) to be the Next.js webpack runtime chunk
+ * (`_next/static/chunks/webpack-*.js`). A real app TypeError that calls
+ * `.call(...)` on an `undefined` value throws inside an app chunk, not the
+ * runtime, so it is never hidden. Returns false when there are no frames
+ * (can't confirm the runtime scope — keep reporting).
+ */
+export function isStaleWebpackRuntimeCallNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  if (normalizeString(input.message) !== STALE_WEBPACK_RUNTIME_CALL_MESSAGE) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  if (frames.length === 0) {
+    return false;
+  }
+  const throwingFrame = frames[frames.length - 1];
+  return isWebpackRuntimeChunkFilename(throwingFrame?.filename);
 }
 
 export function shouldIgnoreBrowserRuntimeNoise(input: {
@@ -315,6 +365,16 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   }
 
   if (environment === 'test' || environment.startsWith('e2e')) {
+    return true;
+  }
+
+  // Stale webpack runtime chunk after a deploy — the throwing frame (last
+  // stack frame) is the Next.js webpack runtime (`__webpack_require__`,
+  // minified `c`) looking up a module id that isn't registered in a
+  // mismatched deployment's module map. One-off, self-heals on reload;
+  // suppress only when the throwing frame is the runtime chunk so a real app
+  // `.call` TypeError keeps reporting. See `isStaleWebpackRuntimeCallNoise`.
+  if (isStaleWebpackRuntimeCallNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause (one line)

Stale-deploy webpack-runtime chunk noise: after a Vercel deploy, a long-lived tab holds app chunks/module ids from one deployment while the webpack runtime chunk is served from another, so `__webpack_require__(moduleId)` (minified to function `c`) looks up a module id that isn't registered in this runtime's `__webpack_modules__` map → `undefined` → `__webpack_modules__[moduleId].call(...)` throws `TypeError: Cannot read properties of undefined (reading 'call')`. One-off browser state that self-heals on the next hard reload — not an app defect.

## Better Stack evidence

- Error: https://errors.betterstack.com/team/t502678/errors/83e0c2af48584c5be4d31a52335a45ebbeb34c638964b16bafb8b053189c3b17?s=2346967
- Incident id / pattern: `83e0c2af48584c5be4d31a52335a45ebbeb34c638964b16bafb8b053189c3b17`
- Application: Kortix Frontend (prod), application_id `2346967`
- Type / message: `TypeError` — `Cannot read properties of undefined (reading 'call')`
- call_site: `app:///_next/static/chunks/webpack-35676c5ce2292e1c.js?dpl=dpl_CTqmc8S7CG7w9gkCs2ySzURsbhxm`, function `c`
- Scale: count 1, 0 identified users, first/last_seen 2026-07-12 08:44 UTC, env `prod`, mechanism `auto.browser.global_handlers.onunhandledrejection`
- Sibling patterns with the identical signature (same message, same webpack `c` call site, count 1, 0 users, same timestamp): `5d02255f...`, `e77f06d4...`, `1cb3009d...`

Raw stack (from Better Stack Telemetry / Sentry S3 event, de-minified frames oldest→newest; the **last** frame is the throwing frame):
```
webpack-35676c5ce2292e1c.js?dpl=dpl_CTqmc8S7CG7w9gkCs2ySzURsbhxm   c          (throwing frame)
app/(app)/projects/[id]/not-found-*.js?dpl=dpl_GnR22QKUwZLPkRykUCM8KBxZmy8o
webpack-35676c5ce2292e1c.js?dpl=dpl_CTqmc8S7CG7w9gkCs2ySzURsbhxm   c
65820-*.js?dpl=dpl_GnR22QKUwZLPkRykUCM8KBxZmy8o
webpack-35676c5ce2292e1c.js?dpl=dpl_CTqmc8S7CG7w9gkCs2ySzURsbhxm   c
27594-*.js?dpl=dpl_GnR22QKUwZLPkRykUCM8KBxZmy8o
webpack-35676c5ce2292e1c.js?dpl=dpl_CTqmc8S7CG7w9gkCs2ySzURsbhxm   c
```

The smoking gun: the webpack runtime chunk carries `?dpl=dpl_CTqmc8S...` while every app chunk in the same stack carries `?dpl=dpl_GnR22QK...` — two different Vercel deployments mixed in one page. The runtime's module map doesn't contain the app chunks' module ids, so the `.call(...)` lookup hits `undefined`. Browser: Chrome 146 / macOS 10.15.7, transaction `/projects/:id`, release `8b9f59e6d3ee75bbef95e87ad63c81c17d0c1f05`.

This is **not** covered by #4522–#4524 (billing-gate 402, `message.includes` typeguard, request-deadline 503).

## Fix

Add a narrowly-scoped Sentry noise suppression in `apps/web/src/lib/browser-error-noise.ts` (the existing telemetry-side backstop used by the Sentry `beforeSend` in `sentry.{client,server,edge}.config.ts`):

- New predicate `isStaleWebpackRuntimeCallNoise({ message, frames })` — suppresses **only** when:
  1. the message is **exactly** `Cannot read properties of undefined (reading 'call')` (the webpack module-loader line, with no `TypeError:` prefix — matching Sentry's `exception.values[0].value`), AND
  2. the **throwing frame** (the last stack frame, per Sentry's oldest-first ordering) is the Next.js webpack runtime chunk (`_next/static/chunks/webpack-*.js`).
- Wired into `shouldIgnoreSentryBrowserNoise` (the `beforeSend` gate that pages Better Stack).

The frame scope is the safety gate the assignment asked for: a real app `TypeError` that calls `.call(...)` on an `undefined` value throws **inside an app chunk**, not the webpack runtime, so it is never hidden. The check also returns `false` when there are no frames (can't confirm the runtime scope → keep reporting). The message is matched exactly, so existing real-app fixtures like `(reading id)` / `(reading src)` are unaffected. Notably this is **not** added to the Sentry `ignoreErrors` list (which is message-only and would over-suppress) — only the frame-aware `beforeSend` path drops it.

Because the scope is by frame shape (webpack runtime chunk as throwing frame), the four sibling patterns are all covered by the same filter — no per-hash enumeration.

## Verification

- New regression tests in `apps/web/src/lib/browser-error-noise.test.mts` (node:test):
  1. `suppresses the stale-deploy webpack-runtime call TypeError (assigned pattern)` — the exact frame chain from the raw 83e0c2af… event → suppressed.
  2. `suppresses a minimal stale-webpack-runtime call event` → suppressed.
  3. `does NOT suppress the same message when the throwing frame is an app chunk` — the safety gate; a real app `.call` TypeError keeps reporting.
  4. `does NOT suppress the webpack-call message when there are no frames` — keep reporting rather than guess.
  5. `does NOT suppress a same-shaped message reading a different property` — `(reading id)` / `(reading src)` / `TypeError: …(reading call)` (with prefix) keep reporting.
- Full suite: `node --experimental-strip-types --test src/lib/browser-error-noise.test.mts` → **32/32 pass** (27 pre-existing + 5 new).

## How to confirm in prod

After this merges + Promotes, the four Better Stack patterns (`83e0c2af…`, `5d02255f…`, `e77f06d4…`, `1cb3009d…`) should drop to zero **new** occurrences and auto-resolve once no longer seen. Confirm by re-querying `remote(t502678_kortix_frontend_metrics)` for those patterns with `dt > <promote time>` — expect no new rows.
