### PR TITLE
fix(web): suppress old-WebKit lookbehind parse noise (Safari < 16.4)

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -75,6 +75,17 @@ if (SENTRY_DSN) {
       // External Safari / WebView video probing noise
       'webkitPresentationMode',
       "null is not an object (evaluating 'document.querySelector('video').webkitPresentationMode')",
+      // Old WebKit (Safari/iOS < 16.4) cannot parse lookbehind assertions
+      // (`(?<=…)` / `(?<!…)`): JSC reads `(?<` as a named-capture-group opener,
+      // sees `=` / `!`, and throws `SyntaxError: Invalid regular expression:
+      // invalid group specifier name` at chunk PARSE time, failing the whole
+      // chunk. The lookbehind literals live in bundled third-party deps
+      // (`mdast-util-gfm-autolink-literal` GFM email-autolink regex +
+      // `@pierre/diffs` `SPLIT_WITH_NEWLINES = /(?<=\n)/`), the wording is
+      // WebKit-specific (V8/Node say "Invalid group"), and only very old
+      // Safari/iOS visitors hit it. `browser-error-noise.ts` drops it from
+      // `beforeSend` too; this string gate covers frameless onerror captures.
+      'invalid group specifier name',
       // Browser extension/runtime bridge noise
       'Invalid call to runtime.sendMessage(). Tab not found.',
       // Third-party injected scripts / wallet extensions

--- a/apps/web/src/app/sentry-ignore-errors.test.ts
+++ b/apps/web/src/app/sentry-ignore-errors.test.ts
@@ -45,3 +45,16 @@ test('sentry.client.config ignores storage-disabled WebView null-access TypeErro
   // JSC variant (older Safari/iOS WebView).
   expect(source).toContain("Cannot read property 'getItem' of null");
 });
+
+test('sentry.client.config drops the old-WebKit lookbehind parse failure', async () => {
+  // Reproduces Better Stack error 6d987ab4...34e7ed (Kortix Frontend prod):
+  // Safari/iOS < 16.4 cannot parse lookbehind assertions and throws
+  // `SyntaxError: Invalid regular expression: invalid group specifier name`
+  // at chunk parse time. The lookbehind lives in bundled third-party deps
+  // (`mdast-util-gfm-autolink-literal`, `@pierre/diffs`), the wording is
+  // WebKit-specific, and only old Safari/iOS visitors hit it. Sentry's
+  // `ignoreErrors` list is checked before an event is sent (covers every
+  // capture path, including frameless onerror), so the marker MUST live here.
+  const source = await Bun.file(`${import.meta.dir}/../../sentry.client.config.ts`).text();
+  expect(source).toContain("'invalid group specifier name'");
+});

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -7,6 +7,7 @@ import {
   isExtensionSource,
   isInjectedAppSource,
   isKnownBrowserNoiseMessage,
+  isOldWebkitRegexNoiseMessage,
   isRuntimeNotReadyNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
@@ -794,4 +795,82 @@ test('does NOT suppress a real 5xx server ApiError', () => {
       `expected real server error "${value}" to keep reporting`,
     )
   }
+})
+
+// Reproduces Better Stack error 6d987ab4...34e7ed (1 occurrence, 0 users),
+// Kortix Frontend (prod), application_id 2346967: a Safari 15.6.1 visitor on
+// the marketing homepage (`https://kortix.com/`) hit a chunk parse-time
+// `SyntaxError: Invalid regular expression: invalid group specifier name`.
+// Old WebKit (< 16.4) cannot parse lookbehind assertions — JSC reads `(?<` as
+// a named-capture-group opener, sees the following `=` / `!`, and throws this
+// message, failing the whole chunk. The lookbehind literals live in bundled
+// THIRD-PARTY deps (`mdast-util-gfm-autolink-literal@2.0.1`'s GFM email
+// autolink regex `/(?<=^|\s|\p{P}|\p{S})…/gu` and `@pierre/diffs`'s
+// `SPLIT_WITH_NEWLINES = /(?<=\n)/`), the wording is WebKit-specific (V8/Node
+// say "Invalid group"), and only very old Safari/iOS visitors hit it. The
+// de-minified frame points at our own chunk, so it is matched by message, not
+// by source.
+const OLD_WEBKIT_REGEX_EVENTS = [
+  // The exact raw event value from Better Stack (Safari 15.6.1, macOS 10.15.7).
+  'Invalid regular expression: invalid group specifier name',
+  // window.onerror can prefix the message with the exception type.
+  'SyntaxError: Invalid regular expression: invalid group specifier name',
+  // An unhandled-rejection wrapper preserving the message.
+  'Unhandled promise rejection: Invalid regular expression: invalid group specifier name',
+]
+
+test('classifies every old-WebKit lookbehind parse variant as noise', () => {
+  for (const message of OLD_WEBKIT_REGEX_EVENTS) {
+    assert.equal(
+      isOldWebkitRegexNoiseMessage(message),
+      true,
+      `expected ${message} to be classified as old-WebKit regex noise`,
+    )
+  }
+})
+
+test('suppresses an old-WebKit lookbehind Sentry event from the marketing site', () => {
+  for (const value of OLD_WEBKIT_REGEX_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [
+                  { filename: 'app:///_next/static/chunks/76904-c52ab52c4900447c.js' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses an old-WebKit lookbehind unhandled rejection from the browser', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        'Unhandled promise rejection: Invalid regular expression: invalid group specifier name',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a real V8/Node regex error with different wording', () => {
+  // Modern V8/Node say "Invalid group" / "Invalid regular expression: \(\?<=\)",
+  // never "invalid group specifier name" — those keep reporting.
+  assert.equal(isOldWebkitRegexNoiseMessage('Invalid regular expression: /(?!<=)/: Invalid group'), false)
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: 'TypeError: Cannot read properties of undefined (reading id)' }] },
+    }),
+    false,
+  )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -117,6 +117,23 @@ function isWebpackRuntimeChunkFilename(filename: unknown): boolean {
   );
 }
 
