### PR TITLE
fix(local-docker): resolve every sandbox-facing URL over the Docker network

### DIFF
--- a/.github/workflows/self-host-e2e.yml
+++ b/.github/workflows/self-host-e2e.yml
@@ -103,13 +103,18 @@ jobs:
       - name: Build all self-host images
         run: bash scripts/build-local-images.sh --tag selfhost-local
       - name: Full self-host e2e (schema + session + update)
+        # Provider is EXPERIMENTAL local-docker (apps/api/src/platform/providers/
+        # local-docker.ts), hardcoded inside run.sh — no cloud sandbox creds
+        # needed, so this stays fully hermetic in CI. TAG selects the images
+        # built just above (kortix/kortix-{frontend,api,gateway}:selfhost-local);
+        # `kortix/kortix-sandbox` is NOT built/used here — local-docker's
+        # per-project snapshot builder produces its own image locally from
+        # `FROM ubuntu:24.04` + the Kortix runtime layer, identically to every
+        # other provider (see local-docker.ts's snapshot-adapter doc comment).
         run: bash tests/e2e/self-hosted-e2e.sh
         env:
+          TAG: selfhost-local
           KORTIX_LOCAL_IMAGES: 'true'
-          FRONTEND_IMAGE: kortix/kortix-frontend:selfhost-local
-          API_IMAGE: kortix/kortix-api:selfhost-local
-          GATEWAY_IMAGE: kortix/kortix-gateway:selfhost-local
-          SANDBOX_IMAGE: kortix/kortix-sandbox:selfhost-local
 
   # Tier 3 — opt-in live checks: tests/self-host-e2e/live/**. Each script
   # no-ops unless RUN_SELFHOST_LIVE=1 (belt-and-suspenders with the `if:`

