### PR TITLE
feat: bootstrap enterprise release publisher

### DIFF
--- a/.github/workflows/deploy-enterprise-release-publisher.yml
+++ b/.github/workflows/deploy-enterprise-release-publisher.yml
@@ -1,0 +1,106 @@
+name: Deploy Enterprise Release Publisher
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Apply the reviewed Terraform plan
+        required: true
+        default: false
+        type: boolean
+      confirm_account_id:
+        description: Type 935064898258 when apply is enabled
+        required: false
+        type: string
+
+concurrency:
+  group: enterprise-release-publisher-terraform
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  terraform:
+    name: Plan or apply publisher
+    runs-on: ubuntu-latest
+    environment: enterprise-stable
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_INPUT: "false"
+      TF_VAR_aws_region: us-west-2
+      TF_VAR_expected_account_id: "935064898258"
+      TF_VAR_repository_bucket_name: kortix-enterprise-releases-935064898258-us-west-2
+      TF_VAR_repository_domain: releases.kortix.com
+      TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_github_oidc_provider_arn: arn:aws:iam::935064898258:oidc-provider/token.actions.githubusercontent.com
+      TF_VAR_permissions_boundary_arn: arn:aws:iam::935064898258:policy/kortix-enterprise-releases-runtime-boundary
+      TF_VAR_customer_event_bus_arns: '["arn:aws:events:us-west-2:935064898258:event-bus/kortix-vpc-demo-releases"]'
+      TF_VAR_tags: '{"Environment":"shared","Owner":"kortix"}'
+      ENTERPRISE_PUBLISHER_TERRAFORM_ROLE_ARN: ${{ vars.ENTERPRISE_PUBLISHER_TERRAFORM_ROLE_ARN }}
+    steps:
+      - name: Validate apply confirmation
+        if: ${{ inputs.apply }}
+        env:
+          CONFIRM_ACCOUNT_ID: ${{ inputs.confirm_account_id }}
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRM_ACCOUNT_ID" != "935064898258" ]; then
+            echo "::error::Apply requires confirm_account_id=935064898258"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+
+      - name: Configure protected AWS identity
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ env.ENTERPRISE_PUBLISHER_TERRAFORM_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Verify pinned AWS account
+        run: |
+          set -euo pipefail
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+          test "$account_id" = "935064898258"
+
+      - name: Require protected inputs
+        run: |
+          set -euo pipefail
+          test -n "${TF_VAR_cloudflare_zone_id:-}"
+          test -n "${TF_VAR_cloudflare_api_token:-}"
+          test -n "${ENTERPRISE_PUBLISHER_TERRAFORM_ROLE_ARN:-}"
+
+      - name: Terraform init
+        working-directory: infra/terraform/environments/enterprise-release-publisher
+        run: |
+          terraform init -reconfigure \
+            -backend-config="bucket=kortix-terraform-state" \
+            -backend-config="key=enterprise-release-publisher/terraform.tfstate" \
+            -backend-config="region=us-west-2" \
+            -backend-config="dynamodb_table=kortix-terraform-locks" \
+            -backend-config="encrypt=true"
+
+      - name: Terraform validate
+        working-directory: infra/terraform/environments/enterprise-release-publisher
+        run: terraform validate
+
+      - name: Terraform plan
+        working-directory: infra/terraform/environments/enterprise-release-publisher
+        run: terraform plan -lock-timeout=10m -out=publisher.tfplan
+
+      - name: Terraform apply
+        if: ${{ inputs.apply }}
+        working-directory: infra/terraform/environments/enterprise-release-publisher
+        run: terraform apply -lock-timeout=10m -auto-approve publisher.tfplan
+
+      - name: Record non-sensitive outputs
+        if: ${{ inputs.apply }}
+        working-directory: infra/terraform/environments/enterprise-release-publisher
+        run: terraform output -json publisher | jq '{repository_url,repository_bucket,promotion_role_arn,timestamp_refresh_role_arn,cloudfront_distribution_id}'

--- a/docs/runbooks/enterprise-vpc-deployment.md
+++ b/docs/runbooks/enterprise-vpc-deployment.md
@@ -11,8 +11,19 @@ exact certified image and bundle digests; it never rebuilds them.
 The shared publisher is Terraform-owned in the Kortix AWS account. Its
 CloudFront hostname, us-east-1 ACM certificate, Cloudflare validation and CNAME
 records, WAF, encrypted WAF logs, immutable request-log bucket, object-locked
