### PR TITLE
fix(selfhost-ec2): data-volume survival, resilient bootstrap, containerd on data volume, alarms

### DIFF
--- a/infra/deployments/vps-demo/backend.tf
+++ b/infra/deployments/vps-demo/backend.tf
@@ -1,6 +1,28 @@
 # Local state on purpose — this is a single demo box, not a shared Kortix
 # environment. State lives at infra/deployments/vps-demo/terraform.tfstate (gitignored,
 # never commit it). See main.tf's header comment for the migrate-to-S3 note.
+#
+# Known tradeoff (documented, not "fixed" here): local state is unlocked —
+# two people (or an agent + a person) running `terraform apply` from
+# different checkouts at the same time can race and corrupt state, and the
+# only copy lives on whichever machine last applied. That's an accepted risk
+# for a single demo box with one operator. If this ever becomes a
+# team-shared environment, move to the standard S3 + DynamoDB-lock backend
+# used by infra/terraform/environments/* — sketch:
+#
+# terraform {
+#   backend "s3" {
+#     bucket         = "kortix-terraform-state"
+#     key            = "deployments/vps-demo/terraform.tfstate"
+#     region         = "us-east-1"
+#     dynamodb_table = "kortix-terraform-locks" # state locking
+#     encrypt        = true
+#   }
+# }
+#
+# Migrating: after adding the block above (and removing the "local" block),
+# run `terraform init -migrate-state` once from a checkout that has the
+# current terraform.tfstate, then delete the local state file.
 terraform {
   backend "local" {
     path = "terraform.tfstate"

--- a/infra/terraform/modules/selfhost-ec2/README.md
+++ b/infra/terraform/modules/selfhost-ec2/README.md
@@ -16,11 +16,17 @@ mechanism to keep in sync with the updater, on purpose.
 - **EC2 instance** (`t3.xlarge` by default) on Ubuntu 24.04 LTS, resolved via
   the public Canonical SSM parameter (or pin `ami_id`). IMDSv2 required, EBS
   optimized, an IAM instance profile with `AmazonSSMManagedInstanceCore`
-  (connect with `aws ssm start-session`, no SSH key or open port needed).
+  (connect with `aws ssm start-session`, no SSH key or open port needed). A
+  plan-time precondition rejects an `instance_type`/AMI architecture mismatch
+  (e.g. a Graviton `instance_type` against the default amd64 AMI) with a
+  clear error instead of failing to boot — see "Instance type / AMI
+  architecture" below.
 - **A separate EBS data volume** (`data_volume_size_gb`, default 100GB, gp3,
-  encrypted, `delete_on_termination = false`) holding **all** durable
-  self-host state — Docker's own data-root (images, containers, the
-  updater/Caddy named volumes) *and* the kortix CLI's instance directory
+  encrypted, `delete_on_termination = false`, `lifecycle.prevent_destroy =
+  true`) holding **all** durable self-host state — Docker's own data-root
+  (images, containers, the updater/Caddy named volumes), **containerd's own
+  root** (the actual image/container filesystem layers — see "Disk layout"
+  below), *and* the kortix CLI's instance directory
   (`KORTIX_SELF_HOST_CONFIG_DIR`), which is where the CLI persists Postgres
   and Supabase Storage as bind mounts. That's why this module doesn't just
   bind-mount `/var/lib/docker`: Postgres data lives under
@@ -39,7 +45,15 @@ mechanism to keep in sync with the updater, on purpose.
   configurable schedule — `backup_interval_hours` (default 24, i.e. once
   daily; any of DLM's supported intervals — 1, 2, 3, 4, 6, 8, 12, 24 — work,
   e.g. `6` for four snapshots a day) and `backup_retention_count` (default 7 —
-  stores up to this many backups before the oldest is pruned).
+  stores up to this many backups before the oldest is pruned). See "Restoring
+  from a snapshot" below for the restore procedure (there is no automated
+  restore — this only creates the snapshots).
+- **CloudWatch monitoring** (`var.enable_alarms`, default on): an EC2
+  status-check alarm plus disk-usage (root and data volume) and memory-usage
+  alarms fed by the CloudWatch agent that bootstrap installs and configures,
+  notifying an SNS topic (`var.alarm_sns_topic_arn` to reuse an existing one,
+  or the module creates its own, optionally with `var.alarm_email`
+  subscribed). See "Monitoring" below.
 
 ## What it deliberately does NOT do
 