+// Old WebKit (Safari < 16.4, iOS < 16.4) cannot parse lookbehind assertions
+// `(?<=…)` / `(?<!…)`. JavaScriptCore reads the `(?<` as a named-capture-group
+// opener, sees the following `=` / `!`, and throws
+// `SyntaxError: Invalid regular expression: invalid group specifier name` at
+// chunk PARSE time — so the entire JS chunk fails to load for that visitor.
+// The lookbehind literals live in bundled THIRD-PARTY deps we ship on the
+// marketing site (the GFM email-autolink regex in `mdast-util-gfm-autolink-
+// literal@2.0.1` and `SPLIT_WITH_NEWLINES = /(?<=\n)/` in `@pierre/diffs`),
+// not in first-party source, and the wording is WebKit-specific — V8/Node
+// never produce it (they say "Invalid group"). Only very old Safari/iOS
+// visitors hit it. Suppress this distinctive message so it stops paging
+// Better Stack; a genuine first-party regex regression surfaces with a
+// different message on modern browsers (which all support lookbehind).
+const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
+  'invalid group specifier name',
+] as const;
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -300,6 +317,21 @@ export function isClientRequestTimeoutMessage(message: unknown): boolean {
   return CLIENT_REQUEST_TIMEOUT_WRAPPERS.some((re) => re.test(normalized));
 }
 
