### PR TITLE
fix(git): recognize a saved managed-git PAT as a connected GitHub account

### DIFF
--- a/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
+++ b/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
@@ -100,8 +100,23 @@ function getTestAuth() {
   return (globalThis as any)[TEST_AUTH_KEY] ?? { userId: USER_ID, userEmail: 'starter@example.test' };
 }
 
+// This repo's local `.env` (loaded automatically by `bun test`) sets real
+// MANAGED_GIT_GITHUB_*/KORTIX_GITHUB_APP_* values for interactive dev use.
+// The "GitHub App installation" scenarios below assert the pure App-only
+// not-connected state (no managed-git PAT fallback, see
+// serializeGitHubInstallations) — left in place, the real dev values would
+// silently make every account look PAT-connected. Same convention as
+// unit-github-app-isconfigured.test.ts / unit-github-owner-type-routing.test.ts.
+const MANAGED_GIT_ENV_KEYS = [
+  'MANAGED_GIT_GITHUB_OWNER',
+  'MANAGED_GIT_GITHUB_INSTALL_ID',
+  'MANAGED_GIT_GITHUB_TOKEN',
+] as const;
+for (const k of MANAGED_GIT_ENV_KEYS) delete process.env[k];
+
 function resetState() {
   setTestAuth();
+  for (const k of MANAGED_GIT_ENV_KEYS) delete process.env[k];
   repoCreateCalls = [];
   fileShaCalls = [];
   commitCalls = [];
@@ -263,6 +278,10 @@ mock.module('../projects/github', () => ({
         description: null,
       }]
     : [],
+  // Not exercised by this file's scenarios (App installations only, no
+  // managed-git PAT fallback here) — stubbed so the mocked module still
+  // satisfies github-repositories.ts's named import.
+  listOwnerRepositories: async () => [],
   listRepositoryBranches: async ({ owner, repo }: { owner: string; repo: string }) => [
     { name: owner === 'acme' && repo === 'portal' ? 'trunk' : 'main', protected: true },
     { name: 'dev', protected: false },

--- a/apps/api/src/__tests__/e2e-project-limit.test.ts
+++ b/apps/api/src/__tests__/e2e-project-limit.test.ts
@@ -73,6 +73,8 @@ mock.module('../projects/git-backends', () => ({
   getDefaultManagedBackend: () => stubBackend,
   githubBackend: stubBackend,
   managedGithubInstallId: () => 'install-1',
+  managedGithubOwner: () => null,
+  managedGithubOwnerType: () => undefined,
   managedGithubToken: () => null,
 }));
 

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -273,6 +273,7 @@ mock.module('../projects/github', () => ({
   }),
   getRepositoryBranch: async ({ branch }: { branch: string }) => ({ name: branch, protected: false }),
   listInstallationRepositories: async () => [],
+  listOwnerRepositories: async () => [],
   listRepositoryBranches: async () => [],
   isGithubAppConfigured: () => false,
   isGithubPatConfigured: () => true,

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -210,6 +210,7 @@ mock.module('../projects/github', () => ({
   }),
   getRepositoryBranch: async ({ branch }: { branch: string }) => ({ name: branch, protected: false }),
   listInstallationRepositories: async () => [],
+  listOwnerRepositories: async () => [],
   listRepositoryBranches: async () => [],
   isGithubAppConfigured: () => false,
   isGithubPatConfigured: () => true,

--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -273,6 +273,7 @@ mock.module('../projects/github', () => ({
     return { name: branch, protected: false };
   },
   listInstallationRepositories: async () => [],
+  listOwnerRepositories: async () => [],
   listRepositoryBranches: async () => [],
   isGithubAppConfigured: () => false,
   isGithubPatConfigured: () => true,

--- a/apps/api/src/__tests__/e2e-projects-provision.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-provision.test.ts
@@ -92,6 +92,8 @@ mock.module('../projects/git-backends', () => ({
   getDefaultManagedBackend: () => stubBackend,
   githubBackend: stubBackend,
   managedGithubInstallId: () => INSTALL_ID,
+  managedGithubOwner: () => REPO_OWNER,
+  managedGithubOwnerType: () => undefined,
   managedGithubToken: () => managedPat,
 }));
 

--- a/apps/api/src/__tests__/unit-github-pat-import.test.ts
+++ b/apps/api/src/__tests__/unit-github-pat-import.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression coverage for the self-host "Use a token" import bug: an account
+ * whose ONLY managed-git connection is a PAT (platform/routes/github-app.ts
+ * POST /pat) has no `account_github_installations` row and
+ * `isGithubAppConfigured()` (App-only, appId+privateKey) is false — so
+ * `GET /projects/github/installations` used to report `configured: false` /
+ * zero installations, and the web Import-repo + New-project UI showed
+ * "GitHub isn't connected on this server yet" even though managed-git
+ * provisioning (POST /projects/provision) worked fine off the same PAT.
+ *
+ * `serializeGitHubInstallations` (projects/lib/serializers.ts) now takes an
+ * optional PAT-fallback owner and synthesizes a connected "installation" for
+ * it — see the matching route wiring in routes/r1.ts (GET
+ * github/installation(s)) and routes/github-repositories.ts /
+ * routes/r2.ts (POST /link-repository), which both recognize the sentinel
+ * `PAT_MANAGED_GIT_INSTALLATION_ID` this produces.
+ *
+ * Pure-function test, no DB/module mocking needed — same convention as
+ * unit-api-contract-serializers.test.ts.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { accountGithubInstallations } from '@kortix/db';
+import {
+  PAT_MANAGED_GIT_INSTALLATION_ID,
+  serializeGitHubInstallations,
+} from '../projects/lib/serializers';
+
+const ACCOUNT_ID = '99999999-8888-4777-8666-555555555555';
+
+function installationRow(
+  overrides: Partial<typeof accountGithubInstallations.$inferSelect> = {},
+): typeof accountGithubInstallations.$inferSelect {
+  return {
+    installationRowId: '11111111-2222-4333-8444-555555555555',
+    accountId: ACCOUNT_ID,
+    installationId: '501',
+    ownerLogin: 'acme-corp',
+    ownerType: 'Organization',
+    repositorySelection: 'all',
+    permissions: {},
+    metadata: {},
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('serializeGitHubInstallations — PAT fallback for the "Use a token" self-host setup', () => {
+  test('no App installation, no PAT fallback owner -> stays not-connected (pre-existing behavior)', () => {
+    const result = serializeGitHubInstallations([], ACCOUNT_ID, null, null);
+    expect(result.installed).toBe(false);
+    expect(result.installations).toEqual([]);
+  });
+
+  test('no App installation, PAT fallback owner given -> synthesizes a connected installation', () => {
+    const result = serializeGitHubInstallations([], ACCOUNT_ID, null, 'Essentia-Innovation');
+
+    expect(result.installed).toBe(true);
+    expect(result.configured).toBe(true);
+    expect(result.requires_installation).toBe(false);
+    expect(result.installation_id).toBe(PAT_MANAGED_GIT_INSTALLATION_ID);
+    expect(result.owner_login).toBe('Essentia-Innovation');
+    expect(result.installations).toEqual([
+      expect.objectContaining({
+        installation_id: PAT_MANAGED_GIT_INSTALLATION_ID,
+        owner_login: 'Essentia-Innovation',
+        installed: true,
+        configured: true,
+      }),
+    ]);
+  });
+
+  test('a real App installation row wins — the PAT fallback is ignored, no duplicate/synthetic entry', () => {
+    const row = installationRow();
+    const result = serializeGitHubInstallations([row], ACCOUNT_ID, null, 'Essentia-Innovation');
+
+    expect(result.installed).toBe(true);
+    expect(result.installations).toHaveLength(1);
+    expect(result.installations[0]!.installation_id).toBe('501');
+    expect(result.installations[0]!.owner_login).toBe('acme-corp');
+  });
+});

--- a/apps/api/src/projects/git-backends/index.ts
+++ b/apps/api/src/projects/git-backends/index.ts
@@ -1,4 +1,10 @@
 export * from './types';
 export { getBackend, getDefaultManagedBackend, hasBackend } from './registry';
-export { githubBackend, managedGithubInstallId, managedGithubOwner, managedGithubToken } from './github';
+export {
+  githubBackend,
+  managedGithubInstallId,
+  managedGithubOwner,
+  managedGithubOwnerType,
+  managedGithubToken,
+} from './github';
 export { seedRepoViaGitPush } from './seed';

--- a/apps/api/src/projects/github.test.ts
+++ b/apps/api/src/projects/github.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
-import { GitHubApiError, getRepositoryBranch, listRepositoryBranches } from './github';
+import {
+  GitHubApiError,
+  getRepositoryBranch,
+  listOwnerRepositories,
+  listRepositoryBranches,
+} from './github';
 
 const originalFetch = globalThis.fetch;
 
@@ -75,5 +80,89 @@ describe('GitHub repository branches', () => {
 
     await expect(request).rejects.toBeInstanceOf(GitHubApiError);
     await expect(request).rejects.toMatchObject({ status: 503 });
+  });
+});
+
+function repo(owner: string, name: string) {
+  return {
+    id: Math.floor(Math.random() * 1_000_000),
+    name,
+    full_name: `${owner}/${name}`,
+    private: true,
+    html_url: `https://github.com/${owner}/${name}`,
+    clone_url: `https://github.com/${owner}/${name}.git`,
+    ssh_url: `git@github.com:${owner}/${name}.git`,
+    default_branch: 'main',
+    description: null,
+  };
+}
+
+describe('listOwnerRepositories — the managed-git PAT backend\'s repo lister', () => {
+  test('an org owner lists via GET /orgs/{owner}/repos, paginated', async () => {
+    const requests: string[] = [];
+    const firstPage = Array.from({ length: 100 }, (_, i) => repo('acme-corp', `repo-${i}`));
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input instanceof Request ? input.url : input);
+      requests.push(url);
+      const body = url.includes('page=2') ? [repo('acme-corp', 'last-one')] : firstPage;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const repos = await listOwnerRepositories({
+      owner: 'acme-corp',
+      ownerType: 'Organization',
+      auth: { token: 'pat-token' },
+    });
+
+    expect(repos).toHaveLength(101);
+    expect(repos[100]!.full_name).toBe('acme-corp/last-one');
+    expect(requests[0]).toBe(
+      'https://api.github.com/orgs/acme-corp/repos?type=all&per_page=100&page=1',
+    );
+    expect(requests.some((u) => u.includes('/user/repos'))).toBe(false);
+  });
+
+  test('a personal (User) owner lists via GET /user/repos, filtered back down to that owner', async () => {
+    let requested = '';
+    const ownRepo = repo('agent-kortix', 'demo');
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      requested = String(input instanceof Request ? input.url : input);
+      // A classic PAT's /user/repos can include repos under OTHER owners
+      // (collaborator access) — these must never leak into "repos for the
+      // configured owner".
+      return Response.json([ownRepo, repo('some-other-org', 'other-repo')]);
+    }) as typeof fetch;
+
+    const repos = await listOwnerRepositories({
+      owner: 'agent-kortix',
+      ownerType: 'User',
+      auth: { token: 'pat-token' },
+    });
+
+    expect(repos).toEqual([ownRepo]);
+    expect(requested).toBe(
+      'https://api.github.com/user/repos?affiliation=owner,collaborator&per_page=100&page=1',
+    );
+  });
+
+  test('no ownerType provided -> falls back to a live account-type lookup', async () => {
+    const requests: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input instanceof Request ? input.url : input);
+      requests.push(url);
+      if (url.match(/\/users\/[^/]+$/)) return Response.json({ type: 'User' });
+      return Response.json([repo('agent-kortix', 'demo')]);
+    }) as typeof fetch;
+
+    const repos = await listOwnerRepositories({
+      owner: 'agent-kortix',
+      auth: { token: 'pat-token' },
+    });
+
+    expect(repos.map((r) => r.full_name)).toEqual(['agent-kortix/demo']);
+    expect(requests[0]).toBe('https://api.github.com/users/agent-kortix');
   });
 });

--- a/apps/api/src/projects/github.ts
+++ b/apps/api/src/projects/github.ts
@@ -357,6 +357,47 @@ export async function listInstallationRepositories(
   return repositories;
 }
 
+/**
+ * List repositories for the managed-git PAT backend ("Use a token" self-host
+ * setup) — the token equivalent of `listInstallationRepositories`, which only
+ * works for a GitHub App installation id. A PAT has no "installation" to
+ * enumerate repos from, so this hits the same org-vs-personal-account
+ * endpoint `createRepo`/`resolveDefaultOwner` already branch on: an org owner
+ * lists via `/orgs/{owner}/repos` (what a fine-grained token scoped to an
+ * organization resource-owner can see), a personal owner via `/user/repos`
+ * (filtered back down to that owner — a classic token can see collaborator
+ * repos under other owners too, which don't belong in "repos for this
+ * configured owner").
+ */
+export async function listOwnerRepositories(input: {
+  owner: string;
+  ownerType?: 'User' | 'Organization';
+  auth: Pick<GitHubAuthContext, 'token'>;
+}): Promise<GitHubRepo[]> {
+  const isOrg = input.ownerType
+    ? input.ownerType !== 'User'
+    : await isOrgAccount(input.owner, input.auth);
+  const path = isOrg
+    ? `/orgs/${encodeURIComponent(input.owner)}/repos?type=all`
+    : '/user/repos?affiliation=owner,collaborator';
+  const perPage = 100;
+  const repositories: GitHubRepo[] = [];
+  for (let page = 1; ; page += 1) {
+    const pageRepositories = await ghFetch<GitHubRepo[]>(
+      `${path}&per_page=${perPage}&page=${page}`,
+      { method: 'GET' },
+      input.auth,
+    );
+    repositories.push(...pageRepositories);
+    if (pageRepositories.length < perPage) break;
+  }
+  return isOrg
+    ? repositories
+    : repositories.filter(
+        (repo) => repo.full_name.split('/')[0]?.toLowerCase() === input.owner.toLowerCase(),
+      );
+}
+
 export async function listRepositoryBranches(input: {
   owner: string;
   repo: string;

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -362,11 +362,46 @@ export function serializeGitHubInstallation(
 }
 
 
+/**
+ * Sentinel `installation_id` for the managed-git PAT backend ("Use a token"
+ * self-host setup, platform/routes/github-app.ts POST /pat) when an account
+ * has no real GitHub App installation. Real installation ids are GitHub's own
+ * numeric ids, so this string can never collide with one. Lets the
+ * Import-repo UI — which only understands the "installations" shape — pick
+ * the PAT the same way it picks a real App install, instead of needing a
+ * parallel UI/API surface just for the token backend. GET /github/repositories
+ * and POST /link-repository both recognize this id and route to the PAT.
+ */
+export const PAT_MANAGED_GIT_INSTALLATION_ID = 'pat';
+
 export function serializeGitHubInstallations(
   rows: Array<typeof accountGithubInstallations.$inferSelect>,
   accountId: string,
   installUrl: string | null,
+  /** Owner of the account-level managed-git PAT, when this account has no
+   *  real App installation but the server has a working token configured —
+   *  see the route handlers in routes/r1.ts. */
+  patFallbackOwner?: string | null,
 ) {
+  if (rows.length === 0 && patFallbackOwner) {
+    const patInstallation = {
+      account_id: accountId,
+      installation_row_id: null,
+      installed: true,
+      configured: true,
+      requires_installation: false,
+      install_url: null,
+      installation_id: PAT_MANAGED_GIT_INSTALLATION_ID,
+      owner_login: patFallbackOwner,
+      owner_type: null,
+      repository_selection: 'all',
+      permissions: {},
+      installation_url: null,
+      updated_at: null,
+    };
+    return { ...patInstallation, installations: [patInstallation] };
+  }
+
   const primary = rows[0] ?? null;
   const base = serializeGitHubInstallation(primary, accountId, installUrl);
   return {

--- a/apps/api/src/projects/routes/github-repositories.ts
+++ b/apps/api/src/projects/routes/github-repositories.ts
@@ -1,9 +1,11 @@
 import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
 import { auth, errors, json } from '../../openapi';
+import { managedGithubOwner, managedGithubOwnerType, managedGithubToken } from '../git-backends';
 import {
   createInstallationToken,
   getRepo,
   listInstallationRepositories,
+  listOwnerRepositories,
   listRepositoryBranches,
 } from '../github';
 import { resolveProjectAccount } from '../lib/access';
@@ -12,7 +14,7 @@ import {
   createGitHubInstallationInstallUrl,
   getAccountGitHubInstallation,
 } from '../lib/git';
-import { normalizeString, serializeGitHubRepo } from '../lib/serializers';
+import { PAT_MANAGED_GIT_INSTALLATION_ID, normalizeString, serializeGitHubRepo } from '../lib/serializers';
 import { createRoute, z } from '@hono/zod-openapi';
 
 const RepositoryBranchesResponseSchema = z.object({
@@ -51,6 +53,36 @@ projectsApp.openapi(
     const installationId = normalizeString(
       c.req.query('installation_id') ?? c.req.query('installationId'),
     );
+
+    // The managed-git PAT ("Use a token" self-host setup) surfaces as a
+    // synthetic installation (see serializeGitHubInstallations) since it has
+    // no real GitHub App installation to list repos from — list via the PAT
+    // itself instead of an installation token.
+    if (installationId === PAT_MANAGED_GIT_INSTALLATION_ID) {
+      const owner = managedGithubOwner();
+      const token = managedGithubToken();
+      if (!owner || !token) {
+        return c.json({ error: 'The managed GitHub token is no longer configured on this server' }, 409);
+      }
+      try {
+        const repos = await listOwnerRepositories({
+          owner,
+          ownerType: managedGithubOwnerType(),
+          auth: { token },
+        });
+        return c.json({
+          account_id: scope.accountId,
+          installation_id: PAT_MANAGED_GIT_INSTALLATION_ID,
+          owner_login: owner,
+          repositories: repos.map(serializeGitHubRepo),
+        });
+      } catch (error) {
+        return c.json({
+          error: (error as Error).message || 'Failed to list GitHub repositories',
+        }, 502);
+      }
+    }
+
     const installation = await getAccountGitHubInstallation(scope.accountId, installationId);
     if (!installation) {
       return c.json({

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -5,7 +5,7 @@ import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
 import { kickProjectTemplatePrebuilds } from '../../snapshots/builder';
 import { isAccountManager, type ProjectRole } from '../access';
-import { getBackend, hasBackend, type GitScope } from '../git-backends';
+import { getBackend, hasBackend, managedGithubOwner, managedGithubToken, type GitScope } from '../git-backends';
 import { seedRepoViaGitPush } from '../git-backends/seed';
 import { createRepo, getGitHubAppInstallation, verifyGitHubAppInstallStatePayload } from '../github';
 import { getProjectSecretValue } from '../secrets';
@@ -760,7 +760,12 @@ projectsApp.openapi(
   const installUrl = canManageGit
     ? await createGitHubInstallationInstallUrl(scope.accountId, scope.userId)
     : null;
-  return c.json(serializeGitHubInstallations(rows, scope.accountId, installUrl));
+  // No account-level GitHub App installation, but the server has a working
+  // managed-git PAT ("Use a token" self-host setup) — fall back to it so this
+  // account isn't told "GitHub isn't connected" just because it never
+  // installed an App (see serializeGitHubInstallations).
+  const patFallbackOwner = rows.length === 0 && managedGithubToken() ? managedGithubOwner() : null;
+  return c.json(serializeGitHubInstallations(rows, scope.accountId, installUrl, patFallbackOwner));
 },
 );
 
@@ -788,7 +793,12 @@ projectsApp.openapi(
   const installUrl = canManageGit
     ? await createGitHubInstallationInstallUrl(scope.accountId, scope.userId)
     : null;
-  return c.json(serializeGitHubInstallations(rows, scope.accountId, installUrl));
+  // No account-level GitHub App installation, but the server has a working
+  // managed-git PAT ("Use a token" self-host setup) — fall back to it so this
+  // account isn't told "GitHub isn't connected" just because it never
+  // installed an App (see serializeGitHubInstallations).
+  const patFallbackOwner = rows.length === 0 && managedGithubToken() ? managedGithubOwner() : null;
+  return c.json(serializeGitHubInstallations(rows, scope.accountId, installUrl, patFallbackOwner));
 },
 );
 

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -6,6 +6,7 @@ import { classifySnapshotError, describeSnapshotError } from '../../snapshots/er
 import { withTimeout } from '../../shared/with-timeout';
 import { templateSlugFromBuildSlug } from '../../snapshots/ppwarm-names';
 import { createTemplate, deleteTemplate, getTemplateById, TemplateNotFoundError, updateTemplate } from '../../snapshots/templates';
+import { managedGithubToken } from '../git-backends';
 import { commitFile, createRepo, getFileSha } from '../github';
 import { buildStarterFiles, normalizeStarterTemplateId } from '../starter';
 import { createRoute, z } from '@hono/zod-openapi';
@@ -13,7 +14,7 @@ import { enforceProjectQuota, loadProjectForUser, resolveProjectAccount, assertP
 import { AnyObject, SandboxTemplateSchema, SnapshotSchema, projectsApp } from '../lib/app';
 import { GitHubInstallationRequiredError, createGitHubInstallationInstallUrl, getProjectGitConnection, loadGitProject, resolveGitHubImport, resolveGitHubImportWithPat, resolveGitHubRepoAuth } from '../lib/git';
 import { registerGitHubLinkedProject, registerPatLinkedProject } from '../lib/project-registration';
-import { deriveProjectName, isRepoNameTakenError, normalizeString, readBody, requestAuditContext, serializeBuildSummary, serializeProject, serializeProjectGitConnection, serializeTemplate } from '../lib/serializers';
+import { PAT_MANAGED_GIT_INSTALLATION_ID, deriveProjectName, isRepoNameTakenError, normalizeString, readBody, requestAuditContext, serializeBuildSummary, serializeProject, serializeProjectGitConnection, serializeTemplate } from '../lib/serializers';
 import { createProjectSession, sendSessionCreateError } from '../lib/sessions';
 import { resolveManifestValidateFormat } from '../lib/manifest-format';
 import { config } from '../../config';
@@ -63,18 +64,31 @@ projectsApp.openapi(
 
   const manifestPath = normalizeString(body.manifest_path ?? body.manifestPath) ?? 'kortix.yaml';
 
-  // PAT path: link an existing repo with a caller-supplied token — no GitHub
-  // App install needed. This is the seamless `kortix ship` flow for a repo you
-  // already own (and the App-free fallback in environments where the App can't
-  // be installed). Everything downstream (`resolveProjectGitAuth` →
-  // `project_credential`) already consumes the stored PAT.
+  const installationIdInput = normalizeString(body.installation_id ?? body.installationId);
+
+  // PAT path: link an existing repo with a token, no GitHub App install
+  // needed — either a caller-supplied token (the seamless `kortix ship` flow
+  // for a repo you already own, and the App-free fallback in environments
+  // where the App can't be installed), or the account-level managed-git PAT
+  // ("Use a token" self-host setup) when the Import-repo UI picked its
+  // synthetic installation (see serializeGitHubInstallations /
+  // GET github/installations). Everything downstream (`resolveProjectGitAuth`
+  // → `project_credential`) already consumes the stored PAT either way.
   const githubToken = normalizeString(body.github_token ?? body.githubToken);
-  if (githubToken) {
+  const managedPatToken =
+    !githubToken && installationIdInput === PAT_MANAGED_GIT_INSTALLATION_ID
+      ? managedGithubToken()
+      : null;
+  if (!githubToken && installationIdInput === PAT_MANAGED_GIT_INSTALLATION_ID && !managedPatToken) {
+    return c.json({ error: 'The managed GitHub token is no longer configured on this server' }, 409);
+  }
+  const patToken = githubToken ?? managedPatToken;
+  if (patToken) {
     let patImport: Awaited<ReturnType<typeof resolveGitHubImportWithPat>>;
     try {
       patImport = await resolveGitHubImportWithPat({
         repoUrl,
-        token: githubToken,
+        token: patToken,
         defaultBranch: normalizeString(body.default_branch ?? body.defaultBranch),
       });
     } catch (error) {
@@ -84,13 +98,13 @@ projectsApp.openapi(
       accountId: scope.accountId,
       userId: scope.userId,
       repo: patImport.repo,
-      token: githubToken,
+      token: patToken,
       name: normalizeString(body.name),
       defaultBranch: patImport.defaultBranch,
       manifestPath,
     });
     kickProjectTemplatePrebuilds(
-      { projectId: row.projectId, repoUrl: row.repoUrl, defaultBranch: row.defaultBranch, manifestPath: row.manifestPath, gitAuthToken: githubToken },
+      { projectId: row.projectId, repoUrl: row.repoUrl, defaultBranch: row.defaultBranch, manifestPath: row.manifestPath, gitAuthToken: patToken },
       { accountId: scope.accountId, source: 'project-create' },
     );
     return c.json({
@@ -104,7 +118,7 @@ projectsApp.openapi(
     imported = await resolveGitHubImport({
       accountId: scope.accountId,
       repoUrl,
-      installationId: normalizeString(body.installation_id ?? body.installationId),
+      installationId: installationIdInput,
       defaultBranch: normalizeString(body.default_branch ?? body.defaultBranch),
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

- On self-host, connecting GitHub via **"Use a token"** (a fine-grained PAT, `POST /platform/github-app/pat`) already made managed-repo provisioning work (`githubBackend.isConfigured()` is PAT-aware), but the account-connection check and repo-listing endpoints only ever recognized a **GitHub App** installation — so the web UI kept showing *"GitHub isn't connected on this server yet"* for both **New project** and **"Already have code on GitHub? Import it"**, even with a working PAT.
- Root cause: `GET /projects/github/installation(s)` (`apps/api/src/projects/routes/r1.ts`) and its serializer (`serializeGitHubInstallation`, `apps/api/src/projects/lib/serializers.ts`) reported `configured: isGithubAppConfigured()`, which checks `appId`+`privateKey` only — never the stored PAT/`patOwner`.
- Fix:
  - `serializeGitHubInstallations` now synthesizes a connected "installation" (sentinel id `"pat"`, exported as `PAT_MANAGED_GIT_INSTALLATION_ID`) for the managed PAT when the account has no real App installation. A real App installation always takes precedence (no duplicate/synthetic entry).
  - `GET /projects/github/repositories` recognizes the `pat` sentinel and lists repos via a new `listOwnerRepositories` helper (`apps/api/src/projects/github.ts`) — org repos via `/orgs/{owner}/repos`, personal-account repos via `/user/repos` (filtered back to the configured owner), mirroring the existing `createRepo`/`resolveDefaultOwner` owner-type routing.
  - `POST /projects/link-repository` resolves the `pat` sentinel to the account's managed token and reuses the **existing** `resolveGitHubImportWithPat` / `registerPatLinkedProject` path — the same one `kortix ship`'s own-token flow already relies on. No new registration logic.
- This was found live on a customer self-host box: the PAT was saved correctly (owner populated, `patOwner: 'globex-corp'`) and managed-repo creation worked, but Import/New-project still showed "not connected" — confirming this is a pure front-end/API gating bug, not a data issue.

**Note:** this should ride after the **v0.10.2** release train — please don't merge yet, a release is in flight.

## Test plan
- [x] `bunx tsc --noEmit` — clean (0 errors)
- [x] New unit tests: `apps/api/src/__tests__/unit-github-pat-import.test.ts` (serializer PAT-fallback behavior, precedence over a real App install)
- [x] Extended `apps/api/src/projects/github.test.ts` with `listOwnerRepositories` coverage (org path, personal-account path w/ collaborator-repo filtering, live-lookup fallback)
- [x] Fixed 6 pre-existing e2e test files that `mock.module('../projects/github')` / `mock.module('../projects/git-backends')` to stub the new exports (`listOwnerRepositories`, `managedGithubOwner`, `managedGithubOwnerType`) so module linking still succeeds
- [x] Verified no regressions: ran each touched/adjacent test file in isolation before and after (via `git stash`) — failure counts are identical pre- and post-change (a few files have pre-existing, unrelated failures on `refactor/generic-self-host` HEAD, confirmed unrelated by reproducing them on the base commit)
- [x] Biome check on touched files: 54 errors after vs 55 before (pre-existing repo-wide lint debt, not introduced by this change)
