### PR TITLE
feat(cli): pre-push sandbox gate — Dockerfile lint in `validate`, `sandboxes build --local`

### DIFF
--- a/apps/cli/src/__tests__/dockerfile-lint.test.ts
+++ b/apps/cli/src/__tests__/dockerfile-lint.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+
+import { PLATFORM_DEFAULT_USER_DOCKERFILE } from '@kortix/shared/sandbox';
+
+import { lintDockerfile } from '../dockerfile-lint.ts';
+
+const lint = (text: string) => lintDockerfile(text, { path: 'Dockerfile' });
+
+describe('lintDockerfile — COPY/ADD from the build context', () => {
+  test('a COPY of a repo file is an error naming the file (the real incident)', () => {
+    // Verbatim from the incident: the cloud build died with
+    // "Path does not exist: /tmp/kortix-snap-XXXX/requirements-kortix.txt".
+    const issues = lint('FROM ubuntu:24.04\nCOPY requirements-kortix.txt .\n');
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('error');
+    expect(issues[0]!.line).toBe(2);
+    expect(issues[0]!.path).toBe('Dockerfile');
+    expect(issues[0]!.message).toContain('requirements-kortix.txt');
+    // It must say WHY, not just "no".
+    expect(issues[0]!.message).toContain('/workspace');
+  });
+
+  test('COPY --from=<stage> is clean — a multi-stage copy reads an image, not the context', () => {
+    expect(
+      lint('FROM golang:1.22 AS builder\nFROM ubuntu:24.04\nCOPY --from=builder /app /app\n'),
+    ).toEqual([]);
+  });
+
+  test('ADD of a remote URL is clean — Docker fetches it over the network', () => {
+    expect(lint('FROM ubuntu:24.04\nADD https://example.com/data.tar.gz /opt/data.tar.gz\n')).toEqual(
+      [],
+    );
+  });
+
+  test('ADD of a repo file is still an error', () => {
+    const issues = lint('FROM ubuntu:24.04\nADD ./seed.sql /opt/seed.sql\n');
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('error');
+    expect(issues[0]!.message).toContain('seed.sql');
+  });
+
+  test('flags every source of a multi-source COPY, and survives continuations', () => {
+    const issues = lint('FROM ubuntu:24.04\nCOPY a.txt \\\n     b.txt \\\n     /opt/\n');
+    expect(issues.map((i) => i.severity)).toEqual(['error', 'error']);
+    expect(issues[0]!.message).toContain('a.txt');
+    expect(issues[1]!.message).toContain('b.txt');
+    // Both belong to the instruction that STARTS on line 2.
+    expect(issues.map((i) => i.line)).toEqual([2, 2]);
+  });
+});
+
+describe('lintDockerfile — RUN heredocs', () => {
+  test('a RUN heredoc is an error (buildah parses its body as instructions)', () => {
+    const issues = lint(
+      ['FROM ubuntu:24.04', "RUN python3 <<'PY'", 'import importlib', 'print("ok")', 'PY', ''].join(
+        '\n',
+      ),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('error');
+    expect(issues[0]!.line).toBe(2);
+    expect(issues[0]!.message).toContain('heredoc');
+    expect(issues[0]!.message).toContain('Platinum');
+  });
+
+  test("the heredoc BODY isn't parsed as instructions (no phantom COPY error)", () => {
+    const issues = lint(
+      ['FROM ubuntu:24.04', 'RUN cat <<EOF', 'COPY not-a-real-instruction here', 'EOF', ''].join('\n'),
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.message).toContain('heredoc');
+  });
+
+  test('a `python3 -c` one-liner — the portable equivalent — is clean', () => {
+    expect(lint(`FROM ubuntu:24.04\nRUN python3 -c 'import sys; print(sys.version)'\n`)).toEqual([]);
+  });
+});
+
+describe('lintDockerfile — non-Debian base', () => {
+  test('FROM alpine:3 warns (not errors — the tag could be a Debian derivative)', () => {
+    const issues = lint('FROM alpine:3\nRUN echo hi\n');
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('warning');
+    expect(issues[0]!.line).toBe(1);
+    expect(issues[0]!.message).toContain('apt-get');
+  });
+
+  test('the family in the TAG is caught too (node:20-alpine)', () => {
+    const issues = lint('FROM node:20-alpine\n');
+    expect(issues.map((i) => i.severity)).toEqual(['warning']);
+  });
+
+  test('an alpine BUILDER stage is fine when the final base is Debian', () => {
+    // The Kortix layer is appended to the END, so only the last stage's base
+    // has to carry apt.
+    expect(lint('FROM alpine:3 AS builder\nRUN echo build\n\nFROM ubuntu:24.04\n')).toEqual([]);
+  });
+
+  test('Debian-family bases are clean', () => {
+    for (const base of ['ubuntu:24.04', 'debian:bookworm-slim', 'python:3.12-slim', 'node:20']) {
+      expect(lint(`FROM ${base}\n`)).toEqual([]);
+    }
+  });
+
+  test('an unresolvable ARG base is not guessed at', () => {
+    expect(lint('ARG BASE_IMAGE=ubuntu:24.04\nFROM ${BASE_IMAGE}\n')).toEqual([]);
+  });
+});
+
+describe('lintDockerfile — the platform default text', () => {
+  test('the Dockerfile Kortix itself ships is clean', () => {
+    // If our own default tripped these checks, the checks would be wrong.
+    expect(lint(PLATFORM_DEFAULT_USER_DOCKERFILE)).toEqual([]);
+  });
+
+  test('comments are never linted', () => {
+    expect(lint('FROM ubuntu:24.04\n# COPY secrets.txt /etc\n# RUN sh <<EOF\n')).toEqual([]);
+  });
+});

--- a/apps/cli/src/__tests__/sandboxes-local-blackbox.test.ts
+++ b/apps/cli/src/__tests__/sandboxes-local-blackbox.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Black-box coverage for the pre-push gate: `kortix validate`'s Dockerfile lint
+ * and `kortix sandboxes build --local`.
+ *
+ * NOTHING here talks to a real Docker daemon (no test in this repo does, and a
+ * test that pulls ubuntu:24.04 and runs apt for 20 minutes would be a test
+ * nobody runs). Instead PATH is pointed at a stub `docker` that records every
+ * invocation — which lets us assert the stronger property anyway: that `--print`
+ * never invokes it at all.
+ */
+import { chmodSync, mkdirSync, mkdtempSync, existsSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+const CLI_ENTRY = join(resolve(import.meta.dir, '..', '..'), 'src', 'index.ts');
+const SANDBOX_ENV_OVERRIDES = [
+  'KORTIX_API_URL',
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_FRONTEND_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_TOKEN',
+  'BASH_ENV',
+] as const;
+
+let tmp: string;
+/** Written by the stub docker on every call — its existence means Docker was touched. */
+let dockerLog: string;
+
+/** A minimal manifest that PASSES the schema, so any error is the lint's. */
+const MANIFEST = (extra: string) =>
+  [
+    'kortix_version: 2',
+    'default_agent: kortix',
+    'project:',
+    '  name: fixture',
+    'agents:',
+    '  kortix: {}',
+    extra,
+    '',
+  ].join('\n');
+
+async function runCli(args: string[], cwd = tmp) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    KORTIX_NO_UPDATE_CHECK: '1',
+    NO_COLOR: '1',
+    FORCE_COLOR: '0',
+    KORTIX_DISABLE_SANDBOX_ENV_FILE: '1',
+    // Stub docker first on PATH: nothing in this suite may reach a real daemon.
+    PATH: `${join(tmp, 'bin')}:${process.env.PATH}`,
+  };
+  for (const key of SANDBOX_ENV_OVERRIDES) delete env[key];
+  const proc = Bun.spawn({ cmd: [process.execPath, CLI_ENTRY, ...args], cwd, env, stdout: 'pipe', stderr: 'pipe' });
+  const timeout = setTimeout(() => proc.kill(), 20_000);
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]).finally(() => clearTimeout(timeout));
+  return { code, stdout, stderr };
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'kortix-local-build-'));
+  mkdirSync(join(tmp, 'bin'));
+  dockerLog = join(tmp, 'docker-was-called');
+  writeFileSync(
+    join(tmp, 'bin', 'docker'),
+    `#!/bin/sh\necho "$@" >> "${dockerLog}"\nexit 0\n`,
+    'utf8',
+  );
+  chmodSync(join(tmp, 'bin', 'docker'), 0o755);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('kortix sandboxes build --local --print', () => {
+  beforeEach(() => {
+    writeFileSync(
+      join(tmp, 'kortix.yaml'),
+      MANIFEST('sandbox:\n  templates:\n    - slug: ml\n      dockerfile: Dockerfile.ml'),
+      'utf8',
+    );
+    writeFileSync(join(tmp, 'Dockerfile.ml'), 'FROM ubuntu:24.04\nRUN echo hello\n', 'utf8');
+  });
+
+  test('prints the composed Dockerfile, exits 0, and never touches Docker', async () => {
+    const r = await runCli(['sandboxes', 'build', '--local', '--print']);
+    expect(r.code).toBe(0);
+    // The user's Dockerfile, verbatim and first.
+    expect(r.stdout.startsWith('FROM ubuntu:24.04\nRUN echo hello\n')).toBe(true);
+    // The Kortix toolchain layer, including the pip floor.
+    expect(r.stdout).toContain('Kortix runtime layer (auto-injected)');
+    expect(r.stdout).toContain('/opt/kortix/pyfloor/bin/pip install');
+    // …but not the artifact tail.
+    expect(r.stdout).not.toContain('scaffold.git');
+    expect(r.stdout).not.toContain('ENTRYPOINT');
+    // No preamble noise — the output must be pipeable into `docker build -`.
+    expect(r.stdout).not.toContain('Building ml');
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  test('resolves the sole declared template without a slug, and honors an explicit one', async () => {
+    const bare = await runCli(['sandboxes', 'build', '--local', '--print']);
+    const named = await runCli(['sandboxes', 'build', '--local', 'ml', '--print']);
+    expect(named.code).toBe(0);
+    expect(named.stdout).toBe(bare.stdout);
+  });
+
+  test('--no-layer prints the user Dockerfile alone', async () => {
+    const r = await runCli(['sandboxes', 'build', '--local', '--print', '--no-layer']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe('FROM ubuntu:24.04\nRUN echo hello\n');
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  test('an unknown slug exits 2 listing the declared slugs, without building', async () => {
+    const r = await runCli(['sandboxes', 'build', '--local', 'nope', '--print']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('nope');
+    expect(r.stderr).toContain('ml');
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  test('--platform\'s value is not mistaken for a slug', async () => {
+    // `positional[0]` is only meaningful after the flag takers have mutated argv.
+    const r = await runCli(['sandboxes', 'build', '--local', '--platform', 'linux/amd64', '--print']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('FROM ubuntu:24.04');
+  });
+
+  test('--local on a cloud subcommand errors instead of silently doing the cloud thing', async () => {
+    const r = await runCli(['sandboxes', 'rebuild', 'ml', '--local']);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('--local only applies');
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  test('needs no login — the whole point of a pre-push gate', async () => {
+    // runCli strips every KORTIX_* credential and there's no config.json in tmp,
+    // so this asserts the command routes above resolveProjectContext.
+    const r = await runCli(['sandboxes', 'build', '--local', '--print']);
+    expect(r.code).toBe(0);
+    expect(r.stderr).not.toContain('Not logged in');
+  });
+});
+
+describe('kortix sandboxes --help', () => {
+  test('renders the local build section', async () => {
+    const r = await runCli(['sandboxes', '--help']);
+    expect(r.code).toBe(0);
+    for (const fragment of [
+      'build --local [slug]',
+      'Local build',
+      '--platform <p>',
+      '--no-layer',
+      '--print',
+      'kortix-local/<slug>:latest',
+    ]) {
+      expect(r.stdout).toContain(fragment);
+    }
+  });
+});
+
+describe('kortix validate — sandbox Dockerfile lint', () => {
+  beforeEach(() => {
+    writeFileSync(
+      join(tmp, 'kortix.yaml'),
+      MANIFEST('sandbox:\n  templates:\n    - slug: ml\n      dockerfile: Dockerfile.ml'),
+      'utf8',
+    );
+    // Incident (a): the repo is never in the build context.
+    writeFileSync(
+      join(tmp, 'Dockerfile.ml'),
+      'FROM ubuntu:24.04\nCOPY requirements-kortix.txt ./\n',
+      'utf8',
+    );
+  });
+
+  test('a template Dockerfile that COPYs a repo file fails validate, naming the file', async () => {
+    const r = await runCli(['validate']);
+    expect(r.code).not.toBe(0);
+    const all = r.stdout + r.stderr;
+    expect(all).toContain('requirements-kortix.txt');
+    expect(all).toContain('Dockerfile.ml');
+  });
+
+  test('--no-dockerfile-lint passes (the manifest itself is fine)', async () => {
+    const r = await runCli(['validate', '--no-dockerfile-lint']);
+    expect(r.code).toBe(0);
+  });
+
+  test('--json carries the Dockerfile issue in the same issues array', async () => {
+    const r = await runCli(['validate', '--json']);
+    expect(r.code).toBe(1);
+    const report = JSON.parse(r.stdout);
+    expect(report.valid).toBe(false);
+    const hit = report.issues.find((i: { path: string }) => i.path === 'Dockerfile.ml');
+    expect(hit.severity).toBe('error');
+    expect(hit.message).toContain('requirements-kortix.txt');
+    expect(hit.line).toBe(2);
+  });
+
+  test('a clean Dockerfile validates', async () => {
+    writeFileSync(join(tmp, 'Dockerfile.ml'), 'FROM ubuntu:24.04\nRUN echo hi\n', 'utf8');
+    const r = await runCli(['validate']);
+    expect(r.code).toBe(0);
+  });
+
+  test('a missing Dockerfile is left to the manifest validator, not double-reported', async () => {
+    rmSync(join(tmp, 'Dockerfile.ml'));
+    const r = await runCli(['validate']);
+    expect(r.stdout + r.stderr).not.toContain('build context');
+  });
+});

--- a/apps/cli/src/__tests__/sandboxes-local.test.ts
+++ b/apps/cli/src/__tests__/sandboxes-local.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { SandboxTemplate } from '@kortix/shared/sandbox';
+
+import {
+  composeLocalDockerfile,
+  dockerBuildArgs,
+  resolveLocalTemplate,
+} from '../commands/sandboxes-local.ts';
+
+const tpl = (slug: string, extra: Partial<SandboxTemplate> = {}): SandboxTemplate => ({
+  slug,
+  spec: {},
+  dockerfile: `${slug}.Dockerfile`,
+  ...extra,
+});
+
+describe('composeLocalDockerfile', () => {
+  const USER = 'FROM ubuntu:24.04\nRUN apt-get update && apt-get install -y gdal-bin\n';
+
+  test('includes the pip floor — the thing the local build exists to exercise', () => {
+    // Incident (b): the floor's `numpy>=1.26` vs a user's dpkg-owned numpy
+    // 1.26.4 → "Cannot uninstall numpy 1.26.4, RECORD file not found". If the
+    // composed text doesn't run pip, this command reproduces nothing.
+    const out = composeLocalDockerfile(USER, { layer: true });
+    expect(out).toContain('/opt/kortix/pyfloor/bin/pip install');
+    expect(out).toContain('"numpy>=1.26"');
+    expect(out).toContain('apt-get install');
+  });
+
+  test('keeps the user Dockerfile verbatim, above the layer', () => {
+    const out = composeLocalDockerfile(USER, { layer: true });
+    expect(out.startsWith('FROM ubuntu:24.04\nRUN apt-get update')).toBe(true);
+    expect(out.indexOf('gdal-bin')).toBeLessThan(out.indexOf('Kortix runtime layer'));
+  });
+
+  test('omits the artifact tail — those COPYs need binaries a consumer cannot stage', () => {
+    const out = composeLocalDockerfile(USER, { layer: true });
+    for (const artifact of [
+      'COPY kortix-agent.gz',
+      'kortix.gz',
+      'kortix-entrypoint',
+      'kortix-slack-cli',
+      'kortix-executor-sdk',
+      'scaffold.git',
+      'install-shims.sh',
+      'ENTRYPOINT',
+    ]) {
+      expect(out).not.toContain(artifact);
+    }
+  });
+
+  test('omits the staged-context steps (opencode config warm-up, warm repo)', () => {
+    // Both would emit COPY/clone steps against a context this build doesn't have.
+    const out = composeLocalDockerfile(USER, { layer: true });
+    expect(out).not.toContain('/opt/kortix/warm-config');
+    expect(out).not.toContain('warm-repo');
+  });
+
+  test('--no-layer yields the user text alone', () => {
+    expect(composeLocalDockerfile(USER, { layer: false })).toBe(USER);
+  });
+
+  test('normalizes the legacy starter block the same way the snapshot builder does', () => {
+    const legacy =
+      'FROM ubuntu:24.04\n\n' +
+      '# Bring in baseline tooling. The Kortix layer on top also installs\n' +
+      '# git/curl/ca-certificates/nodejs/npm, but having them in your base\n' +
+      '# makes interactive sessions snappier.\n' +
+      'RUN apt-get update \\\n' +
+      '    && apt-get install -y --no-install-recommends \\\n' +
+      '        ca-certificates \\\n' +
+      '        curl \\\n' +
+      '        git \\\n' +
+      '        build-essential \\\n' +
+      '    && rm -rf /var/lib/apt/lists/*\n';
+    expect(composeLocalDockerfile(legacy, { layer: false })).toBe('FROM ubuntu:24.04\n');
+  });
+});
+
+describe('resolveLocalTemplate', () => {
+  test('an explicit slug wins', () => {
+    const r = resolveLocalTemplate('web', [tpl('web'), tpl('worker')], 'worker');
+    expect(r).toEqual({ template: tpl('web') });
+  });
+
+  test('falls back to sandbox.default', () => {
+    const r = resolveLocalTemplate(undefined, [tpl('web'), tpl('worker')], 'worker');
+    expect('template' in r && r.template.slug).toBe('worker');
+  });
+
+  test('falls back to the sole declared template', () => {
+    const r = resolveLocalTemplate(undefined, [tpl('only')], null);
+    expect('template' in r && r.template.slug).toBe('only');
+  });
+
+  test('never silently picks the platform default — it errors, listing the slugs', () => {
+    // Building `FROM ubuntu:24.04` + the layer would go green while testing
+    // nothing the user wrote. Ambiguity has to be the user's to resolve.
+    const r = resolveLocalTemplate(undefined, [tpl('web'), tpl('worker')], null);
+    expect('error' in r).toBe(true);
+    expect('error' in r && r.error).toContain('web, worker');
+  });
+
+  test('with no templates at all it says so, and points at the explicit opt-in', () => {
+    const r = resolveLocalTemplate(undefined, [], null);
+    expect('error' in r && r.error).toContain('no `sandbox.templates`');
+    expect('error' in r && r.error).toContain('--slug default');
+  });
+
+  test('`--slug default` is honored explicitly', () => {
+    const r = resolveLocalTemplate('default', [tpl('web')], null);
+    expect('template' in r && r.template.isDefault).toBe(true);
+  });
+
+  test('an unknown slug errors, listing what exists', () => {
+    const r = resolveLocalTemplate('nope', [tpl('web')], null);
+    expect('error' in r && r.error).toContain('No sandbox template "nope"');
+    expect('error' in r && r.error).toContain('web');
+  });
+
+  test('a sandbox.default pointing at nothing is called out', () => {
+    const r = resolveLocalTemplate(undefined, [tpl('web')], 'ghost');
+    expect('error' in r && r.error).toContain('ghost');
+  });
+});
+
+describe('dockerBuildArgs', () => {
+  test('feeds the Dockerfile via stdin with an EMPTY context', () => {
+    // A bare `-` context (Dockerfile on stdin) is what makes "the repo is not in
+    // the build context" structural rather than a promise. `-f - -` looks like
+    // it should work and does not: docker rejects it with "can't use stdin for
+    // both build context and dockerfile".
+    expect(dockerBuildArgs({ platform: 'linux/arm64', tag: 't:latest', noCache: false })).toEqual([
+      'build',
+      '--platform',
+      'linux/arm64',
+      '-t',
+      't:latest',
+      '-',
+    ]);
+  });
+
+  test('--no-cache is passed through', () => {
+    expect(dockerBuildArgs({ platform: 'linux/amd64', tag: 't', noCache: true })).toContain(
+      '--no-cache',
+    );
+  });
+});

--- a/apps/cli/src/commands/sandboxes-local.ts
+++ b/apps/cli/src/commands/sandboxes-local.ts
@@ -1,0 +1,332 @@
+/**
+ * `kortix sandboxes build --local [slug]` — build a project's sandbox image on
+ * THIS machine, the way the cloud would.
+ *
+ * `kortix validate`'s Dockerfile lint catches everything decidable from text.
+ * This catches the rest: the failures that only exist once apt/pip/npm actually
+ * run. The motivating one is the Python floor colliding with a user's
+ * dpkg-owned packages ("Cannot uninstall numpy 1.26.4, RECORD file not found")
+ * — invisible until something executes the layer.
+ *
+ * Two choices make this an honest reproduction rather than a lookalike:
+ *
+ *   • The layer is `kortixToolchainLayer` ONLY — not the artifact tail. That
+ *     tail COPYs staged Kortix build outputs (kortix-agent.gz, scaffold.git, …)
+ *     that a consumer developer has no way to produce, and it installs nothing:
+ *     everything that can FAIL on a user's base image lives in the toolchain
+ *     half. Skipping it costs no coverage and makes the command runnable by
+ *     anyone.
+ *
+ *   • The build context is EMPTY, structurally — the Dockerfile goes in over
+ *     stdin (`docker build -f - -`) with `-` as the context. There is no
+ *     directory to accidentally leak the repo in. That is exactly the cloud's
+ *     constraint (the repo is cloned to /workspace at session start, never
+ *     baked), so a `COPY ./src` fails here for the same reason and with a
+ *     similar message.
+ *
+ * What it is NOT: a guarantee. The cloud composes the artifact tail on top,
+ * builds linux/amd64, and may use buildah rather than BuildKit. A green local
+ * build means the user's own Dockerfile + the Kortix floor agree — the most
+ * common failure, not every failure.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import {
+  DEFAULT_SANDBOX_SLUG,
+  PLATFORM_DEFAULT_USER_DOCKERFILE,
+  type SandboxTemplate,
+  extractSandboxDefault,
+  extractSandboxTemplates,
+  kortixToolchainLayer,
+  normalizeUserDockerfileForSnapshot,
+} from '@kortix/shared/sandbox';
+import { AGENT_BROWSER_VERSION, OPENCODE_VERSION } from '@kortix/shared/runtime-versions';
+import { emitJson, takeFlagBool, takeFlagValue } from '../command-helpers.ts';
+import { dockerAvailable, hostPlatform } from '../docker.ts';
+import { loadLocalManifest, resolveLocalManifest } from '../manifest.ts';
+import { C, status } from '../style.ts';
+
+export interface LocalBuildFlags {
+  slug?: string;
+  platform?: string;
+  tag?: string;
+  noCache: boolean;
+  layer: boolean;
+  print: boolean;
+  json: boolean;
+}
+
+/**
+ * Which template a bare `build --local` means. Precedence:
+ *
+ *   1. the slug the user named (positional or --slug)
+ *   2. `sandbox.default` — the template this project's sessions actually boot
+ *   3. the sole declared template, when there's exactly one (unambiguous)
+ *   4. otherwise: error, listing the slugs
+ *
+ * Note what is NOT in that list: the platform `default` slug. Falling back to it
+ * would produce a green build of `FROM ubuntu:24.04` + the layer — a build that
+ * tests nothing the user wrote, while looking like it validated their project.
+ * An explicit `default` is still honored: "build the platform base" is a
+ * legitimate thing to ask for, just never something to assume.
+ */
+export function resolveLocalTemplate(
+  slugArg: string | undefined,
+  templates: SandboxTemplate[],
+  defaultSlug: string | null,
+): { template: SandboxTemplate } | { error: string } {
+  const listSlugs = () =>
+    templates.length === 0
+      ? 'This project declares no `sandbox.templates` in kortix.yaml.'
+      : `Declared templates: ${templates.map((t) => t.slug).join(', ')}.`;
+
+  if (slugArg) {
+    if (slugArg === DEFAULT_SANDBOX_SLUG) {
+      return { template: { slug: DEFAULT_SANDBOX_SLUG, name: 'Default', spec: {}, isDefault: true } };
+    }
+    const hit = templates.find((t) => t.slug === slugArg);
+    if (!hit) return { error: `No sandbox template "${slugArg}". ${listSlugs()}` };
+    return { template: hit };
+  }
+
+  if (defaultSlug) {
+    const hit = templates.find((t) => t.slug === defaultSlug);
+    if (hit) return { template: hit };
+    return {
+      error: `\`sandbox.default\` points at "${defaultSlug}", which isn't declared. ${listSlugs()}`,
+    };
+  }
+
+  if (templates.length === 1) return { template: templates[0]! };
+
+  return {
+    error:
+      templates.length === 0
+        ? `${listSlugs()} Nothing project-specific to build — pass \`--slug default\` to build the platform base image.`
+        : `Ambiguous: ${templates.length} templates and no \`sandbox.default\`. Name one — ${listSlugs()}`,
+  };
+}
+
+/**
+ * The user-Dockerfile bytes a template contributes, exactly as the cloud
+ * builder derives them (apps/api/src/snapshots/templates.ts): a `dockerfile:`
+ * template supplies its file's bytes, an `image:` template a one-line `FROM`
+ * shim, and the platform default its own canned base.
+ */
+export function userDockerfileForTemplate(
+  template: SandboxTemplate,
+  projectRoot: string,
+): { text: string; source: string } | { error: string } {
+  if (template.isDefault) {
+    return { text: PLATFORM_DEFAULT_USER_DOCKERFILE, source: '(platform default base)' };
+  }
+  if (template.dockerfile) {
+    const abs = resolve(projectRoot, template.dockerfile);
+    if (!existsSync(abs)) {
+      return { error: `Template "${template.slug}" points at ${template.dockerfile}, which doesn't exist.` };
+    }
+    try {
+      return { text: readFileSync(abs, 'utf8'), source: template.dockerfile };
+    } catch (err) {
+      return { error: `Can't read ${template.dockerfile}: ${(err as Error).message}` };
+    }
+  }
+  if (template.image) return { text: `FROM ${template.image}\n`, source: `(image: ${template.image})` };
+  return { error: `Template "${template.slug}" declares neither a dockerfile nor an image.` };
+}
+
+/**
+ * Compose what gets built: the user's Dockerfile (normalized the same way the
+ * snapshot builder normalizes it) plus the Kortix toolchain layer.
+ *
+ * `opencodeConfigPath` and `warmRepo` are deliberately OMITTED — both make the
+ * layer emit steps that read staged context (`COPY <config>/ …`) or clone with
+ * build-time credentials, neither of which exists locally. Everything they'd
+ * add is a warm-up, not a correctness step, so their absence changes nothing
+ * about whether the image BUILDS.
+ */
+export function composeLocalDockerfile(userDockerfile: string, opts: { layer: boolean }): string {
+  const user = normalizeUserDockerfileForSnapshot(userDockerfile).trimEnd();
+  if (!opts.layer) return `${user}\n`;
+  return `${user}\n${kortixToolchainLayer({
+    opencodeVersion: OPENCODE_VERSION,
+    agentBrowserVersion: AGENT_BROWSER_VERSION,
+  })}`;
+}
+
+/** The exact `docker build` argv. Pure, so a test can assert the shape. */
+export function dockerBuildArgs(opts: { platform: string; tag: string; noCache: boolean }): string[] {
+  return [
+    'build',
+    '--platform',
+    opts.platform,
+    '-t',
+    opts.tag,
+    ...(opts.noCache ? ['--no-cache'] : []),
+    // A bare `-` context with the Dockerfile on stdin: docker sniffs stdin, sees
+    // a Dockerfile rather than a tar, and builds it against an EMPTY context.
+    // That is the load-bearing bit — "your repo is not in the build context"
+    // stops being a rule someone has to remember and becomes a property of the
+    // build, because there is no directory here to leak it from.
+    //
+    // NOT `-f - -`: docker rejects that outright ("can't use stdin for both
+    // build context and dockerfile"). `-` alone is the supported spelling.
+    '-',
+  ];
+}
+
+/**
+ * `--local` needs no auth and no linked project — it only reads kortix.yaml,
+ * a Dockerfile, and the local Docker daemon. `sandboxes.ts` therefore routes it
+ * above `resolveProjectContext`, alongside add/update/rm, and hands over the
+ * argv it has already taken the shared flags (`--json`, `--project`, …) out of.
+ */
+export function runSandboxBuildLocal(argv: string[], opts: { json: boolean }): number {
+  let flags: LocalBuildFlags;
+  try {
+    const noCache = takeFlagBool(argv, ['--no-cache']);
+    const noLayer = takeFlagBool(argv, ['--no-layer']);
+    const print = takeFlagBool(argv, ['--print']);
+    const platform = takeFlagValue(argv, ['--platform']);
+    const tag = takeFlagValue(argv, ['--tag']);
+    // `--slug x` is accepted as a synonym for the positional so `--slug default`
+    // reads as the deliberate opt-in it is. The positional wins if both appear.
+    const slugFlag = takeFlagValue(argv, ['--slug']);
+    // Positionals only AFTER every flag has been spliced out of argv — the flag
+    // takers mutate it, so reading them earlier would see `--platform`'s VALUE
+    // (`linux/amd64`) sitting there looking exactly like a slug.
+    const positional = argv.filter((a) => !a.startsWith('-'));
+    flags = {
+      slug: positional[0] ?? slugFlag,
+      platform,
+      tag,
+      noCache,
+      layer: !noLayer,
+      print,
+      json: opts.json,
+    };
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n`);
+    return 2;
+  }
+
+  const manifest = resolveLocalManifest(process.cwd());
+  if (!manifest) {
+    process.stderr.write(
+      `${status.err('No kortix.yaml here.')} ${C.dim}Run from your project root.${C.reset}\n`,
+    );
+    return 2;
+  }
+  let parsed: Record<string, unknown> | null;
+  try {
+    parsed = loadLocalManifest(process.cwd())?.data ?? null;
+  } catch (err) {
+    process.stderr.write(`${status.err(`kortix.yaml doesn't parse: ${(err as Error).message}`)}\n`);
+    return 2;
+  }
+
+  const resolved = resolveLocalTemplate(
+    flags.slug,
+    extractSandboxTemplates(parsed),
+    extractSandboxDefault(parsed),
+  );
+  if ('error' in resolved) {
+    process.stderr.write(`${status.err(resolved.error)}\n`);
+    return 2;
+  }
+  const template = resolved.template;
+
+  const projectRoot = dirname(manifest.path);
+  const user = userDockerfileForTemplate(template, projectRoot);
+  if ('error' in user) {
+    process.stderr.write(`${status.err(user.error)}\n`);
+    return 2;
+  }
+
+  const composed = composeLocalDockerfile(user.text, { layer: flags.layer });
+
+  // `--print` is the no-side-effects mode: hand back the exact bytes that would
+  // be fed to `docker build` (pipe it into your own build, diff it, read it) and
+  // never touch Docker. It must stay quiet enough to redirect, so the preamble
+  // below is skipped entirely.
+  if (flags.print) {
+    process.stdout.write(composed);
+    return 0;
+  }
+
+  const platform = flags.platform ?? hostPlatform();
+  const tag = flags.tag ?? `kortix-local/${template.slug}:latest`;
+
+  if (!dockerAvailable()) {
+    // Environment/usage, not a crash: exit 2, no stack trace, and point at the
+    // half of the gate that needs nothing installed.
+    process.stderr.write(
+      `${status.err('Docker is not available (need the `docker` CLI AND a running daemon).')}\n` +
+        `  ${C.dim}Start Docker Desktop / the daemon, or install Docker, then re-run.${C.reset}\n` +
+        `  ${C.dim}The static checks need no Docker at all:${C.reset} ${C.cyan}kortix validate${C.reset}\n` +
+        `  ${C.dim}To see the composed Dockerfile without building:${C.reset} ${C.cyan}kortix sandboxes build --local --print${C.reset}\n`,
+    );
+    return 2;
+  }
+
+  if (flags.json) {
+    emitJson({
+      slug: template.slug,
+      dockerfile: user.source,
+      platform,
+      cloud_platform: 'linux/amd64',
+      layer: flags.layer,
+      tag,
+      no_cache: flags.noCache,
+    });
+  } else {
+    process.stdout.write('\n');
+    process.stdout.write(
+      `${status.info(`Building ${C.bold}${template.slug}${C.reset} from ${C.cyan}${user.source}${C.reset}`)}\n`,
+    );
+    // The single most misleading thing about a local build: it reads what's on
+    // disk right now, while the cloud builds the committed HEAD it fetched.
+    process.stdout.write(
+      `  ${C.dim}Reads your WORKING TREE — the cloud builds the committed HEAD, so uncommitted edits are only tested here.${C.reset}\n`,
+    );
+    process.stdout.write(
+      `  ${C.dim}Platform ${C.reset}${platform}${C.dim} · the cloud always builds ${C.reset}linux/amd64${C.dim}.${C.reset}\n`,
+    );
+    if (platform !== 'linux/amd64') {
+      process.stdout.write(
+        `  ${C.dim}For an exact match pass ${C.reset}${C.cyan}--platform linux/amd64${C.reset}${C.dim} — but under emulation it can take hours (texlive + libreoffice + chromium via QEMU).${C.reset}\n`,
+      );
+    }
+    process.stdout.write(
+      flags.layer
+        ? `  ${C.dim}Kortix toolchain layer ${C.reset}on${C.dim} (apt + pip floor + opencode + chromium) — expect ${C.reset}10–25 min${C.dim} cold, minutes warm.${C.reset}\n`
+        : `  ${C.dim}Kortix toolchain layer ${C.reset}off${C.dim} (--no-layer) — your Dockerfile alone; this skips the floor most build failures come from.${C.reset}\n`,
+    );
+    process.stdout.write(`  ${C.dim}Empty build context — your repo is not in it (same as the cloud).${C.reset}\n`);
+    process.stdout.write(`  ${C.dim}Tag ${C.reset}${tag}\n\n`);
+  }
+
+  // Stream docker's own output straight through — it is already a good progress
+  // display, and the CLI has no spinner primitive to wrap it in.
+  const args = dockerBuildArgs({ platform, tag, noCache: flags.noCache });
+  const res = spawnSync('docker', args, { input: composed, stdio: ['pipe', 'inherit', 'inherit'] });
+  if (res.error) {
+    process.stderr.write(`${status.err(`Couldn't run docker: ${res.error.message}`)}\n`);
+    return 2;
+  }
+  if (res.status !== 0) {
+    process.stderr.write(`\n${status.err(`Build failed (docker exited ${res.status}) — see the output above.`)}\n`);
+    process.stderr.write(
+      `  ${C.dim}Read the composed Dockerfile:${C.reset} ${C.cyan}kortix sandboxes build --local ${template.slug} --print${C.reset}\n`,
+    );
+    return 1;
+  }
+
+  process.stdout.write(`\n${status.ok(`Built ${C.bold}${tag}${C.reset}`)}\n`);
+  process.stdout.write(
+    `  ${C.yellow}Not a guarantee the cloud build passes.${C.reset}${C.dim} The cloud stages Kortix's own artifacts and appends a layer this build skips${platform !== 'linux/amd64' ? `, and it builds linux/amd64` : ''}.${C.reset}\n`,
+  );
+  process.stdout.write(`  ${C.dim}Run it: ${C.reset}${C.cyan}docker run --rm -it ${tag} bash${C.reset}\n`);
+  return 0;
+}

--- a/apps/cli/src/commands/sandboxes.ts
+++ b/apps/cli/src/commands/sandboxes.ts
@@ -12,6 +12,7 @@ import {
   setScalarInArrayBlock,
 } from '../manifest-edit.ts';
 import { C, help, pad, status } from '../style.ts';
+import { runSandboxBuildLocal } from './sandboxes-local.ts';
 
 // ── Shapes (mirror apps/api/src/projects sandbox-template + snapshot routes) ─
 
@@ -64,10 +65,29 @@ Subcommands:
   update <slug> [--name ...] [--image ...] [--dockerfile ...] [--cpu n] [--memory n] [--disk n]
                                     Update a UI-created template.
   build <slug>                      Trigger a rebuild for a template.
+  build --local [slug]              Build the image HERE, on your Docker, before
+                                    you push. See "Local build" below.
   rebuild <slug>                    Force-rebuild (delete existing snapshot first).
   rm <slug>                         Delete a UI-created template.
   fix                               Start a session seeded with the last failed
                                     build log so an agent can repair it.
+
+Local build (build --local):
+  Renders your Dockerfile + the Kortix toolchain layer and builds it with an
+  EMPTY context — the same repo-less constraint the cloud builds under. Needs
+  no login and no linked project, just Docker. For the checks that need neither,
+  run \`kortix validate\` (it lints these Dockerfiles statically).
+
+  Slug: the positional, else \`sandbox.default\`, else your only template.
+
+  --local              Build locally instead of triggering a cloud build.
+  --platform <p>       Target platform (default: this host's). The cloud always
+                       builds linux/amd64; matching it here is exact but slow
+                       under emulation.
+  --tag <t>            Image tag (default: kortix-local/<slug>:latest).
+  --no-cache           Pass --no-cache to docker build.
+  --no-layer           Build only your Dockerfile, without the Kortix layer.
+  --print              Print the composed Dockerfile to stdout and exit.
 
 Options:
   --image <ref>        Public docker image (mutually exclusive with --dockerfile).
@@ -89,8 +109,10 @@ export async function runSandboxes(argv: string[]): Promise<number> {
   const rest = argv.slice(1);
   const f: Record<string, string | undefined> = {};
   let json = false;
+  let local = false;
   try {
     json = takeFlagBool(rest, ['--json']);
+    local = takeFlagBool(rest, ['--local']);
     f.project = takeFlagValue(rest, ['--project']);
     f.host = takeFlagValue(rest, ['--host']);
     f.image = takeFlagValue(rest, ['--image']);
@@ -111,6 +133,22 @@ export async function runSandboxes(argv: string[]): Promise<number> {
   if (sub === 'add' || sub === 'create') return sandboxAddLocal(positional[0], f);
   if (sub === 'update' || sub === 'edit') return sandboxUpdateLocal(positional[0], f);
   if (sub === 'rm' || sub === 'remove' || sub === 'delete') return sandboxRmLocal(positional[0]);
+  // `build --local` is the same kind of thing: it reads kortix.yaml + a
+  // Dockerfile and talks to the local Docker daemon. No token, no linked
+  // project, no network — so it must route above resolveProjectContext, which
+  // would otherwise dead-end a logged-out developer on a pre-push check.
+  // (It takes its own flags out of `rest` and reads the slug positional itself —
+  // `positional` above was computed before --platform/--tag were stripped, so it
+  // would mistake a flag VALUE for a slug.)
+  if (sub === 'build' && local) return runSandboxBuildLocal(rest, { json });
+  if (local) {
+    // `--local` was consumed above, so an unhandled one would otherwise vanish
+    // and the command would quietly do the CLOUD thing instead — `sandboxes
+    // rebuild --local` silently rebuilding a live snapshot is not a mistake
+    // anyone should be able to make by typo.
+    process.stderr.write(`${status.err(`--local only applies to \`sandboxes build\`, not "${sub}".`)}\n`);
+    return 2;
+  }
 
   const ctx = await resolveProjectContext({ projectArg: f.project, hostArg: f.host });
   if (!ctx) return 1;

--- a/apps/cli/src/commands/validate.ts
+++ b/apps/cli/src/commands/validate.ts
@@ -2,7 +2,8 @@
  * `kortix validate` — standalone manifest validator.
  *
  * Reads ./kortix.yaml (or --file <path>), runs the canonical
- * `@kortix/manifest-schema` validator, and prints a colored report.
+ * `@kortix/manifest-schema` validator, then statically lints every sandbox
+ * Dockerfile the manifest points at, and prints one colored report.
  *
  *   exit 0   — no errors (warnings may be present)
  *   exit 1   — one or more errors
@@ -10,28 +11,36 @@
  *
  * Mirrors the same validator that `kortix ship` runs as a pre-flight check
  * and that the backend runs on CR-merge — there is exactly one schema, used
- * in three places.
+ * in three places. The Dockerfile lint rides the same three places for free:
+ * a Dockerfile that can't build in the cloud is as much a broken project as a
+ * malformed manifest, and both are decidable from text alone.
  */
 import { existsSync, readFileSync } from 'node:fs';
-import { basename, resolve } from 'node:path';
+import { basename, dirname, relative, resolve } from 'node:path';
 import {
   GRANTABLE_KORTIX_CLI_ACTIONS,
+  type ManifestIssue,
   formatIssues,
   manifestFormatForPath,
   validateManifest,
 } from '@kortix/manifest-schema';
+import { extractSandboxTemplates } from '@kortix/shared/sandbox';
+import { lintDockerfile } from '../dockerfile-lint.ts';
 import { resolveLocalManifest } from '../manifest.ts';
 import { C, help, status } from '../style.ts';
 
 const HELP = help`Usage: kortix validate [options]
 
-Statically validate the project's kortix.yaml against the canonical schema.
+Statically validate the project's kortix.yaml against the canonical schema,
+and lint every \`sandbox.templates\` Dockerfile for the constraints the cloud
+builder enforces (no COPY from the repo, no RUN heredocs, Debian-family base).
 
 Options:
-  --file <path>   Validate this file instead of ./kortix.yaml.
-  --json          Emit a machine-readable JSON report (no color).
-  --scopes        Print the full grantable kortix_cli action enum and exit.
-  -h, --help      Show this help.
+  --file <path>          Validate this file instead of ./kortix.yaml.
+  --no-dockerfile-lint   Skip the sandbox Dockerfile checks (manifest only).
+  --json                 Emit a machine-readable JSON report (no color).
+  --scopes               Print the full grantable kortix_cli action enum and exit.
+  -h, --help             Show this help.
 `;
 
 interface Flags {
@@ -39,18 +48,54 @@ interface Flags {
   json: boolean;
   help: boolean;
   scopes: boolean;
+  dockerfileLint: boolean;
 }
 
 function parseFlags(argv: string[]): Flags {
-  const flags: Flags = { json: false, help: false, scopes: false };
+  const flags: Flags = { json: false, help: false, scopes: false, dockerfileLint: true };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--file' && argv[i + 1]) flags.file = argv[++i];
     else if (arg === '--json') flags.json = true;
     else if (arg === '--scopes') flags.scopes = true;
+    else if (arg === '--no-dockerfile-lint') flags.dockerfileLint = false;
     else if (arg === '-h' || arg === '--help') flags.help = true;
   }
   return flags;
+}
+
+/**
+ * Lint each `sandbox.templates[].dockerfile` that exists on disk, resolved
+ * relative to the MANIFEST's directory (paths in kortix.yaml are repo-relative,
+ * and --file may point outside the cwd).
+ *
+ * A declared-but-missing Dockerfile is NOT reported here: that's the manifest
+ * validator's business, and inventing a second, differently-worded error for it
+ * would just double up the report.
+ */
+function lintSandboxDockerfiles(
+  parsed: Record<string, unknown> | null,
+  manifestPath: string,
+): ManifestIssue[] {
+  if (!parsed) return [];
+  const root = dirname(manifestPath);
+  const issues: ManifestIssue[] = [];
+  for (const tpl of extractSandboxTemplates(parsed)) {
+    if (!tpl.dockerfile) continue;
+    const abs = resolve(root, tpl.dockerfile);
+    if (!existsSync(abs)) continue;
+    let text: string;
+    try {
+      text = readFileSync(abs, 'utf8');
+    } catch {
+      continue;
+    }
+    // Report the path as written in the manifest when it stays inside the
+    // project, so the author sees the string they typed.
+    const shown = relative(root, abs).startsWith('..') ? abs : tpl.dockerfile;
+    issues.push(...lintDockerfile(text, { path: shown }));
+  }
+  return issues;
 }
 
 /** One line per agent: its assigned connectors + Kortix-CLI powers. */
@@ -118,21 +163,31 @@ export function runValidate(argv: string[]): number {
 
   const result = validateManifest(raw, manifestFormatForPath(filePath));
 
+  // Manifest issues first, then the Dockerfile lint — one merged report, one
+  // exit code. A Dockerfile `error` fails `validate` exactly like a schema
+  // error does, which is the whole point: `ship` and the CR-merge gate then
+  // stop it without any extra wiring.
+  const issues = [
+    ...result.issues,
+    ...(flags.dockerfileLint ? lintSandboxDockerfiles(result.parsed, filePath) : []),
+  ];
+  const valid = !issues.some((i) => i.severity === 'error');
+
   if (flags.json) {
     process.stdout.write(
       JSON.stringify({
-        valid: result.valid,
+        valid,
         path: filePath,
-        issues: result.issues,
+        issues,
       }) + '\n',
     );
-    return result.valid ? 0 : 1;
+    return valid ? 0 : 1;
   }
 
-  const errors = result.issues.filter((i) => i.severity === 'error');
-  const warnings = result.issues.filter((i) => i.severity === 'warning');
+  const errors = issues.filter((i) => i.severity === 'error');
+  const warnings = issues.filter((i) => i.severity === 'warning');
 
-  if (result.valid && warnings.length === 0) {
+  if (valid && warnings.length === 0) {
     process.stdout.write(`${status.ok(`${basename(filePath)} is valid`)}\n`);
     process.stdout.write(describeAgents(result.parsed));
     return 0;

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -1,0 +1,39 @@
+/**
+ * Minimal local-Docker probing for CLI commands that shell out to `docker`.
+ *
+ * Deliberately tiny and dependency-free: two questions, answered the same way
+ * every time. (`self-host.ts` has its own inline `docker --version` probe from
+ * before this existed; leaving it alone here keeps this change to one surface.)
+ */
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Is there a usable Docker on this machine RIGHT NOW?
+ *
+ * Both probes are required. `docker --version` only proves the CLI binary is on
+ * PATH — it exits 0 with the daemon stopped, which is the single most common
+ * way this fails on a laptop ("Docker Desktop isn't running"). `docker info`
+ * is the one that actually talks to the daemon.
+ */
+export function dockerAvailable(): boolean {
+  for (const args of [['--version'], ['info']]) {
+    const r = spawnSync('docker', args, { encoding: 'utf8', stdio: 'ignore' });
+    if (r.error || r.status !== 0) return false;
+  }
+  return true;
+}
+
+/**
+ * The Linux container platform this host builds natively — `linux/arm64` on
+ * Apple Silicon / ARM machines, `linux/amd64` everywhere else (and as the
+ * fallback for an arch we don't map, which is what Docker itself would do).
+ *
+ * Native is the right DEFAULT for a local build even though the cloud is always
+ * linux/amd64: an emulated amd64 build of the Kortix layer (texlive +
+ * libreoffice + chromium under QEMU) takes hours on an M-series Mac, and a gate
+ * nobody waits for gates nothing. Callers print the mismatch and offer
+ * `--platform linux/amd64` for an exact match.
+ */
+export function hostPlatform(): string {
+  return process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64';
+}

--- a/apps/cli/src/dockerfile-lint.ts
+++ b/apps/cli/src/dockerfile-lint.ts
@@ -1,0 +1,301 @@
+/**
+ * Static lint for a project's sandbox Dockerfile — the pre-push gate.
+ *
+ * `kortix validate` used to read kortix.yaml and stop there: every constraint
+ * a sandbox Dockerfile has to satisfy was only discovered by the CLOUD builder,
+ * minutes after a push, as an opaque remote failure. These checks are the ones
+ * that can be decided from the Dockerfile TEXT alone — no Docker, no network,
+ * microseconds — so they belong at authoring time, where `validate` already
+ * runs (standalone, inside `kortix ship`, and in the CR-merge gate).
+ *
+ * The three checks below are each backed by a real incident. None of them is a
+ * style opinion: every one is a build that FAILS in the cloud today.
+ *
+ * Emits `ManifestIssue`s so `validate` can merge them straight into the report
+ * it already prints — `path` carries the Dockerfile's repo-relative path (not a
+ * kortix.yaml dot-path) and `line` is the line WITHIN that Dockerfile, so
+ * `formatIssues` renders `error path/to/Dockerfile: … (line 3)`.
+ */
+import type { ManifestIssue } from '@kortix/manifest-schema';
+
+export interface LintDockerfileOpts {
+  /**
+   * Repo-relative path of the Dockerfile being linted. Used verbatim as the
+   * issue `path` so the report points at the file the author has to edit.
+   */
+  path: string;
+}
+
+/**
+ * The complete set of names `stageBuildContext` (apps/api/src/snapshots/
+ * build-context.ts) stages into the cloud build context. Nothing else exists
+ * there — in particular, NOT the user's repo.
+ *
+ * This is the precision argument for the COPY check being an ERROR rather than
+ * a hint: the context's contents are a CLOSED set, fixed by Kortix, and none of
+ * it is anything a user Dockerfile would legitimately COPY. So every
+ * context-reading COPY in a user Dockerfile is a build that cannot succeed —
+ * there is no false positive to trade against.
+ */
+export const STAGED_CONTEXT_ENTRIES = [
+  'kortix-agent.gz',
+  'kortix.gz',
+  'kortix-entrypoint',
+  'kortix-slack-cli/',
+  'kortix-executor-sdk/',
+  'kortix-opencode-config/',
+  'kortix-llm-catalog.json',
+  'scaffold.git',
+] as const;
+
+/** Bases whose package manager is not apt — the Kortix layer's floor needs it. */
+const NON_DEBIAN_BASES = [
+  'alpine',
+  'amazonlinux',
+  'archlinux',
+  'busybox',
+  'centos',
+  'chainguard',
+  'clearlinux',
+  'distroless',
+  'fedora',
+  'gentoo',
+  'mariner',
+  'nixos',
+  'opensuse',
+  'oraclelinux',
+  'photon',
+  'rhel',
+  'rockylinux',
+  'scratch',
+  'suse',
+  'voidlinux',
+  'wolfi',
+];
+
+/** A logical Dockerfile instruction: continuations joined, comments dropped. */
+interface Instruction {
+  /** Uppercased instruction keyword (`COPY`, `RUN`, `FROM`, …). */
+  keyword: string;
+  /** Everything after the keyword, with `\`-continuations joined into one line. */
+  args: string;
+  /** 1-indexed line where the instruction STARTS. */
+  line: number;
+  /** The instruction's first physical line, verbatim (for heredoc reporting). */
+  firstLine: string;
+}
+
+/**
+ * The buildah-portability guard's heredoc detector, ported VERBATIM from
+ * `stageBuildContext` (apps/api/src/snapshots/build-context.ts). Keep the two
+ * in lock-step: this is the authoring-time copy of a check that otherwise only
+ * fires server-side, mid-build.
+ */
+const HEREDOC_RE = /<<-?['"]?[A-Za-z_]\w*['"]?\s*\\?\s*$/;
+
+/** Extract a heredoc's delimiter so its BODY can be skipped by the parser. */
+function heredocDelimiter(line: string): string | null {
+  const m = line.match(/<<-?['"]?([A-Za-z_]\w*)['"]?\s*\\?\s*$/);
+  return m ? m[1]! : null;
+}
+
+/**
+ * Split a Dockerfile into logical instructions. Deliberately small: it handles
+ * comments, blank lines, `\` continuations and heredoc bodies — which is
+ * everything these three checks need — and does NOT try to be a full parser
+ * (no ARG expansion, no parser directives beyond ignoring them as comments).
+ */
+function parseInstructions(text: string): Instruction[] {
+  const lines = text.split('\n');
+  const out: Instruction[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (raw.trim() === '' || /^\s*#/.test(raw)) continue;
+
+    const startLine = i + 1;
+    const firstLine = raw;
+    // Join `\`-continuations into one logical line. A heredoc opener ends the
+    // JOIN too (its body is not part of the instruction's arg text) — we record
+    // the instruction, then skip the body below.
+    let joined = raw;
+    let heredoc = heredocDelimiter(raw);
+    while (!heredoc && /\\\s*$/.test(lines[i] ?? '') && i + 1 < lines.length) {
+      i++;
+      const next = lines[i]!;
+      joined = `${joined.replace(/\\\s*$/, '')} ${next.trim()}`;
+      heredoc = heredocDelimiter(next);
+    }
+
+    const m = joined.trim().match(/^([A-Za-z]+)\s*(.*)$/s);
+    if (m) out.push({ keyword: m[1]!.toUpperCase(), args: m[2]!.trim(), line: startLine, firstLine });
+
+    // Skip the heredoc body so `COPY foo bar` inside a `RUN cat <<EOF` isn't
+    // mistaken for a real instruction.
+    if (heredoc) {
+      while (i + 1 < lines.length && lines[i + 1]!.trim() !== heredoc) i++;
+      i++; // consume the terminator
+    }
+  }
+  return out;
+}
+
+/** Tokenize instruction args, honoring the JSON-array (exec) form and quotes. */
+function tokenizeArgs(args: string): string[] {
+  const trimmed = args.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const arr = JSON.parse(trimmed);
+      if (Array.isArray(arr)) return arr.map(String);
+    } catch {
+      /* fall through to whitespace splitting */
+    }
+  }
+  return trimmed.match(/"[^"]*"|'[^']*'|\S+/g)?.map((t) => t.replace(/^["']|["']$/g, '')) ?? [];
+}
+
+/** True for an `ADD` source Docker fetches over the network rather than the context. */
+function isRemoteSource(src: string): boolean {
+  return /^(https?|ftp|git):\/\//i.test(src) || /^git@/.test(src);
+}
+
+/** The base image name a `FROM` line names, or null if it can't be read statically. */
+function fromBase(args: string): { base: string; stage?: string } | null {
+  const tokens = tokenizeArgs(args).filter((t) => !t.startsWith('--'));
+  const base = tokens[0];
+  if (!base) return null;
+  // `FROM x AS name`
+  const asIdx = tokens.findIndex((t) => t.toUpperCase() === 'AS');
+  const stage = asIdx > 0 ? tokens[asIdx + 1] : undefined;
+  return { base, stage };
+}
+
+/**
+ * Lint a sandbox Dockerfile for the constraints the Kortix cloud builder
+ * enforces. Returns `ManifestIssue`s in source order; an empty array means the
+ * text passes every static check (it says NOTHING about whether the image
+ * actually builds — see `kortix sandboxes build --local` for that).
+ */
+export function lintDockerfile(text: string, opts: LintDockerfileOpts): ManifestIssue[] {
+  const issues: ManifestIssue[] = [];
+  const instructions = parseInstructions(text);
+
+  // ── 1. COPY/ADD from the build context ───────────────────────────────────
+  // `stageBuildContext` stages ONLY Kortix's own artifacts (see
+  // STAGED_CONTEXT_ENTRIES). The user's repo is NEVER in the build context —
+  // it is git-cloned to /workspace when a session boots, precisely so that a
+  // code change doesn't invalidate the image. So any COPY that reads from the
+  // context can only ever resolve to "Path does not exist" in the cloud. This
+  // is decidable and exact: the only legal reads are `--from=<stage>` (a
+  // multi-stage copy, which reads from an image, not the context) and a remote
+  // `ADD <url>` (which Docker fetches over the network).
+  for (const ins of instructions) {
+    if (ins.keyword !== 'COPY' && ins.keyword !== 'ADD') continue;
+    const tokens = tokenizeArgs(ins.args);
+    if (tokens.some((t) => /^--from=/.test(t))) continue; // reads an image/stage, not the context
+    const operands = tokens.filter((t) => !t.startsWith('--'));
+    if (operands.length < 2) continue; // malformed or heredoc form — not ours to judge
+    const sources = operands.slice(0, -1);
+    for (const src of sources) {
+      if (src.startsWith('<<')) continue; // heredoc content — check 2 owns it
+      if (ins.keyword === 'ADD' && isRemoteSource(src)) continue; // fetched, not staged
+      issues.push({
+        path: opts.path,
+        line: ins.line,
+        severity: 'error',
+        message:
+          `\`${ins.keyword} ${src}\` reads from the build context, but your repo is NOT in it — ` +
+          `the cloud build fails with "Path does not exist: …/${src.replace(/^\.\//, '')}". Kortix ` +
+          `stages only its own artifacts there; your project source is git-cloned to /workspace ` +
+          `when a session boots, so the image never bakes it in. Read it from /workspace at ` +
+          `runtime, inline it with a RUN, or copy it from an earlier stage (\`COPY --from=<stage>\`).`,
+      });
+    }
+  }
+
+  // ── 2. RUN heredocs ──────────────────────────────────────────────────────
+  // Rationale ported verbatim from the buildah-portability guard in
+  // apps/api/src/snapshots/build-context.ts:
+  //
+  //   The SAME composed context ships to BOTH providers. Daytona builds with
+  //   BuildKit (supports `# syntax=docker/dockerfile:1.7` + RUN heredocs);
+  //   Platinum builds with podman/buildah's classic imagebuilder, which
+  //   supports NEITHER — it parses a heredoc body's first line (e.g. `import
+  //   importlib`) as a Dockerfile instruction and aborts EVERY build ("Unknown
+  //   instruction: IMPORT"), failing all Platinum sessions. This exact
+  //   regression (a `<<'PY'` python verify added 2026-06-27) took dev down for
+  //   hours because Daytona silently tolerated it.
+  //
+  // That guard throws SERVER-side, mid-build, and only for Platinum — so on a
+  // Daytona-backed project a heredoc ships green and breaks later. Deciding it
+  // here, from the text, is the same check moved to where it costs nothing.
+  for (const ins of instructions) {
+    if (/^\s*#/.test(ins.firstLine) || !HEREDOC_RE.test(ins.firstLine)) continue;
+    issues.push({
+      path: opts.path,
+      line: ins.line,
+      severity: 'error',
+      message:
+        `RUN heredoc is not buildah-portable: "${ins.firstLine.trim().slice(0, 120)}". Kortix's ` +
+        `Platinum provider builds with buildah's classic imagebuilder, which parses the heredoc ` +
+        `body's first line as a Dockerfile instruction and aborts the build ("Unknown ` +
+        `instruction: …"). Use a single-line equivalent (e.g. \`python3 -c '…'\`) — heredocs and ` +
+        `BuildKit-only \`# syntax\` directives work on Daytona but break every Platinum build.`,
+    });
+  }
+
+  // ── 3. Non-Debian base ───────────────────────────────────────────────────
+  // The Kortix layer's floor opens with `apt-get update && apt-get install`, so
+  // a base without apt cannot carry it. Only the FINAL stage's base matters —
+  // the layer is appended to the end of the user's Dockerfile, so an
+  // alpine BUILDER stage is perfectly legal. This is a WARNING, not an error:
+  // the tag alone can't prove the absence of apt (a Debian derivative can be
+  // named anything, and `FROM myorg/alpine-migrated-to-debian` is a real
+  // shape), so we flag the smell and let the author overrule it.
+  const stages = new Map<string, string>(); // stage name (lower) -> base
+  let finalBase: { base: string; line: number } | null = null;
+  for (const ins of instructions) {
+    if (ins.keyword !== 'FROM') continue;
+    const parsed = fromBase(ins.args);
+    if (!parsed) continue;
+    if (parsed.stage) stages.set(parsed.stage.toLowerCase(), parsed.base);
+    finalBase = { base: parsed.base, line: ins.line };
+  }
+  if (finalBase) {
+    // `FROM builder` in the last stage means the real base is whatever `builder`
+    // was FROM. Resolve through the stage graph (bounded — no cycles possible in
+    // a valid Dockerfile, but cap anyway).
+    let base = finalBase.base;
+    for (let hops = 0; hops < 16 && stages.has(base.toLowerCase()); hops++) {
+      const next = stages.get(base.toLowerCase())!;
+      if (next.toLowerCase() === base.toLowerCase()) break;
+      base = next;
+    }
+    // Skip anything we can't read statically (`FROM ${BASE_IMAGE}`).
+    if (!base.includes('$')) {
+      const [nameRaw, tagRaw = ''] = [base.split(':')[0]!, base.split(':')[1] ?? ''];
+      const name = nameRaw.split('/').pop()!.toLowerCase();
+      const tag = tagRaw.toLowerCase();
+      const hit =
+        NON_DEBIAN_BASES.find((n) => name === n || name.startsWith(`${n}-`) || name.endsWith(`-${n}`)) ??
+        // `node:20-alpine`, `python:3.12-alpine3.19` — the family is in the TAG.
+        NON_DEBIAN_BASES.find((n) => new RegExp(`(^|[-.])${n}([-.\\d]|$)`).test(tag));
+      if (hit) {
+        issues.push({
+          path: opts.path,
+          line: finalBase.line,
+          severity: 'warning',
+          message:
+            `\`FROM ${base}\` looks like a non-Debian base (${hit}). The Kortix runtime layer ` +
+            `appended on top installs its floor with \`apt-get\`, which only exists on ` +
+            `Debian/Ubuntu-family images — on this base the cloud build fails at the layer's ` +
+            `first RUN. Warning, not an error: only the tag is visible here, and it could be a ` +
+            `Debian derivative. If it is, ignore this; otherwise switch to a Debian/Ubuntu base ` +
+            `(e.g. \`ubuntu:24.04\`, \`python:3.12-slim\`).`,
+        });
+      }
+    }
+  }
+
+  return issues.sort((a, b) => (a.line ?? 0) - (b.line ?? 0));
+}


### PR DESCRIPTION
**Stack 3/3.** Base: #4800.

## Why

There is no pre-push gate for a sandbox image. `kortix validate` never opens the Dockerfile, and every `kortix sandboxes` subcommand is a cloud round-trip — so you learn the image is broken *after* pushing. Both real incidents were found that way.

## Part 1 — static Dockerfile lint in `kortix validate` (the higher-leverage half)

No Docker, milliseconds, and `validate` already runs inside `ship` and the CR-merge gate.

1. **`COPY`/`ADD` of a repo file → ERROR.** Precise with no false negatives: `stageBuildContext` stages only its own eight artifacts, so any `COPY <src>` that isn't `--from=<stage>` or a remote `ADD <url>` can never work. Real output:

```
1 error:
  error Dockerfile: `COPY requirements-kortix.txt` reads from the build context, but your
  repo is NOT in it — the cloud build fails with "Path does not exist: …/requirements-kortix.txt".
  Kortix stages only its own artifacts there; your project source is git-cloned to /workspace
  when a session boots, so the image never bakes it in. Read it from /workspace at runtime,
  inline it with a RUN, or copy it from an earlier stage (`COPY --from=<stage>`). (line 2)
```

2. **RUN heredoc → ERROR.** Ported from the server-side portability guard. Today it fires mid-build and only on Platinum (buildah parses the heredoc body's first line as an instruction); Daytona tolerates it, so it ships and *then* breaks dev. Now caught at authoring time.
3. **Non-Debian base → WARNING.** The layer's apt floor will fail on it.

`--no-dockerfile-lint` escapes.

## Part 2 — `kortix sandboxes build --local [slug]`

Renders the user's Dockerfile + `kortixToolchainLayer` (from 1/3) and builds it with an **empty context**, reproducing the repo-less constraint structurally. **This reproduces the numpy incident exactly** — the collision is between the user's stage and the injected floor, so a user-only build would miss it. The artifact tail is skipped (those COPYs need staged binaries a consumer dev cannot produce).

```
  ▸  Building ml from Dockerfile.ml
  Reads your WORKING TREE — the cloud builds the committed HEAD, so uncommitted edits are only tested here.
  Platform linux/arm64 · the cloud always builds linux/amd64.
  For an exact match pass --platform linux/amd64 — but under emulation it can take hours (texlive + libreoffice + chromium via QEMU).
  Kortix toolchain layer on (apt + pip floor + opencode + chromium) — expect 10–25 min cold, minutes warm.
  Empty build context — your repo is not in it (same as the cloud).
  Tag kortix-local/ml:latest
```

Design calls:
- **Layer defaults ON.** The only incident needing Docker at all needs the layer; default-off would hide the flagship failure unless you knew to ask. `--no-layer` for a ~30s user-stage smoke.
- **`--platform` defaults to host arch, not amd64.** Defaulting to amd64 on an M-series Mac runs texlive+libreoffice+chromium under QEMU for hours. Both incidents are arch-independent, so print the mismatch instead of imposing it.
- **No silent guarantee.** Success prints that the cloud stages artifacts this build skips, and that it read the working tree rather than the committed HEAD.
- Docker missing/daemon down → exit 2, no stack trace, points at `kortix validate`.

## Verification

- `apps/cli`: **257 pass / 0 fail**. `packages/shared`: 245 pass / 0 fail. Typechecks clean.
- Beyond the suite: ran a **real** `docker build` end-to-end — image built, and a `COPY requirements-kortix.txt` failed against the empty context *with the file sitting right there in the project dir*, which is the property working. BuildKit `--check` passes the composed Dockerfile with zero warnings. No test touches a real daemon (matching existing convention).
- 4 pre-existing flaky 5s-timeout failures in `apps/cli/src/self-host/__tests__` — confirmed identical on the base branch.

## Deviations worth reading

1. **`docker build -f - -` does not work** — Docker rejects it: `can't use stdin for both build context and dockerfile`. Found only by running it; every unit test asserting the argv would have passed. Corrected to a bare `-` context.
2. **Check 3 only judges the FINAL stage's base.** The layer is appended at the end, so `FROM alpine AS builder` is legal — flagging it would be a false positive. Resolves through the stage graph and skips `FROM ${ARG}`.
3. **Added a `--local` misuse guard.** `--local` is consumed by the shared flag parse, so `sandboxes rebuild ml --local` would have silently triggered a *cloud* rebuild of a live snapshot. Now exits 2 — a one-typo footgun the dispatch design created.
4. A declared-but-missing Dockerfile is left to the manifest validator rather than double-reported.