### PR TITLE
fix(enterprise): break Supabase systemd deadlock

### DIFF
--- a/apps/enterprise-release/src/__tests__/bundles.test.ts
+++ b/apps/enterprise-release/src/__tests__/bundles.test.ts
@@ -77,6 +77,10 @@ describe('enterprise release bundles', () => {
       const start = readFileSync(join(root, 'bin', 'supabase-start'), 'utf8');
       expect(start).toContain('docker inspect supabase-kong');
       expect(start).toContain('--header "apikey: $anon_key"');
+      expect(start).toContain('systemctl enable --now kortix-wal-archive.timer kortix-base-backup.timer');
+      expect(start).not.toContain('systemctl start kortix-wal-archive.service');
+      const walUnit = readFileSync(join(root, 'systemd', 'kortix-wal-archive.service'), 'utf8');
+      expect(walUnit).toContain('After=network-online.target kortix-supabase.service');
       const physicalRoot = start.split('\n').find((line) => line.startsWith('root=$(readlink -f '));
       expect(physicalRoot).toBeDefined();
       symlinkSync('.', join(root, 'current'));

--- a/apps/enterprise-release/src/bundles.ts
+++ b/apps/enterprise-release/src/bundles.ts
@@ -270,7 +270,6 @@ function supabaseStartScript(): string {
     'curl --fail --silent --show-error --max-time 10 --header "apikey: $anon_key" http://127.0.0.1:8000/auth/v1/health >/dev/null',
     'unset anon_key',
     'systemctl enable --now kortix-wal-archive.timer kortix-base-backup.timer',
-    'systemctl start kortix-wal-archive.service',
     '',
   ].join('\n');
 }

--- a/infra/enterprise-releases/0.9.108-e8.json
+++ b/infra/enterprise-releases/0.9.108-e8.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- remove the synchronous WAL service start from inside `kortix-supabase.service` startup
- retain the enabled one-minute WAL timer, which runs only after Supabase reaches active
- add a regression assertion for the systemd ordering boundary
- add the reviewed `0.9.108-e8` compatibility contract

## Live evidence
Customer-zero e6 brought all 13 containers healthy in about 37 seconds, then `kortix-supabase.service` remained activating for 30 minutes. The unit journal proves `supabase-start` synchronously requested `kortix-wal-archive.service`, whose unit declares `After=kortix-supabase.service`, creating a self-wait until systemd killed the start with `Result=timeout`.

## Verification
- `pnpm --filter @kortix/enterprise-release test` (19 pass)
- `pnpm --filter @kortix/enterprise-release typecheck`
- `pnpm --filter @kortix/enterprise-updater test` (37 pass)
- `git diff --check`