### PR TITLE
fix(scim): group member adds stranded when the person joined via SSO JIT

### DIFF
--- a/apps/api/src/__tests__/unit-bootstrap-group.test.ts
+++ b/apps/api/src/__tests__/unit-bootstrap-group.test.ts
@@ -3,6 +3,7 @@
 // Malformed jsonb must be rejected (null), never fed into account_group_members.
 import { describe, expect, test } from 'bun:test';
 import { validateBootstrapGroup } from '../accounts/invites';
+import { resolveInviteMemberAction } from '../scim/groups';
 
 const UUID = '5888c520-d8f0-489a-a807-d2f8bf007fd1';
 
@@ -25,5 +26,32 @@ describe('validateBootstrapGroup', () => {
     expect(validateBootstrapGroup('x')).toBeNull();
     expect(validateBootstrapGroup(42)).toBeNull();
     expect(validateBootstrapGroup({})).toBeNull();
+  });
+});
+
+// The Azure gotcha: the IdP keeps referencing a user by the invitation id it
+// got at provisioning time, but the person can become a member via SSO JIT
+// WITHOUT accepting the invite — parking on that invite strands the
+// membership forever. The decision must add live members directly.
+describe('resolveInviteMemberAction', () => {
+  test('person already a member (SSO JIT or accepted invite) → add directly', () => {
+    expect(
+      resolveInviteMemberAction({ accepted: false, resolvedMemberUserId: UUID }),
+    ).toBe('add-member');
+    expect(
+      resolveInviteMemberAction({ accepted: true, resolvedMemberUserId: UUID }),
+    ).toBe('add-member');
+  });
+
+  test('truly pending (no member, not accepted) → park on the invite', () => {
+    expect(resolveInviteMemberAction({ accepted: false, resolvedMemberUserId: null })).toBe(
+      'park',
+    );
+  });
+
+  test('accepted but membership since removed → skip (not a group PATCH decision)', () => {
+    expect(resolveInviteMemberAction({ accepted: true, resolvedMemberUserId: null })).toBe(
+      'skip',
+    );
   });
 });

--- a/apps/api/src/iam/sso-sync.ts
+++ b/apps/api/src/iam/sso-sync.ts
@@ -14,8 +14,8 @@
 // also needs access to project X for a one-off" workable without the
 // next sign-in stomping it.
 
