### PR TITLE
fix(appliance): work out of the box without SMTP + gate SSO probe

### DIFF
--- a/apps/cli/src/self-host/aws-vpc-secrets.ts
+++ b/apps/cli/src/self-host/aws-vpc-secrets.ts
@@ -10,6 +10,7 @@ import {
   verifyPinnedIdentity,
 } from './aws-vpc-control-plane.ts';
 import type { AwsVpcCoordinates } from './config.ts';
+import { SHARED_SELF_HOST_DEFAULTS } from './shared-runtime-defaults.ts';
 
 export const REQUIRED_OPERATOR_RUNTIME_KEYS = [
   'SMTP_ADMIN_EMAIL',
@@ -159,10 +160,7 @@ export function generateRuntimeDefaults(
     KORTIX_PUBLIC_BACKEND_URL: `${apiUrl}/v1`,
     KORTIX_PUBLIC_SUPABASE_URL: frontendUrl,
     KORTIX_PUBLIC_SUPABASE_ANON_KEY: anonKey,
-    // Lead the sign-in UI with password (not magic-link) so a fresh appliance
-    // works with NO SMTP configured — pairs with ENABLE_EMAIL_AUTOCONFIRM=true.
-    // Operators add 'magic' once SMTP is set up. Matches the docker self-host.
-    KORTIX_PUBLIC_AUTH_METHODS: 'password',
+    // KORTIX_PUBLIC_AUTH_METHODS now comes from SHARED_SELF_HOST_DEFAULTS.
     INTERNAL_KORTIX_ENV: 'prod',
     KORTIX_BILLING_INTERNAL_ENABLED: 'false',
   };
@@ -214,20 +212,9 @@ function generatedInternalDefaults(instance: string, region: string): Record<str
     INTERNAL_SERVICE_KEY: token(32),
     API_KEY_SECRET: token(32),
     TUNNEL_SIGNING_SECRET: token(32),
-    ALLOWED_SANDBOX_PROVIDERS: 'daytona',
-    DAYTONA_SERVER_URL: 'https://app.daytona.io/api',
-    DAYTONA_TARGET: 'us',
-    ENABLE_EMAIL_SIGNUP: 'true',
-    // Auto-confirm email signups by default so a fresh appliance works with NO
-    // SMTP configured (matches the local docker self-host default). GoTrue only
-    // sends confirmation/magic-link email once an operator sets real SMTP creds
-    // and flips this to 'false'; until then, requiring email would make the very
-    // first account impossible (chicken-and-egg). Maps to GOTRUE_MAILER_AUTOCONFIRM.
-    ENABLE_EMAIL_AUTOCONFIRM: 'true',
-    ENABLE_ANONYMOUS_USERS: 'false',
-    ENABLE_PHONE_SIGNUP: 'false',
-    ENABLE_PHONE_AUTOCONFIRM: 'false',
-    DISABLE_SIGNUP: 'false',
+    // Auth + sandbox behavior is target-agnostic — the SAME on docker, AWS EC2,
+    // and any VPS — so it lives in one shared object both generators consume.
+    ...SHARED_SELF_HOST_DEFAULTS,
   };
 }
 

--- a/apps/cli/src/self-host/aws-vpc-secrets.ts
+++ b/apps/cli/src/self-host/aws-vpc-secrets.ts
@@ -159,6 +159,10 @@ export function generateRuntimeDefaults(
     KORTIX_PUBLIC_BACKEND_URL: `${apiUrl}/v1`,
     KORTIX_PUBLIC_SUPABASE_URL: frontendUrl,
     KORTIX_PUBLIC_SUPABASE_ANON_KEY: anonKey,
+    // Lead the sign-in UI with password (not magic-link) so a fresh appliance
+    // works with NO SMTP configured — pairs with ENABLE_EMAIL_AUTOCONFIRM=true.
+    // Operators add 'magic' once SMTP is set up. Matches the docker self-host.
+    KORTIX_PUBLIC_AUTH_METHODS: 'password',
     INTERNAL_KORTIX_ENV: 'prod',
     KORTIX_BILLING_INTERNAL_ENABLED: 'false',
   };
