### PR TITLE
fix(gateway): stamp promoted release version

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -271,7 +271,7 @@ jobs:
           git fetch origin staging:refs/remotes/origin/staging --quiet
           git checkout -B staging origin/staging
           yq -i '.image.tag = strenv(TAG) | .kortixVersion = strenv(VERSION)' "$VALUES"
-          yq -i '.image.tag = strenv(TAG)' "$GATEWAY_VALUES"
+          yq -i '.image.tag = strenv(TAG) | .kortixVersion = strenv(VERSION)' "$GATEWAY_VALUES"
           if git diff --quiet -- "$VALUES" "$GATEWAY_VALUES"; then
             echo "staging GitOps values already pinned to ${TAG}."
           else

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -231,7 +231,7 @@ jobs:
             NEW="$NEW" yq -i '.image.tag = strenv(NEW) | .kortixVersion = strenv(NEW)' infra/k8s/envs/prod/values.yaml
           fi
           if [ -f infra/k8s/envs/prod/gateway-values.yaml ]; then
-            NEW="$NEW" yq -i '.image.tag = strenv(NEW)' infra/k8s/envs/prod/gateway-values.yaml
+            NEW="$NEW" yq -i '.image.tag = strenv(NEW) | .kortixVersion = strenv(NEW)' infra/k8s/envs/prod/gateway-values.yaml
           fi
 
           git add VERSION RELEASE_NOTES.md RELEASE_SOURCE_SHA

--- a/infra/k8s/charts/kortix-gateway/templates/_pod.tpl
+++ b/infra/k8s/charts/kortix-gateway/templates/_pod.tpl
@@ -40,6 +40,10 @@ spec:
       env:
         - name: PORT
           value: {{ .Values.containerPort | quote }}
+        {{- if .Values.kortixVersion }}
+        - name: KORTIX_VERSION
+          value: {{ .Values.kortixVersion | quote }}
+        {{- end }}
         {{- range $k, $v := .Values.extraEnv }}
         - name: {{ $k }}
           value: {{ $v | quote }}

--- a/infra/k8s/charts/kortix-gateway/values.yaml
+++ b/infra/k8s/charts/kortix-gateway/values.yaml
@@ -10,6 +10,11 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+# Runtime version reported by /health/live. Release images are promoted from
+# staging without rebuilding, so production must override the baked staging
+# version just as the API chart does.
+kortixVersion: ""
+
 createNamespace: false
 
 containerPort: 8090


### PR DESCRIPTION
Selective staging hotfix for the production EKS gateway parity incident. Carries #4797 without advancing unrelated main changes.