### PR TITLE
ECS Fargate revival — parallel EKS+ECS with unified Cloudflare router

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -286,6 +286,34 @@ jobs:
           fi
           pnpm --filter @kortix/db migrate
 
+  # ── Roll the freshly-built image onto the dev ECS Fargate service ───────────
+  # Runs in PARALLEL with the EKS GitOps deploy during the ECS↔EKS transition,
+  # so both runtimes stay on the same image and we can flip the Cloudflare router
+  # between them at will. The task-def is rendered from the kortix-dev-env
+  # Secrets Manager blob (the same blob external-secrets syncs into EKS), so the
+  # ECS and EKS env contracts can never drift. When EKS is retired, delete the
+  # deploy-api (EKS) job and this becomes the sole API deploy.
+  deploy-api-ecs:
+    name: Deploy API to dev (ECS Fargate)
+    needs: [detect-changes, tag-api, migrate-db]
+    if: needs.detect-changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC → ECS deploy role
+      contents: read
+    env:
+      AWS_REGION: us-west-2
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Roll the dev ECS service onto the freshly-built image
+        run: bash infra/scripts/ecs-deploy.sh dev "${{ needs.tag-api.outputs.image }}"
+
   deploy-api:
     name: Deploy API to dev (EKS / GitOps)
     needs: [detect-changes, tag-api, migrate-db]

--- a/.github/workflows/deploy-gateway-dev.yml
+++ b/.github/workflows/deploy-gateway-dev.yml
@@ -55,6 +55,31 @@ jobs:
             kortix/kortix-gateway:dev-latest
             kortix/kortix-gateway:${{ steps.meta.outputs.tag }}
 
+  # Roll the freshly-built gateway image onto the dev ECS Fargate gateway service,
+  # in parallel with the EKS GitOps deploy below. The task-def is rendered from the
+  # kortix-dev-env Secrets Manager blob (same blob external-secrets syncs into EKS)
+  # so the two runtimes can't drift. When EKS is retired, this becomes the sole
+  # gateway deploy.
+  deploy-gateway-ecs:
+    name: Deploy gateway to dev (ECS Fargate)
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC → ECS deploy role
+      contents: read
+    env:
+      AWS_REGION: us-west-2
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Roll the dev ECS gateway service onto the freshly-built image
+        run: bash infra/scripts/ecs-deploy.sh dev "kortix/kortix-gateway:${{ needs.build.outputs.tag }}" --service gateway
+
   deploy:
     name: Deploy gateway to dev (GitOps)
     needs: build

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -655,6 +655,34 @@ jobs:
   # This job WATCHES that roll finish on exactly :VERSION, then announces to Slack.
   # kortixVersion comes from the values bump, so /v1/health reports the clean
   # X.Y.Z — no task-def version stamping like the old ECS roll needed.
