### PR TITLE
fix(snapshots): surface sandbox provider status

### DIFF
--- a/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
@@ -1,8 +1,27 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { chmod, mkdir, symlink } from 'node:fs/promises';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('ALLOWED_SANDBOX_PROVIDERS', 'daytona');
+setTestEnv('DAYTONA_API_KEY', 'test-daytona-key');
+setTestEnv('DAYTONA_SERVER_URL', 'https://daytona.example.test');
+setTestEnv('DAYTONA_TARGET', 'test-target');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+setTestEnv('RECALL_BASE_URL', 'https://us-west-2.recall.ai/api/v1');
 
 const fixtureRoot = mkdtempSync(join(tmpdir(), 'kortix-daytona-context-test-'));
 const agentPath = join(fixtureRoot, 'kortix-agent');
@@ -21,7 +40,10 @@ await chmod(entrypointPath, 0o755);
 await mkdir(slackCliPath, { recursive: true });
 await mkdir(executorSdkPath, { recursive: true });
 await mkdir(join(executorSdkPath, 'node_modules'), { recursive: true });
-await symlink('/definitely-not-present/typescript', join(executorSdkPath, 'node_modules', 'typescript'));
+await symlink(
+  '/definitely-not-present/typescript',
+  join(executorSdkPath, 'node_modules', 'typescript'),
+);
 await mkdir(opencodeConfigPath, { recursive: true });
 
 // Set per-test (NOT at module load): build-context reads these lazily, so setting
@@ -35,6 +57,7 @@ beforeEach(() => {
   process.env.KORTIX_SNAPSHOT_EXECUTOR_SDK_PATH = executorSdkPath;
   process.env.KORTIX_SNAPSHOT_OPENCODE_CONFIG_PATH = opencodeConfigPath;
   getSnapshotImpl = async () => ({ state: snapshotState() });
+  deleteSnapshotImpl = async () => {};
 });
 
 let dockerfileSeen = '';
@@ -47,6 +70,7 @@ const contextPaths: string[] = [];
 let createImpl: () => Promise<void> = async () => {};
 let snapshotState: () => string = () => 'active';
 let getSnapshotImpl: () => Promise<{ state: string }> = async () => ({ state: snapshotState() });
