### PR TITLE
feat(cli): manage enterprise AWS VPC installs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,9 @@
 **/.ruff_cache
 .turbo
 **/.turbo
+**/.terraform
+**/*.tfstate
+**/*.tfstate.*
 .vercel
 **/.vercel
 .buildx-cache

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -41,6 +41,16 @@ COPY packages/executor-sdk ./packages/executor-sdk
 COPY packages/manifest-schema ./packages/manifest-schema
 COPY packages/registry ./packages/registry
 COPY packages/starter ./packages/starter
+# The enterprise self-host adapter embeds these reviewed Terraform sources in
+# the compiled CLI. Copy only the source graph it imports; provider caches,
+# state, and unrelated deployment environments never enter this build stage.
+COPY infra/terraform/environments/enterprise-vpc-template ./infra/terraform/environments/enterprise-vpc-template
+COPY infra/terraform/modules/enterprise-platform ./infra/terraform/modules/enterprise-platform
+COPY infra/terraform/modules/enterprise-state ./infra/terraform/modules/enterprise-state
+COPY infra/terraform/modules/enterprise-vpc ./infra/terraform/modules/enterprise-vpc
+COPY infra/terraform/modules/eks ./infra/terraform/modules/eks
+COPY infra/terraform/modules/network ./infra/terraform/modules/network
+COPY infra/terraform/scripts/guard-enterprise-plan.ts ./infra/terraform/scripts/guard-enterprise-plan.ts
 RUN printf '{"name":"kortix-cli-build","private":true,"workspaces":["apps/cli","packages/*"]}\n' > package.json \
     && bun install --no-save \
     && BUN_COMPILE_TARGET=${KORTIX_AGENT_BUN_TARGET} bash apps/cli/scripts/build.sh

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -63,6 +63,15 @@ Options:
   --channel <name>     Release channel (AWS default: stable; Docker: latest).
   --aws-profile <name> AWS CLI profile used to bootstrap/manage the target.
   --region <region>    AWS region (default: AWS config, then us-west-2).
+  --vpc-cidr <cidr>    Dedicated /16 CIDR for an AWS VPC target.
+  --api-domain <name>  Public API DNS name for the AWS target.
+  --frontend-domain <name> Public dashboard DNS name for the AWS target.
+  --release-repository-url <url> Immutable enterprise TUF repository.
+  --tuf-root-sha256 <digest> Offline-reviewed trusted TUF root digest.
+  --updater-bootstrap-url <url> Digest-pinned enterprise updater binary.
+  --updater-bootstrap-sha256 <digest> Updater binary SHA-256.
+  --release-publisher-account-id <id> Account allowed to send wake-up hints.
+  --maintenance-window <window> UTC window, for example Sun:02:00-05:00.
   --local              Use current-source local images instead of registry images.
   --registry           Force registry images even when running from a source checkout.
   --force              Run now, bypassing only the configured maintenance window.
@@ -226,6 +235,15 @@ function parseGlobalFlags(args: string[]): GlobalFlags {
   const awsProfile = takeFlagValue(args, ['--aws-profile']);
   const region = takeFlagValue(args, ['--region']);
   const channel = takeFlagValue(args, ['--channel']);
+  const vpcCidr = takeFlagValue(args, ['--vpc-cidr']);
+  const apiDomain = takeFlagValue(args, ['--api-domain']);
+  const frontendDomain = takeFlagValue(args, ['--frontend-domain']);
+  const releaseRepositoryUrl = takeFlagValue(args, ['--release-repository-url']);
+  const tufRootSha256 = takeFlagValue(args, ['--tuf-root-sha256']);
+  const updaterBootstrapUrl = takeFlagValue(args, ['--updater-bootstrap-url']);
+  const updaterBootstrapSha256 = takeFlagValue(args, ['--updater-bootstrap-sha256']);
+  const releasePublisherAccountId = takeFlagValue(args, ['--release-publisher-account-id']);
+  const maintenanceWindow = takeFlagValue(args, ['--maintenance-window']);
   if (local && registry) {
     throw new Error('use either --local or --registry, not both');
   }
@@ -240,6 +258,15 @@ function parseGlobalFlags(args: string[]): GlobalFlags {
     target,
     awsProfile,
     region,
+    vpcCidr,
+    apiDomain,
+    frontendDomain,
+    releaseRepositoryUrl,
+    tufRootSha256,
+    updaterBootstrapUrl,
+    updaterBootstrapSha256,
+    releasePublisherAccountId,
+    maintenanceWindow,
     yes,
     local,
     registry,

--- a/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
+++ b/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
@@ -4,36 +4,131 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 const CLI_ENTRY = resolve(import.meta.dir, '..', '..', 'index.ts');
+const TRUSTED_ROOT = 'a'.repeat(64);
+const BOOTSTRAP_DIGEST = 'b'.repeat(64);
 
 describe('kortix self-host aws-vpc', () => {
   let tmp: string;
   let configRoot: string;
   let fakeBin: string;
+  let awsLog: string;
+  let terraformLog: string;
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'kortix-aws-vpc-cli-'));
     configRoot = join(tmp, 'self-host');
     fakeBin = join(tmp, 'bin');
+    awsLog = join(tmp, 'aws.log');
+    terraformLog = join(tmp, 'terraform.log');
     mkdirSync(fakeBin, { recursive: true });
+    installFakeAws();
+    installFakeTerraform();
+    installSuccessfulTool('kubectl', '{"clientVersion":{"gitVersion":"v1.32.0"}}');
+    installSuccessfulTool('helm', 'v3.17.0');
+  });
+
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  function installFakeAws(): void {
     const aws = join(fakeBin, 'aws');
     writeFileSync(
       aws,
       `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_AWS_LOG"
 case "$*" in
   *"sts get-caller-identity"*)
-    printf '%s\n' '{"UserId":"fake","Account":"935064898258","Arn":"arn:aws:iam::935064898258:user/fake"}'
+    account="\${FAKE_AWS_ACCOUNT:-935064898258}"
+    case "$*" in *"--profile wrong-account"*) account="327903111249" ;; esac
+    printf '{"UserId":"fake","Account":"%s","Arn":"arn:aws:iam::%s:user/fake"}\n' "$account" "$account"
     ;;
+  *"states start-execution"*)
+    printf '%s\n' '{"executionArn":"arn:aws:states:us-west-2:935064898258:execution:kortix-vpc-demo-reconcile:cli-1","startDate":"2026-07-13T12:00:00Z"}'
+    ;;
+  *"states list-executions"*)
+    printf '%s\n' '{"executions":[{"executionArn":"arn:aws:states:us-west-2:935064898258:execution:kortix-vpc-demo-reconcile:hourly-1","name":"hourly-1","status":"SUCCEEDED","startDate":"2026-07-13T11:00:00Z","stopDate":"2026-07-13T11:05:00Z"}]}'
+    ;;
+  *"dynamodb get-item"*)
+    printf '%s\n' '{"Item":{"instance":{"S":"kortix-vpc-demo"},"release":{"S":"0.9.84-e1"},"channel":{"S":"stable"},"status":{"S":"healthy"},"updated_at":{"S":"2026-07-13T11:05:00Z"}}}'
+    ;;
+  *"eks describe-cluster"*)
+    printf '%s\n' '{"cluster":{"name":"kortix-vpc-demo","status":"ACTIVE","version":"1.32","endpoint":"https://private.example"}}'
+    ;;
+  *"codebuild batch-get-projects"*)
+    printf '%s\n' '{"projects":[{"name":"kortix-vpc-demo-updater","arn":"arn:aws:codebuild:us-west-2:935064898258:project/kortix-vpc-demo-updater"}],"projectsNotFound":[]}'
+    ;;
+  *"ec2 describe-instances"*)
+    printf '%s\n' '{"Reservations":[{"Instances":[{"InstanceId":"i-0123456789","State":{"Name":"running"},"PrivateIpAddress":"10.60.16.10"}]}]}'
+    ;;
+  *"logs tail"*) printf '%s\n' '2026-07-13T11:05:00Z updater healthy' ;;
   *"--version"*) printf '%s\n' 'aws-cli/2.31.0' ;;
   *) printf '%s\n' "unexpected aws args: $*" >&2; exit 64 ;;
 esac
 `,
     );
     chmodSync(aws, 0o755);
-  });
+  }
 
-  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+  function installFakeTerraform(): void {
+    const terraform = join(fakeBin, 'terraform');
+    writeFileSync(
+      terraform,
+      `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_TERRAFORM_LOG"
+case "$*" in
+  "version -json") printf '%s\n' '{"terraform_version":"1.9.8"}' ;;
+  *"show -json"*)
+    printf '%s\n' '{"format_version":"1.2","resource_changes":[{"address":"module.enterprise.aws_iam_role.updater","type":"aws_iam_role","change":{"actions":["create"]}}]}'
+    ;;
+  *"output -json backend_config"*)
+    printf '%s\n' '{"bucket":"kortix-vpc-demo-935064898258-us-west-2-tfstate","dynamodb_table":"kortix-vpc-demo-terraform-locks","region":"us-west-2","encrypt":true,"kms_key_id":"arn:aws:kms:us-west-2:935064898258:key/state"}'
+    ;;
+  *"output -json permissions_boundary_arn"*)
+    printf '%s\n' '"arn:aws:iam::935064898258:policy/kortix-vpc-demo-workload-boundary"'
+    ;;
+  *"output -json instance"*)
+    printf '%s\n' '{"name":"kortix-vpc-demo","account_id":"935064898258","region":"us-west-2","cluster_name":"kortix-vpc-demo","state_machine_arn":"arn:aws:states:us-west-2:935064898258:stateMachine:kortix-vpc-demo-reconcile","release_state_table":"kortix-vpc-demo-release-state","supabase_instance_id":"i-0123456789"}'
+    ;;
+  *"state pull"*)
+    for arg in "$@"; do case "$arg" in -chdir=*) dir="\${arg#-chdir=}" ;; esac; done
+    case "\${dir:-}" in */state)
+      if [ ! -f "$dir/terraform.bootstrap.tfstate" ]; then
+        printf '%s\n' '{"version":4,"serial":7,"lineage":"lineage-123"}' > "$dir/terraform.bootstrap.tfstate"
+      fi
+      ;;
+    esac
+    printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":7,"lineage":"lineage-123","outputs":{},"resources":[]}'
+    ;;
+  *"plan"*)
+    for arg in "$@"; do case "$arg" in -out=*) : > "\${arg#-out=}" ;; esac; done
+    printf '%s\n' 'Plan: 1 to add, 0 to change, 0 to destroy.'
+    ;;
+  *"apply"*)
+    for arg in "$@"; do case "$arg" in -chdir=*) dir="\${arg#-chdir=}" ;; esac; done
+    case "\${dir:-}" in */state) printf '%s\n' '{"version":4,"serial":7,"lineage":"lineage-123"}' > "$dir/terraform.bootstrap.tfstate" ;; esac
+    printf '%s\n' 'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
+    ;;
+  *"init -input=false -migrate-state"*)
+    if [ "\${FAKE_TERRAFORM_FAIL_MIGRATE:-}" = "1" ]; then
+      printf '%s\n' 'simulated state migration failure' >&2
+      exit 65
+    fi
+    printf '%s\n' 'Terraform has been successfully initialized!'
+    ;;
+  *"init"*) printf '%s\n' 'Terraform has been successfully initialized!' ;;
+  *) printf '%s\n' "unexpected terraform args: $*" >&2; exit 64 ;;
+esac
+`,
+    );
+    chmodSync(terraform, 0o755);
+  }
 
