### PR TITLE
content: publish Kortix vs Glean comparison

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -799,7 +799,147 @@ const aiTransformationCompanyOs: BlogPostEntry = {
   ],
 };
 
+const kortixVsGlean: BlogPostEntry = {
+  slug: 'kortix-vs-glean',
+  title: 'Kortix vs Glean: search or an agent platform that runs work?',
+  description:
+    "Glean is the best permission-aware enterprise search. But search finds work — it doesn't do it. Here's where you outgrow it, and the open runtime alternative.",
+  date: '2026-07-13',
+  author: 'team',
+  cover: '/banner.png',
+  tags: ['Comparisons', 'Enterprise', 'Open Source'],
+  coverLogos: [{ domain: 'glean.com', name: 'Glean' }],
+  readingTime: 5,
+  blocks: [
+    {
+      type: 'lead',
+      text: "Glean is genuinely the best permission-aware enterprise search you can buy. It indexes your apps, respects your ACLs, and answers in plain language with citations. So this isn't a \"they're bad, we're good\" post. The honest question is a different one: once you can find anything in your company, what actually does the work with it?",
+    },
+    {
+      type: 'logos',
+      label: 'Compared here:',
+      items: [{ domain: 'glean.com', name: 'Glean' }],
+    },
+    { type: 'h2', text: 'What Glean is great at' },
+    {
+      type: 'ul',
+      items: [
+        '**Permission-aware search done right** — it inherits your source-system ACLs, so a result you can see is a result you can act on.',
+        '**Mature connectors** — it reaches across the usual enterprise stack and keeps the index fresh.',
+        '**Serious compliance posture** — built for the security review that enterprise search has to survive.',
+        '**A clean assistant on top of retrieval** — ask a question, get a cited answer instead of ten blue links.',
+      ],
+    },
+    { type: 'h2', text: 'Where it stops: search finds work, it doesn’t do it' },
+    {
+      type: 'p',
+      text: 'Glean’s center of gravity is the index. Agents are a layer on top of retrieval, not a workforce that runs your company. The moment the job is “open the tickets, enrich the accounts, draft and send the outreach, land the fix, close the book” — search has stopped being the bottleneck and a chat assistant over the index isn’t the answer either. You need a runtime that hands a task to agents and they return finished work.',
+    },
+    {
+      type: 'ul',
+      items: [
+        '**Retrieval-first, agents bolted on.** The product answers “where is it?” well; it is not built to run a fleet of agents that take real actions across your tools.',
+        '**Closed and vendor-hosted.** You query Glean; you don’t own it. It is SaaS or vendor-managed cloud — your company’s knowledge leaves your walls to be indexed somewhere else.',
+        '**Seat-priced and sales-led.** Public reporting puts Glean at roughly [$50–75 per user/month with a ~100-seat minimum](https://www.gosearch.ai/faqs/glean-enterprise-search-pricing-explained-costs-tiers-hidden-fees-gosearch-comparison) — about a $60k/year floor before infrastructure and implementation. That locks out the small team and the single-department pilot.',
+        '**Configured in a console, not as code.** Connectors, assistants, and prompts live in a vendor dashboard. There is no diff to review, no version to roll back, no repo to fork.',
+      ],
+    },
+    {
+      type: 'p',
+      text: 'None of that is a flaw in a search product. It is exactly the line you cross when “let me find it” becomes “let something do it.” If you want the broader framing, [beyond the chat box](/blog/beyond-the-chat-box) makes the same argument against chat assistants: input→output stops short of work.',
+    },
+    { type: 'h2', text: 'A runtime that does the work, not just retrieves it' },
+    {
+      type: 'p',
+      text: 'Kortix is an open agent runtime — the command center where a workforce of agents runs your company, not a search bar over it. Hand a task to a project and agents run in isolated sandboxes, take real actions through scoped connectors, and land durable change back to one shared `main` through a reviewed change request. The context they need is files in a repo you own, not an index someone else rents back to you.',
+    },
+    {
+      type: 'p',
+      text: 'That is the real split. Glean makes your existing knowledge searchable; Kortix makes your company’s operating layer — agents, skills, memory, connectors, policies — into [files in one repo](/blog/introducing-kortix) that agents run against. One is a window onto work; the other is where the work happens.',
+    },
+    { type: 'h2', text: 'Own the data, pick the model, skip the seat tax' },
+    {
+      type: 'p',
+      text: 'Because Kortix is open-source and self-hostable, your data never has to leave your walls — your cloud, your VPC, on-prem, or your own GPUs. And because you bring your own key and run any model, the bill is not bundled into a per-seat license. An open-weight model like **GLM-5.2** runs about **5–7× cheaper** than Claude Opus or GPT on output (~$4.40 vs $25–30 per 1M tokens), and **DeepSeek** is **50×+ cheaper** on output. Route a cheap model for the bulk of the work and a frontier model only where it earns its keep.',
+    },
+    {
+      type: 'callout',
+      text: 'No 100-seat floor, no sales process to start. Open-source means you can run one project today and a whole company on it tomorrow — on infrastructure where the data, config, and model belong to you.',
+    },
+    { type: 'h2', text: 'Side by side' },
+    {
+      type: 'compare',
+      them: 'Glean',
+      rows: [
+        {
+          dimension: 'Core job',
+          them: 'Find & answer over company data',
+          kortix: 'Build & run agents that do the work',
+        },
+        {
+          dimension: 'Runs a fleet of agents in parallel',
+          them: 'Assistants bolted onto search',
+          kortix: 'Thousands of agents, isolated sandboxes',
+        },
+        {
+          dimension: 'Self-hostable / own your data',
+          them: 'No — SaaS or vendor-managed cloud',
+          kortix: 'Yes — your cloud, VPC, on-prem',
+        },
+        {
+          dimension: 'Choose your models',
+          them: 'Vendor-managed, bundled in seat',
+          kortix: 'Any model — your keys',
+        },
+        {
+          dimension: 'Pricing model',
+          them: '~$50–75/user/mo, ~100-seat min',
+          kortix: 'Open-source; cloud or self-host, any size',
+        },
+        {
+          dimension: 'Accessible below 100 seats',
+          them: 'No — sales-led, large-enterprise floor',
+          kortix: 'Yes — start with one project',
+        },
+        {
+          dimension: 'Agents, skills & policies as code',
+          them: 'Configured in a vendor console',
+          kortix: 'Files in one repo you own',
+        },
+        {
+          dimension: 'Versioned, reviewable, roll-back-able',
+          them: 'Console settings, no diff',
+          kortix: 'Git history + change requests',
+        },
+        {
+          dimension: 'Multi-tenant governance',
+          them: 'Enterprise permissions on search',
+          kortix: 'Departments, roles, scoped connectors',
+        },
+      ],
+    },
+    { type: 'h2', text: 'When to pick which' },
+    {
+      type: 'verdict',
+      themLabel: 'Glean',
+      them: 'you want the best permission-aware enterprise search and assistant, you’re fine with a closed SaaS and a sales-led ~100-seat contract, and “find the answer” is the job.',
+      kortix:
+        'you want to run agents that actually do the work — across departments, any model, self-hosted, with everything versioned and owned by you.',
+    },
+    {
+      type: 'p',
+      text: 'They can coexist, too. Plenty of companies will keep Glean as the search layer and run the work itself on Kortix — agents that read, decide, and act, with the operating layer they need to do it governed as code. If that operating layer is what you’re missing, the [company OS post](/blog/ai-transformation-company-os) and the [secure connector model](/blog/secure-ai-agent-tool-access) are the next reads.',
+    },
+    {
+      type: 'cta',
+      title: "Don't just find the work. Run it.",
+      body: 'Connect your tools and hand a Kortix agent a real task. Free to start, free to self-host.',
+    },
+  ],
+};
+
 export const BLOG_POSTS: BlogPostEntry[] = [
+  kortixVsGlean,
   secureAiAgentToolAccess,
   aiTransformationCompanyOs,
   kortixVsClaudeCowork,


### PR DESCRIPTION
## What

New blog post: **Kortix vs Glean: search or an agent platform that runs work?** (`/blog/kortix-vs-glean`).

Uncovered comparison cluster. Existing comparison posts cover Claude Cowork, OpenClaw/Hermes, and ChatGPT/Claude/Grok — Glean (enterprise search) was missing, and it is a high-commercial-intent enterprise term where Kortix's "open runtime that does the work vs. closed search that finds it" wedge is defensible.

## Audience

Enterprise / AI-transformation buyers evaluating Glean who hit one of: closed SaaS, ~100-seat sales-led floor, "search finds work but doesn't do it," or "configured in a console, not as code."

## New vs. refresh

New post. Diff is content-only: one new `BlogPostEntry` added to `apps/web/src/lib/blog-posts.ts` and registered first in `BLOG_POSTS`. No type, renderer, route, import, or shared-UI changes.

## Performance evidence / research

Degraded mode — Search Console and PostHog are still unconfigured (recorded in `.kortix/memory/seo-blog-log.md`). Topic selected from public demand + product truth:

- Glean public pricing/positioning: ~$50-75/user/month, ~100-seat minimum (~$60k/year ACV), SaaS/vendor-managed cloud, retrieval-first with agents bolted on. Source linked in-post: https://www.gosearch.ai/faqs/glean-enterprise-search-pricing-explained-costs-tiers-hidden-fees-gosearch-comparison (corroborated by onyx.app and aiagentsquare.com).
- Kortix claims sourced to current product/positioning: open-source + self-hostable, any model / BYO key, GLM-5.2 ~5-7x cheaper and DeepSeek 50x+ cheaper on output (competitors.md), agents/skills/policies as files in one repo, microVM sandboxes, multi-tenant governance.

## Claim-source map

- Glean permission-aware search / mature connectors / compliance -> product truth, competitors.md.
- Glean ~100-seat floor / ~$50-75 per user / SaaS-only -> public source linked in prose.
- Kortix self-host / own data / any model / cost multiples / files-as-code -> positioning.md, competitors.md, /docs/guides/connecting-tools.
- No first-party clicks/impressions invented.

## Brand / comms gate

- Say: command center, open, self-hostable, Git-backed, one repo, memory/connectors/policies, isolated sandboxes, auditable agent work, real work not chat. OK.
- Avoid: AI SDR, "revolutionize," "unlock productivity," generic agent-platform slop. OK.
- Honesty gate: names what Glean is genuinely great at before the differentiators (matches competitors.md "different, not worse"). OK.
- CTA standard: "Get started" via BlogCta. OK.

## SEO/GEO gate

- Primary cluster: Glean vs Kortix / Glean alternative. Secondary: open-source enterprise search, self-hostable AI agent platform, AI command center.
- Title 60 chars. Description 158 chars.
- Core query answered in the lead (Glean = best permission-aware enterprise search; the real question is what does the work with what you find).
- Internal links: /blog/introducing-kortix, /blog/beyond-the-chat-box, /blog/ai-transformation-company-os, /blog/secure-ai-agent-tool-access. External source link to Glean pricing reporting.
- compare + verdict + cta blocks; scannable H2s.

## Verification run

- prettier --check src/lib/blog-posts.ts -> clean.
- eslint src/lib/blog-posts.ts -> no errors/warnings.
- Bun registry import: kortix-vs-glean exists, draft false, sorts first by date (2026-07-13), expected metadata, all 4 internal links + external source link present, cta/compare/verdict blocks present, 20 blocks total.
- next build --experimental-build-mode compile (KORTIX_PREVIEW_BUILD=1, 8GB heap): got past MDX + Sentry init; OOM-killed in the 12GB sandbox during the optimized production build (same as prior SEO runs). Authoritative frontend build is GitHub CI.

## Self-merge intent

Diff is limited to post objects in apps/web/src/lib/blog-posts.ts. Per the seo-blog runbook the loop will self-merge after all GitHub checks are green/skipped/neutral AND the authenticated Vercel preview verifies /blog/kortix-vs-glean, /blog, and /blog/rss.xml return 200 with the expected content.
