### PR TITLE
fix(auth): silent token refresh + never render a dead auth page

### DIFF
--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '@/features/providers/auth-provider';
 import { invalidateTokenCache, setBootstrapAuthToken } from '@/lib/auth-token';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
 import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
+import { isSessionExpired } from '@/lib/auth/session-expiry';
 import {
   type CredentialsMode,
   type EmailFlowMode,
@@ -823,10 +824,21 @@ function AuthCardForm({
 
 /* ─── Page shell ───────────────────────────────────────────────────────── */
 
+// How long the "signed in, redirecting" placeholder is allowed to sit on
+// screen before we stop trusting it. A legitimate redirect (the overwhelming
+// common case) leaves this page well within this window — router.replace is a
+// same-tab client transition, not a network round trip. This is a safety net
+// for the case the client's cached `user` is stale (e.g. a revoked/rotated
+// refresh token that hasn't hit its own `exp` yet, so the cheaper local
+// expiry check below doesn't catch it) and the redirect it kicks off keeps
+// bouncing back here instead of leaving — without this, the placeholder is a
+// dead end with no form, spinner, or escape hatch.
+const STALE_SESSION_FALLBACK_MS = 2500;
+
 function AuthContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { user, session, isLoading } = useAuth();
+  const { user, session, isLoading, signOut } = useAuth();
   const returnUrl = sanitizeAuthReturnUrl(
     searchParams.get('returnUrl') || searchParams.get('redirect'),
   );
@@ -834,11 +846,35 @@ function AuthContent() {
     searchParams.get('mobile_callback') === '1' ? searchParams.get('state') : null;
   const hasStartedMobileHandoff = useRef(false);
 
+  // `useAuth()`'s `user` can be stale: it's seeded from whatever session the
+  // client already had cached, and only gets corrected once something
+  // (an ambient refresh timer, another API call) happens to notice it died.
+  // Landing on /auth with a `redirect`/`returnUrl` param is itself a strong
+  // signal the session just failed server-side validation — so the moment we
+  // can locally prove the cached session is dead (its own `expires_at` is
+  // already in the past), stop trusting it immediately instead of waiting for
+  // that ambient correction, which can take seconds in production and leaves
+  // this component committed to the placeholder below with nothing on screen.
+  const sessionExpired = isSessionExpired(session);
+
+  const [forceForm, setForceForm] = useState(false);
+  const trustedUser = !!user && !sessionExpired && !forceForm;
+
   // A web session may already exist when the mobile user returns to this page.
   // Preserve the native handoff instead of routing that browser session to the
   // web dashboard and stranding the mobile app on its auth screen.
   useEffect(() => {
-    if (isLoading || !user) return;
+    if (isLoading) return;
+
+    if (user && sessionExpired) {
+      // Dead session, proven locally — clear it now and fall through to the
+      // real form on this same render pass rather than the placeholder.
+      setForceForm(true);
+      void signOut();
+      return;
+    }
+
+    if (!trustedUser) return;
 
     if (mobileCallbackState) {
       // Strict Mode re-runs effects after the deep-link navigation begins.
@@ -861,12 +897,33 @@ function AuthContent() {
     }
 
     router.replace(returnUrl);
-  }, [isLoading, mobileCallbackState, returnUrl, router, session, user]);
+  }, [
+    isLoading,
+    mobileCallbackState,
+    returnUrl,
+    router,
+    session,
+    sessionExpired,
+    signOut,
+    trustedUser,
+    user,
+  ]);
+
+  // Safety net for staleness the local expiry check can't see (a refresh
+  // token invalidated server-side while the access token's own `exp` is still
+  // in the future): if we're still showing the placeholder after a beat, stop
+  // trusting the cached session and render the form instead of leaving the
+  // visitor on a dead screen.
+  useEffect(() => {
+    if (!trustedUser) return;
+    const timer = setTimeout(() => setForceForm(true), STALE_SESSION_FALLBACK_MS);
+    return () => clearTimeout(timer);
+  }, [trustedUser]);
 
   // A session is already established — the effect above is redirecting (or
   // handing off to mobile). Keep the quiet branded frame up instead of a
   // spinner, a blank screen, or a dead form.
-  if (user) {
+  if (trustedUser) {
     return (
       <AuthFrame footerVariant="default">
         <StepHeader title="Welcome to Kortix" tagline="Your AI Command Center" />
@@ -877,6 +934,8 @@ function AuthContent() {
   // Render the form immediately — even while the session check is still in
   // flight. Signed-out visitors (the common case) get an instantly usable
   // page; a signed-in visitor sees the form for a beat before the redirect.
+  // A stale/invalidated session (sessionExpired, or forceForm from the
+  // safety-net timeout) also lands here — never a dead shell.
   return (
     <AuthFrame footerVariant="continue">
       <AuthCardForm returnUrl={returnUrl} mobileCallbackState={mobileCallbackState} />

--- a/apps/web/src/lib/auth/session-expiry.test.ts
+++ b/apps/web/src/lib/auth/session-expiry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isSessionExpired } from './session-expiry';
+
+describe('isSessionExpired', () => {
+  test('false for a session expiring in the future', () => {
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    expect(isSessionExpired({ expires_at: future })).toBe(false);
+  });
+
+  test('true for a session whose expires_at is already in the past', () => {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    expect(isSessionExpired({ expires_at: past })).toBe(true);
+  });
+
+  test('true for a session expiring this instant (boundary)', () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(isSessionExpired({ expires_at: now })).toBe(true);
+  });
+
+  test('false for null/undefined session — nothing to prove expired locally', () => {
+    expect(isSessionExpired(null)).toBe(false);
+    expect(isSessionExpired(undefined)).toBe(false);
+  });
+
+  test('false when expires_at is missing or not a number', () => {
+    expect(isSessionExpired({})).toBe(false);
+    expect(isSessionExpired({ expires_at: null })).toBe(false);
+    expect(isSessionExpired({ expires_at: '123' as unknown as number })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/session-expiry.ts
+++ b/apps/web/src/lib/auth/session-expiry.ts
@@ -1,0 +1,21 @@
+export interface SessionExpiryLike {
+  expires_at?: number | null;
+}
+
+/**
+ * True when a Supabase session's own `expires_at` claim (unix seconds) is
+ * already in the past.
+ *
+ * Used on the auth page to stop trusting a cached `user`/`session` object the
+ * moment we can prove it's dead, rather than waiting for the ambient
+ * background-refresh timer (or some unrelated API call) to notice and
+ * self-correct. That correction can take seconds in production — during that
+ * window a component that blindly trusts `user` truthiness renders a
+ * "signed in, redirecting" placeholder with no form, spinner, or escape
+ * hatch, which is exactly what stranded users on a blank /auth page.
+ */
+export function isSessionExpired(session: SessionExpiryLike | null | undefined): boolean {
+  return (
+    !!session && typeof session.expires_at === 'number' && Date.now() / 1000 >= session.expires_at
+  );
+}

--- a/apps/web/src/lib/supabase/redirect-preserving-session.test.ts
+++ b/apps/web/src/lib/supabase/redirect-preserving-session.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { NextResponse } from 'next/server';
+
+import { redirectPreservingCookies } from './redirect-preserving-session';
+
+describe('redirectPreservingCookies', () => {
+  test('carries cookies staged on the source response onto the redirect', () => {
+    const staged = NextResponse.next();
+    staged.cookies.set('sb-kortix-auth-token', '', { path: '/', maxAge: 0 });
+    staged.cookies.set('other-cookie', 'keep-me');
+
+    const redirect = redirectPreservingCookies(
+      new URL('https://kortix.local/auth?redirect=%2Fprojects'),
+      staged.cookies,
+    );
+
+    expect(redirect.headers.get('location')).toBe('https://kortix.local/auth?redirect=%2Fprojects');
+    expect(redirect.cookies.get('sb-kortix-auth-token')?.value).toBe('');
+    expect(redirect.cookies.get('other-cookie')?.value).toBe('keep-me');
+  });
+
+  test('a plain NextResponse.redirect() drops those cookies — the exact regression this guards against', () => {
+    const staged = NextResponse.next();
+    staged.cookies.set('sb-kortix-auth-token', '', { path: '/', maxAge: 0 });
+
+    const bareRedirect = NextResponse.redirect(new URL('https://kortix.local/auth'));
+
+    expect(bareRedirect.cookies.get('sb-kortix-auth-token')).toBeUndefined();
+  });
+
+  test('no cookies staged on the source means no cookies on the redirect', () => {
+    const staged = NextResponse.next();
+    const redirect = redirectPreservingCookies(new URL('https://kortix.local/auth'), staged.cookies);
+    expect(redirect.cookies.getAll()).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/supabase/redirect-preserving-session.ts
+++ b/apps/web/src/lib/supabase/redirect-preserving-session.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Minimal shape of `NextResponse.cookies` needed to copy staged mutations.
+ * Deliberately has no index signature: `ResponseCookies.getAll()` returns
+ * objects with more fields (path, maxAge, httpOnly, …), and TS only allows
+ * that wider shape to satisfy this narrower one when this interface doesn't
+ * itself declare an index signature.
+ */
+export interface CookieJar {
+  getAll(): Array<{ name: string; value: string }>;
+}
+
+/**
+ * Build a redirect response that preserves cookie mutations already staged on
+ * `sourceCookies` — a transparently-refreshed session, or a self-heal
+ * cookie-clear — instead of the caller having to remember to copy them by
+ * hand on every redirect site.
+ *
+ * `NextResponse.redirect()` always constructs a brand-new `Response`. Any
+ * `Set-Cookie` mutations made earlier in middleware (e.g. on a shared
+ * `supabaseResponse`) are silently dropped unless copied onto that new
+ * response explicitly. Without this, a redirect issued right after the
+ * Supabase client runs can bounce the browser to a new URL while it still
+ * carries the exact stale/invalid cookie that caused the redirect in the
+ * first place — the classic "self-heal that never reaches the browser" bug.
+ */
+export function redirectPreservingCookies(url: URL, sourceCookies: CookieJar): NextResponse {
+  const response = NextResponse.redirect(url);
+  for (const cookie of sourceCookies.getAll()) {
+    response.cookies.set(cookie as never);
+  }
+  return response;
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,6 +2,7 @@ import { locales, type Locale } from '@/i18n/config';
 import { getMaintenanceConfig } from '@/lib/maintenance-store';
 import { MAINTENANCE_BYPASS_COOKIE, verifyBypassToken } from '@/lib/maintenance-bypass';
 import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
+import { redirectPreservingCookies } from '@/lib/supabase/redirect-preserving-session';
 import { createServerClient } from '@supabase/ssr';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -245,6 +246,14 @@ export async function middleware(request: NextRequest) {
     request,
   });
 
+  // Every redirect issued after the Supabase client below runs must go
+  // through this (see redirect-preserving-session.ts for why): otherwise the
+  // browser gets bounced while still carrying the very cookie that caused the
+  // bounce — the single-use refresh token never actually gets cleared/rotated
+  // on the client, so the next request just repeats the same failure.
+  const redirectPreservingSession = (url: URL) =>
+    redirectPreservingCookies(url, supabaseResponse.cookies);
+
   // IMPORTANT: NEXT_PUBLIC_ vars are inlined at build time by Next.js, so in
   // Docker containers they contain placeholder values. We MUST use runtime
   // env vars (SUPABASE_URL, SUPABASE_ANON_KEY) with fallback to NEXT_PUBLIC_.
@@ -336,12 +345,12 @@ export async function middleware(request: NextRequest) {
 
   // FAST PATH: authenticated users hitting the homepage go straight to /projects.
   if (pathname === '/' && user) {
-    return NextResponse.redirect(new URL('/projects', request.url));
+    return redirectPreservingSession(new URL('/projects', request.url));
   }
 
   // Desktop shell never shows the marketing homepage — bounce to /projects.
   if (pathname === '/' && request.headers.get('user-agent')?.includes('KortixDesktop')) {
-    return NextResponse.redirect(new URL('/projects', request.url));
+    return redirectPreservingSession(new URL('/projects', request.url));
   }
 
   // Self-host: when the landing/marketing site is disabled
@@ -361,7 +370,7 @@ export async function middleware(request: NextRequest) {
       pathname === '/' ||
       SELF_HOST_MARKETING_ONLY.some((route) => pathname === route || pathname.startsWith(`${route}/`));
     if (isMarketingContent) {
-      return NextResponse.redirect(new URL(user ? '/projects' : '/auth', request.url));
+      return redirectPreservingSession(new URL(user ? '/projects' : '/auth', request.url));
     }
   }
 
@@ -381,7 +390,11 @@ export async function middleware(request: NextRequest) {
       url.pathname = '/auth';
       const redirectTarget = `${pathname}${request.nextUrl.search || ''}`;
       url.searchParams.set('redirect', redirectTarget);
-      return NextResponse.redirect(url);
+      // Must preserve the self-heal cookie-clear above — without it, the
+      // browser bounces to /auth still carrying the poisoned cookie, and the
+      // auth page's own client-side session check has to rediscover the same
+      // invalidity from scratch before it can show a usable form.
+      return redirectPreservingSession(url);
     }
 
     // ── Billing-related routes (activate-trial, etc.) ────────────────────


### PR DESCRIPTION
## Summary

Marko's report: after last night's unified auth-flow refactor (#4754,
`7009ed1b7`), an invalidated session bounces the user to
`/auth?redirect=...` and renders **only** the "Welcome to Kortix / Your AI
Command Center" header + legal footer — no form, nothing interactive. Two
related bugs, both introduced/exposed the same night:

**Bug 2 (root cause) — `apps/web/src/middleware.ts`**
The self-heal added in `3710dc3a8` clears the poisoned Supabase auth cookie
on `supabaseResponse` when `getUser()` reports an invalid/rotated refresh
token — but the unauthenticated bounce (and a few other post-auth redirects:
the `/` fast-path, the desktop-shell bounce, the self-host
landing-page bounce) all returned a bare `NextResponse.redirect(url)`, which
constructs a **brand-new** response. The `Set-Cookie` clearing the bad cookie
never reached the browser, so the client kept carrying the exact cookie that
caused the bounce. Verified with a raw `curl` against the middleware: before
the fix, the 307 to `/auth` has **no** `Set-Cookie` header at all; after the
fix, it does.

Fix: extracted a small, unit-tested `redirectPreservingCookies()` helper
(`apps/web/src/lib/supabase/redirect-preserving-session.ts`) and routed every
post-Supabase-client redirect in middleware through it.

**Bug 1 (the visible symptom) — `apps/web/src/app/(auth)/auth/page.tsx`**
`AuthContent` renders a bare "signed in, redirecting" placeholder (header +
footer only) whenever `useAuth()`'s `user` is truthy — but `AuthProvider`
only validates the session once per mount, not on every soft (client-side)
navigation. Landing on `/auth` with a `redirect`/`returnUrl` param is itself
proof the session just failed server-side validation, yet the page kept
trusting the stale cached `user` with no escape hatch: no form, no spinner,
no timeout — a genuinely dead page whenever the correction (an ambient
refresh timer noticing the session died) took more than an instant.

Reproduced live: signed in, poisoned the session cookie in-place (no reload),
then triggered a same-tab client-side `<Link>` navigation into a protected
route — landed on `/auth?redirect=...` showing literally just the header,
exactly as reported.

Fix:
- Extracted `isSessionExpired()` (`apps/web/src/lib/auth/session-expiry.ts`)
  and use it to stop trusting the cached session the instant its own
  `expires_at` proves it's dead — clears it and renders the form immediately
  instead of waiting on the ambient refresh timer.
- Added a bounded 2.5s safety-net timeout for staleness the local check can't
  see (a refresh token revoked server-side while the access token's own `exp`
  hasn't hit yet) — the placeholder can never persist past that window; it
  always resolves to the real, working entry form.

`sanitizeAuthReturnUrl` (`apps/web/src/lib/auth/return-url.ts`) was already
robust against the double-encoded/open-redirect concerns raised in the
investigation brief (same-origin relative-path validation, decode wrapped in
try/catch) — confirmed via its existing test suite, no changes needed there.

## Test plan

- [x] Repro'd pre-fix: raw `curl` with a poisoned cookie against
  `/projects` shows a 307 to `/auth` with no `Set-Cookie` clearing the cookie.
- [x] Repro'd pre-fix: live browser — signed in, poisoned the session cookie,
  triggered a soft navigation — landed on `/auth?redirect=...` showing only
  the header, no form (screenshot-equivalent via accessibility snapshot).
- [x] Post-fix: same raw `curl` now shows `Set-Cookie: sb-kortix-auth-token-...=; ... Expires=Thu, 01 Jan 1970 ...` on the 307.
- [x] Post-fix: same live-browser repro now always resolves to the working
  entry form (immediately when locally provable, within the 2.5s safety net
  otherwise) — never a dead shell.
- [x] Added regression tests: `session-expiry.test.ts` (5 cases),
  `redirect-preserving-session.test.ts` (3 cases, including one that proves
  a bare `NextResponse.redirect()` — the pre-fix behavior — drops the cookie).
- [x] Full web suite: `bun test` → 1142 pass / 0 fail (136 files).
- [x] `tsc --noEmit` clean on all touched files (4 pre-existing, unrelated
  errors on `main` — `.source` codegen + 2 markdown null-arg — confirmed via
  `git stash` diff, untouched by this change).
- [x] Verified the redirect chain end-to-end: expired session on a protected
  route → bounce with `redirect` param intact → working form → (existing,
  unchanged) `sanitizeAuthReturnUrl` validates it's a same-origin relative
  path before honoring it on sign-in.

Rides v0.10.3 — **not merging**, per instructions.