### PR TITLE
fix(desktop): restore clickable native window chrome

### DIFF
--- a/apps/desktop-electron/src/main.js
+++ b/apps/desktop-electron/src/main.js
@@ -26,6 +26,10 @@ const {
 const path = require('node:path');
 const fs = require('node:fs');
 const { setupAutoUpdates, checkForUpdatesInteractive } = require('./updater');
+const {
+  DESKTOP_CHROME_JS,
+  configureNativeWindowControls,
+} = require('./window-chrome');
 
 // Name comes from the bundle (productName): "Kortix" for prod, "Kortix Dev" for
 // dev builds. Per-name data dir so dev + prod coexist without sharing a session,
@@ -70,82 +74,6 @@ const UA_TOKEN = 'KortixDesktop/0.1.0';
 // the brand surface, never a white flash. Tauri sets this on <body> via CSS;
 // here it's the native window background.
 const BG_COLOR = '#0a0a0a';
-
-// Window-drag zones. Tauri drives dragging with a JS mousedown→startDragging
-// shim because WKWebView ignores `-webkit-app-region`. Electron/Chromium honors
-// app-region natively, so we just mark the same zones draggable and carve every
-// interactive element back out (mirrors the Tauri INTERACTIVE_TAGS + role list).
-// Injected on every load. Two jobs:
-//   1. Mark the window-drag zones with `-webkit-app-region: drag` via an AUTHOR
-//      <style> element. IMPORTANT: `webContents.insertCSS()` does NOT honor
-//      -webkit-app-region — only a real <style>/<link> in the document does, so
-//      we inject it here instead of via insertCSS.
-//   2. Keep a full-width drag strip pinned across the very top of the window so
-//      it's movable from ANYWHERE up top — not just over the sidebar/tab-bar.
-//      The web app reserves a ~40px title-bar band at the top on desktop
-//      (--kx-titlebar-inset), so on pages whose main panel has no tab bar that
-//      band was dead space you couldn't grab. The strip fills it.
-//
-// The strip is the FIRST child of <body> and `pointer-events:none`, which is
-// what lets it coexist with the tab bar instead of covering it (the reason the
-// old strip had to be removed once the app shell mounted):
-//   • Draggable regions resolve in DOM order, so the tab-bar tabs / sidebar
-//     buttons — all marked `no-drag` and later in the DOM — punch holes back
-//     through the strip's drag region and stay grabbable as buttons.
-//   • `pointer-events:none` means clicks in those holes pass straight through to
-//     the real controls; only the bare band stays a drag handle.
-const IS_MAC = process.platform === 'darwin';
-// Skip the macOS traffic-light gutter on the left; Win/Linux have no left
-// controls (their min/max/close render on the right and are `no-drag` buttons).
-const DRAG_STRIP_LEFT = IS_MAC ? 80 : 0;
-// Match the reserved title-bar band (--kx-titlebar-inset: 40px macOS / 28px
-// else); 32px on Win/Linux leaves the strip comfortably grabbable.
-const DRAG_STRIP_HEIGHT = IS_MAC ? 40 : 32;
-const DESKTOP_CHROME_JS = `
-(function () {
-  if (window.__kortixChrome) return;
-  window.__kortixChrome = true;
-
-  var style = document.createElement('style');
-  style.id = 'kortix-chrome-style';
-  style.textContent =
-    '[role="tablist"],[data-sidebar="header"],[data-sidebar="sidebar"],' +
-    '.kx-desktop-drag,.kx-desktop-chrome,#kortix-drag-strip{-webkit-app-region:drag;}' +
-    'button,a,input,textarea,select,option,label,summary,video,audio,iframe,' +
-    '[role="button"],[role="tab"],[role="link"],[role="menuitem"],[role="textbox"],' +
-    '[contenteditable],[data-no-drag]{-webkit-app-region:no-drag;}';
-  (document.head || document.documentElement).appendChild(style);
-
-  var ID = 'kortix-drag-strip';
-  function ensureStrip() {
-    if (!document.body) return;
-    var strip = document.getElementById(ID);
-    if (!strip) {
-      strip = document.createElement('div');
-      strip.id = ID;
-      strip.setAttribute('aria-hidden', 'true');
-      // pointer-events:none → clicks fall through to controls beneath; the drag
-      // region still works (it's OS-level, not pointer-event driven). z-index:0
-      // so it never visually layers over content (it's transparent regardless).
-      strip.style.cssText =
-        'position:fixed;top:0;left:${DRAG_STRIP_LEFT}px;right:0;height:${DRAG_STRIP_HEIGHT}px;' +
-        'z-index:0;pointer-events:none;-webkit-app-region:drag;';
-    }
-    // First child so every interactive element (later in the DOM, all no-drag)
-    // overrides the strip and stays clickable; bare band stays draggable.
-    if (strip !== document.body.firstChild) {
-      document.body.insertBefore(strip, document.body.firstChild);
-    }
-  }
-  ensureStrip();
-  // SPA route changes swap the DOM without a reload — keep the strip first.
-  var t;
-  new MutationObserver(function () {
-    clearTimeout(t);
-    t = setTimeout(ensureStrip, 250);
-  }).observe(document.documentElement, { childList: true, subtree: true });
-})();
-`;
 
 /* ─── Frontend URL override (self-hosting) ────────────────────────────────
    Persisted as a single line in userData/frontend_url — same contract as the
@@ -426,12 +354,9 @@ function createMainWindow() {
     },
   });
 
-  // macOS: hide the native traffic lights — on macOS 26 (Tahoe) they render
-  // permanently gray/inactive for hidden-title-bar Electron windows (even
-  // focused, even on hover). The web app draws its own colored lights in the
-  // same spot (DesktopChrome → MacTrafficLights), wired to the kortix:window
-  // IPC, so close/minimize/zoom keep working.
-  if (isMac) mainWindow.setWindowButtonVisibility(false);
+  // Keep one canonical set of controls. Web-rendered traffic lights could
+  // coexist with native buttons after focus/reload transitions.
+  configureNativeWindowControls(mainWindow, isMac);
 
   // Reveal once content is in. did-finish-load fires when the document + its
   // subresources are loaded — good enough to swap the splash for real chrome
@@ -453,9 +378,8 @@ function createMainWindow() {
     }
   }, 12_000);
 
-  // Inject the drag-zone <style> + fallback strip on every load (full reloads
-  // from the Frontend URL switcher; SPA route changes are handled by the
-  // MutationObserver inside DESKTOP_CHROME_JS).
+  // Inject the drag-zone author style on every full load. The web shell owns
+  // the thin top-edge drag handle; no compositor-level overlay covers content.
   mainWindow.webContents.on('did-finish-load', () => {
     mainWindow?.webContents.executeJavaScript(DESKTOP_CHROME_JS).catch(() => {});
     // Render diagnostic (blur): on Retina expect dpr=2 and zoom=1.

--- a/apps/desktop-electron/src/window-chrome.js
+++ b/apps/desktop-electron/src/window-chrome.js
@@ -1,0 +1,30 @@
+// Electron window chrome shared by the main process and its focused tests.
+
+// Keep drag behavior on explicit web-app regions only. A previous fallback
+// inserted a 40px, full-width drag strip over the title-bar band. Chromium
+// treats app regions at the compositor level, so pointer-events:none did not
+// make the controls underneath clickable; Projects, workspace, Upgrade, and
+// account actions could all become window-drag targets instead.
+const DESKTOP_CHROME_JS = `
+(function () {
+  if (window.__kortixChrome) return;
+  window.__kortixChrome = true;
+
+  var style = document.createElement('style');
+  style.id = 'kortix-chrome-style';
+  style.textContent =
+    '[role="tablist"],[data-sidebar="header"],[data-sidebar="sidebar"],' +
+    '.kx-desktop-drag,.kx-desktop-chrome{-webkit-app-region:drag;}' +
+    'button,a,input,textarea,select,option,label,summary,video,audio,iframe,' +
+    '[role="button"],[role="tab"],[role="link"],[role="menuitem"],[role="textbox"],' +
+    '[contenteditable],[data-no-drag]{-webkit-app-region:no-drag;}';
+  (document.head || document.documentElement).appendChild(style);
+})();
+`;
+
+/** Use the platform controls instead of painting a second web copy. */
+function configureNativeWindowControls(window, isMac) {
+  if (isMac) window.setWindowButtonVisibility(true);
+}
+
+module.exports = { DESKTOP_CHROME_JS, configureNativeWindowControls };

--- a/apps/desktop-electron/src/window-chrome.test.js
+++ b/apps/desktop-electron/src/window-chrome.test.js
@@ -1,0 +1,37 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+  DESKTOP_CHROME_JS,
+  configureNativeWindowControls,
+} = require('./window-chrome');
+
+describe('desktop window chrome', () => {
+  test('keeps interactive title-bar elements outside drag regions', () => {
+    expect(DESKTOP_CHROME_JS).toContain('button,a,input,textarea');
+    expect(DESKTOP_CHROME_JS).toContain('-webkit-app-region:no-drag');
+  });
+
+  test('does not inject a full-width drag overlay', () => {
+    expect(DESKTOP_CHROME_JS).not.toContain('kortix-drag-strip');
+    expect(DESKTOP_CHROME_JS).not.toContain('pointer-events:none');
+    expect(DESKTOP_CHROME_JS).not.toContain('MutationObserver');
+  });
+
+  test('uses native macOS window controls', () => {
+    const calls = [];
+    configureNativeWindowControls(
+      { setWindowButtonVisibility: (visible) => calls.push(visible) },
+      true,
+    );
+    expect(calls).toEqual([true]);
+  });
+
+  test('does not configure macOS controls on other platforms', () => {
+    const calls = [];
+    configureNativeWindowControls(
+      { setWindowButtonVisibility: (visible) => calls.push(visible) },
+      false,
+    );
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/web/src/components/desktop/desktop-chrome.tsx
+++ b/apps/web/src/components/desktop/desktop-chrome.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslations } from 'next-intl';
 
-import { useEffect, useState } from 'react';
 import {
   desktopPlatform,
   desktopWindow,
@@ -14,6 +13,7 @@ import {
   zoomReset,
   type DesktopPlatform,
 } from '@/lib/desktop';
+import { useEffect, useState } from 'react';
 
 /**
  * Invisible top-of-window drag region. The web app's own UI extends to the
@@ -25,18 +25,10 @@ import {
  */
 export function DesktopChrome() {
   const [platform, setPlatform] = useState<DesktopPlatform | null>(null);
-  // Only the Electron shell hides the native macOS traffic lights (its
-  // preload exposes this marker) — the Tauri shell keeps them, so drawing
-  // our own there would double them up.
-  const [isElectronShell, setIsElectronShell] = useState(false);
 
   useEffect(() => {
     if (!isDesktop()) return;
     setPlatform(desktopPlatform());
-    setIsElectronShell(
-      (window as unknown as { kortixDesktop?: { shell?: string } }).kortixDesktop?.shell ===
-        'electron',
-    );
 
     // Reapply persisted zoom on mount. WKWebView resets to 1.0 each launch,
     // so we always have to push the saved value back in.
@@ -68,95 +60,14 @@ export function DesktopChrome() {
     // WKWebView default) consumes it — otherwise Cmd+R can be silently
     // swallowed before our window-level bubble handler ever runs.
     window.addEventListener('keydown', onKey, { capture: true });
-    return () => window.removeEventListener('keydown', onKey, { capture: true } as EventListenerOptions);
+    return () =>
+      window.removeEventListener('keydown', onKey, { capture: true } as EventListenerOptions);
   }, []);
 
   return (
     <div className="kx-desktop-chrome" aria-hidden>
       <div className="kx-desktop-drag" data-tauri-drag-region />
-      {platform === 'macos' && isElectronShell ? <MacTrafficLights /> : null}
       {platform && platform !== 'macos' ? <WindowControls /> : null}
-    </div>
-  );
-}
-
-/**
- * Custom macOS traffic lights. The native ones render permanently gray on
- * macOS 26 (Tahoe) for hidden-title-bar Electron windows, so the shell hides
- * them (main.js `setWindowButtonVisibility(false)`) and we draw our own in
- * the same zone (x 10–70, center y≈26 — the calibrated title-bar line) wired
- * to the same window controls. Native behaviors kept: glyphs appear on
- * group hover, dots dim to gray when the window loses focus.
- */
-const MAC_LIGHTS = [
-  {
-    action: () => void desktopWindow.close(),
-    label: 'Close',
-    color: '#ff5f57',
-    glyph: (
-      <path d="M3.5 3.5 L9.5 9.5 M9.5 3.5 L3.5 9.5" stroke="#4d0000" strokeWidth="1.2" strokeLinecap="round" />
-    ),
-  },
-  {
-    action: () => void desktopWindow.minimize(),
-    label: 'Minimize',
-    color: '#febc2e',
-    glyph: <path d="M3 6.5 L10 6.5" stroke="#985712" strokeWidth="1.2" strokeLinecap="round" />,
-  },
-  {
-    action: () => void desktopWindow.toggleMaximize(),
-    label: 'Zoom',
-    color: '#28c840',
-    glyph: (
-      <path d="M6.5 3 L6.5 10 M3 6.5 L10 6.5" stroke="#0b5d16" strokeWidth="1.2" strokeLinecap="round" />
-    ),
-  },
-] as const;
-
-function MacTrafficLights() {
-  // Native lights dim to gray when the window isn't focused — mirror that.
-  const [focused, setFocused] = useState(true);
-  useEffect(() => {
-    setFocused(document.hasFocus());
-    const onFocus = () => setFocused(true);
-    const onBlur = () => setFocused(false);
-    window.addEventListener('focus', onFocus);
-    window.addEventListener('blur', onBlur);
-    return () => {
-      window.removeEventListener('focus', onFocus);
-      window.removeEventListener('blur', onBlur);
-    };
-  }, []);
-
-  return (
-    // Native geometry, pinned in raw px (rem drifts with the root font):
-    // 20px hit boxes butted together → dot centers at x 16/36/56, zone ends
-    // at 66 — inside the ~70px gutter every header indent already clears.
-    <div className="group fixed top-[16px] left-[6px] z-[10000] flex [-webkit-app-region:no-drag] [app-region:no-drag]">
-      {MAC_LIGHTS.map((light) => (
-        <button
-          key={light.label}
-          type="button"
-          aria-label={light.label}
-          onClick={light.action}
-          className="flex h-[20px] w-[20px] cursor-default items-center justify-center"
-        >
-          <span
-            className="flex h-[13px] w-[13px] items-center justify-center rounded-full shadow-[inset_0_0_0_0.5px_rgba(0,0,0,0.15)] transition-[background-color] duration-150"
-            style={{ backgroundColor: focused ? light.color : 'var(--kx-light-inactive, #8e8e8e)' }}
-          >
-            <svg
-              width="13"
-              height="13"
-              viewBox="0 0 13 13"
-              aria-hidden
-              className="opacity-0 transition-opacity duration-100 group-hover:opacity-100"
-            >
-              {light.glyph}
-            </svg>
-          </span>
-        </button>
-      ))}
     </div>
   );
 }
@@ -164,7 +75,12 @@ function MacTrafficLights() {
 function WindowControls() {
   const tHardcodedUi = useTranslations('hardcodedUi');
   return (
-    <div className="kx-desktop-controls" aria-label={tHardcodedUi.raw('componentsDesktopDesktopChrome.line74JsxAttrAriaLabelWindowControls')}>
+    <div
+      className="kx-desktop-controls"
+      aria-label={tHardcodedUi.raw(
+        'componentsDesktopDesktopChrome.line74JsxAttrAriaLabelWindowControls',
+      )}
+    >
       <button
         type="button"
         className="kx-desktop-ctrl"

--- a/apps/web/src/features/auth/auth-card-shell.tsx
+++ b/apps/web/src/features/auth/auth-card-shell.tsx
@@ -16,14 +16,19 @@ import Link from 'next/link';
 
 import { KortixLogo } from '@/components/ui/kortix-logo';
 import { AuthMobileLogo } from '@/features/auth/auth-primitives';
+import { openExternalRoute } from '@/lib/desktop';
 
 const EASE = [0.23, 1, 0.32, 1] as const;
 
 /** Tiny legal line pinned to the bottom of every auth surface. */
 export function AuthLegalFooter({ variant = 'default' }: { variant?: 'default' | 'signup' }) {
+  const onLegalClick = (event: React.MouseEvent<HTMLAnchorElement>, href: string) => {
+    if (openExternalRoute(href)) event.preventDefault();
+  };
   const terms = (
     <Link
       href="/legal?tab=terms"
+      onClick={(event) => onLegalClick(event, '/legal?tab=terms')}
       className="hover:text-muted-foreground underline-offset-4 transition-colors hover:underline"
     >
       Terms of Service
@@ -32,6 +37,7 @@ export function AuthLegalFooter({ variant = 'default' }: { variant?: 'default' |
   const privacy = (
     <Link
       href="/legal?tab=privacy"
+      onClick={(event) => onLegalClick(event, '/legal?tab=privacy')}
       className="hover:text-muted-foreground underline-offset-4 transition-colors hover:underline"
     >
       Privacy Policy
@@ -41,7 +47,9 @@ export function AuthLegalFooter({ variant = 'default' }: { variant?: 'default' |
   return (
     <footer className="text-muted-foreground/60 mx-auto max-w-[380px] px-6 pb-10 text-center text-sm text-balance">
       {variant === 'signup' ? (
-        <>By creating an account, you agree to the {terms} and {privacy}</>
+        <>
+          By creating an account, you agree to the {terms} and {privacy}
+        </>
       ) : (
         <>
           {terms} and {privacy}

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
-import { desktopPlatform, desktopShellPlatform, isDesktop } from '@/lib/desktop';
+import { desktopPlatform, desktopShellPlatform, isDesktop, openExternalRoute } from '@/lib/desktop';
 
 const originalNavigator = globalThis.navigator;
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
 
 function setNavigator(userAgent: string, platform: string) {
   Object.defineProperty(globalThis, 'navigator', {
@@ -17,6 +19,57 @@ afterEach(() => {
     value: originalNavigator,
     configurable: true,
     writable: true,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    value: originalDocument,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'window', {
+    value: originalWindow,
+    configurable: true,
+    writable: true,
+  });
+});
+
+describe('desktop external routes', () => {
+  test('routes each legal page through a real top-level navigation on desktop', () => {
+    setNavigator('Mozilla/5.0 KortixDesktop/0.1.0', 'MacIntel');
+    const clicks: Array<{ href: string; target?: string; rel?: string }> = [];
+    const anchor = {
+      href: '',
+      target: undefined as string | undefined,
+      rel: undefined as string | undefined,
+      click() {
+        clicks.push({ href: this.href, target: this.target, rel: this.rel });
+      },
+      remove() {},
+    };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location: { origin: 'https://kortix.com' } },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      value: {
+        createElement: () => anchor,
+        body: { appendChild() {} },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    expect(openExternalRoute('/legal?tab=terms')).toBe(true);
+    expect(openExternalRoute('/legal?tab=privacy')).toBe(true);
+    expect(clicks).toEqual([
+      { href: 'https://kortix.com/legal?tab=terms', target: undefined, rel: undefined },
+      { href: 'https://kortix.com/legal?tab=privacy', target: undefined, rel: undefined },
+    ]);
+  });
+
+  test('leaves legal navigation to Next.js in a regular browser', () => {
+    setNavigator('Mozilla/5.0 Safari/605.1.15', 'MacIntel');
+    expect(openExternalRoute('/legal?tab=terms')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary\n- use native macOS traffic lights instead of rendering a duplicate web control set\n- remove the 40px compositor drag overlay so Projects header actions remain clickable\n- open auth Terms of Service and Privacy Policy through the desktop external-navigation path\n\n## Verification\n- bun test apps/desktop-electron/src/window-chrome.test.js apps/desktop-electron/src/update-channel.test.js\n- pnpm --filter Kortix-Computer-Frontend exec bun test src/lib/desktop.test.ts\n- pnpm --filter Kortix-Computer-Frontend exec eslint src/components/desktop/desktop-chrome.tsx src/features/auth/auth-card-shell.tsx src/lib/desktop.test.ts\n- pnpm --filter Kortix-Computer-Frontend exec prettier --check src/components/desktop/desktop-chrome.tsx src/features/auth/auth-card-shell.tsx src/lib/desktop.test.ts\n- CSC_IDENTITY_AUTO_DISCOVERY=false Electron packaging plus ad-hoc signing\n- live Electron: one native control cluster, no #kortix-drag-strip, workspace and avatar menus open from top-bar mouse events, Terms/Privacy route externally while auth remains in-app