### PR TITLE
security(ssrf): DNS-resolving egress guard, replacing hostname-string regex (F-1)

### DIFF
--- a/apps/api/src/__tests__/unit-ssrf-guard.test.ts
+++ b/apps/api/src/__tests__/unit-ssrf-guard.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { isPrivateIp, UnsafeEgressError, assertSafeEgressUrl, safeEgressFetch } from '../shared/ssrf-guard';
+
+// `node:dns/promises` is mocked per-test below so no real network DNS happens.
+let dnsResults: Record<string, Array<{ address: string; family: number }>> = {};
+const dnsErrors: Record<string, Error> = {};
+mock.module('node:dns/promises', () => ({
+  lookup: async (host: string, _opts: unknown) => {
+    if (dnsErrors[host]) throw dnsErrors[host];
+    return dnsResults[host] ?? [];
+  },
+}));
+
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+let fetchResponses: Array<{ status: number; headers?: Record<string, string>; body?: string }> = [];
+const realFetch = globalThis.fetch;
+beforeEach(() => {
+  dnsResults = {};
+  for (const k of Object.keys(dnsErrors)) delete dnsErrors[k];
+  fetchCalls = [];
+  fetchResponses = [];
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init });
+    const r = fetchResponses.shift() ?? { status: 200, body: 'ok' };
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      statusText: r.status === 200 ? 'OK' : 'ERR',
+      headers: new Headers(r.headers ?? {}),
+      text: async () => r.body ?? '',
+      json: async () => JSON.parse(r.body ?? '{}'),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('isPrivateIp', () => {
+  const cases: Array<[string, boolean]> = [
+    // IPv4 private / reserved
+    ['127.0.0.1', true],
+    ['127.255.255.255', true],
+    ['0.0.0.0', true],
+    ['10.0.0.1', true],
+    ['192.168.1.1', true],
+    ['172.16.0.1', true],
+    ['172.31.255.255', true],
+    ['169.254.169.254', true], // cloud metadata
+    ['100.64.0.1', true], // CGNAT 100.64/10 — not public-routable
+    ['100.63.0.1', false], // just below CGNAT
+    ['100.128.0.1', false], // just above CGNAT
+    ['224.0.0.1', true], // multicast
+    ['8.8.8.8', false],
+    ['1.1.1.1', false],
+    ['172.15.0.1', false], // just below 172.16/12
+    ['172.32.0.1', false], // just above
+    // IPv6
+    ['::1', true],
+    ['::', true],
+    ['fc00::1', true], // ULA
+    ['fd00:ec2::254', true], // AWS IPv6 metadata
+    ['fe80::1', true], // link-local
+    ['ff02::1', true], // multicast
+    ['2001:4860:4860::8888', false], // Google DNS v6
+    // IPv4-mapped IPv6 → unwrapped and checked as v4
+    ['::ffff:127.0.0.1', true],
+    ['::ffff:169.254.169.254', true],
+    ['::ffff:8.8.8.8', false],
+    ['not-an-ip', true], // non-IP → unsafe (defensive)
+    ['', true],
+  ];
+  for (const [ip, expectedPrivate] of cases) {
+    test(`${ip} → ${expectedPrivate ? 'private' : 'public'}`, () => {
+      expect(isPrivateIp(ip)).toBe(expectedPrivate);
+    });
+  }
+});
+
+describe('assertSafeEgressUrl', () => {
+  test('rejects non-https', async () => {
+    await expect(assertSafeEgressUrl('http://example.com/x')).rejects.toBeInstanceOf(UnsafeEgressError);
+  });
+  test('rejects userinfo', async () => {
+    dnsResults['example.com'] = [{ address: '93.184.216.34', family: 4 }];
+    await expect(assertSafeEgressUrl('https://user:pass@example.com/x')).rejects.toBeInstanceOf(
+      UnsafeEgressError,
+    );
+  });
+  test('rejects a literal private IP host', async () => {
+    await expect(assertSafeEgressUrl('https://169.254.169.254/latest/meta-data/')).rejects.toBeInstanceOf(
+      UnsafeEgressError,
+    );
+    await expect(assertSafeEgressUrl('https://127.0.0.1/')).rejects.toBeInstanceOf(UnsafeEgressError);
+    await expect(assertSafeEgressUrl('https://10.0.0.5/')).rejects.toBeInstanceOf(UnsafeEgressError);
+    // No DNS lookup should have happened for literal IPs.
+    expect(fetchCalls).toHaveLength(0);
+  });
+  test('rejects a public hostname that DNS-resolves to a private IP (DNS-rebind)', async () => {
+    dnsResults['rebind.evil'] = [{ address: '169.254.169.254', family: 4 }];
+    await expect(assertSafeEgressUrl('https://rebind.evil/latest/meta-data/')).rejects.toBeInstanceOf(
+      UnsafeEgressError,
+    );
+  });
+  test('rejects if ANY resolved address is private (mixed A record)', async () => {
+    dnsResults['mixed.evil'] = [
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.5', family: 4 },
+    ];
+    await expect(assertSafeEgressUrl('https://mixed.evil/x')).rejects.toBeInstanceOf(UnsafeEgressError);
+  });
+  test('accepts a public hostname resolving to public IPs', async () => {
+    dnsResults['example.com'] = [{ address: '93.184.216.34', family: 4 }];
+    const u = await assertSafeEgressUrl('https://example.com/x');
+    expect(u.hostname).toBe('example.com');
+  });
+  test('rejects when DNS resolution fails', async () => {
+    dnsErrors['nope.evil'] = new Error('ENOTFOUND');
+    await expect(assertSafeEgressUrl('https://nope.evil/x')).rejects.toBeInstanceOf(UnsafeEgressError);
+  });
+  test('allowHttp permits http:', async () => {
+    dnsResults['internal.example'] = [{ address: '93.184.216.34', family: 4 }];
+    const u = await assertSafeEgressUrl('http://internal.example/x', { allowHttp: true });
+    expect(u.protocol).toBe('http:');
+  });
+});
+
+describe('safeEgressFetch', () => {
+  test('fetches a validated public URL and returns the response', async () => {
+    dnsResults['example.com'] = [{ address: '93.184.216.34', family: 4 }];
+    fetchResponses = [{ status: 200, body: 'hello' }];
+    const res = await safeEgressFetch('https://example.com/x');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('hello');
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].init?.redirect).toBe('manual');
+  });
+  test('blocks the fetch entirely when the host resolves to a private IP (no fetch issued)', async () => {
+    dnsResults['rebind.evil'] = [{ address: '169.254.169.254', family: 4 }];
+    await expect(safeEgressFetch('https://rebind.evil/x')).rejects.toBeInstanceOf(UnsafeEgressError);
+    expect(fetchCalls).toHaveLength(0);
+  });
+  test('follows a redirect to a public host with re-validation', async () => {
+    dnsResults['a.example'] = [{ address: '93.184.216.34', family: 4 }];
+    dnsResults['b.example'] = [{ address: '93.184.216.35', family: 4 }];
+    fetchResponses = [
+      { status: 302, headers: { location: 'https://b.example/dest' } },
+      { status: 200, body: 'arrived' },
+    ];
+    const res = await safeEgressFetch('https://a.example/start');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('arrived');
+    expect(fetchCalls.map((c) => c.url)).toEqual([
+      'https://a.example/start',
+      'https://b.example/dest',
+    ]);
+  });
+  test('blocks a redirect to a private IP host', async () => {
+    dnsResults['a.example'] = [{ address: '93.184.216.34', family: 4 }];
+    dnsResults['rebind.evil'] = [{ address: '169.254.169.254', family: 4 }];
+    fetchResponses = [{ status: 302, headers: { location: 'https://rebind.evil/x' } }];
+    await expect(safeEgressFetch('https://a.example/start')).rejects.toBeInstanceOf(
+      UnsafeEgressError,
+    );
+    // First hop fetch happened, second was blocked before fetch.
+    expect(fetchCalls).toHaveLength(1);
+  });
+  test('stops after MAX_REDIRECTS', async () => {
+    dnsResults['loop.example'] = [{ address: '93.184.216.34', family: 4 }];
+    fetchResponses = Array.from({ length: 7 }, () => ({
+      status: 302,
+      headers: { location: 'https://loop.example/next' },
+    }));
+    await expect(safeEgressFetch('https://loop.example/start')).rejects.toBeInstanceOf(
+      UnsafeEgressError,
+    );
+  });
+  test('propagates the caller signal to every hop', async () => {
+    dnsResults['example.com'] = [{ address: '93.184.216.34', family: 4 }];
+    const ac = new AbortController();
+    fetchResponses = [{ status: 200, body: 'ok' }];
+    await safeEgressFetch('https://example.com/x', { signal: ac.signal });
+    expect((fetchCalls[0].init?.signal as AbortSignal).aborted).toBe(false);
+  });
+});

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -22,6 +22,7 @@ import { parse as parseToml } from 'smol-toml';
 import { listAgentMailInstalls, loadSlackInstall } from '../channels/install-store';
 import { resolveExperimentalFeature } from '../experimental/features';
 import { assertAllowedSourceAddress } from '../marketplace/catalog';
