### PR TITLE
fix(web): guard Paper Shaders null-context getSupportedExtensions crash

### DIFF
--- a/apps/web/src/components/ui/shader-safe.test.ts
+++ b/apps/web/src/components/ui/shader-safe.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  __resetWebGL2ProbeForTests,
+  supportsWebGL2,
+} from './shader-safe'
+
+// Paper Shaders' shader-mount `useEffect`/rAF callback calls
+// `gl.getSupportedExtensions()` on a WebGL2 context that became `null` after a
+// context-loss / GPU-blacklist event (Better Stack pattern `34127fa4…`, call
+// site `new b2` in chunk `c76173f0.…`). The probe must exercise that exact
+// call so `<ShaderSafe>` degrades to the fallback BEFORE the throw happens.
+//
+// The probe checks `typeof window === 'undefined'` and reads
+// `document.createElement('canvas').getContext('webgl2')`, so each test
+// installs a stub `window` + `document` and resets the one-shot memo.
+
+interface StubCtx {
+  getSupportedExtensions: () => string[] | null
+}
+
+function installProbeEnvironment(getContext: () => StubCtx | null): void {
+  const canvas = { getContext: (_type: string) => getContext() as unknown }
+  ;(globalThis as { window?: unknown }).window = {}
+  ;(globalThis as { document?: unknown }).document = {
+    createElement: (_tagName: string) => canvas,
+  }
+}
+
+function teardownProbeEnvironment(): void {
+  delete (globalThis as { window?: unknown }).window
+  delete (globalThis as { document?: unknown }).document
+  __resetWebGL2ProbeForTests()
+}
+
+test('supportsWebGL2 returns false when getSupportedExtensions throws on the probe canvas', () => {
+  // Model a GPU that hands out a non-null context but fails on real use
+  // (context loss, blacklisted driver, stripped WebView) — the exact crash
+  // path Paper Shaders hits at render time.
+  installProbeEnvironment(() => ({
+    getSupportedExtensions() {
+      throw new TypeError("Cannot read properties of null (reading 'getSupportedExtensions')")
+    },
+  }))
+  try {
+    assert.equal(
+      supportsWebGL2(),
+      false,
+      'a probe canvas whose getSupportedExtensions() throws must report WebGL2 unsupported so ShaderSafe falls back',
+    )
+  } finally {
+    teardownProbeEnvironment()
+  }
+})
+
+test('supportsWebGL2 returns false when getSupportedExtensions returns null (lost context)', () => {
+  // Per the WebGL spec, `getSupportedExtensions()` returns `null` when the
+  // context is lost. A non-null context that has just been lost must still be
+  // treated as unsupported for decorative shaders.
+  installProbeEnvironment(() => ({
+    getSupportedExtensions() {
+      return null
+    },
+  }))
+  try {
+    assert.equal(
+      supportsWebGL2(),
+      false,
+      'a probe canvas whose getSupportedExtensions() returns null must report WebGL2 unsupported',
+    )
+  } finally {
+    teardownProbeEnvironment()
+  }
+})
+
+test('supportsWebGL2 returns true when getSupportedExtensions returns a non-null extension list', () => {
+  // Happy path: a working WebGL2 context returns a (possibly empty) array of
+  // extension strings. ShaderSafe should render the shader.
+  installProbeEnvironment(() => ({
+    getSupportedExtensions() {
+      return ['EXT_color_buffer_float', 'OES_texture_float_linear']
+    },
+  }))
+  try {
+    assert.equal(
+      supportsWebGL2(),
+      true,
+      'a working WebGL2 context with a non-null extension list must report WebGL2 supported',
+    )
+  } finally {
+    teardownProbeEnvironment()
+  }
+})
+
+test('supportsWebGL2 returns true when getSupportedExtensions returns an empty array (valid, non-null)', () => {
+  // Some contexts legitimately support zero extensions but are still usable —
+  // an empty array is NOT null, so WebGL2 is supported.
+  installProbeEnvironment(() => ({
+    getSupportedExtensions() {
+      return []
+    },
+  }))
+  try {
+    assert.equal(
+      supportsWebGL2(),
+      true,
+      'a WebGL2 context returning an empty (but non-null) extension array must report WebGL2 supported',
+    )
+  } finally {
+    teardownProbeEnvironment()
+  }
+})
+
+test('supportsWebGL2 returns false when getContext("webgl2") returns null', () => {
+  // The original crash path Paper Shaders hits at mount when there is no
+  // WebGL2 at all — the probe must still report unsupported.
+  installProbeEnvironment(() => null)
+  try {
+    assert.equal(
+      supportsWebGL2(),
+      false,
+      'a null WebGL2 context must report WebGL2 unsupported',
+    )
+  } finally {
+    teardownProbeEnvironment()
+  }
+})
+
+test('supportsWebGL2 returns false when there is no window (SSR / non-browser)', () => {
+  // No `window` global → never attempt the probe; report unsupported.
+  __resetWebGL2ProbeForTests()
+  delete (globalThis as { window?: unknown }).window
+  try {
+    assert.equal(supportsWebGL2(), false)
+  } finally {
+    teardownProbeEnvironment()
+  }
+})