@@ -214,7 +218,12 @@ function generatedInternalDefaults(instance: string, region: string): Record<str
     DAYTONA_SERVER_URL: 'https://app.daytona.io/api',
     DAYTONA_TARGET: 'us',
     ENABLE_EMAIL_SIGNUP: 'true',
-    ENABLE_EMAIL_AUTOCONFIRM: 'false',
+    // Auto-confirm email signups by default so a fresh appliance works with NO
+    // SMTP configured (matches the local docker self-host default). GoTrue only
+    // sends confirmation/magic-link email once an operator sets real SMTP creds
+    // and flips this to 'false'; until then, requiring email would make the very
+    // first account impossible (chicken-and-egg). Maps to GOTRUE_MAILER_AUTOCONFIRM.
+    ENABLE_EMAIL_AUTOCONFIRM: 'true',
     ENABLE_ANONYMOUS_USERS: 'false',
     ENABLE_PHONE_SIGNUP: 'false',
     ENABLE_PHONE_AUTOCONFIRM: 'false',

--- a/apps/cli/src/self-host/shared-runtime-defaults.ts
+++ b/apps/cli/src/self-host/shared-runtime-defaults.ts
@@ -1,0 +1,42 @@
+// Single source of truth for the target-AGNOSTIC runtime env defaults shared by
+// every self-host flavor (docker "this machine", AWS EC2 appliance, bare VPS).
+// These are semantic product defaults — auth behavior, sandbox provider, feature
+// flags — that must be IDENTICAL everywhere. Only genuinely target-specific
+// values (public URLs, image refs, host ports, AWS ARNs) live in the per-target
+// generators, which spread these in.
+//
+// Historically the docker and AWS paths each hard-coded their own copy; they
+// drifted (the AWS copy required email confirmation while docker auto-confirmed),
+// which made the first account impossible on a fresh appliance with no SMTP. One
+// object prevents that class of drift.
+
+/**
+ * Auth behavior. Defaults make a fresh install usable with NO SMTP configured:
+ * email signups auto-confirm and the sign-in UI leads with password (not
+ * magic-link, which needs email). Operators enable email/magic-link — and flip
+ * ENABLE_EMAIL_AUTOCONFIRM to 'false' — once they configure real SMTP.
+ */
+export const SHARED_AUTH_DEFAULTS: Record<string, string> = {
+  DISABLE_SIGNUP: 'false',
+  ENABLE_EMAIL_SIGNUP: 'true',
+  ENABLE_EMAIL_AUTOCONFIRM: 'true',
+  ENABLE_ANONYMOUS_USERS: 'false',
+  ENABLE_PHONE_SIGNUP: 'false',
+  ENABLE_PHONE_AUTOCONFIRM: 'false',
+  // Sign-in UI method order. Password-first so no email is required out of the
+  // box; add 'magic' after SMTP is configured.
+  KORTIX_PUBLIC_AUTH_METHODS: 'password',
+};
+
+/** Agent code-execution sandbox provider (Daytona SaaS by default). */
+export const SHARED_SANDBOX_DEFAULTS: Record<string, string> = {
+  ALLOWED_SANDBOX_PROVIDERS: 'daytona',
+  DAYTONA_SERVER_URL: 'https://app.daytona.io/api',
+  DAYTONA_TARGET: 'us',
+};
+
+/** Every target-agnostic default in one object, for a single spread. */
+export const SHARED_SELF_HOST_DEFAULTS: Record<string, string> = {
+  ...SHARED_AUTH_DEFAULTS,
+  ...SHARED_SANDBOX_DEFAULTS,
+};

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -30,7 +30,7 @@ import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
 import { authRedirectUrl } from '@/lib/desktop';
 import { getEnv } from '@/lib/env-config';
 import { emailDomain, isWorkEmail } from '@/lib/personal-email';
