### PR TITLE
chore(web): add sample PR demo badge

### DIFF
--- a/apps/web/src/app/(system)/debug/tools/page.tsx
+++ b/apps/web/src/app/(system)/debug/tools/page.tsx
@@ -474,7 +474,7 @@ export default function DebugToolsPage() {
             <h1 className="text-base font-semibold">
               {tHardcodedUi.raw('appDebugToolsPage.line268JsxTextToolRenderers')}
             </h1>
-            <Badge variant="kortix" size="xs">
+            <Badge variant="kortix" size="xs" title="Sample PR evidence demo">
               Sample PR demo
             </Badge>
           </div>

--- a/apps/web/src/app/(system)/debug/tools/page.tsx
+++ b/apps/web/src/app/(system)/debug/tools/page.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
+import { Badge } from '@/components/ui/badge';
 import { SessionActionsPanel } from '@/features/session/session-actions-panel';
 import { SessionFilesExplorer } from '@/features/session/session-files-explorer';
 import { SessionFilesPanel } from '@/features/session/session-files-panel';
@@ -469,9 +470,14 @@ export default function DebugToolsPage() {
     <div className="bg-background text-foreground min-h-screen w-full">
       <div className="border-border/60 bg-background/80 sticky top-0 z-10 flex items-center justify-between border-b px-6 py-3 backdrop-blur">
         <div>
-          <h1 className="text-base font-semibold">
-            {tHardcodedUi.raw('appDebugToolsPage.line268JsxTextToolRenderers')}
-          </h1>
+          <div className="flex items-center gap-1.5">
+            <h1 className="text-base font-semibold">
+              {tHardcodedUi.raw('appDebugToolsPage.line268JsxTextToolRenderers')}
+            </h1>
+            <Badge variant="kortix" size="xs">
+              Sample PR demo
+            </Badge>
+          </div>
           <p className="text-muted-foreground text-xs">
             {tHardcodedUi.raw(
               'appDebugToolsPage.line270JsxTextDebugToolsVisualHarnessForSessionToolChrome',


### PR DESCRIPTION
$## Demo\n- Live frontend preview: https://suna-git-preview-sample-pr-evidence-demo-kortixai.vercel.app/debug/tools\n- Preview backend health: https://pr-4692.preview-api.kortix.com/v1/health\n- Live preview demo video: https://slack-files.com/T07FUFNT3RV-F0BH3TXER43-b2b170eb0e\n- Live preview header screenshot: https://slack-files.com/T07FUFNT3RV-F0BH6SFEQJH-81cf546304\n- Live preview body screenshot: https://slack-files.com/T07FUFNT3RV-F0BHC3AP42V-1385ceeaaa\n\n## Why\nCreate a deliberately tiny, low-risk sample PR that demonstrates how Kortix returns visual evidence for Slack-originated work.\n\n## What changed\n- Added a small `Sample PR demo` badge to the `/debug/tools` harness header using the existing `Badge` primitive.\n- Added a title tooltip on the badge so the sample evidence cue is self-describing.\n\n## Verification\n- `node /opt/suna/node_modules/.pnpm/eslint@9.39.4/node_modules/eslint/bin/eslint.js "src/app/(system)/debug/tools/page.tsx"`\n- `NODE_OPTIONS="--max-old-space-size=6144" node /opt/suna/node_modules/.pnpm/next@15.5.18_@babel+core@7.29.7_@opentelemetry+api@1.9.0_@playwright+test@1.61.1_react-dom@19.1.0_react@19.1.0/node_modules/next/dist/bin/next build`\n- Live preview E2E: opened `/debug/tools` on the Vercel preview, waited for `Sample PR demo`, captured video + screenshots.\n- Backend preview: `curl https://pr-4692.preview-api.kortix.com/v1/health` returns `environment=preview`, `version=pr-4692`.\n\n## Risk / rollback\nLow. Debug-only visual harness change; revert the two commits to remove the badge.