### PR TITLE
feat(ci): moving dev/staging/prod image tags for self-host tracking

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -482,6 +482,32 @@ jobs:
             echo "Live: \`$(printf '%s' "$h" | jq -c '{version,commit,environment}' 2>/dev/null || echo '?')\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # ── Move the self-host `:dev` channel tag onto the image that just deployed ─
+  # `kortix self-host init/update --tag dev` (or `--channel dev` once that
+  # lands) pulls `kortix/kortix-api:dev` — a MOVING tag self-hosters track for
+  # the current dev environment (may break at any time). Re-tag by digest ONLY
+  # (docker buildx imagetools create — zero rebuild) and ONLY after BOTH dev
+  # backends (ECS active + EKS standby) report success, so `:dev` never points
+  # at a build that failed to actually reach the dev environment.
+  promote-dev-channel-api:
+    name: Move :dev → this build (API)
+    needs: [detect-changes, tag-api, deploy-api, deploy-api-ecs]
+    if: needs.detect-changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-tag ${{ needs.tag-api.outputs.image }} → kortix/kortix-api:dev
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag kortix/kortix-api:dev \
+            "${{ needs.tag-api.outputs.image }}"
+          echo "✓ kortix/kortix-api:dev → ${{ needs.tag-api.outputs.image }}"
+
   # ── Build + push the multi-arch gateway image ───────────────────────────────
   # Standalone LLM gateway (apps/llm-gateway). Same dev-<sha8> versioning + GitOps
   # roll as the API, into the SAME kortix-dev namespace (reuses kortix-api-env).
@@ -669,6 +695,34 @@ jobs:
           done
           echo "::warning::dev gateway not rolled out to :${TAG} (likely missing ACM cert ARN in gateway-values, or Argo lag)."
 
+  # ── Move the self-host `:dev` channel tag onto the image that just deployed ─
+  # Same idea as promote-dev-channel-api. NOTE: the gateway rollout wait above
+  # is `continue-on-error: true` (a not-yet-certed Ingress can't roll out on the
+  # very first deploy), so "deploy-gateway succeeded" is weaker than the API's
+  # gate — it means the image was pushed and Argo was asked to reconcile it,
+  # not necessarily that pods are Ready. Accepted trade-off: gating on a hard
+  # rollout here would make :dev gateway stall on the same pre-cert case the
+  # deploy job itself tolerates.
+  promote-dev-channel-gateway:
+    name: Move :dev → this build (gateway)
+    needs: [detect-changes, tag-gateway, deploy-gateway]
+    if: needs.detect-changes.outputs.gateway == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-tag kortix/kortix-gateway:dev-${{ github.sha }} → :dev
+        run: |
+          set -euo pipefail
+          SHA8="${GITHUB_SHA::8}"
+          docker buildx imagetools create \
+            --tag kortix/kortix-gateway:dev \
+            "kortix/kortix-gateway:dev-${SHA8}"
+          echo "✓ kortix/kortix-gateway:dev → dev-${SHA8}"
+
   # ── Build + push the multi-arch frontend image ──────────────────────────────
   # dev.kortix.com is served by Vercel (auto-deploys from `main`); this image is
   # for self-hosters, so there is no deploy step here.
@@ -722,6 +776,41 @@ jobs:
             --tag "kortix/kortix-frontend:dev-${SHA8}" \
             "kortix/kortix-frontend:dev-latest"
           echo "Pushed kortix/kortix-frontend:dev-${SHA8} + :dev-latest"
