### PR TITLE
fix(teams): harden tenant binding and login tokens

### DIFF
--- a/apps/api/src/__tests__/unit-teams-binding.test.ts
+++ b/apps/api/src/__tests__/unit-teams-binding.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let dbResults: unknown[][] = [];
+let dbWrites: Array<{ op: string; payload?: unknown }> = [];
+
+type DbChain = Promise<unknown[]> & {
+  from: () => DbChain;
+  where: () => DbChain;
+  limit: () => DbChain;
+  onConflictDoUpdate: () => DbChain;
+  values: (payload: unknown) => DbChain;
+};
+
+function makeChain(op: string): DbChain {
+  const chain = Promise.resolve(dbResults.shift() ?? []) as DbChain;
+  for (const method of ['from', 'where', 'limit', 'onConflictDoUpdate'] as const) {
+    chain[method] = () => chain;
+  }
+  chain.values = (payload: unknown) => {
+    dbWrites.push({ op: `${op}.values`, payload });
+    return chain;
+  };
+  return chain;
+}
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => makeChain('select'),
+    insert: () => makeChain('insert'),
+  },
+  hasDatabase: () => true,
+}));
+
+const { resolveConversationProject, setConversationProject } = await import(
+  '../channels/teams/binding'
+);
+
+beforeEach(() => {
+  dbResults = [];
+  dbWrites = [];
+});
+
+describe('Teams conversation binding', () => {
+  test('ignores a stale binding to a project that is no longer installed for the tenant', async () => {
+    dbResults = [[{ projectId: 'proj-stale' }], [], [{ projectId: 'proj-installed' }]];
+
+    await expect(resolveConversationProject('tenant-1', 'conv-1')).resolves.toBe('proj-installed');
+  });
+
+  test('refuses to bind a project that is not installed for the tenant', async () => {
+    dbResults = [[]];
+    const switched = await setConversationProject({
+      tenantId: 'tenant-1',
+      conversationId: 'conv-1',
+      projectId: 'proj-other',
+    });
+
+    expect(switched).toBe(false);
+    expect(dbWrites.some((w) => w.op === 'insert.values')).toBe(false);
+  });
+
+  test('binds the conversation when the project is installed for the tenant', async () => {
+    dbResults = [[{ projectId: 'proj-1' }], []];
+    const switched = await setConversationProject({
+      tenantId: 'tenant-1',
+      conversationId: 'conv-1',
+      projectId: 'proj-1',
+    });
+
+    expect(switched).toBe(true);
+    expect(dbWrites.find((w) => w.op === 'insert.values')?.payload).toMatchObject({
+      platform: 'teams',
+      workspaceId: 'tenant-1',
+      channelId: 'conv-1',
+      projectId: 'proj-1',
+    });
+  });
+});

--- a/apps/api/src/__tests__/unit-teams-channel-catalog.test.ts
+++ b/apps/api/src/__tests__/unit-teams-channel-catalog.test.ts
@@ -11,10 +11,26 @@ describe('teams channel catalog', () => {
     const actions = channelCatalog('teams');
     const byPath = Object.fromEntries(actions.map((a) => [a.path, a]));
     expect(Object.keys(byPath).sort()).toEqual(
-      ['get_channel', 'get_team', 'get_user', 'list_channels', 'list_members'].sort(),
+      [
+        'get_channel',
+        'get_message',
+        'get_team',
+        'get_user',
+        'list_channels',
+        'list_members',
+        'list_messages',
+        'list_replies',
+        'list_teams',
+      ].sort(),
     );
-    const listChannels = byPath.list_channels!;
-    expect(listChannels.binding).toEqual({ kind: 'http', method: 'GET', path: '/teams/{team-id}/channels' });
+    const listChannels = byPath.list_channels;
+    expect(listChannels).toBeDefined();
+    if (!listChannels) throw new Error('list_channels missing from Teams catalog');
+    expect(listChannels.binding).toEqual({
+      kind: 'http',
+      method: 'GET',
+      path: '/teams/{team-id}/channels',
+    });
     expect(listChannels.risk).toBe('read');
     expect(channelCatalog('teams').every((a) => a.risk === 'read')).toBe(true);
   });

