### PR TITLE
fix(web): filter Android WebView native-bridge postMessage noise (Java object is gone)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  isAndroidWebViewNativeBridgePostMessageNoise,
   isClientRequestTimeoutMessage,
   isEmptyMessageUnresolvedBrowserChunkNoise,
   isExpectedBillingGateMessage,
@@ -1449,4 +1450,191 @@ test('does NOT suppress a real first-party Proxy `set` failure on a DIFFERENT pr
       `expected non-TronLink Proxy message "${value}" to keep reporting`,
     )
   }
+})
+
+// Reproduces Better Stack error e6a45fe4999b5a60f5cd64fd4153b18c2beebfc4409a3d54da456a4bbc24e5d2
+// (Kortix Frontend prod, application_id 2346967): 1 occurrence, 0 identified
+// users, 2026-07-12 19:31:47 UTC. A Threads (Barcelona) in-app Android WebView
+// (Android 14 / Chrome 149, referer https://l.threads.com/) visited the
+// marketing homepage (`https://kortix.com/`). The Android System WebView
+// injects a synthetic `app://navigation_performance_logger_android` script
+// that records navigation timing (FBNavResponseStart / FBNavDomContentLoaded /
+// …) and ships it to its native Java bridge via `sendDataToNative` →
+// `postMessage`. The bridge holds only a WEAK reference to the Java object,
+// so once it is garbage-collected (page navigation / WebView teardown / the
+// in-app browser dismissing the tab) the next `postMessage` throws
+// `Error invoking postMessage: Java object is gone`. Sentry's
+// `BrowserApiErrors` integration auto-wraps `addEventListener` on
+// `EventTarget` and captures the throw as a global error. The frames (Sentry
+// oldest-first → last is the throwing frame) are the Android bridge internals:
+//   app:///_next/static/chunks/66499-…?dpl=dpl_…   (Sentry wrapper frame `u`)
+//   app://navigation_performance_logger_android   `?`
+//   app://navigation_performance_logger_android   `sendJsBlockingTimeMessage`
+//   app://navigation_performance_logger_android   `sendDataToNative`  (throw)
+// This is the WebView's OWN instrumentation, never first-party code. The
+// matcher requires BOTH the exact message AND a frame whose filename is the
+// Android bridge source, so a genuine first-party `window.postMessage`
+// failure keeps reporting.
+const ANDROID_NAV_PERF_LOGGER_FRAME = 'app://navigation_performance_logger_android'
+const ANDROID_WEBVIEW_BRIDGE_EVENTS = [
+  // The exact raw exception value from the production event.
+  'Error invoking postMessage: Java object is gone',
+  // An unhandled-rejection wrapper preserving the message.
+  'Unhandled promise rejection: Error invoking postMessage: Java object is gone',
+]
+
+test('classifies the Android WebView native-bridge postMessage noise (with a bridge frame)', () => {
+  for (const message of ANDROID_WEBVIEW_BRIDGE_EVENTS) {
+    assert.equal(
+      isAndroidWebViewNativeBridgePostMessageNoise({
+        message,
+        frames: [{ filename: ANDROID_NAV_PERF_LOGGER_FRAME }],
+      }),
+      true,
+      `expected "${message}" from the Android bridge frame to be classified as noise`,
+    )
+  }
+})
+
+test('suppresses the Android WebView bridge Sentry event via the beforeSend gate', () => {
+  // Exact frame chain from the raw production event (oldest-first → throwing
+  // frame last).
+  for (const value of ANDROID_WEBVIEW_BRIDGE_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'app:///_next/static/chunks/66499-704f783b0e8ea993.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy',
+                    function: 'u',
+                  },
+                  { filename: ANDROID_NAV_PERF_LOGGER_FRAME, function: '?' },
+                  {
+                    filename: ANDROID_NAV_PERF_LOGGER_FRAME,
+                    function: 'sendJsBlockingTimeMessage',
+                  },
+                  {
+                    filename: ANDROID_NAV_PERF_LOGGER_FRAME,
+                    function: 'sendDataToNative',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses the Android WebView bridge noise via the runtime (window.onerror) gate with a bridge filename', () => {
+  for (const message of ANDROID_WEBVIEW_BRIDGE_EVENTS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: ANDROID_NAV_PERF_LOGGER_FRAME,
+      }),
+      true,
+      `expected runtime gate to suppress "${message}" with the Android bridge filename`,
+    )
+  }
+})
+
+test('does NOT suppress the Android bridge message with NO bridge frame (conservative — keep reporting)', () => {
+  // The message wording is generic enough that a real first-party
+  // `window.postMessage` failure could share it; without the Android bridge
+  // frame/filename we cannot confirm origin — keep reporting.
+  for (const message of ANDROID_WEBVIEW_BRIDGE_EVENTS) {
+    assert.equal(
+      isAndroidWebViewNativeBridgePostMessageNoise({ message }),
+      false,
+      `expected frameless "${message}" to keep reporting`,
+    )
+    assert.equal(
+      isAndroidWebViewNativeBridgePostMessageNoise({
+        message,
+        frames: [{ filename: 'app:///_next/static/chunks/main.js' }],
+      }),
+      false,
+      `expected "${message}" from an app chunk (no bridge frame) to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message }] },
+      }),
+      false,
+      `expected frameless Sentry event for "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a real first-party postMessage failure that throws from an app chunk', () => {
+  // A genuine `window.postMessage` / structured-clone failure in our own code
+  // throws the SAME message wording, but from an `app:///_next/…` chunk (or a
+  // de-minified `apps/web/src/…` frame), NEVER from the Android bridge source.
+  // It must keep reporting so a real postMessage regression is never hidden.
+  const realAppFrames: Array<{ filename: unknown }> = [
+    { filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js' },
+    { filename: 'apps/web/src/features/messaging/postmessage-bridge.ts' },
+  ]
+  for (const frames of [realAppFrames, [{ filename: 'app:///apps/web/src/features/messaging/bridge.ts' }]]) {
+    assert.equal(
+      isAndroidWebViewNativeBridgePostMessageNoise({
+        message: 'Error invoking postMessage: Java object is gone',
+        frames,
+      }),
+      false,
+      `expected real first-party postMessage error from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: 'Error invoking postMessage: Java object is gone',
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting real first-party postMessage error from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Error invoking postMessage: Java object is gone',
+      filename: 'apps/web/src/features/messaging/postmessage-bridge.ts',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a same-worded message from a different bridge / non-Android source', () => {
+  // The matcher is anchored on the EXACT `app://navigation_performance_logger_android`
+  // source — a near-identical filename (e.g. a hypothetical iOS sibling or a
+  // typo) must NOT be swallowed by this guard.
+  assert.equal(
+    isAndroidWebViewNativeBridgePostMessageNoise({
+      message: 'Error invoking postMessage: Java object is gone',
+      frames: [{ filename: 'app://navigation_performance_logger_ios' }],
+    }),
+    false,
+  )
+  assert.equal(
+    isAndroidWebViewNativeBridgePostMessageNoise({
+      message: 'Error invoking postMessage: Java object is gone',
+      frames: [{ filename: 'app://navigation_performance_logger_androidx' }],
+    }),
+    false,
+  )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -194,6 +194,47 @@ const OLD_BROWSER_SYNTAX_PARSE_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
   /^Cannot use import statement outside a module$/,
 ];
 
+// Android System WebView native-bridge instrumentation noise. The Android
+// WebView injects a synthetic `app://navigation_performance_logger_android`
+// script that records navigation timing (FBNavResponseStart / FBNavDomContent-
+// Loaded / …) and ships it back to its native Java bridge via
+// `sendDataToNative` → `postMessage`. The bridge holds only a WEAK reference
+// to its Java object, so once that object is garbage-collected — page
+// navigation, WebView teardown, or the host in-app browser (Threads/Barcelona,
+// Facebook, Instagram, …) dismissing the tab — the next `postMessage` throws
+// `Error invoking postMessage: Java object is gone`. This is the WebView's OWN
+// instrumentation, never first-party code: `app://navigation_performance_logger_android`
+// is a synthetic source injected by the System WebView (NOT an `app:///_next/…`
+// bundle frame and NOT a de-minified `apps/web/src/…` frame), and
+// `sendDataToNative` / `sendJsBlockingTimeMessage` are its internal functions.
+// Sentry's `BrowserApiErrors` integration auto-wraps `addEventListener` on
+// `EventTarget`, captures the throw, and leaks it to Better Stack as a global
+// error. Seen once (pattern `e6a45fe4…`, 1 occurrence, 0 identified users,
+// 2026-07-12 19:31:47 UTC) from a Threads (Barcelona) in-app WebView on Android
+// 14 / Chrome 149 visiting the marketing homepage (`https://kortix.com/`,
+// referer `https://l.threads.com/`).
+//
+// The message wording is generic enough that a genuine first-party
+// `window.postMessage` failure could conceivably share it, so — like the
+// stale-webpack-runtime and old-browser-SyntaxError classes — this is anchored
+// on BOTH the exact message AND a frame whose filename is the Android
+// navigation-performance-logger bridge source. A real app `postMessage` error
+// throws inside an `app:///_next/…` chunk (or a de-minified `apps/web/src/…`
+// frame), never from `app://navigation_performance_logger_android`, so it keeps
+// reporting. Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors`
+// list — that gate has no frame context, so a bare-string match there could
+// swallow a real first-party postMessage failure; the frame-aware `beforeSend`
+// hook (which calls `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTMESSAGE_NOISE_MESSAGES = [
+  'Error invoking postMessage: Java object is gone',
+] as const;
+
+const ANDROID_NAV_PERF_LOGGER_FRAME_SOURCE = 'app://navigation_performance_logger_android';
+
+function isAndroidNavPerfLoggerFrame(filename: unknown): boolean {
+  return normalizeString(filename) === ANDROID_NAV_PERF_LOGGER_FRAME_SOURCE;
+}
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -595,6 +636,41 @@ export function isOldBrowserSyntaxParseError(input: {
   return sources.some((filename) => isMinifiedChunkSource(filename));
 }
 
+/**
+ * Whether an event is the Android System WebView native-bridge
+ * `Error invoking postMessage: Java object is gone` noise class: the WebView's
+ * injected `app://navigation_performance_logger_android` script calls
+ * `sendDataToNative` → `postMessage` on a native Java bridge whose object has
+ * been garbage-collected (page navigation / WebView teardown / in-app browser
+ * dismiss). This is the WebView's own instrumentation, not first-party code.
+ * Requires BOTH the exact message AND a frame whose filename is the Android
+ * navigation-performance-logger bridge source, so a genuine first-party
+ * `window.postMessage` failure (which throws from an app chunk or a
+ * de-minified `apps/web/src/…` frame) keeps reporting. Never page Better Stack
+ * for this class. See
+ * `ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTMESSAGE_NOISE_MESSAGES` for the full
+ * rationale.
+ */
+export function isAndroidWebViewNativeBridgePostMessageNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const message = stripErrorWrappers(normalizeString(input.message));
+  if (
+    !ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTMESSAGE_NOISE_MESSAGES.some(
+      (noise) => message === noise,
+    )
+  ) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  return sources.some((filename) => isAndroidNavPerfLoggerFrame(filename));
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -668,6 +744,20 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   // Requires a `_next/static/chunks/` / `?dpl=dpl_…` filename so a real
   // first-party eval/`new Function` SyntaxError keeps reporting.
   if (isOldBrowserSyntaxParseError({ message, filename: input.filename })) {
+    return true;
+  }
+
+  // Android System WebView native-bridge instrumentation noise — the WebView's
+  // injected `app://navigation_performance_logger_android` script
+  // `sendDataToNative` → `postMessage` to a GC'd Java bridge object. Requires
+  // BOTH the exact message AND the Android bridge frame/filename, so a real
+  // first-party `window.postMessage` failure keeps reporting.
+  if (
+    isAndroidWebViewNativeBridgePostMessageNoise({
+      message,
+      filename: input.filename,
+    })
+  ) {
     return true;
   }
 
@@ -783,6 +873,17 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // SyntaxErrors. The `beforeSend` hook (which calls this helper) is the only
   // safe gate because it can anchor on the chunk frame.
   if (isOldBrowserSyntaxParseError({ message, frames })) {
+    return true;
+  }
+
+  // Android System WebView native-bridge instrumentation noise — the WebView's
+  // injected `app://navigation_performance_logger_android` script
+  // `sendDataToNative` → `postMessage` to a GC'd Java bridge object, captured
+  // by Sentry's `BrowserApiErrors` addEventListener auto-wrapper. Requires BOTH
+  // the exact message AND a frame whose filename is the Android bridge source,
+  // so a genuine first-party `window.postMessage` failure keeps reporting. Not
+  // in `ignoreErrors` (no frame context there).
+  if (isAndroidWebViewNativeBridgePostMessageNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Resolves Better Stack error `e6a45fe4999b5a60f5cd64fd4153b18c2beebfc4409a3d54da456a4bbc24e5d2` — *Kortix Frontend (prod)*, application_id `2346967`: **`Error invoking postMessage: Java object is gone`** (1 occurrence / 0 users, first & last seen 2026-07-12 19:31:47 UTC). Call site `app://navigation_performance_logger_android`, function `sendDataToNative`.

**One-line root cause:** Android System WebView's injected `navigation_performance_logger_android` script calls `sendDataToNative` → `postMessage` on a native Java bridge whose backing object has been garbage-collected (page navigation / WebView teardown / the host in-app browser dismissing the tab); Sentry's `BrowserApiErrors` `addEventListener` auto-wrapper captures the throw and leaks it to Better Stack. This is the WebView's own instrumentation — **not first-party code** — so the fix extends the browser noise filter to drop this exact class.

## Evidence (from Better Stack telemetry / raw exception payload)

- **Error page:** https://errors.betterstack.com/team/t502678/errors/e6a45fe4999b5a60f5cd64fd4153b18c2beebfc4409a3d54da456a4bbc24e5d2?s=2346967
- **Metrics row:** pattern `e6a45fe4…`, message `Error invoking postMessage: Java object is gone`, type `Error`, call_site_file `app://navigation_performance_logger_android`, call_site_function `sendDataToNative`, total 1, first/last 2026-07-12 19:31:45 UTC.
- **Raw occurrence (S3):** `dt = 2026-07-12 19:31:47.534`, `environment = prod`, `release = 8c12bb88…`.
  - **URL:** `https://kortix.com/` (marketing homepage)
  - **Referer:** `https://l.threads.com/`
  - **User-Agent:** `Mozilla/5.0 (Linux; Android 14; 22101320G …; wv) … Chrome/149.0.7827.159 Mobile Safari/537.36 Barcelona 438.0.0.17.88 Android …` → the `wv` token = Android **WebView**, the `Barcelona` token = **Threads in-app browser**.
  - **Browser/OS/Device:** Chrome 149 / Android 14 / mobile (Xiaomi/POCO 22101320G), locale `id-ID`, timezone `Asia/Jakarta`.
  - **Capture mechanism:** `auto.browser.browserapierrors.addEventListener`, `handled: false`, target `EventTarget`.
  - **Stack frames (Sentry oldest-first → last is the throwing frame):**
    1. `app:///_next/static/chunks/66499-704f783b0e8ea993.js?dpl=dpl_…` — `u` (Sentry wrapper frame)
    2. `app://navigation_performance_logger_android` — `?`
    3. `app://navigation_performance_logger_android` — `sendJsBlockingTimeMessage`
    4. `app://navigation_performance_logger_android` — `sendDataToNative`  ← **throw**
  - **Breadcrumbs:** the WebView's own `FBNavResponseStart` / `FBNavResponseEnd` / `FBNavDomContentLoaded` / `FBNavFirstContentfulPaint` / `FBNavLargestContentfulPaint` / `FBNavMaxLongtaskMs` navigation-timing log lines immediately precede the throw — confirming the throw originates from the WebView's injected navigation-performance logger, not our code.

A user clicked a Threads link → opened `kortix.com` in the Threads (Barcelona) in-app Android WebView → the Android System WebView's injected `navigation_performance_logger_android` script tried to `postMessage` performance data back to its native Java bridge via `sendDataToNative`, but the Java object had been GC'd (bridge weak ref cleared during navigation/teardown) → threw `Error invoking postMessage: Java object is gone`. `app://navigation_performance_logger_android` is a **synthetic source injected by the System WebView** (not an `app:///_next/…` bundle frame, not a de-minified `apps/web/src/…` frame), and `sendDataToNative` / `sendJsBlockingTimeMessage` are its internal functions. **Confirmed third-party Android WebView native-bridge instrumentation noise.**

## Fix

Extend `apps/web/src/lib/browser-error-noise.ts` with a new noise class `isAndroidWebViewNativeBridgePostMessageNoise`, wired into both capture-path gates (`shouldIgnoreSentryBrowserNoise` — the Sentry `beforeSend` hook, primary; and `shouldIgnoreBrowserRuntimeNoise` — the `window.onerror`/`onunhandledrejection` gate, defense-in-depth).

**Conservative, frame-anchored match** (mirrors the precedent of `isStaleWebpackRuntimeCallNoise` / `isOldBrowserSyntaxParseError`):
- Requires BOTH the **exact** message `Error invoking postMessage: Java object is gone` (after stripping canonical `Unhandled promise rejection: ` / `…Error: ` wrappers) **AND** a frame whose filename is exactly `app://navigation_performance_logger_android`.
- A genuine first-party `window.postMessage` failure throws the same message wording **from an `app:///_next/…` chunk or a de-minified `apps/web/src/…` frame**, never from the Android bridge source → it keeps reporting.
- **Deliberately NOT added** to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party postMessage failure. The frame-aware `beforeSend` hook is the only safe gate.

## Tests

Adds 6 tests to `apps/web/src/lib/browser-error-noise.test.mts` (59 → 65 passing), reproducing the exact production frame chain plus negative guards:
- ✅ classifies the noise (with a bridge frame) — V8 raw + `Unhandled promise rejection:` wrapper
- ✅ suppresses via the Sentry `beforeSend` gate (exact 4-frame production chain)
- ✅ suppresses via the runtime `window.onerror` gate (with the bridge filename)
- ❌ does NOT suppress the message with NO bridge frame (conservative — keep reporting)
- ❌ does NOT suppress a real first-party postMessage failure that throws from an app chunk / de-minified `apps/web/src/…` frame
- ❌ does NOT suppress a same-worded message from a different/sibling bridge source (`…logger_ios`, `…logger_androidx`)

## Verification (local)

- `node --experimental-strip-types --test src/lib/browser-error-noise.test.mts` → **65 pass / 0 fail** (node 22)
- `bun test src/lib/browser-error-noise.test.mts` → **65 pass / 0 fail** (CI parity — `package-tests` runs `bun test`)
- `bun test src/app/sentry-ignore-errors.test.ts` → **4 pass / 0 fail** (untouched, regression-safe)
- `tsc` on `browser-error-noise.ts` under the project's `tsconfig.base.json` strictness (`strict`, `skipLibCheck`, `moduleResolution: bundler`) → **clean** (the `.mts` test is not in the project `include` and is runtime-tested, not typechecked; matches existing pattern)

## Confirmation of resolution

After merge + promote, this exact Better Stack pattern (`e6a45fe4…`) should drop to **zero new occurrences**: any subsequent Threads/Facebook/Instagram in-app Android WebView visit that triggers the GC'd-bridge throw will be dropped at the Sentry `beforeSend` gate before reaching Better Stack. A real first-party `postMessage` regression surfaces as a *different* pattern (message from an app/source frame) and is unaffected.

## Incident reference

- Error id: `e6a45fe4999b5a60f5cd64fd4153b18c2beebfc4409a3d54da456a4bbc24e5d2`
- Error URL: https://errors.betterstack.com/team/t502678/errors/e6a45fe4999b5a60f5cd64fd4153b18c2beebfc4409a3d54da456a4bbc24e5d2?s=2346967
- Application: Kortix Frontend (prod), application_id `2346967`
