### PR TITLE
feat(self-host): add target-aware enterprise foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
               - 'apps/api/src/config.ts'
               - 'packages/db/**'
               - 'apps/cli/src/commands/self-host.ts'
+              - 'apps/cli/src/self-host/**'
               - 'apps/cli/scripts/self-host-e2e/**'
 
   api-typecheck:

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -65,9 +65,18 @@ or run `kortix ship` to create the cloud project and push in one step.
 
 ## Self-host
 
+One command surface manages two deployment targets. Docker is the backward-
+compatible default for local and smaller installations; `aws-vpc` is the
+enterprise target and records only AWS coordinates and release policy locally.
+Secrets for AWS deployments are written directly to the customer account.
+
+### Docker
+
 ```sh
 pnpm install
 ./bin/kortix --help
+./bin/kortix self-host init --target docker
+./bin/kortix self-host plan
 ./bin/kortix self-host start
 ./bin/kortix self-host configure
 ./bin/kortix self-host env set PUBLIC_URL=https://kortix.example.com API_PUBLIC_URL=https://api.example.com
@@ -79,3 +88,33 @@ pnpm install
 `self-host start` creates the config when needed and only asks for product
 integrations: Freestyle, GitHub, and Pipedream. Run `self-host configure` later
 to change those credentials.
+
+The generated Docker distribution embeds a pinned copy of the official full
+Supabase stack: PostgreSQL 17, Auth, REST, Realtime, Storage, imgproxy, Meta,
+Edge Runtime, Kong, Studio, Supavisor, Logflare, and Vector. Published ports
+bind to loopback by default, and all generated secret material is stored in the
+owner-only instance `.env`.
+
+### Enterprise AWS VPC
+
+```sh
+export AWS_PROFILE=customer
+
+./bin/kortix self-host init \
+  --target aws-vpc \
+  --instance customer \
+  --region us-west-2 \
+  --channel stable \
+  --yes
+
+./bin/kortix self-host doctor --instance customer
+./bin/kortix self-host plan --instance customer
+./bin/kortix self-host deploy --instance customer
+./bin/kortix self-host status --instance customer
+./bin/kortix self-host reconcile --instance customer --channel stable
+```
+
+For AWS, the CLI is the bootstrap and operator remote control. The customer-
+owned updater, scheduler, EKS controllers, and recovery automation continue
+operating after the CLI exits. `start`, `stop`, and direct environment-file
+editing are intentionally Docker-only.

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -1,5 +1,4 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { randomBytes, createHmac } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
@@ -10,6 +9,16 @@ import { takeFlagBool, takeFlagValue } from '../command-helpers.ts';
 import { getHost, upsertHost, type Host } from '../api/config.ts';
 import { prompt, selectFrom } from '../prompts.ts';
 import { C, help, status } from '../style.ts';
+import { runAwsVpcCommand } from '../self-host/aws-vpc.ts';
+import {
+  instanceDir as targetInstanceDir,
+  loadInstanceConfig,
+  parseSelfHostTarget,
+  resolveInstanceTarget,
+  writeInstanceConfig,
+} from '../self-host/config.ts';
+import type { SelfHostCommandFlags } from '../self-host/types.ts';
+import { renderFullDockerCompose, writeSupabaseVendorAssets } from '../self-host/compose-assets.ts';
 
 const DEFAULT_INSTANCE = 'default';
 const DEFAULT_TAG = 'latest';
@@ -24,34 +33,50 @@ const LOCAL_SOURCE_TAG = 'selfhost-local';
 
 const HELP = help`Usage: kortix self-host <subcommand> [options]
 
-Run your own Kortix Cloud locally or on your infrastructure using the
-published Docker images from Docker Hub.
+Run Kortix locally with Docker or deploy a production enterprise stack into
+an AWS VPC. Existing Docker instances remain fully compatible.
 
 Subcommands:
-  init                 Create self-host config with production defaults.
+  init                 Create Docker or AWS VPC instance config.
+  configure            Configure target integrations and secrets.
+  plan                 Preview target changes without applying them.
+  deploy               Bootstrap or converge the selected target.
   start                Pull images and start your self-hosted Kortix.
-  update [--tag <v>]   Pull a newer version, apply migrations, recreate (default: latest).
+  update               Apply a selected Docker tag or signed AWS release.
+  reconcile            Check and converge to the configured release channel.
+  rollback             Roll back to a compatible signed release.
   version              Show the running version and image tags.
   stop                 Stop the stack.
   restart              Restart the stack.
-  status               Show Docker Compose service status.
+  status               Show target health and deployment status.
+  doctor               Validate local tools, credentials, and target access.
   logs [service]       Tail logs.
-  open                 Open the local dashboard.
-  configure            Guided config (sandbox provider, Freestyle, GitHub, Pipedream).
+  open                 Open the target dashboard.
   env ls              Show persistent environment values.
   env set KEY=VALUE    Update persistent environment values.
 
 Options:
   --instance <name>    Instance name (default: ${DEFAULT_INSTANCE}).
+  --target <target>    docker or aws-vpc (default: docker for new instances).
   --tag <tag>          Docker image tag / version (default: ${DEFAULT_TAG}).
+  --release <version>  Immutable enterprise release (for example 0.9.84-e1).
+  --channel <name>     Release channel (AWS default: stable; Docker: latest).
+  --aws-profile <name> AWS CLI profile used to bootstrap/manage the target.
+  --region <region>    AWS region (default: AWS config, then us-west-2).
   --local              Use current-source local images instead of registry images.
   --registry           Force registry images even when running from a source checkout.
+  --force              Run now, bypassing only the configured maintenance window.
+  --json               Emit machine-readable output where supported.
   --yes                Accept defaults in non-interactive flows.
   -h, --help           Show this help.
 
 Examples:
   kortix self-host init
   kortix self-host start
+  kortix self-host init --target aws-vpc --instance customer --aws-profile customer --region us-west-2
+  kortix self-host plan --instance customer
+  kortix self-host deploy --instance customer
+  kortix self-host reconcile --instance customer --channel stable
   kortix self-host update                 # update to the latest published version
   kortix self-host update --tag 0.9.72    # pin to a specific version
   kortix self-host version