+/**
+ * Whether a message is the old-WebKit (< 16.4) lookbehind parse failure
+ * `SyntaxError: Invalid regular expression: invalid group specifier name`.
+ * The lookbehind lives in bundled third-party deps
+ * (`mdast-util-gfm-autolink-literal`, `@pierre/diffs`), the wording is
+ * WebKit-specific (V8/Node say "Invalid group"), and only very old Safari/iOS
+ * visitors hit it — never page Better Stack for it.
+ */
+export function isOldWebkitRegexNoiseMessage(message: unknown): boolean {
+  const normalized = normalizeString(message).toLowerCase();
+  return OLD_WEBKIT_REGEX_NOISE_PATTERNS.some((pattern) =>
+    normalized.includes(pattern.toLowerCase()),
+  );
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -348,6 +380,12 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   // SDK's `ApiError` reaches window.onerror / unhandledrejection before
   // `handleApiError` can gate it.
   if (isExpectedBillingGateMessage(message)) {
+    return true;
+  }
+
+  // Old-WebKit (< 16.4) lookbehind parse failure from bundled third-party
+  // deps — WebKit-specific wording, only old Safari/iOS visitors hit it.
+  if (isOldWebkitRegexNoiseMessage(message)) {
     return true;
   }
 
@@ -423,6 +461,14 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // pages Better Stack. Real `ApiError`s are never matched — only the exact
   // strings the billing gate emits are.
   if (isExpectedBillingGateMessage(message)) {
+    return true;
+  }
+
+  // Old-WebKit (< 16.4) lookbehind parse failure from bundled third-party
+  // deps on the marketing site — WebKit-specific wording, only old Safari/iOS
+  // visitors hit it. The de-minified frame points at our own chunk, so this
+  // is matched by message, not by source.
+  if (isOldWebkitRegexNoiseMessage(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Narrowly-scoped telemetry suppression for **Better Stack error `6d987ab4c7334484bfa110058d74fd693ef8b9b08c2a411d8d692d8cd934e7ed`** (Kortix Frontend prod, application_id `2346967`) — a `SyntaxError: Invalid regular expression: invalid group specifier name` thrown at chunk parse time on old Safari.

- **Error URL:** https://errors.betterstack.com/team/t502678/errors/6d987ab4c7334484bfa110058d74fd693ef8b9b08c2a411d8d692d8cd934e7ed?s=2346967
- **Error id:** `6d987ab4c7334484bfa110058d74fd693ef8b9b08c2a411d8d692d8cd934e7ed`
- **Count / users:** 1 occurrence, 0 attributed users · last_seen 2026-07-12 12:30:34 UTC · env prod

## Evidence (raw event from Better Stack ClickHouse)

Pulled the raw exception via the Better Stack telemetry MCP (S3 exceptions collection):

```
type:      SyntaxError
value:     Invalid regular expression: invalid group specifier name
url:       https://kortix.com/
browser:   Safari 15.6.1 (macOS 10.15.7)
mechanism: auto.browser.global_handlers.onerror (handled: false)
release:   051d9bbc99f50f44a121b1f37d840944f5bed96b
frame:     app:///_next/static/chunks/76904-c52ab52c4900447c.js  function ?  lineno 1
```

## Root cause

Old WebKit (**Safari / iOS < 16.4**) cannot parse lookbehind assertions `(?<=...)` / `(?<!...)`. JavaScriptCore reads the `(?<` as a named-capture-group opener, sees the following `=` / `!`, and throws `SyntaxError: Invalid regular expression: invalid group specifier name` at **chunk parse time** — so the entire JS chunk fails to load for that visitor.

The offending lookbehind **literals** are in bundled **third-party** deps (confirmed by downloading the deployed chunk `76904-...js` from kortix.com and grepping):

1. `mdast-util-gfm-autolink-literal@2.0.1` (`lib/index.js:135`) — the GFM email-autolink regex:
   `/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu`
2. `@pierre/diffs@1.1.22` (`dist/constants.js:8`) — `SPLIT_WITH_NEWLINES = /(?<=\n)/`

Safari parses the chunk left-to-right and fails at the first lookbehind literal (the email regex). Patching only one would just shift the failure to the diff regex; patching `@pierre/diffs` cleanly isn't feasible (a lookbehind-free equivalent requires call-site changes in a minified dist). The message is **WebKit-specific** — V8/Node say "Invalid group", never "invalid group specifier name" — and only very old Safari/iOS visitors hit it. Per the `betterstack-error-triage` playbook (third-party / old-browser parse noise), the proportionate fix is a narrowly-scoped telemetry suppression.

## Fix

Add the distinctive message `invalid group specifier name` to both telemetry gates so this error stops paging Better Stack regardless of capture path:

- `apps/web/sentry.client.config.ts` — `ignoreErrors` entry (SDK-level gate; checked before an event is sent; covers frameless `onerror` captures).
- `apps/web/src/lib/browser-error-noise.ts` — new `isOldWebkitRegexNoiseMessage` predicate wired into `shouldIgnoreBrowserRuntimeNoise` and `shouldIgnoreSentryBrowserNoise` (the `beforeSend` backstop).

A genuine first-party regex regression would surface with a different message on modern browsers (which all support lookbehind), so this does not mask real bugs.

## Verification

- `bun test src/lib/browser-error-noise.test.mts` — 31 pass / 0 fail (incl. 4 new regression tests: classifies every variant, suppresses the Sentry event from the marketing site, suppresses the unhandled-rejection form, does NOT suppress V8/Node regex errors with different wording).
- `bun test src/app/sentry-ignore-errors.test.ts` — 3 pass / 0 fail (incl. new guard asserting the `ignoreErrors` marker exists).
- Direct repro feeding the **exact raw Better Stack event** (Safari 15.6.1, `kortix.com/`, chunk `76904-...js`) through `shouldIgnoreSentryNoiseEvent` -> `true` (suppressed).
- `eslint` on all 4 changed files — clean.
- `tsc --noEmit` — no errors in the changed files (filtered out the known bogus TS2786 noise).

## How to confirm in prod

After this merges + promotes, the Better Stack error `6d987ab4...` should drop to zero new occurrences (Sentry drops the event client-side before it reaches Better Stack, so Better Stack auto-resolves once it stops seeing it).

## Files changed

- `apps/web/sentry.client.config.ts` — add `ignoreErrors` entry + comment.
- `apps/web/src/lib/browser-error-noise.ts` — add `OLD_WEBKIT_REGEX_NOISE_PATTERNS` + `isOldWebkitRegexNoiseMessage`, wire into both guards.
- `apps/web/src/lib/browser-error-noise.test.mts` — regression tests.
- `apps/web/src/app/sentry-ignore-errors.test.ts` — config guard test.

## Scope / conflict note

Touches only `apps/web` Sentry-noise files (`sentry.client.config.ts`, `src/lib/browser-error-noise.ts` + its test). These are the shared browser-noise suppression files; another active worker editing the same files would conflict. No `@kortix/sdk`, API, or infra files touched.
