### PR TITLE
fix(enterprise): allow updater to read cluster state

### DIFF
--- a/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
@@ -162,4 +162,16 @@ describe('embedded enterprise Terraform graph', () => {
     expect(applyPolicy).not.toContain('ManageTaggedKortixInfrastructure');
     expect(applyPolicy).not.toMatch(/"(?:autoscaling|backup|cloudwatch|codebuild|ec2|ecr|eks|elasticloadbalancing|events|logs|secretsmanager|ssm|states|tag):\*"/);
   });
+
+  test('lets the platform apply role read the pinned cluster remote state', () => {
+    const updater = enterpriseTerraformAssets['modules/enterprise-vpc/updater.tf'];
+    const applyPolicy = updater.slice(
+      updater.indexOf('data "aws_iam_policy_document" "updater_apply"'),
+      updater.indexOf('resource "aws_iam_role_policy" "updater_apply"'),
+    );
+
+    expect(applyPolicy).toContain('sid       = "ReadClusterTerraformState"');
+    expect(applyPolicy).toContain('actions   = ["s3:GetObject"]');
+    expect(applyPolicy).toContain('"arn:${local.partition}:s3:::${var.terraform_state_bucket}/enterprise/cluster.tfstate"');
+  });
 });

--- a/infra/enterprise-releases/0.9.108-e10.json
+++ b/infra/enterprise-releases/0.9.108-e10.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}

--- a/infra/terraform/modules/enterprise-vpc/updater.tf
+++ b/infra/terraform/modules/enterprise-vpc/updater.tf
@@ -248,6 +248,12 @@ data "aws_iam_policy_document" "updater_apply" {
   }
 
   statement {
+    sid       = "ReadClusterTerraformState"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:${local.partition}:s3:::${var.terraform_state_bucket}/enterprise/cluster.tfstate"]
+  }
+
+  statement {
     sid = "LockPlatformTerraformState"
     actions = [
       "dynamodb:DeleteItem",


### PR DESCRIPTION
## Summary
- grant the guarded platform apply role read-only access to the pinned cluster Terraform state object
- keep platform-state writes and cluster-state reads in separate IAM statements
- add an embedded Terraform asset regression test for the exact object-level permission

## Live evidence
Customer-zero e9 reached platform Terraform after the private EKS network fix, then failed during `terraform init/plan` with:

```
Error: Unable to access object "enterprise/cluster.tfstate" ... S3: HeadObject ... StatusCode: 403
```

The coordinated Supabase rollback completed successfully. The automatic retry and parent execution were stopped before another install; the hourly rule remains disabled.

## Verification
- `bun test apps/cli/src/self-host/__tests__` (48 pass)
- Terraform 1.15.8 `fmt -check` on `updater.tf`
- Terraform 1.15.8 enterprise cluster `init -backend=false` + `validate`
- `git diff --check`
