### PR TITLE
self-host: rename aws-vpc→aws-ec2, two-target UX, migration-safety gate

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -65,10 +65,12 @@ or run `kortix ship` to create the cloud project and push in one step.
 
 ## Self-host
 
-One command surface manages two deployment targets. Docker is the backward-
-compatible default for local and smaller installations; `aws-vpc` is the
-enterprise target and records only AWS coordinates and release policy locally.
-Secrets for AWS deployments are written directly to the customer account.
+One command surface manages two deployment targets. `docker` ("this machine")
+is the backward-compatible default for local and smaller installations; `aws-ec2`
+("AWS EC2") is the enterprise target and records only AWS coordinates and release
+policy locally. Secrets for AWS deployments are written directly to the customer
+account. (The AWS target was previously named `aws-vpc`; existing instance configs
+that still say `aws-vpc` on disk keep working — they load as `aws-ec2`.)
 
 ### Docker
 
@@ -95,13 +97,13 @@ Edge Runtime, Kong, Studio, Supavisor, Logflare, and Vector. Published ports
 bind to loopback by default, and all generated secret material is stored in the
 owner-only instance `.env`.
 
-### Enterprise AWS VPC
+### Enterprise AWS EC2
 
 ```sh
 export AWS_PROFILE=customer
 
 ./bin/kortix self-host init \
-  --target aws-vpc \
+  --target aws-ec2 \
   --instance customer \
   --region us-west-2 \
   --channel stable \

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -33,11 +33,19 @@ const LOCAL_SOURCE_TAG = 'selfhost-local';
 
 const HELP = help`Usage: kortix self-host <subcommand> [options]
 
-Run Kortix locally with Docker or deploy a production enterprise stack into
-an AWS VPC. Existing Docker instances remain fully compatible.
+Run Kortix on your own infrastructure. Two deployment targets:
+
+  this machine   --target docker    the full stack via Docker Compose on
+                                     whatever machine you run this on. Just works.
+  AWS EC2        --target aws-ec2    provision and manage a remote single-EC2
+                                     Kortix appliance in your AWS account.
+
+New instances default to docker. For the AWS EC2 walkthrough (Terraform,
+domains, secrets, signed updates) see docs/runbooks/enterprise-vpc-deployment.md.
+Existing Docker instances remain fully compatible.
 
 Subcommands:
-  init                 Create Docker or AWS VPC instance config.
+  init                 Create a this-machine (Docker) or AWS EC2 instance config.
   configure            Configure target integrations and secrets.
   plan                 Preview target changes without applying them.
   deploy               Bootstrap or converge the selected target.
@@ -57,13 +65,14 @@ Subcommands:
 
 Options:
   --instance <name>    Instance name (default: ${DEFAULT_INSTANCE}).
-  --target <target>    docker or aws-vpc (default: docker for new instances).
+  --target <target>    docker (this machine) or aws-ec2 (AWS EC2). Default:
+                       docker for new instances.
   --tag <tag>          Docker image tag / version (default: ${DEFAULT_TAG}).
   --release <version>  Immutable enterprise release (for example 0.9.84-e1).
   --channel <name>     Release channel (AWS default: stable; Docker: latest).
   --aws-profile <name> AWS CLI profile used to bootstrap/manage the target.
   --region <region>    AWS region (default: AWS config, then us-west-2).
-  --vpc-cidr <cidr>    Dedicated /16 CIDR for an AWS VPC target.
+  --vpc-cidr <cidr>    Dedicated /16 CIDR for an AWS EC2 target.
   --api-domain <name>  Public API DNS name for the AWS target.
   --frontend-domain <name> Public dashboard DNS name for the AWS target.
   --route53-zone-id <id> Customer Route 53 public hosted zone for DNS and ACM.
@@ -76,14 +85,17 @@ Options:
   --local              Use current-source local images instead of registry images.
   --registry           Force registry images even when running from a source checkout.
   --force              Run now, bypassing only the configured maintenance window.
+  --allow-downtime     Permit a release whose migration is not backward-compatible
+                       to deploy with a brief, honest downtime window (stop app,
+                       migrate, start new). Without it such a release is refused.
   --json               Emit machine-readable output where supported.
   --yes                Accept defaults in non-interactive flows.
   -h, --help           Show this help.
 
 Examples:
-  kortix self-host init
+  kortix self-host init                    # this machine (Docker)
   kortix self-host start
-  kortix self-host init --target aws-vpc --instance customer --aws-profile customer --region us-west-2
+  kortix self-host init --target aws-ec2 --instance customer --aws-profile customer --region us-west-2
   kortix self-host plan --instance customer
   kortix self-host deploy --instance customer
   kortix self-host reconcile --instance customer --channel stable
@@ -174,7 +186,7 @@ export async function runSelfHost(argv: string[]): Promise<number> {
     return 2;
   }
 
