### PR TITLE
feat(api/teams): true one-click org install via delegated auth-code publish

### DIFF
--- a/apps/api/src/__tests__/unit-teams-catalog-publish.test.ts
+++ b/apps/api/src/__tests__/unit-teams-catalog-publish.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { publishTeamsAppToCatalog } from '../channels/teams/catalog';
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function jsonRes(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+describe('publishTeamsAppToCatalog — delegated org-catalog publish', () => {
+  test('an admin publishes immediately (201) and gets the catalog id', async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    globalThis.fetch = (async (url: any, init: any) => {
+      calls.push({ url: String(url), method: init?.method });
+      return jsonRes(201, { id: 'catalog-123' });
+    }) as any;
+
+    const r = await publishTeamsAppToCatalog({ accessToken: 'tok', baseUrl: 'https://dev-api', appId: 'app-1', appName: 'Kortix Dev' });
+
+    expect(r).toMatchObject({ ok: true, published: true, teamsAppId: 'catalog-123' });
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.url).not.toContain('requiresReview');
+  });
+
+  test('a non-admin (403) is submitted for admin review', async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (url: any) => {
+      const u = String(url);
+      urls.push(u);
+      if (!u.includes('requiresReview')) return jsonRes(403, { error: { code: 'Forbidden' } });
+      return jsonRes(201, { id: 'submitted-9' });
+    }) as any;
+
+    const r = await publishTeamsAppToCatalog({ accessToken: 'tok', baseUrl: 'https://dev-api', appId: 'app-1' });
+
+    expect(r).toMatchObject({ ok: true, published: false, pendingReview: true, teamsAppId: 'submitted-9' });
+    expect(urls.some((u) => u.includes('requiresReview=true'))).toBe(true);
+  });
+
+  test('an already-published app (409) resolves its id via externalId lookup', async () => {
+    globalThis.fetch = (async (url: any, init: any) => {
+      if (init?.method === 'POST') return new Response('', { status: 409 });
+      return jsonRes(200, { value: [{ id: 'existing-77' }] });
+    }) as any;
+
+    const r = await publishTeamsAppToCatalog({ accessToken: 'tok', baseUrl: 'https://dev-api', appId: 'app-1' });
+
+    expect(r).toMatchObject({ ok: true, published: true, teamsAppId: 'existing-77' });
+  });
+
+  test('reports failure when the publish is rejected outright', async () => {
+    globalThis.fetch = (async () => jsonRes(500, { error: 'boom' })) as any;
+
+    const r = await publishTeamsAppToCatalog({ accessToken: 'tok', baseUrl: 'https://dev-api', appId: 'app-1' });
+
+    expect(r.ok).toBe(false);
+    expect(r.published).toBe(false);
+  });
+});

--- a/apps/api/src/channels/teams-oauth.ts
+++ b/apps/api/src/channels/teams-oauth.ts
@@ -7,6 +7,8 @@ import { saveTeamsInstall, setTeamsCatalogAppId, setTeamsOrgInstalled } from './
 import { publishTeamsAppToCatalog } from './teams/catalog';
 
 const STATE_TTL_MS = 10 * 60 * 1000;
