### PR TITLE
fix(web): suppress storage-blocked SecurityError localStorage noise (BS 09b9cf65…/ac75f0d8…)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -15,6 +15,7 @@ import {
   isRuntimeNotReadyNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
+  isStorageSecurityErrorNoise,
   isTronLinkProxyNoise,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
@@ -530,6 +531,186 @@ test('does NOT suppress a real null-access error on a non-storage method', () =>
     }),
     false,
   )
+})
+
+// Reproduces Better Stack error patterns
+// 09b9cf65ca7c954bf031fc6fb570a96c4e47ce4ed5f0b9ed8b10c688fc2f27de and
+// ac75f0d8a9b73ae88b68f02693d72ecc5137b5e1d2c14a430de5190a42cdfd64
+// (Kortix Frontend prod, application_id 2346967), both
+// `SecurityError: Failed to read the 'localStorage' property from 'window':
+// Access is denied for this document.`, 1 occurrence each, 0 identified users,
+// last 2026-07-12 17:54:04 UTC. Storage-blocked browser contexts (Safari
+// private mode, sandboxed/cross-origin iframe, partitioned storage, some in-app
+// WebViews) reject the `window.localStorage`/`sessionStorage` accessor READ
+// itself with this `SecurityError`; a direct `window.localStorage` call site
+// that bypasses the managed-storage try/catch throws it uncaught → Sentry →
+// Better Stack. Browser-environment noise, not an app defect. The matcher
+// drops it UNLESS the stack carries a resolved first-party `apps/web/src/…`
+// frame (our own code is the direct-access culprit → actionable to fix).
+const STORAGE_SECURITY_ERROR_EVENTS = [
+  // The exact raw production message (localStorage).
+  "SecurityError: Failed to read the 'localStorage' property from 'window': Access is denied for this document.",
+  // Bare message (no `SecurityError:` prefix).
+  "Failed to read the 'localStorage' property from 'window': Access is denied for this document.",
+  // Unhandled-rejection leak path preserving the message.
+  "Unhandled promise rejection: SecurityError: Failed to read the 'localStorage' property from 'window': Access is denied for this document.",
+  // The sessionStorage sibling variant (same root class, same instant).
+  "SecurityError: Failed to read the 'sessionStorage' property from 'window': Access is denied for this document.",
+  "Failed to read the 'sessionStorage' property from 'window': Access is denied for this document.",
+  "Unhandled promise rejection: Failed to read the 'sessionStorage' property from 'window': Access is denied for this document.",
+]
+
+// A raw minified chunk frame (no resolved `apps/web/src/…` source) — the
+// browser-environment noise shape: storage blocked, no traceable first-party
+// call site. Should be suppressed.
+const CHUNK_FRAME_STORAGE = 'app:///_next/static/chunks/21544-ac9e889808bbe0af.js'
+
+test('classifies every storage-blocked SecurityError variant as noise (no first-party frame)', () => {
+  for (const message of STORAGE_SECURITY_ERROR_EVENTS) {
+    assert.equal(
+      isStorageSecurityErrorNoise({ message }),
+      true,
+      `expected "${message}" to be classified as storage SecurityError noise`,
+    )
+    assert.equal(
+      isStorageSecurityErrorNoise({ message, frames: [{ filename: CHUNK_FRAME_STORAGE }] }),
+      true,
+      `expected "${message}" from a minified chunk frame to be noise`,
+    )
+    assert.equal(
+      isStorageSecurityErrorNoise({ message, filename: CHUNK_FRAME_STORAGE }),
+      true,
+      `expected "${message}" from a chunk filename to be noise`,
+    )
+  }
+})
+
+test('suppresses the storage SecurityError Sentry event via the beforeSend gate', () => {
+  for (const value of STORAGE_SECURITY_ERROR_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: { frames: [{ filename: CHUNK_FRAME_STORAGE }] },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a frameless storage SecurityError Sentry event (no first-party frame to preserve)', () => {
+  // A frameless capture carries no resolved first-party frame, so the negative
+  // guard does not apply — the message is the browser's own access-control
+  // throw (never an app-logic error), so it is safe to drop.
+  for (const value of STORAGE_SECURITY_ERROR_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      true,
+      `expected frameless Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses the storage SecurityError unhandled rejection via the runtime (window.onerror) gate', () => {
+  for (const message of STORAGE_SECURITY_ERROR_EVENTS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message }),
+      true,
+      `expected runtime gate to suppress "${message}"`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message, filename: CHUNK_FRAME_STORAGE }),
+      true,
+      `expected runtime gate to suppress "${message}" from a chunk filename`,
+    )
+  }
+})
+
+test('does NOT suppress a storage SecurityError whose stack resolves to a first-party app frame', () => {
+  // A de-minified `apps/web/src/…` frame means our own code is reading
+  // `window.localStorage` directly (bypassing managed-storage) — actionable,
+  // so it must keep reporting so the call site can be fixed. This is the
+  // negative guard that distinguishes actionable noise from the rest.
+  const realAppFrames: Array<{ filename: unknown }> = [
+    [{ filename: 'app:///apps/web/src/lib/storage/some-store.ts' }],
+    [{ filename: 'apps/web/src/features/auth/use-auth.ts' }],
+  ]
+  for (const frames of realAppFrames) {
+    for (const message of STORAGE_SECURITY_ERROR_EVENTS) {
+      assert.equal(
+        isStorageSecurityErrorNoise({ message, frames }),
+        false,
+        `expected first-party event "${message}" from ${JSON.stringify(frames)} to keep reporting`,
+      )
+      assert.equal(
+        shouldIgnoreSentryBrowserNoise({
+          exception: {
+            values: [{ value: message, stacktrace: { frames } }],
+          },
+        }),
+        false,
+        `expected Sentry gate to keep reporting first-party "${message}" from ${JSON.stringify(frames)}`,
+      )
+    }
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  for (const message of STORAGE_SECURITY_ERROR_EVENTS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: 'apps/web/src/lib/storage/some-store.ts',
+      }),
+      false,
+      `expected runtime gate to keep reporting first-party "${message}"`,
+    )
+  }
+})
+
+test('does NOT suppress a storage SecurityError when only ONE of several frames is first-party', () => {
+  // A mixed stack (chunk frame + one resolved first-party frame) still has a
+  // traceable first-party call site — keep reporting it.
+  assert.equal(
+    isStorageSecurityErrorNoise({
+      message: "SecurityError: Failed to read the 'localStorage' property from 'window': Access is denied for this document.",
+      frames: [
+        { filename: CHUNK_FRAME_STORAGE },
+        { filename: 'app:///apps/web/src/lib/desktop.ts' },
+      ],
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a non-storage SecurityError with the same shape', () => {
+  // A SecurityError on a DIFFERENT window property is not the storage-blocked
+  // class — keep reporting it.
+  for (const value of [
+    "SecurityError: Failed to read the 'parent' property from 'Window': Access is denied for this document.",
+    "Failed to read the 'document' property from 'window'",
+    'Access is denied for this document.',
+  ]) {
+    assert.equal(
+      isStorageSecurityErrorNoise({ message: value }),
+      false,
+      `expected non-storage message "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected Sentry event "${value}" to keep reporting`,
+    )
+  }
 })
 
 // Reproduces Better Stack error 83e0c2af...189c3b17 (Kortix Frontend prod,

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -34,6 +34,46 @@ const STORAGE_NULL_ACCESS_NOISE_PATTERNS = [
   "Cannot read property 'removeItem' of null",
 ] as const;
 
