### PR TITLE
chore(api/teams): log org-install outcome in the oauth callback

### DIFF
--- a/apps/api/src/channels/teams-oauth.ts
+++ b/apps/api/src/channels/teams-oauth.ts
@@ -165,5 +165,12 @@ teamsOauthApp.get('/callback', async (c: any) => {
   void reconcileChannelConnectors(state.projectId);
 
   const status = published.published ? 'connected' : published.pendingReview ? 'review' : 'consented';
+  console.info('[teams-oauth] install complete', {
+    projectId: state.projectId,
+    tenantId,
+    status,
+    teamsAppId: published.teamsAppId ?? null,
+    error: published.error ?? null,
+  });
   return c.redirect(dest(status), 302);
 });


### PR DESCRIPTION
Minimal observability change: emit one info line at the end of the Teams OAuth callback with the project id, tenant, resolved status (`connected`/`review`/`consented`), catalog app id, and any publish error — so the one-click install result is visible in the API logs during bring-up.

Also re-triggers the dev API deploy (the prior merges landed on `main` but the `deploy-dev` run was cancelled by the `cancel-in-progress` concurrency group).

Log-only change → `no-tests-needed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)