+const GRAPH_PUBLISH_SCOPE = 'https://graph.microsoft.com/AppCatalog.ReadWrite.All offline_access openid';
+const AUTHORITY = 'https://login.microsoftonline.com/organizations/oauth2/v2.0';
 
 interface OauthState {
   projectId: string;
@@ -17,6 +19,10 @@ interface OauthState {
 
 function stateKey(): string {
   return config.MICROSOFT_APP_PASSWORD ?? 'kortix-dev-teams-oauth-key';
+}
+
+function callbackRedirectUri(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}/v1/webhooks/teams/oauth/callback`;
 }
 
 function signState(projectId: string, baseUrl: string): string {
@@ -44,14 +50,73 @@ function verifyState(token: string | undefined): OauthState | null {
   }
 }
 
+function tenantFromJwt(token: string): string | null {
+  try {
+    const payload = JSON.parse(Buffer.from(token.split('.')[1] ?? '', 'base64url').toString('utf8')) as { tid?: string };
+    return typeof payload.tid === 'string' ? payload.tid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function exchangeCodeForToken(
+  code: string,
+  baseUrl: string,
+): Promise<{ accessToken: string; tenantId: string | null } | null> {
+  const appId = config.MICROSOFT_APP_ID;
+  const secret = config.MICROSOFT_APP_PASSWORD;
+  if (!appId || !secret) return null;
+  const body = new URLSearchParams({
+    client_id: appId,
+    client_secret: secret,
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: callbackRedirectUri(baseUrl),
+    scope: GRAPH_PUBLISH_SCOPE,
+  });
+  let res: Response;
+  try {
+    res = await fetch(`${AUTHORITY}/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (err) {
+    console.error('[teams-oauth] token exchange error', (err as Error)?.message);
+    return null;
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    console.warn('[teams-oauth] token exchange failed', { status: res.status, body: text.slice(0, 300) });
+    return null;
+  }
+  let parsed: { access_token?: string };
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed.access_token) return null;
+  return { accessToken: parsed.access_token, tenantId: tenantFromJwt(parsed.access_token) };
+}
+
+/**
+ * Authorization-code URL for the one-click install. A Teams admin signs in
+ * once and consents to the delegated AppCatalog.ReadWrite.All scope; the
+ * callback exchanges the code for a delegated token and publishes the app to
+ * the org catalog. (App-only publishing is not supported by Graph — see
+ * teams/catalog.ts.)
+ */
 export function teamsOrgConsentUrl(input: { projectId: string; baseUrl: string }): string | null {
   const appId = config.MICROSOFT_APP_ID;
   if (!appId || !teamsChannelEnabled()) return null;
-  const redirect = `${input.baseUrl.replace(/\/+$/, '')}/v1/webhooks/teams/oauth/callback`;
-  const url = new URL('https://login.microsoftonline.com/organizations/v2.0/adminconsent');
+  const url = new URL(`${AUTHORITY}/authorize`);
   url.searchParams.set('client_id', appId);
-  url.searchParams.set('scope', 'https://graph.microsoft.com/.default');
-  url.searchParams.set('redirect_uri', redirect);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('response_mode', 'query');
+  url.searchParams.set('redirect_uri', callbackRedirectUri(input.baseUrl));
+  url.searchParams.set('scope', GRAPH_PUBLISH_SCOPE);
   url.searchParams.set('state', signState(input.projectId, input.baseUrl));
   return url.toString();
 }
@@ -66,28 +131,39 @@ teamsOauthApp.get('/callback', async (c: any) => {
 
   const dest = (status: string) => `${frontend}/projects/${state.projectId}?teams=${status}`;
 
-  if (c.req.query('error') || c.req.query('admin_consent') !== 'True') {
+  if (c.req.query('error')) {
+    console.warn('[teams-oauth] authorize error', {
+      error: c.req.query('error'),
+      description: c.req.query('error_description')?.slice(0, 200),
+    });
     return c.redirect(dest('declined'), 302);
   }
-  const tenantId = c.req.query('tenant');
-  if (!tenantId) return c.redirect(dest('declined'), 302);
+  const code = c.req.query('code');
+  if (!code) return c.redirect(dest('declined'), 302);
   const appId = config.MICROSOFT_APP_ID;
   if (!appId) return c.redirect(dest('unconfigured'), 302);
+
+  const token = await exchangeCodeForToken(code, state.baseUrl);
+  if (!token) return c.redirect(dest('failed'), 302);
+  const tenantId = token.tenantId;
+  if (!tenantId) return c.redirect(dest('failed'), 302);
 
   await saveTeamsInstall({ projectId: state.projectId, tenantId }).catch((err) =>
     console.error('[teams-oauth] saveTeamsInstall failed', err),
   );
   const published = await publishTeamsAppToCatalog({
-    tenantId,
+    accessToken: token.accessToken,
     baseUrl: state.baseUrl,
     appId,
     appName: config.TEAMS_APP_NAME,
-  }).catch(() => ({ ok: false, teamsAppId: undefined as string | undefined }));
-  if (published.ok) {
+  }).catch(() => ({ ok: false, published: false }) as Awaited<ReturnType<typeof publishTeamsAppToCatalog>>);
+
+  if (published.published) {
     await setTeamsOrgInstalled(state.projectId, true).catch(() => {});
     if (published.teamsAppId) await setTeamsCatalogAppId(state.projectId, published.teamsAppId).catch(() => {});
   }
   void reconcileChannelConnectors(state.projectId);
 
-  return c.redirect(dest(published.ok ? 'connected' : 'consented'), 302);
+  const status = published.published ? 'connected' : published.pendingReview ? 'review' : 'consented';
+  return c.redirect(dest(status), 302);
 });

