### PR TITLE
fix(scim): close the shadowed-invite holes (offboarding, group remove/replace/create)

### DIFF
--- a/apps/api/src/__tests__/unit-bootstrap-group.test.ts
+++ b/apps/api/src/__tests__/unit-bootstrap-group.test.ts
@@ -3,7 +3,7 @@
 // Malformed jsonb must be rejected (null), never fed into account_group_members.
 import { describe, expect, test } from 'bun:test';
 import { validateBootstrapGroup } from '../accounts/invites';
-import { resolveInviteMemberAction } from '../scim/groups';
+import { resolveInviteMemberAction, stripGroupGrant } from '../scim/groups';
 
 const UUID = '5888c520-d8f0-489a-a807-d2f8bf007fd1';
 
@@ -53,5 +53,39 @@ describe('resolveInviteMemberAction', () => {
     expect(resolveInviteMemberAction({ accepted: true, resolvedMemberUserId: null })).toBe(
       'skip',
     );
+  });
+});
+
+// Un-parking is the flip side of parking: an IdP that removes a
+// not-yet-signed-in person from a group (or replaces the member set) must
+// strip the parked grant, or the person joins at first sign-in anyway.
+describe('stripGroupGrant', () => {
+  const OTHER = '22fc7147-483d-44fe-a824-763622eec789';
+
+  test('removes only the matching group entry', () => {
+    const grants = [{ group_id: UUID }, { group_id: OTHER }];
+    const { changed, remaining } = stripGroupGrant(grants, UUID);
+    expect(changed).toBe(true);
+    expect(remaining).toEqual([{ group_id: OTHER }]);
+  });
+
+  test('project grants pass through untouched', () => {
+    const grants = [{ project_id: OTHER, role: 'member' }, { group_id: UUID }];
+    const { changed, remaining } = stripGroupGrant(grants, UUID);
+    expect(changed).toBe(true);
+    expect(remaining).toEqual([{ project_id: OTHER, role: 'member' }]);
+  });
+
+  test('no match → unchanged (no pointless DB write)', () => {
+    const grants = [{ group_id: OTHER }];
+    const { changed, remaining } = stripGroupGrant(grants, UUID);
+    expect(changed).toBe(false);
+    expect(remaining).toEqual(grants);
+  });
+
+  test('null/empty grants are safe', () => {
+    expect(stripGroupGrant(null, UUID)).toEqual({ changed: false, remaining: [] });
+    expect(stripGroupGrant(undefined, UUID)).toEqual({ changed: false, remaining: [] });
+    expect(stripGroupGrant([], UUID)).toEqual({ changed: false, remaining: [] });
   });
 });

