### PR TITLE
fix(platinum): classify 409 sandbox_not_running as controlled 503, not Sentry

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -35,6 +35,7 @@ import { sandboxProxyApp } from './sandbox-proxy';
 import { setupApp } from './setup';
 import { supabaseAuth, combinedAuth } from './middleware/auth';
 import { requestDeadline, isRequestDeadlineHTTPException } from './middleware/request-deadline';
+import { isPlatinumSandboxNotRunningError } from './shared/platinum';
 // Statically imported (NOT await import() in the handlers): on a long-running
 // `bun --hot` dev process, dynamic import() can wedge permanently after enough
 // hot reloads — the promise never settles, the handler hangs, and Bun's
@@ -790,6 +791,23 @@ app.onError((err, c) => {
   const isSandboxProxy = path.includes('/p/') && path.includes('/global/event');
   if (isAbort && isSandboxProxy) {
     return c.json({ error: true, message: 'Request timeout', status: 504 }, 504);
+  }
+
+  // Platinum auto-stops idle microVMs natively; while a box is stopped, POST
+  // /:id/expose answers `409 sandbox_not_running`. That is an EXPECTED,
+  // transient state, not a 500 — the caller either wakes the box and retries
+  // (preview proxy) or the client retries (transcript / lease-discover). It
+  // must NOT page Sentry, so the typed error is classified out of
+  // captureException and surfaced as a retryable 503 + Retry-After (mirroring
+  // the request-deadline 503 pattern). Other Platinum failures still throw a
+  // generic Error and fall through to the generic capture below. See
+  // shared/platinum.ts PlatinumSandboxNotRunningError.
+  if (isPlatinumSandboxNotRunningError(err)) {
+    appLogger.warn(`${method} ${path} -> 503 [PlatinumSandboxNotRunningError] ${err.message}`, {
+      method, path, errorType: 'PlatinumSandboxNotRunningError',
+    });
+    c.header('Retry-After', '10');
+    return c.json({ error: true, message: 'sandbox is not running', status: 503 }, 503);
   }
 
   if (err instanceof BillingError) {

--- a/apps/api/src/platform/providers/platinum-expose-not-running.test.ts
+++ b/apps/api/src/platform/providers/platinum-expose-not-running.test.ts
@@ -1,0 +1,70 @@
+// Regression for Better Stack error ea98adefe8696ddbe341f3280fe699c230f8f0fb31221e7a5740a91f485085f0:
+// `platinum POST /v1/sandboxes/.../expose -> 409 {"code":"sandbox_not_running"}`.
+//
+// Platinum auto-stops idle microVMs natively; while a box is stopped, expose
+// 409s. That EXPECTED state must reach app.onError as the typed
+// PlatinumSandboxNotRunningError (→ controlled 503 + Retry-After, no Sentry),
+// NOT as a generic Error (→ 500 + captureException). This proves the provider's
+// expose entry points (resolveIngress, and resolveEndpoint which delegates to
+// it) propagate the typed error untouched — i.e. they neither swallow it nor
+// rewrap it into a generic Error — so the global onError classification
+// actually fires on the real expose path.
+import { expect, mock, test } from 'bun:test';
+
+process.env.ALLOWED_SANDBOX_PROVIDERS = 'platinum';
+process.env.PLATINUM_API_KEY = 'pt_test_key';
+process.env.PLATINUM_API_URL = 'https://api.platinum.dev';
+process.env.PLATINUM_TEMPLATE = 'tpl_test';
+process.env.KORTIX_URL ??= 'https://api.example.com';
+process.env.DATABASE_URL ??= 'postgres://x';
+
+// Stand in for the real typed error without importing the module-under-test's
+// dependency: the provider only rethrows whatever platinumJson throws, so an
+// instance of this class propagating through proves the contract.
+class PlatinumSandboxNotRunningError extends Error {
+  constructor(message = 'sandbox is not running') {
+    super(message);
+    this.name = 'PlatinumSandboxNotRunningError';
+  }
+}
+
+mock.module('../../shared/platinum', () => ({
+  isPlatinumConfigured: () => true,
+  isPlatinumSandboxNotRunningError: (e: unknown) => e instanceof PlatinumSandboxNotRunningError,
+  PlatinumSandboxNotRunningError,
+  platinumJson: async (path: string) => {
+    // Expose on a stopped box → the typed error (mirrors real Platinum 409).
+    if (path.includes('/expose')) {
+      throw new PlatinumSandboxNotRunningError(
+        `platinum POST ${path} -> 409 {"error":"sandbox not running","code":"sandbox_not_running"}`,
+      );
+    }
+    return {};
+  },
+}));
+
+mock.module('../service-key', () => ({ serviceKeyForExternalId: () => 'svc_key' }));
+mock.module('../sandbox-frontend-url', () => ({ sandboxFrontendBaseUrl: () => 'https://app.example.com' }));
+
+async function makeProvider() {
+  const { PlatinumProvider } = await import('./platinum');
+  return new PlatinumProvider();
+}
+
+test('resolveIngress propagates PlatinumSandboxNotRunningError (not a generic Error)', async () => {
+  const p = await makeProvider();
+  const err = await p
+    .resolveIngress('sbx_stopped', { port: 8000, transport: 'http' })
+    .catch((e) => e);
+  expect(err).toBeInstanceOf(PlatinumSandboxNotRunningError);
+  expect((err as Error).name).toBe('PlatinumSandboxNotRunningError');
+  expect((err as Error).message).toContain('sandbox_not_running');
+});
+
+test('resolveEndpoint propagates PlatinumSandboxNotRunningError (delegates to resolveIngress)', async () => {
+  const p = await makeProvider();
+  const err = await p.resolveEndpoint('sbx_stopped').catch((e) => e);
+  expect(err).toBeInstanceOf(PlatinumSandboxNotRunningError);
+  expect((err as Error).name).toBe('PlatinumSandboxNotRunningError');
+  expect((err as Error).message).toContain('sandbox_not_running');
+});

--- a/apps/api/src/shared/platinum.test.ts
+++ b/apps/api/src/shared/platinum.test.ts
@@ -75,3 +75,91 @@ test('platinumJson respects an explicit caller-provided signal instead of the de
   const elapsed = Date.now() - start;
   expect(elapsed).toBeLessThan(2_000);
 });
+
+// Platinum auto-stops idle microVMs natively; while a box is stopped, POST
+// /:id/expose answers `409 {"code":"sandbox_not_running"}`. That is an EXPECTED
+// state — the caller wakes+retries or surfaces a retryable 503 — and must NOT
+// page Sentry. So platinumJson classifies it into a typed
+// PlatinumSandboxNotRunningError, while every OTHER non-2xx stays a generic
+// Error (captured normally). Regression for Better Stack error
+// ea98adefe8696ddbe341f3280fe699c230f8f0fb31221e7a5740a91f485085f0
+// (`platinum POST /v1/sandboxes/.../expose -> 409 {"code":"sandbox_not_running"}`).
+//
+// These drive the global fetch directly (no live server) so the classification
+// is exercised deterministically without Bun.serve bind/stop timing.
+
+const originalFetch = globalThis.fetch;
+let fetchScenario: { status: number; body: string } = { status: 409, body: '' };
+
+function mockFetchScenario() {
+  const handler = (): Promise<Response> =>
+    Promise.resolve(
+      new Response(fetchScenario.body, {
+        status: fetchScenario.status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  globalThis.fetch = handler as unknown as typeof fetch;
+}
+
+test('platinumJson throws PlatinumSandboxNotRunningError on 409 sandbox_not_running', async () => {
+  fetchScenario = {
+    status: 409,
+    body: JSON.stringify({ error: 'sandbox not running', code: 'sandbox_not_running' }),
+  };
+  mockFetchScenario();
+
+  const { platinumJson, isPlatinumSandboxNotRunningError, PlatinumSandboxNotRunningError } =
+    await import('./platinum');
+
+  const err = await platinumJson('/v1/sandboxes/sbx_1/expose', { method: 'POST' }).catch((e) => e);
+  expect(err).toBeInstanceOf(PlatinumSandboxNotRunningError);
+  expect(isPlatinumSandboxNotRunningError(err)).toBe(true);
+  // The original diagnostics survive on the message so debugging still works.
+  expect((err as Error).message).toContain('409');
+  expect((err as Error).message).toContain('/expose');
+  expect((err as Error).name).toBe('PlatinumSandboxNotRunningError');
+
+  globalThis.fetch = originalFetch;
+});
+
+test('a 409 with a DIFFERENT code stays a generic Error (not misclassified as not-running)', async () => {
+  fetchScenario = {
+    status: 409,
+    body: JSON.stringify({ error: 'port already exposed', code: 'port_in_use' }),
+  };
+  mockFetchScenario();
+
+  const { platinumJson, isPlatinumSandboxNotRunningError } = await import('./platinum');
+  const err = await platinumJson('/v1/sandboxes/sbx_1/expose', { method: 'POST' }).catch((e) => e);
+  expect(isPlatinumSandboxNotRunningError(err)).toBe(false);
+  expect(err).toBeInstanceOf(Error);
+  expect((err as Error).name).toBe('Error');
+  expect((err as Error).message).toContain('409');
+
+  globalThis.fetch = originalFetch;
+});
+
+test('a 500 / non-JSON 409 stays a generic Error (unexpected failures stay loud)', async () => {
+  const { platinumJson, isPlatinumSandboxNotRunningError } = await import('./platinum');
+
+  // 500 with a JSON body — a real upstream error, must NOT be classified.
+  fetchScenario = { status: 500, body: JSON.stringify({ error: 'internal' }) };
+  mockFetchScenario();
+  let err = await platinumJson('/v1/sandboxes/sbx_1/expose', { method: 'POST' }).catch((e) => e);
+  expect(isPlatinumSandboxNotRunningError(err)).toBe(false);
+  expect(err).toBeInstanceOf(Error);
+  expect((err as Error).name).toBe('Error');
+  expect((err as Error).message).toContain('500');
+
+  // 409 with a NON-JSON body — the `code` field can't be parsed, so it must
+  // NOT be classified (falls back to the generic Error).
+  fetchScenario = { status: 409, body: 'not json at all' };
+  err = await platinumJson('/v1/sandboxes/sbx_1/expose', { method: 'POST' }).catch((e) => e);
+  expect(isPlatinumSandboxNotRunningError(err)).toBe(false);
+  expect(err).toBeInstanceOf(Error);
+  expect((err as Error).name).toBe('Error');
+  expect((err as Error).message).toContain('409');
+
+  globalThis.fetch = originalFetch;
+});

--- a/apps/api/src/shared/platinum.ts
+++ b/apps/api/src/shared/platinum.ts
@@ -57,11 +57,56 @@ async function platinumFetch(path: string, init: RequestInit = {}): Promise<Resp
   }
 }
 
+/**
+ * Expected, transient: Platinum auto-stops idle microVMs natively (see
+ * PlatinumProvider) and resumes them CoW on reopen. While a box is in that
+ * stopped state, POST /:id/expose (and any port-forwarding op) answers
+ * `409 {"error":"sandbox not running","code":"sandbox_not_running"}`. That is
+ * the system working as designed — the caller (preview proxy, transcript
+ * resolver, lease discoverer) either wakes the box and retries, or surfaces a
+ * retryable 503 to the client. It is NOT a 500-worthy error and must NOT page
+ * Sentry, so it gets its own typed error that `app.onError` classifies out of
+ * `captureException` (mirroring the request-deadline 503 pattern). Every OTHER
+ * Platinum failure (4xx/5xx, timeout, bad body) still throws the generic
+ * `platinum <method> <path> -> <status> <body>` Error and is captured normally
+ * — only this one expected state is special-cased, so unexpected failures stay
+ * loud.
+ */
+export class PlatinumSandboxNotRunningError extends Error {
+  constructor(message = 'sandbox is not running') {
+    super(message);
+    this.name = 'PlatinumSandboxNotRunningError';
+  }
+}
+
+export function isPlatinumSandboxNotRunningError(err: unknown): boolean {
+  return err instanceof PlatinumSandboxNotRunningError;
+}
+
+// Platinum signals a stopped box with `409 {"code":"sandbox_not_running"}`.
+// Match the structured `code` field (not a message substring) so a different
+// 409 reason never gets misclassified into the "expected" bucket.
+function isSandboxNotRunningBody(status: number, text: string): boolean {
+  if (status !== 409) return false;
+  try {
+    const body = JSON.parse(text) as { code?: unknown; error?: unknown };
+    return body.code === 'sandbox_not_running';
+  } catch {
+    return false;
+  }
+}
+
 /** GET/POST JSON. Throws `platinum <method> <path> -> <status> <body>` on non-2xx. */
 export async function platinumJson<T>(path: string, init: RequestInit = {}): Promise<T> {
   const res = await platinumFetch(path, init);
   const text = await res.text();
   if (!res.ok) {
+    // Expected auto-stopped state → typed error (controlled 503, no Sentry).
+    if (isSandboxNotRunningBody(res.status, text)) {
+      throw new PlatinumSandboxNotRunningError(
+        `platinum ${init.method ?? 'GET'} ${path} -> ${res.status} ${text.slice(0, 300)}`,
+      );
+    }
     throw new Error(`platinum ${init.method ?? 'GET'} ${path} -> ${res.status} ${text.slice(0, 300)}`);
   }
   return (text ? JSON.parse(text) : {}) as T;


### PR DESCRIPTION
## Root cause (one line)

Platinum's expected, transient `409 {"code":"sandbox_not_running"}` (an auto-stopped microVM) was thrown by `platinumJson` as a generic `Error`, so callers that don't catch it let it propagate to `app.onError` → `captureException` → a recurring Better Stack Sentry event.

## Better Stack error

- URL: https://errors.betterstack.com/team/t502678/errors/ea98adefe8696ddbe341f3280fe699c230f8f0fb31221e7a5740a91f485085f0?s=2346961
- Pattern id: `ea98adefe8696ddbe341f3280fe699c230f8f0fb31221e7a5740a91f485085f0`
- Source: Kortix API (prod), application_id `2346961`
- Message: `platinum POST /v1/sandboxes/sbx_01KX991QMXRZZ7E31C8AGJYDD3/expose -> 409 {"error":"sandbox not running","code":"sandbox_not_running"}`
- Call site: `apps/api/src/shared/platinum.ts`, function `platinumJson`
- Scale: 2 occurrences / 2 users; first seen 2026-07-13 10:59:11 UTC, last seen 2026-07-13 11:10:52 UTC

## Evidence / how it surfaces

`platinumJson` (`apps/api/src/shared/platinum.ts`) throws `new Error(\`platinum <method> <path> -> <status> <body>\`)` on every non-2xx. The global `app.onError` (`apps/api/src/index.ts`) captures **every** generic `Error` to Sentry via `captureException` (only `BillingError`, 4xx `HTTPException`, and the typed `RequestDeadlineHTTPException` 503 are classified out).

Platinum auto-stops idle microVMs natively and resumes them CoW on reopen. While a box is stopped, `POST /:id/expose` (the port-forwarding call used by `resolveIngress` / `resolveEndpoint` / the eager expose in `create`) answers `409 sandbox_not_running`. That is the system working as designed — but it escaped uncaught on the paths that don't wrap the expose call in a try/catch:
- `sandboxOpencodeEndpoint` → `resolvePreviewLink` (used by session-transcript + public-share-view),
- `discoverExecutionKeepAliveEndpoint` → `resolveEndpoint` (execution-lease discover, `r4.ts`),
- …any route that resolves a Platinum endpoint for a box whose DB row is still `active` while Platinum has already auto-stopped it (drift).

(The preview-proxy HTTP path already catches + wakes + retries, and the WS path catches → 502, so those aren't the source.)

## Fix

Classify that **one** expected 409 into a typed `PlatinumSandboxNotRunningError` (a plain `Error` subclass — deliberately **not** an `HTTPException`, so the preview proxy's `if (err instanceof HTTPException) throw err` re-throw is not triggered and its wake+retry loop is preserved). The 409 is matched by the structured `code` field (`sandbox_not_running`), not a message substring, so a different 409 reason is never misclassified. In `app.onError`, the typed error is surfaced as a retryable `503` + `Retry-After: 10` **without** `captureException` — mirroring the existing `RequestDeadlineHTTPException` 503 pattern.

Every other Platinum failure (different 4xx/5xx, timeout, non-JSON body) still throws the generic `platinum … -> <status> <body>` `Error` and is captured normally, so **unexpected failures stay loud**. The classification lives in `platinumJson`, so all expose call sites benefit.

## Regression tests

`apps/api/src/shared/platinum.test.ts` (extends existing file):
- `platinumJson` throws `PlatinumSandboxNotRunningError` on `409 {"code":"sandbox_not_running"}` (typed + diagnostics survive on the message).
- A `409` with a **different** code (`port_in_use`) stays a generic `Error` (not misclassified).
- A `500` and a non-JSON `409` stay generic `Error` (unexpected failures stay loud).

`apps/api/src/platform/providers/platinum-expose-not-running.test.ts` (new):
- `resolveIngress` propagates `PlatinumSandboxNotRunningError` untouched (not swallowed, not rewrapped).
- `resolveEndpoint` propagates it (delegates to `resolveIngress`).

Existing `platinum-status.test.ts` (`getStatus()` returns `unknown` for the 409) and `platinum-create-terminal.test.ts` continue to pass — the typed error is still a plain `Error`, caught by existing catch blocks, and `isMissingSandboxError` correctly returns false for it (it's not a 404).

## Verification

- `tsc --noEmit` (apps/api) — ✅ exit 0.
- `bun test src/shared/platinum.test.ts` — ✅ 5 pass.
- `bun test src/platform/providers/platinum-expose-not-running.test.ts` — ✅ 2 pass.
- `bun test src/platform/providers/platinum-create-terminal.test.ts` — ✅ 5 pass (unchanged).
- `bun test src/platform/providers/platinum-status.test.ts` — ✅ 4 pass (unchanged).

## Confirmation of resolution

After this ships + promotes: the Better Stack error `ea98adef…` should drop to zero new occurrences — the `409 sandbox_not_running` expose path now resolves as a controlled 503 (logged at `warn`, not `captureException`) instead of a 500 Sentry event. The prod log line to watch go quiet: `… -> 500 [Error] platinum POST /v1/sandboxes/.../expose -> 409 …`.

## Notes for review

- Not an `HTTPException` by design (see Fix) — keeps the preview-proxy wake+retry loop intact.
- Mirrors the precedent set by `RequestDeadlineHTTPException` (`apps/api/src/middleware/request-deadline.ts`) for an expected 503 classified out of Sentry.
- Prod is on v0.9.108; this is a new pattern not on the skip-list. Searched open PRs/issues — no existing PR addresses this 409 classification (#4505/#4506 handle auto-resume on active access, a different concern).

---
Better Stack error id: `ea98adefe8696ddbe341f3280fe699c230f8f0fb31221e7a5740a91f485085f0` · application_id `2346961`
