### PR TITLE
docs: fix SDK namespace for repo imports — kortix.github.linkRepository

### DIFF
--- a/apps/web/content/docs/concepts/projects.mdx
+++ b/apps/web/content/docs/concepts/projects.mdx
@@ -27,7 +27,7 @@ the same GitHub repo can be a separate Kortix project with its own sessions and
 change requests, so `main` and `dev` can be managed as independent workspaces.
 The SDK exposes branch discovery through
 `kortix.github.listRepositoryBranches` and imports via
-`kortix.projects.linkRepository`.
+`kortix.github.linkRepository`.
 
 Either backing mode gives the project a `default_branch` that every
 [session](/docs/concepts/sessions) branches from and every


### PR DESCRIPTION
## What

One-line accuracy fix in `apps/web/content/docs/concepts/projects.mdx:30`.

`kortix.projects.linkRepository` → `kortix.github.linkRepository`

## Why

The docs claimed repo imports go through the `kortix.projects` SDK namespace, but `linkRepository` lives on the **`kortix.github`** namespace (account-scoped GitHub App installation + repository linking), not the project-scoped `projects` namespace.

Source proof (`packages/sdk/src/core/client/kortix.ts` at origin/main head `bae7daffa`):
- `const github = { linkRepository: P.linkRepository, … }` — **kortix.ts:250-251**
- `const projects = { list, listForAccount, get, detail, create, createRepo, provision, update, archive, llmCatalog, modelPicker, sandboxHealth, sandboxTemplates, sessions, createSession }` — **kortix.ts:230-247** — no `linkRepository` member.

The sibling claim on the same line (`kortix.github.listRepositoryBranches`) was already correct, and `/docs/sdk/the-client` already documents `linkRepository` under the `github` namespace.

## Scope

**Docs-only.** Single token swap in one MDX file. No code, config, or behavior change.

## Verification

- `node …/check-fumadocs.mjs apps/web/content/docs` → PASS (40 pages, 5 nav, 40 routes)
- `git diff --check` → clean
- `grep -rn 'projects.linkRepository' apps/web/content/docs` → 0 matches after edit
- `grep -rn 'github.linkRepository' apps/web/content/docs` → the fixed line

## Audit window

Part of the docs-maintainer 2026-07-15 sweep. Suna window: `258962941`..\`bae7daffa` (8 commits). This namespace drift pre-dates the window (identified in the 2026-07-14 run but unshipped due to a missing credential; shipped now that `AGENT_KORTIX_GITHUB_TOKEN` is available).