--- a/apps/api/src/iam/sso-sync.ts
+++ b/apps/api/src/iam/sso-sync.ts
@@ -15,7 +15,7 @@
 // next sign-in stomping it.
 
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
-import { accountGroupMembers, accountInvitations, accountMembers } from '@kortix/db';
+import { accountGroupMembers, accountGroups, accountInvitations, accountMembers } from '@kortix/db';
 import { db } from '../shared/db';
 import { invalidateIamCacheForUser } from './cache-invalidation';
 import {
@@ -215,10 +215,20 @@ async function consumeInviteGroupGrants(
       .filter((id) => GROUP_UUID_RE.test(id));
     if (groupIds.length === 0) return;
 
-    await db
-      .insert(accountGroupMembers)
-      .values(groupIds.map((groupId) => ({ groupId, userId })))
-      .onConflictDoNothing();
+    // A parked group may have been deleted since parking; its id would FK-fail
+    // the WHOLE batch insert and lose the healthy grants with it. Keep only
+    // groups that still exist — scoped to this account, which also stops a
+    // grant from ever landing in another account's group.
+    const liveGroups = await db
+      .select({ groupId: accountGroups.groupId })
+      .from(accountGroups)
+      .where(and(eq(accountGroups.accountId, accountId), inArray(accountGroups.groupId, groupIds)));
+    if (liveGroups.length > 0) {
+      await db
+        .insert(accountGroupMembers)
+        .values(liveGroups.map(({ groupId }) => ({ groupId, userId })))
+        .onConflictDoNothing();
+    }
 
     const remaining = grants.filter((g) => !('group_id' in g));
     await db

--- a/apps/api/src/scim/groups.ts
+++ b/apps/api/src/scim/groups.ts
@@ -3,7 +3,7 @@
 
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountInvitations, accountMembers } from '@kortix/db';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { invalidateIamCacheForGroup, invalidateIamCacheForUsers } from '../iam/cache-invalidation';
 import { scimError } from '../middleware/scim-auth';
 import { errors, json } from '../openapi';
@@ -128,6 +128,91 @@ export function resolveInviteMemberAction(args: {
   if (args.resolvedMemberUserId) return 'add-member';
   if (!args.accepted) return 'park';
   return 'skip';
+}
+
+/**
+ * Pure: strip a parked `{group_id}` entry from an invite's bootstrap_grants.
+ * Exported for unit tests. Project grants and other groups pass through.
+ */
+export function stripGroupGrant(
+  grants: Array<Record<string, unknown>> | null | undefined,
+  groupId: string,
+): { changed: boolean; remaining: Array<Record<string, unknown>> } {
+  const all = grants ?? [];
+  const remaining = all.filter((g) => !('group_id' in g && g.group_id === groupId));
+  return { changed: remaining.length !== all.length, remaining };
+}
+
+/**
+ * Un-park a group from pending invites' bootstrap_grants — the flip side of
+ * addGroupMembersOrDeferInvites. Without this, an IdP that removes a
+ * not-yet-signed-in person from a group (or replaces the member set) leaves
+ * the parked grant behind, and the person joins the group at first sign-in
+ * despite the IdP having removed them.
+ */
+async function unparkGroupFromInvites(
+  accountId: string,
+  groupId: string,
+  onlyInviteId?: string,
+): Promise<void> {
+  const conds = [
+    eq(accountInvitations.accountId, accountId),
+    isNull(accountInvitations.acceptedAt),
+  ];
+  if (onlyInviteId) conds.push(eq(accountInvitations.inviteId, onlyInviteId));
+  const invites = await db
+    .select({
+      inviteId: accountInvitations.inviteId,
+      bootstrapGrants: accountInvitations.bootstrapGrants,
+    })
+    .from(accountInvitations)
+    .where(and(...conds));
+  for (const inv of invites) {
+    const { changed, remaining } = stripGroupGrant(inv.bootstrapGrants, groupId);
+    if (!changed) continue;
+    await db
+      .update(accountInvitations)
+      .set({ bootstrapGrants: remaining as typeof inv.bootstrapGrants })
+      .where(eq(accountInvitations.inviteId, inv.inviteId));
+  }
+}
+
+/**
+ * Remove one SCIM-referenced member from a group, mirroring the resolution
+ * rules of the add path. The IdP may reference the person by user_id OR by
+ * the invitation id it cached at provisioning time, so:
+ *   1. delete a membership row keyed by the value directly,
+ *   2. if the value is an invitation: un-park the group from it AND resolve
+ *      its email to a live member (SSO JIT) and delete THAT row too.
+ * Without (2) a removal for a JIT-signed-in member silently no-ops — access
+ * the IdP revoked would persist.
+ */
+async function removeGroupMemberValue(
+  accountId: string,
+  groupId: string,
+  value: string,
+): Promise<void> {
+  await db
+    .delete(accountGroupMembers)
+    .where(and(eq(accountGroupMembers.groupId, groupId), eq(accountGroupMembers.userId, value)));
+
+  const [invite] = await db
+    .select({ inviteId: accountInvitations.inviteId, email: accountInvitations.email })
+    .from(accountInvitations)
+    .where(and(eq(accountInvitations.accountId, accountId), eq(accountInvitations.inviteId, value)))
+    .limit(1);
+  if (!invite) return;
+
+  await unparkGroupFromInvites(accountId, groupId, invite.inviteId);
+
+  const resolvedUserId = await userIdByEmail(invite.email, accountId);
+  if (resolvedUserId) {
+    await db
+      .delete(accountGroupMembers)
+      .where(
+        and(eq(accountGroupMembers.groupId, groupId), eq(accountGroupMembers.userId, resolvedUserId)),
+      );
+  }
 }
 
 // ─── Groups ───────────────────────────────────────────────────────────────
@@ -271,24 +356,14 @@ scimRouter.openapi(
       throw err;
     }
 
-    // Initial members can be supplied in the create body.
+    // Initial members can be supplied in the create body (Okta's group push
+    // does this). Same resolution rules as PATCH adds — a plain member-only
+    // filter here would silently drop invited/JIT people.
     if (Array.isArray(body.members)) {
       const userIds = (body.members as Array<{ value?: unknown }>)
         .map((m) => (typeof m.value === 'string' ? m.value : null))
         .filter((v): v is string => !!v);
-      if (userIds.length > 0) {
-        const valid = await db
-          .select({ userId: accountMembers.userId })
-          .from(accountMembers)
-          .where(
-            and(eq(accountMembers.accountId, accountId), inArray(accountMembers.userId, userIds)),
-          );
-        const validSet = new Set(valid.map((v) => v.userId));
-        const rows = userIds.filter((u) => validSet.has(u)).map((u) => ({ groupId, userId: u }));
-        if (rows.length > 0) {
-          await db.insert(accountGroupMembers).values(rows).onConflictDoNothing();
-        }
-      }
+      await addGroupMembersOrDeferInvites(accountId, groupId, userIds);
     }
 
     await invalidateIamCacheForGroup(groupId);
@@ -401,9 +476,12 @@ scimRouter.openapi(
           const userIds = (v.members as Array<{ value?: unknown }>)
             .map((m) => (typeof m.value === 'string' ? m.value : null))
             .filter((u): u is string => !!u);
-          // Wholesale replace: drop existing, then add the new set — real members
-          // join now, pending invites ride their bootstrap_grants until accept.
+          // Wholesale replace: drop existing rows AND parked grants, then add
+          // the new set — real members join now, pending invites re-park. The
+          // un-park keeps a person the IdP dropped pre-login from joining the
+          // group at first sign-in off a stale grant.
           await db.delete(accountGroupMembers).where(eq(accountGroupMembers.groupId, groupId));
+          await unparkGroupFromInvites(accountId, groupId);
           await addGroupMembersOrDeferInvites(accountId, groupId, userIds);
         }
         continue;
@@ -418,15 +496,18 @@ scimRouter.openapi(
         continue;
       }
 
-      // Member removes: path looks like members[value eq "userId"]
+      // Member removes: path looks like members[value eq "userId"]. The value
+      // may be a user_id OR the invitation id the IdP cached at provisioning —
+      // removeGroupMemberValue resolves both (and un-parks a pending grant).
       if (opName === 'remove' && path.startsWith('members')) {
         const m = path.match(/value\s+eq\s+"([^"]+)"/i);
         if (m) {
-          await db
-            .delete(accountGroupMembers)
-            .where(
-              and(eq(accountGroupMembers.groupId, groupId), eq(accountGroupMembers.userId, m[1]!)),
-            );
+          await removeGroupMemberValue(accountId, groupId, m[1]!);
+        } else if (!path.includes('[')) {
+          // Bare `remove members` (no filter) — empty the group, both live
+          // rows and parked grants.
+          await db.delete(accountGroupMembers).where(eq(accountGroupMembers.groupId, groupId));
+          await unparkGroupFromInvites(accountId, groupId);
         }
         continue;
       }

--- a/apps/api/src/scim/users.ts
+++ b/apps/api/src/scim/users.ts
@@ -51,6 +51,77 @@ async function pendingInviteRows(
     .where(and(...conds));
 }
 
+type MemberRow = {
+  userId: string;
+  accountRole: string;
+  scimExternalId: string | null;
+  joinedAt: Date;
+};
+
+async function getMember(accountId: string, userId: string): Promise<MemberRow | null> {
+  const [member] = await db
+    .select({
+      userId: accountMembers.userId,
+      accountRole: accountMembers.accountRole,
+      scimExternalId: accountMembers.scimExternalId,
+      joinedAt: accountMembers.joinedAt,
+    })
+    .from(accountMembers)
+    .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)))
+    .limit(1);
+  return member ?? null;
+}
+
+/**
+ * A pending invitation is "shadowed" when its email already belongs to a live
+ * member — the person signed in via SSO JIT instead of accepting the invite.
+ * The IdP still references them by the invitation id it cached at provisioning
+ * time, so id-addressed operations must resolve through the email to the real
+ * member or deprovisioning silently no-ops (the offboarding hole).
+ */
+async function shadowMemberForInvite(
+  accountId: string,
+  inviteEmail: string,
+): Promise<MemberRow | null> {
+  const resolvedUserId = await userIdByEmail(inviteEmail, accountId);
+  if (!resolvedUserId) return null;
+  return getMember(accountId, resolvedUserId);
+}
+
+/**
+ * Deprovision a live member: remove the membership, bust the IAM cache, and
+ * revoke PATs + live sandbox tokens. Callers must run the last-owner guard
+ * BEFORE calling. Returns the token-revocation error message (if any) for the
+ * audit event; the membership removal itself always proceeds.
+ */
+async function deprovisionMember(accountId: string, userId: string): Promise<string | null> {
+  await db
+    .delete(accountMembers)
+    .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)));
+  invalidateIamCacheForUser(userId);
+  return revokeAllAccountTokensForUser(userId, accountId).then(
+    () => null,
+    (err) => {
+      console.error(
+        '[scim] token revocation FAILED on deprovision — user may retain live tokens',
+        { userId, accountId },
+        err,
+      );
+      return err instanceof Error ? err.message : String(err);
+    },
+  );
+}
+
+/** Last-owner guard shared by every deprovision path. */
+async function isLastOwner(accountId: string, member: MemberRow): Promise<boolean> {
+  if (member.accountRole !== 'owner') return false;
+  const owners = await db
+    .select({ userId: accountMembers.userId })
+    .from(accountMembers)
+    .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.accountRole, 'owner')));
+  return owners.length <= 1;
+}
+
 scimRouter.openapi(
   createRoute({
     method: 'get',
@@ -90,11 +161,19 @@ scimRouter.openapi(
 
     const emails = await emailsByUserId(members.map((m) => m.userId));
     const invites = await pendingInviteRows(accountId);
+    // Hide invites shadowed by a live member (same email, joined via SSO JIT
+    // instead of accepting) — otherwise the IdP sees TWO resources with one
+    // userName and reconciles against the stale invite id.
+    const memberEmails = new Set(
+      [...emails.values()].map((e) => e.trim().toLowerCase()).filter(Boolean),
+    );
     const allResources: UserShape[] = [
       ...members
         .filter((m) => emails.has(m.userId))
         .map((m) => buildUser(accountId, m, emails.get(m.userId)!)),
-      ...invites.map((i) => buildInviteUser(accountId, i)),
+      ...invites
+        .filter((i) => !memberEmails.has(i.email.trim().toLowerCase()))
+        .map((i) => buildInviteUser(accountId, i)),
     ];
 
     if (!filter) return c.json(listResponse(allResources));
@@ -151,7 +230,13 @@ scimRouter.openapi(
 
     // Not a live member — maybe a pending invitation (SCIM id = invitation id).
     const [invite] = await pendingInviteRows(accountId, userId);
-    if (invite) return c.json(buildInviteUser(accountId, invite));
+    if (invite) {
+      // Shadowed by a JIT member → 404 so the IdP re-resolves by userName and
+      // picks up the member's id (list/GET hide the stale invite identity).
+      const shadow = await shadowMemberForInvite(accountId, invite.email);
+      if (shadow) return scimError(c, 404, 'User not found in this account');
+      return c.json(buildInviteUser(accountId, invite));
+    }
 
     return scimError(c, 404, 'User not found in this account');
   },
@@ -361,53 +446,23 @@ async function applyUserWrite(
   userId: string,
   changes: Map<string, unknown>,
 ) {
-  const [member] = await db
-    .select({
-      userId: accountMembers.userId,
-      accountRole: accountMembers.accountRole,
-      scimExternalId: accountMembers.scimExternalId,
-      joinedAt: accountMembers.joinedAt,
-    })
-    .from(accountMembers)
-    .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)))
-    .limit(1);
+  const member = await getMember(accountId, userId);
 
   if (member) {
     // Deactivate
     if (changes.get('active') === false) {
       // Refuse to deactivate the last owner — same invariant the human UI
       // enforces, so an IdP misconfiguration can't lock everyone out.
-      if (member.accountRole === 'owner') {
-        const owners = await db
-          .select({ userId: accountMembers.userId })
-          .from(accountMembers)
-          .where(
-            and(eq(accountMembers.accountId, accountId), eq(accountMembers.accountRole, 'owner')),
-          );
-        if (owners.length <= 1) {
-          return scimError(c, 409, 'Cannot deactivate the last owner of this account');
-        }
+      if (await isLastOwner(accountId, member)) {
+        return scimError(c, 409, 'Cannot deactivate the last owner of this account');
       }
       const emailsBefore = await emailsByUserId([userId]);
-      await db
-        .delete(accountMembers)
-        .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)));
-      invalidateIamCacheForUser(userId);
-      // IdP-driven offboarding: revoke PATs + live sandbox session tokens so
-      // deactivation is immediate. A failure would leave a "deactivated" user
-      // with LIVE tokens — a silent offboarding hole — so surface it loudly and
-      // record it on the audit event, while still removing the membership.
-      const revocationError = await revokeAllAccountTokensForUser(userId, accountId).then(
-        () => null,
-        (err) => {
-          console.error(
-            '[scim] token revocation FAILED on deactivate — user may retain live tokens',
-            { userId, accountId },
-            err,
-          );
-          return err instanceof Error ? err.message : String(err);
-        },
-      );
+      // IdP-driven offboarding: remove the membership and revoke PATs + live
+      // sandbox session tokens so deactivation is immediate. A revocation
+      // failure would leave a "deactivated" user with LIVE tokens — a silent
+      // offboarding hole — so it's logged loudly and recorded on the audit
+      // event, while the membership removal still stands.
+      const revocationError = await deprovisionMember(accountId, userId);
       await scimAudit(c, {
         accountId,
         action: 'scim.user.deactivate',
@@ -439,6 +494,31 @@ async function applyUserWrite(
   const [invite] = await pendingInviteRows(accountId, userId);
   if (invite) {
     if (changes.get('active') === false) {
+      // The person may ALSO be a live member under a different id — SSO JIT
+      // creates the membership without accepting the invite, and the IdP
+      // keeps deprovisioning against the invite id it cached. Revoking only
+      // the invite would leave the member with full access and live tokens:
+      // the offboarding hole. Resolve the email and deprovision both.
+      const shadow = await shadowMemberForInvite(accountId, invite.email);
+      if (shadow) {
+        if (await isLastOwner(accountId, shadow)) {
+          return scimError(c, 409, 'Cannot deactivate the last owner of this account');
+        }
+        const revocationError = await deprovisionMember(accountId, shadow.userId);
+        await scimAudit(c, {
+          accountId,
+          action: 'scim.user.deactivate',
+          resourceType: 'account_member',
+          resourceId: shadow.userId,
+          before: { user_id: shadow.userId, account_role: shadow.accountRole },
+          metadata: {
+            via_invite_id: invite.inviteId,
+            ...(revocationError
+              ? { token_revocation_failed: true, token_revocation_error: revocationError }
+              : {}),
+          },
+        });
+      }
       await db.delete(accountInvitations).where(eq(accountInvitations.inviteId, invite.inviteId));
       await scimAudit(c, {
         accountId,
@@ -508,16 +588,35 @@ scimRouter.openapi(
     const accountId = c.req.param('accountId');
     const userId = c.req.param('userId');
 
-    const [member] = await db
-      .select({ accountRole: accountMembers.accountRole })
-      .from(accountMembers)
-      .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)))
-      .limit(1);
+    const member = await getMember(accountId, userId);
     if (!member) {
-      // Not a live member — if the id is a pending invitation, revoke it
-      // (deprovision). Either way DELETE is idempotent → 204.
+      // Not a live member — if the id is a pending invitation, revoke it. The
+      // person may ALSO be a live member under a different id (SSO JIT never
+      // accepts the invite), so resolve the email and deprovision them too —
+      // otherwise the IdP's delete silently leaves live access + tokens.
+      // Either way DELETE is idempotent → 204.
       const [invite] = await pendingInviteRows(accountId, userId);
       if (invite) {
+        const shadow = await shadowMemberForInvite(accountId, invite.email);
+        if (shadow) {
+          if (await isLastOwner(accountId, shadow)) {
+            return scimError(c, 409, 'Cannot delete the last owner of this account');
+          }
+          const revocationError = await deprovisionMember(accountId, shadow.userId);
+          await scimAudit(c, {
+            accountId,
+            action: 'scim.user.delete',
+            resourceType: 'account_member',
+            resourceId: shadow.userId,
+            before: { user_id: shadow.userId, account_role: shadow.accountRole },
+            metadata: {
+              via_invite_id: invite.inviteId,
+              ...(revocationError
+                ? { token_revocation_failed: true, token_revocation_error: revocationError }
+                : {}),
+            },
+          });
+        }
         await db
           .delete(accountInvitations)
           .where(eq(accountInvitations.inviteId, invite.inviteId));
@@ -533,37 +632,15 @@ scimRouter.openapi(
     }
 
     // Same last-owner guard as PATCH active=false.
-    if (member.accountRole === 'owner') {
-      const owners = await db
-        .select({ userId: accountMembers.userId })
-        .from(accountMembers)
-        .where(
-          and(eq(accountMembers.accountId, accountId), eq(accountMembers.accountRole, 'owner')),
-        );
-      if (owners.length <= 1) {
-        return scimError(c, 409, 'Cannot delete the last owner of this account');
-      }
+    if (await isLastOwner(accountId, member)) {
+      return scimError(c, 409, 'Cannot delete the last owner of this account');
     }
 
-    await db
-      .delete(accountMembers)
-      .where(and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, userId)));
-    invalidateIamCacheForUser(userId);
-    // Revoke PATs + live sandbox session tokens so the deprovision is immediate.
-    // A failure must not be swallowed — a "deleted" member with live tokens is a
-    // silent offboarding hole — so log loudly and record it on the audit event.
-    const revocationError = await revokeAllAccountTokensForUser(userId, accountId).then(
-      () => null,
-      (err) => {
-        console.error(
-          '[scim] token revocation FAILED on delete — user may retain live tokens',
-          { userId, accountId },
-          err,
-        );
-        return err instanceof Error ? err.message : String(err);
-      },
-    );
-
+    // Remove the membership and revoke PATs + live sandbox session tokens so
+    // the deprovision is immediate. A revocation failure must not be swallowed
+    // — a "deleted" member with live tokens is a silent offboarding hole — so
+    // it's logged loudly and recorded on the audit event.
+    const revocationError = await deprovisionMember(accountId, userId);
     await scimAudit(c, {
       accountId,
       action: 'scim.user.delete',


### PR DESCRIPTION
Audit follow-up to #4555 — the IdP's cached invitation id vs SSO-JIT membership race affected more paths than group adds:

- **Offboarding (critical):** deactivate/DELETE via a shadowed invite id now also deprovisions the live member (tokens revoked, last-owner guard, audited).
- Group member **remove / wholesale replace / create-with-members** now resolve invite ids and un-park stale grants, symmetric with the add path.
- Users list/GET hide invites shadowed by a member so the IdP reconciles one resource per person.
- JIT grant-consume survives a deleted parked group.

7 new unit tests; tsc + biome clean.