### PR TITLE
release(enterprise): review 0.9.108-e2 contract

### DIFF
--- a/infra/enterprise-releases/0.9.108-e2.json
+++ b/infra/enterprise-releases/0.9.108-e2.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the immutable compatibility contract for enterprise revision 0.9.108-e2
- retain the exact 0.9.108 production migration baseline and EKS 1.32 compatibility
- leave rollback disabled until the concrete downgrade drill passes

## Verification
- `jq -e . infra/enterprise-releases/0.9.108-e2.json`
- recomputed the 0.9.108 prod source migration archive SHA-256: `cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133`
- `pnpm --filter @kortix/enterprise-release test` (19 passed)