### PR TITLE
fix(cli): verify migrated Terraform state content

### DIFF
--- a/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
+++ b/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
@@ -103,7 +103,15 @@ case "$*" in
     for arg in "$@"; do case "$arg" in -chdir=*) dir="\${arg#-chdir=}" ;; esac; done
     case "\${dir:-}" in */state)
       if [ ! -f "$dir/terraform.bootstrap.tfstate" ]; then
-        printf '%s\n' '{"version":4,"serial":7,"lineage":"lineage-123"}' > "$dir/terraform.bootstrap.tfstate"
+        printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":7,"lineage":"lineage-123","outputs":{},"resources":[]}' > "$dir/terraform.bootstrap.tfstate"
+      fi
+      if grep -q 'backend "s3"' "$dir/backend.tf"; then
+        if [ "\${FAKE_TERRAFORM_REMOTE_DIFFERENT:-}" = "1" ]; then
+          printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":1,"lineage":"remote-lineage","outputs":{},"resources":[{"mode":"managed","type":"terraform_data","name":"stale","provider":"provider[\\"terraform.io/builtin/terraform\\"]","instances":[]}]}'
+        else
+          printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":1,"lineage":"remote-lineage","outputs":{},"resources":[]}'
+        fi
+        exit 0
       fi
       ;;
     esac
@@ -115,7 +123,7 @@ case "$*" in
     ;;
   *"apply"*)
     for arg in "$@"; do case "$arg" in -chdir=*) dir="\${arg#-chdir=}" ;; esac; done
-    case "\${dir:-}" in */state) printf '%s\n' '{"version":4,"serial":7,"lineage":"lineage-123"}' > "$dir/terraform.bootstrap.tfstate" ;; esac
+    case "\${dir:-}" in */state) printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":7,"lineage":"lineage-123","outputs":{},"resources":[]}' > "$dir/terraform.bootstrap.tfstate" ;; esac
     printf '%s\n' 'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
     ;;
   *"init -input=false -migrate-state"*)
@@ -291,7 +299,7 @@ esac
     expect(result.code, result.stderr).toBe(0);
     expect(JSON.parse(result.stdout)).toMatchObject({
       instance: 'kortix-vpc-demo',
-      state_migration: { verified: true, lineage: 'lineage-123', serial: 7 },
+      state_migration: { verified: true, lineage: 'remote-lineage', serial: 1 },
       cluster: { decision: 'manual_review', applied: true },
       reconciliation: { execution_arn: expect.stringContaining('kortix-vpc-demo-reconcile') },
     });
@@ -348,6 +356,22 @@ esac
     expect(result.stderr).toContain('local bootstrap state was preserved');
     const stateRoot = join(configRoot, 'kortix-vpc-demo/terraform/environments/enterprise-vpc/state');
     expect(readFileSync(join(stateRoot, 'backend.tf'), 'utf8')).toContain('backend "local"');
+    expect(existsSync(join(stateRoot, 'terraform.bootstrap.tfstate'))).toBe(true);
+    expect(readFileSync(awsLog, 'utf8')).not.toContain('states start-execution');
+  });
+
+  test('rejects a migrated remote state whose resources differ from the preserved bootstrap state', async () => {
+    await initConfigured();
+    writeFileSync(terraformLog, '');
+    writeFileSync(awsLog, '');
+
+    const result = await run(
+      ['deploy', '--instance', 'kortix-vpc-demo', '--yes'],
+      { FAKE_TERRAFORM_REMOTE_DIFFERENT: '1' },
+    );
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('remote state verification failed');
+    const stateRoot = join(configRoot, 'kortix-vpc-demo/terraform/environments/enterprise-vpc/state');
     expect(existsSync(join(stateRoot, 'terraform.bootstrap.tfstate'))).toBe(true);
     expect(readFileSync(awsLog, 'utf8')).not.toContain('states start-execution');
   });

