### PR TITLE
fix(self-host): warn when non-interactive init leaves no platform admin

### DIFF
--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -371,6 +371,13 @@ async function selfHostInit(flags: GlobalFlags): Promise<number> {
   applyFeatureFlags(env, flags);
   applyReachabilityFlags(env, flags);
   applyAdminEmail(env, flags);
+  // Non-interactive fresh init never reaches promptAdminEmail below, so a
+  // missing admin email would otherwise fail silently — and the operator only
+  // finds out at the "Only a platform admin can configure GitHub" dead-end in
+  // the dashboard. Same loud warning the interactive blank-answer path gets.
+  if (!shouldPrompt(flags) && existing === null && !env.KORTIX_PLATFORM_ADMIN_EMAILS.trim()) {
+    warnNoAdminEmail();
+  }
   warnIfReachabilityUnconfigured(env, flags);
 
   // The complete guided `init` flow, in this exact order and no other
@@ -896,12 +903,18 @@ async function promptAdminEmail(env: SelfHostEnv, flags: GlobalFlags): Promise<v
     env.KORTIX_PLATFORM_ADMIN_EMAILS || '',
   );
   env.KORTIX_PLATFORM_ADMIN_EMAILS = answer;
-  if (!answer.trim()) {
-    process.stdout.write(
-      `  ${C.yellow}warning${C.reset}  ${C.dim}No admin email set — some in-app server settings (e.g. Settings → Git)${C.reset}\n` +
-        `           ${C.dim}need at least one platform admin. Set later: ${C.reset}${C.cyan}kortix self-host env set KORTIX_PLATFORM_ADMIN_EMAILS=you@example.com${C.reset}\n\n`,
-    );
-  }
+  if (!answer.trim()) warnNoAdminEmail();
+}
+
+/** Shared by the interactive blank-answer path and non-interactive fresh
+ *  init (--yes / no TTY / piped) — the two ways an instance ends up with no
+ *  platform admin. */
+function warnNoAdminEmail(): void {
+  process.stdout.write(
+    `  ${C.yellow}warning${C.reset}  ${C.dim}No admin email set — some in-app server settings (e.g. Settings → Git)${C.reset}\n` +
+      `           ${C.dim}need at least one platform admin. Pass ${C.reset}${C.cyan}--admin-email you@example.com${C.reset}${C.dim} or set later:${C.reset}\n` +
+      `           ${C.cyan}kortix self-host env set KORTIX_PLATFORM_ADMIN_EMAILS=you@example.com${C.reset}\n\n`,
+  );
 }
 
 /**

--- a/tests/self-host-e2e/fast/init-defaults.test.ts
+++ b/tests/self-host-e2e/fast/init-defaults.test.ts
@@ -97,4 +97,36 @@ describe('self-host init: fresh render (fast, no Docker)', () => {
     expect(second.SUPABASE_JWT_SECRET).toBe(first.SUPABASE_JWT_SECRET);
     expect(second.POSTGRES_PASSWORD).toBe(first.POSTGRES_PASSWORD);
   });
+
+  // Non-interactive fresh init (`--yes`, no TTY) skips promptAdminEmail
+  // entirely, so a missing admin email used to fail silently — the operator
+  // only found out later, at the "Only a platform admin can configure GitHub"
+  // dead-end in the dashboard. `init` now prints the same loud warning the
+  // interactive blank-answer path gives, and still exits 0 (this is a warning,
+  // never a hard block — same contract as required-secrets.test.ts).
+  test('non-interactive fresh init WITHOUT --admin-email warns that no platform admin is set', async () => {
+    const { code, stdout } = await sandbox.run(['init', '--yes']);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain('No admin email set');
+    expect(stdout).toContain('--admin-email you@example.com');
+    expect(stdout).toContain('kortix self-host env set KORTIX_PLATFORM_ADMIN_EMAILS=');
+    expect(sandbox.readEnv().KORTIX_PLATFORM_ADMIN_EMAILS ?? '').toBe('');
+  });
+
+  test('non-interactive fresh init WITH --admin-email does not warn, and sets the admin email', async () => {
+    const { code, stdout } = await sandbox.run(['init', '--yes', '--admin-email', 'owner@example.com']);
+
+    expect(code).toBe(0);
+    expect(stdout).not.toContain('No admin email set');
+    expect(sandbox.readEnv().KORTIX_PLATFORM_ADMIN_EMAILS).toBe('owner@example.com');
+  });
+
+  test('a re-run of init on an already-configured instance never re-warns, even with no admin email set', async () => {
+    await sandbox.run(['init', '--yes']);
+
+    const { code, stdout } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    expect(stdout).not.toContain('No admin email set');
+  });
 });


### PR DESCRIPTION
A non-interactive fresh init (--yes, piped, CI) skipped the admin-email prompt silently; the instance then dead-ends at 'Only a platform admin can configure GitHub' in the dashboard. Interactive blank-answer and non-interactive fresh-init now share one loud warning that also suggests --admin-email. Hit live tonight while setting up a local test instance. tsc clean; self-host-cli tests show the identical 4 pre-existing environmental errors with and without the change.