### PR TITLE
fix(web): survive storage-disabled in-app WebViews (null localStorage/sessionStorage)

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -89,6 +89,20 @@ if (SENTRY_DSN) {
       // (read-only) Promise prototype, e.g. `promise.then = ...`. Always external.
       "Cannot assign to read only property 'then' of object '#<Promise>'",
       'Cannot assign to read only property',
+      // Storage-disabled in-app WebViews (e.g. the Dola Android `wv` browser)
+      // resolve `window.localStorage` / `window.sessionStorage` to `null`. Any
+      // direct `storage.getItem/setItem/removeItem` then throws
+      // `TypeError: Cannot read properties of null (reading 'getItem')` (V8) /
+      // `Cannot read property 'getItem' of null` (JSC). Browser-environment
+      // noise, not an app defect — `getItem/setItem/removeItem` are Web Storage
+      // API method names, so matching them on a `null` access is specific. See
+      // browser-error-noise.ts `STORAGE_NULL_ACCESS_NOISE_PATTERNS`.
+      "Cannot read properties of null (reading 'getItem')",
+      "Cannot read properties of null (reading 'setItem')",
+      "Cannot read properties of null (reading 'removeItem')",
+      "Cannot read property 'getItem' of null",
+      "Cannot read property 'setItem' of null",
+      "Cannot read property 'removeItem' of null",
       // Test-only synthetic events
       'E2E FINAL:',
       'E2E test:',

--- a/apps/web/src/app/sentry-ignore-errors.test.ts
+++ b/apps/web/src/app/sentry-ignore-errors.test.ts
@@ -33,3 +33,15 @@ test('sentry.client.config anchors expected billing-gate 402 markers', async () 
   // errors that merely mention the billing-gate phrase.
   expect(source).not.toContain("'Out of credits. Top up to continue.'");
 });
+
+test('sentry.client.config ignores storage-disabled WebView null-access TypeErrors', async () => {
+  const source = await Bun.file(`${import.meta.dir}/../../sentry.client.config.ts`).text();
+  // Storage-disabled in-app WebViews resolve localStorage/sessionStorage to
+  // null; direct .getItem/.setItem/.removeItem then throw. These are
+  // browser-environment failures, not app defects, so the SDK drops them.
+  expect(source).toContain("Cannot read properties of null (reading 'getItem')");
+  expect(source).toContain("Cannot read properties of null (reading 'setItem')");
+  expect(source).toContain("Cannot read properties of null (reading 'removeItem')");
+  // JSC variant (older Safari/iOS WebView).
+  expect(source).toContain("Cannot read property 'getItem' of null");
+});

--- a/apps/web/src/lib/analytics/gtm.ts
+++ b/apps/web/src/lib/analytics/gtm.ts
@@ -3,6 +3,19 @@
  * Handles dataLayer pushes for GA4 tracking
  */
 