-TUF bucket, KMS signing keys, and GitHub OIDC roles are one deployment. Supply
-the scoped Cloudflare credential only at apply time:
+TUF bucket, KMS signing keys, and GitHub OIDC roles are one deployment.
+
+The one-time `enterprise-release-publisher-bootstrap` root creates the GitHub
+OIDC Terraform role from an authenticated Kortix administrator session. Store
+its `terraform_role_arn` output as the repository variable
+`ENTERPRISE_PUBLISHER_TERRAFORM_ROLE_ARN`; store the Kortix Cloudflare zone as
+`CLOUDFLARE_ZONE_ID`. The protected `enterprise-stable` environment then runs
+`Deploy Enterprise Release Publisher`, consuming the existing
+`CLOUDFLARE_API_TOKEN` secret without exporting it. Plan is the default; apply
+requires the pinned account confirmation and environment approval.
+
+For emergency local recovery only, supply the scoped Cloudflare credential at
+apply time:
 
 ```bash
 export TF_VAR_cloudflare_api_token="$(dotenvx get CLOUDFLARE_API_TOKEN -f apps/api/.env)"

--- a/infra/terraform/environments/enterprise-release-publisher-bootstrap/.terraform.lock.hcl
+++ b/infra/terraform/environments/enterprise-release-publisher-bootstrap/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = ">= 6.0.0, < 7.0.0"
+  hashes = [
+    "h1:i89hWLGo3bPwJKYBv3+S67qbfr0tydFqs70Hq5VcoYs=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
+  ]
+}

--- a/infra/terraform/environments/enterprise-release-publisher-bootstrap/backend.tf
+++ b/infra/terraform/environments/enterprise-release-publisher-bootstrap/backend.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0, < 7.0"
+    }
+  }
+
+  backend "s3" {}
+}

--- a/infra/terraform/environments/enterprise-release-publisher-bootstrap/main.tf
+++ b/infra/terraform/environments/enterprise-release-publisher-bootstrap/main.tf
@@ -1,0 +1,210 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+locals {
+  tags = merge(var.tags, {
+    ManagedBy = "terraform"
+    System    = "kortix-enterprise-release"
+  })
+}
+
+resource "terraform_data" "account_guard" {
+  lifecycle {
+    precondition {
+      condition     = data.aws_caller_identity.current.account_id == var.expected_account_id
+      error_message = "publisher bootstrap AWS account mismatch"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "github_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repository}:environment:${var.github_environment}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "terraform" {
+  name                 = var.terraform_role_name
+  description          = "Protected GitHub Terraform role for the Kortix enterprise release publisher"
+  assume_role_policy   = data.aws_iam_policy_document.github_assume.json
+  max_session_duration = 3600
+  tags                 = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "power_user" {
+  role       = aws_iam_role.terraform.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/PowerUserAccess"
+}
+
+data "aws_iam_policy_document" "publisher_iam" {
+  statement {
+    sid     = "CreateOnlyBoundedPublisherRoles"
+    actions = ["iam:CreateRole"]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${var.expected_account_id}:role/${var.publisher_name}-promotion",
+      "arn:${data.aws_partition.current.partition}:iam::${var.expected_account_id}:role/${var.publisher_name}-timestamp-refresh",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [aws_iam_policy.publisher_runtime_boundary.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/System"
+      values   = ["kortix-enterprise-release"]
+    }
+  }
+
+  statement {
+    sid = "ReadOnlyPublisherRoleState"
+    actions = [
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${var.expected_account_id}:role/${var.publisher_name}-promotion",
+      "arn:${data.aws_partition.current.partition}:iam::${var.expected_account_id}:role/${var.publisher_name}-timestamp-refresh",
+    ]
+  }
+
+  statement {
+    sid = "ManageOnlyTaggedPublisherRoles"
+    actions = [
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:UpdateRole",
+      "iam:UpdateRoleDescription",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${var.expected_account_id}:role/${var.publisher_name}-promotion",
+      "arn:${data.aws_partition.current.partition}:iam::${var.expected_account_id}:role/${var.publisher_name}-timestamp-refresh",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:ResourceTag/System"
+      values   = ["kortix-enterprise-release"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "publisher_iam" {
+  name   = "${var.publisher_name}-terraform-iam"
+  role   = aws_iam_role.terraform.id
+  policy = data.aws_iam_policy_document.publisher_iam.json
+}
+
+data "aws_iam_policy_document" "publisher_runtime_boundary" {
+  statement {
+    sid = "UseOnlyOnlinePublisherSigningKeys"
+    actions = [
+      "kms:GetPublicKey",
+      "kms:Sign",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "kms:ResourceAliases"
+      values = [
+        "alias/${var.publisher_name}-tuf-targets",
+        "alias/${var.publisher_name}-tuf-snapshot",
+        "alias/${var.publisher_name}-tuf-timestamp",
+        "alias/${var.publisher_name}-cosign",
+      ]
+    }
+  }
+
+  statement {
+    sid = "UseOnlyPublisherRepositoryEncryptionKey"
+    actions = [
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "kms:ResourceAliases"
+      values   = ["alias/${var.publisher_name}-repository"]
+    }
+  }
+
+  statement {
+    sid = "UseOnlyPublisherRepositoryObjects"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+      "s3:PutObject",
+      "s3:PutObjectRetention",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.repository_bucket_name}",
+      "arn:${data.aws_partition.current.partition}:s3:::${var.repository_bucket_name}/*",
+    ]
+  }
+
+  statement {
+    sid       = "InvalidateOnlyPublisherDistributions"
+    actions   = ["cloudfront:CreateInvalidation", "cloudfront:GetInvalidation"]
+    resources = ["arn:${data.aws_partition.current.partition}:cloudfront::${var.expected_account_id}:distribution/*"]
+  }
+
+  dynamic "statement" {
+    for_each = length(var.customer_event_bus_arns) == 0 ? [] : [1]
+    content {
+      sid       = "SendOnlyConfiguredCustomerHints"
+      actions   = ["events:PutEvents"]
+      resources = var.customer_event_bus_arns
+    }
+  }
+}
+
+resource "aws_iam_policy" "publisher_runtime_boundary" {
+  name        = "${var.publisher_name}-runtime-boundary"
+  description = "Maximum permissions for enterprise release promotion and timestamp roles"
+  policy      = data.aws_iam_policy_document.publisher_runtime_boundary.json
+  tags        = local.tags
+}
+
+output "terraform_role_arn" {
+  value = aws_iam_role.terraform.arn
+}
+
+output "publisher_runtime_boundary_arn" {
+  value = aws_iam_policy.publisher_runtime_boundary.arn
+}

--- a/infra/terraform/environments/enterprise-release-publisher-bootstrap/terraform.tfvars.example
+++ b/infra/terraform/environments/enterprise-release-publisher-bootstrap/terraform.tfvars.example
@@ -1,14 +1,16 @@
 aws_region                = "us-west-2"
-name                      = "kortix-enterprise-releases"
 expected_account_id       = "935064898258"
+publisher_name            = "kortix-enterprise-releases"
+terraform_role_name       = "kortix-enterprise-publisher-terraform"
 repository_bucket_name    = "kortix-enterprise-releases-935064898258-us-west-2"
-repository_domain         = "releases.kortix.com"
-cloudflare_zone_id          = "00000000000000000000000000000000"
 github_oidc_provider_arn  = "arn:aws:iam::935064898258:oidc-provider/token.actions.githubusercontent.com"
-permissions_boundary_arn = "arn:aws:iam::935064898258:policy/kortix-enterprise-releases-runtime-boundary"
 github_repository         = "kortix-ai/suna"
 github_environment        = "enterprise-stable"
-github_refresh_environment = "enterprise-tuf-refresh"
 customer_event_bus_arns = [
   "arn:aws:events:us-west-2:935064898258:event-bus/kortix-vpc-demo-releases",
 ]
+
+tags = {
+  Environment = "shared"
+  Owner       = "kortix"
+}

--- a/infra/terraform/environments/enterprise-release-publisher-bootstrap/variables.tf
+++ b/infra/terraform/environments/enterprise-release-publisher-bootstrap/variables.tf
@@ -1,0 +1,46 @@
+variable "aws_region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "expected_account_id" {
+  type = string
+}
+
+variable "publisher_name" {
+  type    = string
+  default = "kortix-enterprise-releases"
+}
+
+variable "terraform_role_name" {
+  type    = string
+  default = "kortix-enterprise-publisher-terraform"
+}
+
+variable "repository_bucket_name" {
+  type = string
+}
+
+variable "github_oidc_provider_arn" {
+  type = string
+}
+
+variable "github_repository" {
+  type    = string
+  default = "kortix-ai/suna"
+}
+
+variable "github_environment" {
+  type    = string
+  default = "enterprise-stable"
+}
+
+variable "customer_event_bus_arns" {
+  type    = list(string)
+  default = []
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/terraform/environments/enterprise-release-publisher/main.tf
+++ b/infra/terraform/environments/enterprise-release-publisher/main.tf
@@ -37,6 +37,7 @@ module "publisher" {
   repository_domain          = var.repository_domain
   repository_certificate_arn = module.repository_certificate.certificate_arn
   github_oidc_provider_arn   = var.github_oidc_provider_arn
+  permissions_boundary_arn   = var.permissions_boundary_arn
   github_repository          = var.github_repository
   github_environment         = var.github_environment
   github_refresh_environment = var.github_refresh_environment

--- a/infra/terraform/environments/enterprise-release-publisher/variables.tf
+++ b/infra/terraform/environments/enterprise-release-publisher/variables.tf
@@ -15,6 +15,7 @@ variable "cloudflare_api_token" {
   sensitive = true
 }
 variable "github_oidc_provider_arn" { type = string }
+variable "permissions_boundary_arn" { type = string }
 variable "github_repository" {
   type    = string
   default = "kortix-ai/suna"

--- a/infra/terraform/modules/enterprise-release-publisher/iam.tf
+++ b/infra/terraform/modules/enterprise-release-publisher/iam.tf
@@ -21,6 +21,7 @@ data "aws_iam_policy_document" "github_assume" {
 resource "aws_iam_role" "promotion" {
   name                 = "${var.name}-promotion"
   assume_role_policy   = data.aws_iam_policy_document.github_assume.json
+  permissions_boundary = var.permissions_boundary_arn
   max_session_duration = 3600
   tags                 = local.tags
 }
@@ -110,6 +111,7 @@ data "aws_iam_policy_document" "github_timestamp_refresh_assume" {
 resource "aws_iam_role" "timestamp_refresh" {
   name                 = "${var.name}-timestamp-refresh"
   assume_role_policy   = data.aws_iam_policy_document.github_timestamp_refresh_assume.json
+  permissions_boundary = var.permissions_boundary_arn
   max_session_duration = 3600
   tags                 = merge(local.tags, { TufRole = "timestamp" })
 }

--- a/infra/terraform/modules/enterprise-release-publisher/main.tf
+++ b/infra/terraform/modules/enterprise-release-publisher/main.tf
@@ -218,6 +218,9 @@ resource "aws_s3_bucket_acl" "access_logs" {
   }
 }
 
+# Legacy CloudFront standard logging rejects SSE-KMS destinations; this
+# dedicated object-locked bucket uses SSE-S3 and blocks all public access.
+#trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "access_logs" {
   #checkov:skip=CKV_AWS_145:Legacy CloudFront standard logging supports SSE-S3, not SSE-KMS, on its ACL-enabled destination bucket.
   bucket = aws_s3_bucket.access_logs.id

--- a/infra/terraform/modules/enterprise-release-publisher/variables.tf
+++ b/infra/terraform/modules/enterprise-release-publisher/variables.tf
@@ -38,6 +38,15 @@ variable "github_oidc_provider_arn" {
   type        = string
 }
 
+variable "permissions_boundary_arn" {
+  description = "Permissions boundary capping the GitHub promotion and timestamp roles."
+  type        = string
+  validation {
+    condition     = can(regex("^arn:[^:]+:iam::[0-9]{12}:policy/.+$", var.permissions_boundary_arn))
+    error_message = "permissions_boundary_arn must be an IAM policy ARN."
+  }
+}
+
 variable "github_repository" {
   type    = string
   default = "kortix-ai/suna"


### PR DESCRIPTION
## Summary
- add a protected GitHub OIDC Terraform bootstrap for the shared enterprise release publisher
- cap promotion and timestamp identities with a customer-managed permissions boundary that excludes offline root signing keys
- add reviewed plan/apply CI using the existing encrypted Cloudflare token and pinned Kortix AWS account
- document bootstrap and emergency recovery paths

## Verification
- Terraform 1.9.8 validate: bootstrap + publisher roots
- live AWS bootstrap plan: 5 add, 0 change, 0 destroy
- Checkov: bootstrap 44 passed / 0 failed; publisher 185 passed / 0 failed
- TFLint recursive: clean
- actionlint: clean
- Trivy HIGH/CRITICAL: clean (one documented CloudFront access-log SSE-S3 exception)
- git diff --check: clean