### PR TITLE
fix(llm-gateway): translate max_tokens -> max_completion_tokens for genuine OpenAI

### DIFF
--- a/apps/api/src/llm-gateway/models/provider-registry.test.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.test.ts
@@ -10,6 +10,19 @@ describe('runtime catalog provider resolution', () => {
     });
   });
 
+  // Pins the exact host the openai-compat transport's max_tokens ->
+  // max_completion_tokens translation keys off of (see
+  // packages/llm-gateway/src/transports/openai-compat/index.ts). If this ever
+  // resolves to something other than the real api.openai.com host, that
+  // translation silently stops firing for genuine OpenAI BYOK traffic.
+  test('resolves OpenAI to the genuine api.openai.com host', () => {
+    expect(resolveCatalogUpstream('openai')).toMatchObject({
+      kind: 'openai-compat',
+      envVar: 'OPENAI_API_KEY',
+      baseUrl: 'https://api.openai.com/v1',
+    });
+  });
+
   test('resolves Anthropic with its native transport', () => {
     expect(resolveCatalogUpstream('anthropic')).toMatchObject({
       kind: 'anthropic',

--- a/packages/llm-gateway/src/transports/openai-compat/index.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/index.ts
@@ -12,6 +12,39 @@ function trimTrailingSlash(url: string): string {
   return url.slice(0, end);
 }
 
+const GENUINE_OPENAI_HOSTNAME = 'api.openai.com';
+
+// True only for the real OpenAI API host, never for an OpenAI-COMPATIBLE
+// upstream (OpenRouter, Groq, self-hosted vLLM/LiteLLM/Ollama, "custom", etc.)
+// even though those share `kind: 'openai-compat'` and flow through this same
+// transport. Checked on the resolved base URL rather than `descriptor.provider`
+// so it stays correct even if a future catalog entry mislabels the provider id.
+function isGenuineOpenAiUpstream(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname === GENUINE_OPENAI_HOSTNAME;
+  } catch {
+    return false;
+  }
+}
+
+// OpenAI's chat completions endpoint now rejects `max_tokens` for its current
+// chat models (o-series, gpt-5.x, and newer gpt-4o snapshots all 400 with
+// "Unsupported parameter: 'max_tokens' is not supported with this model. Use
+// 'max_completion_tokens' instead.") — observed live against api.openai.com.
+// `max_completion_tokens` is accepted for every model OpenAI still serves
+// under chat/completions, so the translation is unconditional for genuine
+// OpenAI traffic rather than a model-name allowlist that would need upkeep as
+// OpenAI ships new model families. If the caller already sent
+// `max_completion_tokens` (e.g. opencode/the SDK already speaks the new
+// field), it passes through untouched and `max_tokens` is left alone too.
+function translateMaxTokensForGenuineOpenAi(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!('max_tokens' in payload) || 'max_completion_tokens' in payload) return payload;
+  const { max_tokens, ...rest } = payload;
+  return { ...rest, max_completion_tokens: max_tokens };
+}
+
 export function buildUpstreamRequest(
   body: Record<string, unknown>,
   descriptor: UpstreamDescriptor,
@@ -27,6 +60,9 @@ export function buildUpstreamRequest(
   let payload = body;
   if (descriptor.bodyExtras) payload = { ...payload, ...descriptor.bodyExtras };
   if (descriptor.resolvedModel) payload = { ...payload, model: descriptor.resolvedModel };
+  if (isGenuineOpenAiUpstream(descriptor.baseUrl)) {
+    payload = translateMaxTokensForGenuineOpenAi(payload);
+  }
 
   return {
     url: `${trimTrailingSlash(descriptor.baseUrl)}/chat/completions`,

--- a/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
@@ -43,6 +43,72 @@ describe('openai-compat transport', () => {
   });
 });
 
+describe('openai-compat max_tokens -> max_completion_tokens translation', () => {
+  const openaiDescriptor: UpstreamDescriptor = {
+    ...descriptor,
+    provider: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    resolvedModel: 'gpt-5.6-sol',
+  };
+
+  test('genuine OpenAI: renames max_tokens to max_completion_tokens', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openai/gpt-5.6-sol', messages: [], max_tokens: 4096 },
+      openaiDescriptor,
+    );
+    expect(req.payload.max_completion_tokens).toBe(4096);
+    expect('max_tokens' in req.payload).toBe(false);
+  });
+
+  test('genuine OpenAI: leaves an explicit max_completion_tokens untouched and drops nothing', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openai/gpt-5.6-sol', messages: [], max_completion_tokens: 2048 },
+      openaiDescriptor,
+    );
+    expect(req.payload.max_completion_tokens).toBe(2048);
+    expect('max_tokens' in req.payload).toBe(false);
+  });
+
+  test('genuine OpenAI: does not invent max_completion_tokens when neither field is sent', () => {
+    const req = buildUpstreamRequest({ model: 'openai/gpt-5.6-sol', messages: [] }, openaiDescriptor);
+    expect('max_completion_tokens' in req.payload).toBe(false);
+    expect('max_tokens' in req.payload).toBe(false);
+  });
+
+  test('genuine OpenAI: if both are already present, the client value wins (no silent drop of data)', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openai/gpt-5.6-sol', messages: [], max_tokens: 999, max_completion_tokens: 111 },
+      openaiDescriptor,
+    );
+    expect(req.payload.max_completion_tokens).toBe(111);
+    expect(req.payload.max_tokens).toBe(999);
+  });
+
+  test('OpenRouter (openai-compat, different host): keeps max_tokens as-is', () => {
+    const req = buildUpstreamRequest(
+      { model: 'kortix/glm-5.2', messages: [], max_tokens: 4096 },
+      { ...descriptor, provider: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1' },
+    );
+    expect(req.payload.max_tokens).toBe(4096);
+    expect('max_completion_tokens' in req.payload).toBe(false);
+  });
+
+  test('other openai-compat upstreams (Groq, x.ai, self-hosted/custom) keep max_tokens as-is', () => {
+    const req = buildUpstreamRequest({ model: 'xai/grok-4.3', messages: [], max_tokens: 512 }, descriptor);
+    expect(req.payload.max_tokens).toBe(512);
+    expect('max_completion_tokens' in req.payload).toBe(false);
+  });
+
+  test('a baseUrl that merely contains "api.openai.com" as a substring (not the real host) is not translated', () => {
+    const req = buildUpstreamRequest(
+      { model: 'evil/model', messages: [], max_tokens: 1 },
+      { ...descriptor, provider: 'evil', baseUrl: 'https://not-api.openai.com.evil.example/v1' },
+    );
+    expect(req.payload.max_tokens).toBe(1);
+    expect('max_completion_tokens' in req.payload).toBe(false);
+  });
+});
+
 describe('openai-compat bodyExtras', () => {
   test('merges descriptor bodyExtras into the payload, overriding client fields', () => {
     const req = buildUpstreamRequest(


### PR DESCRIPTION
## Summary
- On a self-host box (essentia.kortix.cloud), agent sessions using BYOK OpenAI models (`openai/gpt-5.5`, `openai/gpt-5.6-sol`) failed in-session with an upstream 400: `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.` Captured live from gateway logs (project `e7170bf8-eb8a-490e-b0f9-4c29150e5d91`, session `7f86d14b-ffbe-4862-9b31-46b8b254e609`).
- Root cause: `packages/llm-gateway/src/transports/openai-compat/index.ts`'s `buildUpstreamRequest` forwards the client body verbatim to every upstream sharing `kind: 'openai-compat'` — genuine OpenAI, OpenRouter, Groq, x.ai, Mistral, DeepSeek, self-hosted/custom — nothing ever renamed the field.
- Fix: translate `max_tokens` → `max_completion_tokens` only when the resolved base URL's hostname is the genuine `api.openai.com` (checked on the URL, not `provider`/`kind`, so a mislabeled catalog entry can't bypass or wrongly trigger it). No model-name allowlist — `max_completion_tokens` is accepted by every model OpenAI still serves under chat/completions, so this doesn't need upkeep as OpenAI ships new model families. OpenAI-compatible upstreams that still require `max_tokens` (OpenRouter, Groq, self-hosted, etc.) are untouched.
- Verified the fix is also load-bearing for `apps/api/src/projects/routes/gateway.ts`'s `/gateway/playground` test-a-model endpoint, which hardcodes `max_tokens: 512` and calls the same `callUpstream`/`buildUpstreamRequest` path — it was broken for any OpenAI reasoning/gpt-5.x model and is fixed by this same change with no extra edit needed.
- Swept for other direct-OpenAI-call sites: `apps/api/src/router/routes/proxy/handlers.ts` is an intentional raw byte passthrough to `api.openai.com` (client's own params, client's responsibility) — left alone. No other direct OpenAI SDK/fetch call sites exist under `apps/**`.
- Flagged, not fixed (out of scope / not evidenced as currently broken): `apps/kortix-sandbox-agent-server/src/opencode.ts`'s `MINIMAL_FALLBACK_MODELS` boot-fallback catalog blanket-declares `temperature: true` for every entry including `openai/gpt-5.5`; the *real* served catalog (`apps/api/src/llm-gateway/models/catalog-models.ts`) sources `temperature` from models.dev per-model instead, and the two live failures we captured were only ever the `max_tokens` error (no co-occurring `temperature`/`top_p` 400), so this fallback-only table is a low-severity metadata smell, not a confirmed live bug — worth a follow-up look, not blocking this fix.

## Test plan
- [x] `bun test` in `packages/llm-gateway` — 150 pass / 0 fail (new `openai-compat.test.ts` cases cover: genuine OpenAI renames `max_tokens`→`max_completion_tokens`; an explicit client-sent `max_completion_tokens` passes through untouched; neither field is invented when absent; both-present keeps the client's `max_completion_tokens` and doesn't silently drop `max_tokens`; OpenRouter/Groq/x.ai and other openai-compat upstreams keep `max_tokens`; a spoofed hostname containing `api.openai.com` as a substring is NOT treated as genuine OpenAI).
- [x] `bun test src/llm-gateway/models/provider-registry.test.ts` in `apps/api` — 4 pass / 0 fail (new canary test pins `resolveCatalogUpstream('openai')` to the real `api.openai.com` host the transport keys off of).
- [x] `tsc --noEmit` clean in both `packages/llm-gateway` and `apps/api`.