### PR TITLE
fix(enterprise): pin Supabase runtime paths

### DIFF
--- a/apps/enterprise-release/src/__tests__/bundles.test.ts
+++ b/apps/enterprise-release/src/__tests__/bundles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -55,6 +55,7 @@ describe('enterprise release bundles', () => {
       expect(overlay).toContain('archive_timeout=300s');
       expect(overlay).toContain('/var/lib/kortix/wal:/var/lib/kortix-wal:Z');
       expect(overlay).toContain('/var/lib/kortix/recovery-wal:/var/lib/kortix-recovery-wal:ro,Z');
+      expect(overlay).toContain('supavisor:\n    ulimits:\n      nofile:\n        soft: 100000\n        hard: 100000');
 
       for (const script of ['install', 'supabase-start', 'supabase-stop', 'wal-archive', 'base-backup', 'pitr-restore']) {
         const path = join(root, 'bin', script);
@@ -72,6 +73,16 @@ describe('enterprise release bundles', () => {
       expect(readFileSync(join(root, 'bin', 'wal-archive'), 'utf8')).toContain('s3api head-object');
       expect(readFileSync(join(root, 'bin', 'base-backup'), 'utf8')).toContain('pg_basebackup');
       expect(installer).not.toContain('kortix-api');
+
+      const start = readFileSync(join(root, 'bin', 'supabase-start'), 'utf8');
+      const physicalRoot = start.split('\n').find((line) => line.startsWith('root=$(readlink -f '));
+      expect(physicalRoot).toBeDefined();
+      symlinkSync('.', join(root, 'current'));
+      const probe = join(root, 'bin', 'root-probe');
+      writeFileSync(probe, `#!/usr/bin/env bash\nset -euo pipefail\n${physicalRoot}\nprintf '%s\\n' "$root"\n`, { mode: 0o755 });
+      const resolved = spawnSync(join(root, 'current', 'bin', 'root-probe'), [], { encoding: 'utf8' });
+      expect({ status: resolved.status, stderr: resolved.stderr, root: resolved.stdout.trim() })
+        .toEqual({ status: 0, stderr: '', root: realpathSync(root) });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/enterprise-release/src/bundles.ts
+++ b/apps/enterprise-release/src/bundles.ts
@@ -175,6 +175,11 @@ function enterpriseSupabaseOverlay(): string {
       - archive_timeout=300s
       - -c
       - archive_command=cp %p /var/lib/kortix-wal/.%f.tmp && mv /var/lib/kortix-wal/.%f.tmp /var/lib/kortix-wal/%f
+  supavisor:
+    ulimits:
+      nofile:
+        soft: 100000
+        hard: 100000
 `;
 }
 
@@ -202,7 +207,7 @@ function supabaseHostInstallScript(): string {
     'for value in "$runtime_secret_arn" "$release" "$instance" "$api_domain" "$frontend_domain"; do',
     '  [ -n "$value" ] || { echo "missing required Supabase install option" >&2; exit 2; }',
     'done',
-    'root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)',
+    'root=$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")/..")',
     '',
     'jq -e --arg release "$release" \'.schema_version == 1 and .kind == "kortix-enterprise-supabase" and .version == $release and (.compose_files == ["docker-compose.yml", "docker-compose.logs.yml", "docker-compose.enterprise.yml"]) and (.persistent_paths["volumes/db/data"] == "/var/lib/kortix/postgres") and (.persistent_paths["volumes/storage"] == "/var/lib/kortix/storage") and (.persistent_paths.wal_spool == "/var/lib/kortix/wal") and (.persistent_paths.recovery_wal == "/var/lib/kortix/recovery-wal") and (.backup == {archive_timeout_seconds:300,wal_upload_interval_seconds:60,base_backup_interval:"daily"}) and (.image_digests | type == "object" and length > 0 and all(to_entries[]; (.key | type == "string") and (.value | test("^sha256:[a-f0-9]{64}$"))))\' "$root/bundle.json" >/dev/null',
     '',
@@ -256,7 +261,7 @@ function supabaseStartScript(): string {
   return [
     '#!/usr/bin/env bash',
     'set -euo pipefail',
-    'root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)',
+    'root=$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")/..")',
     'instance=$(<"$root/.instance")',
     'compose=(docker compose --project-name "kortix-$instance" --env-file "$root/.env" -f "$root/docker-compose.yml" -f "$root/docker-compose.logs.yml" -f "$root/docker-compose.enterprise.yml")',
     '"${compose[@]}" up --detach --remove-orphans --wait --wait-timeout 900',
@@ -271,7 +276,7 @@ function supabaseStopScript(): string {
   return [
     '#!/usr/bin/env bash',
     'set -euo pipefail',
-    'root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)',
+    'root=$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")/..")',
     'instance=$(<"$root/.instance")',
     'systemctl stop kortix-wal-archive.timer kortix-base-backup.timer || true',
     'exec docker compose --project-name "kortix-$instance" --env-file "$root/.env" -f "$root/docker-compose.yml" -f "$root/docker-compose.logs.yml" -f "$root/docker-compose.enterprise.yml" down --timeout 120',
@@ -367,7 +372,7 @@ function pitrRestoreScript(): string {
     'target_epoch=$(date -u -d "$target_time" +%s) || { echo "invalid target time" >&2; exit 2; }',
     '[ "$target_epoch" -le "$(date -u +%s)" ] || { echo "target time cannot be in the future" >&2; exit 2; }',
     '',
-    'root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)',
+    'root=$(readlink -f "$(dirname -- "${BASH_SOURCE[0]}")/..")',
     'bundle_instance=$(<"$root/.instance")',
     '[ "$bundle_instance" = "$KORTIX_INSTANCE" ] || { echo "active bundle instance does not match recovery instance" >&2; exit 1; }',
     'data_dir=${KORTIX_POSTGRES_DATA_DIR:-/var/lib/kortix/postgres}',

--- a/infra/enterprise-releases/0.9.108-e5.json
+++ b/infra/enterprise-releases/0.9.108-e5.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- resolve every release-rooted Supabase script to the immutable physical release directory instead of the mutable `/opt/kortix/current` symlink
- set the official Supavisor container `nofile` soft/hard limit to its required 100000 in the enterprise-only Compose overlay
- execute the generated root expression through a real symlink and assert it resolves to the physical release
- add the immutable 0.9.108-e5 compatibility contract

## Live failure evidence
Customer-zero e4 initialized PostgreSQL and brought 12/13 Supabase services healthy. Supavisor failed because its bind mount retained `/opt/kortix/current` and because the hardened host default hard limit was 65536. The installer rolled back; no release was committed.

## Verification
- enterprise release/TUF/backup/bundle tests: 19 passed
- generated bundle script syntax checks pass
- real symlink-root probe resolves to the physical immutable release directory
- enterprise updater tests: 35 passed
- enterprise release and updater typechecks pass