### PR TITLE
fix(api): stop masking git mirror clone timeouts as 'Cloning into' progress noise (BS 8d0cffbb)

### DIFF
--- a/apps/api/src/__tests__/unit-git-mirror-clone.test.ts
+++ b/apps/api/src/__tests__/unit-git-mirror-clone.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression test for Better Stack error `8d0cffbb…`
+ * ("Cloning into bare repository '/tmp/kortix/git-cache/….git'…" — state
+ * Reoccurred, call site `runGit` at `apps/api/src/projects/git/mirror.ts`).
+ *
+ * Root cause: `git clone --bare` writes its progress line
+ *   `Cloning into bare repository '/…/….git'...`
+ * to stderr IMMEDIATELY, then starts the transfer. When the 30s `runGit`
+ * timeout fired mid-transfer, Node SIGTERM'd git, and the ONLY stderr Node
+ * captured was that benign progress line. `runGit`'s old catch did
+ * `throw new Error(stderr || stdout || err.message)` — so the timeout cause
+ * was completely masked and Sentry/Better Stack received the opaque progress
+ * line as the Error message (with `errorType: 'Error'`), making the group
+ * unactionable. Worse, the killed clone left a partial `.git` dir with no
+ * `shallow` marker, so the next access saw `existsSync(repoPath)` true,
+ * skipped the clone, and tried to `fetch` from a broken half-repo — wedging
+ * every reader for the process lifetime.
+ *
+ * The fix (in `projects/git/mirror.ts`):
+ *   1. `runGit` now throws a typed `GitOperationError` (kind 'timeout' |
+ *      'failed'). A killed/timed-out process is `kind: 'timeout'` with a
+ *      message that names the timeout + signal — NEVER the `Cloning into …`
+ *      progress line. A normal non-zero exit is `kind: 'failed'` with the real
+ *      `fatal:` line (progress stripped).
+ *   2. The cold bare-clone path always `rm -rf`s the partial mirror dir on
+ *      failure and retries once on a transient timeout, so a killed clone no
+ *      longer poisons the cache.
+ *   3. The global `onError` classifies `kind: 'timeout'` into a retryable 503
+ *      + Retry-After WITHOUT paging Sentry (mirrors Platinum / request-deadline).
+ *
+ * These tests prove the classification (pure, deterministic) + the
+ * partial-clone cleanup (real local git repo, no network).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const {
+  classifyGitError,
+  stripGitProgress,
+  GitOperationError,
+  refreshMirror,
+  repoCachePath,
+} = await import('../projects/git/mirror');
+
+async function git(args: string[], cwd: string) {
+  await execFileAsync('git', args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'T',
+      GIT_AUTHOR_EMAIL: 't@t.t',
+      GIT_COMMITTER_NAME: 'T',
+      GIT_COMMITTER_EMAIL: 't@t.t',
+    },
+  });
+}
+
+describe('stripGitProgress', () => {
+  test('removes benign progress lines, keeps fatal lines', () => {
+    const out = stripGitProgress(
+      [
+        "Cloning into bare repository '/tmp/kortix/git-cache/abc.git'...",
+        'remote: Enumerating objects: 42, done.',
+        'remote: Counting objects: 100% (42/42), done.',
+        'Receiving objects: 100% (42/42), done.',
+        "fatal: repository '/nonexistent' does not exist",
+      ].join('\n'),
+    );
+    expect(out).toBe("fatal: repository '/nonexistent' does not exist");
+  });
+
+  test('returns empty string when only progress lines are present', () => {
+    expect(
+      stripGitProgress("Cloning into bare repository '/x.git'...\nremote: Counting objects: 1, done."),
+    ).toBe('');
+  });
+});
+
+describe('classifyGitError — the 8d0cffbb root cause', () => {
+  test('a killed/timeout clone does NOT surface the "Cloning into" progress line', () => {
+    // The EXACT error shape Node's execFile produces on a timeout: killed:true,
+    // signal:'SIGTERM', stderr = only git's progress line (no fatal line, since
+    // git was killed mid-transfer before emitting one).
+    const nodeTimeoutError = Object.assign(new Error("Command failed: git clone --bare /repo /cache\nCloning into bare repository '/tmp/kortix/git-cache/5837336aa90fe415914ab32916bff7ad.git'...\n"), {
+      killed: true,
+      signal: 'SIGTERM',
+      code: null,
+      stderr: Buffer.from("Cloning into bare repository '/tmp/kortix/git-cache/5837336aa90fe415914ab32916bff7ad.git'...\n"),
+      stdout: Buffer.from(''),
+    });
+
+    const classified = classifyGitError(nodeTimeoutError, ['clone', '--bare', '/repo', '/cache'], 30_000);
+
+    expect(classified).toBeInstanceOf(GitOperationError);
+    expect(classified.kind).toBe('timeout');
+    expect(classified.signal).toBe('SIGTERM');
+    // The opaque progress line MUST NOT be the message — that was the bug.
+    expect(classified.message).not.toContain('Cloning into bare repository');
+    // The real cause (timeout + signal) MUST be the message.
+    expect(classified.message).toContain('timed out');
+    expect(classified.message).toContain('SIGTERM');
+    expect(classified.message).toContain('clone');
+    // Raw stderr is preserved for debugging.
+    expect(classified.stderr).toContain('Cloning into bare repository');
+  });
+
+  test('a normal non-zero exit surfaces the real fatal line, not progress noise', () => {
+    const nodeExitError = Object.assign(new Error('Command failed: git clone --bare /nope /cache'), {
+      killed: false,
+      signal: null,
+      code: 128,
+      stderr: Buffer.from(
+        [
+          "Cloning into bare repository '/cache'...",
+          "fatal: repository '/nope' does not exist",
+        ].join('\n') + '\n',
+      ),
+      stdout: Buffer.from(''),
+    });
+
+    const classified = classifyGitError(nodeExitError, ['clone', '--bare', '/nope', '/cache'], 30_000);
+
+    expect(classified.kind).toBe('failed');
+    expect(classified.exitCode).toBe(128);
+    expect(classified.message).toBe("fatal: repository '/nope' does not exist");
+    expect(classified.message).not.toContain('Cloning into bare repository');
+  });
+
+  test('ETIMEDOUT code (no signal) is also classified as timeout', () => {
+    const err = Object.assign(new Error('Command timed out after 30000ms'), {
+      killed: false,
+      signal: null,
+      code: 'ETIMEDOUT',
+      stderr: Buffer.from("Cloning into bare repository '/x.git'...\n"),
+      stdout: Buffer.from(''),
+    });
+    const classified = classifyGitError(err, ['clone', '--bare', '/r', '/c'], 30_000);
+    expect(classified.kind).toBe('timeout');
+    expect(classified.message).toContain('timed out');
+    expect(classified.message).not.toContain('Cloning into');
+  });
+});
+
+describe('refreshMirror — partial-clone cleanup on failure', () => {
+  test('a failed bare clone removes the partial mirror dir so the next call re-clones', async () => {
+    const workdir = await mkdtemp(join(tmpdir(), 'mirror-cleanup-'));
+    const cacheDir = join(workdir, 'cache');
+    await mkdir(cacheDir, { recursive: true });
+    // A real, fast, deterministic clone failure: nonexistent local source.
+    const badUpstream = join(workdir, 'does-not-exist');
+
+    const project = {
+      projectId: 'cccccccc-0000-0000-0000-000000000003',
+      repoUrl: badUpstream,
+      defaultBranch: 'main',
+      manifestPath: '',
+      gitAuthToken: 'unused-for-local',
+    } as never;
+
+    const prevCacheDir = process.env.KORTIX_GIT_CACHE_DIR;
+    process.env.KORTIX_GIT_CACHE_DIR = cacheDir;
+    try {
+      const repoPath = repoCachePath(project);
+      await expect(refreshMirror(project)).rejects.toBeInstanceOf(GitOperationError);
+      // The bug: a killed/failed clone left a partial .git dir that poisoned
+      // every subsequent read. The fix removes it on failure.
+      expect(existsSync(repoPath)).toBe(false);
+      // And the surfaced error is the real fatal line, not "Cloning into …".
+      await expect(refreshMirror(project)).rejects.toThrow(/does not exist|repository|clone/i);
+    } finally {
+      process.env.KORTIX_GIT_CACHE_DIR = prevCacheDir;
+      await rm(workdir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  test('a successful clone is served from the warm cache on the next call', async () => {
+    const workdir = await mkdtemp(join(tmpdir(), 'mirror-ok-'));
+    const cacheDir = join(workdir, 'cache');
+    const upstream = join(workdir, 'upstream');
+    await mkdir(upstream, { recursive: true });
+    await mkdir(cacheDir, { recursive: true });
+    await git(['init', '-b', 'main'], upstream);
+    await writeFile(join(upstream, 'README.md'), '# hi\n');
+    await git(['add', '.'], upstream);
+    await git(['commit', '-m', 'init'], upstream);
+
+    const project = {
+      projectId: 'dddddddd-0000-0000-0000-000000000004',
+      repoUrl: upstream,
+      defaultBranch: 'main',
+      manifestPath: '',
+      gitAuthToken: 'caller-supplied-token',
+    } as never;
+
+    const prevCacheDir = process.env.KORTIX_GIT_CACHE_DIR;
+    process.env.KORTIX_GIT_CACHE_DIR = cacheDir;
+    try {
+      const repoPath = await refreshMirror(project);
+      expect(existsSync(join(repoPath, 'HEAD'))).toBe(true);
+      // Second call is a warm hit (no network) and must still resolve.
+      const repoPath2 = await refreshMirror(project);
+      expect(repoPath2).toBe(repoPath);
+    } finally {
+      process.env.KORTIX_GIT_CACHE_DIR = prevCacheDir;
+      await rm(workdir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -36,6 +36,7 @@ import { setupApp } from './setup';
 import { supabaseAuth, combinedAuth } from './middleware/auth';
 import { requestDeadline, isRequestDeadlineHTTPException } from './middleware/request-deadline';
 import { isPlatinumSandboxNotRunningError } from './shared/platinum';
+import { GitOperationError, isGitOperationError } from './projects/git/mirror';
 // Statically imported (NOT await import() in the handlers): on a long-running
 // `bun --hot` dev process, dynamic import() can wedge permanently after enough
 // hot reloads — the promise never settles, the handler hangs, and Bun's
@@ -806,6 +807,27 @@ app.onError((err, c) => {
     });
     c.header('Retry-After', '10');
     return c.json({ error: true, message: 'sandbox is not running', status: 503 }, 503);
+  }
+
+  // A bare-clone / fetch of a project's git mirror that exceeds its timeout
+  // (SIGTERM mid-transfer, large repo, transient network) is EXPECTED and
+  // retryable — the mirror already retries once internally before surfacing.
+  // Previously these surfaced as the opaque Better Stack pattern `8d0cffbb…`
+  // ("Cloning into bare repository '/tmp/kortix/git-cache/….git'…" — git's
+  // progress line captured on stderr before the kill, masking the real cause).
+  // `runGit` now throws a typed `GitOperationError` (kind 'timeout') whose
+  // message names the timeout; classify the transient kind into a retryable
+  // 503 + Retry-After WITHOUT paging Sentry (mirroring Platinum /
+  // request-deadline), while a real `failed` kind (auth / missing repo) still
+  // falls through to Sentry with a meaningful `fatal:` message. See
+  // projects/git/mirror.ts.
+  if (isGitOperationError(err) && err.kind === 'timeout') {
+    appLogger.warn(`${method} ${path} -> 503 [GitOperationError:timeout] ${err.message}`, {
+      method, path, errorType: 'GitOperationError', gitKind: 'timeout',
+      gitArgs: err.gitArgs, signal: err.signal,
+    });
+    c.header('Retry-After', '10');
+    return c.json({ error: true, message: 'git mirror is temporarily unavailable', status: 503 }, 503);
   }
 
   if (err instanceof BillingError) {

--- a/apps/api/src/projects/git/mirror.ts
+++ b/apps/api/src/projects/git/mirror.ts
@@ -97,6 +97,135 @@ function gitAuthEnv(token?: string | null, authHost = 'github.com'): Record<stri
   };
 }
 
+/** Default per-op timeout for `runGit` (ms). Bare clones override this via `timeoutMs`. */
+const GIT_DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Benign git progress / informational lines that git writes to **stderr** even
+ * on a SUCCESSFUL run (`Cloning into …`, `remote:`, `Counting objects`, …) and
+ * that are therefore the FIRST — and on a mid-clone timeout often the ONLY —
+ * stderr a killed `git clone`/`git fetch` leaves behind. Surfacing them as the
+ * Error message hides the real cause (timeout / signal / `fatal:`) and produced
+ * the recurring opaque Better Stack pattern `8d0cffbb…`
+ * ("Cloning into bare repository '/tmp/kortix/git-cache/….git'…"). Strip them
+ * so a surfaced git error shows its actual `fatal:` line (or nothing, when the
+ * process was killed before emitting one).
+ */
+const GIT_PROGRESS_LINE_RE = /^(?:Cloning into|remote:|Counting objects|Compressing objects|Receiving objects|Resolving deltas|From |\s*\d+%|\s*remote:)/;
+
+export function stripGitProgress(text: string): string {
+  if (!text) return '';
+  return text
+    .split('\n')
+    .filter((line) => line.trim() !== '' && !GIT_PROGRESS_LINE_RE.test(line))
+    .join('\n')
+    .trim();
+}
+
+/**
+ * Typed error thrown by `runGit` (and anything downstream of a bare-clone /
+ * fetch failure). Replaces the old `throw new Error(stderr || stdout || …)`
+ * which surfaced git's harmless `Cloning into bare repository …` progress line
+ * — the only stderr a SIGTERM'd mid-clone leaves — as the Sentry message,
+ * completely masking the real timeout/signal cause (Better Stack `8d0cffbb…`).
+ *
+ * `kind: 'timeout'` marks a transient, retryable failure (process killed /
+ * SIGTERM'd / exceeded the timeout). The global `onError` classifies those into
+ * a retryable 503 + Retry-After WITHOUT paging Sentry (mirroring the Platinum
+ * / request-deadline de-noise pattern), since the mirror's own retry usually
+ * clears them and they are upstream/network noise, not a code bug.
+ * `kind: 'failed'` is a real non-zero exit (auth, missing repo, bad ref) —
+ * still surfaced to Sentry, but now with a meaningful `fatal:` message instead
+ * of progress noise.
+ */
+export class GitOperationError extends Error {
+  readonly kind: 'timeout' | 'failed';
+  readonly gitArgs: readonly string[];
+  readonly signal: string | null;
+  readonly exitCode: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  constructor(opts: {
+    kind: 'timeout' | 'failed';
+    message: string;
+    gitArgs: readonly string[];
+    signal?: string | null;
+    exitCode?: number | null;
+    stdout?: string;
+    stderr?: string;
+    cause?: unknown;
+  }) {
+    super(opts.message, { cause: opts.cause });
+    this.name = 'GitOperationError';
+    this.kind = opts.kind;
+    this.gitArgs = opts.gitArgs;
+    this.signal = opts.signal ?? null;
+    this.exitCode = opts.exitCode ?? null;
+    this.stdout = opts.stdout ?? '';
+    this.stderr = opts.stderr ?? '';
+  }
+}
+
+/**
+ * Pure classifier (unit-testable without a real git process): turn a Node
+ * `execFile` rejection into a typed `GitOperationError`. A killed/timed-out
+ * process (signal set, or Node's "timed out" message) is `kind: 'timeout'`
+ * with a message naming the timeout + signal — NEVER the partial `Cloning
+ * into …` progress line Node captured on stderr before the kill. A normal
+ * non-zero exit is `kind: 'failed'` with the real `fatal:` line (progress
+ * stripped).
+ */
+export function classifyGitError(error: unknown, args: readonly string[], timeoutMs: number): GitOperationError {
+  const err = error as {
+    stderr?: Buffer | string;
+    stdout?: Buffer | string;
+    message?: string;
+    code?: string | number;
+    signal?: string;
+    killed?: boolean;
+  };
+  const stderr = err.stderr?.toString() || '';
+  const stdout = err.stdout?.toString() || '';
+  const signal = err.signal ?? null;
+  const killed = Boolean(err.killed);
+  const msg = err.message || '';
+  // Node fires `killed: true` + `signal: 'SIGTERM'` (no numeric exitCode) when
+  // the `timeout` elapses, OR sets `code: 'ETIMEDOUT'`. Either way the real
+  // cause is the timeout — the stderr git managed to write before being killed
+  // is just the `Cloning into …` / `remote: …` progress line and must NOT
+  // become the message.
+  const isTimeout = killed || Boolean(signal) || msg.includes('timed out') || err.code === 'ETIMEDOUT';
+  const subcommand = args[0] || 'git';
+  if (isTimeout) {
+    const detail = signal ? ` (signal ${signal})` : '';
+    return new GitOperationError({
+      kind: 'timeout',
+      message: `git ${subcommand} timed out after ${timeoutMs}ms${detail}`,
+      gitArgs: args,
+      signal,
+      exitCode: null,
+      stdout,
+      stderr,
+      cause: error,
+    });
+  }
+  const cleaned = stripGitProgress(stderr) || stripGitProgress(stdout) || msg || 'git failed';
+  return new GitOperationError({
+    kind: 'failed',
+    message: cleaned,
+    gitArgs: args,
+    signal,
+    exitCode: typeof err.code === 'number' ? err.code : null,
+    stdout,
+    stderr,
+    cause: error,
+  });
+}
+
+export function isGitOperationError(err: unknown): err is GitOperationError {
+  return err instanceof GitOperationError;
+}
+
 export async function runGit(
   args: string[],
   cwd?: string,
@@ -104,6 +233,7 @@ export async function runGit(
   authToken?: string | null,
   extraEnv?: Record<string, string>,
   authHost = 'github.com',
+  timeoutMs: number = GIT_DEFAULT_TIMEOUT_MS,
 ) {
   const authEnv = auth ? gitAuthEnv(authToken, authHost) : {};
   try {
@@ -111,17 +241,14 @@ export async function runGit(
       cwd,
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0', ...authEnv, ...(extraEnv || {}) },
       maxBuffer: 10 * 1024 * 1024,
-      timeout: 30_000,
+      timeout: timeoutMs,
     });
     return {
       stdout: result.stdout.toString(),
       stderr: result.stderr.toString(),
     };
   } catch (error) {
-    const err = error as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string };
-    const stderr = err.stderr?.toString() || '';
-    const stdout = err.stdout?.toString() || '';
-    throw new Error((stderr || stdout || err.message || 'git failed').trim());
+    throw classifyGitError(error, args, timeoutMs);
   }
 }
 
@@ -164,6 +291,18 @@ function refreshIntervalMs() {
   return Number.isFinite(value) && value >= 0 ? value : 60_000;
 }
 
+/** Per-op timeout (ms) for a cold bare `git clone --bare` of a project mirror. */
+function bareCloneTimeoutMs(): number {
+  const value = Number(process.env.KORTIX_GIT_BARE_CLONE_TIMEOUT_MS || 90_000);
+  return Number.isFinite(value) && value > 0 ? value : 90_000;
+}
+
+const BARE_CLONE_TIMEOUT_MS = bareCloneTimeoutMs();
+/** Cold clones can transiently exceed the timeout (large repo / network blip);
+ * retry once before surfacing — most timeouts clear on a 2nd attempt. */
+const BARE_CLONE_MAX_ATTEMPTS = 2;
+const BARE_CLONE_RETRY_DELAY_MS = 500;
+
 async function doRefreshMirror(project: GitBackedProject, force = false) {
   const repoPath = repoCachePath(project);
   await mkdir(dirname(repoPath), { recursive: true });
@@ -187,12 +326,33 @@ async function doRefreshMirror(project: GitBackedProject, force = false) {
     // Bare clone with ALL branches — required for the version/checkpoint
     // viewer. Older callers cloned --single-branch; we self-heal those on
     // refresh below by rewriting the fetch refspec.
-    await runGit([
-      'clone',
-      '--bare',
-      project.repoUrl,
-      repoPath,
-    ], undefined, true, authToken, undefined, authHost);
+    //
+    // Cold clones of large repos legitimately exceed the default 30s `runGit`
+    // timeout; a SIGTERM mid-transfer leaves only git's `Cloning into …`
+    // progress line on stderr (the root of the recurring opaque Better Stack
+    // pattern `8d0cffbb…`) AND — critically — leaves a partial `.git` dir
+    // with no `shallow` marker, so the next access sees `existsSync(repoPath)`
+    // true, skips the clone, and tries to `fetch` from a broken half-repo,
+    // wedging every reader for the process lifetime. So: give the cold clone a
+    // longer budget, retry once on a transient timeout, and ALWAYS remove the
+    // partial dir on failure so the next caller re-clones cleanly.
+    const cloneArgs = ['clone', '--bare', project.repoUrl, repoPath] as const;
+    let lastErr: unknown = null;
+    for (let attempt = 1; attempt <= BARE_CLONE_MAX_ATTEMPTS; attempt++) {
+      try {
+        await runGit([...cloneArgs], undefined, true, authToken, undefined, authHost, BARE_CLONE_TIMEOUT_MS);
+        lastErr = null;
+        break;
+      } catch (err) {
+        lastErr = err;
+        // Remove the partial bare repo a killed/failed clone leaves behind.
+        await rm(repoPath, { recursive: true, force: true }).catch(() => {});
+        const transient = err instanceof GitOperationError && err.kind === 'timeout';
+        if (attempt >= BARE_CLONE_MAX_ATTEMPTS || !transient) break;
+        await new Promise((resolve) => setTimeout(resolve, BARE_CLONE_RETRY_DELAY_MS));
+      }
+    }
+    if (lastErr) throw lastErr;
     lastRefreshAt.set(project.projectId, Date.now());
     return repoPath;
   }


### PR DESCRIPTION
## BS 8d0cffbb — git mirror clone timeout masked as "Cloning into" progress noise

**Better Stack error:** https://errors.betterstack.com/team/t502678/errors/8d0cffbb3c105d61e03c5052bee04f6a1a4ef628a9f7270f9d79789fd8f5f7b1?s=2346961
**Type:** `Error` · **State:** `Reoccurred` · **Call site:** `runGit` at `/app/apps/api/src/projects/git/mirror.ts`
**First seen:** 2026-06-11 · **Last seen:** 2026-07-15 08:54:06 UTC · **App:** Kortix API prod (`application_id 2346961`)
**Error message:** `Cloning into bare repository '/tmp/kortix/git-cache/5837336aa90fe415914ab32916bff7ad.git'...`

### One-line root cause
`runGit`'s catch did `throw new Error(stderr || stdout || err.message)` — but `git clone --bare` writes its benign progress line `Cloning into bare repository '...'...` to **stderr immediately**, and on a 30s timeout Node **SIGTERMs** git mid-transfer, leaving that progress line as the **only** captured stderr. The real cause (timeout / SIGTERM) was completely masked, so Sentry/Better Stack received the opaque progress line as the `Error` message — unactionable, recurring since 2026-06-11.

### Evidence
- **Reproduced Node's exact error shape** (the proof, since the rotating Better Stack ClickHouse shard tables weren't reachable from the load-balanced query nodes):
  ```sh
  $ node -e '...execFile("fake-git.sh", [], {timeout:800})'
  message: "Command failed: ...\nCloning into bare repository '/tmp/kortix/git-cache/abc.git'...\n"
  signal:  SIGTERM
  killed:  true
  stderr:  "Cloning into bare repository '/tmp/kortix/git-cache/abc.git'...\n"
  stdout:  ""
  ```
  `stderr` is **exactly** `Cloning into bare repository '…'...` — identical to the Better Stack message — because git was killed before writing any `fatal:` line.
- Old `runGit` catch: `throw new Error((stderr || stdout || err.message || 'git failed').trim())` → `stderr` is truthy → the thrown message is the progress line. **This is the bug.**
- **Second-order wedge:** a killed bare clone leaves a partial `.git` dir with **no `shallow` marker** (bare clones aren't shallow), so the next access sees `existsSync(repoPath)` true, skips the clone, and tries to `fetch` from a broken half-repo — failing every concurrent reader for the process lifetime.
- Error-sweep ledger (`.kortix/memory/error-sweep-log.md`) already flagged this group as the candidate: *"API file-content git mirror expected failures (`8d0cff…`) — candidate small API PR to convert expected git errors into typed 4xx/503 responses without Sentry."* No prior PR (`gh pr list --search 8d0cffbb --state all` → none). Distinct from the `df7a31d…` socket-close group (#4530).

### Fix (`apps/api/src/projects/git/mirror.ts`)
1. **Typed error + classifier.** `runGit` now throws a `GitOperationError` (`kind: 'timeout' | 'failed'`) built by a pure, unit-tested `classifyGitError`. A killed/timed-out process (`killed` / `signal` / `ETIMEDOUT`) is `kind: 'timeout'` with a message **naming the timeout + signal** — never the `Cloning into …` progress line. A normal non-zero exit is `kind: 'failed'` with the real `fatal:` line (`stripGitProgress` removes benign progress lines). Original error preserved as `cause`; raw `stderr`/`stdout` kept on the error for debugging.
2. **Resilient cold clone.** `doRefreshMirror`'s bare-clone path now: uses a longer **90s** budget (env `KORTIX_GIT_BARE_CLONE_TIMEOUT_MS`), **always `rm -rf`s the partial mirror dir on failure** (kills the poisoned-cache wedge), and **retries once** on a transient timeout (most clear on a 2nd attempt).
3. **De-noise (`apps/api/src/index.ts` `onError`).** Classifies `GitOperationError` `kind: 'timeout'` into a retryable **503 + `Retry-After: 10`** **without** paging Sentry (mirrors the established `PlatinumSandboxNotRunningError` / `request-deadline` de-noise pattern — structured `appLogger.warn` still records it for ClickHouse/metrics). `kind: 'failed'` (auth / missing repo) still surfaces to Sentry, now with a meaningful `fatal:` message instead of progress noise.

### Regression test (`apps/api/src/__tests__/unit-git-mirror-clone.test.ts`)
- `stripGitProgress`: removes `Cloning into`/`remote:`/`Counting objects`/…, keeps `fatal:`.
- `classifyGitError` — the 8d0cffbb root cause: a Node timeout error (`killed:true, signal:'SIGTERM', stderr:"Cloning into bare repository '…'..."`) → `GitOperationError`, `kind: 'timeout'`, message **does not contain** `Cloning into bare repository`, **does** contain `timed out` + `SIGTERM`; raw stderr preserved.
- `classifyGitError`: a normal non-zero exit → `kind: 'failed'`, message is the real `fatal: repository '…' does not exist`, not progress noise.
- `classifyGitError`: `ETIMEDOUT` code (no signal) also classified as `timeout`.
- `refreshMirror`: a failed bare clone (real local git, nonexistent source) **removes the partial mirror dir** so the next call re-clones (proves the wedge fix), and the surfaced error is the real fatal line.
- `refreshMirror`: a successful clone is served from the warm cache on the next call (no regression to the warm path).

### Verification
- `bun test src/__tests__/unit-git-mirror-clone.test.ts` → **7 pass / 0 fail** (22 expects).
- Full mirror suite (`unit-git-mirror-clone` + `unit-git-mirror-auth` + `mirror.reaper` + `hashing` + `unit-git-ref`) → **24 pass / 0 fail**.
- `tsc --noEmit` (apps/api) → **EXIT 0** (clean).
- Backward compatible: `runGit`'s new `timeoutMs` is the 7th optional param; all existing callers pass ≤6 args and use the 30s default. `GitOperationError extends Error`, so callers that `.catch(() => …)` swallow or read `.message` are unaffected.

### How to confirm resolution
After merge + Promote: the Better Stack group `8d0cffbb…` should drop to **zero new occurrences** — a timed-out bare clone now logs `errorType: 'GitOperationError' gitKind: 'timeout'` (warn, no Sentry page) and returns a retryable 503 instead of a 500 with the "Cloning into …" message. Any residual `kind: 'failed'` occurrences (real auth/missing-repo) will appear as a new, actionable `GitOperationError` group with the actual `fatal:` line rather than the opaque progress text.

### Notes for reviewer
- Not merged — orchestrator owns review + merge.
- Scope is deliberately tight: `runGitCapture` (the never-throw variant used for `merge-tree` conflict detection) is intentionally left unchanged — it's not part of this error group and its control-flow semantics (non-zero exit = expected) must not change.
