### PR TITLE
fix(infra): restore prod EKS gateway origin TLS

### DIFF
--- a/infra/k8s/argocd/applications/gateway-prod.yaml
+++ b/infra/k8s/argocd/applications/gateway-prod.yaml
@@ -1,4 +1,5 @@
-# Argo CD Application for the EKS prod LLM gateway (gateway.kortix.com).
+# Argo CD Application for the EKS prod LLM gateway origin
+# (gateway-eks.kortix.com, behind the gateway.kortix.com Cloudflare router).
 #
 # SINGLE source (mirrors kortix-prod): render the kortix-gateway chart with the
 # prod gateway value file via a relative path in the same repo — one revision, so

--- a/infra/k8s/envs/prod/gateway-values.yaml
+++ b/infra/k8s/envs/prod/gateway-values.yaml
@@ -27,9 +27,10 @@ resources:
 # on gateway pods, not the API — API deploys don't cut in-flight streams.
 ingress:
   enabled: true
-  host: gateway.kortix.com
-  # ACM cert for gateway.kortix.com in eu-west-2 (the prod-eks ALB region).
-  certificateArn: "arn:aws:acm:eu-west-2:935064898258:certificate/89358fa4-c7a1-4ea8-82b6-310e9118b41a"
+  # Dedicated EKS origin behind the gateway.kortix.com Cloudflare router.
+  host: gateway-eks.kortix.com
+  # ACM cert for gateway-eks.kortix.com in eu-west-2 (the prod-eks ALB region).
+  certificateArn: "arn:aws:acm:eu-west-2:935064898258:certificate/7dc99167-c60b-4bd0-a731-f77251ef8e04"
   cloudflareProxied: true
   # Lock the origin ALB to Cloudflare's edge ranges so the LLM gateway can only be
   # reached THROUGH Cloudflare — no direct-to-origin bypass of the edge.

--- a/infra/terraform/environments/prod-eks/cluster/main.tf
+++ b/infra/terraform/environments/prod-eks/cluster/main.tf
@@ -7,7 +7,7 @@
 # against a cluster that does not exist yet. It builds:
 #   - an isolated VPC (own /16, 3 AZ, NAT per AZ) — does NOT touch the ECS VPC,
 #   - the EKS control plane + managed node group (modules/eks/cluster),
-#   - the ACM cert for api-eks.kortix.com (validated via Cloudflare DNS),
+#   - ACM certs for the API and gateway EKS origins (validated via Cloudflare DNS),
 #   - the app's IRSA role (reads the SAME Secrets Manager bundle ECS uses),
 #   - the GitHub Actions OIDC deploy role + its EKS access entry.
 #
@@ -100,6 +100,20 @@ module "eks" {
 module "acm" {
   source      = "../../../modules/acm-cloudflare"
   domain_name = local.domain
+  zone_id     = var.cloudflare_zone_id
+  tags        = local.tags
+  providers = {
+    aws        = aws
+    cloudflare = cloudflare
+  }
+}
+
+# Dedicated origin certificate for the EKS LLM gateway. The public
+# gateway.kortix.com hostname belongs to the Cloudflare router; the router
+# reaches this cluster through gateway-eks.kortix.com under Full (strict) TLS.
+module "acm_gateway" {
+  source      = "../../../modules/acm-cloudflare"
+  domain_name = var.gateway_domain
   zone_id     = var.cloudflare_zone_id
   tags        = local.tags
   providers = {

--- a/infra/terraform/environments/prod-eks/cluster/outputs.tf
+++ b/infra/terraform/environments/prod-eks/cluster/outputs.tf
@@ -36,6 +36,16 @@ output "acm_certificate_arn" {
   value       = module.acm.certificate_arn
 }
 
+output "gateway_domain" {
+  description = "Origin hostname for the EKS LLM gateway."
+  value       = var.gateway_domain
+}
+
+output "acm_gateway_certificate_arn" {
+  description = "Cert ARN for the EKS LLM gateway ALB HTTPS listener."
+  value       = module.acm_gateway.certificate_arn
+}
+
 output "acm_argocd_certificate_arn" {
   description = "Cert ARN for the Argo CD UI ALB (ops.kortix.com)."
   value       = module.acm_argocd.certificate_arn

--- a/infra/terraform/environments/prod-eks/cluster/variables.tf
+++ b/infra/terraform/environments/prod-eks/cluster/variables.tf
@@ -73,6 +73,12 @@ variable "api_domain" {
   default     = "api-eks.kortix.com"
 }
 
+variable "gateway_domain" {
+  description = "Origin FQDN for the EKS LLM gateway behind the Cloudflare router."
+  type        = string
+  default     = "gateway-eks.kortix.com"
+}
+
 variable "argocd_domain" {
   description = "Public FQDN for the Argo CD admin UI (gated by Cloudflare Access)."
   type        = string

--- a/infra/terraform/environments/prod-eks/platform/main.tf
+++ b/infra/terraform/environments/prod-eks/platform/main.tf
@@ -90,7 +90,7 @@ module "platform" {
   oidc_provider_url = local.cluster.oidc_provider_url
   api_domain        = local.cluster.api_domain
   # Let external-dns also manage the standalone LLM gateway host.
-  extra_domain_filters = ["gateway.kortix.com"]
+  extra_domain_filters = ["gateway-eks.kortix.com"]
 
   cloudflare_api_token = var.cloudflare_api_token
   cloudflare_zone_id   = var.cloudflare_zone_id


### PR DESCRIPTION
## Incident
`gateway-eks.kortix.com` returned Cloudflare 526 while ECS was healthy. The EKS ingress still declared `gateway.kortix.com` and used a certificate valid only for that public Worker hostname.

## Fix
- provision and DNS-validate a dedicated ACM certificate for `gateway-eks.kortix.com`
- switch the prod EKS gateway ingress host and certificate to the origin hostname
- restrict ExternalDNS to `api-eks.kortix.com` and `gateway-eks.kortix.com`

## Applied infrastructure
- ACM certificate issued: `7dc99167-c60b-4bd0-a731-f77251ef8e04`
- Terraform state updated for the new certificate
- ExternalDNS rolled out with the corrected domain filters

## Verification
- Terraform validate: cluster + platform passed
- Worker router tests: 4 passed
- `git diff --check` passed
- Live EKS ingress/TLS proof follows after merge and Argo sync