### PR TITLE
chore(web): add sample PR demo badge

### DIFF
--- a/apps/web/src/app/(system)/debug/tools/page.tsx
+++ b/apps/web/src/app/(system)/debug/tools/page.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
+import { Badge } from '@/components/ui/badge';
 import { SessionActionsPanel } from '@/features/session/session-actions-panel';
 import { SessionFilesExplorer } from '@/features/session/session-files-explorer';
 import { SessionFilesPanel } from '@/features/session/session-files-panel';
@@ -469,9 +470,14 @@ export default function DebugToolsPage() {
     <div className="bg-background text-foreground min-h-screen w-full">
       <div className="border-border/60 bg-background/80 sticky top-0 z-10 flex items-center justify-between border-b px-6 py-3 backdrop-blur">
         <div>
-          <h1 className="text-base font-semibold">
-            {tHardcodedUi.raw('appDebugToolsPage.line268JsxTextToolRenderers')}
-          </h1>
+          <div className="flex items-center gap-1.5">
+            <h1 className="text-base font-semibold">
+              {tHardcodedUi.raw('appDebugToolsPage.line268JsxTextToolRenderers')}
+            </h1>
+            <Badge variant="kortix" size="xs">
+              Sample PR demo
+            </Badge>
+          </div>
           <p className="text-muted-foreground text-xs">
             {tHardcodedUi.raw(
               'appDebugToolsPage.line270JsxTextDebugToolsVisualHarnessForSessionToolChrome',


### PR DESCRIPTION
$## Demo\n- Backend preview is live: https://pr-4691.preview-api.kortix.com/v1/health returns `environment=preview`, `version=pr-4691`.\n- Frontend preview status: the sticky preview comment currently points at https://suna-1xhmsscdb-kortixai.vercel.app, but that Vercel deployment renders `Deployment was cancelled` because the auto deployment was ignored and the preview workflow redeploy call returned HTTP 400.\n- Demo video uploaded in the originating Slack thread: https://slack-files.com/T07FUFNT3RV-F0BH80SSNES-497df9004a\n- Header screenshot uploaded in Slack: https://slack-files.com/T07FUFNT3RV-F0BHA0V4RPU-162b3ab9c7\n- Body screenshot uploaded in Slack: https://slack-files.com/T07FUFNT3RV-F0BHBTNQSBB-400b483c7a\n\n## Why\nCreate a deliberately tiny, low-risk sample PR that demonstrates how Kortix returns visual evidence for Slack-originated work.\n\n## What changed\n- Added a small `Sample PR demo` badge to the `/debug/tools` harness header using the existing `Badge` primitive.\n\n## Verification\n- `node /opt/suna/node_modules/.pnpm/eslint@9.39.4/node_modules/eslint/bin/eslint.js "src/app/(system)/debug/tools/page.tsx"`\n- `NODE_OPTIONS="--max-old-space-size=6144" node /opt/suna/node_modules/.pnpm/next@15.5.18_@babel+core@7.29.7_@opentelemetry+api@1.9.0_@playwright+test@1.61.1_react-dom@19.1.0_react@19.1.0/node_modules/next/dist/bin/next build`\n- GitHub checks: all passing or intentionally skipped for unaffected packages.\n- Backend preview: `curl https://pr-4691.preview-api.kortix.com/v1/health` → `environment=preview`, `version=pr-4691`.\n\n## Risk / rollback\nLow. Debug-only visual harness change; revert the commit to remove the badge.\n\n## Known issue\nThe frontend preview URL reported by the sticky preview comment is not usable for this PR because Vercel cancelled the ignored auto-deployment and the preview workflow redeploy API call returned HTTP 400. Evidence files are attached in Slack so the requested demo is still reviewable.