### PR TITLE
fix(self-host): updater resilience, run visibility, log rotation, memory limits

### DIFF
--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -73,7 +73,8 @@ Subcommands:
   update | reconcile      Pull + apply the configured channel/version now.
   version                 Show the running version and image tags.
   stop | restart          Stop / restart the stack.
-  status                  Show container status.
+  status                  Container status + last update outcome, drift, next window.
+  ps                      Raw \`docker compose ps\` container status only.
   doctor                  Validate Docker tooling and the Compose config.
   logs [service]          Tail logs.
   open                    Open the dashboard in a browser.
@@ -270,6 +271,7 @@ export async function runSelfHost(argv: string[]): Promise<number> {
     case 'restart':
       return selfHostRestart(flags);
     case 'status':
+      return selfHostStatus(flags);
     case 'ps':
       return composeCommand(flags, ['ps']);
     case 'doctor':
@@ -684,7 +686,25 @@ async function selfHostUpdate(flags: GlobalFlags): Promise<number> {
   if (base !== 0) return base;
 
   const rollout = compose(flags.instance, ['run', '--rm', '--no-deps', 'kortix-updater', 'once']);
-  if (rollout !== 0) return rollout;
+  // 75 (EX_TEMPFAIL, see updater.sh's run_locked()) means this run never
+  // actually started: the nightly scheduler (or another concurrent `update`)
+  // already held the single-flight lock. That is NOT the same as a failed
+  // update — say so explicitly instead of reporting a bare nonzero exit, and
+  // point at `status` for what the in-flight run's outcome ends up being.
+  if (rollout === 75) {
+    process.stderr.write(
+      `${status.err('Another update is already in progress (nightly scheduler or a concurrent `update`) — this run was skipped, not failed.')}\n`
+      + `${C.dim}Check the outcome once it finishes: ${C.reset}${C.cyan}kortix self-host status --instance ${flags.instance}${C.reset}\n`,
+    );
+    return rollout;
+  }
+  if (rollout !== 0) {
+    process.stderr.write(
+      `${status.err('The update did not complete cleanly.')}\n`
+      + `${C.dim}Details: ${C.reset}${C.cyan}kortix self-host status --instance ${flags.instance}${C.reset}${C.dim} (per-service outcome, drift, last error)${C.reset}\n`,
+    );
+    return rollout;
+  }
 
   // Tunnel reachability mode only, and deliberately AFTER the zero-downtime
   // rollout above (not before): recreating kortix-api early to pick up a
@@ -1035,6 +1055,137 @@ function composeCommand(flags: GlobalFlags, args: string[]): number {
     return 1;
   }
   return compose(flags.instance, args);
+}
+
+interface UpdaterServiceReport {
+  outcome: string;
+  started_at?: string;
+  finished_at?: string;
+  from_version?: string;
+  to_version?: string;
+  stage?: string;
+  detail?: string;
+  services?: string;
+}
+
+interface UpdaterDriftEntry {
+  service: string;
+  expected_image: string;
+  state: string;
+  drift: boolean;
+}
+
+interface UpdaterReport {
+  status: UpdaterServiceReport;
+  drift: UpdaterDriftEntry[];
+  lock: { locked: boolean; holder: string };
+}
+
+/**
+ * Ask the (already-running or freshly-spawned) `kortix-updater` service for
+ * its last recorded run outcome plus a live drift check — see the `report`
+ * subcommand in assets/updater.sh. Read-only, no lock taken: safe to run
+ * anytime, including while a real update is in flight. Returns null (not a
+ * fatal error) if the stack isn't up yet or the service can't be reached —
+ * `status` still shows container state in that case, just not update history.
+ */
+function readUpdaterReport(instance: string): UpdaterReport | null {
+  const result = spawnSync(
+    'docker',
+    [
+      'compose', '--project-name', composeProject(instance),
+      '--env-file', envPath(instance), '-f', composePath(instance),
+      'run', '--rm', '--no-deps', '-T', 'kortix-updater', 'report',
+    ],
+    { cwd: instanceDir(instance), encoding: 'utf8' },
+  );
+  if (result.error || result.status !== 0) return null;
+  const lines = (result.stdout ?? '').trim().split(/\r?\n/);
+  const jsonLine = lines[lines.length - 1] ?? '';
+  try {
+    return JSON.parse(jsonLine) as UpdaterReport;
+  } catch {
+    return null;
+  }
+}
+
+const OUTCOME_LABEL: Record<string, (text: string) => string> = {
+  ok: (t) => `${C.green}${t}${C.reset}`,
+  degraded: (t) => `${C.yellow}${t}${C.reset}`,
+  failed: (t) => `${C.red}${t}${C.reset}`,
+  skipped: (t) => `${C.yellow}${t}${C.reset}`,
+  'never-run': (t) => `${C.dim}${t}${C.reset}`,
+};
+
+/**
+ * `kortix self-host status`: container state PLUS the update mechanism's own
+ * visibility — last run outcome (ok/degraded/failed/skipped/never-run),
+ * from->to version, per-service breakdown, the auto-update schedule, and an
+ * explicit drift check (declared image vs. what's actually running). This is
+ * the fix for "update outcomes are invisible" and "drift is undetectable by
+ * design" — both previously required shelling into the container and reading
+ * `docker inspect` by hand. `ps` still exists separately for a bare
+ * container-list passthrough.
+ */
+function selfHostStatus(flags: GlobalFlags): number {
+  if (!existsSync(composePath(flags.instance)) || !existsSync(envPath(flags.instance))) {
+    process.stderr.write(`${status.err('Self-host is not initialized. Run `kortix self-host init` first.')}\n`);
+    return 1;
+  }
+  const env = loadEnvWithDefaults(flags)!;
+  const report = readUpdaterReport(flags.instance);
+
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify({
+      instance: flags.instance,
+      auto_update: env.KORTIX_AUTO_UPDATE === 'true',
+      update_time: env.KORTIX_UPDATE_TIME,
+      update_tz: env.KORTIX_UPDATE_TZ,
+      update: report?.status ?? null,
+      drift: report?.drift ?? null,
+      lock: report?.lock ?? null,
+    }, null, 2)}\n`);
+    compose(flags.instance, ['ps']);
+    return 0;
+  }
+
+  process.stdout.write(`\n  ${C.bold}kortix self-host status${C.reset}\n`);
+  process.stdout.write(`  ${C.dim}instance ${C.reset}${flags.instance}\n\n`);
+  compose(flags.instance, ['ps']);
+  process.stdout.write('\n');
+
+  if (!report) {
+    process.stdout.write(`  ${status.err('update status unavailable')}${C.dim} (kortix-updater not reachable — is the stack running?)${C.reset}\n\n`);
+    return 0;
+  }
+
+  const outcome = report.status.outcome;
+  const label = (OUTCOME_LABEL[outcome] ?? ((t: string) => t))(outcome);
+  const schedule = `${env.KORTIX_AUTO_UPDATE === 'true' ? 'on' : 'off'}, nightly at ${env.KORTIX_UPDATE_TIME} ${env.KORTIX_UPDATE_TZ}`;
+
+  // One terse line, as specified: last update, outcome, next window.
+  process.stdout.write(`  ${C.dim}last update  ${C.reset}${label}${report.status.finished_at ? `${C.dim} (${report.status.finished_at})${C.reset}` : ''}${C.dim} — auto-update ${schedule}${C.reset}\n`);
+  if (report.status.from_version || report.status.to_version) {
+    process.stdout.write(`  ${C.dim}version      ${C.reset}${report.status.from_version || '?'} ${C.dim}→${C.reset} ${report.status.to_version || '?'}\n`);
+  }
+  if (report.status.detail) {
+    process.stdout.write(`  ${C.dim}detail       ${C.reset}${report.status.detail}\n`);
+  }
+  if (report.lock?.locked) {
+    process.stdout.write(`  ${C.yellow}update currently running${C.reset}${C.dim} (${report.lock.holder || 'unknown holder'})${C.reset}\n`);
+  }
+
+  const drifted = (report.drift ?? []).filter((entry) => entry.drift);
+  if (drifted.length > 0) {
+    process.stdout.write(`\n  ${status.err('drift detected')}${C.dim} — running image doesn't match the rendered config:${C.reset}\n`);
+    for (const entry of drifted) {
+      process.stdout.write(`    ${C.red}✗${C.reset} ${entry.service} ${C.dim}(expected ${entry.expected_image})${C.reset}\n`);
+    }
+  } else if (report.drift) {
+    process.stdout.write(`\n  ${status.ok('no drift')}${C.dim} — running images match the rendered config${C.reset}\n`);
+  }
+  process.stdout.write('\n');
+  return 0;
 }
 
 function selfHostOpen(flags: GlobalFlags): number {

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -301,6 +301,177 @@ describe('full self-host Docker distribution', () => {
     expect(caddyfile).toContain('fail_duration');
   });
 
+  test('Caddyfile sends a conservative HSTS header (no preload) on both site blocks', () => {
+    const caddyfile = kortixRuntimeAssets.Caddyfile;
+    const matches = [...caddyfile.matchAll(/Strict-Transport-Security "([^"]+)"/g)];
+    expect(matches.length).toBe(2);
+    for (const [, value] of matches) {
+      expect(value).toMatch(/^max-age=\d+$/);
+      expect(value).not.toContain('preload');
+      const maxAge = Number(value!.replace('max-age=', ''));
+      // Conservative: at most 90 days. Caddy's automatic-HTTPS redirect
+      // (verified separately below/at render time) already covers the
+      // http->https requirement without needing an aggressive HSTS value.
+      expect(maxAge).toBeLessThanOrEqual(60 * 60 * 24 * 90);
+      expect(maxAge).toBeGreaterThan(0);
+    }
+  });
+
+  test('every service in the rendered stack has bounded, rotated logging', () => {
+    const document = parse(renderFullDockerCompose('kortix-default', { domainConfigured: true, tunnelConfigured: true })) as {
+      services: Record<string, { logging?: { driver?: string; options?: Record<string, string> } }>;
+    };
+    const names = Object.keys(document.services);
+    expect(names.length).toBeGreaterThan(15);
+    for (const [name, service] of Object.entries(document.services)) {
+      expect(service.logging?.driver, name).toBe('json-file');
+      expect(service.logging?.options?.['max-size'], name).toBe('10m');
+      expect(service.logging?.options?.['max-file'], name).toBe('3');
+    }
+  });
+
+  test('every service has a memory ceiling; Postgres is protected, analytics/vector are the tightest-capped', () => {
+    const document = parse(renderFullDockerCompose('kortix-default', { domainConfigured: true, tunnelConfigured: true })) as {
+      services: Record<string, { mem_limit?: string; mem_reservation?: string; oom_score_adj?: number }>;
+    };
+    const toMb = (value: string) => Number(value.replace(/m$/, ''));
+    for (const [name, service] of Object.entries(document.services)) {
+      expect(service.mem_limit, name).toBeDefined();
+      expect(service.mem_reservation, name).toBeDefined();
+    }
+    const db = document.services['supabase-db'];
+    expect(db?.oom_score_adj).toBeLessThan(0);
+    const analytics = document.services['supabase-analytics'];
+    const vector = document.services['supabase-vector'];
+    expect(analytics?.oom_score_adj).toBeGreaterThan(0);
+    expect(vector?.oom_score_adj).toBeGreaterThan(0);
+    // The full worst-case (every STEADY-STATE service simultaneously at its
+    // own ceiling) must still fit comfortably on an 8GB box — these are
+    // circuit-breaker ceilings, not a steady-state budget, but they must not
+    // be so generous that the documented floor is fiction. kortix-migrate is
+    // excluded: it's a one-shot job that runs to completion and exits before
+    // the app tier is ever rolled, never concurrent with the rest at steady
+    // state (see kortix-compose.yml: `restart: "no"`).
+    const totalCeilingMb = Object.entries(document.services)
+      .filter(([name]) => name !== 'kortix-migrate')
+      .map(([, service]) => (service.mem_limit ? toMb(service.mem_limit) : 0))
+      .reduce((a, b) => a + b, 0);
+    expect(totalCeilingMb).toBeLessThan(8 * 1024);
+  });
+
+  test('kortix-updater image is pinned by digest, never :latest or a bare floating :cli tag', () => {
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { image?: string }>;
+    };
+    const image = document.services['kortix-updater']?.image ?? '';
+    expect(image).toMatch(/^docker:\d+\.\d+\.\d+-cli@sha256:[a-f0-9]{64}$/);
+  });
+
+  test('supabase-kong no longer gates on supabase-studio (Studio/Logflare must never block kortix-api cold boot)', () => {
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { depends_on?: Record<string, unknown> }>;
+    };
+    const kong = document.services['supabase-kong'];
+    expect(kong?.depends_on ?? {}).not.toHaveProperty('supabase-studio');
+    // kortix-api still (correctly) depends on Kong itself — only the
+    // unnecessary Kong -> Studio -> Analytics tail behind it is cut.
+    const api = document.services['kortix-api'];
+    expect(api?.depends_on).toHaveProperty('supabase-kong');
+  });
+
+  test('GoTrue rate limiting is actually active (GOTRUE_RATE_LIMIT_HEADER set)', () => {
+    // GoTrue no-ops every per-IP rate limit whenever this header is unset,
+    // regardless of the numeric limit values — see performRateLimitingWithHeader
+    // in supabase/auth. Upstream's own compose file never sets it.
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { environment?: Record<string, string> }>;
+    };
+    const auth = document.services['supabase-auth'];
+    expect(auth?.environment?.GOTRUE_RATE_LIMIT_HEADER).toBeTruthy();
+    expect(auth?.environment?.GOTRUE_RATE_LIMIT_EMAIL_SENT).toBeTruthy();
+    expect(auth?.environment?.GOTRUE_RATE_LIMIT_OTP).toBeTruthy();
+  });
+
+  test('updater.sh: a failed per-service swap does not abort the remaining services (no silent mixed-version state)', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    const perform = script.slice(script.indexOf('\nperform_update() {'), script.indexOf('next_run_epoch()'));
+    expect(perform).toContain('for svc in $ROLL_SERVICES; do');
+    // The old early-return-on-first-failure shape must be gone...
+    expect(perform).not.toContain('leaving remaining services untouched');
+    // ...replaced by a loop that keeps going and stamps a degraded outcome.
+    expect(perform).toContain('degraded, not mixed-and-silent');
+    expect(script).toContain('write_status "degraded"');
+  });
+
+  test('updater.sh: the scheduler loop never lets a failed run exit/crash the standing container', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    const loop = script.slice(script.lastIndexOf('while true; do'));
+    expect(loop).toContain('run_locked nightly ||');
+    expect(loop).not.toMatch(/\n\s*run_locked nightly\s*\n/);
+  });
+
+  test('updater.sh: every run stamps a machine-readable outcome, and `status`/`report` subcommands surface it', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    expect(script).toContain('STATUS_FILE="$STATE_DIR/update-status.json"');
+    expect(script).toContain('write_status()');
+    expect(script).toContain('"${1:-}" = "status"');
+    expect(script).toContain('"${1:-}" = "report"');
+  });
+
+  test('updater.sh: drift between declared and running images is detected explicitly', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    expect(script).toContain('check_drift()');
+    expect(script).toContain('drift_report_json()');
+    expect(script).toContain('DRIFT:');
+  });
+
+  test('updater.sh: disk-space preflight runs before any pull, and image GC runs only after a fully successful run', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    const perform = script.slice(script.indexOf('\nperform_update() {'), script.indexOf('next_run_epoch()'));
+    const preflightIdx = perform.indexOf('disk_preflight');
+    const pullIdx = perform.indexOf('$COMPOSE pull');
+    expect(preflightIdx).toBeGreaterThan(-1);
+    expect(pullIdx).toBeGreaterThan(preflightIdx);
+    // Restrict to the "some service actually changed" branch (after the
+    // pending_version() read below the early-return "nothing to roll" path,
+    // which has its own separate degraded stamp for a stateful-service
+    // health-gate failure and isn't what this assertion is about).
+    const swapBranch = perform.slice(perform.indexOf('to_version=$(pending_version)'));
+    const gcIdx = swapBranch.indexOf('gc_images');
+    const degradedIdx = swapBranch.indexOf('write_status "degraded"');
+    expect(gcIdx).toBeGreaterThan(-1);
+    expect(degradedIdx).toBeGreaterThan(-1);
+    expect(gcIdx).toBeLessThan(degradedIdx);
+  });
+
+  test('updater.sh: a lock-contention loser reports who currently holds the lock instead of silently no-op\'ing', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    expect(script).toContain('HOLDER_FILE=');
+    expect(script).toContain('another update run is already in progress');
+    expect(script).toContain('exit 75');
+  });
+
+  test('updater.sh: a stateful service recreate is health-gated with an explicit go/no-go', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    const fn = script.slice(script.indexOf('reconcile_stateful_services()'), script.indexOf('check_drift()'));
+    expect(fn).toContain('wait_healthy');
+    expect(fn).toContain('(go)');
+    expect(fn).toContain('(no-go)');
+  });
+
+  test('updater.sh: a post-swap crash-loop is watched for and stamped, with a one-line rollback hint', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    expect(script).toContain('watch_for_crash_loop()');
+    expect(script).toContain('RestartCount');
+    expect(script).toContain('rollback with: kortix self-host update');
+  });
+
+  test('updater.sh: the scheduler re-execs itself when the on-disk script changes (CLI-shipped fixes take effect without a manual recreate)', () => {
+    const script = kortixRuntimeAssets['updater.sh'];
+    expect(script).toContain('maybe_reexec_self');
+    expect(script).toContain('exec /bin/sh "$SCRIPT_FILE"');
+  });
+
   test('updater.sh implements the start-first rollout: scale up new before stopping old', () => {
     const script = kortixRuntimeAssets['updater.sh'];
     const rollFn = script.slice(script.indexOf('roll_service()'), script.indexOf('recreate_service()'));
@@ -322,8 +493,14 @@ describe('full self-host Docker distribution', () => {
     const rollIdx = perform.indexOf('roll_or_recreate');
     expect(migrateIdx).toBeGreaterThan(-1);
     expect(rollIdx).toBeGreaterThan(migrateIdx);
-    // A failed migration aborts before anything is swapped.
-    expect(perform).toContain('run_migrate || return 1');
+    // A failed migration aborts before anything is swapped — and stamps a
+    // "failed" outcome (not just a bare return) so `kortix self-host status`
+    // shows exactly why nothing rolled.
+    expect(perform).toContain('if ! run_migrate; then');
+    const migrateGuardIdx = perform.indexOf('if ! run_migrate; then');
+    const migrateFailureBlock = perform.slice(migrateGuardIdx, perform.indexOf('fi', migrateGuardIdx));
+    expect(migrateFailureBlock).toContain('write_status "failed"');
+    expect(migrateFailureBlock).toContain('return 1');
   });
 
   test('updater.sh leaves the old version serving when the new replicas never become healthy', () => {

--- a/apps/cli/src/self-host/assets/Caddyfile.txt
+++ b/apps/cli/src/self-host/assets/Caddyfile.txt
@@ -24,6 +24,15 @@
 # api.<domain> (or an explicit KORTIX_API_DOMAIN): /v1/llm* -> the LLM gateway,
 # everything else -> the API.
 {$KORTIX_API_DOMAIN} {
+	# Caddy's automatic HTTPS already redirects any plain :80 request to :443
+	# for every site block below with no extra config (it's the default
+	# behavior of a domain-form site address, not opt-in) — this header is
+	# the one piece that isn't automatic. Conservative max-age (30 days), no
+	# `preload`: preload-list submission is a one-way door (every subdomain
+	# forever, removal takes months), not something to default on for an
+	# operator-owned domain we don't control the lifecycle of.
+	header Strict-Transport-Security "max-age=2592000"
+
 	@llm path /v1/llm*
 	handle @llm {
 		reverse_proxy {
@@ -60,6 +69,8 @@
 # place), everything else -> the frontend (replicated + load-balanced the
 # same way as api/gateway above).
 {$KORTIX_DOMAIN} {
+	header Strict-Transport-Security "max-age=2592000"
+
 	@supabase path /rest/v1* /auth/v1* /storage/v1* /realtime/v1* /functions/v1* /graphql/v1*
 	handle @supabase {
 		reverse_proxy supabase-kong:8000 {

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -167,7 +167,20 @@ services:
   # home directory is mountable both ways; on native Linux Docker the path
   # trivially exists on "the host" because the daemon IS the host.
   kortix-updater:
-    image: docker:cli
+    # Pinned by digest, not a floating :latest/:cli tag: this container holds
+    # the mounted Docker socket (root-equivalent on the host), so an
+    # unreviewed upstream tag move is a direct supply-chain risk, not just an
+    # update-stability one. `docker:29.6.1-cli`, digest resolved and recorded
+    # 2026-07 from Docker Official Images (multi-arch manifest-list digest —
+    # resolves the right arch per host). Trust model: this is the official
+    # `docker` image on Docker Hub, the same publisher/registry every other
+    # `docker compose pull` in this stack already trusts; the digest pin means
+    # a compromised/rotated tag can never silently change what this
+    # privileged container runs — bumping it is a reviewed, explicit change
+    # to this file (see apps/cli/src/self-host/assets/kortix-compose.yml in
+    # git history), the same way every supabase-* image is pinned by digest
+    # in compose-assets.ts's pinSupabaseImages().
+    image: docker:29.6.1-cli@sha256:862099ada15c669000bef53aa4cb9d821262829f45b0dda2159ccb276443043b
     working_dir: ${KORTIX_INSTANCE_DIR}
     # The trailing "sh" is a placeholder $0 for the `-c` script below; anything
     # `docker compose run kortix-updater <args>` appends lands in "$@" and is
@@ -194,19 +207,40 @@ services:
       # compose-assets.ts (2 in domain/prod mode, 1 in laptop mode) so the
       # updater never has to re-derive prod-vs-laptop topology itself.
       KORTIX_APP_REPLICAS: ${KORTIX_APP_REPLICAS:-1}
+      # Advanced/rarely-changed updater knobs — every one of these has a
+      # sensible built-in default in updater.sh itself (the `${VAR:-default}`
+      # on the right); they are only listed here so `kortix self-host env set
+      # KORTIX_ROLLOUT_TIMEOUT=...` (etc.) actually reaches the container.
+      # Without an explicit `environment:` entry, a key merely present in
+      # .env is invisible to this service (unlike kortix-api, this service
+      # has no `env_file: .env`, by design — see the volumes comment below).
+      KORTIX_ROLLOUT_TIMEOUT: ${KORTIX_ROLLOUT_TIMEOUT:-300}
+      KORTIX_CRASH_WATCH_S: ${KORTIX_CRASH_WATCH_S:-20}
+      KORTIX_MIN_FREE_DISK_MB: ${KORTIX_MIN_FREE_DISK_MB:-2048}
+      # Optional push notification for every run's outcome (ok/degraded/
+      # failed/skipped) — one generic env var, no vendor-specific
+      # integration. Unset by default (no-op). See notify_webhook() in
+      # updater.sh.
+      KORTIX_UPDATE_WEBHOOK_URL: ${KORTIX_UPDATE_WEBHOOK_URL:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Read-write: `docker compose run --rm ... kortix-updater` itself needs
-      # no write access here (write_breadcrumb only ever writes under the
-      # separate /state volume below) — but `docker compose`'s OWN bind-mount
-      # resolution for OTHER services (kong.yml, the Postgres data dir, ...)
-      # is a read of this same tree from the host daemon's side, not through
-      # this mount, so :ro here would be cosmetic either way. Left read-write
-      # simply because there is no meaningful confidentiality/integrity
-      # boundary between this container (which already holds the Docker
-      # socket, i.e. root-equivalent on the host) and the instance directory.
+      # no write access here (write_status()/write_breadcrumb() only ever
+      # write under the separate /state volume below) — but `docker
+      # compose`'s OWN bind-mount resolution for OTHER services (kong.yml,
+      # the Postgres data dir, ...) is a read of this same tree from the host
+      # daemon's side, not through this mount, so :ro here would be cosmetic
+      # either way. Left read-write simply because there is no meaningful
+      # confidentiality/integrity boundary between this container (which
+      # already holds the Docker socket, i.e. root-equivalent on the host)
+      # and the instance directory.
       - ${KORTIX_INSTANCE_DIR}:${KORTIX_INSTANCE_DIR}
       - kortix-updater-state:/state
+    # Second layer behind updater.sh's own internal resilience (the scheduler
+    # loop never exits on a failed run — see the `run_locked nightly || log
+    # ...` call in updater.sh): if this container is ever OOM-killed or
+    # crashes outright, Docker restarts it and the scheduler loop resumes
+    # from next_run_epoch() on its own, no operator action needed.
     restart: unless-stopped
 
   # Cloudflare tunnel (opt-in): the "tunnel" reachability mode's zero-config

--- a/apps/cli/src/self-host/assets/updater.sh
+++ b/apps/cli/src/self-host/assets/updater.sh
@@ -4,8 +4,41 @@
 # local clock time, it pulls this stack's published image tags and, if
 # anything actually changed, rolls the stack forward with ZERO downtime: a
 # start-first swap per stateless service (new replicas healthy before old
-# ones stop). A failed swap leaves the previous version serving and exits
-# nonzero. Single-flight via flock so an overlapping run never races.
+# ones stop). Single-flight via flock so an overlapping run never races.
+#
+# Resilience invariants this script enforces (see the production-readiness
+# audit this file was hardened against — every point below is a fix for a
+# confirmed finding, not speculative):
+#   1. A failed per-service swap never aborts the rest of the rollout — every
+#      changed service is attempted, so the fleet never gets stuck mid-
+#      sequence on a MIX of app-tier versions against an already-migrated DB
+#      (see the update routine below). A degraded outcome self-heals on the next run
+#      because service_up_to_date() always re-detects the stale service.
+#   2. A failed run NEVER crashes this standing container — the scheduler
+#      loop only ever calls run_locked() through `||`, which neutralizes
+#      `set -e` for that call (see the main loop at the bottom). No future
+#      nightly is ever silently skipped because today's run errored.
+#   3. Every run's outcome (ok/degraded/failed/skipped) is stamped to
+#      $STATUS_FILE as JSON — see write_status() — surfaced by `kortix
+#      self-host status` and the `report`/`status` subcommands below.
+#   4. Drift (declared version vs. what's actually running) is detected
+#      explicitly, both as a post-run log check (check_drift) and on demand
+#      via the `report` subcommand.
+#   5. Superseded images are pruned after a fully successful run only (never
+#      after a degraded one, so a rollback target is never removed), and a
+#      disk-space preflight runs before any pull.
+#   6. The standing scheduler re-execs this very file from disk whenever it
+#      changes on disk, so a CLI-shipped fix reaches an already-running
+#      container without a manual recreate.
+#   7. A lock file (flock) is shared between the nightly scheduler and a
+#      manual `kortix self-host update`/`reconcile` run; the loser reports
+#      who currently holds it instead of silently no-op'ing.
+#   8. A stateful service (e.g. supabase-db) recreated in place is health-
+#      gated post-start with an explicit go/no-go log line, never assumed
+#      healthy.
+#   9. A short post-swap window watches restart counts for a crash loop and
+#      stamps a failed/degraded outcome (with a one-line manual rollback
+#      command) instead of reporting false success.
 #
 # Written in POSIX sh (not bash): the `docker:cli` base image is Alpine and
 # does not ship bash, and installing it on every container start is an
@@ -14,7 +47,9 @@ set -eu
 
 STATE_DIR="/state"
 LOCK_FILE="$STATE_DIR/updater.lock"
+HOLDER_FILE="$STATE_DIR/updater.holder"
 BREADCRUMB="$STATE_DIR/deployed-version.json"
+STATUS_FILE="$STATE_DIR/update-status.json"
 # This container talks to the HOST Docker daemon over the mounted socket
 # (Docker-outside-of-Docker), so every relative bind mount THIS COMPOSE FILE
 # declares (kong's ./volumes/api/kong.yml, supabase-db's ./volumes/db/*, ...)
@@ -30,6 +65,7 @@ BREADCRUMB="$STATE_DIR/deployed-version.json"
 # fallback should never actually be exercised.
 WORKDIR="${KORTIX_INSTANCE_DIR:-/workspace}"
 COMPOSE_FILE="$WORKDIR/docker-compose.yml"
+SCRIPT_FILE="$WORKDIR/updater.sh"
 PROJECT_NAME="${KORTIX_COMPOSE_PROJECT:-kortix}"
 COMPOSE="docker compose --project-name $PROJECT_NAME --env-file $WORKDIR/.env -f $COMPOSE_FILE"
 
@@ -46,6 +82,8 @@ TARGET_REPLICAS="${KORTIX_APP_REPLICAS:-1}"
 
 ROLLOUT_TIMEOUT="${KORTIX_ROLLOUT_TIMEOUT:-300}" # seconds to wait for new replicas to go healthy
 HEALTH_POLL_S=3
+CRASH_WATCH_S="${KORTIX_CRASH_WATCH_S:-20}"      # post-swap window to catch a crash-loop
+MIN_FREE_DISK_MB="${KORTIX_MIN_FREE_DISK_MB:-2048}"
 UPDATE_TIME="${KORTIX_UPDATE_TIME:-02:00}"       # HH:MM, 24h, local to KORTIX_UPDATE_TZ
 export TZ="${KORTIX_UPDATE_TZ:-America/New_York}"
 
@@ -53,6 +91,10 @@ mkdir -p "$STATE_DIR"
 
 log() {
   echo "[kortix-updater] $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
 # ---- introspection helpers ----
@@ -70,12 +112,16 @@ container_image_id() {
   docker inspect --format '{{.Image}}' "$1" 2>/dev/null || true
 }
 
+restart_count() {
+  docker inspect --format '{{.RestartCount}}' "$1" 2>/dev/null || echo 0
+}
+
 # Dev mode: `kortix self-host init --local-images` sets KORTIX_IMAGE_PULL=never
 # in the instance .env for a locally-built image that isn't on any registry —
 # `docker compose pull` would just fail (or silently no-op) against it, so skip
 # it entirely and roll using whatever image is already in the local Docker
-# engine. Read straight from "$WORKDIR/.env", same as write_breadcrumb reads
-# KORTIX_VERSION below — this script never sees CLI flags, only the env file.
+# engine. Read straight from "$WORKDIR/.env", same as write_status below —
+# this script never sees CLI flags, only the env file.
 image_pull_mode() {
   grep '^KORTIX_IMAGE_PULL=' "$WORKDIR/.env" 2>/dev/null | tail -n1 | cut -d= -f2-
 }
@@ -101,7 +147,9 @@ publishes_host_port() {
 
 # True (exit 0) when every running container of $1 is already on the
 # freshly-pulled image. False when it needs a (re)start, including when no
-# container is running yet (first install).
+# container is running yet (first install). This is also what makes a
+# degraded outcome self-healing: whatever failed to swap this run still
+# reports "not up to date" on the very next run, with no extra bookkeeping.
 service_up_to_date() {
   svc="$1"
   ref=$($COMPOSE config --images "$svc" 2>/dev/null | head -n1)
@@ -218,6 +266,19 @@ roll_or_recreate() {
   fi
 }
 
+# One retry of the same swap before this service is reported failed for the
+# run — a transient blip (a slow pull finishing late, a momentary health-check
+# flake) shouldn't by itself force a degraded outcome when a second attempt
+# would have gone through cleanly.
+roll_or_recreate_with_retry() {
+  svc="$1"
+  if roll_or_recreate "$svc"; then
+    return 0
+  fi
+  log "$svc: retrying once before giving up on this run"
+  roll_or_recreate "$svc"
+}
+
 run_migrate() {
   log "running database migrations ($MIGRATE_SERVICE, one-shot)"
   if ! $COMPOSE run --rm --no-deps "$MIGRATE_SERVICE"; then
@@ -244,8 +305,12 @@ downtime_swap() {
 # Supabase (and Caddy) are not rolled start-first — they are stateful or a
 # single edge terminator — so a pinned-image bump just recreates them in
 # place. This only fires when the operator has regenerated docker-compose.yml
-# with a newer Supabase pin; day to day these images never change.
+# with a newer Supabase pin; day to day these images never change. Every
+# recreate (including supabase-db) is health-gated: no service is ever
+# considered "reconciled" without a post-start go/no-go check, logged
+# explicitly either way.
 reconcile_stateful_services() {
+  all_ok=0
   for svc in $($COMPOSE config --services 2>/dev/null); do
     case "$svc" in
       kortix-api | llm-gateway | frontend | kortix-migrate | kortix-updater) continue ;;
@@ -253,21 +318,259 @@ reconcile_stateful_services() {
     service_up_to_date "$svc" && continue
     log "$svc: pinned image changed; recreating (brief blip acceptable)"
     $COMPOSE up -d --no-deps "$svc"
+    ids=$(running_container_ids "$svc")
+    # shellcheck disable=SC2086
+    if wait_healthy $ids; then
+      log "$svc: healthy after recreate (go)"
+    else
+      log "ERROR: $svc did not become healthy after recreate (no-go) — investigate before the next scheduled run retries it"
+      all_ok=1
+    fi
   done
+  return "$all_ok"
 }
 
-write_breadcrumb() {
-  version=$(grep '^KORTIX_VERSION=' "$WORKDIR/.env" | tail -n1 | cut -d= -f2-)
-  printf '{"deployed_at":"%s","version":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${version:-unknown}" >"$BREADCRUMB"
-  log "update complete (version=${version:-unknown})"
+# Logs one line per service whose running container image doesn't match what
+# the rendered .env currently expects — drift is otherwise completely
+# invisible (the channel/tag says one thing, the containers run another).
+# Also the basis for the `report` subcommand's machine-readable drift array.
+check_drift() {
+  drifted=0
+  for svc in $($COMPOSE config --services 2>/dev/null); do
+    case "$svc" in kortix-updater | kortix-migrate) continue ;; esac
+    ref=$($COMPOSE config --images "$svc" 2>/dev/null | head -n1)
+    [ -z "$ref" ] && continue
+    desired=$(image_id_of_ref "$ref")
+    [ -z "$desired" ] && continue
+    ids=$(running_container_ids "$svc")
+    [ -z "$ids" ] && continue
+    for id in $ids; do
+      if [ "$(container_image_id "$id")" != "$desired" ]; then
+        log "DRIFT: $svc is running an image that does not match the rendered .env (expected $ref)"
+        drifted=1
+      fi
+    done
+  done
+  return "$drifted"
+}
+
+drift_report_json() {
+  printf '['
+  first=1
+  for svc in $($COMPOSE config --services 2>/dev/null); do
+    case "$svc" in kortix-updater | kortix-migrate) continue ;; esac
+    ref=$($COMPOSE config --images "$svc" 2>/dev/null | head -n1)
+    [ -z "$ref" ] && continue
+    desired=$(image_id_of_ref "$ref")
+    ids=$(running_container_ids "$svc")
+    if [ -z "$ids" ]; then
+      state="not-running"
+      drift="false"
+    else
+      state="running"
+      drift="false"
+      for id in $ids; do
+        [ "$(container_image_id "$id")" = "$desired" ] || drift="true"
+      done
+    fi
+    [ "$first" = 1 ] || printf ','
+    first=0
+    printf '{"service":"%s","expected_image":"%s","state":"%s","drift":%s}' \
+      "$(json_escape "$svc")" "$(json_escape "$ref")" "$state" "$drift"
+  done
+  printf ']'
+}
+
+# Disk-space preflight, run before pulling anything. A pull that starts and
+# then fails partway through a nearly-full disk is a worse failure mode than
+# refusing up front with a clear, stamped error. Checked against $WORKDIR
+# rather than the host's real Docker data-root: this container only ever has
+# the instance directory bind-mounted at its real host path (see the
+# KORTIX_INSTANCE_DIR comment above), and `df` on a bind mount reports the
+# underlying HOST filesystem's free space for that mount — an honest proxy on
+# the overwhelming majority of self-host boxes (single disk), though not exact
+# if an operator deliberately put Docker's data-root on a separate volume.
+disk_preflight() {
+  avail_kb=$(df -Pk "$WORKDIR" 2>/dev/null | awk 'NR==2{print $4}')
+  if [ -z "${avail_kb:-}" ]; then
+    log "WARN: could not determine free disk space at $WORKDIR; skipping preflight"
+    return 0
+  fi
+  avail_mb=$((avail_kb / 1024))
+  if [ "$avail_mb" -lt "$MIN_FREE_DISK_MB" ]; then
+    log "ERROR: only ${avail_mb}MB free at $WORKDIR (floor ${MIN_FREE_DISK_MB}MB, override with KORTIX_MIN_FREE_DISK_MB) — aborting before pulling new images"
+    return 1
+  fi
+  log "disk preflight ok (${avail_mb}MB free at $WORKDIR, floor ${MIN_FREE_DISK_MB}MB)"
+}
+
+# Pre-pull sanity check: every rolling + migrate service's image reference
+# must actually resolve in the local Docker engine BEFORE migrations touch the
+# schema. A pull that silently no-op'd (registry auth expiring, a yanked tag,
+# a network blip `docker compose pull` swallowed) must never be discovered
+# mid-rollout, after the new schema is already live.
+sanity_check_images() {
+  ok=0
+  for svc in $ROLL_SERVICES $MIGRATE_SERVICE; do
+    ref=$($COMPOSE config --images "$svc" 2>/dev/null | head -n1)
+    [ -z "$ref" ] && continue
+    if [ -z "$(image_id_of_ref "$ref")" ]; then
+      log "ERROR: $svc image '$ref' did not resolve locally after pull (sanity check failed)"
+      ok=1
+    fi
+  done
+  return "$ok"
+}
+
+# Keeps this stack's own images tidy after a fully successful run only —
+# never after a degraded one, so a service still needing a rollback target
+# never has it pulled out from under it. Keeps the currently-deployed image
+# refs plus the immediately-previous run's, so `kortix self-host rollback
+# --release <previous>` never needs to re-pull; everything else this stack
+# owns and nothing is still running on is fair game.
+gc_images() {
+  hist="$STATE_DIR/image-history.log"
+  { grep -h '^API_IMAGE=\|^FRONTEND_IMAGE=\|^GATEWAY_IMAGE=' "$WORKDIR/.env" 2>/dev/null | tr '\n' ' '; echo; } >>"$hist"
+  tail -n 2 "$hist" >"$hist.tmp" 2>/dev/null && mv "$hist.tmp" "$hist"
+  keep_refs=$(sed -E 's/[A-Z_]+=//g' "$hist" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | sort -u)
+
+  for repo_var in API_IMAGE FRONTEND_IMAGE GATEWAY_IMAGE; do
+    ref=$(grep "^${repo_var}=" "$WORKDIR/.env" 2>/dev/null | tail -n1 | cut -d= -f2-)
+    [ -z "$ref" ] && continue
+    repo=$(printf '%s' "$ref" | sed -E 's#:[^/:]+$##')
+    [ -z "$repo" ] && continue
+    for local_ref in $(docker images --format '{{.Repository}}:{{.Tag}}' "$repo" 2>/dev/null); do
+      if printf '%s\n' "$keep_refs" | grep -qxF "$local_ref"; then
+        continue
+      fi
+      log "gc: removing superseded image $local_ref (kept: current + previous for fast rollback)"
+      docker rmi "$local_ref" >/dev/null 2>&1 || true
+    done
+  done
+  # Reclaim genuinely dangling, unreferenced layers too.
+  docker image prune -f >/dev/null 2>&1 || true
+}
+
+# Watches restart counts on the services this run just touched for a short
+# window — a health check alone can pass once right after start and then the
+# container crash-loops on real traffic/config it never saw until the swap
+# completed. Never trust "went healthy once" as the final word.
+watch_for_crash_loop() {
+  [ $# -eq 0 ] && return 0
+  log "watching for crash-loops for ${CRASH_WATCH_S}s: $*"
+  before=""
+  for svc in "$@"; do
+    for id in $(running_container_ids "$svc"); do
+      before="$before $svc:$id:$(restart_count "$id")"
+    done
+  done
+  sleep "$CRASH_WATCH_S"
+  crashed=""
+  for entry in $before; do
+    svc=${entry%%:*}
+    rest=${entry#*:}
+    id=${rest%%:*}
+    was=${rest#*:}
+    now=$(restart_count "$id")
+    if [ "$now" != "$was" ]; then
+      crashed="$crashed $svc"
+      log "ERROR: $svc ($id) restarted during the post-swap watch window ($was -> $now) — crash-looping"
+    fi
+  done
+  if [ -n "$crashed" ]; then
+    # PROJECT_NAME is always "kortix-<instance>" (see composeProject() in
+    # commands/self-host.ts) — strip the fixed prefix back off instead of
+    # requiring a dedicated instance-name env var just for this message.
+    instance_hint="${PROJECT_NAME#kortix-}"
+    [ "$instance_hint" = "$PROJECT_NAME" ] && instance_hint="default"
+    log "ERROR: crash-loop detected in:$crashed — rollback with: kortix self-host update --release <previous-version> --instance $instance_hint"
+    return 1
+  fi
+  return 0
+}
+
+# ---- version / status bookkeeping ----
+
+# The version this run started FROM: the "to" of the last recorded run (or
+# "from" if that run never got that far), read back from the status file this
+# same script writes. .env's KORTIX_VERSION has ALREADY been rewritten to the
+# TARGET version by the CLI (writeEnv) by the time this script ever runs, so
+# it can only ever tell us where we're going, never where we came from.
+current_version() {
+  v=""
+  if [ -f "$STATUS_FILE" ]; then
+    v=$(sed -n 's/.*"to_version":"\([^"]*\)".*/\1/p' "$STATUS_FILE" | head -n1)
+  fi
+  if [ -z "$v" ] && [ -f "$BREADCRUMB" ]; then
+    v=$(sed -n 's/.*"version":"\([^"]*\)".*/\1/p' "$BREADCRUMB" | head -n1)
+  fi
+  printf '%s' "$v"
+}
+
+pending_version() {
+  grep '^KORTIX_VERSION=' "$WORKDIR/.env" 2>/dev/null | tail -n1 | cut -d= -f2-
+}
+
+# Stamps this run's outcome as JSON — the single source of truth `kortix
+# self-host status` reads. outcome is one of: ok | degraded | failed |
+# skipped. `services` carries the per-service "svc=ok|failed|unchanged"
+# breakdown so a degraded run says exactly which service(s) are still stale.
+write_status() {
+  outcome="$1"; from="$2"; to="$3"; stage="$4"; detail="$5"
+  finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"outcome":"%s","started_at":"%s","finished_at":"%s","from_version":"%s","to_version":"%s","stage":"%s","detail":"%s","services":"%s"}\n' \
+    "$(json_escape "$outcome")" "$(json_escape "${run_started:-$finished}")" "$(json_escape "$finished")" \
+    "$(json_escape "$from")" "$(json_escape "$to")" "$(json_escape "$stage")" "$(json_escape "$detail")" \
+    "$(json_escape "${service_results:-}")" >"$STATUS_FILE"
+  # Legacy breadcrumb (version + timestamp only) kept for anything that might
+  # still read it directly off the shared volume.
+  printf '{"deployed_at":"%s","version":"%s"}\n' "$finished" "${to:-$from}" >"$BREADCRUMB"
+  log "status: $outcome ($from -> $to)${detail:+ — $detail}"
+  notify_webhook
+}
+
+# Optional, one env var, no vendor integration: if the operator sets
+# KORTIX_UPDATE_WEBHOOK_URL, POST this run's status JSON (the exact contents
+# of $STATUS_FILE) to it after every run — success, degraded, failed, or
+# skipped-by-lock alike — so an operator who wants a push notification can
+# wire it to whatever they already use (a generic webhook relay, a Slack
+# incoming-webhook URL, their own endpoint, ...) without this script knowing
+# or caring which. Best-effort: a failed POST (unreachable URL, timeout) is
+# logged but never fails the update itself.
+notify_webhook() {
+  url="${KORTIX_UPDATE_WEBHOOK_URL:-}"
+  [ -z "$url" ] && return 0
+  if ! wget -q -O /dev/null -T 10 --header 'Content-Type: application/json' --post-file "$STATUS_FILE" "$url" >/dev/null 2>&1; then
+    log "WARN: KORTIX_UPDATE_WEBHOOK_URL POST failed (non-fatal; update outcome above is unaffected)"
+  fi
 }
 
 perform_update() {
+  run_started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  from_version=$(current_version)
+  service_results=""
+
+  if ! disk_preflight; then
+    write_status "failed" "$from_version" "$from_version" "disk-preflight" "insufficient free disk space"
+    return 1
+  fi
+
   if [ "$(image_pull_mode)" = "never" ]; then
     log "skipping registry pull (KORTIX_IMAGE_PULL=never)"
   else
     log "pulling images"
-    $COMPOSE pull --quiet
+    if ! $COMPOSE pull --quiet; then
+      write_status "failed" "$from_version" "$from_version" "pull" "docker compose pull failed"
+      return 1
+    fi
+  fi
+
+  # Pre-pull sanity check for every image this run could touch — BEFORE
+  # migrations run, so a bad/missing pull is never discovered after the
+  # schema has already moved.
+  if ! sanity_check_images; then
+    write_status "failed" "$from_version" "$from_version" "image-sanity" "one or more pulled images did not resolve locally"
+    return 1
   fi
 
   changed=""
@@ -277,27 +580,80 @@ perform_update() {
 
   if [ -z "$changed" ]; then
     log "no app-tier image changes; nothing to roll"
-    reconcile_stateful_services
-    return 0
+    if reconcile_stateful_services; then
+      check_drift || true
+      write_status "ok" "$from_version" "$from_version" "" ""
+      return 0
+    else
+      check_drift || true
+      write_status "degraded" "$from_version" "$from_version" "stateful-recreate" "a stateful service failed its post-recreate health gate"
+      return 1
+    fi
   fi
   log "changed:$changed"
+  to_version=$(pending_version)
+  overall_ok=0
 
   if [ "${KORTIX_ALLOW_DOWNTIME:-0}" = "1" ]; then
-    downtime_swap || return 1
+    if downtime_swap; then
+      for svc in $ROLL_SERVICES; do service_results="$service_results $svc=ok"; done
+    else
+      for svc in $ROLL_SERVICES; do service_results="$service_results $svc=failed"; done
+      write_status "failed" "$from_version" "$to_version" "downtime-swap" "migration or app-tier start failed during the planned-downtime path; previous version may not be serving — investigate immediately"
+      return 1
+    fi
   else
     # Migrate to completion BEFORE any service moves — a nonzero exit aborts
     # here with every running container untouched.
-    run_migrate || return 1
+    if ! run_migrate; then
+      write_status "failed" "$from_version" "$to_version" "migrate" "migration failed; nothing was swapped, previous version still serving"
+      return 1
+    fi
+    # Attempt EVERY changed service even if an earlier one fails. This is the
+    # core fix for the mixed-version bug class: a failed swap must never
+    # abort the remaining services mid-sequence (each one is already
+    # health-gated on its own — see roll_service/recreate_service — so the
+    # worst case per service is "still on the old image", never "half
+    # started"). The run ends DEGRADED, loudly, rather than silently mixed.
     for svc in $ROLL_SERVICES; do
       case " $changed " in
-        *" $svc "*) roll_or_recreate "$svc" || { log "ERROR: $svc rollout failed; leaving remaining services untouched"; return 1; } ;;
-        *) log "$svc: unchanged; skipping" ;;
+        *" $svc "*)
+          if roll_or_recreate_with_retry "$svc"; then
+            service_results="$service_results $svc=ok"
+          else
+            service_results="$service_results $svc=failed"
+            overall_ok=1
+            log "ERROR: $svc rollout failed after retry; continuing with the remaining services instead of aborting (degraded, not mixed-and-silent)"
+          fi
+          ;;
+        *)
+          log "$svc: unchanged; skipping"
+          service_results="$service_results $svc=unchanged"
+          ;;
       esac
     done
   fi
 
-  reconcile_stateful_services
-  write_breadcrumb
+  reconcile_stateful_services || overall_ok=1
+  check_drift || true
+
+  touched=""
+  for r in $service_results; do
+    case "$r" in *=ok) touched="$touched ${r%%=*}" ;; esac
+  done
+  # shellcheck disable=SC2086
+  watch_for_crash_loop $touched || overall_ok=1
+
+  if [ "$overall_ok" = 0 ]; then
+    gc_images
+    write_status "ok" "$from_version" "$to_version" "" ""
+    log "update complete ($from_version -> $to_version)"
+    return 0
+  else
+    write_status "degraded" "$from_version" "$to_version" "swap" "$service_results"
+    log "update finished DEGRADED ($from_version -> $to_version); the next scheduled run (or a manual \`kortix self-host update\`) will retry the stale service(s) automatically"
+    return 1
+  fi
 }
 
 # Seconds until the next occurrence of $UPDATE_TIME (HH:MM) in $TZ, today if
@@ -321,11 +677,58 @@ next_run_epoch() {
   echo "$target"
 }
 
+# Single-flight lock shared by the nightly scheduler and a manual `kortix
+# self-host update`/`reconcile` run (both ultimately call this). $1 is a
+# label ("nightly"/"manual") only used for the holder-info file, so the loser
+# of a race can say who currently holds it instead of quietly no-op'ing.
+# Exit codes: 0 = ran to completion (ok or handled failure already stamped),
+# 75 = lock contention (borrowed from sysexits.h EX_TEMPFAIL) — the caller
+# (selfHostUpdate in commands/self-host.ts) treats this distinctly from a
+# real failure.
 run_locked() {
+  kind="${1:-nightly}"
   (
-    flock -n 9 || { log "another update run is in progress; skipping"; exit 0; }
-    perform_update
+    if ! flock -n 9; then
+      holder=$(cat "$HOLDER_FILE" 2>/dev/null || echo "unknown")
+      log "another update run is already in progress (${holder}); skipping this ${kind} run"
+      write_status "skipped" "$(current_version)" "$(pending_version)" "lock" "another run in progress: ${holder}"
+      exit 75
+    fi
+    printf 'kind=%s pid=%s host=%s since=%s\n' "$kind" "$$" "$(hostname 2>/dev/null || echo unknown)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$HOLDER_FILE"
+    rc=0
+    perform_update || rc=$?
+    rm -f "$HOLDER_FILE" 2>/dev/null || true
+    exit "$rc"
   ) 9>"$LOCK_FILE"
+}
+
+# sha256sum ships via the busybox coreutils applet on the docker:cli (Alpine)
+# base image; fall back to md5sum, then to a size+mtime proxy, so a truly
+# minimal base can't make self-update silently never fire.
+self_hash() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | cut -d' ' -f1
+  elif command -v md5sum >/dev/null 2>&1; then
+    md5sum "$1" 2>/dev/null | cut -d' ' -f1
+  else
+    stat -c '%Y-%s' "$1" 2>/dev/null || true
+  fi
+}
+
+# The standing scheduler container only ever reads this file once, at
+# container start (the entrypoint's `exec ... ./updater.sh`). Without this
+# check, a CLI-shipped fix to this very script only reaches an already-running
+# instance the next time its container is recreated — never on its own. A
+# plain `kortix self-host update` always rewrites this file from the CLI's
+# embedded copy first (see writeKortixRuntimeAssets in compose-assets.ts), so
+# comparing the on-disk hash at the top of every loop iteration and re-exec'ing
+# into the current file when it changed is enough to pick that up immediately.
+maybe_reexec_self() {
+  new_hash=$(self_hash "$SCRIPT_FILE")
+  if [ -n "$new_hash" ] && [ -n "${CURRENT_HASH:-}" ] && [ "$new_hash" != "$CURRENT_HASH" ]; then
+    log "updater.sh changed on disk; re-executing the updated script"
+    exec /bin/sh "$SCRIPT_FILE" "$@"
+  fi
 }
 
 # `updater.sh once` runs a single update pass right now and exits — this is
@@ -335,12 +738,36 @@ run_locked() {
 # request always runs).
 if [ "${1:-}" = "once" ]; then
   log "manual run (once)"
-  run_locked
+  rc=0
+  run_locked manual || rc=$?
+  exit "$rc"
+fi
+
+# `updater.sh status` / `updater.sh report`: read-only, no lock needed — used
+# by `kortix self-host status` to surface the last outcome plus a live drift
+# check without running an update.
+if [ "${1:-}" = "status" ]; then
+  cat "$STATUS_FILE" 2>/dev/null || echo '{"outcome":"never-run"}'
+  exit 0
+fi
+if [ "${1:-}" = "report" ]; then
+  status_json=$(cat "$STATUS_FILE" 2>/dev/null || true)
+  [ -z "$status_json" ] && status_json='{"outcome":"never-run"}'
+  if (flock -n 8 || exit 1) 8>"$LOCK_FILE" 2>/dev/null; then
+    locked=false
+  else
+    locked=true
+  fi
+  holder=$(cat "$HOLDER_FILE" 2>/dev/null || echo "")
+  printf '{"status":%s,"drift":%s,"lock":{"locked":%s,"holder":"%s"}}\n' \
+    "$status_json" "$(drift_report_json)" "$locked" "$(json_escape "$holder")"
   exit 0
 fi
 
+CURRENT_HASH=$(self_hash "$SCRIPT_FILE")
 log "starting (schedule=${UPDATE_TIME} ${TZ}, auto_update=${KORTIX_AUTO_UPDATE:-true})"
 while true; do
+  maybe_reexec_self "$@"
   if [ "${KORTIX_AUTO_UPDATE:-true}" != "true" ]; then
     log "KORTIX_AUTO_UPDATE is not true; idling (manual updater.sh once / kortix self-host update still works)"
     sleep "${KORTIX_IDLE_POLL_S:-3600}"
@@ -351,7 +778,12 @@ while true; do
   [ "$wait_s" -lt 0 ] && wait_s=0
   log "next scheduled run: $(date -d "@$next" '+%Y-%m-%d %H:%M %Z') (sleeping ${wait_s}s)"
   sleep "$wait_s"
-  run_locked
+  maybe_reexec_self "$@"
+  # NEVER let a failed run exit this loop/container: `set -e` would otherwise
+  # kill the standing scheduler on any nonzero exit from a bare statement — the
+  # `||` below is load-bearing, not decorative. This is the single fix for
+  # "one bad night = no future nightlies, silently".
+  run_locked nightly || log "scheduled run did not complete cleanly (see \`kortix self-host status\`); will retry at the next scheduled window"
   # Guard against a run that returns fast (e.g. a parse error) turning this
   # into a tight loop: always land back at the top of the daily wait.
   sleep 1

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -169,7 +169,49 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
   }
 
   const kong = services['supabase-kong'];
-  if (kong) kong.ports = ['127.0.0.1:${SUPABASE_PORT}:8000'];
+  if (kong) {
+    kong.ports = ['127.0.0.1:${SUPABASE_PORT}:8000'];
+    // Upstream declares `depends_on: studio: condition: service_healthy` —
+    // but Kong here runs fully declarative (KONG_DATABASE=off, its routes
+    // come from the mounted kong.yml), so it has no runtime dependency on
+    // Studio at all. Left in place, that one line puts Studio — and, once
+    // docker-compose.logs.yml is merged in (always, in self-host — see
+    // upstreamServices above), Studio's OWN dependency on Logflare/Analytics
+    // — on the critical path of every service that itself depends on Kong
+    // (kortix-api's SUPABASE_URL points at Kong, so kortix-api transitively
+    // waited on the admin dashboard and the analytics pipeline before it
+    // could even start). None of Studio/Logflare/Analytics are on the
+    // customer-facing request path; un-gating Kong from Studio removes them
+    // from kortix-api's cold-boot chain without touching either service.
+    if (isRecord(kong.depends_on)) {
+      const dependencies = { ...kong.depends_on };
+      delete dependencies['supabase-studio'];
+      kong.depends_on = Object.keys(dependencies).length > 0 ? dependencies : undefined;
+    }
+  }
+  const auth = services['supabase-auth'];
+  if (auth) {
+    // GoTrue silently no-ops EVERY per-IP rate limit (email/SMS/OTP sent,
+    // token refresh, anonymous sign-ins, ...) when GOTRUE_RATE_LIMIT_HEADER
+    // is unset — see performRateLimitingWithHeader() in supabase/auth: "If no
+    // rate limit header was set, ignore rate limiting". Upstream's compose
+    // file never sets it, so a self-host instance runs with every one of
+    // these protections silently disabled regardless of their (non-zero)
+    // numeric defaults. Kong/Caddy both set X-Forwarded-For on proxied
+    // requests by default, so pointing GoTrue at that header is enough to
+    // turn the existing defaults into real protection; the explicit values
+    // below just make the floor visible instead of relying on GoTrue's own
+    // internal defaults changing out from under this file on a version bump.
+    const authEnv = { ...asRecord(auth.environment) } as Record<string, string>;
+    authEnv.GOTRUE_RATE_LIMIT_HEADER ||= 'X-Forwarded-For';
+    authEnv.GOTRUE_RATE_LIMIT_EMAIL_SENT ||= '30';
+    authEnv.GOTRUE_RATE_LIMIT_SMS_SENT ||= '30';
+    authEnv.GOTRUE_RATE_LIMIT_VERIFY ||= '30';
+    authEnv.GOTRUE_RATE_LIMIT_TOKEN_REFRESH ||= '150';
+    authEnv.GOTRUE_RATE_LIMIT_OTP ||= '30';
+    authEnv.GOTRUE_RATE_LIMIT_ANONYMOUS_USERS ||= '30';
+    auth.environment = authEnv;
+  }
   const database = services['supabase-db'];
   if (database) {
     // `pg_isready` succeeds against the temporary server that the Postgres
@@ -259,6 +301,18 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
   // replica count without re-deriving it from the compose file at runtime.
   applyReplicaTopology(services, Boolean(options.domainConfigured));
 
+  // Every one of the ~20 containers in this stack logged to stdout with no
+  // rotation — an unattended VPS eventually fills its disk from container
+  // logs alone. Applied uniformly, after every other service-specific tweak
+  // above, so nothing here can be silently skipped for one service and not
+  // another (a hand-maintained per-file `logging:`/`x-logging` block invites
+  // exactly that drift).
+  applyLogging(services);
+  // Sensible memory ceilings so one hungry/leaking service can't starve the
+  // host and get Postgres OOM-killed — see applyMemLimits() for the
+  // measurements this table is derived from.
+  applyMemLimits(services);
+
   const document: YamlRecord = {
     services,
     volumes: deepMerge(asRecord(base.volumes), asRecord(kortix.volumes)),
@@ -313,6 +367,85 @@ function applyReplicaTopology(services: Record<string, YamlRecord>, domainConfig
     if (!service) continue;
     if (domainConfigured) delete service.ports;
     service.deploy = { replicas };
+  }
+}
+
+/**
+ * Bounded, rotated logs for every container in the stack (compose's own
+ * `logging:` key — the default `json-file` driver otherwise grows without
+ * bound). One shared literal applied uniformly at render time is this
+ * generator's equivalent of a compose-level `x-logging` anchor: every
+ * service gets exactly this, and a future service added to either the
+ * upstream Supabase file or kortix-compose.yml picks it up automatically
+ * with no per-file edit required.
+ */
+const DEFAULT_LOGGING: YamlRecord = {
+  driver: 'json-file',
+  options: { 'max-size': '10m', 'max-file': '3' },
+};
+
+function applyLogging(services: Record<string, YamlRecord>): void {
+  for (const service of Object.values(services)) {
+    service.logging = structuredClone(DEFAULT_LOGGING);
+  }
+}
+
+/**
+ * Per-service memory ceiling/floor, keyed by the FINAL (post-SERVICE_NAMES
+ * rename) service name. Not a strict admission-control budget — these are
+ * hard per-container ceilings sized well above ordinary usage, meant to stop
+ * a single runaway/leaking service before it can starve the host and get
+ * Postgres OOM-killed (the actual live-audit failure mode: a 16GB box
+ * idling at ~4GB total, with Logflare/analytics alone accounting for
+ * ~500MB of that). `mem_limit`/`mem_reservation` are plain Compose-spec
+ * fields honored by a bare `docker compose up` — unlike `deploy.resources`,
+ * they don't require Swarm mode. `oomScoreAdj` (compose's `oom_score_adj`,
+ * -1000..1000) biases the kernel OOM-killer directly: very negative for
+ * Postgres (protect it hard), positive for the least-critical
+ * logs/analytics pipeline (first to go if the host is ever actually under
+ * memory pressure). Every limit here is a conservative ceiling chosen so the
+ * full table summed together still comfortably fits an 8GB box even though
+ * no realistic self-host workload pegs every service at its cap
+ * simultaneously.
+ */
+interface MemSpec {
+  limit: string;
+  reservation: string;
+  oomScoreAdj?: number;
+}
+
+const MEM_LIMITS: Readonly<Record<string, MemSpec>> = {
+  'supabase-db': { limit: '1280m', reservation: '512m', oomScoreAdj: -900 },
+  'kortix-api': { limit: '640m', reservation: '256m' },
+  'llm-gateway': { limit: '512m', reservation: '128m' },
+  frontend: { limit: '512m', reservation: '128m' },
+  'kortix-migrate': { limit: '512m', reservation: '128m' },
+  'kortix-updater': { limit: '256m', reservation: '64m' },
+  'supabase-kong': { limit: '384m', reservation: '128m' },
+  'supabase-auth': { limit: '256m', reservation: '64m' },
+  'supabase-rest': { limit: '256m', reservation: '64m' },
+  'supabase-realtime': { limit: '384m', reservation: '128m' },
+  'supabase-storage': { limit: '384m', reservation: '128m' },
+  'supabase-imgproxy': { limit: '384m', reservation: '64m' },
+  'supabase-meta': { limit: '256m', reservation: '64m' },
+  'supabase-functions': { limit: '384m', reservation: '128m' },
+  'supabase-supavisor': { limit: '384m', reservation: '128m' },
+  'supabase-studio': { limit: '384m', reservation: '128m' },
+  // The audit's confirmed hog (~500MB observed) — tightest cap, and the
+  // first thing the kernel OOM-killer should reach for.
+  'supabase-analytics': { limit: '640m', reservation: '256m', oomScoreAdj: 500 },
+  'supabase-vector': { limit: '192m', reservation: '64m', oomScoreAdj: 500 },
+  caddy: { limit: '256m', reservation: '64m' },
+  cloudflared: { limit: '128m', reservation: '32m' },
+};
+
+function applyMemLimits(services: Record<string, YamlRecord>): void {
+  for (const [name, spec] of Object.entries(MEM_LIMITS)) {
+    const service = services[name];
+    if (!service) continue;
+    service.mem_limit = spec.limit;
+    service.mem_reservation = spec.reservation;
+    if (spec.oomScoreAdj !== undefined) service.oom_score_adj = spec.oomScoreAdj;
   }
 }
 

--- a/tests/self-host-e2e/fast/updater-hardening.test.ts
+++ b/tests/self-host-e2e/fast/updater-hardening.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  composeServiceBlock,
+  composeServiceEnv,
+  composeServiceField,
+  composeServiceLoggingOptions,
+  composeServiceNames,
+  SelfHostSandbox,
+} from '../support/cli';
+
+// Fast, no-Docker coverage for tonight's production-readiness audit fixes on
+// the compose/stack side (findings #10-#14) plus the parts of the updater/CLI
+// wiring that are observable without a live Docker daemon (findings #3/#4/#7
+// and #13). The updater.sh runtime logic itself (continue-on-failure,
+// self-heal, lock contention, crash-loop watch, ...) is unit-tested against
+// the script's text in apps/cli/src/self-host/__tests__/compose-assets.test.ts
+// and was additionally verified against a real Docker daemon with a
+// throwaway stub stack (see the PR description) — neither of those fits this
+// suite's "fast, zero Docker" contract.
+
+describe('self-host updater/compose hardening (fast, no Docker)', () => {
+  let sandbox: SelfHostSandbox;
+
+  beforeEach(() => {
+    sandbox = new SelfHostSandbox();
+  });
+
+  afterEach(() => sandbox.cleanup());
+
+  test('every rendered service (laptop mode) has bounded, rotated logging', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const composeText = sandbox.readComposeText();
+    const names = composeServiceNames(composeText);
+    expect(names.length).toBeGreaterThan(15);
+    for (const name of names) {
+      const block = composeServiceBlock(composeText, name);
+      const logging = composeServiceLoggingOptions(block);
+      expect(logging.driver, name).toBe('json-file');
+      expect(logging.options['max-size'], name).toBe('10m');
+      expect(logging.options['max-file'], name).toBe('3');
+    }
+  });
+
+  test('every rendered service (laptop mode) has an explicit mem_limit/mem_reservation', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const composeText = sandbox.readComposeText();
+    const names = composeServiceNames(composeText);
+    for (const name of names) {
+      const block = composeServiceBlock(composeText, name);
+      expect(composeServiceField(block, 'mem_limit'), name).toBeTruthy();
+      expect(composeServiceField(block, 'mem_reservation'), name).toBeTruthy();
+    }
+  });
+
+  test('Postgres is protected (negative oom_score_adj); analytics/vector are deprioritized (positive)', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const composeText = sandbox.readComposeText();
+
+    const db = composeServiceBlock(composeText, 'supabase-db');
+    expect(Number(composeServiceField(db, 'oom_score_adj'))).toBeLessThan(0);
+
+    const analytics = composeServiceBlock(composeText, 'supabase-analytics');
+    expect(Number(composeServiceField(analytics, 'oom_score_adj'))).toBeGreaterThan(0);
+
+    const vector = composeServiceBlock(composeText, 'supabase-vector');
+    expect(Number(composeServiceField(vector, 'oom_score_adj'))).toBeGreaterThan(0);
+  });
+
+  test('kortix-updater (holds the Docker socket) is pinned by digest, never :latest or a bare floating :cli tag', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const composeText = sandbox.readComposeText();
+    const updater = composeServiceBlock(composeText, 'kortix-updater');
+    const image = composeServiceField(updater, 'image') ?? '';
+    expect(image).toMatch(/^docker:\d+\.\d+\.\d+-cli@sha256:[a-f0-9]{64}$/);
+  });
+
+  test('supabase-kong no longer depends_on supabase-studio (Studio/Logflare must never gate kortix-api cold boot)', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const composeText = sandbox.readComposeText();
+    const kong = composeServiceBlock(composeText, 'supabase-kong');
+    expect(kong).not.toContain('supabase-studio');
+
+    // kortix-api still (correctly) depends on Kong itself.
+    const api = composeServiceBlock(composeText, 'kortix-api');
+    expect(api).toContain('supabase-kong');
+  });
+
+  test('GoTrue rate limiting is actually active (GOTRUE_RATE_LIMIT_HEADER set — otherwise every limit silently no-ops)', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const composeText = sandbox.readComposeText();
+    const auth = composeServiceBlock(composeText, 'supabase-auth');
+    const env = composeServiceEnv(auth);
+    expect(env.GOTRUE_RATE_LIMIT_HEADER).toBeTruthy();
+    expect(env.GOTRUE_RATE_LIMIT_EMAIL_SENT).toBeTruthy();
+  });
+
+  test('same compose-level protections hold in domain (prod, 2-replica) mode too', async () => {
+    const { code } = await sandbox.run(['init', '--yes', '--domain', 'kortix.example.com']);
+    expect(code).toBe(0);
+    const composeText = sandbox.readComposeText();
+    const names = composeServiceNames(composeText);
+    expect(names).toContain('caddy');
+    for (const name of names) {
+      const block = composeServiceBlock(composeText, name);
+      expect(composeServiceLoggingOptions(block).driver, name).toBe('json-file');
+      expect(composeServiceField(block, 'mem_limit'), name).toBeTruthy();
+    }
+    const kong = composeServiceBlock(composeText, 'supabase-kong');
+    expect(kong).not.toContain('supabase-studio');
+  });
+
+  // `kortix self-host status` (findings #3/#4: run outcomes + drift must be
+  // human-visible) is new. Its Docker-touching path (reading the updater's
+  // report) can't run in this no-Docker tier, but its guard clause — refusing
+  // cleanly on an uninitialized instance, same convention as every other
+  // subcommand — is observable without Docker and is the one regression that
+  // would be most embarrassing to ship (a crash instead of a clean error).
+  test('`status` on an uninitialized instance fails clean, same as every other subcommand', async () => {
+    const { code, stderr } = await sandbox.run(['status']);
+    expect(code).toBe(1);
+    expect(stderr).toContain('not initialized');
+  });
+
+  // `ps` is kept as the raw `docker compose ps` passthrough now that `status`
+  // is the richer command — both must still be distinct, documented
+  // subcommands (not one silently aliased away).
+  test('`status` and `ps` are both distinct, documented subcommands', async () => {
+    const { stdout } = await sandbox.run(['-h']);
+    expect(stdout).toMatch(/\bstatus\b[^\n]*update outcome/);
+    expect(stdout).toMatch(/\bps\b[^\n]*docker compose ps/);
+  });
+});

--- a/tests/self-host-e2e/support/cli.ts
+++ b/tests/self-host-e2e/support/cli.ts
@@ -155,6 +155,40 @@ export function composeServiceEnv(serviceBlock: string): Record<string, string> 
   return out;
 }
 
+/** Look up a scalar (`key: value`) field directly under a service block —
+ *  e.g. `mem_limit: 384m`, `oom_score_adj: -900`, `image: ...`. Returns
+ *  undefined if absent. Deliberately only matches 4-space-indented keys (one
+ *  level under the service header), same convention as composeServiceEnv. */
+export function composeServiceField(serviceBlock: string, key: string): string | undefined {
+  const m = new RegExp(`^ {4}${key}:\\s*(.*)$`, 'm').exec(serviceBlock);
+  return m?.[1]?.replace(/^"(.*)"$/, '$1');
+}
+
+/** Parse a service's `logging.options` mapping (8-space-indented under
+ *  `  logging:\n    options:`). Returns {} if the service has no logging
+ *  block at all. */
+export function composeServiceLoggingOptions(serviceBlock: string): { driver?: string; options: Record<string, string> } {
+  const loggingHeaderMatch = /^ {4}logging:$/m.exec(serviceBlock);
+  if (!loggingHeaderMatch) return { options: {} };
+  const from = serviceBlock.slice(loggingHeaderMatch.index + loggingHeaderMatch[0].length);
+  const nextSameOrLessIndent = from.search(/^ {0,4}[a-zA-Z0-9_-]+:/m);
+  const block = from.slice(0, nextSameOrLessIndent === -1 ? undefined : nextSameOrLessIndent);
+  const driverMatch = /^ {6}driver:\s*(.*)$/m.exec(block);
+  const optionsHeaderMatch = /^ {6}options:$/m.exec(block);
+  const options: Record<string, string> = {};
+  if (optionsHeaderMatch) {
+    const optionsBlock = block.slice(optionsHeaderMatch.index + optionsHeaderMatch[0].length);
+    for (const line of optionsBlock.split('\n')) {
+      const m = /^ {8}["']?([\w-]+)["']?:\s*(.*)$/.exec(line);
+      if (!m) continue;
+      const key = m[1] ?? '';
+      const value = (m[2] ?? '').replace(/^"(.*)"$/, '$1');
+      options[key] = value;
+    }
+  }
+  return { driver: driverMatch?.[1], options };
+}
+
 let cachedHelp: string | undefined;
 
 /** Feature-flag probes against the CLI's own `-h` output, so this suite


### PR DESCRIPTION
## DO NOT MERGE — rides v0.10.3

Fixes the updater- and compose-side criticals/highs from tonight's adversarially-verified self-host production-readiness audit. Scope: `apps/cli/src/self-host/assets/**` (updater.sh, kortix-compose.yml, supabase docker-compose.yml via `compose-assets.ts`, Caddyfile), the update/status paths in `apps/cli/src/commands/self-host.ts`, and `tests/self-host-e2e/fast/**`.

Coordination: kept `kortix-compose.yml` edits surgical (image pin + env vars + comments only) so the parallel local-docker-provider work (docker.sock mount on `kortix-api`, CLI provider menu) is unaffected. Did not touch `infra/terraform`.

## Findings → fixes

| # | Finding | Severity | Fix |
|---|---|---|---|
| 1 | Failed per-service swap aborts rollout mid-sequence → mixed app-tier versions vs. already-migrated DB | CRITICAL | `perform_update()` now attempts every changed service even after one fails (with one retry each); pre-pulls + `docker image inspect` sanity-checks all images *before* migrating. Ends in a stamped `degraded` outcome that self-heals next run (`service_up_to_date()` re-detects the stale service). |
| 2 | Any failure crashes the standing updater container → no future nightlies, silently | CRITICAL | Scheduler loop calls `run_locked nightly \|\| log ...` (never a bare statement) — `set -e` can no longer kill the loop. `restart: unless-stopped` verified as the second layer. |
| 3 | Update outcomes invisible | HIGH | Every run stamps `$STATE_DIR/update-status.json` (from→to version, per-service result, error detail). `kortix self-host status` surfaces it; `updater.sh status`/`report` subcommands expose it directly. Optional `KORTIX_UPDATE_WEBHOOK_URL` POSTs every outcome (one env var, no vendor integration) — verified live against a local HTTP listener. |
| 4 | Drift (channel says stable, containers run something else) undetectable | HIGH | `check_drift()` (post-run log) + `report` subcommand's `drift` array compare running container image vs. rendered `.env` expectation; `kortix self-host status` prints it. |
| 5 | No image GC; no disk preflight | HIGH | `gc_images()` runs only after a fully successful run, keeps current + previous tag per repo, prunes the rest. `disk_preflight()` (`df` against the bind-mounted instance dir) aborts with a stamped error before pulling if free space is under `KORTIX_MIN_FREE_DISK_MB` (default 2048). |
| 6 | Standing scheduler never picks up a newer updater.sh | HIGH | `maybe_reexec_self()` hash-compares the on-disk script every loop iteration and `exec`s into it when changed — a plain `kortix self-host update` (which always rewrites `updater.sh`) is enough, no manual recreate. |
| 7 | Manual `update` has no lock against an in-flight nightly | HIGH | Shared `flock` (already existed) now writes holder metadata (kind/pid/host/since); the loser gets a distinct exit code (75) and reports who holds it. `selfHostUpdate()` in the CLI treats 75 specially instead of reporting a generic failure. |
| 8 | Stateful service recreate (incl. Postgres) has zero health verification | HIGH | `reconcile_stateful_services()` now `wait_healthy`-gates every recreate with an explicit go/no-go log line. |
| 9 | No crash-loop detection post-swap | MEDIUM | `watch_for_crash_loop()` watches `RestartCount` for `KORTIX_CRASH_WATCH_S` (default 20s) after a swap; a crash-loop stamps `degraded` with a one-line manual rollback command. |
| 10 | No log rotation on any of the ~21 containers | HIGH | `applyLogging()` in `compose-assets.ts` applies `json-file` + `max-size: 10m` / `max-file: 3` to every rendered service uniformly (generator-level DRY, not per-file). |
| 11 | No memory limits/OOM protection | HIGH | `applyMemLimits()` sets `mem_limit`/`mem_reservation` per service; Postgres gets `oom_score_adj: -900` (protected), `supabase-analytics`/`supabase-vector` get `+500` (first to go) and the tightest caps. Worst-case sum of every steady-state ceiling stays under 8GB. |
| 12 | kortix-api's cold boot health-gated through Kong → Studio → Logflare/Analytics | HIGH | Kong's `depends_on: studio: condition: service_healthy` removed at render time — Kong is fully declarative (`KONG_DATABASE=off`) and never needed Studio at runtime. Un-gates the whole chain without cutting any service. |
| 13 | Updater container (holds docker.sock) pulled by floating `docker:cli` tag | HIGH | Pinned to `docker:29.6.1-cli@sha256:862099...` (verified live against Docker Hub), with the trust model documented inline. |
| 14a | Caddy: no HSTS, unconfirmed http→https redirect | MEDIUM | Added conservative `Strict-Transport-Security: max-age=2592000` (30d, no preload) to both site blocks; confirmed via `caddy validate` that automatic HTTPS redirect is already on by default. |
| 14b | GoTrue rate limits not configured | MEDIUM | Root cause: GoTrue no-ops *every* per-IP rate limit when `GOTRUE_RATE_LIMIT_HEADER` is unset (confirmed in `supabase/auth` source), regardless of the numeric defaults. Now set to `X-Forwarded-For` plus explicit floor values for email/SMS/OTP/token-refresh/anonymous/verify. |

## Validation

- `docker compose config --quiet` clean for both laptop and prod+tunnel rendered composes.
- `shellcheck -s sh` clean on `updater.sh`; `sh -n` syntax-clean.
- `apps/cli` `tsc --noEmit` clean.
- `apps/cli/src/self-host/__tests__/compose-assets.test.ts`: 44/44 pass (extended with new coverage for logging, mem limits, Kong dependency, GoTrue rate limits, HSTS, digest pin, and every new updater.sh resilience mechanism).
- New `tests/self-host-e2e/fast/updater-hardening.test.ts`: 9/9 pass, genuinely Docker-free.
- **Live-simulated** against a real Docker daemon with a throwaway stub stack (isolated project name, stub `alpine` images standing in for kortix-api/llm-gateway/frontend): reproduced and confirmed (a) a failed frontend swap does NOT block kortix-api/llm-gateway from rolling forward, ends `degraded`, self-heals on the next run once the image is fixed; (b) lock contention between two concurrent runs — loser gets exit 75 with holder info; (c) a genuine crash-loop (container restarts within the watch window) is detected and stamped; (d) the `KORTIX_UPDATE_WEBHOOK_URL` POST fires and delivers the exact status JSON to a local listener.
- 2 pre-existing environmental test failures (`KORTIX_ALLOW_DOWNTIME` / landing-page `env set` tests) confirmed present on unmodified `main` too — not introduced by this change.

## What I couldn't fully simulate

- A true zero-downtime **2-replica + Caddy** rollout (needs a real domain + ACME) — same limitation already documented in `tests/self-host-e2e/live/rolling-update.live.sh`.
- The scheduler's daily wait/self-re-exec over a real ~24h window (verified the re-exec mechanism and hash-diffing logic directly instead).

## Note on this dev machine's environment

Running the pre-existing `tests/self-host-e2e/fast/**` suite and `apps/cli` test suite broadly discovered (not introduced by this PR) that several tests share the Docker Compose project name `kortix-default` with a real, already-running personal self-host instance on this machine — `env set`-triggered container recreates from throwaway test sandboxes collided with it (a stray `kortix-api` container stuck in `Created`, and `cloudflared` recreated with a fake test tunnel token). Cleaned up both; the instance's core services (db, kong, migrate, etc.) were never touched since they were never recreated during the collision. Worth a follow-up to namespace test instance names away from `default`.