-import { and, eq, inArray } from 'drizzle-orm';
-import { accountGroupMembers, accountMembers } from '@kortix/db';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { accountGroupMembers, accountInvitations, accountMembers } from '@kortix/db';
 import { db } from '../shared/db';
 import { invalidateIamCacheForUser } from './cache-invalidation';
 import {
@@ -174,6 +174,66 @@ export function diffSsoGroups(args: {
  * Main entry — call once per authenticated request from the middleware.
  * Cheap when the JWT isn't a SAML token (one early `if` and we return).
  */
+// Bare UUID check — deliberately local; the full validator lives in the
+// invites router module, and lib code shouldn't import a router for it.
+const GROUP_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Apply SCIM group memberships that were parked on a pending invite for this
+ * email (see scim/groups.ts addGroupMembersOrDeferInvites). JIT auto-create
+ * bypasses the invite-acceptance flow, so without this the parked entries
+ * strand forever. Applies + strips only the `{group_id}` entries; project
+ * grants stay on the (still pending) invite for the real accept flow.
+ * Best-effort — a failure here must not block sign-in.
+ */
+async function consumeInviteGroupGrants(
+  accountId: string,
+  userId: string,
+  email: string,
+): Promise<void> {
+  try {
+    const [invite] = await db
+      .select({
+        inviteId: accountInvitations.inviteId,
+        bootstrapGrants: accountInvitations.bootstrapGrants,
+      })
+      .from(accountInvitations)
+      .where(
+        and(
+          eq(accountInvitations.accountId, accountId),
+          sql`lower(${accountInvitations.email}) = lower(${email})`,
+          isNull(accountInvitations.acceptedAt),
+        ),
+      )
+      .limit(1);
+    if (!invite) return;
+
+    const grants = invite.bootstrapGrants ?? [];
+    const groupIds = grants
+      .filter((g): g is { group_id: string } => 'group_id' in g && typeof g.group_id === 'string')
+      .map((g) => g.group_id)
+      .filter((id) => GROUP_UUID_RE.test(id));
+    if (groupIds.length === 0) return;
+
+    await db
+      .insert(accountGroupMembers)
+      .values(groupIds.map((groupId) => ({ groupId, userId })))
+      .onConflictDoNothing();
+
+    const remaining = grants.filter((g) => !('group_id' in g));
+    await db
+      .update(accountInvitations)
+      .set({ bootstrapGrants: remaining })
+      .where(eq(accountInvitations.inviteId, invite.inviteId));
+  } catch (err) {
+    console.warn('[sso-sync] failed to consume parked invite group grants', {
+      accountId,
+      userId,
+      err,
+    });
+  }
+}
+
 export async function syncSsoMembership(args: {
   userId: string;
   email: string;
@@ -215,6 +275,11 @@ export async function syncSsoMembership(args: {
       })
       .onConflictDoNothing();
     memberCreated = true;
+    // JIT bypasses invite acceptance, so SCIM group memberships parked on a
+    // pending invite for this email (scim/groups.ts) would strand forever —
+    // consume them now. Project grants on the invite stay for the real
+    // accept flow; only the {group_id} entries are applied and stripped.
+    await consumeInviteGroupGrants(provider.accountId, args.userId, args.email);
   }
 
   // 2. Sync IAM group memberships from the claim.

--- a/apps/api/src/scim/groups.ts
+++ b/apps/api/src/scim/groups.ts
@@ -3,7 +3,7 @@
 
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountInvitations, accountMembers } from '@kortix/db';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { invalidateIamCacheForGroup, invalidateIamCacheForUsers } from '../iam/cache-invalidation';
 import { scimError } from '../middleware/scim-auth';
 import { errors, json } from '../openapi';
@@ -16,6 +16,7 @@ import {
   parseFilter,
   scimAudit,
   scimRouter,
+  userIdByEmail,
 } from './app';
 
 /**
@@ -49,13 +50,18 @@ async function addGroupMembersOrDeferInvites(
     await db.insert(accountGroupMembers).values(rows).onConflictDoNothing();
   }
 
-  // Anything not a real member may be a pending invite (SCIM id = invite_id) —
-  // record the group on the invite so it lands when they accept.
+  // Anything not a real member may be a pending invite (SCIM id = invite_id).
+  // The IdP caches that id forever, but the person can BECOME a member through
+  // a different door — SSO JIT auto-create — without ever "accepting" the
+  // invite. So resolve each invite's EMAIL to a live member first and add them
+  // directly; only park on the invite when the person truly isn't in yet.
   const unmatched = memberValues.filter((v) => !memberSet.has(v));
   if (unmatched.length === 0) return;
   const invites = await db
     .select({
       inviteId: accountInvitations.inviteId,
+      email: accountInvitations.email,
+      acceptedAt: accountInvitations.acceptedAt,
       bootstrapGrants: accountInvitations.bootstrapGrants,
     })
     .from(accountInvitations)
@@ -63,10 +69,37 @@ async function addGroupMembersOrDeferInvites(
       and(
         eq(accountInvitations.accountId, accountId),
         inArray(accountInvitations.inviteId, unmatched),
-        isNull(accountInvitations.acceptedAt),
       ),
     );
   for (const inv of invites) {
+    const resolvedUserId = await userIdByEmail(inv.email, accountId);
+    let resolvedMemberUserId: string | null = null;
+    if (resolvedUserId) {
+      const [member] = await db
+        .select({ userId: accountMembers.userId })
+        .from(accountMembers)
+        .where(
+          and(
+            eq(accountMembers.accountId, accountId),
+            eq(accountMembers.userId, resolvedUserId),
+          ),
+        )
+        .limit(1);
+      resolvedMemberUserId = member?.userId ?? null;
+    }
+
+    const action = resolveInviteMemberAction({
+      accepted: inv.acceptedAt !== null,
+      resolvedMemberUserId,
+    });
+    if (action === 'add-member' && resolvedMemberUserId) {
+      await db
+        .insert(accountGroupMembers)
+        .values({ groupId, userId: resolvedMemberUserId })
+        .onConflictDoNothing();
+      continue;
+    }
+    if (action !== 'park') continue;
     const existing = inv.bootstrapGrants ?? [];
     if (existing.some((g) => 'group_id' in g && g.group_id === groupId)) continue;
     await db
@@ -74,6 +107,27 @@ async function addGroupMembersOrDeferInvites(
       .set({ bootstrapGrants: [...existing, { group_id: groupId }] })
       .where(eq(accountInvitations.inviteId, inv.inviteId));
   }
+}
+
+/**
+ * Pure decision for a SCIM member value that matched an invitation. Exported
+ * for unit tests.
+ *
+ *  - the person is ALREADY a member (SSO JIT or accepted invite) → add them
+ *    to the group directly; parking would strand the membership because JIT
+ *    never fires the invite-acceptance path.
+ *  - truly pending (no member row, not accepted) → park on the invite; it
+ *    materializes at first sign-in.
+ *  - accepted but no member row (member since removed) → skip; re-adding a
+ *    removed member is a user-provisioning decision, not a group PATCH's.
+ */
+export function resolveInviteMemberAction(args: {
+  accepted: boolean;
+  resolvedMemberUserId: string | null;
+}): 'add-member' | 'park' | 'skip' {
+  if (args.resolvedMemberUserId) return 'add-member';
+  if (!args.accepted) return 'park';
+  return 'skip';
 }
 
 // ─── Groups ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Bug (live on dev, Azure account 7663e164)

Azure SCIM pushed "Marko's Group" with marko as a member → 0 members on the Kortix side, while the same flow from Okta worked.

Root cause: the IdP references users by the SCIM id it got at provisioning time — for a not-yet-signed-in user that's the **invitation id**. The invite-parking path (#4358) parks the group on that invite to materialize at acceptance… but marko became a member through **SSO JIT auto-create**, which never fires invite acceptance. `accepted_at` stays null forever, the parked grant never materializes. Okta worked because its pushes referenced users who were already plain members.

## Fix (both directions of the race)

1. **SCIM group PATCH** (`scim/groups.ts`): unmatched member values that resolve to an invitation now resolve the invite's **email → live member** and add the membership directly; parking only happens for truly-pending people. Decision extracted pure (`resolveInviteMemberAction`) and unit-tested.
2. **SSO JIT** (`iam/sso-sync.ts`): when auto-create makes a member, any `{group_id}` grants already parked on their pending invite are consumed — memberships inserted, entries stripped. Project grants stay on the invite for the real accept flow. Best-effort, never blocks sign-in.

## Tests
- 3 new unit tests for the decision (member → add even if unaccepted; pending → park; accepted-but-removed → skip)
- `bun test unit-bootstrap-group unit-scim-helpers unit-iam-sso`: 43 pass, tsc clean