### PR TITLE
fix(billing): grant credits on direct subscription checkout with saved card

### DIFF
--- a/apps/api/src/__tests__/billing/subscriptions.test.ts
+++ b/apps/api/src/__tests__/billing/subscriptions.test.ts
@@ -25,6 +25,7 @@ let upsertCreditAccountCalls: any[] = [];
 let updateCreditAccountCalls: any[] = [];
 let upsertCustomerCalls: any[] = [];
 let resetExpiringCreditsCalls: any[] = [];
+let grantCreditsCalls: any[] = [];
 let stripeCancelSubCalls: any[] = [];
 
 beforeEach(() => {
@@ -32,6 +33,7 @@ beforeEach(() => {
   updateCreditAccountCalls = [];
   upsertCustomerCalls = [];
   resetExpiringCreditsCalls = [];
+  grantCreditsCalls = [];
   stripeCancelSubCalls = [];
   resetMockRegistry();
 
@@ -75,7 +77,9 @@ beforeEach(() => {
   };
 
   // Credit service defaults
-  mockRegistry.grantCredits = async () => {};
+  mockRegistry.grantCredits = async (...args: any[]) => {
+    grantCreditsCalls.push(args);
+  };
   mockRegistry.resetExpiringCredits = async (...args: any[]) => {
     resetExpiringCreditsCalls.push(args);
   };
@@ -169,6 +173,50 @@ describe('createCheckoutSession', () => {
     expect(capturedParams).not.toBeNull();
     expect(capturedParams.line_items[0].price_data.unit_amount).toBe(2000);
     expect(capturedParams.line_items[0].price_data.recurring.interval).toBe('month');
+  });
+
+  test('grants tier credits when a saved card instant-creates the subscription', async () => {
+    mockRegistry.getCreditAccount = async () =>
+      createMockCreditAccount({ tier: 'free', stripeSubscriptionId: null });
+
+    mockRegistry.stripeClient.customers.retrieve = async () => ({
+      id: 'cus_test_123',
+      invoice_settings: { default_payment_method: 'pm_saved_card' },
+      deleted: false,
+    });
+    mockRegistry.stripeClient.paymentMethods.list = async () => ({
+      data: [{ id: 'pm_saved_card' }],
+    });
+
+    let checkoutCreateCalled = false;
+    mockRegistry.stripeClient.checkout.sessions.create = async () => {
+      checkoutCreateCalled = true;
+      return { id: 'cs_new_123', url: 'https://checkout.stripe.com/test' };
+    };
+
+    mockRegistry.stripeClient.subscriptions.create = async () =>
+      createMockStripeSubscription({
+        id: 'sub_direct_123',
+        status: 'active',
+      });
+
+    const result = await createCheckoutSession({
+      accountId: 'acc_test_123',
+      email: 'test@example.com',
+      tierKey: 'per_seat',
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+    });
+
+    expect((result as any).status).toBe('subscription_created');
+    expect((result as any).subscription_id).toBe('sub_direct_123');
+    expect(checkoutCreateCalled).toBe(false);
+    expect(grantCreditsCalls.length).toBe(1);
+    expect(grantCreditsCalls[0][0]).toBe('acc_test_123');
+    expect(grantCreditsCalls[0][1]).toBe(25);
+    expect(grantCreditsCalls[0][2]).toBe('tier_grant');
+    expect(grantCreditsCalls[0][4]).toBe(true);
+    expect(grantCreditsCalls[0][5]).toBe('subscription_activation:sub_direct_123');
   });
 });
 

--- a/apps/api/src/billing/services/subscriptions.ts
+++ b/apps/api/src/billing/services/subscriptions.ts
@@ -11,6 +11,7 @@ import { BillingError, SubscriptionError } from '../../errors';
 import { getTier, isUpgrade, resolvePriceId, getComputeDisplayPriceCents, getComputeProductId, getComputeDescription, resolvePerSeatPriceId, MAX_SEATS_PER_ACCOUNT } from './tiers';
 import { countActiveMembers } from './seat-management';
 import { grantCredits, resetExpiringCredits } from './credits';
+import { grantMachineBonusOnce, getStripeMachineBonusKey } from './machine-bonus';
 import { isPlatformAdmin } from '../../shared/platform-roles';
 import Stripe from 'stripe';
 import { AUTO_TOPUP_DEFAULT_AMOUNT, AUTO_TOPUP_DEFAULT_THRESHOLD } from '@kortix/shared';
@@ -188,12 +189,50 @@ export async function createCheckoutSession(params: {
           active: true,
         });
 
+        // Grant activation credits inline — this path skips hosted Checkout, so
+        // checkout.session.completed never runs and the webhook won't backfill
+        // the wallet (stripeSubscriptionId is already set). Mirror the grant
+        // logic in handleSubscriptionCheckout (webhooks.ts) and
+        // confirmCheckoutSession below.
+        const creditAmount = tier.monthlyCredits;
+        if (creditAmount > 0) {
+          try {
+            await grantCredits(
+              accountId,
+              creditAmount,
+              'tier_grant',
+              `${tier.displayName} subscription activated: ${creditAmount} credits`,
+              true,
+              `subscription_activation:${subscription.id}`,
+            );
+          } catch (err) {
+            console.error('[Billing] Failed to grant initial plan credits during direct subscription create:', err);
+          }
+        }
+
+        // Compute purchases include a one-time machine bonus — same as the
+        // checkout webhook path when server_type is in session metadata.
+        if (serverType) {
+          try {
+            await grantMachineBonusOnce({
+              accountId,
+              idempotencyKey: getStripeMachineBonusKey(subscription.id),
+            });
+          } catch (err) {
+            console.error(`[Billing] Failed to grant machine bonus for ${accountId} (sub=${subscription.id}):`, err);
+          }
+        }
+
+        if (previousFreeSubscriptionId && previousFreeSubscriptionId !== subscription.id) {
+          // Free → paid re-purchase: drop the stale free-tier Stripe sub so we
+          // don't carry two active subscription ids on the account.
+          await cancelFreeSubscriptionForUpgrade(previousFreeSubscriptionId, accountId);
+        }
+
         // Legacy auto-provision of a per-account sandbox at checkout time
         // has been removed — sandboxes are now per-session, provisioned on
         // demand under /v1/projects/:id/sessions.
-        void serverType;
         void location;
-        void tierKey;
 
         return {
           status: 'subscription_created' as const,


### PR DESCRIPTION
<!--
  Every change to a protected branch goes through this PR + review (SOC 2 CC8.1).
  Fill out each section. PRs cannot be merged without a passing CI check and an
  approving review from someone other than the author.
-->

## Summary
- Fix a billing bug where customers with a saved card were charged and activated via `subscription_created`, but never received tier credits (or the compute machine bonus).
- The direct path in `createCheckoutSession` skipped hosted Stripe Checkout, so `checkout.session.completed` never ran and the webhook could not backfill credits because `stripeSubscriptionId` was already persisted.
- After a successful direct subscription create, grant activation credits inline — mirroring `handleSubscriptionCheckout` (webhooks) and `confirmCheckoutSession`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [x] Security fix
- [ ] Breaking change

## How was this tested?

- [x] `cd apps/api && bun test src/__tests__/billing/subscriptions.test.ts` — 24/24 pass

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [x] Authorization checks are in place for any new/changed endpoints (IAM / access control)
- [x] User input is validated (e.g. Zod) and output is safe
- [x] No sensitive data (tokens, PII, secrets) is written to logs
- [x] DB schema / migration changes are reviewed and reversible
- [x] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner

## Rollout / rollback

<!-- Migrations, feature flags, env vars, and how to revert if this misbehaves. -->

## Reviewer checklist

- [x] Change is scoped and understandable
- [x] Tests/CI pass and cover the change
- [x] Security & data review above is satisfied
