### PR TITLE
fix(runtime): refresh managed model catalog on warm fork

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test'
-import { writeFileSync, mkdtempSync } from 'fs'
+import { readFileSync, writeFileSync, mkdtempSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -16,7 +16,7 @@ import {
   stopExecutorProxy,
   EXECUTOR_PROXY_PLACEHOLDER_KEY,
 } from '../llm-proxy'
-import { buildOpencodeConfigContent } from '../opencode'
+import { buildOpencodeConfigContent, refreshGatewayCatalogFile } from '../opencode'
 
 // A mock upstream that echoes back the Authorization header + path it received,
 // so we can prove the proxy injects the live token (not the placeholder).
@@ -169,5 +169,67 @@ describe('buildOpencodeConfigContent — proxy mode vs direct mode', () => {
     expect(cfg.provider.kortix.options.baseURL).toBe('https://gateway.kortix.test/v1/llm')
     expect(cfg.provider.kortix.options.apiKey).toBe('real-session-llm-key')
     expect(cfg.mcp).toBeUndefined()
+  })
+})
+
+describe('refreshGatewayCatalogFile — warm snapshot catalog recovery', () => {
+  test('replaces a stale frozen catalog with the authenticated live catalog', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'catalog-refresh-'))
+    const frozen = join(dir, 'frozen.json')
+    const refreshed = join(dir, 'refreshed.json')
+    writeFileSync(frozen, JSON.stringify({ models: { 'retired-model': { name: 'Retired' } } }))
+
+    const liveModels = {
+      'glm-5.2': { name: 'GLM 5.2' },
+      'claude-sonnet-4.6': { name: 'Claude Sonnet 4.6' },
+    }
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        expect(req.headers.get('authorization')).toBe('Bearer live-session-token')
+        return Response.json({ models: liveModels })
+      },
+    })
+
+    try {
+      const result = await refreshGatewayCatalogFile({
+        currentCatalogFile: frozen,
+        targetCatalogFile: refreshed,
+        fetchBaseURL: `http://127.0.0.1:${server.port}`,
+        fetchApiKey: 'live-session-token',
+      })
+
+      expect(result).toEqual({ changed: true, catalogFile: refreshed })
+      expect(JSON.parse(readFileSync(refreshed, 'utf8'))).toEqual({ models: liveModels })
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  test('keeps the no-restart path when the frozen and live catalogs match', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'catalog-current-'))
+    const frozen = join(dir, 'frozen.json')
+    const refreshed = join(dir, 'refreshed.json')
+    const liveModels = { 'glm-5.2': { name: 'GLM 5.2' } }
+    writeFileSync(frozen, JSON.stringify({ models: liveModels }))
+
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ models: liveModels }),
+    })
+
+    try {
+      const result = await refreshGatewayCatalogFile({
+        currentCatalogFile: frozen,
+        targetCatalogFile: refreshed,
+        fetchBaseURL: `http://127.0.0.1:${server.port}`,
+        fetchApiKey: 'live-session-token',
+      })
+
+      expect(result).toEqual({ changed: false, catalogFile: refreshed })
+      expect(JSON.parse(readFileSync(refreshed, 'utf8'))).toEqual({ models: liveModels })
+    } finally {
+      server.stop(true)
+    }
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -13,7 +13,13 @@ import {
   runGitCredentialHelper,
 } from './git'
 import { logger } from './logger'
-import { createOpencodeSupervisor, OPENCODE_HOME, waitForOpencodeReady, type Opencode } from './opencode'
+import {
+  createOpencodeSupervisor,
+  OPENCODE_HOME,
+  refreshGatewayCatalogFile,
+  waitForOpencodeReady,
+  type Opencode,
+} from './opencode'
 import { ensureOpencodeConfigDeps } from './opencode-config-deps'
 import { ensureInjectedManagedSkills } from './injected-skills'
 import { isSharedSeedBakedRoot, OPENCODE_SEED_BAKED_PIN_PATH } from './opencode-fork-root'
