### PR TITLE
feat(mfa): complete the account-wide Require MFA loop (member enroll + step-up)

### DIFF
--- a/apps/api/src/__tests__/unit-iam-mfa-denial.test.ts
+++ b/apps/api/src/__tests__/unit-iam-mfa-denial.test.ts
@@ -1,0 +1,35 @@
+// The account_mfa_required denial is the one ACTIONABLE deny: the caller can
+// complete an MFA challenge and retry. Its 403 must carry a machine-readable
+// `code` (the web's step-up dialog keys on it); every other reason stays a
+// plain humanized message with no code leak.
+import { describe, expect, test } from 'bun:test';
+import { buildDenialError } from '../iam/dispatcher';
+
+describe('buildDenialError', () => {
+  test('account_mfa_required → 403 with machine-readable code in the body', async () => {
+    const err = buildDenialError('project.create', 'account_mfa_required');
+    expect(err.status).toBe(403);
+    const res = err.getResponse();
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = (await res.json()) as { error: string; code: string };
+    expect(body.code).toBe('account_mfa_required');
+    expect(body.error).toContain('multi-factor');
+  });
+
+  test('ordinary role denial → humanized message, NO code', async () => {
+    const err = buildDenialError('project.create', 'account_role_insufficient');
+    expect(err.status).toBe(403);
+    const res = err.getResponse();
+    const text = await res.text();
+    expect(text).toContain("don't have permission");
+    expect(text).not.toContain('account_mfa_required');
+    expect(text).not.toContain('account_role_insufficient');
+  });
+
+  test('unknown action still yields the generic phrase with the action code', async () => {
+    const err = buildDenialError('made.up_action', undefined);
+    const res = err.getResponse();
+    const text = await res.text();
+    expect(text).toContain('made.up_action');
+  });
+});