--- a/apps/api/src/__tests__/unit-teams-file-proxy.test.ts
+++ b/apps/api/src/__tests__/unit-teams-file-proxy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { TeamsActivity } from '../channels/teams/types';
 
 let apiCalls: Array<{ fn: string; args: unknown[] }> = [];
 mock.module('../channels/teams-api', () => ({
@@ -11,26 +12,42 @@ mock.module('../channels/teams-api', () => ({
   sendTyping: async () => {},
   sendText: async () => 'text-1',
   updateActivity: async () => true,
-  cardActivity: (c: unknown) => ({ type: 'message', attachments: [{ contentType: 'x', content: c }] }),
+  cardActivity: (c: unknown) => ({
+    type: 'message',
+    attachments: [{ contentType: 'x', content: c }],
+  }),
 }));
-mock.module('../channels/teams-auth', () => ({ graphToken: async () => 'graph-tok' }));
+mock.module('../channels/teams-auth', () => ({
+  graphToken: async () => 'graph-tok',
+  teamsChannelEnabled: () => true,
+  teamsConfigured: () => true,
+}));
 mock.module('../channels/install-store', () => ({
+  loadTeamsBotCredentials: async () => ({ appId: 'app-1', appPassword: 'secret' }),
   loadTeamsTenantForProject: async () => 'tenant-1',
   saveTeamsServiceUrl: async () => {},
 }));
 
 let dbResults: unknown[][] = [];
 let dbWrites: Array<{ op: string; payload?: unknown }> = [];
-function makeChain(op: string): any {
-  const chain: any = {};
-  for (const m of ['from', 'where', 'limit', 'returning']) chain[m] = () => chain;
+
+type DbChain = Promise<unknown[]> & {
+  from: () => DbChain;
+  where: () => DbChain;
+  limit: () => DbChain;
+  returning: () => DbChain;
+  values: (payload: unknown) => DbChain;
+};
+
+function makeChain(op: string): DbChain {
+  const chain = Promise.resolve(dbResults.shift() ?? []) as DbChain;
+  for (const method of ['from', 'where', 'limit', 'returning'] as const) {
+    chain[method] = () => chain;
+  }
   chain.values = (payload: unknown) => {
     dbWrites.push({ op: `${op}.values`, payload });
     return chain;
   };
-  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(dbResults.shift() ?? []));
-  chain.catch = () => chain;
-  chain.finally = () => chain;
   return chain;
 }
 mock.module('../shared/db', () => ({
@@ -45,7 +62,9 @@ mock.module('../shared/db', () => ({
   hasDatabase: () => true,
 }));
 
-const { downloadTeamsFile, initiateTeamsUpload, handleFileConsentInvoke } = await import('../channels/teams/file-proxy');
+const { downloadTeamsFile, initiateTeamsUpload, handleFileConsentInvoke } = await import(
+  '../channels/teams/file-proxy'
+);
 
 let fetchCalls: Array<{ url: string; method: string }> = [];
 let nextFetchOk = true;
@@ -58,7 +77,12 @@ beforeEach(() => {
   nextFetchOk = true;
   globalThis.fetch = (async (url: string, init: { method?: string }) => {
     fetchCalls.push({ url: String(url), method: init?.method ?? 'GET' });
-    return { ok: nextFetchOk, status: nextFetchOk ? 200 : 502, arrayBuffer: async () => new ArrayBuffer(8), headers: { get: () => 'application/pdf' } };
+    return {
+      ok: nextFetchOk,
+      status: nextFetchOk ? 200 : 502,
+      arrayBuffer: async () => new ArrayBuffer(8),
+      headers: { get: () => 'application/pdf' },
+    };
   }) as unknown as typeof fetch;
 });
 afterEach(() => {
@@ -91,7 +115,10 @@ describe('initiateTeamsUpload', () => {
   });
 
   test('stashes the file and posts a consent card', async () => {
-    const r = await initiateTeamsUpload('proj-1', { ...base, contentBase64: Buffer.from('hello').toString('base64') });
+    const r = await initiateTeamsUpload('proj-1', {
+      ...base,
+      contentBase64: Buffer.from('hello').toString('base64'),
+    });
     expect(r.ok).toBe(true);
     expect(dbWrites.some((w) => w.op === 'insert.values')).toBe(true);
     expect(apiCalls.map((c) => c.fn)).toEqual(['sendActivity']);
@@ -100,20 +127,43 @@ describe('initiateTeamsUpload', () => {
 
 describe('handleFileConsentInvoke', () => {
   test('decline deletes the pending upload, no PUT', async () => {
-    await handleFileConsentInvoke({ type: 'invoke', value: { action: 'decline', context: { uploadId: 'u1' } } } as any);
+    await handleFileConsentInvoke({
+      type: 'invoke',
+      value: { action: 'decline', context: { uploadId: 'u1' } },
+    } as TeamsActivity);
     expect(dbWrites.some((w) => w.op === 'delete')).toBe(true);
     expect(fetchCalls.some((f) => f.method === 'PUT')).toBe(false);
   });
 
   test('accept loads the row, PUTs the bytes, posts a file-info card, deletes the row', async () => {
-    dbResults = [[{ uploadId: 'u1', filename: 'r.pdf', contentBase64: Buffer.from('hi').toString('base64'), serviceUrl: 'https://smba/', conversationId: 'conv-1' }]];
+    dbResults = [
+      [
+        {
+          uploadId: 'u1',
+          filename: 'r.pdf',
+          contentBase64: Buffer.from('hi').toString('base64'),
+          serviceUrl: 'https://smba/',
+          conversationId: 'conv-1',
+        },
+      ],
+    ];
     await handleFileConsentInvoke({
       type: 'invoke',
       serviceUrl: 'https://smba/',
       conversation: { id: 'conv-1' },
-      value: { action: 'accept', context: { uploadId: 'u1' }, uploadInfo: { uploadUrl: 'https://upload/slot', contentUrl: 'https://sp/r.pdf', name: 'r.pdf' } },
-    } as any);
-    expect(fetchCalls.some((f) => f.method === 'PUT' && f.url === 'https://upload/slot')).toBe(true);
+      value: {
+        action: 'accept',
+        context: { uploadId: 'u1' },
+        uploadInfo: {
+          uploadUrl: 'https://upload/slot',
+          contentUrl: 'https://sp/r.pdf',
+          name: 'r.pdf',
+        },
+      },
+    } as TeamsActivity);
+    expect(fetchCalls.some((f) => f.method === 'PUT' && f.url === 'https://upload/slot')).toBe(
+      true,
+    );
     expect(apiCalls.map((c) => c.fn)).toEqual(['sendActivity']);
     expect(dbWrites.some((w) => w.op === 'delete')).toBe(true);
   });

--- a/apps/api/src/channels/teams-manifest.ts
+++ b/apps/api/src/channels/teams-manifest.ts
@@ -45,7 +45,8 @@ export interface BuildTeamsManifestConfig {
   longDescription?: string;
 }
 
-const SHORT_DESCRIPTION = 'Your AI workforce, in Teams — @-mention an agent and it does the real work.';
+const SHORT_DESCRIPTION =
+  'Your AI workforce, in Teams — @-mention an agent and it does the real work.';
 
 const LONG_DESCRIPTION =
   'Kortix brings a workforce of AI agents into Microsoft Teams. Add the bot to a chat or channel, @-mention it with a task, and an agent gets on it — working across your connected tools and replying right here as it goes, with live progress. Follow-ups stay in the same conversation. Managed by Kortix · https://kortix.com';
@@ -60,9 +61,9 @@ function hostOf(baseUrl: string): string {
 
 export function buildTeamsManifest(cfg: BuildTeamsManifestConfig): TeamsManifest {
   const appName = cfg.appName ?? 'Kortix';
-  const botName = cfg.botName ?? 'Kortix';
   return {
-    $schema: 'https://developer.microsoft.com/en-us/json-schemas/teams/v1.16/MicrosoftTeams.schema.json',
+    $schema:
+      'https://developer.microsoft.com/en-us/json-schemas/teams/v1.16/MicrosoftTeams.schema.json',
     manifestVersion: '1.16',
     version: '1.0.0',
     id: cfg.appId,

--- a/apps/api/src/channels/teams/binding.ts
+++ b/apps/api/src/channels/teams/binding.ts
@@ -1,5 +1,5 @@
-import { and, eq } from 'drizzle-orm';
 import { chatChannelBindings, chatInstalls, projects } from '@kortix/db';
+import { and, eq } from 'drizzle-orm';
 import { db } from '../../shared/db';
 import type { ChannelCtx } from '../slack/selection';
 
@@ -42,7 +42,20 @@ export async function resolveConversationProject(
       ),
     )
     .limit(1);
-  if (binding?.projectId) return binding.projectId;
+  if (binding?.projectId) {
+    const [installed] = await db
+      .select({ projectId: chatInstalls.projectId })
+      .from(chatInstalls)
+      .where(
+        and(
+          eq(chatInstalls.platform, PLATFORM),
+          eq(chatInstalls.workspaceId, tenantId),
+          eq(chatInstalls.projectId, binding.projectId),
+        ),
+      )
+      .limit(1);
+    if (installed) return binding.projectId;
+  }
 
   const [install] = await db
     .select({ projectId: chatInstalls.projectId })
@@ -58,7 +71,20 @@ export async function ensureTeamsConversationBinding(input: {
   projectId: string;
   channelName?: string | null;
   channelType?: string | null;
-}): Promise<void> {
+}): Promise<boolean> {
+  const [installed] = await db
+    .select({ projectId: chatInstalls.projectId })
+    .from(chatInstalls)
+    .where(
+      and(
+        eq(chatInstalls.platform, PLATFORM),
+        eq(chatInstalls.workspaceId, input.tenantId),
+        eq(chatInstalls.projectId, input.projectId),
+      ),
+    )
+    .limit(1);
+  if (!installed) return false;
+
   await db
     .insert(chatChannelBindings)
     .values({
@@ -70,9 +96,14 @@ export async function ensureTeamsConversationBinding(input: {
       channelType: input.channelType ?? null,
     })
     .onConflictDoUpdate({
-      target: [chatChannelBindings.platform, chatChannelBindings.workspaceId, chatChannelBindings.channelId],
+      target: [
+        chatChannelBindings.platform,
+        chatChannelBindings.workspaceId,
+        chatChannelBindings.channelId,
+      ],
       set: { projectId: input.projectId },
     });
+  return true;
 }
 
 export async function setConversationProject(input: {
@@ -80,6 +111,5 @@ export async function setConversationProject(input: {
   conversationId: string;
   projectId: string;
 }): Promise<boolean> {
-  await ensureTeamsConversationBinding(input);
-  return true;
+  return ensureTeamsConversationBinding(input);
 }

--- a/apps/api/src/channels/teams/commands.ts
+++ b/apps/api/src/channels/teams/commands.ts
@@ -1,5 +1,5 @@
 import { config } from '../../config';
-import { listPickerModels, labelForModelRef } from '../../llm-gateway/models/picker';
+import { labelForModelRef, listPickerModels } from '../../llm-gateway/models/picker';
 import { isModelServableForAccount } from '../../llm-gateway/resolution/default-model';
 import { toOpencodeModelRef, toWireModel } from '../../llm-gateway/resolution/effective';
 import { channelModelContext } from '../slack/model-gate';
@@ -11,23 +11,23 @@ import {
 } from '../slack/selection';
 import { sendCard } from '../teams-api';
 import {
-  buildChoiceCard,
-  buildConnectAccountCard,
-  buildHelpCard,
-  buildNoticeCard,
-  buildPanelCard,
-} from './cards';
-import {
   ensureTeamsConversationBinding,
   listTenantProjects,
   resolveConversationProject,
   setConversationProject,
   teamsChannelCtx,
 } from './binding';
+import {
+  buildChoiceCard,
+  buildConnectAccountCard,
+  buildHelpCard,
+  buildNoticeCard,
+  buildPanelCard,
+} from './cards';
 import { lookupTeamsIdentity, revokeTeamsIdentity, teamsUserId } from './identity';
 import { buildTeamsLoginUrl } from './login';
-import { type TeamsCommand } from './util';
 import type { TeamsActivity, TeamsConversationRef } from './types';
+import type { TeamsCommand } from './util';
 
 export { parseTeamsCommand } from './util';
 
@@ -56,7 +56,7 @@ export async function handleTeamsCommand(input: {
   const ref = conversationRef(input.activity, input.projectId);
   if (!ref) return false;
   const { verb, arg } = input.command;
-  const conversationId = input.activity.conversation!.id!;
+  const conversationId = ref.conversationId;
   const ctx = teamsChannelCtx(input.tenantId, conversationId);
   const userId = teamsUserId(input.activity);
 
@@ -66,19 +66,29 @@ export async function handleTeamsCommand(input: {
     case 'login':
     case 'connect': {
       if (userId) {
-        await post(buildConnectAccountCard(buildTeamsLoginUrl({ tenantId: input.tenantId, teamsUserId: userId })));
+        await post(
+          buildConnectAccountCard(
+            buildTeamsLoginUrl({ tenantId: input.tenantId, teamsUserId: userId }),
+          ),
+        );
       }
       return true;
     }
     case 'logout':
     case 'disconnect': {
       const revoked = userId ? await revokeTeamsIdentity(input.tenantId, userId) : false;
-      await post(buildNoticeCard(revoked ? 'Disconnected. Run `/login` to reconnect.' : "You weren't connected."));
+      await post(
+        buildNoticeCard(
+          revoked ? 'Disconnected. Run `/login` to reconnect.' : "You weren't connected.",
+        ),
+      );
       return true;
     }
     case 'whoami':
     case 'who':
-      await post(await buildWhoamiCard(ctx, input.tenantId, conversationId, userId, input.projectId));
+      await post(
+        await buildWhoamiCard(ctx, input.tenantId, conversationId, userId, input.projectId),
+      );
       return true;
     case 'help':
       await post(helpCard());
@@ -116,7 +126,11 @@ export async function handleTeamsCommand(input: {
   }
 }
 
-async function ensureBinding(tenantId: string, conversationId: string, projectId: string): Promise<void> {
+async function ensureBinding(
+  tenantId: string,
+  conversationId: string,
+  projectId: string,
+): Promise<void> {
   await ensureTeamsConversationBinding({ tenantId, conversationId, projectId });
 }
 
@@ -143,7 +157,12 @@ async function buildStatusCard(
   const rows = [
     { label: 'Project', value: projectId },
     { label: 'Agent', value: selection?.agentName || 'default' },
-    { label: 'Model', value: selection?.opencodeModel ? labelForModelRef(selection.opencodeModel) : 'project default' },
+    {
+      label: 'Model',
+      value: selection?.opencodeModel
+        ? labelForModelRef(selection.opencodeModel)
+        : 'project default',
+    },
   ];
   return buildPanelCard({
     title: 'This conversation',
@@ -161,9 +180,7 @@ async function buildWhoamiCard(
 ) {
   const identity = userId ? await lookupTeamsIdentity(tenantId, userId) : null;
   if (!identity) {
-    return buildConnectAccountCard(
-      buildTeamsLoginUrl({ tenantId, teamsUserId: userId ?? '' }),
-    );
+    return buildConnectAccountCard(buildTeamsLoginUrl({ tenantId, teamsUserId: userId ?? '' }));
   }
   return buildStatusCard(ctx, tenantId, conversationId, projectId);
 }
@@ -219,7 +236,9 @@ async function setModel(ctx: ReturnType<typeof teamsChannelCtx>, arg: string) {
     model: id,
   });
   if (!servable) {
-    return buildNoticeCard(`\`${id}\` isn't available here. Pick one with /models or connect that provider in Kortix.`);
+    return buildNoticeCard(
+      `\`${id}\` isn't available here. Pick one with /models or connect that provider in Kortix.`,
+    );
   }
   const stored = toOpencodeModelRef(id);
   await setChannelModel(ctx, stored);
@@ -240,7 +259,11 @@ async function buildAgentsCard(ctx: ReturnType<typeof teamsChannelCtx>, projectI
       data: { agent: a.name },
     })),
   ];
-  return buildChoiceCard({ title: 'Agent for this conversation', verb: 'teams_set_agent', choices });
+  return buildChoiceCard({
+    title: 'Agent for this conversation',
+    verb: 'teams_set_agent',
+    choices,
+  });
 }
 
 async function setAgent(ctx: ReturnType<typeof teamsChannelCtx>, arg: string) {
@@ -260,7 +283,8 @@ async function setAgent(ctx: ReturnType<typeof teamsChannelCtx>, arg: string) {
 
 async function buildProjectsCard(tenantId: string, currentProjectId: string) {
   const projects = await listTenantProjects(tenantId);
-  if (projects.length === 0) return buildNoticeCard('No Kortix projects are connected to this Teams tenant yet.');
+  if (projects.length === 0)
+    return buildNoticeCard('No Kortix projects are connected to this Teams tenant yet.');
   const choices = projects.slice(0, 6).map((p) => ({
     title: `${p.projectId === currentProjectId ? '✓ ' : ''}${p.name}`,
     data: { projectId: p.projectId },
@@ -279,7 +303,16 @@ async function switchProject(tenantId: string, conversationId: string, arg: stri
   const match = q
     ? projects.find((p) => p.name.toLowerCase() === q || p.projectId === arg.trim())
     : null;
-  if (!match) return buildProjectsCard(tenantId, (await resolveConversationProject(tenantId, conversationId)) ?? '');
-  await setConversationProject({ tenantId, conversationId, projectId: match.projectId });
+  if (!match)
+    return buildProjectsCard(
+      tenantId,
+      (await resolveConversationProject(tenantId, conversationId)) ?? '',
+    );
+  const switched = await setConversationProject({
+    tenantId,
+    conversationId,
+    projectId: match.projectId,
+  });
+  if (!switched) return buildNoticeCard("That project isn't connected to this Teams tenant.");
   return buildNoticeCard(`This conversation now runs *${match.name}*.`);
 }

--- a/apps/api/src/channels/teams/file-proxy.ts
+++ b/apps/api/src/channels/teams/file-proxy.ts
@@ -1,16 +1,17 @@
 import { randomUUID } from 'node:crypto';
-import { and, eq, lt } from 'drizzle-orm';
 import { teamsPendingUploads } from '@kortix/db';
+import { eq, lt } from 'drizzle-orm';
 import { db } from '../../shared/db';
-import { graphToken } from '../teams-auth';
 import { loadTeamsBotCredentials, loadTeamsTenantForProject } from '../install-store';
 import { sendActivity } from '../teams-api';
+import { graphToken } from '../teams-auth';
 import type { TeamsActivity, TeamsConversationRef } from './types';
 
 const MAX_UPLOAD_BYTES = 4 * 1024 * 1024;
 const UPLOAD_TTL_MS = 15 * 60 * 1000;
 
-const ALLOWED_DOWNLOAD_HOST = /(^|\.)(sharepoint\.com|sharepoint-df\.com|svc\.ms|microsoft\.com|office\.com)$/i;
+const ALLOWED_DOWNLOAD_HOST =
+  /(^|\.)(sharepoint\.com|sharepoint-df\.com|svc\.ms|microsoft\.com|office\.com)$/i;
 
 export type FileProxyError = { ok: false; error: string; status: number };
 
@@ -61,15 +62,26 @@ export async function initiateTeamsUpload(
   args: TeamsUploadArgs,
 ): Promise<{ ok: true; uploadId: string } | FileProxyError> {
   if (!args.serviceUrl || !args.conversationId || !args.filename || !args.contentBase64) {
-    return { ok: false, error: 'serviceUrl, conversationId, filename and content_base64 are required', status: 400 };
+    return {
+      ok: false,
+      error: 'serviceUrl, conversationId, filename and content_base64 are required',
+      status: 400,
+    };
   }
   const size = Buffer.byteLength(args.contentBase64, 'base64');
   if (size <= 0) return { ok: false, error: 'empty file', status: 400 };
   if (size > MAX_UPLOAD_BYTES) {
-    return { ok: false, error: `file exceeds the ${MAX_UPLOAD_BYTES} byte upload limit`, status: 400 };
+    return {
+      ok: false,
+      error: `file exceeds the ${MAX_UPLOAD_BYTES} byte upload limit`,
+      status: 400,
+    };
   }
 
-  await db.delete(teamsPendingUploads).where(lt(teamsPendingUploads.expiresAt, new Date())).catch(() => {});
+  await db
+    .delete(teamsPendingUploads)
+    .where(lt(teamsPendingUploads.expiresAt, new Date()))
+    .catch(() => {});
 
   const uploadId = randomUUID();
   await db.insert(teamsPendingUploads).values({
@@ -85,7 +97,12 @@ export async function initiateTeamsUpload(
     expiresAt: new Date(Date.now() + UPLOAD_TTL_MS),
   });
 
-  const ref: TeamsConversationRef = { serviceUrl: args.serviceUrl, conversationId: args.conversationId, botId: args.botId, projectId };
+  const ref: TeamsConversationRef = {
+    serviceUrl: args.serviceUrl,
+    conversationId: args.conversationId,
+    botId: args.botId,
+    projectId,
+  };
   const posted = await sendActivity(ref, {
     type: 'message',
     attachments: [
@@ -94,7 +111,7 @@ export async function initiateTeamsUpload(
         content: {
           description: args.description ?? `Kortix wants to send you ${args.filename}.`,
           sizeInBytes: size,
-            acceptContext: { uploadId },
+          acceptContext: { uploadId },
           declineContext: { uploadId },
         },
         name: args.filename,
@@ -102,7 +119,10 @@ export async function initiateTeamsUpload(
     ],
   });
   if (!posted) {
-    await db.delete(teamsPendingUploads).where(eq(teamsPendingUploads.uploadId, uploadId)).catch(() => {});
+    await db
+      .delete(teamsPendingUploads)
+      .where(eq(teamsPendingUploads.uploadId, uploadId))
+      .catch(() => {});
     return { ok: false, error: 'failed to post the file consent card', status: 502 };
   }
   return { ok: true, uploadId };
@@ -111,7 +131,13 @@ export async function initiateTeamsUpload(
 interface FileConsentValue {
   action?: 'accept' | 'decline';
   context?: { uploadId?: string };
-  uploadInfo?: { uploadUrl?: string; contentUrl?: string; name?: string; uniqueId?: string; fileType?: string };
+  uploadInfo?: {
+    uploadUrl?: string;
+    contentUrl?: string;
+    name?: string;
+    uniqueId?: string;
+    fileType?: string;
+  };
 }
 
 export async function handleFileConsentInvoke(activity: TeamsActivity): Promise<void> {
@@ -133,14 +159,23 @@ export async function handleFileConsentInvoke(activity: TeamsActivity): Promise<
   };
 
   if (value.action !== 'accept') {
-    await db.delete(teamsPendingUploads).where(eq(teamsPendingUploads.uploadId, uploadId)).catch(() => {});
+    await db
+      .delete(teamsPendingUploads)
+      .where(eq(teamsPendingUploads.uploadId, uploadId))
+      .catch(() => {});
     return;
   }
   if (!row || !value.uploadInfo?.uploadUrl) {
     if (ref.serviceUrl && ref.conversationId) {
-      await sendActivity(ref, { type: 'message', text: 'That upload expired — ask me to send the file again.' });
+      await sendActivity(ref, {
+        type: 'message',
+        text: 'That upload expired — ask me to send the file again.',
+      });
     }
-    await db.delete(teamsPendingUploads).where(eq(teamsPendingUploads.uploadId, uploadId)).catch(() => {});
+    await db
+      .delete(teamsPendingUploads)
+      .where(eq(teamsPendingUploads.uploadId, uploadId))
+      .catch(() => {});
     return;
   }
 
@@ -155,7 +190,10 @@ export async function handleFileConsentInvoke(activity: TeamsActivity): Promise<
     signal: AbortSignal.timeout(120_000),
   }).catch(() => null);
 
-  await db.delete(teamsPendingUploads).where(eq(teamsPendingUploads.uploadId, uploadId)).catch(() => {});
+  await db
+    .delete(teamsPendingUploads)
+    .where(eq(teamsPendingUploads.uploadId, uploadId))
+    .catch(() => {});
 
   if (!put || !put.ok) {
     if (ref.serviceUrl && ref.conversationId) {

--- a/apps/api/src/channels/teams/identity-routes.ts
+++ b/apps/api/src/channels/teams/identity-routes.ts
@@ -1,14 +1,15 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { inArray } from 'drizzle-orm';
 import { projects } from '@kortix/db';
-import { db } from '../../shared/db';
+import { inArray } from 'drizzle-orm';
+import type { Context } from 'hono';
 import { config } from '../../config';
-import { auth, errors, json, makeOpenApiApp } from '../../openapi';
 import { combinedAuth } from '../../middleware/auth';
+import { auth, errors, json, makeOpenApiApp } from '../../openapi';
+import { db } from '../../shared/db';
 import { listProjectsForWorkspace, loadTeamsInstall } from '../install-store';
 import { consumePendingTeamsAuthMessage } from './auth-resume';
-import { verifyTeamsLoginState } from './login';
 import { isAccountMember, linkTeamsIdentity } from './identity';
+import { verifyTeamsLoginState } from './login';
 import { createOrJoinTeamsConversationSession } from './session';
 
 export const teamsIdentityApp = makeOpenApiApp();
@@ -22,8 +23,8 @@ teamsIdentityApp.openapi(
     request: { params: z.object({ token: z.string().min(1) }) },
     responses: { 200: { description: 'HTML redirect to web Teams login page' } },
   }),
-  async (c: any) => {
-    const token = c.req.param('token');
+  async (c: Context) => {
+    const token = c.req.param('token') ?? '';
     const base = (config.FRONTEND_URL || 'https://kortix.com').replace(/\/+$/, '');
     const target = `${base}/teams/login/${encodeURIComponent(token)}`;
     return c.html(`<!doctype html>
@@ -60,16 +61,23 @@ teamsIdentityApp.openapi(
     ...auth,
     middleware: [combinedAuth] as const,
     request: { body: { content: { 'application/json': { schema: BindBody } } } },
-    responses: { 200: json(BindResult, 'Identity linked'), ...errors(400, 403, 404, 410) },
+    responses: { 200: json(BindResult, 'Identity linked'), ...errors(400, 403, 404, 410, 503) },
   }),
-  async (c: any) => {
+  async (c: Context) => {
     if (!config.TEAMS_REQUIRE_USER_IDENTITY) return c.json({ error: 'Not found' }, 404);
+    if (!config.MICROSOFT_APP_PASSWORD) {
+      return c.json({ error: 'Teams identity binding is not configured on this server.' }, 503);
+    }
     const userId = c.get('userId') as string;
     const { token } = (await c.req.json().catch(() => ({}))) as { token?: string };
     if (!token) return c.json({ error: 'Missing token' }, 400);
 
     const payload = verifyTeamsLoginState(token);
-    if (!payload) return c.json({ error: 'This link is invalid or has expired. Run the Teams login again.' }, 410);
+    if (!payload)
+      return c.json(
+        { error: 'This link is invalid or has expired. Run the Teams login again.' },
+        410,
+      );
 
     const projectIds = await listProjectsForWorkspace('teams', payload.tenantId);
     if (projectIds.length === 0) {
@@ -83,7 +91,11 @@ teamsIdentityApp.openapi(
     const memberships = await Promise.all(accountIds.map((a) => isAccountMember(userId, a)));
     const hasAccess = memberships.some(Boolean);
 
-    await linkTeamsIdentity({ tenantId: payload.tenantId, teamsUserId: payload.teamsUserId, userId });
+    await linkTeamsIdentity({
+      tenantId: payload.tenantId,
+      teamsUserId: payload.teamsUserId,
+      userId,
+    });
 
     const pending = await consumePendingTeamsAuthMessage({
       pendingId: payload.pendingId,
@@ -98,10 +110,13 @@ teamsIdentityApp.openapi(
         tenantId: payload.tenantId,
         conversationId: pending.activity.conversation?.id ?? '',
         activity: pending.activity,
-      }).catch((err) => console.error('[teams-auth] failed to resume pending Teams message after bind', err));
+      }).catch((err) =>
+        console.error('[teams-auth] failed to resume pending Teams message after bind', err),
+      );
     }
 
-    const workspaceName = (await loadTeamsInstall(projectIds[0]).catch(() => null))?.teamName ?? null;
+    const workspaceName =
+      (await loadTeamsInstall(projectIds[0]).catch(() => null))?.teamName ?? null;
     return c.json({ ok: true, workspaceName, hasAccess, resumed });
   },
 );

--- a/apps/api/src/channels/teams/interactivity.ts
+++ b/apps/api/src/channels/teams/interactivity.ts
@@ -27,14 +27,20 @@ function tenantOf(activity: TeamsActivity): string | null {
   return activity.conversation?.tenantId ?? activity.channelData?.tenant?.id ?? null;
 }
 
-function parseAction(activity: TeamsActivity): { verb: string; data: Record<string, unknown> } | null {
-  const value = activity.value as { action?: { verb?: string; data?: Record<string, unknown> } } | undefined;
+function parseAction(
+  activity: TeamsActivity,
+): { verb: string; data: Record<string, unknown> } | null {
+  const value = activity.value as
+    | { action?: { verb?: string; data?: Record<string, unknown> } }
+    | undefined;
   const verb = value?.action?.verb ?? (value?.action?.data as { verb?: string } | undefined)?.verb;
   if (!verb) return null;
   return { verb, data: value?.action?.data ?? {} };
 }
 
-export async function handleAdaptiveCardAction(activity: TeamsActivity): Promise<TeamsInvokeResponse> {
+export async function handleAdaptiveCardAction(
+  activity: TeamsActivity,
+): Promise<TeamsInvokeResponse> {
   const action = parseAction(activity);
   if (!action) return cardResponse(buildNoticeCard("This action isn't available."));
 
@@ -106,7 +112,13 @@ async function handlePickProject(
   const convo = convoOf(activity);
   const projectId = typeof data.projectId === 'string' ? data.projectId : null;
   if (!convo || !projectId) return cardResponse(buildNoticeCard("I couldn't switch project."));
-  await setConversationProject({ tenantId: convo.tenantId, conversationId: convo.conversationId, projectId });
+  const switched = await setConversationProject({
+    tenantId: convo.tenantId,
+    conversationId: convo.conversationId,
+    projectId,
+  });
+  if (!switched)
+    return cardResponse(buildNoticeCard("That project isn't connected to this Teams tenant."));
   return cardResponse(buildNoticeCard('This conversation now runs the selected project.'));
 }
 
@@ -119,7 +131,8 @@ async function handleAnswer(
   if (!convo || !answer) return cardResponse(buildNoticeCard("I couldn't record that answer."));
 
   const projectId = await resolveConversationProject(convo.tenantId, convo.conversationId);
-  if (!projectId) return cardResponse(buildNoticeCard("This conversation isn't connected to a project."));
+  if (!projectId)
+    return cardResponse(buildNoticeCard("This conversation isn't connected to a project."));
 
   const synthetic: TeamsActivity = {
     ...activity,
@@ -151,20 +164,28 @@ async function handleReview(
   const reviewItemId = typeof data.reviewItemId === 'string' ? data.reviewItemId : null;
   const verdict = typeof data.verdict === 'string' ? VERDICT_MAP[data.verdict] : undefined;
   const uid = teamsUserId(activity);
-  if (!convo || !reviewItemId || !verdict) return cardResponse(buildNoticeCard("I couldn't apply that decision."));
+  if (!convo || !reviewItemId || !verdict)
+    return cardResponse(buildNoticeCard("I couldn't apply that decision."));
 
   const identity = uid ? await lookupTeamsIdentity(convo.tenantId, uid) : null;
   if (!identity) {
-    return cardResponse(buildNoticeCard('Connect your Kortix account (`/login`) to act on reviews.'));
+    return cardResponse(
+      buildNoticeCard('Connect your Kortix account (`/login`) to act on reviews.'),
+    );
   }
 
   const projectId = await resolveConversationProject(convo.tenantId, convo.conversationId);
-  if (!projectId) return cardResponse(buildNoticeCard("This conversation isn't connected to a project."));
+  if (!projectId)
+    return cardResponse(buildNoticeCard("This conversation isn't connected to a project."));
 
   const item = await getReviewItemById(reviewItemId, projectId);
   if (!item) return cardResponse(buildNoticeCard('That review item no longer exists.'));
 
-  await applyVerdict(reviewItemId, projectId, { verdict, feedback: null, actingUserId: identity.userId });
+  await applyVerdict(reviewItemId, projectId, {
+    verdict,
+    feedback: null,
+    actingUserId: identity.userId,
+  });
 
   const decisionLine =
     verdict === 'approve'
@@ -186,7 +207,11 @@ async function handleReview(
   }).catch((err) => console.error('[teams-webhook] review resume failed', err));
 
   const ack =
-    verdict === 'approve' ? `Approved "${item.title}" — resuming the agent.` : verdict === 'reject' ? `Rejected "${item.title}".` : `Requested changes on "${item.title}".`;
+    verdict === 'approve'
+      ? `Approved "${item.title}" — resuming the agent.`
+      : verdict === 'reject'
+        ? `Rejected "${item.title}".`
+        : `Requested changes on "${item.title}".`;
   return cardResponse(buildNoticeCard(ack));
 }
 
@@ -198,7 +223,9 @@ async function handleRequestAccess(
   const userId = teamsUserId(activity);
   const projectId = typeof data.projectId === 'string' ? data.projectId : null;
   if (!tenantId || !userId || !projectId) {
-    return cardResponse(buildNoticeCard("I couldn't file that request. Try again from the prompt."));
+    return cardResponse(
+      buildNoticeCard("I couldn't file that request. Try again from the prompt."),
+    );
   }
 
   const outcome = await createTeamsAccessRequest({ tenantId, teamsUserId: userId, projectId });
@@ -212,9 +239,13 @@ async function handleRequestAccess(
       });
       return cardResponse(buildNoticeCard('Access requested. An admin will approve it in Kortix.'));
     case 'already-member':
-      return cardResponse(buildNoticeCard("You already have access — send your message again and I'll pick it up."));
+      return cardResponse(
+        buildNoticeCard("You already have access — send your message again and I'll pick it up."),
+      );
     case 'no-identity':
-      return cardResponse(buildNoticeCard('Connect your Kortix account first, then request access.'));
+      return cardResponse(
+        buildNoticeCard('Connect your Kortix account first, then request access.'),
+      );
     case 'no-project':
       return cardResponse(buildNoticeCard("I couldn't find that project."));
   }

--- a/apps/api/src/channels/teams/login.ts
+++ b/apps/api/src/channels/teams/login.ts
@@ -12,7 +12,10 @@ export interface TeamsLoginStatePayload {
 }
 
 function loginSigningKey(): string {
-  return config.MICROSOFT_APP_PASSWORD ?? 'kortix-dev-teams-state-key';
+  if (!config.MICROSOFT_APP_PASSWORD) {
+    throw new Error('MICROSOFT_APP_PASSWORD must be configured for Teams login token signing');
+  }
+  return config.MICROSOFT_APP_PASSWORD;
 }
 
 export function signTeamsLoginState(input: {
@@ -40,9 +43,12 @@ export function verifyTeamsLoginState(token: string): TeamsLoginStatePayload | n
   const b = Buffer.from(expected);
   if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
   try {
-    const payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8')) as TeamsLoginStatePayload;
+    const payload = JSON.parse(
+      Buffer.from(body, 'base64url').toString('utf8'),
+    ) as TeamsLoginStatePayload;
     if (typeof payload.exp !== 'number' || payload.exp < Date.now()) return null;
-    if (typeof payload.tenantId !== 'string' || typeof payload.teamsUserId !== 'string') return null;
+    if (typeof payload.tenantId !== 'string' || typeof payload.teamsUserId !== 'string')
+      return null;
     if (payload.pendingId !== undefined && typeof payload.pendingId !== 'string') return null;
     return payload;
   } catch {

--- a/apps/sandbox/slack-cli/channels/teams.ts
+++ b/apps/sandbox/slack-cli/channels/teams.ts
@@ -1,41 +1,61 @@
 #!/usr/bin/env bun
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { ExecutorError, createExecutorClient } from '../../../../packages/executor-sdk/src/index';
 import {
-  parseArgs,
-  out,
   CliError,
-  handleError,
   getEnv,
+  handleError,
+  kortixPost,
   kortixProjectId,
   kortixSessionId,
-  kortixPost,
+  out,
+  parseArgs,
 } from '../lib';
-import { createExecutorClient, ExecutorError } from '../../../../packages/executor-sdk/src/index';
 
 const TEAMS_CONNECTOR = 'teams';
+
+function resolveDownloadOutput(outPath: string): string {
+  const trimmed = outPath.trim();
+  if (!trimmed) throw new CliError('--out must be a file path');
+  if (trimmed.endsWith('/') || trimmed.endsWith('\\'))
+    throw new CliError('--out must point to a file, not a directory');
+  return resolve(trimmed);
+}
 
 async function downloadFile(url: string, outPath: string) {
   const apiUrl = getEnv('KORTIX_API_URL');
   const tok = getEnv('KORTIX_CLI_TOKEN') ?? getEnv('KORTIX_TOKEN');
   const projectId = kortixProjectId();
   if (!apiUrl || !tok || !projectId) {
-    throw new CliError('KORTIX_API_URL / KORTIX_CLI_TOKEN / KORTIX_PROJECT_ID not set — cannot download.');
+    throw new CliError(
+      'KORTIX_API_URL / KORTIX_CLI_TOKEN / KORTIX_PROJECT_ID not set — cannot download.',
+    );
   }
   const proxyUrl = new URL(
     `/v1/projects/${projectId}/channels/teams/file?url=${encodeURIComponent(url)}`,
     apiUrl,
   ).href;
-  const res = await fetch(proxyUrl, { headers: { Authorization: `Bearer ${tok}` }, signal: AbortSignal.timeout(60_000) });
+  const res = await fetch(proxyUrl, {
+    headers: { Authorization: `Bearer ${tok}` },
+    signal: AbortSignal.timeout(60_000),
+  });
   if (!res.ok) {
     let msg = `Download failed: HTTP ${res.status}`;
-    try { const j = (await res.json()) as { error?: string }; if (j?.error) msg = j.error; } catch { /* keep */ }
+    try {
+      const j = (await res.json()) as { error?: string };
+      if (j?.error) msg = j.error;
+    } catch {
+      /* keep */
+    }
     throw new CliError(msg);
   }
   const buf = await res.arrayBuffer();
-  const dir = outPath.split('/').slice(0, -1).join('/');
-  if (dir) mkdirSync(dir, { recursive: true });
-  writeFileSync(outPath, Buffer.from(buf));
-  return { ok: true, path: outPath, size: buf.byteLength };
+  const resolvedOut = resolveDownloadOutput(outPath);
+  mkdirSync(dirname(resolvedOut), { recursive: true });
+  await Bun.write(resolvedOut, Buffer.from(buf));
+  chmodSync(resolvedOut, 0o600);
+  return { ok: true, path: resolvedOut, size: buf.byteLength };
 }
 
 async function sendFile(filePath: string, description?: string) {
@@ -45,7 +65,9 @@ async function sendFile(filePath: string, description?: string) {
   const conversationId = getEnv('MS_TEAMS_CONVERSATION_ID');
   if (!projectId) throw new CliError('KORTIX_PROJECT_ID not set — cannot upload.');
   if (!serviceUrl || !conversationId) {
-    throw new CliError('MS_TEAMS_SERVICE_URL / MS_TEAMS_CONVERSATION_ID not set — no active Teams conversation.');
+    throw new CliError(
+      'MS_TEAMS_SERVICE_URL / MS_TEAMS_CONVERSATION_ID not set — no active Teams conversation.',
+    );
   }
   const data = readFileSync(filePath);
   const filename = filePath.split('/').pop() || 'file';
@@ -71,7 +93,7 @@ function executorClient() {
   return createExecutorClient({ apiUrl, token, projectId: kortixProjectId() });
 }
 
-async function executorCall(action: string, args: Record<string, unknown>): Promise<any> {
+async function executorCall(action: string, args: Record<string, unknown>): Promise<unknown> {
   try {
     const res = await executorClient().call(TEAMS_CONNECTOR, action, args);
     return res.data ?? res;
@@ -149,7 +171,8 @@ async function main(): Promise<void> {
         break;
       }
       const text = readTextFlag(flags) ?? args[0];
-      if (!text) throw new CliError('message text required, e.g. teams send "Done — here is the summary"');
+      if (!text)
+        throw new CliError('message text required, e.g. teams send "Done — here is the summary"');
       const relayed = await relayTurnStream('answer', text.slice(0, 11000));
       if (relayed) {
         out({ ok: true, delivered: 'stream' });
@@ -171,7 +194,9 @@ async function main(): Promise<void> {
       break;
     case 'channel':
       if (!flags.team || !flags.channel) throw new CliError('--team and --channel required');
-      out(await executorCall('get_channel', { 'team-id': flags.team, 'channel-id': flags.channel }));
+      out(
+        await executorCall('get_channel', { 'team-id': flags.team, 'channel-id': flags.channel }),
+      );
       break;
     case 'members':
       if (!flags.team) throw new CliError('--team <team-id> required');
@@ -181,7 +206,6 @@ async function main(): Promise<void> {
       if (!flags.id) throw new CliError('--id <user-id> required');
       out(await executorCall('get_user', { 'user-id': flags.id }));
       break;
-    case 'help':
     default:
       console.log(`
 teams — Microsoft Teams adapter

--- a/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
@@ -40,14 +39,16 @@ import { EmptyState } from '@/features/layout/section/empty-state';
 import { ModelSelector } from '@/features/session/model-selector';
 import { AgentSelector, flattenModels } from '@/features/session/session-chat-input';
 import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
-import { TeamsChannelPanel } from '@/features/workspace/customize/sections/teams-channel-panel';
 import { EmailConnectForm } from '@/features/workspace/customize/sections/connectors-view';
+import { TeamsChannelPanel } from '@/features/workspace/customize/sections/teams-channel-panel';
 import {
+  type ChannelBinding,
   useChannelBindings,
   useUpdateChannelBinding,
-  type ChannelBinding,
 } from '@/hooks/channels/use-channel-bindings';
 import {
+  type EmailInstallation,
+  type SlackInstallation,
   useConnectSlack,
   useDisconnectEmail,
   useDisconnectSlack,
@@ -55,20 +56,19 @@ import {
   useSlackInstall,
   useSlackManifest,
   useSlackMode,
-  type EmailInstallation,
-  type SlackInstallation,
 } from '@/hooks/channels/use-channels-installations';
+import { modelKeyToWire, wireToModelKey } from '@/hooks/opencode/use-model-store';
 import {
+  type Agent,
   useOpenCodeProviders,
   useVisibleAgents,
-  type Agent,
 } from '@/hooks/opencode/use-opencode-sessions';
-import { modelKeyToWire, wireToModelKey } from '@/hooks/opencode/use-model-store';
-import { getProject, listProjectAccess } from '@kortix/sdk/projects-client';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useProjectCan } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
+import { getProject, listProjectAccess } from '@kortix/sdk/projects-client';
 import { Check, CheckCircleSolid, ExternalLinkSolid } from '@mynaui/icons-react';
+import { useQuery } from '@tanstack/react-query';
 import { Copy, Mail, MessageSquare, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
@@ -76,6 +76,12 @@ import { useMemo, useState } from 'react';
 
 /** Reserved slug for the built-in Email channel (see api connectors.ts). */
 const EMAIL_CONNECTOR_SLUG = 'kortix_email';
+const CHANNEL_LOADING_ROWS = ['channel-loading-1', 'channel-loading-2', 'channel-loading-3'];
+const SLACK_MANIFEST_STEPS = [
+  'Click Open Slack, choose "From a manifest", paste the JSON, confirm.',
+  'On the next screen, click Install to Workspace and approve.',
+  'Copy the Bot User OAuth Token (xoxb-…) and Signing Secret.',
+];
 
 export function ChannelsView({ projectId }: { projectId: string | null }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
@@ -93,7 +99,10 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
     EMAIL_CONNECTOR_SLUG,
   );
   const loading =
-    loadingInstall || loadingMode || projectQuery.isLoading || (emailChannelEnabled && loadingEmail);
+    loadingInstall ||
+    loadingMode ||
+    projectQuery.isLoading ||
+    (emailChannelEnabled && loadingEmail);
   const oauthInstallUrl = mode?.oauth_available ? mode.install_url : null;
   const canWrite =
     useProjectCan(projectId ?? undefined, PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE).allowed === true;
@@ -125,8 +134,8 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
           </InfoBanner>
         ) : loading ? (
           <div className="space-y-1">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-10 rounded-md" />
+            {CHANNEL_LOADING_ROWS.map((key) => (
+              <Skeleton key={key} className="h-10 rounded-md" />
             ))}
           </div>
         ) : !oauthInstallUrl && !install ? (
@@ -205,15 +214,11 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
               <BringYourOwnPanel projectId={projectId} />
             ) : null}
 
-            {projectId ? (
-              <div className="border-border/60 border-t pt-6">
-                <TeamsChannelPanel projectId={projectId} />
-              </div>
-            ) : null}
+            <div className="border-border/60 border-t pt-6">
+              <TeamsChannelPanel projectId={projectId} />
+            </div>
 
-            {install ? (
-              <ChannelBindingsSection projectId={projectId} canWrite={canWrite} />
-            ) : null}
+            {install ? <ChannelBindingsSection projectId={projectId} canWrite={canWrite} /> : null}
           </>
         )}
       </div>
@@ -251,8 +256,8 @@ function ChannelBindingsSection({
     <div className="space-y-2">
       <Label>Channel bindings</Label>
       <p className="text-muted-foreground text-xs">
-        Which agent, model, and join policy each connected channel uses. A channel with
-        no override follows the project default.
+        Which agent, model, and join policy each connected channel uses. A channel with no override
+        follows the project default.
       </p>
       <Table>
         <TableHeader>
@@ -279,11 +284,12 @@ function ChannelBindingsSection({
   );
 }
 
-const CONVERSATION_POLICIES: Array<{ value: ChannelBinding['conversationPolicy']; label: string }> = [
-  { value: 'project_open', label: 'Project members can join' },
-  { value: 'owner_only', label: 'Owner only' },
-  { value: 'owner_approval', label: 'Owner approval' },
-];
+const CONVERSATION_POLICIES: Array<{ value: ChannelBinding['conversationPolicy']; label: string }> =
+  [
+    { value: 'project_open', label: 'Project members can join' },
+    { value: 'owner_only', label: 'Owner only' },
+    { value: 'owner_approval', label: 'Owner approval' },
+  ];
 
 /** Label for the synthetic agent-picker entry meaning "inherit the project's default agent". */
 function agentDefaultLabel(projectDefaultAgent: string | null): string {
@@ -304,7 +310,9 @@ function stripOpencodeNamespace(model: string): string {
 function describeEffectiveModel(binding: ChannelBinding): string {
   if (binding.opencodeModel) {
     const label = stripOpencodeNamespace(binding.opencodeModel);
-    return binding.effectiveModel.source === 'explicit' ? label : `${label} (unavailable — using default)`;
+    return binding.effectiveModel.source === 'explicit'
+      ? label
+      : `${label} (unavailable — using default)`;
   }
   const resolved = binding.effectiveModel.model;
   return resolved ? `Project default (${stripOpencodeNamespace(resolved)})` : 'Project default';
@@ -339,7 +347,7 @@ function ChannelBindingTableRow({
   const agentSelectorAgents = useMemo<Agent[]>(() => {
     const defaultEntry = {
       name: agentDefaultLabel(projectDefaultAgent),
-      description: 'Falls back to the project\'s configured default agent.',
+      description: "Falls back to the project's configured default agent.",
       mode: 'primary',
       permission: {},
       options: {},
@@ -349,7 +357,14 @@ function ChannelBindingTableRow({
     // removed, so the picker never renders a value it can't display.
     const missingCurrent =
       binding.agentName && !names.has(binding.agentName)
-        ? [{ name: binding.agentName, mode: 'primary', permission: {}, options: {} } as unknown as Agent]
+        ? [
+            {
+              name: binding.agentName,
+              mode: 'primary',
+              permission: {},
+              options: {},
+            } as unknown as Agent,
+          ]
         : [];
     return [defaultEntry, ...visibleAgents, ...missingCurrent];
   }, [visibleAgents, projectDefaultAgent, binding.agentName]);
@@ -357,7 +372,9 @@ function ChannelBindingTableRow({
 
   const { data: providers } = useOpenCodeProviders();
   const models = useMemo(() => flattenModels(providers), [providers]);
-  const selectedModel = binding.opencodeModel ? wireToModelKey(stripOpencodeNamespace(binding.opencodeModel)) : null;
+  const selectedModel = binding.opencodeModel
+    ? wireToModelKey(stripOpencodeNamespace(binding.opencodeModel))
+    : null;
 
   const update = useUpdateChannelBinding();
 
@@ -772,12 +789,8 @@ function BringYourOwnPanel({ projectId, inline = false }: { projectId: string; i
         </div>
 
         <ol className="text-muted-foreground list-decimal space-y-1.5 pl-5 text-sm">
-          {[
-            'Click Open Slack, choose "From a manifest", paste the JSON, confirm.',
-            'On the next screen, click Install to Workspace and approve.',
-            'Copy the Bot User OAuth Token (xoxb-…) and Signing Secret.',
-          ].map((line, i) => (
-            <li key={i}>{line}</li>
+          {SLACK_MANIFEST_STEPS.map((line) => (
+            <li key={line}>{line}</li>
           ))}
         </ol>
 


### PR DESCRIPTION
## Summary
- Block Teams conversation project switches unless the target project is installed for that Teams tenant.
- Require a configured Microsoft app password for Teams login-state token signing/binding.
- Clean up CodeQL/Strix comments around Teams file download, manifest dead code, and the channels UI conditional.

## Verification
- bun test src/__tests__/unit-teams-*.test.ts
- node node_modules/typescript/bin/tsc --noEmit (apps/api)
- node node_modules/typescript/bin/tsc --noEmit (apps/web, after fumadocs-mdx generated source)
- biome check --write on touched files