+
+  # ── Move the self-host `:dev` channel tag onto the image that just built ────
+  # Frontend has no separate "deploy" job in this pipeline (dev.kortix.com is
+  # Vercel's own Git integration off `main`, not this image) — the image build
+  # succeeding IS the self-host artifact's release event, so gate on
+  # build-frontend directly.
+  promote-dev-channel-frontend:
+    name: Move :dev → this build (frontend)
+    needs: [detect-changes, build-frontend]
+    if: needs.detect-changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-tag kortix/kortix-frontend:dev-${{ github.sha }} → :dev
+        run: |
+          set -euo pipefail
+          SHA8="${GITHUB_SHA::8}"
+          docker buildx imagetools create \
+            --tag kortix/kortix-frontend:dev \
+            "kortix/kortix-frontend:dev-${SHA8}"
+          echo "✓ kortix/kortix-frontend:dev → dev-${SHA8}"
+
+  # NOTE (gap, out of scope for this PR): kortix/kortix-sandbox is NOT built or
+  # pushed by ANY pipeline — dev, staging, or prod. It only exists as a LOCAL
+  # build (scripts/build-local-images.sh) used by the self-host-e2e test. The
+  # Docker Hub repo `kortix/kortix-sandbox` does not exist today (verified: GET
+  # https://hub.docker.com/v2/repositories/kortix/kortix-sandbox returns 404),
+  # so there is nothing to re-tag :dev from here — even the existing :stable
+  # self-host channel has no sandbox image. Wiring up a real build+publish for
+  # apps/sandbox/Dockerfile is a separate, larger effort; until then a
+  # self-hosted box on any channel keeps whatever SANDBOX_IMAGE it already has.
 
   # ── Build dev CLI (4 targets on one Linux runner via Bun cross-compile) ─────
   build-cli:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1263,3 +1263,42 @@ jobs:
         env:
           MAINTENANCE_TOKEN: ${{ secrets.PROD_MAINTENANCE_TOKEN }}
         run: bash scripts/ci-maintenance-banner.sh off
+
+  # ── Move the self-host `:prod` channel tag onto the release that just went live ─
+  # `kortix self-host init/update --tag prod` pulls `kortix/kortix-*:prod` — a
+  # MOVING tag self-hosters track for whatever is live on api.kortix.com right
+  # now (may break at any time; it is NOT the curated `:stable` channel —
+  # see promote-self-host-stable.yml). Deliberately placed AFTER
+  # verify-live-version (default `if: success()`, same gate as
+  # maintenance-banner-off/github-release) so `:prod` never points at a build
+  # that failed to actually reach prod, exactly like the v0.10.0/v0.10.1
+  # incident this whole verify-live-version gate exists to prevent. Re-tag by
+  # digest only (imagetools create — zero rebuild) from the already-published
+  # :VERSION manifest (retag-images already proved it matches the promoted
+  # staging/dev source).
+  #
+  # kortix/kortix-sandbox is NOT included: it has no CI publish pipeline at
+  # all (see the note in deploy-dev.yml) — the Docker Hub repo doesn't exist,
+  # so there is nothing to re-tag it from. (This is a pre-existing gap: even
+  # promote-self-host-stable.yml's `:stable` channel has never covered it.)
+  promote-prod-channel:
+    name: Move :prod → v${{ needs.version.outputs.version }}
+    needs: [version, retag-images, verify-live-version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-tag api/gateway/frontend → :prod
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          for IMAGE in kortix/kortix-api kortix/kortix-gateway kortix/kortix-frontend; do
+            docker buildx imagetools create \
+              --tag "$IMAGE:prod" \
+              "$IMAGE:${VERSION}"
+            echo "✓ $IMAGE:prod → ${VERSION}"
+          done

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -542,3 +542,37 @@ jobs:
             echo "- Web: https://${WEB_HOST} serves staging runtime config"
             echo "- GitOps: API ALB ${{ needs.deploy-k8s.outputs.api_alb }}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Move the self-host `:staging` channel tag onto the images just verified ─
+  # `kortix self-host init/update --tag staging` pulls `kortix/kortix-*:staging`
+  # — a MOVING tag self-hosters track for the current staging environment (may
+  # break at any time). Gated on `verify` (the last job — live staging
+  # confirmed serving this exact build), so `:staging` never points at a
+  # rollout that didn't actually land. Re-tag by digest only (imagetools
+  # create — zero rebuild) from the immutable staging-<sha8> images
+  # build-staging.yml already pushed for this commit.
+  #
+  # kortix/kortix-sandbox is NOT included: it has no CI publish pipeline at
+  # all (see the note in deploy-dev.yml) — the Docker Hub repo doesn't exist,
+  # so there is nothing to re-tag it from.
+  promote-staging-channel:
+    name: Move :staging → staging-${{ needs.preflight.outputs.sha8 }}
+    needs: [preflight, verify]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-tag api/gateway/frontend → :staging
+        env:
+          SHA8: ${{ needs.preflight.outputs.sha8 }}
+        run: |
+          set -euo pipefail
+          for IMAGE in kortix/kortix-api kortix/kortix-gateway kortix/kortix-frontend; do
+            docker buildx imagetools create \
+              --tag "$IMAGE:staging" \
+              "$IMAGE:staging-${SHA8}"
+            echo "✓ $IMAGE:staging → staging-${SHA8}"
+          done

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -88,6 +88,7 @@ Options:
   --domain <domain>       Public domain reachability (recommended, production).
   --tunnel cloudflare     Cloudflare-tunnel reachability (no public domain; evaluation).
   --version <ref>         Pin a release/channel/dev build. Alias: --tag/--release.
+                          dev/staging/prod track those live environments (may break any time); stable is the promoted default.
   --channel <name>        stable|latest to track (default: stable).
   --auto-update <on|off>  Override the default (ON everywhere except --local-images).
   --update-time <HH:MM> / --update-tz <tz>   Auto-updater schedule.

--- a/apps/web/content/docs/guides/self-hosting.mdx
+++ b/apps/web/content/docs/guides/self-hosting.mdx
@@ -172,6 +172,28 @@ kortix self-host init --version 0.10.1             # pin an exact released versi
 kortix self-host init --version dev-a1b2c3d        # pin a published dev build (e.g. from a branch's CI)
 ```
 
+### Tracking dev/staging/prod
+
+CI keeps `kortix/kortix-{api,gateway,frontend}:dev` / `:staging` / `:prod`
+pointed at whatever's actually deployed to that live environment right now
+(re-tagged after each environment's deploy succeeds — never a rebuild).
+`--version`/`--tag` already accepts any published tag, so tracking one is the
+same recipe as any other moving tag:
+
+```sh
+kortix self-host init --tag dev --auto-update on     # track dev.kortix.com's current build, nightly
+kortix self-host init --tag staging --auto-update on # track staging.kortix.com
+kortix self-host init --tag prod --auto-update on    # track api.kortix.com's current release
+```
+
+These may break at any time — `dev` especially — and are for testing against
+a specific live environment, not production self-hosting. `stable` (the
+default) is the only curated, promoted channel.
+
+`kortix/kortix-sandbox` isn't published by any of these pipelines yet, so the
+sandbox image doesn't move with `dev`/`staging`/`prod` — a box keeps whatever
+`SANDBOX_IMAGE` it already has.
+
 Testing a locally-built image (never pushed to any registry):
 
 ```sh

--- a/tests/self-host-e2e/fast/version-channel-images.test.ts
+++ b/tests/self-host-e2e/fast/version-channel-images.test.ts
@@ -138,6 +138,88 @@ describe.skipIf(!caps.localImages)(
       expect(env.KORTIX_AUTO_UPDATE).toBe('false');
     });
 
