### PR TITLE
fix(enterprise): stabilize Supabase restarts and keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           grep -Fq "api@${api_digest}" /tmp/api.yaml
           grep -Fq "gateway@${gateway_digest}" /tmp/gateway.yaml
           grep -Fq "frontend@${frontend_digest}" /tmp/edge.yaml
-          grep -Fq 'command: ["bun", "scripts/migrate.ts", "up"]' /tmp/api.yaml
+          grep -Fq 'command: ["bun", "scripts/migrate.ts", "bootstrap"]' /tmp/api.yaml
 
   api-typecheck:
     name: API typecheck

--- a/apps/cli/src/self-host/__tests__/aws-vpc-secrets.test.ts
+++ b/apps/cli/src/self-host/__tests__/aws-vpc-secrets.test.ts
@@ -21,7 +21,7 @@ describe('AWS VPC runtime secret bootstrap', () => {
     const secret = generateRuntimeDefaults({}, coordinates);
 
     expect(secret.POSTGRES_PASSWORD.length).toBeGreaterThanOrEqual(32);
-    expect(secret.DATABASE_URL).toContain('@10.60.16.10:5432/postgres');
+    expect(secret.DATABASE_URL).toMatch(/^postgresql:\/\/postgres\.kortix-vpc-demo:.+@10\.60\.16\.10:5432\/postgres$/);
     expect(secret.SUPABASE_URL).toBe('http://10.60.16.10:8000');
     expect(secret.SUPABASE_PUBLIC_URL).toBe('https://api.vpc-demo.kortix.com');
     expect(secret.PUBLIC_URL).toBe('https://vpc-demo.kortix.com');
@@ -30,6 +30,8 @@ describe('AWS VPC runtime secret bootstrap', () => {
     expect(secret.SECRET_KEY_BASE.length).toBeGreaterThanOrEqual(64);
     expect(verifyJwt(secret.ANON_KEY, secret.JWT_SECRET, 'anon')).toBe(true);
     expect(verifyJwt(secret.SERVICE_ROLE_KEY, secret.JWT_SECRET, 'service_role')).toBe(true);
+    expect(secret.SUPABASE_PUBLISHABLE_KEY).toMatch(/^sb_publishable_[A-Za-z0-9_-]{32}$/);
+    expect(secret.SUPABASE_SECRET_KEY).toMatch(/^sb_secret_[A-Za-z0-9_-]{43}$/);
     expect(missingOperatorRuntimeKeys(secret)).toEqual([
       'SMTP_ADMIN_EMAIL', 'SMTP_HOST', 'SMTP_PORT', 'SMTP_USER',
       'SMTP_PASS', 'SMTP_SENDER_NAME', 'DAYTONA_API_KEY', 'OPENROUTER_API_KEY',
@@ -48,9 +50,11 @@ describe('AWS VPC runtime secret bootstrap', () => {
 
     expect(second.JWT_SECRET).toBe(first.JWT_SECRET);
     expect(second.ANON_KEY).toBe(first.ANON_KEY);
+    expect(second.SUPABASE_PUBLISHABLE_KEY).toBe(first.SUPABASE_PUBLISHABLE_KEY);
+    expect(second.SUPABASE_SECRET_KEY).toBe(first.SUPABASE_SECRET_KEY);
     expect(second.API_KEY_SECRET).toBe(first.API_KEY_SECRET);
     expect(second.SMTP_HOST).toBe('smtp.example.com');
-    expect(second.DATABASE_URL).toContain('@10.60.16.11:5432/postgres');
+    expect(second.DATABASE_URL).toMatch(/^postgresql:\/\/postgres\.kortix-vpc-demo:.+@10\.60\.16\.11:5432\/postgres$/);
   });
 
   test('parses only explicit non-empty uppercase assignments', () => {

--- a/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/enterprise-assets.test.ts
@@ -81,6 +81,13 @@ describe('embedded enterprise Terraform graph', () => {
     expect(userData).toContain('aws --version');
   });
 
+  test('allows the Supabase stack enough time for its graceful Compose shutdown', () => {
+    const userData = enterpriseTerraformAssets['modules/enterprise-vpc/files/supabase-user-data.sh.tftpl'];
+
+    expect(userData).toContain('TimeoutStartSec=1800');
+    expect(userData).toContain('TimeoutStopSec=300');
+  });
+
   test('allows SSM managed instances to use both command transport services through the workload boundary', () => {
     const state = enterpriseTerraformAssets['modules/enterprise-state/main.tf'];
     const boundary = state.slice(

--- a/apps/cli/src/self-host/aws-vpc-secrets.ts
+++ b/apps/cli/src/self-host/aws-vpc-secrets.ts
@@ -26,6 +26,7 @@ const UPDATER_MANAGED_RUNTIME_KEYS = new Set([
   'POSTGRES_PASSWORD', 'DATABASE_URL',
   'JWT_SECRET', 'SUPABASE_JWT_SECRET', 'ANON_KEY', 'SUPABASE_ANON_KEY',
   'SERVICE_ROLE_KEY', 'SUPABASE_SERVICE_ROLE_KEY',
+  'SUPABASE_PUBLISHABLE_KEY', 'SUPABASE_SECRET_KEY',
   'DASHBOARD_PASSWORD', 'SECRET_KEY_BASE', 'REALTIME_DB_ENC_KEY', 'VAULT_ENC_KEY',
   'PG_META_CRYPTO_KEY', 'LOGFLARE_PUBLIC_ACCESS_TOKEN', 'LOGFLARE_PRIVATE_ACCESS_TOKEN',
   'S3_PROTOCOL_ACCESS_KEY_ID', 'S3_PROTOCOL_ACCESS_KEY_SECRET', 'POOLER_TENANT_ID',
@@ -120,6 +121,8 @@ export function generateRuntimeDefaults(
   const postgresPassword = current.POSTGRES_PASSWORD || token(32);
   const anonKey = current.ANON_KEY || supabaseJwt('anon', jwtSecret);
   const serviceRoleKey = current.SERVICE_ROLE_KEY || supabaseJwt('service_role', jwtSecret);
+  const publishableKey = current.SUPABASE_PUBLISHABLE_KEY || `sb_publishable_${randomBytes(24).toString('base64url')}`;
+  const secretKey = current.SUPABASE_SECRET_KEY || `sb_secret_${randomBytes(32).toString('base64url')}`;
   const supabaseInternalUrl = `http://${coordinates.supabasePrivateIp}:8000`;
   const apiUrl = `https://${coordinates.apiDomain}`;
   const frontendUrl = `https://${coordinates.frontendDomain}`;
@@ -134,7 +137,11 @@ export function generateRuntimeDefaults(
     SUPABASE_ANON_KEY: anonKey,
     SERVICE_ROLE_KEY: serviceRoleKey,
     SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
-    DATABASE_URL: `postgresql://postgres:${encodeURIComponent(postgresPassword)}@${coordinates.supabasePrivateIp}:5432/postgres`,
+    SUPABASE_PUBLISHABLE_KEY: publishableKey,
+    SUPABASE_SECRET_KEY: secretKey,
+    // Port 5432 is the official Supabase Supavisor session endpoint. Supavisor
+    // selects the tenant from the username suffix before proxying to Postgres.
+    DATABASE_URL: `postgresql://postgres.${coordinates.instance}:${encodeURIComponent(postgresPassword)}@${coordinates.supabasePrivateIp}:5432/postgres`,
     SUPABASE_URL: supabaseInternalUrl,
     SUPABASE_PUBLIC_URL: apiUrl,
     PUBLIC_URL: frontendUrl,

--- a/apps/enterprise-release/src/__tests__/bundles.test.ts
+++ b/apps/enterprise-release/src/__tests__/bundles.test.ts
@@ -127,6 +127,8 @@ describe('enterprise release bundles', () => {
       for (const chart of Object.values(descriptor.charts)) {
         expect(readFileSync(join(root, chart, 'Chart.yaml'), 'utf8')).toContain('apiVersion: v2');
       }
+      expect(readFileSync(join(root, descriptor.charts.api, 'templates/migrate-job.yaml'), 'utf8'))
+        .toContain('command: ["bun", "scripts/migrate.ts", "bootstrap"]');
       expect(readFileSync(join(root, descriptor.charts.api, 'templates/_helpers.tpl'), 'utf8'))
         .toContain('@%s');
       expect(readFileSync(join(root, descriptor.charts.edge, 'templates/ingress.yaml'), 'utf8'))

--- a/apps/enterprise-updater/src/__tests__/installer.test.ts
+++ b/apps/enterprise-updater/src/__tests__/installer.test.ts
@@ -132,6 +132,7 @@ class InstallerRunner implements CommandRunner {
   readonly events: string[];
   failOn: string | null = null;
   apiVersion = '0.9.84';
+  apiFailures = 0;
 
   constructor(events: string[]) {
     this.events = events;
@@ -167,6 +168,10 @@ class InstallerRunner implements CommandRunner {
     }
     const requestUrl = args.at(-1);
     if (command === 'curl' && requestUrl === 'https://api.vpc-demo.kortix.com/v1/health') {
+      if (this.apiFailures > 0) {
+        this.apiFailures -= 1;
+        throw new Error('simulated DNS propagation delay');
+      }
       return JSON.stringify({ version: this.apiVersion });
     }
     return '';
@@ -224,12 +229,18 @@ class InstallerAws {
 }
 
 function materializePlatformBundle(root: string): void {
+  // Test-only root comes from mkdtempSync beneath the checked-out repository.
+  // lgtm[js/insecure-temporary-file]
   mkdirSync(join(root, 'platform'), { recursive: true });
   for (const chart of ['api', 'gateway', 'edge']) {
+    // lgtm[js/insecure-temporary-file]
     mkdirSync(join(root, 'charts', chart), { recursive: true });
+    // lgtm[js/insecure-temporary-file]
     writeFileSync(join(root, 'charts', chart, 'Chart.yaml'), `apiVersion: v2\nname: ${chart}\nversion: 1.0.0\n`);
   }
+  // lgtm[js/insecure-temporary-file]
   writeFileSync(join(root, 'platform', 'main.tf'), 'terraform {}\n');
+  // lgtm[js/insecure-temporary-file]
   writeFileSync(join(root, 'bundle.json'), JSON.stringify({
     schema_version: 1,
     kind: 'kortix-enterprise-platform',
@@ -356,6 +367,7 @@ describe('release installation transaction', () => {
       const recovery = eventIndex(fixture.events, 'Verify fresh Kortix recovery point before update');
       const terraform = eventIndex(fixture.events, 'run:terraform -chdir=');
       const externalSecrets = eventIndex(fixture.events, 'run:kubectl apply --filename');
+      const forceRefresh = eventIndex(fixture.events, 'annotate --overwrite externalsecret/kortix-runtime force-sync=');
       const runtimeSecret = eventIndex(fixture.events, 'ExternalSecret kortix-runtime did not become Ready');
       const api = eventIndex(fixture.events, 'run:helm upgrade --install kortix-api');
       const gateway = eventIndex(fixture.events, 'run:helm upgrade --install kortix-gateway');
@@ -365,10 +377,12 @@ describe('release installation transaction', () => {
       expect(recovery).toBeLessThan(supabase);
       expect(supabase).toBeLessThan(terraform);
       expect(terraform).toBeLessThan(externalSecrets);
-      expect(externalSecrets).toBeLessThan(runtimeSecret);
+      expect(externalSecrets).toBeLessThan(forceRefresh);
+      expect(forceRefresh).toBeLessThan(runtimeSecret);
       expect(runtimeSecret).toBeLessThan(api);
       expect(fixture.events[runtimeSecret]).toContain('SECONDS + 600');
       expect(fixture.events[runtimeSecret]).toContain('jsonpath={range .status.conditions[?(@.type=="Ready")]}{.status}{end}');
+      expect(fixture.events[runtimeSecret]).toContain('jsonpath={.status.refreshTime}');
       expect(fixture.events.some((event) => event.includes('kubectl --namespace kortix wait'))).toBe(false);
       expect(api).toBeLessThan(gateway);
       expect(gateway).toBeLessThan(edge);
@@ -425,6 +439,20 @@ describe('release installation transaction', () => {
         .toBeLessThan(eventIndex(fixture.events, 'helm uninstall kortix-edge'));
       expect(eventIndex(fixture.events, 'helm uninstall kortix-api'))
         .toBeLessThan(eventIndex(fixture.events, 'Rollback Supabase after failed'));
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  test('waits for public DNS and ALB health propagation before accepting the release', () => {
+    const fixture = installerFixture();
+    fixture.runner.apiFailures = 2;
+    try {
+      fixture.installer.install(
+        releaseManifest(), '/tmp/platform.tar.gz', '/tmp/supabase.tar.gz', mirroredImages(),
+      );
+      expect(fixture.events.filter((event) => event === 'run:sleep 10')).toHaveLength(2);
+      expect(fixture.events.filter((event) => event.includes('api.vpc-demo.kortix.com/v1/health'))).toHaveLength(3);
     } finally {
       rmSync(fixture.root, { recursive: true, force: true });
     }

--- a/apps/enterprise-updater/src/installer.ts
+++ b/apps/enterprise-updater/src/installer.ts
@@ -111,11 +111,14 @@ exit 1
 const EXTERNAL_SECRET_WAIT_SCRIPT = `
 set -euo pipefail
 namespace="$1"
+minimum_refresh="$2"
 deadline=$((SECONDS + 600))
 while (( SECONDS < deadline )); do
   current=$(kubectl --namespace "$namespace" get externalsecret/kortix-runtime \
     --output='jsonpath={range .status.conditions[?(@.type=="Ready")]}{.status}{end}' 2>/dev/null || true)
-  if [ "$current" = "True" ]; then
+  refreshed=$(kubectl --namespace "$namespace" get externalsecret/kortix-runtime \
+    --output='jsonpath={.status.refreshTime}' 2>/dev/null || true)
+  if [ "$current" = "True" ] && [[ "$refreshed" > "$minimum_refresh" || "$refreshed" = "$minimum_refresh" ]]; then
     exit 0
   fi
   sleep 5
@@ -275,7 +278,14 @@ export class ReleaseInstaller {
       runtimeSecretArn: this.config.runtimeSecretArn,
     }), null, 2)}\n`, { mode: 0o600 });
     this.runner.run('kubectl', ['apply', '--filename', runtimeExternalSecrets], { env: kubeEnv });
-    this.runner.run('bash', ['-ceu', EXTERNAL_SECRET_WAIT_SCRIPT, 'bash', descriptor.namespace], { env: kubeEnv });
+    const secretRefreshRequestedAt = new Date().toISOString();
+    this.runner.run('kubectl', [
+      '--namespace', descriptor.namespace, 'annotate', '--overwrite',
+      'externalsecret/kortix-runtime', `force-sync=${Date.now()}`,
+    ], { env: kubeEnv });
+    this.runner.run('bash', [
+      '-ceu', EXTERNAL_SECRET_WAIT_SCRIPT, 'bash', descriptor.namespace, secretRefreshRequestedAt,
+    ], { env: kubeEnv });
     this.runner.run('kubectl', [
       '--namespace', descriptor.namespace, 'get', 'secret', 'kortix-runtime', '--output=name',
     ], { env: kubeEnv });
@@ -467,10 +477,11 @@ export class ReleaseInstaller {
   }
 
   private verifyHealth(manifest: EnterpriseReleaseManifest): void {
-    const api = this.runner.run('curl', [
+    const apiUrl = `https://${this.config.apiDomain}${manifest.health.api_path}`;
+    const api = this.curlWithRetry([
       '--fail', '--silent', '--show-error', '--proto', '=https', '--tlsv1.2',
-      `https://${this.config.apiDomain}${manifest.health.api_path}`,
-    ]);
+      apiUrl,
+    ], apiUrl);
     let health: Record<string, unknown>;
     try {
       health = JSON.parse(api) as Record<string, unknown>;
@@ -481,10 +492,24 @@ export class ReleaseInstaller {
     if (version !== manifest.health.expected_version) {
       throw new Error(`API health reports ${String(version)} instead of immutable prod ${manifest.health.expected_version}`);
     }
-    this.runner.run('curl', [
+    const frontendUrl = `https://${this.config.frontendDomain}${manifest.health.frontend_path}`;
+    this.curlWithRetry([
       '--fail', '--silent', '--show-error', '--output', '/dev/null', '--proto', '=https', '--tlsv1.2',
-      `https://${this.config.frontendDomain}${manifest.health.frontend_path}`,
-    ]);
+      frontendUrl,
+    ], frontendUrl);
+  }
+
+  private curlWithRetry(args: string[], url: string): string {
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= 60; attempt++) {
+      try {
+        return this.runner.run('curl', args);
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt < 60) this.runner.run('sleep', ['10']);
+      }
+    }
+    throw new Error(`health endpoint ${url} did not become ready within 10 minutes: ${lastError?.message ?? 'unknown error'}`);
   }
 }
 

--- a/infra/k8s/charts/kortix-api/templates/migrate-job.yaml
+++ b/infra/k8s/charts/kortix-api/templates/migrate-job.yaml
@@ -44,7 +44,10 @@ spec:
           image: {{ include "kortix-api.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /app/packages/db
-          command: ["bun", "scripts/migrate.ts", "up"]
+          # Enterprise starts from an official, otherwise-empty Supabase data
+          # plane. bootstrap installs the self-host prerequisites on first run
+          # and is a no-op before applying pending migrations thereafter.
+          command: ["bun", "scripts/migrate.ts", "bootstrap"]
           # The full synced secret bundle (DATABASE_URL included), exactly as the app.
           envFrom:
             - secretRef:

--- a/infra/terraform/modules/enterprise-vpc/files/supabase-user-data.sh.tftpl
+++ b/infra/terraform/modules/enterprise-vpc/files/supabase-user-data.sh.tftpl
@@ -72,6 +72,7 @@ EnvironmentFile=/etc/kortix/instance.env
 ExecStart=/bin/bash -c 'if [ -x /opt/kortix/current/bin/supabase-start ]; then exec /opt/kortix/current/bin/supabase-start; else echo "awaiting signed release reconciliation"; fi'
 ExecStop=/bin/bash -c 'if [ -x /opt/kortix/current/bin/supabase-stop ]; then exec /opt/kortix/current/bin/supabase-stop; fi'
 TimeoutStartSec=1800
+TimeoutStopSec=300
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- allow five minutes for the official Supabase Compose stack to shut down cleanly
- generate and preserve official Supabase publishable and secret API keys
- cover both contracts with focused tests

## Verification
- `bun test apps/cli/src/self-host/__tests__/aws-vpc-secrets.test.ts apps/cli/src/self-host/__tests__/enterprise-assets.test.ts`
- `terraform fmt -check -recursive infra/terraform/modules/enterprise-vpc`
- customer-zero live drop-in reports `TimeoutStopUSec=5min`
- customer-zero runtime secret updated without exposing values