### PR TITLE
fix(teams): loading card, /whoami, beautiful commands, widen ids

### DIFF
--- a/apps/api/src/__tests__/unit-teams-cards.test.ts
+++ b/apps/api/src/__tests__/unit-teams-cards.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 import {
   buildAnswerCard,
-  buildChoiceCard,
   buildConnectAccountCard,
   buildFinalCard,
   buildPlanCard,
   buildQuestionCard,
   buildRequestAccessCard,
   buildReviewCard,
+  buildSelectCard,
 } from '../channels/teams/cards';
 import type { StreamTaskChunk } from '../channels/slack-api';
 
@@ -23,6 +23,22 @@ function texts(card: Record<string, unknown>): string[] {
 
 function actions(card: Record<string, unknown>): Array<{ type: string; verb?: string; url?: string; data?: Record<string, unknown> }> {
   return (card.actions as Array<{ type: string; verb?: string; url?: string; data?: Record<string, unknown> }>) ?? [];
+}
+
+function allExecuteActions(
+  node: unknown,
+): Array<{ type: string; title?: string; verb?: string; data?: Record<string, unknown> }> {
+  const out: Array<{ type: string; title?: string; verb?: string; data?: Record<string, unknown> }> = [];
+  const walk = (n: unknown) => {
+    if (Array.isArray(n)) return n.forEach(walk);
+    if (n && typeof n === 'object') {
+      const o = n as Record<string, unknown>;
+      if (o.type === 'Action.Execute') out.push(o as (typeof out)[number]);
+      for (const v of Object.values(o)) walk(v);
+    }
+  };
+  walk(node);
+  return out;
 }
 
 describe('buildPlanCard', () => {
@@ -84,15 +100,23 @@ describe('interactive cards', () => {
     expect(a[0]?.data?.projectId).toBe('proj-1');
   });
 
-  test('choice card renders one Execute action per choice (capped at 6)', () => {
-    const card = buildChoiceCard({
-      title: 'Pick',
+  test('select card renders one per-row Execute action, marks the current option', () => {
+    const card = buildSelectCard({
+      emoji: '🧠',
+      title: 'Model',
       verb: 'teams_set_model',
-      choices: Array.from({ length: 8 }, (_, i) => ({ title: `m${i}`, data: { model: `m${i}` } })),
+      options: [
+        { label: 'a', current: true, data: { model: 'a' } },
+        { label: 'b', current: false, data: { model: 'b' } },
+        { label: 'c', current: false, data: { model: 'c' } },
+      ],
     });
-    const a = actions(card);
-    expect(a).toHaveLength(6);
-    expect(a.every((x) => x.type === 'Action.Execute' && x.verb === 'teams_set_model')).toBe(true);
+    const execs = allExecuteActions(card);
+    expect(execs).toHaveLength(3);
+    expect(execs.every((x) => x.verb === 'teams_set_model')).toBe(true);
+    expect(execs.map((x) => (x.data as { model?: string }).model)).toEqual(['a', 'b', 'c']);
+    expect(execs[0]!.title).toContain('In use');
+    expect(execs[1]!.title).toBe('Use');
   });
 
   test('question card turns option labels into answer actions', () => {

--- a/apps/api/src/channels/teams-oauth.ts
+++ b/apps/api/src/channels/teams-oauth.ts
@@ -77,10 +77,12 @@ teamsOauthApp.get('/callback', async (c: any) => {
   await saveTeamsInstall({ projectId: state.projectId, tenantId }).catch((err) =>
     console.error('[teams-oauth] saveTeamsInstall failed', err),
   );
-  const published = await publishTeamsAppToCatalog({ tenantId, baseUrl: state.baseUrl, appId }).catch(() => ({
-    ok: false,
-    teamsAppId: undefined as string | undefined,
-  }));
+  const published = await publishTeamsAppToCatalog({
+    tenantId,
+    baseUrl: state.baseUrl,
+    appId,
+    appName: config.TEAMS_APP_NAME,
+  }).catch(() => ({ ok: false, teamsAppId: undefined as string | undefined }));
   if (published.ok) {
     await setTeamsOrgInstalled(state.projectId, true).catch(() => {});
     if (published.teamsAppId) await setTeamsCatalogAppId(state.projectId, published.teamsAppId).catch(() => {});

--- a/apps/api/src/channels/teams/cards.ts
+++ b/apps/api/src/channels/teams/cards.ts
@@ -112,68 +112,124 @@ export function buildAnswerCard(body: string, sessionUrl?: string): Record<strin
   return card(elements);
 }
 
+function headerBlock(emoji: string, title: string, subtitle?: string): CardElement[] {
+  const els: CardElement[] = [text(`${emoji}  ${title}`, { size: 'large', weight: 'bolder', spacing: 'none' })];
+  if (subtitle) els.push(text(subtitle, { isSubtle: true, size: 'small', spacing: 'small' }));
+  return els;
+}
+
+function emphasisContainer(items: CardElement[]): CardElement {
+  return { type: 'Container', style: 'emphasis', spacing: 'medium', bleed: true, items };
+}
+
 export function buildConnectAccountCard(loginUrl: string): Record<string, unknown> {
   return card(
-    [text('Connect a Kortix account to let me run from Teams.', { weight: 'bolder', size: 'medium' })],
+    headerBlock(
+      '🔗',
+      'Connect your Kortix account',
+      'Link once so I run as you — your own credentials, secrets and connected apps, never the installer’s.',
+    ),
     [openUrlAction('Connect or create account', loginUrl)],
   );
 }
 
 export function buildRequestAccessCard(projectId: string): Record<string, unknown> {
   return card(
-    [text("You're connected, but your account doesn't have access to this project yet.", { weight: 'bolder' })],
+    headerBlock('🔒', 'Request access', "You're connected, but your account can't run this project yet."),
     [executeAction('Request access', 'teams_request_access', { projectId })],
   );
 }
 
-export function buildNoticeCard(body: string): Record<string, unknown> {
-  return card([text(body, { wrap: true })]);
+export function buildNoticeCard(body: string, emoji = ''): Record<string, unknown> {
+  return card([text(emoji ? `${emoji}  ${body}` : body, { wrap: true })]);
 }
 
-export function buildChoiceCard(opts: {
+export interface SelectOption {
+  label: string;
+  hint?: string;
+  current?: boolean;
+  data: Record<string, unknown>;
+}
+
+function selectRow(o: SelectOption, verb: string, separator: boolean): CardElement {
+  const labelItems: CardElement[] = [
+    text(o.label, { weight: o.current ? 'bolder' : 'default', spacing: 'none', color: o.current ? 'good' : 'default' }),
+  ];
+  if (o.hint) labelItems.push(text(o.hint, { isSubtle: true, size: 'small', spacing: 'none' }));
+  return {
+    type: 'ColumnSet',
+    separator,
+    spacing: 'medium',
+    columns: [
+      { type: 'Column', width: 'stretch', verticalContentAlignment: 'center', items: labelItems },
+      {
+        type: 'Column',
+        width: 'auto',
+        verticalContentAlignment: 'center',
+        items: [
+          {
+            type: 'ActionSet',
+            actions: [
+              {
+                type: 'Action.Execute',
+                title: o.current ? '✓ In use' : 'Use',
+                verb,
+                data: { verb, ...o.data },
+                ...(o.current ? {} : { style: 'positive' }),
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function buildSelectCard(opts: {
+  emoji: string;
   title: string;
+  subtitle?: string;
   verb: string;
-  choices: Array<{ title: string; data: Record<string, unknown> }>;
-  body?: string;
+  options: SelectOption[];
+  footer?: string;
 }): Record<string, unknown> {
-  const elements: CardElement[] = [text(opts.title, { weight: 'bolder', size: 'medium' })];
-  if (opts.body) elements.push(text(opts.body, { isSubtle: true, size: 'small', spacing: 'none' }));
-  const actions = opts.choices.slice(0, 6).map((c) => executeAction(c.title, opts.verb, c.data));
-  return card(elements, actions);
+  const body: CardElement[] = [...headerBlock(opts.emoji, opts.title, opts.subtitle)];
+  if (opts.options.length) {
+    body.push(emphasisContainer(opts.options.map((o, i) => selectRow(o, opts.verb, i > 0))));
+  }
+  if (opts.footer) body.push(text(opts.footer, { isSubtle: true, size: 'small', spacing: 'small', wrap: true }));
+  return card(body);
 }
 
 export function buildPanelCard(opts: {
+  emoji?: string;
   title: string;
   rows: Array<{ label: string; value: string }>;
   url?: string;
 }): Record<string, unknown> {
-  const facts = opts.rows.map((r) => ({ title: r.label, value: r.value }));
-  const elements: CardElement[] = [
-    text(opts.title, { weight: 'bolder', size: 'medium' }),
-    { type: 'FactSet', facts },
+  const body: CardElement[] = [
+    ...headerBlock(opts.emoji ?? 'ℹ️', opts.title),
+    emphasisContainer([{ type: 'FactSet', facts: opts.rows.map((r) => ({ title: r.label, value: r.value })) }]),
   ];
   const actions = opts.url ? [openUrlAction('Open in Kortix', opts.url)] : undefined;
-  return card(elements, actions);
+  return card(body, actions);
 }
 
 export function buildQuestionCard(
   questions: Array<{ question: string; options?: Array<{ label: string }> }>,
 ): Record<string, unknown> {
-  const elements: CardElement[] = [];
-  for (const q of questions) {
-    elements.push(text(q.question, { weight: 'bolder', wrap: true }));
-  }
-  const options = questions.flatMap((q) => q.options ?? []);
+  const body: CardElement[] = [...headerBlock('💬', 'A quick question')];
+  for (const q of questions) body.push(text(q.question, { weight: 'bolder', wrap: true, spacing: 'small' }));
   const seen = new Set<string>();
   const actions: CardElement[] = [];
-  for (const o of options) {
+  for (const o of questions.flatMap((q) => q.options ?? [])) {
     if (!o.label || seen.has(o.label)) continue;
     seen.add(o.label);
     actions.push(executeAction(o.label, 'teams_answer', { answer: o.label }));
     if (actions.length >= 6) break;
   }
-  elements.push(text('Tap an option or just reply in the chat.', { isSubtle: true, size: 'small', spacing: 'small' }));
-  return card(elements, actions.length ? actions : undefined);
+  body.push(text('Tap an option, or just reply in the chat.', { isSubtle: true, size: 'small', spacing: 'medium' }));
+  return card(body, actions.length ? actions : undefined);
 }
 
 export function buildReviewCard(opts: {
@@ -183,35 +239,46 @@ export function buildReviewCard(opts: {
   risk: string;
   viewUrl?: string;
 }): Record<string, unknown> {
-  const elements: CardElement[] = [
-    text(opts.title, { weight: 'bolder', size: 'medium' }),
-    text(opts.summary, { wrap: true, isSubtle: true, size: 'small' }),
-  ];
+  const riskColor = opts.risk === 'high' ? 'attention' : opts.risk === 'medium' ? 'warning' : 'good';
+  const body: CardElement[] = [...headerBlock('📝', opts.title, opts.summary)];
   if (opts.risk && opts.risk !== 'none') {
-    elements.push(text(`Risk: ${opts.risk}`, { size: 'small', spacing: 'none', color: opts.risk === 'high' ? 'attention' : 'warning' }));
+    body.push(
+      emphasisContainer([
+        text(`Risk · ${opts.risk}`, { size: 'small', weight: 'bolder', color: riskColor, spacing: 'none' }),
+      ]),
+    );
   }
   const actions: CardElement[] = [
-    executeAction('Approve', 'teams_review', { reviewItemId: opts.reviewItemId, verdict: 'approve' }),
+    { type: 'Action.Execute', title: 'Approve', verb: 'teams_review', data: { verb: 'teams_review', reviewItemId: opts.reviewItemId, verdict: 'approve' }, style: 'positive' },
     executeAction('Request changes', 'teams_review', { reviewItemId: opts.reviewItemId, verdict: 'changes' }),
-    executeAction('Deny', 'teams_review', { reviewItemId: opts.reviewItemId, verdict: 'reject' }),
+    { type: 'Action.Execute', title: 'Deny', verb: 'teams_review', data: { verb: 'teams_review', reviewItemId: opts.reviewItemId, verdict: 'reject' }, style: 'destructive' },
   ];
   if (opts.viewUrl) actions.push(openUrlAction('View in Kortix', opts.viewUrl));
-  return card(elements, actions);
+  return card(body, actions);
 }
 
 export function buildWelcomeCard(opts: { projectUrl?: string }): Record<string, unknown> {
-  const elements: CardElement[] = [
-    text('Kortix is connected here', { weight: 'bolder', size: 'medium' }),
-    text('@-mention me with a task and an agent gets on it, replying right here with live progress. Type `/help` to see what I can do.'),
-  ];
+  const body = headerBlock(
+    '👋',
+    'Kortix is connected here',
+    '@-mention me with a task and an agent gets on it — replying right here with live progress. Type `/help` to see what I can do.',
+  );
   const actions = opts.projectUrl ? [openUrlAction('Open in Kortix', opts.projectUrl)] : undefined;
-  return card(elements, actions);
+  return card(body, actions);
 }
 
 export function buildHelpCard(commands: Array<{ cmd: string; desc: string }>): Record<string, unknown> {
-  const elements: CardElement[] = [text('Kortix commands', { weight: 'bolder', size: 'medium' })];
-  for (const c of commands) {
-    elements.push(text(`**${c.cmd}** — ${c.desc}`, { spacing: 'none', size: 'small' }));
-  }
-  return card(elements);
+  const rows: CardElement[] = commands.map((c, i) => ({
+    type: 'ColumnSet',
+    separator: i > 0,
+    spacing: 'small',
+    columns: [
+      { type: 'Column', width: '90px', items: [text(c.cmd, { weight: 'bolder', spacing: 'none', color: 'accent' })] },
+      { type: 'Column', width: 'stretch', items: [text(c.desc, { isSubtle: true, size: 'small', spacing: 'none', wrap: true })] },
+    ],
+  }));
+  return card([
+    ...headerBlock('⚡', 'Kortix commands', 'Run a command, or just @-mention me with a task.'),
+    emphasisContainer(rows),
+  ]);
 }

--- a/apps/api/src/channels/teams/catalog.ts
+++ b/apps/api/src/channels/teams/catalog.ts
@@ -7,11 +7,12 @@ export async function publishTeamsAppToCatalog(input: {
   tenantId: string;
   baseUrl: string;
   appId: string;
+  appName?: string;
 }): Promise<{ ok: boolean; teamsAppId?: string; error?: string }> {
   const token = await graphToken(input.tenantId).catch(() => null);
   if (!token) return { ok: false, error: 'could not mint a Graph token for the tenant' };
 
-  const zip = buildTeamsAppPackage({ appId: input.appId, baseUrl: input.baseUrl });
+  const zip = buildTeamsAppPackage({ appId: input.appId, baseUrl: input.baseUrl, appName: input.appName, botName: input.appName });
   let res: Response;
   try {
     res = await fetch(CATALOG_URL, {

--- a/apps/api/src/channels/teams/commands.ts
+++ b/apps/api/src/channels/teams/commands.ts
@@ -12,11 +12,12 @@ import {
 } from '../slack/selection';
 import { sendCard } from '../teams-api';
 import {
-  buildChoiceCard,
   buildConnectAccountCard,
   buildHelpCard,
   buildNoticeCard,
   buildPanelCard,
+  buildSelectCard,
+  type SelectOption,
 } from './cards';
 import {
   ensureTeamsConversationBinding,
@@ -63,57 +64,63 @@ export async function handleTeamsCommand(input: {
 
   const post = (card: unknown) => sendCard(ref, card as Record<string, unknown>);
 
-  switch (verb) {
-    case 'login':
-    case 'connect': {
-      if (userId) {
-        await post(buildConnectAccountCard(buildTeamsLoginUrl({ tenantId: input.tenantId, teamsUserId: userId })));
+  try {
+    switch (verb) {
+      case 'login':
+      case 'connect': {
+        if (userId) {
+          await post(buildConnectAccountCard(buildTeamsLoginUrl({ tenantId: input.tenantId, teamsUserId: userId })));
+        }
+        return true;
       }
-      return true;
+      case 'logout':
+      case 'disconnect': {
+        const revoked = userId ? await revokeTeamsIdentity(input.tenantId, userId) : false;
+        await post(buildNoticeCard(revoked ? 'Disconnected. Run `/login` to reconnect.' : "You weren't connected.", revoked ? '✅' : ''));
+        return true;
+      }
+      case 'whoami':
+      case 'who':
+        await post(await buildWhoamiCard(ctx, input.tenantId, conversationId, userId, input.projectId));
+        return true;
+      case 'help':
+        await post(helpCard());
+        return true;
+      case 'status':
+      case 'config':
+      case 'settings':
+        await post(await buildStatusCard(ctx, input.tenantId, conversationId, input.projectId));
+        return true;
+      case 'models':
+        await ensureBinding(input.tenantId, conversationId, input.projectId);
+        await post(await buildModelsCard(ctx));
+        return true;
+      case 'model':
+        await ensureBinding(input.tenantId, conversationId, input.projectId);
+        await post(await setModel(ctx, arg));
+        return true;
+      case 'agents':
+        await ensureBinding(input.tenantId, conversationId, input.projectId);
+        await post(await buildAgentsCard(ctx, input.projectId));
+        return true;
+      case 'agent':
+        await ensureBinding(input.tenantId, conversationId, input.projectId);
+        await post(await setAgent(ctx, arg));
+        return true;
+      case 'projects':
+        await post(await buildProjectsCard(input.tenantId, input.projectId));
+        return true;
+      case 'use':
+      case 'switch':
+        await post(await switchProject(input.tenantId, conversationId, arg));
+        return true;
+      default:
+        return false;
     }
-    case 'logout':
-    case 'disconnect': {
-      const revoked = userId ? await revokeTeamsIdentity(input.tenantId, userId) : false;
-      await post(buildNoticeCard(revoked ? 'Disconnected. Run `/login` to reconnect.' : "You weren't connected."));
-      return true;
-    }
-    case 'whoami':
-    case 'who':
-      await post(await buildWhoamiCard(ctx, input.tenantId, conversationId, userId, input.projectId));
-      return true;
-    case 'help':
-      await post(helpCard());
-      return true;
-    case 'status':
-    case 'config':
-    case 'settings':
-      await post(await buildStatusCard(ctx, input.tenantId, conversationId, input.projectId));
-      return true;
-    case 'models':
-      await ensureBinding(input.tenantId, conversationId, input.projectId);
-      await post(await buildModelsCard(ctx));
-      return true;
-    case 'model':
-      await ensureBinding(input.tenantId, conversationId, input.projectId);
-      await post(await setModel(ctx, arg));
-      return true;
-    case 'agents':
-      await ensureBinding(input.tenantId, conversationId, input.projectId);
-      await post(await buildAgentsCard(ctx, input.projectId));
-      return true;
-    case 'agent':
-      await ensureBinding(input.tenantId, conversationId, input.projectId);
-      await post(await setAgent(ctx, arg));
-      return true;
-    case 'projects':
-      await post(await buildProjectsCard(input.tenantId, input.projectId));
-      return true;
-    case 'use':
-    case 'switch':
-      await post(await switchProject(input.tenantId, conversationId, arg));
-      return true;
-    default:
-      return false;
+  } catch (err) {
+    console.error('[teams-command] failed', { verb, message: (err as Error)?.message });
+    await post(buildNoticeCard('Something went wrong running that command — give it a moment and try again.', '⚠️')).catch(() => {});
+    return true;
   }
 }
 
@@ -140,15 +147,19 @@ async function buildStatusCard(
   conversationId: string,
   projectId: string,
 ) {
-  const selection = await currentChannelSelection(ctx);
-  const rows = [
-    { label: 'Project', value: projectId },
-    { label: 'Agent', value: selection?.agentName || 'default' },
-    { label: 'Model', value: selection?.opencodeModel ? labelForModelRef(selection.opencodeModel) : 'project default' },
-  ];
+  const [selection, projects] = await Promise.all([
+    currentChannelSelection(ctx),
+    listTenantProjects(tenantId).catch(() => []),
+  ]);
+  const projectName = projects.find((p) => p.projectId === projectId)?.name ?? projectId;
   return buildPanelCard({
+    emoji: '⚙️',
     title: 'This conversation',
-    rows,
+    rows: [
+      { label: 'Project', value: projectName },
+      { label: 'Agent', value: selection?.agentName || 'default' },
+      { label: 'Model', value: selection?.opencodeModel ? labelForModelRef(selection.opencodeModel) : 'project default' },
+    ],
     url: `${dashboardBase()}/projects/${projectId}`,
   });
 }
@@ -168,6 +179,7 @@ async function buildWhoamiCard(
   }
   const email = (await lookupEmailsByUserIds([identity.userId]).catch(() => null))?.get(identity.userId);
   return buildPanelCard({
+    emoji: '👤',
     title: 'You',
     rows: [
       { label: 'Connected as', value: email || identity.userId },
@@ -179,7 +191,7 @@ async function buildWhoamiCard(
 
 async function buildModelsCard(ctx: ReturnType<typeof teamsChannelCtx>) {
   const gate = await channelModelContext(ctx);
-  if (!gate) return buildNoticeCard('Connect a project to this conversation first.');
+  if (!gate) return buildNoticeCard('Connect a project to this conversation first — try /projects.', '📁');
   const selection = await currentChannelSelection(ctx);
   const current = selection?.opencodeModel ?? null;
   const isCurrent = (id: string) => !!current && toWireModel(current) === toWireModel(id);
@@ -192,22 +204,23 @@ async function buildModelsCard(ctx: ReturnType<typeof teamsChannelCtx>) {
     agentName: selection?.agentName ?? null,
   });
 
-  const choices = [
-    {
-      title: `${current ? '' : '✓ '}Project default${projectDefault.label ? ` · ${projectDefault.label}` : ''}`,
-      data: { model: '' },
-    },
-    ...models.slice(0, 5).map((m) => ({
-      title: `${isCurrent(m.id) ? '✓ ' : ''}${m.label}`,
+  const options: SelectOption[] = [
+    { label: 'Project default', hint: projectDefault.label ?? undefined, current: !current, data: { model: '' } },
+    ...models.slice(0, 6).map((m) => ({
+      label: m.label,
+      hint: m.id,
+      current: isCurrent(m.id),
       data: { model: m.id },
     })),
   ];
 
-  return buildChoiceCard({
-    title: 'Model for this conversation',
+  return buildSelectCard({
+    emoji: '🧠',
+    title: 'Model',
+    subtitle: current ? `Currently ${labelForModelRef(current)}` : 'Currently the project default',
     verb: 'teams_set_model',
-    body: current ? `Currently ${labelForModelRef(current)}.` : 'Currently the project default.',
-    choices,
+    options,
+    footer: 'Or set any provider/model-id you have connected in Kortix: `/model anthropic/claude-sonnet-4.6`.',
   });
 }
 
@@ -236,20 +249,33 @@ async function setModel(ctx: ReturnType<typeof teamsChannelCtx>, arg: string) {
 }
 
 async function buildAgentsCard(ctx: ReturnType<typeof teamsChannelCtx>, projectId: string) {
-  const governance = await loadProjectAgentGovernance(projectId);
-  const selection = await currentChannelSelection(ctx);
+  const [governance, selection] = await Promise.all([
+    loadProjectAgentGovernance(projectId),
+    currentChannelSelection(ctx),
+  ]);
   const current = selection?.agentName ?? null;
   if (governance.agents.length === 0) {
-    return buildNoticeCard('This project has no declared agents — it runs the default agent.');
+    return buildNoticeCard(
+      'This project has no declared agents, so it runs the default agent. Declare agents in `kortix.yaml` to switch here.',
+      '🤖',
+    );
   }
-  const choices = [
-    { title: `${current ? '' : '✓ '}Default`, data: { agent: '' } },
-    ...governance.agents.slice(0, 5).map((a) => ({
-      title: `${current === a.name ? '✓ ' : ''}${a.name}`,
+  const options: SelectOption[] = [
+    { label: 'Default', current: !current, data: { agent: '' } },
+    ...governance.agents.slice(0, 6).map((a) => ({
+      label: a.name,
+      hint: a.description ?? undefined,
+      current: current === a.name,
       data: { agent: a.name },
     })),
   ];
-  return buildChoiceCard({ title: 'Agent for this conversation', verb: 'teams_set_agent', choices });
+  return buildSelectCard({
+    emoji: '🤖',
+    title: 'Agent',
+    subtitle: current ? `Currently ${current}` : 'Currently the default agent',
+    verb: 'teams_set_agent',
+    options,
+  });
 }
 
 async function setAgent(ctx: ReturnType<typeof teamsChannelCtx>, arg: string) {
@@ -269,16 +295,20 @@ async function setAgent(ctx: ReturnType<typeof teamsChannelCtx>, arg: string) {
 
 async function buildProjectsCard(tenantId: string, currentProjectId: string) {
   const projects = await listTenantProjects(tenantId);
-  if (projects.length === 0) return buildNoticeCard('No Kortix projects are connected to this Teams tenant yet.');
-  const choices = projects.slice(0, 6).map((p) => ({
-    title: `${p.projectId === currentProjectId ? '✓ ' : ''}${p.name}`,
+  if (projects.length === 0) {
+    return buildNoticeCard('No Kortix projects are connected to this Teams tenant yet.', '📁');
+  }
+  const options: SelectOption[] = projects.slice(0, 8).map((p) => ({
+    label: p.name,
+    current: p.projectId === currentProjectId,
     data: { projectId: p.projectId },
   }));
-  return buildChoiceCard({
+  return buildSelectCard({
+    emoji: '📁',
     title: 'Connected projects',
+    subtitle: 'Pick which project this conversation runs.',
     verb: 'teams_pick_project',
-    body: 'Pick which project this conversation runs.',
-    choices,
+    options,
   });
 }
 

--- a/apps/api/src/channels/teams/commands.ts
+++ b/apps/api/src/channels/teams/commands.ts
@@ -1,4 +1,5 @@
 import { config } from '../../config';
+import { lookupEmailsByUserIds } from '../../projects/lib/access';
 import { listPickerModels, labelForModelRef } from '../../llm-gateway/models/picker';
 import { isModelServableForAccount } from '../../llm-gateway/resolution/default-model';
 import { toOpencodeModelRef, toWireModel } from '../../llm-gateway/resolution/effective';
@@ -165,7 +166,15 @@ async function buildWhoamiCard(
       buildTeamsLoginUrl({ tenantId, teamsUserId: userId ?? '' }),
     );
   }
-  return buildStatusCard(ctx, tenantId, conversationId, projectId);
+  const email = (await lookupEmailsByUserIds([identity.userId]).catch(() => null))?.get(identity.userId);
+  return buildPanelCard({
+    title: 'You',
+    rows: [
+      { label: 'Connected as', value: email || identity.userId },
+      { label: 'Runs act as', value: 'you — your credentials & secrets' },
+    ],
+    url: `${dashboardBase()}/projects/${projectId}`,
+  });
 }
 
 async function buildModelsCard(ctx: ReturnType<typeof teamsChannelCtx>) {

--- a/apps/api/src/channels/teams/interactivity.ts
+++ b/apps/api/src/channels/teams/interactivity.ts
@@ -73,11 +73,11 @@ async function handleSetModel(
   const ctx = teamsChannelCtx(convo.tenantId, convo.conversationId);
   if (!model) {
     await setChannelModel(ctx, null);
-    return cardResponse(buildNoticeCard('Model reset to the project default.'));
+    return cardResponse(buildNoticeCard('Model reset to the project default.', '✅'));
   }
   const stored = toOpencodeModelRef(model);
   await setChannelModel(ctx, stored);
-  return cardResponse(buildNoticeCard(`Model set to ${labelForModelRef(stored)}.`));
+  return cardResponse(buildNoticeCard(`Model set to ${labelForModelRef(stored)}.`, '✅'));
 }
 
 async function handleSetAgent(
@@ -90,13 +90,13 @@ async function handleSetAgent(
   const ctx = teamsChannelCtx(convo.tenantId, convo.conversationId);
   if (!agent) {
     await setChannelAgent(ctx, null);
-    return cardResponse(buildNoticeCard('Agent reset to the project default.'));
+    return cardResponse(buildNoticeCard('Agent reset to the project default.', '✅'));
   }
   const res = await setChannelAgent(ctx, agent);
   if (!res.ok && res.reason === 'unknown_agent') {
     return cardResponse(buildNoticeCard(`\`${agent}\` isn't a declared agent in this project.`));
   }
-  return cardResponse(buildNoticeCard(`Agent set to ${agent}.`));
+  return cardResponse(buildNoticeCard(`Agent set to ${agent}.`, '✅'));
 }
 
 async function handlePickProject(
@@ -107,7 +107,7 @@ async function handlePickProject(
   const projectId = typeof data.projectId === 'string' ? data.projectId : null;
   if (!convo || !projectId) return cardResponse(buildNoticeCard("I couldn't switch project."));
   await setConversationProject({ tenantId: convo.tenantId, conversationId: convo.conversationId, projectId });
-  return cardResponse(buildNoticeCard('This conversation now runs the selected project.'));
+  return cardResponse(buildNoticeCard('This conversation now runs the selected project.', '✅'));
 }
 
 async function handleAnswer(
@@ -210,7 +210,7 @@ async function handleRequestAccess(
         accountId: outcome.accountId,
         requesterUserId: outcome.requesterUserId,
       });
-      return cardResponse(buildNoticeCard('Access requested. An admin will approve it in Kortix.'));
+      return cardResponse(buildNoticeCard('Access requested. An admin will approve it in Kortix.', '✅'));
     case 'already-member':
       return cardResponse(buildNoticeCard("You already have access — send your message again and I'll pick it up."));
     case 'no-identity':

--- a/apps/api/src/channels/teams/turn.ts
+++ b/apps/api/src/channels/teams/turn.ts
@@ -120,6 +120,7 @@ export async function startTurn(
     projectId,
   };
   await sendTyping(ref);
+  const messageActivityId = (await sendCard(ref, buildPlanCard(LIVE_PLAN_TITLE, []))) ?? '';
 
   return {
     conversationId,
@@ -128,7 +129,7 @@ export async function startTurn(
     botId: activity.recipient?.id,
     fromId: activity.from?.id,
     triggerActivityId: activity.id,
-    messageActivityId: '',
+    messageActivityId,
     steps: [],
     expiry: Date.now() + STREAM_TTL_MS,
     finalized: false,
@@ -247,7 +248,7 @@ export async function finalizeTurn(
       : undefined;
 
   try {
-    if (handle.messageActivityId && handle.steps.length > 0) {
+    if (handle.messageActivityId) {
       const last = handle.steps[handle.steps.length - 1];
       if (last && last.status === 'in_progress') last.status = opts.error ? 'error' : 'complete';
       await updateCard(

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -236,6 +236,7 @@ const envSchema = z.object({
   MICROSOFT_BOT_OPENID_METADATA: optUrl('https://login.botframework.com/v1/.well-known/openidconfiguration'),
   TEAMS_REQUIRE_USER_IDENTITY: optBoolTrue,
   TEAMS_CHANNEL_ENABLED: optBoolFalse,
+  TEAMS_APP_NAME: optStrDefault('Kortix'),
 
   // ── LLM Providers (optional — only needed in cloud mode) ─────────────────
   OPENROUTER_API_URL:          optUrl('https://openrouter.ai/api/v1'),
@@ -664,6 +665,7 @@ export const config = {
   MICROSOFT_BOT_OPENID_METADATA: env.MICROSOFT_BOT_OPENID_METADATA,
   TEAMS_REQUIRE_USER_IDENTITY: env.TEAMS_REQUIRE_USER_IDENTITY,
   TEAMS_CHANNEL_ENABLED: env.TEAMS_CHANNEL_ENABLED,
+  TEAMS_APP_NAME: env.TEAMS_APP_NAME,
 
   // ─── LLM Providers ────────────────────────────────────────────────────────
   OPENROUTER_API_URL: env.OPENROUTER_API_URL,

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -943,7 +943,7 @@ projectsApp.openapi(
     if (!mode.available || !mode.appId) {
       return c.json({ error: 'Teams is not configured on this server' }, 409);
     }
-    return c.json(buildTeamsManifest({ appId: mode.appId, baseUrl }));
+    return c.json(buildTeamsManifest({ appId: mode.appId, baseUrl, appName: config.TEAMS_APP_NAME, botName: config.TEAMS_APP_NAME }));
   },
 );
 

--- a/packages/db/migrations/20260713000000000_widen_chat_channel_thread_ids.sql
+++ b/packages/db/migrations/20260713000000000_widen_chat_channel_thread_ids.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "kortix"."chat_channel_bindings" ALTER COLUMN "channel_id" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "kortix"."chat_threads" ALTER COLUMN "thread_id" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "kortix"."chat_thread_participants" ALTER COLUMN "thread_id" SET DATA TYPE text;

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -802,7 +802,7 @@ export const chatChannelBindings = kortixSchema.table(
     }),
     platform: varchar('platform', { length: 32 }).notNull(),
     workspaceId: varchar('workspace_id', { length: 128 }).notNull(),
-    channelId: varchar('channel_id', { length: 128 }).notNull(),
+    channelId: text('channel_id').notNull(),
     channelName: varchar('channel_name', { length: 256 }),
     channelType: varchar('channel_type', { length: 32 }),
     pickerTs: varchar('picker_ts', { length: 64 }),
@@ -842,7 +842,7 @@ export const chatThreads = kortixSchema.table(
       .references(() => projects.projectId, { onDelete: 'cascade' }),
     platform: varchar('platform', { length: 32 }).notNull(),
     workspaceId: varchar('workspace_id', { length: 128 }).notNull(),
-    threadId: varchar('thread_id', { length: 256 }).notNull(),
+    threadId: text('thread_id').notNull(),
     sessionId: text('session_id')
       .notNull()
       .references(() => projectSessions.sessionId, { onDelete: 'cascade' }),
@@ -891,7 +891,7 @@ export const chatThreadParticipants = kortixSchema.table(
     participantId: uuid('participant_id').defaultRandom().primaryKey(),
     platform: varchar('platform', { length: 32 }).notNull(),
     workspaceId: varchar('workspace_id', { length: 128 }).notNull(),
-    threadId: varchar('thread_id', { length: 256 }).notNull(),
+    threadId: text('thread_id').notNull(),
     sessionId: text('session_id')
       .notNull()
       .references(() => projectSessions.sessionId, { onDelete: 'cascade' }),


### PR DESCRIPTION
Follow-ups to #4527 (Microsoft Teams revival), from live testing on a real tenant.

- **Instant loading feedback** — post the "Working on it…" card immediately when a
  turn starts (before the sandbox boots) instead of lazily on the first `teams step`;
  finalize always updates that card so a direct `teams send` doesn't orphan it.
- **`/whoami` fixed** — showed the same card as `/status`; now shows the linked
  Kortix account ("Connected as <email>").
- **Beautiful, robust command cards** — headers + grouped containers + per-row
  Use/✓ buttons for `/models` `/agents` `/projects`, FactSet panels for `/status`
  `/whoami`, two-column `/help`; every command wrapped in try/catch so a failure
  posts a visible ⚠️ instead of silently dropping.
- **Widen id columns to text** — Teams conversation ids (the `a:1VGXWW…` blobs)
  exceed the varchar(128)/(256) limits sized for Slack, which broke conversation
  binding (and thus session creation) with `value too long for character
  varying(128)`. Migration widens `chat_channel_bindings.channel_id` +
  `chat_threads/chat_thread_participants.thread_id` to `text`.

Supersedes #4546 (its commit is included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)