### PR TITLE
feat(web): add machine-readable SEO surface

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,6 +1,7 @@
 # Kortix Robots.txt
 User-agent: *
 Allow: /
+Allow: /api/ai
 
 # Sitemap
 Sitemap: https://kortix.com/sitemap.xml
@@ -10,6 +11,7 @@ Disallow: /api/
 Disallow: /_next/
 Disallow: /admin/
 
-# Allow crawling of public pages
-Allow: /suna/
-
+# Machine-readable public content is intentionally crawlable.
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /markdown/

--- a/apps/web/src/app/(public)/(marketing)/contact/layout.tsx
+++ b/apps/web/src/app/(public)/(marketing)/contact/layout.tsx
@@ -1,0 +1,8 @@
+import { marketingMetadata } from '@/lib/seo/metadata';
+import type { ReactNode } from 'react';
+
+export const metadata = marketingMetadata('/contact');
+
+export default function ContactLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/(marketing)/developers/layout.tsx
+++ b/apps/web/src/app/(public)/(marketing)/developers/layout.tsx
@@ -1,0 +1,8 @@
+import { marketingMetadata } from '@/lib/seo/metadata';
+import type { ReactNode } from 'react';
+
+export const metadata = marketingMetadata('/developers');
+
+export default function DevelopersLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/(marketing)/enterprise/layout.tsx
+++ b/apps/web/src/app/(public)/(marketing)/enterprise/layout.tsx
@@ -1,0 +1,8 @@
+import { marketingMetadata } from '@/lib/seo/metadata';
+import type { ReactNode } from 'react';
+
+export const metadata = marketingMetadata('/enterprise');
+
+export default function EnterpriseLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/(marketing)/marketplace/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/marketplace/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 
 import { MarketplaceExplore } from '@/features/marketplace/marketplace-explore';
 import { loadMarketplaceExploreData } from '@/lib/marketplace-public';
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
 
 export const revalidate = 3600;
 
@@ -13,11 +14,15 @@ export const metadata: Metadata = {
     title: 'Kortix Marketplace — Extend the agent',
     description:
       'Browse skills, agents, and commands from every source. Add them to a Kortix project in one click.',
+    url: `${CANONICAL_ORIGIN}/marketplace`,
   },
+  alternates: { canonical: `${CANONICAL_ORIGIN}/marketplace` },
 };
 
 export default async function MarketplacePage() {
   const { itemsPage, marketplacesPage } = await loadMarketplaceExploreData();
 
-  return <MarketplaceExplore items={itemsPage.items} marketplaces={marketplacesPage.marketplaces} />;
+  return (
+    <MarketplaceExplore items={itemsPage.items} marketplaces={marketplacesPage.marketplaces} />
+  );
 }

--- a/apps/web/src/app/(public)/(marketing)/pricing/layout.tsx
+++ b/apps/web/src/app/(public)/(marketing)/pricing/layout.tsx
@@ -1,0 +1,8 @@
+import { marketingMetadata } from '@/lib/seo/metadata';
+import type { ReactNode } from 'react';
+
+export const metadata = marketingMetadata('/pricing');
+
+export default function PricingLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/(marketing)/support/layout.tsx
+++ b/apps/web/src/app/(public)/(marketing)/support/layout.tsx
@@ -1,0 +1,8 @@
+import { marketingMetadata } from '@/lib/seo/metadata';
+import type { ReactNode } from 'react';
+
+export const metadata = marketingMetadata('/support');
+
+export default function SupportLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/(seo)/about/page.tsx
+++ b/apps/web/src/app/(public)/(seo)/about/page.tsx
@@ -1,3 +1,4 @@
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
 import type { Metadata } from 'next';
 import AboutPageClient from './about-client';
 
@@ -11,7 +12,7 @@ export const metadata: Metadata = {
     title: 'About Kortix – Building Self-Driving Companies',
     description:
       'We take process-heavy companies and turn them into AI-operated ones. Full agent teams doing engineering, product, operations, finance, support, and growth.',
-    url: 'https://www.kortix.com/about',
+    url: `${CANONICAL_ORIGIN}/about`,
     images: [
       {
         url: '/images/team.webp',
@@ -29,7 +30,7 @@ export const metadata: Metadata = {
     images: ['/images/team.webp'],
   },
   alternates: {
-    canonical: 'https://www.kortix.com/about',
+    canonical: `${CANONICAL_ORIGIN}/about`,
   },
 };
 

--- a/apps/web/src/app/(public)/(seo)/careers/page.tsx
+++ b/apps/web/src/app/(public)/(seo)/careers/page.tsx
@@ -1,3 +1,4 @@
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
 import type { Metadata } from 'next';
 import CareersPageClient from './careers-client';
 
@@ -10,8 +11,8 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Careers at Kortix – Build the Autonomous Company OS',
     description:
-      'An extremely small, tight-knit team building the operating system for autonomous companies. Founders, builders, hackers, engineers — we care that you\'ve built something real.',
-    url: 'https://www.kortix.com/careers',
+      "An extremely small, tight-knit team building the operating system for autonomous companies. Founders, builders, hackers, engineers — we care that you've built something real.",
+    url: `${CANONICAL_ORIGIN}/careers`,
     images: [
       {
         url: '/images/careers/shackleton.png',
@@ -25,11 +26,11 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Careers at Kortix – Build the Autonomous Company OS',
     description:
-      'An extremely small, tight-knit team building the operating system for autonomous companies. Founders, builders, hackers, engineers — we care that you\'ve built something real.',
+      "An extremely small, tight-knit team building the operating system for autonomous companies. Founders, builders, hackers, engineers — we care that you've built something real.",
     images: ['/images/careers/shackleton.png'],
   },
   alternates: {
-    canonical: 'https://www.kortix.com/careers',
+    canonical: `${CANONICAL_ORIGIN}/careers`,
   },
 };
 

--- a/apps/web/src/app/(public)/(seo)/changelog/page.tsx
+++ b/apps/web/src/app/(public)/(seo)/changelog/page.tsx
@@ -1,3 +1,4 @@
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import ReactMarkdown from 'react-markdown';
@@ -21,14 +22,14 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Kortix Changelog',
     description: 'Every Kortix release, straight from the source.',
-    url: 'https://www.kortix.com/changelog',
+    url: `${CANONICAL_ORIGIN}/changelog`,
   },
   twitter: {
     card: 'summary',
     title: 'Kortix Changelog',
     description: 'Every Kortix release, straight from the source.',
   },
-  alternates: { canonical: 'https://www.kortix.com/changelog' },
+  alternates: { canonical: `${CANONICAL_ORIGIN}/changelog` },
 };
 
 // Rebuild hourly so new releases show up without a deploy.

--- a/apps/web/src/app/(public)/(seo)/legal/layout.tsx
+++ b/apps/web/src/app/(public)/(seo)/legal/layout.tsx
@@ -1,0 +1,8 @@
+import { marketingMetadata } from '@/lib/seo/metadata';
+import type { ReactNode } from 'react';
+
+export const metadata = marketingMetadata('/legal');
+
+export default function LegalLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/markdown/[...path]/route.ts
+++ b/apps/web/src/app/(public)/markdown/[...path]/route.ts
@@ -1,0 +1,12 @@
+import { resolvePublicMarkdown } from '@/lib/seo/public-content';
+import { markdownResponse } from '@/lib/seo/response';
+
+export const dynamic = 'force-static';
+export const revalidate = 3600;
+
+export async function GET(_: Request, context: { params: Promise<{ path: string[] }> }) {
+  const { path } = await context.params;
+  const result = resolvePublicMarkdown(path);
+  if (!result) return new Response('Not found\n', { status: 404 });
+  return markdownResponse(result.markdown, result.record);
+}

--- a/apps/web/src/app/(public)/share/[shareId]/layout.tsx
+++ b/apps/web/src/app/(public)/share/[shareId]/layout.tsx
@@ -1,12 +1,16 @@
-import { Metadata } from 'next';
 import { getServerPublicEnv } from '@/lib/public-env-server';
+import { Metadata } from 'next';
 