--- a/apps/api/src/channels/teams/catalog.ts
+++ b/apps/api/src/channels/teams/catalog.ts
@@ -1,36 +1,98 @@
-import { graphToken } from '../teams-auth';
 import { buildTeamsAppPackage } from './app-package';
 
 const CATALOG_URL = 'https://graph.microsoft.com/v1.0/appCatalogs/teamsApps';
 
+export interface PublishResult {
+  ok: boolean;
+  published: boolean;
+  pendingReview?: boolean;
+  teamsAppId?: string;
+  error?: string;
+}
+
+function postPackage(url: string, zip: Buffer, accessToken: string): Promise<Response> {
+  return fetch(url, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${accessToken}`, 'content-type': 'application/zip' },
+    body: new Uint8Array(zip),
+    signal: AbortSignal.timeout(30_000),
+  });
+}
+
+async function lookupCatalogAppId(accessToken: string, externalId: string): Promise<string | undefined> {
+  try {
+    const url = `${CATALOG_URL}?$filter=externalId eq '${encodeURIComponent(externalId)}'`;
+    const res = await fetch(url, {
+      headers: { authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { value?: Array<{ id?: string }> };
+    return body.value?.[0]?.id;
+  } catch {
+    return undefined;
+  }
+}
+
+async function firstId(res: Response): Promise<string | undefined> {
+  const body = (await res.json().catch(() => ({}))) as { id?: string };
+  return body.id;
+}
+
+/**
+ * Publish the Teams app package to the tenant's org app catalog using a
+ * DELEGATED admin token. `POST /appCatalogs/teamsApps` does not support
+ * app-only auth — a signed-in admin is required (see teamsapp-publish docs).
+ * A Teams admin publishes immediately; a non-admin's package is submitted for
+ * admin review (`requiresReview=true`) instead. `appId` is the manifest id,
+ * which becomes the catalog `externalId` we look installs up by.
+ */
 export async function publishTeamsAppToCatalog(input: {
-  tenantId: string;
+  accessToken: string;
   baseUrl: string;
   appId: string;
   appName?: string;
-}): Promise<{ ok: boolean; teamsAppId?: string; error?: string }> {
-  const token = await graphToken(input.tenantId).catch(() => null);
-  if (!token) return { ok: false, error: 'could not mint a Graph token for the tenant' };
+}): Promise<PublishResult> {
+  const zip = buildTeamsAppPackage({
+    appId: input.appId,
+    baseUrl: input.baseUrl,
+    appName: input.appName,
+    botName: input.appName,
+  });
 
-  const zip = buildTeamsAppPackage({ appId: input.appId, baseUrl: input.baseUrl, appName: input.appName, botName: input.appName });
   let res: Response;
   try {
-    res = await fetch(CATALOG_URL, {
-      method: 'POST',
-      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/zip' },
-      body: new Uint8Array(zip),
-      signal: AbortSignal.timeout(30_000),
-    });
+    res = await postPackage(CATALOG_URL, zip, input.accessToken);
   } catch (err) {
-    return { ok: false, error: (err as Error)?.message ?? 'graph request failed' };
+    return { ok: false, published: false, error: (err as Error)?.message ?? 'graph request failed' };
   }
 
   if (res.status === 201) {
-    const body = (await res.json().catch(() => ({}))) as { id?: string };
-    return { ok: true, teamsAppId: body.id };
+    return { ok: true, published: true, teamsAppId: await firstId(res) };
   }
-  if (res.status === 409) return { ok: true };
+  if (res.status === 409) {
+    const id = await lookupCatalogAppId(input.accessToken, input.appId);
+    return { ok: true, published: true, teamsAppId: id };
+  }
+  if (res.status === 403) {
+    let rev: Response;
+    try {
+      rev = await postPackage(`${CATALOG_URL}?requiresReview=true`, zip, input.accessToken);
+    } catch (err) {
+      return { ok: false, published: false, error: (err as Error)?.message ?? 'graph review request failed' };
+    }
+    if (rev.status === 201 || rev.status === 202) {
+      return { ok: true, published: false, pendingReview: true, teamsAppId: await firstId(rev) };
+    }
+    if (rev.status === 409) {
+      const id = await lookupCatalogAppId(input.accessToken, input.appId);
+      return { ok: true, published: true, teamsAppId: id };
+    }
+    const text = await rev.text().catch(() => '');
+    console.warn('[teams-catalog] review submit failed', { status: rev.status, body: text.slice(0, 300) });
+    return { ok: false, published: false, error: `Graph app-catalog review submit failed (${rev.status})` };
+  }
   const text = await res.text().catch(() => '');
   console.warn('[teams-catalog] publish failed', { status: res.status, body: text.slice(0, 300) });
-  return { ok: false, error: `Graph app-catalog publish failed (${res.status})` };
+  return { ok: false, published: false, error: `Graph app-catalog publish failed (${res.status})` };
 }


### PR DESCRIPTION
## Why

The Teams one-click install could **never** publish the app to the org catalog. `POST /appCatalogs/teamsApps` [does not support application (app-only) auth](https://learn.microsoft.com/en-us/graph/api/teamsapp-publish) — it's delegated-only. Our flow used `adminconsent` + an app-only Graph token, so Graph returned `403 AccessDenied "User not authorized"` on every attempt (verified on dev: the token even carried `AppCatalog.ReadWrite.All`, but app-only just isn't accepted for this endpoint).

## What

Switch the one-click to a standard **authorization-code** flow:

1. **`teams-oauth.ts`** — `teamsOrgConsentUrl` now builds an `/authorize` URL (`response_type=code`, delegated scope `AppCatalog.ReadWrite.All offline_access openid`) instead of `adminconsent`. The admin signs in once and consents.
2. The callback exchanges the `code` for a **delegated** token (tenant read from the token's `tid` claim) and publishes the package with *that* token.
3. **`catalog.ts`** — `publishTeamsAppToCatalog` now takes the delegated `accessToken`:
   - Teams admin → immediate publish (`201`) → app in catalog, `orgInstalled` set, deep link lights up.
   - Non-admin → `403` → resubmit with `?requiresReview=true` → app queued for admin approval → redirect `?teams=review`.
   - Already published → `409` → resolve the catalog id via `externalId` lookup so the deep link still works.

`graphToken` (app-only) stays for the file-proxy / executor read paths where app-only Graph is valid — only *publish* needed delegated auth.

## Azure setup note

The app registration (`62b4470a` on dev) now needs `AppCatalog.ReadWrite.All` under **Delegated** permissions (it currently has the Application one). Incremental consent means the admin consenting at sign-in grants it, but pre-adding it + granting admin consent avoids the "needs admin approval" detour. The existing `/v1/webhooks/teams/oauth/callback` Web redirect URI is reused unchanged.

## Test

`unit-teams-catalog-publish.test.ts` (mocks `fetch`): admin 201, non-admin 403→review, already-published 409→lookup, and outright failure. API typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)