### PR TITLE
fix(sessions): guard Daytona 429 on transcript + public-share reads (post-#3567)

### DIFF
--- a/apps/api/src/__tests__/unit-session-transcript.test.ts
+++ b/apps/api/src/__tests__/unit-session-transcript.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+// When set, `sandboxOpencodeEndpoint` throws this error instead of resolving —
+// simulates a Daytona 429 `ThrottlerException` / archived box on preview-link
+// resolution (the post-#3567 recurrence path).
+let endpointThrow: Error | null = null;
+let endpointResult: { url: string; headers: Record<string, string> } | null = {
+  url: 'http://daemon.local',
+  headers: {},
+};
+let ensuredPin: string | null = 'oc-root-1';
+let ensuredReason: 'unchanged' | 'healed' | 'not_ready' | 'unreachable' = 'unchanged';
+
+mock.module('../projects/opencode-mapping', () => ({
+  sandboxOpencodeEndpoint: async () => {
+    if (endpointThrow) throw endpointThrow;
+    return endpointResult;
+  },
+  ensureOpencodeSessionPin: async () => ({
+    pin: ensuredPin,
+    changed: false,
+    reason: ensuredReason,
+    sessions: [],
+  }),
+}));
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ orderBy: () => ({ limit: async () => [] }) }) }) }),
+  },
+}));
+
+const { buildSessionTranscriptDigest } = await import('../projects/lib/session-transcript');
+
+afterEach(() => {
+  endpointThrow = null;
+  endpointResult = { url: 'http://daemon.local', headers: {} };
+  ensuredPin = 'oc-root-1';
+  ensuredReason = 'unchanged';
+});
+
+function session(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'session-1',
+    projectId: 'project-1',
+    accountId: 'account-1',
+    opencodeSessionId: 'oc-root-1',
+    status: 'running',
+    // Embeds the external id (/p/<externalId>/) so resolveSessionExternalId
+    // short-circuits without a DB hit.
+    sandboxUrl: 'https://preview.kortix.com/v1/p/sandbox-ext-1/8000',
+    metadata: {},
+    ...overrides,
+  } as any;
+}
+
+describe('buildSessionTranscriptDigest', () => {
+  test('degrades to an unavailable digest when endpoint resolution throws a Daytona 429 (post-#3567 regression)', async () => {
+    // Regression: sandboxOpencodeEndpoint resolves the Daytona preview link,
+    // which throws DaytonaRateLimitError / ThrottlerException when the shared
+    // org is throttled. The transcript read must NOT 500 / surface an unhandled
+    // Sentry event — it must degrade to an unavailable digest (sibling of the
+    // #3567 title-sync fix; this is the post-#3567 call site that was left
+    // unguarded).
+    endpointThrow = new Error('DaytonaRateLimitError: ThrottlerException: Too Many Requests');
+    const result = await buildSessionTranscriptDigest({
+      session: session(),
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+      limit: 40,
+      maxChars: 700,
+    });
+    expect(result.available).toBe(false);
+    expect(result.message_count).toBe(0);
+    expect(result.opencode_session_id).toBe('oc-root-1');
+    // The provider error is surfaced as a controlled reason (NOT propagated),
+    // so the route returns a 200 unavailable digest instead of 500ing.
+    expect(result.reason).toContain('could not reach sandbox');
+    expect(result.reason).toContain('ThrottlerException');
+  });
+
+  test('degrades to unavailable when the sandbox has no service key', async () => {
+    endpointResult = null;
+    const result = await buildSessionTranscriptDigest({
+      session: session(),
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+      limit: 40,
+      maxChars: 700,
+    });
+    expect(result.available).toBe(false);
+    expect(result.reason).toContain('service key');
+  });
+
+  test('returns a real transcript when the daemon answers', async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify([
+          {
+            info: { role: 'assistant', time: { created: 1000, completed: 2000 } },
+            parts: [{ type: 'text', text: 'hello' }],
+          },
+        ]),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+    const result = await buildSessionTranscriptDigest({
+      session: session(),
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+      limit: 40,
+      maxChars: 700,
+    });
+    expect(result.available).toBe(true);
+    expect(result.message_count).toBe(1);
+    expect(result.messages[0].text).toBe('hello');
+  });
+});

--- a/apps/api/src/projects/lib/session-transcript.ts
+++ b/apps/api/src/projects/lib/session-transcript.ts
@@ -99,7 +99,23 @@ export async function buildSessionTranscriptDigest(input: {
     };
   }
 
