### PR TITLE
fix(ci): isolate self-host schema bootstrap services

### DIFF
--- a/apps/cli/scripts/self-host-e2e/schema-check.sh
+++ b/apps/cli/scripts/self-host-e2e/schema-check.sh
@@ -37,6 +37,38 @@ die() { printf "  ${RED}✗${RESET} %s\n" "$1" >&2; exit 1; }
 compose() { docker compose --project-name "kortix-$INSTANCE" --env-file "$CONFIG_DIR/.env" -f "$CONFIG_DIR/docker-compose.yml" "$@"; }
 psqls() { compose exec -T supabase-db psql -v ON_ERROR_STOP=0 -tAU postgres -d postgres "$@" 2>&1; }
 
+container_id() { compose ps -aq "$1"; }
+
+wait_healthy() {
+  local service=$1 timeout=${2:-120} start id state
+  start=$(date +%s)
+  while true; do
+    id=$(container_id "$service")
+    state=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$id" 2>/dev/null || true)
+    [ "$state" = "healthy" ] && return 0
+    if [ $(( $(date +%s) - start )) -ge "$timeout" ]; then
+      compose logs "$service" 2>&1 | tail -80 >&2
+      die "$service never became healthy (state=${state:-missing})"
+    fi
+    sleep 2
+  done
+}
+
+wait_completed() {
+  local service=$1 timeout=${2:-180} start id state
+  start=$(date +%s)
+  while true; do
+    id=$(container_id "$service")
+    state=$(docker inspect -f '{{.State.Status}}' "$id" 2>/dev/null || true)
+    [ "$state" = "exited" ] && return 0
+    if [ $(( $(date +%s) - start )) -ge "$timeout" ]; then
+      compose logs "$service" 2>&1 | tail -80 >&2
+      die "$service did not complete (state=${state:-missing})"
+    fi
+    sleep 2
+  done
+}
+
 cleanup() {
   local rc=$?
   set +e
@@ -78,7 +110,21 @@ $CLI self-host env set --instance "$INSTANCE" \
 ok "config initialized"
 
 section "Bring Up Data Plane (db, auth, rest, kong, migrate, api)"
-compose up -d supabase-db supabase-auth supabase-rest supabase-kong kortix-api
+# Start the schema gate's deliberately small service set explicitly. The full
+# official Supabase graph makes Kong wait for Studio, which in turn starts the
+# analytics stack; that is correct for a real full-stack boot but wastes CI
+# resources and made this focused gate vulnerable to unrelated Logflare/Studio
+# startup timing. `--no-deps` keeps this test honest about exactly what it uses.
+compose up -d --no-deps supabase-db
+wait_healthy supabase-db 120
+compose up -d --no-deps supabase-auth supabase-rest
+wait_healthy supabase-auth 120
+wait_healthy supabase-rest 120
+compose up -d --no-deps kortix-migrate
+wait_completed kortix-migrate 180
+compose up -d --no-deps supabase-kong
+wait_healthy supabase-kong 120
+compose up -d --no-deps kortix-api
 ok "compose up"
 
 section "Schema Bootstrap (migrate one-shot)"

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -17,6 +17,7 @@ describe('full self-host Docker distribution', () => {
         container_name?: string;
         ports?: string[];
         depends_on?: Record<string, unknown>;
+        healthcheck?: { test?: string[] };
       }>;
     };
 
@@ -42,6 +43,10 @@ describe('full self-host Docker distribution', () => {
     expect(document.services['supabase-db']?.image).toBe('supabase/postgres:17.6.1.136');
     expect(document.services['supabase-studio']?.image).toBe('supabase/studio:2026.07.07-sha-a6a04f2');
     expect(document.services['supabase-analytics']?.image).toBe('supabase/logflare:1.43.1');
+    expect(document.services['supabase-db']?.healthcheck?.test).toEqual([
+      'CMD-SHELL',
+      'PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
+    ]);
 
     for (const [name, service] of Object.entries(document.services)) {
       expect(service.container_name, `${name} must support multiple Kortix instances`).toBeUndefined();

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from 'bun:test';
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { parse } from 'yaml';
 
 import {
   renderFullDockerCompose,
   SUPABASE_UPSTREAM_COMMIT,
   supabaseVendorAssets,
+  writeSupabaseVendorAssets,
 } from '../compose-assets.ts';
 
 describe('full self-host Docker distribution', () => {
@@ -80,6 +83,20 @@ describe('full self-host Docker distribution', () => {
     ]);
     for (const [path, content] of Object.entries(supabaseVendorAssets)) {
       expect(content.length, `${path} must not be empty`).toBeGreaterThan(10);
+    }
+  });
+
+  test('writes bind-mounted assets with container-readable modes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-supabase-assets-'));
+    try {
+      writeSupabaseVendorAssets(root);
+
+      for (const relativePath of Object.keys(supabaseVendorAssets)) {
+        const mode = statSync(join(root, relativePath)).mode & 0o777;
+        expect(mode, relativePath).toBe(relativePath.endsWith('.sh') ? 0o755 : 0o644);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -45,7 +45,7 @@ describe('full self-host Docker distribution', () => {
     expect(document.services['supabase-analytics']?.image).toBe('supabase/logflare:1.43.1');
     expect(document.services['supabase-db']?.healthcheck?.test).toEqual([
       'CMD-SHELL',
-      'PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
+      'tr \'\\0\' \' \' </proc/1/cmdline | grep -q \'/postgres \' && PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
     ]);
 
     for (const [name, service] of Object.entries(document.services)) {

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -45,7 +45,7 @@ describe('full self-host Docker distribution', () => {
     expect(document.services['supabase-analytics']?.image).toBe('supabase/logflare:1.43.1');
     expect(document.services['supabase-db']?.healthcheck?.test).toEqual([
       'CMD-SHELL',
-      'tr \'\\0\' \' \' </proc/1/cmdline | grep -q \'/postgres \' && PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
+      'tr \'\\0\' \' \' </proc/1/cmdline | grep -q \'/postgres \' && PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h supabase-db -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
     ]);
 
     for (const [name, service] of Object.entries(document.services)) {

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -89,6 +89,25 @@ export function renderFullDockerCompose(composeProject: string): string {
 
   const kong = services['supabase-kong'];
   if (kong) kong.ports = ['127.0.0.1:${SUPABASE_PORT}:8000'];
+  const database = services['supabase-db'];
+  if (database) {
+    // `pg_isready` succeeds against the temporary server that the Postgres
+    // entrypoint uses while running init scripts. Auth can therefore start
+    // before the late 99-roles.sql script has assigned its password and enter
+    // a permanent restart loop. Treat the database as ready only after a real
+    // password-authenticated query using Auth's role succeeds. `$$` defers the
+    // environment expansion from Compose to the healthcheck container.
+    database.healthcheck = {
+      test: [
+        'CMD-SHELL',
+        'PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
+      ],
+      interval: '5s',
+      timeout: '5s',
+      retries: 20,
+      start_period: '10s',
+    };
+  }
   const supavisor = services['supabase-supavisor'];
   if (supavisor) {
     supavisor.ports = [

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -135,9 +135,17 @@ export function renderFullDockerCompose(composeProject: string): string {
 export function writeSupabaseVendorAssets(root: string): void {
   for (const [relativePath, content] of Object.entries(supabaseVendorAssets)) {
     const path = join(root, relativePath);
+    const mode = relativePath.endsWith('.sh') ? 0o755 : 0o644;
     mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, content, { encoding: 'utf8', mode: relativePath.endsWith('.sh') ? 0o700 : 0o600 });
-    if (relativePath.endsWith('.sh')) chmodSync(path, 0o700);
+    // These files are bind-mounted into containers that intentionally run as
+    // non-root users. Docker Desktop can mask restrictive host modes, while a
+    // native Linux Docker engine preserves them and rejects a 0600 SQL/config
+    // file owned by the host user. The assets contain no secrets; runtime
+    // secrets remain in the separately protected .env file.
+    writeFileSync(path, content, { encoding: 'utf8', mode });
+    // `mode` only applies when creating a file. Reconcile an existing install
+    // too so upgrading repairs assets emitted by an older CLI.
+    chmodSync(path, mode);
   }
   mkdirSync(join(root, 'volumes', 'db', 'data'), { recursive: true, mode: 0o700 });
   mkdirSync(join(root, 'volumes', 'storage'), { recursive: true, mode: 0o700 });

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -94,13 +94,15 @@ export function renderFullDockerCompose(composeProject: string): string {
     // `pg_isready` succeeds against the temporary server that the Postgres
     // entrypoint uses while running init scripts. Auth can therefore start
     // before the late 99-roles.sql script has assigned its password and enter
-    // a permanent restart loop. Treat the database as ready only after a real
-    // password-authenticated query using Auth's role succeeds. `$$` defers the
+    // a permanent restart loop. The temporary init server can also accept a
+    // successful query and then shut down underneath a just-started Auth
+    // process, so require PID 1 to be the final postgres process as well as a
+    // real password-authenticated query using Auth's role. `$$` defers the
     // environment expansion from Compose to the healthcheck container.
     database.healthcheck = {
       test: [
         'CMD-SHELL',
-        'PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
+        'tr \'\\0\' \' \' </proc/1/cmdline | grep -q \'/postgres \' && PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
       ],
       interval: '5s',
       timeout: '5s',

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -97,12 +97,15 @@ export function renderFullDockerCompose(composeProject: string): string {
     // a permanent restart loop. The temporary init server can also accept a
     // successful query and then shut down underneath a just-started Auth
     // process, so require PID 1 to be the final postgres process as well as a
-    // real password-authenticated query using Auth's role. `$$` defers the
-    // environment expansion from Compose to the healthcheck container.
+    // real password-authenticated query using Auth's role over the Docker
+    // network. The network hop is important: localhost can use a more
+    // permissive pg_hba rule than Auth's container and hide a bad role
+    // password. `$$` defers environment expansion from Compose to the
+    // healthcheck container.
     database.healthcheck = {
       test: [
         'CMD-SHELL',
-        'tr \'\\0\' \' \' </proc/1/cmdline | grep -q \'/postgres \' && PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h 127.0.0.1 -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
+        'tr \'\\0\' \' \' </proc/1/cmdline | grep -q \'/postgres \' && PGPASSWORD="$${POSTGRES_PASSWORD}" psql -h supabase-db -U supabase_auth_admin -d "$${POSTGRES_DB}" -tAc \'select 1\' >/dev/null',
       ],
       interval: '5s',
       timeout: '5s',


### PR DESCRIPTION
## What changed
- make Supabase DB health require the final Postgres PID plus a password-authenticated `supabase_auth_admin` query over the Docker service network
- start only DB/Auth/REST/Kong/migrator/API in the focused schema gate
- wait explicitly for service health and migration completion
- keep the full official Supabase graph unchanged for normal self-host and nightly E2E

## Root cause
The upstream `pg_isready` check can succeed against Postgres's temporary init server before late role/password initialization is durable. A localhost query was also insufficient because pg_hba can differ from the container-network path GoTrue actually uses. On Linux, GoTrue therefore boot-looped with SQLSTATE 28P01.

## Verification
- `pnpm --filter @kortix/cli test src/self-host/__tests__/compose-assets.test.ts` — 3 pass
- `pnpm --filter @kortix/cli typecheck`
- fresh local full schema gate — 98 tables, migrator exit 0, API healthy, owner bootstrap, authenticated `GET /v1/accounts`
- explicit `linux/amd64` Postgres + GoTrue probe under emulation — generated password accepted over `supabase-db`, wrong password rejected, GoTrue healthy