### PR TITLE
feat(projects): add session branch environments

### DIFF
--- a/apps/api/src/projects/lib/session-base-ref-resolution.ts
+++ b/apps/api/src/projects/lib/session-base-ref-resolution.ts
@@ -1,0 +1,57 @@
+import { accountGroupMembers, accountGroups, projectGroupGrants } from '@kortix/db';
+import { and, eq, gt, isNotNull, isNull, or } from 'drizzle-orm';
+
+import { db } from '../../shared/db';
+import { selectEffectiveSessionBaseRef, type EffectiveSessionBaseRef } from './session-base-ref';
+
+export async function resolveEffectiveSessionBaseRef(input: {
+  userId: string;
+  accountId: string;
+  projectId: string;
+  projectDefaultRef: string;
+  explicitRef?: string | null;
+}): Promise<EffectiveSessionBaseRef> {
+  if (input.explicitRef?.trim()) {
+    return selectEffectiveSessionBaseRef({
+      explicitRef: input.explicitRef,
+      projectDefaultRef: input.projectDefaultRef,
+      groupDefaults: [],
+    });
+  }
+
+  const now = new Date();
+  const groupDefaults = await db
+    .select({
+      groupId: projectGroupGrants.groupId,
+      groupName: accountGroups.name,
+      baseRef: projectGroupGrants.defaultBaseRef,
+    })
+    .from(accountGroupMembers)
+    .innerJoin(
+      projectGroupGrants,
+      and(
+        eq(projectGroupGrants.groupId, accountGroupMembers.groupId),
+        eq(projectGroupGrants.projectId, input.projectId),
+        eq(projectGroupGrants.accountId, input.accountId),
+        isNotNull(projectGroupGrants.defaultBaseRef),
+        or(isNull(projectGroupGrants.expiresAt), gt(projectGroupGrants.expiresAt, now)),
+      ),
+    )
+    .innerJoin(accountGroups, eq(accountGroups.groupId, projectGroupGrants.groupId))
+    .where(eq(accountGroupMembers.userId, input.userId));
+
+  return selectEffectiveSessionBaseRef({
+    projectDefaultRef: input.projectDefaultRef,
+    groupDefaults: groupDefaults.flatMap((entry) =>
+      entry.baseRef
+        ? [
+            {
+              groupId: entry.groupId,
+              groupName: entry.groupName,
+              baseRef: entry.baseRef,
+            },
+          ]
+        : [],
+    ),
+  });
+}

--- a/apps/api/src/projects/lib/session-base-ref.test.ts
+++ b/apps/api/src/projects/lib/session-base-ref.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+
+import { selectEffectiveSessionBaseRef } from './session-base-ref';
+
+const groups = (...rows: Array<[string, string, string]>) =>
+  rows.map(([groupId, groupName, baseRef]) => ({
+    groupId,
+    groupName,
+    baseRef,
+  }));
+
+describe('selectEffectiveSessionBaseRef', () => {
+  test('an explicit per-session ref wins over project and group defaults', () => {
+    expect(
+      selectEffectiveSessionBaseRef({
+        explicitRef: 'feature/shadcn',
+        projectDefaultRef: 'main',
+        groupDefaults: groups(['g1', 'Developers', 'dev']),
+      }),
+    ).toEqual({
+      ref: 'feature/shadcn',
+      source: 'explicit',
+      groups: [],
+      conflict: false,
+      conflictingRefs: [],
+    });
+  });
+
+  test('one group default overrides the project default', () => {
+    expect(
+      selectEffectiveSessionBaseRef({
+        projectDefaultRef: 'main',
+        groupDefaults: groups(['g1', 'Developers', 'dev']),
+      }),
+    ).toEqual({
+      ref: 'dev',
+      source: 'group',
+      groups: [{ groupId: 'g1', groupName: 'Developers' }],
+      conflict: false,
+      conflictingRefs: [],
+    });
+  });
+
+  test('multiple groups may agree on the same default', () => {
+    expect(
+      selectEffectiveSessionBaseRef({
+        projectDefaultRef: 'main',
+        groupDefaults: groups(['g1', 'Developers', 'staging'], ['g2', 'QA', 'staging']),
+      }),
+    ).toEqual({
+      ref: 'staging',
+      source: 'group',
+      groups: [
+        { groupId: 'g1', groupName: 'Developers' },
+        { groupId: 'g2', groupName: 'QA' },
+      ],
+      conflict: false,
+      conflictingRefs: [],
+    });
+  });
+
+  test('conflicting group defaults fall back to the project default visibly', () => {
+    expect(
+      selectEffectiveSessionBaseRef({
+        projectDefaultRef: 'main',
+        groupDefaults: groups(['g2', 'QA', 'staging'], ['g1', 'Developers', 'dev']),
+      }),
+    ).toEqual({
+      ref: 'main',
+      source: 'project',
+      groups: [],
+      conflict: true,
+      conflictingRefs: ['dev', 'staging'],
+    });
+  });
+
+  test('the project default applies when no group default exists', () => {
+    expect(
+      selectEffectiveSessionBaseRef({
+        projectDefaultRef: 'prod',
+        groupDefaults: [],
+      }),
+    ).toEqual({
+      ref: 'prod',
+      source: 'project',
+      groups: [],
+      conflict: false,
+      conflictingRefs: [],
+    });
+  });
+});

--- a/apps/api/src/projects/lib/session-base-ref.ts
+++ b/apps/api/src/projects/lib/session-base-ref.ts
@@ -1,0 +1,66 @@
+export type SessionBaseRefGroupDefault = {
+  groupId: string;
+  groupName: string;
+  baseRef: string;
+};
+
+export type EffectiveSessionBaseRef = {
+  ref: string;
+  source: 'explicit' | 'group' | 'project';
+  groups: Array<{ groupId: string; groupName: string }>;
+  conflict: boolean;
+  conflictingRefs: string[];
+};
+
+/**
+ * Resolve the branch a session forks from.
+ *
+ * Explicit per-session selection wins. Group defaults apply only when every
+ * matching group agrees on one ref. A user in groups with different defaults
+ * falls back to the project default instead of receiving an order-dependent
+ * branch from Postgres row order.
+ */
+export function selectEffectiveSessionBaseRef(input: {
+  explicitRef?: string | null;
+  projectDefaultRef: string;
+  groupDefaults: SessionBaseRefGroupDefault[];
+}): EffectiveSessionBaseRef {
+  const explicitRef = input.explicitRef?.trim();
+  if (explicitRef) {
+    return {
+      ref: explicitRef,
+      source: 'explicit',
+      groups: [],
+      conflict: false,
+      conflictingRefs: [],
+    };
+  }
+
+  const defaults = input.groupDefaults
+    .map((entry) => ({ ...entry, baseRef: entry.baseRef.trim() }))
+    .filter((entry) => entry.baseRef.length > 0);
+  const refs = [...new Set(defaults.map((entry) => entry.baseRef))].sort();
+
+  if (refs.length === 1) {
+    const ref = refs[0]!;
+    const groups = defaults
+      .filter((entry) => entry.baseRef === ref)
+      .map(({ groupId, groupName }) => ({ groupId, groupName }))
+      .sort((a, b) => a.groupName.localeCompare(b.groupName) || a.groupId.localeCompare(b.groupId));
+    return {
+      ref,
+      source: 'group',
+      groups,
+      conflict: false,
+      conflictingRefs: [],
+    };
+  }
+
+  return {
+    ref: input.projectDefaultRef,
+    source: 'project',
+    groups: [],
+    conflict: refs.length > 1,
+    conflictingRefs: refs.length > 1 ? refs : [],
+  };
+}

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -32,6 +32,7 @@ import { AmbiguousSecretGrantError, listProjectSecretsSnapshotForUser } from '..
 import { resolveCompiledAgentConfigForSession } from './compile-agent-config';
 import { resolveProjectGitAuth } from './git';
 import { resolveSessionProvider } from './provider-precedence';
