### PR TITLE
fix(web): filter iOS WebKit stack-overflow RangeError noise (BS 87ccbef9)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -18,6 +18,7 @@ import {
   isStorageDisabledWebViewNoiseMessage,
   isStorageSecurityErrorNoise,
   isTronLinkProxyNoise,
+  isUnresolvableStackOverflowNoise,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
 } from './browser-error-noise.ts'
@@ -1812,10 +1813,139 @@ test('does NOT suppress a same-worded message from a different bridge / non-Andr
     }),
     false,
   )
+    assert.equal(
+      isAndroidWebViewNativeBridgePostMessageNoise({
+        message: 'Error invoking postMessage: Java object is gone',
+        frames: [{ filename: 'app://navigation_performance_logger_androidx' }],
+      }),
+      false,
+    )
+})
+
+// ---------------------------------------------------------------------------
+// iOS-WebKit stack-overflow noise
+// (Better Stack pattern 87ccbef98ea62fbf90df2446141a26b78ba7f928a28642b099d53b40e8613031,
+// Kortix Frontend prod, application_id 2346967). iOS WebKit (Safari,
+// Chrome-on-iOS, Google Search App — all WKWebView/JSC) surfaces
+// `RangeError: Maximum call stack size exceeded.` through `window.onerror`
+// (Sentry mechanism `auto.browser.global_handlers.onerror`) with NO usable
+// stack: the single exception frame is the synthetic
+// `{ function: '?', filename: 'undefined', lineno: <n> }` placeholder, so
+// `call_site_file` is `undefined` and `call_site_function` is `?`. ~30
+// lifetime occurrences, 0 identified users, first 2026-04-21 / last
+// 2026-07-14, 100% iOS across 7 releases over 2.5 months — browser/engine
+// noise, NOT a deterministic app regression. The matcher is anchored on the
+// canonical message AND the absence of ANY resolvable source location so a
+// real first-party (or third-party) recursion that carries a real chunk/URL/
+// `apps/web/src/…` frame keeps reporting.
+// ---------------------------------------------------------------------------
+
+// The exact synthetic frame the iOS-WebKit global-onerror capture produces —
+// pulled verbatim from the production raw exception payload.
+const IOS_STACK_OVERFLOW_SYNTHETIC_FRAME = { function: '?', filename: 'undefined', lineno: 31 }
+const IOS_STACK_OVERFLOW_MESSAGES = [
+  'Maximum call stack size exceeded.',
+  'RangeError: Maximum call stack size exceeded.',
+  'Unhandled promise rejection: RangeError: Maximum call stack size exceeded.',
+]
+
+test('classifies the iOS-WebKit stack-overflow capture as noise', () => {
+  for (const message of IOS_STACK_OVERFLOW_MESSAGES) {
+    assert.equal(
+      isUnresolvableStackOverflowNoise({
+        message,
+        frames: [IOS_STACK_OVERFLOW_SYNTHETIC_FRAME],
+      }),
+      true,
+      `expected "${message}" with the synthetic undefined frame to be noise`,
+    )
+  }
+})
+
+test('suppresses the iOS-WebKit stack-overflow noise via the Sentry beforeSend gate', () => {
+  // The exact production event shape: single synthetic `{ filename: 'undefined' }`
+  // frame captured by Sentry's GlobalHandlers (window.onerror) integration.
+  for (const message of IOS_STACK_OVERFLOW_MESSAGES) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: message,
+              stacktrace: { frames: [IOS_STACK_OVERFLOW_SYNTHETIC_FRAME] },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry gate to suppress "${message}" with the synthetic undefined frame`,
+    )
+  }
+  // Frameless global-onerror capture (no stacktrace at all) is also noise.
   assert.equal(
-    isAndroidWebViewNativeBridgePostMessageNoise({
-      message: 'Error invoking postMessage: Java object is gone',
-      frames: [{ filename: 'app://navigation_performance_logger_androidx' }],
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: 'Maximum call stack size exceeded.' }] },
+    }),
+    true,
+  )
+})
+
+test('suppresses the iOS-WebKit stack-overflow noise via the runtime (window.onerror) gate', () => {
+  // window.onerror for the noise capture carries no resolvable filename
+  // (event.filename is undefined/empty) — the engine truncated the stack.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({ message: 'Maximum call stack size exceeded.' }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Maximum call stack size exceeded.',
+      filename: '',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a real first-party RangeError recursion with a resolved apps/web/src frame', () => {
+  // A genuine infinite recursion in our own code still produces a real stack;
+  // Sentry's sourcemap resolution rewrites the top frame back to
+  // `apps/web/src/…`. The negative guard MUST preserve it so the call site can
+  // be found + fixed — this is the whole reason the matcher is frame-aware.
+  for (const frames of [
+    [{ filename: 'apps/web/src/features/co-worker/recursion-loop.ts', function: 'deepRecurse' }],
+    [
+      { filename: 'apps/web/src/features/co-worker/recursion-loop.ts', function: 'deepRecurse' },
+      IOS_STACK_OVERFLOW_SYNTHETIC_FRAME,
+    ],
+  ]) {
+    assert.equal(
+      isUnresolvableStackOverflowNoise({
+        message: 'Maximum call stack size exceeded.',
+        frames,
+      }),
+      false,
+      `expected real first-party recursion with frames ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: 'Maximum call stack size exceeded.',
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting real first-party recursion with frames ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Maximum call stack size exceeded.',
+      filename: 'apps/web/src/features/co-worker/recursion-loop.ts',
     }),
     false,
   )
