### PR TITLE
fix(api): free the SAML domain on SSO disconnect

### DIFF
--- a/apps/api/src/__tests__/unit-sso-provisioning.test.ts
+++ b/apps/api/src/__tests__/unit-sso-provisioning.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import {
   buildSamlAttributeMapping,
+  deleteSupabaseSamlProvider,
   registerSupabaseSamlProvider,
 } from '../accounts/iam/sso-provisioning';
 
@@ -132,6 +133,44 @@ describe('buildSamlAttributeMapping', () => {
       metadataUrl: 'https://idp/meta',
       domains: ['acme.com'],
     });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(502);
+  });
+});
+
+describe('deleteSupabaseSamlProvider', () => {
+  test('DELETEs the provider at the GoTrue admin endpoint', async () => {
+    let captured: { url: string; method: string } | null = null;
+    globalThis.fetch = (async (url: any, init: any) => {
+      captured = { url: String(url), method: String(init?.method) };
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    const r = await deleteSupabaseSamlProvider('prov-123');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.providerId).toBe('prov-123');
+    expect(captured!.url).toContain('/auth/v1/admin/sso/providers/prov-123');
+    expect(captured!.method).toBe('DELETE');
+  });
+
+  test('treats a 404 (already unregistered) as success', async () => {
+    respond(404, 'not found');
+    const r = await deleteSupabaseSamlProvider('gone');
+    expect(r.ok).toBe(true);
+  });
+
+  test('surfaces a non-404 failure as a non-ok result, never a throw', async () => {
+    respond(500, 'boom');
+    const r = await deleteSupabaseSamlProvider('prov-1');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+
+  test('a network failure is a 502, never a throw', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const r = await deleteSupabaseSamlProvider('prov-1');
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.status).toBe(502);
   });

--- a/apps/api/src/accounts/iam/sso-provisioning.ts
+++ b/apps/api/src/accounts/iam/sso-provisioning.ts
@@ -163,3 +163,55 @@ export async function syncSupabaseSamlAttributeMapping(
   }
   return { ok: true, providerId: supabaseProviderId };
 }
+
+/**
+ * Delete a registered SAML provider from Supabase Auth. Called when an account
+ * disconnects SSO so the IdP is unregistered AND — crucially — the email
+ * domain it claimed is freed, letting the admin re-import the same domain later
+ * without hitting Supabase's "domain already registered" 422. Without this the
+ * Kortix row is removed but the Supabase provider is orphaned, stranding the
+ * domain with no self-serve way to reclaim it.
+ *
+ * A 404 is treated as SUCCESS: the provider is already gone (deleted out-of-band
+ * or a double-disconnect), which is the state the caller wanted. Never throws —
+ * disconnecting SSO must never fail on a Supabase hiccup, so the caller logs a
+ * non-ok result and still removes the local row.
+ */
+export async function deleteSupabaseSamlProvider(
+  supabaseProviderId: string,
+): Promise<ProvisionResult> {
+  if (!config.SUPABASE_URL || !config.SUPABASE_SERVICE_ROLE_KEY) {
+    return {
+      ok: false,
+      error: 'SSO provisioning is not configured on this deployment',
+      status: 501,
+    };
+  }
+  const base = config.SUPABASE_URL.replace(/\/+$/, '');
+  let resp: Response;
+  try {
+    resp = await fetch(`${base}/auth/v1/admin/sso/providers/${supabaseProviderId}`, {
+      method: 'DELETE',
+      headers: {
+        apikey: config.SUPABASE_SERVICE_ROLE_KEY,
+        authorization: `Bearer ${config.SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Could not reach Supabase auth: ${(e as Error).message}`,
+      status: 502,
+    };
+  }
+  // 404 = already unregistered; that's the desired end state, so treat as ok.
+  if (!resp.ok && resp.status !== 404) {
+    const detail = (await resp.text().catch(() => '')).slice(0, 400);
+    return {
+      ok: false,
+      error: detail ? `Supabase rejected the provider deletion: ${detail}` : `Supabase rejected the provider deletion (${resp.status})`,
+      status: 400,
+    };
+  }
+  return { ok: true, providerId: supabaseProviderId };
+}

--- a/apps/api/src/accounts/iam/sso.ts
+++ b/apps/api/src/accounts/iam/sso.ts
@@ -22,7 +22,11 @@ import {
   SsoMappingSchema,
 } from './app';
 import { auditIam, isUniqueViolation, readBody, requireEntitlement } from './helpers';
-import { registerSupabaseSamlProvider, syncSupabaseSamlAttributeMapping } from './sso-provisioning';
+import {
+  deleteSupabaseSamlProvider,
+  registerSupabaseSamlProvider,
+  syncSupabaseSamlAttributeMapping,
+} from './sso-provisioning';
 
 function ssoProviderResponse(p: NonNullable<Awaited<ReturnType<typeof getSsoProvider>>>) {
   return {
@@ -309,6 +313,19 @@ iamRouter.openapi(
   const before = await getSsoProvider(accountId);
   const ok = await deleteSsoProvider(accountId);
   if (!ok) return c.json({ error: 'no SSO provider configured' }, 404);
+
+  // Unregister the provider in Supabase too — that's what frees the email
+  // domain so the admin can re-import it later. Best-effort: the Kortix row is
+  // already gone and disconnect must never fail, so a Supabase hiccup is logged
+  // (leaving a reclaimable orphan) rather than surfaced. A 404 counts as ok.
+  if (before?.supabaseSsoProviderId) {
+    const unregistered = await deleteSupabaseSamlProvider(before.supabaseSsoProviderId);
+    if (!unregistered.ok) {
+      console.warn(
+        `[sso] Supabase provider deletion failed for account ${accountId}: ${unregistered.error}`,
+      );
+    }
+  }
 
   await auditIam(c, {
     accountId,


### PR DESCRIPTION
## Problem

Disconnecting SSO (`DELETE /accounts/:id/iam/sso/provider`) deleted only our `account_sso_providers` row and left the IdP registered inside Supabase. Supabase keeps the email **domain claimed** by that orphaned provider, so re-importing the same domain later hits Supabase's 422 (which we map to a 409 "domain already claimed") — with **no self-serve way** for the admin to clear it. They'd have to email us to delete the provider by hand in Supabase.

The `from-metadata` handler's own comment already assumed this was handled ("make the admin delete first, which also frees the domain") — but delete didn't free the domain.

## Fix

`DELETE /iam/sso/provider` now also calls the GoTrue admin API (`DELETE /auth/v1/admin/sso/providers/:id`) to unregister the Supabase provider, which frees the domain for re-import.

- **Best-effort / non-throwing**: the Kortix row is already gone and disconnect must never fail, so a Supabase hiccup is logged (leaving a *reclaimable* orphan) rather than surfaced. Disconnect still succeeds.
- **404 = success**: provider already unregistered (out-of-band delete or double-disconnect) is the desired end state.

## Tests

4 new unit tests on `deleteSupabaseSamlProvider` (correct endpoint + DELETE verb, 404-as-success, non-404 failure surfaced without throwing, network failure → 502). Full `unit-sso-provisioning` suite: 14 pass.

## Not included

Deliberately did **not** add an explicit "Sign in with SSO" button to the auth page — email-based home-realm discovery stays the zero-config default.