### PR TITLE
fix(web): 'Kortix Computer is starting' -> 'Kortix Session is starting'

### DIFF
--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -364,7 +364,7 @@ export function SessionBootChecklistInline({
   const elapsed = formatDuration(now - startRef.current);
   return (
     <div className={cn('flex items-center gap-2', className)}>
-      <div aria-label="Starting your Kortix Computer">
+      <div aria-label="Starting your Kortix Session">
         <BootStepList active={active} />
       </div>
       {elapsed ? (

--- a/apps/web/translations/de.json
+++ b/apps/web/translations/de.json
@@ -7883,7 +7883,7 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "Version. Schlage die Änderungen vor, damit sie geprüft und übernommen werden.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Umbenennen…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Teilen…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix Computer startet",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix-Sitzung wird gestartet",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Neues Terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Dateiansicht",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Alle Dateien",

--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -7943,7 +7943,7 @@
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Rename…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Share…",
     "autoFeaturesSessionInstantSessionShellJsxAttrSessionTitleNewSession6b8dfd00": "New session",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix Computer is starting",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix Session is starting",
     "autoFeaturesSessionSessionTerminalPanelJsxTextConnecting80303e70": "Connecting…",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "New terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Files view",

--- a/apps/web/translations/es.json
+++ b/apps/web/translations/es.json
@@ -7883,7 +7883,7 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versión. Propón los cambios para que se revisen y apliquen.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Cambiar nombre…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Comparte…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "La computadora Kortix se está iniciando",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "La sesión de Kortix se está iniciando",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nueva terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Vista de archivos",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Todos los archivos",

--- a/apps/web/translations/fr.json
+++ b/apps/web/translations/fr.json
@@ -7883,7 +7883,7 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "version. Proposez les modifications pour qu’elles soient relues et appliquées.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Renommer…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Partager…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "L'ordinateur Kortix démarre",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "La session Kortix démarre",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nouvelle borne",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Vue Fichiers",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Tous les fichiers",

--- a/apps/web/translations/it.json
+++ b/apps/web/translations/it.json
@@ -7883,7 +7883,7 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versione. Proponi le modifiche per farle revisionare e applicare.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Rinomina…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Condividi…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Il computer Kortix è in fase di avvio",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "La sessione Kortix è in fase di avvio",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Nuovo terminale",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Visualizzazione dei file",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Tutti i file",

--- a/apps/web/translations/ja.json
+++ b/apps/web/translations/ja.json
@@ -7883,7 +7883,7 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "バージョン。変更を提案してレビューと適用を受けてください。",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "名前を変更…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "シェア…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix コンピューターが起動しています",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix セッションを起動しています",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "新しいターミナル",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "ファイルビュー",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "すべてのファイル",

--- a/apps/web/translations/pt.json
+++ b/apps/web/translations/pt.json
@@ -7883,7 +7883,7 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "versão. Proponha as alterações para que sejam revisadas e aplicadas.",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "Renomear…",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "Compartilhe…",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "O computador Kortix está iniciando",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "A sessão Kortix está iniciando",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "Novo terminal",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "Visualização de arquivos",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "Todos os arquivos",

--- a/apps/web/translations/zh.json
+++ b/apps/web/translations/zh.json
@@ -7883,7 +7883,7 @@
     "autoFeaturesSessionHeaderSessionChangesIndicatorJsxTextVersionYet922de6bd": "版本中。提议这些更改以供审核和应用。",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextRename41731a53": "重命名...",
     "autoFeaturesSessionHeaderSessionSiteHeaderJsxTextShared7d34d4f": "分享...",
-    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix 计算机正在启动",
+    "autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a": "Kortix 会话正在启动",
     "autoFeaturesSessionSessionTerminalPanelJsxTextNewTerminaleeb6bbb9": "新航站楼",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463": "文件视图",
     "autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738": "所有文件",


### PR DESCRIPTION
## What

Renames the session boot loader heading from **"Kortix Computer is starting"** to **"Kortix Session is starting"**, aligning the copy with the product's session terminology.

## Why

The loader is shown while a *session* boots/provisions, but the heading said "Computer" — a leftover from older terminology. Switch it to "Session".

## Where

- `apps/web/src/features/session/session-starting-loader.tsx` — screen-reader `aria-label` on the inline boot checklist (`"Starting your Kortix Computer"` -> `"Starting your Kortix Session"`).
- All 8 web locale files (`en`, `fr`, `es`, `de`, `it`, `pt`, `ja`, `zh`) — translation key `autoFeaturesSessionSessionStartingLoaderJsxTextKortixComputerIs7c42f59a` (the visible heading); each locale updated to its natural "Session" phrasing.

## Verification

- All 8 JSON locale files re-parse cleanly.
- No other occurrences of `"Kortix Computer is starting"` remain in `apps/`.

## Scope note

The translation *key* itself still contains `KortixComputerIs` (auto-generated from the original JSX text). Renaming the key would cascade into the extraction pipeline and every locale; left untouched to keep this a pure copy change. Only the *values* and the `aria-label` change.