### PR TITLE
chore(enterprise): 0.9.108-e15 contract

### DIFF
--- a/infra/enterprise-releases/0.9.108-e15.json
+++ b/infra/enterprise-releases/0.9.108-e15.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "kubernetes_minor": ["1.32"],
+  "rollback_from": ["0.9.108-e14"],
+  "migrations": [
+    {
+      "id": "baseline",
+      "sha256": "cb19e630c106a6af6a62c5a32b443c2a65ce2ad9c13f1a4cfe368d05f445d133",
+      "reversible": false,
+      "backward_compatible": false
+    }
+  ]
+}


### PR DESCRIPTION
e15 carries the healthcheck fixes from #4706 (gateway /health, frontend node probe). rollback_from: [0.9.108-e14].