@@ -59,13 +84,7 @@ Examples:
   kortix hosts ls
 `;
 
-interface GlobalFlags {
-  instance: string;
-  tag: string;
-  yes: boolean;
-  local: boolean;
-  registry: boolean;
-}
+type GlobalFlags = SelfHostCommandFlags;
 
 interface SelfHostEnv {
   KORTIX_VERSION: string;
@@ -139,16 +158,36 @@ export async function runSelfHost(argv: string[]): Promise<number> {
     return 2;
   }
 
+  let target;
+  try {
+    target = resolveInstanceTarget(flags.instance, flags.target);
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n`);
+    return 2;
+  }
+
+  if (target === 'aws-vpc') {
+    return runAwsVpcCommand(sub, args, flags);
+  }
+
   switch (sub) {
     case 'init':
     case 'setup':
       return selfHostInit(flags);
+    case 'plan':
+      return selfHostDockerPlan(flags);
+    case 'deploy':
+      return selfHostStart(flags);
     case 'start':
     case 'up':
       return selfHostStart(flags);
     case 'update':
     case 'upgrade':
       return selfHostUpdate(flags);
+    case 'reconcile':
+      return selfHostUpdate(flags);
+    case 'rollback':
+      return selfHostDockerRollback(flags);
     case 'version':
       return selfHostVersion(flags);
     case 'stop':
@@ -159,6 +198,8 @@ export async function runSelfHost(argv: string[]): Promise<number> {
     case 'status':
     case 'ps':
       return composeCommand(flags, ['ps']);
+    case 'doctor':
+      return selfHostDockerDoctor(flags);
     case 'logs':
       return composeCommand(flags, ['logs', '-f', ...args]);
     case 'open':
@@ -178,15 +219,35 @@ function parseGlobalFlags(args: string[]): GlobalFlags {
   const yes = takeFlagBool(args, ['--yes', '-y']);
   const local = takeFlagBool(args, ['--local']);
   const registry = takeFlagBool(args, ['--registry']);
+  const json = takeFlagBool(args, ['--json']);
+  const force = takeFlagBool(args, ['--force']);
   const instance = takeFlagValue(args, ['--instance']) ?? DEFAULT_INSTANCE;
-  const tag = takeFlagValue(args, ['--tag', '--version']) ?? DEFAULT_TAG;
+  const release = takeFlagValue(args, ['--release']);
+  const tag = takeFlagValue(args, ['--tag', '--version']) ?? release ?? DEFAULT_TAG;
+  const target = parseSelfHostTarget(takeFlagValue(args, ['--target']));
+  const awsProfile = takeFlagValue(args, ['--aws-profile']);
+  const region = takeFlagValue(args, ['--region']);
+  const channel = takeFlagValue(args, ['--channel']);
   if (local && registry) {
     throw new Error('use either --local or --registry, not both');
   }
   if (!/^[a-zA-Z][a-zA-Z0-9._-]*$/.test(instance)) {
     throw new Error('instance must start with a letter and contain only letters, digits, dots, underscores, or dashes');
   }
-  return { instance, tag, yes, local, registry };
+  return {
+    instance,
+    tag,
+    release,
+    channel,
+    target,
+    awsProfile,
+    region,
+    yes,
+    local,
+    registry,
+    json,
+    force,
+  };
 }
 
 async function selfHostInit(flags: GlobalFlags): Promise<number> {
@@ -215,9 +276,15 @@ async function selfHostInit(flags: GlobalFlags): Promise<number> {
   }
 
   writeEnv(flags.instance, env);
-  writeDbInit(flags.instance, env);
-  writeKongConfig(flags.instance);
   writeCompose(flags.instance);
+  const existingConfig = loadInstanceConfig(flags.instance);
+  writeInstanceConfig({
+    schema_version: 1,
+    instance: flags.instance,
+    target: 'docker',
+    channel: flags.channel ?? existingConfig?.channel ?? 'latest',
+    ...(flags.release || existingConfig?.release ? { release: flags.release ?? existingConfig?.release } : {}),
+  });
   renderInitSummary(flags.instance, dir, env, existing !== null);
   return 0;
 }
@@ -254,8 +321,6 @@ async function selfHostStart(flags: GlobalFlags): Promise<number> {
   }
   const portChanges = await reconcilePorts(flags.instance, env);
   writeEnv(flags.instance, env);
-  writeDbInit(flags.instance, env);
-  writeKongConfig(flags.instance);
   writeCompose(flags.instance);
 
   process.stdout.write(`\n  ${C.bold}kortix self-host start${C.reset}\n`);
@@ -310,6 +375,82 @@ async function selfHostRestart(flags: GlobalFlags): Promise<number> {
   const down = composeCommand(flags, ['down']);
   if (down !== 0) return down;
   return selfHostStart(flags);
+}
+
+function selfHostDockerPlan(flags: GlobalFlags): number {
+  if (!existsSync(composePath(flags.instance)) || !existsSync(envPath(flags.instance))) {
+    process.stderr.write(`${status.err('Self-host is not initialized. Run `kortix self-host init` first.')}\n`);
+    return 1;
+  }
+  const code = compose(flags.instance, ['config', '--quiet']);
+  if (code !== 0) return code;
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify({
+      instance: flags.instance,
+      target: 'docker',
+      valid: true,
+      compose_file: composePath(flags.instance),
+    }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${status.ok(`Docker Compose plan is valid for ${flags.instance}`)}\n`);
+    process.stdout.write(`${C.dim}No changes were applied.${C.reset}\n`);
+  }
+  return 0;
+}
+
+function selfHostDockerRollback(flags: GlobalFlags): Promise<number> | number {
+  const release = flags.release ?? (flags.tag !== DEFAULT_TAG ? flags.tag : undefined);
+  if (!release) {
+    process.stderr.write(
+      `${status.err('Docker rollback requires an explicit --release <version> or --tag <version>.')}\n`,
+    );
+    return 2;
+  }
+  return selfHostUpdate({ ...flags, tag: release });
+}
+
+function selfHostDockerDoctor(flags: GlobalFlags): number {
+  const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
+  for (const [name, args] of [
+    ['docker', ['--version']],
+    ['docker-compose', ['compose', 'version']],
+  ] as const) {
+    const result = spawnSync('docker', args, { encoding: 'utf8' });
+    checks.push({
+      name,
+      ok: !result.error && result.status === 0,
+      detail: result.error?.message ?? (result.stdout || result.stderr).trim().split(/\r?\n/, 1)[0] ?? '',
+    });
+  }
+  if (existsSync(composePath(flags.instance)) && existsSync(envPath(flags.instance))) {
+    const result = spawnSync(
+      'docker',
+      [
+        'compose',
+        '--project-name', composeProject(flags.instance),
+        '--env-file', envPath(flags.instance),
+        '-f', composePath(flags.instance),
+        'config', '--quiet',
+      ],
+      { cwd: instanceDir(flags.instance), encoding: 'utf8' },
+    );
+    checks.push({
+      name: 'compose-config',
+      ok: !result.error && result.status === 0,
+      detail: result.error?.message ?? (result.stderr.trim() || 'valid'),
+    });
+  }
+  const ok = checks.every((check) => check.ok);
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify({ instance: flags.instance, target: 'docker', ok, checks }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`\n  ${C.bold}kortix self-host doctor${C.reset}\n\n`);
+    for (const check of checks) {
+      process.stdout.write(`${check.ok ? status.ok(check.name) : status.err(check.name)} ${C.dim}${check.detail}${C.reset}\n`);
+    }
+    process.stdout.write('\n');
+  }
+  return ok ? 0 : 1;
 }
 
 /**
@@ -485,8 +626,6 @@ function selfHostEnv(args: string[], flags: GlobalFlags): number {
       env[pair.slice(0, idx)] = pair.slice(idx + 1);
     }
     writeEnv(flags.instance, env);
-    writeDbInit(flags.instance, env);
-    writeKongConfig(flags.instance);
     writeCompose(flags.instance);
     process.stdout.write(`${status.ok('Updated self-host environment')}\n`);
     return 0;
@@ -503,8 +642,6 @@ async function selfHostConfigure(flags: GlobalFlags): Promise<number> {
   }
   await configureIntegrations(env);
   writeEnv(flags.instance, env);
-  writeDbInit(flags.instance, env);
-  writeKongConfig(flags.instance);
   writeCompose(flags.instance);
   process.stdout.write(`${status.ok('Updated self-host integration config')}\n`);
   renderIntegrationSummary(env);
@@ -748,6 +885,7 @@ async function reconcilePorts(instance: string, env: SelfHostEnv): Promise<strin
   await ensurePort(env, 'API_PORT', 'API_PUBLIC_URL', changes);
   await ensurePort(env, 'SUPABASE_PORT', 'SUPABASE_PUBLIC_URL', changes);
   await ensurePort(env, 'POSTGRES_PORT', undefined, changes);
+  await ensurePort(env, 'POOLER_PORT', undefined, changes);
 
   if (changes.length > 0) {
     writeEnv(instance, env);
@@ -757,7 +895,7 @@ async function reconcilePorts(instance: string, env: SelfHostEnv): Promise<strin
 
 async function ensurePort(
   env: SelfHostEnv,
-  portKey: 'FRONTEND_PORT' | 'API_PORT' | 'SUPABASE_PORT' | 'POSTGRES_PORT',
+  portKey: 'FRONTEND_PORT' | 'API_PORT' | 'SUPABASE_PORT' | 'POSTGRES_PORT' | 'POOLER_PORT',
   urlKey: 'PUBLIC_URL' | 'API_PUBLIC_URL' | 'SUPABASE_PUBLIC_URL' | undefined,
   changes: string[],
 ): Promise<void> {
@@ -842,6 +980,8 @@ function defaultEnv(flags: GlobalFlags): SelfHostEnv {
     API_PORT: '13738',
     SUPABASE_PORT: '13740',
     POSTGRES_PORT: '13741',
+    POOLER_PORT: '13742',
+    SUPABASE_POSTGRES_INTERNAL_PORT: '5432',
     FRONTEND_IMAGE: `${DEFAULT_FRONTEND_IMAGE_REPO}:${flags.tag}`,
     API_IMAGE: `${DEFAULT_API_IMAGE_REPO}:${flags.tag}`,
     GATEWAY_IMAGE: `${DEFAULT_GATEWAY_IMAGE_REPO}:${flags.tag}`,
@@ -854,6 +994,62 @@ function defaultEnv(flags: GlobalFlags): SelfHostEnv {
     SUPABASE_JWT_SECRET: jwtSecret,
     SUPABASE_ANON_KEY: supabaseJwt('anon', jwtSecret),
     SUPABASE_SERVICE_ROLE_KEY: supabaseJwt('service_role', jwtSecret),
+    JWT_SECRET: jwtSecret,
+    JWT_JWKS: '',
+    ANON_KEY: supabaseJwt('anon', jwtSecret),
+    SERVICE_ROLE_KEY: supabaseJwt('service_role', jwtSecret),
+    ANON_KEY_ASYMMETRIC: '',
+    SERVICE_ROLE_KEY_ASYMMETRIC: '',
+    SUPABASE_PUBLISHABLE_KEY: '',
+    SUPABASE_SECRET_KEY: '',
+    POSTGRES_HOST: 'supabase-db',
+    POSTGRES_DB: 'postgres',
+    JWT_EXPIRY: '3600',
+    API_EXTERNAL_URL: 'http://localhost:13740/auth/v1',
+    SITE_URL: DEFAULT_PUBLIC_URL,
+    ADDITIONAL_REDIRECT_URLS: '',
+    DISABLE_SIGNUP: 'false',
+    ENABLE_EMAIL_SIGNUP: 'true',
+    ENABLE_EMAIL_AUTOCONFIRM: 'true',
+    ENABLE_ANONYMOUS_USERS: 'false',
+    ENABLE_PHONE_SIGNUP: 'false',
+    ENABLE_PHONE_AUTOCONFIRM: 'false',
+    SMTP_ADMIN_EMAIL: 'admin@localhost',
+    SMTP_HOST: 'localhost',
+    SMTP_PORT: '587',
+    SMTP_USER: 'unused',
+    SMTP_PASS: 'unused',
+    SMTP_SENDER_NAME: 'Kortix',
+    MAILER_URLPATHS_INVITE: '/auth/v1/verify',
+    MAILER_URLPATHS_CONFIRMATION: '/auth/v1/verify',
+    MAILER_URLPATHS_RECOVERY: '/auth/v1/verify',
+    MAILER_URLPATHS_EMAIL_CHANGE: '/auth/v1/verify',
+    DASHBOARD_USERNAME: 'kortix',
+    DASHBOARD_PASSWORD: token(24),
+    SECRET_KEY_BASE: token(48),
+    REALTIME_DB_ENC_KEY: token(8),
+    VAULT_ENC_KEY: token(16),
+    PG_META_CRYPTO_KEY: token(24),
+    LOGFLARE_PUBLIC_ACCESS_TOKEN: token(24),
+    LOGFLARE_PRIVATE_ACCESS_TOKEN: token(24),
+    S3_PROTOCOL_ACCESS_KEY_ID: token(16),
+    S3_PROTOCOL_ACCESS_KEY_SECRET: token(32),
+    PGRST_DB_SCHEMAS: 'public',
+    PGRST_DB_MAX_ROWS: '1000',
+    PGRST_DB_EXTRA_SEARCH_PATH: 'public',
+    POOLER_TENANT_ID: composeProject(flags.instance),
+    POOLER_DEFAULT_POOL_SIZE: '20',
+    POOLER_MAX_CLIENT_CONN: '100',
+    POOLER_DB_POOL_SIZE: '5',
+    STUDIO_DEFAULT_ORGANIZATION: 'Kortix',
+    STUDIO_DEFAULT_PROJECT: flags.instance,
+    OPENAI_API_KEY: '',
+    FUNCTIONS_VERIFY_JWT: 'false',
+    GLOBAL_S3_BUCKET: 'kortix-storage',
+    STORAGE_TENANT_ID: composeProject(flags.instance),
+    REGION: 'local',
+    IMGPROXY_AUTO_WEBP: 'true',
+    DOCKER_SOCKET_LOCATION: '/var/run/docker.sock',
     INTERNAL_SERVICE_KEY: token(32),
     API_KEY_SECRET: token(32),
     TUNNEL_SIGNING_SECRET: token(32),
@@ -885,353 +1081,14 @@ function defaultEnv(flags: GlobalFlags): SelfHostEnv {
 }
 
 function writeCompose(instance: string): void {
-  const project = composeProject(instance);
-  const text = `services:
-  supabase-db:
-    image: supabase/postgres:15.8.1.085
-    ports:
-      - "127.0.0.1:\${POSTGRES_PORT}:5432"
-    volumes:
-      - supabase-db-data:/var/lib/postgresql/data
-      - ./volumes/db/roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:ro
-      - ./volumes/db/kortix.sql:/docker-entrypoint-initdb.d/init-scripts/99-kortix.sql:ro
-    environment:
-      POSTGRES_HOST: /var/run/postgresql
-      POSTGRES_PORT: "5432"
-      POSTGRES_PASSWORD: \${POSTGRES_PASSWORD}
-      POSTGRES_DB: postgres
-      JWT_SECRET: \${SUPABASE_JWT_SECRET}
-      JWT_EXP: "3600"
-    command:
-      - postgres
-      - -c
-      - config_file=/etc/postgresql/postgresql.conf
-      - -c
-      - log_min_messages=fatal
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -h localhost"]
-      interval: 5s
-      timeout: 3s
-      retries: 20
-    restart: unless-stopped
-
-  supabase-auth:
-    image: supabase/gotrue:v2.186.0
-    depends_on:
-      supabase-db:
-        condition: service_healthy
-    environment:
-      GOTRUE_API_HOST: 0.0.0.0
-      GOTRUE_API_PORT: "9999"
-      API_EXTERNAL_URL: \${SUPABASE_PUBLIC_URL}
-      GOTRUE_DB_DRIVER: postgres
-      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:\${POSTGRES_PASSWORD}@supabase-db:5432/postgres
-      GOTRUE_SITE_URL: \${PUBLIC_URL}
-      GOTRUE_URI_ALLOW_LIST: ""
-      GOTRUE_DISABLE_SIGNUP: "false"
-      GOTRUE_JWT_ADMIN_ROLES: service_role
-      GOTRUE_JWT_AUD: authenticated
-      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
-      GOTRUE_JWT_EXP: "3600"
-      GOTRUE_JWT_SECRET: \${SUPABASE_JWT_SECRET}
-      GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
-      GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: "false"
-      GOTRUE_MAILER_AUTOCONFIRM: "true"
-      GOTRUE_SMTP_ADMIN_EMAIL: admin@localhost
-      GOTRUE_SMTP_HOST: localhost
-      GOTRUE_SMTP_PORT: "587"
-      GOTRUE_SMTP_USER: unused
-      GOTRUE_SMTP_PASS: unused
-      GOTRUE_SMTP_SENDER_NAME: Kortix
-      GOTRUE_MAILER_URLPATHS_INVITE: /auth/v1/verify
-      GOTRUE_MAILER_URLPATHS_CONFIRMATION: /auth/v1/verify
-      GOTRUE_MAILER_URLPATHS_RECOVERY: /auth/v1/verify
-      GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: /auth/v1/verify
-    restart: unless-stopped
-
-  supabase-rest:
-    image: postgrest/postgrest:v14.5
-    depends_on:
-      supabase-db:
-        condition: service_healthy
-    environment:
-      PGRST_DB_URI: postgres://authenticator:\${POSTGRES_PASSWORD}@supabase-db:5432/postgres
-      PGRST_DB_SCHEMAS: public
-      PGRST_DB_ANON_ROLE: anon
-      PGRST_JWT_SECRET: \${SUPABASE_JWT_SECRET}
-      PGRST_DB_USE_LEGACY_GUCS: "false"
-      PGRST_APP_SETTINGS_JWT_SECRET: \${SUPABASE_JWT_SECRET}
-      PGRST_APP_SETTINGS_JWT_EXP: "3600"
-    command: ["postgrest"]
-    restart: unless-stopped
-
-  supabase-kong:
-    image: kong:2.8.1
-    ports:
-      - "127.0.0.1:\${SUPABASE_PORT}:8000"
-    volumes:
-      - ./kong.yml:/home/kong/temp.yml:ro
-    depends_on:
-      supabase-auth:
-        condition: service_started
-      supabase-rest:
-        condition: service_started
-    environment:
-      KONG_DATABASE: "off"
-      KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
-      KONG_DNS_ORDER: LAST,A,CNAME
-      KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth
-      SUPABASE_ANON_KEY: \${SUPABASE_ANON_KEY}
-      SUPABASE_SERVICE_KEY: \${SUPABASE_SERVICE_ROLE_KEY}
-    entrypoint: bash -c 'eval "echo \\"$$(cat ~/temp.yml)\\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
-    restart: unless-stopped
-
-  frontend:
-    image: \${FRONTEND_IMAGE}
-    ports:
-      - "127.0.0.1:\${FRONTEND_PORT}:3000"
-    extra_hosts:
-      - "localhost:host-gateway"
-    environment:
-      KORTIX_PUBLIC_SUPABASE_URL: \${SUPABASE_PUBLIC_URL}
-      KORTIX_PUBLIC_SUPABASE_ANON_KEY: \${SUPABASE_ANON_KEY}
-      KORTIX_PUBLIC_BACKEND_URL: \${API_PUBLIC_URL}/v1
-      KORTIX_PUBLIC_BILLING_ENABLED: "false"
-      KORTIX_PUBLIC_APP_URL: \${PUBLIC_URL}
-      # Self-host has no real email transport, so magic-link sign-in can't work —
-      # password is the only functional method. (Override to "magic,password" if
-      # you wire up SMTP via GoTrue.)
-      KORTIX_PUBLIC_AUTH_METHODS: \${KORTIX_PUBLIC_AUTH_METHODS}
-      SUPABASE_URL: \${SUPABASE_PUBLIC_URL}
-      SUPABASE_SERVER_URL: http://supabase-kong:8000
-      SUPABASE_ANON_KEY: \${SUPABASE_ANON_KEY}
-      BACKEND_URL: \${API_PUBLIC_URL}/v1
-      # Localhost shares one cookie jar across every port, so running several
-      # self-host/dev stacks piles up Supabase auth cookies until the request
-      # header blows Node's 16KB default → HTTP 431 on first navigation. Raise it.
-      NODE_OPTIONS: "--max-http-header-size=131072"
-    depends_on:
-      kortix-api:
-        condition: service_started
-    restart: unless-stopped
-
-  # One-shot: provision the database schema before the API serves traffic.
-  # On a FRESH db this installs the non-kortix prerequisites (public credit
-  # RPCs, welcome webhook, storage buckets) then applies all migrations; on an
-  # already-provisioned db it is a no-op.
-  # Runs the migrator from the API image, which bundles migrations + runner.
-  kortix-migrate:
-    image: \${API_IMAGE}
-    user: "0:0"
-    command: ["bun", "/app/packages/db/scripts/migrate.ts", "bootstrap"]
-    environment:
-      DATABASE_URL: postgresql://postgres:\${POSTGRES_PASSWORD}@supabase-db:5432/postgres
-    depends_on:
-      supabase-db:
-        condition: service_healthy
-      supabase-auth:
-        condition: service_started
-    restart: "no"
-
-  kortix-api:
-    image: \${API_IMAGE}
-    user: "0:0"
-    ports:
-      - "127.0.0.1:\${API_PORT}:8008"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    env_file:
-      - .env
-    environment:
-      PORT: "8008"
-      SUPABASE_URL: http://supabase-kong:8000
-      DATABASE_URL: postgresql://postgres:\${POSTGRES_PASSWORD}@supabase-db:5432/postgres
-      SUPABASE_SERVICE_ROLE_KEY: \${SUPABASE_SERVICE_ROLE_KEY}
-      ALLOWED_SANDBOX_PROVIDERS: \${ALLOWED_SANDBOX_PROVIDERS}
-      DAYTONA_API_KEY: \${DAYTONA_API_KEY}
-      DAYTONA_SERVER_URL: \${DAYTONA_SERVER_URL}
-      DAYTONA_TARGET: \${DAYTONA_TARGET}
-      KORTIX_URL: http://kortix-api:8008
-      FRONTEND_URL: \${PUBLIC_URL}
-      CORS_ALLOWED_ORIGINS: \${PUBLIC_URL},\${API_PUBLIC_URL}
-      SANDBOX_IMAGE: \${SANDBOX_IMAGE}
-      SANDBOX_NETWORK: ${project}_default
-      KORTIX_LOCAL_IMAGES: \${KORTIX_LOCAL_IMAGES}
-      KORTIX_ROUTER_INTERNAL_ENABLED: "false"
-      KORTIX_BILLING_INTERNAL_ENABLED: "false"
-      LLM_GATEWAY_ENABLED: "true"
-      LLM_GATEWAY_BASE_URL: http://llm-gateway:8090/v1/llm
-      GATEWAY_INTERNAL_TOKEN: \${GATEWAY_INTERNAL_TOKEN}
-      OPENROUTER_API_KEY: \${OPENROUTER_API_KEY}
-    depends_on:
-      supabase-db:
-        condition: service_healthy
-      supabase-kong:
-        condition: service_started
-      kortix-migrate:
-        condition: service_completed_successfully
-    restart: unless-stopped
-
-  llm-gateway:
-    image: \${GATEWAY_IMAGE}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    environment:
-      PORT: "8090"
-      KORTIX_API_URL: http://kortix-api:8008
-      GATEWAY_INTERNAL_TOKEN: \${GATEWAY_INTERNAL_TOKEN}
-    depends_on:
-      kortix-api:
-        condition: service_started
-    restart: unless-stopped
-
-volumes:
-  supabase-db-data:
-`;
-  writeFileSync(composePath(instance), text, 'utf8');
+  const root = instanceDir(instance);
+  writeSupabaseVendorAssets(root);
+  writeFileSync(
+    composePath(instance),
+    renderFullDockerCompose(composeProject(instance)),
+    { encoding: 'utf8', mode: 0o600 },
+  );
 }
-
-function writeDbInit(instance: string, env: SelfHostEnv): void {
-  const dbDir = join(instanceDir(instance), 'volumes', 'db');
-  mkdirSync(dbDir, { recursive: true });
-
-  const roles = `-- Supabase roles required by GoTrue and PostgREST
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
-    CREATE ROLE anon NOLOGIN NOINHERIT;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
-    CREATE ROLE authenticated NOLOGIN NOINHERIT;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
-    CREATE ROLE service_role NOLOGIN NOINHERIT BYPASSRLS;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN
-    CREATE ROLE supabase_auth_admin LOGIN NOINHERIT CREATEROLE CREATEDB;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_admin') THEN
-    CREATE ROLE supabase_admin LOGIN NOINHERIT CREATEROLE CREATEDB REPLICATION BYPASSRLS;
-  END IF;
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
-    CREATE ROLE authenticator LOGIN NOINHERIT;
-  END IF;
-END
-$$;
-
-GRANT anon TO authenticator;
-GRANT authenticated TO authenticator;
-GRANT service_role TO authenticator;
-GRANT supabase_auth_admin TO authenticator;
-GRANT supabase_admin TO postgres;
-
-CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
-GRANT ALL ON SCHEMA auth TO supabase_auth_admin;
-GRANT USAGE ON SCHEMA auth TO postgres;
-ALTER ROLE supabase_auth_admin SET search_path = 'auth';
-
-ALTER ROLE supabase_auth_admin WITH PASSWORD '${sqlString(env.POSTGRES_PASSWORD)}';
-ALTER ROLE authenticator WITH PASSWORD '${sqlString(env.POSTGRES_PASSWORD)}';
-ALTER ROLE supabase_admin WITH PASSWORD '${sqlString(env.POSTGRES_PASSWORD)}';
-`;
-
-  const kortix = `-- Kortix bootstrap: extensions and schemas
-CREATE EXTENSION IF NOT EXISTS pg_cron;
-CREATE EXTENSION IF NOT EXISTS pg_net;
-CREATE SCHEMA IF NOT EXISTS kortix;
-`;
-
-  writeFileSync(join(dbDir, 'roles.sql'), roles, 'utf8');
-  writeFileSync(join(dbDir, 'kortix.sql'), kortix, 'utf8');
-}
-
-function writeKongConfig(instance: string): void {
-  const text = `_format_version: '2.1'
-_transform: true
-
-consumers:
-  - username: anon
-    keyauth_credentials:
-      - key: $SUPABASE_ANON_KEY
-  - username: service_role
-    keyauth_credentials:
-      - key: $SUPABASE_SERVICE_KEY
-
-acls:
-  - consumer: anon
-    group: anon
-  - consumer: service_role
-    group: admin
-
-services:
-  - name: auth-v1-open
-    url: http://supabase-auth:9999/verify
-    routes:
-      - name: auth-v1-open
-        strip_path: true
-        paths:
-          - /auth/v1/verify
-    plugins:
-      - name: cors
-  - name: auth-v1-open-callback
-    url: http://supabase-auth:9999/callback
-    routes:
-      - name: auth-v1-open-callback
-        strip_path: true
-        paths:
-          - /auth/v1/callback
-    plugins:
-      - name: cors
-  - name: auth-v1-open-authorize
-    url: http://supabase-auth:9999/authorize
-    routes:
-      - name: auth-v1-open-authorize
-        strip_path: true
-        paths:
-          - /auth/v1/authorize
-    plugins:
-      - name: cors
-  - name: auth-v1
-    url: http://supabase-auth:9999/
-    routes:
-      - name: auth-v1-all
-        strip_path: true
-        paths:
-          - /auth/v1/
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: false
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
-            - anon
-  - name: rest-v1
-    url: http://supabase-rest:3000/
-    routes:
-      - name: rest-v1-all
-        strip_path: true
-        paths:
-          - /rest/v1/
-    plugins:
-      - name: cors
-      - name: key-auth
-        config:
-          hide_credentials: true
-      - name: acl
-        config:
-          hide_groups_header: true
-          allow:
-            - admin
-            - anon
-`;
-  mkdirSync(instanceDir(instance), { recursive: true });
-  writeFileSync(join(instanceDir(instance), 'kong.yml'), text, 'utf8');
-}
-
 function loadEnv(instance: string): SelfHostEnv | null {
   const path = envPath(instance);
   if (!existsSync(path)) return null;
@@ -1248,15 +1105,35 @@ function loadEnv(instance: string): SelfHostEnv | null {
 function loadEnvWithDefaults(flags: GlobalFlags): SelfHostEnv | null {
   const existing = loadEnv(flags.instance);
   if (!existing) return null;
-  return { ...defaultEnv(flags), ...existing };
+  const env = { ...defaultEnv(flags), ...existing };
+  normalizeFullSupabaseEnv(flags.instance, env);
+  return env;
 }
 
 function writeEnv(instance: string, env: SelfHostEnv): void {
+  normalizeFullSupabaseEnv(instance, env);
   mkdirSync(instanceDir(instance), { recursive: true });
   const lines = Object.entries(env)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => `${key}=${value}`);
   writeFileSync(envPath(instance), `${lines.join('\n')}\n`, { encoding: 'utf8', mode: 0o600 });
+}
+
+function normalizeFullSupabaseEnv(instance: string, env: SelfHostEnv): void {
+  // The official Supabase distribution uses the unprefixed names. Keep the
+  // historical Kortix variables canonical and derive upstream aliases so an
+  // existing .env upgrades without rotating its JWT or API keys.
+  env.JWT_SECRET = env.SUPABASE_JWT_SECRET;
+  env.ANON_KEY = env.SUPABASE_ANON_KEY;
+  env.SERVICE_ROLE_KEY = env.SUPABASE_SERVICE_ROLE_KEY;
+  env.POSTGRES_HOST = 'supabase-db';
+  env.POSTGRES_DB = 'postgres';
+  env.SUPABASE_POSTGRES_INTERNAL_PORT = '5432';
+  env.API_EXTERNAL_URL = `${env.SUPABASE_PUBLIC_URL.replace(/\/$/, '')}/auth/v1`;
+  env.SITE_URL = env.PUBLIC_URL;
+  env.POOLER_TENANT_ID ||= composeProject(instance);
+  env.STORAGE_TENANT_ID ||= composeProject(instance);
+  env.STUDIO_DEFAULT_PROJECT ||= instance;
 }
 
 function compose(instance: string, args: string[]): number {
@@ -1286,7 +1163,7 @@ function registerLocalHost(name: string, apiUrl: string): void {
 }
 
 function instanceDir(instance: string): string {
-  return resolve(homedir(), '.config', 'kortix', 'self-host', instance);
+  return targetInstanceDir(instance);
 }
 
 function envPath(instance: string): string {
@@ -1314,10 +1191,6 @@ function supabaseJwt(role: string, secret: string): string {
 
 function b64url(value: string): string {
   return Buffer.from(value).toString('base64url');
-}
-
-function sqlString(value: string): string {
-  return value.replace(/'/g, "''");
 }
 
 function openInBrowser(url: string): void {

--- a/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
+++ b/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const CLI_ENTRY = resolve(import.meta.dir, '..', '..', 'index.ts');
+
+describe('kortix self-host aws-vpc', () => {
+  let tmp: string;
+  let configRoot: string;
+  let fakeBin: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'kortix-aws-vpc-cli-'));
+    configRoot = join(tmp, 'self-host');
+    fakeBin = join(tmp, 'bin');
+    mkdirSync(fakeBin, { recursive: true });
+    const aws = join(fakeBin, 'aws');
+    writeFileSync(
+      aws,
+      `#!/bin/sh
+case "$*" in
+  *"sts get-caller-identity"*)
+    printf '%s\n' '{"UserId":"fake","Account":"935064898258","Arn":"arn:aws:iam::935064898258:user/fake"}'
+    ;;
+  *"--version"*) printf '%s\n' 'aws-cli/2.31.0' ;;
+  *) printf '%s\n' "unexpected aws args: $*" >&2; exit 64 ;;
+esac
+`,
+    );
+    chmodSync(aws, 0o755);
+  });
+
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  async function run(args: string[]) {
+    const proc = Bun.spawn({
+      cmd: [process.execPath, CLI_ENTRY, 'self-host', ...args],
+      cwd: tmp,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+        KORTIX_SELF_HOST_CONFIG_DIR: configRoot,
+        KORTIX_CONFIG_FILE: join(tmp, 'cli-config.json'),
+        KORTIX_NO_UPDATE_CHECK: '1',
+        NO_COLOR: '1',
+        FORCE_COLOR: '0',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    return { code, stdout, stderr };
+  }
+
+  test('initializes a secret-free instance pinned to the verified AWS account', async () => {
+    const result = await run([
+      'init',
+      '--target', 'aws-vpc',
+      '--instance', 'kortix-vpc-demo',
+      '--aws-profile', 'default',
+      '--region', 'us-west-2',
+      '--channel', 'stable',
+      '--yes',
+      '--json',
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).not.toContain('✗');
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      instance: 'kortix-vpc-demo',
+      target: 'aws-vpc',
+      channel: 'stable',
+      aws: {
+        profile: 'default',
+        region: 'us-west-2',
+        account_id: '935064898258',
+      },
+    });
+    const instanceDir = join(configRoot, 'kortix-vpc-demo');
+    expect(JSON.parse(readFileSync(join(instanceDir, 'instance.json'), 'utf8'))).toMatchObject({
+      target: 'aws-vpc',
+      aws: { account_id: '935064898258' },
+    });
+    expect(existsSync(join(instanceDir, '.env'))).toBe(false);
+  });
+
+  test('does not reinterpret Docker lifecycle commands for AWS', async () => {
+    const initialized = await run([
+      'init', '--target', 'aws-vpc', '--instance', 'enterprise', '--aws-profile', 'default', '--region', 'us-west-2', '--yes',
+    ]);
+    expect(initialized.code).toBe(0);
+
+    const result = await run(['start', '--instance', 'enterprise']);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('start is only available for Docker targets');
+    expect(result.stderr).toContain('kortix self-host deploy --instance enterprise');
+  });
+
+  test('advertises the production management command surface', async () => {
+    const result = await run(['--help']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('plan');
+    expect(result.stdout).toContain('deploy');
+    expect(result.stdout).toContain('reconcile');
+    expect(result.stdout).toContain('rollback');
+    expect(result.stdout).toContain('doctor');
+    expect(result.stdout).toContain('--target <target>');
+    expect(result.stdout).toContain('--aws-profile <name>');
+  });
+});

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { parse } from 'yaml';
+
+import {
+  renderFullDockerCompose,
+  SUPABASE_UPSTREAM_COMMIT,
+  supabaseVendorAssets,
+} from '../compose-assets.ts';
+
+describe('full self-host Docker distribution', () => {
+  test('renders the complete pinned Supabase and Kortix service set', () => {
+    const document = parse(renderFullDockerCompose('kortix-enterprise')) as {
+      services: Record<string, {
+        image?: string;
+        container_name?: string;
+        ports?: string[];
+        depends_on?: Record<string, unknown>;
+      }>;
+    };
+
+    expect(Object.keys(document.services).sort()).toEqual([
+      'frontend',
+      'kortix-api',
+      'kortix-migrate',
+      'llm-gateway',
+      'supabase-analytics',
+      'supabase-auth',
+      'supabase-db',
+      'supabase-functions',
+      'supabase-imgproxy',
+      'supabase-kong',
+      'supabase-meta',
+      'supabase-realtime',
+      'supabase-rest',
+      'supabase-storage',
+      'supabase-studio',
+      'supabase-supavisor',
+      'supabase-vector',
+    ]);
+    expect(document.services['supabase-db']?.image).toBe('supabase/postgres:17.6.1.136');
+    expect(document.services['supabase-studio']?.image).toBe('supabase/studio:2026.07.07-sha-a6a04f2');
+    expect(document.services['supabase-analytics']?.image).toBe('supabase/logflare:1.43.1');
+
+    for (const [name, service] of Object.entries(document.services)) {
+      expect(service.container_name, `${name} must support multiple Kortix instances`).toBeUndefined();
+      if (service.image && !service.image.startsWith('${')) {
+        expect(service.image, `${name} image must be immutable`).not.toEndWith(':latest');
+      }
+      for (const port of service.ports ?? []) {
+        expect(port, `${name} must bind only on loopback`).toStartWith('127.0.0.1:');
+      }
+      for (const dependency of Object.keys(service.depends_on ?? {})) {
+        expect(document.services[dependency], `${name} depends on missing ${dependency}`).toBeDefined();
+      }
+    }
+  });
+
+  test('embeds every upstream runtime asset required by the Compose mounts', () => {
+    expect(Object.keys(supabaseVendorAssets).sort()).toEqual([
+      'volumes/api/kong-entrypoint.sh',
+      'volumes/api/kong.yml',
+      'volumes/db/_supabase.sql',
+      'volumes/db/jwt.sql',
+      'volumes/db/logs.sql',
+      'volumes/db/pooler.sql',
+      'volumes/db/realtime.sql',
+      'volumes/db/roles.sql',
+      'volumes/db/webhooks.sql',
+      'volumes/functions/hello/index.ts',
+      'volumes/functions/main/index.ts',
+      'volumes/logs/vector.yml',
+      'volumes/pooler/pooler.exs',
+    ]);
+    for (const [path, content] of Object.entries(supabaseVendorAssets)) {
+      expect(content.length, `${path} must not be empty`).toBeGreaterThan(10);
+    }
+  });
+
+  test('matches the reviewed upstream commit and content lock', () => {
+    const lock = JSON.parse(
+      readFileSync(new URL('../assets/supabase/upstream-lock.json', import.meta.url), 'utf8'),
+    ) as { commit: string; files: Record<string, string> };
+    expect(lock.commit).toBe(SUPABASE_UPSTREAM_COMMIT);
+
+    const embeddedFiles: Record<string, string> = {
+      'docker-compose.yml': readFileSync(new URL('../assets/supabase/docker-compose.yml', import.meta.url), 'utf8'),
+      'docker-compose.logs.yml': readFileSync(new URL('../assets/supabase/docker-compose.logs.yml', import.meta.url), 'utf8'),
+      ...Object.fromEntries(
+        Object.entries(supabaseVendorAssets).map(([path, content]) => [
+          path.endsWith('/index.ts') ? `${path}.txt` : path,
+          content,
+        ]),
+      ),
+    };
+    expect(Object.keys(embeddedFiles).sort()).toEqual(Object.keys(lock.files).sort());
+    for (const [path, content] of Object.entries(embeddedFiles)) {
+      expect(createHash('sha256').update(content).digest('hex'), path).toBe(lock.files[path]);
+    }
+  });
+});

--- a/apps/cli/src/self-host/__tests__/config.test.ts
+++ b/apps/cli/src/self-host/__tests__/config.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  instanceConfigPath,
+  instanceDir,
+  loadInstanceConfig,
+  resolveInstanceTarget,
+  writeInstanceConfig,
+  type SelfHostInstanceConfig,
+} from '../config.ts';
+
+describe('self-host instance config', () => {
+  let root: string;
+  let previousRoot: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'kortix-self-host-config-'));
+    previousRoot = process.env.KORTIX_SELF_HOST_CONFIG_DIR;
+    process.env.KORTIX_SELF_HOST_CONFIG_DIR = root;
+  });
+
+  afterEach(() => {
+    if (previousRoot === undefined) delete process.env.KORTIX_SELF_HOST_CONFIG_DIR;
+    else process.env.KORTIX_SELF_HOST_CONFIG_DIR = previousRoot;
+  });
+
+  test('legacy .env-only instances remain Docker targets', () => {
+    mkdirSync(instanceDir('legacy'), { recursive: true });
+    writeFileSync(join(instanceDir('legacy'), '.env'), 'KORTIX_VERSION=0.9.72\n');
+
+    expect(loadInstanceConfig('legacy')).toEqual({
+      schema_version: 1,
+      instance: 'legacy',
+      target: 'docker',
+      channel: 'latest',
+    });
+    expect(resolveInstanceTarget('legacy')).toBe('docker');
+  });
+
+  test('writes a secret-free AWS target config with owner-only permissions', () => {
+    const config: SelfHostInstanceConfig = {
+      schema_version: 1,
+      instance: 'kortix-vpc-demo',
+      target: 'aws-vpc',
+      channel: 'stable',
+      aws: {
+        profile: 'default',
+        region: 'us-west-2',
+        account_id: '935064898258',
+      },
+    };
+
+    writeInstanceConfig(config);
+
+    expect(loadInstanceConfig(config.instance)).toEqual(config);
+    expect(JSON.parse(readFileSync(instanceConfigPath(config.instance), 'utf8'))).toEqual(config);
+    expect(statSync(instanceConfigPath(config.instance)).mode & 0o777).toBe(0o600);
+  });
+
+  test('rejects invalid or secret-bearing instance configs', () => {
+    mkdirSync(instanceDir('broken'), { recursive: true });
+    writeFileSync(
+      instanceConfigPath('broken'),
+      JSON.stringify({
+        schema_version: 1,
+        instance: 'broken',
+        target: 'aws-vpc',
+        channel: 'stable',
+        aws: { profile: 'default', region: 'us-west-2', account_id: '123456789012' },
+        api_key: 'must-not-live-here',
+      }),
+    );
+    chmodSync(instanceConfigPath('broken'), 0o600);
+
+    expect(() => loadInstanceConfig('broken')).toThrow('unsupported field "api_key"');
+  });
+
+  test('requires complete AWS coordinates', () => {
+    mkdirSync(instanceDir('incomplete'), { recursive: true });
+    writeFileSync(
+      instanceConfigPath('incomplete'),
+      JSON.stringify({
+        schema_version: 1,
+        instance: 'incomplete',
+        target: 'aws-vpc',
+        channel: 'stable',
+        aws: { profile: 'default', region: 'us-west-2' },
+      }),
+    );
+
+    expect(() => loadInstanceConfig('incomplete')).toThrow('aws.account_id');
+  });
+});

--- a/apps/cli/src/self-host/assets.d.ts
+++ b/apps/cli/src/self-host/assets.d.ts
@@ -1,0 +1,19 @@
+declare module '*.sh' {
+  const text: string;
+  export default text;
+}
+
+declare module '*.sql' {
+  const text: string;
+  export default text;
+}
+
+declare module '*.exs' {
+  const text: string;
+  export default text;
+}
+
+declare module '*.txt' {
+  const text: string;
+  export default text;
+}

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -1,0 +1,94 @@
+services:
+  frontend:
+    image: ${FRONTEND_IMAGE}
+    ports:
+      - "127.0.0.1:${FRONTEND_PORT}:3000"
+    extra_hosts:
+      - "localhost:host-gateway"
+    environment:
+      KORTIX_PUBLIC_SUPABASE_URL: ${SUPABASE_PUBLIC_URL}
+      KORTIX_PUBLIC_SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
+      KORTIX_PUBLIC_BACKEND_URL: ${API_PUBLIC_URL}/v1
+      KORTIX_PUBLIC_BILLING_ENABLED: "false"
+      KORTIX_PUBLIC_APP_URL: ${PUBLIC_URL}
+      KORTIX_PUBLIC_AUTH_METHODS: ${KORTIX_PUBLIC_AUTH_METHODS}
+      SUPABASE_URL: ${SUPABASE_PUBLIC_URL}
+      SUPABASE_SERVER_URL: http://supabase-kong:8000
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
+      BACKEND_URL: ${API_PUBLIC_URL}/v1
+      NODE_OPTIONS: "--max-http-header-size=131072"
+    depends_on:
+      kortix-api:
+        condition: service_started
+    restart: unless-stopped
+
+  kortix-migrate:
+    image: ${API_IMAGE}
+    user: "0:0"
+    command: ["bun", "/app/packages/db/scripts/migrate.ts", "bootstrap"]
+    environment:
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@supabase-db:5432/postgres
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+      supabase-auth:
+        condition: service_healthy
+    restart: "no"
+
+  kortix-api:
+    image: ${API_IMAGE}
+    user: "0:0"
+    ports:
+      - "127.0.0.1:${API_PORT}:8008"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    env_file:
+      - .env
+    environment:
+      PORT: "8008"
+      SUPABASE_URL: http://supabase-kong:8000
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@supabase-db:5432/postgres
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
+      ALLOWED_SANDBOX_PROVIDERS: ${ALLOWED_SANDBOX_PROVIDERS}
+      DAYTONA_API_KEY: ${DAYTONA_API_KEY}
+      DAYTONA_SERVER_URL: ${DAYTONA_SERVER_URL}
+      DAYTONA_TARGET: ${DAYTONA_TARGET}
+      KORTIX_URL: http://kortix-api:8008
+      FRONTEND_URL: ${PUBLIC_URL}
+      CORS_ALLOWED_ORIGINS: ${PUBLIC_URL},${API_PUBLIC_URL}
+      SANDBOX_IMAGE: ${SANDBOX_IMAGE}
+      SANDBOX_NETWORK: __KORTIX_COMPOSE_PROJECT___default
+      KORTIX_LOCAL_IMAGES: ${KORTIX_LOCAL_IMAGES}
+      KORTIX_ROUTER_INTERNAL_ENABLED: "false"
+      KORTIX_BILLING_INTERNAL_ENABLED: "false"
+      LLM_GATEWAY_ENABLED: "true"
+      LLM_GATEWAY_BASE_URL: http://llm-gateway:8090/v1/llm
+      GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+    depends_on:
+      supabase-db:
+        condition: service_healthy
+      supabase-kong:
+        condition: service_healthy
+      kortix-migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "bun -e \"fetch('http://localhost:8008/v1/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    restart: unless-stopped
+
+  llm-gateway:
+    image: ${GATEWAY_IMAGE}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      PORT: "8090"
+      KORTIX_API_URL: http://kortix-api:8008
+      GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
+    depends_on:
+      kortix-api:
+        condition: service_started
+    restart: unless-stopped

--- a/apps/cli/src/self-host/assets/supabase/docker-compose.logs.yml
+++ b/apps/cli/src/self-host/assets/supabase/docker-compose.logs.yml
@@ -1,0 +1,99 @@
+# This override adds the following to the self-hosted Supabase configuration:
+#   - Logflare: Log management and event analytics platform
+#   - Vector: High-performance observability data pipeline for logs
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.logs.yml up -d
+
+services:
+
+  studio:
+    depends_on:
+      analytics:
+        condition: service_healthy
+    environment:
+      LOGFLARE_PRIVATE_ACCESS_TOKEN: ${LOGFLARE_PRIVATE_ACCESS_TOKEN}
+      LOGFLARE_URL: http://analytics:4000
+      ENABLED_FEATURES_LOGS_ALL: "true"
+
+  analytics:
+    container_name: supabase-analytics
+    image: supabase/logflare:1.43.1
+    restart: unless-stopped
+    #ports:
+    #  - 4000:4000
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sSfL -o /dev/null http://localhost:4000/health"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    environment:
+      LOGFLARE_NODE_HOST: 127.0.0.1
+
+      DB_USERNAME: supabase_admin
+      DB_DATABASE: _supabase
+      DB_HOSTNAME: ${POSTGRES_HOST}
+      DB_PORT: ${POSTGRES_PORT}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_SCHEMA: _analytics
+
+      # Enable single-tenant mode for Logflare
+      LOGFLARE_SINGLE_TENANT: "true"
+      # Seed Supabase-related metadata
+      LOGFLARE_SUPABASE_MODE: "true"
+
+      LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
+      LOGFLARE_PRIVATE_ACCESS_TOKEN: ${LOGFLARE_PRIVATE_ACCESS_TOKEN}
+
+      LOGFLARE_FEATURE_FLAG_OVERRIDE: multibackend=true
+
+      # Comment out the following two variables when switching to
+      # the BigQuery backend for logs
+      POSTGRES_BACKEND_URL: postgresql://supabase_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/_supabase
+      POSTGRES_BACKEND_SCHEMA: _analytics
+
+      # Uncomment to use the BigQuery backend for logs
+      #GOOGLE_PROJECT_ID: ${GOOGLE_PROJECT_ID}
+      #GOOGLE_PROJECT_NUMBER: ${GOOGLE_PROJECT_NUMBER}
+    # Uncomment to use the BigQuery backend for logs (requires gcloud.json
+    # service account key from Google Cloud Console)
+    #volumes:
+    #  - ./gcloud.json:/opt/app/rel/logflare/bin/gcloud.json:ro,z
+
+  vector:
+    container_name: supabase-vector
+    image: timberio/vector:0.53.0-alpine
+    restart: unless-stopped
+    volumes:
+      - ./volumes/logs/vector.yml:/etc/vector/vector.yml:ro,z
+      - ${DOCKER_SOCKET_LOCATION}:/var/run/docker.sock:ro,z
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 --spider http://vector:9001/health"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    depends_on:
+      analytics:
+        condition: service_healthy
+    environment:
+      LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
+    command:
+      [
+        "--config",
+        "/etc/vector/vector.yml"
+      ]
+    security_opt:
+      - "label=disable"

--- a/apps/cli/src/self-host/assets/supabase/docker-compose.yml
+++ b/apps/cli/src/self-host/assets/supabase/docker-compose.yml
@@ -1,0 +1,593 @@
+# Usage
+#   Start:              docker compose up -d
+#   Stop:               docker compose down
+#   Dev mode:           docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up -d
+#   Reset everything:   sh reset.sh
+#
+# Notes:
+#   - Nested variable interpolation (${A:-${B}}) requires podman-compose >= 1.6.0
+#
+
+name: supabase
+
+services:
+
+  studio:
+    container_name: supabase-studio
+    image: supabase/studio:2026.07.07-sha-a6a04f2
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://localhost:3000/api/platform/profile').then((r) => {if (r.status !== 200) throw new Error(r.status)})\""
+        ]
+      timeout: 10s
+      interval: 5s
+      retries: 3
+      start_period: 20s
+    environment:
+      # Listen on all IPv4 interfaces
+      HOSTNAME: "0.0.0.0"
+
+      STUDIO_PG_META_URL: http://meta:8080
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+
+      # See: https://supabase.com/docs/guides/self-hosting/remove-superuser-access
+      POSTGRES_USER_READ_WRITE: postgres
+
+      PG_META_CRYPTO_KEY: ${PG_META_CRYPTO_KEY}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS}
+      PGRST_DB_MAX_ROWS: ${PGRST_DB_MAX_ROWS:-1000}
+      PGRST_DB_EXTRA_SEARCH_PATH: ${PGRST_DB_EXTRA_SEARCH_PATH:-public}
+
+      DEFAULT_ORGANIZATION_NAME: ${STUDIO_DEFAULT_ORGANIZATION}
+      DEFAULT_PROJECT_NAME: ${STUDIO_DEFAULT_PROJECT}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      AUTH_JWT_SECRET: ${JWT_SECRET}
+      SUPABASE_PUBLISHABLE_KEY: ${SUPABASE_PUBLISHABLE_KEY}
+      SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY}
+
+      # See: docker-compose.logs.yml
+      ENABLED_FEATURES_LOGS_ALL: "false"
+
+      SNIPPETS_MANAGEMENT_FOLDER: /app/snippets
+      EDGE_FUNCTIONS_MANAGEMENT_FOLDER: /app/edge-functions
+    volumes:
+      - ./volumes/snippets:/app/snippets:z
+      - ./volumes/functions:/app/edge-functions:ro,z
+
+  kong:
+    container_name: supabase-kong
+    image: kong/kong:3.9.1
+    restart: unless-stopped
+    networks:
+      default:
+        aliases:
+          - api-gw
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      studio:
+        condition: service_healthy
+    ports:
+      - ${KONG_HTTP_PORT}:8000/tcp
+      - ${KONG_HTTPS_PORT}:8443/tcp
+    volumes:
+      - ./volumes/api/kong.yml:/home/kong/temp.yml:ro,z
+      - ./volumes/api/kong-entrypoint.sh:/home/kong/kong-entrypoint.sh:ro,z
+      #- ./volumes/api/server.crt:/home/kong/server.crt:ro
+      #- ./volumes/api/server.key:/home/kong/server.key:ro
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /usr/local/kong/kong.yml
+      KONG_ROUTER_FLAVOR: expressions
+      # https://github.com/supabase/cli/issues/14
+      KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_DNS_NOT_FOUND_TTL: 1
+      KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth,request-termination,ip-restriction,post-function
+      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
+      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+      KONG_PROXY_ACCESS_LOG: /dev/stdout combined
+      #KONG_SSL_CERT: /home/kong/server.crt
+      #KONG_SSL_CERT_KEY: /home/kong/server.key
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      SUPABASE_PUBLISHABLE_KEY: ${SUPABASE_PUBLISHABLE_KEY:-}
+      SUPABASE_SECRET_KEY: ${SUPABASE_SECRET_KEY:-}
+      ANON_KEY_ASYMMETRIC: ${ANON_KEY_ASYMMETRIC:-}
+      SERVICE_ROLE_KEY_ASYMMETRIC: ${SERVICE_ROLE_KEY_ASYMMETRIC:-}
+      DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
+      DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
+    entrypoint: ["/bin/sh", "/home/kong/kong-entrypoint.sh"]
+
+  auth:
+    container_name: supabase-auth
+    image: supabase/gotrue:v2.189.0
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:9999/health"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: ${API_EXTERNAL_URL}
+
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+
+      GOTRUE_SITE_URL: ${SITE_URL}
+      GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS}
+      GOTRUE_DISABLE_SIGNUP: ${DISABLE_SIGNUP}
+
+      GOTRUE_JWT_ADMIN_ROLES: service_role
+      GOTRUE_JWT_AUD: authenticated
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_JWT_EXP: ${JWT_EXPIRY}
+
+      # Legacy symmetric HS256 key
+      GOTRUE_JWT_SECRET: ${JWT_SECRET}
+
+      # JSON array of signing JWKs (EC private + legacy symmetric)
+      # For Podman, use: GOTRUE_JWT_KEYS: ${JWT_KEYS}
+      #GOTRUE_JWT_KEYS: ${JWT_KEYS:-[]}
+
+      GOTRUE_JWT_ISSUER: ${API_EXTERNAL_URL}
+
+      GOTRUE_EXTERNAL_EMAIL_ENABLED: ${ENABLE_EMAIL_SIGNUP}
+      GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED: ${ENABLE_ANONYMOUS_USERS}
+      GOTRUE_MAILER_AUTOCONFIRM: ${ENABLE_EMAIL_AUTOCONFIRM}
+
+      # Uncomment to bypass nonce check in ID Token flow. Commonly set to true when using Google Sign In on mobile.
+      # GOTRUE_EXTERNAL_SKIP_NONCE_CHECK: "true"
+
+      # GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED: "true"
+      # GOTRUE_SMTP_MAX_FREQUENCY: 1s
+      GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
+      GOTRUE_SMTP_HOST: ${SMTP_HOST}
+      GOTRUE_SMTP_PORT: ${SMTP_PORT}
+      GOTRUE_SMTP_USER: ${SMTP_USER}
+      GOTRUE_SMTP_PASS: ${SMTP_PASS}
+      GOTRUE_SMTP_SENDER_NAME: ${SMTP_SENDER_NAME}
+      GOTRUE_MAILER_URLPATHS_INVITE: ${MAILER_URLPATHS_INVITE}
+      GOTRUE_MAILER_URLPATHS_CONFIRMATION: ${MAILER_URLPATHS_CONFIRMATION}
+      GOTRUE_MAILER_URLPATHS_RECOVERY: ${MAILER_URLPATHS_RECOVERY}
+      GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: ${MAILER_URLPATHS_EMAIL_CHANGE}
+
+      GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP}
+      GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM}
+
+      # Uncomment to enable OAuth / social login providers.
+      # GOTRUE_EXTERNAL_GOOGLE_ENABLED: ${GOOGLE_ENABLED}
+      # GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      # GOTRUE_EXTERNAL_GOOGLE_SECRET: ${GOOGLE_SECRET}
+      # GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI: ${API_EXTERNAL_URL}/callback
+
+      # GOTRUE_EXTERNAL_GITHUB_ENABLED: ${GITHUB_ENABLED}
+      # GOTRUE_EXTERNAL_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      # GOTRUE_EXTERNAL_GITHUB_SECRET: ${GITHUB_SECRET}
+      # GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI: ${API_EXTERNAL_URL}/callback
+
+      # GOTRUE_EXTERNAL_AZURE_ENABLED: ${AZURE_ENABLED}
+      # GOTRUE_EXTERNAL_AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
+      # GOTRUE_EXTERNAL_AZURE_SECRET: ${AZURE_SECRET}
+      # GOTRUE_EXTERNAL_AZURE_REDIRECT_URI: ${API_EXTERNAL_URL}/callback
+
+      # Uncomment to configure SMS delivery (phone auth and phone MFA).
+      # GOTRUE_SMS_PROVIDER: ${SMS_PROVIDER}
+      # GOTRUE_SMS_OTP_EXP: ${SMS_OTP_EXP}
+      # GOTRUE_SMS_OTP_LENGTH: ${SMS_OTP_LENGTH}
+      # GOTRUE_SMS_MAX_FREQUENCY: ${SMS_MAX_FREQUENCY}
+      # GOTRUE_SMS_TEMPLATE: ${SMS_TEMPLATE}
+
+      # Twilio credentials (when SMS_PROVIDER=twilio)
+      # GOTRUE_SMS_TWILIO_ACCOUNT_SID: ${SMS_TWILIO_ACCOUNT_SID}
+      # GOTRUE_SMS_TWILIO_AUTH_TOKEN: ${SMS_TWILIO_AUTH_TOKEN}
+      # GOTRUE_SMS_TWILIO_MESSAGE_SERVICE_SID: ${SMS_TWILIO_MESSAGE_SERVICE_SID}
+
+      # Test OTP mappings for development
+      # GOTRUE_SMS_TEST_OTP: ${SMS_TEST_OTP}
+
+      # Uncomment to configure multi-factor authentication (MFA).
+      # GOTRUE_MFA_TOTP_ENROLL_ENABLED: ${MFA_TOTP_ENROLL_ENABLED}
+      # GOTRUE_MFA_TOTP_VERIFY_ENABLED: ${MFA_TOTP_VERIFY_ENABLED}
+      # GOTRUE_MFA_PHONE_ENROLL_ENABLED: ${MFA_PHONE_ENROLL_ENABLED}
+      # GOTRUE_MFA_PHONE_VERIFY_ENABLED: ${MFA_PHONE_VERIFY_ENABLED}
+      # GOTRUE_MFA_MAX_ENROLLED_FACTORS: ${MFA_MAX_ENROLLED_FACTORS}
+
+      # SAML SSO
+      # See: https://supabase.com/docs/guides/self-hosting/self-hosted-saml-sso
+      # GOTRUE_SAML_ENABLED: ${SAML_ENABLED}
+      # GOTRUE_SAML_PRIVATE_KEY: ${SAML_PRIVATE_KEY}
+      # GOTRUE_SAML_ALLOW_ENCRYPTED_ASSERTIONS: ${SAML_ALLOW_ENCRYPTED_ASSERTIONS}
+      # GOTRUE_SAML_RELAY_STATE_VALIDITY_PERIOD: ${SAML_RELAY_STATE_VALIDITY_PERIOD}
+      # GOTRUE_SAML_RATE_LIMIT_ASSERTION: ${SAML_RATE_LIMIT_ASSERTION}
+      # Optional, defaults to API_EXTERNAL_URL if not set
+      # GOTRUE_SAML_EXTERNAL_URL: ${SAML_EXTERNAL_URL}
+
+      # Uncomment to enable custom access token hook.
+      # See: https://supabase.com/docs/guides/auth/auth-hooks for
+      # full list of hooks and additional details about custom_access_token_hook
+
+      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: "true"
+      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI: "pg-functions://postgres/public/custom_access_token_hook"
+      # GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_SECRETS: "<standard-base64-secret>"
+
+      # GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED: "true"
+      # GOTRUE_HOOK_MFA_VERIFICATION_ATTEMPT_URI: "pg-functions://postgres/public/mfa_verification_attempt"
+
+      # GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED: "true"
+      # GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI: "pg-functions://postgres/public/password_verification_attempt"
+
+      # GOTRUE_HOOK_SEND_SMS_ENABLED: "false"
+      # GOTRUE_HOOK_SEND_SMS_URI: "pg-functions://postgres/public/custom_access_token_hook"
+      # GOTRUE_HOOK_SEND_SMS_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
+
+      # GOTRUE_HOOK_SEND_EMAIL_ENABLED: "false"
+      # GOTRUE_HOOK_SEND_EMAIL_URI: "http://host.docker.internal:54321/functions/v1/email_sender"
+      # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
+
+  rest:
+    container_name: supabase-rest
+    image: postgrest/postgrest:v14.12
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "postgrest", "--ready" ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS}
+      PGRST_DB_MAX_ROWS: ${PGRST_DB_MAX_ROWS:-1000}
+      PGRST_DB_EXTRA_SEARCH_PATH: ${PGRST_DB_EXTRA_SEARCH_PATH:-public}
+      PGRST_DB_ANON_ROLE: anon
+
+      PGRST_ADMIN_SERVER_PORT: 3001
+      PGRST_ADMIN_SERVER_HOST: localhost
+
+      # PostgREST accepts a plain-text symmetric secret, a single JWK, or a JWKS.
+      # For Podman, use either PGRST_JWT_SECRET: ${JWT_SECRET} or
+      # PGRST_JWT_SECRET: ${JWT_JWKS}
+      PGRST_JWT_SECRET: ${JWT_JWKS:-${JWT_SECRET}}
+
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+      PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET}
+      PGRST_APP_SETTINGS_JWT_EXP: ${JWT_EXPIRY}
+    command:
+      [
+        "postgrest"
+      ]
+
+  realtime:
+    # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
+    container_name: realtime-dev.supabase-realtime
+    image: supabase/realtime:v2.102.3
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sSfL --head -o /dev/null -H \"Authorization: Bearer ${ANON_KEY}\" http://localhost:4000/api/tenants/realtime-dev/health"
+        ]
+      timeout: 5s
+      interval: 30s
+      retries: 3
+      start_period: 10s
+    environment:
+      PORT: 4000
+      DB_HOST: ${POSTGRES_HOST}
+      DB_PORT: ${POSTGRES_PORT}
+      DB_USER: supabase_admin
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: ${POSTGRES_DB}
+      DB_AFTER_CONNECT_QUERY: 'SET search_path TO _realtime'
+      DB_ENC_KEY: ${REALTIME_DB_ENC_KEY:-supabaserealtime}
+
+      # Legacy symmetric HS256 key
+      API_JWT_SECRET: ${JWT_SECRET}
+
+      # JWKS for token verification (EC public + legacy symmetric).
+      # For Podman, use: API_JWT_JWKS: ${JWT_JWKS}
+      #API_JWT_JWKS: ${JWT_JWKS:-{"keys":[]}}
+
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      METRICS_JWT_SECRET: ${JWT_SECRET}
+      ERL_AFLAGS: -proto_dist inet_tcp
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: "10000"
+      APP_NAME: realtime
+      SEED_SELF_HOST: "true"
+      RUN_JANITOR: "true"
+      DISABLE_HEALTHCHECK_LOGGING: "true"
+
+  # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
+  storage:
+    container_name: supabase-storage
+    image: supabase/storage-api:v1.60.4
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+      rest:
+        condition: service_started
+      imgproxy:
+        condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://storage:5000/status"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+      start_period: 10s
+    environment:
+      ANON_KEY: ${ANON_KEY}
+      SERVICE_KEY: ${SERVICE_ROLE_KEY}
+      POSTGREST_URL: http://rest:3000
+
+      # Legacy symmetric HS256 key
+      AUTH_JWT_SECRET: ${JWT_SECRET}
+
+      # JWKS for token verification (EC public + legacy symmetric).
+      # For Podman, use: JWT_JWKS: ${JWT_JWKS}
+      #JWT_JWKS: ${JWT_JWKS:-{"keys":[]}}
+
+      DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      STORAGE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
+      REQUEST_ALLOW_X_FORWARDED_PATH: "true"
+      FILE_SIZE_LIMIT: 52428800
+      STORAGE_BACKEND: file
+      # S3 bucket when using S3 backend, directory name when using 'file'
+      GLOBAL_S3_BUCKET: ${GLOBAL_S3_BUCKET}
+      # S3 Backend configuration
+      #GLOBAL_S3_ENDPOINT: https://your-s3-endpoint
+      #GLOBAL_S3_PROTOCOL: https
+      #GLOBAL_S3_FORCE_PATH_STYLE: "true"
+      #AWS_ACCESS_KEY_ID: your-access-key-id
+      #AWS_SECRET_ACCESS_KEY: your-secret-access-key
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: ${STORAGE_TENANT_ID}
+      # TODO: https://github.com/supabase/storage-api/issues/55
+      REGION: ${REGION}
+      ENABLE_IMAGE_TRANSFORMATION: "true"
+      IMGPROXY_URL: http://imgproxy:5001
+      # S3 protocol endpoint configuration
+      S3_PROTOCOL_ACCESS_KEY_ID: ${S3_PROTOCOL_ACCESS_KEY_ID}
+      S3_PROTOCOL_ACCESS_KEY_SECRET: ${S3_PROTOCOL_ACCESS_KEY_SECRET}
+    volumes:
+      - ./volumes/storage:/var/lib/storage:z
+
+  imgproxy:
+    container_name: supabase-imgproxy
+    image: darthsim/imgproxy:v3.30.1
+    restart: unless-stopped
+    volumes:
+      - ./volumes/storage:/var/lib/storage:z
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "imgproxy",
+          "health"
+        ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
+    environment:
+      IMGPROXY_BIND: ":5001"
+      IMGPROXY_LOCAL_FILESYSTEM_ROOT: /
+      IMGPROXY_USE_ETAG: "true"
+      IMGPROXY_AUTO_WEBP: ${IMGPROXY_AUTO_WEBP}
+      IMGPROXY_MAX_SRC_RESOLUTION: 16.8
+
+  meta:
+    container_name: supabase-meta
+    image: supabase/postgres-meta:v0.96.6
+    restart: unless-stopped
+    depends_on:
+      db:
+        # Disable this if you are using an external Postgres database
+        condition: service_healthy
+    environment:
+      PG_META_PORT: 8080
+      PG_META_DB_HOST: ${POSTGRES_HOST}
+      PG_META_DB_PORT: ${POSTGRES_PORT}
+      PG_META_DB_NAME: ${POSTGRES_DB}
+      PG_META_DB_USER: postgres
+      PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      CRYPTO_KEY: ${PG_META_CRYPTO_KEY}
+
+  functions:
+    container_name: supabase-edge-functions
+    image: supabase/edge-runtime:v1.74.0
+    restart: unless-stopped
+    volumes:
+      - ./volumes/functions:/home/deno/functions:z
+      - deno-cache:/root/.cache/deno
+    depends_on:
+      kong:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/127.0.0.1/9000'"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+    environment:
+      # Legacy symmetric HS256 key
+      JWT_SECRET: ${JWT_SECRET}
+      # JWKS for token verification (EC public + legacy symmetric).
+      # For Podman, use: SUPABASE_JWKS: ${JWT_JWKS}
+      #SUPABASE_JWKS: ${JWT_JWKS:-{"keys":[]}}
+
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL}
+      # Legacy API keys (HS256-signed JWTs)
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
+      # New opaque API keys
+      SUPABASE_PUBLISHABLE_KEYS: "{\"default\":\"${SUPABASE_PUBLISHABLE_KEY:-}\"}"
+      SUPABASE_SECRET_KEYS: "{\"default\":\"${SUPABASE_SECRET_KEY:-}\"}"
+      SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      # TODO: Allow configuring VERIFY_JWT per function.
+      VERIFY_JWT: "${FUNCTIONS_VERIFY_JWT}"
+    command:
+      [
+        "start",
+        "--main-service",
+        "/home/deno/functions/main"
+      ]
+
+  # Comment out everything below this point if you are using an external Postgres database
+  db:
+    container_name: supabase-db
+    # To upgrade an existing Postgres 15 database in place, see utils/upgrade-pg17.sh.
+    image: supabase/postgres:17.6.1.136
+    restart: unless-stopped
+    volumes:
+      - ./volumes/db/realtime.sql:/docker-entrypoint-initdb.d/migrations/99-realtime.sql:Z
+      # Must be superuser to create event trigger
+      - ./volumes/db/webhooks.sql:/docker-entrypoint-initdb.d/init-scripts/98-webhooks.sql:Z
+      # Must be superuser to alter reserved role
+      - ./volumes/db/roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:Z
+      # Initialize the database settings with JWT_SECRET and JWT_EXP
+      - ./volumes/db/jwt.sql:/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql:Z
+      # PGDATA directory is persisted between restarts
+      - ./volumes/db/data:/var/lib/postgresql/data:Z
+      # Changes required for internal supabase data such as _analytics
+      - ./volumes/db/_supabase.sql:/docker-entrypoint-initdb.d/migrations/97-_supabase.sql:Z
+      # Changes required for Analytics support
+      - ./volumes/db/logs.sql:/docker-entrypoint-initdb.d/migrations/99-logs.sql:Z
+      # Changes required for Pooler support
+      - ./volumes/db/pooler.sql:/docker-entrypoint-initdb.d/migrations/99-pooler.sql:Z
+      # Use named volume to persist pgsodium decryption key between restarts
+      - db-config:/etc/postgresql-custom
+    healthcheck:
+      test:
+        [
+        "CMD",
+        "pg_isready",
+        "-U",
+        "postgres",
+        "-h",
+        "localhost"
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    environment:
+      POSTGRES_HOST: /var/run/postgresql
+      PGPORT: ${POSTGRES_PORT}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATABASE: ${POSTGRES_DB}
+      POSTGRES_DB: ${POSTGRES_DB}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXP: ${JWT_EXPIRY}
+    command:
+      [
+        "postgres",
+        "-c",
+        "config_file=/etc/postgresql/postgresql.conf",
+        "-c",
+        "log_min_messages=fatal" # prevents Realtime polling queries from appearing in logs
+      ]
+
+  # Update the DATABASE_URL if you are using an external Postgres database
+  supavisor:
+    container_name: supabase-pooler
+    image: supabase/supavisor:2.9.5
+    restart: unless-stopped
+    ports:
+      - ${POSTGRES_PORT}:5432
+      - ${POOLER_PROXY_PORT_TRANSACTION}:6543
+    volumes:
+      - ./volumes/pooler/pooler.exs:/etc/pooler/pooler.exs:ro,z
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "curl",
+          "-sSfL",
+          "--head",
+          "-o",
+          "/dev/null",
+          "http://127.0.0.1:4000/api/health"
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PORT: 4000
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DATABASE_URL: ecto://supabase_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/_supabase
+      CLUSTER_POSTGRES: "true"
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      VAULT_ENC_KEY: ${VAULT_ENC_KEY}
+      API_JWT_SECRET: ${JWT_SECRET}
+      METRICS_JWT_SECRET: ${JWT_SECRET}
+      REGION: local
+      ERL_AFLAGS: -proto_dist inet_tcp
+      POOLER_TENANT_ID: ${POOLER_TENANT_ID}
+      POOLER_DEFAULT_POOL_SIZE: ${POOLER_DEFAULT_POOL_SIZE}
+      POOLER_MAX_CLIENT_CONN: ${POOLER_MAX_CLIENT_CONN}
+      POOLER_POOL_MODE: transaction
+      DB_POOL_SIZE: ${POOLER_DB_POOL_SIZE}
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "/app/bin/migrate && /app/bin/supavisor eval \"$$(cat /etc/pooler/pooler.exs)\" && /app/bin/server"
+      ]
+
+volumes:
+  db-config:
+  deno-cache:

--- a/apps/cli/src/self-host/assets/supabase/upstream-lock.json
+++ b/apps/cli/src/self-host/assets/supabase/upstream-lock.json
@@ -1,0 +1,23 @@
+{
+  "repository": "https://github.com/supabase/supabase",
+  "commit": "20649d23740e2facc5d11f7220947b9cddf9480c",
+  "commit_date": "2026-07-13T12:06:15Z",
+  "license": "Apache-2.0",
+  "files": {
+    "docker-compose.logs.yml": "c1c386ee49680a8cd10b6f5a336097f5f4db72608cbbfa211053f146f3785a55",
+    "docker-compose.yml": "3b295bf43c4f01edbbafa2a8aa8642746fd4caab948c64313e474df4a50b7fa0",
+    "volumes/api/kong-entrypoint.sh": "399394576635f7477dfee32e870f509567fc496f0dc86a5a6611f58d1099031f",
+    "volumes/api/kong.yml": "3d6db996d43d4bb9ef119058dfb2806e2ad74c0509991680a4f6f54a06a39174",
+    "volumes/db/_supabase.sql": "9dce462adc04137d6afabcf28efa60a6c355270a4b32d7af58891ac4eb964c5f",
+    "volumes/db/jwt.sql": "1cc94a4f16f6e2932b383cd68e211a96bcae298437ca4120d8a5106396c58465",
+    "volumes/db/logs.sql": "f0463ce5030907acef49326d2bffd36002df0718035071be7c99bd7fc897c63d",
+    "volumes/db/pooler.sql": "df97ebe148d94cfb92a5e37ebf972dfd496be195f0915ecf14396b2cf50efecb",
+    "volumes/db/realtime.sql": "7e9e442e7fc4dae05544c07b67bede37a00d84644304dfce4d937134cb4c8f88",
+    "volumes/db/roles.sql": "3ad717b225daa38aa982da26750f35641eb404e1eb5e69a763c22236ab96c1b2",
+    "volumes/db/webhooks.sql": "b584aaaa0c393f27218f81e01e76e1d07d42f947083249adcd6097ad471cde62",
+    "volumes/functions/hello/index.ts.txt": "924360da7a031b0c649d870863aa69cfa7436550169e7cc0d163bb15de2b0e3f",
+    "volumes/functions/main/index.ts.txt": "5fb63babd5ebe7fda6f2e541fa9b4e3513a7514f8fa511ad7fdb37f46d2b9a95",
+    "volumes/logs/vector.yml": "8f9fa080e3cd8107ac3e6d3bf8d6aa8959b6845d3cd8d5144fb8f28a45607a41",
+    "volumes/pooler/pooler.exs": "d844e49f8915021ccbf6af6b769fef7909a723346bfc8f94ddb0433a328e49b1"
+  }
+}

--- a/apps/cli/src/self-host/assets/supabase/volumes/api/kong-entrypoint.sh
+++ b/apps/cli/src/self-host/assets/supabase/volumes/api/kong-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Custom entrypoint for Kong that builds Lua expressions for request-transformer
+# and performs environment variable substitution in the declarative config.
+
+# Build Lua expressions for translating opaque API keys to asymmetric JWTs.
+# When opaque keys are not configured (empty env vars), expressions fall through
+# to legacy-only behavior - just passing apikey as-is.
+#
+# Full expression logic (when opaque keys are configured):
+#   1. If Authorization header exists and is NOT an sb_ key -> pass through (user session JWT)
+#   2. If apikey matches secret key -> set service_role asymmetric JWT internal "API key"
+#   3. If apikey matches publishable key -> set anon asymmetric JWT internal "API key"
+#   4. Fallback: pass apikey as-is (legacy HS256 JWT)
+
+if [ -n "$SUPABASE_SECRET_KEY" ] && [ -n "$SUPABASE_PUBLISHABLE_KEY" ]; then
+    # Opaque keys configured -> full translation expressions
+    export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or (headers.apikey == '$SUPABASE_SECRET_KEY' and 'Bearer $SERVICE_ROLE_KEY_ASYMMETRIC') or (headers.apikey == '$SUPABASE_PUBLISHABLE_KEY' and 'Bearer $ANON_KEY_ASYMMETRIC') or headers.apikey)"
+
+    # Realtime WebSocket: reads from query_params.apikey (supabase-js sends apikey
+    # via query string), outputs to x-api-key header which Realtime checks first.
+    export LUA_RT_WS_EXPR="\$((query_params.apikey == '$SUPABASE_SECRET_KEY' and '$SERVICE_ROLE_KEY_ASYMMETRIC') or (query_params.apikey == '$SUPABASE_PUBLISHABLE_KEY' and '$ANON_KEY_ASYMMETRIC') or query_params.apikey)"
+else
+    # Legacy API keys, not sb_ API keys -> pass apikey through unchanged
+    export LUA_AUTH_EXPR="\$((headers.authorization ~= nil and headers.authorization:sub(1, 10) ~= 'Bearer sb_' and headers.authorization) or headers.apikey)"
+    export LUA_RT_WS_EXPR="\$(query_params.apikey)"
+fi
+
+# Substitute environment variables in the Kong declarative config.
+# Uses awk instead of eval/echo to preserve YAML quoting (eval strips double
+# quotes, breaking "Header: value" patterns that YAML parses as mappings).
+awk '{
+  result = ""
+  rest = $0
+  while (match(rest, /\$[A-Za-z_][A-Za-z_0-9]*/)) {
+    varname = substr(rest, RSTART + 1, RLENGTH - 1)
+    if (varname in ENVIRON) {
+      result = result substr(rest, 1, RSTART - 1) ENVIRON[varname]
+    } else {
+      result = result substr(rest, 1, RSTART + RLENGTH - 1)
+    }
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+  print result rest
+}' /home/kong/temp.yml > "$KONG_DECLARATIVE_CONFIG"
+
+# Remove empty key-auth credentials (unconfigured opaque keys)
+sed -i '/^[[:space:]]*- key:[[:space:]]*$/d' "$KONG_DECLARATIVE_CONFIG"
+
+exec /entrypoint.sh kong docker-start

--- a/apps/cli/src/self-host/assets/supabase/volumes/api/kong.yml
+++ b/apps/cli/src/self-host/assets/supabase/volumes/api/kong.yml
@@ -1,0 +1,467 @@
+_format_version: '2.1'
+_transform: true
+
+###
+### Consumers / Users
+###
+consumers:
+  - username: DASHBOARD
+  - username: anon
+    keyauth_credentials:
+      - key: $SUPABASE_ANON_KEY
+      - key: $SUPABASE_PUBLISHABLE_KEY
+  - username: service_role
+    keyauth_credentials:
+      - key: $SUPABASE_SERVICE_KEY
+      - key: $SUPABASE_SECRET_KEY
+
+###
+### Access Control List
+###
+acls:
+  - consumer: anon
+    group: anon
+  - consumer: service_role
+    group: admin
+
+###
+### Dashboard credentials
+###
+basicauth_credentials:
+  - consumer: DASHBOARD
+    username: '$DASHBOARD_USERNAME'
+    password: '$DASHBOARD_PASSWORD'
+
+###
+### API Routes
+###
+services:
+  ## Open Auth routes
+  - name: auth-v1-open
+    _comment: 'Auth: /auth/v1/verify* -> http://auth:9999/verify*'
+    url: http://auth:9999/verify
+    routes:
+      - name: auth-v1-open
+        strip_path: true
+        paths:
+          - /auth/v1/verify
+    plugins:
+      - name: cors
+  - name: auth-v1-open-callback
+    _comment: 'Auth: /auth/v1/callback* -> http://auth:9999/callback*'
+    url: http://auth:9999/callback
+    routes:
+      - name: auth-v1-open-callback
+        strip_path: true
+        paths:
+          - /auth/v1/callback
+    plugins:
+      - name: cors
+  - name: auth-v1-open-authorize
+    _comment: 'Auth: /auth/v1/authorize* -> http://auth:9999/authorize*'
+    url: http://auth:9999/authorize
+    routes:
+      - name: auth-v1-open-authorize
+        strip_path: true
+        paths:
+          - /auth/v1/authorize
+    plugins:
+      - name: cors
+  - name: auth-v1-open-jwks
+    _comment: 'Auth: /auth/v1/.well-known/jwks.json -> http://auth:9999/.well-known/jwks.json'
+    url: http://auth:9999/.well-known/jwks.json
+    routes:
+      - name: auth-v1-open-jwks
+        strip_path: true
+        paths:
+          - /auth/v1/.well-known/jwks.json
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-sso-acs
+    url: "http://auth:9999/sso/saml/acs"
+    routes:
+      - name: auth-v1-open-sso-acs
+        strip_path: true
+        paths:
+        - /auth/v1/sso/saml/acs
+    plugins:
+      - name: cors
+
+  - name: auth-v1-open-sso-metadata
+    url: "http://auth:9999/sso/saml/metadata"
+    routes:
+      - name: auth-v1-open-sso-metadata
+        strip_path: true
+        paths:
+        - /auth/v1/sso/saml/metadata
+    plugins:
+      - name: cors
+
+  ## Secure Auth routes
+  - name: auth-v1
+    _comment: 'Auth: /auth/v1/* -> http://auth:9999/*'
+    url: http://auth:9999/
+    routes:
+      - name: auth-v1-all
+        strip_path: true
+        paths:
+          - /auth/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## OpenAPI root - admin only
+  - name: rest-v1-openapi
+    _comment: 'PostgREST OpenAPI root: /rest/v1/ -> <http://rest:3000/> (admin only). See <https://github.com/orgs/supabase/discussions/42949>'
+    url: http://rest:3000/
+    routes:
+      - name: rest-v1-openapi-root
+        strip_path: true
+        expression: 'http.path == "/rest/v1/"'
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+
+  ## Secure PostgREST routes
+  - name: rest-v1
+    _comment: 'PostgREST: /rest/v1/* -> http://rest:3000/*'
+    url: http://rest:3000/
+    routes:
+      - name: rest-v1-all
+        strip_path: true
+        paths:
+          - /rest/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Secure GraphQL routes
+  - name: graphql-v1
+    _comment: 'PostgREST: /graphql/v1/* -> http://rest:3000/rpc/graphql'
+    url: http://rest:3000/rpc/graphql
+    routes:
+      - name: graphql-v1-all
+        strip_path: true
+        paths:
+          - /graphql/v1
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Content-Profile: graphql_public"
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Secure Realtime routes
+  - name: realtime-v1-ws
+    _comment: 'Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*'
+    url: http://realtime-dev.supabase-realtime:4000/socket
+    protocol: ws
+    routes:
+      - name: realtime-v1-ws
+        strip_path: true
+        paths:
+          - /realtime/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "x-api-key:$LUA_RT_WS_EXPR"
+          replace:
+            querystring:
+              - "apikey:$LUA_RT_WS_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  # Block access to /realtime/v1/api/openapi
+  - name: realtime-v1-rest-openapi
+    _comment: 'Realtime: /realtime/v1/api/openapi/* -> http://realtime:4000/api/openapi/* (blocked)'
+    url: http://realtime-dev.supabase-realtime:4000/api/openapi
+    protocol: http
+    routes:
+      - name: realtime-v1-rest-openapi
+        strip_path: true
+        paths:
+          - /realtime/v1/api/openapi
+    plugins:
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+
+  # Block access to /realtime/v1/api/tenants
+  - name: realtime-v1-rest-tenants
+    _comment: 'Realtime: /realtime/v1/api/tenants/* -> http://realtime:4000/api/tenants/* (blocked)'
+    url: http://realtime-dev.supabase-realtime:4000/api/tenants
+    protocol: http
+    routes:
+      - name: realtime-v1-rest-tenants
+        strip_path: true
+        paths:
+          - /realtime/v1/api/tenants
+    plugins:
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+
+  - name: realtime-v1-rest
+    _comment: 'Realtime: /realtime/v1/api/* -> http://realtime:4000/api/*'
+    url: http://realtime-dev.supabase-realtime:4000/api
+    protocol: http
+    routes:
+      - name: realtime-v1-rest
+        strip_path: true
+        paths:
+          - /realtime/v1/api
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Storage API endpoint (with Authorization header transformation).
+  ## No key-auth — S3 protocol requests don't carry an apikey header.
+  ##
+  ## The request-transformer translates opaque API keys to asymmetric JWTs
+  ## and passes through existing Authorization headers (user JWTs, AWS SigV4).
+  ## When no Authorization or apikey header is present (S3 presigned URLs),
+  ## the Lua expression evaluates to nil which Kong renders as empty string.
+  ## The post-function strips this empty header so Storage's S3 signature
+  ## verification falls through to query-parameter parsing.
+  - name: storage-v1
+    _comment: 'Storage: /storage/v1/* -> http://storage:5000/*'
+    url: http://storage:5000/
+    routes:
+      - name: storage-v1-all
+        strip_path: true
+        paths:
+          - /storage/v1/
+    plugins:
+      - name: cors
+      - name: request-transformer
+        config:
+          add:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+          replace:
+            headers:
+              - "Authorization: $LUA_AUTH_EXPR"
+      - name: post-function
+        config:
+          access:
+            - |
+              local auth = kong.request.get_header("authorization")
+              if auth == nil or auth == "" or auth:find("^%s*$") then
+                kong.service.request.clear_header("authorization")
+              end
+
+  ## Edge Functions routes
+  - name: functions-v1
+    _comment: 'Edge Functions: /functions/v1/* -> http://functions:9000/*'
+    url: http://functions:9000/
+    read_timeout: 150000
+    routes:
+      - name: functions-v1-all
+        strip_path: true
+        paths:
+          - /functions/v1/
+    plugins:
+      - name: cors
+
+  ## OAuth 2.0 Authorization Server Metadata (RFC 8414)
+  - name: well-known-oauth
+    _comment: 'Auth: /.well-known/oauth-authorization-server -> http://auth:9999/.well-known/oauth-authorization-server'
+    url: http://auth:9999/.well-known/oauth-authorization-server
+    routes:
+      - name: well-known-oauth
+        strip_path: true
+        paths:
+          - /.well-known/oauth-authorization-server
+    plugins:
+      - name: cors
+
+  ## Analytics routes
+  ## Not used - Studio and Vector talk directly to analytics via Docker networking.
+  ## If external access is needed, add routes with key-auth matching Logflare's x-api-key auth.
+  # - name: analytics-v1-api
+  #   _comment: 'Analytics: /analytics/v1/api/endpoints/* -> http://logflare:4000/api/endpoints/*'
+  #   url: http://analytics:4000/api/endpoints
+  #   routes:
+  #     - name: analytics-v1-api
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1/api/endpoints/
+  # - name: analytics-v1
+  #   _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'
+  #   url: http://analytics:4000/
+  #   routes:
+  #     - name: dashboard-v1-all
+  #       strip_path: true
+  #       paths:
+  #         - /analytics/v1
+  #   plugins:
+  #     - name: cors
+  #     - name: basic-auth
+  #       config:
+  #         hide_credentials: true
+
+  ## Secure Database routes
+  - name: meta
+    _comment: 'pg-meta: /pg/* -> http://pg-meta:8080/*'
+    url: http://meta:8080/
+    routes:
+      - name: meta-all
+        strip_path: true
+        paths:
+          - /pg/
+    plugins:
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+
+  ## Block access to /api/mcp
+  - name: mcp-blocker
+    _comment: 'Block direct access to /api/mcp'
+    url: http://studio:3000/api/mcp
+    routes:
+      - name: mcp-blocker-route
+        strip_path: true
+        paths:
+          - /api/mcp
+    plugins:
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+
+  ## MCP endpoint - local access
+  - name: mcp
+    _comment: 'MCP: /mcp -> http://studio:3000/api/mcp (local access)'
+    url: http://studio:3000/api/mcp
+    routes:
+      - name: mcp
+        strip_path: true
+        paths:
+          - /mcp
+    plugins:
+      # Block access to /mcp by default
+      - name: request-termination
+        config:
+          status_code: 403
+          message: "Access is forbidden."
+      # Enable local access (danger zone!)
+      # 1. Comment out the 'request-termination' section above
+      # 2. Uncomment the entire section below, including 'deny'
+      # 3. Add your local IPs to the 'allow' list
+      #- name: cors
+      #- name: ip-restriction
+      #  config:
+      #    allow:
+      #      - 127.0.0.1
+      #      - ::1
+      #    deny: []
+
+  ## Protected Dashboard - catch all remaining routes
+  - name: dashboard
+    _comment: 'Studio: /* -> http://studio:3000/*'
+    url: http://studio:3000/
+    routes:
+      - name: dashboard-all
+        strip_path: true
+        paths:
+          - /
+    plugins:
+      - name: cors
+      - name: basic-auth
+        config:
+          hide_credentials: true

--- a/apps/cli/src/self-host/assets/supabase/volumes/db/_supabase.sql
+++ b/apps/cli/src/self-host/assets/supabase/volumes/db/_supabase.sql
@@ -1,0 +1,3 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+CREATE DATABASE _supabase WITH OWNER :pguser;

--- a/apps/cli/src/self-host/assets/supabase/volumes/db/jwt.sql
+++ b/apps/cli/src/self-host/assets/supabase/volumes/db/jwt.sql
@@ -1,0 +1,5 @@
+\set jwt_secret `echo "$JWT_SECRET"`
+\set jwt_exp `echo "$JWT_EXP"`
+
+ALTER DATABASE postgres SET "app.settings.jwt_secret" TO :'jwt_secret';
+ALTER DATABASE postgres SET "app.settings.jwt_exp" TO :'jwt_exp';

--- a/apps/cli/src/self-host/assets/supabase/volumes/db/logs.sql
+++ b/apps/cli/src/self-host/assets/supabase/volumes/db/logs.sql
@@ -1,0 +1,6 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+\c _supabase
+create schema if not exists _analytics;
+alter schema _analytics owner to :pguser;
+\c postgres

--- a/apps/cli/src/self-host/assets/supabase/volumes/db/pooler.sql
+++ b/apps/cli/src/self-host/assets/supabase/volumes/db/pooler.sql
@@ -1,0 +1,6 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+\c _supabase
+create schema if not exists _supavisor;
+alter schema _supavisor owner to :pguser;
+\c postgres

--- a/apps/cli/src/self-host/assets/supabase/volumes/db/realtime.sql
+++ b/apps/cli/src/self-host/assets/supabase/volumes/db/realtime.sql
@@ -1,0 +1,4 @@
+\set pguser `echo "$POSTGRES_USER"`
+
+create schema if not exists _realtime;
+alter schema _realtime owner to :pguser;

--- a/apps/cli/src/self-host/assets/supabase/volumes/db/roles.sql
+++ b/apps/cli/src/self-host/assets/supabase/volumes/db/roles.sql
@@ -1,0 +1,8 @@
+-- NOTE: change to your own passwords for production environments
+\set pgpass `echo "$POSTGRES_PASSWORD"`
+
+ALTER USER authenticator WITH PASSWORD :'pgpass';
+ALTER USER pgbouncer WITH PASSWORD :'pgpass';
+ALTER USER supabase_auth_admin WITH PASSWORD :'pgpass';
+ALTER USER supabase_functions_admin WITH PASSWORD :'pgpass';
+ALTER USER supabase_storage_admin WITH PASSWORD :'pgpass';

--- a/apps/cli/src/self-host/assets/supabase/volumes/db/webhooks.sql
+++ b/apps/cli/src/self-host/assets/supabase/volumes/db/webhooks.sql
@@ -1,0 +1,208 @@
+BEGIN;
+  -- Create pg_net extension
+  CREATE EXTENSION IF NOT EXISTS pg_net SCHEMA extensions;
+  -- Create supabase_functions schema
+  CREATE SCHEMA supabase_functions AUTHORIZATION supabase_admin;
+  GRANT USAGE ON SCHEMA supabase_functions TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA supabase_functions GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+  -- supabase_functions.migrations definition
+  CREATE TABLE supabase_functions.migrations (
+    version text PRIMARY KEY,
+    inserted_at timestamptz NOT NULL DEFAULT NOW()
+  );
+  -- Initial supabase_functions migration
+  INSERT INTO supabase_functions.migrations (version) VALUES ('initial');
+  -- supabase_functions.hooks definition
+  CREATE TABLE supabase_functions.hooks (
+    id bigserial PRIMARY KEY,
+    hook_table_id integer NOT NULL,
+    hook_name text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    request_id bigint
+  );
+  CREATE INDEX supabase_functions_hooks_request_id_idx ON supabase_functions.hooks USING btree (request_id);
+  CREATE INDEX supabase_functions_hooks_h_table_id_h_name_idx ON supabase_functions.hooks USING btree (hook_table_id, hook_name);
+  COMMENT ON TABLE supabase_functions.hooks IS 'Supabase Functions Hooks: Audit trail for triggered hooks.';
+  CREATE FUNCTION supabase_functions.http_request()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      request_id bigint;
+      payload jsonb;
+      url text := TG_ARGV[0]::text;
+      method text := TG_ARGV[1]::text;
+      headers jsonb DEFAULT '{}'::jsonb;
+      params jsonb DEFAULT '{}'::jsonb;
+      timeout_ms integer DEFAULT 1000;
+    BEGIN
+      IF url IS NULL OR url = 'null' THEN
+        RAISE EXCEPTION 'url argument is missing';
+      END IF;
+
+      IF method IS NULL OR method = 'null' THEN
+        RAISE EXCEPTION 'method argument is missing';
+      END IF;
+
+      IF TG_ARGV[2] IS NULL OR TG_ARGV[2] = 'null' THEN
+        headers = '{"Content-Type": "application/json"}'::jsonb;
+      ELSE
+        headers = TG_ARGV[2]::jsonb;
+      END IF;
+
+      IF TG_ARGV[3] IS NULL OR TG_ARGV[3] = 'null' THEN
+        params = '{}'::jsonb;
+      ELSE
+        params = TG_ARGV[3]::jsonb;
+      END IF;
+
+      IF TG_ARGV[4] IS NULL OR TG_ARGV[4] = 'null' THEN
+        timeout_ms = 1000;
+      ELSE
+        timeout_ms = TG_ARGV[4]::integer;
+      END IF;
+
+      CASE
+        WHEN method = 'GET' THEN
+          SELECT http_get INTO request_id FROM net.http_get(
+            url,
+            params,
+            headers,
+            timeout_ms
+          );
+        WHEN method = 'POST' THEN
+          payload = jsonb_build_object(
+            'old_record', OLD,
+            'record', NEW,
+            'type', TG_OP,
+            'table', TG_TABLE_NAME,
+            'schema', TG_TABLE_SCHEMA
+          );
+
+          SELECT http_post INTO request_id FROM net.http_post(
+            url,
+            payload,
+            params,
+            headers,
+            timeout_ms
+          );
+        ELSE
+          RAISE EXCEPTION 'method argument % is invalid', method;
+      END CASE;
+
+      INSERT INTO supabase_functions.hooks
+        (hook_table_id, hook_name, request_id)
+      VALUES
+        (TG_RELID, TG_NAME, request_id);
+
+      RETURN NEW;
+    END
+  $function$;
+  -- Supabase super admin
+  DO
+  $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_roles
+      WHERE rolname = 'supabase_functions_admin'
+    )
+    THEN
+      CREATE USER supabase_functions_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+    END IF;
+  END
+  $$;
+  GRANT ALL PRIVILEGES ON SCHEMA supabase_functions TO supabase_functions_admin;
+  GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA supabase_functions TO supabase_functions_admin;
+  GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA supabase_functions TO supabase_functions_admin;
+  ALTER USER supabase_functions_admin SET search_path = "supabase_functions";
+  ALTER table "supabase_functions".migrations OWNER TO supabase_functions_admin;
+  ALTER table "supabase_functions".hooks OWNER TO supabase_functions_admin;
+  ALTER function "supabase_functions".http_request() OWNER TO supabase_functions_admin;
+  GRANT supabase_functions_admin TO postgres;
+  -- Remove unused supabase_pg_net_admin role
+  DO
+  $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_roles
+      WHERE rolname = 'supabase_pg_net_admin'
+    )
+    THEN
+      REASSIGN OWNED BY supabase_pg_net_admin TO supabase_admin;
+      DROP OWNED BY supabase_pg_net_admin;
+      DROP ROLE supabase_pg_net_admin;
+    END IF;
+  END
+  $$;
+  -- pg_net grants when extension is already enabled
+  DO
+  $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_extension
+      WHERE extname = 'pg_net'
+    )
+    THEN
+      GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+    END IF;
+  END
+  $$;
+  -- Event trigger for pg_net
+  CREATE OR REPLACE FUNCTION extensions.grant_pg_net_access()
+  RETURNS event_trigger
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_event_trigger_ddl_commands() AS ev
+      JOIN pg_extension AS ext
+      ON ev.objid = ext.oid
+      WHERE ext.extname = 'pg_net'
+    )
+    THEN
+      GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SECURITY DEFINER;
+      ALTER function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      ALTER function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) SET search_path = net;
+      REVOKE ALL ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      REVOKE ALL ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+      GRANT EXECUTE ON FUNCTION net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) TO supabase_functions_admin, postgres, anon, authenticated, service_role;
+    END IF;
+  END;
+  $$;
+  COMMENT ON FUNCTION extensions.grant_pg_net_access IS 'Grants access to pg_net';
+  DO
+  $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_event_trigger
+      WHERE evtname = 'issue_pg_net_access'
+    ) THEN
+      CREATE EVENT TRIGGER issue_pg_net_access ON ddl_command_end WHEN TAG IN ('CREATE EXTENSION')
+      EXECUTE PROCEDURE extensions.grant_pg_net_access();
+    END IF;
+  END
+  $$;
+  INSERT INTO supabase_functions.migrations (version) VALUES ('20210809183423_update_grants');
+  ALTER function supabase_functions.http_request() SECURITY DEFINER;
+  ALTER function supabase_functions.http_request() SET search_path = supabase_functions;
+  REVOKE ALL ON FUNCTION supabase_functions.http_request() FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION supabase_functions.http_request() TO postgres, anon, authenticated, service_role;
+COMMIT;

--- a/apps/cli/src/self-host/assets/supabase/volumes/functions/hello/index.ts.txt
+++ b/apps/cli/src/self-host/assets/supabase/volumes/functions/hello/index.ts.txt
@@ -1,0 +1,14 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+Deno.serve(async () => {
+  return new Response(
+    `"Hello from Edge Functions!"`,
+    { headers: { "Content-Type": "application/json" } },
+  )
+})
+
+// To invoke:
+// curl 'http://localhost:<KONG_HTTP_PORT>/functions/v1/hello' \
+//   --header 'Authorization: Bearer <anon/service_role API key>'

--- a/apps/cli/src/self-host/assets/supabase/volumes/functions/main/index.ts.txt
+++ b/apps/cli/src/self-host/assets/supabase/volumes/functions/main/index.ts.txt
@@ -1,0 +1,172 @@
+import * as jose from 'jsr:@panva/jose@6'
+
+console.log('main function started')
+
+const JWT_SECRET = Deno.env.get('JWT_SECRET')
+const SUPABASE_JWKS = parseJwks(Deno.env.get('SUPABASE_JWKS'))
+const VERIFY_JWT = Deno.env.get('VERIFY_JWT') === 'true'
+
+// NOTE:(kallebysantos) We don't check for valid keys but just the bare array parsing,
+// let this for 'jose' lib verification
+export function parseJwks(raw: string | undefined): jose.JSONWebKeySet | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed?.keys && Array.isArray(parsed.keys)) {
+      return parsed as jose.JSONWebKeySet
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract JWT token from Authorization header
+ *
+ * Parses the Authorization header to extract the Bearer token.
+ * Expects format: "Bearer <token>"
+ *
+ * @param req - The HTTP request object
+ * @returns The JWT token string
+ * @throws Error if Authorization header is missing or malformed
+ */
+function getAuthToken(req: Request) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) {
+    throw new Error('Missing authorization header')
+  }
+  const [bearer, token] = authHeader.split(' ')
+  if (bearer !== 'Bearer') {
+    throw new Error(`Auth header is not 'Bearer {token}'`)
+  }
+  return token
+}
+
+async function isValidLegacyJWT(jwt: string): Promise<boolean> {
+  if (!JWT_SECRET) {
+    console.error('JWT_SECRET not available for HS256 token verification')
+    return false
+  }
+
+  const encoder = new TextEncoder();
+  const secretKey = encoder.encode(JWT_SECRET);
+
+  try {
+    await jose.jwtVerify(jwt, secretKey);
+  } catch (e) {
+    console.error('Symmetric Legacy JWT verification error', e);
+    return false;
+  }
+  return true;
+}
+
+async function isValidJWT(jwt: string): Promise<boolean> {
+  if (!SUPABASE_JWKS) {
+    console.error('JWKS not available for ES256/RS256 token verification')
+    return false
+  }
+
+  try {
+    const localJwks = jose.createLocalJWKSet(SUPABASE_JWKS);
+    await jose.jwtVerify(jwt, localJwks);
+  } catch (e) {
+    console.error('Asymmetric JWT verification error', e);
+    return false
+  }
+
+  return true;
+}
+
+/**
+ * Verify JWT token, handling both legacy (HS256) and newer (ES256/RS256) algorithms
+ * 
+ * This function automatically detects the algorithm used in the token and applies
+ * the appropriate verification method:
+ * - HS256: Uses JWT_SECRET (symmetric key)
+ * - ES256/RS256: Uses JWKS endpoint (asymmetric public keys)
+ * 
+ * This fix ensures compatibility with both legacy tokens and newer asymmetric tokens,
+ * resolving the "Key for the ES256 algorithm must be of type CryptoKey" error.
+ * 
+ * @param jwt - The JWT token string to verify
+ * @returns Promise resolving to true if verification succeeds, false otherwise
+ */
+async function isValidHybridJWT(jwt: string): Promise<boolean> {
+  const { alg: jwtAlgorithm } = jose.decodeProtectedHeader(jwt)
+
+  if (jwtAlgorithm === 'HS256') {
+    console.log(`Legacy token type detected, attempting ${jwtAlgorithm} verification.`)
+
+    return await isValidLegacyJWT(jwt)
+  }
+
+  if (jwtAlgorithm === 'ES256' || jwtAlgorithm === 'RS256') {
+    return await isValidJWT(jwt)
+  }
+
+  return false;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'OPTIONS' && VERIFY_JWT) {
+    try {
+      const token = getAuthToken(req)
+      const isValidJWT = await isValidHybridJWT(token);
+
+      if (!isValidJWT) {
+        return new Response(JSON.stringify({ msg: 'Invalid JWT' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+    } catch (e) {
+      console.error(e)
+      return new Response(JSON.stringify({ msg: e.toString() }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+  }
+
+  const url = new URL(req.url)
+  const { pathname } = url
+  const path_parts = pathname.split('/')
+  const service_name = path_parts[1]
+
+  if (!service_name || service_name === '') {
+    const error = { msg: 'missing function name in request' }
+    return new Response(JSON.stringify(error), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const servicePath = `/home/deno/functions/${service_name}`
+  console.error(`serving the request with ${servicePath}`)
+
+  const memoryLimitMb = 150
+  const workerTimeoutMs = 1 * 60 * 1000
+  const noModuleCache = false
+  const importMapPath = null
+  const envVarsObj = Deno.env.toObject()
+  const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]])
+
+  try {
+    const worker = await EdgeRuntime.userWorkers.create({
+      servicePath,
+      memoryLimitMb,
+      workerTimeoutMs,
+      noModuleCache,
+      importMapPath,
+      envVars,
+    })
+    return await worker.fetch(req)
+  } catch (e) {
+    const error = { msg: e.toString() }
+    return new Response(JSON.stringify(error), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+})

--- a/apps/cli/src/self-host/assets/supabase/volumes/logs/vector.yml
+++ b/apps/cli/src/self-host/assets/supabase/volumes/logs/vector.yml
@@ -1,0 +1,268 @@
+api:
+  enabled: true
+  address: 0.0.0.0:9001
+
+sources:
+  docker_host:
+    type: docker_logs
+    exclude_containers:
+      - supabase-vector
+
+transforms:
+  project_logs:
+    type: remap
+    inputs:
+      - docker_host
+    source: |-
+      .project = "default"
+      .event_message = del(.message)
+      .appname = del(.container_name)
+      del(.container_created_at)
+      del(.container_id)
+      del(.source_type)
+      del(.stream)
+      del(.label)
+      del(.image)
+      del(.host)
+      del(.stream)
+  router:
+    type: route
+    inputs:
+      - project_logs
+    route:
+      kong: '.appname == "supabase-kong" || .appname == "supabase-envoy"'
+      auth: '.appname == "supabase-auth"'
+      rest: '.appname == "supabase-rest"'
+      realtime: '.appname == "realtime-dev.supabase-realtime"'
+      storage: '.appname == "supabase-storage"'
+      functions: '.appname == "supabase-edge-functions"'
+      db: '.appname == "supabase-db"'
+  # Ignores non nginx errors since they are related with kong booting up
+  kong_logs:
+    type: remap
+    inputs:
+      - router.kong
+    source: |-
+      req, err = parse_nginx_log(.event_message, "combined")
+      if err == null {
+          .timestamp = req.timestamp
+          .metadata.request.headers.referer = req.referer
+          .metadata.request.headers.user_agent = req.agent
+          .metadata.request.headers.cf_connecting_ip = req.client
+          .metadata.response.status_code = req.status
+          url, split_err = split(req.request, " ")
+          if split_err == null {
+              .metadata.request.method = url[0]
+              .metadata.request.path = url[1]
+              .metadata.request.protocol = url[2]
+          }
+      }
+      if err != null {
+        abort
+      }
+  # Ignores non nginx errors since they are related with kong booting up
+  kong_err:
+    type: remap
+    inputs:
+      - router.kong
+    source: |-
+      .metadata.request.method = "GET"
+      .metadata.response.status_code = 200
+      parsed, err = parse_nginx_log(.event_message, "error")
+      if err == null {
+          .timestamp = parsed.timestamp
+          .severity = parsed.severity
+          .metadata.request.host = parsed.host
+          .metadata.request.headers.cf_connecting_ip = parsed.client
+          url, err = split(parsed.request, " ")
+          if err == null {
+              .metadata.request.method = url[0]
+              .metadata.request.path = url[1]
+              .metadata.request.protocol = url[2]
+          }
+      }
+      if err != null {
+        abort
+      }
+  # Gotrue logs are structured json strings which frontend parses directly. But we keep metadata for consistency.
+  auth_logs:
+    type: remap
+    inputs:
+      - router.auth
+    source: |-
+      parsed, err = parse_json(.event_message)
+      if err == null {
+          .metadata.timestamp = parsed.time
+          .metadata = merge!(.metadata, parsed)
+      }
+  # PostgREST logs are structured so we separate timestamp from message using regex
+  rest_logs:
+    type: remap
+    inputs:
+      - router.rest
+    source: |-
+      parsed, err = parse_regex(.event_message, r'^(?P<time>.*): (?P<msg>.*)$')
+      if err == null {
+          .event_message = parsed.msg
+          .timestamp = parse_timestamp!(value: parsed.time,format: "%d/%b/%Y:%H:%M:%S %z")
+          .metadata.host = .project
+      }
+  # Filter out healthcheck logs from Realtime
+  realtime_logs_filtered:
+    type: filter
+    inputs:
+      - router.realtime
+    condition: '!contains(string!(.event_message), "/health")'
+  # Realtime logs are structured so we parse the severity level using regex (ignore time because it has no date)
+  realtime_logs:
+    type: remap
+    inputs:
+      - realtime_logs_filtered
+    source: |-
+      .metadata.project = del(.project)
+      .metadata.external_id = .metadata.project
+      parsed, err = parse_regex(.event_message, r'^(?P<time>\d+:\d+:\d+\.\d+) \[(?P<level>\w+)\] (?P<msg>.*)$')
+      if err == null {
+          .event_message = parsed.msg
+          .metadata.level = parsed.level
+      }
+  # Function logs are unstructured messages on stderr
+  functions_logs:
+    type: remap
+    inputs:
+      - router.functions
+    source: |-
+      .metadata.project_ref = del(.project)
+  # Storage logs may contain json objects so we parse them for completeness
+  storage_logs:
+    type: remap
+    inputs:
+      - router.storage
+    source: |-
+      .metadata.project = del(.project)
+      .metadata.tenantId = .metadata.project
+      parsed, err = parse_json(.event_message)
+      if err == null {
+          .event_message = parsed.msg
+          .metadata.level = parsed.level
+          .metadata.timestamp = parsed.time
+          .metadata.context[0].host = parsed.hostname
+          .metadata.context[0].pid = parsed.pid
+      }
+  # Postgres logs some messages to stderr which we map to warning severity level
+  db_logs:
+    type: remap
+    inputs:
+      - router.db
+    source: |-
+      .metadata.host = "db-default"
+      .metadata.parsed.timestamp = .timestamp
+
+      parsed, err = parse_regex(.event_message, r'.*(?P<level>INFO|NOTICE|WARNING|ERROR|LOG|FATAL|PANIC?):.*', numeric_groups: true)
+
+      if err != null || parsed == null {
+        .metadata.parsed.error_severity = "info"
+      }
+      if parsed.level != null {
+       .metadata.parsed.error_severity = parsed.level
+      }
+      if .metadata.parsed.error_severity == "info" {
+          .metadata.parsed.error_severity = "log"
+      }
+      .metadata.parsed.error_severity = upcase!(.metadata.parsed.error_severity)
+
+sinks:
+  logflare_auth:
+    type: 'http'
+    inputs:
+      - auth_logs
+    encoding:
+      codec: 'json'
+    method: 'post'
+    request:
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
+      headers:
+        x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
+    uri: 'http://analytics:4000/api/logs?source_name=gotrue.logs.prod'
+  logflare_realtime:
+    type: 'http'
+    inputs:
+      - realtime_logs
+    encoding:
+      codec: 'json'
+    method: 'post'
+    request:
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
+      headers:
+        x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
+    uri: 'http://analytics:4000/api/logs?source_name=realtime.logs.prod'
+  logflare_rest:
+    type: 'http'
+    inputs:
+      - rest_logs
+    encoding:
+      codec: 'json'
+    method: 'post'
+    request:
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
+      headers:
+        x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
+    uri: 'http://analytics:4000/api/logs?source_name=postgREST.logs.prod'
+  logflare_db:
+    type: 'http'
+    inputs:
+      - db_logs
+    encoding:
+      codec: 'json'
+    method: 'post'
+    request:
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
+      headers:
+        x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
+    # Route directly to analytics like other sinks. Retry handles the startup
+    # race where analytics may not be ready yet when early DB logs arrive.
+    uri: 'http://analytics:4000/api/logs?source_name=postgres.logs'
+  logflare_functions:
+    type: 'http'
+    inputs:
+      - functions_logs
+    encoding:
+      codec: 'json'
+    method: 'post'
+    request:
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
+      headers:
+        x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
+    uri: 'http://analytics:4000/api/logs?source_name=deno-relay-logs'
+  logflare_storage:
+    type: 'http'
+    inputs:
+      - storage_logs
+    encoding:
+      codec: 'json'
+    method: 'post'
+    request:
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
+      headers:
+        x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
+    uri: 'http://analytics:4000/api/logs?source_name=storage.logs.prod.2'
+  logflare_kong:
+    type: 'http'
+    inputs:
+      - kong_logs
+      - kong_err
+    encoding:
+      codec: 'json'
+    method: 'post'
+    request:
+      retry_max_duration_secs: 30
+      retry_initial_backoff_secs: 1
+      headers:
+        x-api-key: ${LOGFLARE_PUBLIC_ACCESS_TOKEN?LOGFLARE_PUBLIC_ACCESS_TOKEN is required}
+    uri: 'http://analytics:4000/api/logs?source_name=cloudflare.logs.prod'

--- a/apps/cli/src/self-host/assets/supabase/volumes/pooler/pooler.exs
+++ b/apps/cli/src/self-host/assets/supabase/volumes/pooler/pooler.exs
@@ -1,0 +1,30 @@
+{:ok, _} = Application.ensure_all_started(:supavisor)
+
+{:ok, version} =
+  case Supavisor.Repo.query!("select version()") do
+    %{rows: [[ver]]} -> Supavisor.Helpers.parse_pg_version(ver)
+    _ -> nil
+  end
+
+params = %{
+  "external_id" => System.get_env("POOLER_TENANT_ID"),
+  "db_host" => System.get_env("POSTGRES_HOST") || "db",
+  "db_port" => System.get_env("POSTGRES_PORT"),
+  "db_database" => System.get_env("POSTGRES_DB"),
+  "require_user" => false,
+  "auth_query" => "SELECT * FROM pgbouncer.get_auth($1)",
+  "default_max_clients" => System.get_env("POOLER_MAX_CLIENT_CONN"),
+  "default_pool_size" => System.get_env("POOLER_DEFAULT_POOL_SIZE"),
+  "default_parameter_status" => %{"server_version" => version},
+  "users" => [%{
+    "db_user" => "pgbouncer",
+    "db_password" => System.get_env("POSTGRES_PASSWORD"),
+    "mode_type" => System.get_env("POOLER_POOL_MODE"),
+    "pool_size" => System.get_env("POOLER_DEFAULT_POOL_SIZE"),
+    "is_manager" => true
+  }]
+}
+
+if !Supavisor.Tenants.get_tenant_by_external_id(params["external_id"]) do
+  {:ok, _} = Supavisor.Tenants.create_tenant(params)
+end

--- a/apps/cli/src/self-host/aws-vpc.ts
+++ b/apps/cli/src/self-host/aws-vpc.ts
@@ -1,0 +1,304 @@
+import { spawnSync } from 'node:child_process';
+
+import { C, status } from '../style.ts';
+import {
+  loadInstanceConfig,
+  writeInstanceConfig,
+  type AwsVpcCoordinates,
+  type SelfHostInstanceConfig,
+} from './config.ts';
+import type { SelfHostCommandFlags } from './types.ts';
+
+interface AwsIdentity {
+  UserId: string;
+  Account: string;
+  Arn: string;
+}
+
+type AwsVpcCommand =
+  | 'init'
+  | 'setup'
+  | 'plan'
+  | 'deploy'
+  | 'update'
+  | 'upgrade'
+  | 'reconcile'
+  | 'rollback'
+  | 'status'
+  | 'ps'
+  | 'version'
+  | 'doctor'
+  | 'logs'
+  | 'open'
+  | 'configure'
+  | 'config'
+  | 'start'
+  | 'up'
+  | 'stop'
+  | 'down'
+  | 'restart'
+  | 'env';
+
+const DOCKER_ONLY = new Set<AwsVpcCommand>(['start', 'up', 'stop', 'down', 'restart', 'env']);
+
+export async function runAwsVpcCommand(
+  command: string,
+  args: string[],
+  flags: SelfHostCommandFlags,
+): Promise<number> {
+  const typedCommand = command as AwsVpcCommand;
+  if (DOCKER_ONLY.has(typedCommand)) return rejectDockerLifecycleCommand(typedCommand, flags.instance);
+
+  if (typedCommand === 'init' || typedCommand === 'setup') return initAwsVpc(flags);
+
+  const config = loadAwsConfig(flags.instance);
+  if (!config) return 1;
+
+  switch (typedCommand) {
+    case 'doctor':
+      return doctorAwsVpc(config, flags);
+    case 'version':
+      return showAwsVpcVersion(config, flags);
+    case 'status':
+    case 'ps':
+      return showAwsVpcStatus(config, flags);
+    case 'plan':
+    case 'deploy':
+    case 'update':
+    case 'upgrade':
+    case 'reconcile':
+    case 'rollback':
+    case 'logs':
+    case 'open':
+    case 'configure':
+    case 'config':
+      return unavailableUntilBootstrap(typedCommand, config, args, flags);
+    default:
+      process.stderr.write(`${status.err(`unknown AWS VPC self-host command "${command}"`)}\n`);
+      return 2;
+  }
+}
+
+async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
+  if (flags.local || flags.registry || flags.tag !== 'latest') {
+    process.stderr.write(
+      `${status.err('AWS VPC targets use signed releases; --local, --registry, and --tag are Docker-only options.')}\n`,
+    );
+    return 2;
+  }
+
+  const profile = flags.awsProfile?.trim() || process.env.AWS_PROFILE?.trim() || 'default';
+  const region = flags.region?.trim()
+    || process.env.AWS_REGION?.trim()
+    || process.env.AWS_DEFAULT_REGION?.trim()
+    || 'us-west-2';
+
+  let identity: AwsIdentity;
+  try {
+    identity = awsIdentity({ profile, region, account_id: '000000000000' });
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  }
+
+  const existing = loadInstanceConfig(flags.instance);
+  if (existing?.aws && existing.aws.account_id !== identity.Account) {
+    process.stderr.write(
+      `${status.err(`AWS account mismatch: instance is pinned to ${existing.aws.account_id}, profile ${profile} resolved to ${identity.Account}`)}\n`,
+    );
+    return 1;
+  }
+
+  const config: SelfHostInstanceConfig = {
+    schema_version: 1,
+    instance: flags.instance,
+    target: 'aws-vpc',
+    channel: flags.channel ?? existing?.channel ?? 'stable',
+    ...(flags.release || existing?.release ? { release: flags.release ?? existing?.release } : {}),
+    aws: { profile, region, account_id: identity.Account },
+  };
+  writeInstanceConfig(config);
+
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
+    return 0;
+  }
+
+  process.stdout.write(`\n  ${C.bold}Kortix Enterprise VPC${C.reset}\n\n`);
+  process.stdout.write(`${status.ok(existing ? 'AWS VPC instance config verified' : 'AWS VPC instance config created')}\n`);
+  process.stdout.write(`  ${C.dim}instance  ${C.reset}${config.instance}\n`);
+  process.stdout.write(`  ${C.dim}target    ${C.reset}${config.target}\n`);
+  process.stdout.write(`  ${C.dim}account   ${C.reset}${identity.Account}\n`);
+  process.stdout.write(`  ${C.dim}profile   ${C.reset}${profile}\n`);
+  process.stdout.write(`  ${C.dim}region    ${C.reset}${region}\n`);
+  process.stdout.write(`  ${C.dim}channel   ${C.reset}${config.channel}\n\n`);
+  process.stdout.write(`  ${C.dim}Next: ${C.reset}${C.cyan}kortix self-host doctor --instance ${config.instance}${C.reset}\n`);
+  process.stdout.write(`        ${C.cyan}kortix self-host plan --instance ${config.instance}${C.reset}\n\n`);
+  return 0;
+}
+
+function doctorAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
+  const coordinates = config.aws!;
+  const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
+  try {
+    const identity = awsIdentity(coordinates);
+    checks.push({
+      name: 'aws-identity',
+      ok: identity.Account === coordinates.account_id,
+      detail: `${identity.Account} (${identity.Arn})`,
+    });
+  } catch (error) {
+    checks.push({ name: 'aws-identity', ok: false, detail: (error as Error).message });
+  }
+  for (const [name, command, args] of [
+    ['terraform', 'terraform', ['version', '-json']],
+    ['kubectl', 'kubectl', ['version', '--client=true', '--output=json']],
+    ['helm', 'helm', ['version', '--short']],
+  ] as const) {
+    const result = spawnSync(command, args, { encoding: 'utf8' });
+    checks.push({
+      name,
+      ok: !result.error && result.status === 0,
+      detail: result.error?.message ?? (firstLine(result.stdout || result.stderr) || `exit ${result.status ?? 1}`),
+    });
+  }
+
+  const ok = checks.every((check) => check.ok);
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify({ instance: config.instance, target: config.target, ok, checks }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`\n  ${C.bold}kortix self-host doctor${C.reset}\n`);
+    process.stdout.write(`  ${C.dim}instance ${C.reset}${config.instance}\n\n`);
+    for (const check of checks) {
+      process.stdout.write(`${check.ok ? status.ok(check.name) : status.err(check.name)} ${C.dim}${check.detail}${C.reset}\n`);
+    }
+    process.stdout.write('\n');
+  }
+  return ok ? 0 : 1;
+}
+
+function showAwsVpcVersion(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
+  const payload = {
+    instance: config.instance,
+    target: config.target,
+    channel: config.channel,
+    release: config.release ?? null,
+  };
+  if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  else {
+    process.stdout.write(`\n  ${C.bold}kortix self-host version${C.reset}\n`);
+    process.stdout.write(`  ${C.dim}instance ${C.reset}${config.instance}\n`);
+    process.stdout.write(`  ${C.dim}channel  ${C.reset}${config.channel}\n`);
+    process.stdout.write(`  ${C.dim}release  ${C.reset}${config.release ?? 'not deployed'}\n\n`);
+  }
+  return 0;
+}
+
+function showAwsVpcStatus(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
+  const coordinates = config.aws!;
+  let identity: AwsIdentity;
+  try {
+    identity = awsIdentity(coordinates);
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  }
+  if (identity.Account !== coordinates.account_id) {
+    process.stderr.write(
+      `${status.err(`AWS account mismatch: expected ${coordinates.account_id}, resolved ${identity.Account}`)}\n`,
+    );
+    return 1;
+  }
+  const payload = {
+    instance: config.instance,
+    target: config.target,
+    account_id: coordinates.account_id,
+    region: coordinates.region,
+    channel: config.channel,
+    release: config.release ?? null,
+    bootstrap: 'pending',
+  };
+  if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  else {
+    process.stdout.write(`\n  ${C.bold}kortix self-host status${C.reset}\n`);
+    for (const [key, value] of Object.entries(payload)) {
+      process.stdout.write(`  ${C.dim}${key.padEnd(11)}${C.reset}${value ?? 'none'}\n`);
+    }
+    process.stdout.write('\n');
+  }
+  return 0;
+}
+
+function unavailableUntilBootstrap(
+  command: AwsVpcCommand,
+  config: SelfHostInstanceConfig,
+  _args: string[],
+  _flags: SelfHostCommandFlags,
+): number {
+  process.stderr.write(
+    `${status.err(`AWS VPC ${command} is not available until the enterprise bootstrap bundle is installed for ${config.instance}.`)}\n`,
+  );
+  process.stderr.write(`${C.dim}Run ${C.reset}${C.cyan}kortix self-host doctor --instance ${config.instance}${C.reset}${C.dim} first.${C.reset}\n`);
+  return 1;
+}
+
+function rejectDockerLifecycleCommand(command: AwsVpcCommand, instance: string): number {
+  const canonical = command === 'up' ? 'start' : command === 'down' ? 'stop' : command;
+  process.stderr.write(`${status.err(`${canonical} is only available for Docker targets.`)}\n`);
+  if (canonical === 'start') {
+    process.stderr.write(
+      `${C.dim}AWS VPC environments are continuously reconciled; bootstrap with ${C.reset}${C.cyan}kortix self-host deploy --instance ${instance}${C.reset}${C.dim}.${C.reset}\n`,
+    );
+  }
+  return 2;
+}
+
+function loadAwsConfig(instance: string): SelfHostInstanceConfig | null {
+  let config: SelfHostInstanceConfig | null;
+  try {
+    config = loadInstanceConfig(instance);
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return null;
+  }
+  if (!config) {
+    process.stderr.write(
+      `${status.err(`Self-host instance "${instance}" is not initialized. Run \`kortix self-host init --target aws-vpc --instance ${instance}\` first.`)}\n`,
+    );
+    return null;
+  }
+  if (config.target !== 'aws-vpc' || !config.aws) {
+    process.stderr.write(`${status.err(`Self-host instance "${instance}" is not an AWS VPC target.`)}\n`);
+    return null;
+  }
+  return config;
+}
+
+function awsIdentity(coordinates: AwsVpcCoordinates): AwsIdentity {
+  const result = spawnSync(
+    'aws',
+    [
+      '--profile', coordinates.profile,
+      '--region', coordinates.region,
+      'sts', 'get-caller-identity',
+      '--output', 'json',
+      '--no-cli-pager',
+    ],
+    { encoding: 'utf8' },
+  );
+  if (result.error) throw new Error(`unable to run AWS CLI: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new Error(`AWS identity check failed for profile ${coordinates.profile}: ${firstLine(result.stderr) || `exit ${result.status}`}`);
+  }
+  try {
+    const identity = JSON.parse(result.stdout) as AwsIdentity;
+    if (!/^\d{12}$/.test(identity.Account) || !identity.Arn) throw new Error('missing Account or Arn');
+    return identity;
+  } catch (error) {
+    throw new Error(`AWS identity response was invalid: ${(error as Error).message}`);
+  }
+}
+
+function firstLine(value: string): string {
+  return value.trim().split(/\r?\n/, 1)[0] ?? '';
+}

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -1,0 +1,158 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { parse, stringify } from 'yaml';
+
+import kortixCompose from './assets/kortix-compose.yml' with { type: 'text' };
+import supabaseCompose from './assets/supabase/docker-compose.yml' with { type: 'text' };
+import supabaseLogsCompose from './assets/supabase/docker-compose.logs.yml' with { type: 'text' };
+import kongEntrypoint from './assets/supabase/volumes/api/kong-entrypoint.sh' with { type: 'text' };
+import kongConfig from './assets/supabase/volumes/api/kong.yml' with { type: 'text' };
+import supabaseInternalSql from './assets/supabase/volumes/db/_supabase.sql' with { type: 'text' };
+import jwtSql from './assets/supabase/volumes/db/jwt.sql' with { type: 'text' };
+import logsSql from './assets/supabase/volumes/db/logs.sql' with { type: 'text' };
+import poolerSql from './assets/supabase/volumes/db/pooler.sql' with { type: 'text' };
+import realtimeSql from './assets/supabase/volumes/db/realtime.sql' with { type: 'text' };
+import rolesSql from './assets/supabase/volumes/db/roles.sql' with { type: 'text' };
+import webhooksSql from './assets/supabase/volumes/db/webhooks.sql' with { type: 'text' };
+import helloFunction from './assets/supabase/volumes/functions/hello/index.ts.txt' with { type: 'text' };
+import mainFunction from './assets/supabase/volumes/functions/main/index.ts.txt' with { type: 'text' };
+import vectorConfig from './assets/supabase/volumes/logs/vector.yml' with { type: 'text' };
+import poolerConfig from './assets/supabase/volumes/pooler/pooler.exs' with { type: 'text' };
+
+type YamlRecord = Record<string, unknown>;
+
+const SERVICE_NAMES: Record<string, string> = {
+  studio: 'supabase-studio',
+  kong: 'supabase-kong',
+  auth: 'supabase-auth',
+  rest: 'supabase-rest',
+  realtime: 'supabase-realtime',
+  storage: 'supabase-storage',
+  imgproxy: 'supabase-imgproxy',
+  meta: 'supabase-meta',
+  functions: 'supabase-functions',
+  db: 'supabase-db',
+  supavisor: 'supabase-supavisor',
+  analytics: 'supabase-analytics',
+  vector: 'supabase-vector',
+};
+
+export const SUPABASE_UPSTREAM_COMMIT = '20649d23740e2facc5d11f7220947b9cddf9480c';
+
+export const supabaseVendorAssets: Readonly<Record<string, string>> = {
+  'volumes/api/kong-entrypoint.sh': kongEntrypoint,
+  'volumes/api/kong.yml': kongConfig,
+  'volumes/db/_supabase.sql': supabaseInternalSql,
+  'volumes/db/jwt.sql': jwtSql,
+  'volumes/db/logs.sql': logsSql,
+  'volumes/db/pooler.sql': poolerSql,
+  'volumes/db/realtime.sql': realtimeSql,
+  'volumes/db/roles.sql': rolesSql,
+  'volumes/db/webhooks.sql': webhooksSql,
+  'volumes/functions/hello/index.ts': helloFunction,
+  'volumes/functions/main/index.ts': mainFunction,
+  'volumes/logs/vector.yml': vectorConfig,
+  'volumes/pooler/pooler.exs': poolerConfig,
+};
+
+/**
+ * Compose the pinned official Supabase Docker distribution with the Kortix
+ * application services. The upstream service definitions and image pins stay
+ * intact; we only remove globally-conflicting container names, add legacy
+ * Kortix service names, and restrict every published port to loopback.
+ */
+export function renderFullDockerCompose(composeProject: string): string {
+  const base = parse(
+    supabaseCompose.replaceAll('${POSTGRES_PORT}', '${SUPABASE_POSTGRES_INTERNAL_PORT}'),
+  ) as YamlRecord;
+  const logs = parse(
+    supabaseLogsCompose.replaceAll('${POSTGRES_PORT}', '${SUPABASE_POSTGRES_INTERNAL_PORT}'),
+  ) as YamlRecord;
+  const kortix = parse(
+    kortixCompose.replaceAll('__KORTIX_COMPOSE_PROJECT__', composeProject),
+  ) as YamlRecord;
+
+  const upstreamServices = deepMerge(
+    asRecord(base.services),
+    asRecord(logs.services),
+  ) as Record<string, YamlRecord>;
+  const services: Record<string, YamlRecord> = {};
+
+  for (const [upstreamName, rawService] of Object.entries(upstreamServices)) {
+    const serviceName = SERVICE_NAMES[upstreamName] ?? upstreamName;
+    const service = structuredClone(rawService);
+    delete service.container_name;
+    service.depends_on = renameDependencies(service.depends_on);
+    service.networks = addNetworkAlias(service.networks, upstreamName);
+    services[serviceName] = service;
+  }
+
+  const kong = services['supabase-kong'];
+  if (kong) kong.ports = ['127.0.0.1:${SUPABASE_PORT}:8000'];
+  const supavisor = services['supabase-supavisor'];
+  if (supavisor) {
+    supavisor.ports = [
+      '127.0.0.1:${POSTGRES_PORT}:5432',
+      '127.0.0.1:${POOLER_PORT}:6543',
+    ];
+  }
+
+  for (const [name, rawService] of Object.entries(asRecord(kortix.services))) {
+    services[name] = rawService as YamlRecord;
+  }
+
+  const document: YamlRecord = {
+    services,
+    volumes: deepMerge(asRecord(base.volumes), asRecord(kortix.volumes)),
+  };
+  return stringify(document, { lineWidth: 0 });
+}
+
+export function writeSupabaseVendorAssets(root: string): void {
+  for (const [relativePath, content] of Object.entries(supabaseVendorAssets)) {
+    const path = join(root, relativePath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, { encoding: 'utf8', mode: relativePath.endsWith('.sh') ? 0o700 : 0o600 });
+    if (relativePath.endsWith('.sh')) chmodSync(path, 0o700);
+  }
+  mkdirSync(join(root, 'volumes', 'db', 'data'), { recursive: true, mode: 0o700 });
+  mkdirSync(join(root, 'volumes', 'storage'), { recursive: true, mode: 0o700 });
+  mkdirSync(join(root, 'volumes', 'snippets'), { recursive: true, mode: 0o700 });
+}
+
+function renameDependencies(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([name, condition]) => [SERVICE_NAMES[name] ?? name, condition]),
+  );
+}
+
+function addNetworkAlias(value: unknown, alias: string): YamlRecord {
+  const networks = isRecord(value) ? structuredClone(value) : {};
+  const currentDefault = isRecord(networks.default) ? networks.default : {};
+  const aliases = Array.isArray(currentDefault.aliases)
+    ? currentDefault.aliases.filter((item): item is string => typeof item === 'string')
+    : [];
+  currentDefault.aliases = [...new Set([...aliases, alias])];
+  networks.default = currentDefault;
+  return networks;
+}
+
+function deepMerge(left: YamlRecord, right: YamlRecord): YamlRecord {
+  const merged: YamlRecord = structuredClone(left);
+  for (const [key, value] of Object.entries(right)) {
+    const previous = merged[key];
+    merged[key] = isRecord(previous) && isRecord(value)
+      ? deepMerge(previous, value)
+      : structuredClone(value);
+  }
+  return merged;
+}
+
+function asRecord(value: unknown): YamlRecord {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is YamlRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/cli/src/self-host/config.ts
+++ b/apps/cli/src/self-host/config.ts
@@ -1,0 +1,157 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export type SelfHostTarget = 'docker' | 'aws-vpc';
+
+export interface AwsVpcCoordinates {
+  profile: string;
+  region: string;
+  account_id: string;
+}
+
+export interface SelfHostInstanceConfig {
+  schema_version: 1;
+  instance: string;
+  target: SelfHostTarget;
+  channel: string;
+  release?: string;
+  aws?: AwsVpcCoordinates;
+}
+
+const INSTANCE_PATTERN = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
+const REGION_PATTERN = /^[a-z]{2}(?:-gov)?-[a-z]+-\d$/;
+const TOP_LEVEL_FIELDS = new Set(['schema_version', 'instance', 'target', 'channel', 'release', 'aws']);
+const AWS_FIELDS = new Set(['profile', 'region', 'account_id']);
+
+export function selfHostConfigRoot(): string {
+  const override = process.env.KORTIX_SELF_HOST_CONFIG_DIR?.trim();
+  return override ? resolve(override) : resolve(homedir(), '.config', 'kortix', 'self-host');
+}
+
+export function instanceDir(instance: string): string {
+  assertInstanceName(instance);
+  return join(selfHostConfigRoot(), instance);
+}
+
+export function instanceConfigPath(instance: string): string {
+  return join(instanceDir(instance), 'instance.json');
+}
+
+export function loadInstanceConfig(instance: string): SelfHostInstanceConfig | null {
+  const path = instanceConfigPath(instance);
+  if (!existsSync(path)) {
+    // Before target-aware self-hosting, Docker instances persisted only a .env
+    // and generated Compose assets. Treat that layout as the Docker adapter so
+    // every existing install remains usable without a migration command.
+    if (existsSync(join(instanceDir(instance), '.env'))) {
+      return {
+        schema_version: 1,
+        instance,
+        target: 'docker',
+        channel: 'latest',
+      };
+    }
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    throw new Error(`invalid self-host instance config at ${path}: ${(error as Error).message}`);
+  }
+  return validateInstanceConfig(parsed, instance);
+}
+
+export function writeInstanceConfig(config: SelfHostInstanceConfig): void {
+  const validated = validateInstanceConfig(config, config.instance);
+  const dir = instanceDir(validated.instance);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = instanceConfigPath(validated.instance);
+  writeFileSync(path, `${JSON.stringify(validated, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+export function resolveInstanceTarget(instance: string, requested?: SelfHostTarget): SelfHostTarget {
+  const configured = loadInstanceConfig(instance);
+  if (requested && configured && requested !== configured.target) {
+    throw new Error(
+      `instance "${instance}" targets ${configured.target}; create a different instance to use ${requested}`,
+    );
+  }
+  return requested ?? configured?.target ?? 'docker';
+}
+
+export function parseSelfHostTarget(value: string | undefined): SelfHostTarget | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'docker' || value === 'aws-vpc') return value;
+  throw new Error(`target must be "docker" or "aws-vpc", got "${value}"`);
+}
+
+function validateInstanceConfig(value: unknown, expectedInstance: string): SelfHostInstanceConfig {
+  if (!isRecord(value)) throw new Error('self-host instance config must be a JSON object');
+  rejectUnknownFields(value, TOP_LEVEL_FIELDS);
+
+  if (value.schema_version !== 1) throw new Error('self-host instance config schema_version must be 1');
+  if (value.instance !== expectedInstance) {
+    throw new Error(`self-host instance config belongs to "${String(value.instance)}", expected "${expectedInstance}"`);
+  }
+  assertInstanceName(expectedInstance);
+
+  const target = parseSelfHostTarget(asRequiredString(value.target, 'target'))!;
+  const channel = asRequiredString(value.channel, 'channel');
+  if (!/^[a-zA-Z0-9._-]+$/.test(channel)) {
+    throw new Error('channel may contain only letters, digits, dots, underscores, or dashes');
+  }
+
+  const release = optionalString(value.release, 'release');
+  let aws: AwsVpcCoordinates | undefined;
+  if (target === 'aws-vpc') {
+    if (!isRecord(value.aws)) throw new Error('aws-vpc instance config requires aws coordinates');
+    rejectUnknownFields(value.aws, AWS_FIELDS, 'aws.');
+    const profile = asRequiredString(value.aws.profile, 'aws.profile');
+    const region = asRequiredString(value.aws.region, 'aws.region');
+    const accountId = asRequiredString(value.aws.account_id, 'aws.account_id');
+    if (!REGION_PATTERN.test(region)) throw new Error(`invalid aws.region "${region}"`);
+    if (!/^\d{12}$/.test(accountId)) throw new Error('aws.account_id must be a 12-digit AWS account ID');
+    aws = { profile, region, account_id: accountId };
+  } else if (value.aws !== undefined) {
+    throw new Error('Docker instance config must not contain aws coordinates');
+  }
+
+  return {
+    schema_version: 1,
+    instance: expectedInstance,
+    target,
+    channel,
+    ...(release ? { release } : {}),
+    ...(aws ? { aws } : {}),
+  };
+}
+
+function assertInstanceName(instance: string): void {
+  if (!INSTANCE_PATTERN.test(instance)) {
+    throw new Error('instance must start with a letter and contain only letters, digits, dots, underscores, or dashes');
+  }
+}
+
+function rejectUnknownFields(value: Record<string, unknown>, allowed: Set<string>, prefix = ''): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`unsupported field "${prefix}${key}" in self-host instance config`);
+  }
+}
+
+function asRequiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') throw new Error(`${field} must be a non-empty string`);
+  return value.trim();
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  return asRequiredString(value, field);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/cli/src/self-host/types.ts
+++ b/apps/cli/src/self-host/types.ts
@@ -1,0 +1,16 @@
+import type { SelfHostTarget } from './config.ts';
+
+export interface SelfHostCommandFlags {
+  instance: string;
+  tag: string;
+  release?: string;
+  channel?: string;
+  target?: SelfHostTarget;
+  awsProfile?: string;
+  region?: string;
+  yes: boolean;
+  local: boolean;
+  registry: boolean;
+  json: boolean;
+  force: boolean;
+}


### PR DESCRIPTION
Summary:
- preserve Docker self-host compatibility while adding a secret-free aws-vpc instance contract and management command surface
- replace the embedded minimal Supabase subset with a pinned full official Supabase Docker distribution on PostgreSQL 17
- add immutable upstream content locking, loopback-only ports, multi-instance-safe service names, and compiled-binary asset embedding

Verification:
- pnpm --filter @kortix/cli typecheck
- pnpm --filter @kortix/cli test (205 passed)
- pnpm --filter @kortix/cli build
- compiled darwin-arm64 CLI init plus docker compose config --quiet
- fresh self-host schema-bootstrap E2E: 98 tables, healthy API, owner bootstrap, authenticated accounts read