+// Storage-blocked browser contexts (Safari private mode, sandboxed/cross-origin
+// iframes, partitioned storage, some in-app WebViews) reject the
+// `window.localStorage` / `window.sessionStorage` accessor READ itself with a
+// `SecurityError: Failed to read the 'localStorage' property from 'window':
+// Access is denied for this document.` — distinct from the #4529 null-access
+// `TypeError` class (where the accessor resolves to `null`). The managed-storage
+// layer (`getLocalStorage`/`getSessionStorage`) wraps the accessor in try/catch
+// and returns null on throw, so call sites routed through it are safe; but a
+// direct `window.localStorage` read elsewhere in the bundle bypasses that guard
+// and the uncaught `SecurityError` reaches Sentry → Better Stack. Two sibling
+// patterns (`09b9cf65…` / `ac75f0d8…`), 1 occurrence each, 0 identified users,
+// 2026-07-12 17:54 UTC, prod — browser-environment noise, not an app defect.
+//
+// The wording is the browser's OWN access-control throw on the Web Storage
+// accessor (never an app-logic TypeError/ReferenceError), so matching the
+// canonical `Failed to read the '<storage>' property from 'window'` prefix is
+// specific. BUT a first-party call site that reads `window.localStorage`
+// directly (bypassing managed-storage) IS actionable — we want to know which
+// call site to fix — so a NEGATIVE guard preserves any event whose stack
+// carries a resolved first-party `apps/web/src/…` frame (sourcemap-de-minified).
+// Only events with NO resolved first-party frame (third-party / extension /
+// injected / unresolved-minified-chunk / frameless captures) are dropped.
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list —
+// that gate has no frame context, so a bare-string match there would swallow the
+// actionable first-party case the negative guard exists to preserve. The
+// frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`)
+// is the only safe gate.
+const STORAGE_SECURITY_ERROR_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
+  /^Failed to read the 'localStorage' property from 'window'/,
+  /^Failed to read the 'sessionStorage' property from 'window'/,
+];
+
+// A de-minified first-party source frame: Sentry's sourcemap resolution
+// rewrote the raw `_next/static/chunks/…` filename back to the original
+// `apps/web/src/…` source path (with or without an `app:///` origin prefix).
+// A throw from such a frame originates in our own code, so it is actionable.
+function isFirstPartyResolvedSource(filename: unknown): boolean {
+  return normalizeString(filename).includes('apps/web/src/');
+}
+
 const KNOWN_TEST_NOISE_MESSAGES = [
   'E2E FINAL:',
   'E2E test:',
@@ -357,6 +397,39 @@ export function isKnownBrowserNoiseMessage(message: unknown): boolean {
 export function isStorageDisabledWebViewNoiseMessage(message: unknown): boolean {
   const normalized = normalizeString(message);
   return containsKnownPattern(normalized, STORAGE_NULL_ACCESS_NOISE_PATTERNS);
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the storage-blocked
+ * `SecurityError: Failed to read the 'localStorage'/'sessionStorage' property
+ * from 'window'` class — the browser rejecting the Web Storage accessor READ
+ * itself in a storage-blocked context (Safari private mode, sandboxed/
+ * cross-origin iframe, partitioned storage, some in-app WebViews). Distinct
+ * from #4529's null-access `TypeError` class. Requires the canonical
+ * `Failed to read the '<storage>' property from 'window'` message prefix, AND
+ * a NEGATIVE guard: if any frame (or the window.onerror filename) resolves to
+ * a de-minified first-party `apps/web/src/…` source, the event keeps reporting
+ * — that means our own code is reading `window.localStorage` directly
+ * (bypassing managed-storage) and is actionable to fix. Only events with NO
+ * resolved first-party frame are dropped. See
+ * `STORAGE_SECURITY_ERROR_NOISE_PATTERNS` for the full rationale.
+ */
+export function isStorageSecurityErrorNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!STORAGE_SECURITY_ERROR_NOISE_PATTERNS.some((re) => re.test(stripped))) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party frame means our own code is the
+  // direct-access culprit — keep reporting so the call site can be fixed.
+  return !sources.some(isFirstPartyResolvedSource);
 }
 
 // Sentry events whose exception carries NO message ("No error message" in
@@ -691,6 +764,18 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Storage-blocked browser contexts (Safari private mode, sandboxed/cross-
+  // origin iframe, partitioned storage, some in-app WebViews) reject the
+  // `window.localStorage`/`sessionStorage` accessor READ itself with a
+  // `SecurityError: Failed to read the '<storage>' property from 'window'`.
+  // A direct `window.localStorage` call site that bypasses managed-storage
+  // throws this uncaught. Browser-environment noise; drop it UNLESS the stack
+  // carries a resolved first-party `apps/web/src/…` frame (our own code is the
+  // culprit → actionable). See `isStorageSecurityErrorNoise`.
+  if (isStorageSecurityErrorNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
   // Browser-native <img> / next/image load failures can surface as this exact
   // message through window.onerror. Keep this exact: pptx-react-viewer throws
   // actionable errors such as "Failed to load image for colour change
@@ -801,6 +886,18 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // throw `null.getItem/setItem/removeItem` TypeErrors. Browser-environment
   // noise, never an app defect — drop it at the Sentry gate too.
   if (isStorageDisabledWebViewNoiseMessage(message)) {
+    return true;
+  }
+
+  // Storage-blocked browser contexts (Safari private mode, sandboxed/cross-
+  // origin iframe, partitioned storage, some in-app WebViews) reject the
+  // `window.localStorage`/`sessionStorage` accessor READ itself with a
+  // `SecurityError: Failed to read the '<storage>' property from 'window'`.
+  // A direct `window.localStorage` call site that bypasses managed-storage
+  // throws this uncaught. Browser-environment noise; drop it UNLESS the stack
+  // carries a resolved first-party `apps/web/src/…` frame (our own code is the
+  // culprit → actionable). See `isStorageSecurityErrorNoise`.
+  if (isStorageSecurityErrorNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause

Storage-blocked browser contexts (Safari private mode, sandboxed/cross-origin iframe, partitioned storage, some in-app WebViews) reject the `window.localStorage` / `window.sessionStorage` accessor **READ itself** with `SecurityError: Failed to read the 'localStorage' property from 'window': Access is denied for this document.`. A code path that reads `window.localStorage` **directly** (bypassing the try/catch in `apps/web/src/lib/storage/managed-storage.ts` `getLocalStorage`/`getSessionStorage`, which already return `null` on throw) throws this uncaught → Sentry `beforeSend` → Better Stack. This is a distinct failure class from #4529's null-access `TypeError` (where the accessor *resolves to `null`*); here the accessor *read is rejected*.

## Better Stack evidence

Two sibling prod patterns, same root class, same instant (Kortix Frontend prod, application_id 2346967):
- `09b9cf65ca7c954bf031fc6fb570a96c4e47ce4ed5f0b9ed8b10c688fc2f27de` — `SecurityError: Failed to read the 'localStorage' property from 'window'…` — count 1 / 0 users / last 2026-07-12 17:54:04 UTC / Unresolved. https://errors.betterstack.com/team/t502678/errors/09b9cf65ca7c954bf031fc6fb570a96c4e47ce4ed5f0b9ed8b10c688fc2f27de?s=2346967
- `ac75f0d8a9b73ae88b68f02693d72ecc5137b5e1d2c14a430de5190a42cdfd64` — same message — count 1 / 0 users / last 2026-07-12 17:54:04 UTC / Unresolved. https://errors.betterstack.com/team/t502678/errors/ac75f0d8a9b73ae88b68f02693d72ecc5137b5e1d2c14a430de5190a42cdfd64?s=2346967

0 users / 1 occurrence each = browser-environment noise, not an app defect. The managed-storage layer already wraps the accessor in try/catch, so call sites routed through it are safe — but a residual direct `window.localStorage` call site bypasses it.

## Why a noise filter (not a call-site hunt)

Hunting every direct `window.localStorage`/`window.sessionStorage` read across the bundle is fragile and endless (many third-party deps read it directly). The robust, precedent-aligned fix is to extend `browser-error-noise.ts` — same philosophy as #4529 (null-access TypeError), #4538 (old-WebKit regex), #4540 (old-browser SyntaxError), the Android-bridge, and TronLink matchers.

## The fix

New exported matcher `isStorageSecurityErrorNoise` in `apps/web/src/lib/browser-error-noise.ts`:
- Matches the canonical `Failed to read the 'localStorage' property from 'window'` / `'sessionStorage'` message prefix (after stripping `SecurityError: ` / `Unhandled promise rejection: ` wrappers, so all capture paths classify consistently).
- **Negative guard**: if any frame (or the `window.onerror` filename) resolves to a de-minified first-party `apps/web/src/…` source, the event **keeps reporting** — that means our own code is reading `window.localStorage` directly (bypassing managed-storage) and is actionable to fix the call site. Only events with NO resolved first-party frame (third-party / extension / injected / unresolved-minified-chunk / frameless captures) are dropped.
- Wired into BOTH `shouldIgnoreBrowserRuntimeNoise` (window.onerror / onunhandledrejection) and `shouldIgnoreSentryBrowserNoise` (Sentry `beforeSend`) — same as #4529.
- **Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list**: that gate has no frame context, so a bare-string match there would swallow the actionable first-party case the negative guard exists to preserve. The frame-aware `beforeSend` hook is the only safe gate (same precedent as the old-browser SyntaxError / Android bridge / TronLink matchers, which all explicitly document this).

## Test coverage (`apps/web/src/lib/browser-error-noise.test.mts`)

- ✅ SecurityError `localStorage` message (raw, bare, unhandled-rejection wrapper) is suppressed.
- ✅ SecurityError `sessionStorage` sibling variant is suppressed.
- ✅ Frameless + minified-chunk-frame captures are suppressed.
- ✅ **Negative guard**: a SecurityError whose stack resolves to a first-party `apps/web/src/…` frame is **NOT** suppressed (actionable).
- ✅ Mixed stack with one first-party frame keeps reporting.
- ✅ Non-storage SecurityError with the same shape (`'parent'`, `'document'`) keeps reporting.
- ✅ Existing #4529 null-access `TypeError` tests unchanged — full file: **79 pass / 0 fail** (`bun test src/lib/browser-error-noise.test.mts`).

## Verification

- `bun test apps/web/src/lib/browser-error-noise.test.mts` → 79 pass / 0 fail.
- `bun build` transpile of the noise module → clean.
- Full `tsc --noEmit` + lint gate deferred to CI (per the noise-filter PR workflow — local tmpfs worktree avoids full `pnpm install`).
- Repro is "browser blocks `localStorage` + a direct-access call site throws SecurityError"; full live e2e isn't feasible (needs a real storage-blocked browser), so the unit tests are the verification: the matcher suppresses the exact message, the negative guard preserves real first-party SecurityErrors, and existing tests stay green.

## How to confirm resolution

After merge + Promote to prod, the two Better Stack patterns (`09b9cf65…` / `ac75f0d8…`) should drop to zero new occurrences (Better Stack auto-resolves once no longer seen). A real first-party direct-`window.localStorage` regression would still surface (de-minified `apps/web/src/…` frame bypasses the filter), so actionable signal is preserved.

**Do not merge** — leaving open and green for orchestrator review.
