### PR TITLE
fix(enterprise): allow updater to reach private EKS

### DIFF
--- a/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
@@ -101,6 +101,21 @@ describe('embedded enterprise Terraform graph', () => {
     expect(enterprisePlatform).toContain('argo_cd_enabled             = false');
   });
 
+  test('allows only the customer updater security group into the private EKS API', () => {
+    const eks = enterpriseTerraformAssets['modules/enterprise-vpc/eks.tf'];
+    const rule = eks.slice(
+      eks.indexOf('resource "aws_vpc_security_group_ingress_rule" "updater_eks_api"'),
+      eks.indexOf('data "aws_iam_policy_document" "app_secrets"'),
+    );
+
+    expect(rule).toContain('security_group_id            = module.eks.cluster_security_group_id');
+    expect(rule).toContain('referenced_security_group_id = aws_security_group.updater.id');
+    expect(rule).toContain('ip_protocol                  = "tcp"');
+    expect(rule).toContain('from_port                    = 443');
+    expect(rule).toContain('to_port                      = 443');
+    expect(rule).not.toContain('cidr_ipv4');
+  });
+
   test('recovers missed publisher hints through the same authoritative hourly reconciler', () => {
     const updater = enterpriseTerraformAssets['modules/enterprise-vpc/updater.tf'];
     const hintTarget = updater.slice(

--- a/apps/enterprise-updater/src/__tests__/process.test.ts
+++ b/apps/enterprise-updater/src/__tests__/process.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ProcessRunner } from '../process.ts';
+
+describe('process failure diagnostics', () => {
+  test('reports the Terraform error instead of its ANSI box border', () => {
+    const runner = new ProcessRunner();
+    expect(() => runner.run('bash', [
+      '-ceu',
+      "printf '\\033[31m╷\\033[0m\\n\\033[31m│ Error: Invalid configuration for API client\\033[0m\\n' >&2; exit 1",
+    ])).toThrow('bash -ceu failed: Error: Invalid configuration for API client');
+  });
+});

--- a/apps/enterprise-updater/src/process.ts
+++ b/apps/enterprise-updater/src/process.ts
@@ -32,7 +32,11 @@ export class ProcessRunner implements CommandRunner {
 }
 
 function firstUsefulLine(value: string): string {
-  return value.trim().split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? '';
+  const lines = value.split(/\r?\n/)
+    .map((line) => line.replace(/\u001b\[[0-9;]*m/g, '').trim())
+    .map((line) => line.replace(/^[╷│╵]\s*/, '').trim())
+    .filter((line) => line.length > 0 && !/^[╷│╵─]+$/.test(line));
+  return lines.find((line) => line.startsWith('Error:')) ?? lines[0] ?? '';
 }
 
 function redact(value: string, secrets: string[]): string {

--- a/infra/enterprise-releases/0.9.108-e9.json
+++ b/infra/enterprise-releases/0.9.108-e9.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}

--- a/infra/terraform/modules/enterprise-vpc/eks.tf
+++ b/infra/terraform/modules/enterprise-vpc/eks.tf
@@ -25,6 +25,17 @@ module "eks" {
   depends_on = [terraform_data.account_guard]
 }
 
+resource "aws_vpc_security_group_ingress_rule" "updater_eks_api" {
+  security_group_id            = module.eks.cluster_security_group_id
+  referenced_security_group_id = aws_security_group.updater.id
+  description                  = "Private Kubernetes API access from the customer-owned updater"
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+
+  tags = local.tags
+}
+
 data "aws_iam_policy_document" "app_secrets" {
   statement {
     actions   = ["secretsmanager:DescribeSecret", "secretsmanager:GetSecretValue"]


### PR DESCRIPTION
## Summary
- allow TCP/443 from only the customer updater security group to the private EKS cluster security group
- preserve the existing updater egress boundary and keep the Kubernetes endpoint private
- report the actual Terraform `Error:` line instead of an ANSI box border
- add focused network-boundary and process-diagnostic regression tests
- add the reviewed `0.9.108-e9` compatibility contract

## Live evidence
Customer-zero e8 completed Supabase activation in 41 seconds, then platform Terraform failed with `Invalid configuration for API client`: the VPC CodeBuild runner resolved the private EKS endpoint to `10.60.153.50:443` but timed out because no SG-to-SG ingress edge existed. The updater rolled Supabase back successfully and the Step Functions retry was stopped before a second SSM command.

## Verification
- `pnpm --filter @kortix/enterprise-updater test` (38 pass)
- `pnpm --filter @kortix/enterprise-updater typecheck`
- `bun test apps/cli/src/self-host/__tests__/enterprise-assets.test.ts` (14 pass)
- Terraform 1.15.8 validate of the enterprise VPC cluster root
- `git diff --check`