### PR TITLE
fix(enterprise): allow Cosign key metadata lookup

### DIFF
--- a/infra/terraform/environments/enterprise-release-publisher-bootstrap/main.tf
+++ b/infra/terraform/environments/enterprise-release-publisher-bootstrap/main.tf
@@ -128,6 +128,7 @@ data "aws_iam_policy_document" "publisher_runtime_boundary" {
   statement {
     sid = "UseOnlyOnlinePublisherSigningKeys"
     actions = [
+      "kms:DescribeKey",
       "kms:GetPublicKey",
       "kms:Sign",
     ]

--- a/infra/terraform/modules/enterprise-release-publisher/iam.tf
+++ b/infra/terraform/modules/enterprise-release-publisher/iam.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "promotion" {
 
   statement {
     sid       = "SignOnlineMetadataAndArtifacts"
-    actions   = ["kms:GetPublicKey", "kms:Sign"]
+    actions   = ["kms:DescribeKey", "kms:GetPublicKey", "kms:Sign"]
     resources = concat([for key in aws_kms_key.online : key.arn], [aws_kms_key.cosign.arn])
   }
 


### PR DESCRIPTION
## Summary
- allow the protected promotion role to call `kms:DescribeKey` on online TUF/Cosign signing keys
- admit the same narrowly conditioned capability through the publisher runtime permissions boundary

## Why
Cosign resolves KMS key metadata before signing. Stable promotion run 29291057059 passed production provenance, then failed closed because both IAM layers omitted `kms:DescribeKey`.

## Verification
- Terraform 1.9.8 fmt clean
- publisher root and bootstrap root validate
- bootstrap plan: 0 add, 2 in-place policy refreshes, 0 destroy
- failed promotion evidence: https://github.com/kortix-ai/suna/actions/runs/29291057059