### PR TITLE
fix(cli): report secret availability consistently

### DIFF
--- a/apps/cli/src/__tests__/secrets.test.ts
+++ b/apps/cli/src/__tests__/secrets.test.ts
@@ -26,14 +26,29 @@ let tmp: string;
 let originalCwd: string;
 let stdout = '';
 let stderr = '';
-let requests: Array<{ url: string; method: string; body: any }> = [];
+type RequestBody = Record<string, unknown> | string | undefined;
+let requests: Array<{ url: string; method: string; body: RequestBody }> = [];
 
 /** Shared secret rows the mocked GET returns; mutate per-test. */
-let secretItems: Array<{ identifier: string; name: string }>;
+let secretItems: Array<{
+  identifier: string;
+  name: string;
+  configured?: boolean;
+  effective_source?: 'mine' | 'shared' | 'none';
+}>;
 let manifestRequired: string[];
 let manifestOptional: string[];
 
-function secret(identifier: string, name = identifier) {
+function secret(
+  identifier: string,
+  name = identifier,
+  state: {
+    configured?: boolean;
+    effective_source?: 'mine' | 'shared' | 'none';
+  } = {},
+) {
+  const configured = state.configured ?? true;
+  const effectiveSource = state.effective_source ?? (configured ? 'shared' : 'none');
   return {
     identifier,
     name,
@@ -42,6 +57,8 @@ function secret(identifier: string, name = identifier) {
     created_by: 'user_1',
     created_at: '2026-01-01T00:00:00.000Z',
     updated_at: '2026-01-01T00:00:00.000Z',
+    configured,
+    effective_source: effectiveSource,
   };
 }
 
@@ -70,8 +87,16 @@ function writeConfig(): void {
 function captureOutput() {
   stdout = '';
   stderr = '';
-  (process.stdout as any).write = (chunk: unknown) => ((stdout += String(chunk)), true);
-  (process.stderr as any).write = (chunk: unknown) => ((stderr += String(chunk)), true);
+  const stdoutStream = process.stdout as unknown as { write: (chunk: unknown) => boolean };
+  const stderrStream = process.stderr as unknown as { write: (chunk: unknown) => boolean };
+  stdoutStream.write = (chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  };
+  stderrStream.write = (chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  };
 }
 
 function json(data: unknown, status = 200): Response {
@@ -85,7 +110,7 @@ function mockApi() {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     const method = (init?.method ?? 'GET').toUpperCase();
-    let body: any = undefined;
+    let body: RequestBody = undefined;
     if (typeof init?.body === 'string') {
       try {
         body = JSON.parse(init.body);
@@ -97,7 +122,7 @@ function mockApi() {
 
     if (url.includes('/projects/proj_1/secrets') && method === 'GET') {
       return json({
-        items: secretItems.map((s) => secret(s.identifier, s.name)),
+        items: secretItems.map((s) => secret(s.identifier, s.name, s)),
         required: manifestRequired,
         optional: manifestOptional,
         can_manage: true,
@@ -106,8 +131,9 @@ function mockApi() {
       });
     }
     if (url.includes('/projects/proj_1/secrets') && method === 'POST') {
-      const name = String(body.name).toUpperCase();
-      const identifier = (body.identifier ?? name) as string;
+      const input = typeof body === 'object' && body !== null ? body : {};
+      const name = String(input.name).toUpperCase();
+      const identifier = String(input.identifier ?? name);
       return json(secret(identifier, name));
     }
     if (url.includes('/projects/proj_1/secrets/') && method === 'DELETE') {
@@ -139,8 +165,10 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
-  (process.stdout as any).write = ORIGINAL_STDOUT_WRITE;
-  (process.stderr as any).write = ORIGINAL_STDERR_WRITE;
+  const stdoutStream = process.stdout as unknown as { write: (chunk: unknown) => boolean };
+  const stderrStream = process.stderr as unknown as { write: (chunk: unknown) => boolean };
+  stdoutStream.write = ORIGINAL_STDOUT_WRITE as unknown as (chunk: unknown) => boolean;
+  stderrStream.write = ORIGINAL_STDERR_WRITE as unknown as (chunk: unknown) => boolean;
   process.chdir(originalCwd);
   for (const key of ENV_KEYS) {
     if (saved[key] === undefined) delete process.env[key];
@@ -153,20 +181,25 @@ function posts() {
   return requests.filter((r) => r.method === 'POST');
 }
 
+function objectBody(request: (typeof requests)[number]): Record<string, unknown> {
+  expect(request.body).toBeObject();
+  return request.body as Record<string, unknown>;
+}
+
 describe('kortix secrets set — identifier', () => {
   test('KEY=VALUE with no identifier posts {name,value}, identifier defaults server-side', async () => {
     const code = await runSecrets(['set', 'STRIPE_API_KEY=sk_live_1']);
     expect(code).toBe(0);
     const [p] = posts();
-    expect(p.body).toEqual({ name: 'STRIPE_API_KEY', value: 'sk_live_1' });
-    expect('identifier' in p.body).toBe(false);
+    expect(objectBody(p)).toEqual({ name: 'STRIPE_API_KEY', value: 'sk_live_1' });
+    expect('identifier' in objectBody(p)).toBe(false);
     expect(stripAnsi(stdout)).toContain('STRIPE_API_KEY');
   });
 
   test('lowercase key is uppercased before it is sent (web KEY_NAME parity)', async () => {
     const code = await runSecrets(['set', 'stripe_api_key=sk_live_1']);
     expect(code).toBe(0);
-    expect(posts()[0].body.name).toBe('STRIPE_API_KEY');
+    expect(objectBody(posts()[0]).name).toBe('STRIPE_API_KEY');
   });
 
   test('--identifier stores a second value under the same key', async () => {
@@ -178,7 +211,7 @@ describe('kortix secrets set — identifier', () => {
     ]);
     expect(code).toBe(0);
     const [p] = posts();
-    expect(p.body).toEqual({
+    expect(objectBody(p)).toEqual({
       name: 'GOOGLE_MAPS_API_KEY',
       identifier: 'GMAPS-backup',
       value: 'backup_val',
@@ -191,7 +224,7 @@ describe('kortix secrets set — identifier', () => {
   test('--id is an accepted alias for --identifier', async () => {
     const code = await runSecrets(['set', 'GOOGLE_MAPS_API_KEY=v', '--id', 'GMAPS-primary']);
     expect(code).toBe(0);
-    expect(posts()[0].body.identifier).toBe('GMAPS-primary');
+    expect(objectBody(posts()[0]).identifier).toBe('GMAPS-primary');
   });
 
   test('--identifier with multiple pairs is rejected (addresses one secret)', async () => {
@@ -241,25 +274,78 @@ describe('kortix secrets ls — identifier-first', () => {
     expect(out).toContain('1 required secret missing');
   });
 
-  test('--json emits identifier, key, has_value and source', async () => {
+  test('--json exposes API names and explicit availability with compatibility aliases', async () => {
     secretItems = [{ identifier: 'GMAPS-backup', name: 'GOOGLE_MAPS_API_KEY' }];
     manifestRequired = ['STRIPE_API_KEY'];
     const code = await runSecrets(['ls', '--json']);
     expect(code).toBe(0);
     const parsed = JSON.parse(stdout);
-    const backup = parsed.secrets.find((s: { identifier: string }) => s.identifier === 'GMAPS-backup');
+    const backup = parsed.secrets.find(
+      (s: { identifier: string }) => s.identifier === 'GMAPS-backup',
+    );
     expect(backup).toEqual({
       identifier: 'GMAPS-backup',
+      name: 'GOOGLE_MAPS_API_KEY',
+      configured: true,
+      available: true,
+      effective_source: 'shared',
       key: 'GOOGLE_MAPS_API_KEY',
       has_value: true,
       source: 'undeclared',
     });
-    const stripe = parsed.secrets.find((s: { identifier: string }) => s.identifier === 'STRIPE_API_KEY');
+    const stripe = parsed.secrets.find(
+      (s: { identifier: string }) => s.identifier === 'STRIPE_API_KEY',
+    );
     expect(stripe).toEqual({
       identifier: 'STRIPE_API_KEY',
+      name: 'STRIPE_API_KEY',
+      configured: false,
+      available: false,
+      effective_source: 'none',
       key: 'STRIPE_API_KEY',
       has_value: false,
       source: 'required',
+    });
+  });
+
+  test('does not report a value-less API row as set merely because the row exists', async () => {
+    secretItems = [
+      {
+        identifier: 'EMPTY_SLOT',
+        name: 'EMPTY_SLOT',
+        configured: false,
+        effective_source: 'none',
+      },
+    ];
+    const code = await runSecrets(['ls', '--json']);
+    expect(code).toBe(0);
+    const [row] = JSON.parse(stdout).secrets;
+    expect(row).toMatchObject({
+      identifier: 'EMPTY_SLOT',
+      configured: false,
+      available: false,
+      effective_source: 'none',
+      has_value: false,
+    });
+  });
+
+  test('distinguishes a personal effective value from a shared configured value', async () => {
+    secretItems = [
+      {
+        identifier: 'PERSONAL_SLOT',
+        name: 'PERSONAL_SLOT',
+        configured: false,
+        effective_source: 'mine',
+      },
+    ];
+    const code = await runSecrets(['ls', '--json']);
+    expect(code).toBe(0);
+    const [row] = JSON.parse(stdout).secrets;
+    expect(row).toMatchObject({
+      configured: false,
+      available: true,
+      effective_source: 'mine',
+      has_value: true,
     });
   });
 });

--- a/apps/cli/src/api/types.ts
+++ b/apps/cli/src/api/types.ts
@@ -53,6 +53,10 @@ export interface ProjectSecret {
   created_by: string;
   created_at: string;
   updated_at: string;
+  /** Whether the shared/project value exists. Mirrors the API + SDK field. */
+  configured: boolean;
+  /** Which value is effective for the requesting user. */
+  effective_source: 'mine' | 'shared' | 'none';
 }
 
 export interface ProjectSecretsResponse {
@@ -118,14 +122,7 @@ export interface ProjectSession {
   /** User-set name override (authoritative); null when unset. */
   custom_name: string | null;
   agent_name: string;
-  status:
-    | 'queued'
-    | 'branching'
-    | 'provisioning'
-    | 'running'
-    | 'stopped'
-    | 'failed'
-    | 'completed';
+  status: 'queued' | 'branching' | 'provisioning' | 'running' | 'stopped' | 'failed' | 'completed';
   error: string | null;
   metadata: Record<string, unknown>;
   created_at: string;

--- a/apps/cli/src/commands/secrets.ts
+++ b/apps/cli/src/commands/secrets.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import type { ProjectSecret, ProjectSecretsResponse } from '../api/types.ts';
 import {
   emitJson,
   resolveProjectContext,
@@ -8,10 +9,6 @@ import {
 } from '../command-helpers.ts';
 import { loadLocalManifest } from '../manifest.ts';
 import { C, help, pad, status } from '../style.ts';
-import type {
-  ProjectSecret,
-  ProjectSecretsResponse,
-} from '../api/types.ts';
 
 const HELP = help`Usage: kortix secrets <subcommand> [options]
 
@@ -28,6 +25,9 @@ common case. Set it explicitly to keep a second value under the same key
 Subcommands:
   ls                                List secrets (by identifier, → key when it
                                     differs) + manifest [env] spec. --json.
+                                    JSON mirrors API fields: name, configured,
+                                    available, effective_source. Legacy key and
+                                    has_value aliases remain available.
   set KEY=VALUE [KEY=VALUE …]       Upsert one or more secrets. Identifier
                                     defaults to KEY.
                                     Use \`KEY=-\` to read VALUE from stdin.
@@ -100,7 +100,9 @@ type SecretRow = {
   identifier: string;
   key: string;
   spec: 'required' | 'optional' | 'undeclared';
-  set: boolean;
+  configured: boolean;
+  available: boolean;
+  effectiveSource: 'mine' | 'shared' | 'none';
 };
 
 async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
@@ -109,9 +111,7 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
 
   let resp: ProjectSecretsResponse;
   try {
-    resp = await ctx.client.get<ProjectSecretsResponse>(
-      `/projects/${ctx.projectId}/secrets`,
-    );
+    resp = await ctx.client.get<ProjectSecretsResponse>(`/projects/${ctx.projectId}/secrets`);
   } catch (err) {
     return surfaceApiError(err);
   }
@@ -129,8 +129,9 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
     }
   })();
   const usingLocal = resp.manifest_status !== 'loaded' && local !== null;
-  const required = usingLocal ? local!.env.required : resp.required;
-  const optional = usingLocal ? local!.env.optional : resp.optional;
+  const localEnv = usingLocal && local ? local.env : null;
+  const required = localEnv?.required ?? resp.required;
+  const optional = localEnv?.optional ?? resp.optional;
 
   // The manifest [env] contract is by env KEY (uppercased names the runtime
   // needs); a secret is addressed by IDENTIFIER and injects one KEY. So we match
@@ -138,8 +139,19 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
   // two identifiers under one key as two distinct rows (the web does the same).
   const requiredSet = new Set(required);
   const optionalSet = new Set(optional);
-  const setKeys = new Set(resp.items.map((s) => s.name));
-  const requiredMissing = required.filter((k) => !setKeys.has(k));
+  const itemState = (secret: ProjectSecret) => {
+    const configured = secret.configured ?? true;
+    const effectiveSource = secret.effective_source ?? (configured ? 'shared' : 'none');
+    return {
+      configured,
+      effectiveSource,
+      available: effectiveSource !== 'none',
+    } as const;
+  };
+  const availableKeys = new Set(
+    resp.items.filter((secret) => itemState(secret).available).map((secret) => secret.name),
+  );
+  const requiredMissing = required.filter((key) => !availableKeys.has(key));
 
   const declaredOrder: string[] = [];
   const seenDeclared = new Set<string>();
@@ -155,16 +167,25 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
     const spec = requiredSet.has(key) ? 'required' : 'optional';
     const backing = resp.items.filter((s) => s.name === key);
     if (backing.length === 0) {
-      allRows.push({ identifier: key, key, spec, set: false });
+      allRows.push({
+        identifier: key,
+        key,
+        spec,
+        configured: false,
+        available: false,
+        effectiveSource: 'none',
+      });
     } else {
       for (const s of backing) {
-        allRows.push({ identifier: s.identifier, key: s.name, spec, set: true });
+        const state = itemState(s);
+        allRows.push({ identifier: s.identifier, key: s.name, spec, ...state });
       }
     }
   }
   for (const s of resp.items) {
     if (!seenDeclared.has(s.name)) {
-      allRows.push({ identifier: s.identifier, key: s.name, spec: 'undeclared', set: true });
+      const state = itemState(s);
+      allRows.push({ identifier: s.identifier, key: s.name, spec: 'undeclared', ...state });
     }
   }
 
@@ -172,8 +193,13 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
     emitJson({
       secrets: allRows.map((r) => ({
         identifier: r.identifier,
+        name: r.key,
+        configured: r.configured,
+        available: r.available,
+        effective_source: r.effectiveSource,
+        // Backward-compatible aliases for older CLI JSON consumers.
         key: r.key,
-        has_value: r.set,
+        has_value: r.available,
         source: r.spec,
       })),
       manifest: {
@@ -204,18 +230,16 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
   }
 
   const nameW = Math.max(...allRows.map((r) => r.identifier.length), 4);
-  process.stdout.write(
-    `  ${C.dim}${pad('IDENTIFIER', nameW)}   STATUS    SPEC${C.reset}\n`,
-  );
+  process.stdout.write(`  ${C.dim}${pad('IDENTIFIER', nameW)}   STATUS    SPEC${C.reset}\n`);
   for (const r of allRows) {
-    const marker = r.set ? `${C.green}● ${C.reset}` : `${C.yellow}○ ${C.reset}`;
-    const statusTxt = r.set ? 'set     ' : 'missing ';
+    const marker = r.available ? `${C.green}● ${C.reset}` : `${C.yellow}○ ${C.reset}`;
+    const statusTxt = r.available
+      ? r.effectiveSource === 'mine'
+        ? 'personal'
+        : 'set     '
+      : 'missing ';
     const specColor =
-      r.spec === 'required' && !r.set
-        ? C.yellow
-        : r.spec === 'undeclared'
-          ? C.faded
-          : C.dim;
+      r.spec === 'required' && !r.available ? C.yellow : r.spec === 'undeclared' ? C.faded : C.dim;
     // Show the injected env key only when it differs from the identifier —
     // the second-value-under-same-key case (mirrors the web's "→ key").
     const keyHint = r.key !== r.identifier ? ` ${C.dim}→ ${r.key}${C.reset}` : '';
@@ -234,8 +258,9 @@ async function secretsLs(opts: CtxOpts, json = false): Promise<number> {
       )}\n`,
     );
   }
+  const availableCount = allRows.filter((row) => row.available).length;
   process.stdout.write(
-    `  ${C.dim}${resp.items.length} set · ${required.length} required · ${optional.length} optional${C.reset}\n\n`,
+    `  ${C.dim}${availableCount} available · ${required.length} required · ${optional.length} optional${C.reset}\n\n`,
   );
   return 0;
 }


### PR DESCRIPTION
## Demo

```json
{
  "contract": "kortix secrets ls --json",
  "evidence": {
    "apiNames": ["name", "configured", "available", "effective_source"],
    "compatAliases": ["key", "has_value"],
    "sharedValue": {
      "identifier": "GMAPS-backup",
      "name": "GOOGLE_MAPS_API_KEY",
      "configured": true,
      "available": true,
      "effective_source": "shared",
      "key": "GOOGLE_MAPS_API_KEY",
      "has_value": true,
      "source": "undeclared"
    },
    "emptyApiRow": {
      "identifier": "EMPTY_SLOT",
      "configured": false,
      "available": false,
      "effective_source": "none",
      "has_value": false
    },
    "personalValue": {
      "configured": false,
      "available": true,
      "effective_source": "mine",
      "has_value": true
    }
  }
}
```

## Summary

- Make `kortix secrets ls` use API secret presence fields instead of treating every returned row as set.
- Expose `name`, `configured`, `available`, and `effective_source` in JSON while keeping `key` and `has_value` aliases.
- Count required secrets as satisfied by effective availability, including personal values.

## Verification

```json
{
  "local": [
    "pnpm --filter @kortix/cli test src/__tests__/secrets.test.ts -> 13 pass",
    "pnpm --filter @kortix/cli test -> 245 pass",
    "pnpm --filter @kortix/cli typecheck -> pass",
    "pnpm exec biome check apps/cli/src/__tests__/secrets.test.ts apps/cli/src/api/types.ts apps/cli/src/commands/secrets.ts -> pass",
    "pnpm --filter @kortix/cli build -> pass",
    "git diff --check -> pass"
  ]
}
```
