### PR TITLE
content: refresh Introducing Kortix wording

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -65,12 +65,12 @@ const introducingKortix: BlogPostEntry = {
     },
     {
       type: 'callout',
-      text: 'A company that runs on AI shouldn’t be a black box you rent. It should be a codebase you own.',
+      text: 'A company that runs on AI shouldn’t be a dashboard you rent and can’t inspect. It should be a codebase you own.',
     },
-    { type: 'h2', text: 'kortix.toml: the single source of truth' },
+    { type: 'h2', text: 'kortix.yaml: the single source of truth' },
     {
       type: 'p',
-      text: 'At the root of every project sits one file — `kortix.toml` when this was written, `kortix.yaml` today. Any repo with a valid manifest at its root *is* a Kortix project — that file defines what the project is, what it’s allowed to do, and how it runs. Here’s a real one:',
+      text: 'At the root of every project sits one file: `kortix.yaml`. Any repo with a valid manifest at its root *is* a Kortix project — that file defines what the project is, what it’s allowed to do, and how it runs. Here’s a real one:',
     },
     {
       type: 'code',
@@ -151,7 +151,7 @@ connectors:
     { type: 'h2', text: 'Self-hostable, open, and yours' },
     {
       type: 'p',
-      text: 'When AI becomes how your company gets work done, the system running it stops being a tool and becomes infrastructure. Infrastructure you don’t own can be changed, repriced, or switched off without your say. So Kortix is **open and source-available**, and you can run the entire stack on your own infrastructure — one command brings up a production-style Kortix on your own machines, and the same CLI switches between our cloud and yours.',
+      text: 'When AI becomes how your company gets work done, the system running it stops being a tool and becomes infrastructure. Infrastructure you don’t own can be changed, repriced, or switched off without your say. So Kortix is **open-source and self-hostable**, and you can run the entire stack on your own infrastructure — one command brings up a production-style Kortix on your own machines, and the same CLI switches between our cloud and yours.',
     },
     {
       type: 'p',


### PR DESCRIPTION
## Summary

Refresh the flagship `Introducing Kortix` post so it matches the current Kortix positioning and manifest format.

Changed only `apps/web/src/lib/blog-posts.ts`:
- `kortix.toml` wording -> `kortix.yaml`
- removed the legacy manifest-transition sentence
- replaced stale "black box" wording with a concrete dashboard phrase
- `open and source-available` -> `open-source and self-hostable`

This is the same same-day SEO-007 work as closed PR #4675; that PR was closed while recovering the preview branch target. This PR is the single active replacement content PR for the run.

## SEO-007 experiment contract

- **Hypothesis:** fixing stale wording on the flagship intro post improves brand/technical accuracy for organic and answer-engine readers landing on `/blog/introducing-kortix`.
- **Baseline:** the post still referenced `kortix.toml`, contained "black box" wording from the don't-say list, and described Kortix as "open and source-available" instead of the sanctioned "open-source and self-hostable" language.
- **Target:** zero targeted stale markers in the introducing post and visible copy that matches canonical positioning.
- **Primary metric:** source-to-route accuracy and crawlable page copy correctness immediately; GSC page/query metrics after production publication when the production boundary is proven.
- **Guardrails:** content-registry-only diff; no route, renderer, auth, billing, runtime, infra, dependency, or schema changes.
- **Observation window:** starts only after production `kortix.com` carries this content; dev/main verification is not production publication.
- **Rollback:** revert this single content commit if route rendering or content-registry import fails.

## Verification

- `pnpm install`
- `node node_modules/prettier/bin/prettier.cjs --check apps/web/src/lib/blog-posts.ts`
- `cd apps/web && node node_modules/eslint/bin/eslint.js src/lib/blog-posts.ts`
- Bun registry import check confirmed:
  - slug `introducing-kortix` exists
  - not draft
  - has `kortix.yaml: the single source of truth`
  - zero targeted stale markers for `kortix.toml`, `black box`, and `source-available`
  - `BLOG_POSTS` remains newest-date sorted

## Preview checks planned

After the `preview` deployment is live, verify exact-head:
- `/blog/introducing-kortix` returns 200 and contains the new copy
- `/blog` returns 200 and links the post
- `/blog/rss.xml` remains 200
