### PR TITLE
fix(api): filter bare Bun fetch TimeoutError from Sentry (BS c672fb5e)

### DIFF
--- a/apps/api/src/__tests__/unit-sentry-noise-filter.test.ts
+++ b/apps/api/src/__tests__/unit-sentry-noise-filter.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for the Sentry noise filter (ignoreErrors).
+ *
+ * Better Stack pattern c672fb5e8c4f366e2aecab35a4abf23c8bb3fa26f0eb1d8cafddf3cd3ca26e55
+ * — an UNHANDLED `TimeoutError: The operation timed out.` from prod
+ * (Kortix API, application_id 2346961), 3 occurrences, 0 users, last seen
+ * 2026-07-14 19:34:39 UTC, first seen 2026-06-10. The raw Sentry event carried:
+ *
+ *   - mechanism: auto.node.onunhandledrejection (handled: false)
+ *   - type: TimeoutError, value: "The operation timed out."
+ *   - call_site_function / call_site_file: null  (NO JS stack)
+ *   - runtime: bun 1.2.23, environment: prod
+ *   - url: http://new-api.kortix.com/v1/router/tavily/search
+ *
+ * Root cause: the /v1/router/tavily/* catch-all billed-upstream proxy returns
+ * `new Response(upstream.body, …)` to the client (handlers.ts). When the Tavily
+ * upstream stalls mid-response-body, Bun's internal fetch body pump throws a
+ * native `TimeoutError` "The operation timed out." with no JS stack. Because the
+ * response was already handed to the client, that rejection fires OUTSIDE the
+ * request handler's try/catch and Hono's onError, so it surfaces via
+ * process.on('unhandledRejection') → captureException → Sentry → Better Stack.
+ *
+ * It cannot be caught/converted at the JS layer, and the proxy path is
+ * request-deadline-exempt (middleware/request-deadline.ts EXEMPT_PREFIXES
+ * includes '/v1/router'), so the correct, codebase-consistent fix is to drop
+ * this transient upstream/network class in the Sentry ignoreErrors filter — the
+ * same pattern sentry.ts already uses for sibling classes (ETIMEDOUT,
+ * AbortError, "The operation was aborted", socket-close). This test pins that
+ * coverage so a future refactor can't silently re-enable the paging.
+ */
+import { describe, test, expect } from 'bun:test';
+import { SENTRY_IGNORE_ERRORS, isSentryIgnoredError } from '../lib/sentry';
+
+describe('Sentry ignoreErrors noise filter (BS c672fb5e)', () => {
+  test('the bare Bun fetch TimeoutError from the Tavily proxy is filtered', () => {
+    // Exact type + value from the prod Sentry event (no stack, no call site).
+    expect(isSentryIgnoredError('TimeoutError', 'The operation timed out.')).toBe(true);
+    // Also covered when only the message is present (how captureException sees
+    // a string-coerced reason, or an Error whose .name was stripped).
+    expect(isSentryIgnoredError(undefined, 'The operation timed out.')).toBe(true);
+  });
+
+  test('the timeout pattern is registered in SENTRY_IGNORE_ERRORS', () => {
+    expect(SENTRY_IGNORE_ERRORS).toContain('The operation timed out.');
+  });
+
+  test('sibling transient timeout/abort classes remain filtered (no regression)', () => {
+    expect(isSentryIgnoredError('Error', 'connect ECONNREFUSED 127.0.0.1:5432')).toBe(true);
+    expect(isSentryIgnoredError('Error', 'read ECONNRESET')).toBe(true);
+    expect(isSentryIgnoredError('Error', 'connect ETIMEDOUT 1.2.3.4:443')).toBe(true);
+    expect(isSentryIgnoredError('AbortError', 'The operation was aborted.')).toBe(true);
+    expect(
+      isSentryIgnoredError('Error', 'The socket connection was closed unexpectedly'),
+    ).toBe(true);
+    expect(isSentryIgnoredError('HTTPException', 'Unauthorized')).toBe(true);
+  });
+
+  test('a real, actionable error with a distinct message is NOT filtered', () => {
+    // Guards against an over-broad filter: a genuine code bug must still page.
+    expect(isSentryIgnoredError('TypeError', "Cannot read properties of undefined (reading 'x')"))
+      .toBe(false);
+    expect(isSentryIgnoredError('Error', 'relation "sessions" does not exist')).toBe(false);
+  });
+
+  test('empty type/message is not filtered (never swallow unknown errors)', () => {
+    expect(isSentryIgnoredError(undefined, undefined)).toBe(false);
+    expect(isSentryIgnoredError('', '')).toBe(false);
+  });
+});

--- a/apps/api/src/lib/sentry.ts
+++ b/apps/api/src/lib/sentry.ts
@@ -17,6 +17,59 @@ const SENTRY_DSN = process.env.BETTERSTACK_API_SENTRY_DSN;
 const ENV = process.env.INTERNAL_KORTIX_ENV || 'dev';
 const VERSION = process.env.SANDBOX_VERSION || 'dev';
 