-import { createClient as createBrowserSupabaseClient } from '@/lib/supabase/client';
+import { createClient as createBrowserSupabaseClient, fetchSamlEnabled } from '@/lib/supabase/client';
 import {
   signIn as signInWithMagicLink,
   signInWithPassword,
@@ -159,6 +159,21 @@ function AuthCardForm({
   }, []);
   const googleEnabled = enabledProviders.includes('google');
 
+  // Only probe SSO when the Supabase instance actually has SAML enabled. A fresh
+  // self-hosted deployment has it off, so probing every work-email Continue would
+  // just surface a scary `saml_provider_disabled` 404. Gate on the live setting so
+  // SSO stays an opt-in path that lights up once an operator configures a provider.
+  const [samlEnabled, setSamlEnabled] = useState(false);
+  useEffect(() => {
+    let active = true;
+    void fetchSamlEnabled().then((enabled) => {
+      if (active) setSamlEnabled(enabled);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
   const clearNotices = () => {
     setErrorMessage(null);
     setInfo(null);
@@ -278,7 +293,7 @@ function AuthCardForm({
     // routing with the email flow as the always-present fallback.
     try {
       const domain = emailDomain(trimmed);
-      if (domain && isWorkEmail(trimmed)) {
+      if (samlEnabled && domain && isWorkEmail(trimmed)) {
         try {
           const supabase = createBrowserSupabaseClient();
           const callbackParams = new URLSearchParams();

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -19,6 +19,27 @@ function resolveBrowserSupabaseUrl(url: string): string {
   return url
 }
 
+/**
+ * Whether this Supabase instance has SAML/SSO enabled. Used to gate the
+ * work-email SSO probe on the auth screen: a fresh self-hosted deployment has it
+ * off, so probing would only surface a `saml_provider_disabled` 404. Fails closed
+ * (returns false) on any error so SSO stays opt-in.
+ */
+export async function fetchSamlEnabled(): Promise<boolean> {
+  try {
+    const runtimeEnv = getEnv()
+    const url = resolveBrowserSupabaseUrl(runtimeEnv.SUPABASE_URL)
+    const key = runtimeEnv.SUPABASE_ANON_KEY
+    if (!url || !key) return false
+    const res = await fetch(`${url}/auth/v1/settings`, { headers: { apikey: key } })
+    if (!res.ok) return false
+    const data = (await res.json()) as { saml_enabled?: boolean }
+    return Boolean(data?.saml_enabled)
+  } catch {
+    return false
+  }
+}
+
 export function createClient() {
   const runtimeEnv = getEnv()
   const url = resolveBrowserSupabaseUrl(runtimeEnv.SUPABASE_URL)

--- a/infra/terraform/modules/enterprise-vpc/supabase.tf
+++ b/infra/terraform/modules/enterprise-vpc/supabase.tf
@@ -41,6 +41,18 @@ resource "aws_security_group" "appliance" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Supabase Auth (GoTrue) sends confirmation/magic-link emails via the
+  # configured SMTP relay. Without submission-port egress, every email-based
+  # signup/sign-in hangs and returns 504. 587 (STARTTLS) + 465 (implicit TLS).
+  #trivy:ignore:AVD-AWS-0104
+  egress {
+    description = "SMTP submission for GoTrue auth email (587 STARTTLS, 465 TLS)"
+    protocol    = "tcp"
+    from_port   = 465
+    to_port     = 587
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     description = "DNS to the VPC resolver"
     protocol    = "udp"


### PR DESCRIPTION
Fresh-appliance auth fixes, caught testing customer-zero (account creation returned 504):

- **SMTP egress (587/465)** added to the appliance SG — GoTrue could not reach the SMTP relay, so every email signup hung → 504.
- **ENABLE_EMAIL_AUTOCONFIRM defaults `true`** (was `false` for enterprise, `true` for docker self-host) — signups auto-confirm, so a fresh box works with **no SMTP**; operators flip it off once SMTP is set up.
- **KORTIX_PUBLIC_AUTH_METHODS defaults `password`** for enterprise (matches docker self-host) — the UI leads with password instead of magic-link (which needs email).
- **SSO probe gated on `saml_enabled`** — a fresh deploy has SAML off, so the work-email Continue no longer fires `/auth/v1/sso` (the `saml_provider_disabled` 404 you saw). SSO becomes opt-in, lighting up once a provider is configured.

Verified live: after the SG + autoconfirm fix, signup → 200 and immediate password sign-in → 200 with zero SMTP.