### PR TITLE
fix(iam-web): auto-provision groups defaults ON for new SSO connections

### DIFF
--- a/apps/web/src/components/iam/sso-card.tsx
+++ b/apps/web/src/components/iam/sso-card.tsx
@@ -411,7 +411,9 @@ function EditProviderDialog({
   const [domain, setDomain] = useState(existing?.primary_domain ?? '');
   const [claim, setClaim] = useState(existing?.group_claim_name ?? 'groups');
   const [autoCreate, setAutoCreate] = useState(existing?.auto_create_members ?? true);
-  const [autoProvision, setAutoProvision] = useState(existing?.auto_provision_groups ?? false);
+  // New connections default auto-provision ON (groups appear without
+  // hand-mapping); an existing provider keeps whatever the admin chose.
+  const [autoProvision, setAutoProvision] = useState(existing ? existing.auto_provision_groups : true);
   // New providers register by importing the IdP metadata (XML or URL) — the
   // backend handles the identity-provider registration; no internals surface in
   // the UI. Edits reuse the stored provider id under the hood.
@@ -426,7 +428,7 @@ function EditProviderDialog({
       setDomain(existing?.primary_domain ?? '');
       setClaim(existing?.group_claim_name ?? 'groups');
       setAutoCreate(existing?.auto_create_members ?? true);
-      setAutoProvision(existing?.auto_provision_groups ?? false);
+      setAutoProvision(existing ? existing.auto_provision_groups : true);
       setMetaKind('xml');
       setMetaXml('');
       setMetaUrl('');

--- a/apps/web/src/features/sso-setup/setup-wizard.tsx
+++ b/apps/web/src/features/sso-setup/setup-wizard.tsx
@@ -536,7 +536,11 @@ function ImportForm({
   const [domain, setDomain] = useState('');
   const [claim, setClaim] = useState(config.groupClaimName);
   const [autoCreate, setAutoCreate] = useState(true);
-  const [autoProvision, setAutoProvision] = useState(false);
+  // Default ON: connecting an IdP should make its groups appear in Kortix
+  // without hand-mapping each claim — the admin just attaches project roles.
+  // (Groups auto-created this way are source='sso' and never annex manual
+  // groups; the toggle stays for admins who want mapping-only.)
+  const [autoProvision, setAutoProvision] = useState(true);
   // Default to the form this IdP actually hands out (Google: XML only).
   const [metaKind, setMetaKind] = useState<'url' | 'xml'>(config.preferredMetadata ?? 'url');
   const [metaUrl, setMetaUrl] = useState('');

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -185,3 +185,15 @@ describe('directory sync wizard wiring', () => {
     expect(scimCardSource).toContain('/scim-setup');
   });
 });
+
+describe('auto-provision groups default', () => {
+  test('the wizard connect form defaults auto-provision ON', () => {
+    expect(wizardSource).toContain('setAutoProvision] = useState(true)');
+  });
+
+  test('the SSO card dialog defaults ON for new providers, stored value for existing', () => {
+    expect(cardSource).toContain(
+      'useState(existing ? existing.auto_provision_groups : true)',
+    );
+  });
+});


### PR DESCRIPTION
Connecting Okta/Entra SAML is expected to auto-create group mappings and fill them on provisioning — the engine does exactly that, but both connect surfaces (wizard + SSO card dialog) defaulted the toggle OFF, so most real connections never got it. New connections now default ON; existing providers keep their stored choice; the raw API default is unchanged.

Verified end to end: ensureAutoProvisionedGroup (mapping-wins, source='sso', never annexes manual groups), same-login membership diff, and the SCIM member-add hardening already on main. Structural tests assert both defaults.