### PR TITLE
fix(cli): recover refreshed remote Terraform state

### DIFF
--- a/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
+++ b/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
@@ -108,6 +108,8 @@ case "$*" in
       if grep -q 'backend "s3"' "$dir/backend.tf"; then
         if [ "\${FAKE_TERRAFORM_REMOTE_DIFFERENT:-}" = "1" ]; then
           printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":1,"lineage":"remote-lineage","outputs":{},"resources":[{"mode":"managed","type":"terraform_data","name":"stale","provider":"provider[\\"terraform.io/builtin/terraform\\"]","instances":[]}]}'
+        elif [ "\${FAKE_TERRAFORM_REMOTE_REFRESHED:-}" = "1" ]; then
+          printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":2,"lineage":"remote-lineage","outputs":{},"resources":[{"mode":"managed","type":"terraform_data","name":"account_guard","provider":"provider[\\"terraform.io/builtin/terraform\\"]","instances":[{"schema_version":0,"attributes":{"id":"guard-1","output":{"provider_filled":true}}}]}]}'
         else
           printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":1,"lineage":"remote-lineage","outputs":{},"resources":[]}'
         fi
@@ -123,7 +125,12 @@ case "$*" in
     ;;
   *"apply"*)
     for arg in "$@"; do case "$arg" in -chdir=*) dir="\${arg#-chdir=}" ;; esac; done
-    case "\${dir:-}" in */state) printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":7,"lineage":"lineage-123","outputs":{},"resources":[]}' > "$dir/terraform.bootstrap.tfstate" ;; esac
+    case "\${dir:-}" in */state)
+      if ! grep -q 'backend "s3"' "$dir/backend.tf"; then
+        printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":7,"lineage":"lineage-123","outputs":{},"resources":[]}' > "$dir/terraform.bootstrap.tfstate"
+      fi
+      ;;
+    esac
     printf '%s\n' 'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
     ;;
   *"init -input=false -migrate-state"*)
@@ -299,7 +306,12 @@ esac
     expect(result.code, result.stderr).toBe(0);
     expect(JSON.parse(result.stdout)).toMatchObject({
       instance: 'kortix-vpc-demo',
-      state_migration: { verified: true, lineage: 'remote-lineage', serial: 1 },
+      state_migration: {
+        verified: true,
+        lineage: 'remote-lineage',
+        serial: 1,
+        verification_mode: 'exact-content',
+      },
       cluster: { decision: 'manual_review', applied: true },
       reconciliation: { execution_arn: expect.stringContaining('kortix-vpc-demo-reconcile') },
     });
@@ -374,6 +386,34 @@ esac
     const stateRoot = join(configRoot, 'kortix-vpc-demo/terraform/environments/enterprise-vpc/state');
     expect(existsSync(join(stateRoot, 'terraform.bootstrap.tfstate'))).toBe(true);
     expect(readFileSync(awsLog, 'utf8')).not.toContain('states start-execution');
