### PR TITLE
Self-host hardening: verified laptop+VPS e2e, init overhaul, git/login fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,11 @@ infra/terraform/**/.terraform.lock.hcl
 infra/terraform/**/*.tfstate
 infra/terraform/**/*.tfstate.*
 infra/terraform/**/*.tfvars
+kortix-selfhost/terraform/**/.terraform/
+kortix-selfhost/terraform/**/.terraform.lock.hcl
+kortix-selfhost/terraform/**/*.tfstate
+kortix-selfhost/terraform/**/*.tfstate.*
+kortix-selfhost/terraform/**/*.tfvars
 .cursor
 
 apps/mobile/.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,11 @@ kortix-selfhost/terraform/**/.terraform.lock.hcl
 kortix-selfhost/terraform/**/*.tfstate
 kortix-selfhost/terraform/**/*.tfstate.*
 kortix-selfhost/terraform/**/*.tfvars
+deployments/**/.terraform/
+deployments/**/.terraform.lock.hcl
+deployments/**/*.tfstate
+deployments/**/*.tfstate.*
+deployments/**/*.tfvars
 .cursor
 
 apps/mobile/.env.example

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -29,3 +29,8 @@ c4283d9b3f477ebac6c0a7bed3cc57320e0824d8:apps/api/src/__tests__/unit-github-app-
 # generic-api-key rule matched the ACM certificate key_algorithm field (an
 # elliptic-curve algorithm NAME, not a credential) in the since-DELETED enterprise-vpc module.
 8887265c9d328380c42805206bc6a5bcebd6ecd5:infra/terraform/modules/enterprise-vpc/acm.tf:generic-api-key:5
+
+# Fake one-shot tokens in the CLI browser-auth CORS contract tests (literal
+# test fixtures, not credentials).
+940e6b256e1a75eb87b8ea954fe8fee074c63818:apps/cli/src/__tests__/browser-auth.test.ts:generic-api-key:73
+940e6b256e1a75eb87b8ea954fe8fee074c63818:apps/cli/src/__tests__/browser-auth.test.ts:generic-api-key:86

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -34,3 +34,7 @@ c4283d9b3f477ebac6c0a7bed3cc57320e0824d8:apps/api/src/__tests__/unit-github-app-
 # test fixtures, not credentials).
 940e6b256e1a75eb87b8ea954fe8fee074c63818:apps/cli/src/__tests__/browser-auth.test.ts:generic-api-key:73
 940e6b256e1a75eb87b8ea954fe8fee074c63818:apps/cli/src/__tests__/browser-auth.test.ts:generic-api-key:86
+
+# Historical version of this file (commit 791a47c8) whose comment quoted the
+# flagged value before being reworded — same self-reference as 619d83ee.
+791a47c8930ef3a8d2daa30f971e4d48535274bc:.gitleaksignore:generic-api-key:29

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -24,3 +24,8 @@ c4283d9b3f477ebac6c0a7bed3cc57320e0824d8:apps/api/src/__tests__/unit-github-app-
 89befc961579cdfe770042fd0637f537c17297c8:apps/cli/src/self-host/__tests__/connect-github.test.ts:private-key:136
 89befc961579cdfe770042fd0637f537c17297c8:apps/cli/src/self-host/__tests__/connect-github.test.ts:private-key:260
 0a56dc3d5fec8d49935be8275faeb8169642e332:apps/cli/src/self-host/__tests__/secrets.test.ts:generic-api-key:255
+
+# False positive in a HISTORICAL commit inside the v0.10.0 promote range: the
+# generic-api-key rule matched `key_algorithm = "EC_prime256v1"` (an ACM cert
+# algorithm name, not a credential) in the since-DELETED enterprise-vpc module.
+8887265c9d328380c42805206bc6a5bcebd6ecd5:infra/terraform/modules/enterprise-vpc/acm.tf:generic-api-key:5

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -26,6 +26,6 @@ c4283d9b3f477ebac6c0a7bed3cc57320e0824d8:apps/api/src/__tests__/unit-github-app-
 0a56dc3d5fec8d49935be8275faeb8169642e332:apps/cli/src/self-host/__tests__/secrets.test.ts:generic-api-key:255
 
 # False positive in a HISTORICAL commit inside the v0.10.0 promote range: the
-# generic-api-key rule matched `key_algorithm = "EC_prime256v1"` (an ACM cert
-# algorithm name, not a credential) in the since-DELETED enterprise-vpc module.
+# generic-api-key rule matched the ACM certificate key_algorithm field (an
+# elliptic-curve algorithm NAME, not a credential) in the since-DELETED enterprise-vpc module.
 8887265c9d328380c42805206bc6a5bcebd6ecd5:infra/terraform/modules/enterprise-vpc/acm.tf:generic-api-key:5

--- a/apps/api/src/__tests__/unit-github-app-installation-health.test.ts
+++ b/apps/api/src/__tests__/unit-github-app-installation-health.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for the "torn config" detection added to
+ * platform/routes/github-app.ts's `GET /status`: a stored App-installation
+ * config can go stale when the App half (appId/privateKey) and the
+ * installation half (owner/installationId) were written by two different
+ * manifest-flow runs — `isConfigured()` only checks that all four fields are
+ * present, not that installationId actually belongs to the CURRENT app.
+ *
+ * `checkManagedGithubAppInstallationHealthy` re-proves that belongs-to-app
+ * invariant via `GET /app/installations/{id}` signed with the current app's
+ * JWT (same call `getGitHubAppInstallation` makes) — GitHub 404s that call
+ * outright when the installation doesn't belong to the signing app.
+ *
+ * Mocks `platform/services/managed-github-app` (for the appId/privateKey the
+ * JWT signer reads) + global fetch. Must run in its own `bun test <file>`
+ * invocation (mock.module is process-global — same caveat as
+ * unit-github-app-isconfigured.test.ts / unit-github-owner-type-routing.test.ts).
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
+import type { ManagedGithubAppConfig } from '../platform/services/managed-github-app';
+
+const TEST_APP_PRIVATE_KEY = generateKeyPairSync('rsa', { modulusLength: 2048 })
+  .privateKey.export({ type: 'pkcs8', format: 'pem' })
+  .toString();
+
+let dbConfig: ManagedGithubAppConfig = { appId: '12345', privateKey: TEST_APP_PRIVATE_KEY };
+
+mock.module('../platform/services/managed-github-app', () => ({
+  managedGithubAppConfig: () => dbConfig,
+  refreshManagedGithubAppConfig: async () => {},
+  invalidateManagedGithubAppConfig: () => {},
+  updateManagedGithubAppConfig: async (patch: ManagedGithubAppConfig) => {
+    dbConfig = { ...dbConfig, ...patch };
+    return dbConfig;
+  },
+  resetManagedGithubAppConfig: async () => {
+    dbConfig = {};
+  },
+}));
+
+const { checkManagedGithubAppInstallationHealthy, resetManagedGithubAppInstallationHealthCache } =
+  await import('../platform/routes/github-app');
+
+// Same `.env`-leak concern as unit-github-owner-type-routing.test.ts: clear
+// the env fallbacks so only the mocked DB config drives `createGitHubAppJwt`.
+const ENV_KEYS = [
+  'KORTIX_GITHUB_APP_ID',
+  'GITHUB_APP_ID',
+  'KORTIX_GITHUB_APP_PRIVATE_KEY',
+  'GITHUB_APP_PRIVATE_KEY',
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+
+const originalFetch = globalThis.fetch;
+let fetchCallCount = 0;
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  dbConfig = { appId: '12345', privateKey: TEST_APP_PRIVATE_KEY };
+  fetchCallCount = 0;
+  resetManagedGithubAppInstallationHealthCache();
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const k of ENV_KEYS) {
+    const value = savedEnv[k];
+    if (value === undefined) delete process.env[k];
+    else process.env[k] = value;
+  }
+});
+
+function mockInstallationLookup(behavior: 'found' | 'not_found') {
+  globalThis.fetch = mock(async (url: string | URL | Request) => {
+    const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+    if (href.endsWith('/app/installations/501')) {
+      fetchCallCount += 1;
+      return behavior === 'found'
+        ? json({ id: 501, account: { login: 'kortix-managed', type: 'Organization' } })
+        : json({ message: 'Not Found' }, 404);
+    }
+    return json({ message: 'not found' }, 404);
+  }) as unknown as typeof fetch;
+}
+
+describe('checkManagedGithubAppInstallationHealthy', () => {
+  test('true when the installation resolves under the current app', async () => {
+    mockInstallationLookup('found');
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(true);
+  });
+
+  test('false when GitHub 404s (installation belongs to a different/older app, or was removed)', async () => {
+    mockInstallationLookup('not_found');
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(false);
+  });
+
+  test('caches the result — a second call within the TTL does not re-hit GitHub', async () => {
+    mockInstallationLookup('found');
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(true);
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(true);
+    expect(fetchCallCount).toBe(1);
+  });
+
+  test('resetManagedGithubAppInstallationHealthCache forces a fresh check', async () => {
+    mockInstallationLookup('found');
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(true);
+    resetManagedGithubAppInstallationHealthCache();
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(true);
+    expect(fetchCallCount).toBe(2);
+  });
+
+  test('skipCache bypasses the cache without needing an explicit reset', async () => {
+    mockInstallationLookup('found');
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(true);
+    expect(await checkManagedGithubAppInstallationHealthy('501', { skipCache: true })).toBe(true);
+    expect(fetchCallCount).toBe(2);
+  });
+
+  test("a different installationId is checked independently (not served from another id's cache entry)", async () => {
+    mockInstallationLookup('found');
+    expect(await checkManagedGithubAppInstallationHealthy('501')).toBe(true);
+    fetchCallCount = 0;
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+      fetchCallCount += 1;
+      if (href.endsWith('/app/installations/999')) return json({ message: 'Not Found' }, 404);
+      return json({ message: 'not found' }, 404);
+    }) as unknown as typeof fetch;
+    expect(await checkManagedGithubAppInstallationHealthy('999')).toBe(false);
+    expect(fetchCallCount).toBe(1);
+  });
+});

--- a/apps/api/src/__tests__/unit-github-app-pat.test.ts
+++ b/apps/api/src/__tests__/unit-github-app-pat.test.ts
@@ -16,30 +16,66 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { generateKeyPairSync } from 'node:crypto';
-import { resolveManagedGitSource, verifyPastedGithubAppInstallation } from '../platform/routes/github-app';
+import {
+  resolveInstallationOwnerType,
+  resolveManagedGitSource,
+  verifyPastedGithubAppInstallation,
+} from '../platform/routes/github-app';
+
+describe('resolveInstallationOwnerType', () => {
+  test('"User" -> User (personal-account installs, e.g. a throwaway bot account)', () => {
+    expect(resolveInstallationOwnerType('User')).toBe('User');
+  });
+
+  test('"Organization" -> Organization', () => {
+    expect(resolveInstallationOwnerType('Organization')).toBe('Organization');
+  });
+
+  test('missing/unexpected values default to Organization (the historical assumption)', () => {
+    expect(resolveInstallationOwnerType(undefined)).toBe('Organization');
+    expect(resolveInstallationOwnerType('Bot')).toBe('Organization');
+    expect(resolveInstallationOwnerType('')).toBe('Organization');
+  });
+});
 
 describe('resolveManagedGitSource', () => {
   test('none when nothing is configured', () => {
     expect(
-      resolveManagedGitSource({ dbAppConfigured: false, envAppConfigured: false, patConfigured: false }),
+      resolveManagedGitSource({
+        dbAppConfigured: false,
+        envAppConfigured: false,
+        patConfigured: false,
+      }),
     ).toBe('none');
   });
 
   test('pat when only a token is configured', () => {
     expect(
-      resolveManagedGitSource({ dbAppConfigured: false, envAppConfigured: false, patConfigured: true }),
+      resolveManagedGitSource({
+        dbAppConfigured: false,
+        envAppConfigured: false,
+        patConfigured: true,
+      }),
     ).toBe('pat');
   });
 
   test('env App wins over a PAT', () => {
     expect(
-      resolveManagedGitSource({ dbAppConfigured: false, envAppConfigured: true, patConfigured: true }),
+      resolveManagedGitSource({
+        dbAppConfigured: false,
+        envAppConfigured: true,
+        patConfigured: true,
+      }),
     ).toBe('env');
   });
 
   test('DB App (manifest flow or pasted) wins over both an env App and a PAT', () => {
     expect(
-      resolveManagedGitSource({ dbAppConfigured: true, envAppConfigured: true, patConfigured: true }),
+      resolveManagedGitSource({
+        dbAppConfigured: true,
+        envAppConfigured: true,
+        patConfigured: true,
+      }),
     ).toBe('db');
   });
 });
@@ -57,14 +93,27 @@ describe('verifyPastedGithubAppInstallation', () => {
     const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
       capturedUrl = String(url);
       capturedAuth = (init?.headers as Record<string, string>)?.Authorization ?? '';
-      return new Response(JSON.stringify({ id: 987, account: { login: 'acme-corp' } }), { status: 200 });
+      return new Response(JSON.stringify({ id: 987, account: { login: 'acme-corp' } }), {
+        status: 200,
+      });
     }) as typeof fetch;
 
     const result = await verifyPastedGithubAppInstallation('12345', pem, '987', fetchImpl);
 
-    expect(result).toEqual({ owner: 'acme-corp' });
+    expect(result).toEqual({ owner: 'acme-corp', ownerType: 'Organization' });
     expect(capturedUrl).toBe('https://api.github.com/app/installations/987');
     expect(capturedAuth).toMatch(/^Bearer /);
