### PR TITLE
feat(mfa): members-list MFA status + verification recovers the screen

### DIFF
--- a/apps/api/src/accounts/core/accounts.ts
+++ b/apps/api/src/accounts/core/accounts.ts
@@ -1,24 +1,24 @@
-import { createRoute, z } from "@hono/zod-openapi";
-import { and, count, eq, sql } from "drizzle-orm";
-import { json, errors, auth } from "../../openapi";
-import { accountMembers, accounts, projects } from "@kortix/db";
-import { bootstrapPersonalAccount } from "./bootstrap-personal-account";
-import { config } from "../../config";
-import { db } from "../../shared/db";
-import { ACCOUNT_ACTIONS, assertAuthorized } from "../../iam";
+import { createRoute, z } from '@hono/zod-openapi';
+import { accountMembers, accounts, projects } from '@kortix/db';
+import { and, count, eq, sql } from 'drizzle-orm';
+import { config } from '../../config';
+import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
+import { auth, errors, json } from '../../openapi';
+import { db } from '../../shared/db';
 import {
-  accountsRouter,
-  accountDisplayName,
-  resolveAccountDisplayNames,
-  AccountSummarySchema,
   AccountDetailSchema,
   AccountIdParam,
-  readBody,
-  normalizeString,
-  getMembership,
-  serializeAccount,
+  AccountSummarySchema,
+  accountDisplayName,
+  accountsRouter,
   autoClaimPendingInvites,
-} from "./app";
+  getMembership,
+  normalizeString,
+  readBody,
+  resolveAccountDisplayNames,
+  serializeAccount,
+} from './app';
+import { bootstrapPersonalAccount } from './bootstrap-personal-account';
 
 // Routes are registered via this function (called by the orchestrator in the
 // original route-registration order).
@@ -26,22 +26,19 @@ export function registerAccountRoutes(): void {
   // GET /v1/accounts — list user's accounts.
   accountsRouter.openapi(
     createRoute({
-      method: "get",
-      path: "/",
-      tags: ["accounts"],
+      method: 'get',
+      path: '/',
+      tags: ['accounts'],
       summary: "List the user's accounts",
       ...auth,
       responses: {
-        200: json(
-          z.array(AccountSummarySchema),
-          "Accounts the user belongs to",
-        ),
+        200: json(z.array(AccountSummarySchema), 'Accounts the user belongs to'),
         ...errors(401),
       },
     }),
     async (c: any) => {
-      const userId = c.get("userId") as string;
-      const userEmail = c.get("userEmail") as string;
+      const userId = c.get('userId') as string;
+      const userEmail = c.get('userEmail') as string;
 
       await autoClaimPendingInvites(userId, userEmail);
 
@@ -67,12 +64,10 @@ export function registerAccountRoutes(): void {
             account_id: m.accountId,
             name: displayNames.get(m.accountId) ?? accountDisplayName(m.name, userEmail),
             slug: m.accountId.slice(0, 8),
-            created_at:
-              m.createdAt?.toISOString() ?? new Date().toISOString(),
-            updated_at:
-              m.updatedAt?.toISOString() ?? new Date().toISOString(),
-            account_role: m.accountRole || "owner",
-            is_primary_owner: m.accountRole === "owner",
+            created_at: m.createdAt?.toISOString() ?? new Date().toISOString(),
+            updated_at: m.updatedAt?.toISOString() ?? new Date().toISOString(),
+            account_role: m.accountRole || 'owner',
+            is_primary_owner: m.accountRole === 'owner',
           })),
         );
       }
@@ -85,9 +80,7 @@ export function registerAccountRoutes(): void {
           .where(eq(accounts.accountId, accountId))
           .limit(1);
         if (!row) {
-          throw new Error(
-            `Personal account ${accountId} missing after bootstrap`,
-          );
+          throw new Error(`Personal account ${accountId} missing after bootstrap`);
         }
         return c.json([
           {
@@ -96,13 +89,13 @@ export function registerAccountRoutes(): void {
             slug: row.accountId.slice(0, 8),
             created_at: row.createdAt.toISOString(),
             updated_at: row.updatedAt.toISOString(),
-            account_role: "owner",
+            account_role: 'owner',
             is_primary_owner: true,
           },
         ]);
       } catch (err) {
-        console.warn("[accounts] Failed to bootstrap personal account:", err);
-        return c.json({ error: "Failed to initialize account" }, 500);
+        console.warn('[accounts] Failed to bootstrap personal account:', err);
+        return c.json({ error: 'Failed to initialize account' }, 500);
       }
     },
   );
