### PR TITLE
fix(sandbox): venv-isolate the Python floor, stop wiping custom /workspace, stop blaming users

### DIFF
--- a/apps/api/src/__tests__/unit-snapshot-error-classify.test.ts
+++ b/apps/api/src/__tests__/unit-snapshot-error-classify.test.ts
@@ -43,6 +43,33 @@ describe('classifySnapshotError', () => {
     expect(classifySnapshotError('build timed out after 600s')).toBe('timeout');
   });
 
+  test('Kortix runtime layer failures outrank the generic dockerfile bucket', () => {
+    // The real incident: a project apt-installed gdal-bin → dpkg-owned
+    // python3-numpy, and OUR injected pip floor tried to uninstall it. The user's
+    // Dockerfile was CORRECT — classifying this as 'dockerfile' dispatched an
+    // agent to "fix" it. Note each of these ALSO matches the 'dockerfile' rule
+    // (apt-get / did not complete successfully / non-zero code), so these assert
+    // rule ORDER, not just the patterns.
+    expect(classifySnapshotError(
+      'failed to solve: process "/bin/sh -c python3 -m pip install --break-system-packages numpy>=1.26" did not complete successfully: exit code: 1\n' +
+      'ERROR: Cannot uninstall numpy 1.26.4, RECORD file not found. Hint: The package was installed by debian.',
+    )).toBe('layer');
+    expect(classifySnapshotError('error: externally-managed-environment')).toBe('layer');
+    expect(classifySnapshotError('/bin/sh: 1: apt-get: not found')).toBe('layer');
+    expect(classifySnapshotError(
+      'process "/bin/sh -c /opt/kortix/pyfloor/bin/pip install --no-cache-dir" did not complete successfully: exit code: 2',
+    )).toBe('layer');
+  });
+
+  test('a real user Dockerfile failure still classifies as dockerfile', () => {
+    // Guard the other direction: the layer rule must not swallow ordinary
+    // user-repo build failures, which stay agent-fixable.
+    expect(classifySnapshotError(
+      'failed to solve: process "/bin/sh -c apt-get install -y nosuchpkg" did not complete successfully: exit code: 100\n' +
+      'E: Unable to locate package nosuchpkg',
+    )).toBe('dockerfile');
+  });
+
   test('Daytona provider / transport errors', () => {
     expect(classifySnapshotError('Your socket connection to the server was not read from or written to within the timeout period')).toBe('timeout'); // timeout wins, both non-fixable
     expect(classifySnapshotError('daytona snapshot.create failed: bad gateway 502')).toBe('provider');
@@ -63,6 +90,10 @@ describe('describeSnapshotError fixability', () => {
     expect(describeSnapshotError('provider').fixableByAgent).toBe(false);
     expect(describeSnapshotError('timeout').fixableByAgent).toBe(false);
     expect(describeSnapshotError('runtime').fixableByAgent).toBe(false);
+    // A layer failure is OUR bug: never send an agent at the user's Dockerfile,
+    // and say so in the hint.
+    expect(describeSnapshotError('layer').fixableByAgent).toBe(false);
+    expect(describeSnapshotError('layer').hint).toContain('Kortix runtime layer');
   });
 
   test('classify + describe compose to a full descriptor', () => {

--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -93,11 +93,16 @@ export interface WarmRepoContext {
  * Stage a build context for `snapshotName` from the user's Dockerfile. Returns
  * the temp dir + composed Dockerfile path. The CALLER is responsible for
  * removing contextDir when done.
+ *
+ * `isSharedDefault` is the caller's `BuildableTemplate.isShared` — it tells the
+ * layer whether /workspace is the platform's to wipe after the opencode warm-up
+ * or the user's to leave alone (see `KortixToolchainLayerOpts.isSharedDefault`).
  */
 export async function stageBuildContext(
   snapshotName: string,
   userDockerfile: string,
   warmRepo?: WarmRepoContext,
+  isSharedDefault?: boolean,
 ): Promise<StagedContext> {
   const AGENT_BIN_PATH = agentBinPath();
   const CLI_BIN_PATH = cliBinPath();
@@ -188,6 +193,7 @@ export async function stageBuildContext(
     executorSdkPath: 'kortix-executor-sdk',
     opencodeConfigPath,
     catalogPath: 'kortix-llm-catalog.json',
+    isSharedDefault,
     warmRepo,
   });
 

--- a/apps/api/src/snapshots/error-classify.ts
+++ b/apps/api/src/snapshots/error-classify.ts
@@ -18,6 +18,8 @@ export type SnapshotErrorCategory =
   | 'quota'
   /** User's Dockerfile / build steps failed (RUN, COPY, apt-get, npm…). Fixable by an agent. */
   | 'dockerfile'
+  /** A step in the KORTIX-INJECTED runtime layer failed. Platform's fault, not the repo's. */
+  | 'layer'
   /** Kortix callback URL (KORTIX_URL) unreachable — usually a down dev tunnel. */
   | 'tunnel'
   /** Daytona transport / gateway / socket blip — transient provider infra. */
@@ -77,6 +79,24 @@ const RULES: Array<{ category: SnapshotErrorCategory; test: RegExp }> = [
     category: 'provider',
     test: /daytona|snapshot with name .* not found|socket connection|idle connection|socket hang up|bad gateway|\bgateway\b|\b50[234]\b|econnreset|econnrefused|etimedout|\beof\b|network error/i,
   },
+  // A step in the KORTIX-INJECTED runtime layer failed — the user's Dockerfile is
+  // fine and an agent "fixing" it can only make things worse. MUST outrank
+  // 'dockerfile', whose generic patterns ('apt-get', 'did not complete
+  // successfully', 'non-zero code') match these too — that miscategorization is
+  // exactly what dispatched an agent to repair a CORRECT Dockerfile after the
+  // floor's pip tried to uninstall a dpkg-owned numpy.
+  //
+  // Markers are the ones that can only plausibly come from our own layer: the
+  // pyfloor venv path, dpkg-vs-pip ownership conflicts, and an apt-less base
+  // (our floor assumes Debian-family; the user's own FROM may not be).
+  // Caveat: a user Dockerfile that itself pip-installs over a dpkg-owned package
+  // can produce the same dpkg-conflict text and land here. We accept that — the
+  // hint points at the platform and the failure is one a human should read either
+  // way, which beats dispatching an agent at a Dockerfile that is not broken.
+  {
+    category: 'layer',
+    test: /\/opt\/kortix\/pyfloor|record file not found|installed by debian|externally-managed-environment|apt-get: (not found|command not found)|apt-get: No such file/i,
+  },
   // The user's Dockerfile / build steps failed.
   {
     category: 'dockerfile',
@@ -104,6 +124,11 @@ const INFO: Record<SnapshotErrorCategory, Omit<SnapshotErrorInfo, 'category'>> =
     title: 'Dockerfile build failed',
     hint: 'A step in the project Dockerfile failed. An agent can inspect the build error and fix the Dockerfile.',
     fixableByAgent: true,
+  },
+  layer: {
+    title: 'Kortix runtime layer failed',
+    hint: 'A step in the Kortix runtime layer that gets appended to every image (the Python package floor or the apt floor) failed against this base image — your Dockerfile is not the cause, and editing it will not help. This is a platform issue: retry the build, and report it if it persists.',
+    fixableByAgent: false,
   },
   git: {
     title: 'Repository access failed',

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -114,7 +114,7 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       // reports as "Path does not exist: …/scaffold.git". Re-staging self-heals
       // it so the auto/background build recovers on its own instead of needing a
       // manual rebuild (the "always have to manually start" symptom).
-      const ctx = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo);
+      const ctx = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo, input.isShared);
       const buildLogs: string[] = [];
       try {
         await daytona.snapshot.create(

--- a/apps/api/src/snapshots/providers/e2b.ts
+++ b/apps/api/src/snapshots/providers/e2b.ts
@@ -60,7 +60,7 @@ class E2BAdapter implements SandboxProviderAdapter {
       throw new Error('E2BAdapter.buildSnapshot: neither image nor userDockerfile set');
     }
     const userDockerfile = input.userDockerfile ?? `FROM ${input.image}\n`;
-    const context = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo);
+    const context = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo, input.isShared);
     observeTemplates.invalidate();
     try {
       // fromDockerfile() converts the Dockerfile ENTRYPOINT into E2B's start

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -115,7 +115,7 @@ class PlatinumAdapter implements SandboxProviderAdapter {
    *  staging and the S3 upload self-heals (mirrors the daytona adapter). */
   private async buildOnce(input: BuildableTemplate, userDockerfile: string, tap?: BuildLogTap): Promise<void> {
     // Stage the SAME context Daytona builds (Dockerfile + agent/cli/entrypoint/…).
-    const ctx = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo);
+    const ctx = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo, input.isShared);
     const tarPath = join(ctx.contextDir, '..', `${input.snapshotName.replace(/[^a-zA-Z0-9_.-]/g, '_')}.tar.gz`);
     try {
       const tar = Bun.spawn(['tar', '-czf', tarPath, '-C', ctx.contextDir, '.']);

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -116,7 +116,21 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // seeded kortix-system <live-skills> pointer (`kortix skills get <name>`)
 // resolves — without this rebake, fresh sandboxes run an older baked CLI that
 // hard-errors on `kortix skills`.
-const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v25';
+// v26: layer robustness. (a) The starter Python floor moved OUT of the system
+// interpreter into a `--system-site-packages` venv at /opt/kortix/pyfloor (on the
+// front of PATH): the old `pip install --break-system-packages` fought dpkg for
+// any floor package the USER's Dockerfile had apt-installed — a project's
+// `gdal-bin` pulled dpkg-owned python3-numpy 1.26.4, our `numpy>=1.26` resolved
+// to 2.x, pip tried to uninstall it and hard-failed the build ("RECORD file not
+// found ... installed by debian") on a CORRECT user image. pip in a venv cannot
+// uninstall a dpkg package at all, which retires the whole class (every floor
+// member has a dpkg counterpart). (b) The post-warm-up `find /workspace
+// -mindepth 1 -delete` is now emitted ONLY for the shared default image; custom
+// templates get a targeted cleanup of just the staged starter config, so an
+// image that seeds /workspace (a documented WORKDIR) no longer has it silently
+// deleted. (c) ENV DEBIAN_FRONTEND=noninteractive is set by the layer instead of
+// being inherited by luck from the user's base.
+const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v26';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/apps/mobile/components/pages/SandboxPage.tsx
+++ b/apps/mobile/components/pages/SandboxPage.tsx
@@ -97,6 +97,7 @@ const STATUS_STYLE: Record<ProjectSnapshotStatus, { label: string; color: string
 
 const CATEGORY_LABEL: Record<SnapshotErrorCategory, string> = {
   dockerfile: 'Dockerfile build failed',
+  layer: 'Kortix runtime layer failed',
   git: 'Repository access failed',
   tunnel: 'Sandbox callback unreachable',
   provider: 'Sandbox provider error',

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -67,6 +67,7 @@ const TEMPLATE_SKELETON_ROWS = [
 const CATEGORY_LABEL: Record<SnapshotErrorCategory, string> = {
   quota: 'Snapshot quota reached',
   dockerfile: 'Dockerfile build failed',
+  layer: 'Kortix runtime layer failed',
   git: 'Repository access failed',
   tunnel: 'Sandbox callback unreachable',
   provider: 'Sandbox provider error',

--- a/packages/sdk/src/core/rest/projects-client/sandbox.ts
+++ b/packages/sdk/src/core/rest/projects-client/sandbox.ts
@@ -14,6 +14,8 @@ export type SnapshotErrorCategory =
   /** Daytona org snapshot quota exhausted — infra, not repo-fixable. */
   | 'quota'
   | 'dockerfile'
+  /** A step in the Kortix-injected runtime layer failed — platform's fault, not the repo's. */
+  | 'layer'
   | 'tunnel'
   | 'provider'
   | 'timeout'

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -1,0 +1,527 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`rendered layer (golden) shared platform default 1`] = `
+"# syntax=docker/dockerfile:1.7
+# Kortix platform default sandbox base.
+# Sessions clone the project workspace at boot — nothing project-specific
+# is baked in here. Customize via \`sandbox.templates\` in kortix.yaml.
+FROM ubuntu:24.04
+
+WORKDIR /workspace
+
+# ─── Kortix runtime layer (auto-injected) ──────────────────────────
+# Everything below is added by the Kortix snapshot builder. Do not
+# edit by hand — your project Dockerfile above is preserved verbatim.
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+RUN base_py="$(command -v python3 || true)" \\
+    && apt-get update \\
+    && apt-get install -y --no-install-recommends \\
+        ca-certificates curl git gzip nodejs npm unzip tmux iproute2 iputils-arping \\
+        build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\
+        latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \\
+        python3 python3-dev python3-pip python3-venv \\
+        texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\
+        texlive-latex-extra texlive-latex-recommended \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && "\${base_py:-python3}" -m venv --system-site-packages /opt/kortix/pyfloor \\
+    && /opt/kortix/pyfloor/bin/python -c 'import sys; print("pyfloor interpreter:", sys.version)'
+
+ENV PATH=/opt/kortix/pyfloor/bin:$PATH
+
+# Starter skill Python package floor (document/data/PDF/presentation helpers).
+# Installed INTO the venv via its own pip, which cannot touch a dpkg-owned
+# package no matter what the resolver picks.
+RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\
+        "beautifulsoup4>=4.12" \\
+        "lxml>=5" \\
+        "markdownify>=0.13" \\
+        "markitdown[pptx]>=0.1.0" \\
+        "matplotlib>=3.8" \\
+        "numpy>=1.26" \\
+        "openpyxl>=3.1" \\
+        "pandas>=2.2" \\
+        "pdf2docx>=0.5" \\
+        "pdf2image>=1.17" \\
+        "pdfplumber>=0.11" \\
+        "pillow>=10" \\
+        "playwright>=1.58" \\
+        "plotly>=5.22" \\
+        "pymupdf>=1.24" \\
+        "pypdf>=4" \\
+        "pypdfium2>=4.30" \\
+        "pytesseract>=0.3" \\
+        "python-docx>=1.1" \\
+        "python-pptx>=1.0" \\
+        "reportlab>=4.2" \\
+        "requests>=2.32" \\
+        "scikit-learn>=1.4" \\
+        "scipy>=1.12" \\
+        "seaborn>=0.13" \\
+        "youtube-transcript-api>=0.6" \\
+    && /opt/kortix/pyfloor/bin/python -c 'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")'
+
+RUN npm install -g --no-audit --no-fund "opencode-ai@1.17.11" \\
+    && command -v opencode \\
+    && opencode --version
+
+RUN set +e; \\
+    export HOME=/opt/kortix/home \\
+        XDG_DATA_HOME=/opt/kortix/home/.local/share \\
+        XDG_CONFIG_HOME=/opt/kortix/home/.config \\
+        XDG_CACHE_HOME=/opt/kortix/home/.cache; \\
+    mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME"; \\
+    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-bake.log 2>&1 & oc_pid=$!; \\
+    for i in $(seq 1 180); do \\
+        curl -s -o /dev/null -m 2 http://127.0.0.1:4096/ && break; \\
+        kill -0 "$oc_pid" 2>/dev/null || break; \\
+        sleep 1; \\
+    done; \\
+    sleep 3; \\
+    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\
+    echo "=== migration-bake: opencode data dir ==="; ls -laR "$XDG_DATA_HOME/opencode" 2>/dev/null | head -40; \\
+    echo "=== migration-bake: opencode log tail ==="; tail -25 /tmp/oc-bake.log; \\
+    rm -f /tmp/oc-bake.log; true
+
+RUN curl -fsSL https://bun.com/install | bash \\
+    && install -m 755 /root/.bun/bin/bun /usr/local/bin/bun \\
+    && bun --version
+
+RUN mkdir -p /opt/kortix/home/.bun/install/cache /opt/kortix/opencode-config-deps \\
+    && cd /opt/kortix/opencode-config-deps \\
+    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.17.11","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.16.0","form-data":"4.0.6"}}' > package.json \\
+    && HOME=/opt/kortix/home BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache bun install
+
+RUN cd /opt/kortix/opencode-config-deps \\
+    && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\
+    && rm -rf /tmp/opencode-deps-bundle-check \\
+    && echo "opencode-config-deps: baked tree bundles cleanly"
+
+COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN cd /opt/kortix/warm-config/.kortix/opencode \\
+    && rm -rf node_modules \\
+    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\
+    && HOME=/opt/kortix/home bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \\
+    && rm -rf /tmp/opencode-tools-bundle-check \\
+    && echo "opencode-config-deps: starter tool files bundle cleanly"
+
+RUN set +e; \\
+    export HOME=/opt/kortix/home \\
+        XDG_DATA_HOME=/opt/kortix/home/.local/share \\
+        XDG_CONFIG_HOME=/opt/kortix/home/.config \\
+        XDG_CACHE_HOME=/opt/kortix/home/.cache \\
+        BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache; \\
+    mkdir -p /workspace/.kortix; \\
+    staged_starter_config=0; \\
+    [ -d /workspace/.kortix/opencode ] || { cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode && staged_starter_config=1; }; \\
+    rm -rf /workspace/.kortix/opencode/node_modules; \\
+    ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules; \\
+    export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode; \\
+    cd /workspace; \\
+    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log 2>&1 & oc_pid=$!; \\
+    ready=0; \\
+    for i in $(seq 1 300); do \\
+        code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:4096/session?directory=/workspace" 2>/dev/null); \\
+        case "$code" in 200|204|301|302) ready=1; break;; esac; \\
+        kill -0 "$oc_pid" 2>/dev/null || break; \\
+        sleep 1; \\
+    done; \\
+    echo "=== instance-warm: ready=$ready ==="; \\
+    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\
+    find /workspace -mindepth 1 -delete 2>/dev/null; \\
+    rm -rf /opt/kortix/warm-config; \\
+    echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\
+    rm -f /tmp/oc-warm.log; true
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
+COPY kortix-agent.gz /tmp/kortix-agent.gz
+COPY kortix.gz /tmp/kortix.gz
+COPY kortix-entrypoint /usr/local/bin/kortix-entrypoint
+COPY kortix-slack-cli/ /opt/kortix/apps/sandbox/slack-cli/
+COPY kortix-executor-sdk/ /opt/kortix/packages/executor-sdk/
+COPY kortix-llm-catalog.json /opt/kortix/llm-catalog.json
+COPY scaffold.git /opt/kortix/scaffold.git
+RUN gunzip -c /tmp/kortix-agent.gz > /usr/local/bin/kortix-agent \\
+    && gunzip -c /tmp/kortix.gz > /usr/local/bin/kortix \\
+    && rm /tmp/kortix-agent.gz /tmp/kortix.gz \\
+    && chmod +x /usr/local/bin/kortix-agent /usr/local/bin/kortix /usr/local/bin/kortix-entrypoint \\
+        /opt/kortix/apps/sandbox/slack-cli/install-shims.sh \\
+    && bash /opt/kortix/apps/sandbox/slack-cli/install-shims.sh /opt/kortix/apps/sandbox/slack-cli \\
+    && kortix --version
+
+ENV KORTIX_WORKSPACE=/workspace
+RUN mkdir -p /workspace /opt/kortix/home /ephemeral/kortix-master/opencode
+WORKDIR /workspace
+EXPOSE 8000
+ENTRYPOINT ["/usr/local/bin/kortix-entrypoint"]
+"
+`;
+
+exports[`rendered layer (golden) custom template (user seeds /workspace) 1`] = `
+"FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends gdal-bin
+
+WORKDIR /workspace
+RUN mkdir -p /workspace/data && echo seed > /workspace/data/basemap.tif
+
+# ─── Kortix runtime layer (auto-injected) ──────────────────────────
+# Everything below is added by the Kortix snapshot builder. Do not
+# edit by hand — your project Dockerfile above is preserved verbatim.
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+RUN base_py="$(command -v python3 || true)" \\
+    && apt-get update \\
+    && apt-get install -y --no-install-recommends \\
+        ca-certificates curl git gzip nodejs npm unzip tmux iproute2 iputils-arping \\
+        build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\
+        latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \\
+        python3 python3-dev python3-pip python3-venv \\
+        texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\
+        texlive-latex-extra texlive-latex-recommended \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && "\${base_py:-python3}" -m venv --system-site-packages /opt/kortix/pyfloor \\
+    && /opt/kortix/pyfloor/bin/python -c 'import sys; print("pyfloor interpreter:", sys.version)'
+
+ENV PATH=/opt/kortix/pyfloor/bin:$PATH
+
+# Starter skill Python package floor (document/data/PDF/presentation helpers).
+# Installed INTO the venv via its own pip, which cannot touch a dpkg-owned
+# package no matter what the resolver picks.
+RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\
+        "beautifulsoup4>=4.12" \\
+        "lxml>=5" \\
+        "markdownify>=0.13" \\
+        "markitdown[pptx]>=0.1.0" \\
+        "matplotlib>=3.8" \\
+        "numpy>=1.26" \\
+        "openpyxl>=3.1" \\
+        "pandas>=2.2" \\
+        "pdf2docx>=0.5" \\
+        "pdf2image>=1.17" \\
+        "pdfplumber>=0.11" \\
+        "pillow>=10" \\
+        "playwright>=1.58" \\
+        "plotly>=5.22" \\
+        "pymupdf>=1.24" \\
+        "pypdf>=4" \\
+        "pypdfium2>=4.30" \\
+        "pytesseract>=0.3" \\
+        "python-docx>=1.1" \\
+        "python-pptx>=1.0" \\
+        "reportlab>=4.2" \\
+        "requests>=2.32" \\
+        "scikit-learn>=1.4" \\
+        "scipy>=1.12" \\
+        "seaborn>=0.13" \\
+        "youtube-transcript-api>=0.6" \\
+    && /opt/kortix/pyfloor/bin/python -c 'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")'
+
+RUN npm install -g --no-audit --no-fund "opencode-ai@1.17.11" \\
+    && command -v opencode \\
+    && opencode --version
+
+RUN set +e; \\
+    export HOME=/opt/kortix/home \\
+        XDG_DATA_HOME=/opt/kortix/home/.local/share \\
+        XDG_CONFIG_HOME=/opt/kortix/home/.config \\
+        XDG_CACHE_HOME=/opt/kortix/home/.cache; \\
+    mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME"; \\
+    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-bake.log 2>&1 & oc_pid=$!; \\
+    for i in $(seq 1 180); do \\
+        curl -s -o /dev/null -m 2 http://127.0.0.1:4096/ && break; \\
+        kill -0 "$oc_pid" 2>/dev/null || break; \\
+        sleep 1; \\
+    done; \\
+    sleep 3; \\
+    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\
+    echo "=== migration-bake: opencode data dir ==="; ls -laR "$XDG_DATA_HOME/opencode" 2>/dev/null | head -40; \\
+    echo "=== migration-bake: opencode log tail ==="; tail -25 /tmp/oc-bake.log; \\
+    rm -f /tmp/oc-bake.log; true
+
+RUN curl -fsSL https://bun.com/install | bash \\
+    && install -m 755 /root/.bun/bin/bun /usr/local/bin/bun \\
+    && bun --version
+
+RUN mkdir -p /opt/kortix/home/.bun/install/cache /opt/kortix/opencode-config-deps \\
+    && cd /opt/kortix/opencode-config-deps \\
+    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.17.11","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.16.0","form-data":"4.0.6"}}' > package.json \\
+    && HOME=/opt/kortix/home BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache bun install
+
+RUN cd /opt/kortix/opencode-config-deps \\
+    && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\
+    && rm -rf /tmp/opencode-deps-bundle-check \\
+    && echo "opencode-config-deps: baked tree bundles cleanly"
+
+COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN cd /opt/kortix/warm-config/.kortix/opencode \\
+    && rm -rf node_modules \\
+    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\
+    && HOME=/opt/kortix/home bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \\
+    && rm -rf /tmp/opencode-tools-bundle-check \\
+    && echo "opencode-config-deps: starter tool files bundle cleanly"
+
+RUN set +e; \\
+    export HOME=/opt/kortix/home \\
+        XDG_DATA_HOME=/opt/kortix/home/.local/share \\
+        XDG_CONFIG_HOME=/opt/kortix/home/.config \\
+        XDG_CACHE_HOME=/opt/kortix/home/.cache \\
+        BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache; \\
+    mkdir -p /workspace/.kortix; \\
+    staged_starter_config=0; \\
+    [ -d /workspace/.kortix/opencode ] || { cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode && staged_starter_config=1; }; \\
+    rm -rf /workspace/.kortix/opencode/node_modules; \\
+    ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules; \\
+    export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode; \\
+    cd /workspace; \\
+    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log 2>&1 & oc_pid=$!; \\
+    ready=0; \\
+    for i in $(seq 1 300); do \\
+        code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:4096/session?directory=/workspace" 2>/dev/null); \\
+        case "$code" in 200|204|301|302) ready=1; break;; esac; \\
+        kill -0 "$oc_pid" 2>/dev/null || break; \\
+        sleep 1; \\
+    done; \\
+    echo "=== instance-warm: ready=$ready ==="; \\
+    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\
+    [ "$staged_starter_config" = 1 ] && rm -rf /workspace/.kortix/opencode; rmdir /workspace/.kortix 2>/dev/null; \\
+    rm -rf /opt/kortix/warm-config; \\
+    echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\
+    rm -f /tmp/oc-warm.log; true
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
+COPY kortix-agent.gz /tmp/kortix-agent.gz
+COPY kortix.gz /tmp/kortix.gz
+COPY kortix-entrypoint /usr/local/bin/kortix-entrypoint
+COPY kortix-slack-cli/ /opt/kortix/apps/sandbox/slack-cli/
+COPY kortix-executor-sdk/ /opt/kortix/packages/executor-sdk/
+COPY kortix-llm-catalog.json /opt/kortix/llm-catalog.json
+COPY scaffold.git /opt/kortix/scaffold.git
+RUN gunzip -c /tmp/kortix-agent.gz > /usr/local/bin/kortix-agent \\
+    && gunzip -c /tmp/kortix.gz > /usr/local/bin/kortix \\
+    && rm /tmp/kortix-agent.gz /tmp/kortix.gz \\
+    && chmod +x /usr/local/bin/kortix-agent /usr/local/bin/kortix /usr/local/bin/kortix-entrypoint \\
+        /opt/kortix/apps/sandbox/slack-cli/install-shims.sh \\
+    && bash /opt/kortix/apps/sandbox/slack-cli/install-shims.sh /opt/kortix/apps/sandbox/slack-cli \\
+    && kortix --version
+
+ENV KORTIX_WORKSPACE=/workspace
+RUN mkdir -p /workspace /opt/kortix/home /ephemeral/kortix-master/opencode
+WORKDIR /workspace
+EXPOSE 8000
+ENTRYPOINT ["/usr/local/bin/kortix-entrypoint"]
+"
+`;
+
+exports[`rendered layer (golden) per-project cold warm (warmRepo) 1`] = `
+"# syntax=docker/dockerfile:1.7
+# Kortix platform default sandbox base.
+# Sessions clone the project workspace at boot — nothing project-specific
+# is baked in here. Customize via \`sandbox.templates\` in kortix.yaml.
+FROM ubuntu:24.04
+
+WORKDIR /workspace
+
+# ─── Kortix runtime layer (auto-injected) ──────────────────────────
+# Everything below is added by the Kortix snapshot builder. Do not
+# edit by hand — your project Dockerfile above is preserved verbatim.
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+RUN base_py="$(command -v python3 || true)" \\
+    && apt-get update \\
+    && apt-get install -y --no-install-recommends \\
+        ca-certificates curl git gzip nodejs npm unzip tmux iproute2 iputils-arping \\
+        build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\
+        latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \\
+        python3 python3-dev python3-pip python3-venv \\
+        texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\
+        texlive-latex-extra texlive-latex-recommended \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && "\${base_py:-python3}" -m venv --system-site-packages /opt/kortix/pyfloor \\
+    && /opt/kortix/pyfloor/bin/python -c 'import sys; print("pyfloor interpreter:", sys.version)'
+
+ENV PATH=/opt/kortix/pyfloor/bin:$PATH
+
+# Starter skill Python package floor (document/data/PDF/presentation helpers).
+# Installed INTO the venv via its own pip, which cannot touch a dpkg-owned
+# package no matter what the resolver picks.
+RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\
+        "beautifulsoup4>=4.12" \\
+        "lxml>=5" \\
+        "markdownify>=0.13" \\
+        "markitdown[pptx]>=0.1.0" \\
+        "matplotlib>=3.8" \\
+        "numpy>=1.26" \\
+        "openpyxl>=3.1" \\
+        "pandas>=2.2" \\
+        "pdf2docx>=0.5" \\
+        "pdf2image>=1.17" \\
+        "pdfplumber>=0.11" \\
+        "pillow>=10" \\
+        "playwright>=1.58" \\
+        "plotly>=5.22" \\
+        "pymupdf>=1.24" \\
+        "pypdf>=4" \\
+        "pypdfium2>=4.30" \\
+        "pytesseract>=0.3" \\
+        "python-docx>=1.1" \\
+        "python-pptx>=1.0" \\
+        "reportlab>=4.2" \\
+        "requests>=2.32" \\
+        "scikit-learn>=1.4" \\
+        "scipy>=1.12" \\
+        "seaborn>=0.13" \\
+        "youtube-transcript-api>=0.6" \\
+    && /opt/kortix/pyfloor/bin/python -c 'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")'
+
+RUN npm install -g --no-audit --no-fund "opencode-ai@1.17.11" \\
+    && command -v opencode \\
+    && opencode --version
+
+RUN set +e; \\
+    export HOME=/opt/kortix/home \\
+        XDG_DATA_HOME=/opt/kortix/home/.local/share \\
+        XDG_CONFIG_HOME=/opt/kortix/home/.config \\
+        XDG_CACHE_HOME=/opt/kortix/home/.cache; \\
+    mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME"; \\
+    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-bake.log 2>&1 & oc_pid=$!; \\
+    for i in $(seq 1 180); do \\
+        curl -s -o /dev/null -m 2 http://127.0.0.1:4096/ && break; \\
+        kill -0 "$oc_pid" 2>/dev/null || break; \\
+        sleep 1; \\
+    done; \\
+    sleep 3; \\
+    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\
+    echo "=== migration-bake: opencode data dir ==="; ls -laR "$XDG_DATA_HOME/opencode" 2>/dev/null | head -40; \\
+    echo "=== migration-bake: opencode log tail ==="; tail -25 /tmp/oc-bake.log; \\
+    rm -f /tmp/oc-bake.log; true
+
+RUN curl -fsSL https://bun.com/install | bash \\
+    && install -m 755 /root/.bun/bin/bun /usr/local/bin/bun \\
+    && bun --version
+
+RUN mkdir -p /opt/kortix/home/.bun/install/cache /opt/kortix/opencode-config-deps \\
+    && cd /opt/kortix/opencode-config-deps \\
+    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.17.11","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.16.0","form-data":"4.0.6"}}' > package.json \\
+    && HOME=/opt/kortix/home BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache bun install
+
+RUN cd /opt/kortix/opencode-config-deps \\
+    && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\
+    && rm -rf /tmp/opencode-deps-bundle-check \\
+    && echo "opencode-config-deps: baked tree bundles cleanly"
+
+
+# ─── Per-project COLD warm: bake repo checkout into /workspace ──────
+RUN cd / \\
+    && rm -rf /tmp/kortix-warm-repo && mkdir -p /tmp/kortix-warm-repo /workspace \\
+    && git -c http.extraHeader='Authorization: Bearer redacted' clone --depth 1 --branch 'main' 'https://git.example.com/acme/app.git' /tmp/kortix-warm-repo \\
+    && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} + \\
+    && (shopt -s dotglob 2>/dev/null || true) && cp -a /tmp/kortix-warm-repo/. /workspace/ \\
+    && rm -rf /tmp/kortix-warm-repo \\
+    && git -C /workspace remote set-url origin 'https://kortix.example.com/v1/git/proj.git' \\
+    && echo "warm-repo: baked $(git -C /workspace rev-parse HEAD) on main"
+
+COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN cd /opt/kortix/warm-config/.kortix/opencode \\
+    && rm -rf node_modules \\
+    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\
+    && HOME=/opt/kortix/home bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \\
+    && rm -rf /tmp/opencode-tools-bundle-check \\
+    && echo "opencode-config-deps: starter tool files bundle cleanly"
+
+RUN set +e; \\
+    export HOME=/opt/kortix/home \\
+        XDG_DATA_HOME=/opt/kortix/home/.local/share \\
+        XDG_CONFIG_HOME=/opt/kortix/home/.config \\
+        XDG_CACHE_HOME=/opt/kortix/home/.cache \\
+        BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache; \\
+    mkdir -p /workspace/.kortix; \\
+    staged_starter_config=0; \\
+    [ -d /workspace/.kortix/opencode ] || { cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode && staged_starter_config=1; }; \\
+    rm -rf /workspace/.kortix/opencode/node_modules; \\
+    ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules; \\
+    export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode; \\
+    cd /workspace; \\
+    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log 2>&1 & oc_pid=$!; \\
+    ready=0; \\
+    for i in $(seq 1 300); do \\
+        code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:4096/session?directory=/workspace" 2>/dev/null); \\
+        case "$code" in 200|204|301|302) ready=1; break;; esac; \\
+        kill -0 "$oc_pid" 2>/dev/null || break; \\
+        sleep 1; \\
+    done; \\
+    echo "=== instance-warm: ready=$ready ==="; \\
+    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\
+    echo "warm-repo: keeping baked /workspace checkout"; \\
+    rm -rf /opt/kortix/warm-config; \\
+    echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\
+    rm -f /tmp/oc-warm.log; true
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
+COPY kortix-agent.gz /tmp/kortix-agent.gz
+COPY kortix.gz /tmp/kortix.gz
+COPY kortix-entrypoint /usr/local/bin/kortix-entrypoint
+COPY kortix-slack-cli/ /opt/kortix/apps/sandbox/slack-cli/
+COPY kortix-executor-sdk/ /opt/kortix/packages/executor-sdk/
+COPY kortix-llm-catalog.json /opt/kortix/llm-catalog.json
+COPY scaffold.git /opt/kortix/scaffold.git
+RUN gunzip -c /tmp/kortix-agent.gz > /usr/local/bin/kortix-agent \\
+    && gunzip -c /tmp/kortix.gz > /usr/local/bin/kortix \\
+    && rm /tmp/kortix-agent.gz /tmp/kortix.gz \\
+    && chmod +x /usr/local/bin/kortix-agent /usr/local/bin/kortix /usr/local/bin/kortix-entrypoint \\
+        /opt/kortix/apps/sandbox/slack-cli/install-shims.sh \\
+    && bash /opt/kortix/apps/sandbox/slack-cli/install-shims.sh /opt/kortix/apps/sandbox/slack-cli \\
+    && kortix --version
+
+ENV KORTIX_WORKSPACE=/workspace
+RUN mkdir -p /workspace /opt/kortix/home /ephemeral/kortix-master/opencode
+WORKDIR /workspace
+EXPOSE 8000
+ENTRYPOINT ["/usr/local/bin/kortix-entrypoint"]
+"
+`;

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Golden + invariant tests over the RENDERED layer text.
+ *
+ * Why a golden: the rendered Dockerfile is not hashed into snapshot identity (it
+ * enters only via RUNTIME_LAYER_VERSION in apps/api/src/snapshots/templates.ts),
+ * it is never executed in CI, and its failures land minutes later inside a remote
+ * provider build. So the text is effectively unreviewed — a
+ * `find /workspace -mindepth 1 -delete` sat inside a `set +e … true` block,
+ * silently wiping /workspace for every custom template, and nothing caught it.
+ * layer-split.test.ts pins that the two halves CONCATENATE correctly, and
+ * apps/api's unit-dockerfile-layer.test.ts spot-checks individual substrings;
+ * neither makes the whole emitted script reviewable as a diff. This does: any
+ * change to the layer shows up here as an explicit before/after, so `bun test -u`
+ * is the moment you notice you also need the RUNTIME_LAYER_VERSION bump.
+ *
+ * The `test`s below the golden pin the invariants that a snapshot update could
+ * otherwise wave through.
+ */
+import { describe, expect, test } from 'bun:test';
+import { AGENT_BROWSER_VERSION, OPENCODE_VERSION } from '../../runtime-versions';
+import {
+  buildLayeredDockerfile,
+  type BuildLayeredDockerfileOpts,
+  kortixToolchainLayer,
+  PLATFORM_DEFAULT_USER_DOCKERFILE,
+} from '../dockerfile-layer';
+
+const COMMON = {
+  opencodeVersion: OPENCODE_VERSION,
+  agentBrowserVersion: AGENT_BROWSER_VERSION,
+  agentBinaryPath: 'kortix-agent.gz',
+  cliBinaryPath: 'kortix.gz',
+  entrypointScriptPath: 'kortix-entrypoint',
+  slackCliPath: 'kortix-slack-cli',
+  executorSdkPath: 'kortix-executor-sdk',
+  opencodeConfigPath: 'kortix-opencode-config',
+  catalogPath: 'kortix-llm-catalog.json',
+};
+
+/**
+ * A custom template that seeds /workspace — the shape the wipe used to destroy.
+ * `gdal-bin` is the real incident: it pulls python3-gdal → dpkg-owned
+ * python3-numpy, which the old `pip install --break-system-packages` floor then
+ * tried to uninstall, hard-failing the build on a perfectly correct image.
+ */
+const GDAL_USER_DOCKERFILE = `FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends gdal-bin
+
+WORKDIR /workspace
+RUN mkdir -p /workspace/data && echo seed > /workspace/data/basemap.tif
+`;
+
+/** The three shapes the production builder actually renders. */
+const CASES: Array<{ label: string; opts: BuildLayeredDockerfileOpts }> = [
+  {
+    label: 'shared platform default',
+    opts: { userDockerfile: PLATFORM_DEFAULT_USER_DOCKERFILE, isSharedDefault: true, ...COMMON },
+  },
+  {
+    label: 'custom template (user seeds /workspace)',
+    opts: { userDockerfile: GDAL_USER_DOCKERFILE, ...COMMON },
+  },
+  {
+    label: 'per-project cold warm (warmRepo)',
+    opts: {
+      userDockerfile: PLATFORM_DEFAULT_USER_DOCKERFILE,
+      ...COMMON,
+      warmRepo: {
+        cloneUrl: 'https://git.example.com/acme/app.git',
+        cloneHeaders: { Authorization: 'Bearer redacted' },
+        branch: 'main',
+        originUrl: 'https://kortix.example.com/v1/git/proj.git',
+      },
+    },
+  },
+];
+
+describe('rendered layer (golden)', () => {
+  for (const { label, opts } of CASES) {
+    test(label, () => {
+      expect(buildLayeredDockerfile(opts)).toMatchSnapshot();
+    });
+  }
+});
+
+describe('the Python floor is venv-isolated from dpkg', () => {
+  const toolchain = kortixToolchainLayer({ opencodeVersion: OPENCODE_VERSION });
+
+  test('never lets pip write to the system interpreter', () => {
+    // The whole dpkg-conflict class in one assertion: pip inside a venv cannot
+    // uninstall a dpkg-owned package, so it can never reproduce "Cannot uninstall
+    // numpy 1.26.4, RECORD file not found ... installed by debian".
+    expect(toolchain).not.toContain('--break-system-packages');
+    expect(toolchain).toContain('RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\');
+  });
+
+  test('builds the venv from the base image python, not the one apt just added', () => {
+    // Risk 1a: on `python:3.12-slim` the apt floor drops Debian's python3 at
+    // /usr/bin/python3. Building the venv from THAT (then PATH-shadowing) would
+    // downgrade the image's own interpreter. `base_py` is resolved BEFORE apt runs.
+    expect(toolchain).toContain('RUN base_py="$(command -v python3 || true)" \\');
+    expect(toolchain).toContain(
+      '    && "${base_py:-python3}" -m venv --system-site-packages /opt/kortix/pyfloor \\',
+    );
+    // …and it must be resolved before apt can install a second interpreter.
+    expect(toolchain.indexOf('base_py=')).toBeLessThan(toolchain.indexOf('apt-get update'));
+  });
+
+  test('--system-site-packages keeps the user own installs importable', () => {
+    // Without this the floor's python would lose the user's apt/pip packages
+    // (geopandas, fiona, …) — trading a build failure for an import failure.
+    expect(toolchain).toContain('-m venv --system-site-packages /opt/kortix/pyfloor');
+  });
+
+  test('verifies the import floor through the venv interpreter', () => {
+    expect(toolchain).toContain(
+      "    && /opt/kortix/pyfloor/bin/python -c 'import importlib;",
+    );
+  });
+
+  test('extends PATH rather than stomping it', () => {
+    // Verified against BuildKit AND buildah's classic imagebuilder: both expand
+    // $PATH in ENV from the base image config. A hardcoded absolute PATH here
+    // would silently drop a user's cargo/nvm/conda entries.
+    expect(toolchain).toContain('ENV PATH=/opt/kortix/pyfloor/bin:$PATH');
+  });
+
+  test('sets DEBIAN_FRONTEND itself instead of inheriting it by luck', () => {
+    expect(toolchain).toContain('ENV DEBIAN_FRONTEND=noninteractive');
+  });
+});
+
+describe('the /workspace wipe is scoped to the shared default image', () => {
+  const WIPE = 'find /workspace -mindepth 1 -delete';
+
+  test('the shared default wipes (it owns /workspace)', () => {
+    const shared = buildLayeredDockerfile({
+      userDockerfile: PLATFORM_DEFAULT_USER_DOCKERFILE,
+      isSharedDefault: true,
+      ...COMMON,
+    });
+    expect(shared).toContain(WIPE);
+  });
+
+  test('a custom template does NOT wipe — the user Dockerfile owns /workspace', () => {
+    // The regression this whole fix exists for: opencodeConfigPath is ALWAYS set in
+    // prod and warmRepo is unset for a normal custom template, so this used to be
+    // the wipe path for every custom image.
+    const custom = buildLayeredDockerfile({ userDockerfile: GDAL_USER_DOCKERFILE, ...COMMON });
+    expect(custom).not.toContain(WIPE);
+    // It still cleans up after ITSELF — only the config it staged, and only if it
+    // was the one that staged it.
+    expect(custom).toContain('[ "$staged_starter_config" = 1 ] && rm -rf /workspace/.kortix/opencode');
+  });
+
+  test('a per-project warm keeps the baked checkout (unchanged)', () => {
+    const warm = buildLayeredDockerfile(CASES[2]!.opts);
+    expect(warm).not.toContain(WIPE);
+    expect(warm).toContain('warm-repo: keeping baked /workspace checkout');
+  });
+
+  test('warmRepo outranks isSharedDefault — a baked checkout is never wiped', () => {
+    const both = buildLayeredDockerfile({ ...CASES[2]!.opts, isSharedDefault: true });
+    expect(both).not.toContain(WIPE);
+  });
+});

--- a/packages/shared/src/sandbox/__tests__/layer-split.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-split.test.ts
@@ -146,7 +146,7 @@ describe('the halves join without a seam', () => {
     // stage. (The type system enforces it; this pins the rendered output too.)
     const toolchain = kortixToolchainLayer({ opencodeVersion: OPENCODE_VERSION });
     expect(toolchain).not.toContain('COPY ');
-    expect(toolchain).toContain('RUN apt-get update \\');
+    expect(toolchain).toContain('    && apt-get update \\');
   });
 
   test('the optional catalog COPY only appears when catalogPath is set', () => {

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -88,6 +88,36 @@ export interface KortixToolchainLayerOpts {
    */
   opencodeConfigPath?: string;
   /**
+   * True iff this image is the platform's SHARED default (no user Dockerfile —
+   * `PLATFORM_DEFAULT_USER_DOCKERFILE`). Gates the post-warm-up /workspace WIPE.
+   *
+   * The wipe exists to clear the starter opencode config the warm-up stages into
+   * /workspace, and for the shared default that is ALL /workspace holds, so
+   * "delete everything" is exact. On a CUSTOM template it is not: the user's
+   * Dockerfile ran FIRST and `WORKDIR /workspace` is a documented convention, so
+   * any image that seeds data/caches/a toolchain there had it silently deleted by
+   * a step it never asked for (and one wrapped in `set +e … true`, so it couldn't
+   * even fail loudly). Custom templates therefore get a TARGETED cleanup of only
+   * what the warm-up itself staged.
+   *
+   * KNOWN GAP (narrow, deliberately not closed here). A surviving /workspace is
+   * safe for the daemon's boot clone: materializeRepo (agent-server/src/git.ts)
+   * clones into a temp dir and `rm -rf`s + renames over the target, so a non-empty
+   * /workspace is replaced wholesale rather than cloned INTO — no dirty-target
+   * failure. The one exception is a custom image that bakes a `.git` at the
+   * /workspace ROOT (not a subdir): materializeRepo keys its "using baked repo
+   * checkout (warm)" fast path purely on `${target}/.git` existing. A FRESH session
+   * still re-materializes correctly (the baked HEAD != the session's baseSha →
+   * `mismatched`), but a restart/resume has no baseSha to compare and would reuse
+   * the user's unrelated repo as the project checkout. Previously the wipe hid this
+   * by deleting that .git. The safe close is in the DAEMON, not here: have the fast
+   * path require a platform-written marker (the warmRepo bake / seed paths are the
+   * only things that legitimately bake a /workspace/.git) instead of inferring
+   * ownership from a bare .git. Tracked rather than fixed in this change because it
+   * alters boot semantics for the warm-seed paths too and wants its own rollout.
+   */
+  isSharedDefault?: boolean;
+  /**
    * Per-project COLD warm: bake the project's repo checkout into /workspace at
    * build time so a session booted from this (capture:'none') image skips the
    * boot-time git clone entirely — the daemon's git.ts fast-paths a baked
@@ -188,6 +218,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     opencodeVersion,
     agentBrowserVersion = DEFAULT_AGENT_BROWSER_VERSION,
     opencodeConfigPath,
+    isSharedDefault,
     warmRepo,
   } = opts;
 
@@ -242,7 +273,20 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // inside the guest. Without these the IP never changes → the guest stays on
     // the baked IP while the edge routes to the allocated IP → every request
     // 502s. (Harmless on Daytona, which doesn't memory-restore.)
-    'RUN apt-get update \\',
+    // apt is non-interactive by construction here (no TTY), but a package with a
+    // debconf prompt (tzdata, libreoffice's font EULAs) can still stall or fail
+    // the build. This ENV used to be supplied only by whatever the USER's base
+    // image happened to leak in — ubuntu:24.04 doesn't set it, so the floor was
+    // relying on luck. Set it ourselves. It persists to runtime deliberately:
+    // the agent's own `apt-get install` in a session has no TTY either, and a
+    // debconf prompt there is an unrecoverable hang, not a question anyone answers.
+    'ENV DEBIAN_FRONTEND=noninteractive',
+    // `base_py` MUST be resolved BEFORE the apt floor runs — see the venv step at
+    // the end of this RUN for why. It is a shell var, so it cannot cross a RUN
+    // boundary; that is the only reason the venv is created here rather than in
+    // its own step.
+    'RUN base_py="$(command -v python3 || true)" \\',
+    '    && apt-get update \\',
     '    && apt-get install -y --no-install-recommends \\',
     '        ca-certificates curl git gzip nodejs npm unzip tmux iproute2 iputils-arping \\',
     '        build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\',
@@ -250,10 +294,77 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '        python3 python3-dev python3-pip python3-venv \\',
     '        texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\',
     '        texlive-latex-extra texlive-latex-recommended \\',
-    '    && rm -rf /var/lib/apt/lists/*',
+    '    && rm -rf /var/lib/apt/lists/* \\',
+    // ─── The Python floor lives in a venv, NOT in the system interpreter ───────
+    // History: the floor used to be `pip install --break-system-packages` straight
+    // into the system interpreter. That made it fight dpkg for ownership of any
+    // package the USER's Dockerfile had pulled in via apt. Real incident: a project
+    // apt-installed `gdal-bin` → `python3-gdal` → `python3-numpy` (dpkg-owned
+    // 1.26.4); our floor's `numpy>=1.26` resolved to 2.x, pip tried to UNINSTALL the
+    // dpkg-owned copy and hard-failed the whole snapshot build with "Cannot
+    // uninstall numpy 1.26.4, RECORD file not found. Hint: The package was installed
+    // by debian." The user's image was correct — our layer broke it. numpy was just
+    // the member that got hit: numpy/scipy/pandas/scikit-learn/lxml/pillow/
+    // matplotlib/requests ALL have dpkg counterparts, so ANY dpkg-owned package in
+    // the floor's dependency closure was the same landmine.
+    //
+    // A venv kills the whole class: pip inside it can NEVER uninstall a dpkg-owned
+    // package (worst case it installs a newer copy INTO the venv, shadowing it), and
+    // `--system-site-packages` keeps the user's OWN installs (apt python3-* AND
+    // their `pip install` into dist-packages, e.g. geopandas/fiona next to that
+    // gdal) importable from the floor's interpreter.
+    //
+    // WHICH interpreter the venv is built from is load-bearing. `/opt/kortix/pyfloor
+    // /bin` goes on the front of PATH below, so the venv's python3 SHADOWS whatever
+    // python3 the user's image shipped. That is intended on a bare Debian base (the
+    // interpreter is ours either way) — but on e.g. `python:3.12-slim` the apt floor
+    // above ALSO drops Debian's own python3 at /usr/bin/python3 (whatever the base's
+    // suite pins — 3.13.5 as of writing), and building the venv from THAT would
+    // shadow the image's 3.12 with a different minor: today's harmless bloat becomes
+    // tomorrow's breakage. So we build from `base_py` — the python3 that was
+    // on PATH BEFORE our apt ran. If the user's image had one, the floor IS their
+    // interpreter (+ our packages) and the shadow is semantically a no-op; if it had
+    // none, `base_py` is empty and we fall back to the python3 our apt just
+    // installed. Note this is strictly better than "skip apt python3 when one
+    // exists": a base that apt-installed a bare `python3` with no `python3-venv`
+    // would then have no venv module at all — here our apt supplies it for that very
+    // interpreter.
+    '    && "${base_py:-python3}" -m venv --system-site-packages /opt/kortix/pyfloor \\',
+    `    && /opt/kortix/pyfloor/bin/python -c 'import sys; print("pyfloor interpreter:", sys.version)'`,
+    '',
+    // Put the floor ahead of the system interpreter for every later build step AND
+    // for the agent at runtime. `$PATH` expansion in ENV is REQUIRED to work under
+    // BOTH builders — BuildKit (Daytona) and buildah's classic imagebuilder
+    // (Platinum, which ignores `# syntax` and rejects RUN heredocs; see the
+    // portability guard in build-context.ts). Verified empirically against
+    // buildah bud (isolation=oci AND =chroot) and BuildKit: both expand it from the
+    // base image's config env, yielding
+    // `/opt/kortix/pyfloor/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
+    // Do NOT "simplify" this to a hardcoded absolute PATH: that would stomp any PATH
+    // the user's Dockerfile set (cargo, nvm, conda) — the exact bug class this
+    // change is here to remove.
+    //
+    // CAVEAT 1: anything that spells `/usr/bin/python3` (or `/usr/local/bin/python3`)
+    // explicitly bypasses the floor and sees only the system site-packages. PATH is
+    // the contract; absolute interpreter paths opt out of it.
+    //
+    // CAVEAT 2 (the flip side, and a real one): the venv's site-packages precedes
+    // the system's, so where the floor and the user's apt packages disagree on a
+    // version, the FLOOR wins for `python3`. Verified on the gdal image above: the
+    // floor's python gets numpy 2.x, so `from osgeo import gdal` works but
+    // `osgeo.gdal_array` — a dpkg C extension compiled against numpy 1.x — raises
+    // "numpy.core.multiarray failed to import" under it. `/usr/bin/python3` keeps
+    // the user's coherent numpy-1.x stack and runs that workload fine, so the
+    // escape hatch is real and one line. This is strictly better than the status
+    // quo it replaces, which was: the build hard-fails and there is NO image at
+    // all. We are trading "nothing works" for "both interpreters work, each for
+    // its own stack".
+    'ENV PATH=/opt/kortix/pyfloor/bin:$PATH',
     '',
     '# Starter skill Python package floor (document/data/PDF/presentation helpers).',
-    'RUN python3 -m pip install --break-system-packages --no-cache-dir \\',
+    '# Installed INTO the venv via its own pip, which cannot touch a dpkg-owned',
+    '# package no matter what the resolver picks.',
+    'RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\',
     '        "beautifulsoup4>=4.12" \\',
     '        "lxml>=5" \\',
     '        "markdownify>=0.13" \\',
@@ -287,7 +398,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // instruction "IMPORT" and aborts the build with `Unknown instruction: IMPORT`
     // at STEP 6 — failing EVERY Platinum template build. A -c one-liner is
     // equivalent (still fails the layer if any module is missing) and portable.
-    '    && python3 -c \'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")\'',
+    '    && /opt/kortix/pyfloor/bin/python -c \'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")\'',
     '',
     `RUN npm install -g --no-audit --no-fund "opencode-ai@${opencodeVersion}" \\`,
     '    && command -v opencode \\',
@@ -394,7 +505,8 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // boot. For the SHARED default image we then wipe /workspace (the session
     // clones into it). For a PER-PROJECT COLD warm (warmRepo set) the repo is
     // already baked at /workspace and we KEEP it — the daemon boots off the baked
-    // checkout with NO clone. Either way the warmed caches under /opt/kortix/home
+    // checkout with NO clone. For a CUSTOM template we remove only the config we
+    // staged: /workspace is the user's. Either way the warmed caches under /opt/kortix/home
     // persist in the image layer. Measured: cold first-instance 6–60s → ~2–4s
     // after this bake. Requires opencode + bun + the
     // baked config deps above, so it must come after them. Best effort: a build
@@ -433,7 +545,11 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
           // repo may already ship its own .kortix/opencode — keep it (its config
           // is what the session actually resolves at runtime) and only fall back
           // to the staged starter when the repo has none.
-          '    [ -d /workspace/.kortix/opencode ] || cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode; \\',
+          // `staged_starter_config` records whether the starter config in
+          // /workspace is OURS (we copied it) or the image's own — it decides what
+          // the non-shared cleanup below is allowed to delete.
+          '    staged_starter_config=0; \\',
+          '    [ -d /workspace/.kortix/opencode ] || { cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode && staged_starter_config=1; }; \\',
           '    rm -rf /workspace/.kortix/opencode/node_modules; \\',
           '    ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules; \\',
           '    export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode; \\',
@@ -448,12 +564,22 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
           '    done; \\',
           '    echo "=== instance-warm: ready=$ready ==="; \\',
           '    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\',
-          // Shared default: wipe /workspace (the session clones into it at boot).
-          // Per-project COLD warm (warmRepo): KEEP the baked repo checkout so the
-          // daemon boots off it with no clone.
+          // Three cases, and only one of them may delete indiscriminately:
+          //  • per-project COLD warm (warmRepo): KEEP the baked repo checkout so
+          //    the daemon boots off it with no clone.
+          //  • SHARED default: /workspace contains only what this warm-up put
+          //    there (the base is `PLATFORM_DEFAULT_USER_DOCKERFILE` — a FROM and a
+          //    WORKDIR), so wiping it is exact, and it also clears anything opencode
+          //    itself dropped while serving. The session clones into it at boot.
+          //  • CUSTOM template: the user's Dockerfile owns /workspace. Remove ONLY
+          //    the starter config we staged (and the .kortix dir if that leaves it
+          //    empty) — never their bytes. `rmdir` is the no-op-unless-empty form on
+          //    purpose; a user's own /workspace/.kortix survives untouched.
           warmRepo
             ? '    echo "warm-repo: keeping baked /workspace checkout"; \\'
-            : '    find /workspace -mindepth 1 -delete 2>/dev/null; \\',
+            : isSharedDefault
+              ? '    find /workspace -mindepth 1 -delete 2>/dev/null; \\'
+              : '    [ "$staged_starter_config" = 1 ] && rm -rf /workspace/.kortix/opencode; rmdir /workspace/.kortix 2>/dev/null; \\',
           '    rm -rf /opt/kortix/warm-config; \\',
           '    echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\',
           '    rm -f /tmp/oc-warm.log; true',


### PR DESCRIPTION
**Stack 2/3.** Base: #4799. Contains the `RUNTIME_LAYER_VERSION` **v26** bump — see the rollout note.

## The incident

A GIS project's Dockerfile apt-installed `gdal-bin` → `python3-gdal` → `python3-numpy` (dpkg-owned). The injected floor then failed the whole snapshot build:

```
ERROR: Cannot uninstall numpy 1.26.4, RECORD file not found.
Hint: The package was installed by debian.
```

The user's image was **fine**. The layer broke it. The project's only recourse was to encode an apt taboo in its own Dockerfile ("do not install anything that pulls python3-numpy") — that comment is really a bug report against us.

**The mechanism is not what it looks like.** I reproduced it, and the trimmed repro *passed*: dpkg's numpy 1.26.4 already satisfies our `numpy>=1.26` line. The real trigger is **scipy + scikit-learn requiring numpy>=2**, which forces an upgrade pip cannot perform. So numpy is not special — **any dpkg-owned member of the floor's dependency closure is a landmine** (scipy, pandas, scikit-learn, lxml, pillow, matplotlib, requests all have `python3-*` counterparts).

## Fix 1 — venv-isolate the floor

`python3 -m venv --system-site-packages /opt/kortix/pyfloor` + `ENV PATH=/opt/kortix/pyfloor/bin:$PATH`, and drop `--break-system-packages`. pip inside the venv can never uninstall a dpkg-owned package; `--system-site-packages` keeps the user's own installs importable from the floor's python. Kills the whole class, not just numpy.

Verified against the real gdal image: green, `dpkg -V python3-numpy` clean, user's `osgeo.gdal` still working.

Risks handled rather than assumed:
- **Interpreter choice is load-bearing.** The venv is built from `command -v python3` captured *before* apt. Verified on `python:3.12-slim`: apt drags in Debian 3.13, the floor correctly stays on the image's 3.12, user's `flask` still imports. (I rejected "skip apt python3 when one exists" — a base with a bare `python3` and no `python3-venv` would then have no venv module at all.)
- **`$PATH` expansion in `ENV` under buildah.** Not guessed — ran `buildah bud` with both `oci` and `chroot` isolation *and* BuildKit; all expand it. Kept the `$PATH` form; a hardcoded absolute PATH would stomp user cargo/nvm/conda entries.
- **Known residual, documented:** the venv precedes system site-packages, so a dpkg C extension compiled against numpy 1.x (`osgeo.gdal_array`) fails under the floor's python. `/usr/bin/python3` runs it fine. Strictly better than the status quo, which produced no image at all.

## Fix 2 — stop silently wiping `/workspace`

`find /workspace -mindepth 1 -delete` ran for every custom template (inside a `set +e` block, so it couldn't even fail loudly). The user's Dockerfile runs first and `WORKDIR /workspace` is a documented convention, so any image seeding data there had it deleted — silently. Now gated on `isSharedDefault`; custom templates get a targeted cleanup of only what the warm-up staged.

**The dirty-clone worry was unfounded** — `materializeRepo` clones to a temp dir and renames over the target, so a non-empty `/workspace` is replaced wholesale.

**But it was hiding a real one, reported not shipped:** the "baked repo checkout (warm)" path keys purely on `${target}/.git` existing, so an image baking `.git` at `/workspace` root would — on restart/resume only, where there's no `baseSha` — have its unrelated repo adopted as the project checkout. The safe close is a platform-written marker in the daemon, which touches the warm-seed paths and wants its own rollout. Documented in-code.

## Fix 3 — stop blaming users for our failures

A layer failure (numpy trace, or `apt-get: not found` on a non-Debian base) matched the generic `dockerfile` rule → "Dockerfile build failed", `fixableByAgent: true` → **an agent gets dispatched to "fix" a Dockerfile that is correct**. New `layer` category above it, `fixableByAgent: false`, hint naming the platform. Tests assert **rule order**, not just patterns (every fixture also matches `dockerfile`).

Also updates the duplicated `SnapshotErrorCategory` union in `packages/sdk` that web/mobile label maps key on — without it a `layer` failure renders with no label.

## Fix 4 — `DEBIAN_FRONTEND=noninteractive` + golden tests

The layer apt-installs libreoffice/texlive and only worked because a user's ENV leaked in. The golden test earned itself immediately: it caught my own emitted comment still containing `--break-system-packages`, and I reworded the comment rather than weaken the assertion.

## ⚠️ Rollout — v26

The rendered layer text is **not hashed**; it enters snapshot identity only via `RUNTIME_LAYER_VERSION`. Changing the layer without bumping ships to nobody. One bump for all of the above.

Bumping forces a **full rebuild of every template platform-wide** and moves the non-agent `swapKey`, disabling the agent-swap fast path. That is unavoidable — the constant is global. Ship off-peak and watch the Daytona snapshot quota (a mass rebuild is exactly what fills it) and the quota GC.

## Verification

- `packages/shared`: 245 pass / 0 fail. Typecheck clean.
- `apps/api` change-relevant suites: 49 pass / 1 fail — the known "web SDK … OpenCode SDK pin", confirmed failing identically on the base commit.
- `packages/sdk` clean.

**Caveat:** the full `apps/api` suite could not run — `.env` is dotenvx-encrypted. Environmental, but I have not seen the whole suite green.

## Known trade-off

The `layer` regex can false-positive if a *user's* Dockerfile pip-installs over a dpkg package. Accepted: the hint names the platform, and it beats dispatching an agent at correct code. Separately, mobile's `CATEGORY_LABEL` is already missing `quota` on `main` — pre-existing, left alone.