### PR TITLE
fix(web): drop TronLink extension proxy-trap noise from Sentry

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -14,6 +14,7 @@ import {
   isRuntimeNotReadyNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
+  isTronLinkProxyNoise,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
 } from './browser-error-noise.ts'
@@ -1282,6 +1283,170 @@ test('does NOT suppress a real app TypeError with a different null-property name
       }),
       false,
       `expected Sentry gate to keep reporting real app TypeError "${message}" even from a chunk frame`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// TronLink browser-extension injected-Proxy `set`-trap noise
+// (Better Stack pattern 951c1a316cae8595da3f73877cb1fa8a77d04315ae1a2987b6348a97ec9a049a,
+// Kortix Frontend prod, application_id 2346967). The TronLink wallet extension
+// injects `app:///injected/injected.js` (function `BI`) which wraps a page
+// object in a Proxy exposing `tronlinkParams`; a `set` the trap declines throws
+// `TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'`.
+// 2 occurrences, 0 identified users, first/last 2026-07-12. The throw is inside
+// the EXTENSION's injected script, never first-party code. The matcher requires
+// BOTH the TronLink property name AND an injected/extension source so a real
+// first-party Proxy `set` failure keeps reporting.
+// ---------------------------------------------------------------------------
+
+const TRONLINK_INJECTED_FRAME = { filename: 'app:///injected/injected.js', function: 'BI' }
+
+const TRONLINK_PROXY_EVENTS = [
+  // The exact assigned production message (V8/Chrome).
+  "TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+  // Bare message (no `TypeError:` prefix).
+  "'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+  // Unhandled-rejection leak path preserving the message.
+  "Unhandled promise rejection: TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+  // SpiderMonkey (Firefox) wording, same TronLink property.
+  "proxy set handler returned false for property 'tronlinkParams'",
+  "TypeError: proxy set handler returned false for property 'tronlinkParams'",
+]
+
+test('classifies every TronLink proxy-trap variant as noise when sourced from the injected script', () => {
+  for (const message of TRONLINK_PROXY_EVENTS) {
+    assert.equal(
+      isTronLinkProxyNoise({ message, filename: 'app:///injected/injected.js' }),
+      true,
+      `expected "${message}" from injected.js to be TronLink noise`,
+    )
+    assert.equal(
+      isTronLinkProxyNoise({ message, frames: [TRONLINK_INJECTED_FRAME] }),
+      true,
+      `expected "${message}" with an injected frame to be TronLink noise`,
+    )
+  }
+})
+
+test('classifies TronLink proxy-trap noise from a chrome-extension:// frame', () => {
+  assert.equal(
+    isTronLinkProxyNoise({
+      message: "TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+      frames: [{ filename: 'chrome-extension://egjidmnggjknjgkbjopmfcfhkagpnbgh/injected.js' }],
+    }),
+    true,
+  )
+})
+
+test('suppresses the TronLink proxy-trap Sentry event from the injected script', () => {
+  for (const value of TRONLINK_PROXY_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://app.kortix.com/projects' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: { frames: [TRONLINK_INJECTED_FRAME] },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses the TronLink proxy-trap unhandled rejection from the browser (window.onerror)', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        "Unhandled promise rejection: TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+      filename: 'app:///injected/injected.js',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a TronLink-worded event with NO injected/extension source (conservative — keep reporting)', () => {
+  // No source anchor → can't confirm extension origin; a first-party Proxy
+  // could theoretically throw the same wording, so keep reporting.
+  for (const value of TRONLINK_PROXY_EVENTS) {
+    assert.equal(
+      isTronLinkProxyNoise({ message: value }),
+      false,
+      `expected frameless "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected frameless Sentry event for "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a TronLink-worded event from a first-party app frame', () => {
+  // A genuine first-party Proxy `set` trap returning falsish (MobX/Immer/
+  // Zustand/hand-rolled Proxy) throws the SAME wording but inside app code —
+  // the de-minified frame is `apps/web/src/…`, not the extension's injected
+  // script. It must keep reporting so a real Proxy bug is never hidden.
+  const realAppFrames: Array<{ filename: unknown }> = [
+    { filename: 'app:///apps/web/src/lib/store.ts' },
+    { filename: 'apps/web/src/lib/store.ts' },
+    { filename: 'https://app.kortix.com/_next/static/chunks/store.js' },
+  ]
+  for (const frames of [realAppFrames, [{ filename: 'app:///_next/static/chunks/app.js' }]]) {
+    assert.equal(
+      isTronLinkProxyNoise({
+        message: "TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+        frames,
+      }),
+      false,
+      `expected TronLink-worded event from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: "'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting TronLink-worded event from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "'set' on proxy: trap returned falsish for property 'tronlinkParams'",
+      filename: 'app:///apps/web/src/lib/store.ts',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a real first-party Proxy `set` failure on a DIFFERENT property', () => {
+  // The generic `'set' on proxy: trap returned falsish for property '<X>'`
+  // wording with a non-TronLink property name is a real app Proxy bug — even
+  // from the injected script frame, the property name is the TronLink marker,
+  // so a different property must keep reporting regardless of source.
+  for (const value of [
+    "'set' on proxy: trap returned falsish for property 'foo'",
+    "TypeError: 'set' on proxy: trap returned falsish for property 'bar'",
+    "'set' on proxy: trap returned falsish for property 'tronlinkParams_extra'",
+  ]) {
+    assert.equal(
+      isTronLinkProxyNoise({ message: value, filename: 'app:///injected/injected.js' }),
+      false,
+      `expected non-TronLink Proxy message "${value}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -239,6 +239,40 @@ const INJECTED_APP_SOURCE_PATTERNS = [
   /^app:\/\/\/embed\/embed\.js$/,
 ] as const;
 
+// TronLink (Tron blockchain wallet) browser-extension injected-script noise.
+// The TronLink extension injects a content script
+// (`app:///injected/injected.js`, function `BI`) that wraps a page object
+// (e.g. `window`) in a Proxy and exposes a `tronlinkParams` property for its
+// dapp provider. When the extension's own injected code — or another on-page
+// script — attempts a `set` on that proxied object and the trap declines the
+// assignment (returns falsish), the engine throws
+// `TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'`
+// (V8) / `proxy set handler returned false for property 'tronlinkParams'`
+// (SpiderMonkey). The throw originates INSIDE the extension's injected script,
+// never in first-party app code: `tronlinkParams` is a TronLink-private
+// property our app never touches. Better Stack pattern `951c1a31…`, Kortix
+// Frontend (prod, application_id 2346967), 2 occurrences, 0 identified users,
+// first/last 2026-07-12, call site `app:///injected/injected.js` function `BI`.
+//
+// The `'set' on proxy: trap returned falsish for property '<X>'` wording is a
+// GENERIC Proxy `set`-trap failure that legitimate first-party Proxy users
+// (MobX / Immer / Zustand middleware / a hand-rolled `new Proxy(...)` guard)
+// can also throw when their `set` trap returns `false`. Matching on message
+// alone would swallow those real app Proxy bugs. Require BOTH the
+// TronLink-specific property name AND an injected/extension frame/source so a
+// real first-party Proxy `set` failure keeps reporting.
+const TRONLINK_PROXY_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
+  // V8 (Chrome/Edge/Opera): the observed production wording.
+  /'set' on proxy: trap returned falsish for property 'tronlinkParams'/,
+  // SpiderMonkey (Firefox): different engine, same TronLink property.
+  /proxy set handler returned false for property 'tronlinkParams'/,
+]
+
+function isTronLinkInjectedSource(filename: unknown): boolean {
+  const normalized = normalizeString(filename);
+  return /^app:\/\/\/injected\/injected\.js$/.test(normalized);
+}
+
 function containsKnownPattern(message: string, patterns: readonly string[]): boolean {
   return patterns.some((pattern) => message.includes(pattern));
 }
@@ -356,6 +390,38 @@ export function isExtensionSource(filename: unknown): boolean {
 export function isInjectedAppSource(filename: unknown): boolean {
   const normalized = normalizeString(filename);
   return INJECTED_APP_SOURCE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the TronLink browser-extension
+ * injected-Proxy `set`-trap noise class: a `'set' on proxy: trap returned
+ * falsish for property 'tronlinkParams'` `TypeError` thrown from the
+ * extension's own injected script (`app:///injected/injected.js`) or an
+ * extension-origin frame. TronLink wraps a page object in a Proxy and exposes
+ * `tronlinkParams` for its dapp provider; the throw is in the extension, never
+ * in first-party app code. Requires BOTH the TronLink-specific property name
+ * AND an injected/extension source so a real first-party Proxy `set` failure
+ * (MobX/Immer/Zustand/hand-rolled Proxy) keeps reporting. Returns false when
+ * there is no source anchor at all (can't confirm extension origin — keep
+ * reporting rather than swallow a possible app Proxy bug). See
+ * `TRONLINK_PROXY_NOISE_PATTERNS` for the full rationale.
+ */
+export function isTronLinkProxyNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!TRONLINK_PROXY_NOISE_PATTERNS.some((re) => re.test(stripped))) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  return sources.some(
+    (filename) => isTronLinkInjectedSource(filename) || isExtensionSource(filename),
+  );
 }
 
 export function isKnownTestNoiseMessage(message: unknown): boolean {
@@ -609,6 +675,15 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // TronLink browser-extension injected-Proxy `set`-trap noise — the
+  // extension's `injected.js` wraps a page object in a Proxy and a `set` on
+  // `tronlinkParams` is declined. Requires BOTH the TronLink property name AND
+  // an injected/extension source so a real first-party Proxy `set` failure
+  // keeps reporting. See `isTronLinkProxyNoise`.
+  if (isTronLinkProxyNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
   return isExtensionSource(input.filename) && normalizeString(message).includes('runtime.sendMessage');
 }
 
@@ -738,6 +813,15 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   }
 
   if (frames.some((frame) => isInjectedAppSource(frame.filename))) {
+    return true;
+  }
+
+  // TronLink browser-extension injected-Proxy `set`-trap noise — the
+  // extension's `injected.js` (or an extension-origin frame) declines a `set`
+  // on `tronlinkParams`. Requires BOTH the TronLink property name AND an
+  // injected/extension frame so a real first-party Proxy `set` failure keeps
+  // reporting. See `isTronLinkProxyNoise`.
+  if (isTronLinkProxyNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause

Browser-extension noise, not an app defect. The **TronLink** (Tron blockchain wallet) browser extension injects a content script `app:///injected/injected.js` (function `BI`) that wraps a page object (e.g. `window`) in a `Proxy` and exposes a `tronlinkParams` property for its dapp provider. When the extension's own injected code — or another on-page script — attempts a `set` on that proxied object and the trap declines the assignment (returns falsish), the engine throws:

```
TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'
```

The throw originates **inside the extension's injected script**, never in first-party app code — `tronlinkParams` is a TronLink-private property our app never touches.

## Evidence

- **Better Stack error:** https://errors.betterstack.com/team/t502678/errors/951c1a316cae8595da3f73877cb1fa8a77d04315ae1a2987b6348a97ec9a049a?s=2346967
- **Error id:** `951c1a316cae8595da3f73877cb1fa8a77d04315ae1a2987b6348a97ec9a049a`
- **Source:** Better Stack Kortix Frontend (prod), application_id `2346967`
- **Type/message:** `TypeError: 'set' on proxy: trap returned falsish for property 'tronlinkParams'`
- **Call site:** `app:///injected/injected.js`, function `BI` — a Chrome-extension injected-script pseudo-URL (Sentry's `app:///` scheme), not our bundled app code. This is the smoking gun that it is extension-sourced.
- **Scale:** 2 occurrences / 0 identified users, prod only; first seen 2026-07-12 16:16:02 UTC, last seen 2026-07-12 18:25:27 UTC. Anonymous, low-volume — consistent with a single visitor running TronLink.
- **DNS note:** the Better Stack error-tracking REST API host (`api.betterstack.com`) does not resolve in this sandbox, so I could not pull the raw occurrence payloads (breadcrumbs/browser/OS). The de-minified call site (`app:///injected/injected.js`), the `tronlinkParams` property name, and `0 users` together conclusively identify the TronLink extension source — no app-code path produces these. ClickHouse was checked; it only holds the API (prod/dev) log sources, not frontend Sentry events.

## Fix

Extend the existing browser/Sentry noise filter (`apps/web/src/lib/browser-error-noise.ts`) with a new `isTronLinkProxyNoise` matcher, wired into both the `window.onerror` runtime gate (`shouldIgnoreBrowserRuntimeNoise`) and the Sentry `beforeSend` gate (`shouldIgnoreSentryBrowserNoise`).

The matcher is deliberately **conservative** — it drops the event only when BOTH hold:
1. The message (after stripping `TypeError:` / `Unhandled promise rejection:` wrappers) matches `'set' on proxy: trap returned falsish for property 'tronlinkParams'` (V8/Chrome — the observed prod wording) or the SpiderMonkey sibling `proxy set handler returned false for property 'tronlinkParams'`, **and**
2. A frame/source indicates injected/extension code: `app:///injected/injected.js` (TronLink's injected script) or any `chrome-extension://` / `moz-extension://` / `safari-web-extension://` / `extension://` origin.

**Negative guards (real errors keep reporting):**
- A real first-party `Proxy` `set`-trap failure (MobX / Immer / Zustand middleware / a hand-rolled `new Proxy(...)` guard returning `false`) throws the *same generic wording* but with a non-`tronlinkParams` property name and a de-minified `apps/web/src/…` frame — it is never matched (different property + first-party source).
- The same `tronlinkParams` wording with **no** source anchor is kept (can't confirm extension origin — don't swallow a possible app bug).
- The same `tronlinkParams` wording from a first-party app frame is kept.

## Tests

Added 7 regression tests to `apps/web/src/lib/browser-error-noise.test.mts`:
- classifies every TronLink proxy-trap variant (V8 bare / `TypeError:` / unhandled-rejection / SpiderMonkey) as noise when sourced from `injected.js`
- classifies TronLink noise from a `chrome-extension://` frame
- suppresses the TronLink Sentry event from the injected script
- suppresses the TronLink unhandled rejection via the runtime (window.onerror) gate
- **negative:** does NOT suppress a TronLink-worded event with no injected/extension source
- **negative:** does NOT suppress a TronLink-worded event from a first-party app frame (`apps/web/src/…`, `_next/static/chunks/…`)
- **negative:** does NOT suppress a real first-party Proxy `set` failure on a different property (`foo`/`bar`/`tronlinkParams_extra`)

## Verification

- `bun test apps/web/src/lib/browser-error-noise.test.mts` → **66 pass, 0 fail** (59 pre-existing + 7 new).
- `tsc --strict --skipLibCheck` on `browser-error-noise.ts` → clean (no errors). The test file's only diagnostics are pre-existing (`@types/node` not installed in this isolated checkout; the `function` field on frame objects used throughout the existing tests) and not introduced by this change.

## Confirmation

After merge + promote, Better Stack pattern `951c1a31…` should drop to zero new occurrences (the `beforeSend` gate returns `null` for the matched event before it is sent). Real first-party `Proxy` `set` errors continue to report normally.