+let deleteSnapshotImpl: (snapshot: { state: string }) => Promise<void> = async () => {};
 
 mock.module('@daytonaio/sdk', () => ({
   Image: {
@@ -71,7 +95,7 @@ mock.module('../shared/daytona', () => ({
         await createImpl();
       },
       get: async () => getSnapshotImpl(),
-      delete: async () => undefined,
+      delete: async (snapshot: { state: string }) => deleteSnapshotImpl(snapshot),
     },
   }),
   isDaytonaConfigured: () => true,
@@ -123,6 +147,70 @@ describe('Daytona snapshot state', () => {
     };
 
     expect(await daytonaProvider.getSnapshotState('kortix-new-template')).toBe('unknown');
+  });
+
+  test('keeps a timed-out Daytona probe unknown', async () => {
+    getSnapshotImpl = async () => {
+      throw new Error('Daytona snapshot.get(kortix-timeout-template) timed out');
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-timeout-template')).toBe('unknown');
+  });
+
+  test('suppresses confirmed not-found delete errors and invalidates cached active state', async () => {
+    let getCalls = 0;
+    getSnapshotImpl = async () => {
+      getCalls += 1;
+      return { state: 'active' };
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-delete-missing')).toBe('active');
+
+    deleteSnapshotImpl = async () => {
+      throw Object.assign(new Error('Snapshot with name kortix-delete-missing not found'), {
+        response: { status: 404 },
+      });
+    };
+
+    await daytonaProvider.deleteSnapshot('kortix-delete-missing');
+
+    getSnapshotImpl = async () => {
+      getCalls += 1;
+      throw Object.assign(new Error('Snapshot with name kortix-delete-missing not found'), {
+        statusCode: 404,
+      });
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-delete-missing')).toBe('missing');
+    expect(getCalls).toBe(3);
+  });
+
+  test('propagates Daytona delete outages but still invalidates cached active state', async () => {
+    let getCalls = 0;
+    getSnapshotImpl = async () => {
+      getCalls += 1;
+      return { state: 'active' };
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-delete-outage')).toBe('active');
+
+    deleteSnapshotImpl = async () => {
+      throw Object.assign(new Error('upstream unavailable'), { statusCode: 503 });
+    };
+
+    await expect(daytonaProvider.deleteSnapshot('kortix-delete-outage')).rejects.toThrow(
+      'upstream unavailable',
+    );
+
+    getSnapshotImpl = async () => {
+      getCalls += 1;
+      throw Object.assign(new Error('Snapshot with name kortix-delete-outage not found'), {
+        statusCode: 404,
+      });
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-delete-outage')).toBe('missing');
+    expect(getCalls).toBe(3);
   });
 });
 

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -1,6 +1,6 @@
 import { ACCOUNT_ACTIONS, PROJECT_ACTIONS, assertAuthorized } from '../../iam';
 import { auth, errors, json } from '../../openapi';
-import { DEFAULT_SANDBOX_SLUG, deleteSandboxImage, kickProjectTemplatePrebuilds, kickRoutedPreBuild, listSandboxTemplates, listSnapshotBuilds, reconcileStaleBuilds, templateBuildProviders } from '../../snapshots/builder';
+import { DEFAULT_SANDBOX_SLUG, deleteSandboxImage, kickPreBuild, kickProjectTemplatePrebuilds, kickRoutedPreBuild, listSandboxTemplates, listSnapshotBuilds, reconcileStaleBuilds, templateBuildProviders } from '../../snapshots/builder';
 import { currentFailedSnapshotBuild } from '../../snapshots/build-state';
 import { classifySnapshotError, describeSnapshotError } from '../../snapshots/error-classify';
 import { withTimeout } from '../../shared/with-timeout';
@@ -17,12 +17,12 @@ import { deriveProjectName, isRepoNameTakenError, normalizeString, readBody, req
 import { createProjectSession, sendSessionCreateError } from '../lib/sessions';
 import { resolveManifestValidateFormat } from '../lib/manifest-format';
 import { config } from '../../config';
-import { resolveUsableProjectProviderPin } from '../../snapshots/provider-coverage';
+import { resolveConfiguredProjectProviderPin } from '../../snapshots/provider-coverage';
+import { runProviderActions } from '../../snapshots/provider-actions';
 
 function templateProviderObservation(metadata: unknown) {
-  const selectedProvider = resolveUsableProjectProviderPin(
+  const selectedProvider = resolveConfiguredProjectProviderPin(
     metadata && typeof metadata === 'object' ? metadata as Record<string, unknown> : null,
-    (provider) => config.isProviderEnabled(provider),
   );
   return {
     selectedProvider,
@@ -578,7 +578,7 @@ projectsApp.openapi(
       },
     responses: {
         202: json(z.any(), 'OK'),
-        ...errors(404, 502),
+        ...errors(404, 502, 503),
     },
   }),
   async (c: any) => {
@@ -602,25 +602,42 @@ projectsApp.openapi(
   const slug = slugRaw ? String(slugRaw).trim() : undefined;
 
   const project = await loadGitProject(loaded);
+  const providers = templateBuildProviders();
+  if (providers.length === 0) {
+    return c.json({ error: 'No sandbox template provider is enabled' }, 503);
+  }
   try {
-    const providers = templateBuildProviders();
-    if (providers.length === 0) throw new Error('No sandbox template provider is enabled');
-    const deleted = await Promise.all(
-      providers.map((provider) => deleteSandboxImage(project, { slug, provider })),
+    const attempts = await runProviderActions(
+      providers,
+      async (provider) => {
+        const deleted = await deleteSandboxImage(project, { slug, provider });
+        kickPreBuild(project, {
+          slug: deleted.slug,
+          accountId: loaded.row.accountId,
+          source: 'manual',
+          provider,
+        });
+        return deleted;
+      },
     );
-    const target = deleted[0]!;
-    kickRoutedPreBuild(project, {
-      slug: target.slug,
-      accountId: loaded.row.accountId,
-      source: 'manual',
-    });
+    const notFound = attempts.failed.find(
+      (failure) => failure.error instanceof TemplateNotFoundError,
+    );
+    if (notFound?.error instanceof TemplateNotFoundError) {
+      return c.json({ error: notFound.error.message, code: 'TEMPLATE_NOT_FOUND' }, 404);
+    }
+    if (attempts.started.length === 0) {
+      return c.json({ error: 'Could not start a rebuild on any sandbox provider' }, 503);
+    }
+    const target = attempts.started[0]!.result;
     return c.json(
       {
         status: 'started',
         slug: target.slug,
-        deleted_existing: deleted.some((item) => item.deleted),
+        deleted_existing: attempts.started.some((item) => item.result.deleted),
         snapshot_name: target.snapshotName,
-        providers,
+        providers: attempts.started.map((item) => item.provider),
+        failed_providers: attempts.failed.map((item) => item.provider),
       },
       202,
     );
@@ -803,7 +820,7 @@ projectsApp.openapi(
       },
     responses: {
         201: json(SandboxTemplateSchema, 'The created sandbox template'),
-        ...errors(400, 404, 409),
+        ...errors(400, 404, 409, 503),
     },
   }),
   async (c: any) => {
@@ -840,6 +857,9 @@ projectsApp.openapi(
   const cpu = typeof body.cpu === 'number' ? body.cpu : undefined;
   const memoryGb = typeof body.memory_gb === 'number' ? body.memory_gb : undefined;
   const diskGb = typeof body.disk_gb === 'number' ? body.disk_gb : undefined;
+  if (templateBuildProviders().length === 0) {
+    return c.json({ error: 'No sandbox template provider is enabled' }, 503);
+  }
 
   try {
     const row = await createTemplate({

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -33,7 +33,7 @@ projectsApp.openapi(
       },
     responses: {
         202: json(z.any(), 'OK'),
-        ...errors(404),
+        ...errors(404, 503),
     },
   }),
   async (c: any) => {
@@ -53,6 +53,10 @@ projectsApp.openapi(
   }
 
   const project = await loadGitProject(loaded);
+  const providers = templateBuildProviders();
+  if (providers.length === 0) {
+    return c.json({ error: 'No sandbox template provider is enabled' }, 503);
+  }
   kickRoutedPreBuild(project, {
     slug: row.slug,
     accountId: loaded.row.accountId,
@@ -62,7 +66,7 @@ projectsApp.openapi(
     status: 'started',
     template_id: row.templateId,
     slug: row.slug,
-    providers: templateBuildProviders(),
+    providers,
   }, 202);
 },
 );

--- a/apps/api/src/snapshots/builder-provider-dedupe.test.ts
+++ b/apps/api/src/snapshots/builder-provider-dedupe.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from 'bun:test';
-import { backgroundBuildKey, buildLogProviderCandidates, waitForProviderBuild } from './builder';
+import {
+  backgroundBuildKey,
+  buildLogProviderCandidates,
+  shouldReconcileProviderState,
+  waitForProviderBuild,
+} from './builder';
 
 test('background snapshot build dedup is provider-qualified', () => {
   expect(backgroundBuildKey('daytona', 'kortix-default-abc')).not.toBe(
@@ -17,11 +22,24 @@ test('new snapshot build logs reconcile only against their recorded provider', (
   )).toEqual(['e2b']);
 });
 
-test('historical build logs reconcile against every enabled provider', () => {
+test('historical and unknown build logs remain unattributed', () => {
   expect(buildLogProviderCandidates(
     { source: 'background', slug: 'default-warm' },
     ['daytona', 'platinum', 'e2b', 'e2b'],
-  )).toEqual(['daytona', 'platinum', 'e2b']);
+  )).toEqual([]);
+  expect(buildLogProviderCandidates(
+    { source: 'manual', provider: 'managed' },
+    ['daytona', 'platinum', 'e2b'],
+  )).toEqual([]);
+});
+
+test('project reconciliation never turns an observation outage into a rebuild', () => {
+  expect(shouldReconcileProviderState('unknown')).toBe(false);
+  expect(shouldReconcileProviderState('active')).toBe(false);
+  expect(shouldReconcileProviderState('building')).toBe(false);
+  expect(shouldReconcileProviderState('removing')).toBe(false);
+  expect(shouldReconcileProviderState('missing')).toBe(true);
+  expect(shouldReconcileProviderState('build_failed')).toBe(true);
 });
 
 test('a second replica waits for an existing provider build instead of starting a duplicate', async () => {

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -684,7 +684,7 @@ export async function reconcileStaleBuilds(
       try {
         return { provider: provider.id, state: await provider.getSnapshotState(row.snapshotName) };
       } catch {
-        return { provider: provider.id, state: 'missing' as ProviderState };
+        return { provider: provider.id, state: 'unknown' as ProviderState };
       }
     }));
     if (states.some(({ state }) => state === 'active')) {
@@ -708,8 +708,9 @@ export async function reconcileStaleBuilds(
 
 /**
  * New build rows record the exact provider in metadata. Historical rows do not,
- * so reconcile them against every provider enabled in this environment instead
- * of assuming Daytona.
+ * and multi-provider builds predate this provenance, so legacy rows remain
+ * unresolved instead of being guessed as Daytona or whichever provider happens
+ * to be enabled today.
  */
 export function buildLogProviderCandidates(
   metadata: unknown,
@@ -718,9 +719,14 @@ export function buildLogProviderCandidates(
   const provider = metadata && typeof metadata === 'object'
     ? (metadata as Record<string, unknown>).provider
     : null;
-  return typeof provider === 'string' && provider.trim()
+  return typeof provider === 'string' && allowedProviders.includes(provider)
     ? [provider]
-    : [...new Set(allowedProviders)];
+    : [];
+}
+
+/** Reconcile only when provider truth confirms the current image needs a build. */
+export function shouldReconcileProviderState(state: ProviderState): boolean {
+  return state === 'missing' || state === 'build_failed';
 }
 
 async function openBuildLog(args: {
@@ -1047,7 +1053,8 @@ async function reconcileProjectTemplates(
     }
     for (const providerId of providers) {
       const provider = getSandboxProvider(providerId);
-      if ((await provider.getSnapshotState(identity.snapshotName)) === 'active') continue;
+      const state = await provider.getSnapshotState(identity.snapshotName);
+      if (!shouldReconcileProviderState(state)) continue;
       kickPreBuild(project, {
         slug: t.slug,
         accountId: opts.accountId,

--- a/apps/api/src/snapshots/observation-cache.test.ts
+++ b/apps/api/src/snapshots/observation-cache.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { shortLivedObservation } from './observation-cache';
+
+describe('provider catalog observation cache', () => {
+  test('deduplicates concurrent reads and briefly reuses the result', async () => {
+    let calls = 0;
+    const observe = shortLivedObservation(async () => {
+      calls += 1;
+      await Promise.resolve();
+      return ['template-a', 'template-b'];
+    });
+
+    const [first, second] = await Promise.all([observe(), observe()]);
+    expect(first).toEqual(second);
+    expect(await observe()).toEqual(first);
+    expect(calls).toBe(1);
+  });
+
+  test('never caches a failed provider read', async () => {
+    let calls = 0;
+    const observe = shortLivedObservation(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('temporary failure');
+      return ['recovered'];
+    });
+
+    await expect(observe()).rejects.toThrow('temporary failure');
+    expect(await observe()).toEqual(['recovered']);
+    expect(calls).toBe(2);
+  });
+
+  test('invalidation prevents an older in-flight read from restoring stale data', async () => {
+    let calls = 0;
+    let resolveStale!: (value: string[]) => void;
+    const staleResult = new Promise<string[]>((resolve) => {
+      resolveStale = resolve;
+    });
+    const observe = shortLivedObservation(async () => {
+      calls += 1;
+      return calls === 1 ? staleResult : ['fresh'];
+    });
+
+    const stale = observe();
+    observe.invalidate();
+    expect(await observe()).toEqual(['fresh']);
+    resolveStale(['stale']);
+    expect(await stale).toEqual(['stale']);
+    expect(await observe()).toEqual(['fresh']);
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/api/src/snapshots/observation-cache.ts
+++ b/apps/api/src/snapshots/observation-cache.ts
@@ -1,0 +1,42 @@
+export interface InvalidatableObservation<T> {
+  (): Promise<T>;
+  /** Drop cached/in-flight observations after a provider-side mutation. */
+  invalidate(): void;
+}
+
+/** Collapse concurrent provider catalog reads and briefly reuse a confirmed result. */
+export function shortLivedObservation<T>(
+  observe: () => Promise<T>,
+  ttlMs = 2_000,
+  shouldCache: (value: T) => boolean = () => true,
+): InvalidatableObservation<T> {
+  let cached: { value: T; expiresAt: number } | null = null;
+  let generation = 0;
+  let inflight: { generation: number; promise: Promise<T> } | null = null;
+
+  const observation = async (): Promise<T> => {
+    if (cached && Date.now() < cached.expiresAt) return cached.value;
+    if (inflight?.generation === generation) return inflight.promise;
+
+    const observationGeneration = generation;
+    const promise = observe()
+      .then((value) => {
+        if (generation === observationGeneration && shouldCache(value)) {
+          cached = { value, expiresAt: Date.now() + ttlMs };
+        }
+        return value;
+      })
+      .finally(() => {
+        if (inflight?.promise === promise) inflight = null;
+      });
+    inflight = { generation: observationGeneration, promise };
+    return promise;
+  };
+
+  observation.invalidate = () => {
+    generation += 1;
+    cached = null;
+    inflight = null;
+  };
+  return observation;
+}

--- a/apps/api/src/snapshots/provider-actions.test.ts
+++ b/apps/api/src/snapshots/provider-actions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { runProviderActions } from './provider-actions';
+
+describe('provider action fan-out', () => {
+  test('keeps healthy providers moving when a sibling fails', async () => {
+    const result = await runProviderActions(
+      ['daytona', 'platinum', 'e2b'] as const,
+      async (provider) => {
+        if (provider === 'platinum') throw new Error('provider unavailable');
+        return `${provider}-started`;
+      },
+    );
+
+    expect(result.started).toEqual([
+      { provider: 'daytona', result: 'daytona-started' },
+      { provider: 'e2b', result: 'e2b-started' },
+    ]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.provider).toBe('platinum');
+    expect(result.failed[0]?.error).toBeInstanceOf(Error);
+    expect((result.failed[0]?.error as Error).message).toBe('provider unavailable');
+  });
+});

--- a/apps/api/src/snapshots/provider-actions.ts
+++ b/apps/api/src/snapshots/provider-actions.ts
@@ -5,15 +5,23 @@ export async function runProviderActions<TProvider extends string, TResult>(
   started: Array<{ provider: TProvider; result: TResult }>;
   failed: Array<{ provider: TProvider; error: unknown }>;
 }> {
-  const attempts = await Promise.allSettled(
-    providers.map(async (provider) => ({ provider, result: await action(provider) })),
+  const attempts = await Promise.all(
+    providers.map(async (provider) => {
+      try {
+        return { provider, result: await action(provider), status: 'fulfilled' as const };
+      } catch (error) {
+        return { provider, error, status: 'rejected' as const };
+      }
+    }),
   );
   return {
     started: attempts.flatMap((attempt) =>
-      attempt.status === 'fulfilled' ? [attempt.value] : []),
-    failed: attempts.flatMap((attempt, index) =>
-      attempt.status === 'rejected'
-        ? [{ provider: providers[index]!, error: attempt.reason }]
-        : []),
+      attempt.status === 'fulfilled'
+        ? [{ provider: attempt.provider, result: attempt.result }]
+        : [],
+    ),
+    failed: attempts.flatMap((attempt) =>
+      attempt.status === 'rejected' ? [{ provider: attempt.provider, error: attempt.error }] : [],
+    ),
   };
 }

--- a/apps/api/src/snapshots/provider-actions.ts
+++ b/apps/api/src/snapshots/provider-actions.ts
@@ -1,0 +1,19 @@
+export async function runProviderActions<TProvider extends string, TResult>(
+  providers: readonly TProvider[],
+  action: (provider: TProvider) => Promise<TResult>,
+): Promise<{
+  started: Array<{ provider: TProvider; result: TResult }>;
+  failed: Array<{ provider: TProvider; error: unknown }>;
+}> {
+  const attempts = await Promise.allSettled(
+    providers.map(async (provider) => ({ provider, result: await action(provider) })),
+  );
+  return {
+    started: attempts.flatMap((attempt) =>
+      attempt.status === 'fulfilled' ? [attempt.value] : []),
+    failed: attempts.flatMap((attempt, index) =>
+      attempt.status === 'rejected'
+        ? [{ provider: providers[index]!, error: attempt.reason }]
+        : []),
+  };
+}

--- a/apps/api/src/snapshots/provider-coverage.test.ts
+++ b/apps/api/src/snapshots/provider-coverage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   enabledTemplateBuildProviders,
   observeTemplateProviderCoverage,
+  resolveConfiguredProjectProviderPin,
   resolveRoutedTemplateState,
   resolveUsableProjectProviderPin,
 } from './provider-coverage';
@@ -83,6 +84,21 @@ describe('sandbox template provider coverage', () => {
     expect(result.every((item) => item.state === null)).toBe(true);
   });
 
+  test('bounds a hung provider observation and reports unknown', async () => {
+    const result = await observeTemplateProviderCoverage('snapshot', {
+      isProviderEnabled: (provider) => provider === 'daytona',
+      getProvider: () => ({ getSnapshotState: () => new Promise(() => {}) }),
+      now: () => new Date('2026-07-13T12:00:00.000Z'),
+      observationTimeoutMs: 5,
+    });
+
+    expect(result.find((item) => item.provider === 'daytona')).toMatchObject({
+      status: 'unknown',
+      state: null,
+      launch_ready: false,
+    });
+  });
+
   test('only treats a usable explicit project pin as pinned', () => {
     const enabled = (provider: string) => provider !== 'e2b';
     expect(resolveUsableProjectProviderPin({}, enabled)).toBeNull();
@@ -92,5 +108,15 @@ describe('sandbox template provider coverage', () => {
       .toBeNull();
     expect(resolveUsableProjectProviderPin({ default_sandbox_provider: 'bogus' }, enabled))
       .toBeNull();
+  });
+
+  test('retains a valid configured pin for presentation while unavailable', () => {
+    expect(resolveConfiguredProjectProviderPin({ default_sandbox_provider: 'e2b' }))
+      .toBe('e2b');
+    expect(resolveConfiguredProjectProviderPin({ default_sandbox_provider: 'managed' }))
+      .toBeNull();
+    expect(resolveRoutedTemplateState([
+      { provider: 'e2b', available: false, state: null },
+    ], 'e2b')).toBe('unknown');
   });
 });

--- a/apps/api/src/snapshots/provider-coverage.ts
+++ b/apps/api/src/snapshots/provider-coverage.ts
@@ -26,6 +26,26 @@ export interface ProviderCoverageDependencies {
   isProviderEnabled: (provider: SandboxTemplateProvider) => boolean;
   getProvider: (provider: SandboxTemplateProvider) => Pick<SandboxProviderAdapter, 'getSnapshotState'>;
   now: () => Date;
+  observationTimeoutMs?: number;
+}
+
+export const PROVIDER_COVERAGE_OBSERVATION_TIMEOUT_MS = 5_000;
+
+async function withObservationTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Provider observation timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**
@@ -83,7 +103,10 @@ export async function observeTemplateProviderCoverage(
       }
 
       try {
-        const state = await dependencies.getProvider(provider).getSnapshotState(snapshotName);
+        const state = await withObservationTimeout(
+          dependencies.getProvider(provider).getSnapshotState(snapshotName),
+          dependencies.observationTimeoutMs ?? PROVIDER_COVERAGE_OBSERVATION_TIMEOUT_MS,
+        );
         return {
           provider,
           available: true,
@@ -120,8 +143,9 @@ export function resolveRoutedTemplateState(
   selectedProvider: SandboxTemplateProvider | null,
 ): ProviderState {
   if (selectedProvider) {
-    return coverage.find((item) => item.provider === selectedProvider && item.available)?.state
-      ?? 'missing';
+    const selected = coverage.find((item) => item.provider === selectedProvider);
+    if (!selected || !selected.available) return 'unknown';
+    return selected.state ?? 'unknown';
   }
 
   const states = coverage.filter((item) => item.available).map((item) => item.state);
@@ -139,13 +163,17 @@ export function resolveUsableProjectProviderPin(
   metadata: Record<string, unknown> | null | undefined,
   isProviderEnabled: (provider: SandboxProviderName) => boolean,
 ): SandboxTemplateProvider | null {
+  const provider = resolveConfiguredProjectProviderPin(metadata);
+  return provider && isProviderEnabled(provider) ? provider : null;
+}
+
+/** A valid project pin remains visible even while that provider is unavailable. */
+export function resolveConfiguredProjectProviderPin(
+  metadata: Record<string, unknown> | null | undefined,
+): SandboxTemplateProvider | null {
   const raw = metadata?.default_sandbox_provider;
-  if (
-    typeof raw !== 'string' ||
-    !SANDBOX_TEMPLATE_PROVIDERS.includes(raw as SandboxTemplateProvider)
-  ) {
-    return null;
-  }
-  const provider = raw as SandboxTemplateProvider;
-  return isProviderEnabled(provider) ? provider : null;
+  return typeof raw === 'string' &&
+    SANDBOX_TEMPLATE_PROVIDERS.includes(raw as SandboxTemplateProvider)
+    ? raw as SandboxTemplateProvider
+    : null;
 }

--- a/apps/api/src/snapshots/providers/daytona-errors.test.ts
+++ b/apps/api/src/snapshots/providers/daytona-errors.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'bun:test';
+import { isDaytonaSnapshotNotFoundError } from './daytona';
+
+test('Daytona delete only suppresses confirmed not-found errors', () => {
+  expect(isDaytonaSnapshotNotFoundError(Object.assign(new Error('missing'), { statusCode: 404 })))
+    .toBe(true);
+  expect(isDaytonaSnapshotNotFoundError(new Error('Snapshot with name x not found')))
+    .toBe(true);
+  expect(isDaytonaSnapshotNotFoundError(new Error('Daytona snapshot.get(x) timed out')))
+    .toBe(false);
+  expect(isDaytonaSnapshotNotFoundError(Object.assign(new Error('upstream failed'), { statusCode: 503 })))
+    .toBe(false);
+});

--- a/apps/api/src/snapshots/providers/daytona-errors.test.ts
+++ b/apps/api/src/snapshots/providers/daytona-errors.test.ts
@@ -1,13 +1,47 @@
-import { expect, test } from 'bun:test';
-import { isDaytonaSnapshotNotFoundError } from './daytona';
+import { describe, expect, test } from 'bun:test';
 
-test('Daytona delete only suppresses confirmed not-found errors', () => {
-  expect(isDaytonaSnapshotNotFoundError(Object.assign(new Error('missing'), { statusCode: 404 })))
-    .toBe(true);
-  expect(isDaytonaSnapshotNotFoundError(new Error('Snapshot with name x not found')))
-    .toBe(true);
-  expect(isDaytonaSnapshotNotFoundError(new Error('Daytona snapshot.get(x) timed out')))
-    .toBe(false);
-  expect(isDaytonaSnapshotNotFoundError(Object.assign(new Error('upstream failed'), { statusCode: 503 })))
-    .toBe(false);
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('ALLOWED_SANDBOX_PROVIDERS', 'daytona');
+setTestEnv('DAYTONA_API_KEY', 'test-daytona-key');
+setTestEnv('DAYTONA_SERVER_URL', 'https://daytona.example.test');
+setTestEnv('DAYTONA_TARGET', 'test-target');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+setTestEnv('RECALL_BASE_URL', 'https://us-west-2.recall.ai/api/v1');
+
+const { isDaytonaSnapshotNotFoundError } = await import('./daytona');
+
+describe('Daytona snapshot not-found classifier', () => {
+  test.each([
+    ['statusCode 404', Object.assign(new Error('missing'), { statusCode: 404 })],
+    ['response.status 404', Object.assign(new Error('missing'), { response: { status: 404 } })],
+    ['direct status 404', Object.assign(new Error('missing'), { status: 404 })],
+    ['numeric code 404', Object.assign(new Error('missing'), { code: 404 })],
+    [
+      'DaytonaNotFoundError name case-insensitively',
+      Object.assign(new Error('missing'), { name: 'dAyToNaNoTfOuNdErRoR' }),
+    ],
+    ['precise snapshot-with-name message', new Error('Snapshot with name x not found')],
+  ])('recognizes %s', (_label, err) => {
+    expect(isDaytonaSnapshotNotFoundError(err)).toBe(true);
+  });
+
+  test.each([
+    ['timeout', new Error('Daytona snapshot.get(x) timed out')],
+    ['503', Object.assign(new Error('upstream failed'), { statusCode: 503 })],
+    ['generic not-found text', new Error('repository not found')],
+    ['imprecise snapshot text', new Error('snapshot lookup not found')],
+  ])('rejects %s as an unconfirmed not-found', (_label, err) => {
+    expect(isDaytonaSnapshotNotFoundError(err)).toBe(false);
+  });
 });

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -12,6 +12,7 @@ import { rm } from 'node:fs/promises';
 import { Image } from '@daytonaio/sdk';
 import { getDaytona, isDaytonaConfigured, listDaytonaSnapshots } from '../../shared/daytona';
 import { withTimeout } from '../../shared/with-timeout';
+import { shortLivedObservation, type InvalidatableObservation } from '../observation-cache';
 import {
   stageBuildContext,
   DEFAULT_CPU,
@@ -49,7 +50,38 @@ const SNAPSHOT_STATE_CACHE_TTL_MS = 60_000;
  * if several templates are checked back-to-back.
  */
 const SNAPSHOT_STATE_TIMEOUT_MS = 8_000;
-const snapshotStateCache = new Map<string, { state: ProviderState; expiresAt: number }>();
+const snapshotStateObservations = new Map<string, InvalidatableObservation<ProviderState>>();
+
+function invalidateSnapshotState(snapshotName: string): void {
+  snapshotStateObservations.get(snapshotName)?.invalidate();
+  snapshotStateObservations.delete(snapshotName);
+}
+
+function observeSnapshotState(snapshotName: string): InvalidatableObservation<ProviderState> {
+  const existing = snapshotStateObservations.get(snapshotName);
+  if (existing) return existing;
+  const observation = shortLivedObservation(
+    async (): Promise<ProviderState> => {
+      try {
+        const snap = await withTimeout(
+          getDaytona().snapshot.get(snapshotName),
+          SNAPSHOT_STATE_TIMEOUT_MS,
+          `Daytona snapshot.get(${snapshotName})`,
+        );
+        return snap
+          ? normalizeExistingProviderState((snap as { state?: string }).state)
+          : 'missing';
+      } catch (err) {
+        if (isDaytonaSnapshotNotFoundError(err)) return 'missing';
+        return 'unknown';
+      }
+    },
+    SNAPSHOT_STATE_CACHE_TTL_MS,
+    (state) => state === 'active',
+  );
+  snapshotStateObservations.set(snapshotName, observation);
+  return observation;
+}
 
 class DaytonaAdapter implements SandboxProviderAdapter {
   readonly id = 'daytona' as const;
@@ -62,6 +94,7 @@ class DaytonaAdapter implements SandboxProviderAdapter {
     if (!input.image && !input.userDockerfile) {
       throw new Error('DaytonaAdapter.buildSnapshot: neither image nor userDockerfile set');
     }
+    invalidateSnapshotState(input.snapshotName);
     const daytona = getDaytona();
     const userDockerfile = input.userDockerfile ?? `FROM ${input.image}\n`;
     const resources = {
@@ -106,12 +139,17 @@ class DaytonaAdapter implements SandboxProviderAdapter {
           },
         );
         await this.waitForActive(input.snapshotName);
+        invalidateSnapshotState(input.snapshotName);
         return;
       } catch (err) {
         lastErr = err;
         const settled = await this.waitForSettle(input.snapshotName, POST_FAILURE_SETTLE_TIMEOUT_MS);
-        if (settled === 'active') return;
+        if (settled === 'active') {
+          invalidateSnapshotState(input.snapshotName);
+          return;
+        }
         if (!isRetryableBuildError(err) || attempt === BUILD_ATTEMPTS) {
+          invalidateSnapshotState(input.snapshotName);
           throw new Error(`Snapshot build failed: ${err instanceof Error ? err.message : String(err)}`);
         }
         const msg = err instanceof Error ? err.message : String(err);
@@ -123,6 +161,7 @@ class DaytonaAdapter implements SandboxProviderAdapter {
         await rm(ctx.contextDir, { recursive: true, force: true }).catch(() => {});
       }
     }
+    invalidateSnapshotState(input.snapshotName);
     throw lastErr;
   }
 
@@ -136,46 +175,12 @@ class DaytonaAdapter implements SandboxProviderAdapter {
     // accurate state, and the auto-heal in session-sandbox.ts already covers
     // the rare race where an `active` snapshot disappears between our check
     // and the actual sandbox.create.
-    const cached = snapshotStateCache.get(snapshotName);
-    if (cached && Date.now() < cached.expiresAt) return cached.state;
-    try {
-      // The Daytona SDK takes no per-call timeout, so a degraded upstream can
-      // leave `snapshot.get` pending indefinitely. This runs on the warm boot
-      // path and behind the `/sandbox-health` polling endpoint, where an
-      // unbounded hang stalls the request until the *client* gives up (the
-      // frontend's 30s timeout → "Request timed out after 30s"). Bound it so a
-      // slow Daytona degrades to the same safe `missing` fallback as an error.
-      const snap = await withTimeout(
-        getDaytona().snapshot.get(snapshotName),
-        SNAPSHOT_STATE_TIMEOUT_MS,
-        `Daytona snapshot.get(${snapshotName})`,
-      );
-      const state = snap
-        ? normalizeExistingProviderState((snap as { state?: string }).state)
-        : 'missing';
-      if (state === 'active') {
-        snapshotStateCache.set(snapshotName, {
-          state,
-          expiresAt: Date.now() + SNAPSHOT_STATE_CACHE_TTL_MS,
-        });
-      } else {
-        snapshotStateCache.delete(snapshotName);
-      }
-      return state;
-    } catch (err) {
-      // Daytona represents a missing named snapshot as a 404 exception rather
-      // than `null`. That is definitive provider truth and must be `missing` so
-      // the template coordinator can create it. Transport/timeouts and all
-      // other probe failures remain `unknown` and fail closed.
-      snapshotStateCache.delete(snapshotName);
-      if (isDaytonaNotFoundError(err)) return 'missing';
-      return 'unknown';
-    }
+    return observeSnapshotState(snapshotName)();
   }
 
   async deleteSnapshot(snapshotName: string): Promise<void> {
     if (!isDaytonaConfigured()) return;
-    snapshotStateCache.delete(snapshotName); // invalidate before mutating
+    invalidateSnapshotState(snapshotName);
     try {
       // Bounded for the same reason as getSnapshotState() above: the Daytona
       // SDK's axios client has a 24h default timeout, so an unbounded call
@@ -184,8 +189,10 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       const snap = await withTimeout(getDaytona().snapshot.get(snapshotName), SNAPSHOT_STATE_TIMEOUT_MS, `Daytona snapshot.get(${snapshotName})`);
       if (!snap) return;
       await withTimeout(getDaytona().snapshot.delete(snap), SNAPSHOT_STATE_TIMEOUT_MS, `Daytona snapshot.delete(${snapshotName})`);
-    } catch {
-      // not found / transient — treat as already gone
+    } catch (err) {
+      if (!isDaytonaSnapshotNotFoundError(err)) throw err;
+    } finally {
+      invalidateSnapshotState(snapshotName);
     }
   }
 
@@ -242,23 +249,25 @@ class DaytonaAdapter implements SandboxProviderAdapter {
   }
 }
 
-function isDaytonaNotFoundError(err: unknown): boolean {
+export function isDaytonaSnapshotNotFoundError(err: unknown): boolean {
   const value = err as
     | {
+        status?: unknown;
         name?: unknown;
         message?: unknown;
+        code?: unknown;
         statusCode?: unknown;
         response?: { status?: unknown };
       }
     | null
     | undefined;
-  const status = value?.statusCode ?? value?.response?.status;
+  const status = value?.status ?? value?.statusCode ?? value?.code ?? value?.response?.status;
   const name = String(value?.name ?? '').toLowerCase();
   const message = String(value?.message ?? '').toLowerCase();
   return (
     status === 404 ||
     name === 'daytonanotfounderror' ||
-    (message.includes('snapshot with name') && message.includes('not found'))
+    (message.includes('snapshot') && message.includes('not found'))
   );
 }
 

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -12,21 +12,21 @@ import { rm } from 'node:fs/promises';
 import { Image } from '@daytonaio/sdk';
 import { getDaytona, isDaytonaConfigured, listDaytonaSnapshots } from '../../shared/daytona';
 import { withTimeout } from '../../shared/with-timeout';
-import { shortLivedObservation, type InvalidatableObservation } from '../observation-cache';
 import {
-  stageBuildContext,
   DEFAULT_CPU,
-  DEFAULT_MEMORY_GB,
   DEFAULT_DISK_GB,
+  DEFAULT_MEMORY_GB,
   KORTIX_ENTRYPOINT,
+  stageBuildContext,
 } from '../build-context';
-import { normalizeExistingProviderState } from './state';
+import { type InvalidatableObservation, shortLivedObservation } from '../observation-cache';
 import type {
-  BuildableTemplate,
   BuildLogTap,
+  BuildableTemplate,
   ProviderState,
   SandboxProviderAdapter,
 } from './index';
+import { normalizeExistingProviderState } from './state';
 
 const BUILD_TIMEOUT_MS = 10 * 60 * 1000;
 const BUILD_ATTEMPTS = 3;
@@ -143,14 +143,19 @@ class DaytonaAdapter implements SandboxProviderAdapter {
         return;
       } catch (err) {
         lastErr = err;
-        const settled = await this.waitForSettle(input.snapshotName, POST_FAILURE_SETTLE_TIMEOUT_MS);
+        const settled = await this.waitForSettle(
+          input.snapshotName,
+          POST_FAILURE_SETTLE_TIMEOUT_MS,
+        );
         if (settled === 'active') {
           invalidateSnapshotState(input.snapshotName);
           return;
         }
         if (!isRetryableBuildError(err) || attempt === BUILD_ATTEMPTS) {
           invalidateSnapshotState(input.snapshotName);
-          throw new Error(`Snapshot build failed: ${err instanceof Error ? err.message : String(err)}`);
+          throw new Error(
+            `Snapshot build failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(
@@ -186,9 +191,17 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       // SDK's axios client has a 24h default timeout, so an unbounded call
       // here can hang the caller indefinitely instead of hitting this
       // method's own already-forgiving try/catch.
-      const snap = await withTimeout(getDaytona().snapshot.get(snapshotName), SNAPSHOT_STATE_TIMEOUT_MS, `Daytona snapshot.get(${snapshotName})`);
+      const snap = await withTimeout(
+        getDaytona().snapshot.get(snapshotName),
+        SNAPSHOT_STATE_TIMEOUT_MS,
+        `Daytona snapshot.get(${snapshotName})`,
+      );
       if (!snap) return;
-      await withTimeout(getDaytona().snapshot.delete(snap), SNAPSHOT_STATE_TIMEOUT_MS, `Daytona snapshot.delete(${snapshotName})`);
+      await withTimeout(
+        getDaytona().snapshot.delete(snap),
+        SNAPSHOT_STATE_TIMEOUT_MS,
+        `Daytona snapshot.delete(${snapshotName})`,
+      );
     } catch (err) {
       if (!isDaytonaSnapshotNotFoundError(err)) throw err;
     } finally {
@@ -208,7 +221,11 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       try {
         // Bounded so one hung poll can't defeat this loop's own deadline
         // check — see deleteSnapshot()'s comment above for why.
-        const snap = await withTimeout(getDaytona().snapshot.get(name), SNAPSHOT_STATE_TIMEOUT_MS, `Daytona snapshot.get(${name})`);
+        const snap = await withTimeout(
+          getDaytona().snapshot.get(name),
+          SNAPSHOT_STATE_TIMEOUT_MS,
+          `Daytona snapshot.get(${name})`,
+        );
         lastState = String((snap as { state?: string } | null)?.state ?? 'missing').toLowerCase();
         if (lastState === 'active') return;
         if (lastState === 'error' || lastState === 'build_failed') {
@@ -221,7 +238,9 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       }
       await new Promise((r) => setTimeout(r, 1_000));
     }
-    throw new Error(`Snapshot ${name} did not become active after create (last state: ${lastState})`);
+    throw new Error(
+      `Snapshot ${name} did not become active after create (last state: ${lastState})`,
+    );
   }
 
   private async waitForSettle(
@@ -233,11 +252,19 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       try {
         // Bounded so one hung poll can't defeat this loop's own deadline
         // check — see deleteSnapshot()'s comment above for why.
-        const snap = await withTimeout(getDaytona().snapshot.get(name), SNAPSHOT_STATE_TIMEOUT_MS, `Daytona snapshot.get(${name})`);
+        const snap = await withTimeout(
+          getDaytona().snapshot.get(name),
+          SNAPSHOT_STATE_TIMEOUT_MS,
+          `Daytona snapshot.get(${name})`,
+        );
         const state = (snap as { state?: string } | null | undefined)?.state;
         if (state === 'active') return 'active';
         if (state === 'error' || state === 'build_failed') {
-          await withTimeout(getDaytona().snapshot.delete(snap as never), SNAPSHOT_STATE_TIMEOUT_MS, `Daytona snapshot.delete(${name})`).catch(() => {});
+          await withTimeout(
+            getDaytona().snapshot.delete(snap as never),
+            SNAPSHOT_STATE_TIMEOUT_MS,
+            `Daytona snapshot.delete(${name})`,
+          ).catch(() => {});
           return 'failed';
         }
       } catch {
@@ -261,14 +288,17 @@ export function isDaytonaSnapshotNotFoundError(err: unknown): boolean {
       }
     | null
     | undefined;
-  const status = value?.status ?? value?.statusCode ?? value?.code ?? value?.response?.status;
   const name = String(value?.name ?? '').toLowerCase();
   const message = String(value?.message ?? '').toLowerCase();
-  return (
-    status === 404 ||
-    name === 'daytonanotfounderror' ||
-    (message.includes('snapshot') && message.includes('not found'))
+
+  const statuses = [value?.statusCode, value?.response?.status, value?.status, value?.code];
+  const has404Status = statuses.some((status) => status === 404);
+  const hasDaytonaNotFoundName = name === 'daytonanotfounderror';
+  const hasPreciseSnapshotNotFoundMessage = /\bsnapshot with name\b[\s\S]*\bnot found\b/.test(
+    message,
   );
+
+  return has404Status || hasDaytonaNotFoundName || hasPreciseSnapshotNotFoundMessage;
 }
 
 function isTransientDaytonaError(err: unknown): boolean {
@@ -290,7 +320,9 @@ function isTransientDaytonaError(err: unknown): boolean {
     m.includes('network') ||
     m.includes('gateway') ||
     m.includes('not found') ||
-    m.includes(' 502') || m.includes(' 503') || m.includes(' 504')
+    m.includes(' 502') ||
+    m.includes(' 503') ||
+    m.includes(' 504')
   );
 }
 

--- a/apps/api/src/snapshots/providers/e2b.ts
+++ b/apps/api/src/snapshots/providers/e2b.ts
@@ -15,6 +15,7 @@ import type {
   ProviderState,
   SandboxProviderAdapter,
 } from './index';
+import { shortLivedObservation } from '../observation-cache';
 
 interface E2BTemplateView {
   templateID: string;
@@ -27,24 +28,19 @@ function connectionOpts() {
   return { apiKey: config.E2B_API_KEY, requestTimeoutMs: 30_000 } as const;
 }
 
-let inFlightTemplateList: Promise<E2BTemplateView[]> | null = null;
-
 async function listTemplates(): Promise<E2BTemplateView[]> {
-  if (inFlightTemplateList) return inFlightTemplateList;
-  inFlightTemplateList = (async () => {
-    const response = await fetch('https://api.e2b.dev/templates', {
-      headers: { 'X-API-KEY': config.E2B_API_KEY },
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!response.ok) throw new Error(`E2B list templates -> ${response.status} ${(await response.text()).slice(0, 300)}`);
-    return response.json() as Promise<E2BTemplateView[]>;
-  })();
-  try {
-    return await inFlightTemplateList;
-  } finally {
-    inFlightTemplateList = null;
-  }
+  const response = await fetch('https://api.e2b.dev/templates', {
+    headers: { 'X-API-KEY': config.E2B_API_KEY },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) throw new Error(`E2B list templates -> ${response.status} ${(await response.text()).slice(0, 300)}`);
+  return response.json() as Promise<E2BTemplateView[]>;
 }
+
+const observeTemplates = shortLivedObservation(
+  listTemplates,
+  process.env.NODE_ENV === 'test' ? 0 : 2_000,
+);
 
 function matchesTemplate(template: E2BTemplateView, name: string): boolean {
   return [...(template.names ?? []), ...(template.aliases ?? [])].some(
@@ -65,6 +61,7 @@ class E2BAdapter implements SandboxProviderAdapter {
     }
     const userDockerfile = input.userDockerfile ?? `FROM ${input.image}\n`;
     const context = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo);
+    observeTemplates.invalidate();
     try {
       // fromDockerfile() converts the Dockerfile ENTRYPOINT into E2B's start
       // command. E2B executes that command while finalizing the template, before
@@ -93,6 +90,7 @@ class E2BAdapter implements SandboxProviderAdapter {
         },
       });
     } finally {
+      observeTemplates.invalidate();
       await rm(context.contextDir, { recursive: true, force: true }).catch(() => {});
     }
   }
@@ -100,7 +98,7 @@ class E2BAdapter implements SandboxProviderAdapter {
   async getSnapshotState(snapshotName: string): Promise<ProviderState> {
     if (!this.isConfigured()) return 'missing';
     try {
-      const template = (await listTemplates()).find((item) => matchesTemplate(item, snapshotName));
+      const template = (await observeTemplates()).find((item) => matchesTemplate(item, snapshotName));
       if (!template) return 'missing';
       // Template.exists() becomes true when E2B creates the template identity,
       // before its launchable :default tag exists. Only buildStatus=ready is a
@@ -114,15 +112,20 @@ class E2BAdapter implements SandboxProviderAdapter {
 
   async deleteSnapshot(snapshotName: string): Promise<void> {
     if (!this.isConfigured()) return;
-    const template = (await listTemplates()).find((item) => matchesTemplate(item, snapshotName));
-    if (!template) return;
-    const response = await fetch(`https://api.e2b.dev/templates/${encodeURIComponent(template.templateID)}`, {
-      method: 'DELETE',
-      headers: { 'X-API-KEY': config.E2B_API_KEY },
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!response.ok && response.status !== 404) {
-      throw new Error(`E2B delete template ${snapshotName} -> ${response.status} ${(await response.text()).slice(0, 300)}`);
+    observeTemplates.invalidate();
+    try {
+      const template = (await listTemplates()).find((item) => matchesTemplate(item, snapshotName));
+      if (!template) return;
+      const response = await fetch(`https://api.e2b.dev/templates/${encodeURIComponent(template.templateID)}`, {
+        method: 'DELETE',
+        headers: { 'X-API-KEY': config.E2B_API_KEY },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!response.ok && response.status !== 404) {
+        throw new Error(`E2B delete template ${snapshotName} -> ${response.status} ${(await response.text()).slice(0, 300)}`);
+      }
+    } finally {
+      observeTemplates.invalidate();
     }
   }
 

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -30,6 +30,7 @@ import type {
   ProviderState,
   SandboxProviderAdapter,
 } from './index';
+import { shortLivedObservation } from '../observation-cache';
 
 const ACTIVATE_DEADLINE_MS = 12 * 60 * 1000; // build + activate ceiling
 const POLL_MS = 3_000;
@@ -67,9 +68,14 @@ interface PlatinumTemplate {
 }
 
 async function findTemplateByName(name: string): Promise<PlatinumTemplate | null> {
-  const list = await platinumJson<PlatinumTemplate[]>('/v1/templates');
+  const list = await observeTemplates();
   return list.find((t) => t.name === name) ?? null;
 }
+
+const observeTemplates = shortLivedObservation(
+  () => platinumJson<PlatinumTemplate[]>('/v1/templates'),
+  process.env.NODE_ENV === 'test' ? 0 : 2_000,
+);
 
 class PlatinumAdapter implements SandboxProviderAdapter {
   readonly id = 'platinum' as const;
@@ -85,10 +91,13 @@ class PlatinumAdapter implements SandboxProviderAdapter {
     const userDockerfile = input.userDockerfile ?? `FROM ${input.image}\n`;
     let lastErr: unknown;
     for (let attempt = 1; attempt <= BUILD_ATTEMPTS; attempt++) {
+      observeTemplates.invalidate();
       try {
         await this.buildOnce(input, userDockerfile, tap);
+        observeTemplates.invalidate();
         return;
       } catch (err) {
+        observeTemplates.invalidate();
         lastErr = err;
         if (!isRetryablePlatinumBuildError(err) || attempt === BUILD_ATTEMPTS) throw err;
         const msg = err instanceof Error ? err.message : String(err);
@@ -165,6 +174,7 @@ class PlatinumAdapter implements SandboxProviderAdapter {
    * on Platinum — otherwise it falls back to a normal buildSnapshot.
    */
   async swapAgent(newSnapshotName: string, sourceSnapshotName: string): Promise<void> {
+    observeTemplates.invalidate();
     const { gzPath, cleanup } = await stageAgentBinaryGz();
     try {
       const { upload_url, context_s3_key } = await platinumJson<{ upload_url: string; context_s3_key: string }>(
@@ -187,6 +197,7 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       });
       await this.waitForActive(newSnapshotName);
     } finally {
+      observeTemplates.invalidate();
       await cleanup();
     }
   }
@@ -203,12 +214,19 @@ class PlatinumAdapter implements SandboxProviderAdapter {
 
   async deleteSnapshot(snapshotName: string): Promise<void> {
     if (!isPlatinumConfigured()) return;
+    observeTemplates.invalidate();
     try {
       const tpl = await findTemplateByName(snapshotName);
       if (!tpl) return;
       await platinumJson(`/v1/templates/${tpl.id}`, { method: 'DELETE' });
-    } catch {
-      // not found / transient — treat as already gone
+    } catch (err) {
+      // A lookup/delete race is equivalent to already gone. Provider outages
+      // must propagate so fan-out reports this provider as failed.
+      if (!/ -> 404(?:\s|$)/.test(err instanceof Error ? err.message : String(err))) {
+        throw err;
+      }
+    } finally {
+      observeTemplates.invalidate();
     }
   }
 

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.test.ts
@@ -1,13 +1,32 @@
 import { describe, expect, test } from 'bun:test';
-import { describeProviderCoverage } from './sandbox-provider-coverage';
+import {
+  describeProviderCoverage,
+  describeProviderMode,
+  sandboxProviderLabel,
+} from './sandbox-provider-coverage';
 
 describe('sandbox template provider coverage presentation', () => {
   test('uses explicit launch-readiness language for every provider state', () => {
-    expect(describeProviderCoverage('ready')).toEqual({ label: 'Ready', tone: 'ok' });
+    expect(describeProviderCoverage('ready')).toEqual({ label: 'Latest', tone: 'ok' });
     expect(describeProviderCoverage('building')).toEqual({ label: 'Building', tone: 'busy' });
     expect(describeProviderCoverage('failed')).toEqual({ label: 'Failed', tone: 'fail' });
-    expect(describeProviderCoverage('not_built')).toEqual({ label: 'Not built', tone: 'idle' });
+    expect(describeProviderCoverage('not_built')).toEqual({
+      label: 'Current image not built',
+      tone: 'idle',
+    });
     expect(describeProviderCoverage('unavailable')).toEqual({ label: 'Unavailable', tone: 'idle' });
     expect(describeProviderCoverage('unknown')).toEqual({ label: 'Unknown', tone: 'idle' });
+  });
+
+  test('keeps Automatic neutral and names the selected pinned provider', () => {
+    expect(describeProviderMode('automatic', 'daytona')).toEqual({
+      label: 'Automatic',
+      selectedProvider: null,
+    });
+    expect(describeProviderMode('pinned', 'e2b')).toEqual({
+      label: 'E2B selected',
+      selectedProvider: 'E2B',
+    });
+    expect(sandboxProviderLabel('e2b')).toBe('E2B');
   });
 });

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.ts
@@ -4,18 +4,45 @@ export type ProviderCoverageStatus = NonNullable<
   SandboxTemplate['provider_coverage']
 >[number]['status'];
 
+export type SandboxProviderMode = 'automatic' | 'pinned';
+
+export function sandboxProviderLabel(
+  provider: 'daytona' | 'platinum' | 'e2b',
+): 'Daytona' | 'Platinum' | 'E2B' {
+  switch (provider) {
+    case 'daytona':
+      return 'Daytona';
+    case 'platinum':
+      return 'Platinum';
+    case 'e2b':
+      return 'E2B';
+  }
+}
+
+export function describeProviderMode(
+  mode: SandboxProviderMode,
+  selectedProvider: 'daytona' | 'platinum' | 'e2b' | null,
+): { label: string; selectedProvider: string | null } {
+  if (mode === 'automatic') return { label: 'Automatic', selectedProvider: null };
+  const selected = selectedProvider ? sandboxProviderLabel(selectedProvider) : null;
+  return {
+    label: selected ? `${selected} selected` : 'Pinned provider',
+    selectedProvider: selected,
+  };
+}
+
 export function describeProviderCoverage(
   status: ProviderCoverageStatus,
 ): { label: string; tone: 'ok' | 'busy' | 'fail' | 'idle' } {
   switch (status) {
     case 'ready':
-      return { label: 'Ready', tone: 'ok' };
+      return { label: 'Latest', tone: 'ok' };
     case 'building':
       return { label: 'Building', tone: 'busy' };
     case 'failed':
       return { label: 'Failed', tone: 'fail' };
     case 'not_built':
-      return { label: 'Not built', tone: 'idle' };
+      return { label: 'Current image not built', tone: 'idle' };
     case 'unavailable':
       return { label: 'Unavailable', tone: 'idle' };
     case 'unknown':

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.ts
@@ -31,9 +31,10 @@ export function describeProviderMode(
   };
 }
 
-export function describeProviderCoverage(
-  status: ProviderCoverageStatus,
-): { label: string; tone: 'ok' | 'busy' | 'fail' | 'idle' } {
+export function describeProviderCoverage(status: ProviderCoverageStatus): {
+  label: string;
+  tone: 'ok' | 'busy' | 'fail' | 'idle';
+} {
   switch (status) {
     case 'ready':
       return { label: 'Latest', tone: 'ok' };

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -25,12 +25,6 @@ import { useSandboxRecovery } from '@/features/workspace/project-sidebar/footer/
 import { currentFailedBuild } from '@/features/workspace/project-sidebar/footer/sandbox-alert-state';
 import { cn } from '@/lib/utils';
 import {
-  describeProviderCoverage,
-  describeProviderMode,
-  sandboxProviderLabel,
-  type SandboxProviderMode,
-} from './sandbox-provider-coverage';
-import {
   type ProjectSnapshotBuild,
   type ProjectSnapshotStatus,
   type SandboxTemplate,
@@ -40,11 +34,7 @@ import {
   getProject,
   listProjectSnapshots,
 } from '@kortix/sdk/projects-client';
-import {
-  CheckCircleSolid,
-  SparklesSolid,
-  XCircleSolid,
-} from '@mynaui/icons-react';
+import { CheckCircleSolid, SparklesSolid, XCircleSolid } from '@mynaui/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ChevronDown,
@@ -58,8 +48,21 @@ import {
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type ReactNode, useState } from 'react';
+import {
+  type SandboxProviderMode,
+  describeProviderCoverage,
+  describeProviderMode,
+  sandboxProviderLabel,
+} from './sandbox-provider-coverage';
 
 const SNAPSHOTS_QUERY_KEY = (projectId: string) => ['project-snapshots', projectId];
+const TEMPLATE_SKELETON_ROWS = [
+  'sandbox-template-skeleton-1',
+  'sandbox-template-skeleton-2',
+  'sandbox-template-skeleton-3',
+  'sandbox-template-skeleton-4',
+  'sandbox-template-skeleton-5',
+] as const;
 
 const CATEGORY_LABEL: Record<SnapshotErrorCategory, string> = {
   quota: 'Snapshot quota reached',
@@ -280,11 +283,15 @@ function ProviderCoverage({
             {provider}
             {selected ? (
               <>
-                <span className="opacity-50" aria-hidden="true">&bull;</span>
+                <span className="opacity-50" aria-hidden="true">
+                  &bull;
+                </span>
                 Selected
               </>
             ) : null}
-            <span className="opacity-50" aria-hidden="true">&bull;</span>
+            <span className="opacity-50" aria-hidden="true">
+              &bull;
+            </span>
             {state.label}
           </Badge>
         );
@@ -418,8 +425,13 @@ function TemplateRow({
   const queryClient = useQueryClient();
   const { version: manifestVersion } = useProjectManifestVersion(projectId);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const templateId = template.template_id ?? null;
+  const requireTemplateId = () => {
+    if (!templateId) throw new Error('Sandbox template id is missing');
+    return templateId;
+  };
   const buildMut = useMutation({
-    mutationFn: () => buildSandboxTemplate(projectId, template.template_id!),
+    mutationFn: () => buildSandboxTemplate(projectId, requireTemplateId()),
     onSuccess: () => {
       successToast(`Rebuild started for "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
@@ -427,7 +439,7 @@ function TemplateRow({
     onError: (err: Error) => errorToast(err.message || 'Failed to start build'),
   });
   const deleteMut = useMutation({
-    mutationFn: () => deleteSandboxTemplate(projectId, template.template_id!),
+    mutationFn: () => deleteSandboxTemplate(projectId, requireTemplateId()),
     onSuccess: () => {
       successToast(`Deleted "${template.name}"`);
       queryClient.invalidateQueries({ queryKey: SNAPSHOTS_QUERY_KEY(projectId) });
@@ -495,7 +507,7 @@ function TemplateRow({
         ) : null}
         {canManage && (
           <div className="flex items-center gap-1">
-            {template.template_id && !template.is_default && (
+            {templateId && !template.is_default && (
               <>
                 <Button
                   size="sm"
@@ -526,7 +538,7 @@ function TemplateRow({
                 </Button>
               </>
             )}
-            {template.template_id && (
+            {templateId && (
               <Button
                 size="sm"
                 variant="outline"
@@ -595,9 +607,8 @@ export function SandboxView({ projectId }: { projectId: string }) {
   const data = snapshotsQuery.data;
   const builds = Array.isArray(data?.builds) ? data.builds : [];
   const templates = Array.isArray(data?.templates) ? data.templates : [];
-  const providerMode: SandboxProviderMode = data?.provider_mode === 'pinned'
-    ? 'pinned'
-    : 'automatic';
+  const providerMode: SandboxProviderMode =
+    data?.provider_mode === 'pinned' ? 'pinned' : 'automatic';
   const selectedProvider = data?.selected_provider ?? null;
   const latestFailure = currentFailedBuild(builds);
   const latestReady = builds.find((b) => b.status === 'ready') ?? null;
@@ -639,8 +650,8 @@ export function SandboxView({ projectId }: { projectId: string }) {
     >
       {snapshotsQuery.isLoading ? (
         <div className="space-y-1">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 rounded-md" />
+          {TEMPLATE_SKELETON_ROWS.map((row) => (
+            <Skeleton key={row} className="h-10 rounded-md" />
           ))}
         </div>
       ) : snapshotsQuery.isError ? (

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -24,7 +24,12 @@ import CustomizeSectionWrapper from '@/features/workspace/customize/sections/com
 import { useSandboxRecovery } from '@/features/workspace/project-sidebar/footer/project-sandbox-alert';
 import { currentFailedBuild } from '@/features/workspace/project-sidebar/footer/sandbox-alert-state';
 import { cn } from '@/lib/utils';
-import { describeProviderCoverage } from './sandbox-provider-coverage';
+import {
+  describeProviderCoverage,
+  describeProviderMode,
+  sandboxProviderLabel,
+  type SandboxProviderMode,
+} from './sandbox-provider-coverage';
 import {
   type ProjectSnapshotBuild,
   type ProjectSnapshotStatus,
@@ -36,7 +41,6 @@ import {
   listProjectSnapshots,
 } from '@kortix/sdk/projects-client';
 import {
-  AlarmClockSolid,
   CheckCircleSolid,
   SparklesSolid,
   XCircleSolid,
@@ -121,13 +125,6 @@ const TEMPLATE_STATE_LABEL: Record<
   error: { label: 'Error', tone: 'fail' },
   build_failed: { label: 'Build failed', tone: 'fail' },
   missing: { label: 'Not built yet', tone: 'idle' },
-};
-
-const TEMPLATE_TONE_BADGE = {
-  ok: { variant: 'success' as const },
-  busy: { variant: 'solid' as const, color: 'blue' as const },
-  fail: { variant: 'destructive' as const },
-  idle: { variant: 'muted' as const },
 };
 
 const TEMPLATE_TONE_ICON_TILE: Record<'ok' | 'busy' | 'fail' | 'idle', string> = {
@@ -247,8 +244,10 @@ function BuildRow({ build }: { build: ProjectSnapshotBuild }) {
 
 function ProviderCoverage({
   coverage,
+  selectedProvider,
 }: {
   coverage: NonNullable<SandboxTemplate['provider_coverage']>;
+  selectedProvider: 'daytona' | 'platinum' | 'e2b' | null;
 }) {
   const observedAt = coverage
     .map((item) => item.observed_at)
@@ -269,17 +268,22 @@ function ProviderCoverage({
               : state.tone === 'fail'
                 ? 'destructive'
                 : 'muted';
-        const provider = item.provider === 'e2b'
-          ? 'E2B'
-          : item.provider.charAt(0).toUpperCase() + item.provider.slice(1);
+        const provider = sandboxProviderLabel(item.provider);
+        const selected = item.provider === selectedProvider;
         return (
           <Badge
             key={item.provider}
             variant={variant}
             size="xs"
-            aria-label={`${provider}: ${state.label}`}
+            aria-label={`${provider}${selected ? ' selected' : ''}: ${state.label}`}
           >
             {provider}
+            {selected ? (
+              <>
+                <span className="opacity-50" aria-hidden="true">&bull;</span>
+                Selected
+              </>
+            ) : null}
             <span className="opacity-50" aria-hidden="true">&bull;</span>
             {state.label}
           </Badge>
@@ -400,11 +404,15 @@ function TemplateRow({
   template,
   canManage,
   onEdit,
+  providerMode,
+  selectedProvider,
 }: {
   projectId: string;
   template: SandboxTemplate;
   canManage: boolean;
   onEdit: (tpl: SandboxTemplate) => void;
+  providerMode: SandboxProviderMode;
+  selectedProvider: 'daytona' | 'platinum' | 'e2b' | null;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -444,15 +452,7 @@ function TemplateRow({
           ? 'kortix.yaml'
           : 'kortix.toml';
   const stateInfo = describeState(template.provider_state || template.daytona_state);
-  const stateBadge = TEMPLATE_TONE_BADGE[stateInfo.tone];
-  const StateIcon =
-    stateInfo.tone === 'busy'
-      ? Loading
-      : stateInfo.tone === 'ok'
-        ? CheckCircleSolid
-        : stateInfo.tone === 'fail'
-          ? XCircleSolid
-          : AlarmClockSolid;
+  const providerModeInfo = describeProviderMode(providerMode, selectedProvider);
 
   return (
     <>
@@ -481,17 +481,18 @@ function TemplateRow({
             {tI18nHardcoded.raw('autoComponentsProjectsSandboxSnapshotCardJsxTextGiBDiskd395296d')}{' '}
             &bull; {sourceTag}
           </div>
-          {template.provider_coverage?.length ? (
-            <ProviderCoverage coverage={template.provider_coverage} />
+          {providerMode === 'pinned' && template.provider_coverage?.length ? (
+            <ProviderCoverage
+              coverage={template.provider_coverage}
+              selectedProvider={selectedProvider}
+            />
           ) : null}
         </div>
-        <Badge
-          variant={stateBadge.variant}
-          color={'color' in stateBadge ? stateBadge.color : undefined}
-        >
-          <StateIcon className="size-4 shrink-0" />
-          {stateInfo.label}
-        </Badge>
+        {providerMode === 'automatic' ? (
+          <Badge variant="muted">{providerModeInfo.label}</Badge>
+        ) : !template.provider_coverage?.length ? (
+          <Badge variant="muted">{providerModeInfo.label}</Badge>
+        ) : null}
         {canManage && (
           <div className="flex items-center gap-1">
             {template.template_id && !template.is_default && (
@@ -594,6 +595,10 @@ export function SandboxView({ projectId }: { projectId: string }) {
   const data = snapshotsQuery.data;
   const builds = Array.isArray(data?.builds) ? data.builds : [];
   const templates = Array.isArray(data?.templates) ? data.templates : [];
+  const providerMode: SandboxProviderMode = data?.provider_mode === 'pinned'
+    ? 'pinned'
+    : 'automatic';
+  const selectedProvider = data?.selected_provider ?? null;
   const latestFailure = currentFailedBuild(builds);
   const latestReady = builds.find((b) => b.status === 'ready') ?? null;
   const canFixWithAgent = !!latestFailure && latestFailure.fixable_by_agent && !!latestReady;
@@ -718,6 +723,8 @@ export function SandboxView({ projectId }: { projectId: string }) {
                           template={t}
                           canManage={canManage}
                           onEdit={openEditForm}
+                          providerMode={providerMode}
+                          selectedProvider={selectedProvider}
                         />
                       ))}
                     </ul>

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -767,3 +767,23 @@ and constructed `@kortix/sdk` successfully.
 
 **Shippable to production: YES** for the SDK surface. Parent API/UI rollout and
 live provider verification remain part of the enclosing change.
+
+---
+
+### 2026-07-13 — session `sandbox-template-provider-status-v2` (completion)
+
+Completed the follow-up provider-status and failure-recovery contract on top of
+the provider-neutral synchronization rollout. The additive rebuild response can
+now report providers that failed before their rebuild was started, while the UI
+keeps Automatic neutral and shows selected-provider plus current-image status
+only for pinned projects. Existing provider readiness and `launch_ready` fields
+remain backward compatible.
+
+**Final SDK gates:** `pnpm --filter @kortix/sdk typecheck` exited 0;
+`pnpm --filter @kortix/sdk test` reported **1094 pass / 2 skip / 0 fail**
+across 80 files with 4986 assertions; `pnpm --filter @kortix/sdk run smoke:install` built,
+packed, installed, imported, and constructed `@kortix/sdk` successfully.
+
+**Shippable to production: YES** for the SDK surface. API/web typechecks,
+focused provider tests, and UI lint also pass; live dev verification remains the
+enclosing rollout gate.

--- a/packages/sdk/src/core/rest/projects-client/sandbox-provider-coverage.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/sandbox-provider-coverage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test';
-import type { SandboxTemplate } from './sandbox';
+import type { RebuildSnapshotResponse, SandboxTemplate } from './sandbox';
 
 test('SandboxTemplate types launch readiness independently for every supported provider', () => {
   const template = {
@@ -18,4 +18,18 @@ test('SandboxTemplate types launch readiness independently for every supported p
 
   expect(template.provider_coverage[0].provider).toBe('e2b');
   expect(template.provider_coverage[0].launch_ready).toBe(false);
+});
+
+test('rebuild responses type partial provider startup failures', () => {
+  const response = {
+    status: 'started',
+    slug: 'default',
+    deleted_existing: true,
+    snapshot_name: 'kortix-default-current',
+    providers: ['daytona', 'e2b'],
+    failed_providers: ['platinum'],
+  } satisfies RebuildSnapshotResponse;
+
+  expect(response.providers).toEqual(['daytona', 'e2b']);
+  expect(response.failed_providers).toEqual(['platinum']);
 });

--- a/packages/sdk/src/core/rest/projects-client/sandbox.ts
+++ b/packages/sdk/src/core/rest/projects-client/sandbox.ts
@@ -130,6 +130,7 @@ export interface RebuildSnapshotResponse {
   deleted_existing: boolean;
   snapshot_name: string;
   providers?: Array<'daytona' | 'platinum' | 'e2b'>;
+  failed_providers?: Array<'daytona' | 'platinum' | 'e2b'>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep sandbox template rebuild fan-out provider-neutral while reporting failed provider starts in the response
- make provider catalog/snapshot observations short-lived and invalidatable so UI/API status reads do not duplicate slow provider calls or stale post-mutation state
- keep the Sandbox templates UI neutral in Automatic mode and show per-provider current image status plus selected provider only when a project is pinned
- add additive SDK typing for `failed_providers`

## Verification
- `git diff --check`
- `cd apps/api && dotenvx run -o -f .env --env KORTIX_BILLING_INTERNAL_ENABLED=false --env KORTIX_URL=http://localhost:8008 -- bun test src/snapshots/builder-provider-dedupe.test.ts src/snapshots/observation-cache.test.ts src/snapshots/provider-actions.test.ts src/snapshots/provider-coverage.test.ts src/snapshots/providers/daytona-errors.test.ts src/snapshots/providers/e2b.test.ts src/snapshots/providers/state.test.ts` — 38 pass / 0 fail
- `pnpm --filter kortix-api typecheck`
- `cd apps/web && bun test src/features/workspace/customize/sections/view/sandbox-provider-coverage.test.ts` — 2 pass / 0 fail
- `cd apps/web && pnpm exec fumadocs-mdx && pnpm exec tsc --noEmit --pretty false`
- `cd apps/web && pnpm exec eslint src/features/workspace/customize/sections/view/sandbox-view.tsx src/features/workspace/customize/sections/view/sandbox-provider-coverage.ts src/features/workspace/customize/sections/view/sandbox-provider-coverage.test.ts`
- `pnpm --filter @kortix/sdk typecheck`
- `pnpm --filter @kortix/sdk test` — 1094 pass / 2 skip / 0 fail
- `pnpm --filter @kortix/sdk run smoke:install`

## Follow-up gate
Will wait for checks, preview, browser verification, merge, Deploy Dev, and dev revalidation before closing the delivery.
