### PR TITLE
feat(web/teams): render Microsoft Teams as a channel table row like Slack

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/channels-view.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/channels-view.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 const dir = import.meta.dir;
 const channelsSource = readFileSync(join(dir, 'view/channels-view.tsx'), 'utf8');
 const connectorsSource = readFileSync(join(dir, 'connectors-view.tsx'), 'utf8');
+const teamsPanelSource = readFileSync(join(dir, 'teams-channel-panel.tsx'), 'utf8');
 
 describe('Channels view — connect in place', () => {
   test('reuses the connector connect form inside a modal instead of redirecting', () => {
@@ -74,5 +75,37 @@ describe('Channels view — per-channel binding management (spec §2.5)', () => 
   test('read-only members see static values instead of editable controls', () => {
     expect(channelsSource).toContain('canManage');
     expect(channelsSource).toContain('disabled={!canManage');
+  });
+});
+
+describe('Channels view — Microsoft Teams is a uniform channel row', () => {
+  test('renders Teams as a table row alongside Slack and Email (not a bespoke card)', () => {
+    expect(channelsSource).toContain('function TeamsChannelRow');
+    expect(channelsSource).toContain('<TeamsChannelRow');
+    expect(channelsSource).toContain('Icon.MicrosoftTeams');
+    expect(channelsSource).toMatch(/<SlackChannelRow[\s\S]*<TeamsChannelRow/);
+  });
+
+  test('reuses the shared Teams installation hooks (same source of truth as the panel)', () => {
+    expect(channelsSource).toContain("from '@/hooks/channels/use-teams-installations'");
+    expect(channelsSource).toContain('useTeamsInstall');
+    expect(channelsSource).toContain('useTeamsMode');
+    expect(channelsSource).toContain('useDisconnectTeams');
+  });
+
+  test('keeps the Teams row behind the channel feature flag', () => {
+    expect(channelsSource).toContain('if (mode && !mode.enabled) return null;');
+  });
+
+  test('offers one-click Install / Add to Teams / Disconnect in the row', () => {
+    expect(channelsSource).toContain('orgConsentUrl');
+    expect(channelsSource).toContain('Add to Teams');
+    expect(channelsSource).toContain('deepLinkUrl');
+  });
+
+  test('the standalone Teams panel is repurposed into the bring-your-own-bot card', () => {
+    expect(teamsPanelSource).toContain('Bring your own Microsoft Teams bot');
+    expect(teamsPanelSource).not.toContain('ConnectedPanel');
+    expect(teamsPanelSource).not.toContain('DisconnectedPanel');
   });
 });

--- a/apps/web/src/features/workspace/customize/sections/teams-channel-panel.tsx
+++ b/apps/web/src/features/workspace/customize/sections/teams-channel-panel.tsx
@@ -5,149 +5,43 @@ import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SectionCard } from '@/components/ui/section-card';
-import { Skeleton } from '@/components/ui/skeleton';
 import {
   useConnectTeams,
-  useDisconnectTeams,
-  useTeamsInstall,
   useTeamsManifest,
   useTeamsMode,
-  type TeamsInstallation,
   type TeamsMode,
 } from '@/hooks/channels/use-teams-installations';
-import { Check, Copy, ExternalLink, Loader2, MessagesSquare, X } from 'lucide-react';
+import { Check, ChevronDown, Copy, ExternalLink, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
 export function TeamsChannelPanel({ projectId }: { projectId: string }) {
-  const { data: install, isLoading: loadingInstall } = useTeamsInstall(projectId);
-  const { data: mode, isLoading: loadingMode } = useTeamsMode(projectId);
+  const { data: mode, isLoading } = useTeamsMode(projectId);
+  const [open, setOpen] = useState(false);
 
-  if (!loadingMode && mode && !mode.enabled) return null;
-
-  return (
-    <section className="space-y-3">
-      <header className="flex items-center gap-2">
-        <MessagesSquare className="h-4 w-4" />
-        <h3 className="text-foreground text-sm font-semibold">Microsoft Teams</h3>
-      </header>
-      {loadingInstall || loadingMode ? (
-        <Skeleton className="h-32 w-full rounded-2xl" />
-      ) : install ? (
-        <ConnectedPanel projectId={projectId} installation={install} mode={mode} />
-      ) : (
-        <DisconnectedPanel projectId={projectId} mode={mode} />
-      )}
-    </section>
-  );
-}
-
-function ConnectedPanel({
-  projectId,
-  installation,
-  mode,
-}: {
-  projectId: string;
-  installation: TeamsInstallation;
-  mode: TeamsMode | undefined;
-}) {
-  const disconnect = useDisconnectTeams();
-  const [confirming, setConfirming] = useState(false);
+  if (isLoading || !mode?.enabled) return null;
 
   return (
-    <div className="space-y-4">
-      <InfoBanner
-        tone="success"
-        icon={Check}
-        title={`Connected to ${installation.teamName ?? installation.tenantId}`}
-      >
-        Tenant <code className="font-mono">{installation.tenantId}</code>
-        {installation.byo ? ' · bring-your-own Azure bot' : ' · managed Kortix bot'}
-      </InfoBanner>
-
-      {mode?.deepLinkUrl && installation.orgInstalled ? (
-        <SectionCard title="Add Kortix to a chat or channel">
-          <p className="text-muted-foreground mb-3 text-sm">
-            Kortix is published to your Teams org. Anyone can add it in one click, then @-mention it with a task.
-          </p>
-          <a href={mode.deepLinkUrl} target="_blank" rel="noopener noreferrer" className="inline-flex">
-            <Button size="sm">
-              <MessagesSquare className="mr-1.5 h-3.5 w-3.5" />
-              Add to Teams
-              <ExternalLink className="ml-1.5 h-3 w-3" />
-            </Button>
-          </a>
-        </SectionCard>
-      ) : (
-        <SectionCard title="How to use it">
-          <p className="text-muted-foreground text-sm">
-            @-mention the Kortix bot in any Teams chat or channel and an agent gets on it — replying right
-            here with live progress. The agent posts via the <code className="font-mono text-xs">teams</code> CLI;
-            no token lives in the sandbox.
-          </p>
-        </SectionCard>
-      )}
-
-      <div className="flex items-center justify-end gap-2">
-        {confirming ? (
-          <>
-            <span className="text-muted-foreground text-xs">Removes the Teams binding for this project.</span>
-            <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={disconnect.isPending}
-              onClick={() => disconnect.mutate(projectId, { onSuccess: () => setConfirming(false) })}
-            >
-              {disconnect.isPending ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
-              Disconnect
-            </Button>
-          </>
-        ) : (
-          <Button variant="ghost" size="sm" onClick={() => setConfirming(true)}>
-            <X className="mr-1.5 h-3.5 w-3.5" />
-            Disconnect
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function DisconnectedPanel({ projectId, mode }: { projectId: string; mode: TeamsMode | undefined }) {
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const oneClick = Boolean(mode?.available && !mode.byo && mode.orgConsentUrl);
-
-  if (!oneClick) return <InstallFlow projectId={projectId} mode={mode} />;
-
-  return (
-    <div className="space-y-4">
-      <SectionCard
-        title="Add Kortix to Microsoft Teams"
-        description="One-time admin approval publishes Kortix to your Teams org — then anyone adds it in a click."
-      >
-        <a href={mode!.orgConsentUrl!} className="inline-flex">
-          <Button size="lg">
-            <MessagesSquare className="mr-1.5 h-4 w-4" />
-            Add Kortix to Teams
-            <ExternalLink className="ml-1.5 h-3.5 w-3.5" />
-          </Button>
-        </a>
-        <p className="text-muted-foreground mt-3 text-xs">
-          You&apos;ll grant admin consent for your tenant. This binds this project to your Teams tenant and
-          publishes the app — no manifest, no upload.
-        </p>
-      </SectionCard>
-
+    <div className="border-border bg-muted/20 overflow-hidden rounded-2xl border">
       <button
         type="button"
-        onClick={() => setShowAdvanced((v) => !v)}
-        className="text-muted-foreground hover:text-foreground text-xs underline-offset-4 hover:underline"
+        onClick={() => setOpen((v) => !v)}
+        className="hover:bg-muted/30 flex w-full items-center justify-between gap-3 p-4 text-left transition-colors"
       >
-        {showAdvanced ? 'Hide advanced' : 'Advanced: manual sideload or bring your own bot'}
+        <div>
+          <div className="text-foreground text-sm font-medium">Bring your own Microsoft Teams bot</div>
+          <div className="text-muted-foreground text-xs">
+            For self-hosted setups, or to sideload the app manually.
+          </div>
+        </div>
+        <ChevronDown
+          className={`text-muted-foreground size-4 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
       </button>
-      {showAdvanced ? <InstallFlow projectId={projectId} mode={mode} /> : null}
+      {open ? (
+        <div className="border-border/60 border-t p-4">
+          <InstallFlow projectId={projectId} mode={mode} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
@@ -57,6 +57,11 @@ import {
   useSlackManifest,
   useSlackMode,
 } from '@/hooks/channels/use-channels-installations';
+import {
+  useDisconnectTeams,
+  useTeamsInstall,
+  useTeamsMode,
+} from '@/hooks/channels/use-teams-installations';
 import { modelKeyToWire, wireToModelKey } from '@/hooks/opencode/use-model-store';
 import {
   type Agent,
@@ -190,6 +195,7 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
                     canWrite={canWrite}
                   />
                 ) : null}
+                <TeamsChannelRow projectId={projectId} canWrite={canWrite} />
               </TableBody>
             </Table>
 
@@ -556,6 +562,95 @@ function SlackChannelRow({
         ) : oauthInstallUrl ? (
           <Button size="sm" variant="secondary" asChild>
             <Link href={oauthInstallUrl} target="_blank" rel="noopener noreferrer">
+              Install
+            </Link>
+          </Button>
+        ) : null}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function TeamsChannelRow({ projectId, canWrite }: { projectId: string; canWrite: boolean }) {
+  const { data: install } = useTeamsInstall(projectId);
+  const { data: mode } = useTeamsMode(projectId);
+  const disconnect = useDisconnectTeams();
+  const [confirming, setConfirming] = useState(false);
+
+  if (mode && !mode.enabled) return null;
+
+  const connected = Boolean(install);
+  const installUrl = mode?.orgConsentUrl ?? null;
+  const deepLinkUrl = install?.orgInstalled ? (mode?.deepLinkUrl ?? null) : null;
+
+  return (
+    <TableRow className="hover:bg-transparent">
+      <TableCell>
+        <div className="flex items-center gap-2.5">
+          <Icon.MicrosoftTeams className="size-5 shrink-0" />
+          <span className="text-sm font-medium">Microsoft Teams</span>
+        </div>
+      </TableCell>
+      <TableCell>
+        {connected ? (
+          <Badge variant="success" size="sm">
+            Connected
+          </Badge>
+        ) : (
+          <Badge variant="outline" size="sm" className="text-muted-foreground">
+            Not connected
+          </Badge>
+        )}
+      </TableCell>
+      <TableCell className="text-muted-foreground text-sm">
+        {connected ? (install?.teamName ?? install?.tenantId ?? '—') : '—'}
+      </TableCell>
+      <TableCell>
+        {!canWrite ? null : connected ? (
+          confirming ? (
+            <div className="flex items-center justify-end gap-1">
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={disconnect.isPending}
+                onClick={() =>
+                  disconnect.mutate(projectId, {
+                    onSuccess: () => setConfirming(false),
+                  })
+                }
+              >
+                {disconnect.isPending ? (
+                  <Loading className="size-3.5 shrink-0 animate-spin" />
+                ) : null}
+                Disconnect
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center justify-end gap-1">
+              {deepLinkUrl ? (
+                <Button size="sm" variant="secondary" asChild>
+                  <Link href={deepLinkUrl} target="_blank" rel="noopener noreferrer">
+                    Add to Teams
+                  </Link>
+                </Button>
+              ) : null}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1.5"
+                onClick={() => setConfirming(true)}
+              >
+                <X className="size-3.5 shrink-0" />
+                Disconnect
+              </Button>
+            </div>
+          )
+        ) : installUrl ? (
+          <Button size="sm" variant="secondary" asChild>
+            <Link href={installUrl} target="_blank" rel="noopener noreferrer">
               Install
             </Link>
           </Button>


### PR DESCRIPTION
## What

Makes the Microsoft Teams channel UI uniform with Slack. Previously Teams rendered as a bespoke card while Slack/Email were rows in the channels table — two different UIs for the same thing.

Now Teams is a **table row** just like Slack:
- Microsoft Teams logo + name
- Connection status badge (Connected / Not connected)
- Tenant / team name in the workspace column
- Action button: **Install** (org admin-consent) when disconnected, **Add to Teams** (deep link) + **Disconnect** when connected

The standalone `TeamsChannelPanel` is repurposed from the big bespoke card into a compact collapsible **"Bring your own Microsoft Teams bot"** card, mirroring Slack's bring-your-own-app card. The one-click connect/disconnect flow lives entirely in the row.

## Notes

- Teams row hides itself when the channel feature flag is off (`mode.enabled === false`), so this stays gated until release.
- No backend changes; reuses existing `useTeamsInstall` / `useTeamsMode` / `useDisconnectTeams` hooks.
- Web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)