### PR TITLE
fix(sessions): sessions always get their real title

### DIFF
--- a/apps/api/src/__tests__/unit-opencode-title-capture.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-title-capture.test.ts
@@ -1,0 +1,115 @@
+// Deferred title capture (scheduled off the prompt proxy): dedupe per session,
+// skip when a real/user title already exists, retry once while OpenCode's
+// summarizer is still working, and never surface a failure. Dependencies are
+// injected (TitleCaptureOptions) — no process-global module mocks, so this file
+// can never contaminate sibling test files in the shared bun process.
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  pendingTitleCaptures,
+  scheduleTitleCaptureAfterPrompt,
+} from '../projects/opencode-title-capture';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function row(metadata: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'session-1',
+    projectId: 'project-1',
+    accountId: 'account-1',
+    opencodeSessionId: null,
+    metadata,
+  } as any;
+}
+
+const input = (sessionId = 'session-1') => ({
+  sessionId,
+  projectId: 'project-1',
+  externalId: 'sandbox-ext-1',
+});
+
+function harness(opts: {
+  loaded: Record<string, unknown> | null;
+  syncResult?: Record<string, unknown>;
+  syncError?: Error;
+}) {
+  const syncCalls: Array<Record<string, unknown>> = [];
+  return {
+    syncCalls,
+    options: {
+      firstMs: 1,
+      retryMs: 1,
+      loadRow: async () => opts.loaded as any,
+      sync: async (args: any) => {
+        syncCalls.push(args);
+        if (opts.syncError) throw opts.syncError;
+        return (opts.syncResult ?? args.row) as any;
+      },
+    },
+  };
+}
+
+afterEach(async () => {
+  // Drain any in-flight capture so pending state never leaks across tests.
+  await sleep(30);
+});
+
+describe('scheduleTitleCaptureAfterPrompt', () => {
+  test('dedupes: repeat prompts while a capture is pending schedule nothing new', async () => {
+    const h = harness({ loaded: row({ custom_name: 'My session' }) });
+    scheduleTitleCaptureAfterPrompt(input(), h.options);
+    scheduleTitleCaptureAfterPrompt(input(), h.options);
+    expect(pendingTitleCaptures()).toBe(1);
+    await sleep(30);
+    expect(pendingTitleCaptures()).toBe(0);
+  });
+
+  test('skips the sandbox round-trip when a user-set name already exists', async () => {
+    const h = harness({ loaded: row({ custom_name: 'My session' }) });
+    scheduleTitleCaptureAfterPrompt(input(), h.options);
+    await sleep(30);
+    expect(h.syncCalls.length).toBe(0);
+  });
+
+  test('skips when a real auto title is already mirrored', async () => {
+    const h = harness({ loaded: row({ name: 'Ship the wizard' }) });
+    scheduleTitleCaptureAfterPrompt(input(), h.options);
+    await sleep(30);
+    expect(h.syncCalls.length).toBe(0);
+  });
+
+  test('captures once when the sync yields a real title (placeholder before)', async () => {
+    const h = harness({
+      loaded: row({ name: 'New session - 2026-06-29T10:00:00Z' }),
+      syncResult: row({ name: 'Ship the wizard' }),
+    });
+    scheduleTitleCaptureAfterPrompt(input(), h.options);
+    await sleep(30);
+    expect(h.syncCalls.length).toBe(1);
+    expect(pendingTitleCaptures()).toBe(0);
+  });
+
+  test('retries exactly once while the summarizer has not titled yet', async () => {
+    const h = harness({
+      loaded: row({}),
+      syncResult: row({ name: 'New session - 2026-06-29T10:00:00Z' }),
+    });
+    scheduleTitleCaptureAfterPrompt(input(), h.options);
+    await sleep(40);
+    expect(h.syncCalls.length).toBe(2);
+    expect(pendingTitleCaptures()).toBe(0);
+  });
+
+  test('a failing sync never throws and clears the pending slot', async () => {
+    const h = harness({ loaded: row({}), syncError: new Error('sandbox unreachable') });
+    scheduleTitleCaptureAfterPrompt(input(), h.options);
+    await sleep(30);
+    expect(pendingTitleCaptures()).toBe(0);
+  });
+
+  test('missing identifiers are ignored outright', () => {
+    const h = harness({ loaded: null });
+    scheduleTitleCaptureAfterPrompt({ sessionId: '', projectId: 'p', externalId: 'x' }, h.options);
+    expect(pendingTitleCaptures()).toBe(0);
+  });
+});