-  const endpoint = await sandboxOpencodeEndpoint(externalId, userId);
+  // Endpoint resolution touches the sandbox provider (Daytona preview-link /
+  // service-key lookup) and can throw on a 429 `ThrottlerException` rate limit,
+  // an archived/deleted box, or a transient provider outage. This digest is
+  // best-effort enrichment (the session row is already loaded); a provider
+  // throw must NEVER bubble up and 500 the transcript read (see #3567 for the
+  // sibling title-sync fix — this is the same class of bug on a different
+  // post-#3567 call site). Degrade to an unavailable digest instead.
+  let endpoint: { url: string; headers: Record<string, string> } | null;
+  try {
+    endpoint = await sandboxOpencodeEndpoint(externalId, userId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ...unavailable(`could not reach sandbox: ${message}`),
+      opencode_session_id: opencodeSessionId,
+    };
+  }
   if (!endpoint) {
     return {
       ...unavailable('sandbox service key unavailable'),

--- a/apps/api/src/shared/public-session-share-view.test.ts
+++ b/apps/api/src/shared/public-session-share-view.test.ts
@@ -22,10 +22,17 @@ let endpointResult: { url: string; headers: Record<string, string> } | null = {
   url: 'http://daemon.local',
   headers: {},
 };
+// When set, `sandboxOpencodeEndpoint` throws this error instead of resolving —
+// simulates a Daytona 429 `ThrottlerException` / archived box on preview-link
+// resolution (the post-#3567 recurrence path).
+let endpointThrow: Error | null = null;
 let resolvedRootId: string | null = 'oc-root-1';
 
 mock.module('../projects/opencode-mapping', () => ({
-  sandboxOpencodeEndpoint: async () => endpointResult,
+  sandboxOpencodeEndpoint: async () => {
+    if (endpointThrow) throw endpointThrow;
+    return endpointResult;
+  },
   listSandboxOpencodeSessions: async () => listResult,
   resolveRootSessionId: () => resolvedRootId,
 }));
@@ -36,6 +43,7 @@ beforeEach(() => {
   sessionRows = [];
   listResult = { ok: true, sessions: [] };
   endpointResult = { url: 'http://daemon.local', headers: {} };
+  endpointThrow = null;
   resolvedRootId = 'oc-root-1';
   globalThis.fetch = mock(async () => new Response('[]', { status: 200 })) as unknown as typeof fetch;
 });
@@ -203,6 +211,26 @@ describe('getPublicSessionMessages', () => {
       // reason only (the detail is logged server-side).
       expect(result.transcript.reason).not.toContain('ECONNRESET');
       expect(result.transcript.reason).toBeTruthy();
+    }
+  });
+
+  test('a Daytona 429 rate-limit on endpoint resolution degrades to unavailable (post-#3567 regression)', async () => {
+    // Regression: sandboxOpencodeEndpoint resolves the Daytona preview link,
+    // which throws DaytonaRateLimitError / ThrottlerException when the shared
+    // org is throttled. The public share route must NOT 500 / surface an
+    // unhandled Sentry event — it must degrade to an unavailable digest
+    // (sibling of the #3567 title-sync fix; this is the post-#3567 call site
+    // that was left unguarded).
+    endpointThrow = new Error('DaytonaRateLimitError: ThrottlerException: Too Many Requests');
+    const result = await getPublicSessionMessages(activeShare);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.transcript.available).toBe(false);
+      // Anonymous audience: the raw provider error text must NOT leak.
+      expect(result.transcript.reason).not.toContain('ThrottlerException');
+      expect(result.transcript.reason).not.toContain('DaytonaRateLimit');
+      expect(result.transcript.reason).toBeTruthy();
+      expect(result.transcript.opencode_session_id).toBe('oc-root-1');
     }
   });
 });

--- a/apps/api/src/shared/public-session-share-view.ts
+++ b/apps/api/src/shared/public-session-share-view.ts
@@ -210,7 +210,23 @@ export async function getPublicSessionMessages(
     return { ok: true, transcript: unavailable('No OpenCode session found in the sandbox yet') };
   }
 
-  const endpoint = await sandboxOpencodeEndpoint(row.externalId, undefined);
+  // Endpoint resolution touches the sandbox provider (Daytona preview-link /
+  // service-key lookup) and can throw on a 429 `ThrottlerException` rate limit,
+  // an archived/deleted box, or a transient provider outage. This anonymous
+  // transcript read is best-effort enrichment (the share row is already
+  // resolved); a provider throw must NEVER bubble up and 500 the public share
+  // route (sibling of the #3567 title-sync fix — same class of bug on a
+  // different post-#3567 call site). Degrade to an unavailable digest.
+  let endpoint: { url: string; headers: Record<string, string> } | null;
+  try {
+    endpoint = await sandboxOpencodeEndpoint(row.externalId, undefined);
+  } catch (err) {
+    console.warn('[public-session-share-view] sandbox endpoint resolution failed:', err);
+    return {
+      ok: true,
+      transcript: unavailable('Could not read the shared session right now.', opencodeSessionId),
+    };
+  }
   if (!endpoint) {
     return { ok: true, transcript: unavailable('Sandbox credentials unavailable', opencodeSessionId) };
   }


### PR DESCRIPTION
## What & why

Better Stack error **`ec26b248ce16a96fd45ae638c708926e913c56ba66cd18c53214886c53c83bcb`** —
`DaytonaRateLimitError: ThrottlerException: Too Many Requests` (Kortix API prod,
application_id 2346961). 6 occurrences / 1 user in now-3d; first seen 2026-06-21,
**last seen 2026-07-13 10:20:57 UTC**. Call site: `node_modules @daytonaio/sdk
errors/DaytonaError.js createDaytonaError`.

