### PR TITLE
fix(enterprise-release): pass image digests to build-bundles in promote workflow

### DIFF
--- a/.github/workflows/promote-enterprise-stable.yml
+++ b/.github/workflows/promote-enterprise-stable.yml
@@ -231,11 +231,15 @@ jobs:
       - name: Build deterministic platform, Supabase, and updater artifacts
         env:
           ENTERPRISE_VERSION: ${{ steps.release.outputs.enterprise_version }}
+          API_IMAGE: ${{ steps.images.outputs.api }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend }}
+          GATEWAY_IMAGE: ${{ steps.images.outputs.gateway }}
         run: |
           set -euo pipefail
           BUN_COMPILE_TARGET=bun-linux-x64 pnpm --filter "@kortix/enterprise-updater" build
           test -x apps/enterprise-updater/dist/kortix-enterprise-updater
-          bun apps/enterprise-release/src/build-bundles.ts --version "$ENTERPRISE_VERSION" --output-dir /tmp/bundles
+          bun apps/enterprise-release/src/build-bundles.ts --version "$ENTERPRISE_VERSION" --output-dir /tmp/bundles \
+            --api-image "$API_IMAGE" --frontend-image "$FRONTEND_IMAGE" --gateway-image "$GATEWAY_IMAGE"
           for bundle in platform supabase; do
             tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
               --format=posix --pax-option=delete=atime,delete=ctime \


### PR DESCRIPTION
The appliance app bundle's `build-bundles.ts` now requires `--api-image/--frontend-image/--gateway-image` (to pin and self-assert the compose image digests). The Promote Enterprise Stable workflow called `build-bundles` without them, so a real promotion would fail at the bundle-build step. This feeds the same signed digests already computed for `generate-manifest` (`steps.images.outputs.*`). Blocking fix for promoting the first appliance revision (0.9.108-e13).