### PR TITLE
fix(web): filter EVM-wallet inpage.js addListener/emit noise (BS 17a0ce67/3a6b00dc)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -8,6 +8,7 @@ import {
   isExpectedBillingGateMessage,
   isExtensionSource,
   isInjectedAppSource,
+  isInpageWalletStreamNoise,
   isKnownBrowserNoiseMessage,
   isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
@@ -1818,4 +1819,215 @@ test('does NOT suppress a same-worded message from a different bridge / non-Andr
     }),
     false,
   )
+})
+
+// ---------------------------------------------------------------------------
+// EVM-wallet-extension injected `inpage.js` stream EventEmitter noise
+// (Better Stack patterns 17a0ce67ca03dd51cfa5a9a1ac7e5140a958664a5f66ac8ec74c40604ffd772a
+// (`Cannot read properties of undefined (reading 'addListener')`, 21 occ.)
+// and 3a6b00dc85a3e75f08efab371960c60f74beb2c18059a7f9bcffe409c2591ce6
+// (`Cannot read properties of undefined (reading 'emit')`, 4 occ.),
+// Kortix Frontend prod, application_id 2346967). EVM wallet extensions
+// (MetaMask + derivatives) inject `app:///inpage.js` whose provider stream is
+// `@metamask/post-message-stream`'s `ExtendedBroadcastMessage` (an
+// EventEmitter subclass). During extension init / port-teardown races the
+// underlying stream/port is `undefined`, so an `.addListener` / `.emit` call
+// throws inside `app:///inpage.js` (frames `?` / `fulfilled` /
+// `ExtendedBroadcastMessage.<anonymous>`). 0 identified users, first/last
+// 2026-07-14, request URL `https://kortix.com/`, Chrome 150. The throw is in
+// the EXTENSION's injected script, never first-party code. The matcher
+// requires BOTH one of the exact message markers AND an `app:///inpage.js` /
+// extension source so a real first-party `.addListener`/`.emit` TypeError
+// keeps reporting.
+// ---------------------------------------------------------------------------
+
+const INPAGE_WALLET_INJECTED_FRAME = { filename: 'app:///inpage.js', function: '?' }
+const INPAGE_WALLET_EMIT_FRAME_CHAIN = [
+  { filename: 'app:///inpage.js', function: 'fulfilled' },
+  { filename: '<anonymous>', function: 'Generator.next' },
+  { filename: 'app:///inpage.js', function: 'ExtendedBroadcastMessage.<anonymous>' },
+]
+
+const INPAGE_WALLET_STREAM_EVENTS = [
+  // The exact raw exception values from the two production events (V8/Chrome).
+  "Cannot read properties of undefined (reading 'addListener')",
+  "Cannot read properties of undefined (reading 'emit')",
+  // `TypeError:` prefixed (window.onerror / onunhandledrejection paths).
+  "TypeError: Cannot read properties of undefined (reading 'addListener')",
+  "TypeError: Cannot read properties of undefined (reading 'emit')",
+  // Unhandled-rejection leak path preserving the message.
+  "Unhandled promise rejection: TypeError: Cannot read properties of undefined (reading 'addListener')",
+  "Unhandled promise rejection: TypeError: Cannot read properties of undefined (reading 'emit')",
+  // Old JSC (Safari) wording, same wallet-extension class.
+  "Cannot read property 'addListener' of undefined",
+  "TypeError: Cannot read property 'emit' of undefined",
+]
+
+test('classifies every inpage.js wallet-stream variant as noise when sourced from the injected script', () => {
+  for (const message of INPAGE_WALLET_STREAM_EVENTS) {
+    assert.equal(
+      isInpageWalletStreamNoise({ message, filename: 'app:///inpage.js' }),
+      true,
+      `expected "${message}" from inpage.js to be wallet-stream noise`,
+    )
+    assert.equal(
+      isInpageWalletStreamNoise({ message, frames: [INPAGE_WALLET_INJECTED_FRAME] }),
+      true,
+      `expected "${message}" with an injected frame to be wallet-stream noise`,
+    )
+  }
+})
+
+test('classifies the emit variant from the full ExtendedBroadcastMessage frame chain', () => {
+  assert.equal(
+    isInpageWalletStreamNoise({
+      message: "Cannot read properties of undefined (reading 'emit')",
+      frames: INPAGE_WALLET_EMIT_FRAME_CHAIN,
+    }),
+    true,
+  )
+})
+
+test('classifies inpage.js wallet-stream noise from a chrome-extension:// frame', () => {
+  assert.equal(
+    isInpageWalletStreamNoise({
+      message: "TypeError: Cannot read properties of undefined (reading 'emit')",
+      frames: [{ filename: 'chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/inpage.js' }],
+    }),
+    true,
+  )
+})
+
+test('suppresses the inpage.js wallet-stream Sentry event via the beforeSend gate', () => {
+  for (const value of INPAGE_WALLET_STREAM_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: { frames: INPAGE_WALLET_EMIT_FRAME_CHAIN },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses the inpage.js wallet-stream unhandled rejection from the browser (window.onerror)', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        "Unhandled promise rejection: TypeError: Cannot read properties of undefined (reading 'addListener')",
+      filename: 'app:///inpage.js',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress an inpage.js wallet-stream event with NO injected/extension source (conservative — keep reporting)', () => {
+  // No source anchor → can't confirm extension origin; a first-party emitter
+  // could theoretically throw the same wording, so keep reporting.
+  for (const value of INPAGE_WALLET_STREAM_EVENTS) {
+    assert.equal(
+      isInpageWalletStreamNoise({ message: value }),
+      false,
+      `expected frameless "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected frameless Sentry event for "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress an inpage.js wallet-stream event from a first-party app frame', () => {
+  // A genuine first-party emitter bug (Node `EventEmitter` / `mitt` /
+  // `nanoevents` / hand-rolled emitter) throws the SAME wording but inside
+  // app code — the de-minified frame is `apps/web/src/…` (or an
+  // `app:///_next/…` chunk), never the extension's `app:///inpage.js`. It
+  // must keep reporting so a real emitter bug is never hidden.
+  const realAppFrames: Array<{ filename: unknown }> = [
+    { filename: 'app:///apps/web/src/lib/event-bus.ts' },
+    { filename: 'apps/web/src/lib/event-bus.ts' },
+    { filename: 'https://app.kortix.com/_next/static/chunks/event-bus.js' },
+  ]
+  for (const frames of [realAppFrames, [{ filename: 'app:///_next/static/chunks/app.js' }]]) {
+    assert.equal(
+      isInpageWalletStreamNoise({
+        message: "TypeError: Cannot read properties of undefined (reading 'emit')",
+        frames,
+      }),
+      false,
+      `expected wallet-stream-worded event from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: "Cannot read properties of undefined (reading 'addListener')",
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting wallet-stream-worded event from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "Cannot read properties of undefined (reading 'emit')",
+      filename: 'apps/web/src/lib/event-bus.ts',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a real first-party TypeError on a DIFFERENT method name from inpage.js', () => {
+  // The generic `Cannot read properties of undefined (reading '<X>')` wording
+  // with a non-`addListener`/`emit` method name is NOT the wallet-stream
+  // class — even from the injected script frame it must keep reporting, so a
+  // different injected-script regression is never hidden by this guard.
+  for (const value of [
+    "Cannot read properties of undefined (reading 'addEventListener')",
+    "TypeError: Cannot read properties of undefined (reading 'on')",
+    "Cannot read properties of undefined (reading 'removeListener')",
+  ]) {
+    assert.equal(
+      isInpageWalletStreamNoise({ message: value, filename: 'app:///inpage.js' }),
+      false,
+      `expected non-wallet-stream message "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a same-worded message from a near-miss injected filename', () => {
+  // The matcher is anchored on the EXACT `app:///inpage.js` source — a
+  // near-identical filename (e.g. a path variant or a typo) must NOT be
+  // swallowed by this guard.
+  for (const filename of [
+    'app:///scripts/inpage.js',
+    'app:///inpage.min.js',
+    'app://inpage.js',
+    'app:///injected/inpage.js',
+  ]) {
+    assert.equal(
+      isInpageWalletStreamNoise({
+        message: "Cannot read properties of undefined (reading 'emit')",
+        frames: [{ filename }],
+      }),
+      false,
+      `expected "${filename}" frame to keep reporting`,
+    )
+  }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -354,6 +354,53 @@ function isTronLinkInjectedSource(filename: unknown): boolean {
   return /^app:\/\/\/injected\/injected\.js$/.test(normalized);
 }
 
+// EVM-wallet-extension injected `inpage.js` stream EventEmitter noise. EVM
+// wallet extensions (MetaMask and derivatives — Rabby, Bifrost, …) inject a
+// content script as `app:///inpage.js` whose provider stream is built on
+// `@metamask/post-message-stream`'s `ExtendedBroadcastMessage` (an
+// EventEmitter subclass). During extension init / port-teardown races the
+// underlying stream/port object is `undefined`, so an `.addListener` /
+// `.emit` call on it throws
+//   `TypeError: Cannot read properties of undefined (reading 'addListener')`
+//   `TypeError: Cannot read properties of undefined (reading 'emit')`
+// INSIDE `app:///inpage.js` — never in first-party code. The observed frames
+// are `?` / `fulfilled` / `ExtendedBroadcastMessage.<anonymous>`, all in
+// `app:///inpage.js`. `app:///inpage.js` is the extension's synthetic
+// content-script source (NOT an `app:///_next/…` bundle frame and NOT a
+// de-minified `apps/web/src/…` frame), so it is never a first-party Kortix
+// call site. Better Stack patterns `17a0ce67…` (addListener, 21 occ.) and
+// `3a6b00dc…` (emit, 4 occ.), Kortix Frontend (prod, application_id 2346967),
+// 0 identified users, first/last 2026-07-14, call site `app:///inpage.js`,
+// request URL `https://kortix.com/` (marketing homepage), Chrome 150.
+//
+// The `addListener` / `emit` wording is GENERIC — a first-party
+// EventEmitter-like bug (Node `EventEmitter`, `mitt`, `nanoevents`, a
+// hand-rolled emitter, or any object exposing `addListener`/`emit`) throws
+// the SAME wording, so matching on message alone would swallow real app
+// bugs. Require BOTH one of the exact message markers AND an
+// `app:///inpage.js` injected-source frame (or an extension-origin frame) so
+// a real first-party `.addListener`/`.emit` TypeError keeps reporting.
+// Returns false when there is no source anchor at all (can't confirm
+// extension origin — keep reporting rather than swallow a possible app bug).
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list
+// — that gate has no frame context, so a bare-string match there could
+// swallow a real first-party emitter TypeError; the frame-aware `beforeSend`
+// hook (which calls `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const INPAGE_WALLET_STREAM_NOISE_PATTERNS: ReadonlyArray<RegExp> = [
+  // V8 (Chrome/Edge/Opera): the observed production wording.
+  /Cannot read properties of undefined \(reading 'addListener'\)/,
+  /Cannot read properties of undefined \(reading 'emit'\)/,
+  // Old JSC (Safari < …): "Cannot read property 'addListener' of undefined"
+  // / "'emit' of undefined" — different engine, same wallet-extension class.
+  /Cannot read property 'addListener' of undefined/,
+  /Cannot read property 'emit' of undefined/,
+];
+
+function isInpageWalletInjectedSource(filename: unknown): boolean {
+  const normalized = normalizeString(filename);
+  return /^app:\/\/\/inpage\.js$/.test(normalized);
+}
+
 function containsKnownPattern(message: string, patterns: readonly string[]): boolean {
   return patterns.some((pattern) => message.includes(pattern));
 }
@@ -535,6 +582,39 @@ export function isTronLinkProxyNoise(input: {
   ];
   return sources.some(
     (filename) => isTronLinkInjectedSource(filename) || isExtensionSource(filename),
+  );
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the EVM-wallet-extension
+ * injected-`inpage.js` stream EventEmitter noise class: a `TypeError` from
+ * calling `.addListener` / `.emit` on an `undefined` stream object inside
+ * the extension's `app:///inpage.js` content script
+ * (`@metamask/post-message-stream`'s `ExtendedBroadcastMessage`). The throw
+ * is in the extension's injected code, never in first-party app code.
+ * Requires BOTH one of the exact message markers AND an `app:///inpage.js`
+ * injected-source frame (or an extension-origin frame) so a real first-party
+ * `.addListener`/`.emit` TypeError (Node `EventEmitter` / `mitt` /
+ * `nanoevents` / hand-rolled emitter) keeps reporting. Returns false when
+ * there is no source anchor at all (can't confirm extension origin — keep
+ * reporting rather than swallow a possible app emitter bug). See
+ * `INPAGE_WALLET_STREAM_NOISE_PATTERNS` for the full rationale.
+ */
+export function isInpageWalletStreamNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (!INPAGE_WALLET_STREAM_NOISE_PATTERNS.some((re) => re.test(stripped))) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  return sources.some(
+    (filename) => isInpageWalletInjectedSource(filename) || isExtensionSource(filename),
   );
 }
 
@@ -859,6 +939,16 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // EVM-wallet-extension injected-`inpage.js` stream EventEmitter noise —
+  // MetaMask/derivatives' `app:///inpage.js` (`ExtendedBroadcastMessage`)
+  // calls `.addListener` / `.emit` on an `undefined` stream during init/tear-
+  // down races. Requires BOTH the exact message AND an `app:///inpage.js` /
+  // extension source so a real first-party emitter TypeError keeps reporting.
+  // See `isInpageWalletStreamNoise`.
+  if (isInpageWalletStreamNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
   return isExtensionSource(input.filename) && normalizeString(message).includes('runtime.sendMessage');
 }
 
@@ -1020,6 +1110,16 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // injected/extension frame so a real first-party Proxy `set` failure keeps
   // reporting. See `isTronLinkProxyNoise`.
   if (isTronLinkProxyNoise({ message, frames })) {
+    return true;
+  }
+
+  // EVM-wallet-extension injected-`inpage.js` stream EventEmitter noise —
+  // MetaMask/derivatives' `app:///inpage.js` (`ExtendedBroadcastMessage`)
+  // calls `.addListener` / `.emit` on an `undefined` stream during init/tear-
+  // down races. Requires BOTH the exact message AND an `app:///inpage.js` /
+  // extension frame so a real first-party emitter TypeError keeps reporting.
+  // See `isInpageWalletStreamNoise`.
+  if (isInpageWalletStreamNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## BS 17a0ce67 / 3a6b00dc — EVM-wallet `inpage.js` stream EventEmitter noise

Two sibling Better Stack `TypeError` patterns (Kortix Frontend prod, application_id 2346967), same root cause, same call-site file, same first/last timestamp:

| Pattern | Message | Call site | Count | Users |
| --- | --- | --- | --- | --- |
| `17a0ce67…` | `Cannot read properties of undefined (reading 'addListener')` | `app:///inpage.js` (`?`) | 21 | 0 |
| `3a6b00dc…` | `Cannot read properties of undefined (reading 'emit')` | `app:///inpage.js` (`ExtendedBroadcastMessage.<anonymous>` / `fulfilled`) | 4 | 0 |

- Error URLs:
  - https://errors.betterstack.com/team/t502678/errors/17a0ce67ca03dd51cfa5a9a1ac7e5140a958664a5f66ac8ec74c40604ffd772a?s=2346967
  - https://errors.betterstack.com/team/t502678/errors/3a6b00dc85a3e75f08efab371960c60f74beb2c18059a7f9bcffe409c2591ce6?s=2346967

### Evidence (pulled from Better Stack telemetry raw payloads)
Both occurrences fired on `https://kortix.com/` (marketing homepage), environment `prod`, release `8c12bb88907f7b1d0fcabd76e09d15489967214c`, browser **Chrome 150** (modern — not an old-browser issue). The full stack frames are:

- `addListener` event: single frame `? | app:///inpage.js | 92`
- `emit` event frames: `fulfilled | app:///inpage.js | 92`, `Generator.next | <anonymous>`, `ExtendedBroadcastMessage.<anonymous> | app:///inpage.js | 92`

There are **no first-party frames** — no `apps/web/src/…` de-minified frame, no `app:///_next/static/chunks/…` bundle frame. Breadcrumbs are normal homepage activity (`/api/github-stars` 200, navigation `/`→`/`).

### Root cause
`app:///inpage.js` is the synthetic source of an **EVM-wallet-extension injected content script** (MetaMask + derivatives). Its provider stream is built on `@metamask/post-message-stream`'s `ExtendedBroadcastMessage` (an `EventEmitter` subclass). During extension init / port-teardown races the underlying stream/port object is `undefined`, so an `.addListener` / `.emit` call on it throws inside the extension's own `inpage.js` — never in first-party Kortix code. `app:///inpage.js` (the `app:///` origin with no `/_next/` path and no de-minified `apps/web/src/` path) is never a first-party Kortix bundle. This is the same family as the existing TronLink `app:///injected/injected.js` filter, but bare `app:///inpage.js` was not covered by `isInjectedAppSource` (which only matches `app:///scripts/inpage.js`, `app:///client_data/.../script.js`, `app:///embed/embed.js`).

### Fix
Add a conservative, message+source-anchored matcher `isInpageWalletStreamNoise` (mirroring the TronLink / Android-bridge pattern), wired into both the Sentry `beforeSend` gate (`shouldIgnoreSentryBrowserNoise`) and the `window.onerror` runtime gate (`shouldIgnoreBrowserRuntimeNoise`). It suppresses **only** when BOTH:
1. the message matches one of the exact markers —
   `Cannot read properties of undefined (reading 'addListener')` /
   `(reading 'emit')` (V8) and the JSC `Cannot read property 'addListener'/'emit' of undefined` forms, with `TypeError:` / `Unhandled promise rejection:` wrappers stripped; AND
2. a frame/filename is the injected `app:///inpage.js` source or an extension-origin (`chrome-extension://` / `moz-extension://` / `safari-web-extension://` / `extension://`) frame.

Deliberately **not** added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party emitter `TypeError`.

### Negative guards (kept reporting)
- A same-worded `.addListener`/`.emit` `TypeError` with **no** source anchor → keeps reporting (can't confirm extension origin).
- A same-worded `TypeError` from a first-party `apps/web/src/…` frame or an `app:///_next/static/chunks/…` bundle frame → keeps reporting (a real Node `EventEmitter` / `mitt` / `nanoevents` / hand-rolled-emitter bug).
- A `Cannot read properties of undefined (reading '<other>')` message (e.g. `addEventListener`, `on`, `removeListener`) from `app:///inpage.js` → keeps reporting (not this class).
- A near-miss filename (`app:///scripts/inpage.js`, `app:///inpage.min.js`, `app://inpage.js`, `app:///injected/inpage.js`) → keeps reporting from this matcher.

### Tests
9 new tests in `apps/web/src/lib/browser-error-noise.test.mts` (88 total, all passing under both `node --test` and `bun test`): both exact production messages + `TypeError:` / unhandled-rejection wrappers + JSC form classify as noise from `app:///inpage.js` and from a `chrome-extension://` frame; the full `ExtendedBroadcastMessage` frame chain classifies; both the Sentry and runtime gates suppress; and all four negative guards above keep reporting.

### Verification
- `bun test src/lib/browser-error-noise.test.mts` → 88 pass / 0 fail
- `node --experimental-strip-types --test src/lib/browser-error-noise.test.mts` → 88 pass / 0 fail
- Targeted `tsc --noEmit` of the source file under the project tsconfig settings (strict, bundler resolution) → clean (exit 0). The `.mts` test file is excluded from `next build`'s typecheck `include` and is exercised by `bun test`.

### Confirmation of resolution
After merge + promote, both Better Stack patterns should drop to zero new occurrences (the `beforeSend` gate drops them client-side before they reach Sentry → Better Stack). The existing TronLink sibling (`951c1a31…`) is the precedent: same matcher shape, dropped to zero after its PR merged.
