### PR TITLE
fix(terminal): make PTY tabs recover across providers

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -16,6 +16,7 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { runWithContext } from '../lib/request-context';
+import { classifyPtyWebSocketPath } from '../platform/providers/pty-ingress';
 
 // ─── Mock state ──────────────────────────────────────────────────────────────
 
@@ -201,7 +202,7 @@ mock.module('../platform/providers', () => ({
       const ptyWebsocket =
         name === 'platinum' &&
         request.transport === 'websocket' &&
-        request.path?.startsWith('/pty/');
+        classifyPtyWebSocketPath(request.path) !== null;
       return {
         effectivePort: name === 'platinum' && (request.port === 4096 || ptyWebsocket)
           ? 8000
@@ -433,6 +434,32 @@ describe('Preview proxy: websocket upstream resolution', () => {
       expect(queryContext).toBeTruthy();
       expect(verifyKortixUserContext(queryContext!, TEST_SERVICE_KEY).ok).toBe(true);
       expect(upstream.headers[KORTIX_USER_CONTEXT_HEADER]).toBe(queryContext!);
+    }
+  });
+
+  test('signs the user context into Platinum Kortix-native PTY websocket URLs', async () => {
+    mockDbSandbox = { ...mockDbSandbox, provider: 'platinum' };
+    mockPreviewUrl = 'https://8000-platinum.sbx.example';
+    mockPreviewToken = null;
+
+    const upstream = await resolvePreviewWsUpstream({
+      sandboxId: TEST_SANDBOX_ID,
+      upstreamPort: 8000,
+      userId: TEST_USER_ID,
+      remainingPath: '/kortix/pty/kpty_test/connect',
+      queryString: '',
+    });
+
+    expect(upstream.ok).toBe(true);
+    expect(mockResolvedPreviewPorts).toEqual([8000]);
+    if (upstream.ok) {
+      const url = new URL(upstream.url);
+      expect(`${url.origin}${url.pathname}`).toBe(
+        'wss://8000-platinum.sbx.example/kortix/pty/kpty_test/connect',
+      );
+      const queryContext = url.searchParams.get('__kortix_user_context');
+      expect(queryContext).toBeTruthy();
+      expect(verifyKortixUserContext(queryContext!, TEST_SERVICE_KEY).ok).toBe(true);
     }
   });
 });

--- a/apps/api/src/platform/providers/platinum-create-terminal.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-terminal.test.ts
@@ -83,3 +83,18 @@ test("create() does NOT tear down a still-'provisioning' box (FE poll picks it u
   const deleted = calls.some((c) => c.method === 'DELETE');
   expect(deleted).toBe(false);
 });
+
+test('routeIngress() sends Kortix-native PTY websockets through the authenticated agent bridge', async () => {
+  const p = await makeProvider();
+  expect(p.routeIngress({
+    port: 8000,
+    transport: 'websocket',
+    path: '/kortix/pty/kpty_test/connect',
+  })).toEqual({
+    effectivePort: 8000,
+    websocket: {
+      userContextQueryParam: '__kortix_user_context',
+      queryDefaults: { cursor: '0' },
+    },
+  });
+});

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -29,6 +29,7 @@ import type {
   ResolvedSandboxIngress,
   SandboxIngressRequest,
 } from './index';
+import { classifyPtyWebSocketPath } from './pty-ingress';
 import { providerAutoStopBackstopMinutes } from './index';
 
 const AGENT_PORT = 8000;
