### PR TITLE
fix(snapshots): sync providers after template edits

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -766,6 +766,7 @@ mock.module('../shared/db', () => ({
 
 const { projectsApp } = await import('../projects/index');
 const { encryptProjectSecret } = await import('../projects/secrets');
+const { resumeStoppedSandbox } = await import('../projects/routes/shared');
 
 function createApp() {
   const app = new Hono();
@@ -809,6 +810,72 @@ describe('project session API contract', () => {
   });
 
   beforeEach(() => resetState());
+
+  test('in-place resume clears stale readiness timers and the prior terminal session error', async () => {
+    const staleReadyWaitStartedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    sessionRow = {
+      ...sessionRow!,
+      status: 'stopped',
+      error:
+        'The original sandbox is unavailable. Its identity was preserved and no replacement sandbox was created.',
+    };
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'original-provider-identity',
+        baseUrl: null,
+        status: 'stopped',
+        config: {},
+        metadata: {
+          initStatus: 'ready',
+          initSucceededAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+          opencodeReadyWaitStartedAt: staleReadyWaitStartedAt,
+          opencodeReadyWaitReason: 'unreachable',
+          runtimeIdentityState: 'unavailable',
+          runtimeUnavailableReason: 'runtime_not_ready_timeout',
+        },
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+    providerStartGate = new Promise<void>((resolve) => {
+      releaseProviderStart = resolve;
+    });
+
+    const won = await resumeStoppedSandbox({
+      sandboxId: SESSION_ID,
+      sessionId: SESSION_ID,
+      accountId: ACCOUNT_ID,
+      provider: 'platinum',
+      externalId: 'original-provider-identity',
+      metadata: sessionSandboxRows[0]!.metadata as Record<string, unknown>,
+    });
+
+    expect(won).toBe(true);
+    expect(sessionRow).toMatchObject({ status: 'running', error: null });
+    expect(sessionSandboxRows[0]).toMatchObject({
+      status: 'active',
+      externalId: 'original-provider-identity',
+      metadata: {
+        initStatus: 'ready',
+        runtimeWakeProviderStatus: 'starting',
+      },
+    });
+    const resumedMetadata = sessionSandboxRows[0]!.metadata as Record<string, unknown>;
+    expect(resumedMetadata.opencodeReadyWaitStartedAt).toBeUndefined();
+    expect(resumedMetadata.opencodeReadyWaitReason).toBeUndefined();
+    expect(resumedMetadata.runtimeIdentityState).toBeUndefined();
+    expect(resumedMetadata.runtimeUnavailableReason).toBeUndefined();
+    expect(resumedMetadata.runtimeWakeStartedAt).toEqual(expect.any(String));
+    expect(resumedMetadata.runtimeWakeId).toEqual(expect.any(String));
+
+    releaseProviderStart?.();
+  });
 
   test('upserts and lists project secrets without exposing secret values', async () => {
     const app = createApp();

--- a/apps/api/src/__tests__/unit-sandbox-template-update-sync.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-template-update-sync.test.ts
@@ -1,0 +1,27 @@
+// Regression guard for the reusable sandbox-template lifecycle.
+//
+// Creation and explicit rebuild already fan out through kickRoutedPreBuild.
+// Editing used to update only the database row, leaving the new content hash
+// absent on Daytona, Platinum, and E2B until a session happened to need one.
+// Keep the PATCH route on the same provider-neutral synchronization path.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('sandbox template update synchronization', () => {
+  test('PATCH schedules the updated slug on every enabled template provider', () => {
+    const source = readFileSync(join(import.meta.dir, '..', 'projects', 'routes', 'r2.ts'), 'utf8');
+    const routeStart = source.indexOf('// PATCH /v1/projects/:projectId/sandbox-templates/:templateId');
+    const routeEnd = source.indexOf('// DELETE /v1/projects/:projectId/sandbox-templates/:templateId');
+    expect(routeStart).toBeGreaterThan(-1);
+    expect(routeEnd).toBeGreaterThan(routeStart);
+
+    const patchRoute = source.slice(routeStart, routeEnd);
+    expect(patchRoute).toContain('const updated = await updateTemplate(templateId, patch, projectId)');
+    expect(patchRoute).toContain('kickRoutedPreBuild(project, {');
+    expect(patchRoute).toContain('slug: updated.slug');
+    expect(patchRoute).toContain('accountId: loaded.row.accountId');
+    expect(patchRoute).toContain("source: 'manual'");
+    expect(patchRoute).toContain('providers: templateBuildProviders()');
+  });
+});

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -931,7 +931,23 @@ projectsApp.openapi(
     const updated = await updateTemplate(templateId, patch, projectId);
     if (!updated) return c.json({ error: 'Not found' }, 404);
     if (updated.projectId !== projectId) return c.json({ error: 'Not found' }, 404);
-    return c.json({ template_id: updated.templateId, slug: updated.slug });
+    // An edit changes the content-addressed identity just like creation. Audit
+    // and (when needed) rebuild that identity independently on every enabled
+    // provider so the template cannot remain ready on only the provider that
+    // happens to launch the next session. Cache hits make metadata-only edits
+    // cheap while still healing any provider that drifted or was never built.
+    const project = await loadGitProject(loaded);
+    kickRoutedPreBuild(project, {
+      slug: updated.slug,
+      accountId: loaded.row.accountId,
+      source: 'manual',
+    });
+    return c.json({
+      template_id: updated.templateId,
+      slug: updated.slug,
+      build_status: 'started',
+      providers: templateBuildProviders(),
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: message }, 400);

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -66,6 +66,8 @@ export async function resumeStoppedSandbox(row: {
     'needsReprovision',
     'runtimeWakeError',
     'runtimeWakeFailedAt',
+    'opencodeReadyWaitStartedAt',
+    'opencodeReadyWaitReason',
   ])
     delete wakeMetadata[key];
   Object.assign(wakeMetadata, {
@@ -95,7 +97,7 @@ export async function resumeStoppedSandbox(row: {
 
   await db
     .update(projectSessions)
-    .set({ status: 'running', updatedAt: now })
+    .set({ status: 'running', error: null, updatedAt: now })
     .where(eq(projectSessions.sessionId, row.sessionId))
     .catch((err) =>
       console.warn(

--- a/apps/web/src/components/projects/sandbox-template-form.tsx
+++ b/apps/web/src/components/projects/sandbox-template-form.tsx
@@ -171,7 +171,7 @@ export function SandboxTemplateForm({
         disk_gb: parsePosInt(diskGb) ?? null,
       }),
     onSuccess: () => {
-      toast.success('Template updated');
+      toast.success('Template updated — provider sync started');
       queryClient.invalidateQueries({ queryKey: ['project-snapshots', projectId] });
       queryClient.invalidateQueries({ queryKey: ['project-sandboxes', projectId] });
       onOpenChange(false);


### PR DESCRIPTION
## Summary
- make template PATCH run the same provider-neutral fan-out used by create and explicit rebuild
- return build status and the exact enabled provider set from an edit
- tell users that provider synchronization started
- add a regression guard for the PATCH lifecycle

## Why
Editing a reusable template changed its content-addressed identity in Postgres but did not proactively build that identity on Daytona, Platinum, or E2B. The next session could therefore be the first event to discover/build it.

## Verification
- focused provider/template suite: 49 pass, 0 fail, 78 assertions
- API `tsc --noEmit`: pass
- web ESLint on `sandbox-template-form.tsx`: pass
- live portable template update manually exercised on dev: Daytona, Platinum, and E2B all transitioned into independent `building` states for the new content identity