### PR TITLE
feat(iam-web): setup polish — live SSO verify, resume story, self-hosted SCIM fix

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -204,6 +204,15 @@ const nextConfig = (): NextConfig => ({
         source: '/v1/:path*',
         destination: `${process.env.KORTIX_API_PROXY_TARGET ?? 'http://localhost:8008'}/v1/:path*`,
       },
+      // SCIM mounts at the API ROOT (no /v1 prefix) and identity providers call
+      // it server-to-server at whatever origin the admin was shown. In
+      // same-origin deployments that shown origin is the web origin, so /scim
+      // must forward to the API too — without this, the Tenant URL a
+      // self-hosted admin pastes into Entra/Okta would 404.
+      {
+        source: '/scim/:path*',
+        destination: `${process.env.KORTIX_API_PROXY_TARGET ?? 'http://localhost:8008'}/scim/:path*`,
+      },
       // Same-origin Supabase proxy for the sandbox preview. ENV-GATED: only
       // active when KORTIX_SUPABASE_PROXY_TARGET is set (scripts/dev-local.sh
       // run_sandbox_dev), so prod/normal deployments are untouched. The browser

--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -171,7 +171,11 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
   // which calls it directly — so show the absolute API origin when we know it.
   // Falls back to a relative path (+ the "prepend your origin" hint below) when
   // the backend is configured as a same-origin proxy path.
-  const scimBaseUrl = buildScimBaseUrl(accountId, getEnv().BACKEND_URL);
+  const scimBaseUrl = buildScimBaseUrl(
+    accountId,
+    getEnv().BACKEND_URL,
+    typeof window === 'undefined' ? null : window.location.origin,
+  );
   const scimBaseIsAbsolute = isAbsoluteHttpUrl(scimBaseUrl);
 
   return (
@@ -376,7 +380,11 @@ function CreateScimTokenDialog({
   const [created, setCreated] = useState<CreatedScimToken | null>(null);
   // Same absolute-when-known base URL the card shows, so the post-mint view
   // matches (the API returns a relative path in created.scim_base_url).
-  const scimBaseUrl = buildScimBaseUrl(accountId, getEnv().BACKEND_URL);
+  const scimBaseUrl = buildScimBaseUrl(
+    accountId,
+    getEnv().BACKEND_URL,
+    typeof window === 'undefined' ? null : window.location.origin,
+  );
 
   const mutation = useMutation({
     mutationFn: () => createScimToken(accountId, { name: name.trim() }),

--- a/apps/web/src/features/sso-setup/guides.ts
+++ b/apps/web/src/features/sso-setup/guides.ts
@@ -140,6 +140,7 @@ const importStep = (claimHint: string): GuideStep => ({
   id: 'connect',
   title: 'Connect to Kortix',
   kind: 'import',
+  where: 'kortix',
   intro:
     'Paste the federation metadata from the previous step. Kortix registers your IdP and routes sign-ins for your email domain through it.',
   note: `Group claim is prefilled with ${claimHint} — it must match the claim name your IdP emits, or group sync silently finds nothing.`,
@@ -149,6 +150,7 @@ const testStep = (extra?: string): GuideStep => ({
   id: 'test',
   title: 'Test single sign-on',
   kind: 'test',
+  where: 'kortix',
   intro:
     'Copy the sign-in URL below and open it in a PRIVATE / incognito window (so your own logged-in session doesn’t auto-complete the test), enter a test user’s work email, and complete the sign-in at your identity provider.',
   bullets: [
@@ -160,7 +162,8 @@ const testStep = (extra?: string): GuideStep => ({
   ],
   warning:
     'If the sign-in fails: “not assigned” → assign the user to the app (assign-users step). An attribute/email error → recheck the email claim maps to the IdP’s login attribute (attributes step). Signed in but no groups → recheck the group claim NAME matches what you set at connect.',
-  success: 'The test user shows up under Members on the Identity page — that’s a confirmed round-trip.',
+  success:
+    'The test user shows up under Members on the Identity page — that’s a confirmed round-trip.',
 });
 
 export const PROVIDER_GUIDES: ProviderGuide[] = [

--- a/apps/web/src/features/sso-setup/guides.ts
+++ b/apps/web/src/features/sso-setup/guides.ts
@@ -181,6 +181,8 @@ export const PROVIDER_GUIDES: ProviderGuide[] = [
     steps: [
       {
         id: 'create-app',
+        where: 'idp',
+        menuPath: 'Entra ID → Enterprise applications',
         title: 'Create an enterprise application',
         intro:
           'Sign in to the Microsoft Entra admin center (entra.microsoft.com) as an admin of your tenant.',
@@ -228,6 +230,8 @@ export const PROVIDER_GUIDES: ProviderGuide[] = [
       },
       {
         id: 'basic-saml',
+        where: 'idp',
+        menuPath: 'Your app → Single sign-on → SAML',
         title: 'Basic SAML configuration',
         intro:
           'In the left navigation menu, select the "Single sign-on" tab. Click on the "SAML" tile.',
@@ -278,10 +282,13 @@ export const PROVIDER_GUIDES: ProviderGuide[] = [
             },
           },
         ],
+        note: 'After Save, Entra pops its own "Test single sign-on with Kortix?" dialog — choose "No, I\'ll test later". Kortix isn\'t connected yet; the guided test comes at the last step.',
         doneLabel: 'I’ve completed basic SAML configuration',
       },
       {
         id: 'email-claim',
+        where: 'idp',
+        menuPath: 'Single sign-on → Attributes & Claims',
         title: 'Configure attributes and claims',
         intro:
           'On the same page, locate the "Attributes & Claims" section and click the "Edit" icon in its top right corner.',
@@ -345,11 +352,13 @@ export const PROVIDER_GUIDES: ProviderGuide[] = [
           },
         ],
         warning:
-          'Entra maps email to user.mail by default, which is EMPTY for accounts without a mailbox (any *.onmicrosoft.com user). An empty email breaks sign-in with no useful error — the UPN is always populated.',
+          'Entra maps email to user.mail by default, which is EMPTY for accounts without a mailbox (any *.onmicrosoft.com user). An empty email breaks sign-in with no useful error. The UPN (User Principal Name — the username people sign in with, e.g. jane@yourtenant.onmicrosoft.com) is always populated, which is why every mapping here points at it.',
         doneLabel: 'I’ve configured the attributes and claims',
       },
       {
         id: 'group-claim',
+        where: 'idp',
+        menuPath: 'Attributes & Claims → Add a group claim',
         title: 'Add the group claim',
         intro: 'Still in "Attributes & Claims", click "Add a group claim".',
         content: [
@@ -382,11 +391,13 @@ export const PROVIDER_GUIDES: ProviderGuide[] = [
           'Advanced options → check "Customize the name of the group claim" → Name: memberOf.',
         ],
         warning:
-          'Display names and assigning groups to the app require Entra ID P1/P2. On the Free tier pick "Security groups" + "Group ID" instead — groups arrive as Object IDs (GUIDs), and you map those GUIDs in Kortix. Both work; names are just easier to read.',
+          'Display names and assigning groups to the app require Entra ID P1/P2 (check yours: Entra admin center → Overview → the License row). On the Free tier pick "Security groups" + "Group ID" instead — groups arrive as Object IDs (GUIDs; copy a group\'s Object ID from Entra ID → Groups) and you map those GUIDs in Kortix. EITHER WAY, you must still rename the claim to memberOf under "Advanced options" → "Customize the name of the group claim" — skipping the rename is the #1 cause of groups silently not syncing.',
         doneLabel: 'I’ve added the memberOf group claim',
       },
       {
         id: 'assign-users',
+        where: 'idp',
+        menuPath: 'Your app → Users and groups',
         title: 'Assign users and groups',
         intro:
           'In the left navigation menu, select "Users and groups". Only assigned users can sign in through this application.',
@@ -422,6 +433,8 @@ export const PROVIDER_GUIDES: ProviderGuide[] = [
       },
       {
         id: 'metadata',
+        where: 'idp',
+        menuPath: 'Single sign-on → SAML Certificates',
         title: 'Set identity provider metadata',
         kind: 'metadata-input',
         intro:

--- a/apps/web/src/features/sso-setup/setup-wizard.tsx
+++ b/apps/web/src/features/sso-setup/setup-wizard.tsx
@@ -1279,7 +1279,12 @@ function WizardCore({ accountId, flow }: { accountId: string; flow: Flow }) {
   // of accountId. Lifted here (rather than local to the token step) so the
   // values panel can keep showing both after the step unmounts.
   const scimTenantUrl = useMemo(
-    () => buildScimBaseUrl(accountId, getEnv().BACKEND_URL),
+    () =>
+      buildScimBaseUrl(
+        accountId,
+        getEnv().BACKEND_URL,
+        typeof window === 'undefined' ? null : window.location.origin,
+      ),
     [accountId],
   );
   const [scimMinted, setScimMinted] = useState<CreatedScimToken | null>(null);

--- a/apps/web/src/features/sso-setup/setup-wizard.tsx
+++ b/apps/web/src/features/sso-setup/setup-wizard.tsx
@@ -44,9 +44,9 @@ import {
   type CreatedScimToken,
   createScimToken,
   getSsoProvider,
-  listScimTokens,
   importSsoProviderFromMetadata,
   listGroups,
+  listScimTokens,
 } from '@/lib/iam-client';
 import { type SamlSpUrls, buildSamlSpUrls } from '@/lib/saml-sp';
 import { buildScimBaseUrl } from '@/lib/scim-url';
@@ -887,12 +887,18 @@ function ScimTokenStep({
     enabled: !minted,
     staleTime: 30_000,
   });
-  const priorTokens = priorTokensQuery.data ?? [];
+  // Only ACTIVE tokens count — a revoked/expired one can't authenticate the
+  // IdP, so it must not invite the admin to skip minting.
+  const priorTokens = (priorTokensQuery.data ?? []).filter((t) => t.status === 'active');
 
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: () => createScimToken(accountId, { name: name.trim() }),
     onSuccess: (token) => {
       onMinted(token);
+      // Keep the settings SCIM card and this step's own resume detection in
+      // sync — both read ['scim-tokens', accountId] with a 30s staleTime.
+      queryClient.invalidateQueries({ queryKey: ['scim-tokens', accountId] });
       successToast('SCIM token minted — both values stay visible for the rest of this setup');
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to mint the token'),
@@ -918,67 +924,73 @@ function ScimTokenStep({
         </div>
       ) : null}
 
-      {minted && connectContent && connectContent.length > 0 && (
+      {!minted && (
+        <div className="space-y-3">
+          {priorTokens.length > 0 && (
+            <InfoBanner tone="info" title="You minted a token on a previous visit">
+              Its secret ({priorTokens[0].public_prefix}…) was only shown at mint time. If it's
+              already pasted into your IdP and every IdP-side step below is done, you can continue
+              without minting. If anything is unfinished, mint a fresh token, update the IdP with
+              it, then revoke the old one from the SCIM card in account settings.
+            </InfoBanner>
+          )}
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="min-w-56 space-y-1.5">
+              <Label>Token name</Label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={mutation.isPending}
+              />
+            </div>
+            <Button
+              onClick={() => mutation.mutate()}
+              disabled={name.trim().length === 0 || mutation.isPending}
+              className="gap-1.5"
+            >
+              {mutation.isPending ? (
+                <Loading className="size-3.5 shrink-0" />
+              ) : (
+                <KeyRound className="size-3.5 shrink-0" />
+              )}
+              Mint token
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {(minted || priorTokens.length > 0) && connectContent && connectContent.length > 0 && (
         <div className="space-y-4">
           <div className="border-border/60 border-t pt-4">
             <h4 className="text-foreground text-sm font-semibold">
               Now paste these into {providerName}
             </h4>
             <p className="text-muted-foreground mt-1 text-xs">
-              Both values above stay on this page — copy each one straight into the fields below.
+              {minted
+                ? 'Both values above stay on this page — copy each one straight into the fields below.'
+                : 'Same steps as your previous visit — check each one is actually done before continuing. The Tenant URL above is unchanged; the secret is the one you pasted last time (or mint a fresh one).'}
             </p>
           </div>
           <StepBlocks blocks={connectContent} spUrls={spUrls} />
-          <Button onClick={onDone}>
-            Continue
-            <ArrowRight className="ml-1.5 size-3.5 shrink-0" />
-          </Button>
+          {minted ? (
+            <Button onClick={onDone}>
+              Continue
+              <ArrowRight className="ml-1.5 size-3.5 shrink-0" />
+            </Button>
+          ) : (
+            <Button variant="outline" onClick={onDone}>
+              Continue without minting
+              <ArrowRight className="ml-1.5 size-3.5 shrink-0" />
+            </Button>
+          )}
         </div>
       )}
 
-      {minted && (!connectContent || connectContent.length === 0) ? (
+      {minted && (!connectContent || connectContent.length === 0) && (
         <Button onClick={onDone}>
           Continue
           <ArrowRight className="ml-1.5 size-3.5 shrink-0" />
         </Button>
-      ) : (
-        <div className="space-y-3">
-          {priorTokens.length > 0 && (
-            <InfoBanner tone="info" title="You already minted a token on a previous visit">
-              Its secret ({priorTokens[0].public_prefix}…) was only shown at mint time. If it's
-              already pasted into your IdP and Test Connection passed, skip ahead with Continue
-              below. If not, mint a fresh token now, update the IdP with it, then revoke the old
-              one from the SCIM card in account settings.
-            </InfoBanner>
-          )}
-          <div className="flex flex-wrap items-end gap-3">
-          <div className="min-w-56 space-y-1.5">
-            <Label>Token name</Label>
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              disabled={mutation.isPending}
-            />
-          </div>
-          <Button
-            onClick={() => mutation.mutate()}
-            disabled={name.trim().length === 0 || mutation.isPending}
-            className="gap-1.5"
-          >
-            {mutation.isPending ? (
-              <Loading className="size-3.5 shrink-0" />
-            ) : (
-              <KeyRound className="size-3.5 shrink-0" />
-            )}
-            Mint token
-          </Button>
-          {priorTokens.length > 0 && (
-            <Button variant="ghost" onClick={onDone}>
-              Continue without minting
-            </Button>
-          )}
-          </div>
-        </div>
       )}
     </div>
   );
@@ -1034,7 +1046,17 @@ function ScimValuesPanel({
  * signing in, surfaced as an explicit success ("they're in") instead of the
  * admin eyeballing a second browser window.
  */
-function SsoTestStatusPanel({ accountId }: { accountId: string }) {
+function SsoTestStatusPanel({
+  accountId,
+  baselineRef,
+}: {
+  accountId: string;
+  /** Owned by WizardCore (which outlives step navigation) so the baseline —
+   *  and therefore the "your test user arrived" confirmation — survives the
+   *  admin flipping to another step and back. A panel-local ref would be
+   *  re-seeded from the query cache that already contains the arrival. */
+  baselineRef: React.MutableRefObject<Set<string> | null>;
+}) {
   const membersQuery = useQuery({
     queryKey: ['sso-verify-members', accountId],
     queryFn: () => listAccountMembers(accountId),
@@ -1042,10 +1064,9 @@ function SsoTestStatusPanel({ accountId }: { accountId: string }) {
     staleTime: 4_000,
   });
 
-  // Baseline = whoever was already a member when the step opened. Stored once
-  // on the first successful fetch; never updated, so every later arrival stays
-  // highlighted for the rest of the visit.
-  const baselineRef = useRef<Set<string> | null>(null);
+  // Baseline = whoever was already a member when the TEST STEP was first
+  // reached this visit. Stored once; never updated, so every later arrival
+  // stays highlighted for the rest of the visit.
   const members = membersQuery.data ?? null;
   if (members && baselineRef.current === null) {
     baselineRef.current = new Set(members.map((m) => m.user_id));
@@ -1080,7 +1101,9 @@ function SsoTestStatusPanel({ accountId }: { accountId: string }) {
           <Check className="text-kortix-green mt-0.5 size-4 shrink-0" />
           <div className="min-w-0 text-sm">
             <p className="text-foreground font-medium">
-              {arrived.length === 1 ? 'Your test user just arrived' : `${arrived.length} users arrived`}
+              {arrived.length === 1
+                ? 'Your test user just arrived'
+                : `${arrived.length} users arrived`}
             </p>
             <p className="text-muted-foreground truncate text-xs">
               {arrived.map((m) => m.email ?? m.user_id).join(', ')} — signed in via SSO and
@@ -1188,6 +1211,7 @@ function StepBody({
   scimTenantUrl,
   scimMinted,
   onScimMinted,
+  ssoBaselineRef,
   onCompleteStep,
   onFinish,
 }: {
@@ -1203,6 +1227,8 @@ function StepBody({
   scimTenantUrl: string;
   scimMinted: CreatedScimToken | null;
   onScimMinted: (token: CreatedScimToken) => void;
+  /** SSO-only: arrival baseline owned by WizardCore (survives step nav). */
+  ssoBaselineRef: React.MutableRefObject<Set<string> | null>;
   onCompleteStep: () => void;
   onFinish: () => void;
 }) {
@@ -1311,7 +1337,9 @@ function StepBody({
       ) : step.kind === 'test' ? (
         <div className="space-y-4">
           {flow === 'scim' && <ProvisionedStatusPanel accountId={accountId} />}
-          {flow === 'sso' && <SsoTestStatusPanel accountId={accountId} />}
+          {flow === 'sso' && (
+            <SsoTestStatusPanel accountId={accountId} baselineRef={ssoBaselineRef} />
+          )}
           <div className="flex flex-wrap items-center gap-3">
             {flow === 'sso' && (
               <>
@@ -1393,6 +1421,9 @@ function WizardCore({ accountId, flow }: { accountId: string; flow: Flow }) {
     [accountId],
   );
   const [scimMinted, setScimMinted] = useState<CreatedScimToken | null>(null);
+  // SSO test-step arrival baseline — lives here (not in the panel) so step
+  // navigation within one visit can't erase a confirmed test sign-in.
+  const ssoBaselineRef = useRef<Set<string> | null>(null);
 
   const [activeStep, setActiveStep] = useState(0);
   const [completed, setCompleted] = useState<string[]>([]);
@@ -1534,6 +1565,7 @@ function WizardCore({ accountId, flow }: { accountId: string; flow: Flow }) {
               scimTenantUrl={scimTenantUrl}
               scimMinted={scimMinted}
               onScimMinted={setScimMinted}
+              ssoBaselineRef={ssoBaselineRef}
               onCompleteStep={() => markDone(step.id)}
               onFinish={finish}
             />

--- a/apps/web/src/features/sso-setup/setup-wizard.tsx
+++ b/apps/web/src/features/sso-setup/setup-wizard.tsx
@@ -27,7 +27,7 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { EnterpriseUpsell } from '@/components/iam/enterprise-upsell';
 import { Badge } from '@/components/ui/badge';
@@ -44,6 +44,7 @@ import {
   type CreatedScimToken,
   createScimToken,
   getSsoProvider,
+  listScimTokens,
   importSsoProviderFromMetadata,
   listGroups,
 } from '@/lib/iam-client';
@@ -662,10 +663,16 @@ function ImportForm({
 
   if (alreadyConnected) {
     return (
-      <InfoBanner tone="info" title="Already connected">
-        This account already has an SSO provider. Manage it from the SAML SSO card in account
-        settings — remove it there first to run a fresh import.
-      </InfoBanner>
+      <div className="space-y-3">
+        <InfoBanner tone="info" title="Already connected">
+          This account already has an SSO provider. Manage it from the SAML SSO card in account
+          settings — remove it there first to run a fresh import.
+        </InfoBanner>
+        <Button onClick={onDone} className="gap-1.5">
+          Continue to testing
+          <ArrowRight className="size-3.5 shrink-0" />
+        </Button>
+      </div>
     );
   }
 
@@ -871,6 +878,17 @@ function ScimTokenStep({
 }) {
   const [name, setName] = useState(`${providerName} provisioning`);
 
+  // Resume case: a token was minted on a previous visit, so its secret is gone
+  // from this session (shown once, by design). Detect it and explain the path
+  // forward instead of presenting a silently empty mint form.
+  const priorTokensQuery = useQuery({
+    queryKey: ['scim-tokens', accountId],
+    queryFn: () => listScimTokens(accountId),
+    enabled: !minted,
+    staleTime: 30_000,
+  });
+  const priorTokens = priorTokensQuery.data ?? [];
+
   const mutation = useMutation({
     mutationFn: () => createScimToken(accountId, { name: name.trim() }),
     onSuccess: (token) => {
@@ -924,7 +942,16 @@ function ScimTokenStep({
           <ArrowRight className="ml-1.5 size-3.5 shrink-0" />
         </Button>
       ) : (
-        <div className="flex flex-wrap items-end gap-3">
+        <div className="space-y-3">
+          {priorTokens.length > 0 && (
+            <InfoBanner tone="info" title="You already minted a token on a previous visit">
+              Its secret ({priorTokens[0].public_prefix}…) was only shown at mint time. If it's
+              already pasted into your IdP and Test Connection passed, skip ahead with Continue
+              below. If not, mint a fresh token now, update the IdP with it, then revoke the old
+              one from the SCIM card in account settings.
+            </InfoBanner>
+          )}
+          <div className="flex flex-wrap items-end gap-3">
           <div className="min-w-56 space-y-1.5">
             <Label>Token name</Label>
             <Input
@@ -945,6 +972,12 @@ function ScimTokenStep({
             )}
             Mint token
           </Button>
+          {priorTokens.length > 0 && (
+            <Button variant="ghost" onClick={onDone}>
+              Continue without minting
+            </Button>
+          )}
+          </div>
         </div>
       )}
     </div>
@@ -994,6 +1027,77 @@ function ScimValuesPanel({
  * reported for the whole account (framed honestly below) while the
  * SCIM-group figures are exact.
  */
+/**
+ * Live verification for the SSO test step — the SAML counterpart of the SCIM
+ * flow's ProvisionedStatusPanel. Snapshots the member list when the step
+ * opens, then polls: anyone who arrives AFTER the snapshot is the test user
+ * signing in, surfaced as an explicit success ("they're in") instead of the
+ * admin eyeballing a second browser window.
+ */
+function SsoTestStatusPanel({ accountId }: { accountId: string }) {
+  const membersQuery = useQuery({
+    queryKey: ['sso-verify-members', accountId],
+    queryFn: () => listAccountMembers(accountId),
+    refetchInterval: 8_000,
+    staleTime: 4_000,
+  });
+
+  // Baseline = whoever was already a member when the step opened. Stored once
+  // on the first successful fetch; never updated, so every later arrival stays
+  // highlighted for the rest of the visit.
+  const baselineRef = useRef<Set<string> | null>(null);
+  const members = membersQuery.data ?? null;
+  if (members && baselineRef.current === null) {
+    baselineRef.current = new Set(members.map((m) => m.user_id));
+  }
+  const arrived = (members ?? []).filter(
+    (m) => baselineRef.current && !baselineRef.current.has(m.user_id),
+  );
+
+  return (
+    <div className="border-border/70 bg-popover space-y-3 rounded-md border p-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium tracking-wide uppercase">
+          <span className="bg-kortix-green relative flex size-1.5 shrink-0 rounded-full">
+            <span className="bg-kortix-green absolute inline-flex size-full animate-ping rounded-full opacity-75" />
+          </span>
+          Watching for the test sign-in
+        </p>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          aria-label="Refresh now"
+          onClick={() => membersQuery.refetch()}
+        >
+          <RefreshCw className={cn('size-3.5', membersQuery.isFetching && 'animate-spin')} />
+        </Button>
+      </div>
+      {membersQuery.isLoading ? (
+        <Skeleton className="h-10 w-full rounded-md" />
+      ) : arrived.length > 0 ? (
+        <div className="border-kortix-green/30 bg-kortix-green/10 flex items-start gap-2.5 rounded-md border p-3">
+          <Check className="text-kortix-green mt-0.5 size-4 shrink-0" />
+          <div className="min-w-0 text-sm">
+            <p className="text-foreground font-medium">
+              {arrived.length === 1 ? 'Your test user just arrived' : `${arrived.length} users arrived`}
+            </p>
+            <p className="text-muted-foreground truncate text-xs">
+              {arrived.map((m) => m.email ?? m.user_id).join(', ')} — signed in via SSO and
+              auto-provisioned. The round-trip works.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-sm">
+          {members?.length ?? '—'} members now. Complete the test sign-in in your private window —
+          the moment the user is provisioned, they appear here (checks every few seconds).
+        </p>
+      )}
+    </div>
+  );
+}
+
 function ProvisionedStatusPanel({ accountId }: { accountId: string }) {
   const membersQuery = useQuery({
     queryKey: ['scim-verify-members', accountId],
@@ -1207,6 +1311,7 @@ function StepBody({
       ) : step.kind === 'test' ? (
         <div className="space-y-4">
           {flow === 'scim' && <ProvisionedStatusPanel accountId={accountId} />}
+          {flow === 'sso' && <SsoTestStatusPanel accountId={accountId} />}
           <div className="flex flex-wrap items-center gap-3">
             {flow === 'sso' && (
               <>

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -346,3 +346,46 @@ describe('novice-walkthrough fixes stay fixed', () => {
     }
   });
 });
+
+// Follow-up polish pins (live verify, resume story, no dead-ends, copy fixes).
+describe('setup polish stays fixed', () => {
+  test('the SSO test step has live verification (not eyeball-a-tab)', () => {
+    expect(wizardSource).toContain('SsoTestStatusPanel');
+    expect(wizardSource).toContain("flow === 'sso' && <SsoTestStatusPanel");
+  });
+
+  test('a returning admin with a prior token gets an explanation + a skip', () => {
+    expect(wizardSource).toContain('listScimTokens');
+    expect(wizardSource).toContain('Continue without minting');
+  });
+
+  test('the already-connected import state is not a dead end', () => {
+    expect(wizardSource).toContain('Continue to testing');
+  });
+
+  test('the Free-tier group-claim path restates the memberOf rename', () => {
+    const entra = getProviderGuide('entra')!;
+    const group = entra.steps.find((s) => s.id === 'group-claim')!;
+    expect(group.warning).toContain('memberOf');
+    expect(group.warning).toContain('Advanced options');
+  });
+
+  test('UPN is defined at first use', () => {
+    expect(guidesSource).toContain('User Principal Name');
+  });
+
+  test("Entra's post-Save test popup is preempted", () => {
+    expect(guidesSource).toContain('Test single sign-on with Kortix?');
+  });
+
+  test('every Entra SSO console step carries a breadcrumb', () => {
+    const entra = getProviderGuide('entra')!;
+    for (const step of entra.steps) {
+      if (step.kind === undefined) {
+        // instructions steps happen in the IdP console — they need the
+        // "you are here" path the wizard renders from menuPath.
+        expect(step.menuPath, `step ${step.id} missing menuPath`).toBeTruthy();
+      }
+    }
+  });
+});

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -351,7 +351,8 @@ describe('novice-walkthrough fixes stay fixed', () => {
 describe('setup polish stays fixed', () => {
   test('the SSO test step has live verification (not eyeball-a-tab)', () => {
     expect(wizardSource).toContain('SsoTestStatusPanel');
-    expect(wizardSource).toContain("flow === 'sso' && <SsoTestStatusPanel");
+    // Whitespace-tolerant: the formatter may wrap the JSX condition.
+    expect(flatWizardSource).toContain("flow === 'sso' && ( <SsoTestStatusPanel");
   });
 
   test('a returning admin with a prior token gets an explanation + a skip', () => {

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -389,3 +389,23 @@ describe('setup polish stays fixed', () => {
     }
   });
 });
+
+// Adversarial-review pins: the resume/verify logic can't regress.
+describe('review fixes stay fixed', () => {
+  test('only ACTIVE prior tokens drive the resume banner', () => {
+    expect(wizardSource).toContain("filter((t) => t.status === 'active')");
+  });
+
+  test('minting refreshes the shared token-list cache', () => {
+    expect(wizardSource).toContain("invalidateQueries({ queryKey: ['scim-tokens', accountId] })");
+  });
+
+  test('the arrival baseline is owned by WizardCore, not the panel', () => {
+    expect(wizardSource).toContain('ssoBaselineRef = useRef');
+    expect(wizardSource).toContain('baselineRef={ssoBaselineRef}');
+  });
+
+  test('connect instructions render on resume too (skip is informed, not blind)', () => {
+    expect(wizardSource).toContain('(minted || priorTokens.length > 0) && connectContent');
+  });
+});

--- a/apps/web/src/lib/scim-url.test.ts
+++ b/apps/web/src/lib/scim-url.test.ts
@@ -34,3 +34,30 @@ describe('isAbsoluteHttpUrl', () => {
     expect(isAbsoluteHttpUrl('/scim/v2/accounts/x')).toBe(false);
   });
 });
+
+// Same-origin deployments (BACKEND_URL is a relative proxy path like '/v1'):
+// the page origin IS the public origin, so the Tenant URL must resolve
+// absolute against it — an IdP can't call a relative path.
+describe('buildScimBaseUrl page-origin fallback', () => {
+  test('relative backend + page origin → absolute against the page', () => {
+    expect(buildScimBaseUrl('acc-1', '/v1', 'https://kortix.example.com')).toBe(
+      'https://kortix.example.com/scim/v2/accounts/acc-1',
+    );
+  });
+
+  test('absolute backend still wins over the page origin', () => {
+    expect(buildScimBaseUrl('acc-1', 'https://api.kortix.com/v1', 'https://web.other.com')).toBe(
+      'https://api.kortix.com/scim/v2/accounts/acc-1',
+    );
+  });
+
+  test('trailing slash on the page origin is normalized', () => {
+    expect(buildScimBaseUrl('acc-1', '/v1', 'https://kortix.example.com/')).toBe(
+      'https://kortix.example.com/scim/v2/accounts/acc-1',
+    );
+  });
+
+  test('no backend, no origin (SSR) → relative path unchanged', () => {
+    expect(buildScimBaseUrl('acc-1', '/v1', null)).toBe('/scim/v2/accounts/acc-1');
+  });
+});

--- a/apps/web/src/lib/scim-url.ts
+++ b/apps/web/src/lib/scim-url.ts
@@ -9,17 +9,26 @@
  * `https://api.kortix.com/scim/v2/...`.
  *
  * `backendUrl` may legitimately be a root-relative proxy path (e.g. `/v1`) in
- * same-origin deployments — there we can't derive a public origin, so we return
- * the relative path and the caller keeps its "prepend your API origin" hint.
+ * same-origin deployments. There the web origin IS the public origin (the app
+ * proxies `/scim` to the API — see next.config rewrites), so callers pass the
+ * page origin and we resolve against it. A relative path is returned only when
+ * neither an absolute backend URL nor a page origin is available (SSR).
  */
-export function buildScimBaseUrl(accountId: string, backendUrl: string | null | undefined): string {
+export function buildScimBaseUrl(
+  accountId: string,
+  backendUrl: string | null | undefined,
+  pageOrigin?: string | null,
+): string {
   const path = `/scim/v2/accounts/${accountId}`;
   if (backendUrl && /^https?:\/\//i.test(backendUrl)) {
     try {
       return new URL(backendUrl).origin + path;
     } catch {
-      /* malformed URL — fall through to the relative path */
+      /* malformed URL — fall through to the page-origin fallback */
     }
+  }
+  if (pageOrigin && /^https?:\/\//i.test(pageOrigin)) {
+    return pageOrigin.replace(/\/$/, '') + path;
   }
   return path;
 }


### PR DESCRIPTION
Follow-up to #4767, plus one commit that raced past its merge:

- **Self-hosted SCIM fix** (raced the #4767 merge): on same-origin deployments the Tenant URL rendered as a relative path an IdP can't call, and `/scim` wasn't proxied at all — resolved against the page origin + rewrite added.
- **Live SSO test verification**: the test step now watches the member list and confirms "your test user just arrived" the moment the SSO round-trip completes — no more eyeballing a second window. Baseline survives step navigation.
- **Resume story**: returning with a previously minted token explains itself (active tokens only), keeps the IdP-side instructions visible, and offers an informed "Continue without minting" after them.
- **No dead ends**: the already-connected import state gains "Continue to testing".
- **Copy**: Free-tier group-claim path restates the memberOf rename (the #1 silent group-sync killer) + how to check the Entra tier; UPN defined; Entra's post-Save test popup preempted; breadcrumbs on all Entra SSO steps.

Hardened by an adversarial 3-lens review (5 real findings fixed, all pinned by guard tests). 71 tests green, tsc/biome clean.