+  # Roll prod ECS Fargate (api + gateway) to the release image, keeping it current
+  # alongside EKS. The script skips gracefully until the prod ECS gateway infra
+  # exists, and keeps each service's task-def current WITHOUT changing its desired
+  # count — so prod ECS stays a scaled-to-zero standby (no extra cost) until the
+  # gated prod traffic flip deliberately scales it up. Deploy ≠ flip.
+  deploy-ecs:
+    name: Deploy API + gateway to prod (ECS Fargate)
+    needs: [version, retag-images, migrate-db]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC → ECS deploy role
+      contents: read
+    env:
+      AWS_REGION: eu-west-2
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
+      VERSION: ${{ needs.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Roll prod ECS (api + gateway) from the prod-env blob
+        run: |
+          bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-api:${VERSION}"
+          bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-gateway:${VERSION}" --service gateway
+
   deploy-api:
     name: Deploy API to prod (EKS / GitOps)
     needs: [version, retag-images, migrate-db]

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -217,6 +217,32 @@ jobs:
           fi
           pnpm --filter @kortix/db migrate
 
+  # Roll staging ECS Fargate (api + gateway) alongside the EKS deploy. The script
+  # skips gracefully until the staging ECS infra exists (Terraform greenfield), so
+  # this is safe to keep wired now and auto-activates the moment the services exist.
+  deploy-ecs:
+    name: Deploy API + gateway to staging (ECS Fargate)
+    needs: [preflight, sync-secret, migrate-db]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC → ECS deploy role
+      contents: read
+    env:
+      AWS_REGION: us-west-2
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
+      SHA8: ${{ needs.preflight.outputs.sha8 }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Roll staging ECS (api + gateway) from the staging-env blob
+        run: |
+          bash infra/scripts/ecs-deploy.sh staging "kortix/kortix-api:staging-${SHA8}"
+          bash infra/scripts/ecs-deploy.sh staging "kortix/kortix-gateway:staging-${SHA8}" --service gateway
+
   deploy-k8s:
     name: Deploy API and gateway to staging
     needs: [preflight, sync-secret, migrate-db]

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -1,15 +1,17 @@
-// Kortix API router — the blue/green cutover switch in front of the public API.
+// Kortix API + gateway router — the blue/green cutover switch in front of both
+// public services. One worker per env handles BOTH hostnames:
 //
-//   api.kortix.com          → this worker (env "prod")    → EKS | ECS-Fargate
-//   staging-api.kortix.com  → this worker (env "staging") → EKS | ECS-Fargate
-//   dev-api.kortix.com      → this worker (env "dev")     → EKS | ECS-Fargate
+//   api.kortix.com          → API      → EKS | ECS-Fargate   (ACTIVE_BACKEND)
+//   gateway.kortix.com      → gateway  → EKS | ECS-Fargate   (GATEWAY_ACTIVE_BACKEND)
+//   (staging-/dev- variants route to the "staging"/"dev" worker envs)
 //
-// The active backend is chosen by the `ACTIVE_BACKEND` plain-text var; the two
-// concrete origins are `BACKEND_EKS` / `BACKEND_ECS_FARGATE` (per-env vars in
-// wrangler.toml). Flipping ACTIVE_BACKEND is an instant, instantly-reversible
-// failover with no DNS change. Both backends run the same image against the same
-// DB, so a flip is safe (background-worker leadership is a single global DB lease
-// — see apps/api/src/shared/leader-election.ts — so only one side ever runs cron).
+// The service is chosen by hostname (anything containing "gateway" is the LLM
+// gateway); each service has its OWN active-backend var + origin pair, so the
+// API and the gateway can be flipped or rolled back INDEPENDENTLY from this one
+// router with no DNS change. Both backends of a service run the same image
+// against the same DB, so a flip is safe (background-worker leadership is a
+// single global DB lease — see apps/api/src/shared/leader-election.ts — so only
+// one side ever runs cron). Flipping is instant and instantly reversible.
 const STRICT_TRANSPORT_SECURITY = 'max-age=31536000';
 
 function addSecurityHeaders(response) {
@@ -20,19 +22,20 @@ function addSecurityHeaders(response) {
 
 export default {
   async fetch(request, env) {
-    const active = env.ACTIVE_BACKEND || 'eks';
+    const url = new URL(request.url);
+    const isGateway = url.hostname.includes('gateway');
 
-    const backends = {
-      eks: env.BACKEND_EKS,
-      'ecs-fargate': env.BACKEND_ECS_FARGATE,
-    };
+    const active = (isGateway ? env.GATEWAY_ACTIVE_BACKEND : env.ACTIVE_BACKEND) || 'eks';
+    const backends = isGateway
+      ? { eks: env.GATEWAY_BACKEND_EKS, 'ecs-fargate': env.GATEWAY_BACKEND_ECS_FARGATE }
+      : { eks: env.BACKEND_EKS, 'ecs-fargate': env.BACKEND_ECS_FARGATE };
 
     const backendUrl = backends[active];
     if (!backendUrl) {
-      return new Response(`Invalid backend configuration: ${active}`, { status: 500 });
+      const svc = isGateway ? 'gateway' : 'api';
+      return new Response(`Invalid ${svc} backend configuration: ${active}`, { status: 500 });
     }
 
-    const url = new URL(request.url);
     if (url.protocol !== 'https:') {
       url.protocol = 'https:';
       return new Response(null, {
@@ -61,6 +64,7 @@ export default {
     const response = await fetch(modifiedRequest);
     const newResponse = new Response(response.body, response);
     newResponse.headers.set('X-Backend', active);
+    newResponse.headers.set('X-Backend-Service', isGateway ? 'gateway' : 'api');
     return addSecurityHeaders(newResponse);
   },
 };

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -5,6 +5,11 @@ const env = {
   ACTIVE_BACKEND: 'eks',
   BACKEND_EKS: 'https://api-eks.kortix.com',
   BACKEND_ECS_FARGATE: 'https://api-fargate.kortix.com',
+  // Gateway is deliberately on a DIFFERENT active backend than the API, to prove
+  // the two services flip independently.
+  GATEWAY_ACTIVE_BACKEND: 'ecs-fargate',
+  GATEWAY_BACKEND_EKS: 'https://gateway-eks.kortix.com',
+  GATEWAY_BACKEND_ECS_FARGATE: 'https://gateway-fargate.kortix.com',
 };
 
 const originalFetch = globalThis.fetch;
@@ -51,5 +56,41 @@ describe('api-router worker', () => {
     expect(response.headers.get('Strict-Transport-Security')).toBe('max-age=31536000');
     expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
     expect(response.headers.get('X-Backend')).toBe('eks');
+    expect(response.headers.get('X-Backend-Service')).toBe('api');
+  });
+
+  test('routes gateway hostnames to the gateway backend, independent of the API toggle', async () => {
+    let proxiedUrl = '';
+    globalThis.fetch = async (request) => {
+      proxiedUrl = request.url;
+      return new Response('ok', { status: 200 });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://gateway-dev.kortix.com/health/live'),
+      env,
+    );
+
+    // API is on eks, but the gateway is on ecs-fargate → the gateway origin wins.
+    expect(proxiedUrl).toBe('https://gateway-fargate.kortix.com/health/live');
+    expect(response.headers.get('X-Backend')).toBe('ecs-fargate');
+    expect(response.headers.get('X-Backend-Service')).toBe('gateway');
+  });
+
+  test('gateway HTTPS redirect keeps the gateway hostname', async () => {
+    let fetched = false;
+    globalThis.fetch = async () => {
+      fetched = true;
+      return new Response('unexpected');
+    };
+
+    const response = await worker.fetch(
+      new Request('http://gateway.kortix.com/v1/chat/completions'),
+      env,
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get('Location')).toBe('https://gateway.kortix.com/v1/chat/completions');
+    expect(fetched).toBe(false);
   });
 });

--- a/infra/cloudflare/workers/api-router/wrangler.toml
+++ b/infra/cloudflare/workers/api-router/wrangler.toml
@@ -18,35 +18,55 @@ compatibility_date = "2026-06-01"
 workers_dev = false
 account_id = "9785405a992435bb0c7bd19f9b6d26d5"
 
-# ── PROD: api.kortix.com ──────────────────────────────────────────────────────
+# ── PROD: api.kortix.com + gateway.kortix.com ─────────────────────────────────
 [env.prod]
 name = "api-kortix-router"
-routes = [{ pattern = "api.kortix.com", custom_domain = true }]
+routes = [
+  { pattern = "api.kortix.com", custom_domain = true },
+  { pattern = "gateway.kortix.com", custom_domain = true },
+]
 
 [env.prod.vars]
 # EKS (eu-west-2, colocated with the Supabase DB) is the active backend; ECS
 # Fargate is the warm standby. Flip with `--var ACTIVE_BACKEND:ecs-fargate`
-# (instant, reversible). Both kept current by CI.
+# (instant, reversible). Both kept current by CI. The gateway has its OWN toggle
+# (GATEWAY_ACTIVE_BACKEND) so it flips independently of the API.
 ACTIVE_BACKEND = "eks"
 BACKEND_EKS = "https://api-eks.kortix.com"
 BACKEND_ECS_FARGATE = "https://api-ecs-fargate.kortix.com"
+GATEWAY_ACTIVE_BACKEND = "eks"
+GATEWAY_BACKEND_EKS = "https://gateway-eks.kortix.com"
+GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-ecs-fargate.kortix.com"
 
-# ── STAGING: staging-api.kortix.com ───────────────────────────────────────────
+# ── STAGING: staging-api.kortix.com + gateway-staging.kortix.com ──────────────
 [env.staging]
 name = "staging-api-kortix-router"
-routes = [{ pattern = "staging-api.kortix.com", custom_domain = true }]
+routes = [
+  { pattern = "staging-api.kortix.com", custom_domain = true },
+  { pattern = "gateway-staging.kortix.com", custom_domain = true },
+]
 
 [env.staging.vars]
 ACTIVE_BACKEND = "eks"
 BACKEND_EKS = "https://staging-api-eks.kortix.com"
 BACKEND_ECS_FARGATE = "https://staging-api-ecs-fargate.kortix.com"
+GATEWAY_ACTIVE_BACKEND = "eks"
+GATEWAY_BACKEND_EKS = "https://gateway-staging-eks.kortix.com"
+GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-staging-ecs-fargate.kortix.com"
 
-# ── DEV: dev-api.kortix.com ───────────────────────────────────────────────────
+# ── DEV: dev-api.kortix.com + gateway-dev.kortix.com ──────────────────────────
 [env.dev]
 name = "dev-api-kortix-router"
-routes = [{ pattern = "dev-api.kortix.com", custom_domain = true }]
+routes = [
+  { pattern = "dev-api.kortix.com", custom_domain = true },
+  { pattern = "gateway-dev.kortix.com", custom_domain = true },
+]
 
 [env.dev.vars]
 ACTIVE_BACKEND = "ecs-fargate"
 BACKEND_EKS = "https://dev-api-eks.kortix.com"
 BACKEND_ECS_FARGATE = "https://dev-api-ecs-fargate.kortix.com"
+# Gateway starts on EKS; flip to ecs-fargate once the dev gateway origins are wired.
+GATEWAY_ACTIVE_BACKEND = "eks"
+GATEWAY_BACKEND_EKS = "https://gateway-dev-eks.kortix.com"
+GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-dev-ecs-fargate.kortix.com"

--- a/infra/cloudflare/workers/api-router/wrangler.toml
+++ b/infra/cloudflare/workers/api-router/wrangler.toml
@@ -23,7 +23,7 @@ account_id = "9785405a992435bb0c7bd19f9b6d26d5"
 name = "api-kortix-router"
 routes = [
   { pattern = "api.kortix.com", custom_domain = true },
-  { pattern = "gateway.kortix.com", custom_domain = true },
+  { pattern = "gateway.kortix.com/*", zone_name = "kortix.com" },
 ]
 
 [env.prod.vars]
@@ -43,7 +43,7 @@ GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-ecs-fargate.kortix.com"
 name = "staging-api-kortix-router"
 routes = [
   { pattern = "staging-api.kortix.com", custom_domain = true },
-  { pattern = "gateway-staging.kortix.com", custom_domain = true },
+  { pattern = "gateway-staging.kortix.com/*", zone_name = "kortix.com" },
 ]
 
 [env.staging.vars]
@@ -59,14 +59,16 @@ GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-staging-ecs-fargate.kortix.com"
 name = "dev-api-kortix-router"
 routes = [
   { pattern = "dev-api.kortix.com", custom_domain = true },
-  { pattern = "gateway-dev.kortix.com", custom_domain = true },
+  { pattern = "gateway-dev.kortix.com/*", zone_name = "kortix.com" },
 ]
 
 [env.dev.vars]
 ACTIVE_BACKEND = "ecs-fargate"
 BACKEND_EKS = "https://dev-api-eks.kortix.com"
 BACKEND_ECS_FARGATE = "https://dev-api-ecs-fargate.kortix.com"
-# Gateway starts on EKS; flip to ecs-fargate once the dev gateway origins are wired.
-GATEWAY_ACTIVE_BACKEND = "eks"
+# Dev gateway is flipped to ECS. GATEWAY_BACKEND_EKS is the rollback origin
+# (needs gateway-dev-eks on the EKS ingress + wildcard cert to serve; today rollback
+# = remove the gateway-dev route → external-dns record falls back to EKS directly).
+GATEWAY_ACTIVE_BACKEND = "ecs-fargate"
 GATEWAY_BACKEND_EKS = "https://gateway-dev-eks.kortix.com"
 GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-dev-ecs-fargate.kortix.com"

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -41,9 +41,11 @@ case "$ENV" in
   *) echo "unknown env: $ENV" >&2; exit 2 ;;
 esac
 
-# api service == cluster/service named kortix-<env>; gateway == kortix-<env>-gateway
+# Each service lives in its own cluster (the ecs-api module names cluster==service):
+#   api     → cluster/service kortix-<env>,         container "api"
+#   gateway → cluster/service kortix-<env>-gateway,  container "gateway"
 if [ "$SVC_KIND" = "gateway" ]; then
-  CLUSTER="kortix-${ENV}"
+  CLUSTER="kortix-${ENV}-gateway"
   SERVICE="kortix-${ENV}-gateway"
   CONTAINER="gateway"
 else

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -58,6 +58,16 @@ SECRET_NAME="kortix-${ENV}-env"
 echo "▶ env=$ENV region=$REGION cluster=$CLUSTER service=$SERVICE container=$CONTAINER"
 echo "▶ image=$IMAGE  secrets<-$SECRET_NAME"
 
+# ── skip gracefully if this env's ECS service isn't built yet ────────────────
+# Lets the ECS-roll step live in EVERY env's CI before the staging/prod ECS infra
+# exists — it no-ops until Terraform creates the cluster+service, then auto-rolls.
+STATUS="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" \
+  --services "$SERVICE" --query 'services[0].status' --output text 2>/dev/null || true)"
+if [ "$STATUS" != "ACTIVE" ]; then
+  echo "⏭  ECS service $CLUSTER/$SERVICE not ACTIVE (got '${STATUS:-none}') — skipping ($ENV ECS infra not built yet)."
+  exit 0
+fi
+
 # ── resolve the secrets blob ARN (no hardcoded suffix) ───────────────────────
 SECRET_ARN="$(aws secretsmanager describe-secret --region "$REGION" \
   --secret-id "$SECRET_NAME" --query 'ARN' --output text)"
@@ -98,17 +108,13 @@ NEW_TD="$(aws ecs register-task-definition --region "$REGION" \
 echo "✔ registered $NEW_TD"
 
 # ── roll the service ─────────────────────────────────────────────────────────
-DESIRED="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" \
-  --services "$SERVICE" --query 'services[0].desiredCount' --output text)"
-SCALE_ARG=()
-if [ "${DESIRED:-0}" -lt 1 ]; then
-  echo "▶ service desired=$DESIRED → scaling to 2"
-  SCALE_ARG=(--desired-count 2)
-fi
-
+# Point the service at the new revision and force a fresh deployment. We do NOT
+# change the desired count: whether ECS runs in parallel (dev/staging) or stays a
+# scaled-to-zero standby (prod, until a deliberate flip) is owned by Terraform's
+# desired_count / a manual scale, not by this roll.
 aws ecs update-service --region "$REGION" --cluster "$CLUSTER" --service "$SERVICE" \
-  --task-definition "$NEW_TD" --force-new-deployment "${SCALE_ARG[@]}" >/dev/null
-echo "✔ update-service issued"
+  --task-definition "$NEW_TD" --force-new-deployment >/dev/null
+echo "✔ update-service issued (desired count unchanged)"
 
 if [ "$WAIT" = "1" ]; then
   echo "⏳ waiting for services-stable …"

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# ecs-deploy.sh — roll a Kortix service onto ECS Fargate with a task-def rendered
+# fresh from Secrets Manager, so the ECS env can never drift from the EKS env.
+#
+# The env contract lives in ONE place per environment: the Secrets Manager blob
+# `kortix-<env>-env` (the same blob external-secrets syncs into EKS). We read its
+# keys and wire every one into the task-def as a `secrets` entry pointing back at
+# that blob's JSON key — no hand-maintained secret list, no drift.
+#
+# Usage:
+#   ecs-deploy.sh <env> <image> [--service api|gateway] [--no-wait]
+#
+#   env    dev | staging | prod
+#   image  full image ref to pin, e.g. kortix/kortix-api:dev-481dc551
+#
+# Requires: awscli v2, jq. Assumes the ECS cluster/service/ALB/target-group and
+# the exec/task IAM roles already exist (Terraform owns those).
+
+set -euo pipefail
+
+ENV="${1:?env required: dev|staging|prod}"
+IMAGE="${2:?image required, e.g. kortix/kortix-api:dev-481dc551}"
+shift 2
+
+SVC_KIND="api"
+WAIT=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --service) SVC_KIND="$2"; shift 2 ;;
+    --no-wait) WAIT=0; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ── per-environment coordinates ──────────────────────────────────────────────
+case "$ENV" in
+  dev)     REGION="us-west-2" ;;
+  staging) REGION="us-west-2" ;;
+  prod)    REGION="eu-west-2" ;;
+  *) echo "unknown env: $ENV" >&2; exit 2 ;;
+esac
+
+# api service == cluster/service named kortix-<env>; gateway == kortix-<env>-gateway
+if [ "$SVC_KIND" = "gateway" ]; then
+  CLUSTER="kortix-${ENV}"
+  SERVICE="kortix-${ENV}-gateway"
+  CONTAINER="gateway"
+else
+  CLUSTER="kortix-${ENV}"
+  SERVICE="kortix-${ENV}"
+  CONTAINER="api"
+fi
+SECRET_NAME="kortix-${ENV}-env"
+
+echo "▶ env=$ENV region=$REGION cluster=$CLUSTER service=$SERVICE container=$CONTAINER"
+echo "▶ image=$IMAGE  secrets<-$SECRET_NAME"
+
+# ── resolve the secrets blob ARN (no hardcoded suffix) ───────────────────────
+SECRET_ARN="$(aws secretsmanager describe-secret --region "$REGION" \
+  --secret-id "$SECRET_NAME" --query 'ARN' --output text)"
+[ -n "$SECRET_ARN" ] && [ "$SECRET_ARN" != "None" ] || { echo "secret $SECRET_NAME not found in $REGION" >&2; exit 1; }
+
+# every key in the blob -> a task-def secret entry pointing at that JSON key
+SECRETS_JSON="$(aws secretsmanager get-secret-value --region "$REGION" \
+  --secret-id "$SECRET_ARN" --query 'SecretString' --output text \
+  | jq --arg arn "$SECRET_ARN" '
+      keys
+      | map({ name: ., valueFrom: ($arn + ":" + . + "::") })')"
+KEYCOUNT="$(echo "$SECRETS_JSON" | jq 'length')"
+[ "$KEYCOUNT" -gt 0 ] || { echo "blob $SECRET_NAME has 0 keys — refusing to deploy" >&2; exit 1; }
+echo "▶ wired $KEYCOUNT secret keys from $SECRET_NAME"
+
+# ── base task-def = the service's current one, with runtime fields stripped ──
+CURRENT_TD="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" \
+  --services "$SERVICE" --query 'services[0].taskDefinition' --output text)"
+[ -n "$CURRENT_TD" ] && [ "$CURRENT_TD" != "None" ] || { echo "service $SERVICE has no task-def" >&2; exit 1; }
+
+NEW_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
+  --task-definition "$CURRENT_TD" --query 'taskDefinition' --output json \
+  | jq --arg img "$IMAGE" --arg c "$CONTAINER" --argjson secrets "$SECRETS_JSON" '
+      # drop read-only fields register-task-definition rejects
+      del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+          .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
+      # override image + full secrets on the target container
+      | .containerDefinitions |= map(
+          if .name == $c then .image = $img | .secrets = $secrets else . end)')"
+
+TDFILE="$(mktemp -t ecs-td-XXXX.json)"
+trap 'rm -f "$TDFILE"' EXIT
+echo "$NEW_TD_JSON" > "$TDFILE"
+
+NEW_TD="$(aws ecs register-task-definition --region "$REGION" \
+  --cli-input-json "file://$TDFILE" \
+  --query 'taskDefinition.taskDefinitionArn' --output text)"
+echo "✔ registered $NEW_TD"
+
+# ── roll the service ─────────────────────────────────────────────────────────
+DESIRED="$(aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" \
+  --services "$SERVICE" --query 'services[0].desiredCount' --output text)"
+SCALE_ARG=()
+if [ "${DESIRED:-0}" -lt 1 ]; then
+  echo "▶ service desired=$DESIRED → scaling to 2"
+  SCALE_ARG=(--desired-count 2)
+fi
+
+aws ecs update-service --region "$REGION" --cluster "$CLUSTER" --service "$SERVICE" \
+  --task-definition "$NEW_TD" --force-new-deployment "${SCALE_ARG[@]}" >/dev/null
+echo "✔ update-service issued"
+
+if [ "$WAIT" = "1" ]; then
+  echo "⏳ waiting for services-stable …"
+  aws ecs wait services-stable --region "$REGION" --cluster "$CLUSTER" --services "$SERVICE"
+  aws ecs describe-services --region "$REGION" --cluster "$CLUSTER" --services "$SERVICE" \
+    --query 'services[0].{running:runningCount,desired:desiredCount,rollout:deployments[0].rolloutState}' \
+    --output table
+fi
+echo "✅ $ENV/$CONTAINER now on $IMAGE ($NEW_TD)"

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -119,6 +119,42 @@ module "api" {
   tags                       = local.tags
 }
 
