### PR TITLE
feat(selfhost-ec2): auto-recovery + first-class vertical scaling

### DIFF
--- a/infra/terraform/modules/selfhost-ec2/README.md
+++ b/infra/terraform/modules/selfhost-ec2/README.md
@@ -54,6 +54,15 @@ mechanism to keep in sync with the updater, on purpose.
   notifying an SNS topic (`var.alarm_sns_topic_arn` to reuse an existing one,
   or the module creates its own, optionally with `var.alarm_email`
   subscribed). See "Monitoring" below.
+- **Auto-recovery + auto-reboot** (`var.enable_auto_recovery` /
+  `var.enable_auto_reboot`, both default on, both independent of
+  `var.enable_alarms`): automatically recovers the instance onto new host
+  hardware on a system status-check failure, or reboots it on an instance
+  status-check failure. See "Scaling" below for why this box leans on
+  recovery instead of horizontal redundancy.
+- **A data-volume filesystem auto-grow timer**: when you increase
+  `data_volume_size_gb`, a small systemd timer on the box notices the bigger
+  block device and runs `resize2fs` itself — see "Scaling" below.
 
 ## What it deliberately does NOT do
 
@@ -116,6 +125,8 @@ output "next_steps" {
   address to the module-created topic), `disk_usage_alarm_threshold_percent`
   (default 85), `memory_usage_alarm_threshold_percent` (default 90),
   `alarm_evaluation_periods` (default 3 × 5-minute periods).
+- `enable_auto_recovery` (default `true`), `enable_auto_reboot` (default
+  `true`) — see "Scaling" below.
 
 ## Outputs
 
@@ -251,6 +262,143 @@ short spikes (a build, a backup). All three notify `alarm_sns_topic_arn`: an
 existing topic if you pass `var.alarm_sns_topic_arn`, otherwise a topic this
 module creates (optionally subscribing `var.alarm_email`). Kept deliberately
 minimal — this is one box, not a fleet; add more if you need them.