@@ -110,20 +103,20 @@ export function registerAccountRoutes(): void {
   // POST /v1/accounts — create a new team account.
   accountsRouter.openapi(
     createRoute({
-      method: "post",
-      path: "/",
-      tags: ["accounts"],
-      summary: "Create a new team account",
+      method: 'post',
+      path: '/',
+      tags: ['accounts'],
+      summary: 'Create a new team account',
       ...auth,
       request: {
         body: {
           content: {
-            "application/json": { schema: z.object({ name: z.string() }) },
+            'application/json': { schema: z.object({ name: z.string() }) },
           },
         },
       },
       responses: {
-        201: json(AccountSummarySchema, "The newly created account"),
+        201: json(AccountSummarySchema, 'The newly created account'),
         ...errors(400, 401, 403),
       },
     }),
@@ -135,22 +128,25 @@ export function registerAccountRoutes(): void {
       // practice.
       if (config.KORTIX_SINGLE_ACCOUNT_MODE) {
         return c.json(
-          { error: "Creating additional accounts is disabled on this deployment (single-account mode)" },
+          {
+            error:
+              'Creating additional accounts is disabled on this deployment (single-account mode)',
+          },
           403,
         );
       }
-      const userId = c.get("userId") as string;
+      const userId = c.get('userId') as string;
       const body = await readBody(c);
       const name = normalizeString(body.name);
-      if (!name) return c.json({ error: "name is required" }, 400);
-      if (name.length > 255) return c.json({ error: "name is too long" }, 400);
+      if (!name) return c.json({ error: 'name is required' }, 400);
+      if (name.length > 255) return c.json({ error: 'name is too long' }, 400);
 
       const [account] = await db.insert(accounts).values({ name }).returning();
 
       await db.insert(accountMembers).values({
         userId,
         accountId: account.accountId,
-        accountRole: "owner",
+        accountRole: 'owner',
         isSuperAdmin: true,
       });
 
@@ -161,7 +157,7 @@ export function registerAccountRoutes(): void {
           slug: account.accountId.slice(0, 8),
           created_at: account.createdAt.toISOString(),
           updated_at: account.updatedAt.toISOString(),
-          account_role: "owner",
+          account_role: 'owner',
           is_primary_owner: true,
         },
         201,
@@ -172,30 +168,30 @@ export function registerAccountRoutes(): void {
   // GET /v1/accounts/:accountId — details.
   accountsRouter.openapi(
     createRoute({
-      method: "get",
-      path: "/{accountId}",
-      tags: ["accounts"],
-      summary: "Get account details",
+      method: 'get',
+      path: '/{accountId}',
+      tags: ['accounts'],
+      summary: 'Get account details',
       ...auth,
       request: { params: AccountIdParam },
       responses: {
-        200: json(AccountDetailSchema, "Account details"),
+        200: json(AccountDetailSchema, 'Account details'),
         ...errors(401, 403, 404),
       },
     }),
     async (c: any) => {
-      const userId = c.get("userId") as string;
-      const accountId = c.req.param("accountId");
+      const userId = c.get('userId') as string;
+      const accountId = c.req.param('accountId');
 
       const [row] = await db
         .select()
         .from(accounts)
         .where(eq(accounts.accountId, accountId))
         .limit(1);
-      if (!row) return c.json({ error: "Not found" }, 404);
+      if (!row) return c.json({ error: 'Not found' }, 404);
 
       const membership = await getMembership(userId, accountId);
-      if (!membership) return c.json({ error: "Forbidden" }, 403);
+      if (!membership) return c.json({ error: 'Forbidden' }, 403);
 
       // Member count EXCLUDING phantom self-memberships (user_id == account_id with
       // no auth user) — same definition as billing/countActiveMembers and the
@@ -227,13 +223,11 @@ export function registerAccountRoutes(): void {
       const [projectCountRow] = await db
         .select({ n: count() })
         .from(projects)
-        .where(
-          and(eq(projects.accountId, accountId), eq(projects.status, "active")),
-        );
+        .where(and(eq(projects.accountId, accountId), eq(projects.status, 'active')));
 
       const displayNames = await resolveAccountDisplayNames(
         [{ accountId: row.accountId, name: row.name }],
-        { userId, email: c.get("userEmail") as string },
+        { userId, email: c.get('userEmail') as string },
       );
 
       return c.json({
@@ -242,6 +236,7 @@ export function registerAccountRoutes(): void {
         member_count: memberCount,
         project_count: Number(projectCountRow?.n ?? 0),
         role: membership.accountRole,
+        mfa_required: row.mfaRequired ?? false,
         created_at: row.createdAt.toISOString(),
         updated_at: row.updatedAt.toISOString(),
       });
@@ -251,43 +246,43 @@ export function registerAccountRoutes(): void {
   // PATCH /v1/accounts/:accountId — rename. Gated on account.write via IAM.
   accountsRouter.openapi(
     createRoute({
-      method: "patch",
-      path: "/{accountId}",
-      tags: ["accounts"],
-      summary: "Rename an account",
+      method: 'patch',
+      path: '/{accountId}',
+      tags: ['accounts'],
+      summary: 'Rename an account',
       ...auth,
       request: {
         params: AccountIdParam,
         body: {
           content: {
-            "application/json": { schema: z.object({ name: z.string() }) },
+            'application/json': { schema: z.object({ name: z.string() }) },
           },
         },
       },
       responses: {
-        200: json(AccountSummarySchema, "The updated account"),
+        200: json(AccountSummarySchema, 'The updated account'),
         ...errors(400, 401, 403, 404),
       },
     }),
     async (c: any) => {
-      const userId = c.get("userId") as string;
-      const accountId = c.req.param("accountId");
+      const userId = c.get('userId') as string;
+      const accountId = c.req.param('accountId');
 
       const membership = await getMembership(userId, accountId);
-      if (!membership) return c.json({ error: "Forbidden" }, 403);
+      if (!membership) return c.json({ error: 'Forbidden' }, 403);
       await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.ACCOUNT_WRITE);
 
       const body = await readBody(c);
       const name = normalizeString(body.name);
-      if (!name) return c.json({ error: "name is required" }, 400);
-      if (name.length > 255) return c.json({ error: "name is too long" }, 400);
+      if (!name) return c.json({ error: 'name is required' }, 400);
+      if (name.length > 255) return c.json({ error: 'name is too long' }, 400);
 
       const [row] = await db
         .update(accounts)
         .set({ name, updatedAt: new Date() })
         .where(eq(accounts.accountId, accountId))
         .returning();
-      if (!row) return c.json({ error: "Not found" }, 404);
+      if (!row) return c.json({ error: 'Not found' }, 404);
 
       return c.json(serializeAccount(row));
     },

--- a/apps/api/src/accounts/core/app.ts
+++ b/apps/api/src/accounts/core/app.ts
@@ -1,12 +1,12 @@
-import { Context } from 'hono';
 import { z } from '@hono/zod-openapi';
+import { accountInvitations, accountMembers, type accounts } from '@kortix/db';
 import { and, asc, count, eq, gt, inArray, isNull, sql } from 'drizzle-orm';
+import type { Context } from 'hono';
 import { makeOpenApiApp } from '../../openapi';
-import { accountInvitations, accountMembers, accounts } from '@kortix/db';
-import type { AppEnv } from '../../types';
 import { db } from '../../shared/db';
-import { getSupabase } from '../../shared/supabase';
 import { resolveAccountId } from '../../shared/resolve-account';
+import { getSupabase } from '../../shared/supabase';
+import type { AppEnv } from '../../types';
 
 // ─── Public router (leaf module — no route imports here to avoid cycles) ─────
 export const accountsRouter = makeOpenApiApp<AppEnv>();
@@ -53,6 +53,8 @@ export const AccountDetailSchema = z
     member_count: z.number(),
     project_count: z.number(),
     role: z.string(),
+    /** Account-wide MFA enforcement flag — drives the members-list MFA badges. */
+    mfa_required: z.boolean().optional(),
     created_at: z.string(),
     updated_at: z.string(),
   })
@@ -105,15 +107,17 @@ export const MeSchema = z
   .object({
     user_id: z.string(),
     email: z.string(),
-    token_context: z.object({
-      auth_type: z.string().nullable(),
-      project_id: z.string().nullable(),
-      session_id: z.string().nullable(),
-      agent: z.string().nullable(),
-      connectors: z.union([z.literal('all'), z.array(z.string())]).nullable(),
-      kortix_cli: z.union([z.literal('all'), z.array(z.string())]).nullable(),
-      env: z.union([z.literal('all'), z.array(z.string())]).nullable(),
-    }).optional(),
+    token_context: z
+      .object({
+        auth_type: z.string().nullable(),
+        project_id: z.string().nullable(),
+        session_id: z.string().nullable(),
+        agent: z.string().nullable(),
+        connectors: z.union([z.literal('all'), z.array(z.string())]).nullable(),
+        kortix_cli: z.union([z.literal('all'), z.array(z.string())]).nullable(),
+        env: z.union([z.literal('all'), z.array(z.string())]).nullable(),
+      })
+      .optional(),
     accounts: z.array(
       z.object({
         account_id: z.string(),
@@ -200,7 +204,9 @@ export async function countOwners(accountId: string): Promise<number> {
   return Number(row?.n ?? 0);
 }
 
-export async function lookupEmailsByUserIds(userIds: string[]): Promise<Map<string, string | null>> {
+export async function lookupEmailsByUserIds(
+  userIds: string[],
+): Promise<Map<string, string | null>> {
   const result = new Map<string, string | null>();
   if (userIds.length === 0) return result;
   const supabase = getSupabase();
@@ -241,10 +247,9 @@ export async function resolveAccountDisplayNames(
     const owners = await db
       .select({ accountId: accountMembers.accountId, userId: accountMembers.userId })
       .from(accountMembers)
-      .where(and(
-        inArray(accountMembers.accountId, unnamed),
-        eq(accountMembers.accountRole, 'owner'),
-      ))
+      .where(
+        and(inArray(accountMembers.accountId, unnamed), eq(accountMembers.accountRole, 'owner')),
+      )
       .orderBy(asc(accountMembers.joinedAt));
     for (const o of owners) {
       if (!ownerByAccount.has(o.accountId)) ownerByAccount.set(o.accountId, o.userId);
@@ -260,9 +265,10 @@ export async function resolveAccountDisplayNames(
 
   for (const accountId of unnamed) {
     const ownerId = ownerByAccount.get(accountId);
-    const email = !ownerId || ownerId === caller.userId
-      ? caller.email // ownerless account: caller email beats a bare 'Account'
-      : ownerEmails.get(ownerId) ?? caller.email;
+    const email =
+      !ownerId || ownerId === caller.userId
+        ? caller.email // ownerless account: caller email beats a bare 'Account'
+        : (ownerEmails.get(ownerId) ?? caller.email);
     names.set(accountId, defaultAccountName(email));
   }
   return names;

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -1470,6 +1470,17 @@ function MembersCard({
                             <Badge variant="success" size="sm" title="MFA enrolled">
                               2FA
                             </Badge>
+                          ) : account.mfa_required && !member.is_super_admin ? (
+                            // Account requires MFA and this member has no verified
+                            // factor — they're blocked from gated actions until they
+                            // enrol. Super-admins are exempt, so they're not flagged.
+                            <Badge
+                              variant="destructive"
+                              size="sm"
+                              title="MFA required but not enrolled — this member is blocked from gated actions"
+                            >
+                              No 2FA
+                            </Badge>
                           ) : null}
                         </div>
                         <span className="text-muted-foreground text-xs">

--- a/apps/web/src/features/accounts/settings/cli-tokens-tab.tsx
+++ b/apps/web/src/features/accounts/settings/cli-tokens-tab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge } from '@/components/ui/badge';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -17,6 +18,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { errorToast, successToast } from '@/components/ui/toast';
+import { MFA_REQUIRED_EVENT } from '@/features/auth/mfa-step-up';
 import { Icon } from '@/features/icon/icon';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { useCopy } from '@/hooks/use-copy';
@@ -284,9 +286,28 @@ export function CliTokensTab() {
           <Skeleton className="h-16 w-full rounded-2xl" />
         </div>
       ) : tokensQuery.error ? (
-        <div className="border-destructive bg-destructive/5 text-destructive rounded-2xl border p-4 text-sm">
-          {(tokensQuery.error as Error).message}
-        </div>
+        (tokensQuery.error as { code?: string })?.code === 'account_mfa_required' ? (
+          <InfoBanner
+            tone="warning"
+            title="Multi-factor authentication required"
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => window.dispatchEvent(new CustomEvent(MFA_REQUIRED_EVENT))}
+              >
+                Verify
+              </Button>
+            }
+          >
+            Verify your second factor to manage API keys. Already verified? This
+            list refreshes automatically once your session steps up.
+          </InfoBanner>
+        ) : (
+          <div className="border-destructive bg-destructive/5 text-destructive rounded-2xl border p-4 text-sm">
+            {(tokensQuery.error as Error).message}
+          </div>
+        )
       ) : tokens.length === 0 && !creating ? (
         <EmptyState
           icon={KeyRound}

--- a/apps/web/src/features/accounts/settings/security-tab.tsx
+++ b/apps/web/src/features/accounts/settings/security-tab.tsx
@@ -50,7 +50,9 @@ export function FactorRow({
           <div className="text-foreground truncate text-sm font-medium">
             {factor.friendly_name || (factor.factor_type === 'phone' ? 'Phone' : 'Authenticator app')}
           </div>
-          <div className="text-muted-foreground text-xs capitalize">{factor.factor_type}</div>
+          <div className="text-muted-foreground text-xs">
+            {factor.factor_type === 'phone' ? 'SMS' : 'Authenticator app (TOTP)'}
+          </div>
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-2">
@@ -121,8 +123,11 @@ export function SecurityTab() {
       successToast('Authenticator enrolled — this session is now MFA-verified');
       setEnrolling(null);
       setCode('');
-      queryClient.invalidateQueries({ queryKey: ['mfa-factors'] });
-      queryClient.invalidateQueries({ queryKey: ['mfa-aal'] });
+      // Verifying the first factor elevates this session to aal2. Refetch every
+      // active query so data that 403'd while aal1 (projects, API keys, members)
+      // repopulates on its own — no manual page reload, and the MFA error banners
+      // on those screens clear.
+      queryClient.invalidateQueries();
     },
     onError: (err: Error) => errorToast(err.message || 'Code did not verify'),
   });

--- a/packages/sdk/src/core/rest/projects-client/accounts.ts
+++ b/packages/sdk/src/core/rest/projects-client/accounts.ts
@@ -2,7 +2,7 @@
 
 import { backendApi } from '../../http/api-client';
 import type { ApiError } from '../../http/api/errors';
-import { serverTokenGet, unwrap, type AccountRole, type ServerTokenOptions } from './shared';
+import { type AccountRole, type ServerTokenOptions, serverTokenGet, unwrap } from './shared';
 
 export interface KortixAccount {
   account_id: string;
@@ -22,6 +22,8 @@ export interface AccountDetail {
   member_count: number;
   project_count: number;
   role: AccountRole;
+  /** Account-wide MFA enforcement is on — drives the members-list MFA badges. */
+  mfa_required?: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -111,9 +113,7 @@ export interface AccountInviteDescribeRedacted {
   expires_at?: null;
 }
 
-export type AccountInviteDescribe =
-  | AccountInviteDescribeFull
-  | AccountInviteDescribeRedacted;
+export type AccountInviteDescribe = AccountInviteDescribeFull | AccountInviteDescribeRedacted;
 
 export async function listAccounts() {
   return unwrap(await backendApi.get<KortixAccount[]>('/accounts'));
@@ -128,15 +128,11 @@ export async function getAccount(accountId: string) {
 }
 
 export async function updateAccountName(accountId: string, name: string) {
-  return unwrap(
-    await backendApi.patch<AccountDetail>(`/accounts/${accountId}`, { name }),
-  );
+  return unwrap(await backendApi.patch<AccountDetail>(`/accounts/${accountId}`, { name }));
 }
 
 export async function listAccountMembers(accountId: string) {
-  return unwrap(
-    await backendApi.get<AccountMember[]>(`/accounts/${accountId}/members`),
-  );
+  return unwrap(await backendApi.get<AccountMember[]>(`/accounts/${accountId}/members`));
 }
 
 export async function inviteAccountMember(
@@ -144,28 +140,20 @@ export async function inviteAccountMember(
   input: { email: string; role?: AccountRole },
 ) {
   return unwrap(
-    await backendApi.post<InviteMemberResult>(
-      `/accounts/${accountId}/members`,
-      input,
-      {
-        // 409 (already member) is an expected business error; page surfaces it inline.
-        showErrors: false,
-      },
-    ),
+    await backendApi.post<InviteMemberResult>(`/accounts/${accountId}/members`, input, {
+      // 409 (already member) is an expected business error; page surfaces it inline.
+      showErrors: false,
+    }),
   );
 }
 
 export async function listAccountInvites(accountId: string) {
-  return unwrap(
-    await backendApi.get<AccountInvitation[]>(`/accounts/${accountId}/invites`),
-  );
+  return unwrap(await backendApi.get<AccountInvitation[]>(`/accounts/${accountId}/invites`));
 }
 
 export async function cancelAccountInvite(accountId: string, inviteId: string) {
   return unwrap(
-    await backendApi.delete<{ ok: boolean }>(
-      `/accounts/${accountId}/invites/${inviteId}`,
-    ),
+    await backendApi.delete<{ ok: boolean }>(`/accounts/${accountId}/invites/${inviteId}`),
   );
 }
 
@@ -180,13 +168,10 @@ export async function resendAccountInvite(accountId: string, inviteId: string) {
 
 export async function describeAccountInvite(inviteId: string) {
   return unwrap(
-    await backendApi.get<AccountInviteDescribe>(
-      `/account-invites/${inviteId}`,
-      {
-        // The redirect/landing page handles "not for you" / expired states inline.
-        showErrors: false,
-      },
-    ),
+    await backendApi.get<AccountInviteDescribe>(`/account-invites/${inviteId}`, {
+      // The redirect/landing page handles "not for you" / expired states inline.
+      showErrors: false,
+    }),
   );
 }
 
@@ -200,19 +185,12 @@ export async function acceptAccountInvite(inviteId: string) {
 }
 
 export async function declineAccountInvite(inviteId: string) {
-  return unwrap(
-    await backendApi.post<{ ok: boolean }>(
-      `/account-invites/${inviteId}/decline`,
-      {},
-    ),
-  );
+  return unwrap(await backendApi.post<{ ok: boolean }>(`/account-invites/${inviteId}/decline`, {}));
 }
 
 export async function removeAccountMember(accountId: string, userId: string) {
   return unwrap(
-    await backendApi.delete<{ ok: boolean }>(
-      `/accounts/${accountId}/members/${userId}`,
-    ),
+    await backendApi.delete<{ ok: boolean }>(`/accounts/${accountId}/members/${userId}`),
   );
 }
 
@@ -222,17 +200,12 @@ export async function updateAccountMemberRole(
   role: AccountRole,
 ) {
   return unwrap(
-    await backendApi.patch<AccountMember>(
-      `/accounts/${accountId}/members/${userId}`,
-      { role },
-    ),
+    await backendApi.patch<AccountMember>(`/accounts/${accountId}/members/${userId}`, { role }),
   );
 }
 
 export async function leaveAccount(accountId: string) {
-  return unwrap(
-    await backendApi.post<{ ok: boolean }>(`/accounts/${accountId}/leave`, {}),
-  );
+  return unwrap(await backendApi.post<{ ok: boolean }>(`/accounts/${accountId}/leave`, {}));
 }
 
 /**


### PR DESCRIPTION
Follow-up UX polish on the Require-MFA feature, from testing it live:

- **Members list**: when the account enforces MFA, each member without a verified factor now shows a **"No 2FA"** badge (enrolled members already showed "2FA"; super-admins are exempt). Backed by a new `mfa_required` field on the account detail.
- **Verification recovers the screen**: enrolling the first factor (or stepping up) elevates the session to aal2, but projects / API keys / members that 403'd while aal1 stayed blank until a manual reload. Enrollment now refetches all active queries — no reload needed.
- **API keys tab**: the raw red MFA error is now a proper "verify your second factor" prompt with a **Verify** button (opens the step-up dialog); the list refreshes automatically once verified.
- **Factor row** reads "Authenticator app (TOTP)" instead of "Totp".

tsc + biome clean; existing security-tab / cli-tokens tests green.