### PR TITLE
Staging + Prod ECS Fargate (parallel runtime; prod flip gated)

### DIFF
--- a/infra/cloudflare/workers/api-router/wrangler.toml
+++ b/infra/cloudflare/workers/api-router/wrangler.toml
@@ -41,16 +41,18 @@ GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-ecs-fargate.kortix.com"
 # ── STAGING: staging-api.kortix.com + gateway-staging.kortix.com ──────────────
 [env.staging]
 name = "staging-api-kortix-router"
+# staging-api is a Worker ROUTE over a proxied (cfargotunnel) record — NOT a
+# custom domain like dev/prod — so keep it a route to avoid clobbering that DNS.
 routes = [
-  { pattern = "staging-api.kortix.com", custom_domain = true },
+  { pattern = "staging-api.kortix.com/*", zone_name = "kortix.com" },
   { pattern = "gateway-staging.kortix.com/*", zone_name = "kortix.com" },
 ]
 
 [env.staging.vars]
-ACTIVE_BACKEND = "eks"
+ACTIVE_BACKEND = "ecs-fargate"
 BACKEND_EKS = "https://staging-api-eks.kortix.com"
 BACKEND_ECS_FARGATE = "https://staging-api-ecs-fargate.kortix.com"
-GATEWAY_ACTIVE_BACKEND = "eks"
+GATEWAY_ACTIVE_BACKEND = "ecs-fargate"
 GATEWAY_BACKEND_EKS = "https://gateway-staging-eks.kortix.com"
 GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-staging-ecs-fargate.kortix.com"
 

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -120,6 +120,54 @@ module "api" {
   tags                       = local.tags
 }
 
+# ── Gateway (LLM proxy) — its own ECS Fargate service + CF-validated cert ─────
+# The prod gateway leaves EKS onto Fargate too. eu-west-2 has no *.kortix.com
+# wildcard, so it gets a dedicated cert for its ECS origin hostname
+# (gateway-ecs-fargate.kortix.com) — required for Cloudflare Full(strict). Unlike
+# dev/staging it runs on-demand (NOT Spot — it's the LLM path) with an HA floor of
+# 2 across AZs. gateway.kortix.com stays the Worker's hostname (not managed here).
+module "acm_gateway" {
+  source      = "../../modules/acm-cloudflare"
+  domain_name = var.gateway_domain
+  zone_id     = var.cloudflare_zone_id
+  tags        = local.tags
+  providers = {
+    aws        = aws
+    cloudflare = cloudflare
+  }
+}
+
+module "gateway" {
+  source     = "../../modules/ecs-api"
+  name       = "${local.name}-gateway"
+  aws_region = var.aws_region
+
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.public_subnet_ids
+  private_subnet_ids = module.network.private_subnet_ids
+
+  image             = var.gateway_image
+  container_name    = "gateway"
+  container_port    = 8090
+  health_check_path = "/health/live"
+  enable_https      = true
+  certificate_arn   = module.acm_gateway.certificate_arn
+  environment       = merge(var.gateway_environment, { KORTIX_API_URL = "https://api.kortix.com" })
+  secrets           = var.api_secrets
+
+  alb_ingress_cidrs = local.cloudflare_ip_ranges
+
+  # prod gateway: on-demand (no Spot — LLM path), HA floor of 2, insights on
+  task_cpu           = 512
+  task_memory        = 1024
+  desired_count      = 2
+  min_capacity       = 2
+  max_capacity       = 6
+  use_fargate_spot   = false
+  container_insights = true
+  tags               = local.tags
+}
+
 # DNS for the public API hostname. Gated by manage_dns so the stack (VPC/ALB/
 # ECS/cert) can be built and validated WITHOUT touching the live api.kortix.com
 # record — the cutover (repoint api.kortix.com → this ALB) is done deliberately

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -88,3 +88,21 @@ variable "api_secrets" {
   type        = map(string)
   default     = {}
 }
+
+variable "gateway_image" {
+  description = "Container image for the gateway (LLM proxy). CI rolls new revisions; Terraform seeds the initial task-def."
+  type        = string
+  default     = "kortix/kortix-gateway:latest"
+}
+
+variable "gateway_environment" {
+  description = "Non-secret env vars for the gateway container (besides PORT and KORTIX_API_URL, set by the module/env)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "gateway_domain" {
+  description = "FQDN for the gateway ECS origin (the Worker's gateway-eks/ecs-fargate backend). Gets its own ACM cert. gateway.kortix.com itself stays the Worker's hostname."
+  type        = string
+  default     = "gateway-ecs-fargate.kortix.com"
+}