+# ── Gateway (LLM proxy) as its own ECS Fargate service ────────────────────────
+# Same reusable module as the API, in its own cluster/ALB. Retiring EKS means the
+# gateway leaves the cluster too; on Fargate it reaches the API over the public
+# dev-api hostname (no in-cluster DNS). Shares the dev env blob with the API.
+module "gateway" {
+  source     = "../../modules/ecs-api"
+  name       = "${local.name}-gateway"
+  aws_region = var.aws_region
+
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.public_subnet_ids
+  private_subnet_ids = module.network.private_subnet_ids
+
+  image             = var.gateway_image
+  container_name    = "gateway"
+  container_port    = 8090
+  health_check_path = "/health/live"
+  enable_https      = var.enable_https
+  certificate_arn   = var.enable_https ? one(module.acm[*].certificate_arn) : ""
+  # PORT is auto-injected by the module; the gateway also needs to call back to
+  # the API, which on Fargate is the public (Cloudflare-fronted) dev-api host.
+  environment = merge(var.gateway_environment, { KORTIX_API_URL = "https://dev-api.kortix.com" })
+  secrets     = var.api_secrets
+
+  alb_ingress_cidrs = local.cloudflare_ip_ranges
+
+  # gateway is light (LLM proxy) — smaller than the API
+  task_cpu         = 256
+  task_memory      = 512
+  desired_count    = 1
+  min_capacity     = 1
+  max_capacity     = 3
+  use_fargate_spot = true
+  tags             = local.tags
+}
+
 # ── DNS: dev-api-ecs-fargate.kortix.com → the ALB (Cloudflare-proxied) ─────────
 # This is the ECS fallback backend the dev-api Worker routes to. dev-api itself
 # is the Worker's custom domain (AAAA 100:: placeholder) and is intentionally NOT
