### PR TITLE
fix(enterprise): bind stable to prod migration provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
           grep -Fq "api@${api_digest}" /tmp/api.yaml
           grep -Fq "gateway@${gateway_digest}" /tmp/gateway.yaml
           grep -Fq "frontend@${frontend_digest}" /tmp/edge.yaml
+          grep -Fq 'command: ["bun", "scripts/migrate.ts", "up"]' /tmp/api.yaml
 
   api-typecheck:
     name: API typecheck

--- a/.github/workflows/promote-enterprise-stable.yml
+++ b/.github/workflows/promote-enterprise-stable.yml
@@ -85,14 +85,39 @@ jobs:
           case "$contract_path" in "$GITHUB_WORKSPACE"/infra/enterprise-releases/*) ;; *) echo "compatibility contract must be under infra/enterprise-releases" >&2; exit 1 ;; esac
           test -f "$contract_path"
 
-          git fetch --force origin prod --tags
+          git fetch --force origin \
+            '+refs/heads/prod:refs/remotes/origin/prod' --tags
           gh release view "v$PROD_VERSION" --json isDraft --jq 'select(.isDraft == false) | true' | grep -qx true
-          test "$(git show "v$PROD_VERSION:VERSION" | tr -d '[:space:]')" = "$PROD_VERSION"
-          source_sha=$(git show "v$PROD_VERSION:RELEASE_SOURCE_SHA" | tr -d '[:space:]')
+
+          # GitHub's release tag names the public source tree, while the reviewed
+          # prod release commit records the exact staging image SHA in
+          # RELEASE_SOURCE_SHA. Resolve that version-to-source mapping from prod
+          # history instead of assuming the tag tree contains the provenance
+          # file. All prod commits that introduced this version must agree.
+          mapfile -t source_shas < <(
+            while IFS= read -r commit; do
+              version=$(git show "$commit:VERSION" 2>/dev/null | tr -d '[:space:]' || true)
+              [ "$version" = "$PROD_VERSION" ] || continue
+              git show "$commit:RELEASE_SOURCE_SHA" 2>/dev/null | tr -d '[:space:]'
+              printf '\n'
+            done < <(git rev-list origin/prod -- RELEASE_SOURCE_SHA)
+          )
+          mapfile -t source_shas < <(printf '%s\n' "${source_shas[@]}" | grep -E '^[a-f0-9]{40}$' | sort -u)
+          if [ "${#source_shas[@]}" -ne 1 ]; then
+            echo "::error::prod history must contain exactly one release source for $PROD_VERSION; found ${#source_shas[@]}"
+            exit 1
+          fi
+          source_sha=${source_shas[0]}
           [[ "$source_sha" =~ ^[a-f0-9]{40}$ ]]
           git cat-file -e "$source_sha^{commit}"
+          git merge-base --is-ancestor "$source_sha" origin/prod
 
           enterprise_version="$PROD_VERSION-e$REVISION"
+          test "$(basename "$contract_path")" = "$enterprise_version.json"
+          if jq -e '.migrations[] | select(.id == "baseline")' "$contract_path" >/dev/null; then
+            baseline_sha=$(git archive --format=tar "$source_sha" -- packages/db/migrations | sha256sum | awk '{print $1}')
+            test "$(jq -er '.migrations[] | select(.id == "baseline") | .sha256' "$contract_path")" = "$baseline_sha"
+          fi
           echo "prod_version=$PROD_VERSION" >> "$GITHUB_OUTPUT"
           echo "enterprise_version=$enterprise_version" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"

--- a/infra/enterprise-releases/0.9.108-e1.json
+++ b/infra/enterprise-releases/0.9.108-e1.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}

--- a/infra/enterprise-releases/README.md
+++ b/infra/enterprise-releases/README.md
@@ -11,5 +11,15 @@ workflow refuses to infer rollback or database safety from a version number.
   customer-zero release may use a single reviewed `baseline` entry because
   there is no earlier installed enterprise release to roll back to.
 
+For the first baseline, `sha256` is the deterministic archive digest of the
+canonical node-pg-migrate ledger in the exact production image source commit:
+
+```bash
+git archive --format=tar <RELEASE_SOURCE_SHA> -- packages/db/migrations | sha256sum
+```
+
+The protected promotion workflow recomputes this digest and rejects a baseline
+contract that does not match the production provenance recorded on `prod`.
+
 Contracts are immutable review evidence. Add a new file for every enterprise
 revision; never rewrite a contract after its TUF target has been published.

--- a/infra/k8s/charts/kortix-api/README.md
+++ b/infra/k8s/charts/kortix-api/README.md
@@ -32,8 +32,9 @@ GitOps value files under `infra/k8s/envs/<env>/`:
 The chart `fail`s fast if `serviceAccount.roleArn` or `ingress.certificateArn`
 are unset, so a misconfigured deploy never reaches the cluster.
 
-Database migrations are **not** applied by this chart in the current live deploy
-path. The GitHub Actions `migrate-db` jobs run `pnpm --filter @kortix/db migrate`
-(node-pg-migrate) before the GitOps rollout. The chart still contains a disabled
-legacy PreSync hook; do not enable it until it is ported or removed
-(https://github.com/kortix-ai/suna/issues/3628).
+Kortix Cloud keeps migrations in the GitHub Actions `migrate-db` jobs before its
+GitOps rollout. The chart's hook is disabled by default there. Enterprise VPC
+installations enable the hook because their customer-owned updater has no Kortix
+CI database credentials; it runs the same canonical
+`bun scripts/migrate.ts up` node-pg-migrate ledger from the digest-pinned API
+image before Helm rolls the application.

--- a/infra/k8s/charts/kortix-api/templates/migrate-job.yaml
+++ b/infra/k8s/charts/kortix-api/templates/migrate-job.yaml
@@ -1,11 +1,12 @@
 {{- if .Values.migrate.enabled }}
-# Drizzle migrations as an Argo CD PreSync hook: on every sync (i.e. the promote's
-# image bump), this runs `db:migrate` BEFORE the Deployment rolls. A failed
+# Canonical packages/db migrations as an Argo CD PreSync/Helm hook: on every
+# sync (i.e. the promote's image bump), this runs the same node-pg-migrate
+# ledger as production BEFORE the Deployment rolls. A failed
 # migration fails the hook → the sync halts → the new image never rolls, so code
 # can never ship ahead of its schema. Same image + same synced secret bundle as
 # the app (DATABASE_URL lives there) — no extra credentials, nothing in CI.
-# `drizzle-kit migrate` is idempotent (it records applied migrations), so a sync
-# with nothing pending is a fast no-op.
+# `migrate.ts up` is idempotent (it records applied migrations), so a sync with
+# nothing pending is a fast no-op.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43,7 +44,7 @@ spec:
           image: {{ include "kortix-api.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /app/packages/db
-          command: ["bunx", "drizzle-kit", "migrate"]
+          command: ["bun", "scripts/migrate.ts", "up"]
           # The full synced secret bundle (DATABASE_URL included), exactly as the app.
           envFrom:
             - secretRef:

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -109,8 +109,9 @@ externalSecrets:
   targetSecretName: kortix-api-env # synced k8s Secret
   refreshInterval: 1h
 
-# Drizzle migrations as an Argo CD PreSync hook (templates/migrate-job.yaml):
-# runs `db:migrate` before the Deployment rolls, gating the release on schema.
+# Canonical node-pg-migrate ledger as an Argo CD PreSync/Helm hook
+# (templates/migrate-job.yaml): runs `bun scripts/migrate.ts up` before the
+# Deployment rolls, gating the release on schema.
 # Enable in the env that OWNS the data plane (true for prod); leave false for a
 # pre-prod/canary that shares another env's DB and must never migrate it.
 migrate:


### PR DESCRIPTION
## Summary
- resolve an enterprise stable candidate from the reviewed `prod` release history instead of assuming `RELEASE_SOURCE_SHA` exists inside the GitHub tag tree
- bind the first `0.9.108-e1` contract to the exact 44-file node-pg-migrate baseline from production image source `d3e91c47…`
- replace the enterprise-enabled legacy Drizzle Helm hook with the canonical `bun scripts/migrate.ts up` runner used by current production
- make chart rendering assert the canonical command

## Why
The real `v0.9.108` GitHub tag points at a public source commit and does not contain `RELEASE_SOURCE_SHA`; the reviewed prod release history records the image source separately. The existing stable workflow would fail before AWS.

The enterprise updater also enables a chart hook that still invoked `drizzle-kit migrate`, while the production API image and deploy lane use the newer `packages/db/migrations` node-pg-migrate ledger. A first customer deployment must apply the actual production schema baseline.

## Verification
- exact prod history resolves `0.9.108` to `d3e91c476f7abf5f144c762e34f7ba613d6e9651`
- baseline archive recomputes to `cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133`
- real `kortix/kortix-api:0.9.108` reports that exact commit, contains 44 migrations, and `bun scripts/migrate.ts status` succeeds against local Supabase
- rendered Helm Job command is `[bun, scripts/migrate.ts, up]`
- enterprise updater: 33 passed, 0 failed
- enterprise release: 19 passed, 0 failed
- both package typechecks pass
- local full manifest generation accepts `0.9.108-e1` with exact prod image digests and reviewed contract
- actionlint clean; `git diff --check` clean
