### PR TITLE
fix(snapshots): build missing Daytona templates

### DIFF
--- a/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
   process.env.KORTIX_SNAPSHOT_SLACK_CLI_PATH = slackCliPath;
   process.env.KORTIX_SNAPSHOT_EXECUTOR_SDK_PATH = executorSdkPath;
   process.env.KORTIX_SNAPSHOT_OPENCODE_CONFIG_PATH = opencodeConfigPath;
+  getSnapshotImpl = async () => ({ state: snapshotState() });
 });
 
 let dockerfileSeen = '';
@@ -45,6 +46,7 @@ const contextPaths: string[] = [];
 // Per-test behavior (default: a clean successful build), driven by the tests.
 let createImpl: () => Promise<void> = async () => {};
 let snapshotState: () => string = () => 'active';
+let getSnapshotImpl: () => Promise<{ state: string }> = async () => ({ state: snapshotState() });
 
 mock.module('@daytonaio/sdk', () => ({
   Image: {
@@ -68,7 +70,7 @@ mock.module('../shared/daytona', () => ({
       create: async () => {
         await createImpl();
       },
-      get: async () => ({ state: snapshotState() }),
+      get: async () => getSnapshotImpl(),
       delete: async () => undefined,
     },
   }),
@@ -98,6 +100,29 @@ describe('Daytona snapshot build context', () => {
     expect(dockerfileSeen).toContain('COPY scaffold.git /opt/kortix/scaffold.git');
     expect(scaffoldPresentAtDaytonaBoundary).toBe(true);
     expect(executorNodeModulesPresentAtProviderBoundary).toBe(false);
+  });
+});
+
+describe('Daytona snapshot state', () => {
+  test('reports a Daytona 404 as missing so a new template can be built', async () => {
+    getSnapshotImpl = async () => {
+      throw Object.assign(new Error('Snapshot with name kortix-new-template not found'), {
+        name: 'DaytonaNotFoundError',
+        statusCode: 404,
+      });
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-new-template')).toBe('missing');
+  });
+
+  test('keeps a transient Daytona probe failure unknown', async () => {
+    getSnapshotImpl = async () => {
+      throw Object.assign(new Error('upstream unavailable'), {
+        statusCode: 503,
+      });
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-new-template')).toBe('unknown');
   });
 });
 

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -162,11 +162,13 @@ class DaytonaAdapter implements SandboxProviderAdapter {
         snapshotStateCache.delete(snapshotName);
       }
       return state;
-    } catch {
-      // Error *or* timeout (TimeoutError) → unknown. We never
-      // poison the positive cache here, so the next poll re-checks once Daytona
-      // recovers.
+    } catch (err) {
+      // Daytona represents a missing named snapshot as a 404 exception rather
+      // than `null`. That is definitive provider truth and must be `missing` so
+      // the template coordinator can create it. Transport/timeouts and all
+      // other probe failures remain `unknown` and fail closed.
       snapshotStateCache.delete(snapshotName);
+      if (isDaytonaNotFoundError(err)) return 'missing';
       return 'unknown';
     }
   }
@@ -238,6 +240,26 @@ class DaytonaAdapter implements SandboxProviderAdapter {
     }
     return 'unknown';
   }
+}
+
+function isDaytonaNotFoundError(err: unknown): boolean {
+  const value = err as
+    | {
+        name?: unknown;
+        message?: unknown;
+        statusCode?: unknown;
+        response?: { status?: unknown };
+      }
+    | null
+    | undefined;
+  const status = value?.statusCode ?? value?.response?.status;
+  const name = String(value?.name ?? '').toLowerCase();
+  const message = String(value?.message ?? '').toLowerCase();
+  return (
+    status === 404 ||
+    name === 'daytonanotfounderror' ||
+    (message.includes('snapshot with name') && message.includes('not found'))
+  );
 }
 
 function isTransientDaytonaError(err: unknown): boolean {


### PR DESCRIPTION
## Summary
- classify Daytona SDK 404/not-found snapshot lookups as definitive `missing` provider state
- preserve `unknown` for transient Daytona control-plane failures
- unblock three-provider template synchronization so a never-built Daytona snapshot enters the build path

## Live root-cause evidence
- dev SDK lookup for `kortix-tpl-ed022e1e9f5e` returned `DaytonaNotFoundError`, `statusCode: 404`
- the API log then reported `Cannot verify sandbox image ... on daytona; provider state is unknown` and created no Daytona build row

## Verification
- failing test first: expected `missing`, received `unknown`
- `RECALL_BASE_URL=http://localhost dotenvx run --overload -f .env.dev -- bun test src/__tests__/unit-daytona-snapshot-context.test.ts` — 5 pass
- focused provider/template suite — 48 pass, 0 fail
- `RECALL_BASE_URL=http://localhost dotenvx run --overload -f .env.dev -- bunx tsc --noEmit` — pass
- `git diff --check` — pass