+    // Moving-tag tracking (CI now publishes kortix/kortix-{api,gateway,
+    // frontend}:dev / :staging / :prod by re-tagging the deployed build — see
+    // .github/workflows/deploy-dev.yml, deploy-staging.yml, deploy-prod.yml).
+    // `--channel` itself stays stable|latest only (see isChannel/CHANNELS
+    // above) — `--tag`/`--version` is the existing, already-generic way an
+    // operator points at ANY published tag, moving or pinned. This just
+    // proves the tag→image resolution and the auto-update override work
+    // end-to-end for the new moving tags, exactly as they already do for a
+    // pinned semver above.
+    test('--tag dev renders every *_IMAGE at :dev, auto-update defaults ON (a moving tag)', async () => {
+      const { code } = await sandbox.run(['init', '--yes', '--tag', 'dev']);
+      expect(code).toBe(0);
+      const env = sandbox.readEnv();
+
+      expect(env.KORTIX_VERSION).toBe('dev');
+      expect(env.FRONTEND_IMAGE).toBe('kortix/kortix-frontend:dev');
+      expect(env.API_IMAGE).toBe('kortix/kortix-api:dev');
+      expect(env.GATEWAY_IMAGE).toBe('kortix/kortix-gateway:dev');
+      expect(env.SANDBOX_IMAGE).toBe('kortix/kortix-sandbox:dev');
+      // "dev" isn't one of CHANNELS (stable|latest), so it doesn't invent a
+      // channel name — same rule already covered for a semver pin above.
+      expect(env.KORTIX_CHANNEL).toBe('stable');
+      expect(env.KORTIX_AUTO_UPDATE).toBe('true');
+    });
+
+    test('--tag dev --auto-update on: the explicit flag wins (still ON), so the box actually tracks the moving tag nightly', async () => {
+      const { code } = await sandbox.run([
+        'init',
+        '--yes',
+        '--tag',
+        'dev',
+        '--auto-update',
+        'on',
+      ]);
+      expect(code).toBe(0);
+      const env = sandbox.readEnv();
+      expect(env.API_IMAGE).toBe('kortix/kortix-api:dev');
+      expect(env.KORTIX_AUTO_UPDATE).toBe('true');
+    });
+
+    test('--tag staging / --tag prod render the matching moving-tag images too', async () => {
+      const staging = await sandbox.run(['init', '--yes', '--tag', 'staging']);
+      expect(staging.code).toBe(0);
+      expect(sandbox.readEnv().API_IMAGE).toBe('kortix/kortix-api:staging');
+      expect(sandbox.readEnv().GATEWAY_IMAGE).toBe('kortix/kortix-gateway:staging');
+      expect(sandbox.readEnv().FRONTEND_IMAGE).toBe('kortix/kortix-frontend:staging');
+      expect(sandbox.readEnv().KORTIX_AUTO_UPDATE).toBe('true');
+
+      const prodSandbox = new SelfHostSandbox();
+      try {
+        const prod = await prodSandbox.run(['init', '--yes', '--tag', 'prod']);
+        expect(prod.code).toBe(0);
+        expect(prodSandbox.readEnv().API_IMAGE).toBe('kortix/kortix-api:prod');
+        expect(prodSandbox.readEnv().KORTIX_AUTO_UPDATE).toBe('true');
+      } finally {
+        prodSandbox.cleanup();
+      }
+    });
+
+    // `update` shares the exact same resolveTag()/applyImagesForTag() path as
+    // `init` (see self-host.ts selfHostUpdate) — re-running init on an
+    // already-initialized instance with a different --tag exercises that
+    // same "move the channel forward" code path without needing a live Docker
+    // daemon (which the real `update` subcommand additionally requires, to
+    // actually shell out to `docker compose` — out of scope for this fast,
+    // no-Docker suite).
+    test('re-running init with --tag dev after a prior pin moves every *_IMAGE to :dev (the update path)', async () => {
+      const first = await sandbox.run(['init', '--yes', '--tag', '0.9.107']);
+      expect(first.code).toBe(0);
+      expect(sandbox.readEnv().API_IMAGE).toBe('kortix/kortix-api:0.9.107');
+
+      const second = await sandbox.run(['init', '--yes', '--tag', 'dev']);
+      expect(second.code).toBe(0);
+      const env = sandbox.readEnv();
+      expect(env.KORTIX_VERSION).toBe('dev');
+      expect(env.API_IMAGE).toBe('kortix/kortix-api:dev');
+      expect(env.GATEWAY_IMAGE).toBe('kortix/kortix-gateway:dev');
+      expect(env.FRONTEND_IMAGE).toBe('kortix/kortix-frontend:dev');
+      expect(env.SANDBOX_IMAGE).toBe('kortix/kortix-sandbox:dev');
+      expect(env.KORTIX_AUTO_UPDATE).toBe('true');
+    });
+
     test('--local-images forces auto-update off even on the default stable channel', async () => {
       const { code } = await sandbox.run([
         'init',


### PR DESCRIPTION
## Stacked on #4754

This branch is based on `origin/refactor/generic-self-host` (PR #4754, still
open) because that's where the current self-host CLI surface lives. Until
#4754 merges to `main`, this PR's diff will include its commits too — once it
merges, this PR will shrink down to just the commits below. **Do not merge
this PR** — a release train is in flight; this lands after.

## Summary

Scope note: this replaces an earlier, broader plan to add new
`dev`/`staging`/`prod` **channels** to the self-host CLI. That's dropped —
`--tag <anything>`/`--version` already resolves *any* published tag (moving
or pinned) into every `*_IMAGE` var and defaults auto-update ON regardless of
pin, so the CLI already supports tracking a moving tag end-to-end with zero
code changes. The actual gap was that CI never published moving `:dev` /
`:staging` / `:prod` tags for self-host to point at — this PR fixes that.

### 1. CI now publishes 3 moving tags (zero rebuild, digest re-tag only)

- **`deploy-dev.yml`**: three new jobs (`promote-dev-channel-{api,gateway,frontend}`)
  move `kortix/kortix-{api,gateway,frontend}:dev` to the image that was just
  deployed. API is gated on **both** `deploy-api` (EKS) and `deploy-api-ecs`
  succeeding; gateway is gated on `deploy-gateway` (soft-wait, same caveat the
  job itself already tolerates — documented in a code comment); frontend has
  no separate "deploy" job in this pipeline (dev.kortix.com is Vercel, not this
  image), so it's gated on `build-frontend` itself.
- **`deploy-staging.yml`**: one new job (`promote-staging-channel`) moves all
  three `:staging` tags, gated on the final `verify` job (the one that curls
  `staging.kortix.com` and asserts the live version matches).
- **`deploy-prod.yml`**: one new job (`promote-prod-channel`) moves all three
  `:prod` tags, gated on `verify-live-version` — **after** the same hard gate
  that stops the `vX.Y.Z` GitHub Release from firing on a release that never
  actually reached `api.kortix.com` (the exact class of bug that caused the
  v0.10.0/v0.10.1 incident this gate was built for). `:prod` can never point
  at a build that failed to ship.
- All re-tags use `docker buildx imagetools create --tag ... <already-pushed-ref>`
  — no image is ever rebuilt.

### Gap, documented in code + PR (out of scope to fix here)

`kortix/kortix-sandbox` is **not** re-tagged in any of the three pipelines,
because it isn't built or published by *any* CI pipeline in this repo today —
dev, staging, or prod. `apps/sandbox/Dockerfile` is only ever built locally
(`scripts/build-local-images.sh`), for the `self-host-e2e` full-stack test
fixture. I verified `kortix/kortix-sandbox` doesn't even exist on Docker Hub
(`GET https://hub.docker.com/v2/repositories/kortix/kortix-sandbox` → 404).
This is a pre-existing gap, not introduced here — even the existing `:stable`
channel (`promote-self-host-stable.yml`) has never covered it. Wiring up a
real build+publish pipeline for the sandbox image is a separate, larger
effort; documented with a comment block in `deploy-dev.yml` (and referenced
from the other two workflows) so it isn't silently forgotten.

### 2. CLI: verified end-to-end, added coverage

No `apps/cli` behavior changed — `resolveTag()` / `applyImagesForTag()` /
`applyChannelAndUpdatePolicy()` in `apps/cli/src/commands/self-host.ts`
already do the right thing for any string tag, moving or pinned:
`--tag dev` renders `KORTIX_VERSION=dev` + all four `*_IMAGE` vars at `:dev`,
auto-update defaults ON (a moving tag re-pulling the same tag nightly is a
no-op when nothing changed, so there's no reason to default it off), and an
explicit `--auto-update on/off` always wins. Added fast (no-Docker) tests in
`tests/self-host-e2e/fast/version-channel-images.test.ts` proving:
- `--tag dev` renders every image at `:dev`, channel stays `stable` (dev isn't
  in the `stable|latest` channel enum), auto-update defaults ON.
- `--tag dev --auto-update on` — the explicit flag holds.
- `--tag staging` / `--tag prod` render the matching images.
- Re-running `init` with a new `--tag` moves every image (the `update` code
  path, exercised without requiring a live Docker daemon — the real `update`
  subcommand additionally shells out to `docker compose`, which is out of
  scope for this "fast, no Docker" suite).

Added one help line under `--version`/`--tag` in the `self-host` help text
noting the new moving tags (terse, matches the existing style).

### 3. Docs

`apps/web/content/docs/guides/self-hosting.mdx`: short "Tracking
dev/staging/prod" subsection with the `--tag <x> --auto-update on` recipe and
the sandbox-image gap note.

## Test plan

- [x] `.github/workflows/*.yml` YAML-parsed clean (`python3 -c 'import yaml; yaml.safe_load(...)'`) for all three edited workflows.
- [x] `pnpm --filter @kortix/cli exec tsc --noEmit` — clean.
- [x] `bun test tests/self-host-e2e/fast/version-channel-images.test.ts` — 12/12 pass (8 pre-existing + 4 new).
- [x] `bun test tests/self-host-e2e/fast/` — 25/28 pass; the 3 failures
      (`required-secrets.test.ts`, `feature-flags.test.ts`) are pre-existing
      and environmental, not caused by this change — verified they fail
      identically with this branch's changes stashed. They collide with a
      real self-host Docker stack already running on this dev machine on the
      same default ports (`kortix-default-*` containers, port 13737/13738).
- [x] `apps/cli` own suite (`bun test` in `apps/cli`) — 357/359 pass; the same
      2 pre-existing/environmental failures, verified identically failing
      without this branch's changes.
- [ ] Not run (needs Docker Hub push access + real deploys): the new CI
      re-tag jobs themselves. Reviewed by hand against the existing
      `promote-self-host-stable.yml` re-tag pattern they copy.