### PR TITLE
fix(enterprise): make archive guard awk-portable

### DIFF
--- a/apps/enterprise-updater/src/__tests__/installer.test.ts
+++ b/apps/enterprise-updater/src/__tests__/installer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -39,6 +40,18 @@ describe('Supabase host installer command', () => {
     expect(script).toContain('update-transactions');
     expect(script).toContain('"$transaction.previous"');
     expect(script).toContain('restored the previous release');
+  });
+
+  test('renders a portable executable archive path guard', () => {
+    const script = supabaseInstallScript(input);
+    const line = script.split('\n').find((candidate) => candidate.includes('"$entries" | awk '));
+    const program = line?.match(/\| awk '(.+)'$/)?.[1];
+    expect(program).toBeDefined();
+
+    const run = (entries: string) => spawnSync('awk', [program!], { input: entries, encoding: 'utf8' });
+    expect(run('bundle.json\nvolumes/db/data\n').status).toBe(0);
+    expect(run('/etc/passwd\n').status).toBe(1);
+    expect(run('volumes/../etc/passwd\n').status).toBe(1);
   });
 
   test('emits bounded commit and rollback commands for the exact activation transaction', () => {

--- a/apps/enterprise-updater/src/installer.ts
+++ b/apps/enterprise-updater/src/installer.ts
@@ -529,7 +529,7 @@ aws s3 cp s3://${input.bucket}/${input.key} "$archive"
 echo '${input.sha256}  '"$archive" | sha256sum --check --strict
 entries=$(tar -tzf "$archive")
 test -n "$entries"
-printf '%s\n' "$entries" | awk '{ if ($0 ~ /^\\//) exit 1; count=split($0, segments, "/"); for (index=1; index<=count; index++) if (segments[index] == "..") exit 1 }'
+printf '%s\n' "$entries" | awk '{ if ($0 ~ /^\\//) exit 1; count=split($0, segments, "/"); for (part=1; part<=count; part++) if (segments[part] == "..") exit 1 }'
 tar -tvzf "$archive" | awk '{ type=substr($0, 1, 1); if (type != "-" && type != "d") exit 1 }'
 rm -rf "$staging"
 install -d -m 0700 "$staging"

--- a/infra/enterprise-releases/0.9.108-e3.json
+++ b/infra/enterprise-releases/0.9.108-e3.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- stop using the reserved awk builtin name `index` as an archive-guard loop variable
- execute the rendered awk program in a regression test against safe, absolute, and traversal paths
- add the immutable 0.9.108-e3 compatibility contract for the corrected updater revision

## Live failure evidence
Customer-zero SSM command `e4102ea8-6eb6-4971-8c94-1e620db9e67b` checksum-verified e2, then Amazon Linux awk rejected `for (index=...)` before extraction. No release was activated.

## Verification
- focused installer tests: 12 passed
- all enterprise updater tests: 34 passed
- updater typecheck: passed
- enterprise release/TUF/backup tests: 19 passed
- recomputed prod 0.9.108 migration baseline SHA-256: `cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133`