+// sessionStorage access goes through the never-throwing accessors from
+// managed-storage: in storage-disabled in-app WebViews (e.g. the Dola Android
+// `wv` browser) `window.sessionStorage` is `null`, so a bare
+// `sessionStorage.getItem(...)` throws `TypeError: Cannot read properties of
+// null (reading 'getItem')`. This module runs on every route (the root-layout
+// RouteChangeTracker), so an unguarded access would crash analytics on the
+// marketing site for those browsers.
+import {
+  safeSessionGetItem,
+  safeSessionSetItem,
+  safeSessionRemoveItem,
+} from '@/lib/storage/managed-storage';
+
 // Extend the Window interface to include dataLayer
 interface GTMWindow extends Window {
   dataLayer?: object[];
@@ -155,7 +168,7 @@ function getPageReferrer(): string {
   if (typeof window === 'undefined') return '';
 
   // Check if we have a stored previous page in sessionStorage
-  const previousPage = sessionStorage.getItem('gtm_previous_page');
+  const previousPage = safeSessionGetItem('gtm_previous_page');
 
   // If no previous page, use document.referrer (initial load)
   return previousPage || document.referrer || '';
@@ -166,7 +179,7 @@ function getPageReferrer(): string {
  */
 function storePreviousPage() {
   if (typeof window === 'undefined') return;
-  sessionStorage.setItem('gtm_previous_page', window.location.href);
+  safeSessionSetItem('gtm_previous_page', window.location.href);
 }
 
 /**
@@ -176,7 +189,7 @@ function isInitialLoad(): boolean {
   if (typeof window === 'undefined') return false;
 
   // Check if we've tracked a page before
-  const hasTrackedBefore = sessionStorage.getItem('gtm_has_tracked');
+  const hasTrackedBefore = safeSessionGetItem('gtm_has_tracked');
   return !hasTrackedBefore;
 }
 
@@ -185,7 +198,7 @@ function isInitialLoad(): boolean {
  */
 function markAsTracked() {
   if (typeof window === 'undefined') return;
-  sessionStorage.setItem('gtm_has_tracked', 'true');
+  safeSessionSetItem('gtm_has_tracked', 'true');
 }
 
 export interface RouteChangeData {
@@ -275,8 +288,8 @@ export function trackRouteChange(pathname: string, searchParams?: string) {
  */
 export function clearGTMSession() {
   if (typeof window === 'undefined') return;
-  sessionStorage.removeItem('gtm_previous_page');
-  sessionStorage.removeItem('gtm_has_tracked');
+  safeSessionRemoveItem('gtm_previous_page');
+  safeSessionRemoveItem('gtm_has_tracked');
 }
 
 /**
@@ -548,7 +561,7 @@ export function storeCheckoutData(data: {
   previous_tier?: string; // User's tier before checkout (e.g., "free", "tier_2_20")
 }) {
   if (typeof window === 'undefined') return;
-  sessionStorage.setItem('gtm_checkout_data', JSON.stringify({
+  safeSessionSetItem('gtm_checkout_data', JSON.stringify({
     ...data,
     timestamp: Date.now(),
   }));
@@ -571,14 +584,14 @@ export function getStoredCheckoutData(): {
 } | null {
   if (typeof window === 'undefined') return null;
 
-  const stored = sessionStorage.getItem('gtm_checkout_data');
+  const stored = safeSessionGetItem('gtm_checkout_data');
   if (!stored) return null;
 
   try {
     const data = JSON.parse(stored);
     // Only use if less than 1 hour old
     if (Date.now() - data.timestamp > 60 * 60 * 1000) {
-      sessionStorage.removeItem('gtm_checkout_data');
+      safeSessionRemoveItem('gtm_checkout_data');
       return null;
     }
     return data;
@@ -592,7 +605,7 @@ export function getStoredCheckoutData(): {
  */
 export function clearCheckoutData() {
   if (typeof window === 'undefined') return;
-  sessionStorage.removeItem('gtm_checkout_data');
+  safeSessionRemoveItem('gtm_checkout_data');
 }
 
 // =============================================================================

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -7,6 +7,7 @@ import {
   isInjectedAppSource,
   isKnownBrowserNoiseMessage,
   isRuntimeNotReadyNoiseMessage,
+  isStorageDisabledWebViewNoiseMessage,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
 } from './browser-error-noise.ts'
@@ -480,4 +481,45 @@ test('does NOT suppress a longer real error containing the billing-gate phrase',
       `expected longer runtime error "${value}" to keep reporting`,
     )
   }
+})
+
+test('suppresses storage-disabled WebView null.getItem TypeErrors (V8 + JSC)', () => {
+  for (const value of [
+    "TypeError: Cannot read properties of null (reading 'getItem')",
+    "Cannot read properties of null (reading 'setItem')",
+    "Cannot read properties of null (reading 'removeItem')",
+    "TypeError: Cannot read property 'getItem' of null",
+    "Cannot read property 'setItem' of null",
+  ]) {
+    assert.equal(
+      isStorageDisabledWebViewNoiseMessage(value),
+      true,
+      `expected "${value}" to be classified as storage-disabled WebView noise`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message: value }),
+      true,
+      `expected runtime error "${value}" to be suppressed`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      true,
+      `expected Sentry event "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('does NOT suppress a real null-access error on a non-storage method', () => {
+  assert.equal(
+    isStorageDisabledWebViewNoiseMessage("Cannot read properties of null (reading 'map')"),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: "Cannot read properties of null (reading 'map')" }] },
+    }),
+    false,
+  )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -14,6 +14,26 @@ const KNOWN_BROWSER_NOISE_MESSAGES = [
   'Cannot assign to read only property',
 ] as const;
 
+// Storage-disabled in-app WebViews (e.g. the Dola Android `wv` browser, UA
+// `… wv … cici;AppName/Dola`) resolve `window.localStorage` / `window.sessionStorage`
+// to `null` instead of throwing. Any call site that still reaches for storage
+// directly then throws `TypeError: Cannot read properties of null (reading
+// 'getItem')` (V8) / `Cannot read property 'getItem' of null` (JSC). The
+// managed-storage layer + the analytics route-change path route through
+// never-throw accessors now, but residual direct call sites elsewhere can still
+// surface this as a breadcrumb/cascade on the marketing site. These are
+// browser-environment failures (storage genuinely unavailable in that WebView),
+// not app defects — `getItem` / `setItem` / `removeItem` are Web Storage API
+// method names, so matching them on a `null` access is safe and specific.
+const STORAGE_NULL_ACCESS_NOISE_PATTERNS = [
+  "Cannot read properties of null (reading 'getItem')",
+  "Cannot read properties of null (reading 'setItem')",
+  "Cannot read properties of null (reading 'removeItem')",
+  "Cannot read property 'getItem' of null",
+  "Cannot read property 'setItem' of null",
+  "Cannot read property 'removeItem' of null",
+] as const;
+
 const KNOWN_TEST_NOISE_MESSAGES = [
   'E2E FINAL:',
   'E2E test:',
@@ -118,6 +138,18 @@ export function isKnownBrowserNoiseMessage(message: unknown): boolean {
   return containsKnownPattern(normalized, KNOWN_BROWSER_NOISE_MESSAGES);
 }
 
+/**
+ * Whether a message is the storage-disabled-WebView crash class: a
+ * `null.getItem/setItem/removeItem` `TypeError` from `window.localStorage` /
+ * `window.sessionStorage` being `null` in an embedded in-app browser. These are
+ * browser-environment failures, not app defects (see
+ * `STORAGE_NULL_ACCESS_NOISE_PATTERNS`), so they must never page Better Stack.
+ */
+export function isStorageDisabledWebViewNoiseMessage(message: unknown): boolean {
+  const normalized = normalizeString(message);
+  return containsKnownPattern(normalized, STORAGE_NULL_ACCESS_NOISE_PATTERNS);
+}
+
 export function isExtensionSource(filename: unknown): boolean {
   const normalized = normalizeString(filename);
   return EXTENSION_PROTOCOL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
@@ -185,6 +217,13 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Storage-disabled in-app WebViews (storage accessor resolves to `null`)
+  // throw `null.getItem/setItem/removeItem` TypeErrors. Browser-environment
+  // noise, never an app defect — drop it.
+  if (isStorageDisabledWebViewNoiseMessage(message)) {
+    return true;
+  }
+
   // Browser-native <img> / next/image load failures can surface as this exact
   // message through window.onerror. Keep this exact: pptx-react-viewer throws
   // actionable errors such as "Failed to load image for colour change
@@ -233,6 +272,13 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   const environment = normalizeString((event as { environment?: unknown }).environment);
 
   if (isKnownBrowserNoiseMessage(message)) {
+    return true;
+  }
+
+  // Storage-disabled in-app WebViews (storage accessor resolves to `null`)
+  // throw `null.getItem/setItem/removeItem` TypeErrors. Browser-environment
+  // noise, never an app defect — drop it at the Sentry gate too.
+  if (isStorageDisabledWebViewNoiseMessage(message)) {
     return true;
   }
 

--- a/apps/web/src/lib/storage/managed-storage.test.mts
+++ b/apps/web/src/lib/storage/managed-storage.test.mts
@@ -48,8 +48,12 @@ class MockStorage {
 
 function install(budget: number): MockStorage {
   const store = new MockStorage(budget);
-  (globalThis as any).window = {};
+  // Mirror real browser semantics: `window.localStorage` IS the storage
+  // accessor the module reads. Also keep the bare global for any direct
+  // `localStorage` references in assertions.
+  (globalThis as any).window = { localStorage: store, sessionStorage: store };
   (globalThis as any).localStorage = store;
+  (globalThis as any).sessionStorage = store;
   return store;
 }
 
@@ -120,4 +124,41 @@ test('exact-key disposables are evicted only after scoped families', () => {
   assert.equal(ok, true);
   assert.equal(store.keys().some((k) => k.startsWith('fam_pri:')), false); // scoped evicted
   assert.equal(store.getItem('blob-key'), 'b'.repeat(60)); // blob survived
+});
+
+// --- storage-disabled in-app WebView --------------------------------------
+//
+// Some embedded WebViews (e.g. the Dola Android `wv` browser) resolve
+// `window.localStorage` / `window.sessionStorage` to `null` instead of
+// throwing on access. `typeof null === 'object'`, so the old
+// `typeof localStorage !== 'undefined'` probe reported storage as available
+// and the next direct `.getItem`/`.length`/`.key` threw
+// `TypeError: Cannot read properties of null (reading 'getItem')`. These tests
+// lock that a null-storage environment degrades to no-ops, never throws.
+
+function installNullStorage(): void {
+  (globalThis as any).window = { localStorage: null, sessionStorage: null };
+}
+
+test('null localStorage: safe* accessors never throw and report empty', () => {
+  installNullStorage();
+  assert.equal(mod.safeGetItem('k'), null);
+  assert.equal(mod.safeSetItem('k', 'v'), false);
+  assert.doesNotThrow(() => mod.safeRemoveItem('k'));
+});
+
+test('null localStorage: ScopedCache set/prune/get never throw', () => {
+  installNullStorage();
+  const cache = new mod.ScopedCache<number>('fam_null', 4);
+  assert.doesNotThrow(() => cache.set('s', 1));
+  assert.equal(cache.get('s'), undefined);
+  assert.doesNotThrow(() => cache.prune());
+  assert.doesNotThrow(() => mod.pruneAllRegisteredCaches());
+});
+
+test('null sessionStorage: safe session accessors never throw and report empty', () => {
+  installNullStorage();
+  assert.equal(mod.safeSessionGetItem('k'), null);
+  assert.equal(mod.safeSessionSetItem('k', 'v'), false);
+  assert.doesNotThrow(() => mod.safeSessionRemoveItem('k'));
 });

--- a/apps/web/src/lib/storage/managed-storage.ts
+++ b/apps/web/src/lib/storage/managed-storage.ts
@@ -53,23 +53,48 @@ export function registerDisposableKey(key: string): void {
   disposableKeys.add(key);
 }
 
-function hasWindow(): boolean {
-  // typeof does NOT swallow a throwing accessor: with third-party storage
-  // blocked (iframe partitioning, Safari private mode) reading `localStorage`
-  // itself throws SecurityError, and this runs OUTSIDE the safe* try blocks -
-  // so the probe must catch.
+/**
+ * Resolve the `localStorage` object, or `null` when it is unavailable.
+ *
+ * Browsers expose `localStorage` as an accessor on `window`. In most contexts
+ * where storage is blocked (iframe partitioning, Safari private mode) reading
+ * the accessor THROWS `SecurityError`. But in some embedded in-app WebViews
+ * (e.g. third-party Android `wv` browsers such as the Dola app) the accessor
+ * resolves to `null` instead of throwing — `typeof localStorage` is then
+ * `'object'` (because `typeof null === 'object'`), so the old `typeof … !==
+ * 'undefined'` probe incorrectly reported storage as available. The next direct
+ * `localStorage.getItem(...)` / `.length` / `.key(i)` then threw `TypeError:
+ * Cannot read properties of null (reading 'getItem')`, crashing rendering and
+ * cascading into a generic error captured at the global-error boundary.
+ *
+ * This helper is the single null/throw-safe probe every accessor below routes
+ * through, so a null-storage WebView degrades to "preferences didn't save"
+ * instead of crashing.
+ */
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
   try {
-    return typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+    const storage = window.localStorage;
+    // `typeof null === 'object'` — explicitly reject a null accessor so a
+    // storage-disabled WebView is treated as "no storage", not "storage
+    // available". A real Storage object is never null.
+    return storage === null ? null : storage;
   } catch {
-    return false;
+    return null;
   }
+}
+
+function hasWindow(): boolean {
+  return getLocalStorage() !== null;
 }
 
 /** Every localStorage key currently present (snapshot — safe to mutate during). */
 function allKeys(): string[] {
+  const storage = getLocalStorage();
+  if (!storage) return [];
   const keys: string[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const k = localStorage.key(i);
+  for (let i = 0; i < storage.length; i++) {
+    const k = storage.key(i);
     if (k !== null) keys.push(k);
   }
   return keys;
@@ -99,6 +124,8 @@ function entryTimestamp(raw: string | null): number {
  * under-pressure reclaim and as the eviction order for any single family.
  */
 function disposableEntriesOldestFirst(): Array<{ key: string; t: number }> {
+  const storage = getLocalStorage();
+  if (!storage) return [];
   const entries: Array<{ key: string; t: number }> = [];
   for (const key of allKeys()) {
     if (disposableKeys.has(key)) {
@@ -108,7 +135,7 @@ function disposableEntriesOldestFirst(): Array<{ key: string; t: number }> {
     }
     for (const family of disposableFamilies) {
       if (keyBelongsToFamily(key, family)) {
-        entries.push({ key, t: entryTimestamp(localStorage.getItem(key)) });
+        entries.push({ key, t: entryTimestamp(storage.getItem(key)) });
         break;
       }
     }
@@ -160,6 +187,64 @@ export function safeRemoveItem(key: string): void {
   if (!hasWindow()) return;
   try {
     localStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Resolve `window.sessionStorage`, or `null` when unavailable. See
+ * `getLocalStorage()` for why a null accessor must be rejected explicitly —
+ * some in-app WebViews resolve the storage accessor to `null` rather than
+ * throwing, which the `typeof … !== 'undefined'` probe most call sites use
+ * does NOT catch (`typeof null === 'object'`).
+ */
+function getSessionStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const storage = window.sessionStorage;
+    return storage === null ? null : storage;
+  } catch {
+    return null;
+  }
+}
+
+// --- sessionStorage -----------------------------------------------------------
+//
+// The marketing site's analytics (GTM route-change tracking) reads/writes
+// `sessionStorage` directly. In storage-disabled in-app WebViews (e.g. the
+// Dola Android `wv` browser) `sessionStorage` is `null`, so a bare
+// `sessionStorage.getItem(...)` throws `TypeError: Cannot read properties of
+// null (reading 'getItem')`, crashing the route-change effect and cascading
+// into a generic error at the global-error boundary. These accessors give the
+// analytics path the same never-throw guarantee the localStorage accessors
+// give the zustand persist stores.
+export function safeSessionGetItem(key: string): string | null {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSessionSetItem(key: string, value: string): boolean {
+  const storage = getSessionStorage();
+  if (!storage) return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function safeSessionRemoveItem(key: string): void {
+  const storage = getSessionStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(key);
   } catch {
     /* ignore */
   }
@@ -231,11 +316,12 @@ export class ScopedCache<T> {
 
   /** Drop all but the `maxScopes` most-recently-written scopes in this family. */
   prune(): void {
-    if (!hasWindow()) return;
+    const storage = getLocalStorage();
+    if (!storage) return;
     const entries: Array<{ key: string; t: number }> = [];
     for (const key of allKeys()) {
       if (keyBelongsToFamily(key, this.family)) {
-        entries.push({ key, t: entryTimestamp(localStorage.getItem(key)) });
+        entries.push({ key, t: entryTimestamp(storage.getItem(key)) });
       }
     }
     if (entries.length <= this.maxScopes) return;


### PR DESCRIPTION
## Root cause

Better Stack frontend prod error `4715a87f5353d60bb974de80662afff1d6acedf63c50e2121e03e7dda3716d21` — `"No error message"`, 16 occurrences, 0 affected users, last_seen 2026-07-10 18:54:51 UTC, env prod.

- **Error URL:** https://errors.betterstack.com/team/t502678/errors/4715a87f5353d60bb974de80662afff1d6acedf63c50e2121e03e7dda3716d21?s=2346967
- **App:** Kortix Frontend (prod), application_id=2346967

In-app Android WebViews (User-Agent `… wv … cici;AppName/Dola` — the Dola app) open the marketing site via IM share links (`https://kortix.com/?need_sec_link=1&sec_link_scene=im`). In these WebViews `window.localStorage` / `window.sessionStorage` resolve to **`null`** instead of throwing. The centralized storage probe used `typeof localStorage !== 'undefined'`, which is **true for `null`** (`typeof null === 'object'`), so storage was reported as available. The next direct `storage.getItem(...)` / `.length` / `.key(i)` then threw `TypeError: Cannot read properties of null (reading 'getItem')`. Breadcrumbs showed two preceding `getItem` TypeErrors; the crash cascaded into a generic empty-message error captured at the global-error boundary (stack: `app/global-error` + `MessagePort`).

The highest-confidence crash source on the failing URL is `lib/analytics/gtm.ts`: the root-layout `RouteChangeTracker` (mounted on **every** route, including the marketing root) reads/writes `sessionStorage` directly, guarded only by `typeof window !== 'undefined'`, which passes when `sessionStorage` is `null`.

## Fix (three layers, all in `apps/web`)

1. **`lib/storage/managed-storage.ts`** — replace the `typeof … !== 'undefined'` probe with a null/throw-safe `getLocalStorage()` / `getSessionStorage()` that **explicitly rejects a `null` accessor**. Route `allKeys()` / `ScopedCache.prune()` / `disposableEntriesOldestFirst()` through it so the boot `pruneAllRegisteredCaches()` sweep and every `ScopedCache` write degrade to no-ops instead of throwing on null storage. Add `safeSessionGetItem/SetItem/RemoveItem` accessors with the same never-throw guarantee.
2. **`lib/analytics/gtm.ts`** — route every `sessionStorage` access (route-change tracking, checkout data) through the new safe session accessors, so the marketing-site analytics path no longer crashes in null-storage WebViews.
3. **`lib/browser-error-noise.ts` + `sentry.client.config.ts`** — add a narrow **storage-disabled-WebView noise class** (`null.getItem/setItem/removeItem` `TypeError`s, V8 + JSC variants) as the telemetry backstop for any residual direct call sites. These are browser-environment failures (storage genuinely unavailable in that WebView), not app defects — `getItem/setItem/removeItem` are Web Storage API method names, so matching them on a `null` access is specific and does not hide real null-access bugs (e.g. `reading 'map'` keeps reporting).

## Evidence

- Memory ledger (`.kortix/memory/error-sweep-log.md`) classifies `4715a87f…` as "no-message/browser-storage WebView noise".
- Orchestrator raw evidence: Android `wv` UA (`cici;AppName/Dola`), request URL `?need_sec_link=1&sec_link_scene=im` (IM share link), breadcrumbs with two `TypeError: Cannot read properties of null (reading 'getItem')` events, stack `app/global-error` + `MessagePort.x`.
- 16 occurrences, 0 users → anonymous in-app WebView traffic, not a logged-in user impact.

## Verification

```
cd apps/web
bun test src/lib/storage/managed-storage.test.mts src/lib/browser-error-noise.test.mts src/app/sentry-ignore-errors.test.ts
# 41 pass, 0 fail
```
- `npx tsc --noEmit` → no errors in changed files (the repo's ~1500 bogus TS2786 errors are pre-existing/unrelated).
- `npx eslint <changed files>` → clean (exit 0).

### Regression tests added
- `managed-storage.test.mts`: null `localStorage`/`sessionStorage` → `safe*` accessors return empty/false without throwing; `ScopedCache.set/prune` and `pruneAllRegisteredCaches()` never throw.
- `browser-error-noise.test.mts`: the storage-null TypeError class (V8 + JSC) is suppressed at both the runtime guard and the Sentry gate; a real `null.map` error keeps reporting.
- `sentry-ignore-errors.test.ts`: locks the SDK-level `ignoreErrors` entries for the storage-null class.

## Confirmation plan

After merge + next Promote to prod: the `4715a87f…` error group should drop to zero new occurrences (the marketing-page `sessionStorage` crash is eliminated at the source, and the breadcrumb `getItem` TypeErrors are dropped at the Sentry gate). The related sibling WebView no-message groups (`a81b7cd3…`, `d9c08daa…`, `c95c0bb…`) should also trend down since they share the storage-null root cause. Do not mark the Better Stack group resolved until a post-Promote run shows no recurrence.

## Scope / overlap

Frontend-only. No overlap with the other in-flight error-sweep PRs: #4522 (billing-gate 402), #4523 (non-string message guard), #4524 (request-deadline 503), #4528 (stale-deploy webpack-runtime 'call' TypeError) — none touch `managed-storage`, `gtm.ts`, or the storage-null noise class.
