### PR TITLE
fix(web): gate Shiki wasm highlighter on WebAssembly availability (BS 1604d50a)

### DIFF
--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -27,6 +27,7 @@ import {
   looksLikeFilePath,
   looksLikeUrl,
   normalizeLanguage,
+  shikiWasmAvailable,
 } from '@/components/markdown/unified-markdown-utils';
 import { useFilePreviewStore } from '@/stores/file-preview-store';
 import { getActivePanelSessionId, openFileInSessionPanel } from '@/stores/session-browser-store';
@@ -106,22 +107,31 @@ const shikiTransformers: ShikiTransformer[] = [
 
 // Singleton highlighter — kicked off at module init so the grammar is usually
 // ready by first render, letting us highlight synchronously (no plain→colour flash).
+//
+// Shiki's oniguruma engine compiles to WebAssembly, so skip the eager init
+// entirely (and never leave a rejecting promise) when WebAssembly is unavailable
+// — otherwise the rejection fires `onunhandledrejection` → Sentry on every page
+// load for visitors whose browser blocks/disables WebAssembly. highlightAsync
+// treats a null highlighter as "no highlighting available" and renders plain
+// code. See Better Stack 1604d50a (`WebAssembly is not defined`).
 let highlighterReady: Highlighter | null = null;
 const loadedLangs = new Set<string>(PRELOAD_LANGS.map((l) => l.toLowerCase()));
 const langLoadPromises = new Map<string, Promise<void>>();
 
-const highlighterPromise: Promise<Highlighter> = getSingletonHighlighter({
-  themes: [SHIKI_THEME_DARK, SHIKI_THEME_LIGHT],
-  langs: PRELOAD_LANGS,
-})
-  .then((h) => {
-    highlighterReady = h;
-    return h;
-  })
-  .catch((err) => {
-    console.warn('[unified-markdown] Shiki highlighter init failed:', err);
-    throw err;
-  });
+const highlighterPromise: Promise<Highlighter | null> = shikiWasmAvailable()
+  ? getSingletonHighlighter({
+      themes: [SHIKI_THEME_DARK, SHIKI_THEME_LIGHT],
+      langs: PRELOAD_LANGS,
+    })
+      .then((h) => {
+        highlighterReady = h;
+        return h;
+      })
+      .catch((err) => {
+        console.warn('[unified-markdown] Shiki highlighter init failed:', err);
+        return null;
+      })
+  : Promise.resolve(null);
 
 function ensureLangLoaded(h: Highlighter, lang: string): Promise<void> {
   if (loadedLangs.has(lang)) return Promise.resolve();
@@ -198,6 +208,7 @@ function highlightAsync(code: string, language: string, theme: string): Promise<
 
   const p = highlighterPromise
     .then(async (h) => {
+      if (!h) return null;
       await ensureLangLoaded(h, lang);
       return h.codeToHtml(clampCode(code), { lang, theme, transformers: shikiTransformers });
     })

--- a/apps/web/src/components/markdown/unified-markdown-utils.test.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.test.ts
@@ -7,6 +7,7 @@ import {
   looksLikeFilePath,
   looksLikeUrl,
   normalizeLanguage,
+  shikiWasmAvailable,
 } from './unified-markdown-utils';
 
 describe('isInternalUrl', () => {
@@ -126,5 +127,32 @@ describe('looksLikeFilePath', () => {
     expect(looksLikeFilePath('e.g.')).toBe(false);
     expect(looksLikeFilePath('nofile.txt')).toBe(false);
     expect(looksLikeFilePath('has space/file.ts')).toBe(false);
+  });
+});
+
+// Regression for Better Stack 1604d50a (`WebAssembly is not defined`,
+// `Can't find variable: WebAssembly`): the Shiki highlighter singleton must not
+// be eagerly started when WebAssembly is unavailable, or its rejection fires
+// `onunhandledrejection` → Sentry on every page load for visitors whose browser
+// blocks/disables WebAssembly (privacy browsers, hardened WebViews, spoofed-UA
+// bots). The renderer gates the eager init on this guard.
+describe('shikiWasmAvailable', () => {
+  test('returns true in the normal test environment (WebAssembly present)', () => {
+    // bun's test runtime exposes WebAssembly, matching every modern browser.
+    expect(shikiWasmAvailable()).toBe(true);
+  });
+
+  test('returns false when WebAssembly is undefined (the BS 1604d50a context)', () => {
+    const original = (globalThis as { WebAssembly?: unknown }).WebAssembly;
+    try {
+      // Simulate a browser/context that blocks or disables WebAssembly.
+      // `delete` mirrors how such runtimes expose no WebAssembly global at all.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).WebAssembly;
+      expect(shikiWasmAvailable()).toBe(false);
+    } finally {
+      // Restore — other tests (and the live Shiki init) need WebAssembly.
+      (globalThis as { WebAssembly?: unknown }).WebAssembly = original;
+    }
   });
 });

--- a/apps/web/src/components/markdown/unified-markdown-utils.ts
+++ b/apps/web/src/components/markdown/unified-markdown-utils.ts
@@ -3,6 +3,29 @@ import { looksLikeFilePath as sharedLooksLikeFilePath } from '@/lib/utils/path-d
 // Pure, deterministic helpers used by the unified markdown renderer. Extracted
 // so they can be unit-tested without pulling in React / Shiki / Streamdown.
 
+/**
+ * Is the WebAssembly runtime Shiki needs available in this context?
+ *
+ * Shiki's oniguruma grammar engine compiles to WebAssembly. Some browsers /
+ * contexts block or disable WebAssembly entirely — privacy browsers (Brave with
+ * aggressive shields, LibreWolf, Tor Browser in high-security mode), hardened /
+ * sandboxed WebViews, enterprise-policy-locked browsers, and scrapers/bots with
+ * spoofed Chrome UAs running on runtimes without WebAssembly. In those contexts
+ * eagerly kicking off `getSingletonHighlighter()` at module init leaves a
+ * promise that rejects with `ReferenceError: WebAssembly is not defined` (V8) /
+ * `Can't find variable: WebAssembly` (WebKit). Because the singleton starts
+ * before any code block renders, the rejection has no consumer attached yet and
+ * fires `onunhandledrejection` → Sentry → Better Stack.
+ *
+ * Gate the highlighter on this check so such visitors degrade to plain
+ * (un-highlighted) code instead of paging on every page load.
+ *
+ * See Better Stack 1604d50a (`WebAssembly is not defined`).
+ */
+export function shikiWasmAvailable(): boolean {
+  return typeof WebAssembly !== 'undefined';
+}
+
 /** Same-origin link? Internal links route through next/link; the rest open externally. */
 export function isInternalUrl(href: string | undefined): boolean {
   if (!href) return false;

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -20,6 +20,7 @@ import {
   looksLikeFilePath,
   looksLikeUrl,
   normalizeLanguage,
+  shikiWasmAvailable,
 } from '@/components/markdown/unified-markdown-utils';
 import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
 import { parseSetupLinkHref } from '@/components/setup-links/util';
@@ -106,22 +107,31 @@ const shikiTransformers: ShikiTransformer[] = [
 
 // Singleton highlighter — kicked off at module init so the grammar is usually
 // ready by first render, letting us highlight synchronously (no plain→colour flash).
+//
+// Shiki's oniguruma engine compiles to WebAssembly, so skip the eager init
+// entirely (and never leave a rejecting promise) when WebAssembly is unavailable
+// — otherwise the rejection fires `onunhandledrejection` → Sentry on every page
+// load for visitors whose browser blocks/disables WebAssembly. highlightAsync
+// treats a null highlighter as "no highlighting available" and renders plain
+// code. See Better Stack 1604d50a (`WebAssembly is not defined`).
 let highlighterReady: Highlighter | null = null;
 const loadedLangs = new Set<string>(PRELOAD_LANGS.map((l) => l.toLowerCase()));
 const langLoadPromises = new Map<string, Promise<void>>();
 
-const highlighterPromise: Promise<Highlighter> = getSingletonHighlighter({
-  themes: [SHIKI_THEME_DARK, SHIKI_THEME_LIGHT],
-  langs: PRELOAD_LANGS,
-})
-  .then((h) => {
-    highlighterReady = h;
-    return h;
-  })
-  .catch((err) => {
-    console.warn('[unified-markdown] Shiki highlighter init failed:', err);
-    throw err;
-  });
+const highlighterPromise: Promise<Highlighter | null> = shikiWasmAvailable()
+  ? getSingletonHighlighter({
+      themes: [SHIKI_THEME_DARK, SHIKI_THEME_LIGHT],
+      langs: PRELOAD_LANGS,
+    })
+      .then((h) => {
+        highlighterReady = h;
+        return h;
+      })
+      .catch((err) => {
+        console.warn('[unified-markdown] Shiki highlighter init failed:', err);
+        return null;
+      })
+  : Promise.resolve(null);
 
 function ensureLangLoaded(h: Highlighter, lang: string): Promise<void> {
   if (loadedLangs.has(lang)) return Promise.resolve();
@@ -198,6 +208,7 @@ function highlightAsync(code: string, language: string, theme: string): Promise<
 
   const p = highlighterPromise
     .then(async (h) => {
+      if (!h) return null;
       await ensureLangLoaded(h, lang);
       return h.codeToHtml(clampCode(code), { lang, theme, transformers: shikiTransformers });
     })


### PR DESCRIPTION
## BS 1604d50a — `WebAssembly is not defined` (Kortix Frontend prod, app 2346967)

**Error URL:** https://errors.betterstack.com/team/t502678/errors/1604d50a57cc44606a6157588b588dccc76444bb6c372686eaef9f3a25a2d6cd?s=2346967
**Type:** `ReferenceError` · **Message:** `WebAssembly is not defined` · **State:** Unresolved · **Count/users:** 1 / 0 · **Last seen:** 2026-07-15 14:53:25 UTC
**Call site:** `Module.E` @ `app:///_next/static/chunks/223cfbd8.300d230f16edd9e8.js`

### One-line root cause
The unified-markdown / doc-markdown renderers eagerly start the Shiki highlighter singleton (`getSingletonHighlighter`) at module init; Shiki's oniguruma grammar engine compiles to WebAssembly, so on browsers/contexts that block or disable WebAssembly the singleton promise rejects and — because the `.catch` re-threw and the singleton starts before any code block renders (no consumer attached yet) — fires `onunhandledrejection` → Sentry → Better Stack on every page load.

### Evidence (live telemetry, Better Stack MCP)
- **`1604d50a…`** — `ReferenceError: WebAssembly is not defined`, `Module.E` @ `_next/static/chunks/223cfbd8.…js`, **mechanism `auto.browser.global_handlers.onunhandledrejection`**, `url https://kortix.com/`, release `8c12bb88…`, environment `prod`, browser `Chrome 147` / Windows 10 (UA consistent with a privacy-hardened/locked-down or spoofed-UA client where WebAssembly is unavailable), locale `fr`.
- **Sibling patterns, same chunk / same root cause:**
  - `a9c2d433…` — `Can't find variable: WebAssembly` (WebKit message variant), `E` @ same `223cfbd8` chunk, **6 occurrences**, last 2026-07-09.
  - `51987ccd…` — `Can't find variable: WebAssembly`, same chunk, 1 occurrence, 2026-07-08.
- **Breadcrumb (decisive):** `[unified-markdown] Shiki highlighter init failed: { message: 'WebAssembly is not defined', name: 'ReferenceError' }` — i.e. the error originates from the Shiki highlighter init in `unified-markdown.tsx` (line 122 `console.warn`), which logs and then re-throws.

### Why it pages
`apps/web/src/components/markdown/unified-markdown.tsx` (and its copy `doc-markdown.tsx`) build a module-level singleton:
```ts
const highlighterPromise = getSingletonHighlighter({ themes, langs })
  .then(h => { highlighterReady = h; return h; })
  .catch(err => { console.warn('[unified-markdown] Shiki highlighter init failed:', err); throw err; });
```
This kicks off at **module init** (the marketing landing `/` imports `UnifiedMarkdown` via `features/marketing/story-sections.tsx`; docs pages import `doc-markdown`). When WebAssembly is unavailable, `getSingletonHighlighter` rejects; the `.catch` logs the breadcrumb we see and **re-throws**. The singleton starts before any code block renders, so the rejection has no `.then`/`.catch` consumer attached at the microtask checkpoint → `unhandledrejection` → Sentry.

### Fix (feature-gate the WASM dependency — source fix, not a noise filter)
- New pure, unit-testable helper `shikiWasmAvailable()` (`typeof WebAssembly !== 'undefined'`) in `unified-markdown-utils.ts`.
- In both `unified-markdown.tsx` and `doc-markdown.tsx`: gate the eager init on `shikiWasmAvailable()`. When WebAssembly is unavailable, `highlighterPromise` resolves to `null` (never starts the WASM engine, never rejects). `highlightAsync` treats a null highlighter as "no highlighting available" and renders plain code.
- The `.catch` now resolves to `null` instead of re-throwing, so even a rare WASM-present init failure can no longer leave an unhandled rejection.
- Happy path (WebAssembly available) is byte-identical: same eager singleton, same sync/async highlight path.

This is a real first-party source fix (the playbook prefers feature-gating a browser-only WASM dependency over a Sentry noise filter), so a generic `WebAssembly is not defined` Sentry filter was deliberately NOT added — that would hide genuine future regressions from the other guarded WASM libs (sql.js in `sqlite-renderer`, pdfium in `pdf-thumbnail-utils`, both already try/catch-guarded).

### Regression test
`unified-markdown-utils.test.ts` — `shikiWasmAvailable` describe block:
- returns `true` in the normal test runtime (WebAssembly present, matching every modern browser);
- returns `false` when `WebAssembly` is deleted from `globalThis` — the exact BS 1604d50a context — then restores it.

### Verification
- Local: `bun test apps/web/src/components/markdown/unified-markdown-utils.test.ts` → **19 pass / 0 fail** (17 existing + 2 new). Full typecheck/lint/e2e run in CI.

### How to confirm resolution
After this reaches prod (next Promote), Better Stack patterns `1604d50a…`, `a9c2d433…`, and `51987ccd…` should drop to **0 new occurrences** — the Shiki singleton no longer starts (and no longer rejects) on WebAssembly-disabled visitors; they simply see un-highlighted code blocks. The console breadcrumb `[unified-markdown] Shiki highlighter init failed` should also disappear (no init is attempted).

### Scope / risk
- 4 files, ~97 LOC added / 24 removed. No API or DB change. No change to highlighting output for WebAssembly-capable browsers (the overwhelmingly common case).
- No merge (orchestrator owns review + merge).
