### PR TITLE
fix(enterprise): wait for long SSM installs

### DIFF
--- a/apps/enterprise-updater/src/__tests__/installer.test.ts
+++ b/apps/enterprise-updater/src/__tests__/installer.test.ts
@@ -315,6 +315,20 @@ function eventIndex(events: string[], contains: string): number {
 }
 
 describe('release installation transaction', () => {
+  test('polls long-running SSM installs through their 30-minute command timeout', () => {
+    const fixture = installerFixture();
+    try {
+      fixture.installer.install(releaseManifest(), '/tmp/platform.tar.gz', '/tmp/supabase.tar.gz', mirroredImages());
+
+      const wait = fixture.events.find((event) => event.startsWith('run:bash -ceu'));
+      expect(wait).toContain('SECONDS + 1860');
+      expect(wait).toContain('Success|Cancelled|TimedOut|Failed');
+      expect(fixture.events.some((event) => event.startsWith('run:aws ssm wait command-executed'))).toBe(false);
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
   test('starts Supabase before API migrations and commits only after platform health succeeds', () => {
     const fixture = installerFixture();
     try {

--- a/apps/enterprise-updater/src/installer.ts
+++ b/apps/enterprise-updater/src/installer.ts
@@ -43,6 +43,31 @@ interface PlatformActivation {
   changed: PlatformReleaseName[];
 }
 
+const SSM_COMMAND_WAIT_SCRIPT = `
+set -euo pipefail
+command_id="$1"
+instance_id="$2"
+region="$3"
+deadline=$((SECONDS + 1860))
+while (( SECONDS < deadline )); do
+  if current=$(aws ssm get-command-invocation \
+    --command-id "$command_id" --instance-id "$instance_id" \
+    --region "$region" --query Status --output text 2>&1); then
+    case "$current" in
+      Success|Cancelled|TimedOut|Failed) exit 0 ;;
+      Pending|InProgress|Delayed|Cancelling) ;;
+      *) printf 'Unexpected SSM command status: %s\n' "$current" >&2; exit 1 ;;
+    esac
+  elif [[ "$current" != *InvocationDoesNotExist* ]]; then
+    printf '%s\n' "$current" >&2
+    exit 1
+  fi
+  sleep 5
+done
+printf 'SSM command %s did not reach a terminal state within 31 minutes\n' "$command_id" >&2
+exit 1
+`;
+
 export interface InstallerConfig {
   workDir: string;
   region: string;
@@ -342,9 +367,9 @@ export class ReleaseInstaller {
     ]);
     const commandId = response.Command?.CommandId;
     if (!commandId) throw new Error('SSM did not return a command id for Supabase installation');
-    this.runner.run('aws', [
-      'ssm', 'wait', 'command-executed', '--command-id', commandId,
-      '--instance-id', this.config.supabaseInstanceId, '--region', this.config.region,
+    this.runner.run('bash', [
+      '-ceu', SSM_COMMAND_WAIT_SCRIPT, 'bash', commandId,
+      this.config.supabaseInstanceId, this.config.region,
     ]);
     const result = this.aws.awsJson<{ Status?: string; StandardErrorContent?: string }>([
       'ssm', 'get-command-invocation', '--command-id', commandId, '--instance-id', this.config.supabaseInstanceId,

--- a/infra/enterprise-releases/0.9.108-e7.json
+++ b/infra/enterprise-releases/0.9.108-e7.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the AWS CLI fixed short SSM waiter with a bounded terminal-state poll
- align orchestration waiting with the 30-minute remote Supabase install timeout
- tolerate initial SSM invocation propagation and preserve terminal failure inspection
- add regression coverage proving the built-in short waiter is not used
- add the reviewed `0.9.108-e7` compatibility contract for publishing the fixed updater

## Live evidence
Customer-zero clean install command `c10d2a0a-eee4-4e19-9fac-a4fb1ed921e1` remained InProgress after the AWS CLI waiter exhausted, causing CodeBuild `e818489d-0ecb-4e69-842b-1e8133e7107f` to fail and Step Functions to attempt a retry. The parent execution was aborted and the retry build stopped before it invoked the updater.

## Verification
- `pnpm --filter @kortix/enterprise-updater test` (37 pass)
- `pnpm --filter @kortix/enterprise-updater typecheck`
- `pnpm --filter @kortix/enterprise-updater build`
- `git diff --check`