### PR TITLE
[DEMO — DO NOT MERGE] Auth trust cue evidence test A

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -257,7 +257,7 @@ jobs:
           mkdir -p .vercel
           jq -n --arg org "$TEAM_ID" --arg project "$PROJECT_ID" \
             '{orgId:$org, projectId:$project}' > .vercel/project.json
-          frontend_url="$(VERCEL_ORG_ID="$TEAM_ID" npx vercel deploy --yes --target preview --archive=tgz \
+          frontend_url="$(VERCEL_ORG_ID="$TEAM_ID" VERCEL_PROJECT_ID="$PROJECT_ID" npx vercel deploy --yes --target preview --archive=tgz \
             --token "$VERCEL_TOKEN" \
             -e NEXT_PUBLIC_BACKEND_URL="$BACKEND" \
             -e KORTIX_PUBLIC_BACKEND_URL="$BACKEND" \

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -211,6 +211,10 @@ jobs:
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview'))
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: false
       - name: Guard — Vercel creds present
         run: |
           if [ -z "${VERCEL_TOKEN:-}" ] || [ -z "${PROJECT_ID:-}" ] || [ -z "${TEAM_ID:-}" ]; then
@@ -223,6 +227,8 @@ jobs:
         env:
           NUM: ${{ github.event.pull_request.number }}
           ACTION: ${{ github.event.action }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -uo pipefail
           AUTH=(-H "Authorization: Bearer ${VERCEL_TOKEN}")
@@ -244,29 +250,44 @@ jobs:
             [ "$code" = "200" ] || [ "$code" = "201" ] || { cat "/tmp/env-${key}.json"; exit 1; }
           done
 
-          # 2) On the LABEL event only, trigger a fresh preview build so the env is
-          #    baked immediately. On `synchronize` the env is already set and
-          #    Vercel's own auto-build for the push inherits it — no extra build.
-          if [ "$ACTION" = "labeled" ]; then
-            PROJ="$(curl -sS "${API}/v9/projects/${PROJECT_ID}?teamId=${TEAM_ID}" "${AUTH[@]}")"
-            NAME="$(printf '%s' "$PROJ" | jq -r '.name')"
-            REPO_ID="$(printf '%s' "$PROJ" | jq -r '.link.repoId // empty')"
-            if [ -n "$REPO_ID" ] && [ "$NAME" != "null" ]; then
-              rc=$(curl -sS -o /tmp/dep.json -w '%{http_code}' -X POST \
-                "${API}/v13/deployments?teamId=${TEAM_ID}&forceNew=1&skipAutoDetectionConfirmation=1" \
-                "${AUTH[@]}" -H "Content-Type: application/json" \
-                -d "$(jq -n --arg n "$NAME" --argjson r "$REPO_ID" --arg b "$BRANCH" \
-                      '{name:$n,target:"preview",gitSource:{type:"github",repoId:$r,ref:$b}}')")
-              echo "redeploy HTTP $rc → $(jq -r '.url // .error.message // "?"' /tmp/dep.json 2>/dev/null)"
-            else
-              echo "::notice::Couldn't resolve project repoId — env is set; the next push rebuilds with it."
-            fi
+          # Vercel's GitHub ignored-build step can run before it can see a freshly
+          # added PR label. Deploy the checked-out PR source directly after wiring
+          # the branch-scoped backend env so every `preview` label produces a real,
+          # clickable full-stack frontend for reviewer evidence.
+          mkdir -p .vercel
+          jq -n --arg org "$TEAM_ID" --arg project "$PROJECT_ID" \
+            '{orgId:$org, projectId:$project}' > .vercel/project.json
+          frontend_url="$(VERCEL_ORG_ID="$TEAM_ID" npx vercel deploy --yes --target preview --archive=tgz \
+            --token "$VERCEL_TOKEN" \
+            -e NEXT_PUBLIC_BACKEND_URL="$BACKEND" \
+            -e KORTIX_PUBLIC_BACKEND_URL="$BACKEND" \
+            -b NEXT_PUBLIC_BACKEND_URL="$BACKEND" \
+            -b KORTIX_PUBLIC_BACKEND_URL="$BACKEND" \
+            | tail -n1)"
+          echo "Frontend preview deployed: ${frontend_url}"
+
+          MARKER="<!-- preview-status -->"
+          HOST="pr-${NUM}.preview-api.kortix.com"
+          body="$(printf '%s\n' \
+            "$MARKER" \
+            "## 🔭 Preview environment — ✅ live" \
+            "" \
+            "- **Backend:** https://${HOST} — serving version pr-${NUM}" \
+            "- **Frontend:** ${frontend_url}" \
+            "- **Health:** https://${HOST}/v1/health" \
+            "" \
+            "_Ephemeral; torn down automatically when this PR closes._")"
+          id=$(gh api "repos/${REPO}/issues/${NUM}/comments" --paginate \
+               --jq "map(select(.body | startswith(\"${MARKER}\"))) | .[0].id // empty" | head -1)
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -f body="$body" >/dev/null
           else
-            echo "synchronize — env re-asserted; Vercel's auto-build for this push uses it."
+            gh api -X POST "repos/${REPO}/issues/${NUM}/comments" -f body="$body" >/dev/null
           fi
           {
             echo "### Preview frontend wired"
             echo "Branch \`${BRANCH}\` preview backend envs → \`${BACKEND}\`"
+            echo "Frontend preview → ${frontend_url}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── Remove the branch override when the PR closes or loses the label ────────

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -22,7 +22,13 @@ import Loading from '@/components/ui/loading';
 import { errorToast } from '@/components/ui/toast';
 import { AuthBrowserNoiseGuard } from '@/features/auth/auth-browser-noise-guard';
 import { AuthFrame } from '@/features/auth/auth-card-shell';
-import { CodeInput, FieldLabel, InfoStrip, StepHeader } from '@/features/auth/auth-primitives';
+import {
+  AuthTrustCue,
+  CodeInput,
+  FieldLabel,
+  InfoStrip,
+  StepHeader,
+} from '@/features/auth/auth-primitives';
 import { useAuth } from '@/features/providers/auth-provider';
 import { invalidateTokenCache, setBootstrapAuthToken } from '@/lib/auth-token';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
@@ -728,6 +734,7 @@ function AuthContent() {
         returnUrl={returnUrl}
         mobileCallbackState={mobileCallbackState}
       />
+      <AuthTrustCue />
     </AuthFrame>
   );
 }

--- a/apps/web/src/features/auth/auth-primitives.tsx
+++ b/apps/web/src/features/auth/auth-primitives.tsx
@@ -7,9 +7,11 @@
  */
 
 import { DangerTriangleSolid, InfoCircleSolid } from '@mynaui/icons-react';
+import { LockKeyhole } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { useRef } from 'react';
 
+import { Badge } from '@/components/ui/badge';
 import { KortixLogo } from '@/components/ui/kortix-logo';
 import {
   applyBackspace,
@@ -88,6 +90,21 @@ export function FieldLabel({ htmlFor, children }: { htmlFor: string; children: R
     <label htmlFor={htmlFor} className="text-muted-foreground text-sm font-medium">
       {children}
     </label>
+  );
+}
+
+export function AuthTrustCue() {
+  return (
+    <div className="mt-8 flex justify-center">
+      <Badge
+        variant="muted"
+        size="sm"
+        className="border-border/70 bg-popover text-muted-foreground h-7 cursor-default gap-1.5 rounded-full border px-2.5"
+      >
+        <LockKeyhole className="size-3.5 shrink-0" aria-hidden />
+        <span>Secure access to your Kortix workspace</span>
+      </Badge>
+    </div>
   );
 }
 

--- a/apps/web/src/features/auth/auth-primitives.tsx
+++ b/apps/web/src/features/auth/auth-primitives.tsx
@@ -99,6 +99,7 @@ export function AuthTrustCue() {
       <Badge
         variant="muted"
         size="sm"
+        aria-label="Workspace access security"
         className="border-border/70 bg-popover text-muted-foreground h-7 cursor-default gap-1.5 rounded-full border px-2.5"
       >
         <LockKeyhole className="size-3.5 shrink-0" aria-hidden />

--- a/apps/web/src/features/auth/auth-trust-cue.test.tsx
+++ b/apps/web/src/features/auth/auth-trust-cue.test.tsx
@@ -9,6 +9,7 @@ describe('AuthTrustCue', () => {
 
     expect(html).toContain('Secure access to your Kortix workspace');
     expect(html).toContain('data-slot="badge"');
+    expect(html).toContain('aria-label="Workspace access security"');
     expect(html).toContain('text-muted-foreground');
     expect(html).toContain('aria-hidden="true"');
   });

--- a/apps/web/src/features/auth/auth-trust-cue.test.tsx
+++ b/apps/web/src/features/auth/auth-trust-cue.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { AuthTrustCue } from './auth-primitives';
+
+describe('AuthTrustCue', () => {
+  test('renders a compact security reassurance for the auth surface', () => {
+    const html = renderToStaticMarkup(<AuthTrustCue />);
+
+    expect(html).toContain('Secure access to your Kortix workspace');
+    expect(html).toContain('data-slot="badge"');
+    expect(html).toContain('text-muted-foreground');
+    expect(html).toContain('aria-hidden="true"');
+  });
+});


### PR DESCRIPTION
## Demo
Preview (final): https://suna-41cu460wm-kortixai.vercel.app/auth → backend https://pr-4684.preview-api.kortix.com/v1

Reviewer evidence captured from the final live preview:

### 22-second demo

![22-second auth trust cue demo](https://github.com/kortix-ai/suna/releases/download/pr-4684-review-evidence/auth-trust-cue-demo.gif)

### Screenshots

**Sign-in state**

![Auth sign-in state](https://github.com/kortix-ai/suna/releases/download/pr-4684-review-evidence/auth-trust-cue-signin.png)

**Filled-email state**

![Auth filled-email state](https://github.com/kortix-ai/suna/releases/download/pr-4684-review-evidence/auth-trust-cue-filled.png)

Evidence inspection: files were captured from the final preview, scanned for common token/secret patterns (0 hits), and OCR-checked for legibility. The filled screenshot/video use only the dummy address `evidence-demo@example.com`.

Exact E2E interaction: opened `/auth`, waited for “Secure access to your Kortix workspace”, captured the signed-out sign-in state, filled Email with `evidence-demo@example.com`, captured the filled state, clicked “Sign up”, verified the cue persisted under “Create your account”, clicked “Sign in”, and verified the cue persisted back under “Welcome to Kortix”.

Demo-only note: this PR exists only to test reviewer-evidence workflow A. Do not merge or close; leave open for Marko.

## Why
Demo-only experiment A for the reviewer-evidence workflow. Adds a tiny, polished reassurance line on the public auth surface for Marko to inspect.

## What changed
- Added a compact lock-icon trust cue below the signed-out auth form: “Secure access to your Kortix workspace”.
- Reused existing `Badge` UI primitive, existing `lucide-react` lock icon dependency, and auth/design tokens.
- Added a focused render test for the trust cue copy, badge primitive, muted styling, accessible label, and decorative icon treatment.
- Repaired the preview wiring workflow so `preview`-labeled PRs get a real deployed Vercel preview instead of an ignored/cancelled URL.

## Verification
Local:
- `pnpm --filter Kortix-Computer-Frontend test src/features/auth/auth-trust-cue.test.tsx` ✅
- `pnpm --filter Kortix-Computer-Frontend exec eslint "src/app/(auth)/auth/page.tsx" "src/features/auth/auth-primitives.tsx" "src/features/auth/auth-trust-cue.test.tsx"` ✅
- `pnpm --filter Kortix-Computer-Frontend exec prettier --check "src/app/(auth)/auth/page.tsx" "src/features/auth/auth-primitives.tsx" "src/features/auth/auth-trust-cue.test.tsx"` ✅
- `pnpm --filter Kortix-Computer-Frontend exec tsc --noEmit --pretty false` ⚠️ repo baseline exits 1; touched-file diagnostics: 0 (matches `apps/web` AGENTS note about ambient React type noise)

PR/preview:
- Required PR checks are green or path-filter skipped ✅
- Preview label present ✅
- Preview backend health reports `environment=preview` at https://pr-4684.preview-api.kortix.com/v1/health ✅
- Final preview UI verified at https://suna-41cu460wm-kortixai.vercel.app/auth ✅

## Risk / rollback
Low-risk copy/styling addition isolated to signed-out auth. Roll back by reverting this PR. Do not merge or close; this is a demo-only evidence workflow test.
