### PR TITLE
fix(web): guard undefined/non-array before .filter/.map in customize agents/skills

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/component/config-entity-view.tsx
@@ -19,7 +19,7 @@ import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { MarketplaceSectionButton } from '@/features/workspace/customize/marketplace-section-button';
 import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
-import { splitFrontmatter } from '@/features/workspace/customize/shared/utils';
+import { splitFrontmatter, toArray } from '@/features/workspace/customize/shared/utils';
 import {
   editConfigPrompt,
   newConfigPrompt,
@@ -137,7 +137,13 @@ export function ConfigEntityView<T extends ConfigEntity>(props: ConfigEntityView
   });
 
   const config = detailQuery.data?.config ?? null;
-  const entities = useMemo(() => (config ? select(config) : []), [config, select]);
+  // `select(config)` returns one of `config.agents` / `config.skills` /
+  // `config.commands`. The type marks these required arrays, but the API can
+  // return them as `undefined` (or a non-array) for repo-less / capability-gated
+  // / config-build-failure states — calling `.filter` on that throws into prod
+  // Sentry (the `(intermediate value)…filter is not a function` cluster). `toArray`
+  // guards both the undefined and the non-array cases.
+  const entities = useMemo(() => (config ? toArray(select(config)) : []), [config, select]);
   const isForbidden =
     detailQuery.isError && /403|forbidden/i.test((detailQuery.error as Error)?.message ?? '');
 

--- a/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/agents-view.tsx
@@ -20,7 +20,7 @@ import {
   type ManifestVersion,
   useProjectManifestVersion,
 } from '@/features/workspace/customize/migrate-to-v2/manifest-version';