+import { resolveEffectiveSessionBaseRef } from './session-base-ref-resolution';
 import { RESERVED_SANDBOX_ENV_NAMES, isReservedSandboxEnvName } from './sandbox-env-names';
 import {
   ACTIVE_SESSION_STATUSES,
@@ -433,6 +434,10 @@ export async function createProjectSession(input: {
   metadata?: Record<string, unknown>;
   extraEnvVars?: Record<string, string>;
   request?: RequestAuditContext;
+  /** Human-launched UI/mobile/CLI sessions may inherit an attached group's
+   * branch default. Automation and system sessions stay on the project default
+   * unless they pass an explicit base_ref. */
+  useGroupDefault?: boolean;
   /**
    * Sessions default to private (owner-only). Automation callers (triggers,
    * Slack/Telegram channels) pass 'project' — those sessions belong to the
@@ -474,7 +479,23 @@ export async function createProjectSession(input: {
     };
   }
 
-  const baseRef = normalizeString(body.base_ref ?? body.baseRef) ?? project.defaultBranch;
+  const explicitBaseRef = normalizeString(body.base_ref ?? body.baseRef);
+  const baseRefResolution = input.useGroupDefault
+    ? await resolveEffectiveSessionBaseRef({
+        userId,
+        accountId,
+        projectId,
+        projectDefaultRef: project.defaultBranch,
+        explicitRef: explicitBaseRef,
+      })
+    : {
+        ref: explicitBaseRef ?? project.defaultBranch,
+        source: explicitBaseRef ? ('explicit' as const) : ('project' as const),
+        groups: [],
+        conflict: false,
+        conflictingRefs: [],
+      };
+  const baseRef = baseRefResolution.ref;
   // Explicit request wins; otherwise fall back to the project's default agent
   // (a v2 kortix.yaml's top-level `default_agent`, or a legacy v1 kortix.toml's
   // `[opencode] default_agent` — synced to project metadata, or a UI/Slack

--- a/apps/api/src/projects/routes/r5.ts
+++ b/apps/api/src/projects/routes/r5.ts
@@ -13,6 +13,7 @@ import { applyDetailCapabilityFilter } from '../lib/detail-capability-filter';
 import { filterConfigResourcesForUser, denierFromConfig, resourceDenierForRequest } from '../lib/project-resources';
 import { AnyObject, CommitSchema, ProjectSchema, projectsApp } from '../lib/app';
 import { getProjectGitConnection, withProjectGitAuth } from '../lib/git';
+import { resolveEffectiveSessionBaseRef } from '../lib/session-base-ref-resolution';
 import { normalizeString, readBody, serializeDeploymentRow, serializeProject, serializeProjectGitConnection } from '../lib/serializers';
 
 function isMissingGitPathError(error: unknown): boolean {
@@ -558,19 +559,36 @@ projectsApp.openapi(
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_GITOPS_READ);
 
+  const sessionDefault = await resolveEffectiveSessionBaseRef({
+    userId: loaded.userId,
+    accountId: loaded.row.accountId,
+    projectId,
+    projectDefaultRef: loaded.row.defaultBranch,
+  });
+
+  const payload = (branches: Awaited<ReturnType<typeof listBranches>>) => ({
+    default_branch: loaded.row.defaultBranch,
+    session_default_ref: sessionDefault.ref,
+    session_default_source: sessionDefault.source,
+    session_default_groups: sessionDefault.groups.map((group) => ({
+      group_id: group.groupId,
+      group_name: group.groupName,
+    })),
+    session_default_conflict: sessionDefault.conflict,
+    conflicting_group_refs: sessionDefault.conflictingRefs,
+    branches,
+  });
+
   try {
     const branches = await listBranches(await withProjectGitAuth(loaded.row));
-    return c.json({
-      default_branch: loaded.row.defaultBranch,
-      branches,
-    });
+    return c.json(payload(branches));
   } catch (error) {
     console.warn('[projects] branch listing unavailable', {
       projectId,
       error: error instanceof Error ? error.message : String(error),
     });
     c.header('X-Kortix-Repo-Status', 'unavailable');
-    return c.json({ default_branch: loaded.row.defaultBranch, branches: [] });
+    return c.json(payload([]));
   }
 },
 );

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -71,6 +71,7 @@ projectsApp.openapi(
     .select({
       groupId: projectGroupGrants.groupId,
       role: projectGroupGrants.role,
+      defaultBaseRef: projectGroupGrants.defaultBaseRef,
       grantedBy: projectGroupGrants.grantedBy,
       createdAt: projectGroupGrants.createdAt,
       expiresAt: projectGroupGrants.expiresAt,
@@ -132,6 +133,7 @@ projectsApp.openapi(
         group_id: r.groupId,
         group_name: r.groupName,
         role: r.role,
+        default_base_ref: r.defaultBaseRef,
         granted_by: r.grantedBy,
         created_at: r.createdAt.toISOString(),
         /** Auto-revoke timestamp. NULL = permanent attachment. */
@@ -195,6 +197,14 @@ projectsApp.openapi(
   }
   const expires = parseExpiresAtBody(body.expires_at);
   if (!expires.ok) return c.json({ error: expires.error }, 400);
+  const hasDefaultBaseRef = hasOwn(body, 'default_base_ref') || hasOwn(body, 'defaultBaseRef');
+  const rawDefaultBaseRef = hasOwn(body, 'default_base_ref')
+    ? body.default_base_ref
+    : body.defaultBaseRef;
+  const defaultBaseRef = rawDefaultBaseRef === null ? null : normalizeString(rawDefaultBaseRef);
+  if (hasDefaultBaseRef && rawDefaultBaseRef !== null && !defaultBaseRef) {
+    return c.json({ error: 'default_base_ref must be a non-empty string or null' }, 400);
+  }
 
   // Confirm the group exists and belongs to this account — prevents
   // attaching a foreign-account group via a guessed UUID.
@@ -215,6 +225,7 @@ projectsApp.openapi(
       groupId,
       accountId: loaded.row.accountId,
       role,
+      defaultBaseRef: defaultBaseRef ?? null,
       grantedBy: loaded.userId,
       expiresAt: expires.value ?? null,
     })
@@ -226,11 +237,17 @@ projectsApp.openapi(
         updatedAt: now,
         // Only overwrite when caller explicitly set the field.
         ...(expires.value !== undefined ? { expiresAt: expires.value } : {}),
+        ...(hasDefaultBaseRef ? { defaultBaseRef } : {}),
       },
     });
   await invalidateIamCacheForGroup(groupId);
 
