### PR TITLE
fix(web): drop @embedpdf tiling React #185 render-loop noise (BS 366115d4)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -5,6 +5,7 @@ import {
   isAndroidWebViewNativeBridgePostMessageNoise,
   isClientRequestTimeoutMessage,
   isEmptyMessageUnresolvedBrowserChunkNoise,
+  isEmbedPdfTilingReactUpdateDepthNoise,
   isExpectedBillingGateMessage,
   isExtensionSource,
   isInjectedAppSource,
@@ -2204,6 +2205,167 @@ test('does NOT suppress a different RangeError message', () => {
       isUnresolvableStackOverflowNoise({
         message,
         frames: [IOS_STACK_OVERFLOW_SYNTHETIC_FRAME],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// @embedpdf/plugin-tiling `TilingLayer` React #185 "Maximum update depth
+// exceeded" render-loop noise
+// (Better Stack pattern 366115d4c931a6352fe8f334ff1b366f6d4b2ce9c192769ac681831354521e30,
+// Kortix Frontend prod, application_id 2346967). The `@embedpdf/plugin-tiling`
+// `TilingLayer` React component (used by `pdf-viewer.tsx`'s `<TilingLayer>`)
+// subscribes to the tiling plugin's `onTileRendering` event and calls
+// `setTiles(...)` on every emission; under a rapid zoom/scroll burst the
+// plugin re-emits synchronously during the React commit phase, tripping
+// React's 50-nested-update guard (#185). 1 occurrence, 0 identified users,
+// 2026-07-15 09:36:41 UTC, route `/projects/:id/sessions/:sessionId`, Chrome
+// 142 / Windows 10. The throw frame is `Object.r [as onTileRendering]` in a
+// `_next/static/chunks/…` bundle — never first-party `apps/web/src/…` source.
+// React #185 is ALSO a real first-party setState-loop message, so the matcher
+// requires BOTH the #185 message AND an `onTileRendering` frame, with a
+// first-party negative guard.
+// ---------------------------------------------------------------------------
+
+// The exact React #185 message from the production event.
+const REACT_185 =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
+
+// A representative slice of the production stack frames (oldest-first →
+// throwing frame last): the React reconciler loop (`uE`/`ux`) recursing
+// through the @embedpdf `onTileRendering` callback. All frames are raw
+// `_next/static/chunks/…` bundles — none resolve to first-party source.
+const EMBEDPDF_TILING_REACT_185_FRAMES = [
+  { filename: 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy', function: 'uE' },
+  { filename: 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy', function: 'ux' },
+  { filename: 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy', function: 'o1' },
+  {
+    filename: 'app:///_next/static/chunks/78309.4a49d57927d341e9.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy',
+    function: 'Object.r [as onTileRendering]',
+  },
+  { filename: 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy', function: 't7' },
+]
+
+test('classifies the @embedpdf tiling React #185 render loop as noise', () => {
+  assert.equal(
+    isEmbedPdfTilingReactUpdateDepthNoise({
+      message: REACT_185,
+      frames: EMBEDPDF_TILING_REACT_185_FRAMES,
+    }),
+    true,
+  )
+})
+
+test('suppresses the assigned @embedpdf tiling React #185 Sentry event via the beforeSend gate', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/c4d70885-ce86-4283-b373-bc2fbcd92b85/sessions/917c2468-11bf-4cf0-92e6-20d17fa58e77',
+      },
+      exception: {
+        values: [
+          {
+            value: REACT_185,
+            stacktrace: { frames: EMBEDPDF_TILING_REACT_185_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the @embedpdf tiling React #185 event even with only the onTileRendering frame', () => {
+  // A minimal capture carrying just the tiling callback frame still qualifies.
+  assert.equal(
+    isEmbedPdfTilingReactUpdateDepthNoise({
+      message: REACT_185,
+      frames: [
+        {
+          filename: 'app:///_next/static/chunks/78309.4a49d57927d341e9.js?dpl=dpl_YsEdLTRagkN1LYLYMhUFP3rXtrAy',
+          function: 'Object.r [as onTileRendering]',
+        },
+      ],
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the @embedpdf tiling React #185 when a first-party frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own component is the looping
+  // culprit → actionable; the negative guard MUST preserve it so the call site
+  // can be found + fixed. This is the whole reason the matcher is frame-aware
+  // (React #185 is also a real first-party setState-loop message).
+  for (const frames of [
+    [{ filename: 'apps/web/src/components/ui/extend/pdf-viewer.tsx', function: 'PDFViewerInner' }],
+    [
+      { filename: 'app:///_next/static/chunks/78309.4a49d57927d341e9.js', function: 'Object.r [as onTileRendering]' },
+      { filename: 'app:///apps/web/src/components/ui/extend/pdf-viewer.tsx', function: 'renderPage' },
+    ],
+  ]) {
+    assert.equal(
+      isEmbedPdfTilingReactUpdateDepthNoise({ message: REACT_185, frames }),
+      false,
+      `expected first-party React #185 from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: REACT_185, stacktrace: { frames } }],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party React #185 from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress a React #185 with NO onTileRendering frame (a real app or different third-party loop)', () => {
+  // A real first-party setState loop, or a #185 from a different third-party
+  // lib, carries NO `onTileRendering` frame — it must keep reporting. Only the
+  // @embedpdf-tiling #185 class is dropped.
+  for (const frames of [
+    [{ filename: 'app:///_next/static/chunks/app.js', function: 'useEffect' }],
+    [{ filename: 'apps/web/src/features/session/session-chat.tsx', function: 'SessionChat' }],
+    [],
+  ]) {
+    assert.equal(
+      isEmbedPdfTilingReactUpdateDepthNoise({ message: REACT_185, frames }),
+      false,
+      `expected React #185 from ${JSON.stringify(frames)} (no onTileRendering) to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a different React error (#425) even with an onTileRendering frame', () => {
+  // The matcher is anchored on the EXACT #185 (Maximum update depth) code; a
+  // different React minified error from the tiling plugin is a different,
+  // actionable class and must keep reporting.
+  assert.equal(
+    isEmbedPdfTilingReactUpdateDepthNoise({
+      message:
+        'Minified React error #425; visit https://react.dev/errors/425 for the full message',
+      frames: EMBEDPDF_TILING_REACT_185_FRAMES,
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a non-React message that happens to mention #185', () => {
+  // The matcher anchors on `Minified React error #185` — a different message
+  // wording must not be matched.
+  for (const message of [
+    'Maximum update depth exceeded',
+    'Error #185 in custom handler',
+    'react.dev/errors/185',
+  ]) {
+    assert.equal(
+      isEmbedPdfTilingReactUpdateDepthNoise({
+        message,
+        frames: EMBEDPDF_TILING_REACT_185_FRAMES,
       }),
       false,
       `expected "${message}" to keep reporting`,

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -856,6 +856,57 @@ export function isAndroidWebViewNativeBridgePostMessageNoise(input: {
 // that gate has no frame context, so a bare-string match there would swallow a
 // real RangeError recursion; the frame-aware `beforeSend` hook (which calls
 // `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+// React #185 = "Maximum update depth exceeded" — the canonical React infinite-
+// setState-loop error. The `@embedpdf/plugin-tiling` `TilingLayer` React
+// component (used by `apps/web/src/components/ui/extend/pdf-viewer.tsx`'s
+// `<TilingLayer>`) subscribes to the tiling plugin's `onTileRendering` event
+// and calls `setTiles(event.tiles[pageIndex] ?? [])` on every emission. Under
+// a rapid zoom/scroll burst the tiling plugin emits `onTileRendering`
+// synchronously inside the React commit phase (a tile render resolves
+// synchronously from cache and re-emits), so `setTiles` is called during
+// commit → re-render → `TileImg` re-renders → `renderTile` → `onTileRendering`
+// → `setTiles` → … → React's 50-nested-update guard trips React #185. The
+// throw is INSIDE @embedpdf's bundled `TilingLayer`/`TileImg` (frame
+// `Object.r [as onTileRendering]` in a `_next/static/chunks/…` bundle), never
+// in first-party `apps/web/src/…` source. Better Stack pattern
+// 366115d4c931a6352fe8f334ff1b366f6d4b2ce9c192769ac681831354521e30
+// (Kortix Frontend prod, application_id 2346967): 1 occurrence, 0 identified
+// users, 2026-07-15 09:36:41 UTC, route `/projects/:id/sessions/:sessionId`,
+// Chrome 142 / Windows 10. A transient third-party render loop, not a
+// deterministic app regression (single occurrence, no identified users, no
+// first-party frame, no spike on a release across browsers).
+//
+// React #185 is ALSO the exact message a REAL first-party infinite-setState
+// loop produces, so this matcher is anchored on BOTH the #185 message AND a
+// frame whose function is `onTileRendering` (the @embedpdf tiling subscription
+// callback — never present in first-party code), AND a NEGATIVE guard: if any
+// frame resolves to a de-minified first-party `apps/web/src/…` source, the
+// event keeps reporting — that means our own component is the looping culprit
+// and is actionable to fix. A real first-party #185 surfaces with a resolved
+// `apps/web/src/…` frame (or at least no `onTileRendering` frame) and is
+// preserved; a #185 from a DIFFERENT third-party lib (no `onTileRendering`
+// frame) is preserved too. Only the @embedpdf-tiling #185 class is dropped.
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list —
+// that gate has no frame context, so a bare `#185` match there would swallow a
+// real first-party setState loop; the frame-aware `beforeSend` hook (which
+// calls `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const REACT_UPDATE_DEPTH_NOISE_PATTERN = /^Minified React error #185\b/;
+
+// The @embedpdf/plugin-tiling `TilingLayer` subscription callback frame. The
+// function name `onTileRendering` is the tiling plugin's own event name (see
+// `@embedpdf/plugin-tiling`'s `TilingLayer` → `tilingProvides.onTileRendering`);
+// it never appears in first-party `apps/web/src/…` source, so its presence is a
+// specific third-party anchor.
+const EMBEDPDF_TILING_CALLBACK_FRAME_MARKER = 'onTileRendering';
+
+function frameMatchesEmbedPdfTilingCallback(
+  frame: { function?: unknown } | undefined,
+): boolean {
+  return normalizeString(frame?.function).includes(
+    EMBEDPDF_TILING_CALLBACK_FRAME_MARKER,
+  );
+}
+
 const STACK_OVERFLOW_NOISE_PATTERN = /^Maximum call stack size exceeded\.?$/;
 
 // A frame/filename that points at a REAL source location: non-empty AND not the
@@ -905,6 +956,49 @@ export function isUnresolvableStackOverflowNoise(input: {
     return false;
   }
   return true;
+}
+
+/**
+ * Whether a Sentry exception is the `@embedpdf/plugin-tiling` `TilingLayer`
+ * React #185 "Maximum update depth exceeded" render-loop class: a
+ * `Minified React error #185` thrown from inside the tiling plugin's
+ * `onTileRendering` subscription callback (frame `Object.r [as
+ * onTileRendering]` in a `_next/static/chunks/…` bundle) with NO resolved
+ * first-party `apps/web/src/…` frame. The tiling plugin re-emits
+ * `onTileRendering` synchronously during the React commit phase under a rapid
+ * zoom/scroll burst, so its `setTiles` runs during commit → re-render →
+ * `renderTile` → re-emit → React's 50-nested-update guard trips #185. The
+ * throw is in third-party bundled code, never first-party. Requires BOTH the
+ * #185 message AND an `onTileRendering` frame, AND a NEGATIVE guard: if any
+ * frame resolves to a de-minified first-party `apps/web/src/…` source, the
+ * event keeps reporting (our own component is the looping culprit →
+ * actionable). A real first-party #185, or a #185 from a different third-party
+ * lib, is never matched. Returns false when there are no frames (can't confirm
+ * the tiling anchor — keep reporting). See
+ * `REACT_UPDATE_DEPTH_NOISE_PATTERN` for the full rationale.
+ */
+export function isEmbedPdfTilingReactUpdateDepthNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown; function?: unknown } | undefined>;
+}): boolean {
+  const message = stripErrorWrappers(normalizeString(input.message));
+  if (!REACT_UPDATE_DEPTH_NOISE_PATTERN.test(message)) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  if (frames.length === 0) {
+    return false;
+  }
+  // Negative guard: a resolved first-party frame means our own component is the
+  // looping culprit → actionable; keep reporting so the call site can be found.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  // Anchor: the throw must be inside @embedpdf/plugin-tiling's `onTileRendering`
+  // subscription callback. This frame is never present in first-party code, so a
+  // real first-party #185 (or a #185 from a different third-party lib) is never
+  // matched.
+  return frames.some(frameMatchesEmbedPdfTilingCallback);
 }
 
 export function shouldIgnoreBrowserRuntimeNoise(input: {
@@ -1225,6 +1319,17 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // `isUnresolvableStackOverflowNoise`. NOT in `ignoreErrors` (no frame
   // context there).
   if (isUnresolvableStackOverflowNoise({ message, frames })) {
+    return true;
+  }
+
+  // @embedpdf/plugin-tiling `TilingLayer` React #185 "Maximum update depth
+  // exceeded" render loop — the tiling plugin re-emits `onTileRendering`
+  // synchronously during the React commit phase under a rapid zoom/scroll
+  // burst, tripping React's nested-update guard. Requires BOTH the #185 message
+  // AND an `onTileRendering` frame, with a first-party negative guard, so a
+  // real first-party setState loop keeps reporting. See
+  // `isEmbedPdfTilingReactUpdateDepthNoise`.
+  if (isEmbedPdfTilingReactUpdateDepthNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## BS 366115d4 — drop `@embedpdf/plugin-tiling` React #185 render-loop noise

**Better Stack error:** https://errors.betterstack.com/team/t502678/errors/366115d4c931a6352fe8f334ff1b366f6d4b2ce9c192769ac681831354521e30?s=2346967
**Pattern:** `366115d4c931a6352fe8f334ff1b366f6d4b2ce9c192769ac681831354521e30`
**App:** Kortix Frontend (prod), application_id `2346967`
**Type:** `Error` — `Minified React error #185` (Maximum update depth exceeded)
**State:** Unresolved → 1 occurrence / 0 identified users, first & last 2026-07-15 09:36:41 UTC

### Evidence (from the raw Sentry exception in Better Stack ClickHouse)
- **Message:** `Minified React error #185; visit https://react.dev/errors/185 …` (#185 = React's "Maximum update depth exceeded" nested-update guard).
- **Route:** `/projects/:id/sessions/:sessionId` — `https://kortix.com/projects/<id>/sessions/<sessionId>`.
- **Release/env:** prod, Chrome 142 / Windows 10, React `19.2.0-canary`.
- **Stack:** 50 frames. The only named application frame is `Object.r [as onTileRendering]` in chunk `78309.4a49d57927d341e9.js`; the rest are the React reconciler loop (`uE`/`ux`) and minified chunk frames (`t6`/`t7`/`a5`/`a6`/`o1`). **No frame resolves to first-party `apps/web/src/…`** (sourcemaps left them as raw `_next/static/chunks/…` bundles).
- **Component stack** (top): a `<TilingLayer>` subtree rendered by `pdf-viewer.tsx`'s `renderPage` inside the session page.
- **Breadcrumbs:** a burst of `blob:` URL fetches immediately before the throw (PDF tile blob URLs being created/revoked), then the `console` capture of React #185.

### Root cause
The PDF viewer (`apps/web/src/components/ui/extend/pdf-viewer.tsx`) mounts `@embedpdf/plugin-tiling`'s `<TilingLayer>`. That component subscribes to the tiling plugin's `onTileRendering` event and calls `setTiles(event.tiles[pageIndex] ?? [])` on every emission (verified in `@embedpdf/plugin-tiling@2.14.4/dist/react/index.js`). Under a rapid zoom/scroll burst the tiling plugin re-emits `onTileRendering` **synchronously inside React's commit phase** (a tile render resolves synchronously from cache and re-emits), so `setTiles` runs during commit → re-render → `TileImg` re-renders → `renderTile` → `onTileRendering` → `setTiles` → … → React's 50-nested-update guard trips **#185**. The throw originates entirely inside `@embedpdf`'s bundled `TilingLayer`/`TileImg` (frame `Object.r [as onTileRendering]`), never in first-party source.

This is a transient third-party render loop, not a deterministic app regression: single occurrence, 0 identified users, no first-party frame, no spike on a release across browsers.

### Fix
Frame-aware Sentry `beforeSend` filter (the established pattern in `apps/web/src/lib/browser-error-noise.ts` for third-party/browser-engine render-loop noise). `isEmbedPdfTilingReactUpdateDepthNoise` drops the event **only** when ALL hold:
1. message is `Minified React error #185` (anchored), AND
2. a stack frame's `function` contains `onTileRendering` (the `@embedpdf/plugin-tiling` subscription callback — never present in first-party code), AND
3. **negative guard:** no frame resolves to a de-minified first-party `apps/web/src/…` source.

Wired into the frames-based `shouldIgnoreSentryBrowserNoise` gate only — deliberately **not** added to `sentry.client.config.ts`'s message-only `ignoreErrors` list (that gate has no frame context and would swallow a real first-party #185). The runtime `window.onerror` gate is also intentionally not extended: it has no function-name context, so message-only matching of #185 would be too broad.

### Why this is safe (negative guards)
React #185 is also the exact message a **real first-party** infinite-setState loop produces. The matcher preserves every such case:
- A real first-party #185 → its frames resolve to `apps/web/src/…` → negative guard keeps it. ✅ (test: `does NOT suppress the @embedpdf tiling React #185 when a first-party frame is present`)
- A #185 from a different third-party lib → no `onTileRendering` frame → not matched. ✅ (test: `does NOT suppress a React #185 with NO onTileRendering frame`)
- A different React error (#425) even with an `onTileRendering` frame → not #185 → not matched. ✅
- A frameless #185 capture → can't confirm the tiling anchor → kept. ✅

### Tests
8 new `node:test` cases in `apps/web/src/lib/browser-error-noise.test.mts` (101 pass total, `bun test`):
- the assigned production event (exact message + frame chain) is suppressed via `beforeSend`;
- minimal single-`onTileRendering`-frame capture is suppressed;
- first-party-frame negative guard preserves a real first-party #185;
- no-`onTileRendering`-frame #185 (app or different third-party) keeps reporting;
- a different React code (#425) with the tiling frame keeps reporting;
- a non-React message mentioning `#185` keeps reporting.

### Verification
- `bun test apps/web/src/lib/browser-error-noise.test.mts` → **101 pass / 0 fail**.
- `tsc` on `browser-error-noise.ts` (the file included in the Next.js build typecheck) → **clean**. (`.test.mts` is excluded from the web `tsconfig.json` `include`, so it is not part of the build typecheck — same as all other noise tests.)
- `biome lint` on both files → **clean**. (The `biome check` formatter drift is pre-existing on `main` for these files and is not a CI gate — the CI lint-test-surface step is scoped to `tests packages apps/api/scripts`, not `apps/web`.)

### Confirmation of resolution
After this merges + promotes, the `366115d4…` pattern should drop to zero new occurrences in Better Stack (the `beforeSend` gate returns `null` for the exact tiling #185 class). A real first-party React #185 regression would still report normally — which is the whole point of the frame-aware anchor.

---
*Worker: Better Stack error-triage. Do-not-merge — leaving open and green for the orchestrator to review/merge.*
