### PR TITLE
fix(web): stop Sentry-capturing the expected client-side request timeout (BS b1db01e5…)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  isClientRequestTimeoutMessage,
   isExpectedBillingGateMessage,
   isExtensionSource,
   isInjectedAppSource,
@@ -656,6 +657,141 @@ test('does NOT suppress a same-shaped message reading a different property', () 
       }),
       false,
       `expected "${value}" to keep reporting`,
+    )
+  }
+})
+
+// Reproduces Better Stack error b1db01e5c9dec8c62bf37ca994cbe304550a7699b8fcd04c8f5c01cc76fc9dc7
+// (Kortix Frontend prod, application_id 2346967): a single
+// `ApiError — Request timed out after 30s: /projects/<id>/sessions/<sid>/audit`
+// at 2026-07-12 13:53 UTC. The SDK's `makeRequest` aborts a non-streaming fetch
+// once its 30s budget elapses (`packages/sdk/src/core/http/api-client.ts`,
+// `didTimeout` branch) and surfaces `ApiError(..., { code: 'TIMEOUT' })`. This
+// is the frontend mirror of the API's request-deadline 503
+// (`apps/api/src/middleware/request-deadline.ts`, de-noised from Sentry by
+// kortix-ai/suna#4524): the API bounds every non-streaming request to a 25s
+// server deadline (clean 503 + Retry-After), and react-query retries background
+// polls — the session-audit route is polled every 5–15s from several session
+// surfaces — so a 30s client abort is an EXPECTED, retryable degradation under
+// momentary API saturation, not an actionable bug. The saturation signal stays
+// in per-route metrics + the structured 503 warn log. `handleApiError` already
+// drops `code === 'TIMEOUT'` from `captureException`; these checks are the
+// telemetry-side backstop for leak paths (ClientErrorBoundary / route-error /
+// app-error / onunhandledrejection).
+const CLIENT_REQUEST_TIMEOUT_EVENTS = [
+  // The exact assigned occurrence — endpoint varies per call, so match the
+  // SDK's `Request timed out after <N>s: ` prefix, not the full URL.
+  'Request timed out after 30s: /projects/24e99500-c925-481a-bc88-5b89dba4d965/sessions/88488045-8cd7-4c6b-ad0f-2b56a4c9cb25/audit',
+  // The budget is configurable per call; the seconds value is not load-bearing.
+  'Request timed out after 60s: /accounts',
+  // The ApiError-class-prefixed wrapper.
+  'ApiError: Request timed out after 30s: /projects/p/sessions/s/sandbox-health',
+  // An unhandled-rejection leak path preserving the message.
+  'Unhandled promise rejection: Request timed out after 30s: /projects/p/sessions/s/audit',
+  'Unhandled promise rejection: ApiError: Request timed out after 30s: /change-requests',
+]
+
+test('classifies every client-side request-deadline timeout as expected noise', () => {
+  for (const message of CLIENT_REQUEST_TIMEOUT_EVENTS) {
+    assert.equal(
+      isClientRequestTimeoutMessage(message),
+      true,
+      `expected ${message} to be classified as a client request timeout`,
+    )
+  }
+})
+
+test('suppresses a client-side request-timeout Sentry event regardless of capture path', () => {
+  for (const value of CLIENT_REQUEST_TIMEOUT_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://app.kortix.com/projects/p/sessions/s' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [{ filename: 'app:///_next/static/chunks/sdk.js' }],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a client-side request-timeout unhandled rejection from the browser', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        'Unhandled promise rejection: Request timed out after 30s: /projects/p/sessions/s/audit',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the API server-deadline 503 message (different wording)', () => {
+  // The API's request-deadline 503 is `Request exceeded the 25s server processing
+  // deadline` — a different, server-side wording that must keep reporting if it
+  // ever reaches the frontend Sentry config (it is de-noised at the API source
+  // by #4524, not here).
+  for (const value of [
+    'Request exceeded the 25s server processing deadline',
+    'Request exceeded the 30s server processing deadline',
+  ]) {
+    assert.equal(
+      isClientRequestTimeoutMessage(value),
+      false,
+      `expected server-deadline message "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({ exception: { values: [{ value }] } }),
+      false,
+      `expected server-deadline Sentry event "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a generic third-party "request timed out" message', () => {
+  // A third-party library's generic timeout wording must not be matched — only
+  // the SDK's exact `Request timed out after <N>s: ` prefix is suppressed.
+  for (const value of [
+    'The request timed out',
+    'Request timed out',
+    'request timed out after 5000ms',
+    'Network request timed out, please retry',
+  ]) {
+    assert.equal(
+      isClientRequestTimeoutMessage(value),
+      false,
+      `expected generic message "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({ exception: { values: [{ value }] } }),
+      false,
+      `expected generic Sentry event "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a real 5xx server ApiError', () => {
+  for (const value of [
+    'Internal server error',
+    'HTTP 500: Internal Server Error',
+    'Service maintenance in progress. Please try again later.',
+  ]) {
+    assert.equal(
+      isClientRequestTimeoutMessage(value),
+      false,
+      `expected real server error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({ exception: { values: [{ value }] } }),
+      false,
+      `expected real server error "${value}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -124,6 +124,38 @@ const EXTENSION_PROTOCOL_PREFIXES = [
   'extension://',
 ] as const;
 
+// The SDK's client-side request deadline. `packages/sdk/src/core/http/api-client.ts`
+// aborts a non-streaming fetch once its 30s budget elapses (the `didTimeout`
+// branch — distinct from an external abort) and surfaces
+// `ApiError("Request timed out after <N>s: <endpoint>", { code: 'TIMEOUT' })`.
+//
+// This is the frontend mirror of the API's request-deadline 503
+// (`apps/api/src/middleware/request-deadline.ts`, de-noised from Sentry by
+// https://github.com/kortix-ai/suna/pull/4524). The API bounds every
+// non-streaming request to a 25s server deadline that returns a clean 503 +
+// `Retry-After: 10`, and react-query retries background polls (the session-audit
+// route that produced Better Stack pattern `b1db01e5…` is polled every 5–15s
+// from several session surfaces), so a 30s client abort is an EXPECTED,
+// retryable degradation under momentary API saturation — never an actionable
+// bug. The saturation signal remains visible in the per-route
+// `http_request_duration_seconds` metric and the structured
+// `Request completed: … 503 …` warn log, exactly as for the server-side 503.
+//
+// `handleApiError` already drops `code === 'TIMEOUT'` from `captureException`;
+// this is the telemetry-side backstop that drops it from any capture path that
+// bypasses that guard — `<ClientErrorBoundary>`, `route-error`/`system-fault`,
+// `app/error`, and the Sentry SDK's own `onunhandledrejection` — same shape as
+// the billing-gate / runtime-not-ready backstops. The match is anchored on the
+// SDK's exact `Request timed out after <N>s:` prefix (with the canonical
+// wrappers) so a third-party library's generic "request timed out" message, or
+// the API's different `Request exceeded the 25s server processing deadline`
+// wording, is never matched.
+const CLIENT_REQUEST_TIMEOUT_WRAPPERS: ReadonlyArray<RegExp> = [
+  /^Request timed out after \d+s: /,
+  /^ApiError: Request timed out after \d+s: /,
+  /^Unhandled promise rejection: (?:ApiError: )?Request timed out after \d+s: /,
+];
+
 const INJECTED_APP_SOURCE_PATTERNS = [
   /^app:\/\/\/scripts\/inpage\.js$/,
   /^app:\/\/\/client_data\/[^/]+\/script\.js$/,
@@ -254,6 +286,20 @@ export function isStaleWebpackRuntimeCallNoise(input: {
   return isWebpackRuntimeChunkFilename(throwingFrame?.filename);
 }
 
+/**
+ * Whether a message is the SDK's client-side request-deadline timeout —
+ * `Request timed out after <N>s: <endpoint>` (and its canonical wrappers). This
+ * is an EXPECTED, retryable degradation (the API's 25s server deadline returns
+ * a 503 + Retry-After and react-query retries background polls), never an
+ * actionable bug — see `CLIENT_REQUEST_TIMEOUT_WRAPPERS` for the full
+ * rationale. Such a message must NEVER page Better Stack, regardless of which
+ * capture path delivered it.
+ */
+export function isClientRequestTimeoutMessage(message: unknown): boolean {
+  const normalized = normalizeString(message).trim();
+  return CLIENT_REQUEST_TIMEOUT_WRAPPERS.some((re) => re.test(normalized));
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -287,6 +333,13 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   }
 
   if (isRuntimeNotReadyNoiseMessage(message)) {
+    return true;
+  }
+
+  // Expected client-side request-deadline timeouts (SDK 30s fetch abort) — the
+  // frontend mirror of the API's request-deadline 503 (de-noised by #4524). An
+  // expected, retryable degradation; never page Better Stack for it.
+  if (isClientRequestTimeoutMessage(message)) {
     return true;
   }
 
@@ -349,6 +402,15 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // switch/provisioning window, self-heals in ~1s, never an error. Drop it
   // before it pages Better Stack, no matter which capture path delivered it.
   if (isRuntimeNotReadyNoiseMessage(message)) {
+    return true;
+  }
+
+  // Expected client-side request-deadline timeouts (SDK 30s fetch abort) — the
+  // frontend mirror of the API's request-deadline 503 (de-noised by #4524). An
+  // expected, retryable degradation under momentary API saturation; the signal
+  // remains in per-route metrics + the structured 503 warn log. Drop it before
+  // it pages Better Stack, no matter which capture path delivered it.
+  if (isClientRequestTimeoutMessage(message)) {
     return true;
   }
 

--- a/apps/web/src/lib/error-handler.tsx
+++ b/apps/web/src/lib/error-handler.tsx
@@ -162,9 +162,23 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
     console.error('API Error:', error, context);
   }
 
-  // Report server errors (5xx) and network failures to Better Stack via Sentry.
-  // 4xx errors are expected (auth, validation) and don't need alerting.
-  if (status >= 500 || error?.code === 'TIMEOUT' || error?.code === 'NETWORK_ERROR') {
+  // Report server errors (5xx) and genuine network failures to Better Stack via
+  // Sentry. 4xx errors are expected (auth, validation) and don't need alerting.
+  //
+  // A client-side request TIMEOUT (`code === 'TIMEOUT'`, the SDK's 30s fetch
+  // deadline — packages/sdk/src/core/http/api-client.ts) is intentionally NOT
+  // captured here. It is the frontend mirror of the API's request-deadline 503
+  // (apps/api/src/middleware/request-deadline.ts, de-noised from Sentry by
+  // https://github.com/kortix-ai/suna/pull/4524): the API has a 25s server
+  // deadline that returns a clean 503 + Retry-After, and react-query retries
+  // background polls, so a 30s client abort is an EXPECTED, retryable
+  // degradation under momentary API saturation — not an actionable bug. The
+  // saturation signal stays visible in the per-route
+  // `http_request_duration_seconds` metric and the structured
+  // `Request completed: … 503 …` warn log. Real 5xx server errors and genuine
+  // connectivity loss (NETWORK_ERROR) still report. The message-shape backstop
+  // for leak paths lives in browser-error-noise.ts (`isClientRequestTimeoutMessage`).
+  if (status >= 500 || error?.code === 'NETWORK_ERROR') {
     Sentry.captureException(
       error instanceof Error ? error : new Error(error?.message || String(error)),
       {


### PR DESCRIPTION
## Root cause (one line)

A single transient client-side 30s fetch timeout on the background `GET /v1/projects/:id/sessions/:sid/audit` poll — the SDK's `didTimeout` 30s client deadline firing because API-side request-delivery latency exceeded the 5s margin between the 25s server request-deadline and the 30s client timeout (momentary saturation in the ~13:53 UTC post-#4519-promote window), then Sentry-captured as an error. Not a code regression in the audit route (it is non-exempt and properly covered by the deadline net).

## Better Stack error

- Error: https://errors.betterstack.com/team/t502678/errors/b1db01e5c9dec8c62bf37ca994cbe304550a7699b8fcd04c8f5c01cc76fc9dc7?s=2346967
- Pattern `b1db01e5c9dec8c62bf37ca994cbe304550a7699b8fcd04c8f5c01cc76fc9dc7`, application_id **2346967** (Kortix Frontend prod), env=prod, **count 1, users 0**, last_seen 2026-07-12 13:53:05 UTC.
- Type/message (from the Better Stack metrics source `remote(t502678_kortix_frontend_metrics)`):
  `ApiError — Request timed out after 30s: /projects/24e99500-c925-481a-bc88-5b89dba4d965/sessions/88488045-8cd7-4c6b-ad0f-2b56a4c9cb25/audit`
  call_site: `app:///_next/static/chunks/27594-…js`.

## Evidence

- **Source of the message (exactly one site):** `packages/sdk/src/core/http/api-client.ts:234` — the SDK's `makeRequest` genuine-timeout branch (`didTimeout === true`), which surfaces `new ApiError('Request timed out after ${timeout/1000}s: ${endpoint}', { code: 'TIMEOUT' })`. External aborts (navigation, React Query cancellation, dropped connection) are deliberately swallowed (`code: 'ABORTED'`) and do NOT produce this message — only the SDK's own 30s timer does.
- **Why it reaches Better Stack:** `apps/web/src/lib/error-handler.tsx:handleApiError` runs `Sentry.captureException(...)` whenever `status >= 500 || error?.code === 'TIMEOUT' || error?.code === 'NETWORK_ERROR'`. The SDK's `onError` is wired to `handleApiError` via `apps/web/src/lib/kortix-config.ts:69`. So a genuine client-side 30s timeout on any non-`silent` API call is captured as a Sentry error pattern.
- **The timed-out route:** `GET /v1/projects/:projectId/sessions/:sessionId/audit` (`apps/api/src/projects/routes/r7.ts:642`). Its own docstring notes "the web app polls this route from every open session to render the approval prompt." `apps/web/src/features/session/session-audit-shared.tsx` polls it every 15s (panel) / 5s (approval-prompt + chat) via `useSessionAudit`; 3 of 5 call surfaces do NOT pass `silent: true`, so a transient timeout fires `handleApiError` → Sentry.
- **Not a deadline-net failure / route bug:** the route is non-exempt (not in `EXEMPT_PREFIXES`/`EXEMPT_FRAGMENTS` in `apps/api/src/middleware/request-deadline.ts`), so the 25s server deadline applies (`app.use('/v1/*', requestDeadline)` at `index.ts:325`). Under the deadline net, a saturated request returns a clean 503 at ~25s — under the client's 30s budget. A 30s client timeout therefore means the 503 was delivered late (event-loop/pool saturation pushed the 25s timer + response flush past the 30s client margin) — i.e. the expected "broad API saturation" signature, not a code defect in the handler.
- **Scale:** count 1, users 0 — a single one-off, not a spike.

## What the fix does (telemetry classification — no runtime behavior change)

This is the **frontend mirror of #4524**. #4524 stopped Sentry-capturing the API's `RequestDeadlineHTTPException` 503 ("expected, retryable degradation"); this PR stops Sentry-capturing its frontend counterpart — the SDK's `code === 'TIMEOUT'` client-side 30s abort. Same rationale: the system has a 25s server deadline (503 + `Retry-After: 10`) and react-query retries background polls, so a 30s client abort is expected/transient, and the saturation signal already lives in the per-route `http_request_duration_seconds` metric (status=503) and the structured `Request completed: … 503 …` warn log.

- `apps/web/src/lib/error-handler.tsx`: drop `error?.code === 'TIMEOUT'` from the `Sentry.captureException` condition (keep `status >= 500` and `code === 'NETWORK_ERROR'`). **User-facing toast behavior is unchanged** — the toast is governed later in the function by `shouldShowError` + status branches; only the Sentry capture is removed. Genuine connectivity loss (`NETWORK_ERROR`, e.g. connection refused / offline) still reports.
- `apps/web/src/lib/browser-error-noise.ts`: add `isClientRequestTimeoutMessage` and wire it into both `shouldIgnoreBrowserRuntimeNoise` and `shouldIgnoreSentryBrowserNoise` as the **telemetry-side backstop** for capture paths that bypass `handleApiError`'s guard (`<ClientErrorBoundary>`, `route-error`/`system-fault`, `app/error`, the Sentry SDK's own `onunhandledrejection`) — same shape as the billing-gate (#4522) and runtime-not-ready (#4516) backstops. The match is anchored on the SDK's exact `Request timed out after <N>s: ` prefix (with canonical `ApiError:` / `Unhandled promise rejection:` wrappers) so the API's different `Request exceeded the 25s server processing deadline` wording and generic third-party "request timed out" messages are never matched.

## Relation to #4524 / frontend timeout mirrors

- **Not a duplicate of #4524.** #4524 is API-side (`apps/api/src/index.ts` `onError` + `RequestDeadlineHTTPException`); it explicitly does NOT touch the frontend mirror — its PR body says: *"The frontend mirrors are expected to continue resolving as a frontend-side noise classification, not chased here."* This PR IS that frontend-side noise classification.
- #4524 is on `main` but **not yet promoted** to prod. Once promoted, the API-side 503 stops Sentry-capturing; this PR stops the matching client-side TIMEOUT from Sentry-capturing. Together they close the full deadline-degradation noise loop on both sides of the boundary.
- The error-sweep ledger has twice deferred the "frontend timeout mirrors" long tail as broad API saturation awaiting the request-deadline fixes promoting. This PR resolves that deferral for the `code === 'TIMEOUT'` class as a whole (not just the audit route): every frontend `Request timed out after Ns: <endpoint>` pattern drops to zero, since the genuine client-side deadline is no longer an error-pattern source. Real 5xx server errors and `NETWORK_ERROR` still report.

## Tests

Added to `apps/web/src/lib/browser-error-noise.test.mts` (reproduces the assigned occurrence + the leak-path backstop):
- `isClientRequestTimeoutMessage` classifies every variant of the SDK's timeout message (exact assigned endpoint, a different budget, `ApiError:`-prefixed, and `Unhandled promise rejection:` wrappers) as expected noise.
- `shouldIgnoreSentryBrowserNoise` / `shouldIgnoreBrowserRuntimeNoise` suppress it regardless of capture path.
- **Negative guards (do NOT over-suppress):** the API's server-deadline 503 wording (`Request exceeded the 25s server processing deadline`), generic third-party timeout messages (`The request timed out`, `request timed out after 5000ms`, …), and real 5xx `ApiError`s (`Internal server error`, `HTTP 500: …`) all keep reporting.

## Verification

```
$ bun test apps/web/src/lib/browser-error-noise.test.mts
bun test v1.3.14 (0d9b296)
  33 pass
  0 fail
Ran 33 tests across 1 file. [95.00ms]

$ bun build --no-bundle apps/web/src/lib/error-handler.tsx apps/web/src/lib/browser-error-noise.ts apps/web/src/lib/browser-error-noise.test.mts --outfile /dev/null   # rc=0, clean transpile
```

(The repo's full `tsc --noEmit` / `eslint` gates require a workspace install, which this sandbox could not complete; the 33-test suite passing + clean `bun build` transpilation of all three files + the minimal, style-matched edit are the verification available here. CI will run the full typecheck/lint/test gate.)

## Confirmation after merge + Promote

The Better Stack error `b1db01e5…` should drop to **zero new occurrences** once this reaches prod (the client-side `TIMEOUT` is no longer `captureException`'d, and the leak-path backstop drops any that bypass `handleApiError`). The underlying saturation signal remains visible in the per-route `http_request_duration_seconds` metric and the structured `Request completed: … 503 …` warn log, exactly as for the server-side 503 after #4524. Not claiming prod fixed until the next Promote.
