### PR TITLE
security: pentest run #4 low-severity hardening (S3-2, NEW-1, MFA-1, F-5, SSR-PV1)

### DIFF
--- a/apps/api/src/__tests__/unit-email-channel.test.ts
+++ b/apps/api/src/__tests__/unit-email-channel.test.ts
@@ -159,6 +159,16 @@ describe('AgentMail webhook verification', () => {
         body: rawBody,
       });
       expect(invalidSignature.status).toBe(401);
+
+      // A malformed unsigned body (missing event_type/inbox_id) must NOT be
+      // acked with 200 — that let an unauthenticated caller poison ack/monitoring
+      // with `{}` -> 200 ok. Now rejected with 400 before any signature check.
+      const malformed = await emailWebhookApp.request('/agentmail', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(malformed.status).toBe(400);
     } finally {
       (config as { AGENTMAIL_WEBHOOK_SECRET: string | undefined }).AGENTMAIL_WEBHOOK_SECRET =
         originalSecret;

--- a/apps/api/src/accounts/iam/mfa.ts
+++ b/apps/api/src/accounts/iam/mfa.ts
@@ -139,7 +139,7 @@ iamRouter.openapi(
     tags: ['iam'],
     summary: 'Enable or disable account MFA requirement',
     ...auth,
-    request: { params: AccountIdParam, body: { content: { 'application/json': { schema: z.object({ enabled: z.boolean().optional() }) } } } },
+    request: { params: AccountIdParam, body: { content: { 'application/json': { schema: z.object({ enabled: z.boolean() }) } } } },
     responses: {
       200: json(z.object({ enabled: z.boolean(), unchanged: z.boolean().optional() }), 'Updated MFA-required status'),
       ...errors(401, 403, 404, 409),
@@ -153,7 +153,14 @@ iamRouter.openapi(
   await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
 
   const body = await readBody(c);
-  const enabled = body.enabled === true;
+  // `enabled` is REQUIRED (not optional): the old `z.boolean().optional()` +
+  // `body.enabled === true` meant `{}` or `{"enabled":null}` silently DISABLED
+  // account MFA — a footgun on a security toggle. Mirror the super-admin
+  // hardening (iam/members.ts). See MFA-1 (weekly pentest run #4).
+  if (typeof body.enabled !== 'boolean') {
+    return c.json({ error: 'enabled (boolean) is required' }, 400);
+  }
+  const enabled = body.enabled;
 
   const [before] = await db
     .select({ mfaRequired: accounts.mfaRequired })

--- a/apps/api/src/channels/email/routes.ts
+++ b/apps/api/src/channels/email/routes.ts
@@ -29,7 +29,13 @@ emailWebhookApp.openapi(
     } catch {
       return c.json({ error: 'Invalid JSON' }, 400);
     }
-    if (!event?.event_type || !event.message?.inbox_id) return c.json({ ok: true });
+    // Verify the signature BEFORE any ack. Returning 200 on a malformed unsigned
+    // body (the old behavior) let an unauthenticated caller poison ack/monitoring
+    // with `{}` -> 200 ok. Reject malformed unsigned bodies with 400 instead.
+    // See NEW-1 (weekly pentest run #4).
+    if (!event?.event_type || !event.message?.inbox_id) {
+      return c.json({ error: 'Missing event_type or message.inbox_id' }, 400);
+    }
 
     const projectId = event.message?.inbox_id
       ? await resolveProjectForAgentMailInbox(event.message.inbox_id)

--- a/apps/api/src/channels/slack/file-proxy.ts
+++ b/apps/api/src/channels/slack/file-proxy.ts
@@ -7,9 +7,11 @@
 import { loadSlackTokenForProject } from '../install-store';
 
 const SLACK_API = 'https://slack.com/api';
-// Only ever attach the bot token to Slack's own hosts — `url` is caller-supplied,
-// so this is the SSRF guard that stops the token leaking to an arbitrary origin.
-const SLACK_HOST = /(^|\.)slack\.com$/i;
+// Only ever attach the bot token to Slack's FILE-serving hosts — `url` is
+// caller-supplied, so this is the SSRF guard that stops the token leaking to an
+// arbitrary origin. Narrowed from the apex `slack.com` (where `/api/*` lives,
+// reachable with the bot token attached) to the file subdomains only. See S3-2.
+const SLACK_HOST = /^(files|files-origin|files-priv|files-private|files-public)\.slack\.com$/i;
 
 export type FileProxyError = { ok: false; error: string; status: number };
 

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -522,6 +522,19 @@ projectsApp.openapi(
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_FILE_READ);
 
+  // Visibility isolation: a scoped-out member can't read the commit history of
+  // an agent/skill they aren't granted — return the same 404 as a missing file
+  // so the path isn't confirmed to exist. Mirrors files/content (r5.ts:477-484).
+  // See F-5 (weekly pentest run #4).
+  const denier = await resourceDenierForRequest({
+    userId: loaded.userId,
+    accountId: loaded.row.accountId,
+    projectId,
+    actingTokenId: (c.get('iamTokenId') as string | undefined) ?? undefined,
+    row: loaded.row,
+  });
+  if (denier?.isDenied(path)) return c.json({ error: 'File not found' }, 404);
+
   const ref = c.req.query('ref') || loaded.row.defaultBranch;
   const limit = Number(c.req.query('limit') || '50');
   const skip = Number(c.req.query('skip') || '0');

--- a/apps/api/src/sandbox-proxy/routes/public-share.ts
+++ b/apps/api/src/sandbox-proxy/routes/public-share.ts
@@ -111,6 +111,16 @@ async function forwardPublicShare(c: any, args: {
   if (args.share.resourceType === 'file' && !VIEW_METHODS.has(method)) {
     return c.json({ error: 'This public share is view-only' }, 405);
   }
+  // A view-mode PREVIEW share must also be view-only: without this gate a holder
+  // of a `mode:'view'` preview link could POST/PUT/DELETE to the sandboxed
+  // preview app. Mirrors the file branch above. See SSR-PV1 (weekly pentest #4).
+  if (
+    args.share.resourceType === 'preview' &&
+    args.share.mode === 'view' &&
+    !VIEW_METHODS.has(method)
+  ) {
+    return c.json({ error: 'This public share is view-only' }, 405);
+  }
 
   const sandbox = await loadSandbox(args.share.externalId!);
   if (!sandbox) return c.json({ error: 'Sandbox not found' }, 404);


### PR DESCRIPTION
Bundles five small, independently-safe Low findings from weekly pentest run #4. One commit per finding for easy review/revert.

## S3-2 — Slack file-proxy host too broad
`channels/slack/file-proxy.ts`: `SLACK_HOST` was `/(^|\.)slack\.com$/` so the apex `slack.com` (where `/api/*` lives) was reachable with the bot token attached. Narrowed to the file subdomains only (`files|files-origin|files-priv|files-private|files-public.slack.com`).

## NEW-1 — AgentMail webhook acks 200 before signature verification
`channels/email/routes.ts`: a malformed unsigned body (`{}`, missing `event_type`/`inbox_id`) got `200 {ok:true}` before any signature check — let an unauthenticated caller poison ack/monitoring. Now rejected with `400` before the signature check; dispatch was already sig-gated so no spam/impact change.

## MFA-1 — PATCH mfa-required `enabled` optional footgun
`accounts/iam/mfa.ts`: `z.boolean().optional()` + `body.enabled === true` meant `{}` or `{"enabled":null}` silently **disabled** account MFA. `enabled` is now required (`z.boolean()`) with a 400 on missing/non-boolean, mirroring the super-admin hardening (`iam/members.ts`).

## F-5 — GET /files/history skips resource denier
`projects/routes/r5.ts`: the history handler didn't call `resourceDenierForRequest`, so a member scoped out of an agent/skill could still read its commit log (sha/author/message/date) for a denied path — the 4 sibling handlers (files, archive, search, content) all apply the denier. Added the same denier gate → 404 for denied paths.

## SSR-PV1 — view-mode public preview share forwards non-view methods
`sandbox-proxy/routes/public-share.ts`: the file branch enforced `VIEW_METHODS` for `mode:'view'`, but the preview branch forwarded any HTTP method regardless of `mode`. A holder of a `mode:'view'` preview link could POST/PUT/DELETE to the sandboxed preview app. Added the same `VIEW_METHODS` gate for `resourceType:'preview' && mode:'view'`.

## Verification
- `bun tsc --noEmit -p tsconfig.json` (apps/api) — 0 errors.
- `bun test unit-email-channel.test.ts unit-iam-mfa-cache-invalidation.test.ts unit-teams-file-proxy.test.ts unit-ssrf-guard.test.ts` — all green (with dummy env for the config-importing ones). Added a malformed-body regression case to `unit-email-channel.test.ts`.
- Live authed probes not run (no dev creds in pentest sandbox); CI runs the env-dependent suites.

## Related PRs (run #4)
- #4561 F-7 Teams token leak (HIGH)
- #4562 SSR-7 session deletedAt forge (Med)
- #4563 F-1 SSRF DNS guard (HIGH)