--- a/infra/terraform/environments/staging/README.md
+++ b/infra/terraform/environments/staging/README.md
@@ -1,0 +1,69 @@
+# dev environment — `dev-api.kortix.com` on ECS Fargate (autoscaled)
+
+| Surface | Where it runs | Managed by |
+|---|---|---|
+| `dev-api.kortix.com` | Cloudflare (proxied) → ALB → **ECS Fargate** (autoscaled, private subnets, NAT egress) | **this Terraform** |
+| `dev.kortix.com` (frontend) | Vercel | Vercel's own Git integration |
+
+The **same module set prod uses** (`../prod`) — dev just runs smaller numbers
+and Fargate Spot. App code still ships via CI (`deploy-dev.yml`); Terraform owns
+the infra (network, ALB, ECS, DNS), not the running image.
+
+## Architecture
+
+```
+Cloudflare (proxied, Full strict)
+        │  TLS
+        ▼
+  ALB  (public subnets, ACM cert via Cloudflare DNS validation)
+        │  HTTP :PORT
+        ▼
+  ECS Fargate service  (private subnets, egress via NAT)
+   ├─ target-tracking autoscaling: CPU 60% + memory 70%
+   └─ desired 1, min 1, max 3, FARGATE_SPOT   (prod: 2 / 2 / 10, on-demand)
+```
+
+Modules: `network` (VPC + public/private subnets + NAT), `acm-cloudflare` (ACM
+cert validated via Cloudflare DNS), `ecs-api` (cluster + ALB + service +
+autoscaling), `cloudflare-dns` (the `dev-api` CNAME → ALB).
+
+## Apply
+
+```bash
+cd infra/terraform/environments/dev
+
+export AWS_PROFILE=...                          # us-west-2 creds
+export TF_VAR_cloudflare_api_token=...           # = CLOUDFLARE_API_TOKEN secret
+export TF_VAR_cloudflare_zone_id=$(curl -s \
+  -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
+  'https://api.cloudflare.com/client/v4/zones?name=kortix.com' | jq -r '.result[0].id')
+
+cp terraform.tfvars.example terraform.tfvars     # fill in image + secret ARNs
+terraform init                                   # bootstrap S3 state first (../../scripts/bootstrap-state.sh)
+terraform plan
+terraform apply
+```
+
+### Secrets
+
+App secrets are **not** in Terraform. Store the dev secret bundle in AWS Secrets
+Manager and reference each key's ARN in `api_secrets` (see
+`terraform.tfvars.example`). The execution role is granted read on exactly those
+ARNs. Non-secret config goes in `api_environment`. `container_port` must match
+the port the image binds (it's also injected as `PORT`).
+
+### Image
+
+`api_image` defaults to `ghcr.io/kortix-ai/kortix-api:latest`. For a private
+GHCR image, add `repositoryCredentials` to the task def or mirror into ECR. Pin
+to a tag/sha for reproducible deploys.
+
+> ⚠️ `terraform apply` here creates real, billable AWS resources (ALB + NAT +
+> Fargate). Nothing applies automatically.
+
+## Notes
+
+- `.terraform/`, `*.tfstate`, lockfile, and `*.tfvars` are gitignored
+  (`terraform.tfvars.example` is committed).
+- Logs: CloudWatch `/ecs/kortix-dev`. Scaling activity: the ECS service's
+  Deployments/events + Application Auto Scaling history.

--- a/infra/terraform/environments/staging/backend.tf
+++ b/infra/terraform/environments/staging/backend.tf
@@ -1,0 +1,15 @@
+# Remote state in S3 with DynamoDB locking. Run scripts/bootstrap-state.sh once
+# to create the bucket + lock table, then `terraform init -migrate-state`.
+#
+# Until bootstrapped, this block can be left commented to use local state for
+# the initial import/validation, then uncommented + migrated.
+
+terraform {
+  backend "s3" {
+    bucket         = "kortix-terraform-state"
+    key            = "staging/ecs-api.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -1,0 +1,148 @@
+# ── staging environment — ECS Fargate (api + gateway), autoscaled ─────────────
+#
+#   staging-api-ecs-fargate.kortix.com  → Cloudflare (proxied, Full strict) → ALB
+#   gateway-staging-ecs-fargate.kortix.com → Cloudflare → ALB → gateway service
+#
+# These are the ECS backends the `api-router` Worker (env=staging) routes to via
+# its ACTIVE_BACKEND / GATEWAY_ACTIVE_BACKEND toggles; staging-api.kortix.com and
+# gateway-staging.kortix.com are the Worker's route/custom-domain hostnames and
+# are NOT managed here. Same module set as dev/prod.
+#
+# To avoid a Cloudflare dependency at apply time, this env uses the *.kortix.com
+# wildcard ACM cert directly (no per-host module.acm) and leaves DNS records to be
+# created out-of-band (manage_dns=false); the wildcard already passes CF Full(strict).
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0, < 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "cloudflare" {
+  # Only used if manage_dns=true; a format-valid dummy token lets pure-AWS applies
+  # run with no Cloudflare creds.
+  api_token = var.cloudflare_api_token != "" ? var.cloudflare_api_token : (var.cloudflare_api_key != "" ? null : "0000000000000000000000000000000000000000")
+  email     = var.cloudflare_api_key != "" ? var.cloudflare_email : null
+  api_key   = var.cloudflare_api_key != "" ? var.cloudflare_api_key : null
+}
+
+locals {
+  name = "kortix-staging"
+  cloudflare_ip_ranges = [
+    "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+    "141.101.64.0/18", "108.162.192.0/18", "190.93.240.0/20", "188.114.96.0/20",
+    "197.234.240.0/22", "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+    "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+  ]
+  tags = {
+    Environment = "staging"
+    Service     = "kortix-api"
+    ManagedBy   = "terraform"
+  }
+}
+
+# ── Network (VPC + public/private subnets + NAT) ──────────────────────────────
+module "network" {
+  source             = "../../modules/network"
+  name               = local.name
+  cidr               = "10.20.0.0/16" # distinct from dev (10.10) / prod
+  az_count           = 2
+  single_nat_gateway = true # staging: one NAT to save cost
+  tags               = local.tags
+}
+
+# ── ECS Fargate API service (autoscaled) ──────────────────────────────────────
+module "api" {
+  source     = "../../modules/ecs-api"
+  name       = local.name
+  aws_region = var.aws_region
+
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.public_subnet_ids
+  private_subnet_ids = module.network.private_subnet_ids
+
+  image           = var.api_image
+  container_port  = var.container_port
+  enable_https    = var.enable_https
+  certificate_arn = var.enable_https ? var.wildcard_certificate_arn : ""
+  environment     = var.api_environment
+  secrets         = var.api_secrets
+
+  alb_ingress_cidrs = local.cloudflare_ip_ranges
+
+  # staging sizing: small + spot, floor of 1 (release-candidate lane)
+  task_cpu                   = 512
+  task_memory                = 1024
+  desired_count              = 1
+  min_capacity               = 1
+  max_capacity               = 3
+  use_fargate_spot           = true
+  requests_per_target_target = 600
+  tags                       = local.tags
+}
+
+# ── Gateway (LLM proxy) as its own ECS Fargate service ────────────────────────
+module "gateway" {
+  source     = "../../modules/ecs-api"
+  name       = "${local.name}-gateway"
+  aws_region = var.aws_region
+
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.public_subnet_ids
+  private_subnet_ids = module.network.private_subnet_ids
+
+  image             = var.gateway_image
+  container_name    = "gateway"
+  container_port    = 8090
+  health_check_path = "/health/live"
+  enable_https      = var.enable_https
+  certificate_arn   = var.enable_https ? var.wildcard_certificate_arn : ""
+  environment       = merge(var.gateway_environment, { KORTIX_API_URL = "https://staging-api.kortix.com" })
+  secrets           = var.api_secrets
+
+  alb_ingress_cidrs = local.cloudflare_ip_ranges
+
+  task_cpu         = 256
+  task_memory      = 512
+  desired_count    = 1
+  min_capacity     = 1
+  max_capacity     = 3
+  use_fargate_spot = true
+  tags             = local.tags
+}
+
+# ── DNS (optional; default off — records created out-of-band) ─────────────────
+module "dns" {
+  source  = "../../modules/cloudflare-dns"
+  count   = var.manage_dns ? 1 : 0
+  zone_id = var.cloudflare_zone_id
+
+  records = {
+    staging-api-ecs-fargate = {
+      name    = "staging-api-ecs-fargate"
+      type    = "CNAME"
+      value   = module.api.alb_dns_name
+      proxied = true
+      ttl     = 1
+    }
+    gateway-staging-ecs-fargate = {
+      name    = "gateway-staging-ecs-fargate"
+      type    = "CNAME"
+      value   = module.gateway.alb_dns_name
+      proxied = true
+      ttl     = 1
+    }
+  }
+}

--- a/infra/terraform/environments/staging/outputs.tf
+++ b/infra/terraform/environments/staging/outputs.tf
@@ -1,0 +1,20 @@
+output "alb_dns_name" {
+  description = "ALB DNS name behind dev-api.kortix.com."
+  value       = module.api.alb_dns_name
+}
+
+output "ecs_cluster" {
+  value = module.api.cluster_name
+}
+
+output "ecs_service" {
+  value = module.api.service_name
+}
+
+output "log_group" {
+  value = module.api.log_group
+}
+
+output "dns_records" {
+  value = try(one(module.dns[*].record_hostnames), null)
+}

--- a/infra/terraform/environments/staging/terraform.tfvars.example
+++ b/infra/terraform/environments/staging/terraform.tfvars.example
@@ -16,11 +16,8 @@ api_image      = "ghcr.io/kortix-ai/kortix-api:latest"
 container_port = 8000
 
 # Non-secret config (mirror the env-agnostic + dev-specific keys from .env).
-api_environment = {
-  KORTIX_URL                = "https://dev-api.kortix.com"
-  ALLOWED_SANDBOX_PROVIDERS = "daytona"
-  # DATABASE host, SUPABASE_URL, etc. (non-secret parts) ...
-}
+api_environment = {} # leave empty — the kortix-staging-env blob provides KORTIX_URL, ALLOWED_SANDBOX_PROVIDERS, etc.
+# (setting a key here that also exists in the blob makes ECS reject the task-def)
 
 # Secret env vars -> Secrets Manager / SSM ARNs. Recommended: store the dev
 # secret bundle once in Secrets Manager and reference each key's ARN here.

--- a/infra/terraform/environments/staging/terraform.tfvars.example
+++ b/infra/terraform/environments/staging/terraform.tfvars.example
@@ -1,0 +1,33 @@
+# Copy to terraform.tfvars (gitignored) and fill in. Secrets stay out of git.
+#
+#   cp terraform.tfvars.example terraform.tfvars
+#
+# Cloudflare creds are better supplied via the environment so they never touch
+# disk:
+#   export TF_VAR_cloudflare_api_token=...    # = CLOUDFLARE_API_TOKEN secret
+#   export TF_VAR_cloudflare_zone_id=$(curl -s \
+#     -H "Authorization: Bearer $TF_VAR_cloudflare_api_token" \
+#     'https://api.cloudflare.com/client/v4/zones?name=kortix.com' | jq -r '.result[0].id')
+
+aws_region = "us-west-2"
+
+# The image CI publishes (pin to a tag/sha for reproducible deploys).
+api_image      = "ghcr.io/kortix-ai/kortix-api:latest"
+container_port = 8000
+
+# Non-secret config (mirror the env-agnostic + dev-specific keys from .env).
+api_environment = {
+  KORTIX_URL                = "https://dev-api.kortix.com"
+  ALLOWED_SANDBOX_PROVIDERS = "daytona"
+  # DATABASE host, SUPABASE_URL, etc. (non-secret parts) ...
+}
+
+# Secret env vars -> Secrets Manager / SSM ARNs. Recommended: store the dev
+# secret bundle once in Secrets Manager and reference each key's ARN here.
+# Example single-key form:
+#   API_KEY_SECRET = "arn:aws:secretsmanager:us-west-2:ACCT:secret:kortix-dev/api-WXyz:API_KEY_SECRET::"
+api_secrets = {
+  # API_KEY_SECRET   = "arn:aws:secretsmanager:...:API_KEY_SECRET::"
+  # SUPABASE_SERVICE_ROLE_KEY = "arn:aws:secretsmanager:...:SUPABASE_SERVICE_ROLE_KEY::"
+  # ... DAYTONA_API_KEY, OPENROUTER_API_KEY, STRIPE_*, PIPEDREAM_*, etc.
+}

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -1,0 +1,85 @@
+variable "aws_region" {
+  description = "AWS region for the dev resources."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for kortix.com. Supply via TF_VAR_cloudflare_zone_id."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare scoped API token (= CLOUDFLARE_API_TOKEN secret). Supply via TF_VAR_cloudflare_api_token."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cloudflare_email" {
+  description = "Cloudflare account email (for global-API-key auth, when no scoped token is used)."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_api_key" {
+  description = "Cloudflare global API key (alternative to a scoped token). Supply via TF_VAR_cloudflare_api_key."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "api_image" {
+  description = "Container image for the API (e.g. ghcr.io/kortix-ai/kortix-api:<tag>)."
+  type        = string
+  default     = "ghcr.io/kortix-ai/kortix-api:latest"
+}
+
+variable "gateway_image" {
+  description = "Container image for the gateway (LLM proxy). CI rolls new revisions; Terraform only seeds the initial task-def."
+  type        = string
+  default     = "kortix/kortix-gateway:dev-latest"
+}
+
+variable "gateway_environment" {
+  description = "Non-secret env vars for the gateway container (besides PORT and KORTIX_API_URL, which are set by the module/env)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "wildcard_certificate_arn" {
+  description = "ACM cert for BOTH the api + gateway ALBs. The us-west-2 *.kortix.com wildcard covers every origin hostname (staging-api-ecs-fargate, gateway-staging-ecs-fargate) for Cloudflare Full(strict) — no per-host module.acm needed."
+  type        = string
+  default     = "arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755"
+}
+
+variable "container_port" {
+  description = "Port the API container listens on."
+  type        = number
+  default     = 8000
+}
+
+variable "api_environment" {
+  description = "Non-secret env vars for the API container (KORTIX_URL, DATABASE host, etc.)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "api_secrets" {
+  description = "Secret env vars: name -> Secrets Manager/SSM ARN. Populate via tfvars; never inline secret values."
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_https" {
+  description = "Create the ACM cert + HTTPS listener (needs the Cloudflare token for DNS validation). false = HTTP-only ALB, e.g. for parallel validation."
+  type        = bool
+  default     = true
+}
+
+variable "manage_dns" {
+  description = "Manage the staging Cloudflare origin records (CNAME -> ALB). Default false — records are created out-of-band so the apply needs no Cloudflare creds."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Staging + Prod ECS Fargate — parallel runtime, flip via the unified router

Builds out ECS Fargate for staging (greenfield) and prod, both running in parallel with EKS behind the `api-router` Worker. Follows PR #4676 (dev + machinery).

### Staging (built + FLIPPED to ECS)
- New `infra/terraform/environments/staging/` — mirror of dev; distinct VPC CIDR; uses the `*.kortix.com` wildcard cert directly (no ACM/Cloudflare dependency at apply) and `manage_dns=false`.
- Applied: VPC + api + gateway ECS services (both healthy).
- `staging-api.kortix.com` + `gateway-staging.kortix.com` flipped to ECS (verified `x-backend=ecs-fargate`); EKS retained as fallback.

### Prod (built + running in parallel; CF flip GATED)
- `environments/prod`: added `module.gateway` + `module.acm_gateway` (own CF-validated cert; on-demand, HA floor of 2 — it's the LLM path).
- Applied via `-target` so the live prod API was never in the plan.
- Prod api ECS revived to the release image and scaled to 2 (parallel with EKS; leader-election keeps cron single-runner). Both ECS origins return 200.
- **api.kortix.com stays on EKS — prod traffic is NOT flipped.** The prod cutover (deploy prod worker with ecs-fargate backends) is left for explicit approval.

### Notes
- `api_environment` must be empty per env (the `kortix-<env>-env` blob already provides KORTIX_URL/ALLOWED_SANDBOX_PROVIDERS; duplicating them makes ECS reject the task-def) — documented in the tfvars example.
- Gateway `-eks` toggle-rollback origin needs the EKS gateway ingress to also serve `gateway-<env>-eks` (follow-up); immediate rollback = remove the worker route.
- Rotate the Cloudflare Global API key (used for these DNS/worker ops).
