### PR TITLE
fix(api/teams): Teams install never shows connected (connector-scoped secret read)

### DIFF
--- a/apps/api/src/__tests__/unit-teams-install-store.test.ts
+++ b/apps/api/src/__tests__/unit-teams-install-store.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, describe, expect, mock, test } from 'bun:test';
+
+const tenantRow = {
+  name: 'MS_TEAMS_TENANT_ID',
+  valueEnc: 'enc:435431f6-fc5c-4d3e-8d99-9ff939fec417',
+  updatedAt: new Date('2026-07-12T22:24:46.853Z'),
+};
+
+function makeChain(result: unknown[]): any {
+  const chain: any = {};
+  for (const method of ['from', 'where', 'orderBy', 'limit', 'returning', 'onConflictDoNothing', 'set', 'values']) {
+    chain[method] = () => chain;
+  }
+  chain.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(result));
+  return chain;
+}
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => makeChain([tenantRow]),
+    insert: () => makeChain([]),
+    update: () => makeChain([]),
+    delete: () => makeChain([]),
+  },
+}));
+
+mock.module('../projects/secrets', () => ({
+  listProjectSecrets: async () => ({}),
+  decryptProjectSecret: (_projectId: string, value: string) => value.replace(/^enc:/, ''),
+  encryptProjectSecret: (_projectId: string, value: string) => `enc:${value}`,
+}));
+
+const { loadTeamsInstall } = await import('../channels/install-store');
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe('loadTeamsInstall — connector-scoped Teams secrets', () => {
+  test('resolves the install by reading secrets directly, not via listProjectSecrets (which strips connector scope)', async () => {
+    const install = await loadTeamsInstall('proj-teams');
+    expect(install).not.toBeNull();
+    expect(install?.tenantId).toBe('435431f6-fc5c-4d3e-8d99-9ff939fec417');
+    expect(install?.orgInstalled).toBe(false);
+  });
+});

--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -1,5 +1,5 @@
 import { chatInstalls, projectSecrets } from '@kortix/db';
-import { and, eq, isNull, like } from 'drizzle-orm';
+import { and, eq, inArray, isNull, like } from 'drizzle-orm';
 import { config } from '../config';
 import {
   decryptProjectSecret,
@@ -661,7 +661,7 @@ export async function setTeamsCatalogAppId(projectId: string, catalogAppId: stri
 }
 
 export async function loadTeamsBotCredentials(projectId: string): Promise<TeamsBotCredentials | null> {
-  const secrets = await listProjectSecrets(projectId);
+  const secrets = await readTeamsSecrets(projectId);
   const appId = secrets[MS_TEAMS_APP_ID];
   const appPassword = secrets[MS_TEAMS_APP_PASSWORD];
   if (!appId || !appPassword) return null;
@@ -679,7 +679,7 @@ export async function saveTeamsServiceUrl(projectId: string, serviceUrl: string)
 }
 
 export async function loadTeamsInstall(projectId: string): Promise<TeamsInstallSummary | null> {
-  const secrets = await listProjectSecrets(projectId);
+  const secrets = await readTeamsSecrets(projectId);
   const tenantId = secrets[MS_TEAMS_TENANT_ID];
   if (!tenantId) return null;
   const [row] = await db
@@ -768,6 +768,28 @@ function isUniqueConflict(err: unknown): boolean {
     error?.cause?.code === '23505' ||
     error?.cause?.cause?.code === '23505'
   );
+}
+
+async function readTeamsSecrets(projectId: string): Promise<Record<string, string>> {
+  const rows = await db
+    .select({ name: projectSecrets.name, valueEnc: projectSecrets.valueEnc })
+    .from(projectSecrets)
+    .where(
+      and(
+        eq(projectSecrets.projectId, projectId),
+        isNull(projectSecrets.ownerUserId),
+        inArray(projectSecrets.name, TEAMS_KEYS as unknown as string[]),
+      ),
+    );
+  const out: Record<string, string> = {};
+  for (const row of rows) {
+    if (!row.valueEnc) continue;
+    try {
+      out[row.name] = decryptProjectSecret(projectId, row.valueEnc);
+    } catch {
+    }
+  }
+  return out;
 }
 
 async function readSecret(projectId: string, name: string): Promise<string | null> {


### PR DESCRIPTION
## Bug

After a successful Microsoft Teams admin-consent install, the Kortix UI always showed **Not connected**, and `GET /v1/projects/:id/channels/teams/installation` always returned `null` — even though the install was persisted correctly.

## Root cause

`saveTeamsInstall` writes the `MS_TEAMS_*` secrets (tenant id, team name, and the BYO bot app id/password) with `scope: 'connector'`. That's deliberate and correct: connector-scoped secrets are resolved server-side and **never injected into the sandbox env** (so the bot password can't leak).

But `loadTeamsInstall` and `loadTeamsBotCredentials` read those secrets back through `listProjectSecrets`, which explicitly **strips every `connector`-scoped row**:

```ts
if (row.scope === 'connector') continue;
```

So the reader could never see the tenant secret → `loadTeamsInstall` returned `null` unconditionally → the channel could never display as connected.

Verified on dev DB for a real install: the `chat_installs` row and the `MS_TEAMS_TENANT_ID` secret (scope `connector`) both exist, yet the installation endpoint returned null.

## Fix

Read the `MS_TEAMS_*` rows **directly** via a dedicated `readTeamsSecrets` helper that bypasses the sandbox-env filter — keeping the secrets out of the sandbox (scope unchanged) while letting the server resolve the install. Both `loadTeamsInstall` and `loadTeamsBotCredentials` now use it.

## Test

`unit-teams-install-store.test.ts` mocks `listProjectSecrets` to return `{}` (simulating the connector strip) while the DB holds the connector-scoped tenant row, and asserts `loadTeamsInstall` still resolves the install. This fails on the old code and passes on the fix.

> Note: this is separate from the org-catalog one-click publish, which additionally needs `AppCatalog.ReadWrite.All` granted on the Azure app (Graph returned 403 on `POST /appCatalogs/teamsApps`). This PR fixes the "not connected" display; that Azure permission fixes the auto-publish/bot-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)