### PR TITLE
docs: cover self-host AWS VPC and SDK retries

### DIFF
--- a/apps/web/content/docs/concepts/index.mdx
+++ b/apps/web/content/docs/concepts/index.mdx
@@ -12,7 +12,7 @@ default branch only via a merged **[change request](/docs/concepts/change-reques
 ## The pieces
 
 - **[Projects](/docs/concepts/projects)** — a git repo (Kortix-managed or
-  imported GitHub) plus its manifest.
+  imported GitHub, pinned to one branch) plus its manifest.
 - **[Sessions](/docs/concepts/sessions)** — isolated sandbox VMs, each on
   its own branch. Many run at once without interfering.
 - **[Agents](/docs/concepts/agents)** — OpenCode, governed by the manifest's
@@ -36,7 +36,7 @@ default branch only via a merged **[change request](/docs/concepts/change-reques
 2. It resolves a content-addressed **snapshot** — the platform's default image
    (or your own Dockerfile, if the manifest declares a
    [`sandbox.templates`](/docs/reference/manifest) entry for it) plus the
-   Kortix runtime layer, built by the sandbox provider (Daytona by default).
+    Kortix runtime layer, built by the configured sandbox provider.
    Unchanged projects reuse the cached image.
 3. The sandbox provider boots the VM. The `kortix-agent` daemon clones the repo to
    `/workspace`, fetches git credentials just-in-time, and launches OpenCode.

--- a/apps/web/content/docs/concepts/projects.mdx
+++ b/apps/web/content/docs/concepts/projects.mdx
@@ -21,7 +21,15 @@ Backed two ways:
 - **Imported GitHub repo** — link an existing repo; Kortix operates on it via the
   GitHub API.
 
-Either way the project has a `default_branch` that every
+When importing GitHub, choose the branch that becomes this project's
+`default_branch` (the repo's default is just the default choice). Each branch of
+the same GitHub repo can be a separate Kortix project with its own sessions and
+change requests, so `main` and `dev` can be managed as independent workspaces.
+The SDK exposes branch discovery through
+`kortix.github.listRepositoryBranches` and imports via
+`kortix.projects.linkRepository`.
+
+Either backing mode gives the project a `default_branch` that every
 [session](/docs/concepts/sessions) branches from and every
 [change request](/docs/concepts/change-requests) merges into.
 

--- a/apps/web/content/docs/reference/cli.mdx
+++ b/apps/web/content/docs/reference/cli.mdx
@@ -72,28 +72,53 @@ One Kortix login can belong to many accounts (personal, a company account, …).
 
 ### Self-host
 
-`kortix self-host start` creates and starts a production-style local Kortix stack
-using Docker Compose. On first interactive setup it always collects a Daytona
-API key (the sandbox runtime — required, or agent sessions can't start) and
-managed GitHub access (a PAT or GitHub App — required to create projects), plus
-the optional Pipedream integration for app connectors. Local ports, Supabase, generated secrets, and
-Docker defaults are handled automatically. `start` prints a warning if the
-sandbox provider or git provider still isn't configured.
+`kortix self-host` manages two targets: a local Docker Compose stack
+(`--target docker`, the default for new instances) and a production Enterprise
+AWS VPC stack (`--target aws-vpc`). Existing Docker instances remain fully
+compatible.
+
+For Docker, `start` creates config if needed, starts Supabase/API/web locally,
+and collects the Daytona sandbox key, managed GitHub access, and optional
+Pipedream connector integration. Local ports, generated secrets, and Docker
+defaults are handled automatically.
+
+For AWS VPC, `init --target aws-vpc` stores secret-free desired settings and the
+CLI materializes the reviewed Terraform roots plus signed enterprise updater
+assets. `init`, `configure`, `doctor`, and `plan` are non-mutating; `deploy`
+requires confirmation (or `--yes`) and migrates bootstrap state into customer
+S3. After bootstrap, `reconcile`, `update`, and `rollback` start the
+customer-owned updater workflow and cannot bypass TUF signature, digest,
+compatibility, account, Terraform-plan, migration, or health gates. The full
+operator runbook lives at `docs/runbooks/enterprise-vpc-deployment.md` in the
+repository.
 
 | Command | Effect |
 | --- | --- |
-| `kortix self-host init` | Create the self-host config with production defaults, without starting the stack. |
-| `kortix self-host start` | Create config if needed, start the local stack, and register the `selfhost` host. |
-| `kortix self-host update [--tag <v>]` | Pull a newer version (default: `latest`), apply migrations, and recreate the stack in place — preserves the Postgres volume. |
+| `kortix self-host init [--target docker\|aws-vpc]` | Create the self-host config with production defaults, without starting the target. |
+| `kortix self-host configure` | Re-run the target credential/config wizard. |
+| `kortix self-host doctor` | Validate local tools, credentials, and target access. Non-mutating. |
+| `kortix self-host plan` | Preview target changes without applying them. Non-mutating. |
+| `kortix self-host deploy` | Bootstrap or converge an AWS VPC target from a saved plan. |
+| `kortix self-host start` | Docker only: create config if needed, start the local stack, and register the `selfhost` host. |
+| `kortix self-host update [--tag <v> \| --release <v>]` | Docker: pull a newer image tag and recreate the stack in place. AWS VPC: start the signed updater for an immutable enterprise release. |
+| `kortix self-host reconcile` | Ask an AWS VPC target to converge to its configured release channel. |
+| `kortix self-host rollback --release <v>` | Roll an AWS VPC target back to a compatible signed release. |
 | `kortix self-host version` | Show the running version and image tags. |
-| `kortix self-host restart` | Restart the stack. |
-| `kortix self-host status` | Show Docker Compose service status. |
+| `kortix self-host restart` | Docker only: restart the local stack. |
+| `kortix self-host status` | Show Docker Compose service status or AWS target health/deployment status. |
 | `kortix self-host open` | Open the local dashboard in your browser. |
-| `kortix self-host configure` | Re-run the Daytona, GitHub, and Pipedream credential wizard. |
 | `kortix self-host env ls` | Show persistent self-host env values, masking populated secrets. |
 | `kortix self-host env set KEY=VALUE …` | Update advanced persistent env values before the next start. |
 | `kortix self-host logs [service]` | Tail Docker Compose logs. |
-| `kortix self-host stop` | Stop the stack. |
+| `kortix self-host stop` | Docker only: stop the local stack. |
+
+Common target flags: `--instance`, `--target`, `--json`, and `--yes`. Docker
+adds `--tag`, `--local`, and `--registry`. AWS VPC adds `--release`,
+`--channel`, `--aws-profile`, `--region`, `--vpc-cidr`, `--api-domain`,
+`--frontend-domain`, `--route53-zone-id`, `--release-repository-url`,
+`--tuf-root-sha256`, `--updater-bootstrap-url`,
+`--updater-bootstrap-sha256`, `--release-publisher-account-id`,
+`--maintenance-window`, and `--force`.
 
 ### Projects
 
@@ -561,6 +586,6 @@ The `KORTIX_*` prefix is reserved for platform-injected values. Don't declare pr
 
 ## What the CLI is not
 
-- **Not a separate runtime.** Use `kortix self-host start` to run your own local Kortix Cloud stack, then switch between Cloud and local APIs with `kortix hosts use`.
+- **Not a separate runtime.** Use `kortix self-host start` for local Docker or `kortix self-host deploy --target aws-vpc` for Enterprise AWS VPC, then switch between Cloud and self-hosted APIs with `kortix hosts use`.
 - **Not a `git` replacement.** `kortix cr` composes with `git` rather than wrapping it.
 - **Not the runtime.** OpenCode executes the agent in the sandbox; the CLI is the control plane. See [Kortix vs OpenCode config](/docs/reference/config-boundary).

--- a/apps/web/content/docs/reference/index.mdx
+++ b/apps/web/content/docs/reference/index.mdx
@@ -10,6 +10,7 @@ Every field, default, flag, endpoint, and validator. Plain-language versions liv
 <Cards>
   <Card title="Manifest (kortix.yaml)" href="/docs/reference/manifest">Every field, default, and validation rule — v2 (`kortix.yaml`) and legacy v1 (`kortix.toml`).</Card>
   <Card title="CLI reference" href="/docs/reference/cli">Every `kortix` command, token scopes, env vars, exit codes.</Card>
+  <Card title="Self-hosting" href="/docs/reference/cli#self-host">Docker self-host and Enterprise AWS VPC command surface.</Card>
   <Card title="Change requests" href="/docs/reference/change-requests">Data model, lifecycle, diff/merge semantics, CLI, REST API.</Card>
   <Card title="Session runtime" href="/docs/reference/session-runtime">Lifecycle, branch model, sandbox layout, injected env, daemon.</Card>
   <Card title="Secrets" href="/docs/reference/secrets">How `project_secrets` flow from the manifest to your sandbox.</Card>

--- a/apps/web/content/docs/sdk/error-handling.mdx
+++ b/apps/web/content/docs/sdk/error-handling.mdx
@@ -51,6 +51,13 @@ The class every failed `backendApi`/facade call produces. `name` defaults to
 - `code: 'TIMEOUT'` — the request's own timeout budget elapsed; `url`, `endpoint`, and `timeout` (ms) are set so you know what timed out.
 - Otherwise `status` is the HTTP status code and `code` is the backend's `error_code`/`detail.error_code` (falling back to the status as a string) when the body carried one.
 
+Transient gateway failures are retried before you see them: idempotent reads
+(`GET`/`HEAD`) that return `502`, `503`, or `504` retry up to two times with a
+250ms → 500ms backoff. A single proxy/ALB blip is absorbed silently and never
+reaches `onError`; persistent failures surface as a normal `ApiError` with the
+last status. Mutations (`POST`/`PUT`/`PATCH`/`DELETE`) and deterministic `500`s
+are never retried.
+
 `message` is an **enumerable own property** (not just inherited from `Error`),
 so spreading the error or `JSON.stringify`-logging it includes the message —
 useful for error reporting.

--- a/docs/runbooks/enterprise-vpc-deployment.md
+++ b/docs/runbooks/enterprise-vpc-deployment.md
@@ -35,8 +35,9 @@ for DNS writes but does not persist it as a managed resource attribute.
 
 ## Bootstrap order
 
-1. The CLI resolves the AWS target and prints the STS account, ARN, region, and
-   planned instance name. It refuses an account mismatch.
+1. The CLI resolves the AWS target and prints the STS account, region, and
+   planned instance name. It refuses an account mismatch. `doctor` also prints
+   the resolved caller ARN while validating target access.
 2. The `state` root plans locally. Bootstrap IAM/KMS/S3/DynamoDB changes always
    require explicit customer review.
 3. The state root applies, its local state migrates to the new encrypted S3

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -31,6 +31,10 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - `getPlatformUrl()` no longer reads a bare `process.env`, which threw a
   `ReferenceError` in a browser `<script>` bundle and on React Native.
+- The HTTP layer (`backendApi`/`makeRequest`) now transparently retries transient
+  `502`/`503`/`504` responses on idempotent reads (`GET`/`HEAD`) up to two times
+  with 250ms → 500ms backoff. Mutations and HTTP `500` responses are never
+  retried.
 
 ### Internal
 - `src/` is now tiered: `core/` (isomorphic), `browser/`, `node/`, `react/`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -322,6 +322,10 @@ long-lived SSE event stream is exempt), so a hung sandbox/daemon call can't
 wedge a server-side handler forever — it surfaces as an `ApiError` with
 `code: 'TIMEOUT'` instead.
 
+Idempotent reads (`GET`/`HEAD`) also absorb transient gateway blips: `502`,
+`503`, and `504` retry up to two times with 250ms → 500ms backoff before an
+`ApiError` is surfaced. Mutations and HTTP `500` responses are never retried.
+
 ## Subpath modules
 
 Stable, tree-shakeable surfaces (also reachable via the facade). Not exhaustive


### PR DESCRIPTION
Docs-maintainer follow-up for the 2026-07-14 sweep. Covers drift found by worker shards after the identity-safe replacement PR #4641 merged.

## What changed
- Documents branch-isolated imported GitHub projects on `/docs/concepts/projects` and the concepts index.
- Makes the session snapshot overview provider-neutral instead of saying Daytona is universally default.
- Expands `/docs/reference/cli#self-host` to cover the Enterprise AWS VPC target, command lifecycle, flags, and signed-updater constraints.
- Adds a Self-hosting card to the Reference index.
- Documents SDK transient gateway retries on idempotent reads in the SDK error-handling page, SDK README, and CHANGELOG.

## Source evidence
- `apps/cli/src/commands/self-host.ts` help lists `--target aws-vpc`, `doctor`, `plan`, `deploy`, `reconcile`, `rollback`, and the AWS flags.
- `apps/cli/src/self-host/aws-vpc.ts` rejects Docker-only lifecycle commands for AWS VPC and requires signed releases for AWS updates.
- `docs/runbooks/enterprise-vpc-deployment.md` documents the AWS VPC management plane, non-mutating commands, and signed updater gates.
- `apps/api/src/projects/routes/r1.ts`/`r2.ts` and project contract tests support branch-specific imports via `default_branch`; SDK docs already expose branch discovery/linking.
- `packages/sdk/src/core/http/api-client.ts` and `api-client.test.ts` prove GET/HEAD retries for transient 502/503/504 and no retries for mutations/500.
- Runtime provider source uses configured provider selection; the public session/runtime docs already list Daytona, Platinum, and E2B.

## Verification
- `git diff --check`
- `node /workspace/.kortix/opencode/skills/docs-maintainer/scripts/check-fumadocs.mjs apps/web/content/docs` — passed (40 pages, 5 nav, 40 unique routes)
- `pnpm --filter @kortix/cli cli -- self-host --help` with assertions for AWS VPC flags/subcommands
- `pnpm --filter @kortix/sdk exec bun test --isolate src/core/http/api-client.test.ts` — 13 pass

Docs-only plus SDK README/CHANGELOG docs. I will wait for all checks, run the deterministic docs PR checker, verify exact-head Vercel routes/search, rebase if main moves, merge only if green, and verify the merged dev docs deployment.