### PR TITLE
fix(enterprise): poll external secret readiness

### DIFF
--- a/apps/enterprise-updater/src/__tests__/installer.test.ts
+++ b/apps/enterprise-updater/src/__tests__/installer.test.ts
@@ -356,7 +356,7 @@ describe('release installation transaction', () => {
       const recovery = eventIndex(fixture.events, 'Verify fresh Kortix recovery point before update');
       const terraform = eventIndex(fixture.events, 'run:terraform -chdir=');
       const externalSecrets = eventIndex(fixture.events, 'run:kubectl apply --filename');
-      const runtimeSecret = eventIndex(fixture.events, 'run:kubectl --namespace kortix wait --for=condition=Ready externalsecret/kortix-runtime');
+      const runtimeSecret = eventIndex(fixture.events, 'ExternalSecret kortix-runtime did not become Ready');
       const api = eventIndex(fixture.events, 'run:helm upgrade --install kortix-api');
       const gateway = eventIndex(fixture.events, 'run:helm upgrade --install kortix-gateway');
       const edge = eventIndex(fixture.events, 'run:helm upgrade --install kortix-edge');
@@ -367,6 +367,9 @@ describe('release installation transaction', () => {
       expect(terraform).toBeLessThan(externalSecrets);
       expect(externalSecrets).toBeLessThan(runtimeSecret);
       expect(runtimeSecret).toBeLessThan(api);
+      expect(fixture.events[runtimeSecret]).toContain('SECONDS + 600');
+      expect(fixture.events[runtimeSecret]).toContain('jsonpath={range .status.conditions[?(@.type=="Ready")]}{.status}{end}');
+      expect(fixture.events.some((event) => event.includes('kubectl --namespace kortix wait'))).toBe(false);
       expect(api).toBeLessThan(gateway);
       expect(gateway).toBeLessThan(edge);
       expect(edge).toBeLessThan(health);

--- a/apps/enterprise-updater/src/installer.ts
+++ b/apps/enterprise-updater/src/installer.ts
@@ -108,6 +108,22 @@ printf 'SSM command %s did not reach a terminal state within 31 minutes\n' "$com
 exit 1
 `;
 
+const EXTERNAL_SECRET_WAIT_SCRIPT = `
+set -euo pipefail
+namespace="$1"
+deadline=$((SECONDS + 600))
+while (( SECONDS < deadline )); do
+  current=$(kubectl --namespace "$namespace" get externalsecret/kortix-runtime \
+    --output='jsonpath={range .status.conditions[?(@.type=="Ready")]}{.status}{end}' 2>/dev/null || true)
+  if [ "$current" = "True" ]; then
+    exit 0
+  fi
+  sleep 5
+done
+printf 'ExternalSecret kortix-runtime did not become Ready within 10 minutes\\n' >&2
+exit 1
+`;
+
 export interface InstallerConfig {
   workDir: string;
   region: string;
@@ -259,10 +275,7 @@ export class ReleaseInstaller {
       runtimeSecretArn: this.config.runtimeSecretArn,
     }), null, 2)}\n`, { mode: 0o600 });
     this.runner.run('kubectl', ['apply', '--filename', runtimeExternalSecrets], { env: kubeEnv });
-    this.runner.run('kubectl', [
-      '--namespace', descriptor.namespace, 'wait', '--for=condition=Ready',
-      'externalsecret/kortix-runtime', '--timeout=5m',
-    ], { env: kubeEnv });
+    this.runner.run('bash', ['-ceu', EXTERNAL_SECRET_WAIT_SCRIPT, 'bash', descriptor.namespace], { env: kubeEnv });
     this.runner.run('kubectl', [
       '--namespace', descriptor.namespace, 'get', 'secret', 'kortix-runtime', '--output=name',
     ], { env: kubeEnv });

--- a/apps/web/src/components/iam/sso-card.test.ts
+++ b/apps/web/src/components/iam/sso-card.test.ts
@@ -58,13 +58,13 @@ describe('SSO card — service provider details block', () => {
   });
 
   test('renders the block before a provider is configured, and inside the configure/edit dialog', () => {
-    expect(source).toContain('{!provider && spUrls && <SpDetails');
-    expect(source).toContain('{spUrls && (\n          <SpDetails');
+    expect(source).toMatch(/\{!provider && spUrls && \([\s\S]*?<SpDetails/);
+    expect(source).toMatch(/\{spUrls && (?:\(\s*)?<SpDetails/);
   });
 
   test('hides the block rather than render a broken URL when the origin is unavailable', () => {
     // Null-origin handling is unit-tested in lib/saml-sp.test.ts; the card
     // just guards the render on the derived value.
-    expect(source).toContain('{!provider && spUrls && <SpDetails');
+    expect(source).toMatch(/\{!provider && spUrls && \([\s\S]*?<SpDetails/);
   });
 });

--- a/infra/enterprise-releases/0.9.108-e12.json
+++ b/infra/enterprise-releases/0.9.108-e12.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": [],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the initial-cluster `kubectl wait` watch with a bounded 10-minute status poll
- require the `Ready=True` ExternalSecret condition before verifying the synced Secret and starting API Helm migrations
- add the immutable e12 compatibility contract

## Live evidence
Customer-zero e11 successfully installed the operator/CRDs and applied both runtime resources. The first watch timed out even though the resource later reported:

```
SecretStore/kortix-runtime: Ready=True
ExternalSecret/kortix-runtime: Ready=True, reason=SecretSynced
Secret/kortix-runtime: exists
```

CloudTrail also proved the in-cluster provider fetched the customer Secrets Manager bundle. e11 Supabase rollback succeeded; the automatic retry was stopped.

## Verification
- updater + self-host suites: 87 pass
- updater typecheck passed
- focused red/green contract proves a bounded 600-second status poll and no one-shot `kubectl wait`
- `git diff --check` passed
