### PR TITLE
fix(cli): use projects route for repository linking

### DIFF
--- a/apps/cli/src/__tests__/ship.test.ts
+++ b/apps/cli/src/__tests__/ship.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
+import type { ApiClient } from '../api/client.ts';
+import type { ProjectSummary } from '../api/types.ts';
 import {
+  linkGitHubBackedProject,
   resolveExistingShipGitTarget,
   resolveProvisionShipGitTarget,
 } from '../commands/ship.ts';
-import type { ProjectSummary } from '../api/types.ts';
 
 function project(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
   return {
@@ -22,6 +24,67 @@ function project(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
     ...overrides,
   };
 }
+
+function recordingClient(
+  calls: Array<{ path: string; body: unknown }>,
+  linkedProject: ProjectSummary,
+): ApiClient {
+  return {
+    apiBase: 'https://api.kortix.test',
+    post: async <T>(path: string, body?: unknown) => {
+      calls.push({ path, body });
+      return { project: linkedProject } as T;
+    },
+  } as unknown as ApiClient;
+}
+
+describe('GitHub-backed project linking', () => {
+  test('uses the projects-mounted route with a GitHub PAT', async () => {
+    const calls: Array<{ path: string; body: unknown }> = [];
+
+    await linkGitHubBackedProject(recordingClient(calls, project()), {
+      repoUrl: 'https://github.com/acme/demo.git',
+      name: 'Demo',
+      accountId: 'acct_1',
+      githubToken: 'github_pat_test',
+      yes: true,
+    });
+
+    expect(calls).toEqual([
+      {
+        path: '/projects/link-repository',
+        body: {
+          repo_url: 'https://github.com/acme/demo.git',
+          name: 'Demo',
+          account_id: 'acct_1',
+          github_token: 'github_pat_test',
+        },
+      },
+    ]);
+  });
+
+  test('uses the projects-mounted route with the GitHub App', async () => {
+    const calls: Array<{ path: string; body: unknown }> = [];
+
+    await linkGitHubBackedProject(recordingClient(calls, project()), {
+      repoUrl: 'https://github.com/acme/demo.git',
+      name: 'Demo',
+      accountId: 'acct_1',
+      yes: true,
+    });
+
+    expect(calls).toEqual([
+      {
+        path: '/projects/link-repository',
+        body: {
+          repo_url: 'https://github.com/acme/demo.git',
+          name: 'Demo',
+          account_id: 'acct_1',
+        },
+      },
+    ]);
+  });
+});
 
 describe('ship git target resolution', () => {
   test('first-time managed ship pushes to the managed upstream with the provision token', () => {

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -519,7 +519,7 @@ interface LinkRepoResponse {
  * app entirely (the App-free fallback — handy where the app can't be installed,
  * e.g. local dev whose callback points at prod).
  */
-async function linkGitHubBackedProject(
+export async function linkGitHubBackedProject(
   client: ApiClient,
   opts: { repoUrl: string; name: string; accountId: string; githubToken?: string; yes: boolean },
 ): Promise<ProjectSummary> {
@@ -532,14 +532,17 @@ async function linkGitHubBackedProject(
 
   // PAT path: one shot, no app needed.
   if (opts.githubToken) {
-    const res = await client.post<LinkRepoResponse>('/link-repository', body(opts.githubToken));
+    const res = await client.post<LinkRepoResponse>(
+      '/projects/link-repository',
+      body(opts.githubToken),
+    );
     return res.project;
   }
 
   // App path: retry around the one-click install.
   for (let attempt = 0; attempt < 10; attempt += 1) {
     try {
-      const res = await client.post<LinkRepoResponse>('/link-repository', body());
+      const res = await client.post<LinkRepoResponse>('/projects/link-repository', body());
       return res.project;
     } catch (err) {
       const installUrl =


### PR DESCRIPTION
## Summary
- route `kortix ship` GitHub imports through `/v1/projects/link-repository`
- cover both GitHub PAT and GitHub App linking paths

## Verification
- `bun test apps/cli/src/__tests__/ship.test.ts`
- `pnpm --filter @kortix/cli test` (206 pass)
- `pnpm --filter @kortix/cli typecheck`
- `pnpm --filter @kortix/cli build`

## Note
- focused Biome check still reports pre-existing formatting/lint debt in `ship.ts` and existing test formatting; no new lint category was introduced.