### PR TITLE
fix(enterprise): preserve public Supabase bundle modes

### DIFF
--- a/apps/enterprise-updater/src/__tests__/installer.test.ts
+++ b/apps/enterprise-updater/src/__tests__/installer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { MirroredImage } from '../artifacts.ts';
@@ -52,6 +52,36 @@ describe('Supabase host installer command', () => {
     expect(run('bundle.json\nvolumes/db/data\n').status).toBe(0);
     expect(run('/etc/passwd\n').status).toBe(1);
     expect(run('volumes/../etc/passwd\n').status).toBe(1);
+  });
+
+  test('extracts public bundle assets with container-readable modes under the secure installer umask', () => {
+    const root = mkdtempSync(join('/tmp', 'kortix-supabase-modes-'));
+    try {
+      const source = join(root, 'source');
+      const staging = join(root, 'staging');
+      const archive = join(root, 'bundle.tar.gz');
+      mkdirSync(join(source, 'bin'), { recursive: true });
+      mkdirSync(join(source, 'volumes', 'db'), { recursive: true });
+      writeFileSync(join(source, 'volumes', 'db', 'webhooks.sql'), 'select 1;\n', { mode: 0o644 });
+      writeFileSync(join(source, 'bin', 'install'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+      chmodSync(join(source, 'bin', 'install'), 0o755);
+      expect(spawnSync('tar', ['-czf', archive, '-C', source, '.']).status).toBe(0);
+      mkdirSync(staging);
+
+      const extraction = supabaseInstallScript(input).split('\n')
+        .find((candidate) => candidate.startsWith('(umask 022; tar -xzf '));
+      expect(extraction).toBeDefined();
+      const result = spawnSync('bash', [
+        '-ceu',
+        `umask 077\narchive="$1"\nstaging="$2"\n${extraction}`,
+        'bash', archive, staging,
+      ], { encoding: 'utf8' });
+      expect({ status: result.status, stderr: result.stderr }).toEqual({ status: 0, stderr: '' });
+      expect(statSync(join(staging, 'volumes', 'db', 'webhooks.sql')).mode & 0o777).toBe(0o644);
+      expect(statSync(join(staging, 'bin', 'install')).mode & 0o777).toBe(0o755);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('emits bounded commit and rollback commands for the exact activation transaction', () => {

--- a/apps/enterprise-updater/src/installer.ts
+++ b/apps/enterprise-updater/src/installer.ts
@@ -533,7 +533,7 @@ printf '%s\n' "$entries" | awk '{ if ($0 ~ /^\\//) exit 1; count=split($0, segme
 tar -tvzf "$archive" | awk '{ type=substr($0, 1, 1); if (type != "-" && type != "d") exit 1 }'
 rm -rf "$staging"
 install -d -m 0700 "$staging"
-tar -xzf "$archive" --directory "$staging" --no-same-owner --no-same-permissions
+(umask 022; tar -xzf "$archive" --directory "$staging" --no-same-owner --no-same-permissions)
 test -x "$staging/bin/install"
 test -f "$staging/bundle.json"
 "$staging/bin/install" --runtime-secret-arn '${input.runtimeSecretArn}' --release '${input.version}' --instance '${input.instance}' --api-domain '${input.apiDomain}' --frontend-domain '${input.frontendDomain}'

--- a/infra/enterprise-releases/0.9.108-e4.json
+++ b/infra/enterprise-releases/0.9.108-e4.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- extract the signed public Supabase bundle under a scoped `umask 022` while retaining `umask 077` for generated secrets and transaction state
- execute the rendered extraction command against a real tarball and assert SQL remains 0644 and installer binaries 0755
- add the immutable 0.9.108-e4 compatibility contract

## Live failure evidence
Customer-zero e3 passed checksum, archive guards, extraction, and PostgreSQL initialization, then container `supabase-db` failed reading bind-mounted `98-webhooks.sql` because extraction under `umask 077` produced a host file unreadable to non-root postgres. No release was committed.

## Verification
- focused installer tests: 13 passed
- all updater tests: 35 passed
- updater typecheck: passed
- enterprise release/TUF/backup tests: 19 passed
- real local tar extraction mode assertions: SQL 0644, installer 0755