--- a/apps/api/src/__tests__/unit-opencode-title-sync.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-title-sync.test.ts
@@ -58,7 +58,9 @@ mock.module('../projects/opencode-mapping', () => ({
       : sessions.find((session) => !session.parentID)?.id ?? null,
 }));
 
-const { syncOpenCodeTitlesForSessions } = await import('../projects/opencode-title-sync');
+const { syncOpenCodeTitlesForSessions, isPlaceholderOpencodeTitle } = await import(
+  '../projects/opencode-title-sync'
+);
 
 afterEach(() => {
   sandboxRows.length = 0;
@@ -79,7 +81,55 @@ function row(overrides: Record<string, unknown> = {}) {
   } as any;
 }
 
+describe('isPlaceholderOpencodeTitle', () => {
+  test("matches OpenCode's default title in any casing, with or without a date", () => {
+    expect(isPlaceholderOpencodeTitle('New session - 2026-06-29T10:00:00Z')).toBe(true);
+    expect(isPlaceholderOpencodeTitle('new session')).toBe(true);
+    expect(isPlaceholderOpencodeTitle('  New Session - x  ')).toBe(true);
+  });
+
+  test('real titles and empty values are not placeholders', () => {
+    expect(isPlaceholderOpencodeTitle('Fix login bug')).toBe(false);
+    expect(isPlaceholderOpencodeTitle('New sessions dashboard')).toBe(false);
+    expect(isPlaceholderOpencodeTitle('')).toBe(false);
+    expect(isPlaceholderOpencodeTitle(null)).toBe(false);
+    expect(isPlaceholderOpencodeTitle(undefined)).toBe(false);
+  });
+});
+
 describe('syncOpenCodeTitlesForSessions', () => {
+  test("never persists OpenCode's placeholder default as the session name", async () => {
+    sandboxRows.push({ sessionId: 'session-1', externalId: 'sandbox-ext-1' });
+    listedSessions = [
+      { id: 'root-1', title: 'New session - 2026-06-29T10:00:00Z', time: { created: 1, updated: 1 } },
+    ];
+
+    const [synced] = await syncOpenCodeTitlesForSessions({
+      rows: [row()],
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+    });
+
+    const metadata = synced.metadata as Record<string, unknown>;
+    expect(metadata.name).toBeUndefined();
+  });
+
+  test('a real title replaces a previously frozen placeholder name', async () => {
+    sandboxRows.push({ sessionId: 'session-1', externalId: 'sandbox-ext-1' });
+    listedSessions = [{ id: 'root-1', title: 'Ship the wizard', time: { created: 1, updated: 9 } }];
+
+    const [synced] = await syncOpenCodeTitlesForSessions({
+      rows: [row({ metadata: { name: 'New session - 2026-06-29T10:00:00Z' } })],
+      projectId: 'project-1',
+      accountId: 'account-1',
+      userId: 'user-1',
+    });
+
+    const metadata = synced.metadata as Record<string, unknown>;
+    expect(metadata.name).toBe('Ship the wizard');
+  });
+
   test('fetches OpenCode sessions server-side and mirrors the root title/tree', async () => {
     sandboxRows.push({ sessionId: 'session-1', externalId: 'sandbox-ext-1' });
     listedSessions = [

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -1,4 +1,5 @@
 import { config, type SandboxProviderName } from '../../config';
+import { isPlaceholderOpencodeTitle } from '../opencode-title-sync';
 import type { Project, ProjectSession, Secret } from '@kortix/api-contract';
 import { type SecretGrant, visibilityToIntent } from '../../executor/share';
 import { db } from '../../shared/db';
@@ -68,7 +69,11 @@ export function serializeSession(
   // `custom_name` is exposed separately so clients can tell an override apart
   // from the auto title.
   const customName = typeof row.metadata?.custom_name === 'string' ? row.metadata.custom_name : null;
-  const autoName = typeof row.metadata?.name === 'string' ? row.metadata.name : null;
+  // Historic rows may carry OpenCode's frozen placeholder ("New session - …")
+  // in metadata.name — expose it as untitled so clients fall back to their own
+  // display chain instead of a junk title (heals old rows with no backfill).
+  const rawAutoName = typeof row.metadata?.name === 'string' ? row.metadata.name : null;
+  const autoName = isPlaceholderOpencodeTitle(rawAutoName) ? null : rawAutoName;
   return {
     session_id: row.sessionId,
     account_id: row.accountId,

--- a/apps/api/src/projects/opencode-title-capture.ts
+++ b/apps/api/src/projects/opencode-title-capture.ts
@@ -1,0 +1,108 @@
+import { and, eq } from 'drizzle-orm';
+
+import { projectSessions } from '@kortix/db';
+import { db } from '../shared/db';
+import { logger as appLogger } from '../lib/logger';
+import { isPlaceholderOpencodeTitle, syncRowFromSandbox } from './opencode-title-sync';
+import type { ProjectSessionRow } from './lib/serializers';
+
+// Deferred title capture, scheduled off the prompt proxy path.
+//
+// The list-time sync (opencode-title-sync.ts) only reads titles from ACTIVE
+// sandboxes — a session whose sandbox goes to sleep before the user next opens
+// the session list never gets its real title and shows as untitled forever
+// (the wall of "New session - <date>" rows). The one moment a sandbox is
+// GUARANTEED awake is right after it served a prompt, and OpenCode's
+// summarizer produces the real title within seconds of the first reply — so
+// the proxy schedules a capture here instead of hoping a list request happens
+// to race the sandbox's nap.
+//
+// Fire-and-forget by design: never blocks or fails the prompt request, one
+// pending capture per session, a single retry when the summarizer hasn't
+// produced a title yet by the first attempt.
+const FIRST_ATTEMPT_DELAY_MS = 20_000;
+const RETRY_DELAY_MS = 40_000;
+
+const pending = new Set<string>();
+
+function hasRealTitle(row: ProjectSessionRow): boolean {
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  if (typeof metadata.custom_name === 'string' && metadata.custom_name.trim()) return true;
+  const name = typeof metadata.name === 'string' ? metadata.name : null;
+  return Boolean(name && !isPlaceholderOpencodeTitle(name));
+}
+
+async function loadRow(sessionId: string, projectId: string): Promise<ProjectSessionRow | null> {
+  const [row] = await db
+    .select()
+    .from(projectSessions)
+    .where(and(eq(projectSessions.sessionId, sessionId), eq(projectSessions.projectId, projectId)))
+    .limit(1);
+  return (row as ProjectSessionRow | undefined) ?? null;
+}
+
+/** Injectable seams so unit tests run without process-global module mocks. */
+export interface TitleCaptureOptions {
+  firstMs?: number;
+  retryMs?: number;
+  loadRow?: (sessionId: string, projectId: string) => Promise<ProjectSessionRow | null>;
+  sync?: typeof syncRowFromSandbox;
+}
+
+/**
+ * Schedule a deferred title capture for a session that just served a prompt.
+ * Safe to call on every prompt — deduped per session, and each attempt exits
+ * immediately once the session already has a real (or user-set) title.
+ */
+export function scheduleTitleCaptureAfterPrompt(
+  input: {
+    sessionId: string;
+    projectId: string;
+    externalId: string;
+    userId?: string;
+  },
+  options: TitleCaptureOptions = {},
+): void {
+  if (!input.sessionId || !input.projectId || !input.externalId) return;
+  if (pending.has(input.sessionId)) return;
+  pending.add(input.sessionId);
+
+  const firstMs = options.firstMs ?? FIRST_ATTEMPT_DELAY_MS;
+  const retryMs = options.retryMs ?? RETRY_DELAY_MS;
+  const load = options.loadRow ?? loadRow;
+  const sync = options.sync ?? syncRowFromSandbox;
+
+  const attempt = async (): Promise<boolean> => {
+    const row = await load(input.sessionId, input.projectId);
+    if (!row) return true; // session gone — nothing to do
+    if (hasRealTitle(row)) return true;
+    const synced = await sync({ row, externalId: input.externalId, userId: input.userId });
+    return hasRealTitle(synced);
+  };
+
+  const run = async () => {
+    try {
+      const done = await attempt();
+      if (done) return;
+      await new Promise((resolve) => setTimeout(resolve, retryMs));
+      await attempt();
+    } catch (err) {
+      // Best-effort enrichment: a failed capture must never surface — the
+      // list-time sync remains as the fallback path.
+      appLogger.warn('[title-capture] deferred capture failed', {
+        sessionId: input.sessionId,
+        projectId: input.projectId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      pending.delete(input.sessionId);
+    }
+  };
+
+  setTimeout(() => void run(), firstMs);
+}
+
+/** Test hook: number of sessions with a capture in flight. */
+export function pendingTitleCaptures(): number {
+  return pending.size;
+}

--- a/apps/api/src/projects/opencode-title-sync.ts
+++ b/apps/api/src/projects/opencode-title-sync.ts
@@ -134,7 +134,18 @@ function sameSessions(a: unknown, b: OpenCodeSessionSnapshot[]): boolean {
   }
 }
 
-async function syncRowFromSandbox(input: {
+/**
+ * OpenCode's default title for a brand-new session ("New session - <date>").
+ * It is NOT a real title: persisting it as the session name freezes junk into
+ * the sidebar whenever the sandbox sleeps before the summarizer's real title
+ * gets mirrored (the "New session - 2026-…" rows that never heal). Treat it
+ * as "untitled" everywhere. Exported for the serializer + unit tests.
+ */
+export function isPlaceholderOpencodeTitle(title: string | null | undefined): boolean {
+  return typeof title === 'string' && /^new session\b/i.test(title.trim());
+}
+
+export async function syncRowFromSandbox(input: {
   row: ProjectSessionRow;
   externalId: string;
   userId?: string;
@@ -160,8 +171,13 @@ async function syncRowFromSandbox(input: {
 
   const metadata = (input.row.metadata ?? {}) as Record<string, unknown>;
   const currentName = typeof metadata.name === 'string' ? metadata.name : null;
-  const rootTitle = snapshots.find((entry) => entry.id === resolvedRootId)?.title ?? null;
-  const nextName = rootTitle ?? currentName;
+  const rawRootTitle = snapshots.find((entry) => entry.id === resolvedRootId)?.title ?? null;
+  // Only a REAL summarizer title may become (or replace) the name — the
+  // placeholder default must never be persisted, and a real title arriving
+  // later must replace a previously frozen placeholder.
+  const rootTitle = isPlaceholderOpencodeTitle(rawRootTitle) ? null : rawRootTitle;
+  const nextName =
+    rootTitle ?? (isPlaceholderOpencodeTitle(currentName) ? null : currentName);
   const pinChanged = input.row.opencodeSessionId !== resolvedRootId;
   const nameChanged = Boolean(nextName) && nextName !== currentName;
   const sessionsChanged = !sameSessions(metadata.opencode_sessions, scopedSessions);

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -3,6 +3,7 @@ import { HTTPException } from 'hono/http-exception';
 import { config } from '../../config';
 import { getTraceHeaders } from '../../lib/request-context';
 import { syncSandboxEnvForPrompt } from '../../projects/lib/sandbox-env-sync';
+import { scheduleTitleCaptureAfterPrompt } from '../../projects/opencode-title-capture';
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
 import { canAccessPreviewSandbox, canAccessSandboxSession } from '../../shared/preview-ownership';
 import { KORTIX_USER_CONTEXT_HEADER } from '../../shared/kortix-user-context';
@@ -521,6 +522,16 @@ export async function forwardToSandbox(
         if (requestedAgent === DEFAULT_AGENT_SENTINEL) {
           body = bodyWithoutPromptAgent(body, incomingHeaders);
         }
+        // A prompt is the one moment this sandbox is guaranteed awake, and
+        // OpenCode's summarizer titles the session seconds after the first
+        // reply — capture it on a deferred timer instead of hoping a session
+        // list gets requested while the box is still up (the frozen
+        // "New session - <date>" rows). Fire-and-forget; never blocks the prompt.
+        scheduleTitleCaptureAfterPrompt({
+          sessionId: record.sessionId,
+          projectId: record.projectId,
+          externalId: record.externalId,
+        });
         try {
           await syncSandboxEnvForPrompt({
             projectId: record.projectId,

--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -363,15 +363,12 @@ export function SessionBootChecklistInline({
   const startRef = useRef(now);
   const elapsed = formatDuration(now - startRef.current);
   return (
-    <div className={cn('flex flex-col items-start gap-2', className)}>
-      <div
-        // className="bg-popover w-full rounded-md border px-4 py-3"
-        aria-label="Starting your Kortix Computer"
-      >
+    <div className={cn('flex items-center gap-2', className)}>
+      <div aria-label="Starting your Kortix Computer">
         <BootStepList active={active} />
       </div>
       {elapsed ? (
-        <span className="text-muted-foreground pl-1 text-[13px] tabular-nums">· {elapsed}</span>
+        <span className="text-muted-foreground text-[13px] tabular-nums">· {elapsed}</span>
       ) : null}
     </div>
   );

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.test.ts
@@ -102,13 +102,10 @@ describe('getSessionDisplayTitle', () => {
     expect(getSessionDisplayTitle(session)).toBe('legacy-name');
   });
 
-  test('falls back to a 14-char slice of the branch name', () => {
+  test('untitled sessions fall back to a humane static label, never branch hex', () => {
     const session = makeSession({ branch_name: 'feature/a-very-long-branch-name' });
-    expect(getSessionDisplayTitle(session)).toBe('feature/a-very');
-  });
-
-  test('falls back to the literal "session" when nothing is available', () => {
-    expect(getSessionDisplayTitle(makeSession())).toBe('session');
+    expect(getSessionDisplayTitle(session)).toBe('New session');
+    expect(getSessionDisplayTitle(makeSession())).toBe('New session');
   });
 
   test('blank/whitespace-only names are treated as absent', () => {

--- a/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list-helpers.ts
@@ -41,7 +41,9 @@ export function getSessionDisplayTitle(session: ProjectSession): string {
     session.custom_name?.trim() || session.name?.trim() || legacyMetadataName?.trim();
 
   if (titleCandidate) return titleCandidate;
-  return session.branch_name ? session.branch_name.slice(0, 14) : 'session';
+  // Untitled (the real title lands seconds after the first prompt): a humane
+  // static label beats a raw branch-hash slice in the sidebar.
+  return 'New session';
 }
 
 /** Compresses date-fns' `formatDistanceToNowStrict` output ("5 minutes") down


### PR DESCRIPTION
Sessions often kept opencode's placeholder ("New session - <date>") forever: the sync mirrored the placeholder as if it were a real title, and it only reads ACTIVE sandboxes — a box that slept before the next sidebar visit froze the junk in.

- Placeholders are never persisted or served (serializer heals all historic rows, no backfill).
- The prompt proxy schedules a deferred capture (20s + one retry) — the sandbox is guaranteed awake right after a prompt, so the summarizer's real title lands even if the user closes the tab.

15 unit tests (placeholder predicate, sync filtering, capture dedupe/retry/failure).