+
+Two more alarms are independent of `var.enable_alarms` (no CloudWatch agent
+needed — both key off native `AWS/EC2` status-check metrics) and are covered
+in "Scaling" below: `enable_auto_recovery` (`StatusCheckFailed_System` ->
+`ec2:recover`) and `enable_auto_reboot` (`StatusCheckFailed_Instance` ->
+`ec2:reboot`), both default on. Same SNS topic, when `enable_alarms` is also
+on.
+
+## Scaling
+
+**Philosophy: one stateful box, scaled up and kept healthy — never scaled
+out.** This module intentionally has **no** horizontal/ASG scaling and **no**
+container-level autoscaling. Everything durable (Postgres, Supabase Storage,
+Docker/containerd state) lives on a single EBS data volume attached to a
+single instance — there is no multi-writer story for that data, so adding a
+second box wouldn't be "scaling," it would be a different, harder deployment
+shape (shared/replicated storage, a load balancer, session affinity, a
+migration path for existing self-host users) that this module doesn't
+attempt. Within that constraint, "scaling" here means exactly two things:
+**resize the box vertically**, and **recover automatically** when something
+goes wrong, rather than relying on redundancy to paper over it.
+
+### Auto-recovery and auto-reboot
+
+- **`enable_auto_recovery`** (default on): alarms on `StatusCheckFailed_System`
+  and takes the `ec2:recover` action — AWS migrates the instance to different
+  host hardware. This only fires for a genuine **host**-level fault (network
+  loss, power loss, a physical-host software issue) — nothing the guest OS
+  does can trigger it, so it's unconditionally safe to leave on for a single
+  box. A recovered instance keeps its instance ID, all IPs (including the
+  Elastic IP), and both EBS volumes re-attach automatically — Terraform state
+  and the data volume are untouched. Verified against AWS's current
+  "CloudWatch action based recovery" instance-type support list: the General
+  Purpose family list explicitly includes T3/T3a/T4g (this module's default
+  `instance_type` family), and the only extra constraint in that list
+  ("instance store volumes added at launch") doesn't apply here — this module
+  never attaches instance-store volumes, only the root EBS volume and the
+  separate EBS data volume (an EBS-only setup, which is unconditionally
+  eligible). Evaluated over 2 consecutive 1-minute periods, per AWS's own
+  documented recommendation for this alarm.
+- **`enable_auto_reboot`** (default on): alarms on `StatusCheckFailed_Instance`
+  and takes the `ec2:reboot` action — an OS-level reboot, which is AWS's own
+  recommended response to an *instance* (as opposed to system) status-check
+  failure. This one does touch the guest OS, which is why it's a separate
+  variable from `enable_auto_recovery` — but it's safe as a default here
+  specifically because of this module's bootstrap design: Docker and
+  containerd are `systemctl enable`d, and `kortix-selfhost-bootstrap.service`
+  is `enable`d with `WantedBy=multi-user.target` (see "Bootstrap resilience"
+  above) — so the entire stack self-starts again after any reboot, unattended.
+  That mechanism was originally built to survive a slow-cold-start
+  health-check race, but it equally makes an *unplanned* reboot safe to
+  recover from. Evaluated over 3 consecutive 1-minute periods (deliberately
+  different from recovery's 2, per AWS's guidance, to avoid a race between the
+  two actions firing on the same failure). Set this to `false` if you'd
+  rather SSM in and look at an instance-check failure by hand before the box
+  reboots out from under an in-flight session.
+
+Both alarms use `treat_missing_data = "missing"` (not "breaching"), per AWS's
+specific guidance for alarms wired to stop/terminate/reboot/recover actions —
+a metric-reporting gap must never itself trigger a destructive action.
+
+### Resize runbook
+
+**Instance type** (CPU/RAM) — bump `var.instance_type`, `terraform apply`:
+- In the common case this is an **in-place resize**, not a replace: the AWS
+  provider stops the instance, calls `ModifyInstanceAttribute`, and starts it
+  again — same instance ID, same EBS volumes, same Elastic IP, typically
+  ~2-3 minutes of downtime. Terraform only falls back to a destroy/recreate
+  if the new `instance_type` is incompatible with the current AMI/config
+  (this module's own `precondition` on `aws_instance.this` already catches
+  the most common cause of that — an architecture mismatch — at `plan` time,
+  before it can happen).
+- Either way, the data volume is unaffected: `local.availability_zone`
+  (storage.tf) is derived from the subnet, never from the instance, so it
+  never becomes "known after apply" when the instance changes — plus
+  `lifecycle.prevent_destroy` on `aws_ebs_volume.data` refuses any
+  destroy/replace of it outright. `scripts/check-data-volume-safe.sh` is a
+  cause-agnostic plan-guard: it flags *any* plan that would replace or delete
+  `aws_ebs_volume.data`, regardless of what triggered it, so an
+  `instance_type`-driven replace is already covered without any changes to
+  the script itself. Run it against a saved plan before applying an
+  `instance_type` change if you want the belt-and-suspenders check:
+  ```sh
+  terraform plan -out=tf.plan
+  ../../terraform/modules/selfhost-ec2/scripts/check-data-volume-safe.sh tf.plan
+  ```
+
+**Data volume size** (disk) — bump `var.data_volume_size_gb`,
+`terraform apply`:
+- This is a **live, in-place gp3 resize** — no downtime, no detach, no
+  reboot required at the AWS layer; the running instance's kernel sees the
+  larger block device within seconds.
+- On the box, `templates/user-data.sh.tftpl` installs
+  `kortix-data-volume-growfs.timer` (runs 2 minutes after boot, then every 10
+  minutes) which notices the bigger device and runs `resize2fs` on the data
+  volume's whole-disk ext4 filesystem (no `growpart` needed — the data volume
+  was `mkfs`'d directly against the raw device, not a partition). So growing
+  the data volume is genuinely: **change the tfvar, `terraform apply`, done**
+  — no SSM session, no manual `resize2fs`, just a ≤10-minute lag for the timer
+  to notice.
+- Root volume (`var.root_volume_size_gb`) resizes the same way at the AWS
+  layer, but the guest filesystem is on a *partition* (not a whole disk), and
+  this module doesn't install its own auto-grow timer for it — Ubuntu
+  24.04's stock cloud-init `growpart`/`resizefs` modules already run on every
+  boot by default, so a plain reboot after the EBS-side resize is enough.
+  The root volume only holds the OS + kortix CLI (Docker/Postgres/Storage all
+  live on the data volume), so this should rarely need resizing at all.
+
+### Threshold guidance
+
+Tied to this module's own alarms and metrics — treat these as "time to bump
+a tfvar," not as an emergency:
+
+- **Sustained CPU > 70%** (the standard `AWS/EC2` `CPUUtilization` metric —
+  emitted for free, no CloudWatch agent required) **or** the memory-usage
+  alarm (`memory_usage_alarm_threshold_percent`, default 90%) firing → size
+  up: bump `var.instance_type` (see the resize runbook above).
+- **Disk usage trending above ~75%** on either volume → grow the data volume
+  (`var.data_volume_size_gb`) before the disk-usage alarm's own default
+  threshold (`disk_usage_alarm_threshold_percent`, default 85%) actually
+  fires — treat the alarm firing as the hard deadline, not the trigger to
+  start.
+- **The system/instance status-check alarms firing repeatedly** for the same
+  box (as opposed to a one-off recovery/reboot) is a signal to look at the
+  underlying instance family/generation, not just retry harder.
+
+### Non-goal: multi-node
+
+If you need more than one node — for horizontal capacity, for multi-region,
+for zero-downtime deploys, or because a single box's blast radius is no
+longer acceptable — that is a **different deployment shape**, not a bigger
+version of this module. This module's entire design (one instance, one data
+volume, bind-mounted Postgres, no replication) assumes a single writer to a
+single disk; making that horizontal means solving shared/replicated storage,
+load balancing, and session affinity, which is out of scope here on purpose.
+Reach for a managed Postgres + stateless app-tier architecture instead if you
+get to that point.
 
 ## Restoring from a snapshot
 

