### PR TITLE
content: add inline money-page links to comparison posts

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -226,7 +226,7 @@ const kortixVsClaudeCowork: BlogPostEntry = {
     },
     {
       type: 'callout',
-      text: 'Same agents, a fraction of the bill — and you can run them on your own infrastructure, even your own GPUs, with your data never leaving your walls.',
+      text: 'Same agents, [a fraction of the bill](/pricing) — and you can run them on your own infrastructure, even your own GPUs, with your data never leaving your walls.',
     },
     { type: 'h2', text: 'Side by side' },
     {
@@ -287,7 +287,7 @@ const kortixVsClaudeCowork: BlogPostEntry = {
       themLabel: 'Claude Cowork',
       them: 'you want a brilliant agent on one person’s desktop, you’re happy on Anthropic’s models, and you don’t need to self-host or run a fleet.',
       kortix:
-        'you want that same do-the-work power as a company platform — many agents across departments, any model, self-hosted, with everything versioned and owned by you.',
+        'you want that same do-the-work power as a company platform — many agents [across departments](/enterprise), any model, self-hosted, with everything versioned and owned by you.',
     },
     {
       type: 'p',
@@ -864,7 +864,7 @@ const kortixVsGlean: BlogPostEntry = {
     },
     {
       type: 'callout',
-      text: 'No 100-seat floor, no sales process to start. Open-source means you can run one project today and a whole company on it tomorrow — on infrastructure where the data, config, and model belong to you.',
+      text: 'No 100-seat floor, no sales process to start — [see the plans](/pricing). Open-source means you can run one project today and a whole company on it tomorrow — on infrastructure where the data, config, and model belong to you.',
     },
     { type: 'h2', text: 'Side by side' },
     {
@@ -924,7 +924,7 @@ const kortixVsGlean: BlogPostEntry = {
       themLabel: 'Glean',
       them: 'you want the best permission-aware enterprise search and assistant, you’re fine with a closed SaaS and a sales-led ~100-seat contract, and “find the answer” is the job.',
       kortix:
-        'you want to run agents that actually do the work — across departments, any model, self-hosted, with everything versioned and owned by you.',
+        'you want to run agents that actually do the work — [across departments](/enterprise), any model, self-hosted, with everything versioned and owned by you.',
     },
     {
       type: 'p',


### PR DESCRIPTION
## What

Adds contextual inline links to `/pricing` and `/enterprise` in the two highest-intent comparison posts (`kortix-vs-glean`, `kortix-vs-claude-cowork`). Content-only: 4 single-line edits in the typed blog registry (`apps/web/src/lib/blog-posts.ts`).

## Why (evidence)

The 2026-07-15 SEO-agency internal-link/conversion shard confirmed **0 inline money-page links across all 7 blog posts** — the only conversion path was the uniform end-of-post `BlogCta` buttons. Readers who don't reach the bottom of a comparison post bounce with no route to a money page. The two comparison posts already argue cost (`~$4.40 vs $25–30/1M tokens`, `no 100-seat floor`) and company-wide deployment, so the anchors are natural, not stuffed.

| Post | Anchor | Link | Line |
| --- | --- | --- | --- |
| kortix-vs-claude-cowork | "a fraction of the bill" | `/pricing` | 229 |
| kortix-vs-claude-cowork | "across departments" | `/enterprise` | 290 |
| kortix-vs-glean | "see the plans" | `/pricing` | 867 |
| kortix-vs-glean | "across departments" | `/enterprise` | 927 |

## Experiment contract

- **Hypothesis:** adding contextual inline money-page links to comparison posts routes high-intent blog readers to `/pricing`/`/enterprise` and improves blog→money-page click-through.
- **Baseline:** 0 inline money-page links in either post (2026-07-15 worker shard, source grep).
- **Primary metric:** Search Console impressions/clicks/CTR for the canonical-page cohort, plus PostHog blog→money-page click events once configured.
- **Guardrails:** no cannibalization of canonical category pages; links are natural-anchor, one per route per post (no stuffing); diff stays content-only.
- **Observation window:** 28 completed days after production publication (production boundary TBD pending promotion of the SEO-001 deploy to `kortix.com`).
- **Rollback:** revert this single-file commit.

## Verification

- `bun` registry import: 7 posts; each edited post has exactly 1 `/pricing` + 1 `/enterprise` inline link; newest-first sort intact; titles unchanged.
- `prettier --check`: clean.
- No drift markers introduced (`kortix.toml`/`source-available` count = 0).
- Diff: 1 file, +4/-4.

Exact-head Vercel preview route checks (`/blog/kortix-vs-glean`, `/blog/kortix-vs-claude-cowork`) will be run against the deployment for this head before merge.