### PR TITLE
fix(enterprise): normalize Route 53 zone guard

### DIFF
--- a/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
@@ -51,6 +51,13 @@ describe('embedded enterprise Terraform graph', () => {
     expect(controllerIrsa).toContain('route53:ChangeResourceRecordSets');
   });
 
+  test('accepts only the Route 53 apex or a label-bounded subdomain after provider name normalization', () => {
+    const acm = enterpriseTerraformAssets['modules/enterprise-vpc/acm.tf'];
+    expect(acm).toContain('lower(trimsuffix(data.aws_route53_zone.public.name, "."))');
+    expect(acm).toContain('lower(domain) == local.public_zone_name');
+    expect(acm).toContain('endswith(lower(domain), ".${local.public_zone_name}")');
+  });
+
   test('keeps the customer updater as the only enterprise Helm reconciler', () => {
     const sharedPlatform = enterpriseTerraformAssets['modules/eks/platform/main.tf'];
     const enterprisePlatform = enterpriseTerraformAssets['modules/enterprise-platform/main.tf'];

--- a/infra/terraform/modules/enterprise-vpc/acm.tf
+++ b/infra/terraform/modules/enterprise-vpc/acm.tf
@@ -20,6 +20,10 @@ data "aws_route53_zone" "public" {
   private_zone = false
 }
 
+locals {
+  public_zone_name = lower(trimsuffix(data.aws_route53_zone.public.name, "."))
+}
+
 resource "terraform_data" "public_dns_guard" {
   input = {
     zone     = data.aws_route53_zone.public.name
@@ -29,9 +33,8 @@ resource "terraform_data" "public_dns_guard" {
 
   lifecycle {
     precondition {
-      condition = alltrue([
-        endswith("${var.api_domain}.", data.aws_route53_zone.public.name),
-        endswith("${var.frontend_domain}.", data.aws_route53_zone.public.name),
+      condition = alltrue([for domain in [var.api_domain, var.frontend_domain] :
+        lower(domain) == local.public_zone_name || endswith(lower(domain), ".${local.public_zone_name}")
       ])
       error_message = "api_domain and frontend_domain must both belong to route53_zone_id."
     }


### PR DESCRIPTION
## Summary
- normalize AWS provider Route 53 zone names before enterprise DNS ownership validation
- preserve apex and label-bounded subdomain checks
- add embedded Terraform regression coverage

## Verification
- `bun test apps/cli/src/self-host/__tests__/enterprise-assets.test.ts` (9 passed)
- `pnpm --filter @kortix/cli typecheck`
- Terraform 1.9.8 cluster template validate
- live `kortix self-host plan --instance kortix-vpc-demo --json`: state 0 changes; cluster 141 creates, 0 updates/deletes/replaces; guard accepted hosted zone `Z08967081WIACA6008WUL` in account `935064898258`