### PR TITLE
feat(teams): post the live card immediately (instant loading feedback)

### DIFF
--- a/apps/api/src/channels/teams/turn.ts
+++ b/apps/api/src/channels/teams/turn.ts
@@ -120,6 +120,7 @@ export async function startTurn(
     projectId,
   };
   await sendTyping(ref);
+  const messageActivityId = (await sendCard(ref, buildPlanCard(LIVE_PLAN_TITLE, []))) ?? '';
 
   return {
     conversationId,
@@ -128,7 +129,7 @@ export async function startTurn(
     botId: activity.recipient?.id,
     fromId: activity.from?.id,
     triggerActivityId: activity.id,
-    messageActivityId: '',
+    messageActivityId,
     steps: [],
     expiry: Date.now() + STREAM_TTL_MS,
     finalized: false,
@@ -247,7 +248,7 @@ export async function finalizeTurn(
       : undefined;
 
   try {
-    if (handle.messageActivityId && handle.steps.length > 0) {
+    if (handle.messageActivityId) {
       const last = handle.steps[handle.steps.length - 1];
       if (last && last.status === 'in_progress') last.status = opts.error ? 'error' : 'complete';
       await updateCard(


### PR DESCRIPTION
Follow-up to #4527 (Microsoft Teams revival).

When a Teams turn starts, post the **"Working on it…" Adaptive Card immediately**
— before the sandbox boots — instead of lazily on the agent's first `teams step`.
Previously the user saw no persistent acknowledgement during boot (Teams' typing
indicator is ephemeral, and bots can't react to a user's message like Slack does),
so a long task looked like nothing happened.

- `startTurn` posts the placeholder card up front and stores its activity id.
- `finalizeTurn` now updates that card even when there are zero steps, so a direct
  `teams send` answer replaces the placeholder instead of orphaning it + posting a
  second card.

Net: instant "Working on it…" on every turn → fills in with checkpoints → flips to
"Task complete" with the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)