### PR TITLE
[DEMO — DO NOT MERGE] Interactive auth help evidence test B

### DIFF
--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -10,13 +10,14 @@
  * hardcoded surface.
  */
 
-import { Eye, EyeOff } from 'lucide-react';
+import { ChevronDown, Eye, EyeOff } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { type FormEvent, Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
+import { type FormEvent, Suspense, lazy, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
 import { errorToast } from '@/components/ui/toast';
@@ -31,6 +32,7 @@ import { authRedirectUrl } from '@/lib/desktop';
 import { getEnv } from '@/lib/env-config';
 import { emailDomain, isWorkEmail } from '@/lib/personal-email';
 import { createClient as createBrowserSupabaseClient } from '@/lib/supabase/client';
+import { cn } from '@/lib/utils';
 import {
   signIn as signInWithMagicLink,
   signInWithPassword,
@@ -90,6 +92,42 @@ function PasswordInput({
         {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
       </button>
     </div>
+  );
+}
+
+function SignInHelpDisclosure() {
+  const [open, setOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <Disclosure open={open} onOpenChange={setOpen} className="mt-3">
+      <DisclosureTrigger>
+        <Button
+          type="button"
+          variant="transparent"
+          size="sm"
+          aria-controls={contentId}
+          className="text-muted-foreground hover:text-foreground -mx-2 -my-1 h-10 justify-start gap-1.5 px-2 transition-[color,transform] active:scale-[0.96]"
+        >
+          <span>Sign-in help</span>
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              'size-3.5 transition-transform duration-200 ease-out',
+              open && 'rotate-180',
+            )}
+          />
+        </Button>
+      </DisclosureTrigger>
+      <DisclosureContent contentClassName="pt-1">
+        <p
+          id={contentId}
+          className="border-border bg-muted/50 text-muted-foreground rounded-md border px-3 py-2 text-sm text-pretty"
+        >
+          Use your work email; if your company uses SSO, we&apos;ll route you automatically.
+        </p>
+      </DisclosureContent>
+    </Disclosure>
   );
 }
 
@@ -647,6 +685,8 @@ function AuthCardForm({
             Continue
           </Button>
         </form>
+
+        {mode === 'signin' ? <SignInHelpDisclosure /> : null}
 
         <p className="text-muted-foreground mt-8 text-sm">
           {mode === 'signup' ? 'Already have an account? ' : "Don't have an account? "}

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -10,20 +10,20 @@
  * hardcoded surface.
  */
 
-import { ChevronDown, Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { type FormEvent, Suspense, lazy, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { type FormEvent, Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
 import { errorToast } from '@/components/ui/toast';
 import { AuthBrowserNoiseGuard } from '@/features/auth/auth-browser-noise-guard';
 import { AuthFrame } from '@/features/auth/auth-card-shell';
 import { CodeInput, FieldLabel, InfoStrip, StepHeader } from '@/features/auth/auth-primitives';
+import { SignInHelpDisclosure } from '@/features/auth/sign-in-help-disclosure';
 import { useAuth } from '@/features/providers/auth-provider';
 import { invalidateTokenCache, setBootstrapAuthToken } from '@/lib/auth-token';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
@@ -32,7 +32,6 @@ import { authRedirectUrl } from '@/lib/desktop';
 import { getEnv } from '@/lib/env-config';
 import { emailDomain, isWorkEmail } from '@/lib/personal-email';
 import { createClient as createBrowserSupabaseClient } from '@/lib/supabase/client';
-import { cn } from '@/lib/utils';
 import {
   signIn as signInWithMagicLink,
   signInWithPassword,
@@ -92,42 +91,6 @@ function PasswordInput({
         {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
       </button>
     </div>
-  );
-}
-
-function SignInHelpDisclosure() {
-  const [open, setOpen] = useState(false);
-  const contentId = useId();
-
-  return (
-    <Disclosure open={open} onOpenChange={setOpen} className="mt-3">
-      <DisclosureTrigger>
-        <Button
-          type="button"
-          variant="transparent"
-          size="sm"
-          aria-controls={contentId}
-          className="text-muted-foreground hover:text-foreground -mx-2 -my-1 h-10 justify-start gap-1.5 px-2 transition-[color,transform] active:scale-[0.96]"
-        >
-          <span>Sign-in help</span>
-          <ChevronDown
-            aria-hidden="true"
-            className={cn(
-              'size-3.5 transition-transform duration-200 ease-out',
-              open && 'rotate-180',
-            )}
-          />
-        </Button>
-      </DisclosureTrigger>
-      <DisclosureContent contentClassName="pt-1">
-        <p
-          id={contentId}
-          className="border-border bg-muted/50 text-muted-foreground rounded-md border px-3 py-2 text-sm text-pretty"
-        >
-          Use your work email; if your company uses SSO, we&apos;ll route you automatically.
-        </p>
-      </DisclosureContent>
-    </Disclosure>
   );
 }
 

--- a/apps/web/src/features/auth/sign-in-help-disclosure.test.tsx
+++ b/apps/web/src/features/auth/sign-in-help-disclosure.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { SignInHelpDisclosure } from './sign-in-help-disclosure';
+
+describe('SignInHelpDisclosure', () => {
+  test('renders an accessible compact sign-in help trigger', () => {
+    const html = renderToStaticMarkup(<SignInHelpDisclosure />);
+
+    expect(html).toContain('Sign-in help');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-controls=');
+    expect(html).toContain('h-10');
+  });
+
+  test('renders the helpful sentence when expanded', () => {
+    const html = renderToStaticMarkup(<SignInHelpDisclosure defaultOpen />);
+
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain('Use your work email');
+    expect(html).toContain('we&#x27;ll route you automatically');
+  });
+});

--- a/apps/web/src/features/auth/sign-in-help-disclosure.tsx
+++ b/apps/web/src/features/auth/sign-in-help-disclosure.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import { useId, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
+import { cn } from '@/lib/utils';
+
+export function SignInHelpDisclosure({ defaultOpen = false }: { defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+  const contentId = useId();
+
+  return (
+    <Disclosure open={open} onOpenChange={setOpen} className="mt-3">
+      <DisclosureTrigger>
+        <Button
+          type="button"
+          variant="transparent"
+          size="sm"
+          aria-controls={contentId}
+          className="text-muted-foreground hover:text-foreground -mx-2 -my-1 h-10 justify-start gap-1.5 px-2 transition-[color,transform] active:scale-[0.96]"
+        >
+          <span>Sign-in help</span>
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              'size-3.5 transition-transform duration-200 ease-out',
+              open && 'rotate-180',
+            )}
+          />
+        </Button>
+      </DisclosureTrigger>
+      <DisclosureContent contentClassName="pt-1">
+        <p
+          id={contentId}
+          className="border-border bg-muted/50 text-muted-foreground rounded-md border px-3 py-2 text-sm text-pretty"
+        >
+          Use your work email; if your company uses SSO, we&apos;ll route you automatically.
+        </p>
+      </DisclosureContent>
+    </Disclosure>
+  );
+}


### PR DESCRIPTION
## Demo

- **Live preview:**
  - Frontend: https://suna-dgvx8uhj1-kortixai.vercel.app
  - Backend health: https://pr-4685.preview-api.kortix.com/v1/health (`environment=preview`, `version=pr-4685`)
- **Video:** https://tmpfiles.org/dl/wVwc1jv3sswz/pr-4685-sign-in-help-demo.webm
- **Screenshots:**
  - Collapsed default state: https://tmpfiles.org/dl/wlwO17vEsxeq/01-collapsed.png
  - Expanded help text: https://tmpfiles.org/dl/wcw412vksIlM/02-expanded.png
  - Collapsed again via keyboard: https://tmpfiles.org/dl/w9wN1lvPsOgI/03-collapsed-keyboard.png

**Exact E2E proof:** loaded the public `/auth` sign-in surface; verified the `Sign-in help` control starts collapsed with `aria-expanded=false`; clicked it to expand and reveal “Use your work email; if your company uses SSO, we’ll route you automatically.”; focused the trigger and pressed Space to collapse it again with `aria-expanded=false`; pressed Enter to verify keyboard toggle still expands/collapses. Browser error log was empty. Captures were inspected and show only the public auth page.

**Preview caveat:** the preview backend is live, but the Vercel frontend URL from the sticky preview comment currently serves Vercel’s cancelled/protection page instead of the app. The interaction media above was therefore captured from the same PR head (`272f3c279a812a790766e5c83c23431f8ec3799e`) running the public auth route locally. Slack DM upload to Marko was attempted via the documented route, but this Kortix project reports Slack as not connected (`slack` CLI returns `connector_not_found`), so the media is linked via external upload links instead of Slack permalinks.

## Why

Demo-only experiment B to test the reviewer-evidence workflow. This PR must stay open for Marko to inspect and must not be merged or closed by the agent.

## What changed

- Added a compact `Sign-in help` disclosure on the public `/auth` sign-in form.
- Moved the disclosure into a focused auth component using existing `Button` + `Disclosure` UI primitives and semantic design tokens.
- Added focused coverage for the disclosure trigger/accessibility contract and expanded help copy.

## Verification

- `pnpm install`
- `cd apps/web && ./node_modules/.bin/fumadocs-mdx`
- `cd apps/web && ./node_modules/.bin/eslint "src/app/(auth)/auth/page.tsx" src/features/auth/sign-in-help-disclosure.tsx src/features/auth/sign-in-help-disclosure.test.tsx`
- `cd apps/web && ./node_modules/.bin/prettier --check "src/app/(auth)/auth/page.tsx" src/features/auth/sign-in-help-disclosure.tsx src/features/auth/sign-in-help-disclosure.test.tsx`
- `cd apps/web && bun test src/features/auth/sign-in-help-disclosure.test.tsx`
- `cd apps/web && bun test src/features/auth/code-input-logic.test.ts src/features/auth/sign-in-help-disclosure.test.tsx`
- `cd apps/web && ./node_modules/.bin/tsc --noEmit --pretty false`
- PR checks on head `272f3c279a812a790766e5c83c23431f8ec3799e`: all replacement checks green/pass or skipped.
- Browser proof: see `## Demo` for exact expand/collapse flow and media.

## Risk / rollback

Low-risk, sign-in-page-only demo UI change. Roll back by reverting this PR’s commits.
