### PR TITLE
fix(enterprise): harden updater CodeQL paths

### DIFF
--- a/apps/enterprise-updater/src/__tests__/installer.test.ts
+++ b/apps/enterprise-updater/src/__tests__/installer.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { MirroredImage } from '../artifacts.ts';
@@ -102,7 +101,8 @@ class InstallerRunner implements CommandRunner {
         resource_changes: [{ address: 'helm_release.runtime', type: 'helm_release', change: { actions: ['update'] } }],
       });
     }
-    if (command === 'curl' && args.some((arg) => arg.includes('api.vpc-demo.kortix.com'))) {
+    const requestUrl = args.at(-1);
+    if (command === 'curl' && requestUrl === 'https://api.vpc-demo.kortix.com/v1/health') {
       return JSON.stringify({ version: this.apiVersion });
     }
     return '';
@@ -217,7 +217,7 @@ function mirroredImages(): MirroredImage[] {
 }
 
 function installerFixture() {
-  const root = mkdtempSync(join(tmpdir(), 'kortix-installer-test-'));
+  const root = mkdtempSync(join(realpathSync(process.cwd()), '.kortix-installer-test-'));
   const events: string[] = [];
   const runner = new InstallerRunner(events);
   const aws = new InstallerAws(events);

--- a/apps/enterprise-updater/src/installer.ts
+++ b/apps/enterprise-updater/src/installer.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
 import { classifyEnterprisePlan } from '../../../infra/terraform/scripts/guard-enterprise-plan.ts';

--- a/apps/enterprise-updater/src/reconciler.ts
+++ b/apps/enterprise-updater/src/reconciler.ts
@@ -1,5 +1,4 @@
 import { mkdirSync } from 'node:fs';
-import { join } from 'node:path';
 
 import { parseCustomerRepositories, verifyAndMirrorImages } from './artifacts.ts';
 import type { AwsControlPlane } from './aws.ts';

--- a/apps/enterprise-updater/src/tuf-repository.ts
+++ b/apps/enterprise-updater/src/tuf-repository.ts
@@ -1,5 +1,13 @@
 import { createHash } from 'node:crypto';
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  constants,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { Updater, type TargetFile } from 'tuf-js';
@@ -31,8 +39,7 @@ export class TrustedRepository {
     mkdirSync(options.targetDir, { recursive: true, mode: 0o700 });
     const root = await downloadPinnedRoot(new URL('metadata/1.root.json', base), options.trustedRootSha256);
     const rootPath = join(options.metadataDir, 'root.json');
-    writeFileSync(rootPath, root, { mode: 0o600 });
-    chmodSync(rootPath, 0o600);
+    writeVerifiedRoot(rootPath, root);
 
     const updater = new Updater({
       metadataDir: options.metadataDir,
@@ -84,6 +91,24 @@ export class TrustedRepository {
     const info = await this.updater.getTargetInfo(path);
     if (!info) throw new Error(`signed TUF target not found: ${path}`);
     return info;
+  }
+}
+
+function writeVerifiedRoot(path: string, bytes: Buffer): void {
+  const descriptor = openSync(
+    path,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    let offset = 0;
+    while (offset < bytes.length) {
+      // lgtm[js/http-to-file-access] Bytes reach this sink only after exact offline-pinned SHA-256 verification; the destination is owner-only, exclusive, and no-follow.
+      offset += writeSync(descriptor, bytes, offset, bytes.length - offset, null);
+    }
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
   }
 }
 


### PR DESCRIPTION
## Summary

- require an exact health URL in the updater transaction test instead of substring matching
- create test bundles under the trusted checkout rather than the shared OS temporary directory
- persist the already SHA-256-pinned TUF root through an exclusive owner-only no-follow file descriptor and fsync it before constructing the TUF client
- remove two unused imports reported by CodeQL

## Verification

- enterprise updater: 33 tests, typecheck, Linux binary build
- enterprise release: 19 tests, typecheck
- git diff check clean

Follow-up to #4619 after the post-merge CodeQL result reported seven changed-line annotations.