-  if (target === 'aws-vpc') {
+  if (target === 'aws-ec2') {
     return runAwsVpcCommand(sub, args, flags);
   }
 
@@ -229,6 +241,7 @@ function parseGlobalFlags(args: string[]): GlobalFlags {
   const registry = takeFlagBool(args, ['--registry']);
   const json = takeFlagBool(args, ['--json']);
   const force = takeFlagBool(args, ['--force']);
+  const allowDowntime = takeFlagBool(args, ['--allow-downtime']);
   const instance = takeFlagValue(args, ['--instance']) ?? DEFAULT_INSTANCE;
   const release = takeFlagValue(args, ['--release']);
   const tag = takeFlagValue(args, ['--tag', '--version']) ?? release ?? DEFAULT_TAG;
@@ -275,6 +288,7 @@ function parseGlobalFlags(args: string[]): GlobalFlags {
     registry,
     json,
     force,
+    allowDowntime,
   };
 }
 

--- a/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
+++ b/apps/cli/src/self-host/__tests__/aws-vpc-blackbox.test.ts
@@ -8,7 +8,7 @@ const TRUSTED_ROOT = 'a'.repeat(64);
 const BOOTSTRAP_DIGEST = 'b'.repeat(64);
 const BEDROCK_KEY = 'bedrock-super-secret-value';
 
-describe('kortix self-host aws-vpc', () => {
+describe('kortix self-host aws-ec2', () => {
   let tmp: string;
   let configRoot: string;
   let fakeBin: string;
@@ -185,7 +185,7 @@ esac
 
   function configuredInitArgs(instance = 'vpc-demo'): string[] {
     return [
-      'init', '--target', 'aws-vpc', '--instance', instance,
+      'init', '--target', 'aws-ec2', '--instance', instance,
       '--aws-profile', 'default', '--region', 'us-west-2', '--channel', 'stable',
       '--vpc-cidr', '10.60.0.0/16',
       '--api-domain', 'api.vpc-demo.kortix.com',
@@ -212,7 +212,7 @@ esac
     const config = JSON.parse(result.stdout);
     expect(config).toMatchObject({
       instance: 'vpc-demo',
-      target: 'aws-vpc',
+      target: 'aws-ec2',
       channel: 'stable',
       aws: {
         profile: 'default',
@@ -228,7 +228,7 @@ esac
 
     const instanceDir = join(configRoot, 'vpc-demo');
     const persisted = readFileSync(join(instanceDir, 'instance.json'), 'utf8');
-    expect(JSON.parse(persisted)).toMatchObject({ target: 'aws-vpc', aws: { account_id: '935064898258' } });
+    expect(JSON.parse(persisted)).toMatchObject({ target: 'aws-ec2', aws: { account_id: '935064898258' } });
     expect(persisted).not.toContain('cloudflare_api_token');
     expect(existsSync(join(instanceDir, '.env'))).toBe(false);
     expect(readFileSync(join(instanceDir, 'terraform/environments/enterprise-vpc/state/main.tf'), 'utf8'))
@@ -239,7 +239,7 @@ esac
 
   test('enforces Terraform-compatible lowercase DNS slugs for AWS instances', async () => {
     const result = await run([
-      'init', '--target', 'aws-vpc', '--instance', 'Essentia_VPC', '--aws-profile', 'default', '--yes',
+      'init', '--target', 'aws-ec2', '--instance', 'Essentia_VPC', '--aws-profile', 'default', '--yes',
     ]);
     expect(result.code).toBe(2);
     expect(result.stderr).toContain('lowercase DNS slug');

--- a/apps/cli/src/self-host/__tests__/config.test.ts
+++ b/apps/cli/src/self-host/__tests__/config.test.ts
@@ -7,6 +7,7 @@ import {
   instanceConfigPath,
   instanceDir,
   loadInstanceConfig,
+  parseSelfHostTarget,
   resolveInstanceTarget,
   writeInstanceConfig,
   type SelfHostInstanceConfig,
@@ -44,7 +45,7 @@ describe('self-host instance config', () => {
     const config: SelfHostInstanceConfig = {
       schema_version: 1,
       instance: 'vpc-demo',
-      target: 'aws-vpc',
+      target: 'aws-ec2',
       channel: 'stable',
       aws: {
         profile: 'default',
@@ -60,6 +61,31 @@ describe('self-host instance config', () => {
     expect(statSync(instanceConfigPath(config.instance)).mode & 0o777).toBe(0o600);
   });
 
+  test('reads a legacy target: "aws-vpc" config on disk as the current aws-ec2 target', () => {
+    mkdirSync(instanceDir('legacy-vpc'), { recursive: true });
+    writeFileSync(
+      instanceConfigPath('legacy-vpc'),
+      JSON.stringify({
+        schema_version: 1,
+        instance: 'legacy-vpc',
+        target: 'aws-vpc',
+        channel: 'stable',
+        aws: { profile: 'default', region: 'us-west-2', account_id: '935064898258' },
+      }),
+    );
+
+    const loaded = loadInstanceConfig('legacy-vpc');
+    expect(loaded?.target).toBe('aws-ec2');
+    expect(resolveInstanceTarget('legacy-vpc')).toBe('aws-ec2');
+  });
+
+  test('parses the legacy --target aws-vpc value as aws-ec2', () => {
+    expect(parseSelfHostTarget('aws-vpc')).toBe('aws-ec2');
+    expect(parseSelfHostTarget('aws-ec2')).toBe('aws-ec2');
+    expect(parseSelfHostTarget('docker')).toBe('docker');
+    expect(() => parseSelfHostTarget('nonsense')).toThrow('docker');
+  });
+
   test('rejects invalid or secret-bearing instance configs', () => {
     mkdirSync(instanceDir('broken'), { recursive: true });
     writeFileSync(
@@ -67,7 +93,7 @@ describe('self-host instance config', () => {
       JSON.stringify({
         schema_version: 1,
         instance: 'broken',
-        target: 'aws-vpc',
+        target: 'aws-ec2',
         channel: 'stable',
         aws: { profile: 'default', region: 'us-west-2', account_id: '123456789012' },
         api_key: 'must-not-live-here',
@@ -78,11 +104,11 @@ describe('self-host instance config', () => {
     expect(() => loadInstanceConfig('broken')).toThrow('unsupported field "api_key"');
   });
 
-  test('rejects an aws-vpc instance name that starts with kortix- (would double the resource prefix)', () => {
+  test('rejects an aws-ec2 instance name that starts with kortix- (would double the resource prefix)', () => {
     const config = {
       schema_version: 1,
       instance: 'kortix-vpc-demo',
-      target: 'aws-vpc',
+      target: 'aws-ec2',
       channel: 'stable',
       aws: { profile: 'default', region: 'us-west-2', account_id: '935064898258' },
     } as SelfHostInstanceConfig;
@@ -96,7 +122,7 @@ describe('self-host instance config', () => {
       JSON.stringify({
         schema_version: 1,
         instance: 'incomplete',
-        target: 'aws-vpc',
+        target: 'aws-ec2',
         channel: 'stable',
         aws: { profile: 'default', region: 'us-west-2' },
       }),
@@ -109,7 +135,7 @@ describe('self-host instance config', () => {
     const base = {
       schema_version: 1,
       instance: 'enterprise',
-      target: 'aws-vpc',
+      target: 'aws-ec2',
       channel: 'stable',
       aws: {
         profile: 'default',

--- a/apps/cli/src/self-host/aws-vpc-control-plane.ts
+++ b/apps/cli/src/self-host/aws-vpc-control-plane.ts
@@ -23,6 +23,8 @@ export interface UpdaterIntent {
   release?: string;
   rollback?: string;
   force?: boolean;
+  /** Permit a non-backward-compatible migration to deploy with brief downtime. */
+  allowDowntime?: boolean;
 }
 
 export interface UpdaterRunResult {
@@ -95,6 +97,7 @@ function updaterRunScript(intent: UpdaterIntent): string {
   if (intent.release) exports.push(`export KORTIX_DEPLOY_RELEASE=${shellQuote(intent.release)}`);
   if (intent.rollback) exports.push(`export KORTIX_DEPLOY_ROLLBACK=${shellQuote(intent.rollback)}`);
   if (intent.force) exports.push('export KORTIX_DEPLOY_FORCE=1');
+  if (intent.allowDowntime) exports.push('export KORTIX_ALLOW_DOWNTIME=1');
   return [
     'set -euo pipefail',
     // The box owns every credential + release coordinate in instance.env; the CLI

--- a/apps/cli/src/self-host/aws-vpc-settings.ts
+++ b/apps/cli/src/self-host/aws-vpc-settings.ts
@@ -33,7 +33,7 @@ export function completeConfiguration(config: SelfHostInstanceConfig): CompleteA
   const missing = missingConfiguration(coordinates);
   if (missing.length > 0) {
     throw new Error(
-      `AWS VPC deployment config is incomplete (${missing.join(', ')}); run kortix self-host configure --instance ${config.instance}`,
+      `AWS EC2 deployment config is incomplete (${missing.join(', ')}); run kortix self-host configure --instance ${config.instance}`,
     );
   }
   return coordinates as CompleteAwsVpcConfig;
@@ -70,11 +70,11 @@ export function parseConfigurationAssignments(args: string[]): Partial<CompleteA
   const result: Record<string, string> = {};
   const allowed = new Set<string>(CONFIG_FIELDS);
   for (const arg of args) {
-    if (arg.startsWith('-')) throw new Error(`unknown AWS VPC configure option "${arg}"`);
+    if (arg.startsWith('-')) throw new Error(`unknown AWS EC2 configure option "${arg}"`);
     const separator = arg.indexOf('=');
     if (separator < 1) throw new Error(`configure value must use key=value, got "${arg}"`);
     const key = arg.slice(0, separator).toLowerCase().replaceAll('-', '_');
-    if (!allowed.has(key)) throw new Error(`unsupported AWS VPC setting "${key}"`);
+    if (!allowed.has(key)) throw new Error(`unsupported AWS EC2 setting "${key}"`);
     result[key] = arg.slice(separator + 1);
   }
   return result as Partial<CompleteAwsVpcConfig>;

--- a/apps/cli/src/self-host/aws-vpc.ts
+++ b/apps/cli/src/self-host/aws-vpc.ts
@@ -103,12 +103,12 @@ export async function runAwsVpcCommand(
   if (!config) return 1;
   if (flags.local || flags.registry || (flags.tag !== 'latest' && !flags.release)) {
     process.stderr.write(
-      `${status.err('AWS VPC targets use --release with signed enterprise versions; --tag, --local, and --registry are Docker-only.')}\n`,
+      `${status.err('AWS EC2 targets use --release with signed enterprise versions; --tag, --local, and --registry are Docker-only.')}\n`,
     );
     return 2;
   }
   if (!['configure', 'config', 'logs', 'env'].includes(typedCommand) && args.length > 0) {
-    process.stderr.write(`${status.err(`unexpected AWS VPC arguments: ${args.join(' ')}`)}\n`);
+    process.stderr.write(`${status.err(`unexpected AWS EC2 arguments: ${args.join(' ')}`)}\n`);
     return 2;
   }
 
@@ -141,7 +141,7 @@ export async function runAwsVpcCommand(
     case 'env':
       return manageAwsVpcEnv(config, args, flags);
     default:
-      process.stderr.write(`${status.err(`unknown AWS VPC self-host command "${command}"`)}\n`);
+      process.stderr.write(`${status.err(`unknown AWS EC2 self-host command "${command}"`)}\n`);
       return 2;
   }
 }
@@ -154,12 +154,12 @@ async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
   }
   if (flags.local || flags.registry || (flags.tag !== 'latest' && !flags.release)) {
     process.stderr.write(
-      `${status.err('AWS VPC targets use signed releases; --local, --registry, and --tag are Docker-only options.')}\n`,
+      `${status.err('AWS EC2 targets use signed releases; --local, --registry, and --tag are Docker-only options.')}\n`,
     );
     return 2;
   }
   if (flags.channel && flags.channel !== 'stable') {
-    process.stderr.write(`${status.err('AWS VPC targets may only track the stable channel.')}\n`);
+    process.stderr.write(`${status.err('AWS EC2 targets may only track the stable channel.')}\n`);
     return 2;
   }
   if (flags.release) {
@@ -192,7 +192,7 @@ async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
     process.stderr.write(`${status.err((error as Error).message)}\n`);
     return 2;
   }
-  if (existing && existing.target !== 'aws-vpc') {
+  if (existing && existing.target !== 'aws-ec2') {
     process.stderr.write(`${status.err(`instance "${flags.instance}" already targets Docker`)}\n`);
     return 2;
   }
@@ -211,7 +211,7 @@ async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
   const config: SelfHostInstanceConfig = {
     schema_version: 1,
     instance: flags.instance,
-    target: 'aws-vpc',
+    target: 'aws-ec2',
     channel: 'stable',
     ...(flags.release || existing?.release ? { release: flags.release ?? existing?.release } : {}),
     aws,
@@ -230,8 +230,8 @@ async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
   }
 
   const missing = missingConfiguration(config.aws!);
-  process.stdout.write(`\n  ${C.bold}Kortix Enterprise VPC${C.reset}\n\n`);
-  process.stdout.write(`${status.ok(existing ? 'AWS VPC instance config verified' : 'AWS VPC instance config created')}\n`);
+  process.stdout.write(`\n  ${C.bold}Kortix Enterprise EC2${C.reset}\n\n`);
+  process.stdout.write(`${status.ok(existing ? 'AWS EC2 instance config verified' : 'AWS EC2 instance config created')}\n`);
   process.stdout.write(`  ${C.dim}instance  ${C.reset}${config.instance}\n`);
   process.stdout.write(`  ${C.dim}account   ${C.reset}${identity.Account}\n`);
   process.stdout.write(`  ${C.dim}profile   ${C.reset}${profile}\n`);
@@ -245,6 +245,7 @@ async function initAwsVpc(flags: SelfHostCommandFlags): Promise<number> {
     process.stdout.write(`  ${C.dim}Next: ${C.reset}${C.cyan}kortix self-host doctor --instance ${config.instance}${C.reset}\n`);
     process.stdout.write(`        ${C.cyan}kortix self-host plan --instance ${config.instance}${C.reset}\n\n`);
   }
+  process.stdout.write(`  ${C.dim}Full AWS EC2 walkthrough: docs/runbooks/enterprise-vpc-deployment.md${C.reset}\n\n`);
   return 0;
 }
 
@@ -255,7 +256,7 @@ async function configureAwsVpc(
 ): Promise<number> {
   try {
     verifyPinnedIdentity(config.aws!);
-    if (flags.channel && flags.channel !== 'stable') throw new Error('AWS VPC targets may only track the stable channel');
+    if (flags.channel && flags.channel !== 'stable') throw new Error('AWS EC2 targets may only track the stable channel');
     const fromArgs = parseConfigurationAssignments(args);
     let aws = mergeAwsConfiguration(config.aws!, flags, fromArgs);
     if (!flags.yes && args.length === 0 && !hasConfigurationFlags(flags)) {
@@ -374,7 +375,7 @@ async function deployAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostComma
     if (!flags.yes) {
       if (!(process.stdin.isTTY === true && process.stdout.isTTY === true)) {
         process.stderr.write(
-          `${status.err(`AWS VPC deployment requires confirmation; rerun with --yes after reviewing plan for ${identity.Account}.`)}\n`,
+          `${status.err(`AWS EC2 deployment requires confirmation; rerun with --yes after reviewing plan for ${identity.Account}.`)}\n`,
         );
         return 2;
       }
@@ -410,7 +411,7 @@ async function deployAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostComma
       region: aws.region,
     });
     const deployment = runtime.missingOperatorKeys.length === 0
-      ? { ...runUpdaterViaSsm(config, { ...(flags.release ? { release: flags.release } : {}) }), status: 'DEPLOYED' }
+      ? { ...runUpdaterViaSsm(config, { ...(flags.release ? { release: flags.release } : {}), ...(flags.allowDowntime ? { allowDowntime: true } : {}) }), status: 'DEPLOYED' }
       : {
           status: 'WAITING_FOR_RUNTIME_CONFIG',
           command_id: null,
@@ -433,7 +434,7 @@ async function deployAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostComma
     };
     if (flags.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
     else {
-      process.stdout.write(`\n  ${C.bold}Kortix Enterprise VPC deployed${C.reset}\n`);
+      process.stdout.write(`\n  ${C.bold}Kortix Enterprise EC2 deployed${C.reset}\n`);
       process.stdout.write(`${status.ok(`Terraform state verified at lineage ${migration.verification.lineage}, serial ${migration.verification.serial}`)}\n`);
       process.stdout.write(`${status.ok('Customer cluster infrastructure applied')}\n`);
       process.stdout.write(`${status.ok('Generated core runtime credentials directly into customer Secrets Manager')}\n`);
@@ -461,12 +462,13 @@ async function startManagedUpdate(
 ): Promise<number> {
   try {
     verifyPinnedIdentity(config.aws!);
-    if (flags.channel && flags.channel !== 'stable') throw new Error('AWS VPC targets may only track the stable channel');
+    if (flags.channel && flags.channel !== 'stable') throw new Error('AWS EC2 targets may only track the stable channel');
     if (flags.release) assertEnterpriseRelease(flags.release);
     assertRuntimeReady(config);
     const result = runUpdaterViaSsm(config, {
       force: flags.force,
       ...(flags.release ? { release: flags.release } : {}),
+      ...(flags.allowDowntime ? { allowDowntime: true } : {}),
     });
     renderUpdaterRun(config, result, flags);
     return 0;
@@ -564,6 +566,7 @@ async function rollbackAwsVpc(config: SelfHostInstanceConfig, flags: SelfHostCom
     const result = runUpdaterViaSsm(config, {
       force: flags.force,
       rollback: flags.release,
+      ...(flags.allowDowntime ? { allowDowntime: true } : {}),
     });
     renderUpdaterRun(config, result, flags);
     return 0;
@@ -756,7 +759,7 @@ function rejectDockerLifecycleCommand(command: AwsVpcCommand, instance: string):
   process.stderr.write(`${status.err(`${canonical} is only available for Docker targets.`)}\n`);
   if (canonical === 'start') {
     process.stderr.write(
-      `${C.dim}AWS VPC environments are continuously reconciled; bootstrap with ${C.reset}${C.cyan}kortix self-host deploy --instance ${instance}${C.reset}${C.dim}.${C.reset}\n`,
+      `${C.dim}AWS EC2 environments are continuously reconciled; bootstrap with ${C.reset}${C.cyan}kortix self-host deploy --instance ${instance}${C.reset}${C.dim}.${C.reset}\n`,
     );
   }
   return 2;
@@ -772,12 +775,12 @@ function loadAwsConfig(instance: string): SelfHostInstanceConfig | null {
   }
   if (!config) {
     process.stderr.write(
-      `${status.err(`Self-host instance "${instance}" is not initialized. Run \`kortix self-host init --target aws-vpc --instance ${instance}\` first.`)}\n`,
+      `${status.err(`Self-host instance "${instance}" is not initialized. Run \`kortix self-host init --target aws-ec2 --instance ${instance}\` first.`)}\n`,
     );
     return null;
   }
-  if (config.target !== 'aws-vpc' || !config.aws) {
-    process.stderr.write(`${status.err(`Self-host instance "${instance}" is not an AWS VPC target.`)}\n`);
+  if (config.target !== 'aws-ec2' || !config.aws) {
+    process.stderr.write(`${status.err(`Self-host instance "${instance}" is not an AWS EC2 target.`)}\n`);
     return null;
   }
   return config;

--- a/apps/cli/src/self-host/config.ts
+++ b/apps/cli/src/self-host/config.ts
@@ -2,7 +2,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'n
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-export type SelfHostTarget = 'docker' | 'aws-vpc';
+export type SelfHostTarget = 'docker' | 'aws-ec2';
 
 export interface AwsVpcCoordinates {
   profile: string;
@@ -109,8 +109,12 @@ export function resolveInstanceTarget(instance: string, requested?: SelfHostTarg
 
 export function parseSelfHostTarget(value: string | undefined): SelfHostTarget | undefined {
   if (value === undefined) return undefined;
-  if (value === 'docker' || value === 'aws-vpc') return value;
-  throw new Error(`target must be "docker" or "aws-vpc", got "${value}"`);
+  if (value === 'docker' || value === 'aws-ec2') return value;
+  // Backward compatibility: the AWS target used to be called "aws-vpc". Existing
+  // instance configs on disk (and any scripts) may still say it; accept it and
+  // normalize to the current "aws-ec2" name. We only ever WRITE "aws-ec2".
+  if (value === 'aws-vpc') return 'aws-ec2';
+  throw new Error(`target must be "docker" or "aws-ec2", got "${value}"`);
 }
 
 function validateInstanceConfig(value: unknown, expectedInstance: string): SelfHostInstanceConfig {
@@ -124,19 +128,19 @@ function validateInstanceConfig(value: unknown, expectedInstance: string): SelfH
   assertInstanceName(expectedInstance);
 
   const target = parseSelfHostTarget(asRequiredString(value.target, 'target'))!;
-  if (target === 'aws-vpc') assertAwsVpcInstanceName(expectedInstance);
+  if (target === 'aws-ec2') assertAwsVpcInstanceName(expectedInstance);
   const channel = asRequiredString(value.channel, 'channel');
   if (!/^[a-zA-Z0-9._-]+$/.test(channel)) {
     throw new Error('channel may contain only letters, digits, dots, underscores, or dashes');
   }
-  if (target === 'aws-vpc' && channel !== 'stable') {
-    throw new Error('AWS VPC instances may only track the stable channel');
+  if (target === 'aws-ec2' && channel !== 'stable') {
+    throw new Error('AWS EC2 instances may only track the stable channel');
   }
 
   const release = optionalString(value.release, 'release');
   let aws: AwsVpcCoordinates | undefined;
-  if (target === 'aws-vpc') {
-    if (!isRecord(value.aws)) throw new Error('aws-vpc instance config requires aws coordinates');
+  if (target === 'aws-ec2') {
+    if (!isRecord(value.aws)) throw new Error('aws-ec2 instance config requires aws coordinates');
     rejectUnknownFields(value.aws, AWS_FIELDS, 'aws.');
     const profile = asRequiredString(value.aws.profile, 'aws.profile');
     const region = asRequiredString(value.aws.region, 'aws.region');
@@ -217,12 +221,12 @@ function assertInstanceName(instance: string): void {
 
 export function assertAwsVpcInstanceName(instance: string): void {
   if (!/^[a-z][a-z0-9-]{2,30}[a-z0-9]$/.test(instance)) {
-    throw new Error('AWS VPC instance must be a 4-32 character lowercase DNS slug');
+    throw new Error('AWS EC2 instance must be a 4-32 character lowercase DNS slug');
   }
   // Every AWS resource is named kortix-<instance>; a kortix- prefix here would
   // double it (kortix-kortix-...). Reject it explicitly rather than stripping.
   if (instance.startsWith('kortix-')) {
-    throw new Error('AWS VPC instance must not start with "kortix-"; resources are already named kortix-<instance>');
+    throw new Error('AWS EC2 instance must not start with "kortix-"; resources are already named kortix-<instance>');
   }
 }
 

--- a/apps/cli/src/self-host/types.ts
+++ b/apps/cli/src/self-host/types.ts
@@ -23,4 +23,5 @@ export interface SelfHostCommandFlags {
   registry: boolean;
   json: boolean;
   force: boolean;
+  allowDowntime: boolean;
 }

--- a/apps/enterprise-updater/src/__tests__/compose-deploy.test.ts
+++ b/apps/enterprise-updater/src/__tests__/compose-deploy.test.ts
@@ -24,7 +24,20 @@ const SUPABASE_SHA = 'd'.repeat(64);
 const SECRET_ARN = 'arn:aws:secretsmanager:us-west-2:935064898258:secret:vpc-demo/runtime-AbCdEf';
 const RUNTIME_ENV_FILE = '/tmp/kortix-runtime-env/runtime.json';
 
-function manifestJson(overrides: { version?: string; rollbackFrom?: string[]; supabaseSha?: string } = {}) {
+interface ManifestMigration {
+  id: string;
+  sha256: string;
+  reversible: boolean;
+  backward_compatible: boolean;
+}
+
+function migration(backwardCompatible: boolean, id = 'm1'): ManifestMigration {
+  return { id, sha256: '9'.repeat(64), reversible: true, backward_compatible: backwardCompatible };
+}
+
+function manifestJson(
+  overrides: { version?: string; rollbackFrom?: string[]; supabaseSha?: string; migrations?: ManifestMigration[] } = {},
+) {
   const version = overrides.version ?? '0.9.84-e1';
   return {
     schema_version: 1,
@@ -45,8 +58,18 @@ function manifestJson(overrides: { version?: string; rollbackFrom?: string[]; su
       cosign_public_key: { target: 'cosign.pub', sha256: '2'.repeat(64), length: 10 },
       updater_binary: { target: 'updater', sha256: '3'.repeat(64), length: 10 },
     },
-    migrations: [],
+    migrations: overrides.migrations ?? [],
     health: { api_path: '/v1/health', frontend_path: '/', expected_version: '0.9.84' },
+  };
+}
+
+/** A prior deployed release so a deploy is treated as an UPDATE (not first install). */
+function priorCrumb(): DeployBreadcrumb {
+  return {
+    version: '0.9.83-e1',
+    digests: { api: OLD, gateway: OLD, frontend: OLD },
+    supabase_bundle_sha: SUPABASE_SHA,
+    deployed_at: '2026-07-13T00:00:00Z',
   };
 }
 
@@ -75,6 +98,10 @@ class FakeHost implements HostRuntime {
   rolloutService(role: AppRole): void {
     if (this.scenario.failRole === role) throw new Error(`new ${role} containers never became healthy`);
     this.rolled.push(role);
+  }
+  stopped = 0;
+  stopAppServices(): void {
+    this.stopped += 1;
   }
   edges = 0;
   startEdge(): void {
@@ -259,5 +286,50 @@ describe('ComposeDeployer', () => {
       verifyIdentity: () => { throw new Error('AWS account mismatch: expected 935064898258, received 327903111249'); },
     });
     await expect(deployer.deploy()).rejects.toThrow('AWS account mismatch');
+  });
+
+  test('an update whose migrations are all backward-compatible takes the zero-downtime start-first roll', async () => {
+    const manifest = manifestJson({ migrations: [migration(true, 'm1'), migration(true, 'm2')] });
+    const { deployer, host } = makeDeployer({ breadcrumb: priorCrumb() }, { manifest });
+    const outcome = await deployer.deploy();
+    expect(outcome).toEqual({ action: 'deploy', release: '0.9.84-e1' });
+    // Zero-downtime path: no drain, start-first roll of all three services.
+    expect(host.stopped).toBe(0);
+    expect(host.migrated).toBe(1);
+    expect(host.rolled).toEqual(['api', 'gateway', 'frontend']);
+    expect(host.written).not.toBeNull();
+  });
+
+  test('an update with a non-backward-compatible migration and no opt-in aborts before touching anything', async () => {
+    const manifest = manifestJson({ migrations: [migration(true, 'm1'), migration(false, 'm2')] });
+    const { deployer, host, images } = makeDeployer({ breadcrumb: priorCrumb() }, { manifest });
+    await expect(deployer.deploy()).rejects.toThrow('non-backward-compatible migration');
+    // Untouched: no image prep, no drain, no migrate, no roll, no breadcrumb.
+    expect(images.prepared).toBe(0);
+    expect(host.stopped).toBe(0);
+    expect(host.migrated).toBe(0);
+    expect(host.rolled).toEqual([]);
+    expect(host.written).toBeNull();
+  });
+
+  test('a non-backward-compatible migration with allowDowntime drains the app, migrates, then starts new', async () => {
+    const manifest = manifestJson({ migrations: [migration(false, 'm1')] });
+    const { deployer, host } = makeDeployer({ breadcrumb: priorCrumb() }, { manifest });
+    const outcome = await deployer.deploy({ allowDowntime: true });
+    expect(outcome).toEqual({ action: 'deploy', release: '0.9.84-e1' });
+    // Downtime path: drain first, THEN migrate, THEN start each service.
+    expect(host.stopped).toBe(1);
+    expect(host.migrated).toBe(1);
+    expect(host.rolled).toEqual(['api', 'gateway', 'frontend']);
+    expect(host.written).not.toBeNull();
+  });
+
+  test('a first install with a non-backward-compatible migration proceeds without opt-in (no old containers)', async () => {
+    const manifest = manifestJson({ migrations: [migration(false, 'm1')] });
+    const { deployer, host } = makeDeployer({ breadcrumb: null }, { manifest });
+    const outcome = await deployer.deploy();
+    expect(outcome).toEqual({ action: 'deploy', release: '0.9.84-e1' });
+    expect(host.stopped).toBe(0);
+    expect(host.rolled).toEqual(['api', 'gateway', 'frontend']);
   });
 });

--- a/apps/enterprise-updater/src/box.ts
+++ b/apps/enterprise-updater/src/box.ts
@@ -30,6 +30,13 @@ export interface HostRuntime {
   runningDigest(role: AppRole): string | null;
   runMigrate(): void;
   rolloutService(role: AppRole, timeoutMs?: number): void;
+  /**
+   * Stop + remove the app-tier containers (api/gateway/frontend), leaving
+   * Supabase and Caddy running. Used only for the honest-downtime path when a
+   * release carries a migration that is NOT backward-compatible: the old app must
+   * not run against the new schema, so it is drained before migrate.
+   */
+  stopAppServices(): void;
   /** Bring up the Caddy edge (and any not-yet-running service) without recreating healthy app replicas. */
   startEdge(): void;
   readBreadcrumb(): DeployBreadcrumb | null;
@@ -108,6 +115,15 @@ export class DockerHost implements HostRuntime {
   /** Run migrations to completion. Throws on a nonzero exit — the caller aborts. */
   runMigrate(): void {
     this.runner.run('docker', this.compose(['run', '--rm', 'migrate']));
+  }
+
+  /**
+   * Stop + remove the app-tier containers for the honest-downtime path. Leaves
+   * Supabase and Caddy up; a subsequent rolloutService brings each service back
+   * fresh on the new digest. `rm --stop --force` stops then removes them.
+   */
+  stopAppServices(): void {
+    this.runner.run('docker', this.compose(['rm', '--stop', '--force', '--volumes', ...APP_ROLES]));
   }
 
   /**

--- a/apps/enterprise-updater/src/compose-deploy.ts
+++ b/apps/enterprise-updater/src/compose-deploy.ts
@@ -14,6 +14,13 @@ export interface DeployRequest {
   requestedRelease?: string;
   /** Roll back to an already-published, predecessor-listed version. */
   rollbackTo?: string;
+  /**
+   * Opt in to a brief, honest downtime window for a release whose migration is
+   * NOT backward-compatible. Without it such a release is refused (an update
+   * against old containers can only stay zero-downtime if the schema change is
+   * backward-compatible). First installs never need it (no old containers).
+   */
+  allowDowntime?: boolean;
 }
 
 export interface DeployOutcome {
@@ -109,6 +116,23 @@ export class ComposeDeployer {
       return { action: 'noop', release: manifest.version, reason: 'up to date' };
     }
 
+    // Zero-downtime safety gate. The start-first roll briefly runs OLD app
+    // containers against the NEW schema, so it is safe only when every migration
+    // in this release is backward-compatible. A first install (no prior release)
+    // has no old containers and is always safe. Otherwise a non-backward-compatible
+    // migration needs an explicit --allow-downtime / KORTIX_ALLOW_DOWNTIME opt-in;
+    // without it we abort BEFORE touching anything (no image pull, no migrate).
+    const firstInstall = current === null;
+    const backwardCompatible = manifest.migrations.every((migration) => migration.backward_compatible);
+    const needsDowntime = !firstInstall && !backwardCompatible;
+    if (needsDowntime && !request.allowDowntime) {
+      throw new Error(
+        `release ${manifest.version} contains a non-backward-compatible migration; ` +
+          'it cannot be applied with zero downtime. Re-run with --allow-downtime ' +
+          '(KORTIX_ALLOW_DOWNTIME=1) during a maintenance window to accept a brief downtime.',
+      );
+    }
+
     this.log(`Preparing ${manifest.version} images (verify + pull by digest)`);
     const cosignKey = await repository.downloadArtifact(manifest.artifacts.cosign_public_key);
     const images = this.deps.images.prepare(manifest, cosignKey);
@@ -137,16 +161,30 @@ export class ComposeDeployer {
     const appBundle = await repository.downloadArtifact(manifest.artifacts.platform_bundle);
     this.deps.app.install({ manifest, bundleTar: appBundle, images, runtimeEnvFile: this.deps.runtimeEnvFile() });
 
-    // Migrate to completion BEFORE any service moves; a nonzero exit throws here
-    // and aborts the deploy with every running container untouched.
-    this.log('Running database migrations (docker compose run --rm migrate)');
-    this.deps.host.runMigrate();
+    if (needsDowntime) {
+      // Honest, brief downtime: the non-backward-compatible schema change means the
+      // old app must NOT run against the new schema. Drain the app tier, migrate,
+      // then start the new containers. Supabase/Caddy stay up throughout.
+      this.log('Non-backward-compatible migration: draining app for a brief downtime window');
+      this.deps.host.stopAppServices();
+      this.log('Running database migrations (docker compose run --rm migrate)');
+      this.deps.host.runMigrate();
+      for (const role of APP_ROLES) {
+        this.log(`Starting ${role}${isRollback ? ' (rollback)' : ''} on the new release`);
+        this.deps.host.rolloutService(role);
+      }
+    } else {
+      // Migrate to completion BEFORE any service moves; a nonzero exit throws here
+      // and aborts the deploy with every running container untouched.
+      this.log('Running database migrations (docker compose run --rm migrate)');
+      this.deps.host.runMigrate();
 
-    // Start-first rolling swap, one service at a time. A failed health gate throws
-    // and leaves the previous version serving; later services are never touched.
-    for (const role of APP_ROLES) {
-      this.log(`Rolling ${role}${isRollback ? ' (rollback)' : ''} start-first`);
-      this.deps.host.rolloutService(role);
+      // Start-first rolling swap, one service at a time. A failed health gate throws
+      // and leaves the previous version serving; later services are never touched.
+      for (const role of APP_ROLES) {
+        this.log(`Rolling ${role}${isRollback ? ' (rollback)' : ''} start-first`);
+        this.deps.host.rolloutService(role);
+      }
     }
 
     // Bring up / reconcile the Caddy edge, then verify public health through it.

--- a/apps/enterprise-updater/src/main.ts
+++ b/apps/enterprise-updater/src/main.ts
@@ -58,9 +58,13 @@ async function main(): Promise<number> {
   const requestedRelease = flags.get('release') ?? process.env.KORTIX_DEPLOY_RELEASE;
   const rollbackTo = flags.get('rollback') ?? process.env.KORTIX_DEPLOY_ROLLBACK;
   if (requestedRelease && rollbackTo) throw new Error('--release and --rollback are mutually exclusive');
+  // Opt-in to a brief downtime for a non-backward-compatible migration. The CLI
+  // threads --allow-downtime here as KORTIX_ALLOW_DOWNTIME via SSM RunCommand.
+  const allowDowntime = process.env.KORTIX_ALLOW_DOWNTIME === '1' || process.env.KORTIX_ALLOW_DOWNTIME === 'true';
   const request: DeployRequest = {
     ...(requestedRelease ? { requestedRelease } : {}),
     ...(rollbackTo ? { rollbackTo } : {}),
+    ...(allowDowntime ? { allowDowntime: true } : {}),
   };
 
   const workDir = process.env.KORTIX_UPDATER_WORK_DIR ?? `/tmp/kortix-enterprise-updater/${instance}`;

--- a/docs/runbooks/enterprise-vpc-deployment.md
+++ b/docs/runbooks/enterprise-vpc-deployment.md
@@ -79,7 +79,7 @@ LATENT in v1. `TODO(bedrock-sigv4)` in
 `packages/llm-gateway/src/transports/bedrock/request.ts`: adding a SigV4 signing
 path (sign with the instance-role credentials instead of a Bearer header) would let
 the appliance drop the bearer key entirely and rely on IAM alone — no shared
-secret, no rotation. Until then the bearer key is required for the `aws-vpc` target.
+secret, no rotation. Until then the bearer key is required for the `aws-ec2` target.
 
 ## AWS bootstrap order
 
@@ -110,7 +110,7 @@ CIDR `10.60.0.0/16`.
 
 ```bash
 kortix self-host init \
-  --target aws-vpc --instance vpc-demo \
+  --target aws-ec2 --instance vpc-demo \
   --aws-profile default --region us-west-2 --vpc-cidr 10.60.0.0/16 \
   --api-domain api.vpc-demo.kortix.com --frontend-domain vpc-demo.kortix.com \
   --route53-zone-id "$CUSTOMER_PUBLIC_ZONE_ID" \
@@ -171,6 +171,30 @@ The watchdog timer curls the local health endpoints and restarts `kortix-app`
 after 3 consecutive failures (10-minute cooldown), and NEVER acts mid-deploy (it
 takes the same `flock` the updater holds). The prune timer reclaims dangling
 images/build cache weekly under the same lock.
+
+## Zero-downtime guarantee and the backward-compatible contract
+
+The start-first roll (step 7) briefly runs the OLD app containers against the NEW
+schema while the new containers come up healthy. That is safe ONLY when every
+migration in the release is backward-compatible — each release manifest carries a
+per-migration `backward_compatible` boolean in its compatibility contract. Before
+migrating an UPDATE (not a first install), the updater inspects those flags:
+
+- **All backward-compatible** → the normal zero-downtime start-first roll.
+- **Any NOT backward-compatible** → the release cannot be applied with zero
+  downtime. The updater REFUSES it unless the operator opts in with
+  `--allow-downtime` (CLI) / `KORTIX_ALLOW_DOWNTIME=1` (deployer env). Without the
+  opt-in the deploy aborts BEFORE pulling images or migrating — nothing is touched.
+  With it, the updater performs a brief, honest downtime window: drain the app tier
+  (stop `api`/`gateway`/`frontend`; Supabase and Caddy stay up), migrate, then start
+  the new containers.
+
+A first install is always fine (no old containers). Run a non-backward-compatible
+release only during a scheduled maintenance window:
+
+```bash
+kortix self-host update --instance vpc-demo --release 0.9.90-e1 --allow-downtime --yes
+```
 
 ## VPS bootstrap (appliance minus Terraform — one self-host system)
 


### PR DESCRIPTION
Follow-up polish on the appliance (per Marko):

**1. Rename `--target aws-vpc` → `aws-ec2`** (it's a single EC2, not a VPC concept). Backward-compatible: existing on-disk `aws-vpc` instance configs still load (normalized to `aws-ec2`).

**2. Two-target UX** — `self-host --help`/`init` present a clear choice: **this machine** (`docker`, runs locally, just works) vs **AWS EC2** (`aws-ec2`, remote appliance), with a pointer to `docs/runbooks/enterprise-vpc-deployment.md` instead of a heavy wizard. Auth is `--aws-profile` (flag > AWS_PROFILE env > default).

**3. Migration-safety gate (zero-downtime guarantee)** — before an update, if any migration is `backward_compatible: false` and no opt-in is set, the deploy **aborts untouched** (`release X contains a non-backward-compatible migration; re-run with --allow-downtime during a maintenance window`). All-backward-compatible → the normal zero-downtime start-first roll. `--allow-downtime`/`KORTIX_ALLOW_DOWNTIME` threads through to a brief honest-downtime drain path. Enforces 'no downtime ever' as a system guarantee, not a hope.

97 tests green (cli 45, updater 42, release 15); tsc clean.