@@ -2028,6 +2158,55 @@ test('does NOT suppress a same-worded message from a near-miss injected filename
       }),
       false,
       `expected "${filename}" frame to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a real recursion that carries a resolvable chunk/URL frame', () => {
+  // A real recursion — even a third-party one — surfaces with at least one real
+  // chunk/URL source location (the engine recorded where it overflowed). The
+  // negative guard preserves it; only the frameless synthetic-`undefined`
+  // capture is dropped.
+  const realFrames: Array<{ filename: unknown }> = [
+    { filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js' },
+    { filename: 'https://kortix.com/_next/static/chunks/main-abc.js' },
+    { filename: 'app:///apps/web/src/lib/something.ts' },
+  ]
+  for (const frame of realFrames) {
+    assert.equal(
+      isUnresolvableStackOverflowNoise({
+        message: 'Maximum call stack size exceeded.',
+        frames: [frame, IOS_STACK_OVERFLOW_SYNTHETIC_FRAME],
+      }),
+      false,
+      `expected real recursion with frame ${JSON.stringify(frame)} to keep reporting`,
+    )
+  }
+  // Runtime gate with a real chunk filename keeps reporting too.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Maximum call stack size exceeded.',
+      filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a different RangeError message', () => {
+  // A RangeError with a different message (e.g. an invalid array length) is a
+  // different, actionable error class — never matched by this guard.
+  for (const message of [
+    'Invalid array length',
+    'RangeError: Invalid array length',
+    'Maximum call stack', // prefix-only, not the canonical message
+  ]) {
+    assert.equal(
+      isUnresolvableStackOverflowNoise({
+        message,
+        frames: [IOS_STACK_OVERFLOW_SYNTHETIC_FRAME],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -824,6 +824,89 @@ export function isAndroidWebViewNativeBridgePostMessageNoise(input: {
   return sources.some((filename) => isAndroidNavPerfLoggerFrame(filename));
 }
 
+// iOS WebKit (Safari, Chrome-on-iOS, Google Search App — all WKWebView/JSC)
+// stack-overflow noise. When iOS WebKit exhausts its (lower-than-desktop) call
+// stack, it surfaces `RangeError: Maximum call stack size exceeded.` through
+// `window.onerror` (Sentry mechanism `auto.browser.global_handlers.onerror`)
+// with NO usable stack: the single exception frame is the synthetic
+// `{ function: '?', filename: 'undefined', lineno: <n> }` placeholder, so
+// `call_site_file` is `undefined` and `call_site_function` is `?`. There is no
+// source location to triage and no reproduction (the engine truncated the very
+// stack that overflowed). Better Stack pattern
+// 87ccbef98ea62fbf90df2446141a26b78ba7f928a28642b099d53b40e8613031
+// (Kortix Frontend prod, application_id 2346967): 7 occurrences in the
+// now-3d inventory, ~30 lifetime, 0 identified users (all anonymous), first
+// 2026-04-21 / last 2026-07-14, 100% iOS (Chrome-on-iOS 149/150 + Google
+// Search App 415/425), across 7 different releases spanning 2.5 months — i.e.
+// browser/engine noise on iOS, NOT a deterministic app regression (which would
+// spike on one release across all browsers with identified users). Fires on the
+// marketing site (`/`, `/auth`) AND post-login surfaces (`/projects/…`,
+// `/projects/…/sessions/…`), so no route guard contains it.
+//
+// `RangeError: Maximum call stack size exceeded.` is ALSO the exact message a
+// real first-party infinite recursion produces — so this matcher is anchored on
+// BOTH the canonical message AND the absence of ANY resolvable source location
+// (every frame's filename is empty or the literal `"undefined"` placeholder, and
+// the window.onerror filename is empty/`undefined`). A real app recursion, even
+// truncated, surfaces with at least one real chunk/URL frame
+// (`app:///_next/static/chunks/…`, `https://…`, or a de-minified
+// `apps/web/src/…` frame) and is preserved by the negative guard. Only the
+// frameless synthetic-`undefined` global-onerror capture is dropped.
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list —
+// that gate has no frame context, so a bare-string match there would swallow a
+// real RangeError recursion; the frame-aware `beforeSend` hook (which calls
+// `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const STACK_OVERFLOW_NOISE_PATTERN = /^Maximum call stack size exceeded\.?$/;
+
+// A frame/filename that points at a REAL source location: non-empty AND not the
+// literal `"undefined"` placeholder the global-onerror capture uses when the
+// engine could not produce a stack. A real chunk (`app:///_next/…`), a URL
+// (`https://…`), or a de-minified `apps/web/src/…` path all qualify; the
+// synthetic `{ filename: 'undefined' }` frame does not.
+function isResolvableFrameSource(filename: unknown): boolean {
+  const normalized = normalizeString(filename);
+  return normalized !== '' && normalized !== 'undefined';
+}
+
+/**
+ * Whether a Sentry / window.onerror event is the iOS-WebKit stack-overflow
+ * noise class: a `RangeError: Maximum call stack size exceeded.` captured via
+ * `window.onerror` with NO resolvable source location (every frame's filename
+ * is empty or the literal `"undefined"` placeholder). iOS WebKit surfaces a
+ * stack overflow this way because it truncated the very stack that overflowed;
+ * there is nothing to triage or fix. A real first-party (or third-party)
+ * recursion surfaces with at least one real chunk/URL/`apps/web/src/…` frame
+ * and is preserved by the negative guards — only the frameless
+ * synthetic-`undefined` capture is dropped. See
+ * `STACK_OVERFLOW_NOISE_PATTERN` for the full rationale.
+ */
+export function isUnresolvableStackOverflowNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  if (!STACK_OVERFLOW_NOISE_PATTERN.test(stripErrorWrappers(normalizeString(input.message)))) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard #1: a resolved first-party `apps/web/src/…` frame → our own
+  // code is recursing; keep reporting so the call site can be found + fixed.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  // Negative guard #2: any resolvable source location (real chunk/URL/named
+  // file) → an actionable error (app or third-party recursion) with a real
+  // stack; keep reporting. Only the frameless synthetic-`undefined`
+  // global-onerror capture remains → iOS-WebKit stack-overflow noise.
+  if (sources.some(isResolvableFrameSource)) {
+    return false;
+  }
+  return true;
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -946,6 +1029,16 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   // extension source so a real first-party emitter TypeError keeps reporting.
   // See `isInpageWalletStreamNoise`.
   if (isInpageWalletStreamNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
+  // iOS-WebKit stack-overflow noise — `RangeError: Maximum call stack size
+  // exceeded.` from `window.onerror` with NO resolvable source location (the
+  // engine truncated the very stack that overflowed). Requires the canonical
+  // message AND no real frame/filename so a real first-party recursion that
+  // carries a chunk/source frame keeps reporting. See
+  // `isUnresolvableStackOverflowNoise`.
+  if (isUnresolvableStackOverflowNoise({ message, filename: input.filename })) {
     return true;
   }
 
@@ -1120,6 +1213,18 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // extension frame so a real first-party emitter TypeError keeps reporting.
   // See `isInpageWalletStreamNoise`.
   if (isInpageWalletStreamNoise({ message, frames })) {
+    return true;
+  }
+
+  // iOS-WebKit stack-overflow noise — `RangeError: Maximum call stack size
+  // exceeded.` from Sentry's `auto.browser.global_handlers.onerror` capture
+  // with a single synthetic `{ filename: 'undefined' }` frame (the engine
+  // truncated the very stack that overflowed). Requires the canonical message
+  // AND no resolvable source location so a real first-party recursion that
+  // carries a chunk/`apps/web/src/…` frame keeps reporting. See
+  // `isUnresolvableStackOverflowNoise`. NOT in `ignoreErrors` (no frame
+  // context there).
+  if (isUnresolvableStackOverflowNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## BS 87ccbef9 — Filter iOS WebKit stack-overflow `RangeError` noise

**Better Stack error:** `RangeError` · `Maximum call stack size exceeded.` · Unhandled
- Pattern: `87ccbef98ea62fbf90df2446141a26b78ba7f928a28642b099d53b40e8613031`
- App: Kortix Frontend (prod), `application_id` 2346967
- URL: https://errors.betterstack.com/team/t502678/errors/87ccbef98ea62fbf90df2446141a26b78ba7f928a28642b099d53b40e8613031?s=2346967
- now-3d inventory: 7 / 0 users · last seen 2026-07-14 14:22:51 UTC · first seen 2026-04-21 15:37:08 UTC

### Evidence (pulled from Better Stack telemetry / ClickHouse, not the message alone)

Queried the raw exception payloads (`s3Cluster(primary, t502678_kortix_frontend_s3) WHERE _row_type = 4 AND _pattern = '87ccbef9…'`). Every occurrence is the same shape:

- **Mechanism:** `auto.browser.global_handlers.onerror` (Sentry's GlobalHandlers `window.onerror` auto-capture — not an app-thrown/caught error).
- **Stack:** exactly ONE frame, the synthetic placeholder `{ function: '?', filename: 'undefined', lineno: 31, in_app: true }`. No resolvable source location — `call_site_file = undefined`, `call_site_function = ?`.
- **100% iOS WebKit:** `Chrome 149/150` (Chrome-on-iOS = WKWebView/JSC), `Google Search App 415/425` (WKWebView). client_os all `iOS (iPhone)` (18.7.x → 26.5.x).
- **~30 lifetime occurrences, 0 identified users (all anonymous).**
- **Spans 7 different releases over 2.5 months** (`ae2a8151` … `8c12bb88`), low frequency — NOT a spike on one release.
- **Surfaces everywhere:** marketing site (`/`, `/auth`) AND post-login (`/projects/…`, `/projects/…/sessions/…`) — no route guard contains it.
- Breadcrumbs on the most recent event show normal session activity (auth fetches, `prompt_async`, `ui.click`, console `[handleStop] Stopping session …`) — no deterministic user action precedes it.

### Root cause

iOS WebKit has a lower call-stack limit than desktop engines. When it exhausts the stack, it surfaces `RangeError: Maximum call stack size exceeded.` through `window.onerror` with **no usable stack** — the engine truncated the very stack that overflowed, so Sentry receives only the synthetic `{ filename: 'undefined' }` placeholder frame. There is no source location to triage and no reproduction. This is browser/engine noise on iOS, **not** a deterministic app regression (a real regression would spike on one release across all browsers with identified users).

### Fix (conservative, frame-aware noise filter)

Adds `isUnresolvableStackOverflowNoise` to `apps/web/src/lib/browser-error-noise.ts`, wired into both `shouldIgnoreSentryBrowserNoise` (the `beforeSend` gate — the actual capture path for these events) and `shouldIgnoreBrowserRuntimeNoise` (the runtime backstop).

`Maximum call stack size exceeded` is **also** the exact message a real first-party infinite recursion produces, so the matcher is anchored on BOTH:
1. the canonical message (`/^Maximum call stack size exceeded\.?$/`, after stripping `RangeError: ` / `Unhandled promise rejection: ` wrappers — covers V8/JSC + every capture path), AND
2. the absence of ANY resolvable source location — every frame filename is empty or the literal `"undefined"` placeholder, and the `window.onerror` filename is empty/`undefined`.

**Negative guards preserve actionable errors:**
- any frame resolving to a de-minified first-party `apps/web/src/…` frame → our own code is recursing → **keep reporting** (find + fix the call site);
- any resolvable chunk/URL/named-file frame (`app:///_next/static/chunks/…`, `https://…`) → a real recursion with a real stack (app or third-party) → **keep reporting**.

Only the frameless synthetic-`undefined` global-onerror capture is dropped.

Deliberately **NOT** added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there would swallow a genuine `RangeError` recursion. The frame-aware `beforeSend` hook is the only safe gate (same convention as the stale-webpack-runtime, storage-`SecurityError`, old-browser-`SyntaxError`, Android-bridge, and TronLink noise classes).

### Regression tests

`apps/web/src/lib/browser-error-noise.test.mts` — 6 new tests, all green (`bun test` → 85 pass / 0 fail):
- classifies the exact production synthetic frame `{ function: '?', filename: 'undefined', lineno: 31 }` + canonical/wrapped messages as noise;
- suppresses via the Sentry `beforeSend` gate (incl. frameless capture);
- suppresses via the runtime `window.onerror` gate (empty/undefined filename);
- **does NOT suppress** a real first-party recursion with a resolved `apps/web/src/…` frame (incl. when mixed with the synthetic frame);
- **does NOT suppress** a real recursion carrying a resolvable chunk/URL frame;
- **does NOT suppress** a different `RangeError` message (`Invalid array length`, prefix-only match).

### Confirmation plan

After merge + promote, new occurrences of pattern `87ccbef9…` should drop to zero — the `beforeSend` hook drops the iOS-WebKit global-onerror capture before it reaches Better Stack. A real `RangeError` recursion (which carries a real frame) still reports normally and will open a distinct pattern.

---
*Do not merge from this PR — leaving open and green for orchestrator review.*