-import { formatMode } from '@/features/workspace/customize/shared/utils';
+import { formatMode, toArray } from '@/features/workspace/customize/shared/utils';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
@@ -113,7 +113,7 @@ export function AgentsView({ projectId }: { projectId: string }) {
           <AgentConfigEditor
             projectId={projectId}
             agent={agent}
-            skillsOptions={config.skills.map((s) => ({ id: s.name, label: s.name }))}
+            skillsOptions={toArray(config.skills).map((s) => ({ id: s.name, label: s.name }))}
             fallback={
               <>
                 <AgentModel projectId={projectId} agentName={agent.name} />
@@ -138,7 +138,7 @@ function DefaultAgentSelector({
 }) {
   const queryClient = useQueryClient();
   const isV2 = detectManifestVersion(config.manifest_raw) === 2;
-  const availableAgents = config.agents.filter((agent) => agent.enabled !== false);
+  const availableAgents = toArray(config.agents).filter((agent) => agent.enabled !== false);
   const current = config.open_code_default_agent;
   const mutation = useMutation({
     mutationFn: (agentName: string) => updateProjectDefaultAgent(projectId, agentName),

--- a/apps/web/src/features/workspace/customize/shared/chunk22256-guard.test.ts
+++ b/apps/web/src/features/workspace/customize/shared/chunk22256-guard.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+
+// Regression test for the Better Stack chunk-22256 cluster:
+//   5af76e2b… / c80ef19c… / bb2da889… —
+//     `(intermediate value)(intermediate value)(intermediate value).filter is not a function`
+//   7ef0c059… — `Cannot read properties of undefined (reading 'map')`
+//
+// All four are `.filter` / `.map` called on a `ProjectConfigSummary` array
+// field (`agents` / `skills` / `commands`) that the API can return as
+// `undefined` (or a non-array) for repo-less / capability-gated / config-build
+// failure states. The fix guards every such call site with `toArray(...)` so a
+// missing/non-array field can never throw into prod Sentry. These source-level
+// assertions keep a future refactor from silently restoring the unguarded
+// `.filter` / `.map` (the connectors-view Slack test uses the same pattern).
+
+const agentsView = readFileSync(
+  join(import.meta.dir, '..', 'sections', 'view', 'agents-view.tsx'),
+  'utf8',
+);
+const configEntityView = readFileSync(
+  join(import.meta.dir, '..', 'sections', 'component', 'config-entity-view.tsx'),
+  'utf8',
+);
+
+describe('chunk-22256 .filter/.map guard regression', () => {
+  test('agents-view no longer calls config.skills.map unguarded', () => {
+    expect(agentsView).not.toContain('config.skills.map(');
+    expect(agentsView).toContain('toArray(config.skills).map(');
+  });
+
+  test('agents-view no longer calls config.agents.filter unguarded', () => {
+    expect(agentsView).not.toContain('config.agents.filter(');
+    expect(agentsView).toContain('toArray(config.agents).filter(');
+  });
+
+  test('config-entity-view guards select(config) before any .filter consumer', () => {
+    // The `entities` array (consumed by `entities.filter`) comes from
+    // `select(config)` = one of config.agents/skills/commands; must be coerced.
+    expect(configEntityView).not.toMatch(/\(config \? select\(config\) : \[\]\)/);
+    expect(configEntityView).toContain('toArray(select(config))');
+  });
+});

--- a/apps/web/src/features/workspace/customize/shared/utils.test.ts
+++ b/apps/web/src/features/workspace/customize/shared/utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+
+import { toArray } from './utils';
+
+describe('toArray — guards .filter/.map call sites against undefined / non-array config fields', () => {
+  // Regression for the Better Stack cluster in chunk 22256:
+  //   - `Cannot read properties of undefined (reading 'map')`  (config.skills.map)
+  //   - `(intermediate value)(intermediate value)(intermediate value).filter is not a function`
+  //     (a `(x ?? []).filter` where the prod build downlevels `??` to a ternary
+  //     and `x` is a defined non-array object)
+  // `ProjectConfigSummary.{agents,skills,commands}` are typed as required
+  // arrays, but the API returns them as `undefined` (or a non-array) for
+  // repo-less / capability-gated / config-build-failure states. Calling
+  // `.filter` / `.map` directly throws into prod Sentry; `toArray` must absorb
+  // every one of those shapes without throwing.
+
+  test("undefined -> [] (the \"reading 'map'\" case)", () => {
+    expect(toArray(undefined)).toEqual([]);
+  });
+
+  test('null -> []', () => {
+    expect(toArray(null)).toEqual([]);
+  });
+
+  test('non-array object -> [] (the "filter is not a function" case)', () => {
+    // A defined-but-non-array value: `value ?? []` returns the object itself,
+    // so `.filter` would throw. `Array.isArray` is the only correct guard.
+    expect(toArray({})).toEqual([]);
+    expect(toArray({ agents: [] })).toEqual([]);
+    expect(toArray('not-an-array')).toEqual([]);
+    expect(toArray(42)).toEqual([]);
+  });
+
+  test('a real array passes through unchanged', () => {
+    const agents = [{ name: 'default', path: 'a', description: null }];
+    expect(toArray(agents)).toBe(agents);
+    expect(toArray([])).toEqual([]);
+  });
+
+  test('does not throw when chaining .filter / .map on every bad shape', () => {
+    for (const bad of [undefined, null, {}, { agents: [] }, 'x', 0, false]) {
+      expect(() => toArray(bad).filter(Boolean)).not.toThrow();
+      expect(() => toArray(bad).map((x) => x)).not.toThrow();
+    }
+  });
+});

--- a/apps/web/src/features/workspace/customize/shared/utils.ts
+++ b/apps/web/src/features/workspace/customize/shared/utils.ts
@@ -1,3 +1,23 @@
+/**
+ * Coerce a value that the type system calls an array (but the API can return
+ * as `undefined`/`null` or — for repo-less / capability-gated / config-build
+ * failure states — occasionally a non-array object) into a real array.
+ *
+ * `?? []` alone is NOT enough here: it only covers `null`/`undefined`. When the
+ * field comes back as a defined non-array (e.g. an empty object from a failed
+ * config summary build), `value ?? []` returns that object and the subsequent
+ * `.filter` / `.map` throws `TypeError: …filter is not a function` (the
+ * `(intermediate value)(intermediate value)(intermediate value).filter is not a
+ * function` Better Stack cluster — the prod build downlevels `??` to a ternary,
+ * which is what produces the `(intermediate value)` wording). `Array.isArray`
+ * guards both the undefined and the non-array cases.
+ */
+export function toArray<T>(value: readonly T[] | undefined | null): T[];
+export function toArray<T>(value: unknown): T[];
+export function toArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
 export function splitFrontmatter(raw: string): { frontmatter: string; body: string } {
   if (!raw.startsWith('---')) return { frontmatter: '', body: raw };
   const end = raw.indexOf('\n---', 3);


### PR DESCRIPTION
## Root cause

The **Customize → Agents / Skills / Commands** views call `.filter` / `.map` directly on `ProjectConfigSummary` array fields (`config.agents` / `config.skills` / `config.commands`) that the **type marks required**, but the API returns them as `undefined` (or a non-array) for **repo-less / capability-gated / config-build-failure** project states. Calling `.filter` / `.map` on that throws into prod Sentry — four Better Stack patterns, all in shared chunk `22256`, all the same root cause:

| Pattern | Message | Call site |
| --- | --- | --- |
| `7ef0c059…` | `Cannot read properties of undefined (reading 'map')` | `agents-view.tsx` — `config.skills.map(...)` (unguarded; `config.skills` is `undefined`) |
| `5af76e2b…` / `c80ef19c…` / `bb2da889…` | `(intermediate value)(intermediate value)(intermediate value).filter is not a function` | a `(x ?? []).filter(...)` where the prod build **downlevels `??` to a ternary** (→ the `(intermediate value)` wording) and `x` is a defined non-array; sibling `config-entity-view` consumes `select(config) = config.agents/.skills/.commands` and filters it |

The `(intermediate value)(intermediate value)(intermediate value).filter` wording is the V8 format for a **parenthesized ternary** whose result is `.filter`'d — confirmed by reproducing the exact string from `(x ?? []).filter` after SWC downlevels `??` → `(null!=x?x:[]).filter` (the prod `??` is downleveled, so the ternary surfaces in the minified chunk). `?? []` alone is **not** a sufficient guard: it only covers `null`/`undefined`, not a non-array object.

## Better Stack evidence (Kortix Frontend prod, application_id 2346967)

- `5af76e2b233175d419d28200e097fe9177e2ed0a31054e08012de126c4f06a90` — `app:///_next/static/chunks/22256-2613da804bd83c33.js?dpl=dpl_CTqmc8S7CG7w9gkCs2ySzURsbhxm`, last 2026-07-11 14:47:50 UTC
- `c80ef19c6f5ef461e38c256eda67fbd06616206a0f7d0bc76e85c39b81aa1aa4` — `22256-769e34c09969f508.js?dpl=dpl_Ef2dDDoVx1tURKUQaXTLD1p8dJyz`
- `bb2da8896b5426142c378ae178f348f62cbcd7a134dc8f0f2e9a9ec2a19e2922` — same file as `c80ef19c`
- `7ef0c059c4bf63e173f99cece6edf5458f117a62eb3981744287781d05b69f6e` — `Cannot read properties of undefined (reading 'map')`, last 2026-07-11 14:46:27 UTC, same chunk

The errors cluster on project/customize routes (the Customize panel renders inside project routes). Both prod deployments share chunk id `22256` (different content hashes), and the `.map` + `.filter` patterns are co-located in it (agents-view + config-entity-view are imported together).

## Fix

Guard every such call site with `toArray(...)` (`Array.isArray(value) ? value : []`), which absorbs **both** the `undefined` (→ `.map` "reading 'map'") **and** the non-array (→ `.filter` "is not a function") shapes, so a missing config field can never throw:

- `agents-view.tsx:116` — `config.skills.map(...)` → `toArray(config.skills).map(...)`
- `agents-view.tsx:141` — `config.agents.filter(...)` → `toArray(config.agents).filter(...)`
- `config-entity-view.tsx:140` — `select(config)` (returns `config.agents`/`.skills`/`.commands`, consumed downstream via `entities.filter`) → `toArray(select(config))`

`toArray` is added to `customize/shared/utils.ts` (overloaded so typed array callers keep element-type inference; runtime `Array.isArray` defends the non-array case the type can't express).

## Verification

- `tsc --noEmit -p apps/web/tsconfig.json` → **0 errors**
- `bun test src/features/workspace/customize/shared/utils.test.ts src/features/workspace/customize/shared/chunk22256-guard.test.ts` → **8 pass / 0 fail**
  - `toArray` unit tests: `undefined` / `null` / non-array object / string / number / real array — and a no-throw assertion for `.filter`/`.map` chained on every bad shape
  - source-level assertions (matching the existing `connectors-view.slack-channel.test.ts` style) that the unguarded `config.skills.map` / `config.agents.filter` / `select(config)` call sites stay guarded

## How to confirm resolution

After this merges + promotes, the four Better Stack patterns above should drop to **zero new occurrences** (the `.map`/`.filter` no longer throws on a missing/non-array config field). The structured signal that would have surfaced is gone because the guard returns `[]` and the view renders the empty state instead of crashing.