### PR TITLE
security(teams): block bot connector token leak to caller-supplied serviceUrl (F-7)

### DIFF
--- a/apps/api/src/__tests__/unit-teams-file-proxy.test.ts
+++ b/apps/api/src/__tests__/unit-teams-file-proxy.test.ts
@@ -104,7 +104,23 @@ describe('downloadTeamsFile', () => {
 });
 
 describe('initiateTeamsUpload', () => {
-  const base = { serviceUrl: 'https://smba/', conversationId: 'conv-1', filename: 'r.pdf' };
+  const base = {
+    serviceUrl: 'https://smba.trafficmanager.net/teams/',
+    conversationId: 'conv-1',
+    filename: 'r.pdf',
+  };
+
+  test('rejects a non-Microsoft serviceUrl before touching the DB (F-7)', async () => {
+    const r = await initiateTeamsUpload('proj-1', {
+      ...base,
+      serviceUrl: 'https://attacker.example.com/v3/conversations/x/activities',
+      contentBase64: Buffer.from('hello').toString('base64'),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+    expect(dbWrites.some((w) => w.op === 'insert.values')).toBe(false);
+    expect(apiCalls.map((c) => c.fn)).toEqual([]);
+  });
 
   test('rejects an oversize file before touching the DB', async () => {
     const big = 'A'.repeat(6 * 1024 * 1024);
@@ -142,14 +158,14 @@ describe('handleFileConsentInvoke', () => {
           uploadId: 'u1',
           filename: 'r.pdf',
           contentBase64: Buffer.from('hi').toString('base64'),
-          serviceUrl: 'https://smba/',
+          serviceUrl: 'https://smba.trafficmanager.net/teams/',
           conversationId: 'conv-1',
         },
       ],
     ];
     await handleFileConsentInvoke({
       type: 'invoke',
-      serviceUrl: 'https://smba/',
+      serviceUrl: 'https://smba.trafficmanager.net/teams/',
       conversation: { id: 'conv-1' },
       value: {
         action: 'accept',

--- a/apps/api/src/channels/teams-api.ts
+++ b/apps/api/src/channels/teams-api.ts
@@ -1,5 +1,6 @@
 import { loadTeamsBotCredentials } from './install-store';
 import { botConnectorToken } from './teams-auth';
+import { assertValidTeamsServiceUrl } from './teams-service-url';
 import type { TeamsConversationRef } from './teams/types';
 
 const ADAPTIVE_CARD_CONTENT_TYPE = 'application/vnd.microsoft.card.adaptive';
@@ -20,6 +21,23 @@ async function connectorFetch(
   body: unknown,
   projectId?: string,
 ): Promise<{ ok: boolean; status: number; id: string | null; error?: string }> {
+  // Defense-in-depth chokepoint: the bot connector token is attached below, so
+  // the destination URL MUST be a validated Microsoft Bot Framework endpoint.
+  // This blocks any caller (incl. a future one) from leaking the token to an
+  // attacker-controlled host. See F-7.
+  if (!assertValidTeamsServiceUrl(url)) {
+    console.warn('[teams-api] blocked outbound connector call to untrusted serviceUrl', {
+      method,
+      host: (() => {
+        try {
+          return new URL(url).hostname;
+        } catch {
+          return '<invalid>';
+        }
+      })(),
+    });
+    return { ok: false, status: 0, id: null, error: 'untrusted service url' };
+  }
   try {
     const creds = projectId ? await loadTeamsBotCredentials(projectId) : null;
     const token = await botConnectorToken(creds);

--- a/apps/api/src/channels/teams-service-url.ts
+++ b/apps/api/src/channels/teams-service-url.ts
@@ -1,0 +1,33 @@
+/**
+ * Allowlist of Microsoft Bot Framework / Teams service hosts that may receive
+ * the bot connector token via an outbound `sendActivity`/`updateActivity` call.
+ *
+ * The `serviceUrl` on the outbound path is partially caller-influenced (the
+ * file-upload route accepts it from the request body), so we must not let an
+ * attacker point the bot connector token at an arbitrary host. Legitimate
+ * Teams/Bot Framework service URLs are always one of these suffixes.
+ *
+ * Extracted into its own module so callers (teams-api connectorFetch chokepoint,
+ * teams/file-proxy initiateTeamsUpload) share one source of truth and unit tests
+ * can exercise it without mocking the token-attaching fetch path.
+ */
+const ALLOWED_SERVICE_HOST =
+  /(^|\.)(botframework\.com|botframework\.us|trafficmanager\.net|azurewebsites\.net)$/i;
+
+/**
+ * Returns the validated, https service URL, or `null` if the host is not a
+ * trusted Microsoft Bot Framework endpoint. Callers that attach the bot
+ * connector token MUST gate on this before `fetch`.
+ */
+export function assertValidTeamsServiceUrl(url: string): URL | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' || !ALLOWED_SERVICE_HOST.test(parsed.hostname)) {
+    return null;
+  }
+  return parsed;
+}

--- a/apps/api/src/channels/teams/file-proxy.ts
+++ b/apps/api/src/channels/teams/file-proxy.ts
@@ -4,6 +4,7 @@ import { eq, lt } from 'drizzle-orm';
 import { db } from '../../shared/db';
 import { loadTeamsBotCredentials, loadTeamsTenantForProject } from '../install-store';
 import { sendActivity } from '../teams-api';
+import { assertValidTeamsServiceUrl } from '../teams-service-url';
 import { graphToken } from '../teams-auth';
 import type { TeamsActivity, TeamsConversationRef } from './types';
 
@@ -65,6 +66,16 @@ export async function initiateTeamsUpload(
     return {
       ok: false,
       error: 'serviceUrl, conversationId, filename and content_base64 are required',
+      status: 400,
+    };
+  }
+  // F-7: the caller-supplied serviceUrl must be a trusted Microsoft Bot Framework
+  // endpoint, otherwise the bot connector token would be leaked to an arbitrary
+  // host when the consent card is posted. Reject before persisting.
+  if (!assertValidTeamsServiceUrl(args.serviceUrl)) {
+    return {
+      ok: false,
+      error: 'serviceUrl must be an https Microsoft Bot Framework endpoint',
       status: 400,
     };
   }

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1067,6 +1067,7 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    if (!teamsChannelEnabled()) return c.json({ error: 'Not found' }, 404);
     const body = await readBody(c);
     const result = await initiateTeamsUpload(projectId, {
       serviceUrl: String(body.service_url ?? body.serviceUrl ?? ''),


### PR DESCRIPTION
## Summary

Fixes **F-7 [HIGH]**, found by the weekly Kortix pentest (run #4). Prior run #3 committed a fix to a local worker branch that never merged; this re-stages and lands it.

**Vuln:** `POST /v1/projects/{projectId}/channels/teams/file/upload` accepted an arbitrary caller-supplied `service_url` and forwarded it to `sendActivity`, which attaches the bot connector `Bearer` token via `connectorFetch`. Any project-read member of a Teams-enabled project could point the token at an attacker-controlled host and impersonate the bot across all its conversations.

## Fix (defense in depth)

- **`channels/teams-service-url.ts`** (new): shared allowlist of Microsoft Bot Framework service hosts (`botframework.com`/`.us`, `trafficmanager.net`, `azurewebsites.net`) + https requirement.
- **`channels/teams-api.ts` `connectorFetch`**: reject any outbound call to a non-allowlisted host **before** attaching the Bearer token — the network chokepoint protecting every caller.
- **`channels/teams/file-proxy.ts` `initiateTeamsUpload`**: validate `serviceUrl` before persisting the pending-upload row (clean 400, no DB pollution).
- **`projects/routes/r4.ts`** upload route: add `teamsChannelEnabled()` gate mirroring the sibling Teams routes (`r4.ts:964`, `teams/routes.ts:52`).

## Verification

- `bun tsc --noEmit -p tsconfig.json` (apps/api) — 0 errors.
- `bun test src/__tests__/unit-teams-file-proxy.test.ts` — 7 pass / 0 fail (added an F-7 negative case: evil `serviceUrl` → 400, no DB write, no `sendActivity`; existing fixtures updated to a real Bot Framework host).

## Residual / notes

- Live authed positive/negative probe not run (no dev Supabase service-role key in the pentest sandbox). Unauth-401 gating live-confirmed on dev/staging/prod by the worker fleet. The unit test exercises the real validator end-to-end.
- Allowlist covers the documented Bot Framework endpoints. If a gov/special tenant uses a host outside the suffixes, it will 400 with a clear message and we can add the host — by design a closed allowlist.
- Related carried-over pentest findings (F-1 SSRF, SSR-7, S3-2, B-V6/V7) tracked separately in the pentest log.