+  });
+
+  test('resolves ownerType: User for a personal-account installation', async () => {
+    const pem = keyPair();
+    const fetchImpl = (async (_url: string | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify({ id: 987, account: { login: 'agent-kortix', type: 'User' } }), {
+        status: 200,
+      })) as typeof fetch;
+
+    const result = await verifyPastedGithubAppInstallation('12345', pem, '987', fetchImpl);
+    expect(result).toEqual({ owner: 'agent-kortix', ownerType: 'User' });
   });
 
   test('URL-encodes the installation id', async () => {
@@ -76,7 +125,9 @@ describe('verifyPastedGithubAppInstallation', () => {
     }) as typeof fetch;
 
     await verifyPastedGithubAppInstallation('12345', pem, 'weird/id?', fetchImpl);
-    expect(capturedUrl).toBe(`https://api.github.com/app/installations/${encodeURIComponent('weird/id?')}`);
+    expect(capturedUrl).toBe(
+      `https://api.github.com/app/installations/${encodeURIComponent('weird/id?')}`,
+    );
   });
 
   test('rejects a malformed private key before ever calling GitHub', async () => {

--- a/apps/api/src/__tests__/unit-github-owner-type-routing.test.ts
+++ b/apps/api/src/__tests__/unit-github-owner-type-routing.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression coverage for the self-host VPC-demo incident: a managed GitHub
+ * App installed on a PERSONAL (User) account instead of an Organization made
+ * every managed-git repo create/list 404 on `/orgs/{owner}/repos`, because
+ * `managedAdminAuth()` (projects/git-backends/github.ts) used to hardcode
+ * `ownerType: 'Organization'` for the App-installation path (and gated the
+ * PAT path's live detection behind `INTERNAL_KORTIX_ENV !== 'prod'`, which is
+ * also wrong — a self-host box runs the "prod" build but is not the hosted
+ * multi-tenant SaaS, so "prod always means org" never held there).
+ *
+ * This proves `githubBackend.createRepo()` routes to `/user/repos` for a
+ * personal owner and `/orgs/{owner}/repos` for an org owner, via BOTH:
+ *  - the stored `ownerType` install-callback now writes to the DB config, and
+ *  - the live `isOrgAccount` fallback for configs that don't have it yet.
+ *
+ * Mocks only `platform/services/managed-github-app` (the DB-cache module,
+ * same convention as unit-github-app-isconfigured.test.ts) — everything
+ * downstream runs for real. Must run in its own `bun test <file>` invocation
+ * (mock.module is process-global — see the same caveat documented in that
+ * file and platform/services/session-sandbox.test.ts).
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
+import type { ManagedGithubAppConfig } from '../platform/services/managed-github-app';
+
+// A throwaway RSA key — only used to produce a JWT `createInstallationToken`
+// can sign; the fetch mock below never verifies the signature.
+const TEST_APP_PRIVATE_KEY = generateKeyPairSync('rsa', { modulusLength: 2048 })
+  .privateKey.export({ type: 'pkcs8', format: 'pem' })
+  .toString();
+
+let dbConfig: ManagedGithubAppConfig = {};
+
+mock.module('../platform/services/managed-github-app', () => ({
+  managedGithubAppConfig: () => dbConfig,
+  refreshManagedGithubAppConfig: async () => {},
+  invalidateManagedGithubAppConfig: () => {},
+  updateManagedGithubAppConfig: async (patch: ManagedGithubAppConfig) => {
+    dbConfig = { ...dbConfig, ...patch };
+    return dbConfig;
+  },
+}));
+
+const { githubBackend } = await import('../projects/git-backends/github');
+
+// This repo's local `.env` (loaded automatically by `bun test`) sets real
+// MANAGED_GIT_GITHUB_*/KORTIX_GITHUB_APP_* values for interactive dev use —
+// left in place, they silently win over the DB-mocked config below (env is
+// the documented fallback), making every case here exercise the env path
+// instead of the DB-config path under test. Clear them for the duration of
+// this file, same convention as unit-github-app-isconfigured.test.ts.
+const ENV_KEYS = [
+  'KORTIX_GITHUB_APP_ID',
+  'GITHUB_APP_ID',
+  'KORTIX_GITHUB_APP_PRIVATE_KEY',
+  'GITHUB_APP_PRIVATE_KEY',
+  'MANAGED_GIT_GITHUB_OWNER',
+  'MANAGED_GIT_GITHUB_INSTALL_ID',
+  'MANAGED_GIT_GITHUB_TOKEN',
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+
+const originalFetch = globalThis.fetch;
+let requests: Array<{ url: string; init?: RequestInit }> = [];
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function repoResponse(owner: string) {
+  return {
+    id: 7,
+    name: 'demo',
+    full_name: `${owner}/demo`,
+    private: true,
+    html_url: `https://github.com/${owner}/demo`,
+    clone_url: `https://github.com/${owner}/demo.git`,
+    ssh_url: `git@github.com:${owner}/demo.git`,
+    default_branch: 'main',
+    description: null,
+  };
+}
+
+beforeEach(() => {
+  dbConfig = {};
+  requests = [];
+  for (const k of ENV_KEYS) delete process.env[k];
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+    requests.push({ url: href, init });
+
+    if (href.endsWith('/app/installations/501/access_tokens')) {
+      return json({ token: 'installation-token', expires_at: '2026-01-01T00:00:00Z' });
+    }
+    if (href.match(/\/users\/[^/]+$/)) {
+      const login = href.split('/').pop()!;
+      if (login === 'org-owner-live') return json({ type: 'Organization' });
+      if (login === 'user-owner-live') return json({ type: 'User' });
+      return json({ message: 'not found' }, 404);
+    }
+    if (href.endsWith('/user/repos') && init?.method === 'POST') {
+      return json(repoResponse('whoever'));
+    }
+    const orgReposMatch = href.match(/\/orgs\/([^/]+)\/repos$/);
+    if (orgReposMatch && init?.method === 'POST') {
+      return json(repoResponse(orgReposMatch[1]!));
+    }
+    return json({ message: 'not found' }, 404);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const k of ENV_KEYS) {
+    const value = savedEnv[k];
+    if (value === undefined) delete process.env[k];
+    else process.env[k] = value;
+  }
+});
+
+function findRequest(pathSuffix: string) {
+  return requests.find((r) => r.url.endsWith(pathSuffix));
+}
+
+describe('managed GitHub App createRepo — owner-type routing', () => {
+  test('stored ownerType "User" (install-callback resolved a personal account) -> POST /user/repos', async () => {
+    dbConfig = {
+      appId: '12345',
+      privateKey: TEST_APP_PRIVATE_KEY,
+      owner: 'agent-kortix',
+      ownerType: 'User',
+      installationId: '501',
+    };
+
+    const repo = await githubBackend.createRepo({
+      accountId: 'acct-1',
+      projectId: 'proj-1',
+      slug: 'demo',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+
+    // /user/repos ignores the owner param (it's always "the authenticated
+    // account's repos" on GitHub's side) — the mock reflects that by always
+    // returning a fixed clone_url, independent of the configured owner.
+    expect(repo.upstreamUrl).toBe('https://github.com/whoever/demo.git');
+    expect(findRequest('/user/repos')).toBeTruthy();
+    expect(findRequest('/orgs/agent-kortix/repos')).toBeUndefined();
+  });
+
+  test('stored ownerType "Organization" -> POST /orgs/{owner}/repos (regression guard)', async () => {
+    dbConfig = {
+      appId: '12345',
+      privateKey: TEST_APP_PRIVATE_KEY,
+      owner: 'kortix-managed',
+      ownerType: 'Organization',
+      installationId: '501',
+    };
+
+    const repo = await githubBackend.createRepo({
+      accountId: 'acct-1',
+      projectId: 'proj-1',
+      slug: 'demo',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+
+    expect(repo.upstreamUrl).toBe('https://github.com/kortix-managed/demo.git');
+    expect(findRequest('/orgs/kortix-managed/repos')).toBeTruthy();
+    expect(findRequest('/user/repos')).toBeUndefined();
+  });
+
+  test('no stored ownerType (older config) falls back to a live account-type lookup — User', async () => {
+    dbConfig = {
+      appId: '12345',
+      privateKey: TEST_APP_PRIVATE_KEY,
+      owner: 'user-owner-live',
+      installationId: '501',
+    };
+
+    const repo = await githubBackend.createRepo({
+      accountId: 'acct-1',
+      projectId: 'proj-1',
+      slug: 'demo',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+
+    expect(repo.upstreamUrl).toBe('https://github.com/whoever/demo.git');
+    expect(findRequest('/user/repos')).toBeTruthy();
+  });
+
+  test('no stored ownerType, live lookup says Organization -> org path (regression guard)', async () => {
+    dbConfig = {
+      appId: '12345',
+      privateKey: TEST_APP_PRIVATE_KEY,
+      owner: 'org-owner-live',
+      installationId: '501',
+    };
+
+    const repo = await githubBackend.createRepo({
+      accountId: 'acct-1',
+      projectId: 'proj-1',
+      slug: 'demo',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+
+    expect(repo.upstreamUrl).toBe('https://github.com/org-owner-live/demo.git');
+    expect(findRequest('/orgs/org-owner-live/repos')).toBeTruthy();
+  });
+
+  test('PAT path also routes off a live account-type lookup, not a hardcoded/env-gated assumption', async () => {
+    dbConfig = { pat: 'ghp_dummy', patOwner: 'user-owner-live' };
+
+    const repo = await githubBackend.createRepo({
+      accountId: 'acct-1',
+      projectId: 'proj-1',
+      slug: 'demo',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+
+    expect(repo.upstreamUrl).toBe('https://github.com/whoever/demo.git');
+    expect(findRequest('/user/repos')).toBeTruthy();
+    // Never minted an installation token — the PAT is used directly.
+    expect(findRequest('/access_tokens')).toBeUndefined();
+  });
+});

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -27,13 +27,23 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     llm.get('/health', (c) =>
       c.json({ status: 'ok', service: 'kortix-llm-gateway', mode: 'in-process' }),
     );
-    llm.post('/chat/completions', async (c) =>
+    const chat = async (c: import('hono').Context) =>
       gateway.chatCompletions({
         authorization: c.req.header('authorization'),
         rawBody: await c.req.text(),
-      }),
-    );
-    llm.get('/models', (c) => gateway.listModels(c.req.header('authorization')));
+      });
+    const models = (c: import('hono').Context) =>
+      gateway.listModels(c.req.header('authorization'));
+    llm.post('/chat/completions', chat);
+    llm.get('/models', models);
+    // OpenAI-style clients (opencode's `kortix` provider among them) treat the
+    // base URL as an OpenAI ORIGIN and append `/v1/chat/completions` — so the
+    // in-process mount must also serve the `/v1/...`-prefixed shape, exactly
+    // like the standalone gateway pod does. Without this, a self-host whose
+    // public URL points at the API directly (tunnel/local mode, no Caddy
+    // /v1/llm* split) 404s every completion call.
+    llm.post('/v1/chat/completions', chat);
+    llm.get('/v1/models', models);
     app.route('/v1/llm', llm);
   }
 

--- a/apps/api/src/platform/routes/github-app.ts
+++ b/apps/api/src/platform/routes/github-app.ts
@@ -435,13 +435,28 @@ githubAppSetupRouter.openapi(
       if (!isGithubAppConfigured()) {
         return c.redirect(accountRedirect(accountId, 'error', 'app_not_configured'), 302);
       }
+      // `getGitHubAppInstallation` calls GET /app/installations/{id} signed
+      // with THIS app's own JWT — GitHub 404s that call outright if the
+      // installation id doesn't belong to this app, so a successful response
+      // here already proves the installation-belongs-to-app invariant; no
+      // separate check needed before we persist it.
       const installation = await getGitHubAppInstallation(installationId);
       const owner = installation.account?.login;
       if (!owner) {
         return c.redirect(accountRedirect(accountId, 'error', 'owner_unresolved'), 302);
       }
+      // GitHub tells us for free whether the install target is an
+      // Organization or a personal User account — store it so repo-create
+      // routing (git-backends/github.ts) never has to guess (a personal
+      // owner needs /user/repos, not /orgs/{owner}/repos, or every managed
+      // git operation 404s).
+      const ownerType = resolveInstallationOwnerType(installation.account?.type);
 
-      await updateManagedGithubAppConfig({ owner, installationId });
+      await updateManagedGithubAppConfig({ owner, ownerType, installationId });
+      // A fresh install just replaced whatever installationId (if any) was
+      // previously cached as healthy/unhealthy — don't let a stale cache
+      // entry from before this reconnect answer the next GET /status.
+      resetManagedGithubAppInstallationHealthCache();
       return c.redirect(accountRedirect(accountId, 'connected'), 302);
     } catch (err) {
       console.error(
@@ -470,6 +485,22 @@ githubAppSetupRouter.openapi(
 export type ManagedGitSource = 'db' | 'env' | 'pat' | 'none';
 
 /**
+ * GitHub's installation `account.type` is `'User' | 'Organization'` (per
+ * their docs) but comes back as a loosely-typed string on the wire — pin it
+ * to the two values `resolveDefaultOwner`/`managedAdminAuth` actually branch
+ * on, defaulting to `'Organization'` (the historical assumption, still right
+ * for every managed-git org install) for anything unexpected. Shared by both
+ * places that resolve an installation's owner type (install-callback below,
+ * and `verifyPastedGithubAppInstallation`'s "paste an existing App" path) so
+ * they can never drift from each other on what counts as a personal account.
+ */
+export function resolveInstallationOwnerType(
+  accountType: string | undefined,
+): 'User' | 'Organization' {
+  return accountType === 'User' ? 'User' : 'Organization';
+}
+
+/**
  * Pure precedence rule behind `GET /status`'s `source` field — split out so
  * it's testable without a Hono context/DB (see unit-github-app-pat.test.ts).
  * Mirrors the accessors' own resolution order: App-DB > App-env > PAT.
@@ -483,6 +514,54 @@ export function resolveManagedGitSource(input: {
   if (input.envAppConfigured) return 'env';
   if (input.patConfigured) return 'pat';
   return 'none';
+}
+
+// ─── Torn-config detection ────────────────────────────────────────────────
+// A stored config can go "torn": the App half (appId/privateKey) and the
+// installation half (owner/installationId) were written by two different
+// manifest-flow runs (e.g. an operator re-ran the flow after an earlier
+// attempt, creating a second App, but a stale installationId from the first
+// App is still sitting in the row) — `isConfigured()` can't see this, it
+// only checks that all four fields are non-empty, not that the
+// installationId actually belongs to the CURRENT appId+privateKey.
+//
+// Detected cheaply: `GET /app/installations/{id}` signed with the CURRENT
+// app's JWT — GitHub 404s that call outright if the installation doesn't
+// belong to this app (same call install-callback already relies on to prove
+// the belongs-to-app invariant at write time; here we're just re-checking it
+// hasn't drifted since). Cached briefly since this only runs off a
+// status-polling endpoint, not a hot path, and only for the 'db' source (env-
+// configured Apps and PATs have no "two configs in one row" failure mode).
+const INSTALLATION_HEALTH_TTL_MS = 30_000;
+let installationHealthCache: { key: string; ok: boolean; at: number } | null = null;
+
+export async function checkManagedGithubAppInstallationHealthy(
+  installationId: string,
+  opts: { skipCache?: boolean } = {},
+): Promise<boolean> {
+  if (
+    !opts.skipCache &&
+    installationHealthCache &&
+    installationHealthCache.key === installationId &&
+    Date.now() - installationHealthCache.at < INSTALLATION_HEALTH_TTL_MS
+  ) {
+    return installationHealthCache.ok;
+  }
+  let ok: boolean;
+  try {
+    await getGitHubAppInstallation(installationId);
+    ok = true;
+  } catch {
+    ok = false;
+  }
+  installationHealthCache = { key: installationId, ok, at: Date.now() };
+  return ok;
+}
+
+/** Test-only escape hatch — the cache is module-level so tests need a way to
+ *  force a fresh check between cases. */
+export function resetManagedGithubAppInstallationHealthCache(): void {
+  installationHealthCache = null;
 }
 
 githubAppSetupRouter.openapi(
@@ -501,6 +580,7 @@ githubAppSetupRouter.openapi(
           slug: z.string().nullable(),
           installation_id: z.string().nullable(),
           source: z.enum(['db', 'env', 'pat', 'none']),
+          reason: z.string().optional(),
         }),
         'Managed GitHub App status',
       ),
@@ -512,7 +592,7 @@ githubAppSetupRouter.openapi(
     // rather than re-deriving "is managed-git usable" here — it already
     // covers PAT + App-installation, so this route can never drift from what
     // project creation actually does.
-    const configured = await githubBackend.isConfigured();
+    let configured = await githubBackend.isConfigured();
     const owner = managedGithubOwner();
     const slug = githubAppSlug();
     const installationId = managedGithubInstallId();
@@ -524,12 +604,22 @@ githubAppSetupRouter.openapi(
       patConfigured: Boolean(managedGithubToken()),
     });
 
+    let reason: string | undefined;
+    if (configured && source === 'db' && installationId) {
+      const healthy = await checkManagedGithubAppInstallationHealthy(installationId);
+      if (!healthy) {
+        configured = false;
+        reason = 'installation_not_found_for_app';
+      }
+    }
+
     return c.json({
       configured,
       owner,
       slug,
       installation_id: installationId,
       source,
+      ...(reason ? { reason } : {}),
     });
   },
 );
@@ -547,7 +637,7 @@ export async function verifyPastedGithubAppInstallation(
   privateKey: string,
   installationId: string,
   fetchImpl: typeof fetch = fetch,
-): Promise<{ owner: string }> {
+): Promise<{ owner: string; ownerType: 'User' | 'Organization' }> {
   let jwt: string;
   try {
     jwt = signGitHubAppJwt(appId, privateKey);
@@ -575,10 +665,10 @@ export async function verifyPastedGithubAppInstallation(
         : `GitHub rejected the App credentials (${res.status}): ${detail || res.statusText}`,
     );
   }
-  const body = (await res.json()) as { account?: { login?: string } };
+  const body = (await res.json()) as { account?: { login?: string; type?: string } };
   const owner = body.account?.login;
   if (!owner) throw new Error('Could not resolve the installation owner from GitHub');
-  return { owner };
+  return { owner, ownerType: resolveInstallationOwnerType(body.account?.type) };
 }
 
 githubAppSetupRouter.openapi(
@@ -629,9 +719,11 @@ githubAppSetupRouter.openapi(
     }
 
     let owner: string;
+    let ownerType: 'User' | 'Organization';
     try {
       const verified = await verifyPastedGithubAppInstallation(appId, privateKey, installationId);
       owner = verified.owner;
+      ownerType = verified.ownerType;
     } catch (err) {
       return c.json(
         { error: true, message: err instanceof Error ? err.message : String(err), status: 400 },
@@ -644,12 +736,14 @@ githubAppSetupRouter.openapi(
       privateKey,
       installationId,
       owner,
+      ownerType,
       slug,
       stateSecret: managedGithubAppConfig().stateSecret || randomBytes(32).toString('hex'),
       // Mutually exclusive with a PAT — see POST /pat's matching comment.
       pat: undefined,
       patOwner: undefined,
     });
+    resetManagedGithubAppInstallationHealthCache();
 
     return c.json({ ok: true as const, owner });
   },
@@ -740,6 +834,7 @@ githubAppSetupRouter.openapi(
       clientSecret: undefined,
       webhookSecret: undefined,
       owner: undefined,
+      ownerType: undefined,
       installationId: undefined,
     });
 
@@ -768,6 +863,7 @@ githubAppSetupRouter.openapi(
   async (c: any) => {
     try {
       await resetManagedGithubAppConfig();
+      resetManagedGithubAppInstallationHealthCache();
       return c.json({ ok: true as const });
     } catch (err) {
       return c.json(

--- a/apps/api/src/platform/services/managed-github-app.ts
+++ b/apps/api/src/platform/services/managed-github-app.ts
@@ -36,6 +36,16 @@ export interface ManagedGithubAppConfig {
   stateSecret?: string;
   /** GitHub login (user or org) the App is installed on. */
   owner?: string;
+  /**
+   * Whether `owner` is an Organization or a personal User account — resolved
+   * from the installation's `account.type` at install-callback time (GitHub
+   * tells us this for free; no need to guess or re-detect on every repo
+   * create). Repo-create/list routing (git-backends/github.ts) reads this to
+   * pick `/orgs/{owner}/repos` vs `/user/repos`; a self-host operator can
+   * install the App on either kind of account (e.g. a personal bot account
+   * with no org), and getting this wrong 404s every managed-git operation.
+   */
+  ownerType?: 'User' | 'Organization';
   installationId?: string;
   /** Managed-git via a straight PAT instead of a GitHub App — the "one
    *  server-side key" alternative to the manifest-flow App above (mirrors the
@@ -57,6 +67,10 @@ function coerceString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value : undefined;
 }
 
+function coerceOwnerType(value: unknown): 'User' | 'Organization' | undefined {
+  return value === 'User' || value === 'Organization' ? value : undefined;
+}
+
 function parseConfig(value: unknown): ManagedGithubAppConfig {
   if (!value || typeof value !== 'object') return {};
   const v = value as Record<string, unknown>;
@@ -69,6 +83,7 @@ function parseConfig(value: unknown): ManagedGithubAppConfig {
     webhookSecret: coerceString(v.webhookSecret),
     stateSecret: coerceString(v.stateSecret),
     owner: coerceString(v.owner),
+    ownerType: coerceOwnerType(v.ownerType),
     installationId: coerceString(v.installationId),
     pat: coerceString(v.pat),
     patOwner: coerceString(v.patOwner),

--- a/apps/api/src/projects/git-backends/github.ts
+++ b/apps/api/src/projects/git-backends/github.ts
@@ -1,4 +1,3 @@
-import { config } from '../../config';
 import { managedGithubAppConfig } from '../../platform/services/managed-github-app';
 import {
   type GitHubAuthContext,
@@ -46,6 +45,17 @@ export function managedGithubInstallId(): string | null {
     process.env.MANAGED_GIT_GITHUB_INSTALL_ID?.trim() ||
     null
   );
+}
+
+/**
+ * The stored account type for the App-installation owner (install-callback
+ * records `account.type` straight off the installation payload — see
+ * platform/routes/github-app.ts). `undefined` for configs written before this
+ * field existed, or when running on env vars only; callers fall back to a
+ * live `isOrgAccount` lookup in that case (see `managedAdminAuth` below).
+ */
+export function managedGithubOwnerType(): 'User' | 'Organization' | undefined {
+  return managedGithubAppConfig().ownerType;
 }
 
 /**
@@ -103,16 +113,13 @@ async function managedAdminAuth(): Promise<GitHubAuthContext> {
   if (!owner) throw new Error('Managed GitHub git not configured (MANAGED_GIT_GITHUB_OWNER)');
   const pat = managedGithubToken();
   if (pat) {
-    // owner may be a personal account (throwaway) → createRepo must hit
-    // /user/repos, not /orgs/{owner}/repos. Production managed repos always live
-    // under the configured org, so prod keeps the strict org-only path (no
-    // lookup); only local dev detects a personal owner (cached via isOrgAccount).
-    const ownerType =
-      config.INTERNAL_KORTIX_ENV === 'prod'
-        ? 'Organization'
-        : (await isOrgAccount(owner, { token: pat }))
-          ? 'Organization'
-          : 'User';
+    // owner may be a personal account (e.g. a throwaway bot user, not an org)
+    // → createRepo must hit /user/repos, not /orgs/{owner}/repos. Detected
+    // live every time (self-host operators can point MANAGED_GIT_GITHUB_OWNER
+    // at either kind of account; there is no "prod always means org"
+    // assumption that holds across deployments) — cached by isOrgAccount so
+    // this is a one-time lookup per owner login, not a lookup per request.
+    const ownerType = (await isOrgAccount(owner, { token: pat })) ? 'Organization' : 'User';
     return { token: pat, source: 'pat', owner, ownerType };
   }
   const installId = managedGithubInstallId();
@@ -122,11 +129,19 @@ async function managedAdminAuth(): Promise<GitHubAuthContext> {
     );
   }
   const token = await createInstallationToken(installId);
+  // Prefer the ownerType install-callback already resolved and stored from
+  // GitHub's own `account.type` (no extra API call). Configs written before
+  // that field existed (or set purely via env vars) fall back to a live
+  // lookup — same personal-vs-org detection as the PAT path above, using the
+  // installation token we already have in hand.
+  const ownerType =
+    managedGithubOwnerType() ??
+    ((await isOrgAccount(owner, { token: token.token })) ? 'Organization' : 'User');
   return {
     token: token.token,
     source: 'app_installation',
     owner,
-    ownerType: 'Organization',
+    ownerType,
     installationId: installId,
   };
 }

--- a/apps/cli/src/__tests__/browser-auth.test.ts
+++ b/apps/cli/src/__tests__/browser-auth.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+
+import { startCallbackServer } from '../api/browser-auth.ts';
+
+// The `kortix login` browser-callback flow: the dashboard's `/cli/authorize`
+// page does a cross-origin `fetch()` (its own origin → this loopback
+// listener) with a JSON body, which is a CORS-preflighted request. These
+// tests exercise the real HTTP server (not the CLI-side plumbing) to lock in
+// its CORS contract — including the Private/Local Network Access preflight
+// header some Chrome versions require even for loopback-to-loopback fetches,
+// which otherwise fails with the same generic "Failed to fetch" a CORS
+// block would produce (see browser-auth.ts's OPTIONS handler comment).
+
+describe('startCallbackServer — CORS contract', () => {
+  test('OPTIONS preflight returns 204 with the standard CORS headers', async () => {
+    const session = await startCallbackServer();
+    try {
+      const resp = await fetch(`http://127.0.0.1:${session.port}/callback`, {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'http://localhost:13737',
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type',
+        },
+      });
+      expect(resp.status).toBe(204);
+      expect(resp.headers.get('access-control-allow-origin')).toBe('*');
+      expect(resp.headers.get('access-control-allow-methods')).toContain('POST');
+      expect(resp.headers.get('access-control-allow-headers')?.toLowerCase()).toContain(
+        'content-type',
+      );
+    } finally {
+      session.close();
+    }
+  });
+
+  test('preflight with Access-Control-Request-Private-Network echoes the allow header', async () => {
+    const session = await startCallbackServer();
+    try {
+      const resp = await fetch(`http://127.0.0.1:${session.port}/callback`, {
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'http://localhost:13737',
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Private-Network': 'true',
+        },
+      });
+      expect(resp.status).toBe(204);
+      expect(resp.headers.get('access-control-allow-private-network')).toBe('true');
+    } finally {
+      session.close();
+    }
+  });
+
+  test('preflight without the private-network request header omits the allow header', async () => {
+    const session = await startCallbackServer();
+    try {
+      const resp = await fetch(`http://127.0.0.1:${session.port}/callback`, {
+        method: 'OPTIONS',
+        headers: { Origin: 'http://localhost:13737' },
+      });
+      expect(resp.headers.get('access-control-allow-private-network')).toBeNull();
+    } finally {
+      session.close();
+    }
+  });
+
+  test('a matching POST resolves awaitToken with the token', async () => {
+    const session = await startCallbackServer();
+    const resp = await fetch(`http://127.0.0.1:${session.port}/callback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: session.state, token: 'kortix_pat_abc123' }),
+    });
+    expect(resp.status).toBe(200);
+    const result = await session.awaitToken;
+    expect(result.token).toBe('kortix_pat_abc123');
+  });
+
+  test('state mismatch is rejected with 403 and does not resolve the token', async () => {
+    const session = await startCallbackServer();
+    try {
+      const resp = await fetch(`http://127.0.0.1:${session.port}/callback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ state: 'wrong-state', token: 'kortix_pat_abc123' }),
+      });
+      expect(resp.status).toBe(403);
+    } finally {
+      session.close();
+    }
+  });
+});

--- a/apps/cli/src/__tests__/host-dashboard-url.test.ts
+++ b/apps/cli/src/__tests__/host-dashboard-url.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { saveAuthForHost } from '../api/auth.ts';
+import { getHost, loadConfig, upsertHost } from '../api/config.ts';
+import { webDashboardUrl } from '../web-url.ts';
+
+// Regression coverage for the self-host login bug: `kortix login` used to
+// derive the frontend/dashboard URL purely from the API URL's shape, which
+// assumes cloud conventions (`api.<domain>` → `<domain>`) and a fixed local
+// dev port pairing (`:8008` → `:3000`). Neither holds for `kortix self-host`,
+// whose laptop default is API `:13738` / dashboard `:13737` — so the browser
+// flow opened a dead `:3000` with nothing listening on it. The fix: an
+// authoritative `dashboard_url` on the `Host` record (stamped by
+// `kortix self-host` from its own `PUBLIC_URL`, or settable via
+// `kortix hosts add --dashboard-url`) that `webDashboardUrl` prefers over
+// any guess.
+
+const SAVED = { ...process.env };
+let tmp: string;
+
+beforeEach(() => {
+  delete process.env.KORTIX_FRONTEND_URL;
+  delete process.env.KORTIX_DASHBOARD_URL;
+  delete process.env.BASH_ENV;
+  process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+  tmp = mkdtempSync(join(tmpdir(), 'kortix-cli-host-dashboard-'));
+  process.env.KORTIX_CONFIG_FILE = join(tmp, 'config.json');
+});
+
+afterEach(() => {
+  process.env = { ...SAVED };
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('webDashboardUrl — explicit dashboard_url override', () => {
+  test('self-host laptop default: API :13738 / dashboard :13737 — derivation would guess :3000 and be wrong', () => {
+    // Sanity: this is exactly the bug — the API-shape guess assumes the
+    // pnpm-dev :8008 → :3000 pairing and has no way to know a self-host
+    // stack's actual dashboard port.
+    expect(webDashboardUrl('http://localhost:13738')).toBe('http://localhost:3000');
+    // With the authoritative value (what `kortix self-host` now stamps on
+    // the host record), it resolves correctly instead.
+    expect(webDashboardUrl('http://localhost:13738', 'http://localhost:13737')).toBe(
+      'http://localhost:13737',
+    );
+  });
+
+  test('explicit override wins over KORTIX_FRONTEND_URL / KORTIX_DASHBOARD_URL', () => {
+    process.env.KORTIX_FRONTEND_URL = 'https://wrong.example.com';
+    expect(webDashboardUrl('http://localhost:13738', 'http://localhost:13737')).toBe(
+      'http://localhost:13737',
+    );
+  });
+
+  test('blank/whitespace override falls through to derivation, not a dead link', () => {
+    expect(webDashboardUrl('http://localhost:8008', '')).toBe('http://localhost:3000');
+    expect(webDashboardUrl('http://localhost:8008', '   ')).toBe('http://localhost:3000');
+  });
+
+  test('trailing slash on the override is stripped, same as every other path', () => {
+    expect(webDashboardUrl('http://localhost:13738', 'http://localhost:13737/')).toBe(
+      'http://localhost:13737',
+    );
+  });
+
+  test('domain self-host deployment still resolves without an explicit override (api.<domain> → <domain>)', () => {
+    // The domain case was already correct — PUBLIC_URL/API_PUBLIC_URL both
+    // derive from KORTIX_DOMAIN in self-host.ts's normalizeFullSupabaseEnv,
+    // and api.<domain> → <domain> is exactly what deriveFrontendFromApiBase
+    // already handles. No regression here.
+    expect(webDashboardUrl('https://api.example.com')).toBe('https://example.com');
+  });
+});
+
+describe('Host.dashboard_url — persists through the config file round trip', () => {
+  test('upsertHost → loadConfig → getHost carries dashboard_url through normalizeConfig', () => {
+    upsertHost(
+      'selfhost',
+      {
+        url: 'http://localhost:13738',
+        token: '',
+        user_id: '',
+        user_email: '',
+        account_id: '',
+        dashboard_url: 'http://localhost:13737',
+        logged_in_at: new Date().toISOString(),
+      },
+      true,
+    );
+
+    const reloaded = getHost('selfhost');
+    expect(reloaded?.dashboard_url).toBe('http://localhost:13737');
+
+    // And it survives a raw JSON round trip too (normalizeConfig's cleaning
+    // pass — the same path a real ~/.config/kortix/config.json goes through).
+    const config = loadConfig();
+    expect(config.hosts.selfhost?.dashboard_url).toBe('http://localhost:13737');
+  });
+
+  test('saveAuthForHost (what `kortix login` calls to persist a fresh token) does NOT wipe dashboard_url', () => {
+    // Regression: authToHost() used to rebuild the Host record from scratch
+    // on every login, dropping any field the `Auth` shape doesn't carry.
+    // dashboard_url has no other call site that re-derives it after login
+    // (unlike account_slug/default_project, which login.ts re-sets right
+    // after via setActiveAccount/ensureDefaultProjectBinding) — so the very
+    // first successful `kortix login` against a `kortix self-host`-registered
+    // host silently erased the authoritative frontend URL, and the NEXT
+    // `kortix login` (e.g. after `kortix logout` + `kortix login` again) was
+    // right back to guessing :3000.
+    upsertHost(
+      'selfhost',
+      {
+        url: 'http://localhost:13738',
+        token: '',
+        user_id: '',
+        user_email: '',
+        account_id: '',
+        dashboard_url: 'http://localhost:13737',
+        logged_in_at: new Date().toISOString(),
+      },
+      true,
+    );
+
+    saveAuthForHost(
+      'selfhost',
+      {
+        api_base: 'http://localhost:13738',
+        token: 'kortix_pat_fresh',
+        user_id: 'user_1',
+        user_email: 'user@example.test',
+        account_id: 'account_1',
+        logged_in_at: new Date().toISOString(),
+      },
+      true,
+    );
+
+    const host = getHost('selfhost');
+    expect(host?.token).toBe('kortix_pat_fresh');
+    expect(host?.user_email).toBe('user@example.test');
+    expect(host?.dashboard_url).toBe('http://localhost:13737');
+  });
+
+  test('a host with no dashboard_url (e.g. cloud, manually-added hosts) omits the field rather than defaulting to empty string', () => {
+    writeFileSync(
+      process.env.KORTIX_CONFIG_FILE!,
+      JSON.stringify({
+        active: 'cloud',
+        hosts: {
+          cloud: {
+            url: 'https://api.kortix.com',
+            token: 'kortix_pat_x',
+            user_id: 'u1',
+            user_email: 'a@b.com',
+            account_id: 'acc1',
+            logged_in_at: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }),
+    );
+    const host = getHost('cloud');
+    expect(host?.dashboard_url).toBeUndefined();
+  });
+});

--- a/apps/cli/src/api/auth.ts
+++ b/apps/cli/src/api/auth.ts
@@ -1,13 +1,13 @@
 import {
   DEFAULT_API_BASE,
   DEFAULT_HOST_NAME,
+  type Host,
   activeHost,
   activeHostName,
   configFilePath,
   getHost,
-  upsertHost,
   removeHost,
-  type Host,
+  upsertHost,
 } from './config.ts';
 import { sandboxEnvValue } from './sandbox-env.ts';
 
@@ -43,8 +43,21 @@ function hostToAuth(host: Host): Auth {
   };
 }
 
-function authToHost(auth: Auth): Host {
+/**
+ * Build the Host record to persist for a login. Spreads `previous` first so
+ * fields the `Auth` shape doesn't carry — `dashboard_url`, `account_slug`,
+ * `account_name`, `default_project` — survive a re-login instead of being
+ * silently wiped. `dashboard_url` in particular has no other call site that
+ * re-derives it after login (unlike account_slug/default_project, which
+ * login.ts re-sets right after via setActiveAccount/ensureDefaultProjectBinding),
+ * so without this merge, the very first successful `kortix login` on a
+ * `kortix self-host`-registered host would erase the authoritative frontend
+ * URL `registerLocalHost` had just stamped on it — reintroducing the
+ * API-shape-guessing bug (see web-url.ts) on every login after the first.
+ */
+function authToHost(auth: Auth, previous?: Host | null): Host {
   return {
+    ...previous,
     url: auth.api_base,
     token: auth.token,
     user_id: auth.user_id,
@@ -71,12 +84,12 @@ export function loadAuthForHost(name: string): Auth | null {
  * active. */
 export function saveAuth(auth: Auth): void {
   const targetName = activeHostName() ?? DEFAULT_HOST_NAME;
-  upsertHost(targetName, authToHost(auth), true);
+  upsertHost(targetName, authToHost(auth, getHost(targetName)), true);
 }
 
 /** Persist a named host explicitly. */
 export function saveAuthForHost(name: string, auth: Auth, makeActive: boolean): void {
-  upsertHost(name, authToHost(auth), makeActive);
+  upsertHost(name, authToHost(auth, getHost(name)), makeActive);
 }
 
 /** Remove the active host (or a named one). Returns true if anything was removed. */

--- a/apps/cli/src/api/browser-auth.ts
+++ b/apps/cli/src/api/browser-auth.ts
@@ -1,5 +1,5 @@
-import { createServer, type Server } from 'node:http';
 import { randomBytes } from 'node:crypto';
+import { type Server, createServer } from 'node:http';
 
 export interface BrowserAuthResult {
   /** The plaintext PAT the dashboard minted on behalf of the user. */
@@ -48,6 +48,19 @@ export function startCallbackServer(opts: StartOpts = {}): Promise<BrowserAuthSe
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 
     if (req.method === 'OPTIONS') {
+      // Chrome's Private/Local Network Access preflight: when a page's fetch
+      // targets a "more private" address space (this loopback listener
+      // qualifies even from another loopback origin on some Chrome versions'
+      // stricter phases), the browser adds this request header to the
+      // preflight and requires the matching response header before it will
+      // let the actual request through — otherwise the fetch fails exactly
+      // like a CORS block (generic "Failed to fetch", no distinguishing
+      // detail). Harmless to always send when asked: this is a one-shot
+      // loopback receiver guarded by the `state` nonce, not a same-origin
+      // security boundary.
+      if (req.headers['access-control-request-private-network'] === 'true') {
+        res.setHeader('Access-Control-Allow-Private-Network', 'true');
+      }
       res.writeHead(204);
       res.end();
       return;

--- a/apps/cli/src/api/config.ts
+++ b/apps/cli/src/api/config.ts
@@ -1,11 +1,4 @@
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { sandboxEnvValue } from './sandbox-env.ts';
@@ -82,6 +75,15 @@ export interface Host {
   account_name?: string;
   /** Global default project for this host (see DefaultProjectRef). */
   default_project?: DefaultProjectRef;
+  /**
+   * The frontend/dashboard base URL for this host, when known authoritatively
+   * (e.g. `kortix self-host` registers it from its own `PUBLIC_URL`). Lets
+   * `kortix login`'s browser flow open the right origin instead of guessing
+   * one from the API host's shape — that guess (see web-url.ts) assumes cloud
+   * URL conventions (`api.<domain>` → `<domain>`, `:8008` → `:3000`) which
+   * silently breaks for a self-host stack on non-default ports.
+   */
+  dashboard_url?: string;
   logged_in_at: string;
 }
 
@@ -105,11 +107,7 @@ function defaultConfigPath(): string {
 export function configFilePath(): string {
   // Honor both config path env vars. KORTIX_AUTH_FILE is still used by the
   // existing e2e test harness.
-  return (
-    process.env.KORTIX_CONFIG_FILE ??
-    process.env.KORTIX_AUTH_FILE ??
-    defaultConfigPath()
-  );
+  return process.env.KORTIX_CONFIG_FILE ?? process.env.KORTIX_AUTH_FILE ?? defaultConfigPath();
 }
 
 function singleHostAuthFilePath(): string {
@@ -415,6 +413,7 @@ function normalizeConfig(parsed: Partial<Config>): Config {
       ...(typeof h.account_slug === 'string' ? { account_slug: h.account_slug } : {}),
       ...(typeof h.account_name === 'string' ? { account_name: h.account_name } : {}),
       ...(isDefaultProjectRef(h.default_project) ? { default_project: h.default_project } : {}),
+      ...(typeof h.dashboard_url === 'string' ? { dashboard_url: h.dashboard_url } : {}),
     };
   }
   // Tracks which old names were folded into new ones so we can retarget the
@@ -494,7 +493,9 @@ function defaultHost(url: string): Host {
   };
 }
 
-function importSingleHostAuth(parsed: Record<string, unknown> | Partial<Config> | null): Config | null {
+function importSingleHostAuth(
+  parsed: Record<string, unknown> | Partial<Config> | null,
+): Config | null {
   if (!parsed || typeof parsed !== 'object') return null;
   const p = parsed as Record<string, unknown>;
   const token = typeof p.token === 'string' ? p.token : undefined;
@@ -507,8 +508,7 @@ function importSingleHostAuth(parsed: Record<string, unknown> | Partial<Config> 
     user_id: typeof p.user_id === 'string' ? p.user_id : '',
     user_email: typeof p.user_email === 'string' ? p.user_email : '',
     account_id: typeof p.account_id === 'string' ? p.account_id : '',
-    logged_in_at:
-      typeof p.logged_in_at === 'string' ? p.logged_in_at : new Date().toISOString(),
+    logged_in_at: typeof p.logged_in_at === 'string' ? p.logged_in_at : new Date().toISOString(),
   };
   return {
     active: CLOUD_HOST_NAME,

--- a/apps/cli/src/commands/hosts.ts
+++ b/apps/cli/src/commands/hosts.ts
@@ -1,4 +1,5 @@
 import {
+  type Host,
   activeHostName,
   getHost,
   listHosts,
@@ -6,12 +7,11 @@ import {
   upsertHost,
   useHost,
   validateHostName,
-  type Host,
 } from '../api/config.ts';
-import { confirm, prompt } from '../prompts.ts';
-import { selectFromList } from '../tui-select.ts';
-import { C, help, pad, status } from '../style.ts';
 import { emitJson, takeFlagBool, takeFlagValue } from '../command-helpers.ts';
+import { confirm, prompt } from '../prompts.ts';
+import { C, help, pad, status } from '../style.ts';
+import { selectFromList } from '../tui-select.ts';
 import { runLogin } from './login.ts';
 
 const HELP = help`Usage: kortix hosts <subcommand> [options]
@@ -29,8 +29,12 @@ Built-in hosts (always exist):
 Subcommands:
   ls                                  List hosts (built-ins always exist) (--json)
   use <name>                          Switch the active host
-  add <name> --url <url> [--login]    Register a new host; with --login
-                                      run the browser flow immediately
+  add <name> --url <url>              Register a new host; with --login
+    [--dashboard-url <url>] [--login]  run the browser flow immediately.
+                                      Pass --dashboard-url for a self-host
+                                      instance if \`kortix login\` opens the
+                                      wrong origin (it otherwise guesses the
+                                      frontend URL from the API URL's shape).
   rm <name>                           Remove a custom host; built-ins
                                       are reset instead
   info [<name>]                       Show one host (or the active) (--json)
@@ -121,7 +125,9 @@ function hostsLs(json = false): number {
   const active = rows.find((r) => r.active);
   process.stdout.write(`\n  ${C.green}●${C.reset}${C.dim} active${C.reset}`);
   if (active) {
-    process.stdout.write(`${C.dim}: ${C.reset}${C.bold}${active.name}${C.reset}${C.dim} -> ${active.host.url}${C.reset}`);
+    process.stdout.write(
+      `${C.dim}: ${C.reset}${C.bold}${active.name}${C.reset}${C.dim} -> ${active.host.url}${C.reset}`,
+    );
   }
   process.stdout.write('\n\n');
   return 0;
@@ -166,10 +172,12 @@ async function hostsUse(name: string | undefined): Promise<number> {
 
 async function hostsAdd(args: string[]): Promise<number> {
   let url: string | undefined;
+  let dashboardUrl: string | undefined;
   let runLoginFlow = false;
   let name: string | undefined;
   try {
     url = takeFlagValue(args, ['--url', '--api']);
+    dashboardUrl = takeFlagValue(args, ['--dashboard-url']);
     runLoginFlow = removeBoolFlag(args, ['--login']);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
@@ -209,15 +217,32 @@ async function hostsAdd(args: string[]): Promise<number> {
     process.stderr.write(`${status.err(`"${url}" is not a valid URL.`)}\n`);
     return 1;
   }
+  if (dashboardUrl) {
+    try {
+      new URL(dashboardUrl); // validate
+    } catch {
+      process.stderr.write(`${status.err(`"${dashboardUrl}" is not a valid URL.`)}\n`);
+      return 1;
+    }
+  }
 
   // Persist an empty-credential placeholder so `--host <name>` resolves
   // before login. Subsequent `kortix login --host <name>` fills in token.
+  //
+  // `dashboard_url` (when passed) is the frontend/dashboard origin for this
+  // host — pass it for a self-host instance so `kortix login`'s browser flow
+  // opens the right origin instead of guessing one from the API URL's shape
+  // (a guess that assumes cloud conventions and breaks for non-default local
+  // ports; see web-url.ts). `kortix self-host` sets this automatically for
+  // its own built-in `selfhost` host — only needed here for a manually added
+  // host pointed at a self-host API the CLI didn't itself provision.
   const placeholder: Host = {
     url,
     token: '',
     user_id: '',
     user_email: '',
     account_id: '',
+    ...(dashboardUrl ? { dashboard_url: dashboardUrl } : {}),
     logged_in_at: new Date().toISOString(),
   };
   upsertHost(name, placeholder, false);
@@ -281,7 +306,9 @@ async function hostsRm(args: string[]): Promise<number> {
       `${C.dim}  Active host is now ${C.reset}${C.bold}${result.switchedTo}${C.reset}\n`,
     );
   } else if (isActive) {
-    process.stdout.write(`${C.dim}  Built-in host reset; run ${C.cyan}kortix login --host ${name}${C.reset}${C.dim} to authenticate again.${C.reset}\n`);
+    process.stdout.write(
+      `${C.dim}  Built-in host reset; run ${C.cyan}kortix login --host ${name}${C.reset}${C.dim} to authenticate again.${C.reset}\n`,
+    );
   }
   return 0;
 }
@@ -291,7 +318,9 @@ async function hostsRm(args: string[]): Promise<number> {
 function hostsInfo(name: string | undefined, json = false): number {
   const target = name ?? activeHostName();
   if (!target) {
-    process.stderr.write(`${status.err('No host configured. Pass a name or run `kortix login`.')}\n`);
+    process.stderr.write(
+      `${status.err('No host configured. Pass a name or run `kortix login`.')}\n`,
+    );
     return 1;
   }
   const host = getHost(target);
@@ -310,11 +339,18 @@ function hostsInfo(name: string | undefined, json = false): number {
     `  ${C.bold}${target}${C.reset}${active ? `  ${C.green}● active${C.reset}` : ''}\n`,
   );
   process.stdout.write(`  ${C.dim}url        ${C.reset}${host.url}\n`);
-  process.stdout.write(`  ${C.dim}user       ${C.reset}${host.user_email || host.user_id || '— (not logged in)'}\n`);
+  if (host.dashboard_url) {
+    process.stdout.write(`  ${C.dim}dashboard  ${C.reset}${host.dashboard_url}\n`);
+  }
+  process.stdout.write(
+    `  ${C.dim}user       ${C.reset}${host.user_email || host.user_id || '— (not logged in)'}\n`,
+  );
   if (host.account_id) {
     process.stdout.write(`  ${C.dim}account_id ${C.reset}${host.account_id}\n`);
   }
-  process.stdout.write(`  ${C.dim}token      ${C.reset}${host.token ? `${host.token.slice(0, 18)}…` : '— (none)'}\n`);
+  process.stdout.write(
+    `  ${C.dim}token      ${C.reset}${host.token ? `${host.token.slice(0, 18)}…` : '— (none)'}\n`,
+  );
   process.stdout.write(`  ${C.dim}logged in  ${C.reset}${host.logged_in_at}\n\n`);
   return 0;
 }
@@ -341,6 +377,7 @@ function hostJson(name: string, host: Host, active: boolean) {
   return {
     name,
     url: host.url,
+    dashboard_url: host.dashboard_url || null,
     user_email: host.user_email || null,
     user_id: host.user_id || null,
     account_id: host.account_id || null,

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,7 +1,14 @@
 import { spawn } from 'node:child_process';
 import { hostname } from 'node:os';
 
-import { DEFAULT_API_BASE, authFileLocation, loadAuthForHost, saveAuthForHost } from '../api/auth.ts';
+import {
+  DEFAULT_API_BASE,
+  authFileLocation,
+  loadAuthForHost,
+  saveAuthForHost,
+} from '../api/auth.ts';
+import { startCallbackServer } from '../api/browser-auth.ts';
+import { ApiError, createApiClient } from '../api/client.ts';
 import {
   DEFAULT_HOST_NAME,
   activeHostName,
@@ -9,12 +16,10 @@ import {
   setActiveAccount,
   validateHostName,
 } from '../api/config.ts';
-import { ApiError, createApiClient } from '../api/client.ts';
-import { startCallbackServer } from '../api/browser-auth.ts';
+import type { MeResponse } from '../api/types.ts';
 import { ensureDefaultProjectBinding } from '../project-bind.ts';
 import { C, help, status } from '../style.ts';
 import { webDashboardUrl } from '../web-url.ts';
-import type { MeResponse } from '../api/types.ts';
 
 const HELP = help`Usage: kortix login [options]
 
@@ -89,7 +94,7 @@ export async function runLogin(argv: string[]): Promise<number> {
   }
 
   // Resolve which host we're logging into.
-  let hostName = flags.host ?? activeHostName() ?? DEFAULT_HOST_NAME;
+  const hostName = flags.host ?? activeHostName() ?? DEFAULT_HOST_NAME;
   try {
     validateHostName(hostName);
   } catch (err) {
@@ -100,8 +105,7 @@ export async function runLogin(argv: string[]): Promise<number> {
   // Pick the API base URL with this priority:
   //   --api flag → existing host's URL → KORTIX_API_URL env → default
   const existing = getHost(hostName);
-  const apiBase =
-    flags.api ?? existing?.url ?? process.env.KORTIX_API_URL ?? DEFAULT_API_BASE;
+  const apiBase = flags.api ?? existing?.url ?? process.env.KORTIX_API_URL ?? DEFAULT_API_BASE;
 
   // If this host already has a working token + caller didn't pass
   // --token or --api, treat that as a no-op login.
@@ -115,7 +119,7 @@ export async function runLogin(argv: string[]): Promise<number> {
     return 0;
   }
 
-  const token = flags.token ?? (await browserLogin(apiBase));
+  const token = flags.token ?? (await browserLogin(apiBase, existing?.dashboard_url));
   if (!token) return 1;
 
   if (!token.startsWith('kortix_pat_')) {
@@ -155,10 +159,7 @@ export async function runLogin(argv: string[]): Promise<number> {
   // Persist the active account's display fields (and reconcile any default
   // project) so the context block + `accounts ls` read correctly offline.
   if (primary) {
-    setActiveAccount(
-      { id: primary.account_id, slug: primary.slug, name: primary.name },
-      hostName,
-    );
+    setActiveAccount({ id: primary.account_id, slug: primary.slug, name: primary.name }, hostName);
   }
 
   process.stdout.write(
@@ -191,7 +192,7 @@ export async function runLogin(argv: string[]): Promise<number> {
  * the dashboard to POST the freshly-minted PAT back. Returns the token
  * or null on failure.
  */
-async function browserLogin(apiBase: string): Promise<string | null> {
+async function browserLogin(apiBase: string, dashboardUrl?: string): Promise<string | null> {
   let session;
   try {
     session = await startCallbackServer();
@@ -202,7 +203,7 @@ async function browserLogin(apiBase: string): Promise<string | null> {
     return null;
   }
 
-  const dashUrl = webDashboardUrl(apiBase);
+  const dashUrl = webDashboardUrl(apiBase, dashboardUrl);
   const deviceLabel = encodeURIComponent(safeHostname());
   const url =
     `${dashUrl}/cli/authorize` +

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -497,7 +497,7 @@ async function selfHostStart(flags: GlobalFlags): Promise<number> {
   const tunnelCode = await reconcileTunnelReachability(flags.instance, env);
   if (tunnelCode !== 0) return tunnelCode;
 
-  registerLocalHost(DEFAULT_HOST_NAME, env.API_PUBLIC_URL);
+  registerLocalHost(DEFAULT_HOST_NAME, env.API_PUBLIC_URL, env.PUBLIC_URL);
   process.stdout.write(`${status.ok('Self-hosted Kortix is starting')}\n`);
   process.stdout.write(`${C.dim}  Dashboard: ${C.reset}${C.cyan}${env.PUBLIC_URL}${C.reset}\n`);
   process.stdout.write(`${C.dim}  Logs:      ${C.reset}${C.cyan}kortix self-host logs${C.reset}\n\n`);
@@ -2198,7 +2198,22 @@ function describeReachability(env: SelfHostEnv): string {
   return `${C.yellow}local-only${C.reset}${C.dim} — agent sandboxes and external callbacks will not work${C.reset}`;
 }
 
-function registerLocalHost(name: string, apiUrl: string): void {
+/**
+ * Register (or refresh) the CLI's built-in `selfhost` host entry so
+ * `kortix hosts use selfhost` + `kortix login` work against this stack
+ * out of the box.
+ *
+ * Also stamps `dashboard_url` with this instance's own frontend origin
+ * (`PUBLIC_URL` — loopback port on a laptop, `https://<domain>` once
+ * `KORTIX_DOMAIN` is set). Without it, `kortix login`'s browser flow has to
+ * *guess* the frontend from the API URL's shape (see web-url.ts), which
+ * assumes cloud conventions (`api.<domain>` → `<domain>`, `:8008` → `:3000`)
+ * — a guess that is simply wrong for a self-host stack on non-default ports
+ * (the laptop default is API `:13738` / dashboard `:13737`, not `:3000`).
+ * Storing the real value here means login never has to guess for a host
+ * this CLI itself stood up.
+ */
+function registerLocalHost(name: string, apiUrl: string, dashboardUrl: string): void {
   const existing = getHost(name);
   const sameHost = existing?.url === apiUrl;
   const host: Host = {
@@ -2207,6 +2222,7 @@ function registerLocalHost(name: string, apiUrl: string): void {
     user_id: sameHost ? existing?.user_id ?? '' : '',
     user_email: sameHost ? existing?.user_email ?? '' : '',
     account_id: sameHost ? existing?.account_id ?? '' : '',
+    dashboard_url: dashboardUrl,
     logged_in_at: sameHost ? existing?.logged_in_at ?? new Date().toISOString() : new Date().toISOString(),
   };
   upsertHost(name, host, true);

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -33,7 +33,6 @@ import {
   servicesForKeys,
   type SecretDef,
 } from '../self-host/secrets-registry.ts';
-import { createPastePrompt, runConnectGithubFlow } from '../self-host/connect-github.ts';
 import {
   namedTunnelConfigured,
   reachabilityMode,
@@ -65,163 +64,50 @@ const VPS_FIRST_NOTICE =
 
 const HELP = help`Usage: kortix self-host <subcommand> [options]
 
-Run Kortix on your own VPS/server — ${C.bold}recommended: a VPS with a domain${C.reset}.
-This is one generic Docker Compose stack: ${C.cyan}kortix self-host init${C.reset}
-generates a docker-compose.yml + .env, and ${C.cyan}start${C.reset} runs it. It happens
-to run identically on a laptop too, but production self-hosting means a real
-VPS/server plus a persistent domain (${C.cyan}--domain${C.reset}) — the Cloudflare-tunnel and
-local-only modes below exist for evaluation/development only and are NOT
-recommended for real use (ephemeral URLs, browser connection limits on
-plain-HTTP localhost, and — in local-only mode — agent sandboxes can't call
-back to this instance at all). Running it on your laptop is fine to kick the
-tyres; deploying on your own VPS with a persistent domain is the way.
+Run Kortix on your own VPS — a domain is the production path; laptop modes
+(tunnel/local) are for evaluation only. Docs: kortix.com/docs/self-hosting
 
 Subcommands:
-  init                 Create or refresh this instance's Compose + env config.
-  start                Pull images and start your self-hosted Kortix.
-  update               Pull the configured channel's images now and apply them.
-  reconcile            Same as update — check and converge to the configured
-                       channel/version.
-  version              Show the running version and image tags.
-  stop                 Stop the stack.
-  restart              Restart the stack.
-  status               Show container status.
-  doctor               Validate local Docker tooling and the Compose config.
-  logs [service]       Tail logs.
-  open                 Open the dashboard in a browser.
-  configure            Interactively configure integrations and update policy.
-  connect-github       Create + install a GitHub App owned by your org (or
-                       personal account) and wire it in as managed git — the
-                       easiest GitHub setup, no personal-access-token needed.
-                       This runs automatically as part of ${C.cyan}init${C.reset} on a TTY.
-  env ls              Show persistent environment values.
-  env set KEY=VALUE    Update persistent environment values.
-  secrets [ls]         Show every secret, grouped by category (masked by
-                       default; --show reveals full values).
-  secrets set KEY=VAL  Set one or more secrets (or "secrets set KEY" to be
-    [KEY=VAL ...]      prompted) and restart only the services they affect.
-  secrets rotate KEY   Regenerate one rotatable crypto-random secret (or
-    | --all-generated  every rotatable one) and restart affected services.
+  init                    Create/refresh this instance's Compose + env config.
+  start                   Pull images and start the stack.
+  update | reconcile      Pull + apply the configured channel/version now.
+  version                 Show the running version and image tags.
+  stop | restart          Stop / restart the stack.
+  status                  Show container status.
+  doctor                  Validate Docker tooling and the Compose config.
+  logs [service]          Tail logs.
+  open                    Open the dashboard in a browser.
+  configure               Re-run the guided setup.
+  env ls | set K=V        Show / update persistent environment values.
+  secrets ls              Show every secret, grouped by category (masked).
+  secrets set K=V ...     Set secrets, restarting only affected services.
+  secrets rotate KEY      Regenerate a rotatable secret (or --all-generated).
 
 Options:
-  --instance <name>    Instance name (default: ${DEFAULT_INSTANCE}).
-  --version <ref>      Run any published version or tag — a release
-                       (0.9.107), a moving channel (stable, latest), or a
-                       dev/CI build (dev-<sha>). Works on init/start/update/
-                       configure. Pinning a specific ref (anything other than
-                       stable/latest) defaults auto-update OFF for that
-                       instance — see --auto-update below. Alias: --tag.
-  --tag <tag>          Alias for --version.
-  --release <version>  Alias for --version/--tag.
-  --channel <name>     Which moving tag to track when no explicit --version/
-                       --tag is given: stable or latest (default: stable).
-                       The auto-updater tracks whichever channel is configured.
-  --auto-update <on|off> Enable/disable the in-compose auto-updater. Default
-                       depends on what's pinned: on for a channel (stable/
-                       latest), off for a specific --version/--tag/--release
-                       (pinning means "stay here" — the nightly updater must
-                       not silently move a pinned box). An explicit
-                       --auto-update always wins either way. Off just idles
-                       the updater container; ${C.cyan}update${C.reset} still applies an
-                       on-demand update regardless.
-  --local-images       Dev mode: run images built locally (not on any
-    | --no-pull        registry) — combine with ${C.cyan}--version <localtag>${C.reset} so
-                       *_IMAGE resolves to an image already present in the
-                       local Docker engine. Sets KORTIX_IMAGE_PULL=never (the
-                       updater skips ${C.cyan}docker compose pull${C.reset}) and forces
-                       auto-update off.
-  --update-time <HH:MM> Local clock time the auto-updater rolls the stack,
-                       once a day (default: ${DEFAULT_UPDATE_TIME}).
-  --update-tz <tz>     IANA timezone --update-time is interpreted in
-                       (default: ${DEFAULT_UPDATE_TZ}).
-  --allow-downtime     Accept a brief downtime window instead of a
-                       zero-downtime rolling swap — only needed for a release
-                       whose migration is not backward-compatible. Use during
-                       a maintenance window (sets KORTIX_ALLOW_DOWNTIME=1).
-  --single-account     This deployment is for exactly one account — hide
-                       "New account" and team-management UI, and block
-                       creating additional accounts (403).
-  --landing            Re-enable the marketing landing page for
-                       unauthenticated visitors hitting "/" — self-host
-                       defaults this OFF (straight to sign-in): a self-host
-                       is an app deployment, not a marketing site.
-  --no-landing         Explicitly send unauthenticated visitors hitting "/"
-                       to sign-in instead of the marketing landing page
-                       (redundant with the default — kept for scripts).
-  --enterprise-license You hold a Kortix Enterprise license — unlock SSO,
-                       SCIM, RBAC, and audit-log access platform-wide
-                       (kortix.com/enterprise).
-  --allow-missing-secrets Let "init"/"start" proceed with required secrets
-                       (managed git, sandbox, LLM) unset instead of failing.
-                       Local experimentation only — projects/agent sessions
-                       will not work until they are set.
-  --domain <domain>    Public domain reachability mode (RECOMMENDED — the
-                       VPS-first, production path): this instance is
-                       reachable at https://<domain> — turns on the bundled
-                       Caddy reverse proxy + ACME TLS. For a server/VPS/EC2 box
-                       with DNS pointed at it. Same effect as
-                       ${C.cyan}env set KORTIX_DOMAIN=<domain>${C.reset}. Pass an empty string
-                       to clear a previously configured domain.
-  --tunnel cloudflare  Cloudflare-tunnel reachability mode: no public domain —
-                       a ${C.cyan}cloudflared${C.reset} tunnel exposes the API to the internet so
-                       cloud (Daytona) sandboxes can call back to it. For
-                       evaluation on a laptop when there is no public IP/DNS —
-                       NOT recommended for production (the free quick-tunnel
-                       URL is ephemeral, reassigned on every restart and
-                       re-captured automatically; set CLOUDFLARE_TUNNEL_TOKEN +
-                       CLOUDFLARE_TUNNEL_HOSTNAME for a stable named tunnel
-                       instead — see the runbook — but a VPS + domain is still
-                       the recommended path for real use).
-  --org <name>         GitHub org to create/install the ${C.cyan}connect-github${C.reset} App
-                       under (omit, or pass "." for a personal account).
-  --manual             ${C.cyan}connect-github${C.reset}: headless mode — print URLs and accept
-                       pasted-back code/installation_id instead of opening a
-                       local browser. Automatic on a non-TTY.
-  --skip-github        Skip the guided ${C.cyan}connect-github${C.reset} offer during ${C.cyan}init${C.reset}/
-                       ${C.cyan}configure${C.reset} — drop straight to the advanced "paste an
-                       existing App or PAT" menu.
-  --json               Emit machine-readable output where supported.
-  --yes                Accept defaults in non-interactive flows.
-  -h, --help           Show this help.
-
-Reachability — VPS-first (required for agent sandboxes — see --domain/--tunnel
-above): a cloud (Daytona) sandbox calls back to this instance's API over the
-public internet via KORTIX_URL, which can never be a loopback/internal
-address. Production self-hosting is a VPS/server plus a persistent domain:
-${C.cyan}--domain${C.reset} (server/VPS/EC2 with DNS). ${C.cyan}--tunnel cloudflare${C.reset} (laptop, no DNS)
-and running with neither flag (local-only) are evaluation/development paths
-only and are NOT recommended for production — the tunnel URL is ephemeral,
-and in local-only mode agent sandboxes and other external callbacks
-(webhooks, Slack/Teams OAuth, git-proxy clone) will not work at all, only
-browser-local flows will. ${C.cyan}kortix self-host init${C.reset}/${C.cyan}configure${C.reset} ask
-interactively and default to the domain path.
-
-Public domain + TLS (recommended for production): set KORTIX_DOMAIN (and
-optionally KORTIX_API_DOMAIN, default api.<KORTIX_DOMAIN>) via ${C.cyan}--domain${C.reset} or
-${C.cyan}kortix self-host env set${C.reset} to turn on the bundled Caddy
-reverse proxy, which terminates TLS via ACME HTTP-01 on ports 80/443. Leave it
-unset only for a laptop/local evaluation setup on loopback ports.
+  --instance <name>       Instance name (default: ${DEFAULT_INSTANCE}).
+  --domain <domain>       Public domain reachability (recommended, production).
+  --tunnel cloudflare     Cloudflare-tunnel reachability (laptop, evaluation).
+  --version <ref>         Pin a release/channel/dev build. Alias: --tag/--release.
+  --channel <name>        stable|latest to track (default: stable).
+  --auto-update <on|off>  Override the default (ON everywhere except --local-images).
+  --update-time <HH:MM> / --update-tz <tz>   Auto-updater schedule.
+  --allow-downtime        Accept a brief downtime window for a breaking migration.
+  --local-images          Run locally-built images (dev mode); forces auto-update off.
+  --single-account        Hide multi-account/team UI.
+  --enterprise-license    Unlock SSO/SCIM/RBAC/audit (kortix.com/enterprise).
+  --allow-missing-secrets Proceed without the sandbox-provider key (evaluation only).
+  --admin-email <email>   Grant platform-admin to this account.
+  --json                  Machine-readable output where supported.
+  --yes                   Accept defaults non-interactively.
+  -h, --help              Show this help.
 
 Examples:
   kortix self-host init
   kortix self-host start
-  kortix self-host init --domain kortix.example.com  # recommended: VPS/server with DNS
-  kortix self-host init --tunnel cloudflare          # laptop evaluation only, not for production
-  kortix self-host update                         # pull + apply the stable channel
-  kortix self-host init --version 0.9.72          # pin to a specific released version
-  kortix self-host update --channel latest        # track :latest instead
-  kortix self-host init --version dev-a1b2c3d      # run a dev/CI build (auto-update off)
-  kortix self-host init --version branch-local --local-images  # run a locally-built image
-  kortix self-host version
-  kortix self-host env set KORTIX_DOMAIN=kortix.example.com
-  kortix self-host env set PUBLIC_URL=https://kortix.example.com API_PUBLIC_URL=https://api.example.com
-  kortix self-host connect-github
-  kortix self-host connect-github --org my-org
-  kortix self-host connect-github --manual        # no local browser (remote box)
-  kortix self-host secrets ls
-  kortix self-host secrets set OPENROUTER_API_KEY=sk-or-...
-  kortix self-host secrets rotate DASHBOARD_PASSWORD
-  kortix self-host secrets rotate --all-generated
+  kortix self-host init --domain kortix.example.com
+  kortix self-host init --tunnel cloudflare
+  kortix self-host update --channel latest
+  kortix self-host secrets set DAYTONA_API_KEY=dtn_...
   kortix hosts ls
 `;
 
@@ -389,22 +275,11 @@ function parseGlobalFlags(args: string[]): GlobalFlags {
   const updateTz = takeFlagValue(args, ['--update-tz']);
   const allowDowntime = takeFlagBool(args, ['--allow-downtime']);
   const singleAccount = takeFlagBool(args, ['--single-account']);
-  // Self-host defaults the marketing/landing site to OFF (an app deployment,
-  // not a marketing site — see SHARED_FEATURE_FLAG_DEFAULTS). `--landing`
-  // re-enables it; `--no-landing` is kept (now redundant with the default,
-  // but harmless) for anyone who already scripted it. Both are "undefined
-  // unless passed" so a bare re-init never resets a prior explicit choice;
-  // if both are somehow passed at once, the explicit disable wins.
-  const landingOn = takeFlagBool(args, ['--landing']);
-  const noLanding = takeFlagBool(args, ['--no-landing']);
   const enterpriseLicense = takeFlagBool(args, ['--enterprise-license']);
   const allowMissingSecrets = takeFlagBool(args, ['--allow-missing-secrets']);
   const localImages = takeFlagBool(args, ['--local-images', '--no-pull']);
   const domain = takeFlagValue(args, ['--domain']);
   const tunnelRaw = takeFlagValue(args, ['--tunnel']);
-  const org = takeFlagValue(args, ['--org']);
-  const manual = takeFlagBool(args, ['--manual']);
-  const skipGithub = takeFlagBool(args, ['--skip-github']);
   const adminEmail = takeFlagValue(args, ['--admin-email']);
   if (channelRaw !== undefined && !isChannel(channelRaw)) {
     throw new Error(`--channel must be "stable" or "latest", got "${channelRaw}"`);
@@ -434,15 +309,11 @@ function parseGlobalFlags(args: string[]): GlobalFlags {
     updateTz,
     allowDowntime: allowDowntime || undefined,
     singleAccount: singleAccount || undefined,
-    disableLanding: noLanding ? true : landingOn ? false : undefined,
     enterpriseLicense: enterpriseLicense || undefined,
     allowMissingSecrets: allowMissingSecrets || undefined,
     localImages: localImages || undefined,
     domain,
     tunnel: tunnelRaw as 'cloudflare' | undefined,
-    org,
-    manual: manual || undefined,
-    skipGithub: skipGithub || undefined,
     adminEmail,
     yes,
     json,
@@ -464,34 +335,52 @@ async function selfHostInit(flags: GlobalFlags): Promise<number> {
   applyImagesForTag(env, resolveTag(flags, existing));
   applyFeatureFlags(env, flags);
   applyReachabilityFlags(env, flags);
+  applyAdminEmail(env, flags);
 
+  // The complete guided `init` flow, in this exact order and no other
+  // questions (everything else is dashboard/env-only — see
+  // configureIntegrations()'s own doc comment): 1) reachability — the first
+  // real decision, since it decides whether agent sandboxes can work at all;
+  // 2) admin email; 3) deployment shape (single-account, enterprise
+  // license); 4) sandbox provider + its key; 5) Pipedream (optional); 6) a
+  // compact update-policy block. Only walk through it on a genuinely
+  // first-time init (no prior .env) — a refresh of an already-configured
+  // instance shouldn't re-ask any of this every time `init` happens to run
+  // again. `configure` always asks (see below), using its own fuller
+  // update-policy interrogation (configureUpdatePolicy) instead of this
+  // compact block.
+  if (shouldPrompt(flags) && existing === null) {
+    await promptReachability(env, flags, true);
+    await promptAdminEmail(env, flags);
+    await promptFeatureFlags(env, flags);
+  }
   if (shouldPrompt(flags) && integrationReviewNeeded(env)) {
     await configureIntegrations(env, flags);
   }
-  // Only walk through the deployment-configuration wizard on a genuinely
-  // first-time init (no prior .env) — a refresh of an already-configured
-  // instance shouldn't re-ask single-account/landing-page/license/reachability
-  // every time `init` happens to run again. `configure` always asks (see below).
   if (shouldPrompt(flags) && existing === null) {
-    await promptReachability(env, flags, true);
-    await promptFeatureFlags(env, flags);
+    await promptUpdatePolicyCompact(env, flags);
   }
 
-  // Required secrets (managed git, sandbox, LLM, ...) MUST be set before this
-  // instance is usable — see ensureRequiredSecrets(). Interactively this
-  // drives the guided flow until satisfied; non-interactively (or --yes) it
-  // fails loudly instead of silently producing a box that can't create
-  // projects or run agents. Persist whatever was collected either way so a
-  // follow-up `secrets set` / `configure` has something to build on.
+  // Required secrets — just the agent sandbox runtime (Daytona) now; see
+  // missingRequiredSecrets(). Managed git and the LLM key are configured in
+  // the dashboard after `start`, not gated here. Interactively this drives the
+  // guided flow until satisfied; non-interactively (or --yes) it fails loudly
+  // instead of silently producing a box that can't run agents. Persist
+  // whatever was collected either way so a follow-up `secrets set` /
+  // `configure` has something to build on.
   const secretsExit = await ensureRequiredSecrets(env, flags);
 
   writeEnv(flags.instance, env);
   writeCompose(flags.instance, env);
+  // Reloaded AFTER ensureRequiredSecrets (which may itself have just persisted
+  // allow_missing_secrets via recordAllowMissingSecrets) so this write below
+  // preserves it instead of clobbering it back to unset.
   const existingConfig = loadInstanceConfig(flags.instance);
   writeInstanceConfig({
     schema_version: 1,
     instance: flags.instance,
     ...(flags.release || existingConfig?.release ? { release: flags.release ?? existingConfig?.release } : {}),
+    ...(existingConfig?.allow_missing_secrets ? { allow_missing_secrets: true } : {}),
   });
   if (secretsExit !== 0) return secretsExit;
   renderInitSummary(flags.instance, dir, env, existing !== null);
@@ -517,6 +406,7 @@ function renderInitSummary(instance: string, dir: string, env: SelfHostEnv, refr
   process.stdout.write(`  ${C.dim}Start      ${C.reset}${C.cyan}kortix self-host start${instance === DEFAULT_INSTANCE ? '' : ` --instance ${instance}`}${C.reset}\n`);
   process.stdout.write(`  ${C.dim}Configure  ${C.reset}${C.cyan}kortix self-host configure${C.reset}${C.dim} or ${C.reset}${C.cyan}kortix self-host env set KEY=VALUE${C.reset}\n`);
   process.stdout.write(`  ${C.dim}Switch API  ${C.reset}${C.cyan}kortix hosts use selfhost${C.reset}${C.dim} / ${C.reset}${C.cyan}kortix hosts use cloud${C.reset}\n\n`);
+  renderAfterStartNote();
 }
 
 async function selfHostStart(flags: GlobalFlags): Promise<number> {
@@ -552,20 +442,19 @@ async function selfHostStart(flags: GlobalFlags): Promise<number> {
   }
 
   if (!sandboxProviderConfigured(env)) {
+    const provider = sandboxProviders(env)[0] ?? 'daytona';
+    const key = SANDBOX_PROVIDER_KEY[provider] ?? 'DAYTONA_API_KEY';
     process.stdout.write(
       `${C.yellow}  warning${C.reset}  ${C.dim}sandbox runtime not configured — agent sessions will fail to start.${C.reset}\n`,
     );
     process.stdout.write(
-      `${C.dim}           run ${C.reset}${C.cyan}kortix self-host configure${C.reset}${C.dim} to set ${C.reset}DAYTONA_API_KEY${C.dim}.${C.reset}\n\n`,
+      `${C.dim}           run ${C.reset}${C.cyan}kortix self-host configure${C.reset}${C.dim} to set ${C.reset}${key}${C.dim}.${C.reset}\n\n`,
     );
   }
 
   if (!gitProviderConfigured(env)) {
     process.stdout.write(
-      `${C.yellow}  warning${C.reset}  ${C.dim}managed git not configured — creating projects will fail.${C.reset}\n`,
-    );
-    process.stdout.write(
-      `${C.dim}           run ${C.reset}${C.cyan}kortix self-host configure${C.reset}${C.dim} to connect GitHub (PAT or App).${C.reset}\n\n`,
+      `${C.dim}  note     managed git not configured yet — connect GitHub in the dashboard (Settings → Git) before creating projects.${C.reset}\n\n`,
     );
   }
 
@@ -581,8 +470,20 @@ async function selfHostStart(flags: GlobalFlags): Promise<number> {
     );
   }
 
-  const pull = compose(flags.instance, ['pull']);
-  if (pull !== 0) return pull;
+  // Dev mode (--local-images / KORTIX_IMAGE_PULL=never): the Kortix app
+  // images were built locally and were never pushed to any registry, so a
+  // blanket `docker compose pull` fails outright (`manifest unknown`) instead
+  // of just skipping those services — `docker compose pull` has no per-service
+  // "skip this one" short of a compose-level pull_policy this generic compose
+  // file doesn't set. Skip the whole pull step here, exactly like updater.sh's
+  // perform_update() already does for the same flag (see assets/updater.sh) —
+  // `up -d` below still pulls any *other* (e.g. Supabase/cloudflared) image
+  // that isn't already present locally, since its default pull_policy is
+  // "missing", not "never".
+  if (shouldPullImages(env)) {
+    const pull = compose(flags.instance, ['pull']);
+    if (pull !== 0) return pull;
+  }
   const up = compose(flags.instance, ['up', '-d']);
   if (up !== 0) return up;
   const refreshApp = compose(flags.instance, ['up', '-d', '--force-recreate', '--no-deps', 'kortix-api', 'frontend']);
@@ -601,6 +502,7 @@ async function selfHostStart(flags: GlobalFlags): Promise<number> {
   process.stdout.write(`${C.dim}  Dashboard: ${C.reset}${C.cyan}${env.PUBLIC_URL}${C.reset}\n`);
   process.stdout.write(`${C.dim}  Logs:      ${C.reset}${C.cyan}kortix self-host logs${C.reset}\n\n`);
   renderIntegrationSummary(env);
+  renderAfterStartNote();
   return 0;
 }
 
@@ -711,7 +613,7 @@ async function selfHostUpdate(flags: GlobalFlags): Promise<number> {
 
   applyChannelAndUpdatePolicy(env, flags);
   applyImagesForTag(env, resolveTag(flags, env));
-  // Runtime feature flags (single-account/landing-page/enterprise-license) and
+  // Runtime feature flags (single-account/enterprise-license) and
   // reachability (domain/tunnel/local) are ordinary env — an update only ever
   // moves image tags, so an explicit flag is honored (non-interactively;
   // `update` never prompts) but nothing here resets a value the operator
@@ -752,15 +654,18 @@ function resolveTag(flags: GlobalFlags, existing: SelfHostEnv | null): string {
 
 /**
  * Default auto-update policy for a given resolved tag, absent an explicit
- * --auto-update. Channel tracking (stable/latest) defaults ON, unchanged
- * from historical behavior. A specific pinned ref — a released version, a
- * `dev-<sha>` build, a local branch build — defaults OFF: pinning means
- * "stay here," and the nightly updater must not silently move a pinned
- * dev/test box off of it. An explicit --auto-update still always wins (see
- * call sites below).
+ * --auto-update. Defaults ON everywhere, including a pinned tag (a specific
+ * released version or a `dev-<sha>` build): the nightly updater re-pulling
+ * the SAME immutable pinned tag is a harmless no-op (nothing to roll — see
+ * updater.sh's service_up_to_date() check), not silent drift, so there's no
+ * real reason to default it off just because a tag is pinned. The one actual
+ * exception is `--local-images` (a locally-built image never pushed to any
+ * registry) — applyChannelAndUpdatePolicy()/defaultEnv() force it off
+ * unconditionally for that case, regardless of this default. An explicit
+ * --auto-update still always wins over both (see call sites below).
  */
-function defaultAutoUpdateFor(tag: string): 'true' | 'false' {
-  return isChannel(tag) ? (DEFAULT_AUTO_UPDATE as 'true' | 'false') : 'false';
+function defaultAutoUpdateFor(_tag: string): 'true' | 'false' {
+  return DEFAULT_AUTO_UPDATE as 'true' | 'false';
 }
 
 /** Apply KORTIX_CHANNEL / auto-update policy flags onto env, defaults preserved. */
@@ -848,6 +753,10 @@ async function promptReachability(env: SelfHostEnv, flags: GlobalFlags, isFreshI
   if (mode === 'domain') {
     env.KORTIX_DOMAIN = await prompt('Enter your domain (recommended — VPS + DNS; its A/AAAA record — and the API subdomain\'s — must already point at this box)', env.KORTIX_DOMAIN || '');
     env.KORTIX_REACHABILITY_MODE = 'domain';
+    // Both have sane derived defaults (see normalizeFullSupabaseEnv) — asked
+    // here, with the derived value pre-filled, so enter-to-accept just works.
+    env.KORTIX_API_DOMAIN = await prompt('API subdomain (its own A/AAAA record must also point here)', env.KORTIX_API_DOMAIN || `api.${env.KORTIX_DOMAIN}`);
+    env.KORTIX_ACME_EMAIL = await prompt('ACME email (renewal/expiry notices for the automatic TLS certificate)', env.KORTIX_ACME_EMAIL || `admin@${env.KORTIX_DOMAIN}`);
   } else if (mode === 'tunnel') {
     env.KORTIX_DOMAIN = '';
     env.KORTIX_REACHABILITY_MODE = 'tunnel';
@@ -875,22 +784,57 @@ async function promptReachability(env: SelfHostEnv, flags: GlobalFlags, isFreshI
   }
 }
 
+/** Apply --admin-email onto env, non-interactively — only overwrites when the
+ *  flag was actually passed, same "explicit flag always wins, bare re-init
+ *  never resets" convention as every other apply* helper here. */
+function applyAdminEmail(env: SelfHostEnv, flags: GlobalFlags): void {
+  if (flags.adminEmail !== undefined) env.KORTIX_PLATFORM_ADMIN_EMAILS = flags.adminEmail;
+}
+
 /**
- * Apply --single-account / --landing / --no-landing / --enterprise-license onto env,
- * non-interactively. Each only overwrites when the flag was actually passed
- * (undefined = "not passed", never a literal false — see parseGlobalFlags),
- * so a bare `init`/`update` with no flags never resets a value the operator
- * set via `configure` or `env set`. Applied on every init/configure/update so
- * an explicit flag always wins, same convention as
- * applyChannelAndUpdatePolicy above.
+ * Interactive follow-up to applyAdminEmail: which account(s) become platform
+ * admins on this self-host, able to configure server-wide settings (managed
+ * GitHub, SSO, etc.) in the dashboard. Optional — blank just means "no
+ * platform admin yet," which is fine for evaluation but blocks some in-app
+ * server settings until set (via a later `env set` or `configure`).
+ */
+async function promptAdminEmail(env: SelfHostEnv, flags: GlobalFlags): Promise<void> {
+  if (!shouldPrompt(flags)) return;
+
+  const answer = await prompt(
+    'Admin email (grants platform-admin so you can configure GitHub etc. in the dashboard; blank to skip)',
+    env.KORTIX_PLATFORM_ADMIN_EMAILS || '',
+  );
+  env.KORTIX_PLATFORM_ADMIN_EMAILS = answer;
+  if (!answer.trim()) {
+    process.stdout.write(
+      `  ${C.yellow}warning${C.reset}  ${C.dim}No admin email set — some in-app server settings (e.g. Settings → Git)${C.reset}\n` +
+        `           ${C.dim}need at least one platform admin. Set later: ${C.reset}${C.cyan}kortix self-host env set KORTIX_PLATFORM_ADMIN_EMAILS=you@example.com${C.reset}\n\n`,
+    );
+  }
+}
+
+/**
+ * Apply --single-account / --enterprise-license onto env, non-interactively.
+ * Each only overwrites when the flag was actually passed (undefined = "not
+ * passed", never a literal false — see parseGlobalFlags), so a bare
+ * `init`/`update` with no flags never resets a value the operator set via
+ * `configure` or `env set`. Applied on every init/configure/update so an
+ * explicit flag always wins, same convention as applyChannelAndUpdatePolicy
+ * above.
+ *
+ * The marketing landing page is NOT a guided-flow question (there's no
+ * `--landing`/`--no-landing` flag either) — it's just an env var
+ * (KORTIX_PUBLIC_DISABLE_LANDING_PAGE, defaulted 'true' in
+ * SHARED_SELF_HOST_DEFAULTS) an operator flips directly:
+ * `kortix self-host env set KORTIX_PUBLIC_DISABLE_LANDING_PAGE=false`. It
+ * isn't a decision that needs asking — self-host is an app deployment, not a
+ * marketing site, full stop.
  */
 function applyFeatureFlags(env: SelfHostEnv, flags: GlobalFlags): void {
   if (flags.singleAccount !== undefined) {
     env.KORTIX_SINGLE_ACCOUNT_MODE = flags.singleAccount ? 'true' : 'false';
     env.KORTIX_PUBLIC_SINGLE_ACCOUNT_MODE = env.KORTIX_SINGLE_ACCOUNT_MODE;
-  }
-  if (flags.disableLanding !== undefined) {
-    env.KORTIX_PUBLIC_DISABLE_LANDING_PAGE = flags.disableLanding ? 'true' : 'false';
   }
   if (flags.enterpriseLicense !== undefined) {
     env.ENTERPRISE_LICENSE_AVAILABLE = flags.enterpriseLicense ? 'true' : 'false';
@@ -898,15 +842,16 @@ function applyFeatureFlags(env: SelfHostEnv, flags: GlobalFlags): void {
 }
 
 /**
- * Interactive follow-up to applyFeatureFlags: ask yes/no for anything not
- * already pinned by a flag this run, defaulting to whatever is currently in
- * .env (so re-running `configure` doesn't reset a prior answer). No-ops
- * under --yes / non-TTY (see shouldPrompt).
+ * Interactive follow-up to applyFeatureFlags: the two real deployment-shape
+ * y/n questions — single-account mode, Enterprise license — asked in order,
+ * defaulting to whatever is currently in .env (so re-running `configure`
+ * doesn't reset a prior answer). No-ops under --yes / non-TTY (see
+ * shouldPrompt).
  */
 async function promptFeatureFlags(env: SelfHostEnv, flags: GlobalFlags): Promise<void> {
   if (!shouldPrompt(flags)) return;
 
-  process.stdout.write(`\n  ${C.bold}Deployment configuration${C.reset}\n`);
+  process.stdout.write(`\n  ${C.bold}Deployment shape${C.reset}\n`);
 
   const singleAccount = await selectFrom(
     'Single-account mode? (no teams — hides "New account" and team management)',
@@ -915,13 +860,6 @@ async function promptFeatureFlags(env: SelfHostEnv, flags: GlobalFlags): Promise
   );
   env.KORTIX_SINGLE_ACCOUNT_MODE = singleAccount === 'yes' ? 'true' : 'false';
   env.KORTIX_PUBLIC_SINGLE_ACCOUNT_MODE = env.KORTIX_SINGLE_ACCOUNT_MODE;
-
-  const disableLanding = await selectFrom(
-    'Disable the marketing landing page? (send visitors straight to sign-in)',
-    ['no', 'yes'] as const,
-    env.KORTIX_PUBLIC_DISABLE_LANDING_PAGE === 'true' ? 'yes' : 'no',
-  );
-  env.KORTIX_PUBLIC_DISABLE_LANDING_PAGE = disableLanding === 'yes' ? 'true' : 'false';
 
   const enterpriseLicense = await selectFrom(
     'Do you have an Enterprise license? (SSO / RBAC / Directory Sync / Groups — kortix.com/enterprise)',
@@ -1369,11 +1307,14 @@ async function selfHostConfigure(flags: GlobalFlags): Promise<number> {
     process.stderr.write(`${status.err('Self-host is not initialized. Run `kortix self-host init` first.')}\n`);
     return 1;
   }
-  await configureIntegrations(env, flags);
+  // Same ordering as `init`: reachability first (the decision that determines
+  // whether agent sandboxes can work at all), then feature flags, then
+  // integrations (Daytona) — see selfHostInit() for the full rationale.
   applyFeatureFlags(env, flags);
   applyReachabilityFlags(env, flags);
   await promptReachability(env, flags);
   await promptFeatureFlags(env, flags);
+  await configureIntegrations(env, flags);
   await configureUpdatePolicy(env, flags);
   writeEnv(flags.instance, env);
   writeCompose(flags.instance, env);
@@ -1388,55 +1329,22 @@ async function selfHostConfigure(flags: GlobalFlags): Promise<number> {
 }
 
 /**
- * `kortix self-host connect-github` — the standalone entry point for the
- * GitHub App manifest flow (also invoked inline from the `init`/`configure`
- * guided flow via `runConnectGithubInteractive`). Since this is an explicit,
- * directly-invoked command, it runs unconditionally (no "want to connect
- * GitHub?" confirm) — the operator already said so by typing the command.
- * `--manual` forces the headless/paste-back path; it's also forced
- * automatically on a non-TTY (no local browser to open).
+ * `kortix self-host connect-github` — DEPRECATED. The GitHub App manifest
+ * flow it used to run never worked reliably from a laptop (GitHub rejects the
+ * flow's hook/callback URLs when they aren't reachable over the public
+ * internet: "Hook url is not supported because it isn't reachable over the
+ * public Internet"), while the frontend's in-app GitHub connection flow
+ * (Settings → Git) works everywhere the dashboard itself loads — including
+ * from a laptop, since it's the browser (not this CLI) driving the OAuth
+ * dance. Kept as a no-op alias, not removed outright, so an existing script
+ * that calls it doesn't hard-fail; it prints where to go instead and exits 0.
  */
-async function selfHostConnectGithub(args: string[], flags: GlobalFlags): Promise<number> {
-  const org = takeFlagValue(args, ['--org']) ?? flags.org;
-  const manualFlag = takeFlagBool(args, ['--manual']) || Boolean(flags.manual);
-  const isTTY = process.stdin.isTTY === true && process.stdout.isTTY === true;
-  const manual = manualFlag || !isTTY;
-
-  const env = loadEnvWithDefaults(flags);
-  if (!env) {
-    process.stderr.write(`${status.err('Self-host is not initialized. Run `kortix self-host init` first.')}\n`);
-    return 1;
-  }
-
-  process.stdout.write(`\n  ${C.bold}kortix self-host connect-github${C.reset}\n`);
-  process.stdout.write(`  ${C.dim}instance ${C.reset}${flags.instance}\n`);
-  process.stdout.write(`  ${C.dim}org      ${C.reset}${org?.trim() || '(personal account)'}\n`);
-  if (manual) process.stdout.write(`  ${C.dim}mode     ${C.reset}manual (headless)\n`);
-
-  const result = await runConnectGithubFlow({
-    org,
-    manual,
-    publicUrl: env.PUBLIC_URL || 'https://kortix.ai',
-    currentStateSecret: env.KORTIX_GITHUB_APP_STATE_SECRET,
-    persist: (patch) => {
-      Object.assign(env, patch);
-      writeEnv(flags.instance, env);
-      writeCompose(flags.instance, env);
-    },
-    openBrowser: openInBrowser,
-    print: (msg) => process.stdout.write(`${msg}\n`),
-    findFreePort,
-    promptPaste: manual ? createPastePrompt : undefined,
-  });
-
-  if (!result.ok) {
-    process.stderr.write(`\n${status.err(result.error ?? 'GitHub App connection failed.')}\n`);
-    return 1;
-  }
-
-  process.stdout.write(`\n${status.ok(`GitHub connected: ${result.owner} (installation ${result.installationId})`)}\n`);
-  process.stdout.write(`${C.dim}  Project creation now works against this GitHub App.${C.reset}\n\n`);
-  return restartServicesForKeys(flags.instance, env, ['MANAGED_GIT_GITHUB_OWNER']);
+async function selfHostConnectGithub(_args: string[], _flags: GlobalFlags): Promise<number> {
+  process.stdout.write(
+    `\n  ${C.yellow}kortix self-host connect-github is deprecated.${C.reset}\n` +
+      `  ${C.dim}GitHub (projects) is configured in the dashboard: Settings → Git.${C.reset}\n\n`,
+  );
+  return 0;
 }
 
 /** Interactive (or flag-driven) auto-update channel/interval configuration. */
@@ -1464,174 +1372,151 @@ async function configureUpdatePolicy(env: SelfHostEnv, flags: GlobalFlags): Prom
   env.KORTIX_UPDATE_TZ = updateTz.trim() || DEFAULT_UPDATE_TZ;
 }
 
+/**
+ * The guided `init` flow's compact update-policy step — one y/n plus an
+ * opt-in follow-up, NOT the fuller interrogation configureUpdatePolicy()
+ * (channel/time/tz every time) that `configure` runs. Channel is deliberately
+ * not asked here at all: it stays whatever it already resolved to (stable by
+ * default) — power users pin a channel/version via --channel/--version
+ * instead of being asked on every init.
+ */
+async function promptUpdatePolicyCompact(env: SelfHostEnv, flags: GlobalFlags): Promise<void> {
+  if (!shouldPrompt(flags)) return;
+
+  process.stdout.write(`\n  ${C.bold}Updates${C.reset}\n`);
+  const autoUpdate = await confirm(
+    `Auto-update nightly at ${env.KORTIX_UPDATE_TIME || DEFAULT_UPDATE_TIME} ${env.KORTIX_UPDATE_TZ || DEFAULT_UPDATE_TZ}?`,
+    env.KORTIX_AUTO_UPDATE !== 'false',
+  );
+  env.KORTIX_AUTO_UPDATE = autoUpdate ? 'true' : 'false';
+  if (!autoUpdate) return;
+
+  const customize = await confirm('Change the update time/timezone?', false);
+  if (!customize) return;
+  const updateTime = await prompt('Daily update time (HH:MM, 24h)', env.KORTIX_UPDATE_TIME || DEFAULT_UPDATE_TIME);
+  env.KORTIX_UPDATE_TIME = UPDATE_TIME_PATTERN.test(updateTime) ? updateTime : DEFAULT_UPDATE_TIME;
+  const updateTz = await prompt('Timezone (IANA, e.g. UTC)', env.KORTIX_UPDATE_TZ || DEFAULT_UPDATE_TZ);
+  env.KORTIX_UPDATE_TZ = updateTz.trim() || DEFAULT_UPDATE_TZ;
+}
+
+const SANDBOX_PROVIDER_CHOICES = ['daytona', 'e2b', 'platinum'] as const;
+type SandboxProviderChoice = (typeof SANDBOX_PROVIDER_CHOICES)[number];
+
+/**
+ * The CLI's guided-integrations step: the two things that genuinely cannot
+ * be set any other way — the agent sandbox runtime (an env-only credential
+ * the API reads at boot, no in-app settings surface exists for it) and
+ * Pipedream's OPERATOR-level OAuth app credentials (also env-only — the
+ * database only ever holds each user's own per-connector bindings, never the
+ * platform's Pipedream app itself). Everything else that used to live here —
+ * GitHub/managed-git, the LLM key — is configured in the web dashboard after
+ * `start` instead (GitHub at Settings → Git, the LLM key as BYOK via the
+ * model picker). "The full flow needs to be perfect, all the other bullshit
+ * needs to be removed" — this function IS that trim.
+ */
 async function configureIntegrations(env: SelfHostEnv, flags: GlobalFlags): Promise<void> {
-  process.stdout.write(`\n  ${C.bold}Kortix self-host integrations${C.reset}\n`);
-  process.stdout.write(`  ${C.dim}These power the agent runtime, GitHub repo access, and app connectors.${C.reset}\n`);
-  process.stdout.write(`  ${C.dim}Press enter to skip anything you do not use yet.${C.reset}\n\n`);
+  process.stdout.write(`\n  ${C.bold}Agent sandbox runtime${C.reset}\n`);
+  const currentProvider = sandboxProviders(env)[0];
+  const provider = shouldPrompt(flags)
+    ? await selectFrom(
+        'Sandbox provider',
+        SANDBOX_PROVIDER_CHOICES,
+        (SANDBOX_PROVIDER_CHOICES as readonly string[]).includes(currentProvider ?? '')
+          ? (currentProvider as SandboxProviderChoice)
+          : 'daytona',
+      )
+    : ((currentProvider as SandboxProviderChoice) ?? 'daytona');
+  env.ALLOWED_SANDBOX_PROVIDERS = provider;
 
-  // Sandbox runtime — where agents execute. Like Kortix Cloud, self-host runs
-  // sandboxes on Daytona; the wizard just collects the API key.
-  env.ALLOWED_SANDBOX_PROVIDERS = 'daytona';
-  process.stdout.write(`  ${C.dim}Agent sandbox runtime: Daytona (https://app.daytona.io)${C.reset}\n`);
-  env.DAYTONA_API_KEY = await promptSecret('Daytona API key', env.DAYTONA_API_KEY);
-  env.DAYTONA_SERVER_URL = await prompt('Daytona server URL', env.DAYTONA_SERVER_URL || 'https://app.daytona.io/api');
-  env.DAYTONA_TARGET = await prompt('Daytona target/region', env.DAYTONA_TARGET || 'us');
-
-  await configureManagedGit(env, flags);
-
-  const pdMode = await selectFrom('Pipedream connectors: skip/configure', ['skip', 'configure'] as const, pipedreamConfigured(env) ? 'configure' : 'skip');
-  if (pdMode === 'configure') {
-    env.INTEGRATION_AUTH_PROVIDER = 'pipedream';
-    env.PIPEDREAM_CLIENT_ID = await prompt('Pipedream client ID', env.PIPEDREAM_CLIENT_ID);
-    env.PIPEDREAM_CLIENT_SECRET = await promptSecret('Pipedream client secret', env.PIPEDREAM_CLIENT_SECRET);
-    env.PIPEDREAM_PROJECT_ID = await prompt('Pipedream project ID', env.PIPEDREAM_PROJECT_ID);
-    env.PIPEDREAM_ENVIRONMENT = await selectFrom('Pipedream environment', ['development', 'production'] as const, env.PIPEDREAM_ENVIRONMENT === 'development' ? 'development' : 'production');
-    env.PIPEDREAM_WEBHOOK_SECRET = await promptSecret('Pipedream webhook secret (optional)', env.PIPEDREAM_WEBHOOK_SECRET);
+  if (provider === 'daytona') {
+    process.stdout.write(`  ${C.dim}Daytona (https://app.daytona.io)${C.reset}\n`);
+    env.DAYTONA_API_KEY = await promptSecret('Daytona API key', env.DAYTONA_API_KEY);
+    env.DAYTONA_SERVER_URL = await prompt('Daytona server URL', env.DAYTONA_SERVER_URL || 'https://app.daytona.io/api');
+    env.DAYTONA_TARGET = await prompt('Daytona target/region', env.DAYTONA_TARGET || 'us');
+  } else if (provider === 'e2b') {
+    process.stdout.write(`  ${C.dim}E2B (https://e2b.dev)${C.reset}\n`);
+    env.E2B_API_KEY = await promptSecret('E2B API key', env.E2B_API_KEY);
+  } else {
+    process.stdout.write(`  ${C.dim}Platinum (Kortix's own microVM sandbox provider)${C.reset}\n`);
+    env.PLATINUM_API_KEY = await promptSecret('Platinum API key', env.PLATINUM_API_KEY);
+    env.PLATINUM_API_URL = await prompt('Platinum API URL', env.PLATINUM_API_URL || 'https://api.platinum.dev');
+    env.PLATINUM_TEMPLATE = await prompt('Platinum template (optional — leave blank for the platform default)', env.PLATINUM_TEMPLATE);
   }
-  // Frontend "Connect your tools" / connector-catalogue UI (KORTIX_PUBLIC_
-  // CONNECTORS_ENABLED) mirrors whether Pipedream is FULLY configured on the
-  // backend — same three fields apps/api/src/executor/pipedream.ts's own
-  // pipedreamConfigured() requires. Recomputed every time this runs (both the
-  // 'configure' and 'skip' branches) so turning Pipedream off here also hides
-  // the frontend surfaces again.
-  env.KORTIX_PUBLIC_CONNECTORS_ENABLED =
-    env.PIPEDREAM_CLIENT_ID && env.PIPEDREAM_CLIENT_SECRET && env.PIPEDREAM_PROJECT_ID
-      ? 'true'
-      : 'false';
+
+  // Pipedream (optional, default skip): the ONE other env-only credential
+  // that belongs here — the platform-level OAuth app Pipedream issues per
+  // operator, not a per-user connection (those live in the DB and are
+  // configured per-project in the app). Never gates init/start either way;
+  // KORTIX_PUBLIC_CONNECTORS_ENABLED is re-derived from whatever ends up set
+  // here on every write (see normalizeFullSupabaseEnv), so skipping just
+  // leaves connectors hidden in the frontend rather than half-configured.
+  if (shouldPrompt(flags)) {
+    const pdMode = await selectFrom(
+      'Pipedream connectors (optional, powers the 3,000+ app catalog): configure/skip',
+      ['skip', 'configure'] as const,
+      pipedreamConfigured(env) ? 'configure' : 'skip',
+    );
+    if (pdMode === 'configure') {
+      env.INTEGRATION_AUTH_PROVIDER = 'pipedream';
+      env.PIPEDREAM_CLIENT_ID = await prompt('Pipedream client ID', env.PIPEDREAM_CLIENT_ID);
+      env.PIPEDREAM_CLIENT_SECRET = await promptSecret('Pipedream client secret', env.PIPEDREAM_CLIENT_SECRET);
+      env.PIPEDREAM_PROJECT_ID = await prompt('Pipedream project ID', env.PIPEDREAM_PROJECT_ID);
+      env.PIPEDREAM_ENVIRONMENT = await selectFrom('Pipedream environment', ['development', 'production'] as const, env.PIPEDREAM_ENVIRONMENT === 'development' ? 'development' : 'production');
+      env.PIPEDREAM_WEBHOOK_SECRET = await promptSecret('Pipedream webhook secret (optional)', env.PIPEDREAM_WEBHOOK_SECRET);
+    }
+  }
+
   env.KORTIX_SELF_HOST_INTEGRATIONS_REVIEWED = 'true';
 }
 
-/**
- * Managed git (GitHub) — REQUIRED to create/CRUD projects: every project is a
- * git repo the server provisions. `connect-github`'s GitHub App manifest flow
- * is the default, recommended path (no personal-access-token): it creates a
- * brand-new App owned by the operator's org and lets them pick the repo(s) at
- * install time. A low-key "advanced" menu still lets an operator paste an
- * existing App's credentials or a PAT instead, or leave it unconfigured.
- */
-async function configureManagedGit(env: SelfHostEnv, flags: GlobalFlags): Promise<void> {
-  process.stdout.write(`  ${C.dim}GitHub (managed git) is required to create projects.${C.reset}\n`);
-
-  const alreadyConfigured = gitProviderConfigured(env);
-  if (alreadyConfigured) {
-    process.stdout.write(`  ${C.dim}Already configured: ${describeGithubMode(env)}.${C.reset}\n`);
-  }
-
-  const wantsChange = alreadyConfigured ? await confirm('Change the GitHub setup?', false) : true;
-  if (!wantsChange) return;
-
-  const connectNow =
-    !flags.skipGithub &&
-    (await confirm(
-      'Connect GitHub now? (creates + installs a GitHub App owned by your org — recommended, no PAT needed)',
-      true,
-    ));
-
-  let connected = false;
-  if (connectNow) {
-    connected = await runConnectGithubInteractive(env, flags);
-  }
-  if (connected) return;
-
-  // Advanced escape hatch: paste an existing App's credentials, a PAT, or
-  // leave managed git unconfigured.
-  const githubMode = await selectFrom(
-    'GitHub for projects (advanced): pat/app/none',
-    ['pat', 'app', 'none'] as const,
-    inferGithubMode(env) === 'none' ? 'none' : inferGithubMode(env),
-  );
-  if (githubMode === 'app') {
-    env.KORTIX_GITHUB_APP_ID = await prompt('GitHub App ID', env.KORTIX_GITHUB_APP_ID);
-    env.KORTIX_GITHUB_APP_SLUG = await prompt('GitHub App slug', env.KORTIX_GITHUB_APP_SLUG);
-    env.KORTIX_GITHUB_APP_PRIVATE_KEY = await promptSecret('GitHub App private key (paste with \\n escapes)', env.KORTIX_GITHUB_APP_PRIVATE_KEY);
-    env.MANAGED_GIT_GITHUB_OWNER = await prompt('GitHub owner/org for project repos', env.MANAGED_GIT_GITHUB_OWNER || env.KORTIX_GITHUB_OWNER);
-    env.MANAGED_GIT_GITHUB_INSTALL_ID = await prompt('GitHub App installation ID (on that org)', env.MANAGED_GIT_GITHUB_INSTALL_ID);
-    env.KORTIX_GITHUB_OWNER = env.MANAGED_GIT_GITHUB_OWNER;
-    env.MANAGED_GIT_PROVIDER = 'github';
-    env.KORTIX_GITHUB_TOKEN = '';
-    env.MANAGED_GIT_GITHUB_TOKEN = '';
-  } else if (githubMode === 'pat') {
-    env.KORTIX_GITHUB_TOKEN = await promptSecret('GitHub PAT (repo scope)', env.KORTIX_GITHUB_TOKEN);
-    env.MANAGED_GIT_GITHUB_OWNER = await prompt('GitHub owner/org for project repos', env.MANAGED_GIT_GITHUB_OWNER || env.KORTIX_GITHUB_OWNER);
-    // The managed-git backend reads MANAGED_GIT_GITHUB_*; mirror the PAT + owner.
-    env.MANAGED_GIT_GITHUB_TOKEN = env.KORTIX_GITHUB_TOKEN;
-    env.KORTIX_GITHUB_OWNER = env.MANAGED_GIT_GITHUB_OWNER;
-    env.MANAGED_GIT_PROVIDER = 'github';
-    env.KORTIX_GITHUB_APP_ID = '';
-    env.KORTIX_GITHUB_APP_SLUG = '';
-    env.KORTIX_GITHUB_APP_PRIVATE_KEY = '';
-    env.MANAGED_GIT_GITHUB_INSTALL_ID = '';
-  } else if (!alreadyConfigured) {
-    env.KORTIX_GITHUB_APP_ID = '';
-    env.KORTIX_GITHUB_APP_SLUG = '';
-    env.KORTIX_GITHUB_APP_PRIVATE_KEY = '';
-    env.KORTIX_GITHUB_TOKEN = '';
-    env.MANAGED_GIT_PROVIDER = '';
-    env.MANAGED_GIT_GITHUB_TOKEN = '';
-    env.MANAGED_GIT_GITHUB_OWNER = '';
-    env.MANAGED_GIT_GITHUB_INSTALL_ID = '';
-  }
-}
-
-function describeGithubMode(env: SelfHostEnv): string {
-  const mode = inferGithubMode(env);
-  if (mode === 'app') return `GitHub App "${env.KORTIX_GITHUB_APP_SLUG || env.KORTIX_GITHUB_APP_ID}" on ${env.MANAGED_GIT_GITHUB_OWNER || '(unknown owner)'}`;
-  if (mode === 'pat') return `PAT on ${env.MANAGED_GIT_GITHUB_OWNER || '(unknown owner)'}`;
-  return 'not configured';
-}
-
-/**
- * Runs the `connect-github` GitHub App manifest flow inline (used by the
- * `init`/`configure` guided flow — as opposed to `selfHostConnectGithub`,
- * which is the same flow driven directly from the `connect-github`
- * subcommand). Returns whether it completed successfully; on failure the
- * caller falls through to the advanced paste-credentials menu instead.
- */
-async function runConnectGithubInteractive(env: SelfHostEnv, flags: GlobalFlags): Promise<boolean> {
-  const manual = Boolean(flags.manual);
-  const result = await runConnectGithubFlow({
-    org: flags.org,
-    manual,
-    publicUrl: env.PUBLIC_URL || 'https://kortix.ai',
-    currentStateSecret: env.KORTIX_GITHUB_APP_STATE_SECRET,
-    persist: (patch) => Object.assign(env, patch),
-    openBrowser: openInBrowser,
-    print: (msg) => process.stdout.write(`${msg}\n`),
-    findFreePort,
-    promptPaste: manual ? createPastePrompt : undefined,
-  });
-  if (result.ok) {
-    process.stdout.write(`\n${status.ok(`GitHub connected: ${result.owner} (installation ${result.installationId})`)}\n\n`);
-    return true;
-  }
-  process.stdout.write(`\n${C.yellow}  GitHub App connect failed: ${result.error}${C.reset}\n\n`);
-  return false;
-}
+// Managed git (GitHub) is deliberately NOT configured from this guided flow
+// anymore — see configureIntegrations() above. It's configured in-app instead
+// (Settings → Git, DB-backed) after `start`. The old configureManagedGit()/
+// runConnectGithubInteractive()/describeGithubMode()/inferGithubMode() guided
+// wizard was removed along with it; `connect-github` (the standalone
+// subcommand) is now a deprecated alias — see selfHostConnectGithub() below —
+// that also points at the dashboard instead of running the manifest flow,
+// which never worked reliably on a laptop anyway (GitHub rejects hook/
+// callback URLs that aren't reachable over the public internet).
 
 async function promptSecret(label: string, current: string): Promise<string> {
   const answer = await prompt(current ? `${label} (already set, enter to keep)` : label);
   return answer || current;
 }
 
-function inferGithubMode(env: SelfHostEnv): 'none' | 'app' | 'pat' {
-  if (env.KORTIX_GITHUB_APP_ID || env.KORTIX_GITHUB_APP_PRIVATE_KEY || env.KORTIX_GITHUB_APP_SLUG) return 'app';
-  if (env.KORTIX_GITHUB_TOKEN) return 'pat';
-  return 'none';
-}
-
 function pipedreamConfigured(env: SelfHostEnv): boolean {
   return !!(env.PIPEDREAM_CLIENT_ID || env.PIPEDREAM_CLIENT_SECRET || env.PIPEDREAM_PROJECT_ID);
+}
+
+/**
+ * Whether `start` should run `docker compose pull` at all. False for
+ * KORTIX_IMAGE_PULL=never (set by --local-images — see applyChannelAndUpdatePolicy)
+ * since those images were built locally and were never pushed to any
+ * registry, so a blanket pull fails outright (`manifest unknown`) instead of
+ * skipping just the local ones. Mirrors updater.sh's perform_update(), which
+ * already skips its own pull step under the same flag.
+ */
+export function shouldPullImages(env: Record<string, string>): boolean {
+  return env.KORTIX_IMAGE_PULL !== 'never';
 }
 
 export function sandboxProviders(env: Record<string, string>): string[] {
   return (env.ALLOWED_SANDBOX_PROVIDERS || '').split(',').map((s) => s.trim()).filter(Boolean);
 }
 
-/** A provider is "ready" if daytona has an API key. */
+/** The key each sandbox provider needs to be considered "ready" — mirrors
+ *  isProviderEnabled() in apps/api/src/config.ts. */
+const SANDBOX_PROVIDER_KEY: Record<string, string> = {
+  daytona: 'DAYTONA_API_KEY',
+  e2b: 'E2B_API_KEY',
+  platinum: 'PLATINUM_API_KEY',
+};
+
+/** A configured sandbox provider is one named in ALLOWED_SANDBOX_PROVIDERS
+ *  whose required key is actually set — whichever of daytona/e2b/platinum was
+ *  chosen at `init`/`configure` (see configureIntegrations()). */
 export function sandboxProviderConfigured(env: Record<string, string>): boolean {
-  const providers = sandboxProviders(env);
-  if (providers.includes('daytona')) return !!env.DAYTONA_API_KEY;
-  return false;
+  return sandboxProviders(env).some((provider) => !!env[SANDBOX_PROVIDER_KEY[provider] ?? '']);
 }
 
 /** Managed git provider configured? Required to create/CRUD projects. */
@@ -1688,29 +1573,33 @@ export interface MissingSecretItem {
 }
 
 /**
- * Every required secret this instance is still missing, reconciled against
- * the composite provider checks above so a PAT-mode or App-mode managed-git
- * setup each report as satisfied (not "half the fields are unset"), and a
- * scalar pass over the registry's `required: true` entries otherwise. Pure
- * function of `env` — no filesystem/process access — so it's safe to call
- * from `init`/`start` before anything is written and to unit-test directly.
+ * Every required secret this instance is still missing. The CLI's init-time
+ * gate is deliberately narrow now: ONLY the agent sandbox runtime (Daytona) is
+ * a "cannot proceed without it" secret — it's the one thing that genuinely
+ * can't be set any other way (it's an env-only credential the API reads at
+ * boot, there is no in-app settings surface for it). Managed git (GitHub) and
+ * the LLM key are BOTH configured after `start`, in the web dashboard —
+ * managed git at Settings → Git (DB-backed, not env/CLI-owned) and the LLM key
+ * as BYOK via the model picker — so neither blocks `init`/`start` here
+ * anymore; see gitProviderConfigured()/renderIntegrationSummary() for the
+ * (non-blocking) status display. Reconciled against sandboxProviderConfigured
+ * so a Daytona key configured via any accepted shape reports as satisfied.
+ * Pure function of `env` — no filesystem/process access — so it's safe to
+ * call from `init`/`start` before anything is written and to unit-test
+ * directly.
  */
 export function missingRequiredSecrets(env: Record<string, string>): MissingSecretItem[] {
   const missing: MissingSecretItem[] = [];
 
   if (!sandboxProviderConfigured(env)) {
+    // Name whichever provider is actually configured (ALLOWED_SANDBOX_PROVIDERS),
+    // defaulting to Daytona's hint when nothing has been chosen yet (a bare
+    // `init --yes` with no prior .env) — matches the guided flow's own default.
+    const provider = sandboxProviders(env)[0] ?? 'daytona';
+    const key = SANDBOX_PROVIDER_KEY[provider] ?? 'DAYTONA_API_KEY';
     missing.push({
-      label: 'Agent sandbox runtime (Daytona API key)',
-      hint: 'kortix self-host secrets set DAYTONA_API_KEY=<key>',
-    });
-  }
-
-  if (!gitProviderConfigured(env)) {
-    missing.push({
-      label: 'Managed git for projects (GitHub PAT or GitHub App)',
-      hint:
-        'kortix self-host secrets set MANAGED_GIT_GITHUB_OWNER=<org> MANAGED_GIT_GITHUB_TOKEN=<pat>' +
-        '  (or KORTIX_GITHUB_APP_ID / KORTIX_GITHUB_APP_PRIVATE_KEY / MANAGED_GIT_GITHUB_INSTALL_ID for a GitHub App)',
+      label: `Agent sandbox runtime (${provider} API key)`,
+      hint: `kortix self-host secrets set ${key}=<key>`,
     });
   }
 
@@ -1728,14 +1617,47 @@ export function missingRequiredSecrets(env: Record<string, string>): MissingSecr
 }
 
 /**
+ * Whether this instance has ever had `--allow-missing-secrets` used against
+ * it — persisted in instance.json (see SelfHostInstanceConfig) so the choice
+ * survives across separate CLI invocations. See recordAllowMissingSecrets()
+ * for why this exists.
+ */
+function persistedAllowMissingSecrets(instance: string): boolean {
+  return loadInstanceConfig(instance)?.allow_missing_secrets === true;
+}
+
+/**
+ * Persist that this instance has been explicitly allowed to run with
+ * required secrets missing, so a LATER invocation that omits the flag isn't
+ * re-blocked for a decision the operator already made. Confirmed friction
+ * live: `init --allow-missing-secrets` succeeds, but the very next `start`
+ * (with no flags) re-validates independently (ensureRequiredSecrets runs on
+ * every init/start) and hard-fails again unless the flag is repeated. Merges
+ * into whatever instance.json already has (release, etc.) rather than
+ * clobbering it. No-op (doesn't write) if already persisted.
+ */
+function recordAllowMissingSecrets(instance: string): void {
+  if (persistedAllowMissingSecrets(instance)) return;
+  const existing = loadInstanceConfig(instance);
+  writeInstanceConfig({
+    schema_version: 1,
+    instance,
+    ...(existing?.release ? { release: existing.release } : {}),
+    allow_missing_secrets: true,
+  });
+}
+
+/**
  * Enforce that required secrets are actually set before this instance can be
  * considered usable — the CLI's primary guarantee: a box never comes up
- * silently unable to create projects or run agents. Interactive TTY: drive
- * the guided integrations flow until satisfied or the operator opts out.
- * Non-interactive (`--yes` / no TTY / CI): fail loudly with an itemized list
- * and exact fix commands instead of proceeding into a broken deployment.
+ * silently unable to run agents. Interactive TTY: drive the guided
+ * integrations flow until satisfied or the operator opts out. Non-interactive
+ * (`--yes` / no TTY / CI): fail loudly with an itemized list and exact fix
+ * commands instead of proceeding into a broken deployment.
  * `--allow-missing-secrets` downgrades the non-interactive failure to a loud
- * warning — local experimentation only.
+ * warning — local experimentation only — and that choice is remembered (see
+ * recordAllowMissingSecrets) so a later bare `start`/`update` doesn't
+ * re-demand the same flag for the same still-missing secret.
  *
  * Returns 0 to proceed, non-zero to stop (caller still persists whatever was
  * collected along the way).
@@ -1765,10 +1687,11 @@ async function ensureRequiredSecrets(env: SelfHostEnv, flags: GlobalFlags): Prom
 
   const lines = missing.map((item) => `    ${C.dim}- ${C.reset}${item.label}\n        ${C.cyan}${item.hint}${C.reset}`).join('\n');
 
-  if (flags.allowMissingSecrets) {
+  if (flags.allowMissingSecrets || persistedAllowMissingSecrets(flags.instance)) {
+    recordAllowMissingSecrets(flags.instance);
     process.stdout.write(
       `\n${status.warn('Proceeding with required secrets missing (--allow-missing-secrets):')}\n${lines}\n\n` +
-        `  ${C.dim}This deployment will not be able to create projects and/or run agents until they are set.${C.reset}\n\n`,
+        `  ${C.dim}This deployment will not be able to run agents until they are set.${C.reset}\n\n`,
     );
     return 0;
   }
@@ -1781,11 +1704,12 @@ async function ensureRequiredSecrets(env: SelfHostEnv, flags: GlobalFlags): Prom
 }
 
 function integrationReviewNeeded(env: SelfHostEnv): boolean {
-  // Both the sandbox runtime (the API won't boot without it) and managed git
-  // (you can't create projects without it) are required, so a missing one always
-  // warrants the wizard — even after a prior review.
+  // The sandbox runtime (Daytona) is the only CLI-required integration left —
+  // the API won't boot agent sessions without it, and there is no in-app
+  // settings surface for it (unlike managed git/LLM, both configured in the
+  // dashboard after `start`). A missing key always warrants the wizard, even
+  // after a prior review.
   if (!sandboxProviderConfigured(env)) return true;
-  if (!gitProviderConfigured(env)) return true;
   if (env.KORTIX_SELF_HOST_INTEGRATIONS_REVIEWED === 'true') return false;
   return true;
 }
@@ -1795,21 +1719,17 @@ function shouldPrompt(flags: GlobalFlags): boolean {
 }
 
 function renderIntegrationSummary(env: SelfHostEnv): void {
+  // The ONLY row gated as configured/missing here is the sandbox runtime — the
+  // one integration the CLI still requires (see missingRequiredSecrets()).
+  // Everything else (managed git, LLM key, connectors, SMTP) is dashboard
+  // territory — see renderAfterStartNote() below, not a CLI configured/missing
+  // gate that would incorrectly suggest a CLI fix is needed.
+  const provider = sandboxProviders(env)[0];
   const rows = [
     {
       name: `Agent sandbox runtime (${sandboxProviders(env).join(',') || 'none'})`,
       configured: sandboxProviderConfigured(env),
-      hint: 'DAYTONA_API_KEY (via kortix self-host configure)',
-    },
-    {
-      name: 'Managed git for projects (required)',
-      configured: gitProviderConfigured(env),
-      hint: 'connect GitHub (PAT or App) via kortix self-host configure',
-    },
-    {
-      name: 'Pipedream connectors',
-      configured: pipedreamConfigured(env),
-      hint: 'PIPEDREAM_CLIENT_ID + PIPEDREAM_CLIENT_SECRET + PIPEDREAM_PROJECT_ID',
+      hint: `${SANDBOX_PROVIDER_KEY[provider ?? 'daytona'] ?? 'DAYTONA_API_KEY'} (via kortix self-host configure)`,
     },
   ];
 
@@ -1825,6 +1745,18 @@ function renderIntegrationSummary(env: SelfHostEnv): void {
     process.stdout.write(`  ${C.dim}Configure: ${C.reset}${C.cyan}kortix self-host configure${C.reset}${C.dim} or ${C.reset}${C.cyan}kortix self-host env set KEY=VALUE${C.reset}\n`);
   }
   process.stdout.write('\n');
+}
+
+/**
+ * Everything that happens AFTER `start`, in the dashboard, not the CLI — the
+ * other half of "the CLI only handles what can't be configured in the web
+ * dashboard." Printed at the end of both `init` (renderInitSummary) and
+ * `start` (selfHostStart) so it's the last thing an operator reads either way.
+ */
+function renderAfterStartNote(): void {
+  process.stdout.write(
+    `  ${C.dim}After start ${C.reset}Sign in → Settings → Git to connect GitHub (projects) · connect your model key in the app (BYOK) · optional: connectors, SMTP — all in the dashboard.${C.reset}\n\n`,
+  );
 }
 
 async function reconcilePorts(instance: string, env: SelfHostEnv): Promise<string[]> {
@@ -2036,9 +1968,16 @@ function defaultEnv(flags: GlobalFlags): SelfHostEnv {
     INTERNAL_SERVICE_KEY: token(32),
     API_KEY_SECRET: token(32),
     TUNNEL_SIGNING_SECRET: token(32),
-    // Sandboxes run on a real provider, just like Kortix Cloud. Daytona is the
-    // self-host sandbox provider; `kortix self-host configure` collects the API key.
+    // Sandboxes run on a real provider, just like Kortix Cloud — Daytona,
+    // E2B, or Kortix's own Platinum (SandboxProviderName in
+    // apps/api/src/config.ts); `kortix self-host configure` asks which one
+    // and collects only that provider's key(s).
     DAYTONA_API_KEY: '',
+    E2B_API_KEY: '',
+    PLATINUM_API_KEY: '',
+    PLATINUM_API_URL: '',
+    PLATINUM_TEMPLATE: '',
+    PLATINUM_WEBHOOK_SECRET: '',
     KORTIX_GITHUB_APP_ID: '',
     KORTIX_GITHUB_APP_PRIVATE_KEY: '',
     KORTIX_GITHUB_APP_SLUG: '',
@@ -2071,6 +2010,7 @@ function writeCompose(instance: string, env: SelfHostEnv): void {
     renderFullDockerCompose(composeProject(instance), {
       domainConfigured: Boolean(env.KORTIX_DOMAIN?.trim()),
       tunnelConfigured: reachabilityMode(env) === 'tunnel',
+      namedTunnelConfigured: namedTunnelConfigured(env),
     }),
     { encoding: 'utf8', mode: 0o600 },
   );
@@ -2115,6 +2055,14 @@ function normalizeFullSupabaseEnv(instance: string, env: SelfHostEnv): void {
   env.POSTGRES_HOST = 'supabase-db';
   env.POSTGRES_DB = 'postgres';
   env.SUPABASE_POSTGRES_INTERNAL_PORT = '5432';
+
+  // Frontend "Connect your tools" / connector-catalogue UI mirrors whether
+  // Pipedream is FULLY configured — same three fields
+  // apps/api/src/executor/pipedream.ts's own pipedreamConfigured() requires.
+  // Recomputed on every write (not just when the now-removed guided-init
+  // Pipedream question used to run) so setting/clearing PIPEDREAM_CLIENT_ID
+  // et al. via `env set`/`secrets set` directly keeps this in sync too.
+  env.KORTIX_PUBLIC_CONNECTORS_ENABLED = pipedreamConfigured(env) ? 'true' : 'false';
 
   // Public domain + TLS (opt-in): when KORTIX_DOMAIN is set, the bundled Caddy
   // service fronts the stack on 80/443 and every public URL becomes the real

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -114,13 +114,13 @@ describe('full self-host Docker distribution', () => {
     expect(domainOnly.services).not.toHaveProperty('cloudflared');
   });
 
-  test('includes the cloudflared tunnel service only when tunnel mode is configured', () => {
+  test('includes the cloudflared tunnel service only when tunnel mode is configured (quick-tunnel default)', () => {
     const document = parse(renderFullDockerCompose('kortix-default', { tunnelConfigured: true })) as {
       services: Record<string, {
         image?: string;
-        environment?: Record<string, string>;
+        environment?: Record<string, string> | null;
         depends_on?: Record<string, unknown>;
-        entrypoint?: string[];
+        command?: string[];
       }>;
     };
     const cloudflared = document.services.cloudflared;
@@ -128,18 +128,29 @@ describe('full self-host Docker distribution', () => {
     // Pinned to a specific version, not :latest — same immutability policy as
     // every other non-Supabase service image in this stack.
     expect(cloudflared?.image).toMatch(/^cloudflare\/cloudflared:\d+\.\d+\.\d+$/);
-    expect(cloudflared?.environment).toHaveProperty('CLOUDFLARE_TUNNEL_TOKEN');
     expect(cloudflared?.depends_on).toHaveProperty('kortix-api');
+    // No shell/entrypoint override: the official cloudflared image ships no
+    // shell at all, so branching must happen at compose-render time (see
+    // renderFullDockerCompose) — a runtime `/bin/sh -c` entrypoint can never
+    // start against this image.
+    expect(cloudflared).not.toHaveProperty('entrypoint');
     // Tunnels straight to kortix-api — Caddy is never present alongside it
     // (tunnel mode has no domain), and kortix-api already answers every
     // /v1* route the sandbox and other external callers need.
-    const script = cloudflared?.entrypoint?.join(' ') ?? '';
-    expect(script).toContain('http://kortix-api:8008');
-    // Named-tunnel branch: the same service supports a stable hostname via
-    // CLOUDFLARE_TUNNEL_TOKEN, decided at container-start (not compose-render)
-    // time so switching sub-modes is just an env change + restart.
-    expect(script).toContain('cloudflared tunnel');
-    expect(script).toContain('run --token');
+    const command = cloudflared?.command?.join(' ') ?? '';
+    expect(command).toContain('http://kortix-api:8008');
+  });
+
+  test('named tunnel (CLOUDFLARE_TUNNEL_TOKEN + hostname): cloudflared runs `tunnel run` with TUNNEL_TOKEN, not the quick-tunnel URL', () => {
+    const document = parse(
+      renderFullDockerCompose('kortix-default', { tunnelConfigured: true, namedTunnelConfigured: true }),
+    ) as {
+      services: Record<string, { command?: string[]; environment?: Record<string, string> }>;
+    };
+    const cloudflared = document.services.cloudflared;
+    expect(cloudflared).toBeDefined();
+    expect(cloudflared?.command).toEqual(['tunnel', '--no-autoupdate', 'run']);
+    expect(cloudflared?.environment).toMatchObject({ TUNNEL_TOKEN: '${CLOUDFLARE_TUNNEL_TOKEN}' });
   });
 
   test('cloudflared and caddy are independent — both, either, or neither can be present', () => {

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -76,6 +76,23 @@ describe('full self-host Docker distribution', () => {
     }
   });
 
+  test('supavisor carries an explicit nofile ulimits override (100000/100000)', () => {
+    // supavisor's entrypoint (limits.sh) unconditionally runs `ulimit -n
+    // 100000` before starting. Without an explicit `ulimits:` override, the
+    // container inherits the HOST's default open-files limit, which is well
+    // under 100000 on plenty of real VPS/EC2 images — `ulimit -n 100000` then
+    // fails with EPERM and the container restart-loops forever (confirmed
+    // live on a demo EC2 box). This mirrors the old enterprise appliance's
+    // docker-compose.enterprise.yml override, restored here for the generic
+    // compose file.
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { ulimits?: { nofile?: { soft?: number; hard?: number } } }>;
+    };
+    expect(document.services['supabase-supavisor']?.ulimits).toEqual({
+      nofile: { soft: 100000, hard: 100000 },
+    });
+  });
+
   test('omits the caddy reverse-proxy service when no domain is configured', () => {
     const document = parse(renderFullDockerCompose('kortix-default')) as {
       services: Record<string, unknown>;

--- a/apps/cli/src/self-host/__tests__/config.test.ts
+++ b/apps/cli/src/self-host/__tests__/config.test.ts
@@ -50,6 +50,35 @@ describe('self-host instance config', () => {
     expect(statSync(instanceConfigPath(config.instance)).mode & 0o777).toBe(0o600);
   });
 
+  test('writes and round-trips allow_missing_secrets (persisted --allow-missing-secrets choice)', () => {
+    const config: SelfHostInstanceConfig = {
+      schema_version: 1,
+      instance: 'allow-missing-instance',
+      allow_missing_secrets: true,
+    };
+
+    writeInstanceConfig(config);
+
+    expect(loadInstanceConfig(config.instance)).toEqual(config);
+    expect(JSON.parse(readFileSync(instanceConfigPath(config.instance), 'utf8'))).toEqual(config);
+  });
+
+  test('omits allow_missing_secrets entirely when false/unset — never written as a literal `false`', () => {
+    writeInstanceConfig({ schema_version: 1, instance: 'allow-missing-unset' });
+    const onDisk = JSON.parse(readFileSync(instanceConfigPath('allow-missing-unset'), 'utf8'));
+    expect(onDisk).not.toHaveProperty('allow_missing_secrets');
+    expect(loadInstanceConfig('allow-missing-unset')?.allow_missing_secrets).toBeUndefined();
+  });
+
+  test('rejects a non-boolean allow_missing_secrets', () => {
+    mkdirSync(instanceDir('bad-allow-missing'), { recursive: true });
+    writeFileSync(
+      instanceConfigPath('bad-allow-missing'),
+      JSON.stringify({ schema_version: 1, instance: 'bad-allow-missing', allow_missing_secrets: 'yes' }),
+    );
+    expect(() => loadInstanceConfig('bad-allow-missing')).toThrow('allow_missing_secrets must be a boolean');
+  });
+
   test('rejects invalid or unsupported instance configs', () => {
     mkdirSync(instanceDir('broken'), { recursive: true });
     writeFileSync(

--- a/apps/cli/src/self-host/__tests__/secrets.test.ts
+++ b/apps/cli/src/self-host/__tests__/secrets.test.ts
@@ -11,7 +11,12 @@ import {
   ROTATABLE_GENERATED_KEYS,
   servicesForKeys,
 } from '../secrets-registry.ts';
-import { gitProviderConfigured, missingRequiredSecrets, sandboxProviderConfigured } from '../../commands/self-host.ts';
+import {
+  gitProviderConfigured,
+  missingRequiredSecrets,
+  sandboxProviderConfigured,
+  shouldPullImages,
+} from '../../commands/self-host.ts';
 
 // ── Pure registry helpers (no filesystem/process access) ────────────────────
 
@@ -111,17 +116,32 @@ function baseEnv(overrides: Record<string, string> = {}): Record<string, string>
 }
 
 describe('missingRequiredSecrets', () => {
-  test('a fresh (just-initialized, nothing configured) env reports sandbox, managed git, and LLM', () => {
+  // The CLI's init-time gate is deliberately narrow: ONLY the agent sandbox
+  // runtime (Daytona) is required — the one credential with no in-app
+  // settings surface. Managed git (GitHub, Settings → Git) and the LLM key
+  // (BYOK via the model picker) are both configured in the dashboard after
+  // `start` and no longer block init/start — see missingRequiredSecrets() in
+  // commands/self-host.ts. gitProviderConfigured() itself is unchanged (still
+  // a useful composite "is git set up" check for the dashboard-pointer note
+  // in renderIntegrationSummary), it just no longer feeds this gate.
+  test('a fresh (just-initialized, nothing configured) env reports only the sandbox runtime', () => {
     const missing = missingRequiredSecrets(baseEnv());
     const labels = missing.map((m) => m.label).join(' | ');
     expect(labels).toContain('Agent sandbox');
-    expect(labels).toContain('Managed git');
-    expect(missing.some((m) => m.hint.includes('OPENROUTER_API_KEY'))).toBe(true);
+    expect(labels).not.toContain('Managed git');
+    expect(missing.some((m) => m.hint.includes('OPENROUTER_API_KEY'))).toBe(false);
     expect(sandboxProviderConfigured(baseEnv())).toBe(false);
     expect(gitProviderConfigured(baseEnv())).toBe(false);
   });
 
-  test('a fully-configured env (Daytona + GitHub PAT + OpenRouter) reports nothing missing', () => {
+  test('Daytona alone (no managed git, no OpenRouter) reports nothing missing', () => {
+    const env = baseEnv({ DAYTONA_API_KEY: 'dtn_live_key' });
+    expect(missingRequiredSecrets(env)).toEqual([]);
+    expect(sandboxProviderConfigured(env)).toBe(true);
+    expect(gitProviderConfigured(env)).toBe(false);
+  });
+
+  test('a fully-configured env (Daytona + GitHub PAT + OpenRouter) also reports nothing missing', () => {
     const env = baseEnv({
       DAYTONA_API_KEY: 'dtn_live_key',
       MANAGED_GIT_GITHUB_OWNER: 'kortix-ai',
@@ -133,18 +153,17 @@ describe('missingRequiredSecrets', () => {
     expect(gitProviderConfigured(env)).toBe(true);
   });
 
-  test('managed-git owner set but no PAT/App credentials still counts as missing', () => {
+  test('managed-git owner set but no PAT/App credentials: gitProviderConfigured is still false, but this no longer blocks init/start', () => {
     const env = baseEnv({
       DAYTONA_API_KEY: 'dtn_live_key',
       OPENROUTER_API_KEY: 'sk-or-fake',
       MANAGED_GIT_GITHUB_OWNER: 'kortix-ai', // owner alone is not enough
     });
     expect(gitProviderConfigured(env)).toBe(false);
-    const missing = missingRequiredSecrets(env);
-    expect(missing.some((m) => m.label.includes('Managed git'))).toBe(true);
+    expect(missingRequiredSecrets(env)).toEqual([]);
   });
 
-  test('a complete GitHub App credential set (no PAT) satisfies managed git', () => {
+  test('a complete GitHub App credential set (no PAT) satisfies gitProviderConfigured', () => {
     const env = baseEnv({
       DAYTONA_API_KEY: 'dtn_live_key',
       OPENROUTER_API_KEY: 'sk-or-fake',
@@ -154,10 +173,10 @@ describe('missingRequiredSecrets', () => {
       MANAGED_GIT_GITHUB_INSTALL_ID: '987654',
     });
     expect(gitProviderConfigured(env)).toBe(true);
-    expect(missingRequiredSecrets(env).some((m) => m.label.includes('Managed git'))).toBe(false);
+    expect(missingRequiredSecrets(env)).toEqual([]);
   });
 
-  test('a corrupted/blanked-out internal generated secret is reported even though every provider is configured', () => {
+  test('a corrupted/blanked-out internal generated secret is reported even though the sandbox provider is configured', () => {
     const env = baseEnv({
       DAYTONA_API_KEY: 'dtn_live_key',
       MANAGED_GIT_GITHUB_OWNER: 'kortix-ai',
@@ -167,6 +186,21 @@ describe('missingRequiredSecrets', () => {
     });
     const missing = missingRequiredSecrets(env);
     expect(missing.some((m) => m.hint.includes('TUNNEL_SIGNING_SECRET'))).toBe(true);
+  });
+});
+
+describe('shouldPullImages', () => {
+  test('true when KORTIX_IMAGE_PULL is unset (normal registry pull behavior)', () => {
+    expect(shouldPullImages({})).toBe(true);
+  });
+
+  test('false for KORTIX_IMAGE_PULL=never (--local-images dev mode) — a blanket `docker compose pull` would fail with "manifest unknown" against images that were only ever built locally', () => {
+    expect(shouldPullImages({ KORTIX_IMAGE_PULL: 'never' })).toBe(false);
+  });
+
+  test('true for any other value (defensive — only the literal "never" opts out)', () => {
+    expect(shouldPullImages({ KORTIX_IMAGE_PULL: '' })).toBe(true);
+    expect(shouldPullImages({ KORTIX_IMAGE_PULL: 'always' })).toBe(true);
   });
 });
 
@@ -376,13 +410,31 @@ describe('kortix self-host init/start required-secrets enforcement (CLI)', () =>
     expect(stdout).not.toContain('unknown');
   });
 
-  test('a fully-configured init via env set + secrets set on top of --allow-missing-secrets, then a plain start guard still enforces on a later start', async () => {
-    // init once, letting secrets stay unset...
+  // `start` genuinely shells out to `docker compose pull`/`up` once past this
+  // gate, which this "fast, no Docker" suite must never trigger for real —
+  // so this exercises the exact same ensureRequiredSecrets()/
+  // persistedAllowMissingSecrets() code path `start` uses via a second `init`
+  // call instead (selfHostInit never touches docker).
+  test('--allow-missing-secrets is remembered: a later plain `init` (no flag) on the same instance no longer re-demands it', async () => {
+    // First call actually uses the escape hatch and persists the choice
+    // (recordAllowMissingSecrets, instance.json `allow_missing_secrets`).
+    const first = await run(['init', '--yes', '--allow-missing-secrets']);
+    expect(first.code).toBe(0);
+
+    // Second call, same instance, WITHOUT the flag: must not be re-blocked —
+    // this is the exact friction fixed (previously a bare re-run of the same
+    // gate, e.g. via `start`, hard-failed again until the flag was repeated).
+    const second = await run(['init', '--yes']);
+    expect(second.code).toBe(0);
+    expect(second.stderr).not.toContain('Required secrets are missing');
+  });
+
+  test('once the actual secret is set, missingRequiredSecrets naturally clears regardless of any persisted allow-missing choice', async () => {
     await run(['init', '--yes', '--allow-missing-secrets']);
-    // ...then run `start` on the already-initialized instance without the
-    // escape hatch: it must refuse too, not just `init`.
-    const { code, stderr } = await run(['start', '--yes']);
-    expect(code).not.toBe(0);
-    expect(stderr).toContain('Required secrets are missing');
+    await run(['env', 'set', 'DAYTONA_API_KEY=dtn-test-key']);
+
+    const { code, stdout } = await run(['init', '--yes']);
+    expect(code).toBe(0);
+    expect(stdout).not.toContain('Proceeding with required secrets missing');
   });
 });

--- a/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
+++ b/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
@@ -11,9 +11,10 @@ import { parse } from 'yaml';
 // function would miss.
 //
 // Every `init` call below passes `--allow-missing-secrets`: none of these
-// tests configure DAYTONA_API_KEY/managed-git/OPENROUTER_API_KEY, and `init`
-// now refuses to succeed (non-interactively) with required secrets unset —
-// see secrets.test.ts for coverage of that enforcement itself.
+// tests configure DAYTONA_API_KEY (the ONLY secret `init` gates on
+// non-interactively now — managed git and the LLM key are configured in the
+// dashboard after `start`, not by this CLI), and `init` refuses to succeed
+// with it unset — see secrets.test.ts for coverage of that enforcement.
 const CLI_ENTRY = resolve(import.meta.dir, '..', '..', 'index.ts');
 
 describe('kortix self-host (generic Docker CLI)', () => {
@@ -115,27 +116,32 @@ describe('kortix self-host (generic Docker CLI)', () => {
     expect(env.KORTIX_CHANNEL).toBe('stable');
   });
 
-  test('--version is an alias for --tag: pins the image ref AND defaults auto-update off (pin implies no drift)', async () => {
+  // Auto-update defaults ON everywhere, including a pinned --version/--tag —
+  // the nightly updater re-pulling the SAME immutable pinned tag is a
+  // harmless no-op (nothing to roll), not silent drift, so pinning alone is
+  // no longer a reason to default it off. --local-images (a locally-built
+  // image never pushed to any registry) is the one real exception — see the
+  // --local-images test below.
+  test('--version is an alias for --tag: pins the image ref, auto-update still defaults ON (a no-op nightly re-pull of the same pinned tag)', async () => {
     const { code } = await run(['init', '--yes', '--allow-missing-secrets', '--version', 'dev-a1b2c3d']);
     expect(code).toBe(0);
     const env = readEnv();
     expect(env.KORTIX_VERSION).toBe('dev-a1b2c3d');
     expect(env.API_IMAGE).toBe('kortix/kortix-api:dev-a1b2c3d');
     expect(env.FRONTEND_IMAGE).toBe('kortix/kortix-frontend:dev-a1b2c3d');
-    // A pinned ref is not a channel; the auto-updater must not silently move it.
-    expect(env.KORTIX_AUTO_UPDATE).toBe('false');
+    expect(env.KORTIX_AUTO_UPDATE).toBe('true');
   });
 
-  test('--channel latest (channel tracking, not a pin) keeps auto-update on by default', async () => {
+  test('--channel latest (channel tracking) also keeps auto-update on by default', async () => {
     const { code } = await run(['init', '--yes', '--allow-missing-secrets', '--channel', 'latest']);
     expect(code).toBe(0);
     expect(readEnv().KORTIX_AUTO_UPDATE).toBe('true');
   });
 
-  test('an explicit --auto-update on wins even for a pinned --version', async () => {
-    const { code } = await run(['init', '--yes', '--allow-missing-secrets', '--version', '0.9.99', '--auto-update', 'on']);
+  test('an explicit --auto-update off wins even without --local-images', async () => {
+    const { code } = await run(['init', '--yes', '--allow-missing-secrets', '--version', '0.9.99', '--auto-update', 'off']);
     expect(code).toBe(0);
-    expect(readEnv().KORTIX_AUTO_UPDATE).toBe('true');
+    expect(readEnv().KORTIX_AUTO_UPDATE).toBe('false');
   });
 
   test('--local-images (dev mode): sets KORTIX_IMAGE_PULL=never and forces auto-update off, even over --auto-update on', async () => {
@@ -250,24 +256,21 @@ describe('kortix self-host (generic Docker CLI)', () => {
       expect(env.KORTIX_PUBLIC_SINGLE_ACCOUNT_MODE).toBe('true');
     });
 
-    test('--no-landing sets KORTIX_PUBLIC_DISABLE_LANDING_PAGE (redundant with the default, kept for scripts)', async () => {
-      const { code } = await run(['init', '--yes', '--allow-missing-secrets', '--no-landing']);
-      expect(code).toBe(0);
+    // There is deliberately no `--landing`/`--no-landing` flag: the landing
+    // page isn't a guided-flow decision (self-host is an app deployment, not
+    // a marketing site — full stop), it's just an ordinary env var an
+    // operator can flip directly if they genuinely want it back.
+    test('re-enabling the landing page is a plain `env set`, no dedicated flag', async () => {
+      await run(['init', '--yes', '--allow-missing-secrets']);
       expect(readEnv().KORTIX_PUBLIC_DISABLE_LANDING_PAGE).toBe('true');
-    });
 
-    test('--landing re-enables the marketing landing page (the inverse of the self-host default)', async () => {
-      const { code } = await run(['init', '--yes', '--allow-missing-secrets', '--landing']);
+      const { code } = await run(['env', 'set', 'KORTIX_PUBLIC_DISABLE_LANDING_PAGE=false']);
       expect(code).toBe(0);
       expect(readEnv().KORTIX_PUBLIC_DISABLE_LANDING_PAGE).toBe('false');
-    });
 
-    test('a re-run of init without --landing does not reset a previously-enabled landing page', async () => {
-      await run(['init', '--yes', '--allow-missing-secrets', '--landing']);
-      expect(readEnv().KORTIX_PUBLIC_DISABLE_LANDING_PAGE).toBe('false');
-
-      const { code } = await run(['init', '--yes', '--allow-missing-secrets']);
-      expect(code).toBe(0);
+      // A later plain re-init must not silently flip it back off.
+      const reinit = await run(['init', '--yes', '--allow-missing-secrets']);
+      expect(reinit.code).toBe(0);
       expect(readEnv().KORTIX_PUBLIC_DISABLE_LANDING_PAGE).toBe('false');
     });
 
@@ -426,5 +429,19 @@ describe('kortix self-host (generic Docker CLI)', () => {
       const { code } = await run(['secrets', 'set', 'CLOUDFLARE_TUNNEL_TOKEN=faketoken']);
       expect(code).toBe(0);
     });
+  });
+
+  // `connect-github` is deprecated: managed git is now configured in the web
+  // dashboard (Settings → Git), not by this CLI — the App-manifest flow it
+  // used to run never worked reliably from a laptop (GitHub rejects
+  // hook/callback URLs unreachable over the public internet). The dispatch
+  // case is kept as a no-op alias (not removed outright) so a script that
+  // still calls it doesn't hard-fail.
+  test('connect-github is a deprecated no-op alias: exits 0 and points at the dashboard instead of running the App-manifest flow', async () => {
+    await run(['init', '--yes', '--allow-missing-secrets']);
+    const { code, stdout } = await run(['connect-github']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('deprecated');
+    expect(stdout.toLowerCase()).toContain('settings');
   });
 });

--- a/apps/cli/src/self-host/__tests__/tunnel.test.ts
+++ b/apps/cli/src/self-host/__tests__/tunnel.test.ts
@@ -58,6 +58,21 @@ describe('parseQuickTunnelUrl', () => {
   test('ignores a look-alike domain that is not actually trycloudflare.com', () => {
     expect(parseQuickTunnelUrl('https://evil-trycloudflare.com.attacker.net')).toBeNull();
   });
+
+  test('returns the LAST URL when logs contain more than one — a stale pre-restart URL followed by the fresh one', () => {
+    // `docker compose logs` returns the container's entire cumulative history.
+    // If cloudflared restarted in place (crash + `restart: unless-stopped`, or
+    // a manual `docker restart`) rather than being recreated, the logs contain
+    // both the dead old quick-tunnel URL and the new one minted on reboot.
+    const logs = `
+2026-07-15T00:00:00Z INF |  https://old-dead-tunnel.trycloudflare.com  |
+2026-07-15T00:00:01Z INF Registered tunnel connection connIndex=0
+2026-07-15T00:05:00Z INF Tunnel connection lost, retrying...
+2026-07-15T00:05:02Z INF |  https://fresh-tunnel-after-restart.trycloudflare.com  |
+2026-07-15T00:05:03Z INF Registered tunnel connection connIndex=0
+`;
+    expect(parseQuickTunnelUrl(logs)).toBe('https://fresh-tunnel-after-restart.trycloudflare.com');
+  });
 });
 
 describe('resolveTunnelUrl', () => {

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -88,7 +88,19 @@ services:
       # exactly the bug this fixes (billing used to be hard-pinned "false"
       # here no matter what .env said).
       LLM_GATEWAY_ENABLED: "true"
-      LLM_GATEWAY_BASE_URL: http://llm-gateway:8090/v1/llm
+      # Deliberately NOT set: LLM_GATEWAY_BASE_URL is what gets handed straight
+      # to sandboxes as KORTIX_LLM_BASE_URL (see session-sandbox.ts /
+      # sandbox-env-sync.ts). It used to be pinned here to the compose-internal
+      # `llm-gateway` service (http://llm-gateway:8090/v1/llm) — a hostname a
+      # remote Daytona sandbox VM can never resolve, so every BYOK model call
+      # failed with opencode's "Cannot connect to API: Was there a typo in the
+      # url or port?" the moment a session tried to actually run a turn. Left
+      # unset, the fallback in session-sandbox.ts correctly resolves to
+      # `${KORTIX_URL}/v1/llm` — kortix-api's own in-process gateway mount,
+      # already reachable through the SAME public tunnel/domain origin every
+      # other sandbox call already uses. The standalone `llm-gateway` container
+      # below still runs (control-plane RPC at /internal/gateway), it's just
+      # never the sandbox-facing base URL in self-host.
       GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
     depends_on:

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -3,9 +3,12 @@ services:
     image: ${FRONTEND_IMAGE}
     ports:
       - "127.0.0.1:${FRONTEND_PORT}:3000"
-    extra_hosts:
-      - "localhost:host-gateway"
     environment:
+      # The Next server's internal /v1 rewrite target. Must be the in-network
+      # api service — the old `extra_hosts: localhost:host-gateway` hack only
+      # worked when the api port happened to be published on the host at :8008,
+      # which is never true in domain mode (500s on every proxied /v1/* path).
+      KORTIX_API_PROXY_TARGET: http://kortix-api:8008
       KORTIX_PUBLIC_SUPABASE_URL: ${SUPABASE_PUBLIC_URL}
       KORTIX_PUBLIC_SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
       KORTIX_PUBLIC_BACKEND_URL: ${API_PUBLIC_URL}/v1

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -171,8 +171,15 @@ services:
   # service, and kortix-api already answers every /v1* route the sandbox and
   # any external caller need.
   #
-  # Two sub-modes, branched at container start (not at compose-render time) so
-  # flipping between them is just an env change + restart:
+  # Two sub-modes, branched at COMPOSE-RENDER time (see renderFullDockerCompose
+  # in compose-assets.ts, driven by namedTunnelConfigured() in
+  # self-host/tunnel.ts) — NOT at container start: the official
+  # cloudflare/cloudflared image is a distroless-style image with no shell at
+  # all (no /bin/sh), so a `entrypoint: [/bin/sh, -c, ...]` branch can never
+  # start (`exec: "/bin/sh": stat /bin/sh: no such file or directory`). The
+  # command/environment below are the zero-config quick-tunnel default;
+  # renderFullDockerCompose() overwrites both when a named tunnel is
+  # configured.
   #   - Zero-config quick tunnel (default, no CLOUDFLARE_TUNNEL_TOKEN set): a
   #     fresh https://<random>.trycloudflare.com URL is minted on every start —
   #     EPHEMERAL. `kortix self-host start`/`update` read it back out of this
@@ -181,19 +188,12 @@ services:
   #   - Named tunnel (CLOUDFLARE_TUNNEL_TOKEN + a hostname bound to it in the
   #     Cloudflare Zero Trust dashboard, via CLOUDFLARE_TUNNEL_HOSTNAME): a
   #     STABLE URL that never changes across restarts — no log-scraping.
+  #     cloudflared reads its auth token from the TUNNEL_TOKEN env var natively
+  #     (no shell/script needed) when running `tunnel run` with no positional
+  #     tunnel name/ID.
   cloudflared:
     image: cloudflare/cloudflared:2026.7.2
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        if [ -n "$$CLOUDFLARE_TUNNEL_TOKEN" ]; then
-          exec cloudflared tunnel --no-autoupdate run --token "$$CLOUDFLARE_TUNNEL_TOKEN"
-        else
-          exec cloudflared tunnel --no-autoupdate --url http://kortix-api:8008
-        fi
-    environment:
-      CLOUDFLARE_TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}
+    command: ["tunnel", "--no-autoupdate", "--url", "http://kortix-api:8008"]
     depends_on:
       kortix-api:
         condition: service_started

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -200,6 +200,22 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
       '127.0.0.1:${POSTGRES_PORT}:5432',
       '127.0.0.1:${POOLER_PORT}:6543',
     ];
+    // supavisor's entrypoint (limits.sh) unconditionally runs `ulimit -n 100000`
+    // before starting. Containers with no explicit `ulimits:` inherit the
+    // HOST's default open-files limit (systemd DefaultLimitNOFILE, or
+    // /etc/security/limits.conf) rather than something generously high — on
+    // plenty of real VPS/EC2 images that default is well under 100000 (e.g.
+    // 65535), `ulimit -n 100000` then fails with EPERM, and (the script running
+    // under `set -e`) the container exits 1 and restart-loops forever, so
+    // Postgres access via the pooler never comes up. Pin it explicitly so this
+    // doesn't depend on host ulimit defaults. Matches the old enterprise
+    // appliance's docker-compose.enterprise.yml override for this service.
+    supavisor.ulimits = {
+      nofile: {
+        soft: 100000,
+        hard: 100000,
+      },
+    };
   }
 
   for (const [name, rawService] of Object.entries(asRecord(kortix.services))) {

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -106,6 +106,17 @@ export interface RenderComposeOptions {
    * disabled — so an instance not using it never runs the container.
    */
   tunnelConfigured?: boolean;
+  /**
+   * Whether a STABLE named Cloudflare tunnel is configured (both
+   * CLOUDFLARE_TUNNEL_TOKEN and CLOUDFLARE_TUNNEL_HOSTNAME set — see
+   * namedTunnelConfigured() in self-host/tunnel.ts). Only meaningful when
+   * tunnelConfigured is also true. Selects the cloudflared service's
+   * command/environment at COMPOSE-RENDER time (`tunnel run` + TUNNEL_TOKEN
+   * env var vs. the zero-config `tunnel --url` default already baked into
+   * kortix-compose.yml) — this can't be a runtime shell branch inside the
+   * container because the official cloudflared image ships no shell at all.
+   */
+  namedTunnelConfigured?: boolean;
 }
 
 /**
@@ -209,6 +220,15 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
   // cloudflared image.
   if (!options.tunnelConfigured) {
     delete services.cloudflared;
+  } else if (options.namedTunnelConfigured) {
+    // Stable named tunnel: authenticate with TUNNEL_TOKEN (cloudflared reads
+    // it natively — no CLI flag/shell needed) and run the tunnel bound to
+    // that token instead of minting a new zero-config quick tunnel.
+    const cloudflared = services.cloudflared;
+    if (cloudflared) {
+      cloudflared.command = ['tunnel', '--no-autoupdate', 'run'];
+      cloudflared.environment = { TUNNEL_TOKEN: '${CLOUDFLARE_TUNNEL_TOKEN}' };
+    }
   }
 
   // Prod (domain-configured) vs laptop replica/port topology. In prod mode

--- a/apps/cli/src/self-host/config.ts
+++ b/apps/cli/src/self-host/config.ts
@@ -14,10 +14,23 @@ export interface SelfHostInstanceConfig {
   schema_version: 1;
   instance: string;
   release?: string;
+  /**
+   * Persists an operator's `--allow-missing-secrets` choice across
+   * invocations. Without this, an operator who ran `init --allow-missing-secrets`
+   * (deliberately proceeding without the Daytona key, to configure it later)
+   * would be hard-blocked again the very next time they ran a bare `start`
+   * (ensureRequiredSecrets() re-validates independently on every invocation) —
+   * forcing them to pass the flag a second time for no new decision. Once set
+   * via any invocation that passed the flag, later `start`/`update` calls
+   * remember it instead of re-demanding it. There is no "un-acknowledge" flag;
+   * setting the actual secret (`secrets set DAYTONA_API_KEY=...`) is what
+   * naturally makes missingRequiredSecrets() stop reporting anything anyway.
+   */
+  allow_missing_secrets?: boolean;
 }
 
 const INSTANCE_PATTERN = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
-const TOP_LEVEL_FIELDS = new Set(['schema_version', 'instance', 'release']);
+const TOP_LEVEL_FIELDS = new Set(['schema_version', 'instance', 'release', 'allow_missing_secrets']);
 
 export function selfHostConfigRoot(): string {
   const override = process.env.KORTIX_SELF_HOST_CONFIG_DIR?.trim();
@@ -74,11 +87,13 @@ function validateInstanceConfig(value: unknown, expectedInstance: string): SelfH
   assertInstanceName(expectedInstance);
 
   const release = optionalString(value.release, 'release');
+  const allowMissingSecrets = optionalBoolean(value.allow_missing_secrets, 'allow_missing_secrets');
 
   return {
     schema_version: 1,
     instance: expectedInstance,
     ...(release ? { release } : {}),
+    ...(allowMissingSecrets ? { allow_missing_secrets: true } : {}),
   };
 }
 
@@ -102,6 +117,12 @@ function asRequiredString(value: unknown, field: string): string {
 function optionalString(value: unknown, field: string): string | undefined {
   if (value === undefined) return undefined;
   return asRequiredString(value, field);
+}
+
+function optionalBoolean(value: unknown, field: string): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') throw new Error(`${field} must be a boolean`);
+  return value;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/cli/src/self-host/secrets-registry.ts
+++ b/apps/cli/src/self-host/secrets-registry.ts
@@ -81,11 +81,23 @@ export const SECRET_DEFS: SecretDef[] = [
   { key: 'SMTP_ADMIN_EMAIL', category: 'auth_email', kind: 'operator', required: false },
   { key: 'SMTP_SENDER_NAME', category: 'auth_email', kind: 'operator', required: false },
 
-  // Agent sandbox
+  // Agent sandbox — three interchangeable providers (SandboxProviderName in
+  // apps/api/src/config.ts). `init`/`configure` ask which ONE this instance
+  // runs on (default daytona) and only collect that provider's key(s); the
+  // actual required-secret gate is the composite sandboxProviderConfigured()
+  // check in commands/self-host.ts (whichever provider ALLOWED_SANDBOX_
+  // PROVIDERS names), not a blanket `required` flag per key here — Daytona
+  // stays `required: true` below only because it's the default/recommended
+  // provider, not because it's unconditionally needed.
   { key: 'DAYTONA_API_KEY', category: 'sandbox', kind: 'operator', required: true },
+  { key: 'E2B_API_KEY', category: 'sandbox', kind: 'operator', required: false },
+  { key: 'PLATINUM_API_KEY', category: 'sandbox', kind: 'operator', required: false },
+  { key: 'PLATINUM_WEBHOOK_SECRET', category: 'sandbox', kind: 'operator', required: false },
 
-  // Managed git
-  { key: 'MANAGED_GIT_GITHUB_OWNER', category: 'managed_git', kind: 'operator', required: true },
+  // Managed git — NOT init-required: configured in-app (Settings → Git,
+  // DB-backed) after `start`, not by the CLI. See missingRequiredSecrets() in
+  // commands/self-host.ts.
+  { key: 'MANAGED_GIT_GITHUB_OWNER', category: 'managed_git', kind: 'operator', required: false },
   { key: 'MANAGED_GIT_GITHUB_TOKEN', category: 'managed_git', kind: 'operator', required: false },
   { key: 'MANAGED_GIT_GITHUB_INSTALL_ID', category: 'managed_git', kind: 'operator', required: false },
   { key: 'KORTIX_GITHUB_APP_ID', category: 'managed_git', kind: 'operator', required: false },
@@ -103,8 +115,9 @@ export const SECRET_DEFS: SecretDef[] = [
   // (if unset) alongside the App credentials.
   { key: 'KORTIX_GITHUB_APP_STATE_SECRET', category: 'managed_git', kind: 'generated', required: false, rotatable: true },
 
-  // LLM
-  { key: 'OPENROUTER_API_KEY', category: 'llm', kind: 'operator', required: true },
+  // LLM — NOT init-required: BYOK via the frontend's model picker after
+  // `start`, not collected by the CLI.
+  { key: 'OPENROUTER_API_KEY', category: 'llm', kind: 'operator', required: false },
   { key: 'AWS_BEDROCK_API_KEY', category: 'llm', kind: 'operator', required: false },
   { key: 'AWS_BEDROCK_REGION', category: 'llm', kind: 'operator', required: false },
 
@@ -198,10 +211,15 @@ export const KEY_SERVICE_MAP: Record<string, readonly string[]> = {
   SMTP_ADMIN_EMAIL: ['supabase-auth'],
   SMTP_SENDER_NAME: ['supabase-auth'],
 
-  // Agent sandbox
+  // Agent sandbox — all three interchangeable providers
   DAYTONA_API_KEY: ['kortix-api'],
   DAYTONA_SERVER_URL: ['kortix-api'],
   DAYTONA_TARGET: ['kortix-api'],
+  E2B_API_KEY: ['kortix-api'],
+  PLATINUM_API_KEY: ['kortix-api'],
+  PLATINUM_API_URL: ['kortix-api'],
+  PLATINUM_TEMPLATE: ['kortix-api'],
+  PLATINUM_WEBHOOK_SECRET: ['kortix-api'],
 
   // Managed git
   MANAGED_GIT_GITHUB_OWNER: ['kortix-api'],

--- a/apps/cli/src/self-host/tunnel.ts
+++ b/apps/cli/src/self-host/tunnel.ts
@@ -50,17 +50,28 @@ export function namedTunnelConfigured(env: Record<string, string | undefined>): 
   return Boolean(env.CLOUDFLARE_TUNNEL_TOKEN?.trim() && env.CLOUDFLARE_TUNNEL_HOSTNAME?.trim());
 }
 
-const QUICK_TUNNEL_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+const QUICK_TUNNEL_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/g;
 
 /**
  * Extract the ephemeral https://<random>.trycloudflare.com URL cloudflared
  * prints to its stdout/stderr when it establishes a zero-config quick tunnel.
  * A pure string function so it's unit-testable without any docker/process
  * plumbing — resolveTunnelUrl below is the only caller in normal operation.
+ *
+ * Returns the LAST match, not the first: `docker compose logs` returns the
+ * cloudflared container's ENTIRE cumulative log history, not just since its
+ * most recent boot. If the container was restarted in place (e.g. it crashed
+ * and Compose's `restart: unless-stopped` brought it back, or the operator ran
+ * `docker restart cloudflared`) rather than recreated, those logs still
+ * contain the previous, now-dead quick-tunnel URL followed by the fresh one
+ * cloudflared mints on every boot. Taking the first match would silently pin
+ * KORTIX_URL to a tunnel that no longer exists — this is confirmed live: a
+ * bare `docker restart` of the cloudflared container followed by
+ * `kortix self-host start` used to re-resolve the STALE pre-restart URL.
  */
 export function parseQuickTunnelUrl(logText: string): string | null {
-  const match = logText.match(QUICK_TUNNEL_URL_PATTERN);
-  return match ? match[0] : null;
+  const matches = logText.match(QUICK_TUNNEL_URL_PATTERN);
+  return matches && matches.length > 0 ? matches[matches.length - 1] : null;
 }
 
 export interface TunnelUrlResult {

--- a/apps/cli/src/self-host/types.ts
+++ b/apps/cli/src/self-host/types.ts
@@ -16,13 +16,6 @@ export interface SelfHostCommandFlags {
    *  no teams. Sets KORTIX_SINGLE_ACCOUNT_MODE + the matching KORTIX_PUBLIC_
    *  frontend flag (--single-account). */
   singleAccount?: boolean;
-  /** Redirect unauthenticated visitors hitting "/" straight to /auth instead
-   *  of the marketing landing page (KORTIX_PUBLIC_DISABLE_LANDING_PAGE) — this
-   *  is the self-host DEFAULT (a self-host is an app deployment, not a
-   *  marketing site). `--no-landing` sets this explicitly (redundant with the
-   *  default, kept for scripts); `--landing` sets it to `false` to
-   *  re-enable the marketing site. */
-  disableLanding?: boolean;
   /** Operator holds a Kortix Enterprise license: unlocks SSO/SCIM/RBAC/audit
    *  entitlements platform-wide regardless of billing tier
    *  (ENTERPRISE_LICENSE_AVAILABLE, --enterprise-license). */
@@ -44,17 +37,6 @@ export interface SelfHostCommandFlags {
    *  CLOUDFLARE_TUNNEL_HOSTNAME for the optional stable named-tunnel
    *  alternative to the zero-config ephemeral quick tunnel. */
   tunnel?: 'cloudflare';
-  /** GitHub org (or omit for a personal account) to create/install the
-   *  self-host GitHub App under — `connect-github`, and the guided `init`/
-   *  `configure` GitHub step. */
-  org?: string;
-  /** Force the headless/manual GitHub App connect flow (print URLs, accept
-   *  pasted-back code/installation_id) instead of auto-opening a browser.
-   *  Automatic on a non-TTY even without this flag. */
-  manual?: boolean;
-  /** Skip the guided `connect-github` offer during `init`/`configure` —
-   *  drops straight to the advanced "paste an existing App or PAT" menu. */
-  skipGithub?: boolean;
   /** Operator admin email(s), comma-separated. Sets KORTIX_PLATFORM_ADMIN_EMAILS
    *  so these accounts are platform admins on this self-host (needed to
    *  configure the managed GitHub App and other server-wide settings in-app).

--- a/apps/cli/src/web-url.ts
+++ b/apps/cli/src/web-url.ts
@@ -9,15 +9,23 @@
  * links — so we never guess when an authoritative value is available.
  *
  * Resolution order, most authoritative first:
- *   1. `project.dashboard_url` — the server's own `config.FRONTEND_URL`, baked
- *      into every serialized project. Use it whenever you hold a project object
- *      (see {@link projectWebUrl}).
+ *   1. An explicit `dashboardUrl` argument — e.g. a `Host`'s stored
+ *      `dashboard_url` (see {@link Host} in api/config.ts), captured
+ *      authoritatively at the source: `kortix self-host` knows its own
+ *      `PUBLIC_URL` and stamps it on the `selfhost` host it registers, or
+ *      `project.dashboard_url` — the server's own `config.FRONTEND_URL`,
+ *      baked into every serialized project (see {@link projectWebUrl}).
  *   2. `KORTIX_FRONTEND_URL` — injected into every sandbox right next to
  *      `KORTIX_API_URL` (the server's `config.FRONTEND_URL`, verbatim). Also
  *      settable locally.
  *   3. `KORTIX_DASHBOARD_URL` — legacy local override, kept for back-compat.
  *   4. Derive from the API host (handles `api.`, `api-<env>.`, `<env>-api.`,
- *      localhost) — a best-effort fallback for old servers that don't inject (2).
+ *      localhost) — a best-effort fallback for old servers/hosts that carry
+ *      neither (1) nor (2). NOTE: this guess assumes cloud URL conventions
+ *      and a fixed local dev port pairing (`:8008` → `:3000`); it is WRONG
+ *      for a self-host stack on other ports (e.g. the laptop default
+ *      `:13738` API / `:13737` dashboard) — always prefer (1) when you have
+ *      it, which is why a `Host` should carry `dashboard_url`.
  *   5. https://kortix.com.
  */
 import { sandboxEnvValue } from './api/sandbox-env.ts';
@@ -26,8 +34,16 @@ function stripTrailingSlash(s: string): string {
   return s.replace(/\/+$/, '');
 }
 
-/** The frontend dashboard base URL (no trailing slash), never the API host. */
-export function webDashboardUrl(apiBase: string): string {
+/**
+ * The frontend dashboard base URL (no trailing slash), never the API host.
+ *
+ * @param dashboardUrl An authoritative override when the caller already
+ *   knows it (e.g. `host.dashboard_url` from api/config.ts) — always pass
+ *   this when available so a self-host stack on non-default ports resolves
+ *   correctly instead of falling through to the API-shape guess.
+ */
+export function webDashboardUrl(apiBase: string, dashboardUrl?: string | null): string {
+  if (dashboardUrl && dashboardUrl.trim()) return stripTrailingSlash(dashboardUrl.trim());
   const explicit = sandboxEnvValue('KORTIX_FRONTEND_URL') || process.env.KORTIX_DASHBOARD_URL;
   if (explicit && explicit.trim()) return stripTrailingSlash(explicit.trim());
   return stripTrailingSlash(deriveFrontendFromApiBase(apiBase));
@@ -71,7 +87,11 @@ function deriveFrontendFromApiBase(apiBase: string): string {
  * Web (dashboard) URL for a project. Prefers the server-provided `dashboardUrl`
  * (authoritative) and only falls back to {@link webDashboardUrl} when absent.
  */
-export function projectWebUrl(apiBase: string, projectId: string, dashboardUrl?: string | null): string {
+export function projectWebUrl(
+  apiBase: string,
+  projectId: string,
+  dashboardUrl?: string | null,
+): string {
   if (dashboardUrl && dashboardUrl.trim()) return stripTrailingSlash(dashboardUrl.trim());
   return `${webDashboardUrl(apiBase)}/projects/${projectId}`;
 }

--- a/apps/web/src/components/iam/github-app-setup-card.tsx
+++ b/apps/web/src/components/iam/github-app-setup-card.tsx
@@ -209,9 +209,29 @@ export function GitHubAppSetupCard({ canManage }: GitHubAppSetupCardProps) {
     );
   }
 
-  // Non-fatal: a hiccup here just hides this card rather than blocking the
-  // whole Git tab.
-  if (statusQuery.isError || !statusQuery.data) return null;
+  // NEVER render a blank Git tab. A 403 means the signed-in user isn't a
+  // platform admin (KORTIX_PLATFORM_ADMIN_EMAILS on self-host) — say so
+  // instead of silently hiding the only content in the pane. Any other error
+  // gets a visible, retryable state.
+  if (statusQuery.isError || !statusQuery.data) {
+    const status = (statusQuery.error as { status?: number } | null)?.status;
+    const forbidden = status === 403;
+    return (
+      <div className="space-y-2">
+        <p className="text-foreground text-sm font-medium">Managed GitHub</p>
+        <p className="text-muted-foreground text-sm">
+          {forbidden
+            ? 'Only a platform admin can view or configure the GitHub connection for this server. Ask your operator to add your email to KORTIX_PLATFORM_ADMIN_EMAILS.'
+            : 'Could not load the GitHub connection status.'}
+        </p>
+        {!forbidden ? (
+          <Button variant="outline" size="sm" onClick={() => statusQuery.refetch()}>
+            Retry
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
 
   const status: GitHubAppStatus = statusQuery.data;
   const showSetup = !status.configured || reconfiguring;

--- a/apps/web/src/features/marketplace/add-to-project-modal.tsx
+++ b/apps/web/src/features/marketplace/add-to-project-modal.tsx
@@ -2,8 +2,8 @@
 
 import { KeyRound, Plug, Wrench } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState, type FormEvent } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -33,12 +33,16 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { errorToast } from '@/components/ui/toast';
+import {
+  GitHubSetupRequiredPanel,
+  isAccountGitAdmin,
+} from '@/features/projects/modal/github-setup-required-panel';
 import { startTemplateSetupSession } from '@/features/projects/modal/template-setup-session';
 import { useInstallMarketplaceItemAsSession } from '@/hooks/marketplace';
 import { isManagedGitUnavailableError } from '@/lib/onboarding/ensure-first-project';
 import type { MarketplaceItem, MarketplaceItemDetail } from '@/lib/marketplace-client';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { listAccounts, provisionProject } from '@kortix/sdk/projects-client';
+import { getManagedGitStatus, listAccounts, provisionProject } from '@kortix/sdk/projects-client';
 import { capabilityCount, hasCapabilities } from './marketplace-install';
 import { useProjectPicker } from './marketplace-project-picker';
 
@@ -80,6 +84,33 @@ export function AddToProjectModal({
   const [busy, setBusy] = useState(false);
 
   const installSession = useInstallMarketplaceItemAsSession();
+
+  // Pre-check managed git the same way the New Project modal does — self-host
+  // with nothing configured should route to Git settings instead of letting
+  // the "new project" target hit the provision 503 first.
+  const accountsQuery = useQuery({
+    queryKey: ['accounts'],
+    queryFn: listAccounts,
+    staleTime: 60_000,
+    enabled: open && target === NEW_PROJECT,
+  });
+  // No `personal_account` flag on this API — the bootstrapped personal
+  // account is the one where the caller is the primary owner. Mirrors the
+  // resolution in `onConfirm` below.
+  const candidateAccount = useMemo(() => {
+    const accounts = accountsQuery.data ?? [];
+    return accounts.find((a) => a.is_primary_owner) ?? accounts[0] ?? null;
+  }, [accountsQuery.data]);
+  const isGitAdmin = isAccountGitAdmin(candidateAccount?.account_role);
+
+  const managedGitStatusQuery = useQuery({
+    queryKey: ['managed-git-status'],
+    queryFn: getManagedGitStatus,
+    staleTime: 10_000,
+    enabled: open && target === NEW_PROJECT,
+  });
+  const managedGitUnavailable =
+    target === NEW_PROJECT && managedGitStatusQuery.data?.configured === false;
 
   // Reset to sensible defaults each time the modal opens for a (possibly new) item.
   useEffect(() => {
@@ -176,7 +207,8 @@ export function AddToProjectModal({
   };
 
   const confirmDisabled =
-    busy || (target === NEW_PROJECT && newProjectName.trim().length === 0);
+    busy ||
+    (target === NEW_PROJECT && (managedGitUnavailable || newProjectName.trim().length === 0));
 
   return (
     <Modal open={open} onOpenChange={guardedOpenChange}>
@@ -207,7 +239,14 @@ export function AddToProjectModal({
                 </Select>
               </Field>
 
-              {target === NEW_PROJECT && (
+              {target === NEW_PROJECT && managedGitUnavailable ? (
+                <GitHubSetupRequiredPanel
+                  accountId={candidateAccount?.account_id ?? null}
+                  isAdmin={isGitAdmin}
+                  onNavigate={() => onOpenChange(false)}
+                  size="sm"
+                />
+              ) : target === NEW_PROJECT ? (
                 <Field className="gap-1.5">
                   <FieldLabel htmlFor="mp-new-project-name">Name</FieldLabel>
                   <Input
@@ -219,7 +258,7 @@ export function AddToProjectModal({
                     autoCorrect="off"
                   />
                 </Field>
-              )}
+              ) : null}
 
               {item.dependencies.length > 0 && (
                 <FieldDescription>

--- a/apps/web/src/features/projects/modal/github-setup-required-panel.test.ts
+++ b/apps/web/src/features/projects/modal/github-setup-required-panel.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isAccountGitAdmin } from './github-setup-required-panel';
+
+describe('isAccountGitAdmin', () => {
+  test('owner can manage Git settings', () => {
+    expect(isAccountGitAdmin('owner')).toBe(true);
+  });
+
+  test('admin can manage Git settings', () => {
+    expect(isAccountGitAdmin('admin')).toBe(true);
+  });
+
+  test('a plain member cannot', () => {
+    expect(isAccountGitAdmin('member')).toBe(false);
+  });
+
+  test('an unresolved role is treated as non-admin', () => {
+    expect(isAccountGitAdmin(undefined)).toBe(false);
+    expect(isAccountGitAdmin(null)).toBe(false);
+  });
+});

--- a/apps/web/src/features/projects/modal/github-setup-required-panel.tsx
+++ b/apps/web/src/features/projects/modal/github-setup-required-panel.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+// Shared "GitHub isn't connected yet" panel — shown in place of the
+// create/import UI whenever there's no usable managed git on this server
+// (self-host with no GitHub App or PAT configured yet). Routes the user to
+// the account's Git settings tab instead of the cloud-only "Connect the
+// Kortix GitHub App" install card, which only makes sense on the hosted
+// deployment (there's no hosted Kortix App to install on self-host).
+
+import { Github } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/features/layout/section/empty-state';
+
+/** Owner/admin of the account can fix a missing GitHub connection
+ *  themselves (via the account's Git settings); anyone else can only ask.
+ *  Copy-only signal — the settings page itself is what actually enforces
+ *  authorization, so this never needs to be a hard permission check. */
+export function isAccountGitAdmin(accountRole: string | null | undefined): boolean {
+  return accountRole === 'owner' || accountRole === 'admin';
+}
+
+interface GitHubSetupRequiredPanelProps {
+  /** Account to send the user to Git settings for. Disables the button when
+   *  unresolved rather than guessing a target. */
+  accountId: string | null;
+  /** Owner/admin of the account → they can fix this themselves. Anyone else
+   *  can only ask — the settings page itself enforces authorization, so this
+   *  is just copy, not a permission check. */
+  isAdmin: boolean;
+  /** Called right before navigating (e.g. close the hosting modal). */
+  onNavigate?: () => void;
+  secondaryAction?: ReactNode;
+  size?: 'sm' | 'default';
+}
+
+export function GitHubSetupRequiredPanel({
+  accountId,
+  isAdmin,
+  onNavigate,
+  secondaryAction,
+  size = 'default',
+}: GitHubSetupRequiredPanelProps) {
+  const router = useRouter();
+
+  return (
+    <EmptyState
+      icon={Github}
+      size={size}
+      title="GitHub isn't connected on this server yet"
+      description={
+        isAdmin
+          ? "Every Kortix project is a git repository. Connect GitHub once in this account's Git settings."
+          : "Every Kortix project is a git repository. Ask your admin to connect GitHub in this account's Git settings."
+      }
+      action={
+        <Button
+          type="button"
+          size="sm"
+          className="gap-1.5"
+          disabled={!accountId}
+          onClick={() => {
+            onNavigate?.();
+            if (accountId) router.push(`/accounts/${accountId}?tab=git`);
+          }}
+        >
+          <Github className="size-4" />
+          Set up GitHub
+        </Button>
+      }
+      secondaryAction={secondaryAction}
+    />
+  );
+}

--- a/apps/web/src/features/projects/modal/project-create-modal.tsx
+++ b/apps/web/src/features/projects/modal/project-create-modal.tsx
@@ -24,7 +24,6 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -78,6 +77,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
 import { resolveCreateAccountSelection } from './create-account-selection';
+import { GitHubSetupRequiredPanel, isAccountGitAdmin } from './github-setup-required-panel';
 import {
   startProjectOnboardingSession,
   startTemplateSetupSession,
@@ -176,7 +176,7 @@ export const ProjectCreateModal = ({
   const managedGitStatusQuery = useQuery({
     queryKey: ['managed-git-status'],
     queryFn: getManagedGitStatus,
-    staleTime: 60_000,
+    staleTime: 10_000,
     enabled: open,
   });
   const managedGitUnavailable = managedGitStatusQuery.data?.configured === false;
@@ -185,6 +185,7 @@ export const ProjectCreateModal = ({
     [accountsQuery.data, accountId, pickedAccountId],
   );
   const effectiveAccountId = accountSelection.effectiveAccountId;
+  const isGitAdmin = isAccountGitAdmin(accountSelection.currentAccount?.account_role);
 
   const managedForm = useForm<ManagedProjectFormValues>({
     resolver: zodResolver(managedProjectSchema),
@@ -505,7 +506,32 @@ export const ProjectCreateModal = ({
           />
         ) : null}
 
-        {mode === 'template' ? (
+        {mode !== 'github' && managedGitUnavailable ? (
+          <>
+            <ModalBody>
+              <GitHubSetupRequiredPanel
+                accountId={effectiveAccountId}
+                isAdmin={isGitAdmin}
+                onNavigate={resetAndClose}
+                secondaryAction={
+                  <Button type="button" variant="ghost" size="sm" onClick={switchToGitHubMode}>
+                    Import an existing repo
+                  </Button>
+                }
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                type="button"
+                variant="outline-ghost"
+                className="w-full sm:w-auto"
+                onClick={resetAndClose}
+              >
+                Cancel
+              </Button>
+            </ModalFooter>
+          </>
+        ) : mode === 'template' ? (
           <TemplatePicker
             templates={templates}
             loading={templatesQuery.isLoading}
@@ -541,20 +567,6 @@ export const ProjectCreateModal = ({
                       </FormItem>
                     )}
                   />
-
-                  {managedGitUnavailable ? (
-                    <InfoBanner tone="warning" title="Managed git isn't set up on this server">
-                      Ask your admin to configure GitHub, or{' '}
-                      <button
-                        type="button"
-                        className="underline underline-offset-2"
-                        onClick={switchToGitHubMode}
-                      >
-                        import an existing GitHub repo
-                      </button>{' '}
-                      instead.
-                    </InfoBanner>
-                  ) : null}
 
                   {cloningFromSource ? (
                     <div className="divide-border/60 overflow-hidden rounded-2xl border divide-y">
@@ -614,9 +626,8 @@ export const ProjectCreateModal = ({
                         variant="ghost"
                         size="sm"
                         className="gap-1.5"
-                        disabled={submitting || managedGitUnavailable}
+                        disabled={submitting}
                         onClick={switchToTemplateMode}
-                        title={managedGitUnavailable ? "Managed git isn't set up on this server" : undefined}
                       >
                         <Boxes className="size-4" />
                         Clone from a template
@@ -642,7 +653,7 @@ export const ProjectCreateModal = ({
                 <Button
                   type="submit"
                   className="w-full sm:w-auto"
-                  disabled={submitting || !effectiveAccountId || managedGitUnavailable}
+                  disabled={submitting || !effectiveAccountId}
                 >
                   {submitting ? <Loading /> : <Icon.Plus />}
                   {tHardcodedUi.raw(
@@ -665,38 +676,51 @@ export const ProjectCreateModal = ({
                       )}
                     </div>
                   ) : githubInstallations.length === 0 ? (
-                    <Item variant="outline" className={cn('items-start')}>
-                      <ItemMedia variant="icon" className="rounded-full bg-transparent">
-                        <Icon.Github />
-                      </ItemMedia>
-                      <ItemContent>
-                        <ItemTitle>
-                          {tHardcodedUi.raw(
-                            'componentsProjectsProjectCreateModal.line362JsxAttrTitleConnectTheKortixGithubApp',
-                          )}
-                        </ItemTitle>
-                        <ItemDescription>
-                          {tHardcodedUi.raw(
-                            'componentsProjectsProjectCreateModal.line383JsxTextKortixUsesTheGithubAppToListRepositories',
-                          )}
-                        </ItemDescription>
-                      </ItemContent>
-                      <ItemActions>
-                        <Button
-                          type="button"
-                          size="sm"
-                          className="gap-1.5"
-                          disabled={
-                            isConnectingGitHub ||
-                            (!installUrl && githubInstallationsQuery.isFetching)
-                          }
-                          onClick={handleConnectGitHub}
-                        >
-                          {isConnectingGitHub ? <Loading /> : <Icon.Github />}
-                          {isConnectingGitHub ? 'Connecting' : 'Connect'}
-                        </Button>
-                      </ItemActions>
-                    </Item>
+                    githubInstallationsQuery.data?.configured === false ? (
+                      // No GitHub App exists at all on this server (self-host
+                      // with only a PAT, or nothing, configured) — the "install
+                      // this App" card below has nothing to install. Route to
+                      // Git settings instead of a dead-end Connect button.
+                      <GitHubSetupRequiredPanel
+                        accountId={effectiveAccountId}
+                        isAdmin={isGitAdmin}
+                        onNavigate={resetAndClose}
+                        size="sm"
+                      />
+                    ) : (
+                      <Item variant="outline" className={cn('items-start')}>
+                        <ItemMedia variant="icon" className="rounded-full bg-transparent">
+                          <Icon.Github />
+                        </ItemMedia>
+                        <ItemContent>
+                          <ItemTitle>
+                            {tHardcodedUi.raw(
+                              'componentsProjectsProjectCreateModal.line362JsxAttrTitleConnectTheKortixGithubApp',
+                            )}
+                          </ItemTitle>
+                          <ItemDescription>
+                            {tHardcodedUi.raw(
+                              'componentsProjectsProjectCreateModal.line383JsxTextKortixUsesTheGithubAppToListRepositories',
+                            )}
+                          </ItemDescription>
+                        </ItemContent>
+                        <ItemActions>
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="gap-1.5"
+                            disabled={
+                              isConnectingGitHub ||
+                              (!installUrl && githubInstallationsQuery.isFetching)
+                            }
+                            onClick={handleConnectGitHub}
+                          >
+                            {isConnectingGitHub ? <Loading /> : <Icon.Github />}
+                            {isConnectingGitHub ? 'Connecting' : 'Connect'}
+                          </Button>
+                        </ItemActions>
+                      </Item>
+                    )
                   ) : (
                     <>
                       <FormField

--- a/deployments/vpc-demo/backend.tf
+++ b/deployments/vpc-demo/backend.tf
@@ -1,0 +1,8 @@
+# Local state on purpose — this is a single demo box, not a shared Kortix
+# environment. State lives at deployments/vpc-demo/terraform.tfstate (gitignored,
+# never commit it). See main.tf's header comment for the migrate-to-S3 note.
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}

--- a/deployments/vpc-demo/main.tf
+++ b/deployments/vpc-demo/main.tf
@@ -1,0 +1,59 @@
+# deployments/vpc-demo — the live vpc-demo.kortix.com demo box, provisioned by
+# infra/terraform/modules/selfhost-ec2 (the same module kortix-selfhost/
+# ships). This replaces a hand-deployed EC2 box (i-033713da5cc388b75) with a
+# Terraform-managed one — see the git log / PR description for the migration
+# notes.
+#
+# State is LOCAL (backend.tf) — this is a single demo box, not a shared
+# environment; state lives at deployments/vpc-demo/terraform.tfstate on
+# whichever machine ran `apply` and is gitignored (never commit it). If this
+# needs to become a team-shared environment later, move it to the standard
+# kortix-terraform-state S3 backend used by infra/terraform/environments/*.
+#
+#   cd deployments/vpc-demo
+#   cp terraform.tfvars.example terraform.tfvars   # already filled in for this deploy
+#   terraform init
+#   terraform apply
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "vpc_demo" {
+  source = "../../infra/terraform/modules/selfhost-ec2"
+
+  name        = "vpc-demo-selfhost"
+  domain      = var.domain
+  zone_id     = var.route53_zone_id
+  admin_email = var.admin_email
+
+  instance_type = var.instance_type
+  vpc_id        = var.vpc_id
+  subnet_id     = var.subnet_id
+
+  data_volume_size_gb    = var.data_volume_size_gb
+  backup_interval_hours  = var.backup_interval_hours
+  backup_retention_count = var.backup_retention_count
+
+  kortix_channel     = var.kortix_channel
+  kortix_version     = var.kortix_version
+  kortix_cli_channel = var.kortix_cli_channel
+  auto_update        = var.auto_update
+
+  tags = {
+    Project        = "kortix-selfhost"
+    Environment    = "demo"
+    KortixInstance = "vpc-demo"
+    ManagedBy      = "terraform"
+  }
+}

--- a/deployments/vpc-demo/outputs.tf
+++ b/deployments/vpc-demo/outputs.tf
@@ -1,0 +1,27 @@
+output "public_ip" {
+  value = module.vpc_demo.public_ip
+}
+
+output "instance_id" {
+  value = module.vpc_demo.instance_id
+}
+
+output "data_volume_id" {
+  value = module.vpc_demo.data_volume_id
+}
+
+output "dashboard_url" {
+  value = module.vpc_demo.dashboard_url
+}
+
+output "api_url" {
+  value = module.vpc_demo.api_url
+}
+
+output "ssm_connect_command" {
+  value = module.vpc_demo.ssm_connect_command
+}
+
+output "post_apply_next_steps" {
+  value = module.vpc_demo.post_apply_next_steps
+}

--- a/deployments/vpc-demo/terraform.tfvars.example
+++ b/deployments/vpc-demo/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# The live vpc-demo deployment uses the defaults baked into variables.tf
+# (domain, zone_id, admin_email, selfhost-rc tag, dev CLI channel, daily
+# backups retaining 10) — this file exists for parity with the other
+# terraform roots and as a template if this ever needs re-applying from a
+# clean checkout. No secrets here: DAYTONA_API_KEY etc. are set post-apply via
+# `kortix self-host secrets set` over SSM, never as Terraform inputs.
+
+aws_region      = "us-east-1"
+domain          = "vpc-demo.kortix.com"
+route53_zone_id = "Z08967081WIACA6008WUL"
+admin_email     = "marko@kortix.ai"

--- a/deployments/vpc-demo/variables.tf
+++ b/deployments/vpc-demo/variables.tf
@@ -42,9 +42,9 @@ variable "data_volume_size_gb" {
 }
 
 variable "backup_interval_hours" {
-  description = "Snapshot interval in hours. Daily (24) per the reviewed self-host default — stability over frequency."
+  description = "Snapshot interval in hours. 6 for the demo box — exercises the sub-daily DLM path (four snapshots a day)."
   type        = number
-  default     = 24
+  default     = 6
 }
 
 variable "backup_retention_count" {

--- a/deployments/vpc-demo/variables.tf
+++ b/deployments/vpc-demo/variables.tf
@@ -1,0 +1,75 @@
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "domain" {
+  type    = string
+  default = "vpc-demo.kortix.com"
+}
+
+variable "route53_zone_id" {
+  description = "Route53 hosted zone ID for vpc-demo.kortix.com (a delegated subdomain zone, not the parent kortix.com zone)."
+  type        = string
+  default     = "Z08967081WIACA6008WUL"
+}
+
+variable "admin_email" {
+  type    = string
+  default = "marko@kortix.ai"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.xlarge"
+}
+
+variable "vpc_id" {
+  description = "Reuses the same VPC the hand-deployed box lived in — this account/region has no default VPC."
+  type        = string
+  default     = "vpc-033fc5547c2e48a19"
+}
+
+variable "subnet_id" {
+  description = "Reuses the same public subnet (routes to an IGW; MapPublicIpOnLaunch is false but irrelevant since the module associates an Elastic IP explicitly)."
+  type        = string
+  default     = "subnet-07a9e5c368353971b"
+}
+
+variable "data_volume_size_gb" {
+  type    = number
+  default = 100
+}
+
+variable "backup_interval_hours" {
+  description = "Snapshot interval in hours. Daily (24) per the reviewed self-host default — stability over frequency."
+  type        = number
+  default     = 24
+}
+
+variable "backup_retention_count" {
+  type    = number
+  default = 10
+}
+
+variable "kortix_channel" {
+  type    = string
+  default = "stable"
+}
+
+variable "kortix_version" {
+  description = "Exact app image tag to pin (kortix self-host init --tag). selfhost-rc is the release-candidate build for the generic self-host system this deployment exercises."
+  type        = string
+  default     = "selfhost-rc"
+}
+
+variable "kortix_cli_channel" {
+  description = "prod|dev — which kortix CLI build the installer fetches. \"dev\" because the generic self-host CLI flags this module relies on (--admin-email, --single-account, --tag on init, etc.) merged to main after the last tagged vX.Y.Z release (v0.9.108) — the prod CLI doesn't have them yet."
+  type        = string
+  default     = "dev"
+}
+
+variable "auto_update" {
+  type    = string
+  default = "on"
+}

--- a/docs/runbooks/self-hosting.md
+++ b/docs/runbooks/self-hosting.md
@@ -195,8 +195,10 @@ If you'd rather provision the box declaratively than run a script by hand,
 `infra/terraform/modules/selfhost-ec2` is a **thin, optional convenience
 provisioner** — it is not a different deployment system. Terraform creates the
 EC2 instance, a separate encrypted EBS data volume, a security group (80/443),
-an Elastic IP, optional Route53 records, and a daily-snapshot policy for the
-data volume, then cloud-init runs the *exact same* `kortix self-host init` /
+an Elastic IP, optional Route53 records, and a configurable-schedule snapshot
+policy for the data volume (`backup_interval_hours` / `backup_retention_count`
+— every 24h/7 kept by default, but e.g. every 6h/10 kept works too), then
+cloud-init runs the *exact same* `kortix self-host init` /
 `kortix self-host start` described above. After `apply` finishes, the
 in-compose auto-updater — not Terraform — is what keeps the app current;
 re-running `terraform apply` never redeploys it. Secrets (the Daytona key,

--- a/docs/runbooks/self-hosting.md
+++ b/docs/runbooks/self-hosting.md
@@ -189,6 +189,38 @@ kortix self-host env set DAYTONA_API_KEY=... MANAGED_GIT_GITHUB_TOKEN=... MANAGE
 kortix self-host start           # re-applies env + restarts affected services
 ```
 
+### Provisioning a VPS with Terraform (optional)
+
+If you'd rather provision the box declaratively than run a script by hand,
+`infra/terraform/modules/selfhost-ec2` is a **thin, optional convenience
+provisioner** — it is not a different deployment system. Terraform creates the
+EC2 instance, a separate encrypted EBS data volume, a security group (80/443),
+an Elastic IP, optional Route53 records, and a daily-snapshot policy for the
+data volume, then cloud-init runs the *exact same* `kortix self-host init` /
+`kortix self-host start` described above. After `apply` finishes, the
+in-compose auto-updater — not Terraform — is what keeps the app current;
+re-running `terraform apply` never redeploys it. Secrets (the Daytona key,
+managed git, SMTP, ...) are deliberately not Terraform inputs; the module's
+`post_apply_next_steps` output tells you how to set them (SSM in, `kortix
+self-host configure`, or the dashboard) once the box is up.
+
+```hcl
+module "kortix_selfhost" {
+  source = "github.com/kortix-ai/suna//infra/terraform/modules/selfhost-ec2"
+
+  domain = "kortix.example.com"
+  tags   = { Project = "kortix-selfhost" }
+}
+```
+
+See `infra/terraform/examples/selfhost-ec2` for a runnable root module and
+`infra/terraform/modules/selfhost-ec2/README.md` for the full variable/output
+reference — including why the data volume is mounted the way it is (Postgres
+is a bind mount under the CLI's instance directory, not a Docker named volume,
+so the module points `KORTIX_SELF_HOST_CONFIG_DIR` at the EBS volume rather
+than just bind-mounting `/var/lib/docker`) and how an instance can be replaced
+without losing data (daily EBS snapshots + `delete_on_termination = false`).
+
 ### Evaluating on a laptop (not for production)
 
 This path is for kicking the tyres on your own machine — it is **not**

--- a/docs/runbooks/self-hosting.md
+++ b/docs/runbooks/self-hosting.md
@@ -271,6 +271,48 @@ image tag), `--channel stable|latest`, `--auto-update on|off`,
 
 Full reference: [`/docs/reference/cli#self-host`](../../apps/web/content/docs/reference/cli.mdx).
 
+## Using the main `kortix` CLI against your self-host
+
+`kortix self-host …` only manages the Compose stack itself. Everything else —
+`login`, `whoami`, `projects`, `ship`, `sessions`, … — is the same CLI you'd
+point at Kortix Cloud, just aimed at your own instance via the built-in
+`selfhost` host:
+
+```sh
+kortix hosts use selfhost   # switch the CLI's active host to your self-host stack
+kortix login                # browser-based approval, same flow as Cloud
+kortix whoami                # confirm identity + active account/project
+kortix projects ls
+cd your-project && kortix ship   # first ship creates the project + repo; every ship after just syncs
+```
+
+`kortix self-host init`/`start` register the `selfhost` host for you —
+pointed at `API_PUBLIC_URL` (the API) with `PUBLIC_URL` (the dashboard)
+stamped alongside it as `dashboard_url`, so `kortix login`'s browser flow
+opens the right origin. That matters because the CLI has no other way to
+learn your dashboard's URL from the API URL alone: it normally *derives* one
+from the API URL's shape (`api.<domain>` → `<domain>`, or the `pnpm dev`
+pairing `:8008` → `:3000`), which is right for a domain deployment
+(`https://api.<domain>` → `https://<domain>`) but **wrong** for the laptop
+default (API `:13738`, dashboard `:13737` — not `:3000`) or any custom port.
+If you ever add the host by hand instead of through `kortix self-host`
+(pointing the CLI at a self-host instance from a *different* machine, for
+example) and `kortix login` opens a dead-looking `:3000`, pass the dashboard
+URL explicitly:
+
+```sh
+kortix hosts add selfhost --url http://localhost:13738 --dashboard-url http://localhost:13737   # laptop
+kortix hosts add selfhost --url https://api.kortix.example.com --dashboard-url https://kortix.example.com   # domain
+```
+
+**`kortix ship`** needs a git backend to push to — either an existing GitHub
+remote (via the GitHub App or `--github-token`, both set up in the dashboard
+under **Settings → Git**, see step 4 of the quickstart) or no origin at all
+(ship then creates a managed Kortix-hosted repo, no GitHub needed). If
+managed git isn't configured yet, `ship -n` (dry-run) still validates
+`kortix.yaml`, resolves the target project, and shows the push plan without
+needing it.
+
 ## The auto-updater + channels
 
 Every instance always has a `kortix-updater` service in its Compose file (an

--- a/infra/terraform/examples/selfhost-ec2/backend.tf
+++ b/infra/terraform/examples/selfhost-ec2/backend.tf
@@ -1,0 +1,9 @@
+# Local state on purpose: this is a customer-facing example, not a Kortix-run
+# environment (unlike environments/*, which use the shared kortix-terraform-state
+# S3 backend). Point this at your own backend (S3, Terraform Cloud, ...) for
+# real use — see https://developer.hashicorp.com/terraform/language/backend.
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}

--- a/infra/terraform/examples/selfhost-ec2/main.tf
+++ b/infra/terraform/examples/selfhost-ec2/main.tf
@@ -34,11 +34,12 @@ module "kortix_selfhost" {
   zone_id = var.route53_zone_id
 
   # Everything below is optional — shown at its default for discoverability.
-  instance_type           = "t3.xlarge"
-  data_volume_size_gb     = 100
-  snapshot_retention_days = 7
-  kortix_channel          = "stable"
-  auto_update             = "on"
+  instance_type          = "t3.xlarge"
+  data_volume_size_gb    = 100
+  backup_interval_hours  = 24
+  backup_retention_count = 7
+  kortix_channel         = "stable"
+  auto_update            = "on"
 
   tags = {
     Project     = "kortix-selfhost"

--- a/infra/terraform/examples/selfhost-ec2/main.tf
+++ b/infra/terraform/examples/selfhost-ec2/main.tf
@@ -1,0 +1,47 @@
+# Example root module: a single self-hosted Kortix VPS on EC2.
+#
+# This is a THIN convenience wrapper — it provisions the box once via
+# modules/selfhost-ec2, which runs the exact same `kortix self-host init` /
+# `start` any self-host user runs by hand. It is NOT a parallel deployment
+# system: after `terraform apply` finishes, the in-compose auto-updater keeps
+# the app current, not Terraform.
+#
+#   cd infra/terraform/examples/selfhost-ec2
+#   terraform init
+#   terraform apply -var domain=kortix.example.com
+#
+# Secrets (sandbox provider key, managed git, SMTP, ...) are NOT Terraform
+# inputs — see the post_apply_next_steps output after apply.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "kortix_selfhost" {
+  source = "../../modules/selfhost-ec2"
+
+  domain  = var.domain
+  zone_id = var.route53_zone_id
+
+  # Everything below is optional — shown at its default for discoverability.
+  instance_type           = "t3.xlarge"
+  data_volume_size_gb     = 100
+  snapshot_retention_days = 7
+  kortix_channel          = "stable"
+  auto_update             = "on"
+
+  tags = {
+    Project     = "kortix-selfhost"
+    Environment = "example"
+  }
+}

--- a/infra/terraform/examples/selfhost-ec2/outputs.tf
+++ b/infra/terraform/examples/selfhost-ec2/outputs.tf
@@ -1,0 +1,19 @@
+output "public_ip" {
+  value = module.kortix_selfhost.public_ip
+}
+
+output "dashboard_url" {
+  value = module.kortix_selfhost.dashboard_url
+}
+
+output "api_url" {
+  value = module.kortix_selfhost.api_url
+}
+
+output "ssm_connect_command" {
+  value = module.kortix_selfhost.ssm_connect_command
+}
+
+output "post_apply_next_steps" {
+  value = module.kortix_selfhost.post_apply_next_steps
+}

--- a/infra/terraform/examples/selfhost-ec2/terraform.tfvars.example
+++ b/infra/terraform/examples/selfhost-ec2/terraform.tfvars.example
@@ -1,0 +1,5 @@
+aws_region = "us-west-2"
+domain     = "kortix.example.com"
+
+# Optional — leave unset to manage DNS yourself (see the public_ip output).
+# route53_zone_id = "Z0123456789ABCDEFGHIJ"

--- a/infra/terraform/examples/selfhost-ec2/variables.tf
+++ b/infra/terraform/examples/selfhost-ec2/variables.tf
@@ -1,0 +1,16 @@
+variable "aws_region" {
+  description = "AWS region to provision the box in."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "domain" {
+  description = "Public domain to run this instance on (DNS must point here — see the module README for the no-Route53 path)."
+  type        = string
+}
+
+variable "route53_zone_id" {
+  description = "Optional Route53 hosted zone ID for var.domain. Leave empty to manage DNS yourself (the module still outputs the Elastic IP to point at)."
+  type        = string
+  default     = ""
+}

--- a/infra/terraform/modules/selfhost-ec2/README.md
+++ b/infra/terraform/modules/selfhost-ec2/README.md
@@ -1,0 +1,102 @@
+# selfhost-ec2 — a thin, optional provisioner for `kortix self-host`
+
+**This is convenience sugar over the generic Docker self-host, not a parallel
+deployment system.** Terraform provisions a single EC2 box exactly once —
+instance, a durable data volume, a security group, an Elastic IP, optional
+Route53 records, and daily snapshots — then cloud-init runs the *exact same*
+`kortix self-host init` / `kortix self-host start` any self-host user runs by
+hand (see `scripts/kortix-selfhost-up.sh` and
+`docs/runbooks/self-hosting.md`). After that, the box keeps itself current via
+the in-compose nightly `kortix-updater` service. **Re-running `terraform
+apply` does not redeploy the app** — there is no Terraform-side update
+mechanism to keep in sync with the updater, on purpose.
+
+## What it creates
+
+- **EC2 instance** (`t3.xlarge` by default) on Ubuntu 24.04 LTS, resolved via
+  the public Canonical SSM parameter (or pin `ami_id`). IMDSv2 required, EBS
+  optimized, an IAM instance profile with `AmazonSSMManagedInstanceCore`
+  (connect with `aws ssm start-session`, no SSH key or open port needed).
+- **A separate EBS data volume** (`data_volume_size_gb`, default 100GB, gp3,
+  encrypted, `delete_on_termination = false`) holding **all** durable
+  self-host state — Docker's own data-root (images, containers, the
+  updater/Caddy named volumes) *and* the kortix CLI's instance directory
+  (`KORTIX_SELF_HOST_CONFIG_DIR`), which is where the CLI persists Postgres
+  and Supabase Storage as bind mounts. That's why this module doesn't just
+  bind-mount `/var/lib/docker`: Postgres data lives under
+  `<instance-dir>/volumes/db/data`, not inside Docker's volume store, so
+  losing track of `KORTIX_SELF_HOST_CONFIG_DIR` would silently lose the
+  database on instance replacement. See `templates/user-data.sh.tftpl`.
+- **Security group**: 80 (ACME HTTP-01) + 443 in from `allowed_cidrs`
+  (`0.0.0.0/0` by default — restrict it), all egress. SSH stays closed unless
+  you set `ssh_ingress_cidrs` (and `key_name`).
+- **Elastic IP** (stable across instance replacement) + optional **Route53 A
+  records** for `var.domain` and the API hostname when `zone_id` is set;
+  otherwise point your own DNS at the `public_ip` output.
+- **Daily EBS snapshots** of the data volume (`aws_dlm_lifecycle_policy`,
+  `snapshot_retention_days` days retained, default 7).
+
+## What it deliberately does NOT do
+
+- **No secrets.** `DAYTONA_API_KEY`, managed-git tokens, SMTP, etc. are not
+  Terraform inputs — cloud-init runs `kortix self-host init
+  --allow-missing-secrets` so the box comes up without them, and the
+  `post_apply_next_steps` output tells you how to set them afterward (SSM in,
+  `kortix self-host configure`, or the dashboard).
+- **No ongoing reconciliation.** The in-compose `kortix-updater` (already part
+  of every self-host stack) is what keeps images current on the configured
+  channel — Terraform never touches the running app again after the first
+  boot.
+- **No custom VPC/networking stack.** Bring your own (`vpc_id` / `subnet_id`),
+  or leave both empty to use the account's default VPC/subnet — this module
+  is meant to be genuinely thin, not a rebuild of `modules/network`.
+
+## Usage
+
+See `infra/terraform/examples/selfhost-ec2` for a complete root module. Minimal:
+
+```hcl
+module "kortix_selfhost" {
+  source = "../../modules/selfhost-ec2"
+
+  domain = "kortix.example.com"
+  tags   = { Project = "kortix-selfhost" }
+}
+
+output "next_steps" {
+  value = module.kortix_selfhost.post_apply_next_steps
+}
+```
+
+## Inputs of note
+
+- `domain` (required) — public domain; `KORTIX_API_DOMAIN` defaults to
+  `api.<domain>` (override with `api_domain`).
+- `instance_type` (default `t3.xlarge`), `ami_id` / `ami_ssm_parameter`,
+  `key_name` (optional — SSM works without it), `vpc_id` / `subnet_id`
+  (optional — default VPC/subnet otherwise).
+- `allowed_cidrs` (80/443 ingress), `ssh_ingress_cidrs` (opt-in only).
+- `data_volume_size_gb` (default 100), `data_volume_kms_key_id` (optional CMK).
+- `snapshot_retention_days` (default 7), `snapshot_time`.
+- `zone_id` (optional Route53 zone), `api_domain`, `dns_ttl`.
+- `instance_name` (the `kortix self-host --instance` name), `kortix_channel`
+  (`stable`/`latest`), `kortix_version` (pin an exact tag instead),
+  `auto_update` (`on`/`off`), `single_account_mode`, `admin_email`,
+  `acme_email`.
+
+## Outputs
+
+`public_ip`, `instance_id`, `data_volume_id`, `dashboard_url`, `api_url`,
+`dns_managed_by_terraform`, `ssm_connect_command`, `post_apply_next_steps`
+(what to do next — secrets, dashboard, updates).
+
+## Replacing the instance without losing data
+
+The data volume (`aws_ebs_volume.data`) has `delete_on_termination = false`
+and is attached via a separate `aws_volume_attachment` resource — destroying
+or replacing `aws_instance.this` (a new AMI, instance type, etc.) does not
+destroy it. On the new instance, cloud-init runs again, detects the volume
+already has a filesystem (skips `mkfs`), mounts it at the same path, and
+`kortix self-host init`/`start` find the existing instance directory (same
+`KORTIX_SELF_HOST_CONFIG_DIR`) and reconcile against it rather than creating a
+fresh one.

--- a/infra/terraform/modules/selfhost-ec2/README.md
+++ b/infra/terraform/modules/selfhost-ec2/README.md
@@ -31,7 +31,9 @@ mechanism to keep in sync with the updater, on purpose.
   (`0.0.0.0/0` by default — restrict it), all egress. SSH stays closed unless
   you set `ssh_ingress_cidrs` (and `key_name`).
 - **Elastic IP** (stable across instance replacement) + optional **Route53 A
-  records** for `var.domain` and the API hostname when `zone_id` is set;
+  records** for `var.domain` and the API hostname when `zone_id` is set
+  (`allow_overwrite = true`, so this cleanly takes over a zone that already
+  has an A record under these names — e.g. replacing a hand-deployed box);
   otherwise point your own DNS at the `public_ip` output.
 - **EBS snapshots** of the data volume (`aws_dlm_lifecycle_policy`) on a
   configurable schedule — `backup_interval_hours` (default 24, i.e. once

--- a/infra/terraform/modules/selfhost-ec2/README.md
+++ b/infra/terraform/modules/selfhost-ec2/README.md
@@ -33,8 +33,11 @@ mechanism to keep in sync with the updater, on purpose.
 - **Elastic IP** (stable across instance replacement) + optional **Route53 A
   records** for `var.domain` and the API hostname when `zone_id` is set;
   otherwise point your own DNS at the `public_ip` output.
-- **Daily EBS snapshots** of the data volume (`aws_dlm_lifecycle_policy`,
-  `snapshot_retention_days` days retained, default 7).
+- **EBS snapshots** of the data volume (`aws_dlm_lifecycle_policy`) on a
+  configurable schedule — `backup_interval_hours` (default 24, i.e. once
+  daily; any of DLM's supported intervals — 1, 2, 3, 4, 6, 8, 12, 24 — work,
+  e.g. `6` for four snapshots a day) and `backup_retention_count` (default 7 —
+  stores up to this many backups before the oldest is pruned).
 
 ## What it deliberately does NOT do
 
@@ -77,12 +80,18 @@ output "next_steps" {
   (optional — default VPC/subnet otherwise).
 - `allowed_cidrs` (80/443 ingress), `ssh_ingress_cidrs` (opt-in only).
 - `data_volume_size_gb` (default 100), `data_volume_kms_key_id` (optional CMK).
-- `snapshot_retention_days` (default 7), `snapshot_time`.
+- `backup_interval_hours` (default 24 — 1/2/3/4/6/8/12/24 are the valid DLM
+  intervals), `backup_retention_count` (default 7), `snapshot_time` (only
+  used when `backup_interval_hours = 24`).
 - `zone_id` (optional Route53 zone), `api_domain`, `dns_ttl`.
 - `instance_name` (the `kortix self-host --instance` name), `kortix_channel`
   (`stable`/`latest`), `kortix_version` (pin an exact tag instead),
   `auto_update` (`on`/`off`), `single_account_mode`, `admin_email`,
   `acme_email`.
+- `kortix_cli_install_url` (the CLI installer URL) and `kortix_cli_channel`
+  (`prod`/`dev` — which CLI build the installer fetches; use `dev` if the
+  published `prod` CLI hasn't caught up yet to flags this module passes to
+  `kortix self-host init`).
 
 ## Outputs
 

--- a/infra/terraform/modules/selfhost-ec2/dns.tf
+++ b/infra/terraform/modules/selfhost-ec2/dns.tf
@@ -20,6 +20,11 @@ resource "aws_route53_record" "root" {
   type    = "A"
   ttl     = var.dns_ttl
   records = [aws_eip.this.public_ip]
+
+  # Lets this module take over a zone that already has an A record for this
+  # name (e.g. replacing a hand-deployed box with this same module) instead of
+  # failing on "record already exists" — the new value simply wins.
+  allow_overwrite = true
 }
 
 resource "aws_route53_record" "api" {
@@ -29,4 +34,6 @@ resource "aws_route53_record" "api" {
   type    = "A"
   ttl     = var.dns_ttl
   records = [aws_eip.this.public_ip]
+
+  allow_overwrite = true
 }

--- a/infra/terraform/modules/selfhost-ec2/dns.tf
+++ b/infra/terraform/modules/selfhost-ec2/dns.tf
@@ -1,0 +1,32 @@
+# Elastic IP (stable address across instance replacement) + optional Route53
+# records. Without var.zone_id, DNS is left to the operator — point your own
+# DNS at the eip_public_ip output (A/AAAA for both var.domain and the API
+# hostname).
+
+resource "aws_eip" "this" {
+  domain = "vpc"
+  tags   = merge(local.tags, { Name = "${local.name}-eip" })
+}
+
+resource "aws_eip_association" "this" {
+  instance_id   = aws_instance.this.id
+  allocation_id = aws_eip.this.id
+}
+
+resource "aws_route53_record" "root" {
+  count   = var.zone_id != "" ? 1 : 0
+  zone_id = var.zone_id
+  name    = var.domain
+  type    = "A"
+  ttl     = var.dns_ttl
+  records = [aws_eip.this.public_ip]
+}
+
+resource "aws_route53_record" "api" {
+  count   = var.zone_id != "" ? 1 : 0
+  zone_id = var.zone_id
+  name    = local.api_domain
+  type    = "A"
+  ttl     = var.dns_ttl
+  records = [aws_eip.this.public_ip]
+}

--- a/infra/terraform/modules/selfhost-ec2/main.tf
+++ b/infra/terraform/modules/selfhost-ec2/main.tf
@@ -87,6 +87,7 @@ resource "aws_security_group" "this" {
     }
   }
 
+  #trivy:ignore:AVD-AWS-0104 general-purpose box — outbound to registries/ACME/apt/sandbox targets, no fixed allowlist
   egress {
     description = "All outbound (image pulls, ACME, Daytona API, etc.)"
     from_port   = 0

--- a/infra/terraform/modules/selfhost-ec2/main.tf
+++ b/infra/terraform/modules/selfhost-ec2/main.tf
@@ -1,0 +1,179 @@
+# selfhost-ec2 — a thin, optional convenience provisioner for `kortix
+# self-host`. This is NOT a parallel deployment system: Terraform provisions
+# the box exactly once (instance + data volume + security group + DNS), and
+# cloud-init runs the exact same `kortix self-host init` / `start` any
+# self-host user runs by hand. After that, the box keeps itself current via
+# the in-compose nightly `kortix-updater` service — re-running `terraform
+# apply` does not redeploy the app, and there is no Terraform-side update
+# path to keep in sync with it.
+
+locals {
+  name = var.name
+
+  # Route53 record for the API subdomain — defaults to api.<domain>, matching
+  # the kortix CLI's own default (KORTIX_API_DOMAIN), so this is normally left
+  # unset.
+  api_domain = var.api_domain != "" ? var.api_domain : "api.${var.domain}"
+
+  ami_id = var.ami_id != "" ? var.ami_id : data.aws_ssm_parameter.ubuntu[0].value
+
+  vpc_id    = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default[0].id
+  subnet_id = var.subnet_id != "" ? var.subnet_id : data.aws_subnets.default[0].ids[0]
+
+  tags = merge(var.tags, {
+    Name      = local.name
+    ManagedBy = "terraform"
+    Module    = "selfhost-ec2"
+  })
+}
+
+# ── AMI (Ubuntu 24.04 LTS via Canonical's public SSM parameter) ────────────
+data "aws_ssm_parameter" "ubuntu" {
+  count = var.ami_id == "" ? 1 : 0
+  name  = var.ami_ssm_parameter
+}
+
+# ── Default VPC / subnet fallback (bring-your-own is preferred; this keeps
+#    the module deployable in a stock account with zero network inputs) ─────
+data "aws_vpc" "default" {
+  count   = var.vpc_id == "" ? 1 : 0
+  default = true
+}
+
+data "aws_subnets" "default" {
+  count = var.vpc_id == "" || var.subnet_id == "" ? 1 : 0
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+# ── Security group: 80 (ACME) + 443 (app) in, all out ──────────────────────
+resource "aws_security_group" "this" {
+  #checkov:skip=CKV_AWS_24:SSH ingress is opt-in only (empty by default — dynamic block below only exists when var.ssh_ingress_cidrs is set); SSM Session Manager (AmazonSSMManagedInstanceCore on the instance profile) is the supported no-open-port path.
+  #checkov:skip=CKV_AWS_382:this is a general-purpose self-host box, not an internal service — it needs outbound to Docker Hub/GHCR (image pulls + the in-compose updater), GitHub Releases (CLI install/update), ACME servers, apt/package mirrors, and whatever a sandboxed build reaches; there is no fixed egress allowlist to scope this to.
+  name        = "${local.name}-sg"
+  description = "kortix self-host box: 80/443 in, all out"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description = "HTTP (ACME HTTP-01)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidrs
+  }
+
+  dynamic "ingress" {
+    for_each = length(var.ssh_ingress_cidrs) > 0 ? [1] : []
+    content {
+      description = "SSH (optional — SSM Session Manager needs no open port)"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = var.ssh_ingress_cidrs
+    }
+  }
+
+  egress {
+    description = "All outbound (image pulls, ACME, Daytona API, etc.)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+# ── IAM: SSM Session Manager only — no SSH key required to administer ─────
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = "${local.name}-role"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "${local.name}-profile"
+  role = aws_iam_role.this.name
+  tags = local.tags
+}
+
+# ── Instance ────────────────────────────────────────────────────────────────
+resource "aws_instance" "this" {
+  ami                    = local.ami_id
+  instance_type          = var.instance_type
+  subnet_id              = local.subnet_id
+  vpc_security_group_ids = [aws_security_group.this.id]
+  iam_instance_profile   = aws_iam_instance_profile.this.name
+  key_name               = var.key_name != "" ? var.key_name : null
+  ebs_optimized          = true
+  monitoring             = true
+
+  # IMDSv2 only.
+  metadata_options {
+    http_tokens                 = "required"
+    http_endpoint               = "enabled"
+    http_put_response_hop_limit = 2
+  }
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = var.root_volume_size_gb
+    encrypted             = true
+    delete_on_termination = true
+    tags                  = merge(local.tags, { Name = "${local.name}-root" })
+  }
+
+  user_data = templatefile("${path.module}/templates/user-data.sh.tftpl", {
+    domain                  = var.domain
+    api_domain              = local.api_domain
+    instance_name           = var.instance_name
+    kortix_channel          = var.kortix_channel
+    kortix_version          = var.kortix_version
+    kortix_cli_install_url  = var.kortix_cli_install_url
+    auto_update             = var.auto_update
+    single_account_mode     = var.single_account_mode
+    admin_email             = var.admin_email
+    acme_email              = var.acme_email
+    data_volume_device_name = local.data_volume_device_name
+    data_mount_path         = local.data_mount_path
+  })
+  user_data_replace_on_change = false
+
+  tags = local.tags
+
+  # The data volume is attached out-of-band (aws_volume_attachment below) and
+  # deliberately NOT recreated when the instance is (delete_on_termination =
+  # false on the volume) — an instance replacement must not touch it.
+  lifecycle {
+    ignore_changes = [ami]
+  }
+}

--- a/infra/terraform/modules/selfhost-ec2/main.tf
+++ b/infra/terraform/modules/selfhost-ec2/main.tf
@@ -159,6 +159,7 @@ resource "aws_instance" "this" {
     kortix_channel          = var.kortix_channel
     kortix_version          = var.kortix_version
     kortix_cli_install_url  = var.kortix_cli_install_url
+    kortix_cli_channel      = var.kortix_cli_channel
     auto_update             = var.auto_update
     single_account_mode     = var.single_account_mode
     admin_email             = var.admin_email

--- a/infra/terraform/modules/selfhost-ec2/outputs.tf
+++ b/infra/terraform/modules/selfhost-ec2/outputs.tf
@@ -1,0 +1,58 @@
+output "public_ip" {
+  description = "The box's stable Elastic IP. Point your own DNS here if var.zone_id was left empty."
+  value       = aws_eip.this.public_ip
+}
+
+output "instance_id" {
+  value = aws_instance.this.id
+}
+
+output "data_volume_id" {
+  description = "The EBS volume backing /var/lib/docker (all Docker volumes, incl. Postgres). delete_on_termination = false — it outlives the instance."
+  value       = aws_ebs_volume.data.id
+}
+
+output "dashboard_url" {
+  value = "https://${var.domain}"
+}
+
+output "api_url" {
+  value = "https://${local.api_domain}"
+}
+
+output "dns_managed_by_terraform" {
+  description = "Whether Terraform created the Route53 A records (true when var.zone_id was set)."
+  value       = var.zone_id != ""
+}
+
+output "ssm_connect_command" {
+  description = "Connect to the box with no SSH key and no open SSH port."
+  value       = "aws ssm start-session --target ${aws_instance.this.id}"
+}
+
+output "post_apply_next_steps" {
+  description = "What to do after `terraform apply` finishes — secrets are deliberately NOT Terraform inputs."
+  value       = <<-EOT
+    kortix self-host is provisioning on ${aws_eip.this.public_ip} (this takes a
+    few minutes on first boot — Docker install, image pulls, ACME cert issuance).
+
+    ${var.zone_id == "" ? "DNS was NOT configured by Terraform — point A records for ${var.domain} and ${local.api_domain} at ${aws_eip.this.public_ip} now (ACME HTTP-01 needs them resolving before the cert can issue)." : "DNS: Terraform created A records for ${var.domain} and ${local.api_domain} -> ${aws_eip.this.public_ip}."}
+
+    Secrets (sandbox provider key, managed git, SMTP, ...) are NOT Terraform
+    inputs by design — set them once the box is up:
+
+      aws ssm start-session --target ${aws_instance.this.id}
+      sudo kortix self-host configure --instance ${var.instance_name}
+      # or non-interactively:
+      sudo kortix self-host env set --instance ${var.instance_name} DAYTONA_API_KEY=... MANAGED_GIT_GITHUB_TOKEN=... MANAGED_GIT_GITHUB_OWNER=...
+      sudo kortix self-host start --instance ${var.instance_name}
+
+    Then open the dashboard at https://${var.domain} -> Settings -> Git (and
+    Settings -> Sandbox) to confirm, or finish setup from there directly.
+
+    Updates: the in-compose auto-updater keeps this box current on the
+    ${var.kortix_channel} channel (auto_update=${var.auto_update}) — re-running
+    `terraform apply` does NOT redeploy the app; it only touches the AWS
+    resources (instance, volume, DNS, snapshots).
+  EOT
+}

--- a/infra/terraform/modules/selfhost-ec2/outputs.tf
+++ b/infra/terraform/modules/selfhost-ec2/outputs.tf
@@ -36,23 +36,35 @@ output "post_apply_next_steps" {
     kortix self-host is provisioning on ${aws_eip.this.public_ip} (this takes a
     few minutes on first boot — Docker install, image pulls, ACME cert issuance).
 
-    ${var.zone_id == "" ? "DNS was NOT configured by Terraform — point A records for ${var.domain} and ${local.api_domain} at ${aws_eip.this.public_ip} now (ACME HTTP-01 needs them resolving before the cert can issue)." : "DNS: Terraform created A records for ${var.domain} and ${local.api_domain} -> ${aws_eip.this.public_ip}."}
+    ${var.zone_id != "" ? "DNS: Terraform created these Route53 A records (nothing left to do) ->" : "ACTION NEEDED — DNS was NOT configured by Terraform (var.zone_id was left empty). Create these exact records with your DNS provider before ACME can issue a cert:"}
+        Type  A
+        Name  ${var.domain}
+        Value ${aws_eip.this.public_ip}
 
-    Secrets (sandbox provider key, managed git, SMTP, ...) are NOT Terraform
-    inputs by design — set them once the box is up:
+        Type  A
+        Name  ${local.api_domain}
+        Value ${aws_eip.this.public_ip}
+
+    Secrets (sandbox provider key, managed git PAT, SMTP, ...) are NOT
+    Terraform inputs by design — set them once the box is up:
 
       aws ssm start-session --target ${aws_instance.this.id}
       sudo kortix self-host configure --instance ${var.instance_name}
       # or non-interactively:
-      sudo kortix self-host env set --instance ${var.instance_name} DAYTONA_API_KEY=... MANAGED_GIT_GITHUB_TOKEN=... MANAGED_GIT_GITHUB_OWNER=...
+      sudo kortix self-host secrets set --instance ${var.instance_name} DAYTONA_API_KEY=...
       sudo kortix self-host start --instance ${var.instance_name}
 
-    Then open the dashboard at https://${var.domain} -> Settings -> Git (and
-    Settings -> Sandbox) to confirm, or finish setup from there directly.
+    Then open the dashboard at https://${var.domain} -> Settings -> Git (connect
+    a GitHub App or PAT) and Settings -> Model (connect your own model key,
+    BYOK) to finish setup.
 
     Updates: the in-compose auto-updater keeps this box current on the
-    ${var.kortix_channel} channel (auto_update=${var.auto_update}) — re-running
+    ${var.kortix_channel} channel (auto_update=${var.auto_update}), applying
+    new versions with zero downtime on its own daily schedule — re-running
     `terraform apply` does NOT redeploy the app; it only touches the AWS
     resources (instance, volume, DNS, snapshots).
+
+    Backups: EBS snapshots of the data volume run every ${var.backup_interval_hours}h,
+    keeping the last ${var.backup_retention_count}.
   EOT
 }

--- a/infra/terraform/modules/selfhost-ec2/storage.tf
+++ b/infra/terraform/modules/selfhost-ec2/storage.tf
@@ -21,6 +21,7 @@ locals {
   data_mount_path = "/mnt/kortix-data"
 }
 
+#checkov:skip=CKV2_AWS_9:backups are handled by the aws_dlm_lifecycle_policy in this module (daily snapshots, retention-capped) — an AWS Backup plan would duplicate it
 resource "aws_ebs_volume" "data" {
   availability_zone = aws_instance.this.availability_zone
   size              = var.data_volume_size_gb

--- a/infra/terraform/modules/selfhost-ec2/storage.tf
+++ b/infra/terraform/modules/selfhost-ec2/storage.tf
@@ -68,7 +68,9 @@ resource "aws_iam_role_policy_attachment" "dlm" {
 }
 
 resource "aws_dlm_lifecycle_policy" "data" {
-  description        = "${local.name}: snapshots of the data volume (/var/lib/docker, incl. Postgres) every ${var.backup_interval_hours}h, keeping the last ${var.backup_retention_count}"
+  # DLM's description field only allows [0-9A-Za-z _-]+ — no colons,
+  # parens, commas, or slashes.
+  description        = "${local.name} data volume snapshots every ${var.backup_interval_hours}h retain ${var.backup_retention_count}"
   execution_role_arn = aws_iam_role.dlm.arn
   state              = "ENABLED"
 

--- a/infra/terraform/modules/selfhost-ec2/storage.tf
+++ b/infra/terraform/modules/selfhost-ec2/storage.tf
@@ -1,0 +1,104 @@
+# Separate EBS data volume holding ALL durable self-host state, so it survives
+# an instance replacement untouched. cloud-init (templates/user-data.sh.tftpl)
+# formats it once (if empty), mounts it at var.data_mount_path, points
+# Docker's own data-root at it (images, containers, the updater/Caddy named
+# volumes), AND points the kortix CLI's KORTIX_SELF_HOST_CONFIG_DIR at it —
+# the latter matters because the CLI persists Postgres and Supabase Storage as
+# bind mounts under its instance directory
+# (<config-dir>/<instance>/volumes/db/data, .../volumes/storage), NOT as
+# Docker named volumes, so mounting /var/lib/docker alone would silently lose
+# the database on instance replacement.
+
+locals {
+  # Requested attach point. On Nitro-based instance types (t3, m5, ...) the
+  # kernel exposes this as an NVMe device instead — user-data resolves the
+  # actual block device at boot rather than hardcoding a path.
+  data_volume_device_name = "/dev/sdf"
+
+  # Where the data volume is mounted on the box. Docker's data-root lives at
+  # "<data_mount_path>/docker"; the kortix CLI's KORTIX_SELF_HOST_CONFIG_DIR at
+  # "<data_mount_path>/kortix-self-host".
+  data_mount_path = "/mnt/kortix-data"
+}
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = aws_instance.this.availability_zone
+  size              = var.data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+  kms_key_id        = var.data_volume_kms_key_id != "" ? var.data_volume_kms_key_id : null
+
+  tags = merge(local.tags, {
+    Name   = "${local.name}-data"
+    Backup = "${local.name}-data"
+  })
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = local.data_volume_device_name
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.this.id
+
+  # The volume outlives the instance: replacing the instance (AMI change,
+  # etc.) must never detach-and-destroy the data. Re-attach is manual (or via
+  # a follow-up apply) when swapping instances.
+  stop_instance_before_detaching = true
+}
+
+# ── Daily snapshots (the backup story) ─────────────────────────────────────
+data "aws_iam_policy_document" "dlm_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["dlm.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "dlm" {
+  name               = "${local.name}-dlm"
+  assume_role_policy = data.aws_iam_policy_document.dlm_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "dlm" {
+  role       = aws_iam_role.dlm.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
+}
+
+resource "aws_dlm_lifecycle_policy" "data" {
+  description        = "${local.name}: daily snapshots of the data volume (/var/lib/docker, incl. Postgres)"
+  execution_role_arn = aws_iam_role.dlm.arn
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    target_tags = {
+      Backup = "${local.name}-data"
+    }
+
+    schedule {
+      name = "daily"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = [var.snapshot_time]
+      }
+
+      retain_rule {
+        count = var.snapshot_retention_days
+      }
+
+      tags_to_add = {
+        SnapshotOf = "${local.name}-data"
+      }
+
+      copy_tags = true
+    }
+  }
+
+  tags = local.tags
+}

--- a/infra/terraform/modules/selfhost-ec2/storage.tf
+++ b/infra/terraform/modules/selfhost-ec2/storage.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role_policy_attachment" "dlm" {
 }
 
 resource "aws_dlm_lifecycle_policy" "data" {
-  description        = "${local.name}: daily snapshots of the data volume (/var/lib/docker, incl. Postgres)"
+  description        = "${local.name}: snapshots of the data volume (/var/lib/docker, incl. Postgres) every ${var.backup_interval_hours}h, keeping the last ${var.backup_retention_count}"
   execution_role_arn = aws_iam_role.dlm.arn
   state              = "ENABLED"
 
@@ -80,16 +80,20 @@ resource "aws_dlm_lifecycle_policy" "data" {
     }
 
     schedule {
-      name = "daily"
+      name = "kortix-backup"
 
       create_rule {
-        interval      = 24
+        interval = var.backup_interval_hours
+        # DLM only fires create_rule.times for interval=24 (once-daily)
+        # schedules; for sub-daily intervals the first run is undefined and
+        # DLM just runs every N hours from when the policy was created — so
+        # `times` is only meaningful (and only passed) in the 24h case.
         interval_unit = "HOURS"
-        times         = [var.snapshot_time]
+        times         = var.backup_interval_hours == 24 ? [var.snapshot_time] : null
       }
 
       retain_rule {
-        count = var.snapshot_retention_days
+        count = var.backup_retention_count
       }
 
       tags_to_add = {

--- a/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
+++ b/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
@@ -11,6 +11,11 @@ set -euo pipefail
 exec > >(tee -a /var/log/kortix-bootstrap.log) 2>&1
 echo "=== kortix self-host bootstrap: $(date -u --iso-8601=seconds) ==="
 
+# cloud-init runs this as root but with NO $HOME set — and both the kortix CLI
+# installer (kortix.com/install) and the CLI itself dereference $HOME under
+# `set -u`, so an unset HOME kills the bootstrap ("HOME: unbound variable").
+export HOME="$${HOME:-/root}"
+
 # ── 1. Find + mount the data volume ─────────────────────────────────────────
 # Requested attach point is ${data_volume_device_name}, but Nitro-based
 # instance types (t3, m5, ...) expose EBS volumes as NVMe block devices

--- a/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
+++ b/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Kortix self-host — EC2 bootstrap (runs once, as root, via cloud-init).
+#
+# This does exactly what any self-host user does by hand (see
+# scripts/kortix-selfhost-up.sh and docs/runbooks/self-hosting.md): install
+# Docker, install the kortix CLI, `kortix self-host init`, `kortix self-host
+# start`. Terraform's only value-add here is doing it once on a fresh box with
+# a durable data volume wired up first. It does NOT run again on its own —
+# ongoing updates are the in-compose kortix-updater's job, not Terraform's.
+set -euo pipefail
+exec > >(tee -a /var/log/kortix-bootstrap.log) 2>&1
+echo "=== kortix self-host bootstrap: $(date -u --iso-8601=seconds) ==="
+
+# ── 1. Find + mount the data volume ─────────────────────────────────────────
+# Requested attach point is ${data_volume_device_name}, but Nitro-based
+# instance types (t3, m5, ...) expose EBS volumes as NVMe block devices
+# instead, so probe for whichever one actually shows up.
+echo "Waiting for the data volume to attach..."
+DATA_DEVICE=""
+for _ in $(seq 1 60); do
+  for cand in ${data_volume_device_name} /dev/xvdf /dev/nvme1n1; do
+    if [ -b "$cand" ]; then DATA_DEVICE="$cand"; break 2; fi
+  done
+  sleep 2
+done
+if [ -z "$DATA_DEVICE" ]; then
+  echo "FATAL: data volume never appeared (tried ${data_volume_device_name}, /dev/xvdf, /dev/nvme1n1)" >&2
+  exit 1
+fi
+echo "Data volume: $DATA_DEVICE"
+
+if ! blkid "$DATA_DEVICE" >/dev/null 2>&1; then
+  echo "Formatting $DATA_DEVICE (ext4) — first boot only"
+  mkfs.ext4 -F "$DATA_DEVICE"
+else
+  echo "$DATA_DEVICE already has a filesystem — leaving its contents alone (this is the durable Postgres/Docker state across instance replacement)"
+fi
+
+mkdir -p "${data_mount_path}"
+if ! mountpoint -q "${data_mount_path}"; then
+  mount "$DATA_DEVICE" "${data_mount_path}"
+fi
+DATA_UUID="$(blkid -s UUID -o value "$DATA_DEVICE")"
+grep -q "$DATA_UUID" /etc/fstab || echo "UUID=$DATA_UUID ${data_mount_path} ext4 defaults,nofail 0 2" >> /etc/fstab
+
+DOCKER_DATA_ROOT="${data_mount_path}/docker"
+KORTIX_CONFIG_DIR="${data_mount_path}/kortix-self-host"
+mkdir -p "$DOCKER_DATA_ROOT" "$KORTIX_CONFIG_DIR"
+
+# ── 2. Docker: point data-root at the data volume BEFORE first start ───────
+# Every Docker-managed volume (images, containers, the updater/Caddy named
+# volumes) then lives on the data volume too.
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Installing Docker Engine + Compose plugin"
+  mkdir -p /etc/docker
+  cat > /etc/docker/daemon.json <<JSON
+{
+  "data-root": "$DOCKER_DATA_ROOT"
+}
+JSON
+  curl --fail --silent --show-error --location https://get.docker.com | sh
+  systemctl enable --now docker
+fi
+docker compose version >/dev/null 2>&1 || { echo "FATAL: docker compose plugin unavailable after install" >&2; exit 1; }
+
+# ── 3. Pin KORTIX_SELF_HOST_CONFIG_DIR — every kortix invocation (this
+#    script, and any later `kortix self-host ...` an operator runs over SSM)
+#    must agree on where the instance lives, or the CLI creates a second
+#    instance on the (small, ephemeral) root volume instead of reusing the
+#    one on the data volume. Persist it for future root shells too.
+export KORTIX_SELF_HOST_CONFIG_DIR="$KORTIX_CONFIG_DIR"
+grep -q '^KORTIX_SELF_HOST_CONFIG_DIR=' /etc/environment 2>/dev/null \
+  || echo "KORTIX_SELF_HOST_CONFIG_DIR=$KORTIX_CONFIG_DIR" >> /etc/environment
+cat > /etc/profile.d/kortix-selfhost.sh <<PROFILE
+export KORTIX_SELF_HOST_CONFIG_DIR="$KORTIX_CONFIG_DIR"
+PROFILE
+
+# ── 4. Install the kortix CLI (the published one-click installer) ──────────
+if ! command -v kortix >/dev/null 2>&1; then
+  echo "Installing the kortix CLI from ${kortix_cli_install_url}"
+  curl -fsSL "${kortix_cli_install_url}" | bash
+fi
+KORTIX_BIN="$(command -v kortix || true)"
+if [ -z "$KORTIX_BIN" ] && [ -x /root/.kortix/kortix ]; then
+  KORTIX_BIN=/root/.kortix/kortix
+fi
+[ -n "$KORTIX_BIN" ] || { echo "FATAL: kortix CLI install did not produce a runnable binary" >&2; exit 1; }
+
+# ── 5. Generate the self-host config ────────────────────────────────────────
+INIT_ARGS=(
+  --instance "${instance_name}"
+  --domain "${domain}"
+  --channel "${kortix_channel}"
+  --auto-update "${auto_update}"
+  --allow-missing-secrets
+  --yes
+)
+%{ if kortix_version != "" ~}
+INIT_ARGS+=(--tag "${kortix_version}")
+%{ endif ~}
+%{ if single_account_mode ~}
+INIT_ARGS+=(--single-account)
+%{ endif ~}
+%{ if admin_email != "" ~}
+INIT_ARGS+=(--admin-email "${admin_email}")
+%{ endif ~}
+
+echo "Running: kortix self-host init $${INIT_ARGS[*]}"
+"$KORTIX_BIN" self-host init "$${INIT_ARGS[@]}"
+
+# api_domain / acme_email have no `init` flags (see docs/runbooks/self-hosting.md)
+# — set via `env set`, exactly like scripts/kortix-selfhost-up.sh does.
+"$KORTIX_BIN" self-host env set --instance "${instance_name}" "KORTIX_API_DOMAIN=${api_domain}"
+%{ if acme_email != "" ~}
+"$KORTIX_BIN" self-host env set --instance "${instance_name}" "KORTIX_ACME_EMAIL=${acme_email}"
+%{ endif ~}
+
+# ── 6. Start ─────────────────────────────────────────────────────────────────
+echo "Starting the stack (pulling images — this can take a few minutes on first boot)"
+"$KORTIX_BIN" self-host start --instance "${instance_name}" --yes
+
+echo "=== kortix self-host bootstrap done: $(date -u --iso-8601=seconds) ==="
+echo "Secrets (sandbox provider key, managed git, ...) were NOT set — configure them with:"
+echo "  kortix self-host configure --instance ${instance_name}"

--- a/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
+++ b/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
@@ -76,9 +76,13 @@ export KORTIX_SELF_HOST_CONFIG_DIR="$KORTIX_CONFIG_DIR"
 PROFILE
 
 # ── 4. Install the kortix CLI (the published one-click installer) ──────────
+# kortix_cli_channel selects which build the installer fetches: "prod" (the
+# default — latest tagged vX.Y.Z release) or "dev" (the continuously-rebuilt
+# dev-latest prerelease, tracking main) — use "dev" when the prod CLI hasn't
+# caught up yet to flags this module relies on (see the variable's doc comment).
 if ! command -v kortix >/dev/null 2>&1; then
-  echo "Installing the kortix CLI from ${kortix_cli_install_url}"
-  curl -fsSL "${kortix_cli_install_url}" | bash
+  echo "Installing the kortix CLI from ${kortix_cli_install_url} (channel: ${kortix_cli_channel})"
+  curl -fsSL "${kortix_cli_install_url}" | KORTIX_CHANNEL="${kortix_cli_channel}" bash
 fi
 KORTIX_BIN="$(command -v kortix || true)"
 if [ -z "$KORTIX_BIN" ] && [ -x /root/.kortix/kortix ]; then

--- a/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
+++ b/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
@@ -125,8 +125,12 @@ echo "Running: kortix self-host init $${INIT_ARGS[*]}"
 %{ endif ~}
 
 # ── 6. Start ─────────────────────────────────────────────────────────────────
+# --allow-missing-secrets here too: `start` re-checks required secrets (the
+# sandbox key etc.) and would otherwise refuse — but this module's whole
+# design is that secrets are NOT Terraform inputs and get set post-boot
+# (kortix self-host secrets set / configure / the dashboard).
 echo "Starting the stack (pulling images — this can take a few minutes on first boot)"
-"$KORTIX_BIN" self-host start --instance "${instance_name}" --yes
+"$KORTIX_BIN" self-host start --instance "${instance_name}" --allow-missing-secrets --yes
 
 echo "=== kortix self-host bootstrap done: $(date -u --iso-8601=seconds) ==="
 echo "Secrets (sandbox provider key, managed git, ...) were NOT set — configure them with:"

--- a/infra/terraform/modules/selfhost-ec2/variables.tf
+++ b/infra/terraform/modules/selfhost-ec2/variables.tf
@@ -1,0 +1,191 @@
+# ── Required ───────────────────────────────────────────────────────────────
+
+variable "domain" {
+  description = "Public domain to run Kortix self-host on (e.g. kortix.example.com). Passed straight through to `kortix self-host init --domain`; the API domain defaults to api.<domain> (the CLI's own default — see var.api_domain to override)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.domain)) > 0 && !can(regex("^https?://", var.domain))
+    error_message = "domain is required and must be a bare hostname (no https:// prefix), e.g. kortix.example.com."
+  }
+}
+
+# ── Naming / tags ──────────────────────────────────────────────────────────
+
+variable "name" {
+  description = "Name prefix for all AWS resources (e.g. kortix-selfhost)."
+  type        = string
+  default     = "kortix-selfhost"
+}
+
+variable "tags" {
+  description = "Extra tags applied to every resource this module creates."
+  type        = map(string)
+  default     = {}
+}
+
+# ── Instance ───────────────────────────────────────────────────────────────
+
+variable "instance_type" {
+  description = "EC2 instance type. t3.xlarge (4 vCPU / 16GB) is a reasonable floor for the full stack (Supabase + API + gateway + frontend + sandboxed builds)."
+  type        = string
+  default     = "t3.xlarge"
+}
+
+variable "ami_id" {
+  description = "AMI to launch. Leave empty to resolve the latest Ubuntu 24.04 LTS AMI via the public SSM parameter (var.ami_ssm_parameter)."
+  type        = string
+  default     = ""
+}
+
+variable "ami_ssm_parameter" {
+  description = "SSM public parameter used to resolve the AMI when var.ami_id is empty. Default tracks Canonical's official Ubuntu 24.04 LTS amd64 AMI."
+  type        = string
+  default     = "/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
+}
+
+variable "root_volume_size_gb" {
+  description = "Root (OS) EBS volume size. Docker data lives on the separate data volume, not here — this only needs to hold the OS + kortix CLI."
+  type        = number
+  default     = 30
+}
+
+variable "key_name" {
+  description = "Optional EC2 key pair name for SSH. Leave empty to rely on SSM Session Manager only (recommended — no open SSH port needed)."
+  type        = string
+  default     = ""
+}
+
+# ── Networking ─────────────────────────────────────────────────────────────
+
+variable "vpc_id" {
+  description = "VPC to launch into. Leave empty to use the account/region's default VPC."
+  type        = string
+  default     = ""
+}
+
+variable "subnet_id" {
+  description = "Subnet to launch into (must be public / route to an Internet Gateway so the Elastic IP works). Leave empty to use a default subnet in the default VPC."
+  type        = string
+  default     = ""
+}
+
+variable "allowed_cidrs" {
+  description = "CIDRs allowed to reach the box on 80 (ACME HTTP-01) and 443 (the app). Restrict this once you know your users' egress ranges."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "ssh_ingress_cidrs" {
+  description = "CIDRs allowed to reach port 22. Empty (default) opens no SSH ingress at all — use `aws ssm start-session` instead (see output ssm_connect_command). Only meaningful alongside var.key_name."
+  type        = list(string)
+  default     = []
+}
+
+# ── Data volume (all Docker volumes, incl. Postgres, live here) ────────────
+
+variable "data_volume_size_gb" {
+  description = "Size of the separate EBS data volume that holds all durable self-host state: Docker's own data-root (images, containers, the updater/Caddy named volumes) AND the kortix CLI's instance directory (.env, compose file, and — critically — Postgres and Supabase Storage, which the CLI persists as bind mounts under its instance directory, not as Docker named volumes). Sizing this is really about your database + object storage growth, not the OS."
+  type        = number
+  default     = 100
+}
+
+variable "data_volume_kms_key_id" {
+  description = "Optional customer-managed KMS key ARN for the data volume. Leave empty to use the account's default aws/ebs key (the volume is always encrypted either way)."
+  type        = string
+  default     = ""
+}
+
+# ── Snapshots (backup story for the data volume) ───────────────────────────
+
+variable "snapshot_retention_days" {
+  description = "How many daily EBS snapshots of the data volume to retain (DLM lifecycle policy)."
+  type        = number
+  default     = 7
+}
+
+variable "snapshot_time" {
+  description = "UTC time-of-day (HH:MM) the daily data-volume snapshot runs."
+  type        = string
+  default     = "03:00"
+}
+
+# ── DNS (optional — Route53) ────────────────────────────────────────────────
+
+variable "zone_id" {
+  description = "Route53 hosted zone ID to create records in. Leave empty to skip DNS entirely and point your own DNS at the eip_public_ip output instead."
+  type        = string
+  default     = ""
+}
+
+variable "api_domain" {
+  description = "API hostname to point at this box. Leave empty to default to api.<var.domain> (matches the kortix CLI's own default, so you normally don't need to set this)."
+  type        = string
+  default     = ""
+}
+
+variable "dns_ttl" {
+  description = "TTL (seconds) for the Route53 A records, when created."
+  type        = number
+  default     = 300
+}
+
+# ── kortix self-host bootstrap (see user-data) ──────────────────────────────
+
+variable "instance_name" {
+  description = "The kortix self-host `--instance` name (lets one box run multiple isolated stacks; almost always leave at the default)."
+  type        = string
+  default     = "default"
+}
+
+variable "kortix_channel" {
+  description = "Image channel the stack tracks (`stable` or `latest`) — passed to `kortix self-host init --channel`. Ongoing updates are applied by the in-compose auto-updater, not by re-running Terraform."
+  type        = string
+  default     = "stable"
+
+  validation {
+    condition     = contains(["stable", "latest"], var.kortix_channel)
+    error_message = "kortix_channel must be \"stable\" or \"latest\"."
+  }
+}
+
+variable "kortix_version" {
+  description = "Optional exact version/tag to pin instead of tracking a channel (passed as `kortix self-host init --tag`). Leave empty to track var.kortix_channel."
+  type        = string
+  default     = ""
+}
+
+variable "kortix_cli_install_url" {
+  description = "URL for the one-click kortix CLI installer (the canonical published path)."
+  type        = string
+  default     = "https://kortix.com/install"
+}
+
+variable "auto_update" {
+  description = "Whether the in-compose auto-updater is on (`on`/`off`). This is the ONLY thing that keeps the box current after Terraform provisions it once — Terraform never redeploys the app."
+  type        = string
+  default     = "on"
+
+  validation {
+    condition     = contains(["on", "off"], var.auto_update)
+    error_message = "auto_update must be \"on\" or \"off\"."
+  }
+}
+
+variable "single_account_mode" {
+  description = "Run this instance single-account (no multi-tenant signup) — passed as `kortix self-host init --single-account`."
+  type        = bool
+  default     = false
+}
+
+variable "admin_email" {
+  description = "Optional admin email granted platform-admin on first boot (`kortix self-host init --admin-email`). Leave empty to skip and configure later via `kortix self-host configure`."
+  type        = string
+  default     = ""
+}
+
+variable "acme_email" {
+  description = "Optional ACME (Let's Encrypt) contact email. Leave empty to use the CLI's own default (admin@<domain>)."
+  type        = string
+  default     = ""
+}

--- a/infra/terraform/modules/selfhost-ec2/variables.tf
+++ b/infra/terraform/modules/selfhost-ec2/variables.tf
@@ -96,16 +96,32 @@ variable "data_volume_kms_key_id" {
   default     = ""
 }
 
-# ── Snapshots (backup story for the data volume) ───────────────────────────
+# ── Backups: DLM snapshot schedule for the data volume ─────────────────────
 
-variable "snapshot_retention_days" {
-  description = "How many daily EBS snapshots of the data volume to retain (DLM lifecycle policy)."
+variable "backup_interval_hours" {
+  description = "How often to snapshot the data volume (DLM lifecycle policy), in hours. Must be one of the interval values AWS DLM supports: 1, 2, 3, 4, 6, 8, 12, or 24. Default 24 (once daily); set e.g. 6 for four snapshots a day."
+  type        = number
+  default     = 24
+
+  validation {
+    condition     = contains([1, 2, 3, 4, 6, 8, 12, 24], var.backup_interval_hours)
+    error_message = "backup_interval_hours must be one of the DLM-supported interval values: 1, 2, 3, 4, 6, 8, 12, 24."
+  }
+}
+
+variable "backup_retention_count" {
+  description = "How many snapshots of the data volume to keep (DLM retain_rule.count) — stores up to this many backups before the oldest is pruned. Default 7."
   type        = number
   default     = 7
+
+  validation {
+    condition     = var.backup_retention_count >= 1 && var.backup_retention_count <= 1000
+    error_message = "backup_retention_count must be between 1 and 1000 (DLM's own retain_rule.count limit)."
+  }
 }
 
 variable "snapshot_time" {
-  description = "UTC time-of-day (HH:MM) the daily data-volume snapshot runs."
+  description = "UTC time-of-day (HH:MM) the data-volume snapshot runs. Only meaningful when backup_interval_hours = 24 — DLM only accepts a fixed start time for once-daily schedules; sub-daily intervals run every N hours from policy creation instead."
   type        = string
   default     = "03:00"
 }
@@ -159,6 +175,17 @@ variable "kortix_cli_install_url" {
   description = "URL for the one-click kortix CLI installer (the canonical published path)."
   type        = string
   default     = "https://kortix.com/install"
+}
+
+variable "kortix_cli_channel" {
+  description = "Which CLI build the installer fetches: `prod` (default — latest tagged vX.Y.Z GitHub Release) or `dev` (the continuously-rebuilt `dev-latest` prerelease, tracking `main`). The published `prod` CLI can lag newly merged self-host flags/behavior (e.g. right after a feature merges to main but before the next version is cut) — set this to `dev` if `var.kortix_version`/other flags this module passes to `kortix self-host init` aren't recognized by the current prod CLI yet. Passed as `KORTIX_CHANNEL` to the installer, not to the app itself."
+  type        = string
+  default     = "prod"
+
+  validation {
+    condition     = contains(["prod", "dev"], var.kortix_cli_channel)
+    error_message = "kortix_cli_channel must be \"prod\" or \"dev\"."
+  }
 }
 
 variable "auto_update" {

--- a/infra/terraform/modules/selfhost-ec2/versions.tf
+++ b/infra/terraform/modules/selfhost-ec2/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/kortix-selfhost/README.md
+++ b/kortix-selfhost/README.md
@@ -1,0 +1,196 @@
+# Kortix Self-Host
+
+Run your own private instance of Kortix — the full stack (frontend, API, LLM
+gateway, and the official Supabase distribution) as one Docker Compose
+project, on any box you control. Agent sessions still run on a cloud sandbox
+provider (Daytona, E2B, or Platinum) — sandboxes are managed compute, not part
+of this box.
+
+This is the whole self-contained distribution: a Terraform module for
+provisioning an AWS/EC2 box declaratively, plus this README. For the full
+day-to-day operator reference (troubleshooting, every CLI flag, backup/restore
+mechanics, the auto-updater's internals) see
+[`docs/runbooks/self-hosting.md`](../docs/runbooks/self-hosting.md) in the
+main Kortix repo — this page is intentionally the tight version.
+
+## 1. Any VPS — quickstart
+
+**Prerequisites:** a VPS (2 vCPU / 4GB RAM floor; 4 vCPU / 16GB+ recommended
+for real use) running Linux, and a domain you control.
+
+1. **Point DNS at the box.** Create an A/AAAA record for your domain (and its
+   API subdomain, `api.<domain>` by default) pointing at the box's public IP.
+   Ports **80** and **443** must be reachable from the internet — the bundled
+   Caddy reverse proxy uses ACME HTTP-01 to issue a TLS cert automatically.
+
+2. **Run the bootstrap command** on the box (as root, or a user with sudo):
+
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/kortix-ai/suna/main/scripts/kortix-selfhost-up.sh \
+     | bash -s -- --domain kortix.example.com --email ops@example.com
+   ```
+
+   This is [`scripts/kortix-selfhost-up.sh`](../scripts/kortix-selfhost-up.sh)
+   in the main repo: it installs Docker if missing, installs the `kortix` CLI
+   (the one-click installer at `kortix.com/install`), and drives the same
+   `init`/`start` flow described below. Re-running it is safe — every step is
+   idempotent.
+
+   Or drive it by hand once the CLI is installed:
+
+   ```sh
+   curl -fsSL https://kortix.com/install | bash
+   kortix self-host init --domain app.example.com
+   ```
+
+   `init` is a short guided flow (skippable non-interactively with flags or
+   `--yes` for the defaults) that asks, in order:
+
+   1. **Reachability** — confirms the domain/DNS above (or `--tunnel
+      cloudflare` for laptop evaluation only, or local-only for development;
+      see the runbook for the tradeoffs of each).
+   2. **Admin email** — which account gets platform-admin on first sign-up.
+   3. **Deployment shape** — single-account (hide multi-tenant sign-up UI) or
+      normal, and whether you hold an Enterprise license (SSO/SCIM/RBAC/audit).
+   4. **Sandbox provider** — `daytona` (default), `e2b`, or `platinum`, plus
+      its API key.
+   5. **Pipedream** (optional) — the 3,000+ app connector catalog; skip or
+      configure its OAuth app credentials.
+   6. **Update policy** — auto-update on/off, channel (`stable`/`latest`), and
+      the daily update window.
+
+3. **Start the stack:**
+
+   ```sh
+   kortix self-host start
+   ```
+
+   This pulls images and brings the stack up. `kortix self-host status` /
+   `logs` / `doctor` are your friends while it comes up.
+
+4. **Finish in the dashboard.** Open `https://app.example.com` and sign up
+   with the admin email from step 2, then:
+   - **Settings → Git** — connect a GitHub App (or PAT) so the platform can
+     create project repos. This one dashboard flow replaces the old
+     env-var-only managed-git setup.
+   - **Settings → Model** — connect your own model key (BYOK: Anthropic,
+     OpenAI, OpenRouter, etc.).
+
+That's a complete, working instance. See
+[`docs/runbooks/self-hosting.md`](../docs/runbooks/self-hosting.md) for the
+Cloudflare-tunnel (laptop) and fully-local (dev) paths, SMTP, and the full
+`kortix self-host` command reference.
+
+## 2. Want something more robust on AWS? There's a Terraform for that
+
+The quickstart above is the whole product — this is the same thing, provisioned
+declaratively on EC2 instead of by hand, and it adds two things a hand-run box
+doesn't have out of the box:
+
+- **Automatic backups** — EBS snapshots of the data volume (Postgres, Supabase
+  Storage, everything durable), on a schedule, keeping the last N.
+- **Automatic daily zero-downtime updates** — already true of any self-host
+  install (the in-compose updater), but Terraform sets the policy for you at
+  provision time.
+
+Use [`terraform/`](terraform/) — a thin root module that instantiates
+`selfhost-ec2` (EC2 instance, a durable encrypted EBS data volume, a security
+group, an Elastic IP, optional Route53 records). It provisions the box
+**once**; after that, cloud-init runs the *exact same* `kortix self-host init`
+/ `start` described above, and Terraform never redeploys the running app.
+
+```sh
+cd terraform
+cp terraform.tfvars.example terraform.tfvars   # fill in domain, admin_email, ...
+terraform init
+terraform apply
+```
+
+Minimal `terraform.tfvars`:
+
+```hcl
+aws_region      = "us-east-1"
+domain          = "kortix.example.com"
+admin_email     = "admin@example.com"
+route53_zone_id = "Z0123456789ABCDEFGHIJ"   # optional — see "Domain / DNS" below
+```
+
+See `terraform/variables.tf` for the full input surface (instance type,
+network, backup schedule, update channel, single-account mode, ...).
+
+### Domain / DNS — both ways are supported
+
+The domain **must** end up resolving to the box's Elastic IP — that's not
+optional (ACME can't issue a cert otherwise, and agent sandboxes need a real
+public `KORTIX_URL`). Two ways to get there, either is fine:
+
+1. **Terraform manages it** — set `route53_zone_id` to your domain's Route53
+   hosted zone ID. `apply` creates the `A` records for `domain` and its API
+   subdomain (`api.<domain>` by default) pointing at the new Elastic IP.
+   Nothing else to do.
+2. **You manage it** — leave `route53_zone_id` unset. `apply`'s
+   `post_apply_next_steps` output prints the box's Elastic IP and the *exact*
+   two `A` records to create with whatever DNS provider you use. Create them
+   before the box finishes booting (ACME retries, but won't succeed until DNS
+   resolves).
+
+Either way, **check `terraform apply`'s final output** — it tells you which of
+the two applies and, in case 2, spells out precisely what to create.
+
+### Automatic backups
+
+The data volume is snapshotted via AWS DLM (Data Lifecycle Manager) on a
+schedule, configurable in `terraform.tfvars`:
+
+```hcl
+backup_interval_hours  = 24   # 1, 2, 3, 4, 6, 8, 12, or 24 — AWS DLM's supported intervals
+backup_retention_count = 7    # stores up to this many backups before the oldest is pruned
+```
+
+Defaults to once daily, 7 retained — that's the recommended setting; stability
+over frequency. The interval is configurable if you need something tighter
+(e.g. `backup_interval_hours = 6` for four snapshots a day), but daily is what
+we run ourselves. Snapshots are tagged and discoverable via
+`aws dlm get-lifecycle-policies` / `aws ec2 describe-snapshots --filters
+Name=tag:SnapshotOf,Values=<name>-data`.
+
+### Automatic daily zero-downtime updates
+
+Every instance runs an in-compose `kortix-updater` service — not a Terraform
+concern — that checks for new images on the configured channel and, when one's
+found, pulls it, runs any new database migrations, and rolls the stack forward
+with zero downtime (`docker compose up -d --wait`). This is **on by default**
+(`auto_update = "on"`); the time/timezone for the daily check comes from the
+guided `init` flow (`kortix self-host configure` to change it later) —
+Terraform only sets the initial channel/on-off policy, not the clock.
+
+## 3. Day-2 operations
+
+All of these run on the box itself (SSH, or `aws ssm start-session --target
+<instance-id>` — the Terraform output `ssm_connect_command` gives you the
+exact command, no SSH key or open port required):
+
+```sh
+kortix self-host update            # pull the newest image on your channel now, migrate, roll forward
+kortix self-host secrets ls        # list configured secrets (values masked)
+kortix self-host secrets set KEY=VALUE ...   # set/rotate a secret (sandbox key, GitHub token, SMTP, ...)
+kortix self-host logs [service]    # tail Compose logs
+kortix self-host status            # container status
+```
+
+**Restoring from a snapshot** (disaster recovery / cloning an instance):
+
+1. Find the snapshot: `aws ec2 describe-snapshots --filters
+   Name=tag:SnapshotOf,Values=<name>-data --query
+   'Snapshots|sort_by(@,&StartTime)[-1]'`.
+2. Create a new volume from it in the same AZ as the target instance:
+   `aws ec2 create-volume --snapshot-id <snap-id> --availability-zone <az>`.
+3. Stop the instance, detach the current data volume, attach the restored one
+   at the same device (`/dev/sdf`), start the instance — cloud-init already
+   handles "volume has an existing filesystem" on boot, so it mounts as-is and
+   `kortix self-host` reconciles against the restored state.
+4. `kortix self-host start` to bring the stack back up.
+
+Full detail (whole-directory `tar` backups, logical `pg_dump` backups, and
+every troubleshooting scenario) lives in
+[`docs/runbooks/self-hosting.md`](../docs/runbooks/self-hosting.md).

--- a/kortix-selfhost/README.md
+++ b/kortix-selfhost/README.md
@@ -76,9 +76,21 @@ for real use) running Linux, and a domain you control.
    - **Settings → Model** — connect your own model key (BYOK: Anthropic,
      OpenAI, OpenRouter, etc.).
 
-That's a complete, working instance. See
+That's a complete, working instance. From here on, use the main `kortix` CLI
+against it like you would against Kortix Cloud:
+
+```sh
+kortix hosts use selfhost   # already registered + pointed at your instance by `init`/`start`
+kortix login
+kortix whoami
+kortix projects ls
+cd your-project && kortix ship
+```
+
+See
 [`docs/runbooks/self-hosting.md`](../docs/runbooks/self-hosting.md) for the
-Cloudflare-tunnel (laptop) and fully-local (dev) paths, SMTP, and the full
+Cloudflare-tunnel (laptop) and fully-local (dev) paths, SMTP, using the CLI
+from a different machine than the one you self-hosted on, and the full
 `kortix self-host` command reference.
 
 ## 2. Want something more robust on AWS? There's a Terraform for that

--- a/kortix-selfhost/terraform/backend.tf
+++ b/kortix-selfhost/terraform/backend.tf
@@ -1,0 +1,9 @@
+# Local state by default — this folder is meant to be usable standalone (a
+# customer's own deployment), not a Kortix-run environment. Point this at
+# your own backend (S3, Terraform Cloud, ...) for real use — see
+# https://developer.hashicorp.com/terraform/language/backend.
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}

--- a/kortix-selfhost/terraform/main.tf
+++ b/kortix-selfhost/terraform/main.tf
@@ -1,0 +1,81 @@
+# kortix-selfhost/terraform — AWS/EC2 provisioner for Kortix self-host.
+#
+# This is a THIN root module: it does not define any resources itself, it
+# just instantiates infra/terraform/modules/selfhost-ec2, which does the
+# real work (EC2 instance, durable EBS data volume, security group, Elastic
+# IP, optional Route53 records, and a configurable-schedule snapshot policy),
+# then hands off to the exact same `kortix self-host init` / `start` any
+# self-host user runs by hand — see ../README.md and
+# docs/runbooks/self-hosting.md in the main repo for the full picture.
+#
+#   cd kortix-selfhost/terraform
+#   cp terraform.tfvars.example terraform.tfvars   # fill in your values
+#   terraform init
+#   terraform apply
+#
+# Secrets (sandbox provider key, GitHub App, LLM key, ...) are NOT Terraform
+# inputs — see the post_apply_next_steps output after apply, and finish setup
+# in the dashboard (Settings -> Git, Settings -> Sandbox).
+#
+# NOTE for when kortix-selfhost/ becomes its own standalone repo: flip
+# `source` below from the relative path to this repo's own git URL, e.g.
+#   source = "github.com/kortix-ai/kortix-selfhost//terraform/modules/selfhost-ec2?ref=vX.Y.Z"
+# (or wherever the module ends up living in that repo) — today it stays a
+# relative path so this folder shares one copy of the module with the rest of
+# the monorepo instead of duplicating it.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "kortix_selfhost" {
+  # Relative source into the monorepo module — see the NOTE above for the
+  # standalone-repo path.
+  source = "../../infra/terraform/modules/selfhost-ec2"
+
+  domain      = var.domain
+  zone_id     = var.route53_zone_id
+  api_domain  = var.api_domain
+  admin_email = var.admin_email
+
+  name = var.name
+  tags = var.tags
+
+  instance_type       = var.instance_type
+  ami_id              = var.ami_id
+  root_volume_size_gb = var.root_volume_size_gb
+  key_name            = var.key_name
+
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  allowed_cidrs     = var.allowed_cidrs
+  ssh_ingress_cidrs = var.ssh_ingress_cidrs
+
+  data_volume_size_gb    = var.data_volume_size_gb
+  data_volume_kms_key_id = var.data_volume_kms_key_id
+
+  backup_interval_hours  = var.backup_interval_hours
+  backup_retention_count = var.backup_retention_count
+  snapshot_time          = var.snapshot_time
+
+  dns_ttl = var.dns_ttl
+
+  instance_name          = var.instance_name
+  kortix_channel         = var.kortix_channel
+  kortix_version         = var.kortix_version
+  kortix_cli_install_url = var.kortix_cli_install_url
+  kortix_cli_channel     = var.kortix_cli_channel
+  auto_update            = var.auto_update
+  single_account_mode    = var.single_account_mode
+  acme_email             = var.acme_email
+}

--- a/kortix-selfhost/terraform/outputs.tf
+++ b/kortix-selfhost/terraform/outputs.tf
@@ -1,0 +1,34 @@
+output "public_ip" {
+  description = "The box's stable Elastic IP. Point your own DNS here if route53_zone_id was left empty."
+  value       = module.kortix_selfhost.public_ip
+}
+
+output "instance_id" {
+  value = module.kortix_selfhost.instance_id
+}
+
+output "data_volume_id" {
+  value = module.kortix_selfhost.data_volume_id
+}
+
+output "dashboard_url" {
+  value = module.kortix_selfhost.dashboard_url
+}
+
+output "api_url" {
+  value = module.kortix_selfhost.api_url
+}
+
+output "dns_managed_by_terraform" {
+  value = module.kortix_selfhost.dns_managed_by_terraform
+}
+
+output "ssm_connect_command" {
+  description = "Connect to the box with no SSH key and no open SSH port."
+  value       = module.kortix_selfhost.ssm_connect_command
+}
+
+output "post_apply_next_steps" {
+  description = "What to do after `terraform apply` finishes — secrets are deliberately NOT Terraform inputs."
+  value       = module.kortix_selfhost.post_apply_next_steps
+}

--- a/kortix-selfhost/terraform/terraform.tfvars.example
+++ b/kortix-selfhost/terraform/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Copy to terraform.tfvars and fill in your values, then:
+#   terraform init && terraform apply
+
+aws_region  = "us-east-1"
+domain      = "kortix.example.com"
+admin_email = "admin@example.com"
+
+# Optional — leave unset to manage DNS yourself (see the public_ip output).
+# route53_zone_id = "Z0123456789ABCDEFGHIJ"
+
+# Optional — defaults shown. Uncomment to override.
+# instance_type           = "t3.xlarge"
+# data_volume_size_gb     = 100
+# backup_interval_hours   = 24   # 1, 2, 3, 4, 6, 8, 12, or 24
+# backup_retention_count  = 7
+# kortix_channel          = "stable"
+# auto_update             = "on"
+# single_account_mode     = false

--- a/kortix-selfhost/terraform/variables.tf
+++ b/kortix-selfhost/terraform/variables.tf
@@ -1,0 +1,194 @@
+# All variables here just pass through to modules/selfhost-ec2 — see that
+# module's variables.tf / README.md for the authoritative description of each.
+# Keeping the full surface here (rather than a handful with everything else
+# hardcoded in main.tf) so a standalone `kortix-selfhost` repo doesn't need to
+# reach into the module for anything a normal deployment would tune.
+
+variable "aws_region" {
+  description = "AWS region to provision the box in."
+  type        = string
+  default     = "us-east-1"
+}
+
+# ── Required ────────────────────────────────────────────────────────────────
+
+variable "domain" {
+  description = "Public domain to run this instance on, e.g. kortix.example.com. Its DNS A/AAAA record (and the API subdomain's) must point at the box's public IP for ACME HTTP-01 to issue a cert — either let this module manage it (set route53_zone_id) or point your own DNS at the public_ip output."
+  type        = string
+}
+
+variable "admin_email" {
+  description = "Email granted platform-admin on first boot. Leave empty to configure later via `kortix self-host configure` / the dashboard."
+  type        = string
+  default     = ""
+}
+
+# ── DNS ─────────────────────────────────────────────────────────────────────
+
+variable "route53_zone_id" {
+  description = "Route53 hosted zone ID for var.domain. Leave empty to manage DNS yourself (the module still outputs the Elastic IP to point at)."
+  type        = string
+  default     = ""
+}
+
+variable "api_domain" {
+  description = "API hostname to point at this box. Leave empty to default to api.<var.domain>."
+  type        = string
+  default     = ""
+}
+
+variable "dns_ttl" {
+  description = "TTL (seconds) for the Route53 A records, when created."
+  type        = number
+  default     = 300
+}
+
+# ── Naming / tags ───────────────────────────────────────────────────────────
+
+variable "name" {
+  description = "Name prefix for all AWS resources."
+  type        = string
+  default     = "kortix-selfhost"
+}
+
+variable "tags" {
+  description = "Extra tags applied to every resource this module creates."
+  type        = map(string)
+  default     = { Project = "kortix-selfhost" }
+}
+
+# ── Instance ────────────────────────────────────────────────────────────────
+
+variable "instance_type" {
+  description = "EC2 instance type. t3.xlarge (4 vCPU / 16GB) is a reasonable floor for the full stack."
+  type        = string
+  default     = "t3.xlarge"
+}
+
+variable "ami_id" {
+  description = "AMI to launch. Leave empty to resolve the latest Ubuntu 24.04 LTS AMI automatically."
+  type        = string
+  default     = ""
+}
+
+variable "root_volume_size_gb" {
+  description = "Root (OS) EBS volume size."
+  type        = number
+  default     = 30
+}
+
+variable "key_name" {
+  description = "Optional EC2 key pair name for SSH. Leave empty to rely on SSM Session Manager only (recommended)."
+  type        = string
+  default     = ""
+}
+
+# ── Networking ──────────────────────────────────────────────────────────────
+
+variable "vpc_id" {
+  description = "VPC to launch into. Leave empty to use the account/region's default VPC."
+  type        = string
+  default     = ""
+}
+
+variable "subnet_id" {
+  description = "Subnet to launch into. Leave empty to use a default subnet in the default VPC."
+  type        = string
+  default     = ""
+}
+
+variable "allowed_cidrs" {
+  description = "CIDRs allowed to reach the box on 80/443. Restrict this once you know your users' egress ranges."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "ssh_ingress_cidrs" {
+  description = "CIDRs allowed to reach port 22. Empty (default) opens no SSH ingress at all."
+  type        = list(string)
+  default     = []
+}
+
+# ── Data volume ─────────────────────────────────────────────────────────────
+
+variable "data_volume_size_gb" {
+  description = "Size of the separate EBS data volume holding all durable state (Docker + Postgres + Supabase Storage)."
+  type        = number
+  default     = 100
+}
+
+variable "data_volume_kms_key_id" {
+  description = "Optional customer-managed KMS key ARN for the data volume."
+  type        = string
+  default     = ""
+}
+
+# ── Backups (DLM snapshot schedule for the data volume) ────────────────────
+
+variable "backup_interval_hours" {
+  description = "How often to snapshot the data volume, in hours. One of 1, 2, 3, 4, 6, 8, 12, 24 (AWS DLM's supported intervals). Default 24 (once daily) — set e.g. 6 for four snapshots a day."
+  type        = number
+  default     = 24
+}
+
+variable "backup_retention_count" {
+  description = "How many snapshots to keep — stores up to this many backups before the oldest is pruned. Default 7."
+  type        = number
+  default     = 7
+}
+
+variable "snapshot_time" {
+  description = "UTC time-of-day (HH:MM) the snapshot runs. Only meaningful when backup_interval_hours = 24."
+  type        = string
+  default     = "03:00"
+}
+
+# ── kortix self-host bootstrap ──────────────────────────────────────────────
+
+variable "instance_name" {
+  description = "The kortix self-host `--instance` name."
+  type        = string
+  default     = "default"
+}
+
+variable "kortix_channel" {
+  description = "Image channel the stack tracks (`stable` or `latest`)."
+  type        = string
+  default     = "stable"
+}
+
+variable "kortix_version" {
+  description = "Optional exact image tag to pin instead of tracking a channel (passed as `kortix self-host init --tag`)."
+  type        = string
+  default     = ""
+}
+
+variable "kortix_cli_install_url" {
+  description = "URL for the one-click kortix CLI installer."
+  type        = string
+  default     = "https://kortix.com/install"
+}
+
+variable "kortix_cli_channel" {
+  description = "Which CLI build the installer fetches: `prod` (default) or `dev` (tracks main — use this if the published prod CLI hasn't caught up yet to flags/behavior this deployment relies on)."
+  type        = string
+  default     = "prod"
+}
+
+variable "auto_update" {
+  description = "Whether the in-compose auto-updater is on (`on`/`off`)."
+  type        = string
+  default     = "on"
+}
+
+variable "single_account_mode" {
+  description = "Run this instance single-account (no multi-tenant signup)."
+  type        = bool
+  default     = false
+}
+
+variable "acme_email" {
+  description = "Optional ACME (Let's Encrypt) contact email. Leave empty to use admin@<domain>."
+  type        = string
+  default     = ""
+}

--- a/tests/self-host-e2e/fast/feature-flags.test.ts
+++ b/tests/self-host-e2e/fast/feature-flags.test.ts
@@ -16,7 +16,7 @@ describe('self-host feature-flag matrix (fast, no Docker)', () => {
 
   afterEach(() => sandbox.cleanup());
 
-  test('default: multi-account, marketing OFF, billing off, enterprise off, managed-git required', async () => {
+  test('default: multi-account, marketing OFF, billing off, enterprise off, git provider declared github', async () => {
     const { code } = await sandbox.run(['init', '--yes', '--allow-missing-secrets']);
     expect(code).toBe(0);
     const env = sandbox.readEnv();
@@ -32,9 +32,9 @@ describe('self-host feature-flag matrix (fast, no Docker)', () => {
     expect(env.KORTIX_PUBLIC_BILLING_ENABLED).toBe('false');
     // Enterprise off by default.
     expect(env.ENTERPRISE_LICENSE_AVAILABLE).toBe('false');
-    // Managed git is required (declared provider is github; init doesn't
-    // silently disable the requirement — see required-secrets.test.ts for
-    // enforcement).
+    // Managed git's declared provider is always github, but it's NOT
+    // init-required anymore — it's configured in-app (Settings → Git) after
+    // start, not gated by this CLI. See required-secrets.test.ts.
     expect(env.MANAGED_GIT_PROVIDER).toBe('github');
   });
 
@@ -51,15 +51,17 @@ describe('self-host feature-flag matrix (fast, no Docker)', () => {
     expect(env.KORTIX_PUBLIC_SINGLE_ACCOUNT_MODE).toBe('true');
   });
 
-  test('--no-landing sets KORTIX_PUBLIC_DISABLE_LANDING_PAGE=true', async () => {
-    const { code } = await sandbox.run([
-      'init',
-      '--yes',
-      '--allow-missing-secrets',
-      '--no-landing',
-    ]);
-    expect(code).toBe(0);
+  // There is deliberately no `--landing`/`--no-landing` flag: the landing page
+  // isn't a guided-flow decision (self-host is an app deployment, not a
+  // marketing site), it's just an ordinary env var an operator flips directly
+  // if they genuinely want it back — see the default-off assertion above.
+  test('re-enabling the landing page is a plain `env set`, no dedicated flag', async () => {
+    await sandbox.run(['init', '--yes', '--allow-missing-secrets']);
     expect(sandbox.readEnv().KORTIX_PUBLIC_DISABLE_LANDING_PAGE).toBe('true');
+
+    const { code } = await sandbox.run(['env', 'set', 'KORTIX_PUBLIC_DISABLE_LANDING_PAGE=false']);
+    expect(code).toBe(0);
+    expect(sandbox.readEnv().KORTIX_PUBLIC_DISABLE_LANDING_PAGE).toBe('false');
   });
 
   test('--enterprise-license sets ENTERPRISE_LICENSE_AVAILABLE=true', async () => {
@@ -79,7 +81,6 @@ describe('self-host feature-flag matrix (fast, no Docker)', () => {
       '--yes',
       '--allow-missing-secrets',
       '--single-account',
-      '--no-landing',
       '--enterprise-license',
     ]);
     const env = sandbox.readEnv();

--- a/tests/self-host-e2e/fast/required-secrets.test.ts
+++ b/tests/self-host-e2e/fast/required-secrets.test.ts
@@ -28,17 +28,21 @@ describe.skipIf(!caps.allowMissingSecrets)(
 
     afterEach(() => sandbox.cleanup());
 
-    test('init --yes with required secrets missing fails non-zero and names what is missing', async () => {
+    // Contract as of the frontend-first CLI simplification: the CLI's
+    // init-time gate is narrow — ONLY the agent sandbox runtime (Daytona) is
+    // required. Managed git (GitHub) and the LLM key (OpenRouter) are BOTH
+    // configured in the web dashboard after `start` (Settings → Git / the
+    // model picker, BYOK) — neither blocks init/start anymore. See
+    // missingRequiredSecrets() in apps/cli/src/commands/self-host.ts.
+    test('init --yes with the sandbox runtime missing fails non-zero and names it', async () => {
       const { code, stderr } = await sandbox.run(['init', '--yes']);
 
       expect(code).not.toBe(0);
-      // Managed-git (GitHub), Daytona API key, and an LLM (OpenRouter) key are
-      // the three required-secret groups this deployment can't function
-      // without — the failure message must name all three so an operator knows
-      // exactly what to fix, not just that "something" is missing.
       expect(stderr.toLowerCase()).toContain('daytona');
-      expect(stderr.toLowerCase()).toContain('managed git');
-      expect(stderr.toLowerCase()).toContain('openrouter');
+      // Managed git / LLM are dashboard-configured now — the failure message
+      // must NOT claim they're required.
+      expect(stderr.toLowerCase()).not.toContain('managed git');
+      expect(stderr.toLowerCase()).not.toContain('openrouter');
       expect(stderr).toContain('--allow-missing-secrets');
     });
 
@@ -47,45 +51,37 @@ describe.skipIf(!caps.allowMissingSecrets)(
 
       expect(code).toBe(0);
       expect(stdout.toLowerCase()).toContain('missing');
-      // The env is still written even though secrets are missing — a follow-up
-      // `secrets set` / `env set` has something to build on.
+      // The env is still written even though the secret is missing — a
+      // follow-up `secrets set` / `env set` has something to build on.
       const env = sandbox.readEnv();
-      expect(env.OPENROUTER_API_KEY).toBe('');
       expect(env.DAYTONA_API_KEY).toBe('');
     });
 
-    test('a fully-configured env passes without --allow-missing-secrets', async () => {
+    test('Daytona alone (no managed git, no OpenRouter) passes without --allow-missing-secrets', async () => {
       // Secrets can't be supplied in the same non-interactive `init` call (no
       // flags for them) — the realistic flow is: render once with the escape
-      // hatch, backfill the secrets via `env set`, then a plain re-init (or
+      // hatch, backfill the secret via `env set`, then a plain re-init (or
       // `start`) re-validates and should now pass.
       const first = await sandbox.run(['init', '--yes', '--allow-missing-secrets']);
       expect(first.code).toBe(0);
 
-      const envSet = await sandbox.run([
-        'env',
-        'set',
-        'OPENROUTER_API_KEY=sk-or-test-key',
-        'DAYTONA_API_KEY=dtn-test-key',
-        'MANAGED_GIT_GITHUB_OWNER=acme-corp',
-        'MANAGED_GIT_GITHUB_TOKEN=ghp-test-token',
-      ]);
+      const envSet = await sandbox.run(['env', 'set', 'DAYTONA_API_KEY=dtn-test-key']);
       expect(envSet.code).toBe(0);
 
       const second = await sandbox.run(['init', '--yes']);
       expect(second.code).toBe(0);
       const env = sandbox.readEnv();
-      expect(env.OPENROUTER_API_KEY).toBe('sk-or-test-key');
       expect(env.DAYTONA_API_KEY).toBe('dtn-test-key');
-      expect(env.MANAGED_GIT_GITHUB_OWNER).toBe('acme-corp');
+      // Neither was set, and neither blocks success.
+      expect(env.OPENROUTER_API_KEY).toBe('');
+      expect(env.MANAGED_GIT_GITHUB_OWNER).toBe('');
     });
 
-    test('a GitHub App (instead of a PAT) also satisfies the managed-git requirement', async () => {
+    test('managed git / OpenRouter left unset never blocks init, with or without a GitHub App configured', async () => {
       await sandbox.run(['init', '--yes', '--allow-missing-secrets']);
       await sandbox.run([
         'env',
         'set',
-        'OPENROUTER_API_KEY=sk-or-test-key',
         'DAYTONA_API_KEY=dtn-test-key',
         'MANAGED_GIT_GITHUB_OWNER=acme-corp',
         'KORTIX_GITHUB_APP_ID=12345',

--- a/tests/self-host-e2e/fast/version-channel-images.test.ts
+++ b/tests/self-host-e2e/fast/version-channel-images.test.ts
@@ -28,7 +28,13 @@ describe.skipIf(!caps.localImages)(
 
     afterEach(() => sandbox.cleanup());
 
-    test('--version 0.9.107 pins every *_IMAGE tag to :0.9.107 and defaults auto-update OFF', async () => {
+    // Auto-update defaults ON everywhere, including a pinned --version/--tag:
+    // the nightly updater re-pulling the SAME immutable pinned tag is a
+    // harmless no-op (nothing to roll), not silent drift — so pinning alone
+    // is no longer a reason to default it off. --local-images is the one real
+    // exception (a locally-built image was never pushed to any registry —
+    // see the --local-images tests below).
+    test('--version 0.9.107 pins every *_IMAGE tag to :0.9.107, auto-update still defaults ON', async () => {
       const { code } = await sandbox.run([
         'init',
         '--yes',
@@ -46,9 +52,7 @@ describe.skipIf(!caps.localImages)(
       expect(env.SANDBOX_IMAGE).toBe('kortix/kortix-sandbox:0.9.107');
       // Pinning an explicit version doesn't invent/overwrite the channel name.
       expect(env.KORTIX_CHANNEL).toBe('stable');
-      // A pinned ref means "stay here" — the nightly updater must not silently
-      // move a pinned box off it.
-      expect(env.KORTIX_AUTO_UPDATE).toBe('false');
+      expect(env.KORTIX_AUTO_UPDATE).toBe('true');
     });
 
     test('--tag and --release are accepted aliases for --version', async () => {
@@ -61,7 +65,7 @@ describe.skipIf(!caps.localImages)(
       ]);
       expect(viaTag.code).toBe(0);
       expect(sandbox.readEnv().API_IMAGE).toBe('kortix/kortix-api:0.9.55');
-      expect(sandbox.readEnv().KORTIX_AUTO_UPDATE).toBe('false');
+      expect(sandbox.readEnv().KORTIX_AUTO_UPDATE).toBe('true');
 
       const other = new SelfHostSandbox();
       try {
@@ -74,13 +78,13 @@ describe.skipIf(!caps.localImages)(
         ]);
         expect(viaRelease.code).toBe(0);
         expect(other.readEnv().API_IMAGE).toBe('kortix/kortix-api:0.9.60');
-        expect(other.readEnv().KORTIX_AUTO_UPDATE).toBe('false');
+        expect(other.readEnv().KORTIX_AUTO_UPDATE).toBe('true');
       } finally {
         other.cleanup();
       }
     });
 
-    test('--channel latest tracks :latest and keeps auto-update ON (a moving channel, not a pin)', async () => {
+    test('--channel latest tracks :latest and keeps auto-update ON (a moving channel)', async () => {
       const { code } = await sandbox.run([
         'init',
         '--yes',
@@ -95,15 +99,13 @@ describe.skipIf(!caps.localImages)(
       expect(env.KORTIX_AUTO_UPDATE).toBe('true');
     });
 
-    test('an explicit --auto-update always wins over the pin/channel default', async () => {
+    test('an explicit --auto-update off always wins over the (now-ON-by-default) pin/channel default', async () => {
       const pinnedOn = await sandbox.run([
         'init',
         '--yes',
         '--allow-missing-secrets',
         '--version',
         '0.9.107',
-        '--auto-update',
-        'on',
       ]);
       expect(pinnedOn.code).toBe(0);
       expect(sandbox.readEnv().KORTIX_AUTO_UPDATE).toBe('true');


### PR DESCRIPTION
Post-v0.10.0 hardening from live verification on laptop (tunnel) + EC2 (Terraform), all e2e-proven:

- **Agent turns work on self-host**: stop handing the docker-internal LLM_GATEWAY_BASE_URL to cloud sandboxes (root cause of 'Cannot connect to API'); in-API gateway serves the /v1-prefixed OpenAI path; proven with real BYOK Anthropic completions ×2.
- **Init overhaul (VPS-first)**: domain-first guided flow (reachability → admin email → shape → sandbox provider daytona/e2b/platinum → optional Pipedream → compact updates), help cut ~230→40 lines, auto-update default on, landing flags removed, GitHub/OpenRouter prompts removed (dashboard owns them).
- **Cloudflare tunnel mode**: render-time cloudflared service, URL capture + KORTIX_URL rewire, local-images pull guard, supavisor ulimits restored.
- **GitHub App**: personal-account (User) owner routing, install ownerType stored+validated, torn-config detection; new-project flow routes to Git settings; frontend /v1 proxy targets kortix-api in-network.
- **CLI vs self-host**: login opens the right dashboard (Host.dashboard_url stamped by init/start; merge-on-save regression fixed), PNA preflight header; verified login→whoami→projects→ship-dry-run.
- **kortix-selfhost/**: one-README distribution + thin Terraform (EC2, EBS data volume, daily DLM backups keep-N, Route53-or-manual DNS); vpc-demo now deployed by it.
- e2e proof harness + new unit tests throughout (CLI 349/349, api/web suites green).