### PR TITLE
fix(web): suppress old-browser minified-chunk SyntaxError parse noise

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -7,6 +7,7 @@ import {
   isExtensionSource,
   isInjectedAppSource,
   isKnownBrowserNoiseMessage,
+  isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
   isRuntimeNotReadyNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
@@ -870,6 +871,171 @@ test('does NOT suppress a real V8/Node regex error with different wording', () =
   assert.equal(
     shouldIgnoreSentryBrowserNoise({
       exception: { values: [{ value: 'TypeError: Cannot read properties of undefined (reading id)' }] },
+    }),
+    false,
+  )
+})
+
+// Reproduces the old-browser minified-chunk `SyntaxError` parse-failure cluster
+// (Kortix Frontend prod, application_id 2346967), all 1–2 occurrences each, 0
+// users, from `app:///_next/static/chunks/…` minified bundles on old browsers
+// / stripped-down WebViews. The browser cannot parse modern minified JS —
+// incompatible, not an app defect. Covered Better Stack fingerprints:
+//   Unexpected token '='        0015b43d…, 23ac8ed3…, 0665f05e…, 4bcd8a1a…,
+//                               bb3aef66…, 277d3a4a…
+//   Unexpected token '('        dfe7db0b…, 1aa71b82…, a75e4f55…, 7a61bbd1…,
+//                               38e4f3da…
+//   Unexpected token '{'        aff45748…, 40ed5a29…
+//   Invalid or unexpected token c8f836d4…, 572a247e…
+//   Cannot use import statement outside a module  17aeb077…
+// The message prefixes are generic (a real `new Function('…')` / `eval('…')`
+// eval bug throws the same wording), so the matcher requires BOTH the message
+// prefix AND a minified-chunk frame (`_next/static/chunks/` or `?dpl=dpl_…`).
+// Parse failures fire at raw chunk load time, before Sentry sourcemap
+// resolution, so the frame filename stays as the raw chunk path — a genuine
+// first-party eval bug de-minifies to `apps/web/src/…` and is never hidden.
+const CHUNK_FRAME = 'app:///_next/static/chunks/76904-c52ab52c4900447c.js'
+
+const OLD_BROWSER_SYNTAX_PARSE_EVENTS = [
+  // `Unexpected token '='` family (V8/SpiderMonkey).
+  "Unexpected token '='",
+  "SyntaxError: Unexpected token '='",
+  "Unhandled promise rejection: SyntaxError: Unexpected token '='",
+  // `Unexpected token '('` family.
+  "Unexpected token '('",
+  "SyntaxError: Unexpected token '('",
+  // `Unexpected token '{'` family.
+  "Unexpected token '{'",
+  "SyntaxError: Unexpected token '{'",
+  // `Invalid or unexpected token` (V8).
+  'Invalid or unexpected token',
+  'SyntaxError: Invalid or unexpected token',
+  'Unhandled promise rejection: Invalid or unexpected token',
+  // `Cannot use import statement outside a module` (V8, ES-module chunk
+  // loaded as a classic script by an old browser).
+  'Cannot use import statement outside a module',
+  'SyntaxError: Cannot use import statement outside a module',
+  'Unhandled promise rejection: SyntaxError: Cannot use import statement outside a module',
+]
+
+test('classifies every old-browser minified-chunk SyntaxError variant as noise (with a chunk frame)', () => {
+  for (const message of OLD_BROWSER_SYNTAX_PARSE_EVENTS) {
+    assert.equal(
+      isOldBrowserSyntaxParseError({ message, frames: [{ filename: CHUNK_FRAME }] }),
+      true,
+      `expected "${message}" from a chunk frame to be classified as old-browser parse noise`,
+    )
+  }
+})
+
+test('suppresses every old-browser SyntaxError Sentry event whose frame is a minified chunk', () => {
+  for (const value of OLD_BROWSER_SYNTAX_PARSE_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: { frames: [{ filename: CHUNK_FRAME }] },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" from a chunk frame to be suppressed`,
+    )
+  }
+})
+
+test('suppresses an old-browser SyntaxError from a Vercel ?dpl= deploy-hash chunk URL', () => {
+  // Old browsers loading a chunk from a Vercel deployment URL also surface the
+  // raw `?dpl=dpl_…` filename, not the de-minified source.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: "SyntaxError: Unexpected token '='",
+            stacktrace: {
+              frames: [
+                { filename: 'https://kortix.com/_next/static/chunks/1234-abcd.js?dpl=dpl_abc123' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses an old-browser SyntaxError via the runtime (window.onerror) gate with a chunk filename', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "SyntaxError: Unexpected token '('",
+      filename: CHUNK_FRAME,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Cannot use import statement outside a module',
+      filename: 'https://kortix.com/_next/static/chunks/main-app.js',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress an old-browser SyntaxError with NO chunk frame (conservative — keep reporting)', () => {
+  // Frameless window.onerror / onunhandledrejection captures carry no chunk
+  // anchor. The message prefixes are generic, so without a chunk frame we
+  // cannot tell old-browser noise from a real eval bug — keep reporting.
+  for (const message of OLD_BROWSER_SYNTAX_PARSE_EVENTS) {
+    assert.equal(
+      isOldBrowserSyntaxParseError({ message }),
+      false,
+      `expected frameless "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message }] },
+      }),
+      false,
+      `expected frameless Sentry event for "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a real app SyntaxError from a de-minified first-party frame', () => {
+  // A genuine `new Function('…')` / `eval('…')` eval bug in first-party app
+  // code throws the SAME wording, but Sentry's sourcemap resolution
+  // de-minifies the frame to `apps/web/src/…` — NOT a raw `_next/static/chunks/`
+  // path, and not a `?dpl=dpl_…` URL. The matcher must keep reporting it so a
+  // real eval regression is never hidden.
+  const realAppFrames: Array<{ filename: unknown }> = [
+    { filename: 'app:///apps/web/src/lib/dynamic-eval.ts' },
+    { filename: 'apps/web/src/lib/dynamic-eval.ts' },
+    { filename: 'https://kortix.com/src/lib/dynamic-eval.ts' },
+  ]
+  for (const frames of [realAppFrames, [{ filename: 'app:///apps/web/src/features/foo.tsx' }]]) {
+    for (const message of [
+      "SyntaxError: Unexpected token '}'",
+      'Invalid or unexpected token',
+      'Cannot use import statement outside a module',
+    ]) {
+      assert.equal(
+        isOldBrowserSyntaxParseError({ message, frames }),
+        false,
+        `expected real app SyntaxError "${message}" from ${JSON.stringify(frames)} to keep reporting`,
+      )
+    }
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "SyntaxError: Unexpected token ')'",
+      filename: 'app:///apps/web/src/features/foo.tsx',
     }),
     false,
   )

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -134,6 +134,33 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
   'invalid group specifier name',
 ] as const;
 
+// Old-browser / stripped-down-WebView minified-chunk parse failures. When a
+// browser that cannot parse modern minified JS (old Safari/iOS, legacy Android
+// WebView, in-app browsers, mail-client preview WebViews) tries to evaluate a
+// Next.js `_next/static/chunks/…` bundle, it throws a parse-time `SyntaxError`
+// — `Unexpected token '='` / `'('` / `'{'` (V8/SpiderMonkey), `Invalid or
+// unexpected token` (V8), or `Cannot use import statement outside a module`
+// (V8, when an ES-module chunk is loaded as a classic script) — failing the
+// whole chunk for that visitor. These are NOT product bugs: the browser is
+// simply incompatible with the shipped syntax. They are 1–2 occurrences each,
+// 0 identified users, all from `app:///_next/static/chunks/…` frames.
+//
+// The message prefixes are GENERIC (a real `new Function('…')` / `eval('…')`
+// eval bug in first-party app code throws the same wording), so matching on
+// message alone would swallow real app SyntaxErrors. Require BOTH the message
+// prefix AND a minified-chunk source (`_next/static/chunks/` or a `?dpl=dpl_…`
+// deploy hash). Parse failures happen at raw chunk load time, BEFORE Sentry's
+// sourcemap resolution, so the frame filename stays as the raw chunk path —
+// a genuine first-party eval bug de-minifies to `apps/web/src/…` and is never
+// hidden. `SyntaxError: ` / `Error: ` / `Unhandled promise rejection: ` wrappers
+// are stripped before matching so all capture paths (window.onerror,
+// onunhandledrejection, Sentry exception) classify consistently.
+const OLD_BROWSER_SYNTAX_PARSE_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
+  /^Unexpected token\b/,
+  /^Invalid or unexpected token$/,
+  /^Cannot use import statement outside a module$/,
+];
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -332,6 +359,59 @@ export function isOldWebkitRegexNoiseMessage(message: unknown): boolean {
   );
 }
 
+// Strip the canonical `SyntaxError: ` / `Error: ` / `Unhandled promise
+// rejection: ` (and stacked) wrappers a browser/Sentry prefixes a throw with,
+// so the underlying message can be matched by an anchored pattern regardless
+// of which capture path delivered it.
+function stripErrorWrappers(message: string): string {
+  return message.trim().replace(/^(?:Unhandled promise rejection: )?(?:[A-Za-z]+Error: )?/, '');
+}
+
+// A raw Next.js minified chunk source — `_next/static/chunks/…` (the bundled
+// JS chunk) or a Vercel `?dpl=dpl_…` deploy-hash URL. Parse-time SyntaxErrors
+// in old browsers fire at chunk LOAD time, before Sentry's sourcemap
+// resolution, so the frame filename stays as this raw path. A genuine
+// first-party eval/`new Function` SyntaxError de-minifies to `apps/web/src/…`
+// and is NOT matched here — that is the negative guard.
+function isMinifiedChunkSource(filename: unknown): boolean {
+  const normalized = normalizeString(filename);
+  if (!normalized) return false;
+  return (
+    normalized.includes('/_next/static/chunks/')
+    || /[?&]dpl=dpl_[A-Za-z0-9]+/.test(normalized)
+  );
+}
+
+/**
+ * Whether an event is the old-browser / stripped-down-WebView minified-chunk
+ * parse-failure class: a `SyntaxError` whose message is one of
+ * `Unexpected token …`, `Invalid or unexpected token`, or
+ * `Cannot use import statement outside a module`, AND whose throwing frame (or
+ * window.onerror filename) is a raw `_next/static/chunks/…` / `?dpl=dpl_…`
+ * source. Old browsers that cannot parse modern minified JS throw these at
+ * chunk load time; the browser is incompatible, not broken. Requiring a
+ * minified-chunk source means a real first-party `new Function(...)` /
+ * `eval(...)` SyntaxError (de-minified to `apps/web/src/…`) keeps reporting.
+ * Never page Better Stack for the old-browser class.
+ */
+export function isOldBrowserSyntaxParseError(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const message = normalizeString(input.message);
+  if (!message) return false;
+  const stripped = stripErrorWrappers(message);
+  if (!OLD_BROWSER_SYNTAX_PARSE_NOISE_PATTERNS.some((re) => re.test(stripped))) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  return sources.some((filename) => isMinifiedChunkSource(filename));
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -386,6 +466,16 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   // Old-WebKit (< 16.4) lookbehind parse failure from bundled third-party
   // deps — WebKit-specific wording, only old Safari/iOS visitors hit it.
   if (isOldWebkitRegexNoiseMessage(message)) {
+    return true;
+  }
+
+  // Old-browser / stripped-down-WebView minified-chunk parse failures
+  // (`Unexpected token …`, `Invalid or unexpected token`, `Cannot use import
+  // statement outside a module`) from `window.onerror`. The browser cannot
+  // parse the modern minified chunk — incompatible, not an app defect.
+  // Requires a `_next/static/chunks/` / `?dpl=dpl_…` filename so a real
+  // first-party eval/`new Function` SyntaxError keeps reporting.
+  if (isOldBrowserSyntaxParseError({ message, filename: input.filename })) {
     return true;
   }
 
@@ -469,6 +559,20 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // visitors hit it. The de-minified frame points at our own chunk, so this
   // is matched by message, not by source.
   if (isOldWebkitRegexNoiseMessage(message)) {
+    return true;
+  }
+
+  // Old-browser / stripped-down-WebView minified-chunk parse failures
+  // (`Unexpected token …`, `Invalid or unexpected token`, `Cannot use import
+  // statement outside a module`) thrown when an incompatible browser tries to
+  // evaluate a modern `_next/static/chunks/…` bundle. Requires a chunk frame
+  // so a real first-party `new Function(...)` / `eval(...)` SyntaxError
+  // (de-minified to `apps/web/src/…`) keeps reporting. NOTE: deliberately NOT
+  // added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has
+  // no frame context, so a bare-string match there would swallow real app
+  // SyntaxErrors. The `beforeSend` hook (which calls this helper) is the only
+  // safe gate because it can anchor on the chunk frame.
+  if (isOldBrowserSyntaxParseError({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause

Old browsers / stripped-down WebViews that cannot parse modern minified JS (old Safari/iOS, legacy Android WebView, in-app browsers, mail-client preview WebViews) throw a parse-time `SyntaxError` when they try to evaluate a Next.js `_next/static/chunks/…` bundle:

- `Unexpected token '='` / `'('` / `'{'` (V8/SpiderMonkey)
- `Invalid or unexpected token` (V8)
- `Cannot use import statement outside a module` (V8, ES-module chunk loaded as a classic script)

The whole chunk fails to load for that visitor. These are **NOT product bugs** — the browser is simply incompatible with the shipped syntax. They are 1–2 occurrences each, 0 identified users, all from `app:///_next/static/chunks/…` minified-bundle frames. Sentry captures them because they happen during chunk load/eval.

## Better Stack evidence

Kortix Frontend prod, `application_id` 2346967, `environment=prod`, all unresolved, last 3 days, 0 users. Sample: https://errors.betterstack.com/team/t502678/errors/0015b43d5b14822768d6bf0d2e6b1a82f3588761d69bb119860b0c0328d88ce9?s=2346967

Covered fingerprints (all 1–2 occurrences each):

| Message class | Better Stack fingerprints |
| --- | --- |
| `Unexpected token '='` | `0015b43d…`, `23ac8ed3…`, `0665f05e…`, `4bcd8a1a…`, `bb3aef66…`, `277d3a4a…` |
| `Unexpected token '('` | `dfe7db0b…`, `1aa71b82…`, `a75e4f55…`, `7a61bbd1…`, `38e4f3da…` |
| `Unexpected token '{'` | `aff45748…`, `40ed5a29…` |
| `Invalid or unexpected token` | `c8f836d4…`, `572a247e…` |
| `Cannot use import statement outside a module` | `17aeb077…` |

## Fix

Add `isOldBrowserSyntaxParseError` and wire it into **both** `shouldIgnore*` helpers (`shouldIgnoreBrowserRuntimeNoise` + `shouldIgnoreSentryBrowserNoise`), matching the pattern established by the merged old-WebKit lookbehind PR #4532.

### Conservative negative guard (the key design decision)

The message prefixes are **generic** — a real `new Function('…')` / `eval('…')` eval bug in first-party app code throws the **same wording**. Matching on message alone would swallow real app SyntaxErrors. So the matcher requires **BOTH**:

1. the message prefix (one of `^Unexpected token`, `^Invalid or unexpected token`, `^Cannot use import statement outside a module`, after stripping `SyntaxError: ` / `Error: ` / `Unhandled promise rejection: ` wrappers), **AND**
2. a minified-chunk source: the throwing frame filename (or `window.onerror` filename) is a raw `_next/static/chunks/…` path or a Vercel `?dpl=dpl_…` deploy-hash URL.

Parse failures fire at raw chunk load time, **before** Sentry's sourcemap resolution, so the frame filename stays as the raw chunk path. A genuine first-party eval bug de-minifies to `apps/web/src/…` and is **never** hidden — that is the negative guard.

`SyntaxError: ` / `Error: ` / `Unhandled promise rejection: ` wrappers are stripped before matching so all capture paths (window.onerror, onunhandledrejection, Sentry exception) classify consistently.

### Why NOT in `sentry.client.config.ts` `ignoreErrors`

Deliberately **not** added to the SDK-level `ignoreErrors` list: that gate has **no frame context**, so a bare-string match there would swallow real app SyntaxErrors. The `beforeSend` hook (which calls `shouldIgnoreSentryNoiseEvent` → this helper) is the only safe gate because it can anchor on the chunk frame. This differs from #4532, whose `invalid group specifier name` wording was WebKit-specific enough to be safe as a bare string.

## Dedup vs #4532

#4532 (`fix(web): suppress old-WebKit lookbehind parse noise`) added a narrowly-scoped matcher for the WebKit-specific lookbehind wording `invalid group specifier name` (matched by message alone, safe because V8/Node never produce it). This PR is the **complementary general old-browser SyntaxError parse-failure class** — distinct messages, **not** matched by #4532's matcher, and additionally anchored on a minified-chunk frame for safety. No overlap.

## Tests

`apps/web/src/lib/browser-error-noise.test.mts`:

- `classifies every old-browser minified-chunk SyntaxError variant as noise (with a chunk frame)` — all 4 message classes × canonical wrappers (`SyntaxError: `, `Unhandled promise rejection: `) suppressed when framed by a chunk.
- `suppresses every old-browser SyntaxError Sentry event whose frame is a minified chunk` — end-to-end through `shouldIgnoreSentryBrowserNoise`.
- `suppresses an old-browser SyntaxError from a Vercel ?dpl= deploy-hash chunk URL` — the `?dpl=dpl_…` anchor.
- `suppresses an old-browser SyntaxError via the runtime (window.onerror) gate with a chunk filename` — end-to-end through `shouldIgnoreBrowserRuntimeNoise`.
- **`does NOT suppress an old-browser SyntaxError with NO chunk frame (conservative — keep reporting)`** — negative guard #1: frameless captures keep reporting (cannot distinguish old-browser noise from a real eval bug without a chunk anchor).
- **`does NOT suppress a real app SyntaxError from a de-minified first-party frame`** — negative guard #2: a real `new Function('…')` / `eval('…')` bug whose frame de-minifies to `apps/web/src/…` (or a non-chunk path) keeps reporting via both helpers.

Local verification:
- `bun test apps/web/src/lib/browser-error-noise.test.mts apps/web/src/app/sentry-ignore-errors.test.ts` → **54 pass / 0 fail** (43 pre-existing + 7 new for this class + 4 sentry-ignore-errors).
- `tsc --noEmit` on `browser-error-noise.ts` (self-contained, zero imports) → clean.

## Confirmation

After this merges + the next Promote ships it to prod, the 15 listed Better Stack fingerprints should drop to zero new occurrences (Better Stack auto-resolves once no longer seen). A genuine first-party `SyntaxError` regression still reports normally (the negative-guard tests lock that in).
