### PR TITLE
fix(web/channels): stop the channels table overflowing its card

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/channels-view.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/channels-view.test.ts
@@ -109,3 +109,15 @@ describe('Channels view — Microsoft Teams is a uniform channel row', () => {
     expect(teamsPanelSource).not.toContain('DisconnectedPanel');
   });
 });
+
+describe('Channels view — the table must not overflow its card', () => {
+  test('workspace values truncate (a long tenant id / workspace must not stretch the table)', () => {
+    expect(channelsSource).toMatch(/max-w-\[240px\] truncate/);
+    expect((channelsSource.match(/max-w-\[240px\] truncate/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('the actions column hugs its content instead of a fixed width that clips the buttons', () => {
+    expect(channelsSource).toContain('w-[1%] whitespace-nowrap text-right');
+    expect(channelsSource).not.toContain('<TableHead className="w-[120px]">');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/channels-view.tsx
@@ -176,7 +176,7 @@ export function ChannelsView({ projectId }: { projectId: string | null }) {
                   <TableHead>Platform</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Workspace</TableHead>
-                  <TableHead className="w-[120px]">
+                  <TableHead className="w-[1%] whitespace-nowrap text-right">
                     <span className="sr-only">Actions</span>
                   </TableHead>
                 </TableRow>
@@ -523,7 +523,12 @@ function SlackChannelRow({
         )}
       </TableCell>
       <TableCell className="text-muted-foreground text-sm">
-        {connected ? (installation?.workspaceName ?? installation?.workspaceId ?? '—') : '—'}
+        <span
+          className="block max-w-[240px] truncate"
+          title={connected ? (installation?.workspaceName ?? installation?.workspaceId ?? undefined) : undefined}
+        >
+          {connected ? (installation?.workspaceName ?? installation?.workspaceId ?? '—') : '—'}
+        </span>
       </TableCell>
       <TableCell>
         {!canWrite ? null : connected ? (
@@ -603,7 +608,12 @@ function TeamsChannelRow({ projectId, canWrite }: { projectId: string; canWrite:
         )}
       </TableCell>
       <TableCell className="text-muted-foreground text-sm">
-        {connected ? (install?.teamName ?? install?.tenantId ?? '—') : '—'}
+        <span
+          className="block max-w-[240px] truncate"
+          title={connected ? (install?.teamName ?? install?.tenantId ?? undefined) : undefined}
+        >
+          {connected ? (install?.teamName ?? install?.tenantId ?? '—') : '—'}
+        </span>
       </TableCell>
       <TableCell>
         {!canWrite ? null : connected ? (
@@ -697,7 +707,12 @@ function EmailChannelRow({
         </TableCell>
         <TableCell className="text-muted-foreground text-sm">
           {connected ? (
-            <code className="text-foreground font-mono text-xs">{installation?.email ?? '—'}</code>
+            <code
+              className="text-foreground block max-w-[240px] truncate font-mono text-xs"
+              title={installation?.email ?? undefined}
+            >
+              {installation?.email ?? '—'}
+            </code>
           ) : (
             '—'
           )}


### PR DESCRIPTION
## Bug

On the Channels settings, a connected Microsoft Teams row shows the tenant GUID (`435431f6-fc5c-4d3e-8d99-9ff939fec417`) in the Workspace column. That unbroken 36-char string inflated the column's minimum width, pushing the table past the card's right edge and **clipping the action buttons** (Slack "Install", Teams "Cancel/Disconnect"). The fixed-width `w-[120px]` Actions column also couldn't hold "Cancel + Disconnect".

## Fix

- Truncate the Slack / Teams / Email workspace cells (`max-w-[240px] truncate`, full value preserved in `title`) so a long value can't stretch the table.
- Let the Actions column hug its content (`w-[1%] whitespace-nowrap text-right`) instead of a fixed width that clips the buttons.

Result: everything stays inside the card; long identifiers ellipsize with a hover tooltip.

## Test

Extends `channels-view.test.ts` with a "table must not overflow its card" block asserting the workspace cells truncate and the actions column hugs content. `bun test` green (18/18); web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)