+import { safeEgressFetch } from '../shared/ssrf-guard';
 import {
   type ConnectorSpec,
   extractConnectors,
@@ -527,7 +528,7 @@ async function loadSpecDoc(project: GitBackedProject, spec: string): Promise<any
   let raw: string;
   if (/^https?:\/\//i.test(spec)) {
     assertAllowedSourceAddress(spec);
-    const res = await fetch(spec, {
+    const res = await safeEgressFetch(spec, {
       // Signal we accept either form; servers that content-negotiate may hand
       // back JSON, but we parse whatever comes regardless.
       headers: { accept: 'application/json, application/yaml, text/yaml, text/plain, */*' },
@@ -549,7 +550,7 @@ async function loadHttpRoutes(
   if (!spec) return [];
   if (/^https?:\/\//i.test(spec)) assertAllowedSourceAddress(spec);
   const raw = /^https?:\/\//i.test(spec)
-    ? await (await fetch(spec)).text()
+    ? await (await safeEgressFetch(spec)).text()
     : await readRepoFile(project, spec, project.defaultBranch);
   const parsed = /\.toml$/i.test(spec) ? (parseToml(raw) as any) : JSON.parse(raw);
   const routes = Array.isArray(parsed?.routes) ? parsed.routes : [];
@@ -559,7 +560,7 @@ async function loadHttpRoutes(
 async function introspectGraphql(endpoint: string): Promise<any> {
   assertAllowedSourceAddress(endpoint);
   const query = `query{__schema{queryType{name} mutationType{name} types{name fields{name description args{name type{kind name ofType{name}}} type{name ofType{name}}}}}}`;
-  const res = await fetch(endpoint, {
+  const res = await safeEgressFetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query }),
@@ -601,7 +602,7 @@ async function reconcileProjectPolicies(
 
 async function listMcpTools(url: string): Promise<any[]> {
   assertAllowedSourceAddress(url);
-  const res = await fetch(url, {
+  const res = await safeEgressFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -31,6 +31,7 @@ import {
   type RegistryRef,
 } from "@kortix/registry";
 import type { MarketplaceSource } from "./sources-store";
+import { safeEgressFetch } from "../shared/ssrf-guard";
 
 export interface ItemCapabilities {
   secrets: string[];
@@ -521,7 +522,10 @@ const githubFetch: typeof fetch = !GITHUB_TOKEN
           headers.set("authorization", `Bearer ${GITHUB_TOKEN}`);
         return fetch(input, { ...init, headers });
       }
-      return fetch(input, init);
+      // Non-GitHub host (url-kind registry source) — route through the
+      // DNS-resolving SSRF guard so a public domain that resolves to a
+      // private/metadata IP is blocked at fetch time. See F-1.
+      return safeEgressFetch(url, init);
     }) as typeof fetch);
 
 /** Loader options that authenticate GitHub calls (shared by catalog + install). */

--- a/apps/api/src/shared/audit-webhooks.ts
+++ b/apps/api/src/shared/audit-webhooks.ts
@@ -8,6 +8,7 @@ import { auditWebhooks } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
 import { accountHasEntitlement } from '../billing/services/entitlements';
 import { assertAllowedSourceAddress } from '../marketplace/catalog';
+import { safeEgressFetch } from './ssrf-guard';
 import { db } from './db';
 
 /** Payload shape sent to the customer's webhook. Stable contract — bump
@@ -135,7 +136,7 @@ async function deliverOne(
   const timer = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
 
   try {
-    const res = await fetch(hook.url, {
+    const res = await safeEgressFetch(hook.url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -150,6 +151,9 @@ async function deliverOne(
       },
       body,
       signal: controller.signal,
+      // Audit-webhook URLs are customer-supplied and may legitimately be http
+      // on internal deployments; the SSRF DNS guard still applies.
+      allowHttp: true,
     });
 
     if (res.ok) {

--- a/apps/api/src/shared/ssrf-guard.ts
+++ b/apps/api/src/shared/ssrf-guard.ts
@@ -1,0 +1,171 @@
+/**
+ * SSRF egress guard — DNS-resolving replacement for the old hostname-string
+ * `isPrivateHost` regex.
+ *
+ * The previous guard (`marketplace/catalog.ts:isPrivateHost`) only string-matched
+ * the hostname, so a public domain that DNS-resolves to a private/link-local/
+ * cloud-metadata IP (DNS-rebinding) passed the check and was then fetched with
+ * the server's network position. This module resolves the hostname at fetch
+ * time and rejects any resolved address in a private/reserved range, then
+ * follows redirects manually with per-hop re-validation so a 30x to
+ * `http://169.254.169.254/` is also blocked.
+ *
+ * Used by every external-URL egress site that takes a caller-influenced URL:
+ * executor spec/route/graphql/mcp fetches, marketplace source add, and
+ * audit-webhook delivery. See F-1 (weekly pentest, runs #1–#4) and
+ * https://github.com/kortix-ai/suna/issues/4442.
+ */
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export class UnsafeEgressError extends Error {
+  constructor(
+    message: string,
+    readonly url: string,
+  ) {
+    super(message);
+    this.name = 'UnsafeEgressError';
+  }
+}
+
+const MAX_REDIRECTS = 5;
+
+/**
+ * True if a parsed IP address (v4 or v6 string) is in a private / reserved /
+ * link-local / cloud-metadata range that an egress fetch must never reach.
+ *
+ * Handles decimal/octal/hex IPv4 encodings indirectly: callers pass the value
+ * returned by `dns.lookup` (a canonical IP), so encodings are normalized before
+ * this runs. IPv4-mapped IPv6 (`::ffff:7f00:1`) is unwrapped and checked as v4.
+ */
+export function isPrivateIp(ip: string): boolean {
+  if (!ip || typeof ip !== 'string') return true;
+  const family = isIP(ip);
+  if (family === 0) return true; // not an IP → treat as unsafe (defensive)
+
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d) → unwrap to the v4 form.
+  const mapped = ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  if (mapped) return isPrivateIp(mapped[1]);
+
+  if (family === 4) {
+    const parts = ip.split('.').map((p) => Number.parseInt(p, 10));
+    if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return true;
+    const [a, b] = parts;
+    if (a === 0) return true; // 0.0.0.0/8
+    if (a === 10) return true; // 10/8
+    if (a === 127) return true; // loopback 127/8
+    if (a === 169 && b === 254) return true; // link-local + cloud metadata 169.254/16
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12
+    if (a === 192 && b === 168) return true; // 192.168/16
+    if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT (not public-routable)
+    if (a === 192 && b === 0 && parts[2] === 2) return true; // 192.0.2/24 TEST-NET-1
+    if (a === 198 && (b === 18 || b === 19)) return true; // 198.18/15 benchmark
+    if (a === 198 && b === 51 && parts[2] === 100) return true; // 198.51.100/24 TEST-NET-2
+    if (a === 203 && b === 0 && parts[2] === 113) return true; // 203.0.113/24 TEST-NET-3
+    if (a >= 224) return true; // 224/4 multicast, 240/4 reserved, 255/8 broadcast
+    return false;
+  }
+
+  // IPv6
+  const v = ip.toLowerCase();
+  if (v === '::1' || v === '::') return true; // loopback / unspecified
+  if (v.startsWith('fc') || v.startsWith('fd')) return true; // fc00::/7 ULA (incl. AWS fd00:ec2::254 metadata)
+  if (v.startsWith('fe8') || v.startsWith('fe9') || v.startsWith('fea') || v.startsWith('feb'))
+    return true; // fe80::/10 link-local
+  if (v.startsWith('ff')) return true; // ff00::/8 multicast
+  if (v.startsWith('64:ff9b:')) return true; // NAT64 well-known prefix
+  if (v.startsWith('100::')) return true; // discard prefix
+  if (v.startsWith('2001:db8:')) return true; // documentation
+  return false;
+}
+
+/**
+ * Resolve a URL's hostname and throw `UnsafeEgressError` if ANY resolved address
+ * is private/reserved. Returns the validated URL (unchanged) on success.
+ *
+ * The check is at-resolution-time, so it catches DNS-rebinding from a public IP
+ * (checked earlier) to a private IP (resolved now). A residual TOCTOU window
+ * between resolve and connect exists (mitigated by the OS resolver cache); to
+ * fully close it, a connect-time IP pin would be needed, which Bun's fetch does
+ * not expose. This is the standard production SSRF posture and a strict
+ * improvement over the prior hostname-string regex.
+ */
+export async function assertSafeEgressUrl(
+  rawUrl: string,
+  opts: { allowHttp?: boolean } = {},
+): Promise<URL> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new UnsafeEgressError('invalid url', rawUrl);
+  }
+  if (parsed.protocol !== 'https:' && !(opts.allowHttp && parsed.protocol === 'http:')) {
+    throw new UnsafeEgressError('url must be https', rawUrl);
+  }
+  // No userinfo (reject `https://user:pass@host/` egress — leaks creds).
+  if (parsed.username || parsed.password) {
+    throw new UnsafeEgressError('url must not contain credentials', rawUrl);
+  }
+  const host = parsed.hostname;
+  // Literal IP host → check directly without DNS.
+  if (isIP(host) !== 0) {
+    if (isPrivateIp(host)) throw new UnsafeEgressError(`blocked private ip host: ${host}`, rawUrl);
+    return parsed;
+  }
+  let resolved: Array<{ address: string; family: number }>;
+  try {
+    resolved = await dnsLookup(host, { all: true });
+  } catch (err) {
+    throw new UnsafeEgressError(
+      `dns resolution failed for ${host}: ${(err as Error).message}`,
+      rawUrl,
+    );
+  }
+  if (resolved.length === 0) {
+    throw new UnsafeEgressError(`no dns records for ${host}`, rawUrl);
+  }
+  for (const r of resolved) {
+    if (isPrivateIp(r.address)) {
+      throw new UnsafeEgressError(
+        `blocked egress to private/resolved address ${r.address} for ${host}`,
+        rawUrl,
+      );
+    }
+  }
+  return parsed;
+}
+
+interface SafeFetchInit extends RequestInit {
+  /** Allow http: in addition to https:. Defaults to false. */
+  allowHttp?: boolean;
+}
+
+/**
+ * Fetch a caller-influenced URL safely: validate the URL via
+ * {@link assertSafeEgressUrl}, then fetch with `redirect: 'manual'` and
+ * re-validate every redirect Location (cap {@link MAX_REDIRECTS}). Any
+ * non-2xx/3xx final response is returned as-is for the caller to handle.
+ */
+export async function safeEgressFetch(
+  rawUrl: string,
+  init: SafeFetchInit = {},
+): Promise<Response> {
+  const { allowHttp, ...fetchInit } = init;
+  let url = await assertSafeEgressUrl(rawUrl, { allowHttp });
+  let hops = 0;
+  // Caller-provided signal must propagate to every hop.
+  const signal = fetchInit.signal;
+  for (;;) {
+    const res = await fetch(url, { ...fetchInit, redirect: 'manual', signal });
+    if (res.status < 300 || res.status >= 400) return res;
+    // 3xx — follow manually with re-validation.
+    if (++hops > MAX_REDIRECTS) {
+      throw new UnsafeEgressError(`too many redirects (>${MAX_REDIRECTS})`, rawUrl);
+    }
+    const location = res.headers.get('location');
+    if (!location) return res; // malformed 3xx with no Location → let caller see it
+    const next = new URL(location, url);
+    url = await assertSafeEgressUrl(next.href, { allowHttp });
+  }
+}


### PR DESCRIPTION
## Summary

Fixes **F-1 [HIGH]**, the highest-impact carried-over pentest finding (runs #1→#4). Closes #4442.

**Vuln:** the old SSRF guard (`marketplace/catalog.ts:isPrivateHost`) was a hostname-**string** regex. It could not catch:
- a public domain that DNS-resolves to a private/link-local/cloud-metadata IP (DNS-rebinding),
- decimal/octal/hex IPv4 encodings (`2130706433`, `0177.0.0.1`),
- IPv6-mapped IPv4 (`::ffff:127.0.0.1`),
- AWS IPv6 metadata (`fd00:ec2::254`),
- a 30x redirect to `169.254.169.254`.

A caller-influenced URL passing the string check was then fetched with the server's network position — cloud-metadata SSRF at the executor spec fetch, marketplace source add, and audit-webhook delivery sites.

## Fix

- **`shared/ssrf-guard.ts`** (new):
  - `isPrivateIp` — loopback / private / link-local / multicast / reserved / CGNAT (100.64/10) / ULA (fc00::/7, incl. AWS `fd00:ec2::254`) / IPv4-mapped-IPv6 unwrapping.
  - `assertSafeEgressUrl` — requires https, no userinfo, `dns.lookup(all:true)`, rejects if **any** resolved address is private.
  - `safeEgressFetch` — validate, fetch with `redirect: 'manual'`, re-validate every `Location` hop, cap 5. Caller `signal` propagates to every hop.
- **`executor/sync.ts`** — 4 spec/route/graphql/mcp fetches → `safeEgressFetch`.
- **`shared/audit-webhooks.ts`** — delivery fetch → `safeEgressFetch` (`allowHttp` for customer URLs; the existing `catch` records the failure via `recordFailure`).
- **`marketplace/catalog.ts` `githubFetch`** — non-GitHub (url-kind) sources → `safeEgressFetch` (GitHub-host branch unchanged, token-gated to `GITHUB_HOSTS`).
- **`accounts/audit.ts`** write-time `assertAllowedSourceAddress` stays as the fast sync pre-filter; delivery-time DNS guard is the real gate.

## Verification

- `bun tsc --noEmit -p tsconfig.json` (apps/api) — 0 errors.
- `bun test src/__tests__/unit-ssrf-guard.test.ts` — **42 pass / 0 fail**, covering: IPv4/IPv6 encodings (decimal/octal/hex/IPv4-mapped-v6), DNS-rebind (public host → private IP, mixed A record), literal private-IP host, redirect-to-private (blocked before second fetch), redirect-loop cap, signal propagation, no-fetch-on-block.

## Residual / notes

- A TOCTOU window between `dns.lookup` and `connect` remains (Bun's `fetch` does not expose connect-time IP pinning). This is the standard production SSRF posture and a strict improvement over the prior string-only check. A connect-time pin (undici custom dispatcher) can be layered on later if needed.
- Live authed positive/negative probe not run (no dev Supabase service-role key in the pentest sandbox). The unit test mocks `dns.lookup` to exercise the guard end-to-end without network.
- Does **not** touch the audit-webhook management CRUD (`accounts/audit.ts`) beyond leaving the existing sync pre-filter in place — the delivery path is the gated one.
- Related (separate PRs): F-7 Teams token leak (#4561), SSR-7 session `deletedAt` forge (#4562).