+// ─── Noise filter (ignoreErrors) ────────────────────────────────────────────
+//
+// Patterns Sentry's InboundFilters silently drops (substring match against the
+// exception `type`, `value`/message, or event message). Every entry here is a
+// transient, non-actionable class — the codebase already handles the user-facing
+// consequence (clean 4xx/5xx, retry, refund) and these would otherwise just page
+// on upstream/network noise. Declared before Sentry.init() so it can be passed
+// to `ignoreErrors`; mirrored by isSentryIgnoredError() for unit tests.
+
+export const SENTRY_IGNORE_ERRORS = [
+  // Network/timeout errors from sandbox communication
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  // Bun fetch: upstream socket dropped mid-request/stream. Transient
+  // upstream/network noise — the git smart-HTTP proxy retries idempotent
+  // ref discovery and returns a clean 502 otherwise (see git-proxy/). Even
+  // when one escapes the streamed pack path it is not actionable, so drop
+  // it here instead of paging (Better Stack pattern df7a31d4…).
+  'The socket connection was closed unexpectedly',
+  // Client-side abort
+  'AbortError',
+  'The operation was aborted',
+  // Bun native fetch TimeoutError: thrown by Bun's internal fetch body pump
+  // when an upstream stalls mid-response (after headers are already streamed
+  // back to the client), e.g. a /v1/router/tavily/search proxy call to the
+  // Tavily API. Because the response has already been handed to the client,
+  // the rejection fires from Bun's stream pump OUTSIDE the request handler's
+  // try/catch and Hono's onError — it surfaces as an unhandled rejection
+  // (process.on('unhandledRejection')) with NO JS stack and type
+  // `TimeoutError`, so it is impossible to catch/convert at the JS layer.
+  // The client already sees a truncated/failed response and the proxy is
+  // request-deadline-exempt (/v1/router), so this is pure transient
+  // upstream/network noise — drop it instead of paging
+  // (Better Stack pattern c672fb5e…).
+  'The operation timed out.',
+  // Expected HTTP errors (auth failures, not found, etc.)
+  'HTTPException',
+] as const;
+
+/**
+ * Mirrors Sentry's InboundFilters substring semantics for the
+ * {@link SENTRY_IGNORE_ERRORS} list: returns true if any pattern is a substring
+ * of the error's `type` or `message`. Exported for unit tests so the noise
+ * filter's coverage of a given error class is asserted without booting Sentry.
+ */
+export function isSentryIgnoredError(type: string | undefined, message: string | undefined): boolean {
+  const hay = [type, message].filter((s): s is string => typeof s === 'string' && s.length > 0);
+  if (hay.length === 0) return false;
+  return SENTRY_IGNORE_ERRORS.some((pattern) => hay.some((s) => s.includes(pattern)));
+}
+
 // ─── Initialize ─────────────────────────────────────────────────────────────
 
 if (SENTRY_DSN) {
@@ -31,25 +84,9 @@ if (SENTRY_DSN) {
     // Don't send PII (emails, IPs, etc.) unless explicitly attached
     sendDefaultPii: false,
 
-    // Ignore known non-actionable errors
-    ignoreErrors: [
-      // Network/timeout errors from sandbox communication
-      'ECONNREFUSED',
-      'ECONNRESET',
-      'ETIMEDOUT',
-      'UND_ERR_CONNECT_TIMEOUT',
-      // Bun fetch: upstream socket dropped mid-request/stream. Transient
-      // upstream/network noise — the git smart-HTTP proxy retries idempotent
-      // ref discovery and returns a clean 502 otherwise (see git-proxy/). Even
-      // when one escapes the streamed pack path it is not actionable, so drop
-      // it here instead of paging (Better Stack pattern df7a31d4…).
-      'The socket connection was closed unexpectedly',
-      // Client-side abort
-      'AbortError',
-      'The operation was aborted',
-      // Expected HTTP errors (auth failures, not found, etc.)
-      'HTTPException',
-    ],
+    // Ignore known non-actionable errors. Exported as SENTRY_IGNORE_ERRORS
+    // (above) so the noise filter is unit-tested — see unit-sentry-noise-filter.
+    ignoreErrors: [...SENTRY_IGNORE_ERRORS],
 
     // Filter out high-volume, low-value transactions
     beforeSendTransaction(event) {


### PR DESCRIPTION
## BS c672fb5e — filter bare Bun fetch `TimeoutError` from Sentry (Kortix API prod)

**Better Stack error:** https://errors.betterstack.com/team/t502678/errors/c672fb5e8c4f366e2aecab35a4abf23c8bb3fa26f0eb1d8cafddf3cd3ca26e55?s=2346961
**Pattern:** `c672fb5e8c4f366e2aecab35a4abf23c8bb3fa26f0eb1d8cafddf3cd3ca26e55`
**Type:** `TimeoutError` · **Message:** `The operation timed out.` · **State:** Unhandled
**App:** Kortix API (prod), application_id `2346961`
**Occurrences:** 3 / 0 users · **First seen:** 2026-06-10 06:07:09 UTC · **Last seen:** 2026-07-14 19:34:39 UTC

### Evidence (Better Stack telemetry / ClickHouse `kortix_api_2_metrics` + raw S3 exceptions)

Metrics source for this pattern:
| type | message | call_site_function | call_site_file | count | users | last_seen | releases | environments | url |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| TimeoutError | The operation timed out. | *(null)* | *(null)* | 3 | 0 | 2026-07-14 19:34:30 | kortix-api@0.8.44, kortix-api@dev | prod | `http://new-api.kortix.com/v1/router/tavily/search` |

Raw exception payload (event `90da6e90…`, dt `2026-07-14 19:34:39.869`):
- `exception.values[0].type` = `TimeoutError`, `.value` = `The operation timed out.`
- `mechanism` = `auto.node.onunhandledrejection`, `handled: false`
- `summary.call_site_function` / `call_site_file` = **null** (no JS stack)
- `contexts.runtime` = `bun 1.2.23`; `environment` = `prod`; `cloud` = AWS ECS Fargate `eu-west-2`
- `extra.unhandledPromiseRejection` = `true`
- request `url` = `http://new-api.kortix.com/v1/router/tavily/search`

### Root cause

`/v1/router/tavily/*` is the catch-all billed-upstream proxy (`apps/api/src/router/routes/proxy/handlers.ts`). For the Tavily tool service (`isLlm=false`, only `POST /search` allowed, non-streaming JSON), `handleKortixProxy` does `await fetch(targetUrl, …)` and returns **`new Response(upstream.body, {…})`** to the client — i.e. it streams the upstream body straight through.

When the Tavily upstream stalls **mid-response-body** (after headers are already streamed back to the client), Bun's internal fetch body pump throws a **native `TimeoutError: "The operation timed out."` with no JS stack**. Because the `Response` has already been handed to the client, that rejection fires **OUTSIDE** the request handler's `try/catch` and Hono's `onError` — it surfaces via `process.on('unhandledRejection')` (`apps/api/src/index.ts:87`) → `captureException` → Sentry → Better Stack as the `c672fb5e` pattern. It is structurally **impossible to catch/convert at the JS layer** (the handler already returned), and the proxy path is **request-deadline-exempt** (`/v1/router` is in `EXEMPT_PREFIXES` in `middleware/request-deadline.ts`, intentionally — LLM chat completions stream there). The client already observes a truncated/failed response; nothing actionable remains.

This is the same family of transient upstream/network noise `apps/api/src/lib/sentry.ts` already filters via `ignoreErrors` (`ETIMEDOUT`, `AbortError`, `The operation was aborted`, `The socket connection was closed unexpectedly`, `HTTPException`) — the bare Bun fetch `TimeoutError` simply wasn't in the list.

### Fix

Extend the Sentry `ignoreErrors` noise filter with the bare Bun fetch timeout message `'The operation timed out.'` — specific to this native, stack-less class (a real code-level `TimeoutError` carries a different message/stack and is *not* suppressed). To make the filter unit-testable:
- extract the list to `export const SENTRY_IGNORE_ERRORS` (passed to `Sentry.init({ ignoreErrors: [...] })`),
- add `export function isSentryIgnoredError(type, message)` mirroring Sentry's InboundFilters substring semantics.

No behavior change to request handling, billing, or response shape — purely a telemetry/noise-filter fix. This matches the playbook for an expected timeout/abort class that can't be caught at the JS layer.

### Regression test

`apps/api/src/__tests__/unit-sentry-noise-filter.test.ts` pins:
- the bare prod `TimeoutError` / `The operation timed out.` is filtered (message-only and type+message),
- the pattern is registered in `SENTRY_IGNORE_ERRORS`,
- sibling transient classes (ECONNREFUSED, ECONNRESET, ETIMEDOUT, AbortError, socket-close, HTTPException) remain filtered,
- a genuine actionable error (`TypeError`, a real DB error) is **NOT** filtered,
- empty type/message is never swallowed.

```
bun test src/__tests__/unit-sentry-noise-filter.test.ts
 5 pass, 0 fail, 13 expect() calls
```
`tsc --noEmit` (apps/api) clean.

### Verification plan on preview

1. `preview` label → wait for ephemeral backend at `https://pr-<n>.preview-api.kortix.com/v1/health` → `environment=preview`.
2. Confirm `/v1/router/tavily/search` still proxies (200 from Tavily with a valid key; controlled 4xx/5xx otherwise) — no behavior change from a pure noise-filter edit.
3. Confirm the new unit test is picked up and green in CI.

### Confirmation of resolution

After merge + Promote to prod, the `c672fb5e` pattern should record **zero new occurrences** — Sentry's InboundFilters will drop the bare `TimeoutError: "The operation timed out."` before it ever reaches Better Stack. The transient upstream-stall condition itself is unchanged (and remains visible as a truncated client response + structured logs), but it stops paging.

**Do not merge** — leaving open and green for orchestrator review.