-export async function generateMetadata({ params }: { params: Promise<{ shareId: string }> }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ shareId: string }>;
+}): Promise<Metadata> {
   const { shareId } = await params;
 
   const title = 'Shared Conversation | Kortix';
   const description = 'Replay this Worker conversation on Kortix';
-  const url = getServerPublicEnv().APP_URL || 'https://www.kortix.com';
+  const url = getServerPublicEnv().APP_URL || 'https://kortix.com';
 
   return {
     title,

--- a/apps/web/src/app/(system)/api/ai/route.ts
+++ b/apps/web/src/app/(system)/api/ai/route.ts
@@ -1,0 +1,121 @@
+import {
+  absoluteUrl,
+  getPublicContentRecords,
+  type PublicContentKind,
+} from '@/lib/seo/public-content';
+import { consumeAiIndexRateLimit } from '@/lib/seo/rate-limit';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 50;
+const KINDS = new Set<PublicContentKind>(['marketing', 'blog', 'docs', 'use-case']);
+
+function clientKey(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  return forwarded || request.headers.get('x-real-ip') || 'anonymous';
+}
+
+function decodeCursor(value: string | null): number | null {
+  if (!value) return 0;
+  try {
+    const decoded = Buffer.from(value, 'base64url').toString('utf8');
+    if (!/^\d+$/.test(decoded)) return null;
+    return Number(decoded);
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(offset: number): string {
+  return Buffer.from(String(offset), 'utf8').toString('base64url');
+}
+
+function rateHeaders(result: ReturnType<typeof consumeAiIndexRateLimit>): Record<string, string> {
+  return {
+    'RateLimit-Limit': String(result.limit),
+    'RateLimit-Policy': `${result.limit};w=60`,
+    'RateLimit-Remaining': String(result.remaining),
+    'RateLimit-Reset': String(Math.ceil(result.resetsAt / 1000)),
+  };
+}
+
+export function GET(request: Request): Response {
+  const rate = consumeAiIndexRateLimit(clientKey(request));
+  if (!rate.allowed) {
+    return Response.json(
+      {
+        error: 'rate_limit_exceeded',
+        retry_after_seconds: Math.max(1, Math.ceil((rate.resetsAt - Date.now()) / 1000)),
+      },
+      {
+        status: 429,
+        headers: {
+          ...rateHeaders(rate),
+          'Cache-Control': 'private, no-store',
+          'Retry-After': String(Math.max(1, Math.ceil((rate.resetsAt - Date.now()) / 1000))),
+        },
+      },
+    );
+  }
+
+  const url = new URL(request.url);
+  const cursor = decodeCursor(url.searchParams.get('cursor'));
+  if (cursor === null) {
+    return Response.json(
+      { error: 'invalid_cursor' },
+      { status: 400, headers: { ...rateHeaders(rate), 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const requestedLimit = Number(url.searchParams.get('limit') || DEFAULT_LIMIT);
+  if (!Number.isInteger(requestedLimit) || requestedLimit < 1) {
+    return Response.json(
+      { error: 'invalid_limit', max_limit: MAX_LIMIT },
+      { status: 400, headers: { ...rateHeaders(rate), 'Cache-Control': 'no-store' } },
+    );
+  }
+  const limit = Math.min(requestedLimit, MAX_LIMIT);
+
+  const requestedKind = url.searchParams.get('kind') as PublicContentKind | null;
+  if (requestedKind && !KINDS.has(requestedKind)) {
+    return Response.json(
+      { error: 'invalid_kind', allowed: [...KINDS] },
+      { status: 400, headers: { ...rateHeaders(rate), 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const records = getPublicContentRecords()
+    .filter((record) => !requestedKind || record.kind === requestedKind)
+    .sort((a, b) => a.htmlPath.localeCompare(b.htmlPath));
+  const page = records.slice(cursor, cursor + limit);
+  const nextOffset = cursor + page.length;
+
+  return Response.json(
+    {
+      data: page.map((record) => ({
+        type: record.kind,
+        slug: record.slug,
+        title: record.title,
+        description: record.description ?? null,
+        url: absoluteUrl(record.htmlPath),
+        markdown_url: record.markdownPath ? absoluteUrl(record.markdownPath) : null,
+        last_modified: record.lastModified ?? null,
+      })),
+      pagination: {
+        limit,
+        next_cursor: nextOffset < records.length ? encodeCursor(nextOffset) : null,
+        total: records.length,
+      },
+    },
+    {
+      headers: {
+        ...rateHeaders(rate),
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=3600',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Robots-Tag': 'noindex, follow',
+      },
+    },
+  );
+}

--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -1,6 +1,7 @@
 import { docsMdxComponents } from '@/components/markdown/docs-mdx-components';
 import { Button } from '@/components/ui/button';
 import { Icon } from '@/features/icon/icon';
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
 import { source } from '@/lib/source';
 import { cn } from '@/lib/utils';
 import { getBreadcrumbItems } from 'fumadocs-core/breadcrumb';
@@ -101,9 +102,9 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
           {previous && (
             <Link
               href={previous.url}
-              className="flex flex-col gap-1 rounded-lg border p-4 transition-colors hover:bg-fd-accent"
+              className="hover:bg-fd-accent flex flex-col gap-1 rounded-lg border p-4 transition-colors"
             >
-              <span className="inline-flex items-center gap-1 text-xs text-fd-muted-foreground">
+              <span className="text-fd-muted-foreground inline-flex items-center gap-1 text-xs">
                 <ChevronLeft className="size-3.5" />
                 Previous
               </span>
@@ -113,9 +114,9 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
           {next && (
             <Link
               href={next.url}
-              className="flex flex-col items-end gap-1 rounded-lg border p-4 text-right transition-colors hover:bg-fd-accent sm:col-start-2"
+              className="hover:bg-fd-accent flex flex-col items-end gap-1 rounded-lg border p-4 text-right transition-colors sm:col-start-2"
             >
-              <span className="inline-flex items-center gap-1 text-xs text-fd-muted-foreground">
+              <span className="text-fd-muted-foreground inline-flex items-center gap-1 text-xs">
                 Next
                 <ChevronRight className="size-3.5" />
               </span>
@@ -151,5 +152,6 @@ export async function generateMetadata(props: {
   return {
     title: { absolute: title },
     description: page.data.description ?? 'Kortix developer documentation.',
+    alternates: { canonical: `${CANONICAL_ORIGIN}${page.url}` },
   };
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,12 +8,12 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { RequestDemoProvider } from '@/features/contact/request-demo-provider';
 import { AuthProvider } from '@/features/providers/auth-provider';
 import { DESKTOP_INIT_SCRIPT, DESKTOP_UA_TOKEN } from '@/lib/desktop';
-import { featureFlags } from '@kortix/sdk/feature-flags';
 import { getHardcodedUiServerText } from '@/lib/hardcoded-ui-server';
 import '@/lib/polyfills';
 import { getServerPublicEnv } from '@/lib/public-env-server';
 import { siteMetadata } from '@/lib/site-metadata';
 import { cn } from '@/lib/utils';
+import { featureFlags } from '@kortix/sdk/feature-flags';
 import type { Metadata, Viewport } from 'next';
 import { headers } from 'next/headers';
 import { connection } from 'next/server';
@@ -89,7 +89,7 @@ export const metadata: Metadata = {
   },
   description: siteMetadata.description,
   keywords: siteMetadata.keywords,
-  authors: [{ name: 'Kortix Team', url: 'https://www.kortix.com' }],
+  authors: [{ name: 'Kortix Team', url: siteMetadata.url }],
   creator: 'Kortix Team',
   publisher: 'Kortix Team',
   applicationName: siteMetadata.name,
@@ -233,58 +233,6 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
             `,
           }}
         />
-
-        {/* Static SEO meta tags - rendered in initial HTML */}
-        <title>
-          {tHardcodedUi.raw('appLayout.line196JsxTextKortixTheAutonomousCompanyOperatingSystem')}
-        </title>
-        <meta
-          name="description"
-          content={tHardcodedUi.raw(
-            'appLayout.line197JsxAttrContentACloudComputerWhereAiAgentsRunYour',
-          )}
-        />
-        <meta
-          name="keywords"
-          content={tHardcodedUi.raw(
-            'appLayout.line198JsxAttrContentKortixAutonomousCompanyOperatingSystemAiAgentsSelf',
-          )}
-        />
-        <meta
-          property="og:title"
-          content={tHardcodedUi.raw(
-            'appLayout.line199JsxAttrContentKortixTheAutonomousCompanyOperatingSystem',
-          )}
-        />
-        <meta
-          property="og:description"
-          content={tHardcodedUi.raw(
-            'appLayout.line200JsxAttrContentACloudComputerWhereAiAgentsRunYour',
-          )}
-        />
-        <meta property="og:image" content="https://kortix.com/banner.png" />
-        <meta property="og:url" content="https://kortix.com" />
-        <meta property="og:type" content="website" />
-        <meta property="og:site_name" content="Kortix" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta
-          name="twitter:title"
-          content={tHardcodedUi.raw(
-            'appLayout.line206JsxAttrContentKortixTheAutonomousCompanyOperatingSystem',
-          )}
-        />
-        <meta
-          name="twitter:description"
-          content={tHardcodedUi.raw(
-            'appLayout.line207JsxAttrContentACloudComputerWhereAiAgentsRunYour',
-          )}
-        />
-        <meta name="twitter:image" content="https://kortix.com/banner.png" />
-        <meta
-          name="twitter:site"
-          content={tHardcodedUi.raw('appLayout.line209JsxAttrContentKortix')}
-        />
-        <link rel="canonical" href="https://kortix.com" />
 
         {/* iOS Smart App Banner - shows native install banner in Safari */}
         {!featureFlags.disableMobileAdvertising ? (

--- a/apps/web/src/app/llms-full.txt/route.ts
+++ b/apps/web/src/app/llms-full.txt/route.ts
@@ -1,0 +1,17 @@
+import { renderLlmsFullTxt } from '@/lib/seo/llms';
+import { MACHINE_CONTENT_CACHE_CONTROL } from '@/lib/seo/response';
+
+export const dynamic = 'force-static';
+export const revalidate = 3600;
+
+export function GET() {
+  return new Response(renderLlmsFullTxt(), {
+    headers: {
+      'Cache-Control': MACHINE_CONTENT_CACHE_CONTROL,
+      'Content-Disposition': 'inline',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+}

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,17 @@
+import { renderLlmsTxt } from '@/lib/seo/llms';
+import { MACHINE_CONTENT_CACHE_CONTROL } from '@/lib/seo/response';
+
+export const dynamic = 'force-static';
+export const revalidate = 3600;
+
+export function GET() {
+  return new Response(renderLlmsTxt(), {
+    headers: {
+      'Cache-Control': MACHINE_CONTENT_CACHE_CONTROL,
+      'Content-Disposition': 'inline',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,59 +1,77 @@
-import { MetadataRoute } from 'next';
-import { siteConfig } from '@/lib/site-config';
+import type { MetadataRoute } from 'next';
+
 import { locales } from '@/i18n/config';
-import { getAllPosts } from '@/lib/blog';
+import {
+  absoluteUrl,
+  areUseCasesPublic,
+  getPublicContentRecords,
+  STATIC_PUBLIC_ROUTES,
+} from '@/lib/seo/public-content';
 
-// Marketing pages that support locale routing for SEO
-const MARKETING_ROUTES = [
-  { path: '/', priority: 1, changeFrequency: 'daily' as const },
-  { path: '/legal', priority: 0.5, changeFrequency: 'monthly' as const },
-  { path: '/support', priority: 0.7, changeFrequency: 'weekly' as const },
-];
+type SitemapEntry = MetadataRoute.Sitemap[number];
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = siteConfig.url;
-  const sitemapEntries: MetadataRoute.Sitemap = [];
+const LOCALIZED_ROUTES = ['/', '/legal', '/support'] as const;
 
-  // Generate entries for each marketing route in all locales
-  MARKETING_ROUTES.forEach((route) => {
-    locales.forEach((locale) => {
-      const url = locale === 'en' 
-        ? `${baseUrl}${route.path}` 
-        : `${baseUrl}/${locale}${route.path}`;
-      
-      sitemapEntries.push({
-        url,
-        lastModified: new Date(),
-        changeFrequency: route.changeFrequency,
-        priority: route.priority,
-        alternates: {
-          languages: Object.fromEntries(
-            locales.map((loc) => [
-              loc,
-              loc === 'en' ? `${baseUrl}${route.path}` : `${baseUrl}/${loc}${route.path}`
-            ])
-          ),
-        },
-      });
-    });
-  });
-
-  // Blog index + posts (English only — the blog isn't locale-routed).
-  sitemapEntries.push({
-    url: `${baseUrl}/blog`,
-    lastModified: new Date(),
-    changeFrequency: 'weekly',
-    priority: 0.8,
-  });
-  getAllPosts().forEach((post) => {
-    sitemapEntries.push({
-      url: `${baseUrl}${post.url}`,
-      lastModified: new Date(`${post.data.date}T00:00:00Z`),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    });
-  });
-
-  return sitemapEntries;
+function htmlEntry(pathname: string, lastModified?: string): SitemapEntry {
+  return {
+    url: absoluteUrl(pathname),
+    ...(lastModified ? { lastModified } : {}),
+    changeFrequency: pathname.startsWith('/blog/') ? 'monthly' : 'weekly',
+    priority: pathname === '/' ? 1 : pathname === '/docs' ? 0.9 : 0.7,
+  };
 }
 
+function markdownEntry(pathname: string, lastModified?: string): SitemapEntry {
+  return {
+    url: absoluteUrl(pathname),
+    ...(lastModified ? { lastModified } : {}),
+    changeFrequency: 'weekly',
+    priority: 0.5,
+  };
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const includeUseCases = areUseCasesPublic();
+  const records = getPublicContentRecords({ includeUseCases });
+  const entries = new Map<string, SitemapEntry>();
+
+  for (const pathname of STATIC_PUBLIC_ROUTES) {
+    if (pathname === '/use-cases' && !includeUseCases) continue;
+    const entry = htmlEntry(pathname);
+    entries.set(entry.url, entry);
+  }
+
+  // Keep the explicit locale routes that middleware actually serves. English
+  // uses the unprefixed URL; every alternate stays on the same non-www origin.
+  for (const pathname of LOCALIZED_ROUTES) {
+    const languages = Object.fromEntries(
+      locales.map((locale) => [
+        locale,
+        absoluteUrl(locale === 'en' ? pathname : `/${locale}${pathname === '/' ? '' : pathname}`),
+      ]),
+    );
+    for (const locale of locales) {
+      const localizedPath =
+        locale === 'en' ? pathname : `/${locale}${pathname === '/' ? '' : pathname}`;
+      const entry = htmlEntry(localizedPath);
+      entry.alternates = { languages };
+      entries.set(entry.url, entry);
+    }
+  }
+
+  for (const record of records) {
+    const html = htmlEntry(record.htmlPath, record.lastModified);
+    entries.set(html.url, html);
+    if (record.markdownPath) {
+      const markdown = markdownEntry(record.markdownPath, record.lastModified);
+      entries.set(markdown.url, markdown);
+    }
+  }
+
+  for (const pathname of ['/llms.txt', '/llms-full.txt']) {
+    const entry = markdownEntry(pathname);
+    entries.set(entry.url, entry);
+  }
+
+  return [...entries.values()].sort((a, b) => a.url.localeCompare(b.url));
+}

--- a/apps/web/src/components/common/app-download-qr.tsx
+++ b/apps/web/src/components/common/app-download-qr.tsx
@@ -5,14 +5,8 @@ import { cn } from '@/lib/utils';
 // Kortix symbol SVG
 function KortixSymbol({ size = 24, className }: { size?: number; className?: string }) {
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 30 25"
-      fill="currentColor"
-      className={className}
-    >
-      <path d="M25.5614 24.916H29.8268C29.8268 19.6306 26.9378 15.0039 22.6171 12.4587C26.9377 9.91355 29.8267 5.28685 29.8267 0.00146484H25.5613C25.5613 5.00287 21.8906 9.18692 17.0654 10.1679V0.00146484H12.8005V10.1679C7.9526 9.20401 4.3046 5.0186 4.3046 0.00146484H0.0391572C0.0391572 5.28685 2.92822 9.91355 7.24884 12.4587C2.92818 15.0039 0.0390625 19.6306 0.0390625 24.916H4.30451C4.30451 19.8989 7.95259 15.7135 12.8005 14.7496V24.9206H17.0654V14.7496C21.9133 15.7134 25.5614 19.8989 25.5614 24.916Z"/>
+    <svg width={size} height={size} viewBox="0 0 30 25" fill="currentColor" className={className}>
+      <path d="M25.5614 24.916H29.8268C29.8268 19.6306 26.9378 15.0039 22.6171 12.4587C26.9377 9.91355 29.8267 5.28685 29.8267 0.00146484H25.5613C25.5613 5.00287 21.8906 9.18692 17.0654 10.1679V0.00146484H12.8005V10.1679C7.9526 9.20401 4.3046 5.0186 4.3046 0.00146484H0.0391572C0.0391572 5.28685 2.92822 9.91355 7.24884 12.4587C2.92818 15.0039 0.0390625 19.6306 0.0390625 24.916H4.30451C4.30451 19.8989 7.95259 15.7135 12.8005 14.7496V24.9206H17.0654V14.7496C21.9133 15.7134 25.5614 19.8989 25.5614 24.916Z" />
     </svg>
   );
 }
@@ -20,7 +14,7 @@ function KortixSymbol({ size = 24, className }: { size?: number; className?: str
 /**
  * Universal app download URL - middleware auto-redirects to correct store based on device
  */
-export const APP_DOWNLOAD_URL = 'https://www.kortix.com/app';
+export const APP_DOWNLOAD_URL = 'https://kortix.com/app';
 
 export interface AppDownloadQRProps {
   /** Size of the QR code in pixels */
@@ -46,7 +40,7 @@ export function AppDownloadQR({
   const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&data=${encodeURIComponent(APP_DOWNLOAD_URL)}&format=svg&ecc=H`;
 
   return (
-    <div className={cn("relative bg-white rounded-2xl p-4 shadow-lg", className)}>
+    <div className={cn('relative rounded-2xl bg-white p-4 shadow-lg', className)}>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={qrUrl}
@@ -56,8 +50,8 @@ export function AppDownloadQR({
         className="block"
       />
       {showLogo && (
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          <div className="bg-white p-2 rounded-xl shadow-md">
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="rounded-xl bg-white p-2 shadow-md">
             <KortixSymbol size={logoSize} className="text-black" />
           </div>
         </div>

--- a/apps/web/src/lib/seo/coverage-manifest.ts
+++ b/apps/web/src/lib/seo/coverage-manifest.ts
@@ -1,0 +1,12 @@
+/** Deterministic contracts enforced by public-content.test.ts. */
+export const SEO_COVERAGE_MANIFEST = {
+  canonicalOrigin: 'https://kortix.com',
+  machineRoutes: ['/llms.txt', '/llms-full.txt', '/api/ai'],
+  markdownFamilies: ['marketing', 'blog', 'docs', 'use-case'],
+  requiredMarkdownHeaders: {
+    'Content-Type': 'text/plain; charset=utf-8',
+    'Content-Disposition': 'inline',
+    'X-Robots-Tag': 'index, follow',
+  },
+  maximumAgentApiPageSize: 50,
+} as const;

--- a/apps/web/src/lib/seo/llms.ts
+++ b/apps/web/src/lib/seo/llms.ts
@@ -1,0 +1,63 @@
+import {
+  absoluteUrl,
+  getPublicContentRecords,
+  resolvePublicMarkdown,
+  type PublicContentKind,
+} from '@/lib/seo/public-content';
+import { siteMetadata } from '@/lib/site-metadata';
+
+const SECTION_LABELS: Record<PublicContentKind, string> = {
+  marketing: 'Core pages',
+  docs: 'Documentation',
+  blog: 'Blog',
+  'use-case': 'Use cases',
+};
+
+export function renderLlmsTxt(): string {
+  const records = getPublicContentRecords();
+  const sections: string[] = [];
+  for (const kind of Object.keys(SECTION_LABELS) as PublicContentKind[]) {
+    const items = records.filter((record) => record.kind === kind && record.markdownPath);
+    if (!items.length) continue;
+    if (sections.length) sections.push('');
+    sections.push(
+      `## ${SECTION_LABELS[kind]}`,
+      ...items.map(
+        (item) =>
+          `- [${item.title}](${absoluteUrl(item.markdownPath!)}): ${item.description ?? `Official ${kind} content.`}`,
+      ),
+    );
+  }
+
+  return [
+    '# Kortix',
+    '',
+    `> ${siteMetadata.description}`,
+    '',
+    `Canonical site: ${siteMetadata.url}`,
+    `Full corpus: ${absoluteUrl('/llms-full.txt')}`,
+    `Structured content index: ${absoluteUrl('/api/ai')}`,
+    '',
+    ...sections,
+    '',
+  ].join('\n');
+}
+
+export function renderLlmsFullTxt(): string {
+  const documents = getPublicContentRecords().flatMap((record) => {
+    if (!record.markdownPath) return [];
+    const path = record.markdownPath.replace(/^\/markdown\//, '').split('/');
+    const resolved = resolvePublicMarkdown(path);
+    if (!resolved) return [];
+    return [`<!-- ${record.markdownPath} -->\n\n${resolved.markdown.trim()}`];
+  });
+
+  return [
+    '# Kortix full public content corpus',
+    '',
+    `> ${siteMetadata.description}`,
+    '',
+    ...documents.flatMap((document, index) => (index ? ['', '---', '', document] : [document])),
+    '',
+  ].join('\n');
+}

--- a/apps/web/src/lib/seo/metadata.ts
+++ b/apps/web/src/lib/seo/metadata.ts
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+
+import { getMarketingRecord } from '@/lib/seo/public-content';
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
+
+export function marketingMetadata(pathname: string): Metadata {
+  const record = getMarketingRecord(pathname);
+  if (!record) throw new Error(`Missing marketing SEO record for ${pathname}`);
+  const url = `${CANONICAL_ORIGIN}${pathname}`;
+  return {
+    title: record.title,
+    description: record.description,
+    alternates: { canonical: url },
+    openGraph: {
+      title: record.title,
+      description: record.description,
+      url,
+      siteName: 'Kortix',
+      type: 'website',
+    },
+  };
+}

--- a/apps/web/src/lib/seo/public-content.test.ts
+++ b/apps/web/src/lib/seo/public-content.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { GET as getMarkdown } from '@/app/(public)/markdown/[...path]/route';
+import { GET as getAgentIndex } from '@/app/(system)/api/ai/route';
+import { GET as getLlmsFullTxt } from '@/app/llms-full.txt/route';
+import { GET as getLlmsTxt } from '@/app/llms.txt/route';
+import sitemap from '@/app/sitemap';
+import { SEO_COVERAGE_MANIFEST } from '@/lib/seo/coverage-manifest';
+import { renderLlmsTxt } from '@/lib/seo/llms';
+import {
+  absoluteUrl,
+  getPublicContentRecords,
+  renderPlainMarkdownFromMdx,
+  resolvePublicMarkdown,
+} from '@/lib/seo/public-content';
+import { resetAiIndexRateLimitsForTests } from '@/lib/seo/rate-limit';
+import { markdownResponse } from '@/lib/seo/response';
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
+
+const originalUseCases = process.env.NEXT_PUBLIC_USE_CASES_ENABLED;
+const UNRESOLVED_MDX_COMPONENT =
+  /<\/?(?:Callout|Card|Cards|Fact|Figure|KeyFacts|Stat|StatGrid|Step|Steps)\b/;
+const LINE_START_UNRESOLVED_JSX = /^\s*(?:>\s*)?(?:[-*]\s*)?<\/?[A-Z][A-Za-z0-9_.]*(?:\s|>|\/)/m;
+
+function withoutFencedCode(markdown: string): string {
+  return markdown.replace(/(^|\n)(```|~~~)[\s\S]*?(\n\2)(?=\n|$)/g, '\n');
+}
+
+function expectCleanAgentMarkdown(markdown: string, label: string): void {
+  const prose = withoutFencedCode(markdown);
+  expect(prose, label).not.toMatch(/^---/m);
+  expect(prose, label).not.toMatch(/^\s*(?:import|export)\s/m);
+  expect(prose, label).not.toMatch(UNRESOLVED_MDX_COMPONENT);
+  expect(prose, label).not.toMatch(LINE_START_UNRESOLVED_JSX);
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_USE_CASES_ENABLED = 'true';
+  resetAiIndexRateLimitsForTests();
+});
+
+afterEach(() => {
+  if (originalUseCases === undefined) delete process.env.NEXT_PUBLIC_USE_CASES_ENABLED;
+  else process.env.NEXT_PUBLIC_USE_CASES_ENABLED = originalUseCases;
+});
+
+describe('public SEO/AEO content coverage', () => {
+  test('uses one non-www canonical origin and no hardcoded canonical tag', () => {
+    expect(CANONICAL_ORIGIN).toBe(SEO_COVERAGE_MANIFEST.canonicalOrigin);
+    const appRoot = path.join(process.cwd(), 'src', 'app');
+    const files = fs
+      .readdirSync(appRoot, { recursive: true })
+      .filter((file): file is string => typeof file === 'string')
+      .filter((file) => /\.(tsx?|jsx?)$/.test(file));
+    const source = files
+      .map((file) => fs.readFileSync(path.join(appRoot, file), 'utf8'))
+      .join('\n');
+    expect(source).not.toContain('https://www.kortix.com');
+    expect(source).not.toMatch(/<link\s+rel=["']canonical["']/);
+  });
+
+  test('maps every source-backed document to unique HTML and Markdown URLs', () => {
+    const records = getPublicContentRecords({ includeUseCases: true });
+    const markdownRecords = records.filter((record) => record.markdownPath);
+    expect(new Set(records.map((record) => record.htmlPath)).size).toBe(records.length);
+    expect(new Set(markdownRecords.map((record) => record.markdownPath)).size).toBe(
+      markdownRecords.length,
+    );
+
+    const counts = Object.fromEntries(
+      SEO_COVERAGE_MANIFEST.markdownFamilies.map((kind) => [
+        kind,
+        markdownRecords.filter((record) => record.kind === kind).length,
+      ]),
+    );
+    for (const kind of SEO_COVERAGE_MANIFEST.markdownFamilies)
+      expect(counts[kind]).toBeGreaterThan(0);
+
+    for (const record of markdownRecords) {
+      const pathSegments = record.markdownPath!.replace(/^\/markdown\//, '').split('/');
+      const resolved = resolvePublicMarkdown(pathSegments);
+      expect(resolved?.record.htmlPath).toBe(record.htmlPath);
+      expect(resolved?.markdown.length).toBeGreaterThan(20);
+    }
+  });
+
+  test('serves Markdown inline as crawlable UTF-8 plain text', async () => {
+    const record = getPublicContentRecords({ includeUseCases: true }).find(
+      (item) => item.kind === 'blog' && item.markdownPath,
+    );
+    expect(record).toBeDefined();
+    const resolved = resolvePublicMarkdown(
+      record!.markdownPath!.replace(/^\/markdown\//, '').split('/'),
+    )!;
+    const response = markdownResponse(resolved.markdown, resolved.record);
+
+    for (const [header, value] of Object.entries(SEO_COVERAGE_MANIFEST.requiredMarkdownHeaders)) {
+      expect(response.headers.get(header)).toBe(value);
+    }
+    expect(response.headers.get('Link')).toContain(
+      `<${absoluteUrl(record!.htmlPath)}>; rel="canonical"`,
+    );
+
+    const routeResponse = await getMarkdown(
+      new Request(absoluteUrl(record!.markdownPath!), {
+        headers: { 'user-agent': 'ChatGPT-User/1.0' },
+      }),
+      {
+        params: Promise.resolve({
+          path: record!.markdownPath!.replace(/^\/markdown\//, '').split('/'),
+        }),
+      },
+    );
+    expect(routeResponse.status).toBe(200);
+    expect(routeResponse.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(await routeResponse.text()).toContain(`# ${record!.title}`);
+  });
+
+  test('renders MDX source documents as clean agent-readable Markdown', () => {
+    const resolved = resolvePublicMarkdown(['docs', 'index.md']);
+    expect(resolved?.markdown).toContain('Create a project, run a session, keep the work');
+    expect(resolved?.markdown).toContain('- [Quickstart](/docs/quickstart)');
+    expectCleanAgentMarkdown(resolved!.markdown, '/markdown/docs/index.md');
+
+    const mdx = `---
+title: Sample
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+<Callout type="warn" title="Keep this warning">
+  Do not drop this meaningful content.
+</Callout>
+
+<Figure caption="A truthful diagram" aspect="16/9" />
+
+<StatGrid>
+  <Stat value="3 systems" label="One agent" />
+</StatGrid>
+`;
+    const markdown = renderPlainMarkdownFromMdx(mdx);
+    expect(markdown).toContain('> **Keep this warning**');
+    expect(markdown).toContain('> Do not drop this meaningful content.');
+    expect(markdown).toContain('> Figure: A truthful diagram');
+    expect(markdown).toContain('- **3 systems:** One agent');
+    expectCleanAgentMarkdown(markdown, 'fixture');
+  });
+
+  test('all public Markdown outputs contain no unresolved MDX module syntax or JSX', () => {
+    const records = getPublicContentRecords({ includeUseCases: true }).filter(
+      (record) => record.markdownPath,
+    );
+    expect(records.length).toBeGreaterThan(0);
+
+    for (const record of records) {
+      const resolved = resolvePublicMarkdown(
+        record.markdownPath!.replace(/^\/markdown\//, '').split('/'),
+      );
+      expect(resolved).toBeDefined();
+      expectCleanAgentMarkdown(resolved!.markdown, record.markdownPath!);
+    }
+  });
+
+  test('puts every public HTML and Markdown representation in the sitemap', () => {
+    const urls = new Set(sitemap().map((entry) => entry.url));
+    const records = getPublicContentRecords({ includeUseCases: true });
+    for (const record of records) {
+      expect(urls.has(absoluteUrl(record.htmlPath))).toBe(true);
+      if (record.markdownPath) expect(urls.has(absoluteUrl(record.markdownPath))).toBe(true);
+    }
+    expect(
+      [...urls].every((url) => url.startsWith(CANONICAL_ORIGIN) && !url.includes('www.')),
+    ).toBe(true);
+    expect(urls.has(absoluteUrl('/llms.txt'))).toBe(true);
+    expect(urls.has(absoluteUrl('/llms-full.txt'))).toBe(true);
+  });
+
+  test('publishes llms indexes with all Markdown URLs and required headers', async () => {
+    const llms = renderLlmsTxt();
+    for (const record of getPublicContentRecords({ includeUseCases: true })) {
+      if (record.markdownPath) expect(llms).toContain(absoluteUrl(record.markdownPath));
+    }
+
+    for (const response of [getLlmsTxt(), getLlmsFullTxt()]) {
+      expect(response.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+      expect(response.headers.get('Content-Disposition')).toBe('inline');
+      expect((await response.text()).length).toBeGreaterThan(1_000);
+    }
+  });
+});
+
+describe('bounded public agent index', () => {
+  test('paginates a metadata-only index and clamps page size', async () => {
+    const first = getAgentIndex(
+      new Request('https://kortix.com/api/ai?limit=999', { headers: { 'x-real-ip': '192.0.2.1' } }),
+    );
+    expect(first.status).toBe(200);
+    expect(first.headers.get('Cache-Control')).toContain('s-maxage=300');
+    expect(first.headers.get('X-Robots-Tag')).toBe('noindex, follow');
+    const body = (await first.json()) as any;
+    expect(body.pagination.limit).toBe(SEO_COVERAGE_MANIFEST.maximumAgentApiPageSize);
+    expect(body.data.length).toBeLessThanOrEqual(SEO_COVERAGE_MANIFEST.maximumAgentApiPageSize);
+    expect(body.data[0]).not.toHaveProperty('content');
+    expect(body.data[0].url).toStartWith(CANONICAL_ORIGIN);
+
+    if (body.pagination.next_cursor) {
+      const second = getAgentIndex(
+        new Request(`https://kortix.com/api/ai?limit=999&cursor=${body.pagination.next_cursor}`, {
+          headers: { 'x-real-ip': '192.0.2.1' },
+        }),
+      );
+      expect(second.status).toBe(200);
+      const secondBody = (await second.json()) as any;
+      expect(secondBody.data[0]?.url).not.toBe(body.data[0].url);
+    }
+  });
+
+  test('rejects malformed pagination and enforces the documented rate limit', async () => {
+    const invalid = getAgentIndex(
+      new Request('https://kortix.com/api/ai?cursor=not-valid!', {
+        headers: { 'x-real-ip': '192.0.2.2' },
+      }),
+    );
+    expect(invalid.status).toBe(400);
+
+    let response = invalid;
+    for (let index = 0; index <= 120; index += 1) {
+      response = getAgentIndex(
+        new Request('https://kortix.com/api/ai', { headers: { 'x-real-ip': '192.0.2.3' } }),
+      );
+    }
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBeTruthy();
+  });
+
+  test('robots explicitly allows the machine-readable routes', () => {
+    const robots = fs.readFileSync(path.join(process.cwd(), 'public', 'robots.txt'), 'utf8');
+    for (const route of SEO_COVERAGE_MANIFEST.machineRoutes) {
+      expect(robots).toContain(`Allow: ${route}`);
+    }
+    expect(robots).toContain('Allow: /markdown/');
+  });
+});

--- a/apps/web/src/lib/seo/public-content.ts
+++ b/apps/web/src/lib/seo/public-content.ts
@@ -1,0 +1,499 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Block } from '@/components/blog/blog-content';
+import { PRICING_PLANS } from '@/features/billing/pricing-plans';
+import { BLOG_POSTS } from '@/lib/blog-posts';
+import { CANONICAL_ORIGIN, siteMetadata } from '@/lib/site-metadata';
+
+export type PublicContentKind = 'marketing' | 'blog' | 'docs' | 'use-case';
+
+export type PublicContentRecord = {
+  kind: PublicContentKind;
+  slug: string;
+  title: string;
+  description?: string;
+  htmlPath: string;
+  markdownPath?: string;
+  lastModified?: string;
+};
+
+type SourceDocument = PublicContentRecord & { sourcePath: string };
+
+export const STATIC_PUBLIC_ROUTES = [
+  '/',
+  '/about',
+  '/blog',
+  '/careers',
+  '/changelog',
+  '/contact',
+  '/developers',
+  '/docs',
+  '/enterprise',
+  '/legal',
+  '/marketplace',
+  '/pricing',
+  '/support',
+  '/use-cases',
+] as const;
+
+const MARKETING_RECORDS: PublicContentRecord[] = [
+  {
+    kind: 'marketing',
+    slug: 'index',
+    title: siteMetadata.title,
+    description: siteMetadata.description,
+    htmlPath: '/',
+    markdownPath: '/markdown/index.md',
+  },
+  {
+    kind: 'marketing',
+    slug: 'contact',
+    title: 'Contact Kortix',
+    description: 'Request a tailored Kortix walkthrough for cloud, VPC, or on-prem deployment.',
+    htmlPath: '/contact',
+  },
+  {
+    kind: 'marketing',
+    slug: 'about',
+    title: 'About Kortix',
+    description:
+      'We build self-driving companies. Humans verify, steer, and govern while agent teams do work across engineering, product, operations, finance, support, and growth.',
+    htmlPath: '/about',
+    markdownPath: '/markdown/about.md',
+  },
+  {
+    kind: 'marketing',
+    slug: 'legal',
+    title: 'Kortix legal',
+    description: 'Kortix terms of service and privacy policy.',
+    htmlPath: '/legal',
+  },
+  {
+    kind: 'marketing',
+    slug: 'marketplace',
+    title: 'Kortix Marketplace',
+    description:
+      'Browse skills, agents, and commands from every source. Add them to a Kortix project in one click.',
+    htmlPath: '/marketplace',
+  },
+  {
+    kind: 'marketing',
+    slug: 'developers',
+    title: 'Kortix for developers',
+    description: siteMetadata.description,
+    htmlPath: '/developers',
+    markdownPath: '/markdown/developers.md',
+  },
+  {
+    kind: 'marketing',
+    slug: 'enterprise',
+    title: 'Kortix Enterprise',
+    description: PRICING_PLANS.find((plan) => plan.id === 'enterprise')?.note,
+    htmlPath: '/enterprise',
+    markdownPath: '/markdown/enterprise.md',
+  },
+  {
+    kind: 'marketing',
+    slug: 'pricing',
+    title: 'Kortix pricing',
+    description: 'Current plans and included features.',
+    htmlPath: '/pricing',
+    markdownPath: '/markdown/pricing.md',
+  },
+  {
+    kind: 'marketing',
+    slug: 'support',
+    title: 'Kortix support',
+    description: 'Support resources and contact information for Kortix.',
+    htmlPath: '/support',
+  },
+];
+
+export function getMarketingRecord(htmlPath: string): PublicContentRecord | undefined {
+  return MARKETING_RECORDS.find((record) => record.htmlPath === htmlPath);
+}
+
+function webContentRoot(): string {
+  const direct = path.join(process.cwd(), 'content');
+  return fs.existsSync(direct) ? direct : path.join(process.cwd(), 'apps', 'web', 'content');
+}
+
+function listFiles(root: string, extension: '.mdx' | '.md'): string[] {
+  if (!fs.existsSync(root)) return [];
+  const files: string[] = [];
+  const visit = (directory: string) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(entryPath);
+      else if (entry.isFile() && entry.name.endsWith(extension)) files.push(entryPath);
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function parseFrontmatter(source: string): Record<string, string> {
+  const match = /^---\s*\n([\s\S]*?)\n---(?:\s*\n|$)/.exec(source);
+  if (!match) return {};
+
+  const result: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const field = /^([a-zA-Z][\w-]*):\s*(.*)$/.exec(line);
+    if (field && field[2]) result[field[1]] = unquote(field[2]);
+  }
+  return result;
+}
+
+const MDX_WRAPPER_TAGS = new Set(['Cards', 'KeyFacts', 'StatGrid', 'Steps']);
+const MDX_BLOCK_TAGS = new Set(['Callout', 'Card', 'Fact', 'Step']);
+
+type MdxRenderContext = { tag: string; quote?: boolean };
+
+function withoutFrontmatter(source: string): string {
+  return source.replace(/^---\s*\n[\s\S]*?\n---(?:\s*\n|$)/, '');
+}
+
+function parseMdxAttributes(source: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const pattern =
+    /([A-Za-z_:][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|\{`([^`]*)`\}|\{["']([^"']*)["']\})/g;
+  for (const match of source.matchAll(pattern)) {
+    attributes[match[1]] = match[2] ?? match[3] ?? match[4] ?? match[5] ?? '';
+  }
+  return attributes;
+}
+
+function popMdxContext(stack: MdxRenderContext[], tag: string): void {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    if (stack[index].tag === tag) {
+      stack.splice(index, 1);
+      return;
+    }
+  }
+}
+
+function markdownLink(label: string, href?: string): string {
+  return href ? `[${label}](${href})` : label;
+}
+
+function renderCard(attrs: Record<string, string>, body?: string): string {
+  const title = attrs.title || body || 'Related page';
+  const link = markdownLink(title, attrs.href);
+  return body && body !== title ? `- ${link}: ${body.trim()}` : `- ${link}`;
+}
+
+function renderMdxTagLine(line: string, stack: MdxRenderContext[]): string | null | undefined {
+  if (/^\s*<a\b[^>]*\/?>\s*$/.test(line)) return null;
+
+  const closing = /^\s*<\/([A-Z][A-Za-z0-9_.]*)>\s*$/.exec(line);
+  if (closing) {
+    if (MDX_WRAPPER_TAGS.has(closing[1]) || MDX_BLOCK_TAGS.has(closing[1])) {
+      popMdxContext(stack, closing[1]);
+      return null;
+    }
+    return undefined;
+  }
+
+  const paired = /^\s*<([A-Z][A-Za-z0-9_.]*)\b([^>]*)>([\s\S]*?)<\/\1>\s*$/.exec(line);
+  if (paired) {
+    const [, tag, rawAttrs, body] = paired;
+    const attrs = parseMdxAttributes(rawAttrs);
+    const text = body.trim();
+    if (tag === 'Card') return renderCard(attrs, text);
+    if (tag === 'Fact') return `- **${attrs.label || 'Fact'}:** ${text}`;
+    if (tag === 'Stat') return `- **${attrs.value || 'Stat'}:** ${attrs.label || text}`;
+    if (tag === 'Callout') return `> **${attrs.title || 'Note'}:** ${text}`;
+    return undefined;
+  }
+
+  const selfClosing = /^\s*<([A-Z][A-Za-z0-9_.]*)\b([^>]*)\/>\s*$/.exec(line);
+  if (selfClosing) {
+    const [, tag, rawAttrs] = selfClosing;
+    const attrs = parseMdxAttributes(rawAttrs);
+    if (tag === 'Figure') return attrs.caption ? `> Figure: ${attrs.caption}` : null;
+    if (tag === 'Stat') return `- **${attrs.value || 'Stat'}:** ${attrs.label || ''}`.trimEnd();
+    if (tag === 'Card') return renderCard(attrs);
+    return undefined;
+  }
+
+  const opening = /^\s*<([A-Z][A-Za-z0-9_.]*)\b([^>]*)>\s*$/.exec(line);
+  if (!opening) return undefined;
+
+  const [, tag, rawAttrs] = opening;
+  const attrs = parseMdxAttributes(rawAttrs);
+  if (MDX_WRAPPER_TAGS.has(tag)) return null;
+  if (tag === 'Card') {
+    stack.push({ tag });
+    return renderCard(attrs);
+  }
+  if (tag === 'Callout') {
+    stack.push({ tag, quote: true });
+    const title =
+      attrs.title || (attrs.type ? `${attrs.type[0].toUpperCase()}${attrs.type.slice(1)}` : 'Note');
+    return `> **${title}**`;
+  }
+  if (tag === 'Step') {
+    stack.push({ tag });
+    return attrs.title ? `### ${attrs.title}` : null;
+  }
+  if (tag === 'Fact') {
+    stack.push({ tag });
+    return attrs.label ? `- **${attrs.label}:**` : '-';
+  }
+
+  return undefined;
+}
+
+function formatMdxContentLine(line: string, stack: MdxRenderContext[]): string {
+  const content = stack.length ? line.replace(/^\s{2,}/, '') : line;
+  if (stack.some((item) => item.quote)) return content.trim() ? `> ${content}` : '>';
+  return content;
+}
+
+export function renderPlainMarkdownFromMdx(source: string): string {
+  const lines = withoutFrontmatter(source).split('\n');
+  const rendered: string[] = [];
+  const stack: MdxRenderContext[] = [];
+  let inFence = false;
+  let skippingModule = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    let line = lines[index];
+    const fence = /^\s*(```|~~~)/.test(line);
+    if (fence) {
+      inFence = !inFence;
+      rendered.push(formatMdxContentLine(line, stack));
+      continue;
+    }
+
+    if (inFence) {
+      rendered.push(formatMdxContentLine(line, stack));
+      continue;
+    }
+
+    if (skippingModule) {
+      if (/;\s*$/.test(line.trim())) skippingModule = false;
+      continue;
+    }
+
+    if (
+      /^\s*import\s/.test(line) ||
+      /^\s*export\s+(?:default\s+)?(?:const|let|var|function|type|interface|\{)\b/.test(line)
+    ) {
+      skippingModule = !/;\s*$/.test(line.trim());
+      continue;
+    }
+
+    if (/^\s*<[A-Z][A-Za-z0-9_.]*\b/.test(line) && !line.includes('>')) {
+      const tagLines = [line.trim()];
+      while (index + 1 < lines.length && !tagLines.join(' ').includes('>')) {
+        index += 1;
+        tagLines.push(lines[index].trim());
+      }
+      line = tagLines.join(' ');
+    }
+
+    const transformed = renderMdxTagLine(line, stack);
+    if (transformed === null) continue;
+    rendered.push(transformed ?? formatMdxContentLine(line, stack));
+  }
+
+  return `${rendered
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()}\n`;
+}
+
+function sourceDocuments(kind: 'docs' | 'use-case'): SourceDocument[] {
+  const directory = kind === 'docs' ? 'docs' : 'use-cases';
+  const root = path.join(webContentRoot(), directory);
+
+  return listFiles(root, '.mdx').flatMap((sourcePath) => {
+    const source = fs.readFileSync(sourcePath, 'utf8');
+    const frontmatter = parseFrontmatter(source);
+    if (frontmatter.draft === 'true' && process.env.NODE_ENV === 'production') return [];
+
+    const relative = path
+      .relative(root, sourcePath)
+      .replaceAll(path.sep, '/')
+      .replace(/\.mdx$/, '');
+    const slug = relative === 'index' ? 'index' : relative.replace(/\/index$/, '');
+    const htmlPath =
+      kind === 'docs' ? (slug === 'index' ? '/docs' : `/docs/${slug}`) : `/use-cases/${slug}`;
+    const markdownPath = `/markdown/${directory}/${slug}.md`;
+    return [
+      {
+        kind,
+        slug,
+        title: frontmatter.title || slug.split('/').at(-1)?.replaceAll('-', ' ') || slug,
+        description: frontmatter.description,
+        htmlPath,
+        markdownPath,
+        lastModified:
+          kind === 'use-case' && frontmatter.date ? `${frontmatter.date}T00:00:00.000Z` : undefined,
+        sourcePath,
+      },
+    ];
+  });
+}
+
+function blogRecords(): PublicContentRecord[] {
+  return BLOG_POSTS.filter((post) => process.env.NODE_ENV !== 'production' || !post.draft)
+    .map((post) => ({
+      kind: 'blog' as const,
+      slug: post.slug,
+      title: post.title,
+      description: post.description,
+      htmlPath: `/blog/${post.slug}`,
+      markdownPath: `/markdown/blog/${post.slug}.md`,
+      lastModified: `${post.date}T00:00:00.000Z`,
+    }))
+    .sort((a, b) => b.lastModified.localeCompare(a.lastModified));
+}
+
+export function areUseCasesPublic(): boolean {
+  return process.env.NEXT_PUBLIC_USE_CASES_ENABLED === 'true';
+}
+
+export function getPublicContentRecords(
+  options: { includeUseCases?: boolean } = {},
+): PublicContentRecord[] {
+  const includeUseCases = options.includeUseCases ?? areUseCasesPublic();
+  return [
+    ...MARKETING_RECORDS,
+    ...blogRecords(),
+    ...sourceDocuments('docs'),
+    ...(includeUseCases ? sourceDocuments('use-case') : []),
+  ];
+}
+
+function blocksToMarkdown(blocks: Block[]): string {
+  return blocks
+    .map((block) => {
+      switch (block.type) {
+        case 'lead':
+        case 'p':
+          return block.text;
+        case 'h2':
+          return `## ${block.text}`;
+        case 'ul':
+          return block.items.map((item) => `- ${item}`).join('\n');
+        case 'code':
+          return `\`\`\`\n${block.code}\n\`\`\``;
+        case 'callout':
+          return block.text
+            .split('\n')
+            .map((line) => `> ${line}`)
+            .join('\n');
+        case 'logos':
+          return `${block.label ? `${block.label}\n\n` : ''}${block.items
+            .map((item) => `- ${item.name} (${item.domain})`)
+            .join('\n')}`;
+        case 'verdict':
+          return `### Choose ${block.themLabel} if\n\n${block.them}\n\n### Choose Kortix if\n\n${block.kortix}`;
+        case 'compare': {
+          const escapeCell = (value: string) => value.replaceAll('|', '\\|').replaceAll('\n', ' ');
+          return [
+            `| Dimension | ${escapeCell(block.them)} | Kortix |`,
+            '| --- | --- | --- |',
+            ...block.rows.map(
+              (row) =>
+                `| ${escapeCell(row.dimension)} | ${escapeCell(row.them)} | ${escapeCell(row.kortix)} |`,
+            ),
+          ].join('\n');
+        }
+        case 'cta':
+          return `## ${block.title}${block.body ? `\n\n${block.body}` : ''}`;
+      }
+    })
+    .join('\n\n');
+}
+
+function documentHeader(record: PublicContentRecord): string {
+  return [
+    `# ${record.title}`,
+    record.description,
+    `Canonical page: ${CANONICAL_ORIGIN}${record.htmlPath}`,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function renderMarketingMarkdown(record: PublicContentRecord): string {
+  const links = [
+    `- [Documentation](${CANONICAL_ORIGIN}/docs)`,
+    `- [Blog](${CANONICAL_ORIGIN}/blog)`,
+    `- [Use cases](${CANONICAL_ORIGIN}/use-cases)`,
+    `- [GitHub](https://github.com/kortix-ai/suna)`,
+  ];
+
+  if (record.slug === 'pricing' || record.slug === 'enterprise') {
+    const plans = PRICING_PLANS.filter(
+      (plan) => record.slug === 'pricing' || plan.id === 'enterprise',
+    ).map(
+      (plan) =>
+        `## ${plan.name}\n\n${plan.price}${plan.unit ? ` ${plan.unit}` : ''}\n\n${plan.note}\n\n${plan.features
+          .map((feature) => `- ${feature}`)
+          .join('\n')}`,
+    );
+    return `${documentHeader(record)}\n\n${plans.join('\n\n')}`;
+  }
+
+  return `${documentHeader(record)}\n\n## Official resources\n\n${links.join('\n')}`;
+}
+
+export function resolvePublicMarkdown(pathSegments: string[]): {
+  record: PublicContentRecord;
+  markdown: string;
+} | null {
+  if (!pathSegments.length) return null;
+  const last = pathSegments.at(-1);
+  if (!last?.endsWith('.md')) return null;
+
+  const markdownPath = `/markdown/${pathSegments.join('/')}`;
+  const record = getPublicContentRecords().find((item) => item.markdownPath === markdownPath);
+  if (!record) return null;
+
+  if (record.kind === 'marketing') {
+    return { record, markdown: `${renderMarketingMarkdown(record)}\n` };
+  }
+
+  if (record.kind === 'blog') {
+    const post = BLOG_POSTS.find((item) => item.slug === record.slug);
+    if (!post) return null;
+    const byline = [
+      `Published: ${post.date}`,
+      `Author: ${post.author}`,
+      `Tags: ${post.tags.join(', ')}`,
+    ];
+    return {
+      record,
+      markdown: `${documentHeader(record)}\n\n${byline.join('\n')}\n\n${blocksToMarkdown(post.blocks)}\n`,
+    };
+  }
+
+  const source = sourceDocuments(record.kind).find((item) => item.markdownPath === markdownPath);
+  if (!source) return null;
+  return {
+    record,
+    markdown: `${documentHeader(record)}\n\n${renderPlainMarkdownFromMdx(
+      fs.readFileSync(source.sourcePath, 'utf8'),
+    )}`,
+  };
+}
+
+export function absoluteUrl(pathname: string): string {
+  return `${CANONICAL_ORIGIN}${pathname === '/' ? '' : pathname}`;
+}

--- a/apps/web/src/lib/seo/rate-limit.ts
+++ b/apps/web/src/lib/seo/rate-limit.ts
@@ -1,0 +1,38 @@
+const WINDOW_MS = 60_000;
+export const AI_INDEX_RATE_LIMIT = 120;
+
+type Bucket = { count: number; resetsAt: number };
+const buckets = new Map<string, Bucket>();
+
+export type RateLimitResult = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetsAt: number;
+};
+
+export function consumeAiIndexRateLimit(key: string, now = Date.now()): RateLimitResult {
+  const current = buckets.get(key);
+  const bucket =
+    !current || current.resetsAt <= now ? { count: 0, resetsAt: now + WINDOW_MS } : current;
+  bucket.count += 1;
+  buckets.set(key, bucket);
+
+  // Keep the best-effort in-process limiter bounded in long-lived runtimes.
+  if (buckets.size > 10_000) {
+    for (const [bucketKey, value] of buckets) {
+      if (value.resetsAt <= now) buckets.delete(bucketKey);
+    }
+  }
+
+  return {
+    allowed: bucket.count <= AI_INDEX_RATE_LIMIT,
+    limit: AI_INDEX_RATE_LIMIT,
+    remaining: Math.max(0, AI_INDEX_RATE_LIMIT - bucket.count),
+    resetsAt: bucket.resetsAt,
+  };
+}
+
+export function resetAiIndexRateLimitsForTests(): void {
+  buckets.clear();
+}

--- a/apps/web/src/lib/seo/response.ts
+++ b/apps/web/src/lib/seo/response.ts
@@ -1,0 +1,18 @@
+import type { PublicContentRecord } from '@/lib/seo/public-content';
+import { absoluteUrl } from '@/lib/seo/public-content';
+
+export const MACHINE_CONTENT_CACHE_CONTROL =
+  'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400';
+
+export function markdownResponse(markdown: string, record: PublicContentRecord): Response {
+  return new Response(markdown, {
+    headers: {
+      'Cache-Control': MACHINE_CONTENT_CACHE_CONTROL,
+      'Content-Disposition': 'inline',
+      'Content-Type': 'text/plain; charset=utf-8',
+      Link: `<${absoluteUrl(record.htmlPath)}>; rel="canonical"; type="text/html"`,
+      'X-Content-Type-Options': 'nosniff',
+      'X-Robots-Tag': 'index, follow',
+    },
+  });
+}

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -4,15 +4,12 @@ export type NavSubLink = {
 };
 
 export type NavLink =
-  | { id: number; name: string; href: string }
-  | { id: number; name: string; href: NavSubLink[] };
+  { id: number; name: string; href: string } | { id: number; name: string; href: NavSubLink[] };
+
+import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
 
 export const siteConfig = {
-  url:
-    process.env.KORTIX_PUBLIC_APP_URL ||
-    process.env.NEXT_PUBLIC_APP_URL ||
-    process.env.NEXT_PUBLIC_URL ||
-    'http://localhost:3000',
+  url: CANONICAL_ORIGIN,
   nav: {
     links: [
       { id: 1, name: 'Product', href: '/' },

--- a/apps/web/src/lib/site-metadata.ts
+++ b/apps/web/src/lib/site-metadata.ts
@@ -2,25 +2,19 @@
  * Site metadata configuration - SIMPLE AND WORKING
  */
 
-const DEFAULT_APP_URL = 'https://www.kortix.com';
-// Only accept a real absolute http(s) URL. A missing var — or a non-decrypted
-// dotenvx `encrypted:…` value reaching the Vercel `next build` (which loads the
-// committed apps/web/.env raw) — would otherwise flow into
-// `metadataBase: new URL(...)`, which then crashes SSR on EVERY route when Next
-// resolves relative OG/icon URLs against it (TypeError: Invalid URL).
-const rawAppUrl =
-  process.env.KORTIX_PUBLIC_APP_URL ||
-  process.env.NEXT_PUBLIC_APP_URL ||
-  process.env.NEXT_PUBLIC_URL ||
-  '';
-const baseUrl = /^https?:\/\//.test(rawAppUrl) ? rawAppUrl : DEFAULT_APP_URL;
+/**
+ * One public origin for canonical URLs, sitemaps, structured data, and
+ * machine-readable representations. Runtime app URLs are deliberately not
+ * used here: a preview/dev hostname must never become the canonical origin.
+ */
+export const CANONICAL_ORIGIN = 'https://kortix.com';
 
 export const siteMetadata = {
   name: 'Kortix',
   title: 'Kortix – The AI Command Center for Your Company',
   description:
     'The open-source AI command center for your company. Every agent, skill, and memory is a file in one versioned repo you own — a workforce of AI agents that does real work, shared across your whole team from Slack, Teams, the web, or the CLI. Self-hostable, any model, your keys.',
-  url: baseUrl,
+  url: CANONICAL_ORIGIN,
   keywords:
     'Kortix, AI command center, autonomous company operating system, workforce of AI agents, company as a git repo, agents skills and memory as files, shared AI agents, scoped access, open source AI platform, self-hosted AI agents, connect 3000 tools, agent orchestration, AI-native company, AI operations',
 };


### PR DESCRIPTION
## Summary

Adds the SEO-001 technical/AEO infrastructure surface for Kortix public web:

- normalizes canonical host to `https://kortix.com` across metadata, sitemap, structured data, and selected route metadata
- regenerates sitemap from source-backed public content, including docs, blog, marketing pages, Markdown mirrors, `llms.txt`, and `llms-full.txt`
- adds `/llms.txt`, `/llms-full.txt`, public `/markdown/**` mirrors, and bounded `/api/ai` metadata index for answer-engine crawlers
- explicitly allows machine-readable public routes in `robots.txt`
- strips MDX-only syntax from public `.md` outputs so they are truthful plain Markdown, with regression coverage for no frontmatter/import/export/unresolved MDX components

This intentionally supersedes the untrusted branch `seo-aeo-infrastructure@00504010d` by reapplying only the correct public SEO/AEO scope on current `origin/main` and committing as `Kortix Agent`.

## Experiment contract

- ID: `SEO-001`
- Hypothesis: removing duplicate root canonicals/redirecting `www` sitemap URLs and publishing machine-readable public content will reduce crawl ambiguity and make source-backed Kortix surfaces more reliably fetchable by search and answer engines.
- Baseline evidence:
  - Live `https://www.kortix.com/` redirects to `https://kortix.com/` but production sitemap listed `https://www.kortix.com/...` URLs.
  - GSC URL Inspection: `/`, `/pricing`, `/docs/` pass/indexed; Google canonical is correct, but `userCanonical=https://kortix.com/` for `/pricing` and `/docs/`, confirming the duplicate root-canonical bug.
  - GSC Search Analytics D-3 byPage with page filter `^https://kortix\.com(?:/|$)`, property `sc-domain:kortix.com`: last7 1033 clicks / 20795 impressions / 4.9675% CTR / avg position 5.058; prev7 1103 / 15458 / 7.1355% / 5.450; last28 4101 / 67300 / 6.0936% / 5.330; prev28 744 / 10450 / 7.1196% / 4.328; last90 4846 / 77765 / 6.2316% / 5.195. Query rows are privacy-limited/non-exhaustive; no naive brand/nonbrand regex used.
  - `/llms.txt`, `/llms-full.txt`, Markdown representations, and `/api/ai` were absent in production.
  - Sitemaps API currently reports no submitted sitemap. Do not submit the flawed production sitemap.
- Target: preview and then promoted production emit exactly one apex canonical per public page; sitemap contains only `https://kortix.com` canonical URLs and includes source-backed docs/blog/marketing/Markdown/llms routes; public `.md` outputs are `text/plain; charset=utf-8` with `Content-Disposition: inline`; `/api/ai` returns paginated metadata-only canonical URLs.
- Guardrails: no fabricated indexing/ranking/citation claims; no sitemap submission until this work is promoted to production and exact production routes are verified; no private/auth/billing/runtime behavior changes.
- Observation window: inspect technical coverage immediately after dev/prod deployment; measure GSC canonical/page rows after 7 and 28 completed days post-production promotion.
- Rollback: revert this PR if preview exact-head checks show duplicate canonicals, non-apex sitemap URLs, dirty Markdown syntax, route 500s, or unsafe `/api/ai` content exposure.

## Source map

- Canonical origin: `apps/web/src/lib/site-metadata.ts`, `apps/web/src/lib/site-config.ts`
- Sitemap + route inventory: `apps/web/src/app/sitemap.ts`, `apps/web/src/lib/seo/public-content.ts`
- Machine-readable routes: `apps/web/src/app/llms.txt/route.ts`, `apps/web/src/app/llms-full.txt/route.ts`, `apps/web/src/app/(public)/markdown/[...path]/route.ts`, `apps/web/src/app/(system)/api/ai/route.ts`
- Markdown rendering + tests: `apps/web/src/lib/seo/public-content.ts`, `apps/web/src/lib/seo/public-content.test.ts`
- Robots: `apps/web/public/robots.txt`

## Verification run locally

From `apps/web`:

- `pnpm install`
- `bun test src/lib/seo/public-content.test.ts` → 10 pass / 881 expectations
- `prettier --check` on touched SEO files → pass
- touched-file `eslint` on SEO/web route files → pass
- `pnpm exec tsc --noEmit -p tsconfig.json` → pass
- `NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=--max-old-space-size=8192 pnpm build` → pass; 133 static pages generated
- local `next start` with valid local runtime URLs, then route/header gate:
  - HTML 200 and exactly one apex canonical for `/`, `/pricing`, `/enterprise`, `/docs`, `/docs/reference/manifest`, `/blog/kortix-vs-glean`, `/about`, `/careers`, `/changelog`
  - `/llms.txt`, `/llms-full.txt`, `/markdown/docs/index.md`, `/markdown/blog/kortix-vs-glean.md`, `/markdown/pricing.md` all 200, `text/plain; charset=utf-8`, inline disposition, expected robots tag, and no unresolved MDX component syntax
  - `/sitemap.xml` 200, 134 locs, all `https://kortix.com`, includes pricing/enterprise/docs/manifest/Glean blog/llms/Markdown routes
  - `/robots.txt` allows `/api/ai`, `/llms.txt`, `/llms-full.txt`, and `/markdown/`
  - `/api/ai?limit=3` returns 200, CORS `*`, `X-Robots-Tag: noindex, follow`, canonical URLs, and pagination

## Preview gates still required before merge

Add `preview`; wait for all checks; verify exact-head Vercel frontend with production-like decrypted runtime env for canonical tags and machine routes. Local env cannot replace this because marketing route metadata depends on deployed runtime env.
