### PR TITLE
chore: replace deployment-specific references with codename

### DIFF
--- a/apps/api/src/__tests__/unit-github-pat-import.test.ts
+++ b/apps/api/src/__tests__/unit-github-pat-import.test.ts
@@ -53,17 +53,17 @@ describe('serializeGitHubInstallations — PAT fallback for the "Use a token" se
   });
 
   test('no App installation, PAT fallback owner given -> synthesizes a connected installation', () => {
-    const result = serializeGitHubInstallations([], ACCOUNT_ID, null, 'Essentia-Innovation');
+    const result = serializeGitHubInstallations([], ACCOUNT_ID, null, 'globex-corp');
 
     expect(result.installed).toBe(true);
     expect(result.configured).toBe(true);
     expect(result.requires_installation).toBe(false);
     expect(result.installation_id).toBe(PAT_MANAGED_GIT_INSTALLATION_ID);
-    expect(result.owner_login).toBe('Essentia-Innovation');
+    expect(result.owner_login).toBe('globex-corp');
     expect(result.installations).toEqual([
       expect.objectContaining({
         installation_id: PAT_MANAGED_GIT_INSTALLATION_ID,
-        owner_login: 'Essentia-Innovation',
+        owner_login: 'globex-corp',
         installed: true,
         configured: true,
       }),
@@ -72,7 +72,7 @@ describe('serializeGitHubInstallations — PAT fallback for the "Use a token" se
 
   test('a real App installation row wins — the PAT fallback is ignored, no duplicate/synthetic entry', () => {
     const row = installationRow();
-    const result = serializeGitHubInstallations([row], ACCOUNT_ID, null, 'Essentia-Innovation');
+    const result = serializeGitHubInstallations([row], ACCOUNT_ID, null, 'globex-corp');
 
     expect(result.installed).toBe(true);
     expect(result.installations).toHaveLength(1);

--- a/docs/specs/2026-07-14-enterprise-ecs-simplification.md
+++ b/docs/specs/2026-07-14-enterprise-ecs-simplification.md
@@ -148,7 +148,8 @@ project).
 - **WS-LIVE**: stop the zombie Step Functions execution on customer-zero; tear
   down the EKS-era stack; fresh A-to-Z `init → doctor → plan → deploy`;
   certify (authenticated app flow + agent turn on Bedrock + backup recovery
-  point); then the customer (account 327903111249) from the same signed revision.
+  point); then the enterprise pilot customer's own account from the same
+  signed revision.
 
 ## Certification checklist (per deployment)
 

--- a/infra/deployments/README.md
+++ b/infra/deployments/README.md
@@ -28,15 +28,12 @@ it is **never** committed. That means:
 - Never run `terraform` against a root here speculatively — these are real,
   live customer/demo infrastructure.
 
-## `essentia` moved out of this monorepo entirely
+## Retired: single-tenant customer deployments now live in their own repos
 
-Essentia's single-tenant box (`essentia.kortix.cloud`) used to be provisioned
-from `deployments/essentia` at the repo root (a laptop-local, unlocked
-`terraform.tfstate`). It has been fully adopted into its own repo,
-[`Essentia-Innovation/kortix-infra`](https://github.com/Essentia-Innovation/kortix-infra),
-with state in an S3 backend inside Essentia's own AWS account
-(`327903111249`). That repo pins the same
-[`infra/terraform/modules/selfhost-ec2`](../terraform/modules/selfhost-ec2)
-module by `?ref=` tag — this monorepo has no other artifact tied to that box
-anymore. Don't recreate `deployments/essentia` here; if you need to touch
-that box, do it from `kortix-infra`.
+Single-tenant customer boxes provisioned from this directory have been fully
+adopted into their own dedicated infra repos, each with its own S3-backed
+Terraform state inside the customer's own AWS account. Those repos pin the
+same [`infra/terraform/modules/selfhost-ec2`](../terraform/modules/selfhost-ec2)
+module by `?ref=` tag — this monorepo has no other artifact tied to those
+boxes anymore. Don't recreate a retired deployment directory here; if you
+need to touch one of those boxes, do it from the customer's own infra repo.


### PR DESCRIPTION
## Summary
- Genericizes the current-tree references to a single-tenant customer's identifying details (GitHub org, box hostname, AWS account id) into a neutral codename, so the public repo surface doesn't name any customer.
- `infra/deployments/README.md`: reworded the retirement note to describe the pattern generically instead of naming the customer/repo/account.
- `docs/specs/2026-07-14-enterprise-ecs-simplification.md`: dropped the specific AWS account id from the WS-LIVE workstream note.
- `apps/api/src/__tests__/unit-github-pat-import.test.ts`: swapped a real-looking org name used as a PAT-fallback-owner test fixture for a generic placeholder.

No behavior change — docs/spec wording and one test fixture literal only.

## Test plan
- [x] `bun test src/__tests__/unit-github-pat-import.test.ts` — 3/3 pass with the new fixture value
- [x] `git grep -in essentia` on this branch returns only unrelated homonyms (`build-essential`, `essentially`, `EssentialAI`, etc.) — no genuine customer references remain in the tree