### PR TITLE
chore(enterprise): 0.9.108-e14 contract

### DIFF
--- a/infra/enterprise-releases/0.9.108-e14.json
+++ b/infra/enterprise-releases/0.9.108-e14.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": ["0.9.108-e13"],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
Compatibility contract for e14 — the first appliance revision carrying the 8 live-deploy fixes from #4701 (null-passthrough, CloudTrail ordering, updater re-exec, ECR JSON quoting, public-image pull, cosign install, Caddy ACME email default, Kong-origin env). rollback_from: [0.9.108-e13].