--- a/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-init-state.test.ts
@@ -35,6 +35,7 @@ describe('sandbox init state helpers', () => {
     const provider = {
       name: 'daytona' as const,
       provisioning: { async: true, stages: [] },
+      requiresPublicCallback: true,
       async create() {
         attempts += 1;
         if (attempts < 3) throw new Error(`attempt-${attempts}`);

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -16,7 +16,12 @@ export const SANDBOX_VERSION = process.env.SANDBOX_VERSION || 'unknown';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-export type SandboxProviderName = 'daytona' | 'platinum' | 'e2b';
+// 'local-docker' is EXPERIMENTAL — see platform/providers/local-docker.ts.
+// It runs sandboxes as plain Docker containers on THIS machine (the one
+// running kortix-api) via the local Docker socket — no cloud provider
+// account, no multi-node scheduling. Same contract as every other provider;
+// no caller may special-case its name (see provider-boundary.test.ts).
+export type SandboxProviderName = 'daytona' | 'platinum' | 'e2b' | 'local-docker';
 type InternalKortixEnv = 'dev' | 'staging' | 'prod' | 'preview';
 
 // ─── Zod Helpers ────────────────────────────────────────────────────────────
@@ -399,6 +404,24 @@ const envSchema = z.object({
   E2B_API_KEY:                 optStr,
   E2B_TEMPLATE:                optStr,
 
+  // ── Local Docker — EXPERIMENTAL sandbox provider (same-machine only) ────
+  // Runs sandboxes as Docker containers on the SAME host as kortix-api, via
+  // the local Docker socket. No API key required — "configured" means the
+  // Docker daemon is reachable, checked lazily at first provider use (create/
+  // start/stop/status), never at boot (self-host must still start with no
+  // Docker access so the operator can reach the dashboard).
+  //   LOCAL_DOCKER_NETWORK     — Docker network every kortix-sb-* container
+  //     joins, so kortix-api can reach it by container DNS name
+  //     (http://kortix-sb-<id>:<port>). The self-host CLI points this at the
+  //     Compose project's own default network when local-docker is selected
+  //     (see kortix-compose.yml). Auto-created (idempotent) if missing, so a
+  //     bare `pnpm dev` / standalone use still works.
+  //   LOCAL_DOCKER_SOCKET_PATH — override for the Docker Engine unix socket.
+  //     Empty = dockerode's own default (respects DOCKER_HOST, else
+  //     /var/run/docker.sock).
+  LOCAL_DOCKER_NETWORK:        optStrDefault('kortix-local-docker'),
+  LOCAL_DOCKER_SOCKET_PATH:    optStr,
+
   // ── Sandbox Platform ──────────────────────────────────────────────────────
   // Public API base URL, without a route suffix. Auto-derived from PORT in local mode.
   KORTIX_URL:                  optStr,
@@ -520,7 +543,7 @@ type EnvIssue = { var: string; message: string; level: 'error' | 'warn' };
 // Recognised provider names. Source-of-truth for what can legally appear in
 // ALLOWED_SANDBOX_PROVIDERS — adding a new provider is a one-place change
 // here plus a case in `getProvider()` in platform/providers/index.ts.
-const KNOWN_PROVIDERS: readonly SandboxProviderName[] = ['daytona', 'platinum', 'e2b'] as const;
+export const KNOWN_PROVIDERS: readonly SandboxProviderName[] = ['daytona', 'platinum', 'e2b', 'local-docker'] as const;
 
 /** Parse comma-separated provider list (e.g. "daytona,platinum"). */
 function parseAllowedProviders(raw: string): SandboxProviderName[] {
@@ -817,6 +840,8 @@ export const config = {
   PLATINUM_WEBHOOK_SECRET: env.PLATINUM_WEBHOOK_SECRET,
   E2B_API_KEY: env.E2B_API_KEY,
   E2B_TEMPLATE: env.E2B_TEMPLATE,
+  LOCAL_DOCKER_NETWORK: env.LOCAL_DOCKER_NETWORK,
+  LOCAL_DOCKER_SOCKET_PATH: env.LOCAL_DOCKER_SOCKET_PATH,
 
   // ─── Sandbox Provisioning (Platform) ──────────────────────────────────────
   KORTIX_URL: env.KORTIX_URL,
@@ -933,6 +958,11 @@ export const config = {
       case 'daytona': return !!this.DAYTONA_API_KEY;
       case 'platinum': return !!this.PLATINUM_API_KEY;
       case 'e2b': return !!this.E2B_API_KEY;
+      // No API key: "enabled" means selected. Docker socket reachability is
+      // checked lazily at first real use (create/start/stop/status) — see
+      // platform/providers/local-docker.ts — never here, so an operator can
+      // still start the API/dashboard before Docker is wired up.
+      case 'local-docker': return true;
       default: {
         const exhaustive: never = name;
         return exhaustive;
@@ -956,6 +986,10 @@ export const config = {
 
   isPlatinumEnabled(): boolean {
     return this.ALLOWED_SANDBOX_PROVIDERS.includes('platinum') && !!this.PLATINUM_API_KEY;
+  },
+
+  isLocalDockerEnabled(): boolean {
+    return this.ALLOWED_SANDBOX_PROVIDERS.includes('local-docker');
   },
 
   isE2BEnabled(): boolean {

--- a/apps/api/src/llm-gateway/sandbox-base-url.test.ts
+++ b/apps/api/src/llm-gateway/sandbox-base-url.test.ts
@@ -1,0 +1,64 @@
+// resolveLlmGatewayBaseUrl is the ONE formula both session-sandbox.ts (boot)
+// and projects/lib/sandbox-env-sync.ts (hot env-push) must share — a second,
+// hand-rolled copy at either call site is exactly how local-docker's
+// KORTIX_LLM_BASE_URL fix got silently undone by the very next prompt (the
+// hot-push path kept computing the generic public origin). These tests pin
+// down the formula in isolation so a future edit can't drift the two call
+// sites apart again.
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+process.env.KORTIX_URL = 'https://api.example.com';
+process.env.FRONTEND_URL = 'https://app.example.com';
+delete process.env.LLM_GATEWAY_BASE_URL;
+delete process.env.LLM_GATEWAY_PROXY_PORT;
+delete process.env.LLM_GATEWAY_PROXY_TARGET;
+
+const { config } = await import('../config');
+const { resolveLlmGatewayBaseUrl } = await import('./sandbox-base-url');
+
+describe('resolveLlmGatewayBaseUrl', () => {
+  beforeEach(() => {
+    config.LLM_GATEWAY_BASE_URL = '';
+    config.LLM_GATEWAY_PROXY_PORT = 0;
+    config.LLM_GATEWAY_PROXY_TARGET = '';
+  });
+
+  test('default (no proxy mode): {origin}/v1/llm', () => {
+    expect(resolveLlmGatewayBaseUrl('https://api.example.com')).toBe(
+      'https://api.example.com/v1/llm',
+    );
+  });
+
+  test('strips a trailing slash off the origin before appending the suffix', () => {
+    expect(resolveLlmGatewayBaseUrl('https://api.example.com/')).toBe(
+      'https://api.example.com/v1/llm',
+    );
+  });
+
+  test('local-docker-style origin (Docker network DNS) round-trips the same way', () => {
+    expect(resolveLlmGatewayBaseUrl('http://kortix-api:8008')).toBe(
+      'http://kortix-api:8008/v1/llm',
+    );
+  });
+
+  test('proxy mode (LLM_GATEWAY_PROXY_PORT set): {origin}/v1/llm-gateway/v1/llm', () => {
+    config.LLM_GATEWAY_PROXY_PORT = 8090;
+    expect(resolveLlmGatewayBaseUrl('http://kortix-api:8008')).toBe(
+      'http://kortix-api:8008/v1/llm-gateway/v1/llm',
+    );
+  });
+
+  test('proxy mode via LLM_GATEWAY_PROXY_TARGET (K8s-style) takes the same branch', () => {
+    config.LLM_GATEWAY_PROXY_TARGET = 'llm-gateway:8090';
+    expect(resolveLlmGatewayBaseUrl('https://api.example.com')).toBe(
+      'https://api.example.com/v1/llm-gateway/v1/llm',
+    );
+  });
+
+  test('an explicit LLM_GATEWAY_BASE_URL override always wins, regardless of origin', () => {
+    config.LLM_GATEWAY_BASE_URL = 'https://gateway.internal.example.com/v1/llm';
+    expect(resolveLlmGatewayBaseUrl('http://kortix-api:8008')).toBe(
+      'https://gateway.internal.example.com/v1/llm',
+    );
+  });
+});

--- a/apps/api/src/llm-gateway/sandbox-base-url.ts
+++ b/apps/api/src/llm-gateway/sandbox-base-url.ts
@@ -1,0 +1,29 @@
+/**
+ * The single source of truth for "what URL does OpenCode's in-sandbox `kortix`
+ * LLM provider hit" (KORTIX_LLM_BASE_URL). Takes the ORIGIN a sandbox should
+ * use to reach kortix-api and applies the proxy-mode suffix rule.
+ *
+ * Deliberately a tiny, dependency-free module (only `../config`) rather than
+ * living inline in session-sandbox.ts or sandbox-env-sync.ts: BOTH of those
+ * need it —
+ *   - session-sandbox.ts computes it once at sandbox boot (KORTIX_LLM_BASE_URL
+ *     injected into the container's env), using
+ *     `provider.sandboxFacingApiOrigin() ?? config.KORTIX_URL` as the origin.
+ *   - projects/lib/sandbox-env-sync.ts recomputes it on every prompt / gateway-
+ *     mode toggle (the hot env-push path posts it to the running daemon).
+ * A same-machine provider's fix at boot time is silently undone by the next
+ * prompt's hot push if that second call site keeps its own copy of this
+ * formula hardcoded to the generic public origin — exactly what happened with
+ * local-docker (KORTIX_LLM_BASE_URL fell back to the unreachable
+ * `${KORTIX_URL}/v1/llm` from inside the sandbox's private Docker network).
+ * One implementation, called with the right origin at every call site, closes
+ * that gap for good.
+ */
+import { config } from '../config';
+
+export function resolveLlmGatewayBaseUrl(origin: string): string {
+  if (config.LLM_GATEWAY_BASE_URL) return config.LLM_GATEWAY_BASE_URL;
+  const trimmedOrigin = origin.replace(/\/+$/, '');
+  const llmProxyMode = config.LLM_GATEWAY_PROXY_PORT || config.LLM_GATEWAY_PROXY_TARGET;
+  return llmProxyMode ? `${trimmedOrigin}/v1/llm-gateway/v1/llm` : `${trimmedOrigin}/v1/llm`;
+}

--- a/apps/api/src/platform/providers/compute-rates.ts
+++ b/apps/api/src/platform/providers/compute-rates.ts
@@ -31,6 +31,17 @@ const PROVIDER_COMPUTE_RATE_CARDS: Record<ProviderName, ProviderComputeRateCard>
     diskPerGbSecond: 0,
     providerCostMultiplier: 1,
   },
+  // local-docker runs on the operator's OWN hardware — there is no third-party
+  // bill to pass through. Zero-rate, same modeling approach as Platinum's
+  // internal chargeback (a real rate card, just multiplied by zero) rather
+  // than special-casing this provider out of the billing/metering path
+  // entirely — usage is still recorded, simply at no cost.
+  'local-docker': {
+    cpuPerCoreSecond: 0,
+    memoryPerGbSecond: 0,
+    diskPerGbSecond: 0,
+    providerCostMultiplier: 0,
+  },
 };
 
 export function getProviderComputeRateCard(name: ProviderName): ProviderComputeRateCard {

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -154,6 +154,7 @@ export function daytonaLifecycle(autoStopOverride?: number): {
 
 export class DaytonaProvider implements SandboxProvider {
   readonly name: ProviderName = 'daytona';
+  readonly requiresPublicCallback = true;
 
   readonly provisioning: ProvisioningTraits = {
     async: false,

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -137,6 +137,7 @@ async function ensureKortixEntrypoint(
 
 export class E2BProvider implements SandboxProvider {
   readonly name: ProviderName = 'e2b';
+  readonly requiresPublicCallback = true;
 
   readonly provisioning: ProvisioningTraits = {
     async: false,

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -129,6 +129,23 @@ export interface SandboxProvider {
    */
   readonly requiresPublicCallback: boolean;
 
+  /**
+   * The origin (scheme + host[:port], no trailing slash) sandboxes booted by
+   * this provider should use for any in-sandbox URL that is rooted at
+   * "kortix-api's own HTTP surface" — e.g. the LLM-gateway base URL the
+   * session-env layer hands OpenCode (KORTIX_LLM_BASE_URL), or any future
+   * such URL. OPTIONAL: every remote cloud provider (Daytona/Platinum/E2B)
+   * is happy with the generic public `config.KORTIX_URL`, so callers fall
+   * back to that when a provider doesn't implement this. local-docker is the
+   * one exception — its sandboxes share a private Docker network with
+   * kortix-api instead of reaching it over the public internet — so it's the
+   * only provider that overrides this (see local-docker.ts's
+   * sandboxInternalApiBase()). Keeping the capability on the provider (like
+   * requiresPublicCallback above) means a shared layer that needs "the API's
+   * origin, as this sandbox would see it" never branches on provider name.
+   */
+  sandboxFacingApiOrigin?(): string;
+
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   start(externalId: string): Promise<void>;
   stop(externalId: string): Promise<void>;

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -2,6 +2,7 @@ import { config } from '../../config';
 import { DaytonaProvider } from './daytona';
 import { E2BProvider } from './e2b';
 import { PlatinumProvider } from './platinum';
+import { LocalDockerProvider } from './local-docker';
 
 /**
  * Sandbox provider lineup. Extensible registry — adding a new runtime is
@@ -12,8 +13,10 @@ import { PlatinumProvider } from './platinum';
  *   - daytona — Daytona Cloud
  *   - platinum — Kortix Platinum
  *   - e2b — E2B Cloud
+ *   - local-docker — EXPERIMENTAL. Same-machine Docker containers (see
+ *     local-docker.ts) — no cloud account, not horizontally scalable.
  */
-export type ProviderName = 'daytona' | 'platinum' | 'e2b';
+export type ProviderName = 'daytona' | 'platinum' | 'e2b' | 'local-docker';
 
 /**
  * Thrown by the Daytona warm path when the experimental memory-snapshot restore
@@ -112,6 +115,19 @@ export interface ProvisioningStatus {
 export interface SandboxProvider {
   readonly name: ProviderName;
   readonly provisioning: ProvisioningTraits;
+  /**
+   * Whether this provider's sandboxes reach kortix-api over the PUBLIC
+   * internet. True for every remote cloud provider (Daytona/Platinum/E2B) —
+   * their sandbox VMs/containers run on infrastructure that can only resolve
+   * a publicly reachable KORTIX_URL, never a loopback address. False for a
+   * same-machine provider (local-docker) whose sandboxes reach kortix-api
+   * over the shared Docker network instead, so a loopback KORTIX_URL is
+   * perfectly fine there. Session creation's reachability preflight
+   * (sandboxCallbackUnreachableReason in projects/lib/sessions.ts) is the
+   * ONLY reader of this flag — keeping the capability on the provider
+   * instead of a call-site `provider === 'local-docker'` check.
+   */
+  readonly requiresPublicCallback: boolean;
 
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;
   start(externalId: string): Promise<void>;
@@ -190,6 +206,12 @@ export function getProvider(name: ProviderName): SandboxProvider {
         throw new Error('E2B provider requires E2B_API_KEY to be set.');
       }
       provider = new E2BProvider();
+      break;
+    case 'local-docker':
+      // No required API key — Docker daemon reachability is checked lazily at
+      // first real use (create/start/stop/status), not at construction, so
+      // the API can still boot before Docker is wired up. See local-docker.ts.
+      provider = new LocalDockerProvider();
       break;
     default: {
       const exhaustive: never = name;

--- a/apps/api/src/platform/providers/local-docker-live.test.ts
+++ b/apps/api/src/platform/providers/local-docker-live.test.ts
@@ -1,0 +1,222 @@
+// LIVE integration test against the REAL local Docker daemon — no mocks.
+// Skipped unless RUN_LOCAL_DOCKER_LIVE=1 (this machine has Docker; CI does
+// not enable this by default). Builds a TINY stand-in image (busybox's static
+// httpd — no network needed, `alpine` is already cached locally) rather than
+// the full multi-GB sandbox image, and exercises the exact same
+// create/stop/start/remove/ingress lifecycle a real session goes through.
+//
+// Run: `RUN_LOCAL_DOCKER_LIVE=1 dotenvx run -- bun test src/platform/providers/local-docker-live.test.ts`
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import Docker from 'dockerode';
+
+process.env.ALLOWED_SANDBOX_PROVIDERS = 'local-docker';
+process.env.KORTIX_URL = 'http://localhost:8008';
+process.env.INTERNAL_KORTIX_ENV = 'dev';
+process.env.FRONTEND_URL = 'http://localhost:3000';
+
+const RUN_LIVE = process.env.RUN_LOCAL_DOCKER_LIVE === '1';
+const describeLive = RUN_LIVE ? describe : describe.skip;
+
+// Dedicated, disposable network/image tag names so this never collides with a
+// real self-host instance's own `kortix-local-docker` network on the same
+// machine.
+const TEST_NETWORK = `kortix-ld-live-net-${randomUUID().slice(0, 8)}`;
+const TEST_IMAGE = `kortix-ld-live-image-${randomUUID().slice(0, 8)}:latest`;
+process.env.LOCAL_DOCKER_NETWORK = TEST_NETWORK;
+
+const { LocalDockerProvider } = await import('./local-docker');
+
+let docker: Docker;
+let buildContextDir: string;
+const createdExternalIds: string[] = [];
+
+async function waitFor<T>(fn: () => Promise<T>, predicate: (v: T) => boolean, timeoutMs = 15_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T;
+  do {
+    last = await fn();
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, 250));
+  } while (Date.now() < deadline);
+  return last!;
+}
+
+describeLive('local-docker provider — LIVE against the real Docker daemon', () => {
+  beforeAll(async () => {
+    docker = new Docker();
+    await docker.ping(); // fail fast + loud if Docker genuinely isn't available here
+
+    // Tiny stand-in for the agent daemon: busybox's built-in static httpd,
+    // baked into `alpine` — no package install, no network fetch at build time.
+    buildContextDir = await mkdtemp(join(tmpdir(), 'kortix-ld-live-'));
+    // alpine's busybox build here has no `httpd` applet and no python3 — the
+    // smallest possible HTTP stand-in that needs NOTHING beyond what's
+    // already in the base image is a `nc`-in-a-loop responder that always
+    // answers with whatever is currently in /www/current.txt, ignoring the
+    // request path (path-based routing is irrelevant to what this test
+    // verifies: that writes persist across stop/start and are reachable).
+    await writeFile(
+      join(buildContextDir, 'Dockerfile'),
+      [
+        'FROM alpine:latest',
+        'RUN mkdir -p /www && echo "kortix-local-docker-live-test-boot" > /www/current.txt',
+        'EXPOSE 8000',
+        'CMD ["sh", "-c", "while true; do { printf \'HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\nConnection: close\\r\\n\\r\\n\'; cat /www/current.txt; } | nc -l -p 8000; done"]',
+        '',
+      ].join('\n'),
+    );
+    const stream = await docker.buildImage(
+      { context: buildContextDir, src: ['Dockerfile'] },
+      { t: TEST_IMAGE },
+    );
+    await new Promise<void>((resolve, reject) => {
+      docker.modem.followProgress(stream, (err: Error | null) => (err ? reject(err) : resolve()));
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    for (const id of createdExternalIds) {
+      await docker.getContainer(`kortix-sb-${id}`).remove({ force: true, v: true }).catch(() => {});
+    }
+    await docker.getImage(TEST_IMAGE).remove({ force: true }).catch(() => {});
+    await docker.getNetwork(TEST_NETWORK).remove().catch(() => {});
+    await rm(buildContextDir, { recursive: true, force: true }).catch(() => {});
+  }, 30_000);
+
+  test('create → write a file → stop (preserved) → start (resume) → file persisted → remove (gone)', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create({
+      accountId: 'live-acct',
+      userId: 'live-user',
+      name: 'live-session-1',
+      snapshot: TEST_IMAGE,
+      envVars: { KORTIX_SANDBOX_TOKEN: 'live-test-token' },
+    });
+    createdExternalIds.push(externalId);
+
+    expect(await provider.getStatus(externalId)).toBe('running');
+
+    // Write a file INSIDE the running container via docker exec (simulating
+    // an agent leaving state in the workspace).
+    const container = docker.getContainer(`kortix-sb-${externalId}`);
+    const exec = await container.exec({
+      Cmd: ['sh', '-c', 'echo -n "persisted-content" > /www/current.txt'],
+      AttachStdout: true,
+      AttachStderr: true,
+    });
+    const execStream = await exec.start({});
+    await new Promise<void>((resolve, reject) => {
+      execStream.on('end', () => resolve());
+      execStream.on('error', reject);
+      execStream.resume();
+    });
+
+    // Reachability via the published debug port (this test process runs on
+    // the host, not on the Docker network — see local-docker.ts's comment on
+    // why the provider always ALSO publishes the agent port to loopback).
+    // Re-inspect on every read rather than capturing the port once: Docker
+    // Desktop reassigns a NEW ephemeral host port (HostPort: '0') on every
+    // `docker start` of an existing container — the mapping is stable while
+    // running but is NOT guaranteed stable across a stop/start cycle. This is
+    // exactly why the provider's real (non-debug) path — resolveIngress/
+    // resolveEndpoint — never uses the published port at all; it always
+    // addresses the container by its stable Docker-network DNS name instead.
+    const readFile = async () => {
+      try {
+        const inspected = await container.inspect();
+        const hostPort = inspected.NetworkSettings?.Ports?.['8000/tcp']?.[0]?.HostPort;
+        if (!hostPort) return null;
+        // Each connection is served once by the nc-in-a-loop stand-in (see the
+        // Dockerfile above) and a fresh connection can race the loop
+        // respawning its listener — swallow a transient connection failure
+        // and retry via waitFor rather than treating it as absent content.
+        const res = await fetch(`http://127.0.0.1:${hostPort}/`);
+        return res.ok ? res.text() : null;
+      } catch {
+        return null;
+      }
+    };
+    expect(await waitFor(readFile, (v) => v === 'persisted-content')).toBe('persisted-content');
+
+    // ── stop(): status flips to stopped, container is PRESERVED (not removed) ──
+    await provider.stop(externalId);
+    expect(await provider.getStatus(externalId)).toBe('stopped');
+    await expect(container.inspect()).resolves.toBeTruthy(); // still exists
+
+    // ── start(): resumes; the file written before stop is still there ──
+    await provider.start(externalId);
+    expect(await provider.getStatus(externalId)).toBe('running');
+    expect(await waitFor(readFile, (v) => v === 'persisted-content')).toBe('persisted-content');
+
+    // ── ingress resolution: the container is reachable by its Docker network
+    // DNS name from ANOTHER container on the same network — the real
+    // production path (kortix-api and every sandbox share this network) ──
+    const ingress = await provider.resolveIngress(externalId, { port: 8000 });
+    expect(ingress.url).toBe(`http://kortix-sb-${externalId}:8000`);
+    const prober = await docker.createContainer({
+      Image: TEST_IMAGE,
+      Cmd: ['wget', '-qO-', `http://kortix-sb-${externalId}:8000/`],
+      HostConfig: { NetworkMode: TEST_NETWORK },
+    });
+    await prober.start();
+    await prober.wait();
+    const logs = (await prober.logs({ stdout: true, stderr: true })) as unknown as Buffer;
+    await prober.remove({ force: true }).catch(() => {});
+    expect(logs.toString('utf8')).toContain('persisted-content');
+
+    // ── remove(): container is actually gone ──
+    await provider.remove(externalId);
+    expect(await provider.getStatus(externalId)).toBe('removed');
+    await expect(container.inspect()).rejects.toBeTruthy();
+  }, 60_000);
+
+  test('getStatus() tracks reality when the container is stopped EXTERNALLY (not through the provider)', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create({
+      accountId: 'live-acct',
+      userId: 'live-user',
+      name: 'live-session-external-stop',
+      snapshot: TEST_IMAGE,
+      envVars: { KORTIX_SANDBOX_TOKEN: 'live-test-token' },
+    });
+    createdExternalIds.push(externalId);
+    expect(await provider.getStatus(externalId)).toBe('running');
+
+    // Stop it directly via raw dockerode — an operator running `docker stop`
+    // by hand, completely outside the provider's own bookkeeping.
+    await docker.getContainer(`kortix-sb-${externalId}`).stop();
+    expect(await provider.getStatus(externalId)).toBe('stopped');
+
+    await provider.remove(externalId);
+  }, 30_000);
+
+  test('listManagedRunningSandboxes() is label-scoped across two concurrent sandboxes', async () => {
+    const provider = new LocalDockerProvider();
+    const a = await provider.create({
+      accountId: 'live-acct', userId: 'live-user', name: 'live-a',
+      snapshot: TEST_IMAGE, envVars: { KORTIX_SANDBOX_TOKEN: 'tok-a' },
+    });
+    const b = await provider.create({
+      accountId: 'live-acct', userId: 'live-user', name: 'live-b',
+      snapshot: TEST_IMAGE, envVars: { KORTIX_SANDBOX_TOKEN: 'tok-b' },
+    });
+    createdExternalIds.push(a.externalId, b.externalId);
+
+    const runningBoth = await provider.listManagedRunningSandboxes!();
+    const ids = runningBoth.map((x) => x.externalId);
+    expect(ids).toContain(a.externalId);
+    expect(ids).toContain(b.externalId);
+
+    await provider.stop(b.externalId);
+    const runningOne = await provider.listManagedRunningSandboxes!();
+    expect(runningOne.map((x) => x.externalId)).toContain(a.externalId);
+    expect(runningOne.map((x) => x.externalId)).not.toContain(b.externalId);
+
+    await provider.remove(a.externalId);
+    await provider.remove(b.externalId);
+  }, 45_000);
+});

--- a/apps/api/src/platform/providers/local-docker.test.ts
+++ b/apps/api/src/platform/providers/local-docker.test.ts
@@ -1,0 +1,408 @@
+// Full provider-contract coverage for the EXPERIMENTAL local-docker provider,
+// against a mocked dockerode client — mirrors the shape of daytona.test.ts /
+// e2b.test.ts (real config, real provider class, fake transport).
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+process.env.ALLOWED_SANDBOX_PROVIDERS = 'local-docker';
+process.env.KORTIX_URL = 'https://api.example.com';
+process.env.INTERNAL_KORTIX_ENV = 'dev';
+process.env.FRONTEND_URL = 'https://app.example.com';
+process.env.LOCAL_DOCKER_NETWORK = 'kortix-local-docker-test';
+process.env.PORT = '8008';
+delete process.env.LOCAL_DOCKER_API_HOST;
+delete process.env.LOCAL_DOCKER_API_PORT;
+
+mock.module('../service-key', () => ({
+  serviceKeyForExternalId: async () => 'service-key-test',
+}));
+
+interface FakeContainerRecord {
+  id: string;
+  name: string;
+  image: string;
+  labels: Record<string, string>;
+  running: boolean;
+  createdEpochSeconds: number;
+  hostPort: number;
+}
+
+function dockerError(statusCode: number, message: string): Error {
+  const err = new Error(message) as Error & { statusCode: number };
+  err.statusCode = statusCode;
+  return err;
+}
+
+class FakeDocker {
+  containers = new Map<string, FakeContainerRecord>();
+  networks = new Set<string>();
+  pingOk = true;
+  nextId = 0;
+  createContainerCalls: Array<Record<string, unknown>> = [];
+  createContainerError: Error | null = null;
+
+  async ping() {
+    if (!this.pingOk) throw new Error('connect ECONNREFUSED /var/run/docker.sock');
+    return true;
+  }
+
+  getNetwork(name: string) {
+    return {
+      inspect: async () => {
+        if (!this.networks.has(name)) throw dockerError(404, 'network not found');
+        return { Name: name };
+      },
+    };
+  }
+
+  async createNetwork(opts: { Name: string }) {
+    this.networks.add(opts.Name);
+    return { id: opts.Name };
+  }
+
+  async createContainer(opts: Record<string, unknown>) {
+    this.createContainerCalls.push(opts);
+    if (this.createContainerError) throw this.createContainerError;
+    const name = opts.name as string;
+    if (this.containers.has(name)) {
+      throw dockerError(409, `Conflict. The container name "/${name}" is already in use`);
+    }
+    const id = `cid-${++this.nextId}`;
+    this.containers.set(name, {
+      id,
+      name,
+      image: opts.Image as string,
+      labels: (opts.Labels as Record<string, string>) ?? {},
+      running: false,
+      createdEpochSeconds: 1_700_000_000 + this.nextId,
+      hostPort: 32000 + this.nextId,
+    });
+    return this.containerHandle(name);
+  }
+
+  getContainer(name: string) {
+    return this.containerHandle(name);
+  }
+
+  private containerHandle(name: string) {
+    const docker = this;
+    return {
+      get id() {
+        return docker.containers.get(name)?.id ?? '';
+      },
+      async start() {
+        const c = docker.containers.get(name);
+        if (!c) throw dockerError(404, 'no such container');
+        if (c.running) throw dockerError(304, 'container already started');
+        c.running = true;
+      },
+      async stop() {
+        const c = docker.containers.get(name);
+        if (!c) throw dockerError(404, 'no such container');
+        if (!c.running) throw dockerError(304, 'container already stopped');
+        c.running = false;
+      },
+      async remove() {
+        if (!docker.containers.has(name)) throw dockerError(404, 'no such container');
+        docker.containers.delete(name);
+      },
+      async inspect() {
+        const c = docker.containers.get(name);
+        if (!c) throw dockerError(404, 'no such container');
+        return {
+          Id: c.id,
+          Created: new Date(c.createdEpochSeconds * 1000).toISOString(),
+          State: { Running: c.running, Status: c.running ? 'running' : 'exited' },
+          Config: { Image: c.image },
+          NetworkSettings: {
+            Ports: { '8000/tcp': [{ HostIp: '127.0.0.1', HostPort: String(c.hostPort) }] },
+          },
+        };
+      },
+    };
+  }
+
+  async listContainers(opts: { filters?: string }) {
+    const filters = opts.filters ? JSON.parse(opts.filters) : {};
+    const wantedLabels: string[] = filters.label ?? [];
+    const out: Array<Record<string, unknown>> = [];
+    for (const c of this.containers.values()) {
+      if (!c.running) continue;
+      const matches = wantedLabels.every((kv) => {
+        const [k, v] = kv.split('=');
+        return c.labels[k] === v;
+      });
+      if (!matches) continue;
+      out.push({
+        Id: c.id,
+        Names: [`/${c.name}`],
+        Labels: c.labels,
+        Created: c.createdEpochSeconds,
+      });
+    }
+    return out;
+  }
+}
+
+const { config } = await import('../../config');
+const { LocalDockerProvider, __setDockerClientForTest } = await import('./local-docker');
+const { getProvider } = await import('./index');
+
+let fakeDocker: FakeDocker;
+
+beforeEach(() => {
+  fakeDocker = new FakeDocker();
+  __setDockerClientForTest(fakeDocker);
+});
+
+function baseCreateOpts(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    accountId: 'acct-1',
+    userId: 'user-1',
+    name: 'session-abcd1234',
+    snapshot: 'kortix-default-abc123',
+    envVars: { KORTIX_SANDBOX_TOKEN: 'sb-token-1' },
+    ...overrides,
+  } as any;
+}
+
+describe('local-docker provider — registry admission', () => {
+  test('ALLOWED_SANDBOX_PROVIDERS=local-docker admits it with no API key', () => {
+    expect(config.ALLOWED_SANDBOX_PROVIDERS).toEqual(['local-docker']);
+    expect(config.isProviderEnabled('local-docker')).toBe(true);
+    const provider = getProvider('local-docker');
+    expect(provider.name).toBe('local-docker');
+    expect(provider).toBeInstanceOf(LocalDockerProvider);
+  });
+});
+
+describe('local-docker provider — create()', () => {
+  test('runs a container named kortix-sb-<externalId> with the managed label scheme', async () => {
+    const provider = new LocalDockerProvider();
+    const result = await provider.create(baseCreateOpts());
+
+    expect(result.externalId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(result.baseUrl).toBe(`https://api.example.com/v1/p/${result.externalId}/8000`);
+
+    const call = fakeDocker.createContainerCalls[0]!;
+    expect(call.name).toBe(`kortix-sb-${result.externalId}`);
+    expect(call.Image).toBe('kortix-default-abc123');
+    expect(call.Labels).toEqual({
+      'kortix.managed': 'true',
+      'kortix.env': 'dev',
+      'kortix.sandbox': result.externalId,
+    });
+    const hostConfig = call.HostConfig as Record<string, unknown>;
+    expect(hostConfig.NetworkMode).toBe('kortix-local-docker-test');
+
+    // Container was actually started (persistence semantics start at 'running').
+    const status = await provider.getStatus(result.externalId);
+    expect(status).toBe('running');
+  });
+
+  test('injects the standard sandbox env vars (KORTIX_API_URL, KORTIX_FRONTEND_URL, token)', async () => {
+    const provider = new LocalDockerProvider();
+    await provider.create(baseCreateOpts({ envVars: { KORTIX_SANDBOX_TOKEN: 'tok', KORTIX_CLI_TOKEN: 'cli-tok' } }));
+    const env = fakeDocker.createContainerCalls[0]!.Env as string[];
+    const asMap = Object.fromEntries(env.map((line) => {
+      const idx = line.indexOf('=');
+      return [line.slice(0, idx), line.slice(idx + 1)];
+    }));
+    expect(asMap.KORTIX_API_URL).toBe('http://kortix-api:8008/v1');
+    expect(asMap.KORTIX_FRONTEND_URL).toBe('https://app.example.com');
+    expect(asMap.KORTIX_SANDBOX_TOKEN).toBe('tok');
+    expect(asMap.KORTIX_CLI_TOKEN).toBe('cli-tok');
+  });
+
+  // Regression: buildSessionRuntimeEnv() (projects/lib/session-runtime-env.ts)
+  // unconditionally sets KORTIX_API_URL/KORTIX_FRONTEND_URL from the generic
+  // public config.KORTIX_URL for EVERY provider — the right value for a
+  // remote cloud sandbox, but WRONG for local-docker, whose container must
+  // reach kortix-api by Docker network DNS name instead. Caught live: a
+  // session's sandbox couldn't reach the control plane at all because the
+  // generic value silently clobbered the provider's own Docker-DNS URL.
+  test('KORTIX_API_URL / KORTIX_FRONTEND_URL from this file always win over whatever opts.envVars sets', async () => {
+    const provider = new LocalDockerProvider();
+    await provider.create(baseCreateOpts({
+      envVars: {
+        KORTIX_SANDBOX_TOKEN: 'tok',
+        KORTIX_API_URL: 'https://api.example.com/v1', // the generic (public) value a real caller injects
+        KORTIX_FRONTEND_URL: 'https://api.example.com', // ditto
+      },
+    }));
+    const env = fakeDocker.createContainerCalls[0]!.Env as string[];
+    const asMap = Object.fromEntries(env.map((line) => {
+      const idx = line.indexOf('=');
+      return [line.slice(0, idx), line.slice(idx + 1)];
+    }));
+    expect(asMap.KORTIX_API_URL).toBe('http://kortix-api:8008/v1');
+    expect(asMap.KORTIX_FRONTEND_URL).toBe('https://app.example.com');
+  });
+
+  test('auto-creates the configured Docker network if missing', async () => {
+    expect(fakeDocker.networks.has('kortix-local-docker-test')).toBe(false);
+    const provider = new LocalDockerProvider();
+    await provider.create(baseCreateOpts());
+    expect(fakeDocker.networks.has('kortix-local-docker-test')).toBe(true);
+  });
+
+  test('applies a resource ceiling (--cpus / --memory equivalent) to every container', async () => {
+    const provider = new LocalDockerProvider();
+    await provider.create(baseCreateOpts());
+    const hostConfig = fakeDocker.createContainerCalls[0]!.HostConfig as Record<string, unknown>;
+    expect(typeof hostConfig.NanoCpus).toBe('number');
+    expect(hostConfig.NanoCpus).toBeGreaterThan(0);
+    expect(typeof hostConfig.Memory).toBe('number');
+    expect(hostConfig.Memory).toBeGreaterThan(0);
+  });
+
+  test('throws a clear error when opts.snapshot is missing (no shared fallback image, matches Daytona)', async () => {
+    const provider = new LocalDockerProvider();
+    await expect(provider.create(baseCreateOpts({ snapshot: undefined }))).rejects.toThrow(/opts\.snapshot/);
+  });
+
+  test('throws when KORTIX_SANDBOX_TOKEN is missing', async () => {
+    const provider = new LocalDockerProvider();
+    await expect(provider.create(baseCreateOpts({ envVars: {} }))).rejects.toThrow(/KORTIX_SANDBOX_TOKEN/);
+  });
+
+  test('throws a clear, actionable error when the Docker socket is unreachable', async () => {
+    fakeDocker.pingOk = false;
+    const provider = new LocalDockerProvider();
+    await expect(provider.create(baseCreateOpts())).rejects.toThrow(/Docker daemon is not reachable/);
+  });
+
+  test('propagates a missing-image error from the daemon (error path: image not built yet)', async () => {
+    fakeDocker.createContainerError = dockerError(404, 'No such image: kortix-tpl-doesnotexist:latest');
+    const provider = new LocalDockerProvider();
+    await expect(provider.create(baseCreateOpts({ snapshot: 'kortix-tpl-doesnotexist' })))
+      .rejects.toThrow(/No such image/);
+  });
+
+  test('propagates a container-name conflict from the daemon (error path: name already in use)', async () => {
+    // externalId is a fresh randomUUID per create(), so a real collision never
+    // happens in practice — this exercises that create() propagates the
+    // daemon's 409 unmodified rather than swallowing or misreporting it,
+    // exactly like the missing-image case above.
+    fakeDocker.createContainerError = dockerError(409, 'Conflict. The container name "/kortix-sb-x" is already in use');
+    const provider = new LocalDockerProvider();
+    await expect(provider.create(baseCreateOpts())).rejects.toThrow(/already in use/);
+  });
+});
+
+describe('local-docker provider — lifecycle (start/stop/remove/getStatus)', () => {
+  test('stop() preserves the container (persistence semantics) — status is stopped, not removed', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    await provider.stop(externalId);
+    expect(await provider.getStatus(externalId)).toBe('stopped');
+    expect(fakeDocker.containers.has(`kortix-sb-${externalId}`)).toBe(true);
+  });
+
+  test('start() resumes a stopped container', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    await provider.stop(externalId);
+    await provider.start(externalId);
+    expect(await provider.getStatus(externalId)).toBe('running');
+  });
+
+  test('start()/stop() are idempotent against an already-started/-stopped container (304)', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    // Already running — start() again must not throw.
+    await expect(provider.start(externalId)).resolves.toBeUndefined();
+    await provider.stop(externalId);
+    // Already stopped — stop() again must not throw.
+    await expect(provider.stop(externalId)).resolves.toBeUndefined();
+  });
+
+  test('remove() deletes the container; getStatus() then reports removed', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    await provider.remove(externalId);
+    expect(await provider.getStatus(externalId)).toBe('removed');
+    expect(fakeDocker.containers.has(`kortix-sb-${externalId}`)).toBe(false);
+  });
+
+  test('remove() on an already-missing container is a no-op, not an error', async () => {
+    const provider = new LocalDockerProvider();
+    await expect(provider.remove('never-existed')).resolves.toBeUndefined();
+  });
+
+  test('getStatus() reports removed for a container that vanished externally (e.g. manual `docker rm`)', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    fakeDocker.containers.delete(`kortix-sb-${externalId}`); // simulate external removal
+    expect(await provider.getStatus(externalId)).toBe('removed');
+  });
+
+  test('getStatus() reports unknown (never throws) when the Docker socket is down', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    fakeDocker.pingOk = false;
+    expect(await provider.getStatus(externalId)).toBe('unknown');
+  });
+
+  test('ensureRunning() starts a stopped sandbox and no-ops a running one', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    await provider.ensureRunning(externalId); // already running — no-op
+    expect(await provider.getStatus(externalId)).toBe('running');
+    await provider.stop(externalId);
+    await provider.ensureRunning(externalId); // stopped — should start
+    expect(await provider.getStatus(externalId)).toBe('running');
+  });
+
+  test('ensureRunning() does not attempt to recover a removed sandbox (fails closed)', async () => {
+    const provider = new LocalDockerProvider();
+    await provider.ensureRunning('never-existed'); // must not throw
+    expect(await provider.getStatus('never-existed')).toBe('removed');
+  });
+});
+
+describe('local-docker provider — ingress / endpoint resolution', () => {
+  test('resolveIngress() addresses the container by network DNS name, any port, no pre-registration', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    const ingress = await provider.resolveIngress(externalId, { port: 3000 });
+    expect(ingress.url).toBe(`http://kortix-sb-${externalId}:3000`);
+    expect(ingress.effectivePort).toBe(3000);
+  });
+
+  test('resolveEndpoint() targets the agent port and injects the sandbox service key as a bearer', async () => {
+    const provider = new LocalDockerProvider();
+    const { externalId } = await provider.create(baseCreateOpts());
+    const endpoint = await provider.resolveEndpoint(externalId);
+    expect(endpoint.url).toBe(`http://kortix-sb-${externalId}:8000`);
+    expect(endpoint.headers.Authorization).toBe('Bearer service-key-test');
+    expect(endpoint.headers['Content-Type']).toBe('application/json');
+  });
+
+  test('routeIngress() is the identity mapping', () => {
+    const provider = new LocalDockerProvider();
+    expect(provider.routeIngress({ port: 4096 })).toEqual({ effectivePort: 4096 });
+  });
+});
+
+describe('local-docker provider — listManagedRunningSandboxes (reaper scoping)', () => {
+  test('lists only running, this-environment-labeled containers, scoped like every other provider', async () => {
+    const provider = new LocalDockerProvider();
+    const a = await provider.create(baseCreateOpts({ name: 'sb-a' }));
+    const b = await provider.create(baseCreateOpts({ name: 'sb-b' }));
+    await provider.stop(b.externalId); // stopped boxes must not appear
+    // A foreign-env container must be excluded even if running.
+    fakeDocker.containers.set('kortix-sb-foreign', {
+      id: 'cid-foreign',
+      name: 'kortix-sb-foreign',
+      image: 'x',
+      labels: { 'kortix.managed': 'true', 'kortix.env': 'prod', 'kortix.sandbox': 'foreign' },
+      running: true,
+      createdEpochSeconds: 1_700_000_500,
+      hostPort: 40000,
+    });
+
+    const listed = await provider.listManagedRunningSandboxes!();
+    expect(listed.map((x) => x.externalId).sort()).toEqual([a.externalId].sort());
+    expect(listed[0]!.createdAt).toBeInstanceOf(Date);
+  });
+});

--- a/apps/api/src/platform/providers/local-docker.test.ts
+++ b/apps/api/src/platform/providers/local-docker.test.ts
@@ -11,6 +11,11 @@ process.env.LOCAL_DOCKER_NETWORK = 'kortix-local-docker-test';
 process.env.PORT = '8008';
 delete process.env.LOCAL_DOCKER_API_HOST;
 delete process.env.LOCAL_DOCKER_API_PORT;
+// Deterministic LLM-gateway base-url formula regardless of ambient .env —
+// see the KORTIX_LLM_BASE_URL tests below.
+delete process.env.LLM_GATEWAY_BASE_URL;
+delete process.env.LLM_GATEWAY_PROXY_PORT;
+delete process.env.LLM_GATEWAY_PROXY_TARGET;
 
 mock.module('../service-key', () => ({
   serviceKeyForExternalId: async () => 'service-key-test',
@@ -236,6 +241,52 @@ describe('local-docker provider — create()', () => {
     }));
     expect(asMap.KORTIX_API_URL).toBe('http://kortix-api:8008/v1');
     expect(asMap.KORTIX_FRONTEND_URL).toBe('https://app.example.com');
+  });
+
+  // Regression (live, self-host "ldocker" instance): the same generic-vs-
+  // Docker-network gap as the KORTIX_API_URL bug above, but for OpenCode's own
+  // LLM-gateway base URL. session-sandbox.ts computes KORTIX_LLM_BASE_URL from
+  // the generic public origin (config.KORTIX_URL /
+  // provider.sandboxFacingApiOrigin() when available) BEFORE calling
+  // provider.create() — so opts.envVars.KORTIX_LLM_BASE_URL can still arrive
+  // here already-correct. This asserts local-docker's create() rebuilds it
+  // onto the Docker-network origin regardless, matching KORTIX_API_URL's
+  // belt-and-suspenders override above. Caught live: OpenCode inside the
+  // sandbox looped "Cannot connect to API" because KORTIX_LLM_BASE_URL fell
+  // back to `http://localhost:8777/v1/llm` — unreachable from inside the
+  // container (that's the CONTAINER's own loopback, not the host's).
+  test('KORTIX_LLM_BASE_URL is rewritten onto the Docker-network origin when present', async () => {
+    const provider = new LocalDockerProvider();
+    await provider.create(baseCreateOpts({
+      envVars: {
+        KORTIX_SANDBOX_TOKEN: 'tok',
+        KORTIX_LLM_API_KEY: 'gw-key',
+        KORTIX_LLM_BASE_URL: 'https://api.example.com/v1/llm', // the generic (public) value a real caller injects
+      },
+    }));
+    const env = fakeDocker.createContainerCalls[0]!.Env as string[];
+    const asMap = Object.fromEntries(env.map((line) => {
+      const idx = line.indexOf('=');
+      return [line.slice(0, idx), line.slice(idx + 1)];
+    }));
+    expect(asMap.KORTIX_LLM_BASE_URL).toBe('http://kortix-api:8008/v1/llm');
+    expect(asMap.KORTIX_LLM_API_KEY).toBe('gw-key'); // untouched — no URL inside it
+  });
+
+  test('leaves KORTIX_LLM_BASE_URL absent when the LLM gateway was not enabled for this session', async () => {
+    const provider = new LocalDockerProvider();
+    await provider.create(baseCreateOpts({ envVars: { KORTIX_SANDBOX_TOKEN: 'tok' } }));
+    const env = fakeDocker.createContainerCalls[0]!.Env as string[];
+    const asMap = Object.fromEntries(env.map((line) => {
+      const idx = line.indexOf('=');
+      return [line.slice(0, idx), line.slice(idx + 1)];
+    }));
+    expect(asMap.KORTIX_LLM_BASE_URL).toBeUndefined();
+  });
+
+  test('sandboxFacingApiOrigin() reports the Docker-network origin (used by session-sandbox.ts and sandbox-env-sync.ts)', () => {
+    const provider = new LocalDockerProvider();
+    expect(provider.sandboxFacingApiOrigin?.()).toBe('http://kortix-api:8008');
   });
 
   test('auto-creates the configured Docker network if missing', async () => {

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -1,0 +1,414 @@
+/**
+ * Local Docker sandbox provider — EXPERIMENTAL.
+ *
+ * Runs project sandboxes as plain Docker containers on THIS machine — the
+ * same host running kortix-api — via the local Docker Engine socket. There is
+ * no cloud account, no multi-node scheduling, no remote API: `create()` is a
+ * `docker run`, `stop()`/`start()` are `docker stop`/`docker start` (the
+ * container's writable layer is the persistence — nothing is deleted until
+ * `remove()`), and `getStatus()` is a `docker inspect`.
+ *
+ * Scope, by design: this is a single-machine provider (see the PR description
+ * for the full non-goals list — no Swarm, no multi-node, no per-container
+ * disk quotas in v1). It implements the exact same `SandboxProvider` contract
+ * as Daytona/Platinum/E2B — nothing outside this file knows local-docker
+ * exists (see provider-boundary.test.ts). Any behavior that looks like it
+ * needs a `provider === 'local-docker'` branch elsewhere belongs HERE instead.
+ */
+
+import Docker from 'dockerode';
+import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { config, SANDBOX_VERSION } from '../../config';
+import { serviceKeyForExternalId } from '../service-key';
+import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
+import type {
+  SandboxProvider,
+  ProviderName,
+  CreateSandboxOpts,
+  ProvisionResult,
+  SandboxStatus,
+  ResolvedEndpoint,
+  ProvisioningTraits,
+  ProvisioningStatus,
+  ResolvedSandboxIngress,
+  SandboxIngressRequest,
+} from './index';
+
+/** Agent daemon port every sandbox image EXPOSEs (matches every other provider). */
+const AGENT_PORT = 8000;
+
+/** Every managed container is named `kortix-sb-<externalId>` — grep-able, collision-safe. */
+const CONTAINER_PREFIX = 'kortix-sb-';
+
+/**
+ * Fixed per-container resource ceiling. Daytona/Platinum bake `cpu`/`memoryGb`
+ * from the template's spec into the SNAPSHOT itself (see snapshots/providers/
+ * daytona.ts + build-context.ts DEFAULT_CPU/DEFAULT_MEMORY_GB) and the running
+ * sandbox just inherits it — Docker has no such concept; resource limits are a
+ * `docker run` (HostConfig) property, not an image property, and
+ * `CreateSandboxOpts` (the shared provider contract) carries no per-template
+ * spec today. Rather than thread a new field through every provider for a
+ * same-machine-only implementation, apply one configurable ceiling to every
+ * local-docker container — same numbers the platform already defaults an
+ * unspecified template spec to. A per-template override is a legitimate
+ * follow-up (extend CreateSandboxOpts) but is not required for parity: every
+ * OTHER provider also falls back to its own default when a template omits a
+ * spec.
+ */
+const DEFAULT_CPUS = Number.parseFloat(process.env.LOCAL_DOCKER_CPUS || '2') || 2;
+const DEFAULT_MEMORY_GB = Number.parseFloat(process.env.LOCAL_DOCKER_MEMORY_GB || '6') || 6;
+
+// Labels stamped on every Kortix-managed local-docker container. Mirrors
+// daytona.ts's managedSandboxLabels() exactly — the reaper's
+// listManagedRunningSandboxes() scoping logic is provider-agnostic and reads
+// the SAME two labels regardless of provider.
+function managedLabels(externalId: string): Record<string, string> {
+  return {
+    'kortix.managed': 'true',
+    'kortix.env': config.INTERNAL_KORTIX_ENV,
+    'kortix.sandbox': externalId,
+  };
+}
+
+function containerName(externalId: string): string {
+  return `${CONTAINER_PREFIX}${externalId}`;
+}
+
+/** Resolve the dockerode client options from config (empty = library default). */
+function dockerOptions(): ConstructorParameters<typeof Docker>[0] {
+  const socketPath = config.LOCAL_DOCKER_SOCKET_PATH?.trim();
+  return socketPath ? { socketPath } : {};
+}
+
+let dockerClient: Docker | null = null;
+
+/** Lazily-created, memoized dockerode client. Reset only by tests. */
+export function getDockerClient(): Docker {
+  if (!dockerClient) dockerClient = new Docker(dockerOptions());
+  return dockerClient;
+}
+
+/**
+ * Test-only seam: inject a fake client (unit tests) or reset to force a fresh
+ * one next call (live tests). Typed loosely (`unknown`) so unit tests can
+ * supply a minimal structural fake instead of a full `Docker` instance.
+ */
+export function __setDockerClientForTest(client: unknown): void {
+  dockerClient = client as Docker | null;
+}
+
+/**
+ * Best-effort SYNC hint used by config.ts-adjacent readiness checks (never the
+ * gate itself — the real check is the async `assertDockerReachable` below,
+ * run at first actual provider use). A `unix://` DOCKER_HOST or the resolved
+ * default socket path is checked for existence on disk; a `tcp://` DOCKER_HOST
+ * can't be checked synchronously and is optimistically assumed present.
+ */
+export function localDockerSocketLooksPresent(): boolean {
+  const explicit = config.LOCAL_DOCKER_SOCKET_PATH?.trim();
+  const dockerHost = process.env.DOCKER_HOST?.trim();
+  if (dockerHost && /^tcp:\/\//i.test(dockerHost)) return true;
+  const path = explicit || dockerHost?.replace(/^unix:\/\//, '') || '/var/run/docker.sock';
+  try {
+    return existsSync(path);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The one clear, actionable error every local-docker entry point throws when
+ * the daemon isn't reachable — "fail at first use" per the provider's design
+ * (never at API boot, since self-host must still start with no Docker access
+ * so the operator can reach the dashboard to fix it).
+ */
+async function assertDockerReachable(docker: Docker): Promise<void> {
+  try {
+    await docker.ping();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `[local-docker] Docker daemon is not reachable (${detail}). The local-docker sandbox ` +
+      `provider requires the host's Docker socket mounted into kortix-api (self-host: select ` +
+      `"local-docker" at \`kortix self-host init\`, which wires this automatically) — or, ` +
+      `outside self-host, set LOCAL_DOCKER_SOCKET_PATH / DOCKER_HOST to a reachable Docker Engine.`,
+    );
+  }
+}
+
+/** Get-or-create the shared network every managed container joins (idempotent). */
+async function ensureNetwork(docker: Docker, name: string): Promise<void> {
+  try {
+    await docker.getNetwork(name).inspect();
+  } catch (err) {
+    if (!isNotFoundError(err)) throw err;
+    try {
+      await docker.createNetwork({ Name: name, Driver: 'bridge', CheckDuplicate: true });
+    } catch (createErr) {
+      // Lost a create race with another process/replica — fine, it exists now.
+      if (!isConflictError(createErr)) throw createErr;
+    }
+  }
+}
+
+function isNotFoundError(err: unknown): boolean {
+  const status = (err as { statusCode?: unknown } | null | undefined)?.statusCode;
+  return status === 404;
+}
+
+function isConflictError(err: unknown): boolean {
+  const status = (err as { statusCode?: unknown } | null | undefined)?.statusCode;
+  return status === 409;
+}
+
+/**
+ * The internal URL the CONTAINER uses to call back to kortix-api. Sandboxes
+ * live on the same Docker network as kortix-api in the supported (self-host)
+ * deployment shape, so Docker's own DNS resolves the compose service name —
+ * far more reliable than trying to infer a host-reachable URL from KORTIX_URL
+ * (which may be a public domain or an ephemeral tunnel neither necessary nor
+ * always resolvable from inside a container). `kortix-api` is the fixed
+ * Compose service name (see apps/cli/src/self-host/assets/kortix-compose.yml);
+ * override via LOCAL_DOCKER_API_HOST for a non-Compose topology.
+ */
+function sandboxInternalApiBase(): string {
+  const host = process.env.LOCAL_DOCKER_API_HOST?.trim() || 'kortix-api';
+  const port = process.env.LOCAL_DOCKER_API_PORT?.trim() || String(config.PORT || 8008);
+  return `http://${host}:${port}`;
+}
+
+function isMissingContainerError(err: unknown): boolean {
+  const status = (err as { statusCode?: unknown } | null | undefined)?.statusCode;
+  return status === 404;
+}
+
+function toStatus(info: Docker.ContainerInspectInfo): SandboxStatus {
+  const state = info.State;
+  if (state?.Running) return 'running';
+  if (state?.Status === 'exited' || state?.Status === 'created' || state?.Status === 'dead') return 'stopped';
+  return 'unknown';
+}
+
+export class LocalDockerProvider implements SandboxProvider {
+  readonly name: ProviderName = 'local-docker';
+  // Sandboxes are containers on the SAME machine, reached over the shared
+  // Docker network — never over the public internet. A loopback KORTIX_URL is
+  // exactly right here, so the generic reachability preflight in
+  // projects/lib/sessions.ts skips its "cloud sandbox can't call back to
+  // localhost" check for this provider (see the interface doc on this field).
+  readonly requiresPublicCallback = false;
+
+  readonly provisioning: ProvisioningTraits = {
+    async: false,
+    stages: [
+      { id: 'creating', progress: 50, message: 'Starting local container...' },
+    ],
+  };
+
+  async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
+    return null;
+  }
+
+  async create(opts: CreateSandboxOpts): Promise<ProvisionResult> {
+    // Every sandbox boots from its project's own per-project snapshot — the
+    // SAME per-provider Docker image the local-docker snapshot adapter built
+    // (apps/api/src/snapshots/providers/local-docker.ts). No shared fallback,
+    // matching Daytona's contract exactly (see daytona.ts's identical guard).
+    const snapshot = opts.snapshot;
+    if (!snapshot) {
+      throw new Error(
+        'local-docker create() called without opts.snapshot. Every sandbox must boot from a ' +
+        'per-project image built by apps/api/src/snapshots/builder.ts. There is no shared fallback.',
+      );
+    }
+    if (!opts.envVars?.KORTIX_SANDBOX_TOKEN) {
+      throw new Error('[local-docker] create() called without KORTIX_SANDBOX_TOKEN — sandbox cannot authenticate to the Kortix router.');
+    }
+
+    const docker = getDockerClient();
+    await assertDockerReachable(docker);
+
+    const network = config.LOCAL_DOCKER_NETWORK || 'kortix-local-docker';
+    await ensureNetwork(docker, network);
+
+    const externalId = randomUUID();
+    const name = containerName(externalId);
+
+    // KORTIX_API_URL/KORTIX_FRONTEND_URL are computed here (Docker-network DNS,
+    // not the generic public KORTIX_URL every OTHER provider is happy to reuse
+    // verbatim) and MUST win over whatever the generic session env-builder
+    // put in `opts.envVars` (buildSessionRuntimeEnv() unconditionally sets
+    // KORTIX_API_URL from config.KORTIX_URL for every provider, since that's
+    // the right value for a remote cloud sandbox). Spread opts.envVars FIRST
+    // so these two keys are applied on top, not the other way around.
+    const envVars: Record<string, string> = {
+      ...opts.envVars,
+      KORTIX_API_URL: `${sandboxInternalApiBase()}/v1`,
+      KORTIX_FRONTEND_URL: sandboxFrontendBaseUrl(),
+    };
+    const env = Object.entries(envVars).map(([k, v]) => `${k}=${v}`);
+
+    const container = await docker.createContainer({
+      name,
+      Image: snapshot,
+      Env: env,
+      ExposedPorts: { [`${AGENT_PORT}/tcp`]: {} },
+      Labels: managedLabels(externalId),
+      HostConfig: {
+        NetworkMode: network,
+        // Published to loopback only — convenience for operator/CLI debugging
+        // and for anything reaching the box from OUTSIDE the Docker network
+        // (e.g. a non-containerized `kortix-api` in plain `pnpm dev`). The
+        // in-network path (resolveEndpoint/resolveIngress below) never uses
+        // this; it always addresses the container by its network DNS name —
+        // load-bearing, not just style: an ephemeral `HostPort: '0'` mapping
+        // is NOT guaranteed stable across a stop/start cycle (observed
+        // reassigning to a new port on Docker Desktop), so anything that
+        // depended on this published port surviving a resume would be wrong.
+        PortBindings: { [`${AGENT_PORT}/tcp`]: [{ HostIp: '127.0.0.1', HostPort: '0' }] },
+        NanoCpus: Math.round(DEFAULT_CPUS * 1e9),
+        Memory: Math.round(DEFAULT_MEMORY_GB * 1024 * 1024 * 1024),
+        RestartPolicy: { Name: 'unless-stopped' },
+        // Docker daemon default networking on Linux lets the host reach an
+        // extra_hosts host-gateway; harmless on Docker Desktop where it
+        // already resolves. Costs nothing to always set.
+        ExtraHosts: ['host.docker.internal:host-gateway'],
+      },
+    });
+    await container.start();
+
+    const baseUrl = `${config.KORTIX_URL.replace(/\/+$/, '')}/v1/p/${externalId}/${AGENT_PORT}`;
+
+    return {
+      externalId,
+      baseUrl,
+      metadata: {
+        provisionedBy: opts.userId,
+        containerName: name,
+        containerId: container.id,
+        image: snapshot,
+        network,
+        version: SANDBOX_VERSION,
+      },
+    };
+  }
+
+  async start(externalId: string): Promise<void> {
+    const docker = getDockerClient();
+    await assertDockerReachable(docker);
+    try {
+      await docker.getContainer(containerName(externalId)).start();
+    } catch (err) {
+      // Docker 304s "already started" — treat as success, matching the
+      // idempotent semantics ensureRunning()/callers expect.
+      if (!isAlreadyStartedError(err)) throw err;
+    }
+  }
+
+  async stop(externalId: string): Promise<void> {
+    const docker = getDockerClient();
+    await assertDockerReachable(docker);
+    try {
+      // Stop preserves the container (and its writable layer) — this IS the
+      // persistence semantics: the workspace, installed deps, shell history,
+      // everything survives until an explicit remove().
+      await docker.getContainer(containerName(externalId)).stop({ t: 10 });
+    } catch (err) {
+      if (!isAlreadyStoppedError(err)) throw err;
+    }
+  }
+
+  async remove(externalId: string): Promise<void> {
+    const docker = getDockerClient();
+    await assertDockerReachable(docker);
+    try {
+      await docker.getContainer(containerName(externalId)).remove({ force: true, v: true });
+    } catch (err) {
+      if (!isMissingContainerError(err)) throw err;
+    }
+  }
+
+  async getStatus(externalId: string): Promise<SandboxStatus> {
+    try {
+      const docker = getDockerClient();
+      await assertDockerReachable(docker);
+      const info = await docker.getContainer(containerName(externalId)).inspect();
+      return toStatus(info);
+    } catch (err) {
+      if (isMissingContainerError(err)) return 'removed';
+      return 'unknown';
+    }
+  }
+
+  async resolveIngress(externalId: string, request: SandboxIngressRequest): Promise<ResolvedSandboxIngress> {
+    // Docker's own network DNS makes every port on the container reachable by
+    // name with zero pre-registration — no expose/preview-link step needed
+    // (unlike Daytona/Platinum, whose edges must be told about a port first).
+    return {
+      url: `http://${containerName(externalId)}:${request.port}`,
+      headers: {},
+      effectivePort: request.port,
+    };
+  }
+
+  routeIngress(request: SandboxIngressRequest) {
+    return { effectivePort: request.port };
+  }
+
+  async resolveEndpoint(externalId: string): Promise<ResolvedEndpoint> {
+    const ingress = await this.resolveIngress(externalId, { port: AGENT_PORT, transport: 'http' });
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    try {
+      const serviceKey = await serviceKeyForExternalId(externalId);
+      if (serviceKey) headers['Authorization'] = `Bearer ${serviceKey}`;
+    } catch (err) {
+      console.warn(`[LOCAL-DOCKER] Failed to look up service key for ${externalId}:`, err);
+    }
+    return { url: ingress.url, headers };
+  }
+
+  async ensureRunning(externalId: string): Promise<void> {
+    const status = await this.getStatus(externalId);
+    if (status === 'running') return;
+    if (status === 'stopped') {
+      console.log(`[LOCAL-DOCKER] Sandbox ${externalId} is stopped, starting...`);
+      await this.start(externalId);
+    }
+    // 'removed' / 'unknown': nothing this provider can recover in place (no
+    // recoverInPlace — see the interface doc: callers fail closed).
+  }
+
+  /**
+   * List every container this environment manages, for the orphan-box reaper.
+   * Scoped by BOTH kortix.managed and kortix.env — mirrors daytona.ts exactly.
+   * Unlike the cloud providers, a local Docker daemon is never shared across
+   * environments in practice, but scoping identically keeps the reaper's
+   * cross-provider logic uniform (and safe if a laptop ever runs two
+   * kortix-api instances against the same daemon, e.g. dev + a worktree).
+   */
+  async listManagedRunningSandboxes(): Promise<Array<{ externalId: string; createdAt: Date | null }>> {
+    const docker = getDockerClient();
+    await assertDockerReachable(docker);
+    const containers = await docker.listContainers({
+      all: false,
+      filters: JSON.stringify({
+        label: ['kortix.managed=true', `kortix.env=${config.INTERNAL_KORTIX_ENV}`],
+      }),
+    });
+    return containers.map((c) => ({
+      externalId: c.Labels?.['kortix.sandbox'] || c.Names?.[0]?.replace(/^\//, '').replace(CONTAINER_PREFIX, '') || c.Id,
+      createdAt: c.Created ? new Date(c.Created * 1000) : null,
+    }));
+  }
+}
+
+function isAlreadyStartedError(err: unknown): boolean {
+  const status = (err as { statusCode?: unknown } | null | undefined)?.statusCode;
+  return status === 304;
+}
+
+function isAlreadyStoppedError(err: unknown): boolean {
+  const status = (err as { statusCode?: unknown } | null | undefined)?.statusCode;
+  return status === 304;
+}

--- a/apps/api/src/platform/providers/local-docker.ts
+++ b/apps/api/src/platform/providers/local-docker.ts
@@ -20,6 +20,7 @@ import Docker from 'dockerode';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { config, SANDBOX_VERSION } from '../../config';
+import { resolveLlmGatewayBaseUrl } from '../../llm-gateway/sandbox-base-url';
 import { serviceKeyForExternalId } from '../service-key';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
 import type {
@@ -206,6 +207,17 @@ export class LocalDockerProvider implements SandboxProvider {
     ],
   };
 
+  /**
+   * See the interface doc: this is the ONE provider that overrides it. A
+   * local-docker sandbox shares a private Docker network with kortix-api
+   * (never the public internet), so anything built from "the API's public
+   * origin" — e.g. the LLM-gateway base URL — must be rebuilt on this address
+   * instead, exactly like KORTIX_API_URL already is in create() below.
+   */
+  sandboxFacingApiOrigin(): string {
+    return sandboxInternalApiBase();
+  }
+
   async getProvisioningStatus(): Promise<ProvisioningStatus | null> {
     return null;
   }
@@ -247,6 +259,21 @@ export class LocalDockerProvider implements SandboxProvider {
       KORTIX_API_URL: `${sandboxInternalApiBase()}/v1`,
       KORTIX_FRONTEND_URL: sandboxFrontendBaseUrl(),
     };
+    // Same fix, same reason, for OpenCode's own LLM-gateway base URL: session-
+    // sandbox.ts's provisionSessionSandbox() already asks
+    // `provider.sandboxFacingApiOrigin()` for this (see that file), so by the
+    // time we get here KORTIX_LLM_BASE_URL in opts.envVars should already be
+    // Docker-network-correct — but recompute+override unconditionally anyway,
+    // matching KORTIX_API_URL's belt-and-suspenders posture above, so this
+    // provider is correct even if a future caller reintroduces the generic
+    // public origin (e.g. session-sandbox.ts's provider var got reassigned by
+    // a mid-provision failover to/from another provider before this ran).
+    // `KORTIX_LLM_BASE_URL` is present at all only when the LLM gateway is
+    // enabled + entitled for this session (see session-sandbox.ts) — absent
+    // otherwise, so OpenCode falls back to its native provider behavior.
+    if (envVars.KORTIX_LLM_BASE_URL) {
+      envVars.KORTIX_LLM_BASE_URL = resolveLlmGatewayBaseUrl(sandboxInternalApiBase());
+    }
     const env = Object.entries(envVars).map(([k, v]) => `${k}=${v}`);
 
     const container = await docker.createContainer({

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -64,6 +64,7 @@ function isMissingSandboxError(error: unknown): boolean {
 
 export class PlatinumProvider implements SandboxProvider {
   readonly name: ProviderName = 'platinum';
+  readonly requiresPublicCallback = true;
 
   readonly provisioning: ProvisioningTraits = {
     async: false,

--- a/apps/api/src/platform/providers/provider-boundary.test.ts
+++ b/apps/api/src/platform/providers/provider-boundary.test.ts
@@ -20,7 +20,7 @@ describe('sandbox provider architecture boundary', () => {
     for (const relativePath of GENERIC_DATA_PATHS) {
       const source = readFileSync(resolve(API_SRC, relativePath), 'utf8');
       expect(source, relativePath).not.toMatch(
-        /(?:provider|providerName)\s*(?:===|!==|==|!=)\s*['"](?:daytona|platinum|e2b)['"]/i,
+        /(?:provider|providerName)\s*(?:===|!==|==|!=)\s*['"](?:daytona|platinum|e2b|local-docker)['"]/i,
       );
       expect(source, relativePath).not.toMatch(
         /x-daytona-|x-access-token|e2b-traffic-access-token/i,

--- a/apps/api/src/platform/providers/provider-parity.test.ts
+++ b/apps/api/src/platform/providers/provider-parity.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Cross-cutting parity guard: every ProviderName must be wired into every
+ * shared subsystem — the runtime registry, its compute rate card, and the
+ * snapshot-build adapter registry. Written so that adding a 5th provider
+ * without wiring it into one of these three places fails a test here instead
+ * of silently under-covering it in production (the exact gap this suite
+ * closes for local-docker per the reinforcement in the task brief).
+ */
+import { describe, expect, test } from 'bun:test';
+
+process.env.ALLOWED_SANDBOX_PROVIDERS = 'daytona,platinum,e2b,local-docker';
+process.env.DAYTONA_API_KEY = 'daytona_test_key';
+process.env.DAYTONA_SERVER_URL = 'https://app.daytona.io/api';
+process.env.DAYTONA_TARGET = 'us';
+process.env.PLATINUM_API_KEY = 'pt_test_key';
+process.env.PLATINUM_API_URL = 'https://api.platinum.test';
+process.env.E2B_API_KEY = 'e2b_test_key';
+process.env.KORTIX_URL = 'https://api.example.com';
+process.env.INTERNAL_KORTIX_ENV = 'dev';
+process.env.FRONTEND_URL = 'https://app.example.com';
+
+const { KNOWN_PROVIDERS, config } = await import('../../config');
+const { getProvider } = await import('./index');
+const { getProviderComputeRateCard } = await import('./compute-rates');
+const { getSandboxProvider } = await import('../../snapshots/providers');
+const { SANDBOX_TEMPLATE_PROVIDERS } = await import('../../snapshots/provider-coverage');
+
+describe('sandbox provider parity across shared subsystems', () => {
+  test('config.KNOWN_PROVIDERS is the single canonical provider list every other list must match', () => {
+    expect(KNOWN_PROVIDERS).toContain('local-docker');
+    expect(new Set(SANDBOX_TEMPLATE_PROVIDERS)).toEqual(new Set(KNOWN_PROVIDERS));
+  });
+
+  for (const name of ['daytona', 'platinum', 'e2b', 'local-docker'] as const) {
+    test(`${name}: runtime registry constructs a provider implementing the full contract`, () => {
+      const provider = getProvider(name);
+      expect(provider.name).toBe(name);
+      expect(typeof provider.create).toBe('function');
+      expect(typeof provider.start).toBe('function');
+      expect(typeof provider.stop).toBe('function');
+      expect(typeof provider.remove).toBe('function');
+      expect(typeof provider.getStatus).toBe('function');
+      expect(typeof provider.resolveEndpoint).toBe('function');
+      expect(typeof provider.resolveIngress).toBe('function');
+      expect(typeof provider.routeIngress).toBe('function');
+      expect(typeof provider.ensureRunning).toBe('function');
+      expect(typeof provider.getProvisioningStatus).toBe('function');
+    });
+
+    test(`${name}: has a compute rate card`, () => {
+      const card = getProviderComputeRateCard(name);
+      expect(card).toBeDefined();
+      expect(typeof card.cpuPerCoreSecond).toBe('number');
+      expect(typeof card.memoryPerGbSecond).toBe('number');
+      expect(typeof card.diskPerGbSecond).toBe('number');
+      expect(typeof card.providerCostMultiplier).toBe('number');
+    });
+
+    test(`${name}: has a registered snapshot-build adapter`, () => {
+      const adapter = getSandboxProvider(name);
+      expect(adapter.id).toBe(name);
+      expect(typeof adapter.buildSnapshot).toBe('function');
+      expect(typeof adapter.getSnapshotState).toBe('function');
+      expect(typeof adapter.deleteSnapshot).toBe('function');
+      expect(typeof adapter.listSnapshots).toBe('function');
+      expect(typeof adapter.isConfigured).toBe('function');
+    });
+  }
+
+  test('local-docker requires no provider API key to be admitted (unlike daytona/platinum/e2b)', () => {
+    // config was loaded once above with ALLOWED_SANDBOX_PROVIDERS covering all
+    // four names and every OTHER provider's key set — isProviderEnabled must
+    // still resolve local-docker as enabled with nothing beyond selection.
+    expect(config.isProviderEnabled('local-docker')).toBe(true);
+    expect(config.isLocalDockerEnabled()).toBe(true);
+  });
+});

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -50,6 +50,7 @@ import { accountEntitledToLlmGateway } from '../../shared/account-limits';
 import { readManifest } from '../../projects/triggers';
 import { resolveAgentGrant } from '../../projects/agents';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
+import { resolveLlmGatewayBaseUrl } from '../../llm-gateway/sandbox-base-url';
 import { RuntimeIdentityConflictError } from '../../projects/runtime-identity-error';
 
 // Fallback spec for sandboxes that don't declare `sandbox:` in kortix.yaml.
@@ -336,11 +337,13 @@ export async function provisionSessionSandbox(opts: {
   if (!sandbox) throw new RuntimeIdentityConflictError(sandboxId);
   tl.mark('row+tokens');
 
-  const kortixOrigin = config.KORTIX_URL.replace(/\/+$/, '');
-  const llmProxyMode = config.LLM_GATEWAY_PROXY_PORT || config.LLM_GATEWAY_PROXY_TARGET;
-  const llmBaseUrl =
-    config.LLM_GATEWAY_BASE_URL ||
-    (llmProxyMode ? `${kortixOrigin}/v1/llm-gateway/v1/llm` : `${kortixOrigin}/v1/llm`);
+  // provider.sandboxFacingApiOrigin() (optional) lets a same-machine provider
+  // (local-docker) swap in its private Docker-network origin here — same
+  // reason KORTIX_API_URL is never just config.KORTIX_URL verbatim for that
+  // provider. Every other provider omits the method and falls back to the
+  // generic public origin, unchanged from before.
+  const kortixOrigin = (provider.sandboxFacingApiOrigin?.() ?? config.KORTIX_URL).replace(/\/+$/, '');
+  const llmBaseUrl = resolveLlmGatewayBaseUrl(kortixOrigin);
 
   // The sandbox's OpenCode `kortix` provider only mounts when KORTIX_LLM_* is
   // injected (otherwise OpenCode falls back to showing only its built-in Zen

--- a/apps/api/src/projects/lib/sandbox-callback-unreachable.test.ts
+++ b/apps/api/src/projects/lib/sandbox-callback-unreachable.test.ts
@@ -1,0 +1,30 @@
+// sandboxCallbackUnreachableReason() gates session creation/restart/resume on
+// KORTIX_URL being publicly reachable — but ONLY for providers whose
+// sandboxes actually run remotely. local-docker's containers share the same
+// Docker network as kortix-api, so a loopback KORTIX_URL is correct there,
+// not an error — see the `requiresPublicCallback` capability on
+// platform/providers/index.ts's SandboxProvider interface.
+import { describe, expect, test } from 'bun:test';
+
+// config.KORTIX_URL is snapshotted once at module load (see config.ts) — set
+// it to a loopback address BEFORE importing, so every test in this file
+// observes the same "loopback KORTIX_URL" world and only the provider varies.
+process.env.ALLOWED_SANDBOX_PROVIDERS = 'daytona,local-docker';
+process.env.DAYTONA_API_KEY = 'daytona_test_key';
+process.env.DAYTONA_SERVER_URL = 'https://app.daytona.io/api';
+process.env.DAYTONA_TARGET = 'us';
+process.env.INTERNAL_KORTIX_ENV = 'dev';
+process.env.FRONTEND_URL = 'https://app.example.com';
+process.env.KORTIX_URL = 'http://localhost:8008';
+
+const { sandboxCallbackUnreachableReason } = await import('./sessions');
+
+describe('sandboxCallbackUnreachableReason — provider-aware reachability preflight', () => {
+  test('a loopback KORTIX_URL blocks a remote-cloud provider (daytona)', () => {
+    expect(sandboxCallbackUnreachableReason('daytona')).toMatch(/loopback/i);
+  });
+
+  test('the SAME loopback KORTIX_URL is FINE for local-docker (same-machine, Docker-networked)', () => {
+    expect(sandboxCallbackUnreachableReason('local-docker')).toBeNull();
+  });
+});

--- a/apps/api/src/projects/lib/sandbox-env-sync.test.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.test.ts
@@ -1,0 +1,55 @@
+// Regression for the "hot push undoes the boot-time fix" class of bug: every
+// call site here that pushes KORTIX_LLM_BASE_URL to a RUNNING sandbox
+// (syncSandboxEnvForPrompt on every prompt, propagateLlmGatewayModeToActiveSandboxes
+// on a project's gateway-mode toggle) must resolve it onto the SAME per-provider
+// origin session-sandbox.ts uses at boot — not a second, hardcoded-to-the-public-
+// origin copy. That second copy is exactly how local-docker's KORTIX_LLM_BASE_URL
+// fix got silently undone by the very next prompt (see local-docker.test.ts and
+// llm-gateway/sandbox-base-url.test.ts for the formula itself).
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+process.env.KORTIX_URL = 'https://api.example.com';
+process.env.FRONTEND_URL = 'https://app.example.com';
+delete process.env.LLM_GATEWAY_BASE_URL;
+delete process.env.LLM_GATEWAY_PROXY_PORT;
+delete process.env.LLM_GATEWAY_PROXY_TARGET;
+
+// Fakes a same-machine provider (only local-docker implements this today) vs.
+// every remote cloud provider, which omits sandboxFacingApiOrigin entirely.
+mock.module('../../platform/providers', () => ({
+  getProvider: (name: string) =>
+    name === 'local-docker'
+      ? { sandboxFacingApiOrigin: () => 'http://kortix-api:8008' }
+      : {},
+}));
+
+const { config } = await import('../../config');
+const { llmGatewayBaseUrlForProvider } = await import('./sandbox-env-sync');
+
+describe('llmGatewayBaseUrlForProvider', () => {
+  beforeEach(() => {
+    config.LLM_GATEWAY_BASE_URL = '';
+    config.LLM_GATEWAY_PROXY_PORT = 0;
+    config.LLM_GATEWAY_PROXY_TARGET = '';
+  });
+
+  test('local-docker: resolves onto the Docker-network origin, not the generic public KORTIX_URL', () => {
+    expect(llmGatewayBaseUrlForProvider('local-docker')).toBe('http://kortix-api:8008/v1/llm');
+  });
+
+  test('a remote cloud provider (no sandboxFacingApiOrigin): falls back to the generic public config.KORTIX_URL', () => {
+    expect(llmGatewayBaseUrlForProvider('daytona')).toBe('https://api.example.com/v1/llm');
+    expect(llmGatewayBaseUrlForProvider('e2b')).toBe('https://api.example.com/v1/llm');
+    expect(llmGatewayBaseUrlForProvider('platinum')).toBe('https://api.example.com/v1/llm');
+  });
+
+  test('an explicit LLM_GATEWAY_BASE_URL override wins for every provider, same-machine or not', () => {
+    config.LLM_GATEWAY_BASE_URL = 'https://gateway.internal.example.com/v1/llm';
+    expect(llmGatewayBaseUrlForProvider('local-docker')).toBe(
+      'https://gateway.internal.example.com/v1/llm',
+    );
+    expect(llmGatewayBaseUrlForProvider('daytona')).toBe(
+      'https://gateway.internal.example.com/v1/llm',
+    );
+  });
+});

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -4,11 +4,29 @@ import { db } from '../../shared/db';
 import { resolveSandboxIngress } from '../../sandbox-proxy/backend';
 import { config } from '../../config';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
+import { resolveLlmGatewayBaseUrl } from '../../llm-gateway/sandbox-base-url';
 import { nativeProviderEnvNames } from '../../llm-gateway/sandbox-credentials';
+import { getProvider, type ProviderName } from '../../platform/providers';
 import { listProjectSecretsSnapshotForUser, projectSecretsRevision } from '../secrets';
 import { grantFromLoadedAgents, loadProjectAgents } from '../agents';
 import { sanitizeSandboxEnv } from './sandbox-env-names';
 import { waitForDaemonOpencodeReady } from './sandbox-daemon-ready';
+
+/**
+ * The origin THIS sandbox should reach kortix-api's LLM-gateway surface at —
+ * mirrors session-sandbox.ts's boot-time computation (see that file and
+ * `local-docker.ts`'s `sandboxFacingApiOrigin()`). Every hot env-push call
+ * site here recomputes the LLM-gateway base URL from scratch (a project's
+ * gateway opt-in can toggle, or secrets can rotate, mid-session), so it must
+ * ask the OWNING provider for its origin the same way the boot path does —
+ * otherwise a same-machine provider's boot-time fix is silently undone by the
+ * very next prompt or gateway-mode toggle, which re-pushes the generic public
+ * origin over the daemon's `/kortix/env` and re-breaks connectivity.
+ */
+export function llmGatewayBaseUrlForProvider(providerName: ProviderName): string {
+  const origin = getProvider(providerName).sandboxFacingApiOrigin?.() ?? config.KORTIX_URL;
+  return resolveLlmGatewayBaseUrl(origin);
+}
 
 const SANDBOX_SERVICE_PORT = 8000;
 const FANOUT_CONCURRENCY = 6;
@@ -148,6 +166,10 @@ export async function syncSandboxEnvForPrompt(args: {
   serviceKey: string | null;
   previewUrl: string;
   providerHeaders: Record<string, string>;
+  /** The provider this sandbox actually runs on (`SandboxRecord.provider` at
+   *  the call site) — needed to resolve the LLM-gateway base URL onto the
+   *  RIGHT origin for a same-machine provider. */
+  providerName: ProviderName;
 }): Promise<void> {
   if (!args.serviceKey) return;
   const snapshot = await resolveSandboxEnvSnapshot(args.projectId, args.sessionId);
@@ -160,7 +182,7 @@ export async function syncSandboxEnvForPrompt(args: {
     snapshot,
     refreshModels: true,
     llmGatewayEnabled,
-    llmGatewayBaseUrl: llmGatewayEnabled ? resolveLlmGatewayBaseUrl() : undefined,
+    llmGatewayBaseUrl: llmGatewayEnabled ? llmGatewayBaseUrlForProvider(args.providerName) : undefined,
     llmGatewayDenyEnv: llmGatewayEnabled ? nativeProviderEnvNames().join(',') : '',
   });
   // A model-affecting change just restarted opencode (state !== 'ok'). The prompt
@@ -232,6 +254,7 @@ export async function propagateLlmGatewayModeToActiveSandboxes(
       .select({
         externalId: sessionSandboxes.externalId,
         sessionId: sessionSandboxes.sessionId,
+        provider: sessionSandboxes.provider,
         config: sessionSandboxes.config,
       })
       .from(sessionSandboxes)
@@ -240,7 +263,9 @@ export async function propagateLlmGatewayModeToActiveSandboxes(
     const targets = rows.filter((r): r is typeof r & { externalId: string } => !!r.externalId);
     if (targets.length === 0) return;
 
-    const llmGatewayBaseUrl = resolveLlmGatewayBaseUrl();
+    // Computed PER ROW (not once, hoisted) — a project's active sandboxes can
+    // span more than one provider (mid-migration, failover), and each needs
+    // the base URL resolved onto ITS OWN provider's origin.
     await runBounded(targets, FANOUT_CONCURRENCY, async (row) => {
       const rowConfig = (row.config || {}) as Record<string, unknown>;
       const serviceKey = typeof rowConfig.serviceKey === 'string' ? rowConfig.serviceKey : null;
@@ -257,7 +282,7 @@ export async function propagateLlmGatewayModeToActiveSandboxes(
           snapshot,
           refreshModels: true,
           llmGatewayEnabled: enabled,
-          llmGatewayBaseUrl: enabled ? llmGatewayBaseUrl : undefined,
+          llmGatewayBaseUrl: enabled ? llmGatewayBaseUrlForProvider(row.provider as ProviderName) : undefined,
           llmGatewayDenyEnv: enabled ? nativeProviderEnvNames().join(',') : '',
         });
         await markSandboxLlmGatewayMode(row.sessionId, enabled);
@@ -305,15 +330,6 @@ async function markSandboxLlmGatewayMode(
       updatedAt: new Date(),
     })
     .where(eq(sessionSandboxes.sessionId, sessionId));
-}
-
-function resolveLlmGatewayBaseUrl(): string {
-  const kortixOrigin = config.KORTIX_URL.replace(/\/+$/, '');
-  const llmProxyMode = config.LLM_GATEWAY_PROXY_PORT || config.LLM_GATEWAY_PROXY_TARGET;
-  return (
-    config.LLM_GATEWAY_BASE_URL ||
-    (llmProxyMode ? `${kortixOrigin}/v1/llm-gateway/v1/llm` : `${kortixOrigin}/v1/llm`)
-  );
 }
 
 function emptySandboxEnvSnapshot(reason: string): SandboxEnvSnapshot {

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -12,6 +12,7 @@ import { agentMayUseConnector } from '../../iam/agent-scope';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { nativeProviderEnvNames } from '../../llm-gateway/sandbox-credentials';
 import { auth, json } from '../../openapi';
+import { getProvider } from '../../platform/providers';
 import { sandboxFrontendBaseUrl } from '../../platform/sandbox-frontend-url';
 import { selectProvider } from '../../platform/services/provider-balancer';
 import { ProvisionTimeline } from '../../platform/services/provision-timeline';
@@ -389,18 +390,24 @@ export function proxyGitUrl(projectId: string): string {
 }
 
 /**
- * Cloud sandboxes (the only kind we provision) reach the control plane over the
- * public internet via `$KORTIX_API_URL`. A loopback/unspecified host is never
- * reachable from inside a remote sandbox, so a session booted against one is
+ * Cloud sandboxes reach the control plane over the public internet via
+ * `$KORTIX_API_URL`. A loopback/unspecified host is never reachable from
+ * inside a remote sandbox, so a session booted against one is
  * dead-on-arrival: repo materialization can't fetch its git clone credential and
  * the daemon ends up reporting "OpenCode runtime is not ready" with a cryptic
  * "Unable to connect" boot error ~60s later. Detect it up front so session
  * creation fails fast with an actionable message instead.
  *
+ * A same-machine provider (local-docker) has no such constraint — its
+ * sandboxes reach kortix-api over the shared Docker network, not the public
+ * internet — so this check is skipped for any provider whose
+ * `requiresPublicCallback` capability is false (see platform/providers/index.ts).
+ *
  * Returns a human-readable reason string when unreachable, or null when fine.
  */
 
-export function sandboxCallbackUnreachableReason(): string | null {
+export function sandboxCallbackUnreachableReason(providerName: SandboxProviderName): string | null {
+  if (!getProvider(providerName).requiresPublicCallback) return null;
   let host: string;
   try {
     host = new URL(deriveKortixApiBase()).hostname.toLowerCase();
@@ -573,7 +580,7 @@ export async function createProjectSession(input: {
   const providerName: SandboxProviderName =
     'provider' in picked ? (picked.provider as SandboxProviderName) : await selectProvider();
 
-  const callbackUnreachable = sandboxCallbackUnreachableReason();
+  const callbackUnreachable = sandboxCallbackUnreachableReason(providerName);
   if (callbackUnreachable) {
     return {
       error: { status: 503, body: { error: callbackUnreachable, code: 'KORTIX_URL_UNREACHABLE' } },

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -468,7 +468,7 @@ interface SandboxHealthPayload {
   latest_build: ReturnType<typeof serializeBuildSummary> | null;
   latest_failure: ReturnType<typeof serializeBuildSummary> | null;
   provider_mode: 'automatic' | 'pinned';
-  selected_provider: 'daytona' | 'platinum' | 'e2b' | null;
+  selected_provider: 'daytona' | 'platinum' | 'e2b' | 'local-docker' | null;
 }
 
 // Safe degraded payload: same shape as the happy path, surfaced when any

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -304,7 +304,7 @@ export async function allocateRuntimeOnOpen(
 ): Promise<void> {
   const providerName = session.sandboxProvider as SandboxProviderName;
   if (!(config.ALLOWED_SANDBOX_PROVIDERS as readonly string[]).includes(providerName)) return;
-  if (sandboxCallbackUnreachableReason()) return;
+  if (sandboxCallbackUnreachableReason(providerName)) return;
   await db
     .update(projectSessions)
     .set({ status: 'provisioning', error: null, updatedAt: new Date() })

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -135,7 +135,7 @@ export async function restartSession(input: {
     };
   }
 
-  const restartUnreachable = sandboxCallbackUnreachableReason();
+  const restartUnreachable = sandboxCallbackUnreachableReason(providerName);
   if (restartUnreachable) {
     return {
       status: 503,

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { config } from '../../config';
 import { getTraceHeaders } from '../../lib/request-context';
+import type { ProviderName } from '../../platform/providers';
 import { syncSandboxEnvForPrompt } from '../../projects/lib/sandbox-env-sync';
 import { scheduleTitleCaptureAfterPrompt } from '../../projects/opencode-title-capture';
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
@@ -539,6 +540,7 @@ export async function forwardToSandbox(
             serviceKey,
             previewUrl,
             providerHeaders: ingress.headers,
+            providerName: record.provider as ProviderName,
           });
         } catch (err) {
           const message = errorMessage(err, 'project env sync failed');

--- a/apps/api/src/snapshots/provider-coverage.test.ts
+++ b/apps/api/src/snapshots/provider-coverage.test.ts
@@ -5,23 +5,32 @@ import {
   resolveConfiguredProjectProviderPin,
   resolveRoutedTemplateState,
   resolveUsableProjectProviderPin,
+  SANDBOX_TEMPLATE_PROVIDERS,
 } from './provider-coverage';
 
 describe('sandbox template provider coverage', () => {
-  test('synchronizes reusable templates to every enabled provider regardless of routing pins', () => {
-    expect(enabledTemplateBuildProviders({
-      allowed: ['daytona', 'platinum', 'e2b'],
-      isEnabled: () => true,
-    })).toEqual(['daytona', 'platinum', 'e2b']);
-    expect(enabledTemplateBuildProviders({
-      allowed: ['daytona', 'platinum', 'e2b'],
-      isEnabled: (provider) => provider !== 'platinum',
-    })).toEqual(['daytona', 'e2b']);
+  test('every canonical provider is registered as a template-build provider (parity guard)', () => {
+    // Extends automatically as SANDBOX_TEMPLATE_PROVIDERS grows — this is the
+    // test the reinforcement asked for: adding a provider without wiring it
+    // in here fails loudly instead of silently under-covering it.
+    expect(SANDBOX_TEMPLATE_PROVIDERS).toContain('local-docker');
+    expect(SANDBOX_TEMPLATE_PROVIDERS).toEqual(['daytona', 'platinum', 'e2b', 'local-docker']);
   });
 
-  test('observes the current image independently on Daytona, Platinum, and E2B', async () => {
+  test('synchronizes reusable templates to every enabled provider regardless of routing pins', () => {
+    expect(enabledTemplateBuildProviders({
+      allowed: ['daytona', 'platinum', 'e2b', 'local-docker'],
+      isEnabled: () => true,
+    })).toEqual(['daytona', 'platinum', 'e2b', 'local-docker']);
+    expect(enabledTemplateBuildProviders({
+      allowed: ['daytona', 'platinum', 'e2b', 'local-docker'],
+      isEnabled: (provider) => provider !== 'platinum',
+    })).toEqual(['daytona', 'e2b', 'local-docker']);
+  });
+
+  test('observes the current image independently on Daytona, Platinum, E2B, and local-docker', async () => {
     const calls: string[] = [];
-    const states = { daytona: 'active', platinum: 'building', e2b: 'missing' } as const;
+    const states = { daytona: 'active', platinum: 'building', e2b: 'missing', 'local-docker': 'active' } as const;
 
     const result = await observeTemplateProviderCoverage('kortix-default-current', {
       isProviderEnabled: () => true,
@@ -38,12 +47,14 @@ describe('sandbox template provider coverage', () => {
       'daytona:kortix-default-current',
       'platinum:kortix-default-current',
       'e2b:kortix-default-current',
+      'local-docker:kortix-default-current',
     ]);
     expect(result.map(({ provider, status, launch_ready }) => ({ provider, status, launch_ready })))
       .toEqual([
         { provider: 'daytona', status: 'ready', launch_ready: true },
         { provider: 'platinum', status: 'building', launch_ready: false },
         { provider: 'e2b', status: 'not_built', launch_ready: false },
+        { provider: 'local-docker', status: 'ready', launch_ready: true },
       ]);
   });
 

--- a/apps/api/src/snapshots/provider-coverage.ts
+++ b/apps/api/src/snapshots/provider-coverage.ts
@@ -1,7 +1,7 @@
 import type { SandboxProviderName } from '../config';
 import type { ProviderState, SandboxProviderAdapter } from './providers';
 
-export const SANDBOX_TEMPLATE_PROVIDERS = ['daytona', 'platinum', 'e2b'] as const;
+export const SANDBOX_TEMPLATE_PROVIDERS = ['daytona', 'platinum', 'e2b', 'local-docker'] as const;
 
 export type SandboxTemplateProvider = (typeof SANDBOX_TEMPLATE_PROVIDERS)[number];
 export type SandboxTemplateProviderCoverageStatus =

--- a/apps/api/src/snapshots/providers/index.ts
+++ b/apps/api/src/snapshots/providers/index.ts
@@ -12,6 +12,7 @@
 import { daytonaProvider } from './daytona';
 import { e2bProvider } from './e2b';
 import { platinumProvider } from './platinum';
+import { localDockerSnapshotProvider } from './local-docker';
 import type { WarmRepoContext } from '../build-context';
 
 interface SandboxResourceSpec {
@@ -93,6 +94,7 @@ const ADAPTERS = new Map<string, SandboxProviderAdapter>();
 ADAPTERS.set(daytonaProvider.id, daytonaProvider);
 ADAPTERS.set(platinumProvider.id, platinumProvider);
 ADAPTERS.set(e2bProvider.id, e2bProvider);
+ADAPTERS.set(localDockerSnapshotProvider.id, localDockerSnapshotProvider);
 
 export function getSandboxProvider(id: string): SandboxProviderAdapter {
   const adapter = ADAPTERS.get(id);

--- a/apps/api/src/snapshots/providers/local-docker.test.ts
+++ b/apps/api/src/snapshots/providers/local-docker.test.ts
@@ -1,0 +1,194 @@
+// local-docker snapshot adapter: "build" = docker build against the local
+// daemon, tag = the content-addressed snapshot name, no registry push. Mirrors
+// e2b.test.ts / daytona-errors.test.ts's mocked-transport shape.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+process.env.ALLOWED_SANDBOX_PROVIDERS = 'local-docker';
+process.env.KORTIX_URL = 'https://api.example.com';
+process.env.INTERNAL_KORTIX_ENV = 'dev';
+process.env.FRONTEND_URL = 'https://app.example.com';
+process.env.LOCAL_DOCKER_NETWORK = 'kortix-local-docker-test';
+
+let stagedContexts: Array<{ snapshotName: string; userDockerfile: string }> = [];
+
+mock.module('../build-context', () => ({
+  DEFAULT_CPU: 2,
+  DEFAULT_MEMORY_GB: 6,
+  DEFAULT_DISK_GB: 20,
+  KORTIX_ENTRYPOINT: '/usr/local/bin/kortix-entrypoint',
+  stageBuildContext: async (snapshotName: string, userDockerfile: string) => {
+    stagedContexts.push({ snapshotName, userDockerfile });
+    return {
+      contextDir: '/tmp/kortix-local-docker-adapter-test-does-not-exist',
+      composedPath: '/tmp/kortix-local-docker-adapter-test-does-not-exist/.kortix-snapshot.Dockerfile',
+      dockerfileName: '.kortix-snapshot.Dockerfile',
+    };
+  },
+  stageAgentBinaryGz: async () => {
+    throw new Error('stageAgentBinaryGz is not used by the local-docker adapter test');
+  },
+}));
+
+function normalizeTag(name: string): string {
+  return name.includes(':') ? name : `${name}:latest`;
+}
+
+function dockerError(statusCode: number, message: string): Error {
+  const err = new Error(message) as Error & { statusCode: number };
+  err.statusCode = statusCode;
+  return err;
+}
+
+class FakeDocker {
+  images = new Set<string>();
+  buildImageCalls: Array<{ context: unknown; opts: Record<string, unknown> }> = [];
+  buildErrorMessage: string | null = null;
+  buildThrows: Error | null = null;
+
+  modem = {
+    followProgress: (
+      _stream: unknown,
+      done: (err: Error | null, output: Array<Record<string, unknown>>) => void,
+      onProgress: (event: Record<string, unknown>) => void,
+    ) => {
+      onProgress({ stream: 'Step 1/12 : FROM ubuntu:24.04\n' });
+      if (this.buildErrorMessage) {
+        const frame = { error: this.buildErrorMessage, errorDetail: { message: this.buildErrorMessage } };
+        onProgress(frame);
+        done(null, [{ stream: 'Step 1/12 : FROM ubuntu:24.04\n' }, frame]);
+        return;
+      }
+      onProgress({ stream: 'Successfully tagged image\n' });
+      done(null, [{ stream: 'ok' }]);
+    },
+  };
+
+  async buildImage(context: unknown, opts: Record<string, unknown>) {
+    this.buildImageCalls.push({ context, opts });
+    if (this.buildThrows) throw this.buildThrows;
+    if (!this.buildErrorMessage) this.images.add(normalizeTag(opts.t as string));
+    return 'fake-build-stream';
+  }
+
+  getImage(name: string) {
+    const tag = normalizeTag(name);
+    return {
+      inspect: async () => {
+        if (!this.images.has(tag)) throw dockerError(404, `No such image: ${tag}`);
+        return { Id: `sha256:${tag}` };
+      },
+      remove: async () => {
+        if (!this.images.has(tag)) throw dockerError(404, `No such image: ${tag}`);
+        this.images.delete(tag);
+      },
+    };
+  }
+
+  async listImages() {
+    return [...this.images].map((tag) => ({ RepoTags: [tag] }));
+  }
+}
+
+const { __setDockerClientForTest } = await import('../../platform/providers/local-docker');
+const { localDockerSnapshotProvider } = await import('./local-docker');
+const { getSandboxProvider } = await import('./index');
+
+let fakeDocker: FakeDocker;
+
+beforeEach(() => {
+  fakeDocker = new FakeDocker();
+  __setDockerClientForTest(fakeDocker);
+  stagedContexts = [];
+});
+
+describe('local-docker snapshot adapter — registry', () => {
+  test('is registered under the "local-docker" id', () => {
+    expect(getSandboxProvider('local-docker')).toBe(localDockerSnapshotProvider);
+    expect(localDockerSnapshotProvider.id).toBe('local-docker');
+  });
+});
+
+describe('local-docker snapshot adapter — buildSnapshot', () => {
+  test('docker-builds the composed context and tags it with the content-addressed snapshot name', async () => {
+    await localDockerSnapshotProvider.buildSnapshot({
+      snapshotName: 'kortix-default-abc123',
+      userDockerfile: 'FROM ubuntu:24.04\n',
+      spec: {},
+      slug: 'default',
+      isShared: true,
+    });
+
+    expect(stagedContexts[0]!.snapshotName).toBe('kortix-default-abc123');
+    const call = fakeDocker.buildImageCalls[0]!;
+    expect(call.opts.t).toBe('kortix-default-abc123');
+    expect(call.opts.dockerfile).toBe('.kortix-snapshot.Dockerfile');
+    expect(await localDockerSnapshotProvider.getSnapshotState('kortix-default-abc123')).toBe('active');
+  });
+
+  test('streams build log lines to the tap', async () => {
+    const lines: string[] = [];
+    await localDockerSnapshotProvider.buildSnapshot(
+      { snapshotName: 'kortix-tpl-xyz', userDockerfile: 'FROM ubuntu:24.04\n', spec: {}, slug: 'custom' },
+      { onLine: (line) => lines.push(line) },
+    );
+    expect(lines).toContain('Step 1/12 : FROM ubuntu:24.04');
+    expect(lines).toContain('Successfully tagged image');
+  });
+
+  test('throws when the build stream reports an error frame even though the HTTP response was 200', async () => {
+    fakeDocker.buildErrorMessage = "The command '/bin/sh -c apt-get install -y bogus-package' returned a non-zero code: 100";
+    await expect(
+      localDockerSnapshotProvider.buildSnapshot({
+        snapshotName: 'kortix-tpl-broken',
+        userDockerfile: 'FROM ubuntu:24.04\nRUN apt-get install -y bogus-package\n',
+        spec: {},
+        slug: 'custom',
+      }),
+    ).rejects.toThrow(/bogus-package/);
+    expect(await localDockerSnapshotProvider.getSnapshotState('kortix-tpl-broken')).toBe('missing');
+  });
+
+  test('propagates a hard daemon error (e.g. socket unreachable) from buildImage itself', async () => {
+    fakeDocker.buildThrows = new Error('connect ECONNREFUSED /var/run/docker.sock');
+    await expect(
+      localDockerSnapshotProvider.buildSnapshot({
+        snapshotName: 'kortix-tpl-nodaemon',
+        userDockerfile: 'FROM ubuntu:24.04\n',
+        spec: {},
+        slug: 'custom',
+      }),
+    ).rejects.toThrow(/ECONNREFUSED/);
+  });
+});
+
+describe('local-docker snapshot adapter — getSnapshotState / deleteSnapshot / listSnapshots', () => {
+  test('missing image reports "missing"', async () => {
+    expect(await localDockerSnapshotProvider.getSnapshotState('kortix-default-never-built')).toBe('missing');
+  });
+
+  test('deleteSnapshot removes the local image tag; a repeat delete is a no-op', async () => {
+    await localDockerSnapshotProvider.buildSnapshot({
+      snapshotName: 'kortix-default-todelete',
+      userDockerfile: 'FROM ubuntu:24.04\n',
+      spec: {},
+      slug: 'default',
+    });
+    expect(await localDockerSnapshotProvider.getSnapshotState('kortix-default-todelete')).toBe('active');
+    await localDockerSnapshotProvider.deleteSnapshot('kortix-default-todelete');
+    expect(await localDockerSnapshotProvider.getSnapshotState('kortix-default-todelete')).toBe('missing');
+    await expect(localDockerSnapshotProvider.deleteSnapshot('kortix-default-todelete')).resolves.toBeUndefined();
+  });
+
+  test('listSnapshots only returns Kortix-managed image tags (reapable prefixes)', async () => {
+    await localDockerSnapshotProvider.buildSnapshot({
+      snapshotName: 'kortix-default-listme',
+      userDockerfile: 'FROM ubuntu:24.04\n',
+      spec: {},
+      slug: 'default',
+    });
+    fakeDocker.images.add('ubuntu:24.04'); // an unrelated base image must be excluded
+    const names = (await localDockerSnapshotProvider.listSnapshots()).map((s) => s.name);
+    expect(names).toContain('kortix-default-listme');
+    expect(names).not.toContain('ubuntu');
+  });
+});

--- a/apps/api/src/snapshots/providers/local-docker.ts
+++ b/apps/api/src/snapshots/providers/local-docker.ts
@@ -1,0 +1,156 @@
+/**
+ * Local Docker implementation of `SandboxProviderAdapter` — EXPERIMENTAL.
+ *
+ * "Build" means: `docker build` the SAME composed Dockerfile every other
+ * provider builds (apps/api/src/snapshots/build-context.ts +
+ * dockerfile-layer.ts — the user's Dockerfile, or the platform default
+ * `FROM ubuntu:24.04`, plus the Kortix runtime layer), against the LOCAL
+ * Docker daemon, and tag the result with the content-addressed snapshot name.
+ * No registry push — the tag itself, sitting in the local image store, IS the
+ * "snapshot".
+ *
+ * This is a deliberate design choice, not an oversight: it means local-docker
+ * needs no pre-built `kortix/kortix-sandbox` base image (that Docker Hub repo
+ * does not exist — see the PR description's "image distribution" section) and
+ * stays byte-for-byte the same build recipe every other provider uses, which
+ * is exactly the invariant build-context.ts documents ("the produced image is
+ * byte-identical across providers"). The first build of a given identity is
+ * slow (Debian/pip/npm installs, a few minutes) — the SAME real cost Daytona
+ * and Platinum already pay building this identical layer remotely — and is
+ * cached thereafter like any other provider's snapshot.
+ */
+
+import { rm } from 'node:fs/promises';
+import Docker from 'dockerode';
+import {
+  DEFAULT_CPU,
+  DEFAULT_MEMORY_GB,
+  stageBuildContext,
+} from '../build-context';
+import { getDockerClient, localDockerSocketLooksPresent } from '../../platform/providers/local-docker';
+import { normalizeExistingProviderState } from './state';
+import type {
+  BuildableTemplate,
+  BuildLogTap,
+  ProviderState,
+  SandboxProviderAdapter,
+} from './index';
+
+const REAPABLE_SNAPSHOT_PREFIXES = ['kortix-default-', 'kortix-tpl-', 'kortix-wproj-', 'kortix-ppwarm-'];
+
+function isNotFoundError(err: unknown): boolean {
+  const status = (err as { statusCode?: unknown } | null | undefined)?.statusCode;
+  if (status === 404) return true;
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return message.includes('no such image') || message.includes('404');
+}
+
+/** Build logs stream NDJSON frames; an `error` frame means the build failed
+ *  even though the HTTP response itself was 200 (Docker's build API quirk). */
+function findBuildErrorFrame(frames: Array<Record<string, unknown>>): string | null {
+  for (const frame of frames) {
+    if (typeof frame.error === 'string' && frame.error) return frame.error;
+    const detail = frame.errorDetail as { message?: unknown } | undefined;
+    if (detail && typeof detail.message === 'string' && detail.message) return detail.message;
+  }
+  return null;
+}
+
+class LocalDockerSnapshotAdapter implements SandboxProviderAdapter {
+  readonly id = 'local-docker' as const;
+
+  isConfigured(): boolean {
+    // Cheap, sync hint only (no daemon round-trip) — matches every other
+    // adapter's isConfigured() being a fast, non-blocking check. The real
+    // reachability check happens inside buildImage()/getSnapshotState() and
+    // fails with a clear, actionable error (see local-docker.ts's
+    // assertDockerReachable).
+    return localDockerSocketLooksPresent();
+  }
+
+  async buildSnapshot(input: BuildableTemplate, tap?: BuildLogTap): Promise<void> {
+    if (!input.image && !input.userDockerfile) {
+      throw new Error('LocalDockerAdapter.buildSnapshot: neither image nor userDockerfile set');
+    }
+    const userDockerfile = input.userDockerfile ?? `FROM ${input.image}\n`;
+    const docker: Docker = getDockerClient();
+    const ctx = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo);
+    try {
+      console.info(
+        `[snapshots] ${input.snapshotName}: building (slug="${input.slug}", provider=local-docker, ` +
+        `spec=${JSON.stringify({ cpu: input.spec.cpu ?? DEFAULT_CPU, memory: input.spec.memoryGb ?? DEFAULT_MEMORY_GB })})`,
+      );
+      const stream = await docker.buildImage(
+        { context: ctx.contextDir, src: ['.'] },
+        { t: input.snapshotName, dockerfile: ctx.dockerfileName, rm: true, forcerm: true },
+      );
+      const frames = await new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+        const collected: Array<Record<string, unknown>> = [];
+        docker.modem.followProgress(
+          stream,
+          (err: Error | null, output: Array<Record<string, unknown>>) => {
+            if (err) return reject(err);
+            resolve(output ?? collected);
+          },
+          (event: Record<string, unknown>) => {
+            collected.push(event);
+            const line = typeof event.stream === 'string' ? event.stream.trim() : '';
+            if (line) {
+              console.info(`[snapshots] ${input.snapshotName} [local-docker]: ${line}`);
+              tap?.onLine?.(line);
+            }
+          },
+        );
+      });
+      const buildError = findBuildErrorFrame(frames);
+      if (buildError) {
+        throw new Error(`Snapshot build failed: ${buildError}`);
+      }
+      // Fail loud if the daemon reports success but the tag genuinely isn't
+      // there — a silent no-op build is worse than an explicit error.
+      await docker.getImage(input.snapshotName).inspect();
+    } finally {
+      await rm(ctx.contextDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  async getSnapshotState(snapshotName: string): Promise<ProviderState> {
+    try {
+      await getDockerClient().getImage(snapshotName).inspect();
+      // A local `docker build` is synchronous within buildSnapshot() above —
+      // by the time an inspect succeeds the image is fully built, never
+      // partially. There is no external "building" state to observe (unlike
+      // Daytona/Platinum's async remote build farms); normalizeExistingProviderState
+      // maps the only state we can ever see here ('active') consistently with
+      // every other provider's vocabulary.
+      return normalizeExistingProviderState('active');
+    } catch (err) {
+      if (isNotFoundError(err)) return 'missing';
+      return 'unknown';
+    }
+  }
+
+  async deleteSnapshot(snapshotName: string): Promise<void> {
+    try {
+      await getDockerClient().getImage(snapshotName).remove({ force: true });
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err;
+    }
+  }
+
+  async listSnapshots(): Promise<Array<{ name: string }>> {
+    const images = await getDockerClient().listImages({});
+    const names: string[] = [];
+    for (const image of images) {
+      for (const tag of image.RepoTags ?? []) {
+        const [repo] = tag.split(':');
+        if (repo && REAPABLE_SNAPSHOT_PREFIXES.some((prefix) => repo.startsWith(prefix))) {
+          names.push(repo);
+        }
+      }
+    }
+    return names.map((name) => ({ name }));
+  }
+}
+
+export const localDockerSnapshotProvider = new LocalDockerSnapshotAdapter();

--- a/apps/cli/scripts/self-host-e2e/run.sh
+++ b/apps/cli/scripts/self-host-e2e/run.sh
@@ -13,11 +13,17 @@ SUNA_ROOT=$(cd "$CLI_ROOT/../.." && pwd)
 CLI="bun run $CLI_ROOT/src/index.ts"
 
 INSTANCE=${INSTANCE:-selfhost-e2e-$(date +%s)}
+# TAG selects the image set under the STANDARD repo names
+# (kortix/kortix-{frontend,api,gateway}:$TAG) via `init --tag` — the same
+# convention scripts/build-local-images.sh uses (--tag). Custom per-image repo
+# overrides used to be set via `env set FRONTEND_IMAGE=...` etc.; that's now
+# refused by the CLI (FRONTEND_IMAGE/API_IMAGE/GATEWAY_IMAGE/SANDBOX_IMAGE are
+# updater-managed keys — see secrets-registry.ts's isUpdaterManagedKey — only
+# --tag/--channel/--release may set them), so TAG is the one lever.
 TAG=${TAG:-latest}
-FRONTEND_IMAGE=${FRONTEND_IMAGE:-}
-API_IMAGE=${API_IMAGE:-}
-GATEWAY_IMAGE=${GATEWAY_IMAGE:-}
-SANDBOX_IMAGE=${SANDBOX_IMAGE:-}
+# KORTIX_LOCAL_IMAGES=true → pass --local-images to `init`, which persists
+# KORTIX_IMAGE_PULL=never so `start`/`update` never try to pull images that
+# were only ever built locally (see shouldPullImages()).
 KORTIX_LOCAL_IMAGES=${KORTIX_LOCAL_IMAGES:-false}
 KEEP_ON_FAIL=${KEEP_ON_FAIL:-false}
 KEEP_ON_SUCCESS=${KEEP_ON_SUCCESS:-false}
@@ -27,8 +33,16 @@ CONFIG_DIR="$HOME/.config/kortix/self-host/$INSTANCE"
 WORK_DIR="$SCRIPT_DIR/work/$INSTANCE"
 CLI_CONFIG_FILE="$WORK_DIR/config.json"
 PROJECT_NAME="self-host-e2e-$INSTANCE"
-PROJECT_REPO_URL="https://example.com/$PROJECT_NAME.git"
-PROJECT_COMMIT="0000000000000000000000000000000000000000"
+# A REAL, always-public, tiny, stable repo — not a fake example.com URL. Every
+# session (any provider, including local-docker) git-clones the project's
+# ACTUAL repo_url into /workspace at boot (KORTIX_GIT_PROXY is off by default
+# on self-host, so this is a direct clone, no proxy involved) — a
+# non-existent URL 404s the clone and the sandbox never reaches
+# runtimeReady:true, regardless of provider. octocat/Hello-World is GitHub's
+# own canonical smoke-test repo (tiny, public, default branch `master`).
+PROJECT_REPO_URL="https://github.com/octocat/Hello-World.git"
+PROJECT_DEFAULT_BRANCH="master"
+PROJECT_COMMIT="7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"
 
 GREEN=$'\033[0;32m'
 RED=$'\033[0;31m'
@@ -65,28 +79,6 @@ for _ in range(n):
     ports.append(s.getsockname()[1])
     socks.append(s)
 print(" ".join(map(str, ports)))
-PY
-}
-
-free_port_block() {
-  python3 <<'PY'
-import socket
-for base in range(18000, 26000, 16):
-    socks = []
-    ok = True
-    try:
-        for port in range(base, base + 8):
-            s = socket.socket()
-            s.bind(("127.0.0.1", port))
-            socks.append(s)
-    except OSError:
-        ok = False
-    for s in socks:
-        s.close()
-    if ok:
-        print(base)
-        raise SystemExit(0)
-raise SystemExit("no free 8-port sandbox block found")
 PY
 }
 
@@ -146,6 +138,34 @@ wait_for_db_table() {
   ok "$name ready"
 }
 
+# Poll kortix.session_sandboxes for the provider's external_id (the
+# kortix-sb-<external_id> container name) — the local-docker provider mints
+# this container ASYNCHRONOUSLY off the session-create request (the same as
+# every other provider), and the first-ever build (docker build of the
+# platform-default ubuntu:24.04 + Kortix runtime layer, content-addressed and
+# cached forever after) can legitimately take several minutes cold.
+wait_for_sandbox_external_id() {
+  local session_id=$1
+  local timeout=${2:-600}
+  local start
+  start=$(date +%s)
+  local external_id=""
+  while [ -z "$external_id" ]; do
+    external_id=$(psql_selfhost -tAc \
+      "select external_id from kortix.session_sandboxes where session_id = '$session_id' and external_id is not null limit 1;" \
+      2>/dev/null | tr -d '[:space:]')
+    if [ -n "$external_id" ]; then
+      printf '%s' "$external_id"
+      return 0
+    fi
+    if [ $(( $(date +%s) - start )) -ge "$timeout" ]; then
+      psql_selfhost -tAc "select status, metadata from kortix.session_sandboxes where session_id = '$session_id';" >&2 2>/dev/null || true
+      die "session sandbox never got an external_id (container never created) within ${timeout}s"
+    fi
+    sleep 3
+  done
+}
+
 compose() {
   docker compose \
     --project-name "kortix-$INSTANCE" \
@@ -174,7 +194,12 @@ cleanup() {
   if [ -n "${PROJECT_ID:-}" ]; then
     psql_selfhost -c "delete from kortix.projects where project_id = '$PROJECT_ID'::uuid;" >/dev/null 2>&1
   fi
-  docker rm -f "kortix-$INSTANCE-sandbox" >/dev/null 2>&1
+  # The local-docker sandbox container is NOT part of the Compose project
+  # (kortix-api creates it directly against the host Docker socket) — remove
+  # it explicitly by its provider-assigned name if a session ever got one.
+  if [ -n "${SANDBOX_EXTERNAL_ID:-}" ]; then
+    docker rm -f "kortix-sb-$SANDBOX_EXTERNAL_ID" >/dev/null 2>&1
+  fi
   compose down --remove-orphans --volumes >/dev/null 2>&1
   rm -rf "$WORK_DIR"
   if [ "$rc" -ne 0 ]; then
@@ -185,11 +210,9 @@ trap cleanup EXIT
 
 section "Allocate Isolated Ports"
 read -r FRONTEND_PORT API_PORT SUPABASE_PORT POSTGRES_PORT <<<"$(free_ports 4)"
-SANDBOX_PORT_BASE=$(free_port_block)
 PUBLIC_URL="http://localhost:$FRONTEND_PORT"
 API_PUBLIC_URL="http://localhost:$API_PORT"
 SUPABASE_PUBLIC_URL="http://localhost:$SUPABASE_PORT"
-SANDBOX_HEALTH_URL="http://localhost:$SANDBOX_PORT_BASE/kortix/health"
 mkdir -p "$WORK_DIR"
 export KORTIX_CONFIG_FILE="$CLI_CONFIG_FILE"
 ok "Work folder: $WORK_DIR"
@@ -197,12 +220,27 @@ note "Instance: $INSTANCE"
 note "Dashboard: $PUBLIC_URL"
 note "API: $API_PUBLIC_URL"
 note "Supabase: $SUPABASE_PUBLIC_URL"
-note "Sandbox port base: $SANDBOX_PORT_BASE"
 
 section "CLI Self-host Setup"
 # `init` never blocks on a missing required secret (it warns and proceeds) —
-# this harness sets them via `env set` right after.
-$CLI self-host init --instance "$INSTANCE" --tag "$TAG" >/tmp/kortix-selfhost-init-$INSTANCE.log
+# this harness sets the rest via `env set` right after. Image tags are
+# selected via --tag (standard kortix/kortix-{frontend,api,gateway}:$TAG repo
+# names — see the TAG comment above); --local-images marks them as never
+# pulled from a registry (see shouldPullImages()).
+INIT_ARGS=(self-host init --instance "$INSTANCE" --tag "$TAG")
+if [ "$KORTIX_LOCAL_IMAGES" = "true" ]; then
+  INIT_ARGS+=(--local-images)
+fi
+$CLI "${INIT_ARGS[@]}" >/tmp/kortix-selfhost-init-$INSTANCE.log
+# EXPERIMENTAL local-docker provider (apps/api/src/platform/providers/local-docker.ts):
+# sandboxes run as plain containers on THIS SAME machine via the host Docker
+# socket — no cloud credentials needed, so this golden path stays fully
+# hermetic in CI (previously used Daytona, which needs real API creds CI
+# doesn't have — see the git history of this line for that RED period). This
+# `env set` re-renders docker-compose.yml (writeCompose() in
+# commands/self-host.ts) to mount /var/run/docker.sock into kortix-api and
+# point LOCAL_DOCKER_NETWORK at this instance's own Compose network — see
+# renderFullDockerCompose()'s `localDockerConfigured` option.
 $CLI self-host env set --instance "$INSTANCE" \
   "PUBLIC_URL=$PUBLIC_URL" \
   "API_PUBLIC_URL=$API_PUBLIC_URL" \
@@ -211,23 +249,7 @@ $CLI self-host env set --instance "$INSTANCE" \
   "API_PORT=$API_PORT" \
   "SUPABASE_PORT=$SUPABASE_PORT" \
   "POSTGRES_PORT=$POSTGRES_PORT" \
-  "ALLOWED_SANDBOX_PROVIDERS=daytona" \
-  "KORTIX_LOCAL_IMAGES=$KORTIX_LOCAL_IMAGES" >/dev/null
-# This self-host e2e uses Daytona and therefore needs Daytona credentials in the
-# environment to provision a sandbox — it is no longer hermetic. If those aren't
-# available in CI, this golden path must be reworked or retired.
-if [ -n "$FRONTEND_IMAGE" ]; then
-  $CLI self-host env set --instance "$INSTANCE" "FRONTEND_IMAGE=$FRONTEND_IMAGE" >/dev/null
-fi
-if [ -n "$API_IMAGE" ]; then
-  $CLI self-host env set --instance "$INSTANCE" "API_IMAGE=$API_IMAGE" >/dev/null
-fi
-if [ -n "$GATEWAY_IMAGE" ]; then
-  $CLI self-host env set --instance "$INSTANCE" "GATEWAY_IMAGE=$GATEWAY_IMAGE" >/dev/null
-fi
-if [ -n "$SANDBOX_IMAGE" ]; then
-  $CLI self-host env set --instance "$INSTANCE" "SANDBOX_IMAGE=$SANDBOX_IMAGE" >/dev/null
-fi
+  "ALLOWED_SANDBOX_PROVIDERS=local-docker" >/dev/null
 ok "Config initialized without prompts"
 
 section "Start Stack"
@@ -300,7 +322,7 @@ insert into kortix.projects (
   '$ACCOUNT_ID'::uuid,
   '$PROJECT_NAME',
   '$PROJECT_REPO_URL',
-  'main',
+  '$PROJECT_DEFAULT_BRANCH',
   'kortix.yaml',
   'active',
   '{"self_host_e2e":true}'::jsonb
@@ -333,7 +355,7 @@ insert into kortix.project_snapshot_builds (
   '$ACCOUNT_ID'::uuid,
   '$PROJECT_ID'::uuid,
   '$PROJECT_COMMIT',
-  'main',
+  '$PROJECT_DEFAULT_BRANCH',
   'self-host-e2e-ready',
   'self-host-e2e-ready',
   'ready',
@@ -349,10 +371,31 @@ section "Create Session"
 SESSION_JSON=$(curl -fsS -X POST "$API_PUBLIC_URL/v1/projects/$PROJECT_ID/sessions" \
   -H "authorization: Bearer $ACCESS_TOKEN" \
   -H 'content-type: application/json' \
-  -d '{"provider":"daytona","base_ref":"main","name":"self-host e2e","branch_already_created":true}')
+  -d "{\"provider\":\"local-docker\",\"base_ref\":\"$PROJECT_DEFAULT_BRANCH\",\"name\":\"self-host e2e\",\"branch_already_created\":true}")
 SESSION_ID=$(printf '%s' "$SESSION_JSON" | json_get session_id)
 [ -n "$SESSION_ID" ] || die "session create failed: $SESSION_JSON"
 ok "POST /v1/projects/:id/sessions works: $SESSION_ID"
+
+section "Sandbox Container"
+# Provisioning is async off the create request (same as every provider) — the
+# FIRST session on a fresh instance also pays a real `docker build` of the
+# platform-default image (ubuntu:24.04 + the Kortix runtime layer: opencode,
+# kortix-agent, apt/pip installs) since nothing was pre-built. Generous
+# timeout for that cold path; every later session on this instance reuses the
+# cached, content-addressed image and is fast.
+SANDBOX_EXTERNAL_ID=$(wait_for_sandbox_external_id "$SESSION_ID" 900)
+ok "session sandbox container provisioned: kortix-sb-$SANDBOX_EXTERNAL_ID"
+
+CONTAINER_STATE=$(docker inspect -f '{{.State.Running}}' "kortix-sb-$SANDBOX_EXTERNAL_ID" 2>/dev/null || echo "missing")
+[ "$CONTAINER_STATE" = "true" ] || die "sandbox container kortix-sb-$SANDBOX_EXTERNAL_ID is not running (state=$CONTAINER_STATE)"
+ok "container kortix-sb-$SANDBOX_EXTERNAL_ID is running"
+
+# The provider ALWAYS publishes the agent port to loopback (debug/dev
+# convenience — see local-docker.ts's create()); read back whatever host port
+# Docker actually assigned rather than assuming one.
+SANDBOX_HOST_PORT=$(docker inspect -f '{{ (index (index .NetworkSettings.Ports "8000/tcp") 0).HostPort }}' "kortix-sb-$SANDBOX_EXTERNAL_ID" 2>/dev/null || true)
+[ -n "$SANDBOX_HOST_PORT" ] || die "sandbox container has no published host port for 8000/tcp"
+SANDBOX_HEALTH_URL="http://127.0.0.1:$SANDBOX_HOST_PORT/kortix/health"
 
 section "Sandbox Health"
 wait_for_sandbox_health "$SANDBOX_HEALTH_URL" 240
@@ -363,6 +406,42 @@ status = body.get("status")
 if status not in ("ok", "degraded"):
     raise SystemExit(f"unexpected sandbox health: {body}")'
 ok "Sandbox /kortix/health returned healthy JSON"
+
+section "Sandbox Stop / Resume (persistence semantics)"
+curl -fsS -X POST "$API_PUBLIC_URL/v1/projects/$PROJECT_ID/sessions/$SESSION_ID/stop" \
+  -H "authorization: Bearer $ACCESS_TOKEN" >/dev/null
+STOP_START=$(date +%s)
+while true; do
+  STATE=$(docker inspect -f '{{.State.Running}}' "kortix-sb-$SANDBOX_EXTERNAL_ID" 2>/dev/null || echo "missing")
+  [ "$STATE" = "false" ] && break
+  [ $(( $(date +%s) - STOP_START )) -ge 60 ] && die "sandbox container did not stop within 60s (state=$STATE)"
+  sleep 2
+done
+ok "stop(): container preserved (not removed), status=stopped"
+# Container must still EXIST (persistence = the writable layer survives).
+docker inspect "kortix-sb-$SANDBOX_EXTERNAL_ID" >/dev/null 2>&1 || die "sandbox container was removed by stop() — persistence semantics violated"
+
+curl -fsS -X POST "$API_PUBLIC_URL/v1/projects/$PROJECT_ID/sessions/$SESSION_ID/start" \
+  -H "authorization: Bearer $ACCESS_TOKEN" >/dev/null
+RESUME_START=$(date +%s)
+while true; do
+  STATE=$(docker inspect -f '{{.State.Running}}' "kortix-sb-$SANDBOX_EXTERNAL_ID" 2>/dev/null || echo "missing")
+  [ "$STATE" = "true" ] && break
+  [ $(( $(date +%s) - RESUME_START )) -ge 60 ] && die "sandbox container did not resume within 60s (state=$STATE)"
+  sleep 2
+done
+ok "start(): resumed the SAME container (sub-second Docker start, no new external_id)"
+
+# Re-verify HTTP reachability post-resume — WITHOUT assuming the debug host
+# port is unchanged. It usually is, but some Docker engines reassign a NEW
+# ephemeral host port for a `HostPort: 0` mapping on restart (confirmed on
+# Docker Desktop); the container's stable Docker-network DNS name is the
+# real (non-debug) path production actually uses (see resolveIngress in
+# local-docker.ts) and is unaffected either way.
+SANDBOX_HOST_PORT=$(docker inspect -f '{{ (index (index .NetworkSettings.Ports "8000/tcp") 0).HostPort }}' "kortix-sb-$SANDBOX_EXTERNAL_ID" 2>/dev/null || true)
+[ -n "$SANDBOX_HOST_PORT" ] || die "sandbox container has no published host port for 8000/tcp after resume"
+wait_for_sandbox_health "http://127.0.0.1:$SANDBOX_HOST_PORT/kortix/health" 60
+ok "sandbox healthy again post-resume — persistence semantics confirmed end-to-end"
 
 section "Update Mechanism"
 note "version before update:"

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -1555,7 +1555,10 @@ async function promptUpdatePolicyCompact(env: SelfHostEnv, flags: GlobalFlags): 
   env.KORTIX_UPDATE_TZ = updateTz.trim() || DEFAULT_UPDATE_TZ;
 }
 
-const SANDBOX_PROVIDER_CHOICES = ['daytona', 'e2b', 'platinum'] as const;
+// 'local-docker' is EXPERIMENTAL: runs sandboxes as containers on THIS same
+// machine via the local Docker socket — no cloud account, not horizontally
+// scalable. See apps/api/src/platform/providers/local-docker.ts.
+const SANDBOX_PROVIDER_CHOICES = ['daytona', 'e2b', 'platinum', 'local-docker'] as const;
 type SandboxProviderChoice = (typeof SANDBOX_PROVIDER_CHOICES)[number];
 
 /**
@@ -1585,9 +1588,10 @@ async function configureIntegrations(env: SelfHostEnv, flags: GlobalFlags): Prom
     // Same one-provider-only shape as before (selectFrom, not selectMany) —
     // an instance runs on exactly one sandbox provider.
     process.stdout.write(
-      `  ${C.cyan}daytona${C.reset}   ${C.dim}https://app.daytona.io (default, recommended)${C.reset}\n` +
-        `  ${C.cyan}e2b${C.reset}       ${C.dim}https://e2b.dev${C.reset}\n` +
-        `  ${C.cyan}platinum${C.reset}  ${C.dim}Kortix's own microVM sandbox provider${C.reset}\n`,
+      `  ${C.cyan}daytona${C.reset}      ${C.dim}https://app.daytona.io (default, recommended)${C.reset}\n` +
+        `  ${C.cyan}e2b${C.reset}          ${C.dim}https://e2b.dev${C.reset}\n` +
+        `  ${C.cyan}platinum${C.reset}     ${C.dim}Kortix's own microVM sandbox provider${C.reset}\n` +
+        `  ${C.cyan}local-docker${C.reset} ${C.dim}[experimental] runs sandboxes as containers on this same machine — no extra provider account needed${C.reset}\n`,
     );
     provider = await selectFrom('Sandbox provider', SANDBOX_PROVIDER_CHOICES, defaultProvider);
   }
@@ -1599,11 +1603,14 @@ async function configureIntegrations(env: SelfHostEnv, flags: GlobalFlags): Prom
     env.DAYTONA_TARGET = await prompt('Daytona target/region', env.DAYTONA_TARGET || 'us');
   } else if (provider === 'e2b') {
     env.E2B_API_KEY = await promptSecret('E2B API key', env.E2B_API_KEY);
-  } else {
+  } else if (provider === 'platinum') {
     env.PLATINUM_API_KEY = await promptSecret('Platinum API key', env.PLATINUM_API_KEY);
     env.PLATINUM_API_URL = await prompt('Platinum API URL', env.PLATINUM_API_URL || 'https://api.platinum.dev');
     env.PLATINUM_TEMPLATE = await prompt('Platinum template (optional — leave blank for the platform default)', env.PLATINUM_TEMPLATE);
   }
+  // local-docker: no credentials to collect — the local Docker socket IS the
+  // "account". writeCompose()/renderFullDockerCompose() wires the socket
+  // mount + LOCAL_DOCKER_NETWORK in automatically for this provider.
 
   // Pipedream (optional, default skip): the ONE other env-only credential
   // that belongs here — the platform-level OAuth app Pipedream issues per
@@ -1667,7 +1674,8 @@ export function sandboxProviders(env: Record<string, string>): string[] {
 }
 
 /** The key each sandbox provider needs to be considered "ready" — mirrors
- *  isProviderEnabled() in apps/api/src/config.ts. */
+ *  isProviderEnabled() in apps/api/src/config.ts. 'local-docker' has none: its
+ *  "account" is the local Docker socket, checked lazily by the API itself. */
 const SANDBOX_PROVIDER_KEY: Record<string, string> = {
   daytona: 'DAYTONA_API_KEY',
   e2b: 'E2B_API_KEY',
@@ -1676,9 +1684,12 @@ const SANDBOX_PROVIDER_KEY: Record<string, string> = {
 
 /** A configured sandbox provider is one named in ALLOWED_SANDBOX_PROVIDERS
  *  whose required key is actually set — whichever of daytona/e2b/platinum was
- *  chosen at `init`/`configure` (see configureIntegrations()). */
+ *  chosen at `init`/`configure` (see configureIntegrations()) — or
+ *  'local-docker', which needs no key at all. */
 export function sandboxProviderConfigured(env: Record<string, string>): boolean {
-  return sandboxProviders(env).some((provider) => !!env[SANDBOX_PROVIDER_KEY[provider] ?? '']);
+  return sandboxProviders(env).some(
+    (provider) => provider === 'local-docker' || !!env[SANDBOX_PROVIDER_KEY[provider] ?? ''],
+  );
 }
 
 /** Managed git provider configured? Required to create/CRUD projects. */
@@ -2144,6 +2155,7 @@ function writeCompose(instance: string, env: SelfHostEnv): void {
       domainConfigured: Boolean(env.KORTIX_DOMAIN?.trim()),
       tunnelConfigured: reachabilityMode(env) === 'tunnel',
       namedTunnelConfigured: namedTunnelConfigured(env),
+      localDockerConfigured: sandboxProviders(env).includes('local-docker'),
     }),
     { encoding: 'utf8', mode: 0o600 },
   );

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -118,6 +118,26 @@ describe('full self-host Docker distribution', () => {
     });
   });
 
+  test('never mounts the Docker socket into kortix-api unless local-docker is selected', () => {
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { volumes?: string[]; environment?: Record<string, string> }>;
+    };
+    const api = document.services['kortix-api'];
+    expect(api?.volumes ?? []).not.toContain('/var/run/docker.sock:/var/run/docker.sock');
+    expect(api?.environment?.LOCAL_DOCKER_NETWORK).toBeUndefined();
+  });
+
+  test('mounts the Docker socket + points LOCAL_DOCKER_NETWORK at this Compose project\'s own network when local-docker is selected', () => {
+    const document = parse(renderFullDockerCompose('kortix-default', { localDockerConfigured: true })) as {
+      services: Record<string, { volumes?: string[]; environment?: Record<string, string> }>;
+    };
+    const api = document.services['kortix-api'];
+    expect(api?.volumes).toContain('/var/run/docker.sock:/var/run/docker.sock');
+    expect(api?.environment?.LOCAL_DOCKER_NETWORK).toBe('kortix-default_default');
+    // Existing env (ALLOWED_SANDBOX_PROVIDERS etc.) must survive the merge.
+    expect(api?.environment?.ALLOWED_SANDBOX_PROVIDERS).toBe('${ALLOWED_SANDBOX_PROVIDERS}');
+  });
+
   test('omits the cloudflared tunnel service when tunnel mode is not selected', () => {
     const document = parse(renderFullDockerCompose('kortix-default')) as {
       services: Record<string, unknown>;

--- a/apps/cli/src/self-host/__tests__/secrets.test.ts
+++ b/apps/cli/src/self-host/__tests__/secrets.test.ts
@@ -155,6 +155,12 @@ describe('missingRequiredSecrets', () => {
     expect(gitProviderConfigured(env)).toBe(false);
   });
 
+  test('local-docker (EXPERIMENTAL) alone reports nothing missing — no provider API key required', () => {
+    const env = baseEnv({ ALLOWED_SANDBOX_PROVIDERS: 'local-docker', DAYTONA_API_KEY: '' });
+    expect(missingRequiredSecrets(env)).toEqual([]);
+    expect(sandboxProviderConfigured(env)).toBe(true);
+  });
+
   test('a fully-configured env (Daytona + GitHub PAT + OpenRouter) also reports nothing missing', () => {
     const env = baseEnv({
       DAYTONA_API_KEY: 'dtn_live_key',

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -117,6 +117,19 @@ export interface RenderComposeOptions {
    * container because the official cloudflared image ships no shell at all.
    */
   namedTunnelConfigured?: boolean;
+  /**
+   * Whether the operator selected the EXPERIMENTAL `local-docker` sandbox
+   * provider (ALLOWED_SANDBOX_PROVIDERS includes it — see
+   * configureIntegrations() in commands/self-host.ts). Only then does
+   * kortix-api get the host's Docker socket mounted in (root-equivalent host
+   * access) and LOCAL_DOCKER_NETWORK pointed at this Compose project's own
+   * default network, so sandbox containers created by the provider
+   * (apps/api/src/platform/providers/local-docker.ts) are reachable by
+   * Docker DNS name. Omitted entirely — not merely unset — for every other
+   * provider, so a Daytona/Platinum/E2B instance never grants kortix-api
+   * Docker access it doesn't need.
+   */
+  localDockerConfigured?: boolean;
 }
 
 /**
@@ -220,6 +233,28 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
 
   for (const [name, rawService] of Object.entries(asRecord(kortix.services))) {
     services[name] = rawService as YamlRecord;
+  }
+
+  // local-docker (EXPERIMENTAL) is opt-in, same shape as the Caddy/cloudflared
+  // blocks below: mutate the already-parsed kortix-api service object rather
+  // than baking a static (always-present) block into kortix-compose.yml, so a
+  // non-local-docker instance's rendered compose never even mentions the
+  // Docker socket.
+  if (options.localDockerConfigured) {
+    const api = services['kortix-api'];
+    if (api) {
+      const existingVolumes = Array.isArray(api.volumes) ? api.volumes : [];
+      api.volumes = [...existingVolumes, '/var/run/docker.sock:/var/run/docker.sock'];
+      const existingEnv = isRecord(api.environment) ? api.environment : {};
+      api.environment = {
+        ...existingEnv,
+        // Sandbox containers land on THIS Compose project's own default
+        // network (the same one every other service here joins), so
+        // kortix-api reaches them by Docker DNS name
+        // (http://kortix-sb-<id>:<port> — see local-docker.ts).
+        LOCAL_DOCKER_NETWORK: `${composeProject}_default`,
+      };
+    }
   }
 
   // The Caddy reverse-proxy/TLS service is opt-in: it only makes sense (and

--- a/docs/runbooks/self-hosting.md
+++ b/docs/runbooks/self-hosting.md
@@ -48,10 +48,18 @@ box.
   the reachability mode agent sandboxes need to work reliably. Ports **80**
   and **443** must be reachable from the internet for ACME HTTP-01 once a
   domain is set.
-- **Required for agent sessions to actually run:** a [Daytona](https://app.daytona.io)
-  API key (the sandbox provider) and managed-git access (a GitHub PAT or GitHub
-  App) so the platform can create project repos. Both can be set after first
-  boot with `kortix self-host configure`.
+- **Required for agent sessions to actually run:** a sandbox provider and
+  managed-git access (a GitHub PAT or GitHub App) so the platform can create
+  project repos. The default provider is [Daytona](https://app.daytona.io)
+  (an API key). Both can be set after first boot with `kortix self-host
+  configure`.
+  - **Alternative: `local-docker` (EXPERIMENTAL).** Runs sandboxes as plain
+    Docker containers on THIS SAME machine — no cloud provider account
+    needed, just the host's own Docker socket (mounted into `kortix-api`
+    automatically when you pick it). It is same-machine only: not
+    horizontally scalable, no multi-node scheduling, no per-container disk
+    quotas yet. Good for evaluation or a single-box deployment; pick Daytona
+    or Platinum for anything that needs to scale beyond one host.
 - **Not required to get started:** SMTP. A fresh install auto-confirms email
   signups and leads with password auth, so the first account works with zero
   email configuration. Configure SMTP later to enable magic-link sign-in.

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -173,9 +173,19 @@ describe('ProjectSchema', () => {
     expect(() => ProjectSchema.parse(projectFixture({
       default_sandbox_provider: 'managed',
     }))).toThrow();
+    // The RETIRED single-instance provider ('local_docker', underscore) stays
+    // rejected — a genuinely different identifier from the new EXPERIMENTAL
+    // 'local-docker' (hyphen) provider below.
     expect(() => ProjectSchema.parse(projectFixture({
       available_sandbox_providers: ['daytona', 'local_docker'],
     }))).toThrow();
+  });
+
+  test('accepts the EXPERIMENTAL local-docker (hyphenated) sandbox provider', () => {
+    expect(() => ProjectSchema.parse(projectFixture({
+      default_sandbox_provider: 'local-docker',
+      available_sandbox_providers: ['local-docker'],
+    }))).not.toThrow();
   });
 
   test('rejects an unknown status', () => {
@@ -257,7 +267,7 @@ describe('SessionStartResultSchema', () => {
 
 describe('ProjectSessionSandboxSchema', () => {
   test('accepts every provider the platform can emit', () => {
-    for (const provider of ['daytona', 'platinum', 'e2b']) {
+    for (const provider of ['daytona', 'platinum', 'e2b', 'local-docker']) {
       expect(() =>
         ProjectSessionSandboxSchema.strict().parse(sandboxFixture({ provider })),
       ).not.toThrow();

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -75,11 +75,20 @@ export const PROJECT_ROLES = ['manager', 'editor', 'member'] as const;
 export const ProjectRoleSchema = z.enum(PROJECT_ROLES);
 export type ProjectRole = z.infer<typeof ProjectRoleSchema>;
 
-/** Every sandbox provider the current platform can select or emit. */
+/**
+ * Every sandbox provider the current platform can select or emit.
+ *
+ * 'local-docker' (hyphenated) is EXPERIMENTAL — same-machine Docker
+ * containers, see apps/api/src/platform/providers/local-docker.ts. It is a
+ * deliberately DIFFERENT identifier from the retired 'local_docker'
+ * (underscore) single-instance provider ripped out in 9cbf57dda — the schema
+ * test suite asserts the old identifier stays rejected.
+ */
 export const SANDBOX_PROVIDERS = [
   'daytona',
   'platinum',
   'e2b',
+  'local-docker',
 ] as const;
 export const SandboxProviderSchema = z.enum(SANDBOX_PROVIDERS);
 export type SandboxProvider = z.infer<typeof SandboxProviderSchema>;

--- a/packages/db/migrations/20260716022818156_sandbox_provider_add_local_docker.sql
+++ b/packages/db/migrations/20260716022818156_sandbox_provider_add_local_docker.sql
@@ -1,0 +1,17 @@
+-- Add 'local-docker' to the sandbox_provider enum — the EXPERIMENTAL
+-- same-machine Docker provider (apps/api/src/platform/providers/local-docker.ts).
+--
+-- Same precedent as 'platinum' (20260708154500000_sandbox_provider_add_platinum.sql)
+-- and 'managed' before it: the value lives in the Drizzle schema
+-- (packages/db/src/schema/kortix.ts) so fresh databases already have it; this
+-- migration is what carries it onto every OTHER database (dev/staging/prod,
+-- and any baseline that FAKED past the original CREATE TYPE — see that
+-- migration's comment for the mixed-version-baseline mechanics that make this
+-- ADD VALUE necessary even though the type "already has it" in a fresh schema).
+--
+-- ADD VALUE only (never USED in this same transaction) — Postgres forbids
+-- using a freshly-added enum value in the same transaction that added it, so a
+-- session actually pinning provider='local-docker' must happen in a later
+-- transaction (it always does — this migration only ever runs standalone).
+-- Non-destructive + idempotent.
+ALTER TYPE "kortix"."sandbox_provider" ADD VALUE IF NOT EXISTS 'local-docker';

--- a/packages/db/src/schema/kortix.test.ts
+++ b/packages/db/src/schema/kortix.test.ts
@@ -73,6 +73,7 @@ describe('kortix enums', () => {
       'daytona',
       'platinum',
       'e2b',
+      'local-docker',
     ]);
   });
 

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -32,6 +32,9 @@ export const sandboxProviderEnum = kortixSchema.enum('sandbox_provider', [
   'daytona',
   'platinum',
   'e2b',
+  // EXPERIMENTAL — same-machine Docker containers, see
+  // apps/api/src/platform/providers/local-docker.ts.
+  'local-docker',
 ]);
 
 export const projectStatusEnum = kortixSchema.enum('project_status', ['active', 'archived']);


### PR DESCRIPTION
## Summary

Live symptom on the self-host `ldocker` instance: sessions provisioned but OpenCode inside the sandbox looped **"Cannot connect to API: Unable to connect. Is the computer able to access the url?"**.

Root cause: `local-docker`'s provider already rewrites `KORTIX_API_URL`/`KORTIX_FRONTEND_URL` onto the shared Docker network (`http://kortix-api:8008`) because a same-machine sandbox can't reach the host's own published port at `localhost` (that's the *container's* own loopback, not the host's). **`KORTIX_LLM_BASE_URL` was missed** — `session-sandbox.ts` computes it from the generic public `config.KORTIX_URL` for every provider, so OpenCode's `kortix` LLM provider was handed `http://localhost:8777/v1/llm` inside the sandbox — unreachable.

Verified live (see PR checks / description below) via `docker exec` into a running `kortix-sb-*` container:
```
curl http://kortix-api:8008/v1/llm/models     -> 401 (reachable, auth-gated — correct)
curl http://localhost:8777/v1/llm             -> connection refused (the bug)
```

There is a **second** copy of the same broken formula in `projects/lib/sandbox-env-sync.ts`'s hot env-push path (fires on every prompt, and on the project's LLM-gateway-mode toggle) — a boot-time-only fix would have been silently undone by the very first prompt sent in a session.

## Changes (all inside the provider / session-env layer — no provider-name branches elsewhere)

- New **optional** `SandboxProvider.sandboxFacingApiOrigin()` capability, mirroring the existing `requiresPublicCallback` flag. `local-docker` is the only implementer today, returning the Docker-network origin (`http://kortix-api:8008`).
- `session-sandbox.ts` now asks the provider for this origin (falling back to `config.KORTIX_URL`, unchanged for every other provider) when computing `KORTIX_LLM_BASE_URL` at boot.
- `local-docker.ts`'s `create()` also rewrites `KORTIX_LLM_BASE_URL` unconditionally when present — same belt-and-suspenders posture as the existing `KORTIX_API_URL`/`KORTIX_FRONTEND_URL` override (protects against a future caller reintroducing the generic origin, e.g. a mid-provision provider failover).
- `sandbox-env-sync.ts`'s hot-push call sites (`syncSandboxEnvForPrompt`, `propagateLlmGatewayModeToActiveSandboxes`) now resolve the base URL through the owning provider (threaded via `sessionSandboxes.provider` / `SandboxRecord.provider`) instead of a second hardcoded copy.
- The base-URL formula itself moved to a tiny, dependency-free `llm-gateway/sandbox-base-url.ts` so both call sites share ONE implementation instead of two that can drift apart again.

## Regression tests

- `llm-gateway/sandbox-base-url.test.ts` — the formula in isolation (default/proxy-mode suffixes, explicit override, trailing-slash handling).
- `platform/providers/local-docker.test.ts` — `create()` rewrites `KORTIX_LLM_BASE_URL` when present, leaves it absent when the LLM gateway wasn't enabled for the session, and the new `sandboxFacingApiOrigin()` method.
- `projects/lib/sandbox-env-sync.test.ts` — the hot-push path resolves per-provider (local-docker vs. every remote cloud provider), not just at boot.

All new/touched suites pass locally (`dotenvx run -- bun test <file>`) and `tsc --noEmit` is clean. Pre-existing, unrelated: `platinum.test.ts` / `preview.test.ts` fail in this worktree with `KORTIX_URL required when KORTIX_BILLING_INTERNAL_ENABLED=true` — reproduced on a clean stash of this branch too (predates this change; matches the known "API test suite local run" false-failure pattern).

## Live verification status

In progress on the local `ldocker` self-host instance (`http://localhost:3777`) — rebuilding `kortix/kortix-api:ldocker` from this branch and recreating the API container to retry a real session. Will update this PR body with timings and pass/fail once done, rather than claim it here ahead of the result.

## Scope note

- Terminal **"pty not found"** and cold/warm **provisioning-latency** timing are being investigated separately and are **not** addressed by this PR.

## Branch note

Stacked on `feat/local-docker-provider` (PR #4765, not yet merged to `main` as of this PR) since the local-docker provider doesn't exist on `main` yet. Opened against `main` per request; will show `feat/local-docker-provider`'s full diff until #4765 merges.

## Test plan

- [x] `tsc --noEmit` clean
- [x] New regression tests pass (`sandbox-base-url.test.ts`, `local-docker.test.ts`, `sandbox-env-sync.test.ts`)
- [x] Existing provider tests still pass (`daytona.test.ts`, `e2b.test.ts`, `provider-boundary.test.ts`, `session-sandbox.test.ts`)
- [x] Live end-to-end verification on the `ldocker` instance — sandbox-to-gateway connectivity confirmed fixed (fast, authenticated 400 instead of connection-refused). Full chat completion blocked by a separate, pre-existing self-host gap (no upstream LLM credentials configured on this instance) — see "Live verification results" below.

## Live verification results (2026-07-16, ldocker instance)

Rebuilt `kortix/kortix-api:ldocker` from this branch (warm incremental build, ~90s — most layers cached, only the changed API source layers rebuilt), recreated the `kortix-ldocker-kortix-api-1` container via `docker compose up -d --no-deps kortix-api` (~24s to healthy), then created a brand-new session through the real UI.

**Fixed and proven — the actual bug in scope:**
- New sandbox container env: `KORTIX_LLM_BASE_URL=http://kortix-api:8008/v1/llm` (was `http://localhost:8777/v1/llm` pre-fix).
- From inside the new sandbox: `curl -X POST $KORTIX_LLM_BASE_URL/chat/completions -H "Authorization: Bearer $KORTIX_LLM_API_KEY" ...` → **HTTP 400 in 0.25s** with a real application-level JSON error (`model_unavailable`), not a connection failure. Before the fix, the equivalent call against `http://localhost:8777/...` from inside a sandbox is `connection refused` (container's own loopback). This is the definitive proof the network path is fixed: the sandbox now reaches, authenticates against, and gets processed by the gateway.
- `sandboxFacingApiOrigin()` / the hot-push path were exercised too: the same-machine sandbox never received a `localhost`-based LLM URL at any point in its lifecycle during this test.

**Separate, pre-existing gap this PR does NOT fix (confirmed, not a regression):** this self-host instance has **no upstream LLM credentials wired into the managed gateway at all** (`OPENROUTER_API_KEY` empty on `kortix-api`, no Bedrock creds) — confirmed via `/v1/llm/chat/completions` returning `model_unavailable` for every model tried, and the product UI itself surfacing "Connect a model via provider first" on both a fresh test project and the pre-existing `te` project. A per-project BYOK Anthropic key baked into an older sandbox's env is a **private** key the gateway can't see for routing — this matches the already-tracked "BYOK private-key gateway blindness" class of issue, not something introduced by local-docker or this fix. Consequence for symptom #1 (stuck at "Connecting"): the daemon's initial-session bootstrap tries to get an assistant response and, with zero working upstream on this instance, that call can never succeed — so on THIS instance "Connecting" hangs regardless of provider (Daytona would hang the same way here). This is a self-host configuration gap, not a local-docker-specific or provider-URL-routing bug.

**pty "not found" (symptom #3) — confirmed pre-existing and provider-independent.** The `ws.close(1011, 'pty not found')` in `apps/kortix-sandbox-agent-server/src/proxy.ts` is fired by the SAME baked sandbox-daemon binary on every provider (Daytona/Platinum/E2B/local-docker) — it's not provider-specific code, and a `docker exec` into a running local-docker sandbox confirms pty creation itself worked fine (`[pty] created ... command":"/bin/bash"`). The close fires when a terminal WebSocket reconnects with a `ptyId` no longer present in the in-memory `ptyRegistry` (survives an OpenCode process restart by design, but not a full daemon/container restart, or a client holding a stale id across a page reload) — same failure mode Daytona/Platinum would hit. Out of scope for this PR per the provider-boundary constraint; flagged for separate follow-up, not touched here.

**Timings observed (useful for the docs' expectations section):**
- `kortix-api` image rebuild (warm, only API source changed): ~90s.
- `docker compose up -d --no-deps kortix-api` recreate → healthy: ~24s.
- New session, cold (fresh project → new snapshot reused from cache, `image-cached` provisioning mark): container up in a few seconds; total to "opencode ready" internally: well under a minute. The UI's "Connecting" stage itself does not resolve to a working chat on this instance, for the separate no-upstream-credentials reason above — not a provisioning-speed problem.