https://errors.betterstack.com/team/t502678/errors/ec26b248ce16a96fd45ae638c708926e913c56ba66cd18c53214886c53c83bcb?s=2346961

This was previously deduped to merged **#3567** (`fix(sessions): one bad sandbox
no longer 500s the session list (+ stop Daytona rate-limit amplification)`), which
hardened the **session-list title-sync** path (`listSandboxOpencodeSessions`).
But the error is **recurring on 2026-07-13**, and prod is on **v0.9.108** (released
2026-07-12 13:28 UTC), which **already includes #3567** — so this is a **NEW,
post-#3567 call site**, not the covered one.

### Root cause (one line)
#3567 guarded the OpenCode *session-list* path, but **two other call sites**
resolve the Daytona preview link **directly** without a try/catch, so a 429
`ThrottlerException` propagates uncaught → Hono error handler → Sentry → Better Stack:

1. `apps/api/src/shared/public-session-share-view.ts` — `getPublicSessionMessages`
   → route `GET /public/session-shares/:shareId/messages` (anonymous public share).
2. `apps/api/src/projects/lib/session-transcript.ts` — `buildSessionTranscriptDigest`
   → route `GET /:projectId/sessions/:sessionId/...` (authed transcript read).

Both call `sandboxOpencodeEndpoint(externalId, …)` → `resolveSandboxIngress` →
provider `resolveIngress` → Daytona `getPreviewLink(port)`, which the SDK turns
into `DaytonaRateLimitError` on a 429. The function `listSandboxOpencodeSessions`
already swallows this (the #3567 fix), but these two call `sandboxOpencodeEndpoint`
**directly**, outside any guard.

### Evidence
- Prod health: `{"environment":"prod","version":"0.9.108"}` (confirmed `curl
  https://api.kortix.com/v1/health`). #3567 merged 2026-06-21 07:54 UTC, so it is
  in v0.9.108 → the recurrence is **not** the title-sync path.
- Last occurrence 2026-07-13 10:20:57 UTC is **post**-v0.9.108 (2026-07-12 13:28).
- Source inspection: `sandboxOpencodeEndpoint` is called unguarded at
  `public-session-share-view.ts:213` and `session-transcript.ts:102` (pre-fix);
  both route handlers (`public-session-shares/index.ts:110`, `r7.ts:620`) call the
  function with no surrounding try/catch, so the throw reaches Hono's error
  handler and is captured to Sentry.
- #3567's own PR body flagged this exact gap as a follow-up: *"Global Daytona
  concurrency limiter + backoff across **all** call sites … since title-sync is
  the #1 but not the only source."* — this PR closes the two read-side call sites
  it identified.

## The fix
Wrap the direct `sandboxOpencodeEndpoint` call in both functions so any provider
throw (429 rate limit, archived/deleted box, transient outage) **degrades to an
`unavailable` digest** instead of bubbling — identical philosophy to #3567's
best-effort-enrichment treatment and to the existing fetch try/catch that already
sits one block below in each function. Unexpected errors are still **logged
server-side** (`console.warn` for the public share, surfaced in the `reason` for
the authed transcript); only the **unhandled Sentry propagation** is removed — we
do not silently hide unexpected provider failures.

No behavior change for the happy path or the `no_key` (null endpoint) path.

## Tests
- `apps/api/src/shared/public-session-share-view.test.ts` — new regression:
  `sandboxOpencodeEndpoint` throws `DaytonaRateLimitError: ThrottlerException:
  Too Many Requests` → `getPublicSessionMessages` returns `ok:true` with
  `available:false` (degrades, does NOT propagate; raw provider error text does
  NOT leak to the anonymous audience).
- `apps/api/src/__tests__/unit-session-transcript.test.ts` (new file) — same
  throw → `buildSessionTranscriptDigest` returns an unavailable digest with
  `opencode_session_id` preserved; plus a happy-path (daemon answers) and a
  no-service-key case.

Local verification:
- `bun test src/shared/public-session-share-view.test.ts` → **13 pass / 0 fail**
  (incl. the new rate-limit regression).
- `bun test src/__tests__/unit-session-transcript.test.ts` → **3 pass / 0 fail**.
- `bun test src/__tests__/unit-opencode-title-sync.test.ts` → **4 pass / 0 fail**
  (#3567's regression test still green — no overlap).
- `tsc --noEmit` (apps/api) → clean.

## Confirm resolution
After this merges + promotes, the Daytona 429 should stop surfacing as an
unhandled Sentry event from the transcript / public-share read paths. The Better
Stack group `ec26b248…` should drop to zero new occurrences from these call sites
(it may still fire from other unhardened provider call sites — e.g. the reaper /
warm-pool health / env-sync paths #3567 also flagged — which are out of scope for
this focused read-side fix and would warrant a separate global-limiter PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