@@ -133,6 +169,13 @@ module "dns" {
       name    = "dev-api-ecs-fargate"
       type    = "CNAME"
       value   = module.api.alb_dns_name
+      proxied = true
+      ttl     = 1
+    }
+    gateway-dev-ecs-fargate = {
+      name    = "gateway-dev-ecs-fargate"
+      type    = "CNAME"
+      value   = module.gateway.alb_dns_name
       proxied = true
       ttl     = 1
     }

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -137,7 +137,11 @@ module "gateway" {
   container_port    = 8090
   health_check_path = "/health/live"
   enable_https      = var.enable_https
-  certificate_arn   = var.enable_https ? one(module.acm[*].certificate_arn) : ""
+  # The gateway origin hostname (gateway-<env>-ecs-fargate) must pass Cloudflare
+  # Full(strict) origin verification, so it needs a cert covering THAT host — the
+  # api cert (module.acm, dev-api-ecs-fargate only) does not. Use the *.kortix.com
+  # wildcard, which covers every origin alias.
+  certificate_arn = var.enable_https ? var.gateway_certificate_arn : ""
   # PORT is auto-injected by the module; the gateway also needs to call back to
   # the API, which on Fargate is the public (Cloudflare-fronted) dev-api host.
   environment = merge(var.gateway_environment, { KORTIX_API_URL = "https://dev-api.kortix.com" })

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -36,6 +36,18 @@ variable "api_image" {
   default     = "ghcr.io/kortix-ai/kortix-api:latest"
 }
 
+variable "gateway_image" {
+  description = "Container image for the gateway (LLM proxy). CI rolls new revisions; Terraform only seeds the initial task-def."
+  type        = string
+  default     = "kortix/kortix-gateway:dev-latest"
+}
+
+variable "gateway_environment" {
+  description = "Non-secret env vars for the gateway container (besides PORT and KORTIX_API_URL, which are set by the module/env)."
+  type        = map(string)
+  default     = {}
+}
+
 variable "container_port" {
   description = "Port the API container listens on."
   type        = number

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -48,6 +48,12 @@ variable "gateway_environment" {
   default     = {}
 }
 
+variable "gateway_certificate_arn" {
+  description = "ACM cert for the gateway ALB. Must cover the gateway origin hostname (gateway-<env>-ecs-fargate) for Cloudflare Full(strict). Default: the us-west-2 *.kortix.com wildcard."
+  type        = string
+  default     = "arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755"
+}
+
 variable "container_port" {
   description = "Port the API container listens on."
   type        = number

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -229,7 +229,7 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn            = aws_iam_role.task.arn
 
   container_definitions = jsonencode([{
-    name      = "api"
+    name      = var.container_name
     image     = var.image
     essential = true
     portMappings = [{
@@ -243,7 +243,7 @@ resource "aws_ecs_task_definition" "this" {
       options = {
         "awslogs-group"         = aws_cloudwatch_log_group.this.name
         "awslogs-region"        = var.aws_region
-        "awslogs-stream-prefix" = "api"
+        "awslogs-stream-prefix" = var.container_name
       }
     }
     # No container-level healthCheck: the Bun image has no curl/wget, and the
@@ -275,7 +275,7 @@ resource "aws_ecs_service" "this" {
 
   load_balancer {
     target_group_arn = aws_lb_target_group.this.arn
-    container_name   = "api"
+    container_name   = var.container_name
     container_port   = var.container_port
   }
 

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -42,6 +42,12 @@ variable "container_port" {
   default     = 8000
 }
 
+variable "container_name" {
+  description = "Name of the single container in the task (also the awslogs stream prefix). 'api' for the API service, 'gateway' for the gateway."
+  type        = string
+  default     = "api"
+}
+
 variable "environment" {
   description = "Plain (non-secret) environment variables for the container."
   type        = map(string)


### PR DESCRIPTION
## ECS Fargate revival — run EKS + ECS in parallel, flip via one Cloudflare router

Brings ECS Fargate back as a live, always-current flip-over for EKS across dev/staging/prod, controlled by the existing `api-router` Worker. EKS is fully retained; ECS runs alongside.

### What's in here
- **`infra/scripts/ecs-deploy.sh`** — drift-proof deploy: renders the ECS task-def from the `kortix-<env>-env` Secrets Manager blob (the same blob external-secrets syncs into EKS), so ECS/EKS env can never drift. Skips gracefully if an env's ECS service doesn't exist yet; never changes desired_count.
- **CI wired for all envs** — `deploy-dev.yml` + `deploy-gateway-dev.yml`, `deploy-staging.yml`, `deploy-prod.yml` each roll ECS (api + gateway) in parallel with EKS.
- **Gateway on ECS** — `modules/ecs-api` parameterized (`container_name`); dev `module "gateway"` added.
- **Unified router** — one CF Worker fronts both `api.*` and `gateway.*` with independent per-service EKS⇄ECS toggles (`ACTIVE_BACKEND` / `GATEWAY_ACTIVE_BACKEND`). Tests updated (4/4 pass).

### Live state
- **Dev is flipped to ECS** (api + gateway), verified `x-backend=ecs-fargate`; EKS intact as fallback.
- **Staging**: CI wired, ECS infra not built yet (greenfield) → rolls skip until it exists.
- **Prod**: CI wired; prod ECS api stays a scaled-to-0 standby (task-def kept current, no cost); gateway skips until built. Traffic flip is a separate, gated step.

### Follow-ups (not in this PR)
- Build staging ECS (Terraform greenfield) + prod gateway ECS.
- Gateway EKS toggle-rollback origin (`gateway-<env>-eks` on the EKS ingress + wildcard cert).
- Rotate the Cloudflare Global API key.
- Resolve Platinum/enterprise-VPC EKS dependency before any EKS decommission.