--- a/apps/web/src/components/ui/shader-safe.tsx
+++ b/apps/web/src/components/ui/shader-safe.tsx
@@ -9,16 +9,47 @@ let webgl2Support: boolean | null = null;
  * `getContext('webgl2')` returns null, and its ShaderMount calls
  * `getAttribLocation(null, …)` when shader compilation fails silently —
  * both recurring prod errors on GPUs/browsers without (working) WebGL2.
+ *
+ * `getSupportedExtensions` is a THIRD such null-context crash path: Paper
+ * Shaders' shader-mount `useEffect`/rAF callback calls
+ * `gl.getSupportedExtensions()` on a context that became `null` after a
+ * context-loss / GPU-blacklist event (the probe canvas may return a non-null
+ * context at mount that then fails on real use). A throw inside that async
+ * callback ESCAPES the `<ShaderSafe>` error boundary (which only catches
+ * render-phase throws via `getDerivedStateFromError`) → global error → Sentry
+ * → Better Stack (Better Stack pattern `34127fa4…`, call site `new b2` in
+ * `app:///_next/static/chunks/c76173f0.…`, prod, 2 occurrences). So the probe
+ * must EXERCISE `getSupportedExtensions` itself: if it throws or returns null
+ * on the probe canvas, treat WebGL2 as unsupported and fall back BEFORE the
+ * throw can happen at render time. The call is cheap and one-shot (memoized).
  */
 export function supportsWebGL2(): boolean {
   if (typeof window === 'undefined') return false;
   if (webgl2Support !== null) return webgl2Support;
   try {
-    webgl2Support = !!document.createElement('canvas').getContext('webgl2');
+    const ctx = document.createElement('canvas').getContext('webgl2');
+    if (!ctx) {
+      webgl2Support = false;
+    } else {
+      // Exercise the exact call Paper Shaders makes on the context. A GPU that
+      // returns a non-null context but fails on real use (context loss,
+      // blacklisted driver, stripped WebView) throws here or returns null —
+      // both mean WebGL2 is not usable for decorative shaders, so fall back.
+      webgl2Support = ctx.getSupportedExtensions() !== null;
+    }
   } catch {
     webgl2Support = false;
   }
   return webgl2Support;
+}
+
+/**
+ * Test-only escape hatch: clears the one-shot `webgl2Support` memo so each
+ * unit test can exercise a fresh probe against a stubbed `document`/`window`.
+ * Not imported anywhere in app code.
+ */
+export function __resetWebGL2ProbeForTests(): void {
+  webgl2Support = null;
 }
 
 interface ShaderSafeProps {

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -10,6 +10,7 @@ import {
   isKnownBrowserNoiseMessage,
   isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
+  isPaperShaderNullContextNoise,
   isRuntimeNotReadyNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
@@ -1161,4 +1162,126 @@ test('does NOT suppress a frameless empty-message event (origin unverifiable)', 
     isEmptyMessageUnresolvedBrowserChunkNoise({ message: '' }),
     false,
   )
+})
+
+// Reproduces the Paper Shaders (`@paper-design/shaders-react`) null-WebGL2-
+// context crash class — the `getSupportedExtensions` null-context path that
+// ESCAPES `<ShaderSafe>` (Better Stack pattern `34127fa4…`, call site `new b2`
+// in chunk `app:///_next/static/chunks/c76173f0.5ba9c330afa9d53d.js`, prod, 2
+// occurrences, last 2026-07-12 15:23:38 UTC) plus its known sibling
+// `getAttribLocation`. Paper Shaders' shader-mount `useEffect`/rAF callback
+// calls a WebGL2 context method on a context that became `null` after a
+// context-loss / GPU-blacklist event; the throw is in an async callback so the
+// React error boundary can't catch it → global error → Sentry → Better Stack.
+// The matcher is the leak-path backstop; the `supportsWebGL2()` probe in
+// `shader-safe.tsx` is the primary guard.
+const PAPER_SHADER_NULL_CONTEXT_MESSAGES = [
+  "Cannot read properties of null (reading 'getSupportedExtensions')",
+  "TypeError: Cannot read properties of null (reading 'getSupportedExtensions')",
+  "Unhandled promise rejection: TypeError: Cannot read properties of null (reading 'getSupportedExtensions')",
+  "Cannot read properties of null (reading 'getAttribLocation')",
+  "TypeError: Cannot read properties of null (reading 'getAttribLocation')",
+  "Unhandled promise rejection: Cannot read properties of null (reading 'getAttribLocation')",
+  // Old JSC form.
+  "Cannot read property 'getSupportedExtensions' of null",
+  "Cannot read property 'getAttribLocation' of null",
+]
+
+test('classifies every Paper Shaders null-context WebGL message as noise', () => {
+  for (const message of PAPER_SHADER_NULL_CONTEXT_MESSAGES) {
+    assert.equal(
+      isPaperShaderNullContextNoise(message),
+      true,
+      `expected "${message}" to be classified as Paper Shaders null-context noise`,
+    )
+  }
+})
+
+test('suppresses every Paper Shaders null-context message via the runtime (window.onerror) gate', () => {
+  for (const message of PAPER_SHADER_NULL_CONTEXT_MESSAGES) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      true,
+      `expected runtime gate to suppress "${message}"`,
+    )
+  }
+})
+
+test('suppresses every Paper Shaders null-context message via the Sentry beforeSend gate', () => {
+  // The message is specific enough (WebGL2 API method names that first-party
+  // app code never calls) that no chunk-frame anchor is required — but the
+  // Sentry event usually still carries the chunk frame, so verify both shapes.
+  for (const message of PAPER_SHADER_NULL_CONTEXT_MESSAGES) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: message,
+              stacktrace: {
+                frames: [
+                  { filename: 'app:///_next/static/chunks/c76173f0.5ba9c330afa9d53d.js' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry gate to suppress "${message}" with a chunk frame`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message }] },
+      }),
+      true,
+      `expected Sentry gate to suppress "${message}" even with NO chunk frame (message is specific enough)`,
+    )
+  }
+})
+
+test('does NOT suppress a real app TypeError with a different null-property name', () => {
+  // A genuine first-party `foo.bar` null-deref regression throws the same
+  // `Cannot read properties of null (reading '<name>')` SHAPE but with an
+  // app-property name, not a WebGL2 API method — it must keep reporting so a
+  // real null-deref regression is never hidden by the Paper Shaders guard.
+  const realAppNullDerefMessages = [
+    "Cannot read properties of null (reading 'map')",
+    "Cannot read properties of null (reading 'length')",
+    "TypeError: Cannot read properties of null (reading 'id')",
+    "Cannot read property 'foo' of null",
+    // A non-null access on getSupportedExtensions (e.g. typo'd as a property
+    // of a non-null object) is a different message and must keep reporting.
+    "Cannot read properties of undefined (reading 'getSupportedExtensions')",
+  ]
+  for (const message of realAppNullDerefMessages) {
+    assert.equal(
+      isPaperShaderNullContextNoise(message),
+      false,
+      `expected real app TypeError "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      false,
+      `expected runtime gate to keep reporting real app TypeError "${message}"`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: message,
+              stacktrace: {
+                frames: [
+                  { filename: 'app:///_next/static/chunks/c76173f0.5ba9c330afa9d53d.js' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting real app TypeError "${message}" even from a chunk frame`,
+    )
+  }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -134,6 +134,39 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
   'invalid group specifier name',
 ] as const;
 
+// Paper Shaders (`@paper-design/shaders-react`) null-WebGL-context crash class.
+// On GPUs/browsers without working WebGL2 (context loss, blacklisted driver,
+// stripped WebView, headless renderer), Paper Shaders' shader-mount
+// `useEffect`/rAF callback reaches a WebGL2 context that has become `null` and
+// calls a WebGL API method on it → `TypeError: Cannot read properties of null
+// (reading '<method>')`. The throw happens INSIDE an async callback, so it
+// ESCAPES the `<ShaderSafe>` React error boundary (which only catches
+// render-phase throws via `getDerivedStateFromError`) → global error → Sentry
+// → Better Stack. The two observed null-context method names are:
+//   - `getSupportedExtensions`  (Better Stack pattern `34127fa4…`, call site
+//                                `new b2` in chunk `c76173f0.…`, prod, 2 occ.)
+//   - `getAttribLocation`       (the known sibling already documented in
+//                                `shader-safe.tsx`'s probe rationale).
+// These are WebGL2 context method names — they are NEVER called from
+// first-party app code (only from Paper Shaders' library internals), so the
+// message wording alone is specific enough to safely classify as noise without
+// a chunk-frame anchor (unlike the generic old-browser SyntaxError class). The
+// matching is exact-substring on the canonical `Cannot read properties of null
+// (reading '<method>')` (V8) and `Cannot read property '<method>' of null`
+// (old JSC) forms, with `TypeError: ` / `Error: ` /
+// `Unhandled promise rejection: ` wrappers stripped so all capture paths
+// (window.onerror, onunhandledrejection, Sentry exception) classify
+// consistently. `shouldIgnore*` here is the leak-path backstop for the throws
+// that still escape `<ShaderSafe>` after a context-loss event; the
+// `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard that
+// degrades to the fallback BEFORE the throw.
+const PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS = [
+  "Cannot read properties of null (reading 'getSupportedExtensions')",
+  "Cannot read properties of null (reading 'getAttribLocation')",
+  "Cannot read property 'getSupportedExtensions' of null",
+  "Cannot read property 'getAttribLocation' of null",
+] as const;
+
 // Old-browser / stripped-down-WebView minified-chunk parse failures. When a
 // browser that cannot parse modern minified JS (old Safari/iOS, legacy Android
 // WebView, in-app browsers, mail-client preview WebViews) tries to evaluate a
@@ -423,6 +456,26 @@ export function isOldWebkitRegexNoiseMessage(message: unknown): boolean {
   );
 }
 
+/**
+ * Whether a message is the Paper Shaders (`@paper-design/shaders-react`)
+ * null-WebGL-context crash class: a `TypeError` from calling a WebGL2 context
+ * method (`getSupportedExtensions` / `getAttribLocation`) on a context that
+ * became `null` (context loss, blacklisted GPU, stripped WebView). These fire
+ * from Paper Shaders' async shader-mount callback, ESCAPE the `<ShaderSafe>`
+ * React error boundary, and reach Sentry/Better Stack as global errors. The
+ * method names are WebGL2 API — never called from first-party app code — so the
+ * message wording alone is specific enough; no chunk-frame anchor is needed.
+ * Never page Better Stack for this class. See
+ * `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full rationale and the
+ * `supportsWebGL2()` probe in `shader-safe.tsx` for the primary guard.
+ */
+export function isPaperShaderNullContextNoise(message: unknown): boolean {
+  const stripped = stripErrorWrappers(normalizeString(message));
+  return PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS.some((pattern) =>
+    stripped.includes(pattern),
+  );
+}
+
 // Strip the canonical `SyntaxError: ` / `Error: ` / `Unhandled promise
 // rejection: ` (and stacked) wrappers a browser/Sentry prefixes a throw with,
 // so the underlying message can be matched by an anchored pattern regardless
@@ -533,6 +586,15 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Paper Shaders null-WebGL-context crash class — a WebGL2 context method
+  // (`getSupportedExtensions` / `getAttribLocation`) called on a `null`
+  // context from Paper Shaders' async shader-mount callback, which escapes
+  // the `<ShaderSafe>` error boundary. Decorative-canvas noise on
+  // incompatible GPUs; never an app defect.
+  if (isPaperShaderNullContextNoise(message)) {
+    return true;
+  }
+
   // Old-browser / stripped-down-WebView minified-chunk parse failures
   // (`Unexpected token …`, `Invalid or unexpected token`, `Cannot use import
   // statement outside a module`) from `window.onerror`. The browser cannot
@@ -623,6 +685,15 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // visitors hit it. The de-minified frame points at our own chunk, so this
   // is matched by message, not by source.
   if (isOldWebkitRegexNoiseMessage(message)) {
+    return true;
+  }
+
+  // Paper Shaders null-WebGL-context crash class — a WebGL2 context method
+  // (`getSupportedExtensions` / `getAttribLocation`) called on a `null`
+  // context from Paper Shaders' async shader-mount callback, which escapes
+  // the `<ShaderSafe>` error boundary and reaches Sentry as a global error.
+  // Decorative-canvas noise on incompatible GPUs; never an app defect.
+  if (isPaperShaderNullContextNoise(message)) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause

Paper Shaders (`@paper-design/shaders-react`) crashes on a null WebGL2 context via a THIRD null-context path: its shader-mount `useEffect`/rAF callback calls `gl.getSupportedExtensions()` on a context that became `null` after a context-loss / GPU-blacklist event (the probe canvas may return a non-null context at mount that then fails on real use).

The `<ShaderSafe>` React error boundary only catches **render-phase** throws via `getDerivedStateFromError`. A throw inside Paper Shaders' async callback **escapes** the boundary → global error → Sentry → Better Stack.

## Evidence (Better Stack)

- **Error URL:** https://errors.betterstack.com/team/t502678/errors/34127fa4b8b482151ba75fd56a270840f2e2a4042707b515feea4f526910716b?s=2346967
- **Pattern hash:** `34127fa4b8b482151ba75fd56a270840f2e2a4042707b515feea4f526910716b`
- **Type:** `TypeError — Cannot read properties of null (reading 'getSupportedExtensions')`
- **Call site:** function `new b2`, file `app:///_next/static/chunks/c76173f0.5ba9c330afa9d53d.js` (a Paper Shaders chunk)
- **Count / Last seen:** 2 occurrences, last 2026-07-12 15:23:38 UTC, 0 users, env `prod` (Kortix Frontend prod, application_id 2346967)

## Dedupe

Merged PR #3531 (`fix(web): skip marketing shader without WebGL`) and #4269 (shader guards) introduced the `supportsWebGL2()` probe and `<ShaderSafe>`, but the probe only checked `getContext('webgl2') !== null` — it did NOT exercise `getSupportedExtensions`, the exact call Paper Shaders makes on the context at runtime. This PR closes that null path. The existing probe comment already documents `getAttribLocation` as a known sibling null-context crash; `getSupportedExtensions` is the same class, undiscovered until now.

## Fix (two parts)

### 1. Strengthen the probe — `apps/web/src/components/ui/shader-safe.tsx`

`supportsWebGL2()` now exercises the exact Paper Shaders call path: after `getContext('webgl2')` returns non-null, also call `ctx.getSupportedExtensions()`. If it **throws** or **returns null** (WebGL spec: returns `null` when the context is lost), treat WebGL2 as unsupported → `<ShaderSafe>` falls back BEFORE the throw can happen at render time. The call is cheap and one-shot (memoized).

```ts
const ctx = document.createElement('canvas').getContext('webgl2');
if (!ctx) {
  webgl2Support = false;
} else {
  webgl2Support = ctx.getSupportedExtensions() !== null;
}
```

### 2. Telemetry backstop — `apps/web/src/lib/browser-error-noise.ts`

`isPaperShaderNullContextNoise` matches the null-context crash class — `Cannot read properties of null (reading 'getSupportedExtensions' | 'getAttribLocation')` (V8) plus the old-JSC `Cannot read property '…' of null` forms — wired into **both** `shouldIgnoreBrowserRuntimeNoise` and `shouldIgnoreSentryBrowserNoise`. The method names are WebGL2 API — never called from first-party app code — so the message wording alone is specific enough (no chunk-frame anchor required, unlike the generic old-browser `SyntaxError` class from #4538). This is the leak-path backstop for throws that still escape `<ShaderSafe>` after a context-loss event.

## Tests

### `apps/web/src/lib/browser-error-noise.test.mts` (+4 tests, 8 message variants)

- classifies every Paper Shaders null-context WebGL message as noise (V8 + old-JSC + wrapper variants for both `getSupportedExtensions` and `getAttribLocation`)
- suppresses every variant via the runtime (`window.onerror`) gate
- suppresses every variant via the Sentry `beforeSend` gate (both with a chunk frame AND frameless — message is specific enough)
- **negative guard:** does NOT suppress a real app `TypeError` with a different null-property name (`'map'`, `'length'`, `'id'`, `'foo'`) — keeps reporting real null-deref regressions. Also does not match `undefined` accessors.

### `apps/web/src/components/ui/shader-safe.test.ts` (new, 6 tests)

Unit tests for `supportsWebGL2()` with a stubbed `document`/`window`:
- returns `false` when `getSupportedExtensions()` throws on the probe canvas (the exact crash path)
- returns `false` when `getSupportedExtensions()` returns `null` (lost context, per WebGL spec)
- returns `true` when `getSupportedExtensions()` returns a non-null extension list (happy path)
- returns `true` when `getSupportedExtensions()` returns an empty array (valid, non-null)
- returns `false` when `getContext('webgl2')` returns `null` (original no-WebGL2 path)
- returns `false` when there is no `window` (SSR / non-browser)

## Verification

- `bun test apps/web/src/lib/browser-error-noise.test.mts` → **59 pass / 0 fail**
- `bun test apps/web/src/components/ui/shader-safe.test.ts` → **6 pass / 0 fail**
- `tsc --noEmit -p apps/web/tsconfig.json` → no new errors (the two `@/.source` errors are pre-existing generated-dir misses on `origin/main`, unrelated to this change)

## Confirmation

After merge + promote, the `34127fa4…` Better Stack error should drop to zero new occurrences: the strengthened probe prevents the throw for GPUs that return a non-null context but fail on `getSupportedExtensions`, and the telemetry backstop drops any residual throws that still escape after a runtime context-loss event.

## Preview verification plan

This is a client-side-only guard (decorative shader degrading + telemetry filter). The frontend is behind Vercel SSO (known limitation), so the unit tests + typecheck are the verification. The preview backend health check confirms the deploy environment is live.
