### PR TITLE
feat(leads): demo-request notifications to marko@ + hey@kortix.ai, kortix.ai sender, lead domain classification

### DIFF
--- a/apps/api/src/accounts/core/accounts.ts
+++ b/apps/api/src/accounts/core/accounts.ts
@@ -18,7 +18,6 @@ import {
   resolveAccountDisplayNames,
   serializeAccount,
 } from './app';
-import { bootstrapPersonalAccount } from './bootstrap-personal-account';
 
 // Routes are registered via this function (called by the orchestrator in the
 // original route-registration order).

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -457,7 +457,12 @@ const envSchema = z.object({
   MAILTRAP_FROM_EMAIL:         optStrDefault('noreply@kortix.com'),
   MAILTRAP_FROM_NAME:          optStrDefault('Kortix'),
   // Where public demo-request / "book a demo" lead notifications are sent.
-  DEMO_LEAD_NOTIFY_EMAIL:      optStrDefault('marko@kortix.ai'),
+  // Comma-separated list; every address gets every submission.
+  DEMO_LEAD_NOTIFY_EMAIL:      optStrDefault('marko@kortix.ai,hey@kortix.ai'),
+  // Sender for those notifications. kortix.ai (not the global MAILTRAP_FROM_
+  // EMAIL on kortix.com) so the send is DKIM-aligned with the kortix.ai
+  // recipient inboxes — the kortix.com sender was landing in spam.
+  DEMO_LEAD_FROM_EMAIL:        optStrDefault('hi@kortix.ai'),
 
   // ── Mailtrap contact sync (signup → automation lists) ─────────────────────
   // The email automations themselves live in Mailtrap's Automations UI; the
@@ -868,6 +873,7 @@ export const config = {
   MAILTRAP_FROM_EMAIL: env.MAILTRAP_FROM_EMAIL,
   MAILTRAP_FROM_NAME: env.MAILTRAP_FROM_NAME,
   DEMO_LEAD_NOTIFY_EMAIL: env.DEMO_LEAD_NOTIFY_EMAIL,
+  DEMO_LEAD_FROM_EMAIL: env.DEMO_LEAD_FROM_EMAIL,
 
   // ─── Mailtrap contact sync (signup → automation lists) ────────────────────
   MAILTRAP_ACCOUNT_ID: env.MAILTRAP_ACCOUNT_ID,

--- a/apps/api/src/lib/demo-request-email.test.ts
+++ b/apps/api/src/lib/demo-request-email.test.ts
@@ -4,7 +4,8 @@ const mockConfig = {
   MAILTRAP_API_TOKEN: 'mailtrap-token',
   MAILTRAP_FROM_EMAIL: 'noreply@example.test',
   MAILTRAP_FROM_NAME: 'Kortix Test',
-  DEMO_LEAD_NOTIFY_EMAIL: 'marko@kortix.ai',
+  DEMO_LEAD_NOTIFY_EMAIL: 'marko@kortix.ai,hey@kortix.ai',
+  DEMO_LEAD_FROM_EMAIL: 'hi@kortix-test.ai',
 };
 
 mock.module('../config', () => ({ config: mockConfig }));
@@ -17,7 +18,7 @@ let calls: Array<{ url: string; init: RequestInit }> = [];
 beforeEach(() => {
   calls = [];
   mockConfig.MAILTRAP_API_TOKEN = 'mailtrap-token';
-  mockConfig.DEMO_LEAD_NOTIFY_EMAIL = 'marko@kortix.ai';
+  mockConfig.DEMO_LEAD_NOTIFY_EMAIL = 'marko@kortix.ai,hey@kortix.ai';
   globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
     calls.push({ url: String(url), init: init ?? {} });
     return new Response('', { status: 200 });
@@ -40,7 +41,7 @@ const LEAD = {
 };
 
 describe('sendDemoRequestNotification', () => {
-  test('posts the lead to Mailtrap with the default recipient', async () => {
+  test('posts the lead to Mailtrap with every configured recipient', async () => {
     const result = await sendDemoRequestNotification(LEAD);
     expect(result).toEqual({ ok: true, status: 200 });
     expect(calls).toHaveLength(1);
@@ -50,8 +51,8 @@ describe('sendDemoRequestNotification', () => {
     );
 
     const payload = JSON.parse(String(calls[0].init.body));
-    expect(payload.from).toEqual({ email: 'noreply@example.test', name: 'Kortix Test' });
-    expect(payload.to).toEqual([{ email: 'marko@kortix.ai' }]);
+    expect(payload.from).toEqual({ email: 'hi@kortix-test.ai', name: 'Kortix Test' });
+    expect(payload.to).toEqual([{ email: 'marko@kortix.ai' }, { email: 'hey@kortix.ai' }]);
     expect(payload.subject).toContain('Analytical <Engines>');
     expect(payload.category).toBe('demo-request');
     // HTML escapes untrusted fields.
@@ -60,10 +61,25 @@ describe('sendDemoRequestNotification', () => {
     expect(payload.html).toContain('automate our inbound support triage');
   });
 
-  test('honours the configured recipient override', async () => {
-    mockConfig.DEMO_LEAD_NOTIFY_EMAIL = 'sales@kortix.ai';
+  test('honours the configured recipient override, trimming blanks', async () => {
+    mockConfig.DEMO_LEAD_NOTIFY_EMAIL = ' sales@kortix.ai , , ops@kortix.ai ';
     await sendDemoRequestNotification(LEAD);
-    expect(JSON.parse(String(calls[0].init.body)).to).toEqual([{ email: 'sales@kortix.ai' }]);
+    expect(JSON.parse(String(calls[0].init.body)).to).toEqual([
+      { email: 'sales@kortix.ai' },
+      { email: 'ops@kortix.ai' },
+    ]);
+  });
+
+  test('labels a business-domain lead in the Domain row', async () => {
+    await sendDemoRequestNotification({ ...LEAD, email: 'cto@acme-corp.com' });
+    const html = JSON.parse(String(calls[0].init.body)).html as string;
+    expect(html).toContain('acme-corp.com (business)');
+  });
+
+  test('labels a consumer-domain lead in the Domain row', async () => {
+    await sendDemoRequestNotification({ ...LEAD, email: 'ada@gmail.com' });
+    const html = JSON.parse(String(calls[0].init.body)).html as string;
+    expect(html).toContain('gmail.com (personal)');
   });
 
   test('skips gracefully when the Mailtrap token is not configured', async () => {

--- a/apps/api/src/lib/demo-request-email.ts
+++ b/apps/api/src/lib/demo-request-email.ts
@@ -4,6 +4,7 @@
 // from `config` (fed by AWS Secrets Manager in prod) — mirrors the account
 // invite transport in ../accounts/email.ts. If MAILTRAP_API_TOKEN is not set the
 // send is skipped gracefully so lead capture never fails on account of email.
+import { emailDomain, isWorkEmail } from '../accounts/personal-email';
 import { config } from '../config';
 
 const MAILTRAP_SEND_URL = 'https://send.api.mailtrap.io/api/send';
@@ -46,6 +47,10 @@ function row(label: string, value: string | undefined | null): string {
 
 function renderHtml(lead: DemoRequestLead): string {
   const qualified = lead.qualified ? 'Yes — routed to Cal booking' : 'No — request received';
+  const domain = emailDomain(lead.email);
+  const domainKind = domain
+    ? `${domain} (${isWorkEmail(lead.email) ? 'business' : 'personal'})`
+    : null;
   return `<!DOCTYPE html>
 <html>
   <head><meta charset="utf-8" /><meta name="viewport" content="width=device-width,initial-scale=1" /></head>
@@ -63,6 +68,7 @@ function renderHtml(lead: DemoRequestLead): string {
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width:100%;">
               ${row('Name', lead.name)}
               ${row('Email', lead.email)}
+              ${row('Domain', domainKind)}
               ${row('Company', lead.company_name)}
               ${row('Company size', lead.company_size)}
               ${row('Goal', lead.goal)}
@@ -82,8 +88,9 @@ function renderHtml(lead: DemoRequestLead): string {
 
 /**
  * Send the internal "new demo request" notification. Never throws — returns a
- * result the caller can log. Recipient defaults to config.DEMO_LEAD_NOTIFY_EMAIL
- * (marko@kortix.ai).
+ * result the caller can log. Recipients come from config.DEMO_LEAD_NOTIFY_EMAIL,
+ * a comma-separated list (default marko@kortix.ai,hey@kortix.ai) — every
+ * address gets every submission.
  */
 export async function sendDemoRequestNotification(
   lead: DemoRequestLead,
@@ -92,7 +99,10 @@ export async function sendDemoRequestNotification(
     return { ok: false, skipped: true, reason: 'missing_mailtrap_token' };
   }
 
-  const to = config.DEMO_LEAD_NOTIFY_EMAIL || 'marko@kortix.ai';
+  const recipients = (config.DEMO_LEAD_NOTIFY_EMAIL || 'marko@kortix.ai,hey@kortix.ai')
+    .split(',')
+    .map((address) => address.trim())
+    .filter(Boolean);
   const who = lead.company_name?.trim() || lead.name?.trim() || lead.email;
 
   try {
@@ -103,8 +113,11 @@ export async function sendDemoRequestNotification(
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        from: { email: config.MAILTRAP_FROM_EMAIL, name: config.MAILTRAP_FROM_NAME },
-        to: [{ email: to }],
+        from: {
+          email: config.DEMO_LEAD_FROM_EMAIL || config.MAILTRAP_FROM_EMAIL,
+          name: config.MAILTRAP_FROM_NAME,
+        },
+        to: recipients.map((address) => ({ email: address })),
         subject: `New demo request — ${who}`,
         html: renderHtml(lead),
         category: 'demo-request',


### PR DESCRIPTION
## What

Every demo/booking form submission already fires an internal notification (all company sizes, qualified or not, before any Cal booking). This PR makes sure the right people get it and that it stops landing in spam:

- **Recipients**: `DEMO_LEAD_NOTIFY_EMAIL` is now a comma-separated list, default `marko@kortix.ai,hey@kortix.ai`. Both mailboxes verified to exist (SMTP RCPT probe against Google MX; nonsense addresses 550, so no catch-all masking).
- **Spam fix**: notifications now send from `hi@kortix.ai` (new `DEMO_LEAD_FROM_EMAIL`, kortix.ai is a verified + compliant Mailtrap sending domain) instead of the global kortix.com sender — the kortix.com→kortix.ai cross-domain send was being spam-foldered by Gmail.
- **Lead intel**: the notification now shows the lead's email domain classified business/personal via the shared consumer-domain denylist (`accounts/personal-email.ts`).
- Drive-by: removes a duplicate `bootstrapPersonalAccount` import in `accounts/core/accounts.ts` introduced by the #4700 merge resolution (broke `tsc` on main).

## Testing

- Unit tests extended: multi-recipient default, comma-list parsing with blanks, business/personal Domain row, sender override, skip-without-token, non-2xx handling (6/6 pass)
- `tsc` clean (including the main breakage fix), Biome clean on touched files
- Live prod probe of the existing endpoint returned `{ok:true,emailed:true}` (current behavior verified end-to-end before this change)

No route/shape changes — no ke2e manifest impact. Prod/dev pick up the new defaults on next deploy; no secret changes needed (`DEMO_LEAD_NOTIFY_EMAIL`/`DEMO_LEAD_FROM_EMAIL` unset in AWS SM → defaults apply).