### PR TITLE
fix(enterprise): allow encrypted CloudTrail alerts

### DIFF
--- a/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
+++ b/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
@@ -119,11 +119,11 @@ case "$*" in
     esac
     printf '%s\n' '{"version":4,"terraform_version":"1.9.8","serial":7,"lineage":"lineage-123","outputs":{},"resources":[]}'
     ;;
-  *"plan"*)
-    for arg in "$@"; do case "$arg" in -out=*) : > "\${arg#-out=}" ;; esac; done
-    printf '%s\n' 'Plan: 1 to add, 0 to change, 0 to destroy.'
-    ;;
   *"apply"*)
+    if [ -f "\${FAKE_TERRAFORM_LOG}.fail-apply" ]; then
+      printf '%s\n' '╷' '│ Error: simulated actionable apply failure' '╵' >&2
+      exit 66
+    fi
     for arg in "$@"; do case "$arg" in -chdir=*) dir="\${arg#-chdir=}" ;; esac; done
     case "\${dir:-}" in */state)
       if ! grep -q 'backend "s3"' "$dir/backend.tf"; then
@@ -132,6 +132,10 @@ case "$*" in
       ;;
     esac
     printf '%s\n' 'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.'
+    ;;
+  *"plan"*)
+    for arg in "$@"; do case "$arg" in -out=*) : > "\${arg#-out=}" ;; esac; done
+    printf '%s\n' 'Plan: 1 to add, 0 to change, 0 to destroy.'
     ;;
   *"init -input=false -migrate-state"*)
     if [ "\${FAKE_TERRAFORM_FAIL_MIGRATE:-}" = "1" ]; then
@@ -370,6 +374,15 @@ esac
     expect(readFileSync(join(stateRoot, 'backend.tf'), 'utf8')).toContain('backend "local"');
     expect(existsSync(join(stateRoot, 'terraform.bootstrap.tfstate'))).toBe(true);
     expect(readFileSync(awsLog, 'utf8')).not.toContain('states start-execution');
+  });
+
+  test('surfaces Terraform diagnostics instead of a box-drawing border', async () => {
+    await initConfigured();
+    writeFileSync(`${terraformLog}.fail-apply`, '');
+    const result = await run(['deploy', '--instance', 'kortix-vpc-demo', '--yes']);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Terraform apply failed: Error: simulated actionable apply failure');
+    expect(result.stderr).not.toContain('Terraform apply failed: ╷');
   });
 
   test('rejects a migrated remote state whose resources differ from the preserved bootstrap state', async () => {

--- a/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
@@ -58,6 +58,18 @@ describe('embedded enterprise Terraform graph', () => {
     expect(acm).toContain('endswith(lower(domain), ".${local.public_zone_name}")');
   });
 
+  test('allows CloudTrail to publish through the customer KMS-encrypted alert topic', () => {
+    const kms = enterpriseTerraformAssets['modules/enterprise-vpc/kms.tf'];
+    const cloudTrail = kms.slice(
+      kms.indexOf('sid = "CloudTrailEncryption"'),
+      kms.indexOf('sid = "CloudWatchLogsEncryption"'),
+    );
+    expect(cloudTrail).toContain('"kms:Decrypt"');
+    expect(cloudTrail).toContain('"kms:GenerateDataKey*"');
+    expect(cloudTrail).toContain('identifiers = ["cloudtrail.amazonaws.com"]');
+    expect(cloudTrail).toContain('variable = "aws:SourceArn"');
+  });
+
   test('keeps the customer updater as the only enterprise Helm reconciler', () => {
     const sharedPlatform = enterpriseTerraformAssets['modules/eks/platform/main.tf'];
     const enterprisePlatform = enterpriseTerraformAssets['modules/enterprise-platform/main.tf'];

--- a/apps/cli/src/self-host/enterprise-terraform.ts
+++ b/apps/cli/src/self-host/enterprise-terraform.ts
@@ -309,7 +309,7 @@ function terraform(directory: string, aws: CompleteAwsVpcConfig, args: string[])
   });
   if (result.error) throw new Error(`unable to run Terraform: ${result.error.message}`);
   if (result.status !== 0) {
-    throw new Error(`Terraform ${args[0]} failed: ${firstLine(result.stderr || result.stdout) || `exit ${result.status}`}`);
+    throw new Error(`Terraform ${args[0]} failed: ${terraformDiagnostic(result.stderr || result.stdout) || `exit ${result.status}`}`);
   }
   return result.stdout;
 }
@@ -344,6 +344,11 @@ function assertStateIdentity(state: TerraformStateIdentity, label: string): void
   }
 }
 
-function firstLine(value: string): string {
-  return value.trim().split(/\r?\n/, 1)[0] ?? '';
+function terraformDiagnostic(value: string): string {
+  const lines = value
+    .replace(/\x1B\[[0-?]*[ -\/]*[@-~]/g, '')
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^[│|]\s?/, '').trim())
+    .filter((line) => line !== '' && !/^[╷╵─]+$/.test(line));
+  return lines.find((line) => line.startsWith('Error:')) ?? lines[0] ?? '';
 }

--- a/infra/terraform/modules/enterprise-vpc/kms.tf
+++ b/infra/terraform/modules/enterprise-vpc/kms.tf
@@ -36,6 +36,7 @@ data "aws_iam_policy_document" "data_key" {
   statement {
     sid = "CloudTrailEncryption"
     actions = [
+      "kms:Decrypt",
       "kms:DescribeKey",
       "kms:GenerateDataKey*",
     ]


### PR DESCRIPTION
## Summary
- allow CloudTrail to decrypt data keys for the customer KMS-encrypted SNS delivery topic, constrained to the exact customer trail ARN
- surface the first actionable Terraform diagnostic instead of ANSI box borders
- correct fake Terraform dispatch so black-box tests exercise `apply` before matching `.kortix.plan`

## Customer-zero evidence
- initial apply created 140/141 cluster resources and failed only at `aws_cloudtrail.operations`
- AWS error: `InsufficientSnsTopicPolicyException` because the encrypted SNS CMK did not allow CloudTrail decrypt
- residual patched plan: 1 create, 3 in-place updates, 0 deletes/replacements; the two IAM updates are dependency re-evaluations after KMS policy change

## Verification
- `bun test apps/cli/src/self-host/__tests__/enterprise-assets.test.ts apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts` (26 passed)
- `pnpm --filter @kortix/cli typecheck`
- Terraform 1.9.8 recursive fmt and enterprise cluster validate
- live customer-zero plan against account `935064898258`