--- a/apps/cli/src/self-host/enterprise-terraform.ts
+++ b/apps/cli/src/self-host/enterprise-terraform.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { chmodSync, existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -19,6 +20,7 @@ import type { CompleteAwsVpcConfig } from './aws-vpc-settings.ts';
 interface TerraformStateIdentity {
   lineage: string;
   serial: number;
+  [key: string]: unknown;
 }
 
 export interface BackendConfig {
@@ -114,8 +116,11 @@ export function migrateAndVerifyState(
   aws: CompleteAwsVpcConfig,
   alreadyRemote: boolean,
 ) {
-  const before = terraformJson<TerraformStateIdentity>(stateDirectory, aws, ['state', 'pull']);
-  assertStateIdentity(before, 'local/source');
+  const bootstrapPath = join(stateDirectory, 'terraform.bootstrap.tfstate');
+  const before = alreadyRemote && existsSync(bootstrapPath)
+    ? readStateFile(bootstrapPath, 'preserved local bootstrap')
+    : terraformJson<TerraformStateIdentity>(stateDirectory, aws, ['state', 'pull']);
+  assertStateIdentity(before, alreadyRemote ? 'preserved local bootstrap/remote source' : 'local/source');
   const backend = terraformOutput<BackendConfig>(stateDirectory, aws, 'backend_config');
   const permissionsBoundaryArn = terraformOutput<string>(stateDirectory, aws, 'permissions_boundary_arn');
   const backendPath = join(stateDirectory, 'backend.hcl');
@@ -138,13 +143,15 @@ export function migrateAndVerifyState(
 
   const after = terraformJson<TerraformStateIdentity>(stateDirectory, aws, ['state', 'pull']);
   assertStateIdentity(after, 'remote');
-  if (before.lineage !== after.lineage || before.serial !== after.serial) {
+  const beforeDigest = stateContentDigest(before);
+  const afterDigest = stateContentDigest(after);
+  if (beforeDigest !== afterDigest) {
     throw new Error(
-      `remote state verification failed: source ${before.lineage}/${before.serial}, remote ${after.lineage}/${after.serial}; local bootstrap state was preserved`,
+      `remote state verification failed: source ${before.lineage}/${before.serial} (${beforeDigest}), remote ${after.lineage}/${after.serial} (${afterDigest}); local bootstrap state was preserved`,
     );
   }
-  if (!alreadyRemote) {
-    rmSync(join(stateDirectory, 'terraform.bootstrap.tfstate'), { force: true });
+  if (!alreadyRemote || existsSync(bootstrapPath)) {
+    rmSync(bootstrapPath, { force: true });
     rmSync(join(stateDirectory, 'terraform.bootstrap.tfstate.backup'), { force: true });
   }
   return {
@@ -152,6 +159,34 @@ export function migrateAndVerifyState(
     permissionsBoundaryArn,
     verification: { verified: true, lineage: after.lineage, serial: after.serial, already_remote: alreadyRemote },
   };
+}
+
+function readStateFile(path: string, label: string): TerraformStateIdentity {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as TerraformStateIdentity;
+  } catch (error) {
+    throw new Error(`${label} Terraform state is invalid JSON: ${(error as Error).message}`);
+  }
+}
+
+function stateContentDigest(state: TerraformStateIdentity): string {
+  const content: Record<string, unknown> = { ...state };
+  delete content.lineage;
+  delete content.serial;
+  if (Array.isArray(content.check_results)) {
+    content.check_results = [...content.check_results]
+      .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
+  }
+  return createHash('sha256').update(stableJson(content)).digest('hex');
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
 }
 
 export function terraformOutput<T>(directory: string, aws: CompleteAwsVpcConfig, name: string): T {


### PR DESCRIPTION
## Summary
- verify migrated Terraform state by its complete semantic payload instead of backend-managed lineage/serial
- normalize only check-result ordering, while keeping resources, outputs, and all other state content fail-closed
- recover safely when a previous attempt left a verified remote backend plus preserved local bootstrap state
- add black-box coverage for backend identity rewrites and real semantic mismatch rejection

## Live evidence
Customer-zero S3 migration produced source `78417299-42f6-f22d-cd66-5abeb59d7674/21` and remote `f4d3babf-fe7e-fdf4-e674-0c28d384253f/1`, but both states contain the same 25 resource addresses and outputs. After excluding only lineage/serial and sorting check results, both payloads hash to `6347dc2748266fbd402aa9eb86920d63b155eb55a221363e9fc8599b01f72304`. Cluster creation remained stopped.

## Verification
- focused AWS VPC CLI black box: 14 passed, 0 failed
- CLI typecheck passed
- diff check passed