### PR TITLE
test(enterprise): isolate SSM waiter regression

### DIFF
--- a/apps/enterprise-updater/src/__tests__/installer.test.ts
+++ b/apps/enterprise-updater/src/__tests__/installer.test.ts
@@ -318,7 +318,11 @@ describe('release installation transaction', () => {
   test('polls long-running SSM installs through their 30-minute command timeout', () => {
     const fixture = installerFixture();
     try {
-      fixture.installer.install(releaseManifest(), '/tmp/platform.tar.gz', '/tmp/supabase.tar.gz', mirroredImages());
+      const runSupabaseCommand = Reflect.get(fixture.installer, 'runSupabaseCommand') as (
+        comment: string,
+        script: string,
+      ) => void;
+      runSupabaseCommand.call(fixture.installer, 'Test long-running SSM command', 'true');
 
       const wait = fixture.events.find((event) => event.startsWith('run:bash -ceu'));
       expect(wait).toContain('SECONDS + 1860');


### PR DESCRIPTION
## Summary
- invoke only the private SSM command boundary in the waiter regression test
- remove the unrelated platform fixture filesystem flow that CodeQL attributed to the new test

## Verification
- `pnpm --filter @kortix/enterprise-updater test` (37 pass)
- `pnpm --filter @kortix/enterprise-updater typecheck`
- `git diff --check`

Follow-up to #4655. The production updater code is unchanged.