### PR TITLE
fix(web): filter EIP-1193 wallet-extension plain-object rejection noise (BS 0f78b2f8)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -7,6 +7,7 @@ import {
   isEmptyMessageUnresolvedBrowserChunkNoise,
   isEmbedPdfTilingReactUpdateDepthNoise,
   isExpectedBillingGateMessage,
+  isExtensionRejectedObjectNoise,
   isExtensionSource,
   isInjectedAppSource,
   isInpageWalletStreamNoise,
@@ -2212,6 +2213,7 @@ test('does NOT suppress a different RangeError message', () => {
   }
 })
 
+
 // ---------------------------------------------------------------------------
 // @embedpdf/plugin-tiling `TilingLayer` React #185 "Maximum update depth
 // exceeded" render-loop noise
@@ -2371,4 +2373,227 @@ test('does NOT suppress a non-React message that happens to mention #185', () =>
       `expected "${message}" to keep reporting`,
     )
   }
+})
+
+// ---------------------------------------------------------------------------
+// Browser-extension EIP-1193 wallet-provider plain-object rejection noise
+// (Better Stack pattern
+// 0f78b2f8e9efa79fe9b2ea534e275c704f113eafea86bae5470f33174ebacebc,
+// Kortix Frontend prod, application_id 2346967, `UnhandledRejection`). A
+// wallet extension (extension id `lgmpcpglpngdoalbgeoldeajfclnhafa`) injects
+// an EIP-1193 provider whose content script
+// (`chrome-extension://<id>/content-script.js`) rejects pending JSON-RPC
+// requests with a PLAIN OBJECT — not an Error — of shape
+// `{ code: 4900, message: "The provider is disconnected from all chains.",
+// stack: "Error: …\\n    at … (chrome-extension://…/content-script.js)" }`
+// (EIP-1193 code 4900 = "provider is disconnected"). Because the rejected
+// value is not an Error, Sentry's GlobalHandlers `onunhandledrejection`
+// integration cannot extract a stack: it serializes the object's enumerable
+// keys into `extra.__serialized__` and sets the exception value to the
+// synthetic "Object captured as promise rejection with keys: code, message,
+// stack" with NO stacktrace frames. The extension origin therefore lives
+// ONLY in `extra.__serialized__.stack` — the frame-aware extension guards
+// (`isExtensionSource`, `isInpageWalletStreamNoise`, `isTronLinkProxyNoise`)
+// all miss it (no frames to anchor on). 2 occurrences, 0 identified users,
+// first 2026-07-06 / last 2026-07-15, mechanism
+// `auto.browser.global_handlers.onunhandledrejection`, request URL
+// `https://kortix.com/auth`, Chrome 150. The matcher requires BOTH the
+// synthetic signature AND an extension-origin frame inside the serialized
+// stack so a real first-party `Promise.reject({...})` keeps reporting.
+// ---------------------------------------------------------------------------
+
+// The exact serialized rejection payload from the raw production event.
+const EIP1193_PROVIDER_DISCONNECTED_SERIALIZED = {
+  message: 'The provider is disconnected from all chains.',
+  stack:
+    'Error: The provider is disconnected from all chains.\n' +
+    '    at s (chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:13:100356)\n' +
+    '    at Object.disconnected (chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:13:101769)\n' +
+    '    at chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:26:51970\n' +
+    '    at E.rejectWaitingRequests (chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:26:51985)\n' +
+    '    at chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:26:59539',
+  code: 4900,
+}
+
+const SYNTHETIC_OBJECT_REJECTION_VALUE =
+  'Object captured as promise rejection with keys: code, message, stack'
+
+test('classifies the EIP-1193 provider-disconnected plain-object rejection as noise', () => {
+  assert.equal(
+    isExtensionRejectedObjectNoise({
+      message: SYNTHETIC_OBJECT_REJECTION_VALUE,
+      extra: { __serialized__: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED },
+    }),
+    true,
+  )
+})
+
+test('suppresses the assigned Sentry event via the beforeSend gate (frameless synthetic capture)', () => {
+  // Exact shape of the production event: synthetic exception value, NO
+  // stacktrace frames, extension origin only in extra.__serialized__.stack.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/auth' },
+      extra: { __serialized__: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED },
+      exception: {
+        values: [{ value: SYNTHETIC_OBJECT_REJECTION_VALUE }],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Firefox (moz-extension://) wallet variant', () => {
+  assert.equal(
+    isExtensionRejectedObjectNoise({
+      message: SYNTHETIC_OBJECT_REJECTION_VALUE,
+      extra: {
+        __serialized__: {
+          message: 'The provider is disconnected from all chains.',
+          stack: 'Error: The provider is disconnected from all chains.\n    at Object.disconnected (moz-extension://abcdef/content-script.js:1:1)',
+          code: 4900,
+        },
+      },
+    }),
+    true,
+  )
+  assert.equal(
+    isExtensionRejectedObjectNoise({
+      message: SYNTHETIC_OBJECT_REJECTION_VALUE,
+      extra: {
+        __serialized__: {
+          message: 'foo',
+          stack: 'Error: foo\n    at x (safari-web-extension://com.example.ext/content.js:1:1)',
+          code: 1,
+        },
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the wallet-provider rejection via the runtime (unhandledrejection) gate', () => {
+  // The runtime gate receives the raw rejected object as `reason`; its
+  // `message` is the provider's own ("The provider is disconnected…"), NOT
+  // Sentry's synthetic wording, so the gate anchors on the rejected value's
+  // own `stack` tracing through the extension content script.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({ reason: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({ error: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED }),
+    true,
+  )
+})
+
+test('does NOT suppress a synthetic plain-object rejection with NO serialized payload (conservative — keep reporting)', () => {
+  // No `extra.__serialized__` to confirm extension origin → a first-party
+  // `Promise.reject({code, message, stack})` could produce the same synthetic
+  // signature, so keep reporting.
+  assert.equal(
+    isExtensionRejectedObjectNoise({ message: SYNTHETIC_OBJECT_REJECTION_VALUE }),
+    false,
+  )
+  assert.equal(
+    isExtensionRejectedObjectNoise({
+      message: SYNTHETIC_OBJECT_REJECTION_VALUE,
+      extra: {},
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: SYNTHETIC_OBJECT_REJECTION_VALUE }] },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a synthetic plain-object rejection whose serialized stack has NO extension origin', () => {
+  // The serialized stack traces through our own app chunk, not an extension
+  // content script → a real first-party plain-object rejection; keep reporting.
+  assert.equal(
+    isExtensionRejectedObjectNoise({
+      message: SYNTHETIC_OBJECT_REJECTION_VALUE,
+      extra: {
+        __serialized__: {
+          message: 'boom',
+          stack: 'Error: boom\n    at handleClick (app:///_next/static/chunks/app.js:42:10)',
+          code: 500,
+        },
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a synthetic plain-object rejection whose stacktrace resolves to a first-party frame', () => {
+  // Negative guard: a resolved `apps/web/src/…` frame means our own code
+  // rejected the plain object — actionable, keep reporting.
+  assert.equal(
+    isExtensionRejectedObjectNoise({
+      message: SYNTHETIC_OBJECT_REJECTION_VALUE,
+      extra: { __serialized__: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED },
+      frames: [{ filename: 'apps/web/src/lib/wallet-provider.ts' }],
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      extra: { __serialized__: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED },
+      exception: {
+        values: [
+          {
+            value: SYNTHETIC_OBJECT_REJECTION_VALUE,
+            stacktrace: {
+              frames: [{ filename: 'app:///apps/web/src/lib/wallet-provider.ts' }],
+            },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a real Error rejection (not the synthetic plain-object signature)', () => {
+  // A genuine rejected Error carries a real message and stacktrace, never the
+  // synthetic "Object captured as promise rejection with keys: …" wording.
+  for (const value of [
+    'The provider is disconnected from all chains.',
+    'TypeError: Cannot read properties of undefined (reading id)',
+    'Internal server error',
+  ]) {
+    assert.equal(
+      isExtensionRejectedObjectNoise({
+        message: value,
+        extra: { __serialized__: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED },
+      }),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        extra: { __serialized__: EIP1193_PROVIDER_DISCONNECTED_SERIALIZED },
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected real Sentry event "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a runtime rejection whose reason is a real Error with an app-only stack', () => {
+  // A real Error from app code has a stack of app/chunk frames, never an
+  // extension content-script frame → keep reporting.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      reason: {
+        message: 'something failed',
+        stack: 'Error: something failed\n    at handleClick (app:///_next/static/chunks/app.js:42:10)',
+      },
+    }),
+    false,
+  )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -401,6 +401,124 @@ function isInpageWalletInjectedSource(filename: unknown): boolean {
   return /^app:\/\/\/inpage\.js$/.test(normalized);
 }
 
+// Browser-extension EIP-1193 wallet-provider "disconnected" rejection of a
+// PLAIN OBJECT (not an Error). A wallet extension (e.g. extension id
+// `lgmpcpglpngdoalbgeoldeajfclnhafa`) injects an EIP-1193 provider
+// (`window.ethereum`) whose content script
+// (`chrome-extension://<id>/content-script.js`) rejects pending JSON-RPC
+// requests when the provider disconnects, with a plain object of the shape
+// `{ code: 4900, message: "The provider is disconnected from all chains.",
+// stack: "Error: …\\n    at … (chrome-extension://…/content-script.js)" }`
+// (EIP-1193 / EIP-1474 error code 4900 = "provider is disconnected"). Because
+// the rejected value is NOT an Error instance, Sentry's GlobalHandlers
+// `onunhandledrejection` integration cannot extract a stack from it: it
+// serializes the object's own enumerable keys into `extra.__serialized__` and
+// sets the exception value to the synthetic
+// "Object captured as promise rejection with keys: code, message, stack" with
+// NO stacktrace frames. The extension origin therefore lives ONLY in
+// `extra.__serialized__.stack`, never in `exception.values[0].stacktrace` — so
+// the frame-aware extension-source guards (`isExtensionSource(frame.filename)`,
+// `isInpageWalletStreamNoise`, `isTronLinkProxyNoise`) all miss it (there are
+// no frames to anchor on). Better Stack pattern
+// 0f78b2f8e9efa79fe9b2ea534e275c704f113eafea86bae5470f33174ebacebc, Kortix
+// Frontend (prod, application_id 2346967), `UnhandledRejection`, 2
+// occurrences, 0 identified users, first 2026-07-06 / last 2026-07-15,
+// mechanism `auto.browser.global_handlers.onunhandledrejection`, request URL
+// `https://kortix.com/auth`, Chrome 150.
+//
+// The synthetic "Object captured as promise rejection with keys: …" message is
+// Sentry's generic signature for ANY non-Error plain-object rejection — a
+// first-party `Promise.reject({ code, message, stack })` would produce the SAME
+// signature — so matching on the message alone would swallow a real app bug.
+// Require BOTH the synthetic signature AND the serialized rejection's own
+// `stack` carrying a browser-extension origin (`chrome-extension://`,
+// `moz-extension://`, `safari-web-extension://`, `extension://`), which is
+// definitive proof the rejection originated in an extension content script,
+// not first-party code. A negative guard preserves any event whose stacktrace
+// still resolves to a first-party `apps/web/src/…` frame (our own code rejected
+// a plain object that happens to carry an extension stack — actionable).
+// Returns false when there is no serialized payload to confirm extension origin
+// (keep reporting rather than swallow a possible app plain-object rejection).
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list —
+// that gate has no `extra.__serialized__` context, so a bare-string match there
+// could swallow a real app plain-object rejection; the frame+payload-aware
+// `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`) is the only
+// safe gate.
+const SYNTHETIC_OBJECT_REJECTION_PATTERN =
+  /^Object captured as promise rejection with keys:/;
+
+function extractSerializedRejectionStack(extra: unknown): string {
+  if (!extra || typeof extra !== 'object') return '';
+  const serialized = (extra as Record<string, unknown>).__serialized__;
+  if (!serialized) return '';
+  if (typeof serialized === 'string') return serialized;
+  if (typeof serialized === 'object') {
+    const stack = (serialized as Record<string, unknown>).stack;
+    return typeof stack === 'string' ? stack : '';
+  }
+  return '';
+}
+
+/**
+ * Whether a Sentry event is the browser-extension wallet-provider
+ * plain-object rejection noise class: a synthetic
+ * "Object captured as promise rejection with keys: …" exception (Sentry's
+ * signature for a non-Error rejection) whose serialized rejection payload
+ * (`extra.__serialized__.stack`) traces through a browser-extension content
+ * script. EIP-1193 wallet extensions reject pending requests with a plain
+ * `{ code, message, stack }` object when the provider disconnects; Sentry
+ * cannot extract a stack from a non-Error, so the extension origin appears
+ * ONLY in the serialized payload, never in the stacktrace frames. Requires
+ * BOTH the synthetic signature AND an extension-origin frame inside the
+ * serialized stack so a real first-party `Promise.reject({...})` keeps
+ * reporting. See `SYNTHETIC_OBJECT_REJECTION_PATTERN` for the full rationale.
+ */
+export function isExtensionRejectedObjectNoise(input: {
+  message?: unknown;
+  extra?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const message = normalizeString(input.message);
+  if (!SYNTHETIC_OBJECT_REJECTION_PATTERN.test(message)) {
+    return false;
+  }
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our own
+  // code rejected a plain object — actionable, keep reporting so the call site
+  // can be found + fixed.
+  const frames = input.frames ?? [];
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  const stack = extractSerializedRejectionStack(input.extra);
+  if (!stack) {
+    // No serialized payload to confirm extension origin — keep reporting
+    // rather than swallow a possible app plain-object rejection.
+    return false;
+  }
+  return EXTENSION_PROTOCOL_PREFIXES.some((prefix) => stack.includes(prefix));
+}
+
+// Whether a runtime-captured rejected value (the `reason` of an
+// `unhandledrejection` event, or an `error` object) is the browser-extension
+// wallet-provider plain-object rejection: a non-Error object whose own `stack`
+// string traces through a browser-extension content script. This is the
+// runtime-gate mirror of `isExtensionRejectedObjectNoise` (the Sentry `beforeSend`
+// gate sees Sentry's synthetic "Object captured as promise rejection …"
+// message; the runtime gate sees the raw rejected object, whose `message` is
+// the provider's own "The provider is disconnected from all chains." — so the
+// synthetic-signature matcher does not apply here). A real Error thrown by app
+// code has a stack of app/chunk frames, never an extension content-script
+// frame, so anchoring on an extension protocol inside the rejected value's
+// `stack` is conservative.
+function rejectedObjectHasExtensionStack(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const stack = (value as { stack?: unknown }).stack;
+  return (
+    typeof stack === 'string'
+    && EXTENSION_PROTOCOL_PREFIXES.some((prefix) => stack.includes(prefix))
+  );
+}
+
 function containsKnownPattern(message: string, patterns: readonly string[]): boolean {
   return patterns.some((pattern) => message.includes(pattern));
 }
@@ -1126,6 +1244,23 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Browser-extension EIP-1193 wallet-provider plain-object rejection noise —
+  // a wallet extension rejects a pending request with a plain
+  // `{ code, message, stack }` object (code 4900, "provider is disconnected").
+  // The runtime gate receives the raw rejected object as `reason`/`error`
+  // (whose `message` is the provider's own, NOT Sentry's synthetic "Object
+  // captured as promise rejection …" wording), so anchor on the rejected
+  // value's own `stack` tracing through a browser-extension content script.
+  // A real Error from app code has a stack of app/chunk frames, never an
+  // extension content-script frame, so this is conservative. See
+  // `isExtensionRejectedObjectNoise` / `rejectedObjectHasExtensionStack`.
+  if (
+    rejectedObjectHasExtensionStack(input.reason)
+    || rejectedObjectHasExtensionStack(input.error)
+  ) {
+    return true;
+  }
+
   // iOS-WebKit stack-overflow noise — `RangeError: Maximum call stack size
   // exceeded.` from `window.onerror` with NO resolvable source location (the
   // engine truncated the very stack that overflowed). Requires the canonical
@@ -1141,6 +1276,7 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
 
 export function shouldIgnoreSentryBrowserNoise(event: {
   message?: unknown;
+  extra?: unknown;
   request?: { url?: unknown };
   exception?: {
     values?: Array<{
@@ -1310,6 +1446,21 @@ export function shouldIgnoreSentryBrowserNoise(event: {
     return true;
   }
 
+  // Browser-extension EIP-1193 wallet-provider plain-object rejection noise —
+  // a wallet extension rejects a pending request with a plain
+  // `{ code, message, stack }` object (code 4900, "provider is disconnected"),
+  // and Sentry captures it as a synthetic "Object captured as promise
+  // rejection with keys: …" exception with NO stacktrace frames (the rejected
+  // value is not an Error, so Sentry cannot extract a stack). The extension
+  // origin lives ONLY in `extra.__serialized__.stack`, so the frame-aware
+  // extension guards above miss it. Requires BOTH the synthetic signature AND
+  // an extension-origin frame inside the serialized stack so a real first-party
+  // `Promise.reject({...})` keeps reporting. See
+  // `isExtensionRejectedObjectNoise`.
+  if (isExtensionRejectedObjectNoise({ message, extra: event.extra, frames })) {
+    return true;
+  }
+
   // iOS-WebKit stack-overflow noise — `RangeError: Maximum call stack size
   // exceeded.` from Sentry's `auto.browser.global_handlers.onerror` capture
   // with a single synthetic `{ filename: 'undefined' }` frame (the engine
@@ -1364,6 +1515,7 @@ export function shouldIgnoreSentryBrowserNoise(event: {
 
 export function shouldIgnoreSentryNoiseEvent(event: {
   message?: unknown;
+  extra?: unknown;
   environment?: unknown;
   request?: { url?: unknown };
   exception?: {


### PR DESCRIPTION
## BS 0f78b2f8 — filter EIP-1193 wallet-extension plain-object rejection noise

Resolves Better Stack error **`0f78b2f8e9efa79fe9b2ea534e275c704f113eafea86bae5470f33174ebacebc`**
- URL: https://errors.betterstack.com/team/t502678/errors/0f78b2f8e9efa79fe9b2ea534e275c704f113eafea86bae5470f33174ebacebc?s=2346967
- App: Kortix Frontend (prod), `application_id` 2346967
- Type: `UnhandledRejection` · State: Unresolved
- First seen 2026-07-06 04:41:32 UTC · Last seen 2026-07-15 06:28:44 UTC · 2 occurrences · 0 identified users

### Root cause (one line)
A browser-extension EIP-1193 wallet provider (extension id `lgmpcpglpngdoalbgeoldeajfclnhafa`) rejects a pending JSON-RPC request with a **plain object** `{ code: 4900, message, stack }` when the provider disconnects, and Sentry — unable to extract a stack from a non-Error — reports it as the synthetic `UnhandledRejection` "Object captured as promise rejection with keys: code, message, stack". It is browser-extension noise, not an app defect.

### Evidence (raw telemetry, Better Stack ClickHouse `s3Cluster(primary, t502678_kortix_frontend_s3)`)
Both occurrences are identical:
- `exception.values[0].value` = `"Object captured as promise rejection with keys: code, message, stack"`
- `exception.values[0].stacktrace` = **absent** (Sentry mechanism `auto.browser.global_handlers.onunhandledrejection`, `synthetic: true` — no frames)
- `extra.__serialized__` =
  ```json
  {
    "message": "The provider is disconnected from all chains.",
    "stack": "Error: The provider is disconnected from all chains.\n    at s (chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:13:100356)\n    at Object.disconnected (chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:13:101769)\n    at chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:26:51970\n    at E.rejectWaitingRequests (chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:26:51985)\n    at chrome-extension://lgmpcpglpngdoalbgeoldeajfclnhafa/content-script.js:26:59539",
    "code": 4900
  }
  ```
  → `code: 4900` is EIP-1193/EIP-1474 "provider is disconnected"; every stack frame is inside the extension's `content-script.js`.
- `request.url` = `https://kortix.com/auth` · `transaction` = `/auth` · `browser` = Chrome 150 · `contexts.culture.locale` = `ru` / `Europe/Moscow` · 0 identified users (anonymous).

Because the rejected value is **not an Error instance**, Sentry's `GlobalHandlers` integration cannot extract a stack: it serializes the object's own enumerable keys into `extra.__serialized__` and produces a frameless synthetic exception. The extension origin therefore lives **only** in `extra.__serialized__.stack` — never in `exception.values[0].stacktrace`. Every existing extension guard in `browser-error-noise.ts` (`isExtensionSource(frame.filename)`, `isInpageWalletStreamNoise`, `isTronLinkProxyNoise`) anchors on a stacktrace **frame**, so all of them miss this frameless capture. The MCP `error` detail and the incident payload gave no call site beyond the message for exactly this reason.

### Fix
Add `isExtensionRejectedObjectNoise` to `apps/web/src/lib/browser-error-noise.ts` and wire it into both capture gates:
- **Sentry `beforeSend` gate** (`shouldIgnoreSentryBrowserNoise`) — the load-bearing one. Our `BrowserNoiseGuard` `unhandledrejection` listener is registered in a React `useEffect` (after mount), i.e. *after* Sentry's own `GlobalHandlers` listener registered during `Sentry.init()`, so it cannot `stopImmediatePropagation` Sentry's capture. `beforeSend` is the only gate that can drop the event.
- **Runtime gate** (`shouldIgnoreBrowserRuntimeNoise`) — the mirror; the raw rejected object reaches it as `reason`/`error`, whose `message` is the provider's own ("The provider is disconnected from all chains."), not Sentry's synthetic wording, so it anchors on the rejected value's own `stack` tracing through an extension content script.

The matcher is **conservative** — it requires BOTH:
1. the synthetic `Object captured as promise rejection with keys:` signature (Sentry's generic marker for a non-Error rejection), AND
2. an extension-origin frame (`chrome-extension://` / `moz-extension://` / `safari-web-extension://` / `extension://`) inside `extra.__serialized__.stack`.

Negative guards preserve real app errors:
- a resolved first-party `apps/web/src/…` stacktrace frame → our own code rejected a plain object → keep reporting;
- no serialized payload to confirm extension origin → keep reporting;
- a serialized stack with no extension origin (app/chunk frames) → keep reporting;
- a real Error message (not the synthetic signature) → keep reporting.

Deliberately **not** added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no `extra.__serialized__` context, so a bare-string match there could swallow a real first-party plain-object rejection. The frame+payload-aware `beforeSend` hook is the only safe gate.

### Regression test
`apps/web/src/lib/browser-error-noise.test.mts` — new block covers the exact production event shape plus conservative negatives:
- ✅ classifies the assigned EIP-1193 provider-disconnected rejection as noise
- ✅ suppresses the assigned Sentry event via `beforeSend` (frameless synthetic capture)
- ✅ Firefox `moz-extension://` + Safari `safari-web-extension://` variants
- ✅ suppresses via the runtime `unhandledrejection` gate (`reason` / `error`)
- 🚫 does NOT suppress a synthetic rejection with **no** serialized payload (conservative)
- 🚫 does NOT suppress a synthetic rejection whose serialized stack has **no** extension origin (app chunk stack)
- 🚫 does NOT suppress a synthetic rejection whose stacktrace resolves to a first-party `apps/web/src/…` frame
- 🚫 does NOT suppress a real Error rejection (not the synthetic signature)
- 🚫 does NOT suppress a runtime rejection whose reason is a real Error with an app-only stack

Full suite: **103 tests pass** (`bun test apps/web/src/lib/browser-error-noise.test.mts`).

### Verification
- `bun test apps/web/src/lib/browser-error-noise.test.mts` → 103 pass / 0 fail.
- Targeted `tsc --noEmit --strict` on `browser-error-noise.ts` → clean.
- Frontend build / full web typecheck left to CI (disk-constrained sandbox could not run a full `next build`); change is minimal, self-contained, and follows the existing matcher conventions exactly.

### Confirmation of resolution
After this merges + promotes, no new occurrences of pattern `0f78b2f8…` should be ingested: the `beforeSend` hook drops the event before it reaches Better Stack. The error will auto-resolve once it stops being seen. The signal loss is nil — this is a single anonymous user's wallet-extension provider rejecting a disconnect, never first-party Kortix code.

### Incident reference
- Error id / pattern: `0f78b2f8e9efa79fe9b2ea534e275c704f113eafea86bae5470f33174ebacebc`
- Better Stack: https://errors.betterstack.com/team/t502678/errors/0f78b2f8e9efa79fe9b2ea534e275c704f113eafea86bae5470f33174ebacebc?s=2346967