@@ -299,7 +300,8 @@ export class PlatinumProvider implements SandboxProvider {
   }
 
   routeIngress(request: SandboxIngressRequest) {
-    const ptyWebsocket = request.transport === 'websocket' && request.path?.startsWith('/pty/');
+    const ptyWebsocket =
+      request.transport === 'websocket' && classifyPtyWebSocketPath(request.path) !== null;
     return {
       effectivePort: request.port === 4096 || ptyWebsocket ? AGENT_PORT : request.port,
       websocket: ptyWebsocket

--- a/apps/api/src/platform/providers/pty-ingress.test.ts
+++ b/apps/api/src/platform/providers/pty-ingress.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+
+import { classifyPtyWebSocketPath } from './pty-ingress';
+
+describe('classifyPtyWebSocketPath', () => {
+  test('distinguishes OpenCode and Kortix-native PTY websocket paths', () => {
+    expect(classifyPtyWebSocketPath('/pty/pty_test/connect')).toBe('opencode');
+    expect(classifyPtyWebSocketPath('/kortix/pty/kpty_test/connect')).toBe('kortix');
+  });
+
+  test('does not classify unrelated daemon or preview paths as PTY', () => {
+    expect(classifyPtyWebSocketPath('/kortix/health')).toBeNull();
+    expect(classifyPtyWebSocketPath('/preview/pty/example')).toBeNull();
+    expect(classifyPtyWebSocketPath()).toBeNull();
+  });
+});

--- a/apps/api/src/platform/providers/pty-ingress.ts
+++ b/apps/api/src/platform/providers/pty-ingress.ts
@@ -1,0 +1,17 @@
+/**
+ * Classify the two PTY WebSocket contracts that can traverse sandbox ingress.
+ *
+ * - OpenCode PTY lives on its internal runtime port (`/pty/:id/connect`).
+ * - Kortix-native PTY lives on the sandbox agent (`/kortix/pty/:id/connect`).
+ *
+ * Keeping this path knowledge in one pure helper prevents provider routing and
+ * the API WebSocket proxy from drifting when a terminal backend changes.
+ */
+export type PtyWebSocketKind = 'opencode' | 'kortix';
+
+export function classifyPtyWebSocketPath(path?: string): PtyWebSocketKind | null {
+  if (!path) return null;
+  if (path.startsWith('/kortix/pty/')) return 'kortix';
+  if (path.startsWith('/pty/')) return 'opencode';
+  return null;
+}

--- a/apps/api/src/sandbox-proxy/ws-proxy-close-code.test.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy-close-code.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+
+import { sanitizePreviewWsCloseCode } from './ws-proxy';
+
+describe('sanitizePreviewWsCloseCode', () => {
+  test('preserves standard server error and restart close codes', () => {
+    expect(sanitizePreviewWsCloseCode(1011)).toBe(1011);
+    expect(sanitizePreviewWsCloseCode(1012)).toBe(1012);
+  });
+
+  test('maps reserved wire-only codes to an application error code', () => {
+    expect(sanitizePreviewWsCloseCode(1005)).toBe(4500);
+    expect(sanitizePreviewWsCloseCode(1006)).toBe(4500);
+    expect(sanitizePreviewWsCloseCode(undefined)).toBe(4500);
+  });
+});

--- a/apps/api/src/sandbox-proxy/ws-proxy.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy.ts
@@ -24,6 +24,7 @@
 
 import { authenticatePreviewPrincipal } from './preview-auth';
 import { resolvePreviewWsUpstream } from './routes/preview';
+import { classifyPtyWebSocketPath } from '../platform/providers/pty-ingress';
 
 // opencode's internal port — its PTY WebSocket endpoint lives here, reachable
 // via a dedicated Daytona preview link (the daemon on 8000 can't proxy WS).
@@ -82,7 +83,8 @@ export async function preparePreviewWsUpgrade(
   // opencode PTY (and any other opencode endpoint) must reach opencode directly
   // on 4096 — the daemon on 8000 can't carry a WebSocket. Everything else is
   // proxied against the port the client addressed.
-  const upstreamPort = remainingPath.startsWith('/pty/') ? OPENCODE_INTERNAL_PORT : port;
+  const ptyKind = classifyPtyWebSocketPath(remainingPath);
+  const upstreamPort = ptyKind === 'opencode' ? OPENCODE_INTERNAL_PORT : port;
 
   // Strip our own auth token before forwarding — opencode authenticates via the
   // Daytona preview token header, not our query param.
@@ -111,13 +113,21 @@ export async function preparePreviewWsUpgrade(
   }
 }
 
-// WebSocket close codes are constrained: a server may only emit 1000 or
-// 3000–4999. Anything else (1006 abnormal, 1005 no-status, …) must be mapped.
-function sanitizeCloseCode(code: number | undefined): number {
-  if (typeof code !== 'number') return 1000;
-  if (code === 1000) return 1000;
-  if (code >= 3000 && code <= 4999) return code;
-  return 1000;
+// Preserve meaningful standard close codes, but never emit reserved wire-only
+// values (1005/1006) or an arbitrary invalid number.
+export function sanitizePreviewWsCloseCode(code: number | undefined): number {
+  // 1004/1005/1006/1015 are reserved and cannot be emitted on the wire. Keep
+  // every other standard close code intact so clients can distinguish a clean
+  // shell exit from an upstream restart/server failure. Unknown values use a
+  // stable application code instead of being disguised as a normal 1000 close.
+  if (
+    typeof code === 'number' &&
+    ((code >= 1000 && code <= 1014 && ![1004, 1005, 1006].includes(code)) ||
+      (code >= 3000 && code <= 4999))
+  ) {
+    return code;
+  }
+  return 4500;
 }
 
 // ── Byte-piping handlers, wired into Bun.serve's `websocket` config ──────────
@@ -156,11 +166,11 @@ export const previewWsHandlers = {
     };
 
     upstream.onclose = (ev: CloseEvent) => {
-      try { ws.close(sanitizeCloseCode(ev.code), (ev.reason || '').slice(0, 120)); } catch {}
+      try { ws.close(sanitizePreviewWsCloseCode(ev.code), (ev.reason || '').slice(0, 120)); } catch {}
     };
 
     upstream.onerror = () => {
-      try { ws.close(1011, 'upstream error'); } catch {}
+      try { ws.close(4502, 'upstream error'); } catch {}
     };
   },
 

--- a/apps/web/src/components/tabs/terminal-tab-content.tsx
+++ b/apps/web/src/components/tabs/terminal-tab-content.tsx
@@ -3,12 +3,15 @@
 import { useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
 import { useCreatePty, useOpenCodePtyList, useRemovePty } from '@/hooks/opencode/use-opencode-pty';
+import { useOpenCodeRuntimeReady } from '@/hooks/opencode/use-opencode-sessions';
+import { shouldAutoReplaceTerminal } from '@/features/session/pty-connection';
 import { useServerStore } from '@/stores/server-store';
 import { openTabAndNavigate, useTabStore } from '@/stores/tab-store';
-import { CircleDashed, Plus, Terminal } from 'lucide-react';
+import { Plus, Terminal } from 'lucide-react';
 import dynamic from 'next/dynamic';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 // Lazy-load to avoid SSR issues with xterm.js
 const PtyTerminal = dynamic(
@@ -32,34 +35,41 @@ interface TerminalTabContentProps {
 export function TerminalTabContent({ ptyId, tabId, hidden = false }: TerminalTabContentProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const serverUrl = useServerStore((s) => s.getActiveServerUrl());
+  const runtimeReady = useOpenCodeRuntimeReady();
 
-  const { data: ptys, isLoading, refetch } = useOpenCodePtyList();
+  const { data: ptys, isLoading, refetch } = useOpenCodePtyList({ serverUrl });
   const removePty = useRemovePty();
   const createPty = useCreatePty();
+  const replacementAttempt = useTabStore((state) => {
+    const value = state.tabs[tabId]?.metadata?.terminalReplacementAttempt;
+    return typeof value === 'number' ? value : 0;
+  });
+  const [initialLookupComplete, setInitialLookupComplete] = useState(false);
+  const [unavailable, setUnavailable] = useState(false);
+  const [isReplacing, setIsReplacing] = useState(false);
+  const replacingRef = useRef(false);
 
   // Find the PTY object for this tab
   const pty = ptys?.find((p) => p.id === ptyId) ?? null;
 
-  // Track whether we've ever seen this PTY in the list.
-  // Prevents auto-closing the tab before the list has had a chance to include
-  // the newly created PTY (race between POST /pty and GET /pty).
-  const hasSeenPty = useRef(false);
-  if (pty) hasSeenPty.current = true;
-
-  // If PTY isn't in the list yet (just created), trigger a refetch.
+  // A newly created PTY can race a stale Infinity-cached list. Force one lookup
+  // for this ID, then settle into the recoverable ended state instead of an
+  // infinite "Connecting" spinner when the daemon restarted and forgot it.
   useEffect(() => {
-    if (!pty && !hasSeenPty.current && !isLoading) {
-      refetch();
-    }
-  }, [pty, isLoading, refetch]);
+    setInitialLookupComplete(false);
+    setUnavailable(false);
+    setIsReplacing(false);
+    replacingRef.current = false;
+  }, [ptyId]);
 
-  // If PTY disappears (killed externally), close the tab — but only if we
-  // previously saw it in the list (avoids race on initial mount).
   useEffect(() => {
-    if (!isLoading && ptys && !pty && hasSeenPty.current) {
-      useTabStore.getState().closeTab(tabId);
+    if (!runtimeReady || isLoading || initialLookupComplete) return;
+    if (pty) {
+      setInitialLookupComplete(true);
+      return;
     }
-  }, [isLoading, ptys, pty, tabId]);
+    void refetch().finally(() => setInitialLookupComplete(true));
+  }, [initialLookupComplete, isLoading, pty, refetch, runtimeReady]);
 
   // Kill PTY on the server when the tab is ACTUALLY closed (removed from store).
   // We guard the cleanup by checking whether the tab still exists — this
@@ -78,12 +88,11 @@ export function TerminalTabContent({ ptyId, tabId, hidden = false }: TerminalTab
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ptyId]);
 
-  // Replace this dead terminal tab with a fresh one
-  const handleNewTerminal = useCallback(async () => {
+  // Create the replacement before closing the old tab. If creation fails, the
+  // recoverable state stays visible instead of throwing the user back to an
+  // unrelated tab with no way to retry.
+  const replaceTerminal = useCallback(async (automatic: boolean) => {
     try {
-      // Close this dead tab first
-      useTabStore.getState().closeTab(tabId);
-      // Create a new PTY and open it
       const newPty = await createPty.mutateAsync({
         env: { TERM: 'xterm-256color', COLORTERM: 'truecolor' },
       });
@@ -92,25 +101,46 @@ export function TerminalTabContent({ ptyId, tabId, hidden = false }: TerminalTab
         title: newPty.title || newPty.command || 'Terminal',
         type: 'terminal',
         href: `/terminal/${newPty.id}`,
+        metadata: {
+          terminalReplacementAttempt: automatic ? replacementAttempt + 1 : 0,
+        },
       });
+      useTabStore.getState().closeTab(tabId);
     } catch {
-      // Tab was already closed, nothing more to do
+      replacingRef.current = false;
+      setIsReplacing(false);
+      setUnavailable(true);
     }
-  }, [tabId, createPty]);
+  }, [createPty, replacementAttempt, tabId]);
+
+  const handleNewTerminal = useCallback(() => {
+    replacingRef.current = true;
+    setIsReplacing(true);
+    setUnavailable(false);
+    void replaceTerminal(false);
+  }, [replaceTerminal]);
+
+  const handleUnavailable = useCallback(() => {
+    setUnavailable(true);
+    if (replacingRef.current || !shouldAutoReplaceTerminal(replacementAttempt)) return;
+    replacingRef.current = true;
+    setIsReplacing(true);
+    void replaceTerminal(true);
+  }, [replaceTerminal, replacementAttempt]);
 
   // Loading — also treat "never seen this PTY yet" as loading to handle the
   // race between tab navigation and the PTY list refetch after creation.
-  if (isLoading || (!pty && !hasSeenPty.current)) {
+  if (!runtimeReady || isLoading || !initialLookupComplete || isReplacing) {
     return (
       <div className="bg-background flex h-full w-full flex-col items-center justify-center">
-        <CircleDashed className="text-muted-foreground h-4 w-4 animate-spin" />
+        <Loading className="size-4 shrink-0" />
         <span className="text-muted-foreground mt-2 text-xs">Connecting...</span>
       </div>
     );
   }
 
-  // PTY not found — show prompt to open a new terminal
-  if (!pty) {
+  // Missing, exited, or failed-to-attach PTY — never leave a stale tab spinning.
+  if (!pty || pty.status === 'exited' || unavailable) {
     return (
       <div className="bg-background flex h-full w-full flex-col items-center justify-center gap-3">
         <Terminal className="text-muted-foreground/30 h-8 w-8" />
@@ -131,6 +161,7 @@ export function TerminalTabContent({ ptyId, tabId, hidden = false }: TerminalTab
         pty={pty}
         serverUrl={serverUrl}
         hidden={hidden}
+        onUnavailable={handleUnavailable}
         className="absolute inset-0 h-full w-full"
       />
     </div>

--- a/apps/web/src/features/session/pty-connection.test.ts
+++ b/apps/web/src/features/session/pty-connection.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+
+import { classifyPtyClose, shouldAutoReplaceTerminal } from './pty-connection';
+
+describe('classifyPtyClose', () => {
+  test('replaces a daemon-side PTY that no longer exists even when the proxy reports code 1000', () => {
+    expect(classifyPtyClose({ code: 1000, reason: 'pty not found', hadError: false })).toBe('replace');
+  });
+
+  test('reconnects transport failures regardless of proxy close-code normalization', () => {
+    expect(classifyPtyClose({ code: 1000, reason: 'upstream error', hadError: true })).toBe('reconnect');
+    expect(classifyPtyClose({ code: 1011, reason: 'upstream error', hadError: true })).toBe('reconnect');
+    expect(classifyPtyClose({ code: 1000, reason: 'idle timeout', hadError: false })).toBe('reconnect');
+  });
+
+  test('leaves an intentional shell exit ended', () => {
+    expect(classifyPtyClose({ code: 1000, reason: 'pty exited (0)', hadError: false })).toBe('ended');
+  });
+});
+
+describe('shouldAutoReplaceTerminal', () => {
+  test('allows exactly one automatic replacement per terminal chain', () => {
+    expect(shouldAutoReplaceTerminal(0)).toBe(true);
+    expect(shouldAutoReplaceTerminal(1)).toBe(false);
+    expect(shouldAutoReplaceTerminal(2)).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/pty-connection.ts
+++ b/apps/web/src/features/session/pty-connection.ts
@@ -1,0 +1,34 @@
+export type PtyCloseAction = 'ended' | 'reconnect' | 'replace';
+
+export function classifyPtyClose(input: {
+  code: number;
+  reason: string;
+  hadError: boolean;
+}): PtyCloseAction {
+  const reason = input.reason.trim().toLowerCase();
+
+  // The daemon registry is intentionally process-local. A runtime restart, an
+  // old persisted tab, or a create/attach race can leave the browser holding an
+  // ID that can never succeed by reconnecting. The owner must mint a new PTY.
+  if (reason.includes('pty not found')) return 'replace';
+
+  // A clean shell exit is terminal. Everything that indicates transport loss
+  // remains reconnectable even when an intermediary normalizes the code to
+  // 1000 (the historical proxy behavior behind the user-visible failure).
+  if (reason.includes('pty exited')) return 'ended';
+  if (
+    input.hadError ||
+    reason.includes('idle timeout') ||
+    reason.includes('upstream error') ||
+    input.code !== 1000
+  ) {
+    return 'reconnect';
+  }
+
+  return 'ended';
+}
+
+/** Prevent a bad runtime from creating terminals forever in a replacement loop. */
+export function shouldAutoReplaceTerminal(replacementAttempt: number): boolean {
+  return replacementAttempt < 1;
+}

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -9,6 +9,7 @@ import '@xterm/xterm/css/xterm.css';
 import { getPtyWebSocketUrl, useUpdatePty } from '@/hooks/opencode/use-opencode-pty';
 import { invalidateTokenCache } from '@/lib/auth-token';
 import type { Pty } from '@kortix/sdk/opencode-client';
+import { classifyPtyClose } from './pty-connection';
 
 // ============================================================================
 // Theme
@@ -56,6 +57,8 @@ interface PtyTerminalProps {
   /** Server URL to connect to — locks the WS to this server even after instance switch. */
   serverUrl?: string;
   onStatusChange?: (status: ConnectionStatus) => void;
+  /** Called when reconnecting this ID can never work (daemon no longer owns it). */
+  onUnavailable?: () => void;
 }
 
 // ============================================================================
@@ -117,6 +120,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
   hidden,
   serverUrl,
   onStatusChange,
+  onUnavailable,
 }, ref) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
@@ -340,16 +344,21 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
         console.log('[PtyTerminal] WebSocket closed:', event.code, event.reason);
         wsRef.current = null;
 
-        const reason = (event.reason || '').toLowerCase();
-        const closedByIdleTimeout = event.code === 1000 && reason.includes('idle timeout');
-        const shouldReconnect = closedByIdleTimeout || event.code !== 1000;
+        const action = classifyPtyClose({
+          code: event.code,
+          reason: event.reason || '',
+          hadError: hadErrorRef.current,
+        });
 
         if (!hadErrorRef.current) {
           term.writeln(`\r\n\x1b[33mConnection closed${event.code ? ` (${event.code})` : ''}${event.reason ? ': ' + event.reason : ''}\x1b[0m`);
         }
 
-        if (shouldReconnect) {
-          scheduleReconnect(closedByIdleTimeout ? 'idle timeout' : `code ${event.code}`);
+        if (action === 'replace') {
+          updateStatus('error');
+          onUnavailable?.();
+        } else if (action === 'reconnect') {
+          scheduleReconnect(event.reason || `code ${event.code}`);
         } else {
           reconnectAttemptsRef.current = 0;
           updateStatus('disconnected');

--- a/tests/e2e/scripts/terminal-pty-smoke.ts
+++ b/tests/e2e/scripts/terminal-pty-smoke.ts
@@ -1,0 +1,249 @@
+#!/usr/bin/env bun
+
+/**
+ * Real provider PTY smoke:
+ * auth -> project -> provider-pinned session -> sandbox -> create PTY ->
+ * WebSocket attach -> command I/O -> reconnect replay -> cleanup.
+ *
+ * Run with the isolated stack up:
+ *   dotenvx run -f apps/api/.env -f apps/web/.env -- \
+ *     bun tests/e2e/scripts/terminal-pty-smoke.ts platinum
+ */
+
+const provider = process.argv[2];
+if (provider !== 'platinum' && provider !== 'daytona') {
+  throw new Error('usage: terminal-pty-smoke.ts <platinum|daytona>');
+}
+
+const apiBase = process.env.E2E_API_URL ?? 'http://localhost:23308/v1';
+const supabaseBase = process.env.E2E_SUPABASE_URL ?? 'http://127.0.0.1:54321';
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!serviceRoleKey || !anonKey) {
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY and NEXT_PUBLIC_SUPABASE_ANON_KEY are required');
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const deadline = (ms: number) => Date.now() + ms;
+const marker = `KORTIX_PTY_${provider.toUpperCase()}_${Date.now()}`;
+let token = '';
+let projectId = '';
+let sessionId = '';
+
+function log(message: string, details?: unknown): void {
+  console.log(`[terminal-pty:${provider}] ${message}`, details ?? '');
+}
+
+async function jsonRequest(
+  url: string,
+  init: RequestInit = {},
+): Promise<{ status: number; body: any; text: string }> {
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let body: any = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { status: response.status, body, text };
+}
+
+async function api(path: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers);
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  if (init.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+  return jsonRequest(`${apiBase}${path}`, { ...init, headers });
+}
+
+async function waitForSandbox(): Promise<{ externalId: string }> {
+  const end = deadline(7 * 60_000);
+  let last = '';
+  while (Date.now() < end) {
+    const response = await api(`/projects/${projectId}/sessions/${sessionId}/start?wait_ms=25000`, {
+      method: 'POST',
+      body: '{}',
+    });
+    const stage = response.body?.stage ?? `http-${response.status}`;
+    const externalId = response.body?.sandbox?.external_id ?? '';
+    last = `${stage} ${externalId}`;
+    log('session start poll', last);
+    if (stage === 'ready' && externalId) return { externalId };
+    if (stage === 'failed' || response.body?.retriable === false) {
+      throw new Error(`session start failed: ${response.text}`);
+    }
+    await sleep(1_000);
+  }
+  throw new Error(`session did not become ready: ${last}`);
+}
+
+async function waitForRuntime(externalId: string): Promise<void> {
+  const end = deadline(2 * 60_000);
+  let last = '';
+  while (Date.now() < end) {
+    const response = await api(`/p/${externalId}/8000/kortix/health`);
+    last = `${response.status} ${response.text.slice(0, 160)}`;
+    if (response.status === 200) return;
+    await sleep(3_000);
+  }
+  throw new Error(`runtime did not become reachable: ${last}`);
+}
+
+async function attachAndCollect(wsUrl: string, input?: string): Promise<{ output: string; close?: { code: number; reason: string } }> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    let settled = false;
+    const ws = new WebSocket(wsUrl);
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { ws.close(); } catch {}
+      reject(new Error(`timed out waiting for PTY output; received=${JSON.stringify(output.slice(-500))}`));
+    }, 20_000);
+
+    ws.addEventListener('open', () => {
+      log('websocket opened');
+      if (input) ws.send(input);
+    });
+    ws.addEventListener('message', (event) => {
+      output += typeof event.data === 'string' ? event.data : Buffer.from(event.data as ArrayBuffer).toString();
+      if (output.includes(marker) && !settled) {
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        resolve({ output });
+      }
+    });
+    ws.addEventListener('close', (event) => {
+      log('websocket closed', { code: event.code, reason: event.reason });
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ output, close: { code: event.code, reason: event.reason } });
+    });
+    ws.addEventListener('error', () => {
+      log('websocket error');
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const email = `terminal-pty-${provider}-${Date.now()}@example.test`;
+  const password = 'TerminalPty123!';
+  const createdUser = await jsonRequest(`${supabaseBase}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: {
+      apikey: serviceRoleKey!,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password, email_confirm: true }),
+  });
+  if (createdUser.status < 200 || createdUser.status >= 300) {
+    throw new Error(`create user failed: ${createdUser.status} ${createdUser.text}`);
+  }
+
+  const grant = await jsonRequest(`${supabaseBase}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: anonKey!, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  token = grant.body?.access_token ?? '';
+  if (!token) throw new Error(`password grant failed: ${grant.status} ${grant.text}`);
+
+  const accounts = await api('/accounts');
+  const account = Array.isArray(accounts.body)
+    ? accounts.body.find((candidate: any) => candidate.personal_account) ?? accounts.body[0]
+    : null;
+  if (!account?.account_id) throw new Error(`personal account missing: ${accounts.text}`);
+
+  const project = await api('/projects/provision', {
+    method: 'POST',
+    body: JSON.stringify({
+      account_id: account.account_id,
+      name: `terminal pty ${provider} ${Date.now()}`,
+      seed_starter: true,
+    }),
+  });
+  projectId = project.body?.project_id ?? project.body?.id ?? '';
+  if (!projectId) throw new Error(`project provision failed: ${project.status} ${project.text}`);
+  log('project created', projectId);
+
+  const sessionName = `terminal ${provider} ${Date.now()}`;
+  let session = await api(`/projects/${projectId}/sessions`, {
+    method: 'POST',
+    body: JSON.stringify({ name: sessionName, provider }),
+  });
+  // The API's 25s request deadline can answer 503 while the async create keeps
+  // running. Reconcile by unique name before retrying so the smoke never
+  // creates a duplicate session after an ambiguous response.
+  if (session.status === 503) {
+    const reconcileEnd = deadline(45_000);
+    while (Date.now() < reconcileEnd) {
+      const listed = await api(`/projects/${projectId}/sessions`);
+      const items = Array.isArray(listed.body) ? listed.body : (listed.body?.sessions ?? []);
+      const created = items.find((item: any) => item.name === sessionName);
+      if (created) {
+        session = { status: 201, body: created, text: JSON.stringify(created) };
+        break;
+      }
+      await sleep(2_000);
+    }
+  }
+  sessionId = session.body?.session_id ?? session.body?.id ?? '';
+  if (!sessionId) throw new Error(`session create failed: ${session.status} ${session.text}`);
+  if (session.body?.sandbox_provider !== provider) {
+    throw new Error(`provider mismatch: expected=${provider} body=${session.text}`);
+  }
+  log('session created', sessionId);
+
+  const { externalId } = await waitForSandbox();
+  await waitForRuntime(externalId);
+
+  const createdPty = await api(`/p/${externalId}/8000/kortix/pty`, {
+    method: 'POST',
+    body: JSON.stringify({ env: { TERM: 'xterm-256color', COLORTERM: 'truecolor' } }),
+  });
+  if (createdPty.status !== 200 || !createdPty.body?.id) {
+    throw new Error(`PTY create failed: ${createdPty.status} ${createdPty.text}`);
+  }
+  const ptyId = createdPty.body.id as string;
+  log('PTY created', { ptyId, pid: createdPty.body.pid });
+
+  const wsBase = apiBase.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
+  const wsUrl = `${wsBase}/p/${externalId}/8000/kortix/pty/${encodeURIComponent(ptyId)}/connect?token=${encodeURIComponent(token)}`;
+  const first = await attachAndCollect(wsUrl, `printf '${marker}\\n'\n`);
+  if (!first.output.includes(marker)) {
+    throw new Error(`first attach failed: close=${JSON.stringify(first.close)} output=${JSON.stringify(first.output)}`);
+  }
+
+  const second = await attachAndCollect(wsUrl);
+  if (!second.output.includes(marker)) {
+    throw new Error(`reconnect replay failed: close=${JSON.stringify(second.close)} output=${JSON.stringify(second.output)}`);
+  }
+
+  const listed = await api(`/p/${externalId}/8000/kortix/pty`);
+  if (!Array.isArray(listed.body) || !listed.body.some((pty: any) => pty.id === ptyId && pty.status === 'running')) {
+    throw new Error(`PTY list lost running terminal: ${listed.status} ${listed.text}`);
+  }
+
+  const removed = await api(`/p/${externalId}/8000/kortix/pty/${encodeURIComponent(ptyId)}`, { method: 'DELETE' });
+  if (removed.status !== 200) throw new Error(`PTY delete failed: ${removed.status} ${removed.text}`);
+  log('PASS', { provider, marker, ptyId });
+}
+
+async function cleanup(): Promise<void> {
+  if (sessionId && projectId) {
+    await api(`/projects/${projectId}/sessions/${sessionId}`, { method: 'DELETE' }).catch(() => null);
+  }
+  if (projectId) {
+    await api(`/projects/${projectId}`, { method: 'DELETE' }).catch(() => null);
+  }
+}
+
+try {
+  await main();
+} finally {
+  await cleanup();
+}


### PR DESCRIPTION
## What changed
- route both legacy OpenCode and Kortix-native PTY WebSockets through Platinum's authenticated agent bridge
- preserve meaningful WebSocket close codes instead of disguising failures as normal code 1000 closes
- make Terminal tabs distinguish reconnectable transport loss, missing daemon PTYs, and clean shell exits
- replace a missing/stale PTY once, then expose the existing manual New Terminal recovery without infinite spinners or create loops
- add a real provider PTY smoke covering create, attach, command I/O, reconnect replay, list, and cleanup

## Proof
- `platinum-create-terminal.test.ts`: 6 pass
- preview/provider/close-code suite: 58 pass
- sandbox daemon PTY suite: 8 pass
- frontend PTY close/replacement suite: 4 pass
- API typecheck: pass
- sandbox agent typecheck: pass
- focused frontend ESLint: pass
- focused frontend TypeScript scan: no errors in changed files
- real Platinum run: PASS (`KORTIX_PTY_PLATINUM_1784231590505`)
- real Daytona run: PASS (`KORTIX_PTY_DAYTONA_1784231742290`)

## Browser evidence
The in-app browser exposed no browser target in this session, so DOM/network click proof is explicitly pending dev verification; the black-box provider WebSocket contract above is real, not mocked.