-  return c.json({ project_id: projectId, group_id: groupId, role }, 201);
+  return c.json({
+    project_id: projectId,
+    group_id: groupId,
+    role,
+    default_base_ref: defaultBaseRef ?? null,
+  }, 201);
 },
 );
 
@@ -272,19 +289,32 @@ projectsApp.openapi(
   }
 
   const body = await readBody(c);
-  const role = normalizeProjectRole(body.role);
-  if (!role) {
+  const hasRole = hasOwn(body, 'role');
+  const role = hasRole ? normalizeProjectRole(body.role) : null;
+  if (hasRole && !role) {
     return c.json({ error: 'role must be manager, editor, or member' }, 400);
   }
   const expires = parseExpiresAtBody(body.expires_at);
   if (!expires.ok) return c.json({ error: expires.error }, 400);
+  const hasDefaultBaseRef = hasOwn(body, 'default_base_ref') || hasOwn(body, 'defaultBaseRef');
+  const rawDefaultBaseRef = hasOwn(body, 'default_base_ref')
+    ? body.default_base_ref
+    : body.defaultBaseRef;
+  const defaultBaseRef = rawDefaultBaseRef === null ? null : normalizeString(rawDefaultBaseRef);
+  if (hasDefaultBaseRef && rawDefaultBaseRef !== null && !defaultBaseRef) {
+    return c.json({ error: 'default_base_ref must be a non-empty string or null' }, 400);
+  }
+  if (!hasRole && expires.value === undefined && !hasDefaultBaseRef) {
+    return c.json({ error: 'role, expires_at, or default_base_ref is required' }, 400);
+  }
 
   const result = await db
     .update(projectGroupGrants)
     .set({
-      role,
+      ...(role ? { role } : {}),
       updatedAt: new Date(),
       ...(expires.value !== undefined ? { expiresAt: expires.value } : {}),
+      ...(hasDefaultBaseRef ? { defaultBaseRef } : {}),
     })
     .where(
       and(
@@ -292,11 +322,20 @@ projectsApp.openapi(
         eq(projectGroupGrants.groupId, groupId),
       ),
     )
-    .returning({ groupId: projectGroupGrants.groupId });
+    .returning({
+      groupId: projectGroupGrants.groupId,
+      role: projectGroupGrants.role,
+      defaultBaseRef: projectGroupGrants.defaultBaseRef,
+    });
 
   if (result.length === 0) return c.json({ error: 'grant not found' }, 404);
   await invalidateIamCacheForGroup(groupId);
-  return c.json({ project_id: projectId, group_id: groupId, role: body.role });
+  return c.json({
+    project_id: projectId,
+    group_id: groupId,
+    role: result[0]!.role,
+    default_base_ref: result[0]!.defaultBaseRef,
+  });
 },
 );
 

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -529,6 +529,7 @@ async function executeCreateSession(
     extraEnvVars: command.extraEnvVars,
     request: command.request,
     visibility: command.visibility,
+    useGroupDefault: ['ui', 'mobile', 'cli'].includes(command.source),
   });
 
   if (result.error) {

--- a/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/members-view.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 
 import { errorToast, successToast, warningToast } from '@/components/ui/toast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Bot, Check, Clock, CornerDownRight, KeyRound, Mail, MessageSquare, Plug, Plus, RefreshCw, Shield, Sparkles, User, Users, X } from 'lucide-react';
+import { Bot, Check, Clock, CornerDownRight, GitBranch, KeyRound, Mail, MessageSquare, Plug, Plus, RefreshCw, Shield, Sparkles, User, Users, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 
@@ -73,6 +73,7 @@ import {
   listPendingProjectInvites,
   listProjectAccess,
   listProjectAccessRequests,
+  listProjectBranches,
   listProjectGroupGrants,
   listProjectResourceGrants,
   createProjectResourceGrant,
@@ -1354,6 +1355,12 @@ function ProjectGroupGrantsCard({
     enabled: canManage,
     staleTime: 60_000,
   });
+  const branchesQuery = useQuery({
+    queryKey: ['project-branches', projectId],
+    queryFn: () => listProjectBranches(projectId),
+    enabled: canManage,
+    staleTime: 60_000,
+  });
   // Custom-role policies bound to a GROUP on this project. A group that has BOTH
   // a built-in grant (this list) AND a custom-role policy hits the union trap:
   // allow-only/highest-wins means the built-in role WINS and silently overrides
@@ -1407,6 +1414,7 @@ function ProjectGroupGrantsCard({
     queryClient.invalidateQueries({ queryKey: grantsKey });
     queryClient.invalidateQueries({ queryKey: ['project-access', projectId] });
     queryClient.invalidateQueries({ queryKey: ['project', projectId] });
+    queryClient.invalidateQueries({ queryKey: ['project-branches', projectId] });
   }
 
   const attachMutation = useMutation({
@@ -1426,12 +1434,23 @@ function ProjectGroupGrantsCard({
   });
 
   const updateMutation = useMutation({
-    mutationFn: (input: { groupId: string; role: ProjectRole }) =>
-      updateProjectGroupGrant(projectId, input.groupId, input.role),
+    mutationFn: (input: {
+      groupId: string;
+      role: ProjectRole;
+      defaultBaseRef?: string | null;
+      kind: 'role' | 'branch';
+    }) =>
+      updateProjectGroupGrant(
+        projectId,
+        input.groupId,
+        input.role,
+        undefined,
+        input.defaultBaseRef,
+      ),
     onMutate: (input) => markPending(input.groupId),
     onSettled: (_data, _error, input) => clearPending(input.groupId),
-    onSuccess: () => {
-      successToast('Role updated');
+    onSuccess: (_data, input) => {
+      successToast(input.kind === 'role' ? 'Role updated' : 'Session branch updated');
       invalidate();
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to update role'),
@@ -1565,6 +1584,14 @@ function ProjectGroupGrantsCard({
           <ul className="space-y-2">
             {grants.map((g: ProjectGroupGrant) => {
               const busy = pendingGroupIds.has(g.group_id);
+              const projectDefaultValue = '__project_default__';
+              const branchNames = Array.from(
+                new Set([
+                  g.default_base_ref,
+                  branchesQuery.data?.default_branch,
+                  ...(branchesQuery.data?.branches.map((branch) => branch.name) ?? []),
+                ].filter((value): value is string => Boolean(value))),
+              );
               return (
                 <li key={g.group_id} className={MEMBER_ROW}>
                   <EntityAvatar icon={UsersSolid} size="md" />
@@ -1580,6 +1607,13 @@ function ProjectGroupGrantsCard({
                             {g.member_count} {g.member_count === 1 ? 'member' : 'members'}
                           </span>
                         )}
+                        <span className="inline-flex items-center gap-1">
+                          <GitBranch className="size-3 shrink-0" />
+                          <span className="font-mono">
+                            {g.default_base_ref ?? branchesQuery.data?.default_branch ?? 'project default'}
+                          </span>
+                          {!g.default_base_ref ? <span>(project default)</span> : null}
+                        </span>
                         {typeof g.override_count === 'number' && g.override_count > 0 && (
                           <span
                             className="text-kortix-orange"
@@ -1611,7 +1645,11 @@ function ProjectGroupGrantsCard({
                       <Select
                         value={g.role}
                         onValueChange={(v) =>
-                          updateMutation.mutate({ groupId: g.group_id, role: v as ProjectRole })
+                          updateMutation.mutate({
+                            groupId: g.group_id,
+                            role: v as ProjectRole,
+                            kind: 'role',
+                          })
                         }
                       >
                         <SelectTrigger className="h-8 w-28 text-xs">
@@ -1621,6 +1659,33 @@ function ProjectGroupGrantsCard({
                           <ProjectRoleSelectItem role="member" />
                           <ProjectRoleSelectItem role="editor" />
                           <ProjectRoleSelectItem role="manager" />
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={g.default_base_ref ?? projectDefaultValue}
+                        onValueChange={(value) =>
+                          updateMutation.mutate({
+                            groupId: g.group_id,
+                            role: g.role,
+                            defaultBaseRef: value === projectDefaultValue ? null : value,
+                            kind: 'branch',
+                          })
+                        }
+                      >
+                        <SelectTrigger
+                          className="h-8 w-40 text-xs"
+                          aria-label={`Default session branch for ${g.group_name}`}
+                        >
+                          <GitBranch className="size-3.5 shrink-0" />
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={projectDefaultValue}>Project default</SelectItem>
+                          {branchNames.map((branch) => (
+                            <SelectItem key={branch} value={branch} className="font-mono text-xs">
+                              {branch}
+                            </SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
                       <Button

--- a/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/settings-view.tsx
@@ -40,6 +40,7 @@ import {
   getProject,
   inviteRepoCollaborator,
   isManagedGithubProject,
+  listProjectBranches,
   listProjectTriggers,
   setProjectTriggersActivation,
   updateExperimentalFeature,
@@ -179,6 +180,17 @@ function RepositoryCard({ project, canManage }: { project: KortixProject; canMan
   const githubUrl = githubRepoWebUrl(repoUrl);
   const repoLabel = githubUrl?.replace('https://github.com/', '') || repoUrl || '-';
   const managed = isManagedGithubProject(project);
+  const branchesQuery = useQuery({
+    queryKey: ['project-branches', project.project_id],
+    queryFn: () => listProjectBranches(project.project_id),
+    staleTime: 60_000,
+  });
+  const branchNames = Array.from(
+    new Set([
+      project.default_branch,
+      ...(branchesQuery.data?.branches.map((branch) => branch.name) ?? []),
+    ]),
+  );
 
   const [defaultBranch, setDefaultBranch] = useState(project.default_branch);
   const [manifestPath, setManifestPath] = useState(project.manifest_path);
@@ -202,6 +214,7 @@ function RepositoryCard({ project, canManage }: { project: KortixProject; canMan
     onSuccess: (updated) => {
       queryClient.setQueryData(['project', project.project_id], updated);
       queryClient.invalidateQueries({ queryKey: ['projects'] });
+      queryClient.invalidateQueries({ queryKey: ['project-branches', project.project_id] });
     },
     onError: (error: Error) => errorToast(error.message || 'Failed to update repository'),
   });
@@ -246,19 +259,28 @@ function RepositoryCard({ project, canManage }: { project: KortixProject; canMan
         <FieldGroup className="grid gap-3 sm:grid-cols-2">
           <Field>
             <div className="flex items-center justify-between gap-2">
-              <FieldLabel htmlFor="default-branch">
-                {tHardcodedUi.raw('appProjectsIdCustomizeSettingsPage.line270JsxTextDefaultBranch')}
-              </FieldLabel>
+              <FieldLabel htmlFor="default-branch">Default session branch</FieldLabel>
               {saving ? <SaveStatus /> : null}
             </div>
-            <Input
-              id="default-branch"
+            <Select
               value={defaultBranch}
-              onChange={(e) => setDefaultBranch(e.target.value)}
+              onValueChange={setDefaultBranch}
               disabled={!canManage || isPending}
-              className="font-mono text-xs"
-              variant="popover"
-            />
+            >
+              <SelectTrigger id="default-branch" className="font-mono text-xs" variant="popover">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {branchNames.map((branch) => (
+                  <SelectItem key={branch} value={branch} className="font-mono text-xs">
+                    {branch}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldDescription>
+              New sessions fork from this branch unless a group or one-session override applies.
+            </FieldDescription>
           </Field>
           <Field>
             <FieldLabel htmlFor="manifest-path">

--- a/apps/web/src/features/workspace/project-layout/new-session-create.test.ts
+++ b/apps/web/src/features/workspace/project-layout/new-session-create.test.ts
@@ -14,8 +14,18 @@ describe('buildNewSessionCreateInput', () => {
 
   it('carries the sandbox slug through alongside the agent', () => {
     expect(
-      buildNewSessionCreateInput({ agent: 'builder', sandbox_slug: 'node22' }),
-    ).toEqual({ agent_name: 'builder', sandbox_slug: 'node22' });
+      buildNewSessionCreateInput({
+        agent: 'builder',
+        sandbox_slug: 'node22',
+        base_ref: 'staging',
+      }),
+    ).toEqual({ agent_name: 'builder', sandbox_slug: 'node22', base_ref: 'staging' });
+  });
+
+  it('carries a one-session branch override without requiring another override', () => {
+    expect(buildNewSessionCreateInput({ base_ref: 'feature/shadcn' })).toEqual({
+      base_ref: 'feature/shadcn',
+    });
   });
 
   it('binds only the sandbox slug when no agent is picked', () => {

--- a/apps/web/src/features/workspace/project-layout/new-session-create.ts
+++ b/apps/web/src/features/workspace/project-layout/new-session-create.ts
@@ -3,6 +3,7 @@ import type { ComposerOptions } from '@/features/session/composer-chat-input';
 export interface NewSessionCreateInput {
   sandbox_slug?: string;
   agent_name?: string;
+  base_ref?: string;
 }
 
 /**
@@ -22,10 +23,11 @@ export interface NewSessionCreateInput {
  * no agent was picked), so callers can omit the create overrides entirely.
  */
 export function buildNewSessionCreateInput(
-  options: Pick<ComposerOptions, 'agent'> & { sandbox_slug?: string } = {},
+  options: Pick<ComposerOptions, 'agent'> & { sandbox_slug?: string; base_ref?: string } = {},
 ): NewSessionCreateInput | undefined {
   const input: NewSessionCreateInput = {};
   if (options.sandbox_slug) input.sandbox_slug = options.sandbox_slug;
   if (options.agent) input.agent_name = options.agent;
+  if (options.base_ref) input.base_ref = options.base_ref;
   return Object.keys(input).length > 0 ? input : undefined;
 }

--- a/apps/web/src/features/workspace/project-layout/project-home.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-home.tsx
@@ -2,7 +2,15 @@
 
 import { Icon as IconMynauiType, SparklesSolid, UsersGroupSolid } from '@mynaui/icons-react';
 import { useQuery } from '@tanstack/react-query';
-import { Bell, CalendarClock, Container, FileCode, Package, type LucideIcon } from 'lucide-react';
+import {
+  Bell,
+  CalendarClock,
+  Container,
+  FileCode,
+  GitBranch,
+  Package,
+  type LucideIcon,
+} from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import type { IconType } from 'react-icons/lib';
@@ -33,6 +41,7 @@ import {
   listConnectors,
   listProjectAccess,
   listProjectAccessRequests,
+  listProjectBranches,
   listProjectSandboxes,
   listProjectTriggers,
   type SandboxTemplate,
@@ -44,6 +53,7 @@ const Q = { staleTime: 60_000, refetchOnWindowFocus: false } as const;
 
 export interface ProjectHomeSendOptions extends ComposerOptions {
   sandbox_slug?: string;
+  base_ref?: string;
 }
 
 export function ProjectHome({
@@ -62,6 +72,7 @@ export function ProjectHome({
   const tI18nHardcoded = useTranslations('hardcodedUi');
 
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [selectedBaseRef, setSelectedBaseRef] = useState<string | null>(null);
   const [prefill, setPrefill] = useState<{ text: string; id: number } | null>(null);
 
   const sandboxesQuery = useQuery({
@@ -74,6 +85,13 @@ export function ProjectHome({
   const activeSlug = selectedSlug ?? defaultSlug;
 
   const showSandboxPicker = sandboxItems.length >= 1;
+  const branchesQuery = useQuery({
+    queryKey: ['project-branches', projectId],
+    queryFn: () => listProjectBranches(projectId),
+    ...Q,
+  });
+  const effectiveBaseRef = branchesQuery.data?.session_default_ref ?? null;
+  const activeBaseRef = selectedBaseRef ?? effectiveBaseRef;
   const openCustomize = useCustomizeStore((s) => s.openCustomize);
   const accessRequests = useQuery({
     queryKey: ['project-access-requests', projectId],
@@ -97,9 +115,12 @@ export function ProjectHome({
       onSend(text, files, {
         ...options,
         sandbox_slug: activeSlug,
+        // null means "inherit the server's current group/project default".
+        // Only a deliberate picker choice becomes a per-session override.
+        base_ref: selectedBaseRef ?? undefined,
       });
     },
-    [activeSlug, onSend],
+    [activeSlug, selectedBaseRef, onSend],
   );
 
   const handleCommand = useCallback(
@@ -171,18 +192,103 @@ export function ProjectHome({
             )}
             prefill={prefill}
             toolbarSlot={
-              showSandboxPicker ? (
-                <SandboxPicker
-                  items={sandboxItems}
-                  activeSlug={activeSlug}
-                  onSelect={setSelectedSlug}
-                />
+              showSandboxPicker || activeBaseRef ? (
+                <div className="flex items-center gap-1">
+                  {activeBaseRef ? (
+                    <BranchPicker
+                      response={branchesQuery.data}
+                      activeRef={activeBaseRef}
+                      overridden={selectedBaseRef !== null}
+                      onSelect={(ref) => setSelectedBaseRef(ref === effectiveBaseRef ? null : ref)}
+                    />
+                  ) : null}
+                  {showSandboxPicker ? (
+                    <SandboxPicker
+                      items={sandboxItems}
+                      activeSlug={activeSlug}
+                      onSelect={setSelectedSlug}
+                    />
+                  ) : null}
+                </div>
               ) : null
             }
           />
         }
       />
     </div>
+  );
+}
+
+function BranchPicker({
+  response,
+  activeRef,
+  overridden,
+  onSelect,
+}: {
+  response: Awaited<ReturnType<typeof listProjectBranches>> | undefined;
+  activeRef: string;
+  overridden: boolean;
+  onSelect: (ref: string) => void;
+}) {
+  const branchNames = Array.from(
+    new Set(
+      [
+        response?.session_default_ref,
+        response?.default_branch,
+        ...(response?.branches.map((branch) => branch.name) ?? []),
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  );
+  const defaultSource =
+    response?.session_default_source === 'group' ? 'Group default' : 'Project default';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Session branch: ${activeRef}`}
+          className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex h-8 max-w-44 cursor-pointer items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-colors duration-200 active:scale-[0.96]"
+        >
+          <GitBranch className="size-3.5 shrink-0" />
+          <span className="truncate font-mono">{activeRef}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-80">
+        <DropdownMenuLabel>Session branch</DropdownMenuLabel>
+        <p className="text-muted-foreground px-2 pb-2 text-xs text-pretty">
+          Fork this session from an environment branch. Its work still lands on a separate session
+          branch.
+        </p>
+        {response?.session_default_conflict ? (
+          <p className="text-kortix-orange px-2 pb-2 text-xs text-pretty">
+            Your groups specify different defaults (
+            {(response.conflicting_group_refs ?? []).join(', ')}), so the project default applies.
+          </p>
+        ) : null}
+        <DropdownMenuSeparator />
+        {branchNames.map((ref) => {
+          const isSelected = ref === activeRef;
+          const isEffectiveDefault = ref === response?.session_default_ref;
+          return (
+            <DropdownMenuItem key={ref} onSelect={() => onSelect(ref)} className="gap-2">
+              <GitBranch className="text-muted-foreground size-4 shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-mono text-sm">{ref}</div>
+                {isEffectiveDefault ? (
+                  <div className="text-muted-foreground text-xs">{defaultSource}</div>
+                ) : null}
+              </div>
+              {isSelected ? (
+                <Badge variant="outline" size="xs">
+                  {overridden ? 'this session' : 'default'}
+                </Badge>
+              ) : null}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -51,7 +51,7 @@ export function useNewProjectSession(projectId: string | undefined) {
       // match the agent the composer sends on the first prompt — the API proxy
       // rejects any prompt whose `agent` differs from the session's bound agent
       // with 409 AGENT_SWITCH_REQUIRES_NEW_SESSION (sessions are agent-immutable).
-      create?: { sandbox_slug?: string; agent_name?: string };
+      create?: { sandbox_slug?: string; agent_name?: string; base_ref?: string };
     }) => {
       if (!projectId || creatingRef.current) {
         opts?.onError?.();

--- a/packages/db/migrations/20260713130000000_project_group_default_base_ref.sql
+++ b/packages/db/migrations/20260713130000000_project_group_default_base_ref.sql
@@ -1,0 +1,7 @@
+-- Let an attached project group choose the base Git ref inherited by sessions
+-- its members start. NULL preserves the project's default_branch behavior.
+-- If a member belongs to groups with different non-null refs, application code
+-- deterministically falls back to projects.default_branch.
+
+ALTER TABLE kortix.project_group_grants
+  ADD COLUMN IF NOT EXISTS default_base_ref text;

--- a/packages/db/src/schema/kortix.test.ts
+++ b/packages/db/src/schema/kortix.test.ts
@@ -22,6 +22,7 @@ import {
   accountMembers,
   projects,
   projectMembers,
+  projectGroupGrants,
   projectGitConnections,
   sandboxes,
   sandboxMembers,
@@ -275,6 +276,16 @@ describe('project_members table', () => {
       (i) => i.config.name === 'idx_project_members_project_user',
     );
     expect(unique?.config.unique).toBe(true);
+  });
+});
+
+describe('project_group_grants table', () => {
+  test('stores an optional default base ref for sessions started by group members', () => {
+    const col = getTableConfig(projectGroupGrants).columns.find(
+      (column) => column.name === 'default_base_ref',
+    );
+    expect(col).toBeDefined();
+    expect(col?.notNull).toBe(false);
   });
 });
 

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -2782,6 +2782,10 @@ export const projectGroupGrants = kortixSchema.table(
       .notNull()
       .references(() => accounts.accountId, { onDelete: 'cascade' }),
     role: projectRoleEnum('role').default('member').notNull(),
+    /** Optional session-base override for members of this attached group.
+     *  NULL inherits projects.default_branch. Conflicting defaults from
+     *  multiple memberships intentionally fall back to the project default. */
+    defaultBaseRef: text('default_base_ref'),
     grantedBy: uuid('granted_by'),
     /** Optional auto-revoke timestamp. NULL = permanent attachment.
      *  Same semantics as project_members.expires_at. */

--- a/packages/sdk/API-MAP.md
+++ b/packages/sdk/API-MAP.md
@@ -138,7 +138,7 @@ Client fns in SDK (`git-history.ts`, `change-requests.ts`), **hooks partial** (`
 | op | REST |
 |---|---|
 | commits / commit / diff | `GET /v1/projects/:id/commits[/:sha][/diff]` |
-| branches | `GET /v1/projects/:id/branches` |
+| branches + effective session base ref | `GET /v1/projects/:id/branches` |
 | file history / version-diff | `GET /v1/projects/:id/files/history`, `/version-diff` |
 | change-requests CRUD | `GET/POST/PUT /v1/projects/:id/change-requests[/:cr]` |
 | merge / merge-preview / close / reopen | `POST .../change-requests/:cr/{merge,close,reopen}`, `GET .../merge-preview` |

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,11 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Added
+
+- Project branch responses now expose the current caller's effective session
+  base ref (project or group default), and group-grant mutations can set or
+  clear an optional `default_base_ref`. Existing fields and call signatures
+  remain compatible.
 - The root entry `@kortix/sdk` is now canonical: it exports the whole
   framework-free surface (client, session, turns, files, event stream, errors).
 - CDN builds: a minified ESM bundle (`dist/kortix.esm.min.js`) and an IIFE
@@ -16,6 +21,7 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `@kortix/sdk/internal/*` for the zustand stores. Not covered by semver.
 
 ### Deprecated
+
 - The 20 legacy subpaths (`/projects-client`, `/turns`, `/files`, `/session`,
   `/event-stream`, the stores, …). They still work. Import from the root.
 - `KortixProject` **as exported from `@kortix/sdk/opencode-client`** — renamed to
@@ -23,10 +29,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   unchanged and keeps its name.
 
 ### Fixed
+
 - `getPlatformUrl()` no longer reads a bare `process.env`, which threw a
   `ReferenceError` in a browser `<script>` bundle and on React Native.
 
 ### Internal
+
 - `src/` is now tiered: `core/` (isomorphic), `browser/`, `node/`, `react/`.
   A file's directory declares what it may import, enforced by the tripwire.
 - A bare-global tripwire (`process`/`window`/`document`/`localStorage`/
@@ -86,7 +94,7 @@ domains promoted into the facade.
     `tierConfigurations` (read-only entitlement/usage surface), plus a curated
     mutation surface: `billing.checkout.{createSession, confirmSession}`,
     `billing.subscription.{createPortalSession, cancel, reactivate,
-    scheduleDowngrade, cancelScheduledChange, prorationPreview}`,
+scheduleDowngrade, cancelScheduledChange, prorationPreview}`,
     `billing.credits.{purchase, autoTopupSettings, configureAutoTopup}`.
   - `project(id).marketplace` / `.registry` — install/list/updates/update/
     updateAll/remove for a catalog item on a project's default branch.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -530,3 +530,32 @@ full SDK typecheck, test, and packed-install smoke gates are required before thi
 claim is closed.
 
 **Status:** IN PROGRESS.
+
+---
+
+### 2026-07-13 — session `session-base-branches` (completion)
+
+Completed the additive session branch-environment surface in implementation
+commit `0843d870c`: `ProjectBranchesResponse` now reports the caller's effective
+session default and group-conflict metadata, while project group grants accept
+an optional nullable `default_base_ref`. Existing names and required fields are
+unchanged; compatibility with older servers is preserved through optional
+response fields.
+
+**TDD/regression evidence:** the focused cross-package run passed **103 tests / 0
+failures** across the SDK access client, API branch resolver, DB schema, and web
+session-create input. The real isolated API then proved: attached group default
+`staging` -> persisted session `base_ref: staging`; explicit `dev` -> persisted
+`base_ref: dev`; conflicting `dev`/`staging` group defaults -> project `dev` with
+`session_default_conflict: true`; PATCH `default_base_ref: null` -> effective
+default returned to `staging`. Both sessions retained their generated UUID as
+`branch_name`.
+
+**Final SDK gates:** `pnpm --filter @kortix/sdk typecheck` exited 0;
+`pnpm --filter @kortix/sdk test` reported **1077 pass / 2 skip / 0 fail** across
+72 files with 4955 assertions; `pnpm --filter @kortix/sdk run smoke:install`
+packed, installed, imported, and constructed `@kortix/sdk` successfully.
+
+**Shippable to production: YES** for the SDK surface. The two skipped tests are
+the existing browser-bundle tests that only execute after `build:bundles`; this
+change does not touch bundles or runtime transport.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -517,3 +517,16 @@ gateway credentials were revoked and the Codex-secret mutation was restored.
 **Shippable to production: YES** — SDK public behavior is regression-locked;
 the wider gateway change still follows its normal PR, deploy-dev, and live-dev
 verification lifecycle.
+
+---
+
+### 2026-07-13 — session `session-base-branches` (claim)
+
+Claimed the user-directed additive branch-environment work: preserve the existing
+per-session `base_ref` API, expose effective project/group branch defaults through
+the typed project Git surface, and extend group-grant mutations without renaming or
+removing public SDK symbols. TDD will be RED-watched before implementation; the
+full SDK typecheck, test, and packed-install smoke gates are required before this
+claim is closed.
+
+**Status:** IN PROGRESS.

--- a/packages/sdk/src/core/rest/projects-client/access.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/access.test.ts
@@ -245,6 +245,12 @@ test('attachGroupToProject sends a real expires_at string when given', async () 
   expect(last().body).toEqual({ group_id: 'g1', role: 'member', expires_at: '2026-12-31T00:00:00Z' });
 });
 
+test('attachGroupToProject sends an optional default_base_ref for group session defaults', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'member' } };
+  await attachGroupToProject('P1', 'g1', 'member', undefined, 'staging');
+  expect(last().body).toEqual({ group_id: 'g1', role: 'member', default_base_ref: 'staging' });
+});
+
 test('updateProjectGroupGrant PATCHes with { role } only when expiresAt is undefined', async () => {
   nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'editor' } };
   await updateProjectGroupGrant('P1', 'g1', 'editor');
@@ -263,6 +269,18 @@ test('updateProjectGroupGrant PATCHes with a real expires_at string when given',
   nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'editor' } };
   await updateProjectGroupGrant('P1', 'g1', 'editor', '2026-12-31T00:00:00Z');
   expect(last().body).toEqual({ role: 'editor', expires_at: '2026-12-31T00:00:00Z' });
+});
+
+test('updateProjectGroupGrant PATCHes a group session default without changing expiry', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'editor' } };
+  await updateProjectGroupGrant('P1', 'g1', 'editor', undefined, 'dev');
+  expect(last().body).toEqual({ role: 'editor', default_base_ref: 'dev' });
+});
+
+test('updateProjectGroupGrant can clear a group session default explicitly', async () => {
+  nextResponse = { status: 200, body: { project_id: 'P1', group_id: 'g1', role: 'editor' } };
+  await updateProjectGroupGrant('P1', 'g1', 'editor', undefined, null);
+  expect(last().body).toEqual({ role: 'editor', default_base_ref: null });
 });
 
 test('detachGroupFromProject DELETEs /group-grants/:groupId', async () => {

--- a/packages/sdk/src/core/rest/projects-client/access.ts
+++ b/packages/sdk/src/core/rest/projects-client/access.ts
@@ -229,6 +229,8 @@ export interface ProjectGroupGrant {
   group_id: string;
   group_name: string;
   role: ProjectRole;
+  /** Optional branch new sessions from this group fork from. null = project default. */
+  default_base_ref?: string | null;
   granted_by: string | null;
   created_at: string;
   /** Auto-revoke timestamp (ISO). null = permanent. */
@@ -253,14 +255,15 @@ export async function attachGroupToProject(
   groupId: string,
   role: ProjectRole,
   expiresAt?: string | null,
+  defaultBaseRef?: string | null,
 ) {
+  const body: Record<string, unknown> = { group_id: groupId, role };
+  if (expiresAt !== undefined) body.expires_at = expiresAt;
+  if (defaultBaseRef !== undefined) body.default_base_ref = defaultBaseRef;
   return unwrap(
     await backendApi.post<{ project_id: string; group_id: string; role: ProjectRole }>(
       `/projects/${projectId}/group-grants`,
-      // undefined = field omitted (don't touch); null = clear expiry.
-      expiresAt === undefined
-        ? { group_id: groupId, role }
-        : { group_id: groupId, role, expires_at: expiresAt },
+      body,
     ),
   );
 }
@@ -270,11 +273,15 @@ export async function updateProjectGroupGrant(
   groupId: string,
   role: ProjectRole,
   expiresAt?: string | null,
+  defaultBaseRef?: string | null,
 ) {
+  const body: Record<string, unknown> = { role };
+  if (expiresAt !== undefined) body.expires_at = expiresAt;
+  if (defaultBaseRef !== undefined) body.default_base_ref = defaultBaseRef;
   return unwrap(
     await backendApi.patch<{ project_id: string; group_id: string; role: ProjectRole }>(
       `/projects/${projectId}/group-grants/${groupId}`,
-      expiresAt === undefined ? { role } : { role, expires_at: expiresAt },
+      body,
     ),
   );
 }

--- a/packages/sdk/src/core/rest/projects-client/git-history.ts
+++ b/packages/sdk/src/core/rest/projects-client/git-history.ts
@@ -22,6 +22,13 @@ export interface ProjectBranch {
 
 export interface ProjectBranchesResponse {
   default_branch: string;
+  /** Effective branch for a new session started by the current caller. */
+  session_default_ref?: string;
+  session_default_source?: 'project' | 'group';
+  session_default_groups?: Array<{ group_id: string; group_name: string }>;
+  /** True when multiple group defaults disagreed and the project default won. */
+  session_default_conflict?: boolean;
+  conflicting_group_refs?: string[];
   branches: ProjectBranch[];
 }
 

--- a/tests/spec/end-to-end.md
+++ b/tests/spec/end-to-end.md
@@ -193,7 +193,7 @@ DB `projects` (`status active|archived`, unique `(account_id, repo_url)`). Soft 
 
 DB `project_sessions` (`status queued|branching|provisioning|running|stopped|failed|completed`, unique `(project_id, branch_name)`). Branch name = `session_id`.
 
-`SESS-1` `POST /projects/:id/sessions {agent_name?,initial_prompt?,base_ref?,provider?,name?,session_id?,branch_already_created?,runtime_context?}` → `session` (any project member, **M_VIEWER included** — viewer is the base usable role) → 201 status `provisioning` (fire-and-forget sandbox). `runtime_context` is an optional non-secret scalar map (max 64 entries / 16 KiB UTF-8 JSON; lower-case semantic keys only; no credential-like keys); it is stored outside user-editable session metadata and restored into every replacement runtime as the single server-owned `KORTIX_SESSION_CONTEXT` JSON variable. Nested/oversize/reserved/credential-shaped input → 400 before session persistence or provisioning; raw env/MCP fields are unknown and rejected. MEMBER with no project grant / NONMEMBER → 403. (An invalid `provider` for an allowed caller → 400, proving the role gate passed before provider validation.)
+`SESS-1` `POST /projects/:id/sessions {agent_name?,initial_prompt?,base_ref?,provider?,name?,session_id?,branch_already_created?,runtime_context?}` → `session` (any project member, **M_VIEWER included** — viewer is the base usable role) → 201 status `provisioning` (fire-and-forget sandbox). Base-ref precedence for human UI/mobile/CLI starts is explicit `base_ref` → one agreed non-expired attached-group `default_base_ref` → project `default_branch`; conflicting group defaults deterministically fall back to the project default. Automation/system starts ignore group defaults unless they pass an explicit `base_ref`. `runtime_context` is an optional non-secret scalar map (max 64 entries / 16 KiB UTF-8 JSON; lower-case semantic keys only; no credential-like keys); it is stored outside user-editable session metadata and restored into every replacement runtime as the single server-owned `KORTIX_SESSION_CONTEXT` JSON variable. Nested/oversize/reserved/credential-shaped input → 400 before session persistence or provisioning; raw env/MCP fields are unknown and rejected. MEMBER with no project grant / NONMEMBER → 403. (An invalid `provider` for an allowed caller → 400, proving the role gate passed before provider validation.)
 `SESS-2` concurrency cap — Nth session over tier cap → **429** + `X-RateLimit-Limit/-Remaining` headers.
 `SESS-3` CLI client-branch optimization — `kortix sessions new`: if server can't self-create branch (not managed-freestyle, not GitHub app/pat) AND local `origin` == `project.repo_url`, CLI mints uuid, `git push origin HEAD:refs/heads/<uuid>`, then posts `session_id`+`branch_already_created:true`+`base_ref`.
 `SESS-4` `GET /projects/:id/sessions` → `read` → list (updatedAt desc).
@@ -246,7 +246,7 @@ Repo files are read-only over the project API; live edits happen in the sandbox 
 `FILE-3` `GET /projects/:id/files/search?q=&content=1&ref=&limit=` → filename + grep.
 `FILE-4` `GET /projects/:id/files/history?path=` → commit history for path.
 `FILE-5` `GET /projects/:id/files/archive?path=&ref=` → zip stream.
-`FILE-6` `GET /projects/:id/branches` → branches.
+`FILE-6` `GET /projects/:id/branches` → branches plus the caller's effective `session_default_ref`, source/group metadata, and conflict fallback signal.
 `FILE-7` `GET /projects/:id/commits?ref=&path=` · `GET …/commits/:sha` · `GET …/commits/:sha/diff`.
 `FILE-8` `GET /projects/:id/version-diff?from=|head=&into=|base=` → diff between two refs (params are `from`/`head` and `into`/`base` — there is **no `to`**).
 `FILE-9` live file CRUD inside sandbox → through proxy to OpenCode file API on `:8000` (create/read/update/delete/list). Durable truth = git repo; sandbox tree is ephemeral.
@@ -643,7 +643,7 @@ Scale: ~500 exported symbols / ~520 route handlers in `apps/api/src` — a tract
 `SBX-3` `GET /projects/:id/sandboxes` · `/sandbox-health` · `/sandbox-templates` → 200.
 `SBX-4` `POST /sandbox-templates` → 201; bad → 400; reserved/dup → 409; `PATCH/DELETE/build /:templateId`; unknown → 404.
 `PACC-5` `POST /projects/:id/access/invite` → 201 pending; `GET/POST resend/DELETE pending-invites[/:id]` → manage; missing email → 400; unknown → 404.
-`PACC-6` `GET/POST /projects/:id/group-grants` · `PATCH/DELETE /:groupId` → manage; missing group_id → 400; unknown → 404.
+`PACC-6` `GET/POST /projects/:id/group-grants` · `PATCH/DELETE /:groupId` → manage; POST/PATCH accepts optional nullable `default_base_ref` for that group's human-launched session default; missing group_id → 400; unknown → 404.
 `BILL-10` per-seat: `POST /billing/sync-seat-quantity` · `claim-per-seat` → no-op/skipped on non-legacy.
 `AUTH-1` `POST /v1/auth/logout` → OWNER 200/204; ANON 200/401.
 `BILL-11` `GET /billing/checkout-session/:sessionId` · `POST /billing/confirm-checkout-session` → unknown/missing → 4xx.


### PR DESCRIPTION
## What changed

- resolve session base refs from explicit override, agreed group default, or project default
- expose project and group branch defaults through the API and additive SDK types
- add branch selectors to project Settings, group grants, and the home composer
- add the project_group_grants.default_base_ref migration and contract docs

## Verification

- focused API/DB/SDK/web regressions: 103 pass, 0 fail
- SDK: typecheck; 1077 pass, 2 skip, 0 fail; packed install smoke passed
- API + DB typechecks passed; 48 migrations linted
- touched frontend ESLint: 0 errors (1 pre-existing unrelated hook warning)
- isolated Supabase migration applied; real API precedence, conflict fallback, null clear, and session persistence proved

## UI verification

The local app compiled and touched files lint/typechecked cleanly. The in-app browser backend was unavailable in this agent session, so interactive DOM/network assertions remain to be completed on dev after deployment.