-  async function run(args: string[]) {
+  function installSuccessfulTool(name: string, output: string): void {
+    const executable = join(fakeBin, name);
+    writeFileSync(executable, `#!/bin/sh\nprintf '%s\\n' '${output}'\n`);
+    chmodSync(executable, 0o755);
+  }
+
+  async function run(args: string[], extraEnv: Record<string, string> = {}) {
     const proc = Bun.spawn({
       cmd: [process.execPath, CLI_ENTRY, 'self-host', ...args],
       cwd: tmp,
@@ -43,8 +138,11 @@ esac
         KORTIX_SELF_HOST_CONFIG_DIR: configRoot,
         KORTIX_CONFIG_FILE: join(tmp, 'cli-config.json'),
         KORTIX_NO_UPDATE_CHECK: '1',
+        FAKE_AWS_LOG: awsLog,
+        FAKE_TERRAFORM_LOG: terraformLog,
         NO_COLOR: '1',
         FORCE_COLOR: '0',
+        ...extraEnv,
       },
       stdout: 'pipe',
       stderr: 'pipe',
@@ -57,21 +155,33 @@ esac
     return { code, stdout, stderr };
   }
 
-  test('initializes a secret-free instance pinned to the verified AWS account', async () => {
-    const result = await run([
-      'init',
-      '--target', 'aws-vpc',
-      '--instance', 'kortix-vpc-demo',
-      '--aws-profile', 'default',
-      '--region', 'us-west-2',
-      '--channel', 'stable',
-      '--yes',
-      '--json',
-    ]);
+  function configuredInitArgs(instance = 'kortix-vpc-demo'): string[] {
+    return [
+      'init', '--target', 'aws-vpc', '--instance', instance,
+      '--aws-profile', 'default', '--region', 'us-west-2', '--channel', 'stable',
+      '--vpc-cidr', '10.60.0.0/16',
+      '--api-domain', 'api.vpc-demo.kortix.com',
+      '--frontend-domain', 'vpc-demo.kortix.com',
+      '--release-repository-url', 'https://releases.kortix.com/enterprise',
+      '--tuf-root-sha256', TRUSTED_ROOT,
+      '--updater-bootstrap-url', 'https://releases.kortix.com/enterprise/bootstrap/updater-linux-amd64',
+      '--updater-bootstrap-sha256', BOOTSTRAP_DIGEST,
+      '--release-publisher-account-id', '935064898258',
+      '--maintenance-window', 'Sun:02:00-05:00',
+      '--yes', '--json',
+    ];
+  }
 
+  async function initConfigured(instance = 'kortix-vpc-demo') {
+    const result = await run(configuredInitArgs(instance));
     expect(result.code).toBe(0);
-    expect(result.stderr).not.toContain('✗');
-    expect(JSON.parse(result.stdout)).toMatchObject({
+    return result;
+  }
+
+  test('initializes a secret-free account-pinned instance and embeds the reviewed Terraform graph', async () => {
+    const result = await initConfigured();
+    const config = JSON.parse(result.stdout);
+    expect(config).toMatchObject({
       instance: 'kortix-vpc-demo',
       target: 'aws-vpc',
       channel: 'stable',
@@ -79,22 +189,180 @@ esac
         profile: 'default',
         region: 'us-west-2',
         account_id: '935064898258',
+        vpc_cidr: '10.60.0.0/16',
+        api_domain: 'api.vpc-demo.kortix.com',
+        frontend_domain: 'vpc-demo.kortix.com',
+        tuf_root_sha256: TRUSTED_ROOT,
       },
     });
+
     const instanceDir = join(configRoot, 'kortix-vpc-demo');
-    expect(JSON.parse(readFileSync(join(instanceDir, 'instance.json'), 'utf8'))).toMatchObject({
-      target: 'aws-vpc',
-      aws: { account_id: '935064898258' },
-    });
+    const persisted = readFileSync(join(instanceDir, 'instance.json'), 'utf8');
+    expect(JSON.parse(persisted)).toMatchObject({ target: 'aws-vpc', aws: { account_id: '935064898258' } });
+    expect(persisted).not.toContain('cloudflare_api_token');
     expect(existsSync(join(instanceDir, '.env'))).toBe(false);
+    expect(readFileSync(join(instanceDir, 'terraform/environments/enterprise-vpc/state/main.tf'), 'utf8'))
+      .toContain('module "state"');
+    expect(readFileSync(join(instanceDir, 'terraform/modules/enterprise-vpc/supabase.tf'), 'utf8'))
+      .toContain('aws_instance" "supabase');
+    expect(readFileSync(join(instanceDir, 'terraform/modules/eks/platform/main.tf'), 'utf8'))
+      .toContain('helm_release" "argo_cd');
+  });
+
+  test('enforces Terraform-compatible lowercase DNS slugs for AWS instances', async () => {
+    const result = await run([
+      'init', '--target', 'aws-vpc', '--instance', 'Essentia_VPC', '--aws-profile', 'default', '--yes',
+    ]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('lowercase DNS slug');
+    expect(existsSync(awsLog)).toBe(false);
+  });
+
+  test('plans without mutation and refuses a profile that no longer resolves to the pinned account', async () => {
+    await initConfigured();
+    writeFileSync(terraformLog, '');
+    writeFileSync(awsLog, '');
+
+    const plan = await run(['plan', '--instance', 'kortix-vpc-demo', '--json']);
+    expect(plan.code).toBe(0);
+    expect(JSON.parse(plan.stdout)).toMatchObject({
+      instance: 'kortix-vpc-demo',
+      stages: [{ name: 'state', decision: 'manual_review' }],
+    });
+    expect(readFileSync(terraformLog, 'utf8')).toContain('plan');
+    expect(readFileSync(terraformLog, 'utf8')).not.toContain(' apply ');
+    expect(readFileSync(awsLog, 'utf8')).toContain('sts get-caller-identity');
+
+    writeFileSync(terraformLog, '');
+    const mismatch = await run(
+      ['plan', '--instance', 'kortix-vpc-demo'],
+      { FAKE_AWS_ACCOUNT: '327903111249' },
+    );
+    expect(mismatch.code).toBe(1);
+    expect(mismatch.stderr).toContain('AWS account mismatch');
+    expect(readFileSync(terraformLog, 'utf8')).toBe('');
+  });
+
+  test('does not persist a replacement AWS profile unless it resolves to the pinned account', async () => {
+    await initConfigured();
+    const result = await run([
+      'configure', '--instance', 'kortix-vpc-demo', '--aws-profile', 'wrong-account', '--yes',
+    ]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('AWS account mismatch');
+    const persisted = JSON.parse(readFileSync(join(configRoot, 'kortix-vpc-demo/instance.json'), 'utf8'));
+    expect(persisted.aws.profile).toBe('default');
+  });
+
+  test('requires deployment confirmation before any Terraform or AWS mutation', async () => {
+    await initConfigured();
+    writeFileSync(terraformLog, '');
+    writeFileSync(awsLog, '');
+
+    const result = await run(['deploy', '--instance', 'kortix-vpc-demo']);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('requires confirmation');
+    expect(readFileSync(terraformLog, 'utf8')).toBe('');
+    expect(readFileSync(awsLog, 'utf8')).toContain('sts get-caller-identity');
+    expect(readFileSync(awsLog, 'utf8')).not.toContain('start-execution');
+  });
+
+  test('applies reviewed stages, verifies state migration, and starts customer-owned bootstrap reconciliation', async () => {
+    await initConfigured();
+    writeFileSync(terraformLog, '');
+    writeFileSync(awsLog, '');
+
+    const result = await run(['deploy', '--instance', 'kortix-vpc-demo', '--yes', '--json']);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      instance: 'kortix-vpc-demo',
+      state_migration: { verified: true, lineage: 'lineage-123', serial: 7 },
+      cluster: { decision: 'manual_review', applied: true },
+      reconciliation: { execution_arn: expect.stringContaining('kortix-vpc-demo-reconcile') },
+    });
+
+    const calls = readFileSync(terraformLog, 'utf8');
+    expect(calls).toContain('state apply');
+    expect(calls).toContain('init -input=false -migrate-state -force-copy');
+    expect(calls).toContain('cluster apply');
+    expect(calls.indexOf('state apply')).toBeLessThan(calls.indexOf('cluster apply'));
+    const stateRoot = join(configRoot, 'kortix-vpc-demo/terraform/environments/enterprise-vpc/state');
+    expect(readFileSync(join(stateRoot, 'backend.tf'), 'utf8')).toContain('backend "s3"');
+    expect(existsSync(join(stateRoot, 'terraform.bootstrap.tfstate'))).toBe(false);
+    expect(readFileSync(awsLog, 'utf8')).toContain('states start-execution');
+
+    await run(['configure', '--instance', 'kortix-vpc-demo', '--maintenance-window', 'Sat:03:00-04:00', '--yes']);
+    expect(readFileSync(join(stateRoot, 'backend.tf'), 'utf8')).toContain('backend "s3"');
+  });
+
+  test('preserves local bootstrap state and restores the local backend when migration fails', async () => {
+    await initConfigured();
+    writeFileSync(terraformLog, '');
+    writeFileSync(awsLog, '');
+
+    const result = await run(
+      ['deploy', '--instance', 'kortix-vpc-demo', '--yes'],
+      { FAKE_TERRAFORM_FAIL_MIGRATE: '1' },
+    );
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('local bootstrap state was preserved');
+    const stateRoot = join(configRoot, 'kortix-vpc-demo/terraform/environments/enterprise-vpc/state');
+    expect(readFileSync(join(stateRoot, 'backend.tf'), 'utf8')).toContain('backend "local"');
+    expect(existsSync(join(stateRoot, 'terraform.bootstrap.tfstate'))).toBe(true);
+    expect(readFileSync(awsLog, 'utf8')).not.toContain('states start-execution');
+  });
+
+  test('routes reconcile, force update, and rollback through the customer state machine', async () => {
+    await initConfigured();
+    writeFileSync(awsLog, '');
+
+    const reconcile = await run(['reconcile', '--instance', 'kortix-vpc-demo', '--json']);
+    expect(reconcile.code).toBe(0);
+    const update = await run([
+      'update', '--instance', 'kortix-vpc-demo', '--release', '0.9.85-e1', '--force', '--json',
+    ]);
+    expect(update.code).toBe(0);
+    const rollback = await run([
+      'rollback', '--instance', 'kortix-vpc-demo', '--release', '0.9.84-e1', '--yes', '--json',
+    ]);
+    expect(rollback.code).toBe(0);
+
+    const calls = readFileSync(awsLog, 'utf8');
+    expect(calls.match(/states start-execution/g)).toHaveLength(3);
+    expect(calls).toContain('"trigger":"cli-reconcile"');
+    expect(calls).toContain('"requested_release":"0.9.85-e1"');
+    expect(calls).toContain('"force":true');
+    expect(calls).toContain('"trigger":"cli-rollback"');
+    expect(calls).toContain('"rollback_to":"0.9.84-e1"');
+  });
+
+  test('reports live AWS status/version and tails customer-owned updater logs', async () => {
+    await initConfigured();
+    writeFileSync(awsLog, '');
+
+    const status = await run(['status', '--instance', 'kortix-vpc-demo', '--json']);
+    expect(status.code).toBe(0);
+    expect(JSON.parse(status.stdout)).toMatchObject({
+      instance: 'kortix-vpc-demo',
+      cluster: { status: 'ACTIVE' },
+      supabase: { state: 'running' },
+      updater: { status: 'AVAILABLE' },
+      reconciliation: { status: 'SUCCEEDED' },
+      release: { release: '0.9.84-e1', status: 'healthy' },
+    });
+
+    const version = await run(['version', '--instance', 'kortix-vpc-demo', '--json']);
+    expect(version.code).toBe(0);
+    expect(JSON.parse(version.stdout)).toMatchObject({ release: '0.9.84-e1', channel: 'stable' });
+
+    const logs = await run(['logs', 'updater', '--instance', 'kortix-vpc-demo']);
+    expect(logs.code).toBe(0);
+    expect(logs.stdout).toContain('updater healthy');
+    expect(readFileSync(awsLog, 'utf8')).toContain('logs tail /kortix/kortix-vpc-demo/updater');
   });
 
   test('does not reinterpret Docker lifecycle commands for AWS', async () => {
-    const initialized = await run([
-      'init', '--target', 'aws-vpc', '--instance', 'enterprise', '--aws-profile', 'default', '--region', 'us-west-2', '--yes',
-    ]);
-    expect(initialized.code).toBe(0);
-
+    await initConfigured('enterprise');
     const result = await run(['start', '--instance', 'enterprise']);
     expect(result.code).toBe(2);
     expect(result.stderr).toContain('start is only available for Docker targets');
@@ -111,5 +379,7 @@ esac
     expect(result.stdout).toContain('doctor');
     expect(result.stdout).toContain('--target <target>');
     expect(result.stdout).toContain('--aws-profile <name>');
+    expect(result.stdout).toContain('--vpc-cidr <cidr>');
+    expect(result.stdout).toContain('--tuf-root-sha256 <digest>');
   });
 });

--- a/apps/cli/src/self-host/__tests__/config.test.ts
+++ b/apps/cli/src/self-host/__tests__/config.test.ts
@@ -93,4 +93,22 @@ describe('self-host instance config', () => {
 
     expect(() => loadInstanceConfig('incomplete')).toThrow('aws.account_id');
   });
+
+  test('rejects non-private VPC address space and non-stable enterprise channels', () => {
+    const base = {
+      schema_version: 1,
+      instance: 'enterprise',
+      target: 'aws-vpc',
+      channel: 'stable',
+      aws: {
+        profile: 'default',
+        region: 'us-west-2',
+        account_id: '123456789012',
+        vpc_cidr: '8.8.0.0/16',
+      },
+    };
+    expect(() => writeInstanceConfig(base as SelfHostInstanceConfig)).toThrow('canonical RFC1918 /16');
+    expect(() => writeInstanceConfig({ ...base, channel: 'prod', aws: { ...base.aws, vpc_cidr: '10.60.0.0/16' } } as SelfHostInstanceConfig))
+      .toThrow('only track the stable channel');
+  });
 });

--- a/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { dirname, join, normalize } from 'node:path/posix';
+
+import {
+  enterpriseTerraformAssets,
+  LOCAL_STATE_BACKEND,
+  REMOTE_STATE_BACKEND,
+} from '../enterprise-assets.ts';
+
+describe('embedded enterprise Terraform graph', () => {
+  test('contains every transitive local module referenced by a bundled root or module', () => {
+    const paths = Object.keys(enterpriseTerraformAssets);
+    const missing: string[] = [];
+
+    for (const [path, content] of Object.entries(enterpriseTerraformAssets)) {
+      for (const match of content.matchAll(/^\s*source\s*=\s*"(\.[^"]+)"/gm)) {
+        const target = normalize(join(dirname(path), match[1]));
+        if (!paths.some((candidate) => candidate.startsWith(`${target}/`))) {
+          missing.push(`${path} -> ${match[1]} (${target})`);
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  test('does not bundle Terraform runtime state or provider binaries', () => {
+    const paths = Object.keys(enterpriseTerraformAssets);
+    expect(paths.some((path) => path.includes('/.terraform/'))).toBe(false);
+    expect(paths.some((path) => path.endsWith('.tfstate'))).toBe(false);
+    expect(paths.some((path) => path.includes('terraform-provider-'))).toBe(false);
+  });
+
+  test('ships explicit local-bootstrap and customer-S3 backend modes', () => {
+    expect(LOCAL_STATE_BACKEND).toContain('backend "local"');
+    expect(LOCAL_STATE_BACKEND).toContain('terraform.bootstrap.tfstate');
+    expect(REMOTE_STATE_BACKEND).toContain('backend "s3"');
+    expect(REMOTE_STATE_BACKEND).not.toContain('bucket');
+  });
+
+  test('embeds the ALB controller policy as text for the compiled CLI', () => {
+    const policy = enterpriseTerraformAssets['modules/eks/platform/files/alb-controller-policy.json'];
+    expect(typeof policy).toBe('string');
+    expect(JSON.parse(policy)).toMatchObject({ Version: '2012-10-17' });
+  });
+});

--- a/apps/cli/src/self-host/assets.d.ts
+++ b/apps/cli/src/self-host/assets.d.ts
@@ -17,3 +17,18 @@ declare module '*.txt' {
   const text: string;
   export default text;
 }
+
+declare module '*.tf' {
+  const text: string;
+  export default text;
+}
+
+declare module '*.hcl' {
+  const text: string;
+  export default text;
+}
+
+declare module '*.tftpl' {
+  const text: string;
+  export default text;
+}

--- a/apps/cli/src/self-host/aws-vpc-control-plane.ts
+++ b/apps/cli/src/self-host/aws-vpc-control-plane.ts
@@ -1,0 +1,118 @@
+import { randomBytes } from 'node:crypto';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+
+import type { AwsVpcCoordinates, SelfHostInstanceConfig } from './config.ts';
+
+export interface AwsIdentity {
+  UserId: string;
+  Account: string;
+  Arn: string;
+}
+
+export function startReconciliation(
+  config: SelfHostInstanceConfig,
+  input: Record<string, unknown>,
+  discoveredArn?: string,
+) {
+  const coordinates = config.aws!;
+  const stateMachineArn = discoveredArn || reconciliationStateMachineArn(config);
+  const executionName = `cli-${Date.now()}-${randomBytes(3).toString('hex')}`;
+  const result = awsJson<{ executionArn: string; startDate?: string }>(coordinates, [
+    'states', 'start-execution',
+    '--state-machine-arn', stateMachineArn,
+    '--name', executionName,
+    '--input', JSON.stringify(input),
+  ]);
+  if (!result.executionArn) throw new Error('AWS did not return a Step Functions execution ARN');
+  return {
+    execution_arn: result.executionArn,
+    start_date: result.startDate ?? null,
+    input,
+  };
+}
+
+export function releaseState(config: SelfHostInstanceConfig): Record<string, unknown> | null {
+  const response = awsJsonOptional<{ Item?: Record<string, DynamoAttribute> }>(config.aws!, [
+    'dynamodb', 'get-item',
+    '--table-name', `${config.instance}-release-state`,
+    '--key', JSON.stringify({ instance: { S: config.instance } }),
+    '--consistent-read',
+  ]);
+  if (!response?.Item) return null;
+  return Object.fromEntries(Object.entries(response.Item).map(([key, value]) => [key, fromDynamo(value)]));
+}
+
+type DynamoAttribute = { S?: string; N?: string; BOOL?: boolean; NULL?: boolean };
+
+function fromDynamo(value: DynamoAttribute): unknown {
+  if (value.S !== undefined) return value.S;
+  if (value.N !== undefined) return Number(value.N);
+  if (value.BOOL !== undefined) return value.BOOL;
+  if (value.NULL) return null;
+  return value;
+}
+
+export function awsJson<T>(coordinates: AwsVpcCoordinates, args: string[]): T {
+  const result = spawnAws(coordinates, [...args, '--output', 'json', '--no-cli-pager']);
+  if (result.error) throw new Error(`unable to run AWS CLI: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new Error(`AWS ${args.slice(0, 2).join(' ')} failed: ${firstLine(result.stderr) || `exit ${result.status}`}`);
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch (error) {
+    throw new Error(`AWS ${args.slice(0, 2).join(' ')} returned invalid JSON: ${(error as Error).message}`);
+  }
+}
+
+export function awsJsonOptional<T>(coordinates: AwsVpcCoordinates, args: string[]): T | null {
+  const result = spawnAws(coordinates, [...args, '--output', 'json', '--no-cli-pager']);
+  if (result.error) throw new Error(`unable to run AWS CLI: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = firstLine(result.stderr) || `exit ${result.status}`;
+    if (/ResourceNotFound|NotFound|does not exist|not found/i.test(detail)) return null;
+    throw new Error(`AWS ${args.slice(0, 2).join(' ')} failed: ${detail}`);
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch (error) {
+    throw new Error(`AWS ${args.slice(0, 2).join(' ')} returned invalid JSON: ${(error as Error).message}`);
+  }
+}
+
+export function spawnAws(
+  coordinates: AwsVpcCoordinates,
+  args: string[],
+  stdio?: 'inherit',
+): SpawnSyncReturns<string> {
+  return spawnSync(
+    'aws',
+    ['--profile', coordinates.profile, '--region', coordinates.region, ...args],
+    stdio ? { encoding: 'utf8', stdio } : { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+  );
+}
+
+export function awsIdentity(coordinates: AwsVpcCoordinates): AwsIdentity {
+  const identity = awsJson<AwsIdentity>(coordinates, ['sts', 'get-caller-identity']);
+  if (!/^\d{12}$/.test(identity.Account) || typeof identity.Arn !== 'string' || identity.Arn === '') {
+    throw new Error('AWS identity response is missing a valid Account or Arn');
+  }
+  return identity;
+}
+
+export function verifyPinnedIdentity(coordinates: AwsVpcCoordinates): AwsIdentity {
+  const identity = awsIdentity(coordinates);
+  if (identity.Account !== coordinates.account_id) {
+    throw new Error(`AWS account mismatch: expected ${coordinates.account_id}, resolved ${identity.Account}`);
+  }
+  return identity;
+}
+
+export function reconciliationStateMachineArn(config: SelfHostInstanceConfig): string {
+  const aws = config.aws!;
+  return `arn:aws:states:${aws.region}:${aws.account_id}:stateMachine:${config.instance}-reconcile`;
+}
+
+export function firstLine(value: string): string {
+  return value.trim().split(/\r?\n/, 1)[0] ?? '';
+}

--- a/apps/cli/src/self-host/aws-vpc-settings.ts
+++ b/apps/cli/src/self-host/aws-vpc-settings.ts
@@ -1,0 +1,118 @@
+import { prompt } from '../prompts.ts';
+import type { AwsVpcCoordinates, SelfHostInstanceConfig } from './config.ts';
+import type { SelfHostCommandFlags } from './types.ts';
+
+export interface CompleteAwsVpcConfig extends AwsVpcCoordinates {
+  vpc_cidr: string;
+  api_domain: string;
+  frontend_domain: string;
+  release_repository_url: string;
+  tuf_root_sha256: string;
+  updater_bootstrap_url: string;
+  updater_bootstrap_sha256: string;
+  release_publisher_account_id: string;
+  maintenance_window: string;
+}
+
+const CONFIG_FIELDS: Array<keyof CompleteAwsVpcConfig> = [
+  'vpc_cidr',
+  'api_domain',
+  'frontend_domain',
+  'release_repository_url',
+  'tuf_root_sha256',
+  'updater_bootstrap_url',
+  'updater_bootstrap_sha256',
+  'release_publisher_account_id',
+  'maintenance_window',
+];
+
+export function completeConfiguration(config: SelfHostInstanceConfig): CompleteAwsVpcConfig {
+  const coordinates = config.aws!;
+  const missing = missingConfiguration(coordinates);
+  if (missing.length > 0) {
+    throw new Error(
+      `AWS VPC deployment config is incomplete (${missing.join(', ')}); run kortix self-host configure --instance ${config.instance}`,
+    );
+  }
+  return coordinates as CompleteAwsVpcConfig;
+}
+
+export function missingConfiguration(config: AwsVpcCoordinates): string[] {
+  return CONFIG_FIELDS.filter((field) => !config[field]);
+}
+
+export function mergeAwsConfiguration(
+  current: AwsVpcCoordinates,
+  flags: SelfHostCommandFlags,
+  override: Partial<CompleteAwsVpcConfig>,
+): AwsVpcCoordinates {
+  return {
+    ...current,
+    ...override,
+    ...(flags.awsProfile ? { profile: flags.awsProfile } : {}),
+    ...(flags.region ? { region: flags.region } : {}),
+    ...(flags.vpcCidr ? { vpc_cidr: flags.vpcCidr } : {}),
+    ...(flags.apiDomain ? { api_domain: flags.apiDomain } : {}),
+    ...(flags.frontendDomain ? { frontend_domain: flags.frontendDomain } : {}),
+    ...(flags.releaseRepositoryUrl ? { release_repository_url: flags.releaseRepositoryUrl } : {}),
+    ...(flags.tufRootSha256 ? { tuf_root_sha256: flags.tufRootSha256 } : {}),
+    ...(flags.updaterBootstrapUrl ? { updater_bootstrap_url: flags.updaterBootstrapUrl } : {}),
+    ...(flags.updaterBootstrapSha256 ? { updater_bootstrap_sha256: flags.updaterBootstrapSha256 } : {}),
+    ...(flags.releasePublisherAccountId ? { release_publisher_account_id: flags.releasePublisherAccountId } : {}),
+    ...(flags.maintenanceWindow ? { maintenance_window: flags.maintenanceWindow } : {}),
+  };
+}
+
+export function parseConfigurationAssignments(args: string[]): Partial<CompleteAwsVpcConfig> {
+  const result: Record<string, string> = {};
+  const allowed = new Set<string>(CONFIG_FIELDS);
+  for (const arg of args) {
+    if (arg.startsWith('-')) throw new Error(`unknown AWS VPC configure option "${arg}"`);
+    const separator = arg.indexOf('=');
+    if (separator < 1) throw new Error(`configure value must use key=value, got "${arg}"`);
+    const key = arg.slice(0, separator).toLowerCase().replaceAll('-', '_');
+    if (!allowed.has(key)) throw new Error(`unsupported AWS VPC setting "${key}"`);
+    result[key] = arg.slice(separator + 1);
+  }
+  return result as Partial<CompleteAwsVpcConfig>;
+}
+
+export async function promptForConfiguration(current: AwsVpcCoordinates): Promise<AwsVpcCoordinates> {
+  const next = { ...current } as Record<string, string>;
+  const labels: Record<string, string> = {
+    vpc_cidr: 'Dedicated VPC /16 CIDR',
+    api_domain: 'API DNS name',
+    frontend_domain: 'Dashboard DNS name',
+    release_repository_url: 'Enterprise TUF repository URL',
+    tuf_root_sha256: 'Trusted TUF root SHA-256',
+    updater_bootstrap_url: 'Updater bootstrap URL',
+    updater_bootstrap_sha256: 'Updater bootstrap SHA-256',
+    release_publisher_account_id: 'Kortix release publisher AWS account ID',
+    maintenance_window: 'UTC maintenance window',
+  };
+  for (const field of CONFIG_FIELDS) {
+    const defaultValue = next[field] || (field === 'maintenance_window' ? 'Sun:02:00-05:00' : undefined);
+    next[field] = await prompt(labels[field], defaultValue);
+  }
+  return next as unknown as AwsVpcCoordinates;
+}
+
+export function hasConfigurationFlags(flags: SelfHostCommandFlags): boolean {
+  return Boolean(
+    flags.vpcCidr
+    || flags.apiDomain
+    || flags.frontendDomain
+    || flags.releaseRepositoryUrl
+    || flags.tufRootSha256
+    || flags.updaterBootstrapUrl
+    || flags.updaterBootstrapSha256
+    || flags.releasePublisherAccountId
+    || flags.maintenanceWindow,
+  );
+}
+
+export function assertEnterpriseRelease(release: string): void {
+  if (!/^\d+\.\d+\.\d+-e[1-9]\d*$/.test(release)) {
+    throw new Error('enterprise release must use <prod-version>-e<revision>, for example 0.9.84-e1');
+  }
+}

--- a/apps/cli/src/self-host/aws-vpc.ts
+++ b/apps/cli/src/self-host/aws-vpc.ts
@@ -1,19 +1,55 @@
 import { spawnSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 
+import { confirm } from '../prompts.ts';
 import { C, status } from '../style.ts';
 import {
+  awsIdentity,
+  awsJson,
+  awsJsonOptional,
+  firstLine,
+  reconciliationStateMachineArn,
+  releaseState,
+  spawnAws,
+  startReconciliation,
+  verifyPinnedIdentity,
+  type AwsIdentity,
+} from './aws-vpc-control-plane.ts';
+import {
+  assertEnterpriseRelease,
+  completeConfiguration,
+  hasConfigurationFlags,
+  mergeAwsConfiguration,
+  missingConfiguration,
+  parseConfigurationAssignments,
+  promptForConfiguration,
+} from './aws-vpc-settings.ts';
+import {
+  assertAwsVpcInstanceName,
   loadInstanceConfig,
   writeInstanceConfig,
-  type AwsVpcCoordinates,
   type SelfHostInstanceConfig,
 } from './config.ts';
+import {
+  enterpriseTerraformRoot,
+  writeEnterpriseTerraformAssets,
+} from './enterprise-assets.ts';
+import {
+  ensureApplicable,
+  isRemoteState,
+  migrateAndVerifyState,
+  prepareTerraform,
+  publicPlan,
+  readBackendConfig,
+  terraformApply,
+  terraformOutput,
+  terraformPlan,
+  writeClusterFiles,
+  type EnterpriseInstanceOutput,
+  type StagePlan,
+} from './enterprise-terraform.ts';
 import type { SelfHostCommandFlags } from './types.ts';
-
-interface AwsIdentity {
-  UserId: string;
-  Account: string;
-  Arn: string;
-}
 
 type AwsVpcCommand =
   | 'init'
@@ -53,38 +89,72 @@ export async function runAwsVpcCommand(
 
   const config = loadAwsConfig(flags.instance);
   if (!config) return 1;
+  if (flags.local || flags.registry || (flags.tag !== 'latest' && !flags.release)) {
+    process.stderr.write(
+      `${status.err('AWS VPC targets use --release with signed enterprise versions; --tag, --local, and --registry are Docker-only.')}\n`,
+    );
+    return 2;
+  }
+  if (!['configure', 'config', 'logs'].includes(typedCommand) && args.length > 0) {
+    process.stderr.write(`${status.err(`unexpected AWS VPC arguments: ${args.join(' ')}`)}\n`);
+    return 2;
+  }
 
   switch (typedCommand) {
     case 'doctor':
       return doctorAwsVpc(config, flags);
+    case 'configure':
+    case 'config':
+      return configureAwsVpc(config, args, flags);
+    case 'plan':
+      return planAwsVpc(config, flags);
+    case 'deploy':
+      return deployAwsVpc(config, flags);
+    case 'update':
+    case 'upgrade':
+      return startManagedUpdate(config, 'cli-update', flags);
+    case 'reconcile':
+      return startManagedUpdate(config, 'cli-reconcile', flags);
+    case 'rollback':
+      return rollbackAwsVpc(config, flags);
     case 'version':
       return showAwsVpcVersion(config, flags);
     case 'status':
     case 'ps':
       return showAwsVpcStatus(config, flags);
-    case 'plan':
-    case 'deploy':
-    case 'update':
-    case 'upgrade':
-    case 'reconcile':
-    case 'rollback':
     case 'logs':
+      return showAwsVpcLogs(config, args, flags);
     case 'open':
-    case 'configure':
-    case 'config':
-      return unavailableUntilBootstrap(typedCommand, config, args, flags);
+      return openAwsVpc(config);
     default:
       process.stderr.write(`${status.err(`unknown AWS VPC self-host command "${command}"`)}\n`);
       return 2;
   }
 }
-
 async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
-  if (flags.local || flags.registry || flags.tag !== 'latest') {
+  try {
+    assertAwsVpcInstanceName(flags.instance);
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 2;
+  }
+  if (flags.local || flags.registry || (flags.tag !== 'latest' && !flags.release)) {
     process.stderr.write(
       `${status.err('AWS VPC targets use signed releases; --local, --registry, and --tag are Docker-only options.')}\n`,
     );
     return 2;
+  }
+  if (flags.channel && flags.channel !== 'stable') {
+    process.stderr.write(`${status.err('AWS VPC targets may only track the stable channel.')}\n`);
+    return 2;
+  }
+  if (flags.release) {
+    try {
+      assertEnterpriseRelease(flags.release);
+    } catch (error) {
+      process.stderr.write(`${status.err((error as Error).message)}\n`);
+      return 2;
+    }
   }
 
   const profile = flags.awsProfile?.trim() || process.env.AWS_PROFILE?.trim() || 'default';
@@ -101,7 +171,17 @@ async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
     return 1;
   }
 
-  const existing = loadInstanceConfig(flags.instance);
+  let existing: SelfHostInstanceConfig | null;
+  try {
+    existing = loadInstanceConfig(flags.instance);
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 2;
+  }
+  if (existing && existing.target !== 'aws-vpc') {
+    process.stderr.write(`${status.err(`instance "${flags.instance}" already targets Docker`)}\n`);
+    return 2;
+  }
   if (existing?.aws && existing.aws.account_id !== identity.Account) {
     process.stderr.write(
       `${status.err(`AWS account mismatch: instance is pinned to ${existing.aws.account_id}, profile ${profile} resolved to ${identity.Account}`)}\n`,
@@ -109,51 +189,103 @@ async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
     return 1;
   }
 
+  const aws = mergeAwsConfiguration(
+    existing?.aws ?? { profile, region, account_id: identity.Account },
+    flags,
+    { profile, region, account_id: identity.Account },
+  );
   const config: SelfHostInstanceConfig = {
     schema_version: 1,
     instance: flags.instance,
     target: 'aws-vpc',
-    channel: flags.channel ?? existing?.channel ?? 'stable',
+    channel: 'stable',
     ...(flags.release || existing?.release ? { release: flags.release ?? existing?.release } : {}),
-    aws: { profile, region, account_id: identity.Account },
+    aws,
   };
-  writeInstanceConfig(config);
+  try {
+    writeInstanceConfig(config);
+    writeEnterpriseTerraformAssets(config.instance);
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 2;
+  }
 
   if (flags.json) {
     process.stdout.write(`${JSON.stringify(config, null, 2)}\n`);
     return 0;
   }
 
+  const missing = missingConfiguration(config.aws!);
   process.stdout.write(`\n  ${C.bold}Kortix Enterprise VPC${C.reset}\n\n`);
   process.stdout.write(`${status.ok(existing ? 'AWS VPC instance config verified' : 'AWS VPC instance config created')}\n`);
   process.stdout.write(`  ${C.dim}instance  ${C.reset}${config.instance}\n`);
-  process.stdout.write(`  ${C.dim}target    ${C.reset}${config.target}\n`);
   process.stdout.write(`  ${C.dim}account   ${C.reset}${identity.Account}\n`);
   process.stdout.write(`  ${C.dim}profile   ${C.reset}${profile}\n`);
   process.stdout.write(`  ${C.dim}region    ${C.reset}${region}\n`);
-  process.stdout.write(`  ${C.dim}channel   ${C.reset}${config.channel}\n\n`);
-  process.stdout.write(`  ${C.dim}Next: ${C.reset}${C.cyan}kortix self-host doctor --instance ${config.instance}${C.reset}\n`);
-  process.stdout.write(`        ${C.cyan}kortix self-host plan --instance ${config.instance}${C.reset}\n\n`);
+  process.stdout.write(`  ${C.dim}channel   ${C.reset}stable\n`);
+  process.stdout.write(`  ${C.dim}terraform ${C.reset}${enterpriseTerraformRoot(config.instance)}\n\n`);
+  if (missing.length > 0) {
+    process.stdout.write(`  ${C.dim}Configure ${missing.join(', ')} before planning.${C.reset}\n`);
+    process.stdout.write(`  ${C.cyan}kortix self-host configure --instance ${config.instance}${C.reset}\n\n`);
+  } else {
+    process.stdout.write(`  ${C.dim}Next: ${C.reset}${C.cyan}kortix self-host doctor --instance ${config.instance}${C.reset}\n`);
+    process.stdout.write(`        ${C.cyan}kortix self-host plan --instance ${config.instance}${C.reset}\n\n`);
+  }
   return 0;
+}
+
+async function configureAwsVpc(
+  config: SelfHostInstanceConfig,
+  args: string[],
+  flags: SelfHostCommandFlags,
+): Promise<number> {
+  try {
+    verifyPinnedIdentity(config.aws!);
+    if (flags.channel && flags.channel !== 'stable') throw new Error('AWS VPC targets may only track the stable channel');
+    const fromArgs = parseConfigurationAssignments(args);
+    let aws = mergeAwsConfiguration(config.aws!, flags, fromArgs);
+    if (!flags.yes && args.length === 0 && !hasConfigurationFlags(flags)) {
+      aws = await promptForConfiguration(aws);
+    }
+    verifyPinnedIdentity(aws);
+    const updated: SelfHostInstanceConfig = { ...config, channel: 'stable', aws };
+    writeInstanceConfig(updated);
+    writeEnterpriseTerraformAssets(updated.instance);
+    const missing = missingConfiguration(aws);
+    const payload = {
+      instance: updated.instance,
+      target: updated.target,
+      configured: missing.length === 0,
+      missing,
+      aws,
+    };
+    if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    else {
+      process.stdout.write(`\n  ${C.bold}kortix self-host configure${C.reset}\n`);
+      process.stdout.write(`${status.ok('Secret-free AWS deployment settings saved')}\n`);
+      if (missing.length > 0) process.stdout.write(`  ${C.dim}Still required: ${missing.join(', ')}${C.reset}\n`);
+      else process.stdout.write(`  ${C.dim}Ready for ${C.reset}${C.cyan}kortix self-host plan --instance ${updated.instance}${C.reset}\n`);
+      process.stdout.write('\n');
+    }
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 2;
+  }
 }
 
 function doctorAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
   const coordinates = config.aws!;
   const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
   try {
-    const identity = awsIdentity(coordinates);
-    checks.push({
-      name: 'aws-identity',
-      ok: identity.Account === coordinates.account_id,
-      detail: `${identity.Account} (${identity.Arn})`,
-    });
+    const identity = verifyPinnedIdentity(coordinates);
+    checks.push({ name: 'aws-identity', ok: true, detail: `${identity.Account} (${identity.Arn})` });
   } catch (error) {
     checks.push({ name: 'aws-identity', ok: false, detail: (error as Error).message });
   }
   for (const [name, command, args] of [
+    ['aws-cli', 'aws', ['--version']],
     ['terraform', 'terraform', ['version', '-json']],
-    ['kubectl', 'kubectl', ['version', '--client=true', '--output=json']],
-    ['helm', 'helm', ['version', '--short']],
   ] as const) {
     const result = spawnSync(command, args, { encoding: 'utf8' });
     checks.push({
@@ -162,6 +294,12 @@ function doctorAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCommandFlag
       detail: result.error?.message ?? (firstLine(result.stdout || result.stderr) || `exit ${result.status ?? 1}`),
     });
   }
+  const missing = missingConfiguration(coordinates);
+  checks.push({
+    name: 'deployment-config',
+    ok: missing.length === 0,
+    detail: missing.length === 0 ? 'complete and secret-free' : `missing ${missing.join(', ')}`,
+  });
 
   const ok = checks.every((check) => check.ok);
   if (flags.json) {
@@ -177,69 +315,357 @@ function doctorAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCommandFlag
   return ok ? 0 : 1;
 }
 
-function showAwsVpcVersion(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
-  const payload = {
-    instance: config.instance,
-    target: config.target,
-    channel: config.channel,
-    release: config.release ?? null,
-  };
-  if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-  else {
-    process.stdout.write(`\n  ${C.bold}kortix self-host version${C.reset}\n`);
-    process.stdout.write(`  ${C.dim}instance ${C.reset}${config.instance}\n`);
-    process.stdout.write(`  ${C.dim}channel  ${C.reset}${config.channel}\n`);
-    process.stdout.write(`  ${C.dim}release  ${C.reset}${config.release ?? 'not deployed'}\n\n`);
+function planAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
+  let plans: StagePlan[] = [];
+  try {
+    const aws = completeConfiguration(config);
+    const identity = verifyPinnedIdentity(aws);
+    if (flags.release) assertEnterpriseRelease(flags.release);
+    const roots = prepareTerraform(config.instance, aws);
+    const stateRemote = isRemoteState(config.instance);
+    const stateBackend = stateRemote ? join(roots.state, 'backend.hcl') : undefined;
+    if (stateRemote && !existsSync(stateBackend!)) {
+      throw new Error('migrated state backend is missing backend.hcl; restore it before planning');
+    }
+    plans.push(terraformPlan('state', roots.state, aws, stateBackend));
+    if (stateRemote) {
+      const boundary = terraformOutput<string>(roots.state, aws, 'permissions_boundary_arn');
+      writeClusterFiles(config.instance, aws, boundary, readBackendConfig(stateBackend!));
+      plans.push(terraformPlan('cluster', roots.cluster, aws, join(roots.cluster, 'backend.hcl')));
+    }
+    const payload = {
+      instance: config.instance,
+      account_id: identity.Account,
+      region: aws.region,
+      bootstrap: stateRemote ? 'remote-state' : 'state-bootstrap',
+      stages: plans.map(publicPlan),
+    };
+    if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    else renderPlans(payload.instance, payload.account_id, payload.region, plans);
+    return plans.some((plan) => plan.decision === 'blocked') ? 3 : 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  } finally {
+    for (const plan of plans) rmSync(plan.planPath, { force: true });
   }
-  return 0;
 }
 
-function showAwsVpcStatus(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
-  const coordinates = config.aws!;
-  let identity: AwsIdentity;
+async function deployAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): Promise<number> {
+  const plans: StagePlan[] = [];
   try {
-    identity = awsIdentity(coordinates);
+    const aws = completeConfiguration(config);
+    const identity = verifyPinnedIdentity(aws);
+    if (flags.release) assertEnterpriseRelease(flags.release);
+    if (!flags.yes) {
+      if (!(process.stdin.isTTY === true && process.stdout.isTTY === true)) {
+        process.stderr.write(
+          `${status.err(`AWS VPC deployment requires confirmation; rerun with --yes after reviewing plan for ${identity.Account}.`)}\n`,
+        );
+        return 2;
+      }
+      const approved = await confirm(
+        `Apply reviewed enterprise infrastructure for ${config.instance} in ${identity.Account}/${aws.region}`,
+        false,
+      );
+      if (!approved) return 2;
+    }
+
+    const roots = prepareTerraform(config.instance, aws);
+    const stateWasRemote = isRemoteState(config.instance);
+    const stateBackendPathValue = stateWasRemote ? join(roots.state, 'backend.hcl') : undefined;
+    plans.push(terraformPlan('state', roots.state, aws, stateBackendPathValue));
+    ensureApplicable(plans[0]);
+    terraformApply(roots.state, aws, plans[0].planPath);
+
+    const migration = migrateAndVerifyState(config.instance, roots.state, aws, stateWasRemote);
+    writeClusterFiles(config.instance, aws, migration.permissionsBoundaryArn, migration.backend);
+    plans.push(terraformPlan('cluster', roots.cluster, aws, join(roots.cluster, 'backend.hcl')));
+    ensureApplicable(plans[1]);
+    terraformApply(roots.cluster, aws, plans[1].planPath);
+
+    const instance = terraformOutput<EnterpriseInstanceOutput>(roots.cluster, aws, 'instance');
+    const reconciliation = startReconciliation(config, {
+      trigger: 'bootstrap',
+      force: false,
+      ...(flags.release ? { requested_release: flags.release } : {}),
+    }, instance.state_machine_arn);
+    const payload = {
+      instance: config.instance,
+      account_id: identity.Account,
+      region: aws.region,
+      state: { ...publicPlan(plans[0]), applied: true },
+      state_migration: migration.verification,
+      cluster: { ...publicPlan(plans[1]), applied: true },
+      reconciliation,
+    };
+    if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    else {
+      process.stdout.write(`\n  ${C.bold}Kortix Enterprise VPC deployed${C.reset}\n`);
+      process.stdout.write(`${status.ok(`Terraform state verified at lineage ${migration.verification.lineage}, serial ${migration.verification.serial}`)}\n`);
+      process.stdout.write(`${status.ok('Customer cluster infrastructure applied')}\n`);
+      process.stdout.write(`${status.ok(`Customer reconciler started: ${reconciliation.execution_arn}`)}\n\n`);
+    }
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  } finally {
+    for (const plan of plans) rmSync(plan.planPath, { force: true });
+  }
+}
+
+async function startManagedUpdate(
+  config: SelfHostInstanceConfig,
+  trigger: 'cli-update' | 'cli-reconcile',
+  flags: SelfHostCommandFlags,
+): Promise<number> {
+  try {
+    verifyPinnedIdentity(config.aws!);
+    if (flags.channel && flags.channel !== 'stable') throw new Error('AWS VPC targets may only track the stable channel');
+    if (flags.release) assertEnterpriseRelease(flags.release);
+    const result = startReconciliation(config, {
+      trigger,
+      force: flags.force,
+      channel: 'stable',
+      ...(flags.release ? { requested_release: flags.release } : {}),
+    });
+    renderExecution(config, result, flags);
+    return 0;
   } catch (error) {
     process.stderr.write(`${status.err((error as Error).message)}\n`);
     return 1;
   }
-  if (identity.Account !== coordinates.account_id) {
-    process.stderr.write(
-      `${status.err(`AWS account mismatch: expected ${coordinates.account_id}, resolved ${identity.Account}`)}\n`,
-    );
-    return 1;
-  }
-  const payload = {
-    instance: config.instance,
-    target: config.target,
-    account_id: coordinates.account_id,
-    region: coordinates.region,
-    channel: config.channel,
-    release: config.release ?? null,
-    bootstrap: 'pending',
-  };
-  if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-  else {
-    process.stdout.write(`\n  ${C.bold}kortix self-host status${C.reset}\n`);
-    for (const [key, value] of Object.entries(payload)) {
-      process.stdout.write(`  ${C.dim}${key.padEnd(11)}${C.reset}${value ?? 'none'}\n`);
-    }
-    process.stdout.write('\n');
-  }
-  return 0;
 }
 
-function unavailableUntilBootstrap(
-  command: AwsVpcCommand,
+async function rollbackAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): Promise<number> {
+  try {
+    const identity = verifyPinnedIdentity(config.aws!);
+    if (!flags.release) throw new Error('rollback requires --release <verified-enterprise-version>');
+    assertEnterpriseRelease(flags.release);
+    if (!flags.yes) {
+      if (!(process.stdin.isTTY === true && process.stdout.isTTY === true)) {
+        process.stderr.write(
+          `${status.err('rollback requires confirmation; rerun with --yes after reviewing the compatibility contract')}\n`,
+        );
+        return 2;
+      }
+      const approved = await confirm(
+        `Request rollback of ${config.instance} in ${identity.Account} to ${flags.release}`,
+        false,
+      );
+      if (!approved) return 2;
+    }
+    const result = startReconciliation(config, {
+      trigger: 'cli-rollback',
+      force: flags.force,
+      channel: 'stable',
+      rollback_to: flags.release,
+    });
+    renderExecution(config, result, flags);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  }
+}
+
+function showAwsVpcVersion(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
+  try {
+    verifyPinnedIdentity(config.aws!);
+    const item = releaseState(config);
+    const payload = {
+      instance: config.instance,
+      target: config.target,
+      channel: String(item?.channel ?? config.channel),
+      release: item?.release ?? null,
+      status: item?.status ?? (item ? 'unknown' : 'not-deployed'),
+      updated_at: item?.updated_at ?? null,
+    };
+    if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    else {
+      process.stdout.write(`\n  ${C.bold}kortix self-host version${C.reset}\n`);
+      for (const [key, value] of Object.entries(payload)) {
+        process.stdout.write(`  ${C.dim}${key.padEnd(11)}${C.reset}${value ?? 'none'}\n`);
+      }
+      process.stdout.write('\n');
+    }
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  }
+}
+
+function showAwsVpcStatus(config: SelfHostInstanceConfig, flags: SelfHostCommandFlags): number {
+  try {
+    const coordinates = config.aws!;
+    verifyPinnedIdentity(coordinates);
+    const cluster = awsJsonOptional<{ cluster?: Record<string, unknown> }>(coordinates, [
+      'eks', 'describe-cluster', '--name', config.instance,
+    ])?.cluster ?? null;
+    const supabaseResponse = awsJsonOptional<{
+      Reservations?: Array<{ Instances?: Array<{ InstanceId?: string; State?: { Name?: string }; PrivateIpAddress?: string }> }>;
+    }>(coordinates, [
+      'ec2', 'describe-instances',
+      '--filters', `Name=tag:Name,Values=${config.instance}-supabase`, 'Name=instance-state-name,Values=pending,running,stopping,stopped',
+    ]);
+    const supabaseInstance = supabaseResponse?.Reservations?.flatMap((entry) => entry.Instances ?? [])[0];
+    const stateMachineArn = reconciliationStateMachineArn(config);
+    const updaterProject = awsJsonOptional<{
+      projects?: Array<{ name?: string; arn?: string }>;
+      projectsNotFound?: string[];
+    }>(coordinates, [
+      'codebuild', 'batch-get-projects', '--names', `${config.instance}-updater`,
+    ])?.projects?.[0] ?? null;
+    const execution = awsJsonOptional<{ executions?: Array<Record<string, unknown>> }>(coordinates, [
+      'states', 'list-executions', '--state-machine-arn', stateMachineArn, '--max-results', '1',
+    ])?.executions?.[0] ?? null;
+    const release = releaseState(config);
+    const payload = {
+      instance: config.instance,
+      target: config.target,
+      account_id: coordinates.account_id,
+      region: coordinates.region,
+      cluster: cluster ? {
+        name: cluster.name ?? config.instance,
+        status: cluster.status ?? 'UNKNOWN',
+        version: cluster.version ?? null,
+      } : { name: config.instance, status: 'NOT_DEPLOYED', version: null },
+      supabase: supabaseInstance ? {
+        instance_id: supabaseInstance.InstanceId ?? null,
+        state: supabaseInstance.State?.Name ?? 'unknown',
+        private_ip: supabaseInstance.PrivateIpAddress ?? null,
+      } : { instance_id: null, state: 'NOT_DEPLOYED', private_ip: null },
+      updater: updaterProject ? {
+        name: updaterProject.name ?? `${config.instance}-updater`,
+        status: 'AVAILABLE',
+        arn: updaterProject.arn ?? null,
+      } : { name: `${config.instance}-updater`, status: 'NOT_DEPLOYED', arn: null },
+      reconciliation: execution ? {
+        execution_arn: execution.executionArn ?? null,
+        status: execution.status ?? 'UNKNOWN',
+        started_at: execution.startDate ?? null,
+        stopped_at: execution.stopDate ?? null,
+      } : { execution_arn: null, status: 'NEVER_RUN', started_at: null, stopped_at: null },
+      release: release ?? { release: null, channel: 'stable', status: 'not-deployed', updated_at: null },
+    };
+    if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    else renderLiveStatus(payload);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  }
+}
+
+function showAwsVpcLogs(config: SelfHostInstanceConfig, args: string[], _flags: SelfHostCommandFlags): number {
+  try {
+    const coordinates = config.aws!;
+    verifyPinnedIdentity(coordinates);
+    const unknown = args.filter((arg) => arg.startsWith('-') && !['--follow', '-f'].includes(arg));
+    if (unknown.length > 0) throw new Error(`unknown logs option: ${unknown.join(', ')}`);
+    const services = args.filter((arg) => !arg.startsWith('-'));
+    if (services.length > 1) throw new Error('logs accepts at most one service name');
+    const service = services[0] ?? 'updater';
+    const follow = args.includes('--follow') || args.includes('-f');
+    if (service === 'supabase') {
+      const response = awsJson<{ Reservations?: Array<{ Instances?: Array<{ InstanceId?: string }> }> }>(coordinates, [
+        'ec2', 'describe-instances',
+        '--filters', `Name=tag:Name,Values=${config.instance}-supabase`, 'Name=instance-state-name,Values=running',
+      ]);
+      const instanceId = response.Reservations?.flatMap((entry) => entry.Instances ?? [])[0]?.InstanceId;
+      if (!instanceId) throw new Error(`no running Supabase host found for ${config.instance}`);
+      const result = spawnAws(coordinates, [
+        'ssm', 'start-session', '--target', instanceId,
+        '--document-name', 'AWS-StartInteractiveCommand',
+        '--parameters', 'command=journalctl -u kortix-supabase -f -n 200',
+      ], 'inherit');
+      if (result.status !== 0) throw new Error(`SSM log session failed with exit ${result.status ?? 1}`);
+      return 0;
+    }
+    const groups: Record<string, string> = {
+      updater: `/kortix/${config.instance}/updater`,
+      api: `/kortix/${config.instance}/api`,
+      frontend: `/kortix/${config.instance}/frontend`,
+      gateway: `/kortix/${config.instance}/gateway`,
+    };
+    const group = groups[service];
+    if (!group) throw new Error('logs service must be updater, supabase, api, frontend, or gateway');
+    const result = spawnAws(coordinates, [
+      'logs', 'tail', group, '--since', '1h', ...(follow ? ['--follow'] : []), '--no-cli-pager',
+    ]);
+    if (result.status !== 0) throw new Error(firstLine(result.stderr) || `CloudWatch logs failed with exit ${result.status ?? 1}`);
+    process.stdout.write(result.stdout);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  }
+}
+
+function openAwsVpc(config: SelfHostInstanceConfig): number {
+  try {
+    const aws = completeConfiguration(config);
+    verifyPinnedIdentity(aws);
+    const url = `https://${aws.frontend_domain}`;
+    const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open';
+    const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+    const result = spawnSync(command, args, { stdio: 'ignore' });
+    if (result.error || result.status !== 0) throw new Error(`could not open ${url}`);
+    process.stdout.write(`${url}\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`${status.err((error as Error).message)}\n`);
+    return 1;
+  }
+}
+
+function renderPlans(instance: string, account: string, region: string, plans: StagePlan[]): void {
+  process.stdout.write(`\n  ${C.bold}kortix self-host plan${C.reset}\n`);
+  process.stdout.write(`  ${C.dim}instance ${C.reset}${instance}\n`);
+  process.stdout.write(`  ${C.dim}target   ${C.reset}${account}/${region}\n\n`);
+  for (const plan of plans) {
+    const summary = plan.summary;
+    process.stdout.write(`  ${plan.decision === 'blocked' ? status.err(plan.name) : status.ok(plan.name)} ${plan.decision}\n`);
+    process.stdout.write(`    ${C.dim}create=${summary.create} update=${summary.update} delete=${summary.delete} replace=${summary.replace}${C.reset}\n`);
+    for (const reason of plan.reasons) process.stdout.write(`    ${C.dim}${reason.severity}: ${reason.address}: ${reason.reason}${C.reset}\n`);
+  }
+  process.stdout.write('\n');
+}
+
+function renderExecution(
   config: SelfHostInstanceConfig,
-  _args: string[],
-  _flags: SelfHostCommandFlags,
-): number {
-  process.stderr.write(
-    `${status.err(`AWS VPC ${command} is not available until the enterprise bootstrap bundle is installed for ${config.instance}.`)}\n`,
-  );
-  process.stderr.write(`${C.dim}Run ${C.reset}${C.cyan}kortix self-host doctor --instance ${config.instance}${C.reset}${C.dim} first.${C.reset}\n`);
-  return 1;
+  result: ReturnType<typeof startReconciliation>,
+  flags: SelfHostCommandFlags,
+): void {
+  const payload = { instance: config.instance, channel: 'stable', ...result };
+  if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  else {
+    process.stdout.write(`\n  ${C.bold}Kortix customer-owned reconciliation${C.reset}\n`);
+    process.stdout.write(`${status.ok(result.execution_arn)}\n`);
+    process.stdout.write(`  ${C.dim}The customer state machine enforces signatures, compatibility, plan guard, and health gates.${C.reset}\n\n`);
+  }
+}
+
+function renderLiveStatus(payload: {
+  instance: string;
+  account_id: string;
+  region: string;
+  cluster: { status: unknown };
+  supabase: { state: unknown };
+  reconciliation: { status: unknown };
+  updater: { status: unknown };
+  release: Record<string, unknown>;
+}): void {
+  process.stdout.write(`\n  ${C.bold}kortix self-host status${C.reset}\n`);
+  process.stdout.write(`  ${C.dim}instance       ${C.reset}${payload.instance}\n`);
+  process.stdout.write(`  ${C.dim}target         ${C.reset}${payload.account_id}/${payload.region}\n`);
+  process.stdout.write(`  ${C.dim}cluster        ${C.reset}${String(payload.cluster.status)}\n`);
+  process.stdout.write(`  ${C.dim}supabase       ${C.reset}${String(payload.supabase.state)}\n`);
+  process.stdout.write(`  ${C.dim}updater        ${C.reset}${String(payload.updater.status)}\n`);
+  process.stdout.write(`  ${C.dim}reconciliation ${C.reset}${String(payload.reconciliation.status)}\n`);
+  process.stdout.write(`  ${C.dim}release        ${C.reset}${String(payload.release.release ?? 'not deployed')} (${String(payload.release.status ?? 'unknown')})\n\n`);
 }
 
 function rejectDockerLifecycleCommand(command: AwsVpcCommand, instance: string): number {
@@ -272,33 +698,4 @@ function loadAwsConfig(instance: string): SelfHostInstanceConfig | null {
     return null;
   }
   return config;
-}
-
-function awsIdentity(coordinates: AwsVpcCoordinates): AwsIdentity {
-  const result = spawnSync(
-    'aws',
-    [
-      '--profile', coordinates.profile,
-      '--region', coordinates.region,
-      'sts', 'get-caller-identity',
-      '--output', 'json',
-      '--no-cli-pager',
-    ],
-    { encoding: 'utf8' },
-  );
-  if (result.error) throw new Error(`unable to run AWS CLI: ${result.error.message}`);
-  if (result.status !== 0) {
-    throw new Error(`AWS identity check failed for profile ${coordinates.profile}: ${firstLine(result.stderr) || `exit ${result.status}`}`);
-  }
-  try {
-    const identity = JSON.parse(result.stdout) as AwsIdentity;
-    if (!/^\d{12}$/.test(identity.Account) || !identity.Arn) throw new Error('missing Account or Arn');
-    return identity;
-  } catch (error) {
-    throw new Error(`AWS identity response was invalid: ${(error as Error).message}`);
-  }
-}
-
-function firstLine(value: string): string {
-  return value.trim().split(/\r?\n/, 1)[0] ?? '';
 }

--- a/apps/cli/src/self-host/config.ts
+++ b/apps/cli/src/self-host/config.ts
@@ -8,6 +8,15 @@ export interface AwsVpcCoordinates {
   profile: string;
   region: string;
   account_id: string;
+  vpc_cidr?: string;
+  api_domain?: string;
+  frontend_domain?: string;
+  release_repository_url?: string;
+  tuf_root_sha256?: string;
+  updater_bootstrap_url?: string;
+  updater_bootstrap_sha256?: string;
+  release_publisher_account_id?: string;
+  maintenance_window?: string;
 }
 
 export interface SelfHostInstanceConfig {
@@ -22,7 +31,20 @@ export interface SelfHostInstanceConfig {
 const INSTANCE_PATTERN = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
 const REGION_PATTERN = /^[a-z]{2}(?:-gov)?-[a-z]+-\d$/;
 const TOP_LEVEL_FIELDS = new Set(['schema_version', 'instance', 'target', 'channel', 'release', 'aws']);
-const AWS_FIELDS = new Set(['profile', 'region', 'account_id']);
+const AWS_FIELDS = new Set([
+  'profile',
+  'region',
+  'account_id',
+  'vpc_cidr',
+  'api_domain',
+  'frontend_domain',
+  'release_repository_url',
+  'tuf_root_sha256',
+  'updater_bootstrap_url',
+  'updater_bootstrap_sha256',
+  'release_publisher_account_id',
+  'maintenance_window',
+]);
 
 export function selfHostConfigRoot(): string {
   const override = process.env.KORTIX_SELF_HOST_CONFIG_DIR?.trim();
@@ -100,9 +122,13 @@ function validateInstanceConfig(value: unknown, expectedInstance: string): SelfH
   assertInstanceName(expectedInstance);
 
   const target = parseSelfHostTarget(asRequiredString(value.target, 'target'))!;
+  if (target === 'aws-vpc') assertAwsVpcInstanceName(expectedInstance);
   const channel = asRequiredString(value.channel, 'channel');
   if (!/^[a-zA-Z0-9._-]+$/.test(channel)) {
     throw new Error('channel may contain only letters, digits, dots, underscores, or dashes');
+  }
+  if (target === 'aws-vpc' && channel !== 'stable') {
+    throw new Error('AWS VPC instances may only track the stable channel');
   }
 
   const release = optionalString(value.release, 'release');
@@ -115,7 +141,53 @@ function validateInstanceConfig(value: unknown, expectedInstance: string): SelfH
     const accountId = asRequiredString(value.aws.account_id, 'aws.account_id');
     if (!REGION_PATTERN.test(region)) throw new Error(`invalid aws.region "${region}"`);
     if (!/^\d{12}$/.test(accountId)) throw new Error('aws.account_id must be a 12-digit AWS account ID');
-    aws = { profile, region, account_id: accountId };
+    const vpcCidr = optionalString(value.aws.vpc_cidr, 'aws.vpc_cidr');
+    const apiDomain = optionalString(value.aws.api_domain, 'aws.api_domain');
+    const frontendDomain = optionalString(value.aws.frontend_domain, 'aws.frontend_domain');
+    const releaseRepositoryUrl = optionalString(value.aws.release_repository_url, 'aws.release_repository_url');
+    const tufRootSha256 = optionalString(value.aws.tuf_root_sha256, 'aws.tuf_root_sha256');
+    const updaterBootstrapUrl = optionalString(value.aws.updater_bootstrap_url, 'aws.updater_bootstrap_url');
+    const updaterBootstrapSha256 = optionalString(value.aws.updater_bootstrap_sha256, 'aws.updater_bootstrap_sha256');
+    const releasePublisherAccountId = optionalString(
+      value.aws.release_publisher_account_id,
+      'aws.release_publisher_account_id',
+    );
+    const maintenanceWindow = optionalString(value.aws.maintenance_window, 'aws.maintenance_window');
+    if (vpcCidr && !isValidVpcCidr(vpcCidr)) throw new Error('aws.vpc_cidr must be a canonical RFC1918 /16 CIDR');
+    if (apiDomain && !isValidDomain(apiDomain)) throw new Error('aws.api_domain must be a valid DNS name');
+    if (frontendDomain && !isValidDomain(frontendDomain)) throw new Error('aws.frontend_domain must be a valid DNS name');
+    if (releaseRepositoryUrl && !isHttpsUrl(releaseRepositoryUrl)) {
+      throw new Error('aws.release_repository_url must be an HTTPS URL');
+    }
+    if (tufRootSha256 && !/^[a-f0-9]{64}$/.test(tufRootSha256)) {
+      throw new Error('aws.tuf_root_sha256 must be a lowercase SHA-256 digest');
+    }
+    if (updaterBootstrapUrl && !isHttpsUrl(updaterBootstrapUrl)) {
+      throw new Error('aws.updater_bootstrap_url must be an HTTPS URL');
+    }
+    if (updaterBootstrapSha256 && !/^[a-f0-9]{64}$/.test(updaterBootstrapSha256)) {
+      throw new Error('aws.updater_bootstrap_sha256 must be a lowercase SHA-256 digest');
+    }
+    if (releasePublisherAccountId && !/^\d{12}$/.test(releasePublisherAccountId)) {
+      throw new Error('aws.release_publisher_account_id must be a 12-digit AWS account ID');
+    }
+    if (maintenanceWindow && !/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun):(?:[01]\d|2[0-3]):[0-5]\d-(?:[01]\d|2[0-3]):[0-5]\d$/.test(maintenanceWindow)) {
+      throw new Error('aws.maintenance_window must use UTC Day:HH:MM-HH:MM format');
+    }
+    aws = {
+      profile,
+      region,
+      account_id: accountId,
+      ...(vpcCidr ? { vpc_cidr: vpcCidr } : {}),
+      ...(apiDomain ? { api_domain: apiDomain } : {}),
+      ...(frontendDomain ? { frontend_domain: frontendDomain } : {}),
+      ...(releaseRepositoryUrl ? { release_repository_url: releaseRepositoryUrl } : {}),
+      ...(tufRootSha256 ? { tuf_root_sha256: tufRootSha256 } : {}),
+      ...(updaterBootstrapUrl ? { updater_bootstrap_url: updaterBootstrapUrl } : {}),
+      ...(updaterBootstrapSha256 ? { updater_bootstrap_sha256: updaterBootstrapSha256 } : {}),
+      ...(releasePublisherAccountId ? { release_publisher_account_id: releasePublisherAccountId } : {}),
+      ...(maintenanceWindow ? { maintenance_window: maintenanceWindow } : {}),
+    };
   } else if (value.aws !== undefined) {
     throw new Error('Docker instance config must not contain aws coordinates');
   }
@@ -133,6 +205,12 @@ function validateInstanceConfig(value: unknown, expectedInstance: string): SelfH
 function assertInstanceName(instance: string): void {
   if (!INSTANCE_PATTERN.test(instance)) {
     throw new Error('instance must start with a letter and contain only letters, digits, dots, underscores, or dashes');
+  }
+}
+
+export function assertAwsVpcInstanceName(instance: string): void {
+  if (!/^[a-z][a-z0-9-]{2,30}[a-z0-9]$/.test(instance)) {
+    throw new Error('AWS VPC instance must be a 4-32 character lowercase DNS slug');
   }
 }
 
@@ -154,4 +232,28 @@ function optionalString(value: unknown, field: string): string | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isValidDomain(value: string): boolean {
+  return value.length <= 253
+    && value.includes('.')
+    && value.split('.').every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label));
+}
+
+function isValidVpcCidr(value: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.0\.0\/16$/.exec(value);
+  if (!match) return false;
+  const first = Number(match[1]);
+  const second = Number(match[2]);
+  return first === 10
+    || (first === 172 && second >= 16 && second <= 31)
+    || (first === 192 && second === 168);
 }

--- a/apps/cli/src/self-host/enterprise-assets.ts
+++ b/apps/cli/src/self-host/enterprise-assets.ts
@@ -1,0 +1,161 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import clusterBackend from '../../../../infra/terraform/environments/enterprise-vpc-template/cluster/backend.tf' with { type: 'text' };
+import clusterLock from '../../../../infra/terraform/environments/enterprise-vpc-template/cluster/.terraform.lock.hcl' with { type: 'text' };
+import clusterMain from '../../../../infra/terraform/environments/enterprise-vpc-template/cluster/main.tf' with { type: 'text' };
+import clusterVariables from '../../../../infra/terraform/environments/enterprise-vpc-template/cluster/variables.tf' with { type: 'text' };
+import platformBackend from '../../../../infra/terraform/environments/enterprise-vpc-template/platform/backend.tf' with { type: 'text' };
+import platformLock from '../../../../infra/terraform/environments/enterprise-vpc-template/platform/.terraform.lock.hcl' with { type: 'text' };
+import platformMain from '../../../../infra/terraform/environments/enterprise-vpc-template/platform/main.tf' with { type: 'text' };
+import platformVariables from '../../../../infra/terraform/environments/enterprise-vpc-template/platform/variables.tf' with { type: 'text' };
+import stateBackend from '../../../../infra/terraform/environments/enterprise-vpc-template/state/backend.tf' with { type: 'text' };
+import stateLock from '../../../../infra/terraform/environments/enterprise-vpc-template/state/.terraform.lock.hcl' with { type: 'text' };
+import stateMain from '../../../../infra/terraform/environments/enterprise-vpc-template/state/main.tf' with { type: 'text' };
+import stateVariables from '../../../../infra/terraform/environments/enterprise-vpc-template/state/variables.tf' with { type: 'text' };
+
+import platformModuleMain from '../../../../infra/terraform/modules/enterprise-platform/main.tf' with { type: 'text' };
+import platformModuleOutputs from '../../../../infra/terraform/modules/enterprise-platform/outputs.tf' with { type: 'text' };
+import platformModuleVariables from '../../../../infra/terraform/modules/enterprise-platform/variables.tf' with { type: 'text' };
+import platformModuleVersions from '../../../../infra/terraform/modules/enterprise-platform/versions.tf' with { type: 'text' };
+
+import stateModuleMain from '../../../../infra/terraform/modules/enterprise-state/main.tf' with { type: 'text' };
+import stateModuleOutputs from '../../../../infra/terraform/modules/enterprise-state/outputs.tf' with { type: 'text' };
+import stateModuleVariables from '../../../../infra/terraform/modules/enterprise-state/variables.tf' with { type: 'text' };
+import stateModuleVersions from '../../../../infra/terraform/modules/enterprise-state/versions.tf' with { type: 'text' };
+
+import enterpriseAcm from '../../../../infra/terraform/modules/enterprise-vpc/acm.tf' with { type: 'text' };
+import enterpriseBackup from '../../../../infra/terraform/modules/enterprise-vpc/backup.tf' with { type: 'text' };
+import enterpriseEks from '../../../../infra/terraform/modules/enterprise-vpc/eks.tf' with { type: 'text' };
+import supabaseUserData from '../../../../infra/terraform/modules/enterprise-vpc/files/supabase-user-data.sh.tftpl' with { type: 'text' };
+import updaterBuildspec from '../../../../infra/terraform/modules/enterprise-vpc/files/updater-buildspec.yml.tftpl' with { type: 'text' };
+import enterpriseFlowLogs from '../../../../infra/terraform/modules/enterprise-vpc/flow-logs.tf' with { type: 'text' };
+import enterpriseKms from '../../../../infra/terraform/modules/enterprise-vpc/kms.tf' with { type: 'text' };
+import enterpriseMain from '../../../../infra/terraform/modules/enterprise-vpc/main.tf' with { type: 'text' };
+import enterpriseNetwork from '../../../../infra/terraform/modules/enterprise-vpc/network.tf' with { type: 'text' };
+import enterpriseOperator from '../../../../infra/terraform/modules/enterprise-vpc/operator.tf' with { type: 'text' };
+import enterpriseOutputs from '../../../../infra/terraform/modules/enterprise-vpc/outputs.tf' with { type: 'text' };
+import enterpriseStorage from '../../../../infra/terraform/modules/enterprise-vpc/storage.tf' with { type: 'text' };
+import enterpriseSupabase from '../../../../infra/terraform/modules/enterprise-vpc/supabase.tf' with { type: 'text' };
+import enterpriseUpdater from '../../../../infra/terraform/modules/enterprise-vpc/updater.tf' with { type: 'text' };
+import enterpriseVariables from '../../../../infra/terraform/modules/enterprise-vpc/variables.tf' with { type: 'text' };
+import enterpriseVersions from '../../../../infra/terraform/modules/enterprise-vpc/versions.tf' with { type: 'text' };
+
+import eksClusterAddons from '../../../../infra/terraform/modules/eks/cluster/addons.tf' with { type: 'text' };
+import eksClusterEbsCsi from '../../../../infra/terraform/modules/eks/cluster/ebs-csi.tf' with { type: 'text' };
+import eksClusterIam from '../../../../infra/terraform/modules/eks/cluster/iam.tf' with { type: 'text' };
+import eksClusterMain from '../../../../infra/terraform/modules/eks/cluster/main.tf' with { type: 'text' };
+import eksClusterOutputs from '../../../../infra/terraform/modules/eks/cluster/outputs.tf' with { type: 'text' };
+import eksClusterVariables from '../../../../infra/terraform/modules/eks/cluster/variables.tf' with { type: 'text' };
+import eksIrsaMain from '../../../../infra/terraform/modules/eks/irsa/main.tf' with { type: 'text' };
+import eksIrsaOutputs from '../../../../infra/terraform/modules/eks/irsa/outputs.tf' with { type: 'text' };
+import eksIrsaVariables from '../../../../infra/terraform/modules/eks/irsa/variables.tf' with { type: 'text' };
+import albControllerPolicy from '../../../../infra/terraform/modules/eks/platform/files/alb-controller-policy.json' with { type: 'text' };
+import eksPlatformIrsa from '../../../../infra/terraform/modules/eks/platform/irsa.tf' with { type: 'text' };
+import eksPlatformMain from '../../../../infra/terraform/modules/eks/platform/main.tf' with { type: 'text' };
+import eksPlatformOutputs from '../../../../infra/terraform/modules/eks/platform/outputs.tf' with { type: 'text' };
+import eksPlatformVariables from '../../../../infra/terraform/modules/eks/platform/variables.tf' with { type: 'text' };
+import networkMain from '../../../../infra/terraform/modules/network/main.tf' with { type: 'text' };
+import networkOutputs from '../../../../infra/terraform/modules/network/outputs.tf' with { type: 'text' };
+import networkVariables from '../../../../infra/terraform/modules/network/variables.tf' with { type: 'text' };
+
+import { instanceDir } from './config.ts';
+
+const STATE_BACKEND_PATH = 'environments/enterprise-vpc/state/backend.tf';
+export const LOCAL_STATE_BACKEND = stateBackend;
+
+export const enterpriseTerraformAssets: Readonly<Record<string, string>> = {
+  'environments/enterprise-vpc/cluster/.terraform.lock.hcl': clusterLock,
+  'environments/enterprise-vpc/cluster/backend.tf': clusterBackend,
+  'environments/enterprise-vpc/cluster/main.tf': clusterMain,
+  'environments/enterprise-vpc/cluster/variables.tf': clusterVariables,
+  'environments/enterprise-vpc/platform/.terraform.lock.hcl': platformLock,
+  'environments/enterprise-vpc/platform/backend.tf': platformBackend,
+  'environments/enterprise-vpc/platform/main.tf': platformMain,
+  'environments/enterprise-vpc/platform/variables.tf': platformVariables,
+  'environments/enterprise-vpc/state/.terraform.lock.hcl': stateLock,
+  [STATE_BACKEND_PATH]: LOCAL_STATE_BACKEND,
+  'environments/enterprise-vpc/state/main.tf': stateMain,
+  'environments/enterprise-vpc/state/variables.tf': stateVariables,
+  'modules/enterprise-platform/main.tf': platformModuleMain,
+  'modules/enterprise-platform/outputs.tf': platformModuleOutputs,
+  'modules/enterprise-platform/variables.tf': platformModuleVariables,
+  'modules/enterprise-platform/versions.tf': platformModuleVersions,
+  'modules/enterprise-state/main.tf': stateModuleMain,
+  'modules/enterprise-state/outputs.tf': stateModuleOutputs,
+  'modules/enterprise-state/variables.tf': stateModuleVariables,
+  'modules/enterprise-state/versions.tf': stateModuleVersions,
+  'modules/enterprise-vpc/acm.tf': enterpriseAcm,
+  'modules/enterprise-vpc/backup.tf': enterpriseBackup,
+  'modules/enterprise-vpc/eks.tf': enterpriseEks,
+  'modules/enterprise-vpc/files/supabase-user-data.sh.tftpl': supabaseUserData,
+  'modules/enterprise-vpc/files/updater-buildspec.yml.tftpl': updaterBuildspec,
+  'modules/enterprise-vpc/flow-logs.tf': enterpriseFlowLogs,
+  'modules/enterprise-vpc/kms.tf': enterpriseKms,
+  'modules/enterprise-vpc/main.tf': enterpriseMain,
+  'modules/enterprise-vpc/network.tf': enterpriseNetwork,
+  'modules/enterprise-vpc/operator.tf': enterpriseOperator,
+  'modules/enterprise-vpc/outputs.tf': enterpriseOutputs,
+  'modules/enterprise-vpc/storage.tf': enterpriseStorage,
+  'modules/enterprise-vpc/supabase.tf': enterpriseSupabase,
+  'modules/enterprise-vpc/updater.tf': enterpriseUpdater,
+  'modules/enterprise-vpc/variables.tf': enterpriseVariables,
+  'modules/enterprise-vpc/versions.tf': enterpriseVersions,
+  'modules/eks/cluster/addons.tf': eksClusterAddons,
+  'modules/eks/cluster/ebs-csi.tf': eksClusterEbsCsi,
+  'modules/eks/cluster/iam.tf': eksClusterIam,
+  'modules/eks/cluster/main.tf': eksClusterMain,
+  'modules/eks/cluster/outputs.tf': eksClusterOutputs,
+  'modules/eks/cluster/variables.tf': eksClusterVariables,
+  'modules/eks/irsa/main.tf': eksIrsaMain,
+  'modules/eks/irsa/outputs.tf': eksIrsaOutputs,
+  'modules/eks/irsa/variables.tf': eksIrsaVariables,
+  'modules/eks/platform/files/alb-controller-policy.json': albControllerPolicy as unknown as string,
+  'modules/eks/platform/irsa.tf': eksPlatformIrsa,
+  'modules/eks/platform/main.tf': eksPlatformMain,
+  'modules/eks/platform/outputs.tf': eksPlatformOutputs,
+  'modules/eks/platform/variables.tf': eksPlatformVariables,
+  'modules/network/main.tf': networkMain,
+  'modules/network/outputs.tf': networkOutputs,
+  'modules/network/variables.tf': networkVariables,
+};
+
+export const REMOTE_STATE_BACKEND = `terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0, < 7.0"
+    }
+  }
+  backend "s3" {}
+}
+`;
+
+export function enterpriseTerraformRoot(instance: string): string {
+  return join(instanceDir(instance), 'terraform');
+}
+
+/**
+ * Materialize the exact reviewed graph bundled into this CLI. Terraform state,
+ * backend.hcl, generated tfvars, and the migrated state backend are mutable
+ * instance data and are deliberately never overwritten here.
+ */
+export function writeEnterpriseTerraformAssets(instance: string): string {
+  const root = enterpriseTerraformRoot(instance);
+  for (const [relativePath, content] of Object.entries(enterpriseTerraformAssets)) {
+    const path = join(root, relativePath);
+    if (relativePath === STATE_BACKEND_PATH && existsSync(path)) {
+      const current = readFileSync(path, 'utf8');
+      if (current.includes('backend "s3"')) continue;
+    }
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    writeFileSync(path, content, { encoding: 'utf8', mode: 0o644 });
+    chmodSync(path, 0o644);
+  }
+  return root;
+}
+
+export function stateBackendPath(instance: string): string {
+  return join(enterpriseTerraformRoot(instance), STATE_BACKEND_PATH);
+}

--- a/apps/cli/src/self-host/enterprise-terraform.ts
+++ b/apps/cli/src/self-host/enterprise-terraform.ts
@@ -1,0 +1,245 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  classifyEnterprisePlan,
+  type GuardResult,
+} from '../../../../infra/terraform/scripts/guard-enterprise-plan.ts';
+import type { AwsVpcCoordinates } from './config.ts';
+import {
+  enterpriseTerraformRoot,
+  LOCAL_STATE_BACKEND,
+  REMOTE_STATE_BACKEND,
+  stateBackendPath,
+  writeEnterpriseTerraformAssets,
+} from './enterprise-assets.ts';
+import type { CompleteAwsVpcConfig } from './aws-vpc-settings.ts';
+
+interface TerraformStateIdentity {
+  lineage: string;
+  serial: number;
+}
+
+export interface BackendConfig {
+  bucket: string;
+  dynamodb_table: string;
+  region: string;
+  encrypt: boolean;
+  kms_key_id: string;
+}
+
+export interface EnterpriseInstanceOutput {
+  cluster_name?: string;
+  state_machine_arn?: string;
+  release_state_table?: string;
+  supabase_instance_id?: string;
+  [key: string]: unknown;
+}
+
+export interface StagePlan extends GuardResult {
+  name: 'state' | 'cluster';
+  planPath: string;
+}
+
+export function prepareTerraform(instance: string, aws: CompleteAwsVpcConfig) {
+  const root = writeEnterpriseTerraformAssets(instance);
+  const state = join(root, 'environments', 'enterprise-vpc', 'state');
+  const cluster = join(root, 'environments', 'enterprise-vpc', 'cluster');
+  writeJson(join(state, 'terraform.auto.tfvars.json'), {
+    aws_region: aws.region,
+    name: instance,
+    expected_account_id: aws.account_id,
+    state_bucket_name: stateBucketName(instance, aws),
+    lock_table_name: `${instance}-terraform-locks`,
+    tags: { Environment: 'enterprise', ManagedBy: 'kortix-self-host' },
+  });
+  return { root, state, cluster };
+}
+
+export function writeClusterFiles(
+  instance: string,
+  aws: CompleteAwsVpcConfig,
+  permissionsBoundaryArn: string,
+  backend: BackendConfig,
+): void {
+  const cluster = join(enterpriseTerraformRoot(instance), 'environments', 'enterprise-vpc', 'cluster');
+  writeBackendConfig(join(cluster, 'backend.hcl'), backend, 'enterprise/cluster.tfstate');
+  writeJson(join(cluster, 'terraform.auto.tfvars.json'), {
+    aws_region: aws.region,
+    name: instance,
+    expected_account_id: aws.account_id,
+    vpc_cidr: aws.vpc_cidr,
+    api_domain: aws.api_domain,
+    frontend_domain: aws.frontend_domain,
+    release_repository_url: aws.release_repository_url,
+    tuf_root_sha256: aws.tuf_root_sha256,
+    updater_bootstrap_url: aws.updater_bootstrap_url,
+    updater_bootstrap_sha256: aws.updater_bootstrap_sha256,
+    release_publisher_account_id: aws.release_publisher_account_id,
+    maintenance_window: aws.maintenance_window,
+    permissions_boundary_arn: permissionsBoundaryArn,
+    tags: { Environment: 'enterprise', ManagedBy: 'kortix-self-host' },
+  });
+}
+
+export function terraformPlan(
+  name: 'state' | 'cluster',
+  directory: string,
+  aws: CompleteAwsVpcConfig,
+  backendConfig?: string,
+): StagePlan {
+  const initArgs = ['init', '-input=false'];
+  if (backendConfig) initArgs.push('-reconfigure', `-backend-config=${backendConfig}`);
+  terraform(directory, aws, initArgs);
+  const planPath = join(directory, '.kortix.plan');
+  terraform(directory, aws, ['plan', '-input=false', '-lock-timeout=5m', `-out=${planPath}`]);
+  const plan = terraformJson<Record<string, unknown>>(directory, aws, ['show', '-json', planPath]);
+  return { name, planPath, ...classifyEnterprisePlan(plan) };
+}
+
+export function terraformApply(directory: string, aws: CompleteAwsVpcConfig, planPath: string): void {
+  terraform(directory, aws, ['apply', '-input=false', planPath]);
+}
+
+export function migrateAndVerifyState(
+  instance: string,
+  stateDirectory: string,
+  aws: CompleteAwsVpcConfig,
+  alreadyRemote: boolean,
+) {
+  const before = terraformJson<TerraformStateIdentity>(stateDirectory, aws, ['state', 'pull']);
+  assertStateIdentity(before, 'local/source');
+  const backend = terraformOutput<BackendConfig>(stateDirectory, aws, 'backend_config');
+  const permissionsBoundaryArn = terraformOutput<string>(stateDirectory, aws, 'permissions_boundary_arn');
+  const backendPath = join(stateDirectory, 'backend.hcl');
+  writeBackendConfig(backendPath, backend, 'enterprise/state.tfstate');
+
+  if (!alreadyRemote) {
+    writeFileSync(stateBackendPath(instance), REMOTE_STATE_BACKEND, { encoding: 'utf8', mode: 0o644 });
+    chmodSync(stateBackendPath(instance), 0o644);
+    try {
+      terraform(stateDirectory, aws, [
+        'init', '-input=false', '-migrate-state', '-force-copy', `-backend-config=${backendPath}`,
+      ]);
+    } catch (error) {
+      // Do not let a retry silently reconfigure against an empty remote state.
+      writeFileSync(stateBackendPath(instance), LOCAL_STATE_BACKEND, { encoding: 'utf8', mode: 0o644 });
+      chmodSync(stateBackendPath(instance), 0o644);
+      throw new Error(`Terraform state migration did not complete; local bootstrap state was preserved: ${(error as Error).message}`);
+    }
+  }
+
+  const after = terraformJson<TerraformStateIdentity>(stateDirectory, aws, ['state', 'pull']);
+  assertStateIdentity(after, 'remote');
+  if (before.lineage !== after.lineage || before.serial !== after.serial) {
+    throw new Error(
+      `remote state verification failed: source ${before.lineage}/${before.serial}, remote ${after.lineage}/${after.serial}; local bootstrap state was preserved`,
+    );
+  }
+  if (!alreadyRemote) {
+    rmSync(join(stateDirectory, 'terraform.bootstrap.tfstate'), { force: true });
+    rmSync(join(stateDirectory, 'terraform.bootstrap.tfstate.backup'), { force: true });
+  }
+  return {
+    backend,
+    permissionsBoundaryArn,
+    verification: { verified: true, lineage: after.lineage, serial: after.serial, already_remote: alreadyRemote },
+  };
+}
+
+export function terraformOutput<T>(directory: string, aws: CompleteAwsVpcConfig, name: string): T {
+  return terraformJson<T>(directory, aws, ['output', '-json', name]);
+}
+
+export function readBackendConfig(path: string): BackendConfig {
+  const content = readFileSync(path, 'utf8');
+  const readString = (key: string): string => {
+    const match = new RegExp(`^${key}\\s*=\\s*("(?:[^"\\\\]|\\\\.)*")`, 'm').exec(content);
+    if (!match) throw new Error(`backend config is missing ${key}`);
+    return JSON.parse(match[1]) as string;
+  };
+  return {
+    bucket: readString('bucket'),
+    dynamodb_table: readString('dynamodb_table'),
+    region: readString('region'),
+    encrypt: /^encrypt\s*=\s*true$/m.test(content),
+    kms_key_id: readString('kms_key_id'),
+  };
+}
+
+export function isRemoteState(instance: string): boolean {
+  const path = stateBackendPath(instance);
+  return existsSync(path) && readFileSync(path, 'utf8').includes('backend "s3"');
+}
+
+export function ensureApplicable(plan: StagePlan): void {
+  if (plan.decision === 'blocked') {
+    throw new Error(`${plan.name} Terraform plan is blocked: ${plan.reasons.map((reason) => reason.reason).join('; ')}`);
+  }
+}
+
+export function publicPlan(plan: StagePlan) {
+  return { name: plan.name, decision: plan.decision, summary: plan.summary, reasons: plan.reasons };
+}
+
+function terraformJson<T>(directory: string, aws: CompleteAwsVpcConfig, args: string[]): T {
+  const output = terraform(directory, aws, args);
+  try {
+    return JSON.parse(output) as T;
+  } catch (error) {
+    throw new Error(`Terraform returned invalid JSON for ${args.join(' ')}: ${(error as Error).message}`);
+  }
+}
+
+function terraform(directory: string, aws: CompleteAwsVpcConfig, args: string[]): string {
+  const result = spawnSync('terraform', [`-chdir=${directory}`, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      AWS_PROFILE: aws.profile,
+      AWS_REGION: aws.region,
+      AWS_DEFAULT_REGION: aws.region,
+    },
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) throw new Error(`unable to run Terraform: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new Error(`Terraform ${args[0]} failed: ${firstLine(result.stderr || result.stdout) || `exit ${result.status}`}`);
+  }
+  return result.stdout;
+}
+
+function stateBucketName(instance: string, aws: AwsVpcCoordinates): string {
+  const suffix = `-${aws.account_id}-${aws.region}-tfstate`;
+  return `${instance.slice(0, 63 - suffix.length).replace(/-+$/, '')}${suffix}`;
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+function writeBackendConfig(path: string, backend: BackendConfig, key: string): void {
+  const content = [
+    `bucket         = ${JSON.stringify(backend.bucket)}`,
+    `key            = ${JSON.stringify(key)}`,
+    `region         = ${JSON.stringify(backend.region)}`,
+    `dynamodb_table = ${JSON.stringify(backend.dynamodb_table)}`,
+    `encrypt        = ${backend.encrypt ? 'true' : 'false'}`,
+    `kms_key_id     = ${JSON.stringify(backend.kms_key_id)}`,
+    '',
+  ].join('\n');
+  writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+function assertStateIdentity(state: TerraformStateIdentity, label: string): void {
+  if (!state || typeof state.lineage !== 'string' || !Number.isInteger(state.serial)) {
+    throw new Error(`${label} Terraform state is missing lineage or serial`);
+  }
+}
+
+function firstLine(value: string): string {
+  return value.trim().split(/\r?\n/, 1)[0] ?? '';
+}

--- a/apps/cli/src/self-host/types.ts
+++ b/apps/cli/src/self-host/types.ts
@@ -8,6 +8,15 @@ export interface SelfHostCommandFlags {
   target?: SelfHostTarget;
   awsProfile?: string;
   region?: string;
+  vpcCidr?: string;
+  apiDomain?: string;
+  frontendDomain?: string;
+  releaseRepositoryUrl?: string;
+  tufRootSha256?: string;
+  updaterBootstrapUrl?: string;
+  updaterBootstrapSha256?: string;
+  releasePublisherAccountId?: string;
+  maintenanceWindow?: string;
   yes: boolean;
   local: boolean;
   registry: boolean;

--- a/docs/runbooks/enterprise-vpc-deployment.md
+++ b/docs/runbooks/enterprise-vpc-deployment.md
@@ -20,7 +20,7 @@ exact certified image and bundle digests; it never rebuilds them.
    blocked; the first plan is necessarily manual because it creates trust and
    network boundaries.
 5. After apply, the customer validates ACM DNS records and populates the
-   encrypted runtime secret through the CLI without writing plaintext tfvars.
+   encrypted runtime secret without writing plaintext Terraform variables.
 6. Customer CodeBuild applies the `platform` root through the private EKS
    endpoint and reconciles the certified release.
 7. Certification proves API, frontend, auth, sandbox execution, persistence,
@@ -31,6 +31,60 @@ The permanent customer-zero target is AWS account `935064898258`, region
 `us-west-2`, CIDR `10.60.0.0/16`. Essentia is not touched until customer-zero
 passes the complete certification matrix with the exact artifact digests that
 will be promoted.
+
+## CLI management plane
+
+`kortix self-host` is the one operator surface for Docker and AWS installs.
+Docker commands keep their existing behavior. An AWS target stores only
+secret-free desired settings and an account pin under the named instance; the
+compiled CLI materializes the reviewed Terraform roots and their complete
+local module graph there.
+
+```bash
+kortix self-host init \
+  --target aws-vpc \
+  --instance kortix-vpc-demo \
+  --aws-profile default \
+  --region us-west-2 \
+  --vpc-cidr 10.60.0.0/16 \
+  --api-domain api.vpc-demo.kortix.com \
+  --frontend-domain vpc-demo.kortix.com \
+  --release-repository-url https://releases.kortix.com/enterprise \
+  --tuf-root-sha256 "$REVIEWED_TUF_ROOT_SHA256" \
+  --updater-bootstrap-url https://releases.kortix.com/enterprise/bootstrap/kortix-enterprise-updater-linux-amd64 \
+  --updater-bootstrap-sha256 "$REVIEWED_UPDATER_SHA256" \
+  --release-publisher-account-id 935064898258 \
+  --maintenance-window Sun:02:00-05:00 \
+  --yes
+
+kortix self-host doctor --instance kortix-vpc-demo
+kortix self-host plan --instance kortix-vpc-demo
+kortix self-host deploy --instance kortix-vpc-demo
+```
+
+`init`, `configure`, `doctor`, and `plan` do not mutate AWS. `deploy` requires
+interactive confirmation or `--yes`, applies a saved classified plan, migrates
+bootstrap state into customer S3, and compares remote lineage and serial before
+removing the local state. If migration fails, the CLI restores the local
+backend declaration and preserves the bootstrap state for a safe retry.
+
+After bootstrap, operational commands read or invoke customer-owned AWS
+resources rather than relying on local cached status:
+
+```bash
+kortix self-host status --instance kortix-vpc-demo
+kortix self-host version --instance kortix-vpc-demo
+kortix self-host logs updater --instance kortix-vpc-demo --follow
+kortix self-host logs supabase --instance kortix-vpc-demo
+kortix self-host reconcile --instance kortix-vpc-demo
+kortix self-host update --instance kortix-vpc-demo --release 0.9.84-e1
+kortix self-host update --instance kortix-vpc-demo --release 0.9.84-e1 --force
+kortix self-host rollback --instance kortix-vpc-demo --release 0.9.83-e2
+```
+
+Update, force, reconcile, and rollback only start the customer Step Functions
+state machine. The CLI cannot bypass the updater's signature, digest,
+compatibility, account, Terraform-plan, migration, or health gates.
 
 ## Normal update
 

--- a/infra/terraform/modules/enterprise-vpc/variables.tf
+++ b/infra/terraform/modules/enterprise-vpc/variables.tf
@@ -23,8 +23,12 @@ variable "vpc_cidr" {
   type        = string
 
   validation {
-    condition     = can(cidrsubnet(var.vpc_cidr, 4, 0)) && endswith(var.vpc_cidr, "/16")
-    error_message = "vpc_cidr must be a valid /16 CIDR."
+    condition = can(cidrsubnet(var.vpc_cidr, 4, 0)) && endswith(var.vpc_cidr, "/16") && (
+      startswith(var.vpc_cidr, "10.") ||
+      can(regex("^172\\.(1[6-9]|2[0-9]|3[01])\\.0\\.0/16$", var.vpc_cidr)) ||
+      var.vpc_cidr == "192.168.0.0/16"
+    )
+    error_message = "vpc_cidr must be a canonical RFC1918 /16 CIDR."
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve the Docker self-host UX while implementing the production `aws-vpc` adapter
- embed the reviewed enterprise Terraform roots plus their complete transitive local module graph in the compiled CLI
- add account-pinned init/config/doctor/plan/deploy with guarded plan classification and verified local-to-S3 state migration
- route update, reconcile, force, and rollback through the customer-owned Step Functions reconciler
- query live EKS, EC2/Supabase, CodeBuild, Step Functions, DynamoDB, CloudWatch, and SSM surfaces for status/version/logs/open
- require stable enterprise release syntax and canonical RFC1918 /16 VPC CIDRs

## Verification
- `cd apps/cli && bun run typecheck`
- `cd apps/cli && bun test src` (219 pass, 0 fail)
- standalone `bun-darwin-arm64` CLI build and process smoke
- compiled CLI read-only customer-zero plan: 18 create / 0 update / 0 delete / 0 replace, classified manual_review
- generated state, cluster, and platform roots: Terraform 1.9.8 validate clean
- enterprise-vpc module: Terraform validate and TFLint clean
- Trivy: 0 HIGH/CRITICAL findings
- Checkov: 467 passed / 0 failed / 22 skipped
- Gitleaks: clean for `origin/main..HEAD`

## Safety
- No AWS resources were created, updated, or deleted. Only STS/data-source reads and Terraform planning ran against customer-zero account `935064898258` in `us-west-2`.
- The enterprise pilot customer's environment was not touched.
- AWS apply remains intentionally gated on the signed updater/stable release slice.
