### PR TITLE
security(sessions): forbid client forge of metadata.deletedAt/deletedBy (SSR-7)

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1140,6 +1140,14 @@ describe('project session API contract', () => {
         message: 'field is server-managed: error',
       },
       {
+        body: { metadata: { deletedAt: '2026-07-13T00:00:00Z' } },
+        message: 'metadata key is server-managed: deletedAt',
+      },
+      {
+        body: { metadata: { deletedBy: 'user-x' } },
+        message: 'metadata key is server-managed: deletedBy',
+      },
+      {
         body: { random: 'field' },
         message: 'field is not user-editable: random',
       },

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -1263,6 +1263,26 @@ projectsApp.openapi(
     return c.json({ error: `field is not user-editable: ${unknownField}` }, 400);
   }
 
+  // metadata.deletedAt / deletedBy are SERVER-MANAGED soft-delete markers.
+  // deleteSession() is the only legitimate writer; they are consumed by
+  // isSessionVisibleTo (r7.ts:488 — hides the session from every member's
+  // list), the continue-session guard (session-lifecycle/engine.ts:236 —
+  // returns 'no-session' so queued Slack/trigger follow-ups 404), and the
+  // sandbox reaper (sandbox-reaper.ts:477 — tombstones the live box).
+  // Letting a client forge either via PATCH lets any project member hide
+  // another member's session, block its follow-ups, and trip the reaper.
+  // See SSR-7 (weekly pentest run #4).
+  const SERVER_MANAGED_METADATA_KEYS = ['deletedAt', 'deletedBy'];
+  const metadataInput = body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+    ? (body.metadata as Record<string, unknown>)
+    : null;
+  if (metadataInput) {
+    const forgedKey = SERVER_MANAGED_METADATA_KEYS.find((k) => hasOwn(metadataInput, k));
+    if (forgedKey) {
+      return c.json({ error: `metadata key is server-managed: ${forgedKey}` }, 400);
+    }
+  }
+
   const visible = await loadVisibleSession(loaded, sessionId);
   if (!visible) return c.json({ error: 'Not found' }, 404);
   const existing = visible.row;
@@ -1276,9 +1296,7 @@ projectsApp.openapi(
   // and reverts the session to its auto title.
   const hasNameField = hasOwn(body, 'name');
   const name = normalizeString(body.name);
-  const metadata = body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
-    ? body.metadata as Record<string, unknown>
-    : null;
+  const metadata = metadataInput;
 
   if (hasNameField || metadata) {
     const nextMetadata: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

Fixes **SSR-7 [Med]**, found by the weekly Kortix pentest (run #4). Prior run #3 committed a fix (`c703692da`) to a local worker branch that never merged; this re-stages and lands it.

**Vuln:** `PATCH /v1/projects/{projectId}/sessions/{sessionId}` merged arbitrary client-supplied `metadata` keys, including `deletedAt`/`deletedBy` — the server-managed soft-delete markers consumed by:
- `isSessionVisibleTo` (`r7.ts:488`) — hides the session from **every** member's list
- `session-lifecycle/engine.ts:236` — the continue-session guard returns `no-session`, so queued Slack/trigger follow-ups 404
- `sandbox-reaper.ts:477` — tombstones the live sandbox box

Any project member who can see a session could forge `metadata.deletedAt` and hide another member's session, block its follow-ups, and trip the reaper on a live box.

## Fix

Reject PATCH bodies whose `metadata` contains `deletedAt` or `deletedBy` with a 400 `metadata key is server-managed` (mirrors the existing top-level `serverManagedFields` gate). `deleteSession()` remains the sole writer. The check runs before `loadVisibleSession`.

## Verification

- `bun tsc --noEmit -p tsconfig.json` (apps/api) — 0 errors.
- Extended the existing `rejects server-managed and unknown PATCH fields` case in `e2e-project-session-contract.test.ts` with `deletedAt`/`deletedBy` metadata payloads → expect 400 + the server-managed message. (This test boots the app and needs decrypted env; runs in CI, not in the pentest sandbox.)

## Residual / notes

- The broader SSR-SS2 (PATCH /sessions has no `canManageSharing` ownership gate — a non-owner who can *see* a project-visibility session can rename it) is a separate, lower-severity finding tracked in the pentest log; not addressed here to keep this PR focused on the integrity forge.
- Live authed probe not run (no dev Supabase service-role key in the pentest sandbox).