@@ -80,6 +94,10 @@ output "next_steps" {
 - `instance_type` (default `t3.xlarge`), `ami_id` / `ami_ssm_parameter`,
   `key_name` (optional — SSM works without it), `vpc_id` / `subnet_id`
   (optional — default VPC/subnet otherwise).
+- `availability_zone` — optional override for the data volume's AZ. Leave
+  empty (default) to derive it from the subnet, which is almost always
+  correct; see "Replacing the instance without losing data" for why this is
+  never derived from the instance itself.
 - `allowed_cidrs` (80/443 ingress), `ssh_ingress_cidrs` (opt-in only).
 - `data_volume_size_gb` (default 100), `data_volume_kms_key_id` (optional CMK).
 - `backup_interval_hours` (default 24 — 1/2/3/4/6/8/12/24 are the valid DLM
@@ -93,20 +111,220 @@ output "next_steps" {
   (`prod`/`dev` — which CLI build the installer fetches; use `dev` if the
   published `prod` CLI hasn't caught up yet to flags this module passes to
   `kortix self-host init`).
+- `enable_alarms` (default `true`), `alarm_sns_topic_arn` (reuse an existing
+  topic instead of the module creating one), `alarm_email` (subscribe an
+  address to the module-created topic), `disk_usage_alarm_threshold_percent`
+  (default 85), `memory_usage_alarm_threshold_percent` (default 90),
+  `alarm_evaluation_periods` (default 3 × 5-minute periods).
 
 ## Outputs
 
 `public_ip`, `instance_id`, `data_volume_id`, `dashboard_url`, `api_url`,
-`dns_managed_by_terraform`, `ssm_connect_command`, `post_apply_next_steps`
-(what to do next — secrets, dashboard, updates).
+`dns_managed_by_terraform`, `ssm_connect_command`, `alarm_sns_topic_arn`,
+`post_apply_next_steps` (what to do next — secrets, dashboard, updates).
 
 ## Replacing the instance without losing data
 
-The data volume (`aws_ebs_volume.data`) has `delete_on_termination = false`
-and is attached via a separate `aws_volume_attachment` resource — destroying
-or replacing `aws_instance.this` (a new AMI, instance type, etc.) does not
-destroy it. On the new instance, cloud-init runs again, detects the volume
-already has a filesystem (skips `mkfs`), mounts it at the same path, and
-`kortix self-host init`/`start` find the existing instance directory (same
-`KORTIX_SELF_HOST_CONFIG_DIR`) and reconcile against it rather than creating a
-fresh one.
+The data volume (`aws_ebs_volume.data`) has `delete_on_termination = false`,
+`lifecycle.prevent_destroy = true`, and is attached via a separate
+`aws_volume_attachment` resource — destroying or replacing `aws_instance.this`
+(a new AMI, instance type, etc.) does not destroy it. On the new instance,
+cloud-init runs again, detects the volume already has a filesystem (skips
+`mkfs`), mounts it at the same path, and `kortix self-host init`/`start` find
+the existing instance directory (same `KORTIX_SELF_HOST_CONFIG_DIR`) and
+reconcile against it rather than creating a fresh one.
+
+**The AZ pin is the load-bearing detail here, and it bit us once — fixed
+2026-07-16.** `availability_zone` is a `ForceNew` attribute on
+`aws_ebs_volume`: if the volume's AZ ever depends on `aws_instance.this`'s own
+(post-apply-known) `availability_zone` attribute, then replacing the instance
+makes that value "known after apply" for the volume too — which Terraform can
+only satisfy by **destroying and recreating the volume**, silently taking the
+database with it. A live `terraform plan -replace=aws_instance.this` repro
+against the pre-fix code confirmed exactly this (`aws_ebs_volume.data` showed
+`delete` + `create`); the same repro against the fixed code shows `no-op`
+(`local.availability_zone` — see `main.tf`/`storage.tf` — is derived from the
+subnet via `data.aws_subnet.selected`, never from the instance). Belt and
+suspenders: `lifecycle.prevent_destroy = true` on the volume refuses *any*
+destroy/replace of it outright, regardless of cause — to retire a box's data
+on purpose, remove that block in its own reviewed apply first.
+
+**Guard this doesn't regress**: `scripts/check-data-volume-safe.sh
+<plan-file>` takes a saved `terraform plan -out=...` and fails loudly if
+`aws_ebs_volume.data` would be replaced or deleted. Wire it into CI for any
+root module that consumes this one, e.g.:
+
+```sh
+terraform plan -out=tf.plan
+../../terraform/modules/selfhost-ec2/scripts/check-data-volume-safe.sh tf.plan
+```
+
+## Disk layout: containerd lives on the data volume too
+
+**Root-caused live — fixed 2026-07-16.** Setting Docker's `data-root` in
+`/etc/docker/daemon.json` moves *dockerd's* state (images/containers
+metadata, named volumes), but with the modern containerd-snapshotter setup
+the actual image/container filesystem **layers** live under containerd's own
+`root` (`/var/lib/containerd` by default) — a separate systemd-managed daemon
+docker delegates to, not something `daemon.json` touches. Both live boxes had
+14-16GB under `/var/lib/containerd` on their 30GB root volumes (59-65% full)
+while the 100GB data volume sat almost empty, because only dockerd's
+data-root had been relocated.
+
+Fixed for **new** boxes: `templates/user-data.sh.tftpl` now also writes
+`/etc/containerd/config.toml` with `root = "<data_mount_path>/containerd"`
+*before* containerd's first start (containerd starts as its own systemd unit
+the moment the `containerd.io` package installs, so the daemon is stopped
+immediately after install and restarted only after the config is repointed).
+`daemon.json` also now sets default log rotation
+(`log-driver: json-file`, `max-size: 10m`, `max-file: 3`) so no single
+container's logs can fill the root volume either.
+
+**Existing boxes are NOT migrated automatically** — this only applies to a
+fresh install. To move an already-running box's containerd state onto the
+data volume, an ops agent should do this deliberately (expect a brief outage
+while containerd is stopped):
+
+1. `sudo systemctl stop kortix-selfhost-bootstrap.service` (see "Bootstrap
+   resilience" below) so nothing restarts the stack mid-migration, then
+   `cd $(kortix self-host config-dir)/<instance> && docker compose stop` (or
+   just accept the containers stop when containerd does in the next step).
+2. `sudo systemctl stop docker.service containerd.service`.
+3. `sudo mkdir -p /mnt/kortix-data/containerd && sudo rsync -aHAX --info=progress2 /var/lib/containerd/ /mnt/kortix-data/containerd/`
+   (rsync, not `mv`/`cp`, to preserve hardlinks/xattrs the overlay snapshotter
+   relies on).
+4. Edit `/etc/containerd/config.toml`: set `root =
+   "/mnt/kortix-data/containerd"` (add `version = 2` if the file doesn't
+   already set it).
+5. `sudo mv /var/lib/containerd /var/lib/containerd.bak-$(date +%s)` (keep the
+   backup until you've confirmed containers come back healthy, then delete
+   it to reclaim root-volume space — the whole point of this migration).
+6. `sudo systemctl start containerd.service docker.service`, confirm `docker
+   ps` shows the expected containers, then `sudo systemctl start
+   kortix-selfhost-bootstrap.service` (or `docker compose up -d` directly)
+   and verify the dashboard/API respond.
+7. Confirm `df -h /` has real headroom back, then remove the
+   `.bak-*` directory from step 5.
+
+## Bootstrap resilience: a retried, reboot-surviving systemd unit
+
+**Confirmed live on both boxes — fixed 2026-07-16.** cloud-init has no retry
+of its own: the previous version of `templates/user-data.sh.tftpl` ran
+`kortix self-host init`/`start` inline, and on both live boxes the first
+`docker compose up` attempt hit a slow-cold-start dependency race
+(`kortix-api` didn't report healthy before compose's dependency wait gave up)
+— which made cloud-init itself report `status: error` **permanently**, even
+though `kortix self-host start` run a second time (by hand) succeeded
+immediately. Both boxes are only up today because someone finished the setup
+manually after the fact.
+
+Fixed by splitting responsibilities: `templates/user-data.sh.tftpl` (running
+once, via cloud-init) now *only* installs prerequisites — mounts the data
+volume, installs/configures Docker + containerd, installs the kortix CLI, and
+(if `enable_alarms`) the CloudWatch agent — then writes and enables
+`kortix-selfhost-bootstrap.service`, a systemd oneshot unit
+(`Restart=on-failure`, `RestartSec=30`, a bounded 20-attempts/hour budget so a
+genuinely broken box doesn't crash-loop forever) that runs the actual
+`kortix self-host init`/`env set`/`start` sequence. Cloud-init hands off to it
+with `systemctl start --no-block` and returns immediately — cloud-init's own
+success/failure status is no longer coupled to whether the app's first-boot
+health check race resolves on the first try. Because `init`/`start` are
+idempotent, systemd retrying the whole unit (rather than something bespoke
+inside the script) is sufficient to self-heal, and because the unit is
+`enable`d (`WantedBy=multi-user.target`), **a reboot reruns it fresh** with a
+new retry budget too — so even a box that exhausts one boot's budget picks
+back up on the next reboot without operator intervention.
+
+Check on a box: `systemctl status kortix-selfhost-bootstrap.service`,
+`journalctl -u kortix-selfhost-bootstrap.service`.
+
+## Monitoring
+
+`var.enable_alarms` (default `true`) wires up the CloudWatch agent (installed
+and configured by `templates/user-data.sh.tftpl` — namespace `KortixSelfHost`,
+disk `used_percent` on `/` and the data mount, `mem_used_percent`) and three
+alarms: EC2 status-check failure, disk usage on either volume above
+`disk_usage_alarm_threshold_percent` (default 85%), and memory usage above
+`memory_usage_alarm_threshold_percent` (default 90%) — each sustained for
+`alarm_evaluation_periods` (default 3) consecutive 5-minute periods to absorb
+short spikes (a build, a backup). All three notify `alarm_sns_topic_arn`: an
+existing topic if you pass `var.alarm_sns_topic_arn`, otherwise a topic this
+module creates (optionally subscribing `var.alarm_email`). Kept deliberately
+minimal — this is one box, not a fleet; add more if you need them.
+
+## Restoring from a snapshot
+
+There is no automated restore — DLM only takes the snapshots
+(`aws_dlm_lifecycle_policy.data`, tag-matched via `Backup =
+"<name>-data"`/`SnapshotOf = "<name>-data"`). To restore:
+
+1. **Locate the snapshot**: `aws ec2 describe-snapshots --owner-ids self
+   --filters "Name=tag:SnapshotOf,Values=<name>-data" --query
+   "reverse(sort_by(Snapshots,&StartTime))[:5]"` — pick the one you want.
+2. **Create a new volume from it, in the SAME AZ as the running instance**
+   (this matters — a volume can only attach to an instance in its own AZ; see
+   the `availability_zone` output/`aws_instance.this.availability_zone`):
+   `aws ec2 create-volume --availability-zone <az> --snapshot-id <snap-id>
+   --volume-type gp3`.
+3. **Swap the attachment**: stop the box (`kortix self-host stop` or
+   `docker compose down` first, so nothing is mid-write), detach the current
+   data volume (`aws ec2 detach-volume --volume-id <current-vol>`), attach the
+   restored one at the same device name the module uses (`/dev/sdf` — or
+   wherever it actually landed; Nitro instances expose it as an NVMe device,
+   see `templates/user-data.sh.tftpl`'s device-probing loop), mount it at
+   `/mnt/kortix-data`, then `docker compose up -d` (or `kortix self-host
+   start`) again. If this is a genuinely different EBS volume ID than
+   Terraform's state has recorded, follow up with `terraform apply` (or
+   `terraform state rm` + re-`import`) so Terraform's state matches reality —
+   otherwise the next `apply` will try to "fix" the attachment back to the
+   volume ID it remembers.
+4. **Boot order caveat**: the box's own boot ordering (mount →
+   containerd/docker → `kortix-selfhost-bootstrap.service`) assumes the data
+   volume is already attached and formatted by the time it runs — attach and
+   mount the restored volume *before* rebooting/restarting the stack, not
+   after, or the bootstrap unit's mount-detection loop will just find the
+   already-mounted (restored) volume and proceed, which is fine, but a stale
+   `/etc/fstab` UUID line pointing at the *old* volume's UUID will fail to
+   mount on a subsequent reboot — update `/etc/fstab`'s UUID to the restored
+   volume's (`blkid` it first) as part of the swap.
+5. **Postgres crash-consistency, honestly**: EBS snapshots are
+   crash-consistent for the volume as a block device, but Postgres's own data
+   directory (a bind mount under the CLI's instance directory on this same
+   volume) was almost certainly mid-write when the snapshot fired — this is
+   equivalent to a hard power-cut from Postgres's point of view. Postgres's
+   WAL-based crash recovery handles this correctly (it replays WAL to reach a
+   consistent state on next start; you have not lost committed transactions
+   as of the snapshot's actual instant, only in-flight ones), but expect a
+   delayed startup on first boot after restore while WAL replay runs, and
+   treat it as "consistent as of an unclean shutdown," not "consistent as of
+   a clean `pg_dump`." If you need a guaranteed-clean restore point instead,
+   run `docker compose exec supabase-db psql -c "SELECT
+   pg_backup_start('manual pre-snapshot');"` immediately before triggering a
+   manual snapshot and `pg_backup_stop()` after (DLM's own schedule has no
+   pre/post-script hook for this on Linux — VSS pre/post scripts are a
+   Windows-only DLM feature — so this only applies to manual, ad hoc
+   snapshots taken outside the DLM schedule).
+
+## State
+
+`infra/deployments/vps-demo` uses a local, unlocked `terraform.tfstate` on
+purpose (single demo box, single operator — see that directory's
+`backend.tf`). That's an accepted tradeoff for exactly that use case, not a
+recommendation: two concurrent `apply`s from different checkouts can race and
+corrupt local state, and the only copy of it lives on whoever last ran
+`apply`. If a root module using this module becomes a team-shared
+environment, move to an S3 + DynamoDB-lock backend (the standard one used by
+`infra/terraform/environments/*`) — see the commented example in
+`infra/deployments/vps-demo/backend.tf`.
+
+## Instance type / AMI architecture
+
+`ami_ssm_parameter` defaults to Canonical's **amd64** Ubuntu 24.04 AMI. A
+plan-time `precondition` on `aws_instance.this` (via a `data.aws_ami` lookup
+on whatever AMI actually resolves) checks that against `instance_type`'s
+family: a Graviton (`*g`/`a1`) `instance_type` against an `x86_64` AMI (or
+vice versa — an intentionally-set arm64 `ami_id` against a non-Graviton
+`instance_type`) fails at `terraform plan` with a clear message, instead of
+launching an instance that fails to boot (kernel/arch mismatch). If you
+intentionally want Graviton, set both `instance_type` (e.g. `t4g.xlarge`) and
+an arm64 `ami_id`/`ami_ssm_parameter` together.

--- a/infra/terraform/modules/selfhost-ec2/main.tf
+++ b/infra/terraform/modules/selfhost-ec2/main.tf
@@ -20,11 +20,43 @@ locals {
   vpc_id    = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default[0].id
   subnet_id = var.subnet_id != "" ? var.subnet_id : data.aws_subnets.default[0].ids[0]
 
+  # The data volume's AZ MUST NOT be derived from aws_instance.this — AZ is
+  # ForceNew on aws_ebs_volume, so if it ever depended on the (replaceable)
+  # instance, any instance replacement makes the AZ "known after apply" and
+  # forces a destroy/recreate of the DATA VOLUME. Derive it independently from
+  # the subnet instead (the subnet is what actually pins the instance's AZ —
+  # aws_instance.this has no explicit availability_zone of its own), with an
+  # explicit override for cases where that inference isn't right.
+  availability_zone = var.availability_zone != "" ? var.availability_zone : data.aws_subnet.selected.availability_zone
+
+  # Graviton (arm64) instance-type family prefixes — used to guard against
+  # launching an arm64 instance type against the amd64-only default AMI (see
+  # the precondition on aws_instance.this below).
+  is_graviton_instance_type = can(regex("^(a1|c6g|c6gd|c6gn|c7g|c7gd|c7gn|c7gh|c8g|c8gd|c8gn|g5g|hpc7g|hpc7g4|im4gn|is4gen|m6g|m6gd|m7g|m7gd|m8g|m8gd|r6g|r6gd|r7g|r7gd|r8g|r8gd|t4g|x2gd|i4g|i8g)\\.", var.instance_type))
+
+  # Namespace CloudWatch agent metrics + alarms both key off (see monitoring.tf).
+  cloudwatch_namespace = "KortixSelfHost"
+
   tags = merge(var.tags, {
     Name      = local.name
     ManagedBy = "terraform"
     Module    = "selfhost-ec2"
   })
+}
+
+# Used solely to pin the data volume's AZ independently of the (replaceable)
+# instance — see local.availability_zone above and storage.tf.
+data "aws_subnet" "selected" {
+  id = local.subnet_id
+}
+
+# Used solely to guard against an arch mismatch between var.instance_type and
+# the resolved AMI (see the precondition on aws_instance.this below).
+data "aws_ami" "selected" {
+  filter {
+    name   = "image-id"
+    values = [local.ami_id]
+  }
 }
 
 # ── AMI (Ubuntu 24.04 LTS via Canonical's public SSM parameter) ────────────
@@ -166,6 +198,8 @@ resource "aws_instance" "this" {
     acme_email              = var.acme_email
     data_volume_device_name = local.data_volume_device_name
     data_mount_path         = local.data_mount_path
+    enable_alarms           = var.enable_alarms
+    cloudwatch_namespace    = local.cloudwatch_namespace
   })
   user_data_replace_on_change = false
 
@@ -176,5 +210,21 @@ resource "aws_instance" "this" {
   # false on the volume) — an instance replacement must not touch it.
   lifecycle {
     ignore_changes = [ami]
+
+    # nonsensitive(): aws_ssm_parameter.value is always marked sensitive by
+    # the provider (it might be a SecureString), even though the Canonical
+    # Ubuntu AMI-id parameter this module resolves is public, non-secret
+    # data — without unwrapping it here, Terraform redacts the whole
+    # precondition error_message down to a useless generic warning the one
+    # time this guard actually needs to explain itself.
+    precondition {
+      condition     = !local.is_graviton_instance_type || data.aws_ami.selected.architecture == "arm64"
+      error_message = "instance_type '${var.instance_type}' looks like a Graviton (arm64) family, but the resolved AMI (${nonsensitive(local.ami_id)}) is architecture '${data.aws_ami.selected.architecture}'. Pass a matching arm64 ami_id (or ami_ssm_parameter), or switch instance_type to an x86_64 family."
+    }
+
+    precondition {
+      condition     = local.is_graviton_instance_type || data.aws_ami.selected.architecture == "x86_64"
+      error_message = "instance_type '${var.instance_type}' is x86_64, but the resolved AMI (${nonsensitive(local.ami_id)}) is architecture '${data.aws_ami.selected.architecture}'. This module's default ami_ssm_parameter tracks the amd64 Ubuntu AMI — if you intentionally set an arm64 ami_id, switch instance_type to a Graviton (*g) family instead."
+    }
   }
 }

--- a/infra/terraform/modules/selfhost-ec2/monitoring.tf
+++ b/infra/terraform/modules/selfhost-ec2/monitoring.tf
@@ -1,0 +1,130 @@
+# Minimal, boring CloudWatch monitoring: an EC2 status-check alarm (no
+# agent needed) plus disk/memory alarms fed by the CloudWatch agent that
+# templates/user-data.sh.tftpl installs and configures on the box (see the
+# "monitoring" section there). Everything here is var-gated by
+# var.enable_alarms (default true) — this is a single unmonitored box
+# otherwise, which was finding #4 of the 2026-07 production-readiness audit.
+
+# ── IAM: let the box publish CloudWatch agent metrics/logs ─────────────────
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
+  count      = var.enable_alarms ? 1 : 0
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# ── SNS: notify on alarm ────────────────────────────────────────────────────
+resource "aws_sns_topic" "alarms" {
+  #checkov:skip=CKV_AWS_26:no sensitive payloads pass through this topic (alarm text only) — SNS-managed encryption is the default and adds an unnecessary CMK dependency for a demo/self-host box
+  count = var.enable_alarms && var.alarm_sns_topic_arn == "" ? 1 : 0
+  name  = "${local.name}-alarms"
+  tags  = local.tags
+}
+
+resource "aws_sns_topic_subscription" "alarm_email" {
+  count     = var.enable_alarms && var.alarm_sns_topic_arn == "" && var.alarm_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.alarms[0].arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+locals {
+  alarm_topic_arn = var.alarm_sns_topic_arn != "" ? var.alarm_sns_topic_arn : (
+    var.enable_alarms ? aws_sns_topic.alarms[0].arn : ""
+  )
+}
+
+# ── EC2 status-check alarm (instance + system checks; no agent required) ───
+resource "aws_cloudwatch_metric_alarm" "status_check" {
+  count               = var.enable_alarms ? 1 : 0
+  alarm_name          = "${local.name}-status-check-failed"
+  alarm_description   = "EC2 instance or system status check failed for ${local.name} (${aws_instance.this.id})."
+  namespace           = "AWS/EC2"
+  metric_name         = "StatusCheckFailed"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    InstanceId = aws_instance.this.id
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+  tags          = local.tags
+}
+
+# ── Disk usage (CloudWatch agent, "disk" plugin, drop_device — see
+#    user-data) — one alarm each for the root volume and the data volume. ───
+resource "aws_cloudwatch_metric_alarm" "disk_usage_root" {
+  count               = var.enable_alarms ? 1 : 0
+  alarm_name          = "${local.name}-disk-usage-root"
+  alarm_description   = "Root (\"/\") disk usage on ${local.name} (${aws_instance.this.id}) at or above ${var.disk_usage_alarm_threshold_percent}%."
+  namespace           = local.cloudwatch_namespace
+  metric_name         = "disk_used_percent"
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.disk_usage_alarm_threshold_percent
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "missing"
+
+  dimensions = {
+    InstanceId = aws_instance.this.id
+    path       = "/"
+    fstype     = "ext4"
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "disk_usage_data" {
+  count               = var.enable_alarms ? 1 : 0
+  alarm_name          = "${local.name}-disk-usage-data"
+  alarm_description   = "Data volume (${local.data_mount_path}) disk usage on ${local.name} (${aws_instance.this.id}) at or above ${var.disk_usage_alarm_threshold_percent}%."
+  namespace           = local.cloudwatch_namespace
+  metric_name         = "disk_used_percent"
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.disk_usage_alarm_threshold_percent
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "missing"
+
+  dimensions = {
+    InstanceId = aws_instance.this.id
+    path       = local.data_mount_path
+    fstype     = "ext4"
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+  tags          = local.tags
+}
+
+# ── Memory usage (CloudWatch agent, "mem" plugin — no per-mount dimension) ─
+resource "aws_cloudwatch_metric_alarm" "memory_usage" {
+  count               = var.enable_alarms ? 1 : 0
+  alarm_name          = "${local.name}-memory-usage"
+  alarm_description   = "Memory usage on ${local.name} (${aws_instance.this.id}) at or above ${var.memory_usage_alarm_threshold_percent}%."
+  namespace           = local.cloudwatch_namespace
+  metric_name         = "mem_used_percent"
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = var.alarm_evaluation_periods
+  threshold           = var.memory_usage_alarm_threshold_percent
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "missing"
+
+  dimensions = {
+    InstanceId = aws_instance.this.id
+  }
+
+  alarm_actions = [local.alarm_topic_arn]
+  ok_actions    = [local.alarm_topic_arn]
+  tags          = local.tags
+}

--- a/infra/terraform/modules/selfhost-ec2/outputs.tf
+++ b/infra/terraform/modules/selfhost-ec2/outputs.tf
@@ -30,6 +30,11 @@ output "ssm_connect_command" {
   value       = "aws ssm start-session --target ${aws_instance.this.id}"
 }
 
+output "alarm_sns_topic_arn" {
+  description = "SNS topic the CloudWatch alarms (status-check, disk, memory) notify — either the module-created topic or var.alarm_sns_topic_arn if you supplied one. Empty string when var.enable_alarms = false."
+  value       = local.alarm_topic_arn
+}
+
 output "post_apply_next_steps" {
   description = "What to do after `terraform apply` finishes — secrets are deliberately NOT Terraform inputs."
   value       = <<-EOT

--- a/infra/terraform/modules/selfhost-ec2/scripts/check-data-volume-safe.sh
+++ b/infra/terraform/modules/selfhost-ec2/scripts/check-data-volume-safe.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Plan-guard for finding #1 of the 2026-07 production-readiness audit:
+# Terraform destroying the data volume (aws_ebs_volume.data) on an instance
+# replacement. The bug was the volume's availability_zone depending on
+# aws_instance.this.availability_zone (ForceNew + a replaceable instance
+# upstream == the volume becomes "known after apply" and gets replaced too).
+# That's now fixed (storage.tf pins the AZ from the subnet, independent of
+# the instance, plus lifecycle.prevent_destroy on the volume), but this
+# script is a cheap, permanent tripwire against it — or anything else —
+# regressing: point it at a saved plan (from any root module using this
+# module) and it fails loudly if the plan would touch the data volume.
+#
+# Usage:
+#   terraform plan -out=tf.plan
+#   ./check-data-volume-safe.sh tf.plan
+#
+# Exit 0: no aws_ebs_volume.data resource instance in the plan is being
+#         replaced or deleted (or none exists yet — nothing to check).
+# Exit 1: at least one is — prints which, and refuses.
+set -euo pipefail
+
+PLAN_FILE="${1:?usage: $0 <saved-plan-file>}"
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "FATAL: terraform CLI not found on PATH" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FATAL: jq not found on PATH (required to inspect the plan JSON)" >&2
+  exit 2
+fi
+
+PLAN_JSON="$(terraform show -json "$PLAN_FILE")"
+
+# resource_changes[].address for anything whose type is aws_ebs_volume and
+# whose name is "data" (this module always names it aws_ebs_volume.data,
+# possibly module-prefixed, e.g. module.selfhost.aws_ebs_volume.data), where
+# the planned actions include delete and/or create (i.e. any replace, or a
+# bare destroy).
+UNSAFE="$(echo "$PLAN_JSON" | jq -r '
+  [.resource_changes[]?
+    | select(.type == "aws_ebs_volume" and .name == "data")
+    | select((.change.actions | index("delete")) or (.change.actions | index("create") and (.change.actions | length) > 1))
+  ] | .[] | .address
+')"
+
+if [ -n "$UNSAFE" ]; then
+  echo "REFUSING: the plan in '$PLAN_FILE' would destroy/replace the self-host data volume:" >&2
+  echo "$UNSAFE" >&2
+  echo "" >&2
+  echo "This is almost certainly the AZ-ForceNew class of bug (see storage.tf's" >&2
+  echo "comment on aws_ebs_volume.data and the README's 'Replacing the instance" >&2
+  echo "without losing data' section) unless you are deliberately retiring this" >&2
+  echo "box's data on purpose — in which case remove lifecycle.prevent_destroy" >&2
+  echo "first, in its own reviewed apply, and re-run this check to confirm it's" >&2
+  echo "now the ONLY thing flagged." >&2
+  exit 1
+fi
+
+echo "OK: no aws_ebs_volume.data replacement/destroy in '$PLAN_FILE'."

--- a/infra/terraform/modules/selfhost-ec2/storage.tf
+++ b/infra/terraform/modules/selfhost-ec2/storage.tf
@@ -23,7 +23,21 @@ locals {
 
 #checkov:skip=CKV2_AWS_9:backups are handled by the aws_dlm_lifecycle_policy in this module (daily snapshots, retention-capped) — an AWS Backup plan would duplicate it
 resource "aws_ebs_volume" "data" {
-  availability_zone = aws_instance.this.availability_zone
+  # DELIBERATELY NOT aws_instance.this.availability_zone: AZ is ForceNew on
+  # aws_ebs_volume, so if this depended on the instance's (post-apply-known)
+  # AZ attribute, ANY instance replacement (taint, -replace, instance_type
+  # change, AMI swap that isn't ignore_changes-suppressed, ...) makes this
+  # value "known after apply" and forces Terraform to destroy and recreate the
+  # DATA VOLUME along with the instance — silently destroying the database.
+  # local.availability_zone is derived from the subnet (var.subnet_id /
+  # data.aws_subnet.selected in main.tf), which is stable across instance
+  # replacement, so the volume's AZ never depends on the instance at all.
+  #
+  # Verified via repro: seed state with the instance's AZ known, then
+  # `terraform plan -replace=aws_instance.this` — with this fixed, the plan
+  # shows the volume unchanged; before the fix, the same repro showed the
+  # volume as "must be replaced" purely because of the AZ dependency.
+  availability_zone = local.availability_zone
   size              = var.data_volume_size_gb
   type              = "gp3"
   encrypted         = true
@@ -33,6 +47,16 @@ resource "aws_ebs_volume" "data" {
     Name   = "${local.name}-data"
     Backup = "${local.name}-data"
   })
+
+  # Belt-and-suspenders against the class of bug above (and any other future
+  # change that would force a replace on this resource): refuse to destroy
+  # the data volume via `terraform destroy` / a replace, full stop. To
+  # actually retire this box's data on purpose, remove this block in its own
+  # dedicated, reviewed apply first (see README "Replacing the instance
+  # without losing data").
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_volume_attachment" "data" {

--- a/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
+++ b/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
@@ -1,12 +1,23 @@
 #!/bin/bash
 # Kortix self-host — EC2 bootstrap (runs once, as root, via cloud-init).
 #
-# This does exactly what any self-host user does by hand (see
-# scripts/kortix-selfhost-up.sh and docs/runbooks/self-hosting.md): install
-# Docker, install the kortix CLI, `kortix self-host init`, `kortix self-host
-# start`. Terraform's only value-add here is doing it once on a fresh box with
-# a durable data volume wired up first. It does NOT run again on its own —
-# ongoing updates are the in-compose kortix-updater's job, not Terraform's.
+# This installs exactly what any self-host user installs by hand (see
+# scripts/kortix-selfhost-up.sh and docs/runbooks/self-hosting.md): Docker,
+# the kortix CLI, and (if var.enable_alarms) the CloudWatch agent. Terraform's
+# only value-add here is doing it once on a fresh box with a durable data
+# volume wired up first.
+#
+# IMPORTANT — this script is deliberately ONLY prerequisites + a systemd unit
+# install, not the `kortix self-host init`/`start` calls themselves. Those run
+# out of kortix-selfhost-bootstrap.service (below), a systemd oneshot with
+# Restart=on-failure. This split exists because of a confirmed production
+# incident: cloud-init has no retry of its own, ran init/start inline, and
+# failed identically on two live boxes on a slow-cold-start dependency race
+# (`kortix-api` didn't report healthy before compose's dependency wait gave
+# up) — cloud-init reported the box as permanently broken even though a
+# second attempt (started by hand) succeeded fine. Moving init/start into a
+# retried, reboot-surviving systemd unit means that race self-heals with zero
+# human intervention.
 set -euo pipefail
 exec > >(tee -a /var/log/kortix-bootstrap.log) 2>&1
 echo "=== kortix self-host bootstrap: $(date -u --iso-8601=seconds) ==="
@@ -15,6 +26,8 @@ echo "=== kortix self-host bootstrap: $(date -u --iso-8601=seconds) ==="
 # installer (kortix.com/install) and the CLI itself dereference $HOME under
 # `set -u`, so an unset HOME kills the bootstrap ("HOME: unbound variable").
 export HOME="$${HOME:-/root}"
+
+DATA_MOUNT="${data_mount_path}"
 
 # ── 1. Find + mount the data volume ─────────────────────────────────────────
 # Requested attach point is ${data_volume_device_name}, but Nitro-based
@@ -41,38 +54,80 @@ else
   echo "$DATA_DEVICE already has a filesystem — leaving its contents alone (this is the durable Postgres/Docker state across instance replacement)"
 fi
 
-mkdir -p "${data_mount_path}"
-if ! mountpoint -q "${data_mount_path}"; then
-  mount "$DATA_DEVICE" "${data_mount_path}"
+mkdir -p "$DATA_MOUNT"
+if ! mountpoint -q "$DATA_MOUNT"; then
+  mount "$DATA_DEVICE" "$DATA_MOUNT"
 fi
 DATA_UUID="$(blkid -s UUID -o value "$DATA_DEVICE")"
-grep -q "$DATA_UUID" /etc/fstab || echo "UUID=$DATA_UUID ${data_mount_path} ext4 defaults,nofail 0 2" >> /etc/fstab
+grep -q "$DATA_UUID" /etc/fstab || echo "UUID=$DATA_UUID $DATA_MOUNT ext4 defaults,nofail 0 2" >> /etc/fstab
 
-DOCKER_DATA_ROOT="${data_mount_path}/docker"
-KORTIX_CONFIG_DIR="${data_mount_path}/kortix-self-host"
-mkdir -p "$DOCKER_DATA_ROOT" "$KORTIX_CONFIG_DIR"
+DOCKER_DATA_ROOT="$DATA_MOUNT/docker"
+CONTAINERD_ROOT="$DATA_MOUNT/containerd"
+KORTIX_CONFIG_DIR="$DATA_MOUNT/kortix-self-host"
+mkdir -p "$DOCKER_DATA_ROOT" "$CONTAINERD_ROOT" "$KORTIX_CONFIG_DIR"
 
-# ── 2. Docker: point data-root at the data volume BEFORE first start ───────
-# Every Docker-managed volume (images, containers, the updater/Caddy named
-# volumes) then lives on the data volume too.
+# ── 2. Docker + containerd: point BOTH data stores at the data volume BEFORE
+#    first start ─────────────────────────────────────────────────────────────
+# Docker's own data-root (dockerd: images/containers metadata, the
+# updater/Caddy named volumes) is one thing, but with the modern
+# containerd-snapshotter setup the ACTUAL image/container filesystem layers
+# live under containerd's own root (/var/lib/containerd by default) — setting
+# only dockerd's data-root does NOT move that. This was root-caused live: both
+# boxes had 14-16GB under /var/lib/containerd on their 30GB root volumes
+# (59-65% full) while the 100GB data volume sat nearly empty. containerd's
+# `root` (its snapshot/content store) has to be repointed too, and — since
+# containerd starts as its own systemd unit as soon as the package is
+# installed — that has to happen before containerd's first start, or it lays
+# its state down on the root volume before we get a chance to redirect it.
+#
+# NOTE: this whole section only runs to completion on a NEW box (first
+# install). On an existing box already running with containerd's root on the
+# OS volume, do NOT let this silently "fix" a live install out from under
+# running containers — see the README's documented migration steps for
+# existing boxes (an ops agent applies those separately, deliberately not
+# automated here).
+NEW_DOCKER_INSTALL=0
 if ! command -v docker >/dev/null 2>&1; then
-  echo "Installing Docker Engine + Compose plugin"
-  mkdir -p /etc/docker
-  cat > /etc/docker/daemon.json <<JSON
+  NEW_DOCKER_INSTALL=1
+  echo "Installing Docker Engine + Compose plugin (containerd.io is bundled)"
+  curl --fail --silent --show-error --location https://get.docker.com | sh
+  # get.docker.com's postinst enables+starts docker (and containerd as its
+  # dependency) immediately — stop both right away so we can repoint
+  # containerd's root before anything writes to it.
+  systemctl stop docker.service containerd.service 2>/dev/null || true
+fi
+
+mkdir -p /etc/docker
+cat > /etc/docker/daemon.json <<JSON
 {
-  "data-root": "$DOCKER_DATA_ROOT"
+  "data-root": "$DOCKER_DATA_ROOT",
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
 }
 JSON
-  curl --fail --silent --show-error --location https://get.docker.com | sh
-  systemctl enable --now docker
+
+if [ "$NEW_DOCKER_INSTALL" = "1" ] || ! grep -q "root = \"$CONTAINERD_ROOT\"" /etc/containerd/config.toml 2>/dev/null; then
+  echo "Pointing containerd's root at $CONTAINERD_ROOT (unset fields keep containerd's own defaults)"
+  mkdir -p /etc/containerd
+  cat > /etc/containerd/config.toml <<TOML
+version = 2
+root = "$CONTAINERD_ROOT"
+state = "/run/containerd"
+TOML
 fi
+
+systemctl enable --now containerd.service
+systemctl enable --now docker.service
 docker compose version >/dev/null 2>&1 || { echo "FATAL: docker compose plugin unavailable after install" >&2; exit 1; }
 
 # ── 3. Pin KORTIX_SELF_HOST_CONFIG_DIR — every kortix invocation (this
-#    script, and any later `kortix self-host ...` an operator runs over SSM)
-#    must agree on where the instance lives, or the CLI creates a second
-#    instance on the (small, ephemeral) root volume instead of reusing the
-#    one on the data volume. Persist it for future root shells too.
+#    script's systemd unit, and any later `kortix self-host ...` an operator
+#    runs over SSM) must agree on where the instance lives, or the CLI creates
+#    a second instance on the (small, ephemeral) root volume instead of
+#    reusing the one on the data volume. Persist it for future root shells too.
 export KORTIX_SELF_HOST_CONFIG_DIR="$KORTIX_CONFIG_DIR"
 grep -q '^KORTIX_SELF_HOST_CONFIG_DIR=' /etc/environment 2>/dev/null \
   || echo "KORTIX_SELF_HOST_CONFIG_DIR=$KORTIX_CONFIG_DIR" >> /etc/environment
@@ -94,8 +149,72 @@ if [ -z "$KORTIX_BIN" ] && [ -x /root/.kortix/kortix ]; then
   KORTIX_BIN=/root/.kortix/kortix
 fi
 [ -n "$KORTIX_BIN" ] || { echo "FATAL: kortix CLI install did not produce a runnable binary" >&2; exit 1; }
+# Systemd units don't inherit this script's $PATH/$KORTIX_BIN resolution, so
+# pin a stable, absolute path for kortix-selfhost-bootstrap.sh to call.
+ln -sf "$KORTIX_BIN" /usr/local/bin/kortix
 
-# ── 5. Generate the self-host config ────────────────────────────────────────
+%{ if enable_alarms ~}
+# ── 5. CloudWatch agent (disk + memory metrics feeding this module's alarms) ─
+if ! dpkg -s amazon-cloudwatch-agent >/dev/null 2>&1; then
+  echo "Installing the CloudWatch agent"
+  CWA_DEB="/tmp/amazon-cloudwatch-agent.deb"
+  ARCH="$(dpkg --print-architecture)"
+  curl --fail --silent --show-error --location \
+    "https://amazoncloudwatch-agent.s3.amazonaws.com/ubuntu/$ARCH/latest/amazon-cloudwatch-agent.deb" \
+    -o "$CWA_DEB"
+  dpkg -i "$CWA_DEB" || apt-get install -f -y
+  rm -f "$CWA_DEB"
+fi
+
+mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'CWJSON'
+{
+  "agent": {
+    "metrics_collection_interval": 60
+  },
+  "metrics": {
+    "namespace": "${cloudwatch_namespace}",
+    "append_dimensions": {
+      "InstanceId": "$${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "disk": {
+        "measurement": ["used_percent"],
+        "resources": ["/", "$DATA_MOUNT"],
+        "drop_device": true
+      },
+      "mem": {
+        "measurement": ["mem_used_percent"]
+      }
+    }
+  }
+}
+CWJSON
+# $DATA_MOUNT is a shell variable (resolved by this script), not a Terraform
+# template variable — substitute it into the JSON now that it's on disk (the
+# heredoc above is single-quoted specifically so $${aws:InstanceId} — a
+# CloudWatch-agent-syntax placeholder, not a shell variable — reaches disk
+# literally rather than being shell-expanded).
+sed -i "s#\$DATA_MOUNT#$DATA_MOUNT#" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config -m ec2 -s \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+systemctl enable amazon-cloudwatch-agent
+%{ endif ~}
+
+# ── 6. The actual app bootstrap: retried, reboot-surviving systemd unit ─────
+# `kortix self-host init`/`env set`/`start` are idempotent (safe to rerun),
+# which is exactly what lets a systemd Restart=on-failure loop — and a fresh
+# run on every reboot — self-heal the dependency-health race that broke this
+# on both live boxes, without ever needing an operator to SSM in by hand.
+cat > /usr/local/sbin/kortix-selfhost-bootstrap.sh <<'BOOTSTRAP'
+#!/bin/bash
+set -euo pipefail
+export HOME="$${HOME:-/root}"
+export KORTIX_SELF_HOST_CONFIG_DIR="${data_mount_path}/kortix-self-host"
+KORTIX_BIN=/usr/local/bin/kortix
+
 INIT_ARGS=(
   --instance "${instance_name}"
   --domain "${domain}"
@@ -120,14 +239,53 @@ echo "Running: kortix self-host init $${INIT_ARGS[*]}"
 "$KORTIX_BIN" self-host env set --instance "${instance_name}" "KORTIX_ACME_EMAIL=${acme_email}"
 %{ endif ~}
 
-# ── 6. Start ─────────────────────────────────────────────────────────────────
-# `start` re-checks required secrets (the sandbox key etc.) and warns rather
-# than refusing — this module's whole design is that secrets are NOT
-# Terraform inputs and get set post-boot (kortix self-host env set /
-# configure / the dashboard).
-echo "Starting the stack (pulling images — this can take a few minutes on first boot)"
+echo "Starting the stack (pulling images — this can take a few minutes on first attempt)"
 "$KORTIX_BIN" self-host start --instance "${instance_name}" --yes
 
-echo "=== kortix self-host bootstrap done: $(date -u --iso-8601=seconds) ==="
+echo "kortix self-host bootstrap done: $(date -u --iso-8601=seconds)"
 echo "Secrets (sandbox provider key, managed git, ...) were NOT set — configure them with:"
 echo "  kortix self-host configure --instance ${instance_name}"
+BOOTSTRAP
+chmod +x /usr/local/sbin/kortix-selfhost-bootstrap.sh
+
+cat > /etc/systemd/system/kortix-selfhost-bootstrap.service <<'UNIT'
+[Unit]
+Description=kortix self-host init + start (idempotent; retried on failure)
+After=network-online.target docker.service mnt-kortix\x2ddata.mount
+Wants=network-online.target
+Requires=docker.service mnt-kortix\x2ddata.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/kortix-selfhost-bootstrap.sh
+TimeoutStartSec=1800
+Restart=on-failure
+RestartSec=30
+# Give this a generous but bounded retry budget per boot (20 attempts/hour) —
+# enough to ride out a slow-cold-start health-check race like the one that
+# broke both live boxes, without crash-looping forever if the box is
+# genuinely misconfigured. A reboot resets this budget and reruns the unit
+# fresh (WantedBy=multi-user.target below), which is the other half of
+# "self-heal": even a box that exhausts its retry budget picks back up on the
+# next reboot.
+StartLimitIntervalSec=3600
+StartLimitBurst=20
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable kortix-selfhost-bootstrap.service
+# --no-block: hand it off to systemd's own supervision (Restart=on-failure)
+# and return immediately. This is deliberate — cloud-init itself must never
+# be the thing waiting on (and failing because of) the app's first-boot
+# health-check race; that coupling is exactly what turned a transient,
+# self-healing hiccup into a permanent "cloud-init failed" status on both
+# live boxes. `systemctl enable` (not `--now`) is what makes a reboot rerun
+# it too, since we don't rely on `--now`'s implicit start for that.
+systemctl start --no-block kortix-selfhost-bootstrap.service
+
+echo "=== kortix self-host bootstrap (prerequisites) done: $(date -u --iso-8601=seconds) ==="
+echo "kortix-selfhost-bootstrap.service is now running init/start in the background (retried on failure — see: systemctl status kortix-selfhost-bootstrap.service, journalctl -u kortix-selfhost-bootstrap.service)."

--- a/infra/terraform/modules/selfhost-ec2/variables.tf
+++ b/infra/terraform/modules/selfhost-ec2/variables.tf
@@ -70,6 +70,12 @@ variable "subnet_id" {
   default     = ""
 }
 
+variable "availability_zone" {
+  description = "AZ the data volume (aws_ebs_volume.data) is pinned to. Leave empty to derive it from the subnet (var.subnet_id, or the resolved default subnet) — this is almost always correct since the subnet is what actually determines the instance's AZ. Set explicitly only if you have a reason to decouple the two. Deliberately never derived from aws_instance.this itself: AZ is ForceNew on the volume, so depending on the instance's AZ would force a destroy/recreate of the data volume on any instance replacement."
+  type        = string
+  default     = ""
+}
+
 variable "allowed_cidrs" {
   description = "CIDRs allowed to reach the box on 80 (ACME HTTP-01) and 443 (the app). Restrict this once you know your users' egress ranges."
   type        = list(string)
@@ -209,4 +215,42 @@ variable "acme_email" {
   description = "Optional ACME (Let's Encrypt) contact email. Leave empty to use the CLI's own default (admin@<domain>)."
   type        = string
   default     = ""
+}
+
+# ── Monitoring (CloudWatch alarms + agent) ──────────────────────────────────
+
+variable "enable_alarms" {
+  description = "Whether to install/configure the CloudWatch agent (disk + memory metrics) in bootstrap and create the CloudWatch alarms below (EC2 status-check, disk usage on both the root and data volumes, memory usage). Default on — this is a single box with no other observability; keep it boring and on by default."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_sns_topic_arn" {
+  description = "SNS topic ARN to notify on alarm. Leave empty (default) to have the module create its own topic (optionally with an email subscription — see var.alarm_email); set this to route into an existing topic instead (e.g. a shared ops/PagerDuty integration)."
+  type        = string
+  default     = ""
+}
+
+variable "alarm_email" {
+  description = "Optional email address subscribed to the module-created SNS topic (only used when var.alarm_sns_topic_arn is left empty — an externally-provided topic manages its own subscriptions). Leave empty to create the topic with no subscription and wire it up yourself later."
+  type        = string
+  default     = ""
+}
+
+variable "disk_usage_alarm_threshold_percent" {
+  description = "Alarm when root (\"/\") or data-volume (var.data_mount_path) disk usage stays at or above this percentage for disk_usage_alarm_evaluation_periods consecutive periods."
+  type        = number
+  default     = 85
+}
+
+variable "memory_usage_alarm_threshold_percent" {
+  description = "Alarm when memory usage stays at or above this percentage for disk_usage_alarm_evaluation_periods consecutive periods."
+  type        = number
+  default     = 90
+}
+
+variable "alarm_evaluation_periods" {
+  description = "Number of consecutive 5-minute periods a disk/memory metric must breach its threshold before alarming (reduces noise from short spikes, e.g. a build or backup). The EC2 status-check alarm uses its own fixed evaluation (see monitoring.tf) since that metric is binary."
+  type        = number
+  default     = 3
 }


### PR DESCRIPTION
## Summary

Fixes the Terraform/bootstrap-side criticals and highs from the 2026-07-16 adversarially-verified production-readiness audit of the self-host EC2 module. Every finding below was independently reproduced (live SSM inspection of `vps-demo` i-0707d3aa8378c7479 and the enterprise-pilot box i-08b6c255775e7cf60, both us-east-1 — read-only, no live state changed) and, where applicable, the fix is proven with a live repro (see "Proof" column). Scope: `infra/terraform/modules/selfhost-ec2/**` + its README + `infra/deployments/vps-demo`. Rides v0.10.3 — **do not merge**.

## Findings → fixes

| # | Sev | Finding | Fix | Proof |
|---|-----|---------|-----|-------|
| 1 | Critical | `aws_ebs_volume.data.availability_zone = aws_instance.this.availability_zone`; AZ is ForceNew on the volume, so any instance replacement forces a destroy/recreate of the **data volume**. | AZ now derives from the subnet (`data.aws_subnet.selected`), independent of the instance; added `lifecycle.prevent_destroy` on the volume; added `scripts/check-data-volume-safe.sh` plan-guard. | Live: seeded a real throwaway stack, ran `terraform plan -replace=aws_instance.this` against pre-fix code → `aws_ebs_volume.data` planned `delete`+`create`. Same repro against fixed code → `no-op`. Throwaway stack fully destroyed after. |
| 2 | Critical | Cloud-init ran `kortix self-host init`/`start` inline with zero retry; both live boxes hit the same slow-cold-start dependency race (`kortix-api` unhealthy) and cloud-init reported permanent failure even though a manual retry succeeded immediately. | user-data now only installs prerequisites, then hands off (`systemctl start --no-block`) to `kortix-selfhost-bootstrap.service`, a systemd oneshot with `Restart=on-failure` (bounded retry budget) that runs init/start. Enabled unit reruns fresh on every reboot too. | Confirmed live on both boxes: `cloud-init status --long` → `status: error`, `('scripts_user', RuntimeError(...))`, cloud-init log shows `dependency failed to start: container kortix-default-kortix-api-1 is unhealthy`. |
| 3 | Critical | `daemon.json` relocated dockerd's data-root but not containerd's snapshot store; actual image/container layers stayed on the (30GB) root volume. | `/etc/containerd/config.toml` now points `root` at the data volume before containerd's first start (new boxes); `daemon.json` also sets default log rotation. README documents manual migration steps for existing boxes. | Confirmed live: both boxes had 14-16GB under `/var/lib/containerd` (59-65% root-volume usage) while the 100GB data volume sat ~1% full. |
| 4 | High | Zero CloudWatch alarms. | Added (var-gated, default on) EC2 status-check + disk-usage (root & data volume) + memory alarms via a CloudWatch agent installed/configured in bootstrap, notifying an SNS topic (module-created or bring-your-own, optional email subscription). | `terraform validate` + `checkov` clean; alarm resources visible in `terraform plan`. |
| 5 | Medium | DLM snapshots configured but none existed yet, no restore runbook; local unlocked TF state in vps-demo. | README gains a step-by-step restore runbook (locate → create volume in the pinned AZ → swap attachment → boot-order caveat → honest Postgres crash-consistency note) and documents why DLM has no Linux pre/post-script hook. `vps-demo/backend.tf` gets a commented S3+DynamoDB-lock backend example + migration note. | Documentation only, per the finding's own "at minimum document" bar. |
| 6 | Medium | amd64-only AMI hardcoded, no arch guard against a Graviton `instance_type`. | New `data.aws_ami.selected` + a plan-time `precondition` on `aws_instance.this` rejecting an arch mismatch either direction. | Live: `terraform plan -var instance_type=t4g.xlarge` against the account's real default AMI fails cleanly at plan with a clear message; the default `t3.xlarge` passes. |

## Validation

- `terraform fmt -recursive`, `terraform init -backend=false`, `terraform validate` — clean for both the module and `infra/deployments/vps-demo`.
- `checkov -d infra/terraform/modules/selfhost-ec2`: 54→61 passed, **0 failed** (baseline was also 0 failed); the one new skip (`CKV_AWS_26` on the SNS topic — alarm text only, no sensitive payload) is annotated inline.
- Finding 1's fix was proven against a real, throwaway AWS stack (not vps-demo/the enterprise-pilot box) created solely for this repro and fully destroyed immediately after (instance terminated, volume deleted, no orphaned resources — verified via `aws ec2 describe-instances`/`describe-volumes`/`sns list-topics` post-cleanup).
- Live boxes (`vps-demo`, the enterprise-pilot box) were only ever read via SSM `send-command`; no live state was changed.

## Test plan

- [ ] CI: `terraform fmt -check`, `init -backend=false`, `validate` on the module and `infra/deployments/vps-demo`
- [ ] `checkov -d infra/terraform/modules/selfhost-ec2` stays at 0 failed
- [ ] On next real apply of a fresh box: confirm `kortix-selfhost-bootstrap.service` converges, `/etc/containerd/config.toml` points at the data volume, and the three new alarms appear in CloudWatch
- [ ] Existing boxes (vps-demo, the enterprise-pilot box): apply the documented containerd migration steps separately, out-of-band (not part of this PR)
