### PR TITLE
feat(projects): enable branch-isolated repository projects

### DIFF
--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -36,7 +36,6 @@ const dbState: ProjectsContractDbState = {
   installationRow: null,
   gitConnectionRows: [],
   nextProjectIds: [],
-  repoUniquenessEnforced: true,
 };
 let commitCalls: any[];
 let listRepoFileCalls: any[];
@@ -94,7 +93,6 @@ function resetState() {
   readRepoFileCalls = [];
   archiveCalls = [];
   rejectedBranch = null;
-  dbState.repoUniquenessEnforced = true;
 }
 
 // `authorize` / `assertAuthorized` / `listAccessibleResources` are re-exported
@@ -385,31 +383,42 @@ describe('projects API contract', () => {
     }));
   });
 
-  test('keeps re-import idempotent while the phase-one unique index remains', async () => {
+  test('creates independent projects for different branches of one repository', async () => {
     const app = createApp();
     const payload = {
       account_id: ACCOUNT_ID,
       repo_url: 'https://github.com/kortix-org/new-project.git',
-      default_branch: 'main',
     };
-    const request = (name: string) => app.request('/v1/projects', {
+    const request = (name: string, defaultBranch: string) => app.request('/v1/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...payload, name }),
+      body: JSON.stringify({ ...payload, name, default_branch: defaultBranch }),
     });
 
-    const first = await request('API development');
-    const second = await request('Web development');
+    const first = await request('Production', 'main');
+    const second = await request('Development', 'dev');
     expect([first.status, second.status]).toEqual([201, 201]);
     const [firstBody, secondBody] = await Promise.all([first.json(), second.json()]);
     expect([firstBody.project_id, secondBody.project_id]).toEqual([
       NEW_PROJECT_ID,
-      NEW_PROJECT_ID,
+      SECOND_NEW_PROJECT_ID,
     ]);
     expect(dbState.projectRows.filter((row) => row.repoUrl === payload.repo_url)).toEqual([
-      expect.objectContaining({ projectId: NEW_PROJECT_ID, name: 'Web development' }),
+      expect.objectContaining({
+        projectId: NEW_PROJECT_ID,
+        name: 'Production',
+        defaultBranch: 'main',
+      }),
+      expect.objectContaining({
+        projectId: SECOND_NEW_PROJECT_ID,
+        name: 'Development',
+        defaultBranch: 'dev',
+      }),
     ]);
-    expect(dbState.gitConnectionRows.map((row) => row.projectId)).toEqual([NEW_PROJECT_ID]);
+    expect(dbState.gitConnectionRows.map((row) => [row.projectId, row.defaultBranch])).toEqual([
+      [NEW_PROJECT_ID, 'main'],
+      [SECOND_NEW_PROJECT_ID, 'dev'],
+    ]);
   });
 
   test('rejects a branch GitHub cannot resolve before inserting the project', async () => {

--- a/apps/api/src/__tests__/helpers/projects-contract-db-mock.ts
+++ b/apps/api/src/__tests__/helpers/projects-contract-db-mock.ts
@@ -53,7 +53,6 @@ export interface ProjectsContractDbState {
   installationRow: typeof accountGithubInstallations.$inferSelect | null;
   gitConnectionRows: Array<typeof projectGitConnections.$inferSelect>;
   nextProjectIds: string[];
-  repoUniquenessEnforced: boolean;
 }
 
 export const baseDate = new Date('2026-01-01T00:00:00Z');
@@ -190,17 +189,7 @@ export function createProjectsContractDbMock(
     insert: (table: unknown) => ({
       values: (values: any) => ({
         onConflictDoNothing: () => ({
-          returning: async () => {
-            if (table !== projects) return [];
-            const conflicts =
-              state.repoUniquenessEnforced &&
-              state.projectRows.some(
-                (row) =>
-                  row.accountId === values.accountId &&
-                  row.repoUrl === values.repoUrl,
-              );
-            return conflicts ? [] : [insertProject(state, values)];
-          },
+          returning: async () => [],
         }),
         onConflictDoUpdate: ({ set }: { set?: Record<string, unknown> }) => ({
           returning: async () => {

--- a/apps/api/src/projects/lib/project-registration.ts
+++ b/apps/api/src/projects/lib/project-registration.ts
@@ -1,5 +1,5 @@
 import {
-  accountGithubInstallations,
+  type accountGithubInstallations,
   projectGitConnections,
   projectGitCredentials,
   projectMembers,
@@ -10,8 +10,7 @@ import { invalidateIamCacheForUser } from '../../iam/cache-invalidation';
 import { db } from '../../shared/db';
 import type { GitHubRepo } from '../github';
 import { encryptProjectSecret } from '../secrets';
-import { clampProjectName, deriveProjectName, type ProjectRow } from './serializers';
-import { and, eq } from 'drizzle-orm';
+import { type ProjectRow, clampProjectName, deriveProjectName } from './serializers';
 
 type GitHubInstallation = typeof accountGithubInstallations.$inferSelect;
 
@@ -58,7 +57,7 @@ async function registerLinkedProject(input: RegistrationInput): Promise<ProjectR
   };
 
   const row = await db.transaction(async (tx) => {
-    const [inserted] = await tx
+    const [project] = await tx
       .insert(projects)
       .values({
         accountId: input.accountId,
@@ -70,42 +69,8 @@ async function registerLinkedProject(input: RegistrationInput): Promise<ProjectR
         metadata,
         updatedAt: now,
       })
-      // Phase-one compatibility: production still has the historical unique
-      // (account_id, repo_url) index. Once phase two makes that index
-      // non-unique, this insert naturally creates an independent project.
-      .onConflictDoNothing()
       .returning();
-
-    let project = inserted;
-    if (!inserted) {
-      const [existing] = await tx
-        .select()
-        .from(projects)
-        .where(
-          and(
-            eq(projects.accountId, input.accountId),
-            eq(projects.repoUrl, input.repo.clone_url),
-          ),
-        )
-        .limit(1);
-      if (!existing) {
-        throw new Error('Project registration conflicted without an existing repository project');
-      }
-      const [updated] = await tx
-        .update(projects)
-        .set({
-          name: projectName,
-          defaultBranch: input.defaultBranch,
-          manifestPath: input.manifestPath,
-          status: 'active',
-          metadata,
-          updatedAt: now,
-        })
-        .where(eq(projects.projectId, existing.projectId))
-        .returning();
-      if (!updated) throw new Error('Existing repository project disappeared during registration');
-      project = updated;
-    }
+    if (!project) throw new Error('Project registration did not return the inserted project');
 
     let credentialRef: string | null = null;
     if (input.auth.kind === 'project_credential') {

--- a/packages/db/drizzle/meta/20260713152327_snapshot.json
+++ b/packages/db/drizzle/meta/20260713152327_snapshot.json
@@ -8389,12 +8389,6 @@
           "notNull": true,
           "default": "'member'"
         },
-        "default_base_ref": {
-          "name": "default_base_ref",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "granted_by": {
           "name": "granted_by",
           "type": "uuid",
@@ -10127,7 +10121,7 @@
               "nulls": "last"
             }
           ],
-          "isUnique": true,
+          "isUnique": false,
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/packages/db/migrations/20260713220001000_project_branch_environments.sql
+++ b/packages/db/migrations/20260713220001000_project_branch_environments.sql
@@ -1,0 +1,7 @@
+DROP INDEX "kortix"."idx_projects_account_repo";
+
+CREATE INDEX "idx_projects_account_repo"
+  ON "kortix"."projects" USING btree ("account_id", "repo_url");
+
+ALTER TABLE "kortix"."project_group_grants"
+  DROP COLUMN "default_base_ref";

--- a/packages/db/src/schema/kortix.test.ts
+++ b/packages/db/src/schema/kortix.test.ts
@@ -244,11 +244,11 @@ describe('projects table', () => {
     expect(col?.default).toBe('active');
   });
 
-  test('retains the unique account/repo index through the application rollout', () => {
+  test('indexes account/repo without preventing branch-isolated projects', () => {
     const cfg = getTableConfig(projects);
     const accountRepo = cfg.indexes.find((i) => i.config.name === 'idx_projects_account_repo');
     expect(accountRepo).toBeDefined();
-    expect(accountRepo?.config.unique).toBe(true);
+    expect(accountRepo?.config.unique).toBe(false);
   });
 });
 
@@ -286,12 +286,11 @@ describe('project_members table', () => {
 });
 
 describe('project_group_grants table', () => {
-  test('retains the deprecated base-ref column through the code-removal rollout', () => {
+  test('does not carry branch selection outside the project boundary', () => {
     const col = getTableConfig(projectGroupGrants).columns.find(
       (column) => column.name === 'default_base_ref',
     );
-    expect(col).toBeDefined();
-    expect(col?.notNull).toBe(false);
+    expect(col).toBeUndefined();
   });
 });
 

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -271,7 +271,7 @@ export const projects = kortixSchema.table(
     index('idx_projects_account').on(table.accountId),
     index('idx_projects_status').on(table.status),
     index('idx_projects_updated').on(table.updatedAt),
-    uniqueIndex('idx_projects_account_repo').on(table.accountId, table.repoUrl),
+    index('idx_projects_account_repo').on(table.accountId, table.repoUrl),
   ],
 );
 
@@ -2742,9 +2742,6 @@ export const projectGroupGrants = kortixSchema.table(
       .notNull()
       .references(() => accounts.accountId, { onDelete: 'cascade' }),
     role: projectRoleEnum('role').default('member').notNull(),
-    /** Deprecated release-compatibility column. The branch hierarchy no longer
-     * reads or writes this value; remove only after the code-removal rollout. */
-    defaultBaseRef: text('default_base_ref'),
     grantedBy: uuid('granted_by'),
     /** Optional auto-revoke timestamp. NULL = permanent attachment.
      *  Same semantics as project_members.expires_at. */


### PR DESCRIPTION
## Outcome

Completes the expand-contract rollout started by #4598. One Kortix project now maps cleanly to one repository branch, so the same repository can have independent main/dev/staging/prod projects with separate sessions, secrets, access, profiles, triggers, and settings.

Phase one is already merged and live on dev as API version 0.9.109-dev.034b5229. That code no longer reads or writes project_group_grants.default_base_ref and is compatible with both index shapes.

## Changes

- replace the unique account/repository index with a normal lookup index
- drop the deprecated project_group_grants.default_base_ref column
- delete the phase-one conflict/update compatibility path; project registration is one atomic direct insert
- prove same-repository main and dev imports create distinct projects and Git connections
- update the canonical Drizzle snapshot precisely

## Verification

- DB: 94 pass, 0 fail; typecheck passed; migration lint passed
- Fresh PostgreSQL 16: all 52 migrations applied; no pending migrations
- Fresh catalog: repo_index_unique=false, default_base_ref_columns=0
- API typecheck passed
- API isolated suites: projects 11/11, starter 7/7, sessions 37/37, triggers 23/23, provision 7/7, GitHub 3/3
- Tests package typecheck passed
- ke2e coverage: 392/480, gate passed
- production registration module: Biome clean
- git diff --check clean

## Rollout safety

The destructive migration ships only after #4598 was deployed and live-verified. Old phase-one pods remain compatible with the non-unique index and do not reference the dropped column.
