### PR TITLE
fix(enterprise): allow publisher repository decrypt

### DIFF
--- a/.github/workflows/deploy-enterprise-release-publisher.yml
+++ b/.github/workflows/deploy-enterprise-release-publisher.yml
@@ -103,4 +103,4 @@ jobs:
       - name: Record non-sensitive outputs
         if: ${{ inputs.apply }}
         working-directory: infra/terraform/environments/enterprise-release-publisher
-        run: terraform output -json publisher | jq '{repository_url,repository_bucket,promotion_role_arn,timestamp_refresh_role_arn,cloudfront_distribution_id}'
+        run: terraform output -json publisher | jq '{repository_url,repository_bucket,repository_kms_key_arn,promotion_role_arn,timestamp_refresh_role_arn,cloudfront_distribution_id}'

--- a/infra/terraform/environments/enterprise-release-publisher-bootstrap/main.tf
+++ b/infra/terraform/environments/enterprise-release-publisher-bootstrap/main.tf
@@ -148,6 +148,7 @@ data "aws_iam_policy_document" "publisher_runtime_boundary" {
   statement {
     sid = "UseOnlyPublisherRepositoryEncryptionKey"
     actions = [
+      "kms:Decrypt",
       "kms:DescribeKey",
       "kms:Encrypt",
       "kms:GenerateDataKey",

--- a/infra/terraform/modules/enterprise-release-publisher/iam.tf
+++ b/infra/terraform/modules/enterprise-release-publisher/iam.tf
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "promotion" {
 
   statement {
     sid       = "EncryptPublishedRepositoryObjects"
-    actions   = ["kms:DescribeKey", "kms:Encrypt", "kms:GenerateDataKey"]
+    actions   = ["kms:Decrypt", "kms:DescribeKey", "kms:Encrypt", "kms:GenerateDataKey"]
     resources = [aws_kms_key.repository.arn]
   }
 
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "timestamp_refresh" {
 
   statement {
     sid       = "EncryptTimestampMetadata"
-    actions   = ["kms:DescribeKey", "kms:Encrypt", "kms:GenerateDataKey"]
+    actions   = ["kms:Decrypt", "kms:DescribeKey", "kms:Encrypt", "kms:GenerateDataKey"]
     resources = [aws_kms_key.repository.arn]
   }
 

--- a/infra/terraform/modules/enterprise-release-publisher/outputs.tf
+++ b/infra/terraform/modules/enterprise-release-publisher/outputs.tf
@@ -1,4 +1,5 @@
 output "repository_bucket" { value = aws_s3_bucket.repository.id }
+output "repository_kms_key_arn" { value = aws_kms_key.repository.arn }
 output "repository_url" { value = "https://${var.repository_domain}" }
 output "cloudfront_domain_name" { value = aws_cloudfront_distribution.repository.domain_name }
 output "cloudfront_distribution_id" { value = aws_cloudfront_distribution.repository.id }


### PR DESCRIPTION
## Summary
- allow the protected promotion and timestamp-refresh roles to decrypt objects under the publisher repository KMS key
- add the same narrowly scoped permission to the publisher runtime boundary
- expose the repository KMS key ARN in protected deploy output

## Why
The real protected timestamp refresh assumed its OIDC role and validated repository coordinates, then failed reading the SSE-KMS encrypted timestamp metadata because `kms:Decrypt` was absent. S3 object reads under SSE-KMS require this permission.

The roles remain restricted to the repository key. Timestamp refresh still has no permission to use the root, targets, snapshot, or Cosign signing keys and no object mutation permission outside timestamp metadata.

## Verification
- Terraform 1.9.8 `fmt -check` and `validate` for bootstrap and publisher roots
- actionlint 1.7.7
- TFLint 0.54.0
- Checkov bootstrap: 44 passed, 0 failed
- Checkov publisher: 185 passed, 0 failed
- `git diff --check`
