### PR TITLE
fix(llm-gateway): avoid stale routing policy reads

### DIFF
--- a/apps/api/src/repositories/project-routing-policies.test.ts
+++ b/apps/api/src/repositories/project-routing-policies.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+
+let selectRows: any[] = [];
+let selectCalls = 0;
+
+function selectChain(): any {
+  const chain: any = {};
+  for (const method of ['from', 'where', 'limit']) chain[method] = () => chain;
+  chain.then = (resolve: (rows: any[]) => unknown) => Promise.resolve(resolve(selectRows));
+  return chain;
+}
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => {
+      selectCalls += 1;
+      return selectChain();
+    },
+  },
+  hasDatabase: () => true,
+}));
+
+const { getProjectRoutingPolicy } = await import('./project-routing-policies');
+
+beforeEach(() => {
+  selectRows = [];
+  selectCalls = 0;
+});
+
+test('reads current routing policy from the shared DB on every request', async () => {
+  selectRows = [];
+  expect(await getProjectRoutingPolicy('multi-replica-project')).toBeNull();
+
+  selectRows = [
+    {
+      visionModel: 'glm-5.2',
+      defaultFallbackModels: ['glm-5.2'],
+      defaultFallbackOn: 'any-error',
+      rules: [],
+    },
+  ];
+  expect(await getProjectRoutingPolicy('multi-replica-project')).toEqual({
+    visionModel: 'glm-5.2',
+    defaultFallback: { models: ['glm-5.2'], fallbackOn: 'any-error' },
+    rules: [],
+  });
+  expect(selectCalls).toBe(2);
+});

--- a/apps/api/src/repositories/project-routing-policies.ts
+++ b/apps/api/src/repositories/project-routing-policies.ts
@@ -13,12 +13,6 @@ export interface StoredProjectRoutingPolicy {
   rules: ProjectRoutingRule[];
 }
 
-const TTL_MS = 30_000;
-const cache = new Map<
-  string,
-  { value: StoredProjectRoutingPolicy | null; expiresAt: number }
->();
-
 function fromRow(
   row: typeof projectLlmRoutingPolicies.$inferSelect,
 ): StoredProjectRoutingPolicy {
@@ -38,20 +32,15 @@ function fromRow(
 export async function getProjectRoutingPolicy(
   projectId: string,
 ): Promise<StoredProjectRoutingPolicy | null> {
-  const cached = cache.get(projectId);
-  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  // Do not process-cache this document. API replicas cannot invalidate each
+  // other's memory, so an immediate read after a write can otherwise return a
+  // stale policy from whichever pod served an earlier request.
   const [row] = await db
     .select()
     .from(projectLlmRoutingPolicies)
     .where(eq(projectLlmRoutingPolicies.projectId, projectId))
     .limit(1);
-  const value = row ? fromRow(row) : null;
-  cache.set(projectId, { value, expiresAt: Date.now() + TTL_MS });
-  return value;
-}
-
-export function invalidateProjectRoutingPolicy(projectId: string): void {
-  cache.delete(projectId);
+  return row ? fromRow(row) : null;
 }
 
 /** Persist the complete project document and its default model atomically. */
@@ -116,7 +105,6 @@ export async function setProjectRoutingPolicy(params: {
         },
       });
   });
-  invalidateProjectRoutingPolicy(params.projectId);
 }
 
 export async function resetProjectRoutingPolicy(params: {
@@ -137,5 +125,4 @@ export async function resetProjectRoutingPolicy(params: {
         ),
       );
   });
-  invalidateProjectRoutingPolicy(params.projectId);
 }


### PR DESCRIPTION
## Root cause
Deployed GW-4 exposed a cross-replica stale read: the routing-policy PUT succeeded on one API pod, then the immediate GET landed on another pod whose 30-second process-local cache still held a prior null policy. The default model appeared because it is stored separately; fallback/rules looked lost until cache expiry.

## Fix
Remove the process-local routing-policy cache and read the small indexed project policy row from the shared DB on every request. This settings path is low-frequency, and replicas have no cross-process invalidation channel.

## Verification
- RED: new repository test returned the cached null policy after changing the shared DB result
- GREEN: repository test 1/1
- API typecheck: pass
- picker tests: 11/11
- local GW-4: 1/1
- deployed failure evidence: tests/test-results/20260713201124-64frn0/report.html