### PR TITLE
Fix CLI install guidance

### DIFF
--- a/apps/web/src/app/(public)/(marketing)/developers/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/developers/page.tsx
@@ -10,6 +10,7 @@ import KortixGrid from '@/components/ui/marketing/gridder';
 import { KortixLetterField } from '@/components/ui/marketing/kortix-letter-field';
 import { Icon } from '@/features/icon/icon';
 import { useCopy } from '@/hooks/use-copy';
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
 import { cn } from '@/lib/utils';
 import {
   ArrowRight,
@@ -28,13 +29,12 @@ import {
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { AiOutlineCheck } from 'react-icons/ai';
 import { HiArrowRight } from 'react-icons/hi';
 
 const GITHUB_URL = 'https://github.com/kortix-ai/suna';
 const DOCS_URL = '/docs';
-const DEFAULT_INSTALL_HOST = 'kortix.com';
 const fav = (d: string) => `https://www.google.com/s2/favicons?domain=${d}&sz=128`;
 
 const C = {
@@ -290,8 +290,6 @@ function Step({
   flip?: boolean;
 }) {
   const { copied, copy } = useCopy();
-  const [installHost, setInstallHost] = useState(DEFAULT_INSTALL_HOST);
-  const installCmd = `curl -fsSL https://${installHost}/install | bash`;
 
   const badgeClass =
     'border-border bg-card text-foreground flex size-9 shrink-0 items-center justify-center rounded border font-mono text-sm font-medium ';
@@ -315,9 +313,15 @@ function Step({
             <div className="bg-card mt-5 flex items-center justify-between gap-4 rounded-sm border p-3 px-5">
               <div className="flex gap-3">
                 <span className="text-foreground font-mono text-sm">$ </span>
-                <span className="text-foreground font-mono text-sm select-all">{installCmd}</span>
+                <span className="text-foreground font-mono text-sm select-all">
+                  {KORTIX_CLI_INSTALL_COMMAND}
+                </span>
               </div>
-              <Button size="icon-sm" variant="ghost" onClick={() => copy(installCmd)}>
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                onClick={() => copy(KORTIX_CLI_INSTALL_COMMAND)}
+              >
                 {copied ? <Check className="text-primary size-4" /> : <Copy className="size-4" />}
               </Button>
             </div>
@@ -541,18 +545,11 @@ function HeroWorkspace() {
 export default function DevelopersPage() {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const { copied, copy } = useCopy();
-  const [installHost, setInstallHost] = useState(DEFAULT_INSTALL_HOST);
   const tHardcodedUi = useTranslations('hardcodedUi');
   const tHome = useCallback(
     (key: string) => tHardcodedUi.raw(`appHomePage.${key}`),
     [tHardcodedUi],
   );
-
-  const installCmd = `curl -fsSL https://${installHost}/install | bash`;
-
-  useEffect(() => {
-    setInstallHost(window.location.host);
-  }, []);
 
   return (
     <div className="bg-background relative w-full">
@@ -585,9 +582,15 @@ export default function DevelopersPage() {
               <div className="bg-card flex items-center gap-4 rounded-sm border p-3 px-5">
                 <div className="flex gap-3">
                   <span className="text-foreground font-mono text-sm">$ </span>
-                  <span className="text-foreground font-mono text-sm select-all">{installCmd}</span>
+                  <span className="text-foreground font-mono text-sm select-all">
+                    {KORTIX_CLI_INSTALL_COMMAND}
+                  </span>
                 </div>
-                <Button size="icon-sm" variant="ghost" onClick={() => copy(installCmd)}>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  onClick={() => copy(KORTIX_CLI_INSTALL_COMMAND)}
+                >
                   {copied ? <Check className="text-primary size-4" /> : <Copy className="size-4" />}
                 </Button>
               </div>

--- a/apps/web/src/app/(public)/(marketing)/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/marketing/button';
 import KortixGrid from '@/components/ui/marketing/gridder';
 import { Separator } from '@/components/ui/separator';
 import { useRequestDemo } from '@/features/contact/request-demo-provider';
+import { CliInstallSection } from '@/features/marketing/cli-install-section';
 import {
   CompanyAsCodeSection,
   HowItRunsSection,
@@ -61,27 +62,32 @@ export default function Home() {
 
         <SectionDivider />
 
-        {/* 4. A workforce, one shared main */}
+        {/* 4. CLI install — a terminal-native way to get started */}
+        <CliInstallSection />
+
+        <SectionDivider />
+
+        {/* 5. A workforce, one shared main */}
         <HowItRunsSection />
 
         <SectionDivider />
 
-        {/* 5. The 1% vs the 99% — shared with everyone */}
+        {/* 6. The 1% vs the 99% — shared with everyone */}
         <ProblemSection />
 
         <SectionDivider />
 
-        {/* 6. Open & yours */}
+        {/* 7. Open & yours */}
         <WhyKortix />
 
         <SectionDivider />
 
-        {/* 7. Enterprise & security */}
+        {/* 8. Enterprise & security */}
         <Security />
 
         <SectionDivider />
 
-        {/* 8. CTA — run your whole company from one repo you own */}
+        {/* 9. CTA — run your whole company from one repo you own */}
         <section id="cta" className="relative mx-auto max-w-6xl px-6 py-16 sm:py-24 lg:px-0">
           <Reveal>
             <div className="border-border bg-card relative overflow-hidden rounded-sm border text-center">
@@ -108,7 +114,12 @@ export default function Home() {
                       {tHome('line337JsxTextGetStarted')}
                       <HiArrowRight className="size-4" />
                     </Button>
-                    <Button size="lg" className="w-full" variant="accent" onClick={() => openDemo()}>
+                    <Button
+                      size="lg"
+                      className="w-full"
+                      variant="accent"
+                      onClick={() => openDemo()}
+                    >
                       {tHome('line338JsxTextTalkToSales')}
                     </Button>
                   </div>

--- a/apps/web/src/app/presentation/slides-platform.tsx
+++ b/apps/web/src/app/presentation/slides-platform.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/marketing/button';
 import KortixGrid from '@/components/ui/marketing/gridder';
 import { KortixLetterField } from '@/components/ui/marketing/kortix-letter-field';
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
 import { cn } from '@/lib/utils';
 import {
   ArrowRight,
@@ -96,15 +97,12 @@ function LetterBg({ seed = 3382 }: { seed?: number }) {
 
 /** Copy-style hero install chip (static). */
 function InstallChip() {
-  const tI18nHardcoded = useTranslations('hardcodedUi');
   return (
     <div className="bg-card flex w-full max-w-xl min-w-0 items-center gap-4 rounded-sm border p-3 px-5">
       <div className="flex min-w-0 flex-1 gap-3 overflow-hidden">
         <span className="text-foreground shrink-0 font-mono text-sm">$ </span>
         <span className="text-foreground min-w-0 truncate font-mono text-sm">
-          {tI18nHardcoded.raw(
-            'autoAppPresentationSlidesPlatformJsxTextCurlFsSLHttpsKortix8ac787c7',
-          )}
+          {KORTIX_CLI_INSTALL_COMMAND}
         </span>
       </div>
       <Copy className="text-muted-foreground size-4 shrink-0" />

--- a/apps/web/src/components/home/cli-demo.tsx
+++ b/apps/web/src/components/home/cli-demo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCopy } from '@/hooks/use-copy';
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
 import { cn } from '@/lib/utils';
 import { Check, Copy } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -255,7 +256,6 @@ const PALETTE: { cmd: string; desc: string }[] = [
   { cmd: 'kortix cr open', desc: 'open a change request' },
 ];
 
-const DEFAULT_INSTALL_HOST = 'kortix.com';
 const INSTALL_CTA_MESSAGE =
   'Install the CLI to start an agent from your terminal, give it the right tools, and review every change before you merge.';
 
@@ -363,7 +363,6 @@ export function CliDemo() {
   const [scrollback, setScrollback] = useState<Block[]>([]);
   const [typed, setTyped] = useState('');
   const [isNote, setIsNote] = useState(false);
-  const [installHost, setInstallHost] = useState(DEFAULT_INSTALL_HOST);
 
   const [draft, setDraft] = useState('');
   const [focused, setFocused] = useState(false);
@@ -380,7 +379,7 @@ export function CliDemo() {
   const paletteItems = paletteOpen
     ? PALETTE.filter((p) => p.cmd.toLowerCase().includes(draft.slice(1).trim().toLowerCase()))
     : [];
-  const installCmd = `curl -fsSL https://${installHost}/install | bash`;
+  const installCmd = KORTIX_CLI_INSTALL_COMMAND;
 
   useEffect(() => {
     const el = rootRef.current;
@@ -398,10 +397,6 @@ export function CliDemo() {
     const h = () => setReduced(m.matches);
     m.addEventListener('change', h);
     return () => m.removeEventListener('change', h);
-  }, []);
-
-  useEffect(() => {
-    setInstallHost(window.location.host);
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/components/home/navbar.tsx
+++ b/apps/web/src/components/home/navbar.tsx
@@ -409,18 +409,25 @@ export function Navbar({ isAbsolute = false }: NavbarProps) {
                   {filteredNavLinks.map((item) => {
                     const handleDrawerNavClick =
                       (href: string) => (e: MouseEvent<HTMLAnchorElement>) => {
-                        if (!href.startsWith('#')) {
+                        const anchor = href.startsWith('#')
+                          ? href.slice(1)
+                          : href.startsWith('/#')
+                            ? href.slice(2)
+                            : null;
+
+                        if (!anchor) {
                           setIsDrawerOpen(false);
                           return;
                         }
                         e.preventDefault();
                         if (pathname !== '/') {
-                          router.push(`/${href}`);
+                          router.push(`/#${anchor}`);
                           setIsDrawerOpen(false);
                           return;
                         }
-                        const element = document.getElementById(href.substring(1));
+                        const element = document.getElementById(anchor);
                         element?.scrollIntoView({ behavior: 'smooth' });
+                        window.history.replaceState(null, '', `/#${anchor}`);
                         setIsDrawerOpen(false);
                       };
 

--- a/apps/web/src/features/layout/download-apps-modal.tsx
+++ b/apps/web/src/features/layout/download-apps-modal.tsx
@@ -15,11 +15,10 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { errorToast } from '@/components/ui/toast';
 import { desktopDownloadUrl, startDownload } from '@/lib/desktop';
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
 import { cn } from '@/lib/utils';
 import { Check, Copy, Monitor, Smartphone, Terminal } from 'lucide-react';
 import { useEffect, useState } from 'react';
-
-const CLI_INSTALL_CMD = 'curl -fsSL https://kortix.com/install | bash';
 
 type PlatformId = 'macos' | 'windows' | 'linux';
 
@@ -140,8 +139,7 @@ function TerminalMockup() {
       </div>
       <div className="space-y-1 p-3 font-mono text-[9px] leading-relaxed text-zinc-300">
         <div>
-          <span className="text-emerald-400">$</span>{' '}
-          {tI18nHardcoded.raw('autoFeaturesLayoutDownloadAppsModalJsxTextCurlFsSLKortix0e6a96da')}
+          <span className="text-emerald-400">$</span> {KORTIX_CLI_INSTALL_COMMAND}
         </div>
         <div className="text-zinc-500">
           {tI18nHardcoded.raw('autoFeaturesLayoutDownloadAppsModalJsxTextInstalledKortix44ca8439')}
@@ -230,7 +228,7 @@ export function DownloadAppsModal({
 
   const copyCli = async () => {
     try {
-      await navigator.clipboard.writeText(CLI_INSTALL_CMD);
+      await navigator.clipboard.writeText(KORTIX_CLI_INSTALL_COMMAND);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
@@ -326,7 +324,7 @@ export function DownloadAppsModal({
                       'autoFeaturesLayoutDownloadAppsModalJsxAttrTitleClickTob497d6e9',
                     )}
                   >
-                    <span className="truncate">{CLI_INSTALL_CMD}</span>
+                    <span className="truncate">{KORTIX_CLI_INSTALL_COMMAND}</span>
                     {copied ? (
                       <Check className="size-3.5 shrink-0 text-emerald-500" />
                     ) : (

--- a/apps/web/src/features/marketing/cli-install-section.tsx
+++ b/apps/web/src/features/marketing/cli-install-section.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { Reveal } from '@/components/home/reveal';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/marketing/button';
+import { useAuth } from '@/features/providers/auth-provider';
+import { trackCtaSignup } from '@/lib/analytics/gtm';
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
+import { cn } from '@/lib/utils';
+import { ArrowUpRight, Check, Copy, Terminal } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { HiArrowRight } from 'react-icons/hi2';
+
+const terminalLines = [
+  { id: 'install', type: 'command', text: KORTIX_CLI_INSTALL_COMMAND },
+  { id: 'install-done', type: 'muted', text: '✓ Installed the Kortix CLI' },
+  { id: 'space-project', type: 'space', text: '' },
+  { id: 'init', type: 'command', text: 'kortix init acme-ops' },
+  { id: 'init-done', type: 'muted', text: '✓ Created kortix.yaml and .kortix/' },
+  { id: 'space-attach', type: 'space', text: '' },
+  { id: 'attach', type: 'command', text: 'kortix sessions connect <session-id>' },
+  { id: 'attach-done', type: 'muted', text: '✓ Local proxy ready · opencode attach connected' },
+] as const;
+
+export function CliInstallSection() {
+  const { user } = useAuth();
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleLaunch = useCallback(() => {
+    trackCtaSignup();
+    window.location.href = user ? '/projects' : '/auth';
+  }, [user]);
+
+  const copyInstallCommand = useCallback(() => {
+    void navigator.clipboard.writeText(KORTIX_CLI_INSTALL_COMMAND);
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 1500);
+  }, []);
+
+  useEffect(() => () => void (timer.current && clearTimeout(timer.current)), []);
+
+  return (
+    <section id="cli" className="mx-auto max-w-6xl scroll-mt-24 px-6 py-16 sm:py-24 lg:px-0">
+      <Reveal>
+        <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-stretch">
+          <div className="flex flex-col items-start justify-center space-y-5">
+            <Badge variant="kortix" className="rounded">
+              CLI
+            </Badge>
+            <div className="max-w-xl space-y-4">
+              <h2 className="text-foreground text-3xl font-medium tracking-tight text-balance sm:text-4xl">
+                Install Kortix from your terminal.
+              </h2>
+              <p className="text-muted-foreground text-base leading-relaxed text-pretty">
+                One curl installs the CLI. From there you can create a project, launch sessions, and
+                attach your local OpenCode TUI to any Kortix sandbox.
+              </p>
+            </div>
+
+            <div className="flex w-full max-w-xl flex-col gap-3 sm:flex-row">
+              <Button size="lg" onClick={handleLaunch} className="sm:w-fit">
+                Get started
+                <HiArrowRight className="size-4" />
+              </Button>
+              <Button size="lg" variant="outline" asChild className="sm:w-fit">
+                <Link href="/developers">
+                  See CLI workflow
+                  <ArrowUpRight className="size-4" />
+                </Link>
+              </Button>
+            </div>
+          </div>
+
+          <div className="border-border bg-card overflow-hidden rounded-sm border">
+            <div className="border-border flex items-center justify-between gap-3 border-b px-4 py-3">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <span className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-sm">
+                  <Terminal className="text-muted-foreground size-4" />
+                </span>
+                <div className="min-w-0">
+                  <p className="text-foreground text-sm font-medium">Install the CLI</p>
+                  <p className="text-muted-foreground text-xs">Copy, paste, and start locally.</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={copyInstallCommand}
+                className="border-border text-muted-foreground hover:text-foreground hover:bg-foreground/[0.04] inline-flex h-9 shrink-0 items-center gap-1.5 rounded-sm border px-3 text-xs font-medium transition-[background-color,color,transform] active:scale-[0.96]"
+                aria-label={copied ? 'Copied install command' : 'Copy install command'}
+              >
+                {copied ? (
+                  <Check className="text-kortix-green size-3.5" />
+                ) : (
+                  <Copy className="size-3.5" />
+                )}
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+
+            <div className="bg-background p-4 font-mono text-xs leading-relaxed sm:p-6 sm:text-sm">
+              {terminalLines.map((line) => {
+                if (line.type === 'space') return <div key={line.id} className="h-4" />;
+
+                return (
+                  <div
+                    key={line.id}
+                    className={cn(
+                      'whitespace-pre-wrap break-all',
+                      line.type === 'muted' ? 'text-muted-foreground/70' : 'text-foreground/90',
+                    )}
+                  >
+                    {line.type === 'command' ? (
+                      <>
+                        <span className="text-kortix-green">$</span> {line.text}
+                      </>
+                    ) : (
+                      line.text
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </Reveal>
+    </section>
+  );
+}

--- a/apps/web/src/features/marketing/hero-surfaces.tsx
+++ b/apps/web/src/features/marketing/hero-surfaces.tsx
@@ -4,11 +4,12 @@ import { InteractiveDemoSection } from '@/components/home/interactive-demo-secti
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { Badge } from '@/components/ui/badge';
 import { Icon } from '@/features/icon/icon';
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
 import { cn } from '@/lib/utils';
 import { ArrowUpRight, Code2, Monitor, Smartphone, Terminal } from 'lucide-react';
 import Link from 'next/link';
 import type { ComponentType, ReactNode } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type SurfaceId = 'web' | 'slack' | 'teams' | 'mobile' | 'cli' | 'sdk';
 
@@ -30,8 +31,8 @@ const SURFACES: Surface[] = [
 /* ── shared bits ─────────────────────────────────────────────────────────── */
 
 function MonoLine({ line }: { line: string }) {
-  const slash = line.indexOf('//');
-  const hash = line.indexOf('#');
+  const slash = line.search(/\s\/\//);
+  const hash = line.search(/\s#/);
   const idxs = [slash, hash].filter((i) => i >= 0);
   const ci = idxs.length ? Math.min(...idxs) : -1;
   if (ci >= 0) {
@@ -191,10 +192,13 @@ function MobileSurface() {
 }
 
 const CLI_LINES = [
+  `$ ${KORTIX_CLI_INSTALL_COMMAND}`,
+  '✓ Kortix CLI installed  # one-time setup',
+  '',
   '$ kortix init acme-ops',
   '✓ Initialized Kortix project "acme-ops"  # everything is files',
   '',
-  '$ kortix run "draft the renewal for Acme"',
+  '$ kortix sessions new --prompt "draft the renewal for Acme"',
   '✓ session/renewal-acme · sandbox booted   # isolated branch',
   '→ change request opened: sales/renewals/acme.md',
   '',
@@ -231,7 +235,18 @@ function SurfacePanel({ surface }: { surface: SurfaceId }) {
     case 'mobile':
       return <MobileSurface />;
     case 'cli':
-      return <CodeWindow title="kortix — terminal" lines={CLI_LINES} />;
+      return (
+        <div className="relative h-full">
+          <CodeWindow title="kortix — terminal" lines={CLI_LINES} />
+          <Link
+            href="/#cli"
+            className="border-border bg-card/90 text-foreground hover:bg-foreground/[0.04] absolute right-4 bottom-4 inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium shadow-sm backdrop-blur transition-colors duration-fast"
+          >
+            Get started with the CLI
+            <ArrowUpRight className="size-3.5" />
+          </Link>
+        </div>
+      );
     case 'sdk':
       return (
         <div className="relative h-full">
@@ -250,6 +265,19 @@ function SurfacePanel({ surface }: { surface: SurfaceId }) {
 
 export function HeroSurfaces() {
   const [active, setActive] = useState<SurfaceId>('web');
+
+  useEffect(() => {
+    const syncSurfaceFromHash = () => {
+      const hash = window.location.hash.replace('#', '');
+      if (SURFACES.some((surface) => surface.id === hash)) {
+        setActive(hash as SurfaceId);
+      }
+    };
+
+    syncSurfaceFromHash();
+    window.addEventListener('hashchange', syncSurfaceFromHash);
+    return () => window.removeEventListener('hashchange', syncSurfaceFromHash);
+  }, []);
 
   return (
     <div className="w-full">

--- a/apps/web/src/features/marketing/usp/for-developers-panel.tsx
+++ b/apps/web/src/features/marketing/usp/for-developers-panel.tsx
@@ -2,11 +2,12 @@
 
 import { Button } from '@/components/ui/marketing/button';
 import { useCopy } from '@/hooks/use-copy';
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
 import { cn } from '@/lib/utils';
 import { Check, Copy, GitBranch } from 'lucide-react';
 import { AnimatePresence, motion, useInView } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
-import { FOR_DEVELOPERS, type AuthorType, type Commit } from './section3-content';
+import { type AuthorType, type Commit, FOR_DEVELOPERS } from './section3-content';
 
 const { commits } = FOR_DEVELOPERS;
 
@@ -147,26 +148,17 @@ function CommitRow({ commit, fresh = false }: { commit: Commit; fresh?: boolean 
   );
 }
 
-const DEFAULT_INSTALL_HOST = 'kortix.com';
-
 function CloneBox() {
   const { copied, copy } = useCopy();
-  const [installHost, setInstallHost] = useState(DEFAULT_INSTALL_HOST);
-
-  const installCmd = `curl -fsSL https://${installHost}/install | bash`;
-
-  useEffect(() => {
-    setInstallHost(window.location.host);
-  }, []);
 
   return (
     <div className="border-border bg-background flex h-10 items-center gap-2 rounded-md border px-3 pr-1">
       <div className="flex min-w-0 flex-1 gap-3 overflow-hidden">
         <span className="text-foreground min-w-0 truncate font-mono text-xs select-all">
-          {installCmd}
+          {KORTIX_CLI_INSTALL_COMMAND}
         </span>
       </div>
-      <Button size="icon-sm" variant="ghost" onClick={() => copy(installCmd)}>
+      <Button size="icon-sm" variant="ghost" onClick={() => copy(KORTIX_CLI_INSTALL_COMMAND)}>
         {copied ? (
           <Check className="text-kortix-green size-4" />
         ) : (

--- a/apps/web/src/features/session/session-terminal-connect-bar.tsx
+++ b/apps/web/src/features/session/session-terminal-connect-bar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { KORTIX_CLI_INSTALL_COMMAND } from '@/lib/kortix-cli';
 import { cn } from '@/lib/utils';
 import { Check, ChevronRight, Copy, Laptop } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -18,7 +19,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 export function SessionTerminalConnectBar({ projectSessionId }: { projectSessionId: string }) {
   const [expanded, setExpanded] = useState(false);
   const connectCmd = `kortix sessions connect ${projectSessionId}`;
-  const installCmd = 'npm i -g @kortix/cli';
+  const installCmd = KORTIX_CLI_INSTALL_COMMAND;
 
   return (
     <div className="shrink-0 border-b border-white/10 bg-[#15151d] text-[13px]">
@@ -32,10 +33,7 @@ export function SessionTerminalConnectBar({ projectSessionId }: { projectSession
         <span className="shrink-0 font-medium">Connect from your machine</span>
         <span className="min-w-0 flex-1 truncate font-mono text-white/35">{connectCmd}</span>
         <ChevronRight
-          className={cn(
-            'h-3.5 w-3.5 shrink-0 transition-transform',
-            expanded && 'rotate-90',
-          )}
+          className={cn('h-3.5 w-3.5 shrink-0 transition-transform', expanded && 'rotate-90')}
         />
       </button>
 

--- a/apps/web/src/lib/kortix-cli.ts
+++ b/apps/web/src/lib/kortix-cli.ts
@@ -1,0 +1,1 @@
+export const KORTIX_CLI_INSTALL_COMMAND = 'curl -fsSL https://kortix.com/install | bash';

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -4,7 +4,8 @@ export type NavSubLink = {
 };
 
 export type NavLink =
-  { id: number; name: string; href: string } | { id: number; name: string; href: NavSubLink[] };
+  | { id: number; name: string; href: string }
+  | { id: number; name: string; href: NavSubLink[] };
 
 import { CANONICAL_ORIGIN } from '@/lib/site-metadata';
 
@@ -16,6 +17,7 @@ export const siteConfig = {
       { id: 2, name: 'Enterprise', href: '/enterprise' },
       { id: 3, name: 'Use Cases', href: '/use-cases' },
       { id: 4, name: 'Pricing', href: '/pricing' },
+      { id: 5, name: 'CLI', href: '/#cli' },
       { id: 6, name: 'Docs', href: '/docs' },
     ] as NavLink[],
   },


### PR DESCRIPTION
## Demo
Preview pending — the `preview` label will spin up the full PR environment. Local browser verification already passed on `http://localhost:3000/#cli`: the homepage opens the CLI tab from the hash, shows `curl -fsSL https://kortix.com/install | bash`, and no longer shows the invalid `kortix run` example.

## Why
The session terminal panel still told users to install the CLI with `npm i -g @kortix/cli`, while the canonical installer is `curl -fsSL https://kortix.com/install | bash`. The homepage also had a CLI tab but no clear CLI install/get-started path.

## What changed
- Centralized the public CLI install command in `KORTIX_CLI_INSTALL_COMMAND`.
- Replaced session attach, developer page, download modal, presentation, and CLI demo install copy with the canonical curl installer.
- Added a homepage `/#cli` section with a copyable install command and Get started / CLI workflow CTAs.
- Added a visible navbar CLI link and made `/ #cli` hash navigation select the hero CLI tab.
- Replaced the invalid homepage `kortix run` example with `kortix sessions new --prompt ...`.

## Verification
- `pnpm exec biome check --formatter-enabled=true --organize-imports-enabled=true --linter-enabled=false <changed files>`
- `pnpm --filter ./apps/web exec tsc --noEmit --pretty false`
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter ./apps/web build` (passes; existing warnings only)
- Browser QA with `agent-browser` on `http://localhost:3000/?refresh=1#cli`: verified CLI tab selected, curl installer visible, `kortix sessions new --prompt` visible, and `kortix run` absent.

## Risk / rollback
Low-risk marketing/session copy change. Roll back this commit to restore the previous homepage structure and copy.