--- a/apps/api/src/iam/dispatcher.ts
+++ b/apps/api/src/iam/dispatcher.ts
@@ -44,16 +44,36 @@ export async function assertAuthorized(
 ): Promise<void> {
   const result = await authorize(userId, accountId, action, target, actingTokenId, requestCtx);
   if (!result.allowed) {
-    // User-facing 403 message: "You don't have permission to create
-    // projects." Falls back to a generic "perform this action" when
-    // the action isn't in the verb map, with the action code suffixed
-    // in parens so support / dev tooling can still identify it. The
-    // reason code (account_role_insufficient, etc.) is intentionally
-    // dropped — it's diagnostic, not actionable for end users.
-    throw new HTTPException(403, {
-      message: humanizePermissionDenial(action),
+    throw buildDenialError(action, result.reason);
+  }
+}
+
+/**
+ * Turn a denial into the HTTPException the route layer surfaces. Exported for
+ * unit tests.
+ *
+ * Most reason codes (account_role_insufficient, …) are diagnostic, not
+ * actionable, so the body stays a plain humanized message. The ONE actionable
+ * reason is `account_mfa_required` — the caller can fix it by completing an
+ * MFA challenge and retrying — so that denial carries a machine-readable
+ * `code` the web client keys its step-up dialog on (the SDK's ApiError
+ * already lifts `code` from error bodies).
+ */
+export function buildDenialError(action: string, reason?: string): HTTPException {
+  if (reason === 'account_mfa_required') {
+    const message =
+      'This account requires multi-factor authentication. Verify your second factor and retry.';
+    return new HTTPException(403, {
+      message,
+      res: new Response(JSON.stringify({ error: message, code: 'account_mfa_required' }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+      }),
     });
   }
+  return new HTTPException(403, {
+    message: humanizePermissionDenial(action),
+  });
 }
 
 /**

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { I18nProvider } from '@/components/i18n-provider';
 import { KortixProjectScope } from '@/components/kortix-project-scope';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { RequestDemoProvider } from '@/features/contact/request-demo-provider';
+import { MfaStepUpProvider } from '@/features/auth/mfa-step-up';
 import { AuthProvider } from '@/features/providers/auth-provider';
 import { DESKTOP_INIT_SCRIPT, DESKTOP_UA_TOKEN } from '@/lib/desktop';
 import { getHardcodedUiServerText } from '@/lib/hardcoded-ui-server';
@@ -331,7 +332,12 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
                       so every enterprise CTA across the app (accounts settings,
                       billing, IAM) can open it via useRequestDemo(). */}
                   <RequestDemoProvider>
-                    <KortixProjectScope>{children}</KortixProjectScope>
+                    {/* Account-wide MFA: catches the SDK's kortix:mfa-required
+                        event (coded 403) and walks the user through a TOTP
+                        step-up so the retried action passes the IAM gate. */}
+                    <MfaStepUpProvider>
+                      <KortixProjectScope>{children}</KortixProjectScope>
+                    </MfaStepUpProvider>
                   </RequestDemoProvider>
                   {/* Global maintenance/incident banner (info/warning/critical).
                       Needs the query client, so it mounts inside ReactQueryProvider. */}

--- a/apps/web/src/components/iam/mfa-required-card.tsx
+++ b/apps/web/src/components/iam/mfa-required-card.tsx
@@ -117,7 +117,7 @@ export function MfaRequiredCard({ accountId, canManage }: MfaRequiredCardProps) 
           </p>
           <p className="text-muted-foreground mt-0.5 text-xs">
             When enabled, members must complete a second-factor challenge before any IAM-gated
-            action. Super-admins and Personal Access Tokens are exempt.
+            action. Super-admins and Personal Access Tokens are exempt. Members enroll an authenticator under Settings → Security.
           </p>
         </div>
         {statusQuery.isLoading ? (

--- a/apps/web/src/features/accounts/settings/security-tab.test.tsx
+++ b/apps/web/src/features/accounts/settings/security-tab.test.tsx
@@ -1,0 +1,45 @@
+// The member-side half of account-wide MFA: pure-view pieces render the
+// factor states an admin's "Require MFA" flip depends on, and the QR
+// normalizer must feed <img> both Supabase shapes (data URL vs raw SVG).
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { FactorRow, totpQrSrc } from './security-tab';
+
+describe('totpQrSrc', () => {
+  test('passes a data URL through untouched', () => {
+    const url = 'data:image/svg+xml;utf8,%3Csvg%3E%3C/svg%3E';
+    expect(totpQrSrc(url)).toBe(url);
+  });
+
+  test('wraps raw SVG into an encoded data URL', () => {
+    const out = totpQrSrc('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    expect(out.startsWith('data:image/svg+xml;utf8,')).toBe(true);
+    expect(out).toContain('%3Csvg');
+  });
+});
+
+describe('FactorRow', () => {
+  test('verified authenticator renders name, type, and verified badge', () => {
+    const html = renderToStaticMarkup(
+      <FactorRow
+        factor={{ id: 'f1', friendly_name: 'My phone', factor_type: 'totp', status: 'verified' }}
+        onRemove={() => {}}
+      />,
+    );
+    expect(html).toContain('My phone');
+    expect(html).toContain('verified');
+    expect(html).toContain('Remove factor');
+  });
+
+  test('unnamed totp factor falls back to "Authenticator app"', () => {
+    const html = renderToStaticMarkup(
+      <FactorRow
+        factor={{ id: 'f2', factor_type: 'totp', status: 'unverified' }}
+        onRemove={() => {}}
+      />,
+    );
+    expect(html).toContain('Authenticator app');
+    expect(html).toContain('unverified');
+  });
+});

--- a/apps/web/src/features/accounts/settings/security-tab.tsx
+++ b/apps/web/src/features/accounts/settings/security-tab.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+// Personal security settings: enroll and manage MFA factors (authenticator
+// app / TOTP). This is the member-side half of the account-wide "Require MFA"
+// enforcement — the admin card (components/iam/mfa-required-card.tsx) flips
+// the account flag; THIS tab is where each member enrolls so an aal1 session
+// can step up instead of being locked out. The step-up dialog itself lives in
+// features/auth/mfa-step-up.tsx and keys on the `account_mfa_required` 403.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { KeyRound, Plus, ShieldCheck, Smartphone, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { InfoBanner } from '@/components/ui/info-banner';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
+import { Skeleton } from '@/components/ui/skeleton';
+import { errorToast, successToast } from '@/components/ui/toast';
+import { createClient } from '@/lib/supabase/client';
+import { supabaseMFAService } from '@/lib/supabase/mfa';
+
+/** Supabase hands the TOTP QR back as an SVG data URL (or raw SVG in older
+ *  versions) — normalize both into something an <img> can render. */
+export function totpQrSrc(qr: string): string {
+  if (qr.startsWith('data:')) return qr;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(qr)}`;
+}
+
+/** One enrolled factor row — pure view, exported for render tests. */
+export function FactorRow({
+  factor,
+  onRemove,
+}: {
+  factor: { id: string; friendly_name?: string; factor_type?: string; status?: string };
+  onRemove: (id: string) => void;
+}) {
+  const Icon = factor.factor_type === 'phone' ? Smartphone : KeyRound;
+  return (
+    <div className="border-border/60 bg-popover flex items-center justify-between gap-3 rounded-md border px-4 py-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-md">
+          <Icon className="text-muted-foreground size-4" />
+        </span>
+        <div className="min-w-0">
+          <div className="text-foreground truncate text-sm font-medium">
+            {factor.friendly_name || (factor.factor_type === 'phone' ? 'Phone' : 'Authenticator app')}
+          </div>
+          <div className="text-muted-foreground text-xs capitalize">{factor.factor_type}</div>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Badge variant={factor.status === 'verified' ? 'kortix' : 'outline'} size="xs">
+          {factor.status}
+        </Badge>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Remove factor"
+          onClick={() => onRemove(factor.id)}
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function SecurityTab() {
+  const queryClient = useQueryClient();
+  const [enrolling, setEnrolling] = useState<{ factorId: string; qr: string; secret?: string } | null>(
+    null,
+  );
+  const [code, setCode] = useState('');
+  const [removeTarget, setRemoveTarget] = useState<string | null>(null);
+
+  const factorsQuery = useQuery({
+    queryKey: ['mfa-factors'],
+    queryFn: () => supabaseMFAService.listFactors(),
+    staleTime: 10_000,
+  });
+
+  const aalQuery = useQuery({
+    queryKey: ['mfa-aal'],
+    queryFn: () => supabaseMFAService.getAAL(),
+    staleTime: 10_000,
+  });
+
+  const startEnroll = useMutation({
+    mutationFn: async () => {
+      const supabase = createClient();
+      const { data, error } = await supabase.auth.mfa.enroll({
+        factorType: 'totp',
+        friendlyName: `Authenticator (${new Date().toISOString().slice(0, 10)})`,
+      });
+      if (error) throw new Error(error.message);
+      if (!data?.totp?.qr_code) throw new Error('Enrollment returned no QR code');
+      return { factorId: data.id, qr: data.totp.qr_code, secret: data.totp.secret };
+    },
+    onSuccess: (data) => {
+      setEnrolling(data);
+      setCode('');
+    },
+    onError: (err: Error) => errorToast(err.message || 'Could not start enrollment'),
+  });
+
+  const verifyEnroll = useMutation({
+    mutationFn: async () => {
+      if (!enrolling) throw new Error('No enrollment in progress');
+      await supabaseMFAService.challengeAndVerify({ factor_id: enrolling.factorId, code });
+    },
+    onSuccess: () => {
+      successToast('Authenticator enrolled — this session is now MFA-verified');
+      setEnrolling(null);
+      setCode('');
+      queryClient.invalidateQueries({ queryKey: ['mfa-factors'] });
+      queryClient.invalidateQueries({ queryKey: ['mfa-aal'] });
+    },
+    onError: (err: Error) => errorToast(err.message || 'Code did not verify'),
+  });
+
+  const removeFactor = useMutation({
+    mutationFn: (factorId: string) => supabaseMFAService.unenrollFactor(factorId),
+    onSuccess: () => {
+      successToast('Factor removed');
+      setRemoveTarget(null);
+      queryClient.invalidateQueries({ queryKey: ['mfa-factors'] });
+      queryClient.invalidateQueries({ queryKey: ['mfa-aal'] });
+    },
+    onError: (err: Error) => errorToast(err.message || 'Failed to remove factor'),
+  });
+
+  const factors = factorsQuery.data?.factors ?? [];
+  const verified = factors.filter((f) => f.status === 'verified');
+  const sessionVerified = aalQuery.data?.current_level === 'aal2';
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <h3 className="text-foreground text-sm font-medium">Two-factor authentication</h3>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Add an authenticator app (TOTP) as a second factor. Accounts with
+              “Require MFA” enforce a verified factor before any gated action.
+            </p>
+          </div>
+          {verified.length > 0 && (
+            <Badge variant={sessionVerified ? 'kortix' : 'outline'} size="sm" className="shrink-0">
+              <ShieldCheck />
+              {sessionVerified ? 'Session verified' : 'Enrolled'}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {factorsQuery.isLoading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-14 w-full" />
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {factors.length === 0 && !enrolling && (
+            <InfoBanner tone="info" title="No second factor enrolled">
+              If your organization requires MFA, you’ll be blocked from gated
+              actions until you enroll an authenticator here.
+            </InfoBanner>
+          )}
+          {factors.map((f) => (
+            <FactorRow key={f.id} factor={f} onRemove={(id) => setRemoveTarget(id)} />
+          ))}
+        </div>
+      )}
+
+      {enrolling ? (
+        <div className="border-border/60 bg-popover space-y-4 rounded-md border p-4">
+          <div>
+            <h4 className="text-foreground text-sm font-medium">Scan with your authenticator app</h4>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Use 1Password, Google Authenticator, or any TOTP app — then enter
+              the 6-digit code it shows.
+            </p>
+          </div>
+          <div className="flex items-start gap-4">
+            {/* biome-ignore lint/performance/noImgElement: QR is an inline SVG data URL, next/image adds nothing */}
+            <img
+              src={totpQrSrc(enrolling.qr)}
+              alt="TOTP enrollment QR code"
+              className="border-border/60 size-36 shrink-0 rounded-md border bg-white p-2"
+            />
+            <div className="min-w-0 flex-1 space-y-3">
+              {enrolling.secret && (
+                <div className="space-y-1">
+                  <Label className="text-xs">Manual entry secret</Label>
+                  <code className="border-border/60 bg-muted/30 block truncate rounded border px-2 py-1.5 font-mono text-xs">
+                    {enrolling.secret}
+                  </code>
+                </div>
+              )}
+              <div className="space-y-1">
+                <Label className="text-xs">6-digit code</Label>
+                <Input
+                  value={code}
+                  onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                  placeholder="123456"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  className="w-32 font-mono tracking-widest"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  onClick={() => verifyEnroll.mutate()}
+                  disabled={code.length !== 6 || verifyEnroll.isPending}
+                  className="gap-1.5"
+                >
+                  {verifyEnroll.isPending && <Loading className="size-4" />}
+                  Verify and enable
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    // Abandoning enrollment leaves an unverified factor behind —
+                    // clean it up so the list doesn't accumulate ghosts.
+                    removeFactor.mutate(enrolling.factorId);
+                    setEnrolling(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => startEnroll.mutate()}
+          disabled={startEnroll.isPending}
+          className="gap-1.5"
+        >
+          {startEnroll.isPending ? <Loading className="size-4" /> : <Plus className="size-4" />}
+          Add authenticator app
+        </Button>
+      )}
+
+      <ConfirmDialog
+        open={removeTarget !== null}
+        onOpenChange={(open) => !open && setRemoveTarget(null)}
+        title="Remove this factor?"
+        description="If your organization requires MFA and this is your only verified factor, you will be locked out of gated actions until you enroll again."
+        confirmLabel="Remove factor"
+        confirmVariant="destructive"
+        onConfirm={() => removeTarget && removeFactor.mutate(removeTarget)}
+        isPending={removeFactor.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/accounts/settings/security-tab.tsx
+++ b/apps/web/src/features/accounts/settings/security-tab.tsx
@@ -20,6 +20,7 @@ import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { errorToast, successToast } from '@/components/ui/toast';
+import { invalidateTokenCache } from '@/lib/auth-token';
 import { createClient } from '@/lib/supabase/client';
 import { supabaseMFAService } from '@/lib/supabase/mfa';
 
@@ -113,6 +114,10 @@ export function SecurityTab() {
       await supabaseMFAService.challengeAndVerify({ factor_id: enrolling.factorId, code });
     },
     onSuccess: () => {
+      // Verifying the first factor elevates this session to aal2. Bust the
+      // 30s token cache so the next gated request uses the new token instead
+      // of replaying the stale aal1 one.
+      invalidateTokenCache();
       successToast('Authenticator enrolled — this session is now MFA-verified');
       setEnrolling(null);
       setCode('');

--- a/apps/web/src/features/accounts/settings/side-panel-user-settings.tsx
+++ b/apps/web/src/features/accounts/settings/side-panel-user-settings.tsx
@@ -23,13 +23,14 @@ import {
 import { listSandboxes, type SandboxInfo } from '@kortix/sdk/platform-client';
 import { cn } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
-import { KeyRound } from 'lucide-react';
+import { KeyRound, ShieldCheck } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { AppearanceTab } from './appearance-tab';
 import { CliTokensTab } from './cli-tokens-tab';
 import { GeneralTab } from './general-tab';
+import { SecurityTab } from './security-tab';
 import { KeyboardShortcutsTab } from './keyboard-shortcuts-tab';
 import { NotificationsTab } from './notifications-tab';
 import { SoundsTab } from './sounds-tab';
@@ -89,7 +90,11 @@ function SidePanelUserSettings({
     [hasInstance],
   );
   const accountTabs: Tab[] = React.useMemo(
-    () => withDescription([{ id: 'tokens', label: 'API keys', icon: KeyRound }]),
+    () =>
+      withDescription([
+        { id: 'security', label: 'Security', icon: ShieldCheck },
+        { id: 'tokens', label: 'API keys', icon: KeyRound },
+      ]),
     [],
   );
 
@@ -157,6 +162,7 @@ function SidePanelUserSettings({
   const renderActiveTabContent = () => (
     <>
       {activeContentTab === 'general' && <GeneralTab onClose={() => onOpenChange(false)} />}
+      {activeContentTab === 'security' && <SecurityTab />}
       {activeContentTab === 'appearance' && <AppearanceTab />}
       {activeContentTab === 'sounds' && <SoundsTab />}
       {activeContentTab === 'notifications' && <NotificationsTab />}

--- a/apps/web/src/features/auth/mfa-step-up.tsx
+++ b/apps/web/src/features/auth/mfa-step-up.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+// Global MFA step-up dialog. The SDK's api-client dispatches
+// `kortix:mfa-required` whenever ANY backend call is denied with the coded
+// 403 `account_mfa_required` (account-wide "Require MFA" is on and this
+// session is aal1). This provider — mounted once in the root layout — catches
+// that event and walks the user through a TOTP challenge, upgrading the
+// Supabase session to aal2 so the retried action passes the IAM gate.
+//
+// Members with NO enrolled factor get pointed at Settings → Security instead
+// of a dead-end code prompt.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ShieldCheck } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { InfoBanner } from '@/components/ui/info-banner';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
+import { errorToast, successToast } from '@/components/ui/toast';
+import { supabaseMFAService } from '@/lib/supabase/mfa';
+
+export const MFA_REQUIRED_EVENT = 'kortix:mfa-required';
+export const MFA_VERIFIED_EVENT = 'kortix:mfa-verified';
+
+export function MfaStepUpProvider({ children }: { children?: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [code, setCode] = useState('');
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const onRequired = () => setOpen(true);
+    window.addEventListener(MFA_REQUIRED_EVENT, onRequired);
+    return () => window.removeEventListener(MFA_REQUIRED_EVENT, onRequired);
+  }, []);
+
+  const factorsQuery = useQuery({
+    queryKey: ['mfa-factors'],
+    queryFn: () => supabaseMFAService.listFactors(),
+    enabled: open,
+    staleTime: 10_000,
+  });
+
+  const verified = (factorsQuery.data?.factors ?? []).filter((f) => f.status === 'verified');
+  const factor = verified[0] ?? null;
+
+  const verify = useMutation({
+    mutationFn: async () => {
+      if (!factor) throw new Error('No verified factor enrolled');
+      await supabaseMFAService.challengeAndVerify({ factor_id: factor.id, code });
+    },
+    onSuccess: () => {
+      successToast('Verified — retry what you were doing');
+      setOpen(false);
+      setCode('');
+      queryClient.invalidateQueries({ queryKey: ['mfa-aal'] });
+      window.dispatchEvent(new CustomEvent(MFA_VERIFIED_EVENT));
+    },
+    onError: (err: Error) => errorToast(err.message || 'Code did not verify'),
+  });
+
+  return (
+    <>
+      {children}
+      <Dialog open={open} onOpenChange={(next) => { setOpen(next); if (!next) setCode(''); }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <ShieldCheck className="text-kortix-green size-4" />
+              Verify it’s you
+            </DialogTitle>
+            <DialogDescription>
+              This account requires multi-factor authentication for that
+              action. Enter a code from your authenticator app to verify this
+              session.
+            </DialogDescription>
+          </DialogHeader>
+
+          {factorsQuery.isLoading ? (
+            <div className="py-2">
+              <Loading className="size-4" />
+            </div>
+          ) : factor ? (
+            <div className="space-y-1.5 py-1">
+              <Label className="text-xs">6-digit code</Label>
+              <Input
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                placeholder="123456"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                autoFocus
+                className="w-36 font-mono tracking-widest"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && code.length === 6 && !verify.isPending) verify.mutate();
+                }}
+              />
+            </div>
+          ) : (
+            <InfoBanner tone="warning" title="No second factor enrolled">
+              Enroll an authenticator app under Settings → Security, then retry
+              — this account blocks gated actions until your session is
+              MFA-verified.
+            </InfoBanner>
+          )}
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            {factor && (
+              <Button
+                onClick={() => verify.mutate()}
+                disabled={code.length !== 6 || verify.isPending}
+                className="gap-1.5"
+              >
+                {verify.isPending && <Loading className="size-4" />}
+                Verify
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/features/auth/mfa-step-up.tsx
+++ b/apps/web/src/features/auth/mfa-step-up.tsx
@@ -28,6 +28,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
 import { errorToast, successToast } from '@/components/ui/toast';
+import { invalidateTokenCache } from '@/lib/auth-token';
 import { supabaseMFAService } from '@/lib/supabase/mfa';
 
 export const MFA_REQUIRED_EVENT = 'kortix:mfa-required';
@@ -60,10 +61,20 @@ export function MfaStepUpProvider({ children }: { children?: React.ReactNode }) 
       await supabaseMFAService.challengeAndVerify({ factor_id: factor.id, code });
     },
     onSuccess: () => {
-      successToast('Verified — retry what you were doing');
+      // challengeAndVerify minted a fresh aal2 JWT into Supabase storage, but
+      // the api-client caches the access token for 30s — without busting it the
+      // retried request would replay the stale aal1 token and be denied again,
+      // making step-up look broken for up to 30s. Invalidate so the next call
+      // reads the aal2 token.
+      invalidateTokenCache();
+      successToast('Verified');
       setOpen(false);
       setCode('');
-      queryClient.invalidateQueries({ queryKey: ['mfa-aal'] });
+      // Refetch active queries so reads that failed while the session was aal1
+      // recover on their own — the screen the user was on repopulates without a
+      // manual reload. (Mutations still need a manual retry; react-query dedupes
+      // the refetch storm.)
+      queryClient.invalidateQueries();
       window.dispatchEvent(new CustomEvent(MFA_VERIFIED_EVENT));
     },
     onError: (err: Error) => errorToast(err.message || 'Code did not verify'),

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -100,6 +100,7 @@ export type MenuItemKind =
 
 export type SettingsTabId =
   | 'general'
+  | 'security'
   | 'appearance'
   | 'sounds'
   | 'notifications'

--- a/packages/sdk/src/core/http/api-client.test.ts
+++ b/packages/sdk/src/core/http/api-client.test.ts
@@ -78,7 +78,7 @@ describe('makeRequest keeps ApiError.message a string for non-string body fields
       new Response(JSON.stringify(body), {
         status,
         headers: { 'content-type': 'application/json' },
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
     return () => {
       globalThis.fetch = originalFetch;
     };
@@ -174,10 +174,7 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
   test('503 and 504 are also retried on GET', async () => {
     configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
     for (const status of [503, 504]) {
-      const stub = stubFetchSequence([
-        { status },
-        { status: 200, body: { ok: true } },
-      ]);
+      const stub = stubFetchSequence([{ status }, { status: 200, body: { ok: true } }]);
       try {
         const res = await backendApi.get('/projects/abc/sessions/s1/audit');
         expect(res.success).toBe(true);
@@ -238,6 +235,67 @@ describe('makeRequest retries transient gateway (502/503/504) on idempotent read
       expect(stub.attemptCount()).toBe(1);
     } finally {
       stub.restore();
+    }
+  });
+});
+
+describe('account_mfa_required 403 → kortix:mfa-required browser event', () => {
+  function stubFetch403(body: Record<string, unknown>) {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(body), {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+      })) as unknown as typeof fetch;
+    return () => {
+      globalThis.fetch = originalFetch;
+    };
+  }
+
+  function stubWindow() {
+    const dispatched: string[] = [];
+    const g = globalThis as { window?: unknown };
+    const original = g.window;
+    g.window = {
+      dispatchEvent: (e: { type: string }) => {
+        dispatched.push(e.type);
+        return true;
+      },
+    };
+    return {
+      dispatched,
+      restore: () => {
+        if (original === undefined) delete g.window;
+        else g.window = original;
+      },
+    };
+  }
+
+  test('the coded MFA denial dispatches the step-up event', async () => {
+    configureKortix({ backendUrl: 'http://test', getToken: async () => 'tok' });
+    const restoreFetch = stubFetch403({ error: 'mfa needed', code: 'account_mfa_required' });
+    const win = stubWindow();
+    try {
+      const res = await backendApi.get('/accounts/abc/iam/groups');
+      expect(res.success).toBe(false);
+      expect(win.dispatched).toContain('kortix:mfa-required');
+    } finally {
+      win.restore();
+      restoreFetch();
+    }
+  });
+
+  test('an ordinary 403 dispatches nothing', async () => {
+    configureKortix({ backendUrl: 'http://test', getToken: async () => 'tok' });
+    const restoreFetch = stubFetch403({ error: "You don't have permission to create projects." });
+    const win = stubWindow();
+    try {
+      const res = await backendApi.get('/accounts/abc/iam/groups');
+      expect(res.success).toBe(false);
+      expect(win.dispatched.length).toBe(0);
+    } finally {
+      win.restore();
+      restoreFetch();
     }
   });
 });

--- a/packages/sdk/src/core/http/api-client.ts
+++ b/packages/sdk/src/core/http/api-client.ts
@@ -239,6 +239,23 @@ async function makeRequest<T = any>(
         error = parseBillingError(error);
       }
 
+      // Account-wide MFA gate (403 + code account_mfa_required): the one
+      // actionable authz denial — the user can complete an MFA challenge and
+      // retry. Surface it as a browser event so the app's step-up dialog opens
+      // no matter which call site tripped the gate. No-op outside the browser.
+      if (
+        response.status === 403 &&
+        errorData?.code === 'account_mfa_required' &&
+        typeof window !== 'undefined' &&
+        typeof window.dispatchEvent === 'function'
+      ) {
+        try {
+          window.dispatchEvent(new CustomEvent('kortix:mfa-required'));
+        } catch {
+          // Never let telemetry-grade signaling break the error path.
+        }
+      }
+
       // Handle HTTP 431 - Request Header Fields Too Large
       // This typically happens when uploading many files at once
       if (response.status === 431) {


### PR DESCRIPTION
The admin "Require MFA for all members" toggle enforced correctly (IAM engine denies aal1 JWT sessions; super-admins + PATs exempt; lockout guard on enable) — but the member side was missing: no place to enroll a factor, and a denied action returned a generic 403 with no way to step up. This closes that loop.

- **API**: the `account_mfa_required` denial now carries a machine-readable `code` (the one actionable authz failure).
- **SDK**: a coded-403 dispatches `kortix:mfa-required` so any call site can trigger step-up.
- **Web**: Settings → Security tab to enroll/manage a TOTP authenticator, and a root-mounted step-up dialog that catches the event and upgrades the session to aal2. Admin card points members at Settings → Security.

Tests: coded-denial (api), event-dispatch (sdk), factor-row + QR-normalizer (web). tsc/biome clean.