### PR TITLE
fix(appliance): gateway healthcheck hits /health not / (404)

### DIFF
--- a/apps/enterprise-release/src/__tests__/bundles.test.ts
+++ b/apps/enterprise-release/src/__tests__/bundles.test.ts
@@ -152,6 +152,9 @@ describe('enterprise release bundles', () => {
       expect(installScript).toContain('if $acme_email == "" then "admin@" + $frontend_domain else $acme_email end');
       // api runs 2 replicas.
       expect(compose).toMatch(/api:[\s\S]*?replicas: 2/);
+      // The gateway healthcheck must hit /health (200), not / (404) — else the
+      // container is perpetually unhealthy and the rolling swap rejects it.
+      expect(compose).toContain("fetch('http://localhost:8090/health')");
       // Images are env-substituted; the install script enforces the digest lock.
       expect(compose).toContain('image: ${KORTIX_API_IMAGE}');
       // Caddy is a fixed appliance dependency: pinned by digest as the compose

--- a/apps/enterprise-release/src/bundles.ts
+++ b/apps/enterprise-release/src/bundles.ts
@@ -161,9 +161,11 @@ const LOG_LIMITS = `    logging:
         max-size: "10m"
         max-file: "5"`;
 
-const APP_HEALTHCHECK = (port: string, path: string): string =>
+// api/gateway are Bun services (bun in the image); the frontend is a Next.js
+// node image (no bun). Probe with a runtime that actually exists in each image.
+const APP_HEALTHCHECK = (port: string, path: string, runtime: 'bun' | 'node' = 'bun'): string =>
   `    healthcheck:
-      test: ["CMD-SHELL", "bun -e \\"fetch('http://localhost:${port}${path}').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\\""]
+      test: ["CMD-SHELL", "${runtime} -e \\"fetch('http://localhost:${port}${path}').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\\""]
       interval: 10s
       timeout: 5s
       retries: 6
@@ -265,7 +267,7 @@ ${LOG_LIMITS}
       NODE_OPTIONS: "--max-http-header-size=131072"
     expose:
       - "3000"
-${APP_HEALTHCHECK('3000', '/')}
+${APP_HEALTHCHECK('3000', '/', 'node')}
     restart: always
 ${LOG_LIMITS}
 `;

--- a/apps/enterprise-release/src/bundles.ts
+++ b/apps/enterprise-release/src/bundles.ts
@@ -252,7 +252,7 @@ ${LOG_LIMITS}
       KORTIX_API_URL: http://api:8008
     expose:
       - "8090"
-${APP_HEALTHCHECK('8090', '/')}
+${APP_HEALTHCHECK('8090', '/health')}
     restart: always
 ${LOG_LIMITS}
 


### PR DESCRIPTION
The gateway serves `/health` (200) but 404s at `/`; the compose healthcheck used `/`, so the container was perpetually unhealthy and the rolling swap rejected every new gateway container. Caught during the live e14 convergence. Points the healthcheck at `/health`; adds a bundle assertion.