@@ -626,6 +632,31 @@ async function runWarmSeedMode(
       await ensureOpencodeConfigDeps(adoptedOpencodeConfigDir).catch((err) =>
         logger.warn('[seed] adoption config deps failed', { err: (err as Error).message }),
       )
+      // A warm snapshot freezes OpenCode's provider model registry at capture
+      // time. Managed/BYOK catalogs can change independently of that snapshot,
+      // so refresh from the now-authenticated project gateway before deciding
+      // whether the no-restart fast path is safe. OpenCode only reads provider
+      // models at process start: a changed catalog requires one controlled
+      // restart; an identical catalog keeps the hot-swap path.
+      let gatewayCatalogChanged = false
+      const llmBaseUrl = process.env.KORTIX_LLM_BASE_URL
+      const llmApiKey = process.env.KORTIX_LLM_API_KEY
+      if (llmBaseUrl && llmApiKey) {
+        const currentCatalogFile =
+          process.env.KORTIX_LLM_CATALOG_FILE ?? '/opt/kortix/llm-catalog.json'
+        const targetCatalogFile = `${OPENCODE_HOME}/.config/kortix-llm-catalog.session.json`
+        const refresh = await refreshGatewayCatalogFile({
+          currentCatalogFile,
+          targetCatalogFile,
+          fetchBaseURL: llmBaseUrl,
+          fetchApiKey: llmApiKey,
+        })
+        if (refresh) {
+          process.env.KORTIX_LLM_CATALOG_FILE = refresh.catalogFile
+          gatewayCatalogChanged = refresh.changed
+          if (refresh.changed) bootMark('adopt-gateway-catalog-refreshed')
+        }
+      }
       // NO-RESTART fast path (opt-in, stateful warm-fork only): the seed baked a
       // session-independent opencode config routed through the localhost LLM +
       // executor proxies, so inject the per-session tokens LIVE and reuse the
@@ -639,6 +670,7 @@ async function runWarmSeedMode(
         !!process.env.KORTIX_LLM_PROXY_URL &&
         llmProxyBaseUrl() != null &&
         opencode.getState() === 'ok' &&
+        !gatewayCatalogChanged &&
         !bootState.repoMaterializationError
       ) {
         // LLM gateway: required for the session to function.
@@ -657,6 +689,7 @@ async function runWarmSeedMode(
           if (executorProxyReady()) bootMark('adopt-executor-proxy-ready')
           logger.info('[seed] fork adoption hot-swap: per-session tokens injected via proxies, opencode not restarted', {
             executorReady: executorProxyReady(),
+            gatewayCatalogChanged,
           })
         }
       }

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { chmodSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { access, constants, stat } from 'node:fs/promises'
+import { isDeepStrictEqual } from 'node:util'
 
 import { AGENT_ENV_SH } from './agent-env-file'
 import { LLM_PROXY_PLACEHOLDER_KEY, EXECUTOR_PROXY_PLACEHOLDER_KEY } from './llm-proxy'
@@ -320,6 +321,40 @@ async function fetchGatewayModels(
   }
   logger.error(`[opencode] gateway models unavailable (${url}); caller will fall back to the baked/minimal catalog`)
   return null
+}
+
+export type GatewayCatalogRefreshResult = {
+  changed: boolean
+  catalogFile: string
+}
+
+/**
+ * Refresh the catalog inherited from a warm snapshot with the authenticated,
+ * project-scoped gateway catalog available after fork adoption.
+ *
+ * OpenCode materializes provider models at process start. Updating the file is
+ * therefore not sufficient by itself: callers must restart OpenCode when
+ * `changed` is true. A matching catalog preserves the warm no-restart path.
+ */
+export async function refreshGatewayCatalogFile(opts: {
+  currentCatalogFile: string
+  targetCatalogFile: string
+  fetchBaseURL: string
+  fetchApiKey: string
+}): Promise<GatewayCatalogRefreshResult | null> {
+  const liveModels = await fetchGatewayModels(opts.fetchBaseURL, opts.fetchApiKey)
+  if (!liveModels) return null
+
+  const currentModels = readCatalogFile(opts.currentCatalogFile)
+  const changed = !isDeepStrictEqual(currentModels, liveModels)
+  mkdirSync(dirname(opts.targetCatalogFile), { recursive: true })
+  writeFileSync(opts.targetCatalogFile, JSON.stringify({ models: liveModels }), { mode: 0o600 })
+  logger.info('[opencode] refreshed authenticated gateway catalog', {
+    changed,
+    models: Object.keys(liveModels).length,
+    target: opts.targetCatalogFile,
+  })
+  return { changed, catalogFile: opts.targetCatalogFile }
 }
 
 // New sessions default to AUTO — the gateway's smart router (text → GLM 5.2,


### PR DESCRIPTION
## Incident

All Kortix managed models can be rejected by OpenCode as `Model not found: kortix/<id>` when a warm snapshot was captured before the current managed catalog. Credential hot-swap reused the frozen OpenCode provider registry without validating it against the authenticated project catalog.

## Fix

- fetch the authenticated project gateway catalog during warm-fork adoption
- persist the live catalog into the fork
- restart OpenCode once when the live catalog differs from the frozen snapshot
- preserve the no-restart fast path when catalogs match

## Verification

- `bun test src/__tests__/llm-proxy.test.ts` — 8 pass
- `bun test src/__tests__` — 196 pass
- `bun tsc --noEmit` — pass
- authenticated local API → real Platinum sandbox → real OpenCode `prompt_async` with `{providerID: "kortix", modelID: "glm-5.2"}` — HTTP 204, assistant reply exactly `PONG`, no error