+  });
+
+  test('recovers an already-remote state after provider refresh when all object identities and outputs match', async () => {
+    await initConfigured();
+    const stateRoot = join(configRoot, 'kortix-vpc-demo/terraform/environments/enterprise-vpc/state');
+    writeFileSync(join(stateRoot, 'backend.tf'), 'terraform { backend "s3" {} }\n');
+    writeFileSync(
+      join(stateRoot, 'backend.hcl'),
+      'bucket = "state"\ndynamodb_table = "locks"\nregion = "us-west-2"\nencrypt = true\nkms_key_id = "key"\n',
+    );
+    writeFileSync(
+      join(stateRoot, 'terraform.bootstrap.tfstate'),
+      '{"version":4,"terraform_version":"1.9.8","serial":7,"lineage":"lineage-123","outputs":{},"resources":[{"mode":"managed","type":"terraform_data","name":"account_guard","provider":"provider[\\"terraform.io/builtin/terraform\\"]","instances":[{"schema_version":0,"attributes":{"id":"guard-1"}}]}]}\n',
+    );
+
+    const result = await run(
+      ['deploy', '--instance', 'kortix-vpc-demo', '--yes', '--json'],
+      { FAKE_TERRAFORM_REMOTE_REFRESHED: '1' },
+    );
+    expect(result.code, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      state_migration: {
+        verified: true,
+        already_remote: true,
+        verification_mode: 'refreshed-object-identity',
+      },
+    });
+    expect(existsSync(join(stateRoot, 'terraform.bootstrap.tfstate'))).toBe(false);
   });
 
   test('routes reconcile, force update, and rollback through the customer state machine', async () => {

--- a/apps/cli/src/self-host/enterprise-terraform.ts
+++ b/apps/cli/src/self-host/enterprise-terraform.ts
@@ -145,9 +145,13 @@ export function migrateAndVerifyState(
   assertStateIdentity(after, 'remote');
   const beforeDigest = stateContentDigest(before);
   const afterDigest = stateContentDigest(after);
-  if (beforeDigest !== afterDigest) {
+  const beforeObjects = stateObjectDigest(before);
+  const afterObjects = stateObjectDigest(after);
+  const exactMatch = beforeDigest === afterDigest;
+  const refreshedRecoveryMatch = alreadyRemote && beforeObjects === afterObjects;
+  if (!exactMatch && !refreshedRecoveryMatch) {
     throw new Error(
-      `remote state verification failed: source ${before.lineage}/${before.serial} (${beforeDigest}), remote ${after.lineage}/${after.serial} (${afterDigest}); local bootstrap state was preserved`,
+      `remote state verification failed: source ${before.lineage}/${before.serial} (${beforeDigest}/${beforeObjects}), remote ${after.lineage}/${after.serial} (${afterDigest}/${afterObjects}); local bootstrap state was preserved`,
     );
   }
   if (!alreadyRemote || existsSync(bootstrapPath)) {
@@ -157,7 +161,13 @@ export function migrateAndVerifyState(
   return {
     backend,
     permissionsBoundaryArn,
-    verification: { verified: true, lineage: after.lineage, serial: after.serial, already_remote: alreadyRemote },
+    verification: {
+      verified: true,
+      lineage: after.lineage,
+      serial: after.serial,
+      already_remote: alreadyRemote,
+      verification_mode: exactMatch ? 'exact-content' : 'refreshed-object-identity',
+    },
   };
 }
 
@@ -177,7 +187,60 @@ function stateContentDigest(state: TerraformStateIdentity): string {
     content.check_results = [...content.check_results]
       .sort((left, right) => stableJson(left).localeCompare(stableJson(right)));
   }
-  return createHash('sha256').update(stableJson(content)).digest('hex');
+  return digestJson(content);
+}
+
+/**
+ * Recovery-only projection for a state that Terraform already migrated and
+ * subsequently refreshed against the provider. Refresh may fill computed
+ * attributes (for example an S3 bucket's versioning/policy) and advance the
+ * backend serial, while the tracked object graph remains the same. The state
+ * stage has just been planned, guarded, and applied before this check, so a
+ * recovery is accepted only when every resource instance identity and every
+ * output still match the preserved bootstrap state.
+ */
+function stateObjectDigest(state: TerraformStateIdentity): string {
+  const resources = Array.isArray(state.resources)
+    ? state.resources.map(projectResourceIdentity).sort((left, right) => stableJson(left).localeCompare(stableJson(right)))
+    : state.resources;
+  return digestJson({ outputs: state.outputs, resources });
+}
+
+function projectResourceIdentity(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const resource = value as Record<string, unknown>;
+  const instances = Array.isArray(resource.instances)
+    ? resource.instances.map(projectInstanceIdentity).sort((left, right) => stableJson(left).localeCompare(stableJson(right)))
+    : resource.instances;
+  return {
+    module: resource.module,
+    mode: resource.mode,
+    type: resource.type,
+    name: resource.name,
+    provider: resource.provider,
+    instances,
+  };
+}
+
+function projectInstanceIdentity(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const instance = value as Record<string, unknown>;
+  const attributes = instance.attributes && typeof instance.attributes === 'object' && !Array.isArray(instance.attributes)
+    ? instance.attributes as Record<string, unknown>
+    : {};
+  const identity: Record<string, unknown> = {};
+  for (const key of ['id', 'arn', 'name', 'bucket', 'key_id', 'alias_name', 'table_name']) {
+    if (Object.hasOwn(attributes, key)) identity[key] = attributes[key];
+  }
+  return {
+    index_key: instance.index_key,
+    schema_version: instance.schema_version,
+    identity,
+  };
+}
+
+function digestJson(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
 }
 
 function stableJson(value: unknown): string {


### PR DESCRIPTION
## Summary
- keep exact-content verification for first-time local-to-S3 migration
- recover a previously migrated state only after the guarded state plan/apply and only when every resource instance identity and every output match the preserved bootstrap state
- continue rejecting any added, missing, or changed Terraform object identity
- delete the preserved local bootstrap state only after one of those proofs succeeds

## Live evidence
The retry refreshed provider-computed fields on the same two S3 bucket objects (policy, logging, KMS encryption, lifecycle, versioning), advancing remote serial 1 to 2. All 25 Terraform object identities and outputs still hash identically at `5fb558278adf56597df71d9889c07c0f6a25af812d4d1d6f29a6557191579af3`. No cluster resources have been created.

## Verification
- AWS VPC CLI black box: 15 passed, 0 failed
- explicit provider-refresh recovery contract passed
- changed-resource rejection contract passed
- CLI typecheck passed
- diff check passed