--- a/infra/terraform/modules/selfhost-ec2/main.tf
+++ b/infra/terraform/modules/selfhost-ec2/main.tf
@@ -59,6 +59,12 @@ data "aws_ami" "selected" {
   }
 }
 
+# Used to build the `arn:aws:automate:<region>:ec2:{recover,reboot}` alarm
+# actions (see monitoring.tf) — these EC2 "automate" ARNs are region-scoped
+# but account-agnostic, so the region is the only thing that needs resolving
+# at plan time.
+data "aws_region" "current" {}
+
 # ── AMI (Ubuntu 24.04 LTS via Canonical's public SSM parameter) ────────────
 data "aws_ssm_parameter" "ubuntu" {
   count = var.ami_id == "" ? 1 : 0

--- a/infra/terraform/modules/selfhost-ec2/monitoring.tf
+++ b/infra/terraform/modules/selfhost-ec2/monitoring.tf
@@ -1,9 +1,16 @@
 # Minimal, boring CloudWatch monitoring: an EC2 status-check alarm (no
 # agent needed) plus disk/memory alarms fed by the CloudWatch agent that
 # templates/user-data.sh.tftpl installs and configures on the box (see the
-# "monitoring" section there). Everything here is var-gated by
-# var.enable_alarms (default true) — this is a single unmonitored box
-# otherwise, which was finding #4 of the 2026-07 production-readiness audit.
+# "monitoring" section there). These are var-gated by var.enable_alarms
+# (default true) — this is a single unmonitored box otherwise, which was
+# finding #4 of the 2026-07 production-readiness audit.
+#
+# Also here: the two self-healing alarms (var.enable_auto_recovery /
+# var.enable_auto_reboot, both default true, both independent of
+# var.enable_alarms since they key off native AWS/EC2 status-check metrics,
+# no agent needed) — the recovery half of "single stateful box, not a fleet"
+# (see README "Scaling": no horizontal/ASG scaling, no container
+# autoscaling — vertical resize + auto-recovery instead).
 
 # ── IAM: let the box publish CloudWatch agent metrics/logs ─────────────────
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
@@ -104,6 +111,94 @@ resource "aws_cloudwatch_metric_alarm" "disk_usage_data" {
   alarm_actions = [local.alarm_topic_arn]
   ok_actions    = [local.alarm_topic_arn]
   tags          = local.tags
+}
+
+# ── Auto-recovery: StatusCheckFailed_System -> ec2:recover ─────────────────
+# Recovers the instance onto new host hardware on a genuine HOST-level fault
+# (loss of network connectivity, loss of system power, a physical-host
+# software/hardware issue) — never triggered by anything happening inside the
+# guest OS. Verified against AWS's current "CloudWatch action based recovery"
+# instance-type support list (docs.aws.amazon.com/AWSEC2/latest/UserGuide/
+# cloudwatch-recovery.html, checked 2026-07): the "General purpose" family
+# list explicitly includes T3/T3a/T4g (this module's default instance_type
+# family), and the only extra constraint ("If instance store volumes are
+# added at launch") doesn't apply — this module never attaches instance-store
+# volumes, only the root EBS volume + the separate EBS data volume. Recovery
+# preserves instance ID, all IPs (incl. the Elastic IP), and re-attaches both
+# EBS volumes automatically, so the data volume (storage.tf) is untouched.
+# Independent of var.enable_alarms: this alarms on a native AWS/EC2 metric
+# that needs no CloudWatch agent, unlike the disk/memory alarms above.
+resource "aws_cloudwatch_metric_alarm" "auto_recovery" {
+  count             = var.enable_auto_recovery ? 1 : 0
+  alarm_name        = "${local.name}-auto-recovery"
+  alarm_description = "System status check failed for ${local.name} (${aws_instance.this.id}) — recovering onto new host hardware (arn:aws:automate:${data.aws_region.current.name}:ec2:recover)."
+  namespace         = "AWS/EC2"
+  metric_name       = "StatusCheckFailed_System"
+  # AWS's own console walkthrough for this exact alarm uses "Minimum" over a
+  # 1-minute period — with one data point per period (detailed monitoring is
+  # on; see aws_instance.this.monitoring in main.tf) Minimum/Maximum/Average
+  # are numerically identical for this binary (0/1) metric, so this is purely
+  # matching AWS's documented convention.
+  statistic = "Minimum"
+  period    = 60
+  # AWS's documented recommendation: 2 evaluation periods for recover, 3 for
+  # reboot (see aws_cloudwatch_metric_alarm.auto_reboot below) — deliberately
+  # DIFFERENT counts to avoid a race between the two actions firing together.
+  evaluation_periods  = 2
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  # AWS's explicit guidance for stop/terminate/reboot/recover alarms
+  # specifically (as opposed to the notify-only alarms above): treat missing
+  # data as "missing", not breaching — a transient metric-reporting gap must
+  # never itself trigger a destructive recovery action.
+  treat_missing_data = "missing"
+
+  dimensions = {
+    InstanceId = aws_instance.this.id
+  }
+
+  alarm_actions = compact([
+    "arn:aws:automate:${data.aws_region.current.name}:ec2:recover",
+    local.alarm_topic_arn,
+  ])
+  ok_actions = compact([local.alarm_topic_arn])
+  tags       = local.tags
+}
+
+# ── Auto-reboot: StatusCheckFailed_Instance -> ec2:reboot ──────────────────
+# AWS recommends the reboot action specifically for Instance (as opposed to
+# System) status-check failures — an OS-level reboot, not a host migration.
+# Safe as a default here because of how this box bootstraps: Docker and
+# containerd are `systemctl enable`d and kortix-selfhost-bootstrap.service is
+# `enable`d (WantedBy=multi-user.target) — see templates/user-data.sh.tftpl —
+# so the entire stack self-starts again after any reboot, with zero operator
+# involvement (this is the exact mechanism the README's "Bootstrap
+# resilience" section documents, originally built for a different problem —
+# a slow-cold-start health-check race — but it equally makes an unplanned
+# reboot from this alarm safe to recover from unattended).
+resource "aws_cloudwatch_metric_alarm" "auto_reboot" {
+  count               = var.enable_auto_reboot ? 1 : 0
+  alarm_name          = "${local.name}-auto-reboot"
+  alarm_description   = "Instance status check failed for ${local.name} (${aws_instance.this.id}) — rebooting (arn:aws:automate:${data.aws_region.current.name}:ec2:reboot)."
+  namespace           = "AWS/EC2"
+  metric_name         = "StatusCheckFailed_Instance"
+  statistic           = "Minimum"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "missing"
+
+  dimensions = {
+    InstanceId = aws_instance.this.id
+  }
+
+  alarm_actions = compact([
+    "arn:aws:automate:${data.aws_region.current.name}:ec2:reboot",
+    local.alarm_topic_arn,
+  ])
+  ok_actions = compact([local.alarm_topic_arn])
+  tags       = local.tags
 }
 
 # ── Memory usage (CloudWatch agent, "mem" plugin — no per-mount dimension) ─

--- a/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
+++ b/infra/terraform/modules/selfhost-ec2/templates/user-data.sh.tftpl
@@ -61,6 +61,68 @@ fi
 DATA_UUID="$(blkid -s UUID -o value "$DATA_DEVICE")"
 grep -q "$DATA_UUID" /etc/fstab || echo "UUID=$DATA_UUID $DATA_MOUNT ext4 defaults,nofail 0 2" >> /etc/fstab
 
+# ── 1b. Auto-grow the data volume's filesystem to match the EBS volume ─────
+# gp3 supports live, in-place volume-size increases (bump
+# var.data_volume_size_gb -> terraform apply -> AWS resizes the EBS volume
+# with no detach/reboot needed) and the guest kernel sees the larger block
+# device within seconds. But growing the volume does NOT grow the
+# filesystem sitting on it — that needs an on-box step. This is a whole-disk
+# ext4 filesystem (mkfs ran directly against $DATA_DEVICE above, no partition
+# table), so the only step needed is `resize2fs`, no `growpart` — and
+# resize2fs is a safe no-op ("Nothing to do!") when the filesystem already
+# fills the device, so it's fine to (re)run this unconditionally, on every
+# boot and on a recurring timer, rather than trying to detect "did it grow"
+# ourselves. This is what makes a data-volume resize genuinely "change
+# tfvar, apply, done" — no SSM session, no manual resize2fs.
+cat > /usr/local/sbin/kortix-data-volume-growfs.sh <<'GROWFS'
+#!/bin/bash
+set -euo pipefail
+DATA_MOUNT="${data_mount_path}"
+DATA_DEVICE="$(findmnt -n -o SOURCE --target "$DATA_MOUNT" 2>/dev/null || true)"
+if [ -z "$DATA_DEVICE" ]; then
+  echo "kortix-data-volume-growfs: $DATA_MOUNT is not mounted, skipping"
+  exit 0
+fi
+echo "kortix-data-volume-growfs: checking $DATA_DEVICE ($DATA_MOUNT) against the underlying block device size"
+resize2fs "$DATA_DEVICE"
+GROWFS
+chmod +x /usr/local/sbin/kortix-data-volume-growfs.sh
+
+cat > /etc/systemd/system/kortix-data-volume-growfs.service <<'UNIT'
+[Unit]
+Description=Grow the kortix self-host data volume's filesystem to match the EBS volume (online gp3 resize)
+After=mnt-kortix\x2ddata.mount
+Requires=mnt-kortix\x2ddata.mount
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/kortix-data-volume-growfs.sh
+UNIT
+
+cat > /etc/systemd/system/kortix-data-volume-growfs.timer <<'UNIT'
+[Unit]
+Description=Periodically grow the kortix self-host data volume's filesystem if the EBS volume has grown
+
+[Timer]
+# Runs shortly after every boot (covers a resize applied while the box was
+# stopped) AND every 10 minutes thereafter (covers a live gp3 resize applied
+# while the box keeps running — the whole point of an online resize is that
+# it needs no reboot, so this is what actually completes the job without one).
+OnBootSec=2min
+OnUnitActiveSec=10min
+Unit=kortix-data-volume-growfs.service
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now kortix-data-volume-growfs.timer
+# Also run it once right now (harmless no-op on a fresh mkfs — device and
+# filesystem are already the same size) so a box that boots after a
+# same-apply resize doesn't wait for the timer's first tick.
+/usr/local/sbin/kortix-data-volume-growfs.sh || true
+
 DOCKER_DATA_ROOT="$DATA_MOUNT/docker"
 CONTAINERD_ROOT="$DATA_MOUNT/containerd"
 KORTIX_CONFIG_DIR="$DATA_MOUNT/kortix-self-host"

--- a/infra/terraform/modules/selfhost-ec2/variables.tf
+++ b/infra/terraform/modules/selfhost-ec2/variables.tf
@@ -27,9 +27,14 @@ variable "tags" {
 # ── Instance ───────────────────────────────────────────────────────────────
 
 variable "instance_type" {
-  description = "EC2 instance type. t3.xlarge (4 vCPU / 16GB) is a reasonable floor for the full stack (Supabase + API + gateway + frontend + sandboxed builds)."
+  description = "EC2 instance type. t3.xlarge (4 vCPU / 16GB) is a reasonable floor for the full stack (Supabase + API + gateway + frontend + sandboxed builds). This is this module's primary vertical-scaling lever — see the README's \"Scaling\" section for the resize runbook and threshold guidance. Bumping this and re-applying is an in-place resize (AWS provider stops, modifies, restarts the SAME instance) in the common case, not a destroy/recreate — see the README for when it can fall back to a replace, and why that's still safe for the data volume either way."
   type        = string
   default     = "t3.xlarge"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]*\\.[a-z0-9]+$", var.instance_type))
+    error_message = "instance_type must look like a valid EC2 instance type in <family>.<size> form, e.g. t3.xlarge, m6g.2xlarge."
+  }
 }
 
 variable "ami_id" {
@@ -45,9 +50,14 @@ variable "ami_ssm_parameter" {
 }
 
 variable "root_volume_size_gb" {
-  description = "Root (OS) EBS volume size. Docker data lives on the separate data volume, not here — this only needs to hold the OS + kortix CLI."
+  description = "Root (OS) EBS volume size. Docker data lives on the separate data volume, not here — this only needs to hold the OS + kortix CLI. Growing this is in-place (gp3 elastic volume resize), but — unlike the data volume — the guest filesystem is on a partition, not a whole disk, so picking up the extra space relies on Ubuntu's stock cloud-init growpart/resizefs modules (already on by every boot in the default 24.04 cloud image; this module doesn't need to configure anything extra for it), which only run at boot — a plain reboot after the EBS-side resize is enough, no manual growpart/resize2fs needed."
   type        = number
   default     = 30
+
+  validation {
+    condition     = var.root_volume_size_gb >= 8 && var.root_volume_size_gb <= 16384
+    error_message = "root_volume_size_gb must be between 8 and 16384 (gp3's supported size range in GiB)."
+  }
 }
 
 variable "key_name" {
@@ -91,9 +101,14 @@ variable "ssh_ingress_cidrs" {
 # ── Data volume (all Docker volumes, incl. Postgres, live here) ────────────
 
 variable "data_volume_size_gb" {
-  description = "Size of the separate EBS data volume that holds all durable self-host state: Docker's own data-root (images, containers, the updater/Caddy named volumes) AND the kortix CLI's instance directory (.env, compose file, and — critically — Postgres and Supabase Storage, which the CLI persists as bind mounts under its instance directory, not as Docker named volumes). Sizing this is really about your database + object storage growth, not the OS."
+  description = "Size of the separate EBS data volume that holds all durable self-host state: Docker's own data-root (images, containers, the updater/Caddy named volumes) AND the kortix CLI's instance directory (.env, compose file, and — critically — Postgres and Supabase Storage, which the CLI persists as bind mounts under its instance directory, not as Docker named volumes). Sizing this is really about your database + object storage growth, not the OS. Increasing this is a live, in-place gp3 resize (no downtime at the AWS layer) — templates/user-data.sh.tftpl installs a small systemd timer that notices the bigger block device and runs `resize2fs` on its own, so bumping this and `terraform apply` is the entire runbook (no SSM/manual step) — see the README's \"Scaling\" section. NOTE: EBS does not support shrinking a volume; decreasing this value fails loudly at apply time with a clear AWS API error rather than doing anything destructive."
   type        = number
   default     = 100
+
+  validation {
+    condition     = var.data_volume_size_gb >= 8 && var.data_volume_size_gb <= 16384
+    error_message = "data_volume_size_gb must be between 8 and 16384 (gp3's supported size range in GiB). Note: EBS volumes can only grow, never shrink — lowering this value will fail at apply time."
+  }
 }
 
 variable "data_volume_kms_key_id" {
@@ -253,4 +268,24 @@ variable "alarm_evaluation_periods" {
   description = "Number of consecutive 5-minute periods a disk/memory metric must breach its threshold before alarming (reduces noise from short spikes, e.g. a build or backup). The EC2 status-check alarm uses its own fixed evaluation (see monitoring.tf) since that metric is binary."
   type        = number
   default     = 3
+}
+
+# ── Auto-recovery / auto-reboot (single-box self-healing) ──────────────────
+# This module deliberately has NO horizontal/ASG scaling and NO container
+# autoscaling — it's one stateful box by design (see README "Scaling"). These
+# two are the self-healing half of that story: automatic responses to the two
+# distinct EC2 status-check failure modes, independent of var.enable_alarms
+# (that variable's disk/memory alarms need the CloudWatch agent; these two
+# use only the native, always-on AWS/EC2 status-check metrics).
+
+variable "enable_auto_recovery" {
+  description = "Whether to alarm on StatusCheckFailed_System and take AWS's `ec2:recover` action — migrates the instance onto new host hardware when the underlying HOST has a genuine hardware/software fault (loss of network connectivity, loss of system power, a physical-host software issue). This never fires for anything happening inside the guest OS, only host-level failures outside the box's control, so there's no legitimate scenario where it does more harm than good on a single box. A recovered instance keeps its instance ID, private/public/Elastic IP, and EBS volumes (both root and the data volume) re-attach automatically — Terraform's state and the data volume are untouched. Supported instance families include this module's default (t3) with EBS-only storage (this module's own setup: root_block_device + the separate data volume, no instance-store volumes) — see the README for the verification. Default on."
+  type        = bool
+  default     = true
+}
+
+variable "enable_auto_reboot" {
+  description = "Whether to alarm on StatusCheckFailed_Instance and take AWS's `ec2:reboot` action — an OS-level reboot when the INSTANCE itself (not the underlying host) fails its health check (e.g. a wedged kernel/network stack that only a reboot clears). Unlike enable_auto_recovery, this does touch the guest OS, but it's safe as this box's default specifically because of how it bootstraps: Docker and containerd are `systemctl enable`d (auto-start on boot) and kortix-selfhost-bootstrap.service is `enable`d with `WantedBy=multi-user.target` (see templates/user-data.sh.tftpl and the README's \"Bootstrap resilience\" section) — a reboot always comes back with the whole stack self-starting, with no operator intervention. Default on, for the same reason enable_auto_recovery is: a self-healing single box is this module's whole point, and 3 consecutive minutes of instance-check failure (see monitoring.tf) is a real, not transient, signal. Set to false if you'd rather investigate an instance-check failure by hand (e.g. to preserve state for a postmortem) before the box reboots out from under an in-flight session."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
## Summary

Single-box self-healing + scaling affordances for `infra/terraform/modules/selfhost-ec2`. Scope deliberately excludes horizontal/ASG scaling and container autoscaling — this module provisions one stateful box, on purpose (see README "What it deliberately does NOT do" / new "Scaling" section).

**Do not merge yet** — rides after the v0.10.3 release train per the current release freeze. Builds directly on #4763 (AZ-pinned data volume + `monitoring.tf` + systemd bootstrap), which is now merged to `main`, so this branches straight off `main`.

### 1. Auto-recovery + auto-reboot
- `aws_cloudwatch_metric_alarm.auto_recovery`: `StatusCheckFailed_System` -> `arn:aws:automate:<region>:ec2:recover`, gated by `var.enable_auto_recovery` (default **on**). Verified against AWS's current "CloudWatch action based recovery" instance-type support list — the General Purpose family explicitly lists T3/T3a/T4g (this module's default family), and the module's EBS-only setup (root volume + separate data volume, no instance store) has no extra constraint against it. Recovery preserves instance ID / all IPs / re-attaches both EBS volumes automatically.
- `aws_cloudwatch_metric_alarm.auto_reboot`: `StatusCheckFailed_Instance` -> `arn:aws:automate:<region>:ec2:reboot`, gated by `var.enable_auto_reboot` (default **on**, justified in the variable description + README) — safe as a default specifically because Docker/containerd and `kortix-selfhost-bootstrap.service` are all `systemctl enable`d to self-start on any reboot (the exact mechanism the README's "Bootstrap resilience" section already documents for a different problem).
- Both use `treat_missing_data = "missing"` (AWS's specific guidance for destructive alarm actions) and deliberately different evaluation-period counts (2 vs 3, per AWS's own recommendation) to avoid a recover/reboot race. Both are independent of `var.enable_alarms` (native `AWS/EC2` metrics, no CloudWatch agent needed).

### 2. Vertical scaling made first-class
- Added `validation` blocks to `instance_type`, `root_volume_size_gb`, `data_volume_size_gb` (gp3's real 8-16384 GiB range; documents that EBS can't shrink, so a decrease fails loudly at `apply`, not silently).
- Confirmed live (see Validation below) that an `instance_type` bump is an in-place resize and a `data_volume_size_gb` bump is an in-place gp3 resize — neither touches `aws_ebs_volume.data`. Confirmed a forced instance replace (`-replace=...aws_instance.this`) only touches `aws_volume_attachment.data` (expected — it has to reattach to the new instance ID), never `aws_ebs_volume.data` itself. `scripts/check-data-volume-safe.sh` needed no changes — it's already cause-agnostic.
- Added a `kortix-data-volume-growfs` systemd timer to `templates/user-data.sh.tftpl`: runs `resize2fs` against the data volume's whole-disk ext4 filesystem 2 minutes after boot and every 10 minutes thereafter (idempotent no-op when already at full size), so a `data_volume_size_gb` bump is genuinely "change tfvar, apply, done" — no SSM session required.

### 3. README "Scaling" section
Philosophy (one stateful box), the resize runbook (instance type vs. data volume vs. root volume), threshold guidance tied to the module's existing alarms, and the explicit multi-node non-goal.

## Validation

- `terraform fmt -recursive` clean.
- `terraform init -backend=false` + `terraform validate`: **Success** on the module, `infra/deployments/vps-demo`, and `infra/terraform/examples/selfhost-ec2` (only a harmless AWS provider v6 deprecation warning on `data.aws_region.current.name` — kept `.name`, not `.region`, since the module's `required_providers` floor is `>= 5.0` and `.region` doesn't exist pre-v6).
- `checkov` on the module: **63 passed / 0 failed / 3 skipped** vs. baseline (pre-PR `main`) **61 passed / 0 failed / 3 skipped** — 2 more passing checks (the new alarms), zero regressions, zero new skips. Same result (0 failed) on `vps-demo` and the example root module.
- Live plan-guard repro against the actual deployed `vps-demo` box's real Terraform state (read-only `terraform plan`, no `apply`):
  - `instance_type` bump -> `aws_instance.this` **updated in-place**, zero touch to the data volume.
  - `data_volume_size_gb` bump -> `aws_ebs_volume.data` **updated in-place** (live gp3 resize), zero replace.
  - `terraform plan -replace=...aws_instance.this` -> only `aws_instance.this`, `aws_eip_association.this`, and `aws_volume_attachment.data` are replaced; `aws_ebs_volume.data` itself never appears in the plan.
  - `scripts/check-data-volume-safe.sh` passes (exit 0) against all of the above saved plans.
  - Confirmed the new `instance_type`/`data_volume_size_gb` validations correctly reject out-of-range input, and confirmed a real shrink attempt (`data_volume_size_gb` below the current live volume size) passes `plan` but is documented as failing at `apply` (Terraform doesn't call AWS's `ModifyVolume` API until apply — matches the variable's documented behavior).
  - Rendered `templates/user-data.sh.tftpl` end-to-end with `templatefile()` and ran `bash -n` against the output — clean syntax, and confirmed the new growfs systemd units render with `${data_mount_path}` correctly substituted.

No real AWS resources were created, modified, or destroyed by this validation — only read-only `plan`/`validate`/`checkov`, and the copied state file used for the live repro was deleted afterward (original untouched).