### PR TITLE
fix(llm): correct gpt-5.5 fallback temperature flag + pin playground wire shape

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/fallback-catalog-capabilities.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/fallback-catalog-capabilities.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test'
+import { MINIMAL_FALLBACK_MODELS } from '../opencode'
+
+describe('MINIMAL_FALLBACK_MODELS capability metadata', () => {
+  test('openai/gpt-5.5 does not advertise temperature support', () => {
+    expect(MINIMAL_FALLBACK_MODELS['openai/gpt-5.5']?.temperature).toBe(false)
+  })
+
+  test('no OpenAI reasoning model in the fallback catalog claims temperature support', () => {
+    const offenders = Object.entries(MINIMAL_FALLBACK_MODELS)
+      .filter(([id, model]) => id.startsWith('openai/') && model.reasoning && model.temperature)
+      .map(([id]) => id)
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -371,7 +371,7 @@ type KortixGatewayModel = {
   limit?: { context?: number; output?: number }
 }
 
-const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
+export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
   // AUTO — the default model; present so the baked default never dangles when this
   // fallback is used (gateway + baked catalog both unreachable at boot).
   auto: {
@@ -413,7 +413,12 @@ const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
     reasoning: true,
     tool_call: true,
     attachment: true,
-    temperature: true,
+    // models.dev: false — OpenAI reasoning models (gpt-5.x) reject a
+    // client-sent `temperature`, so advertising support here would make
+    // OpenCode send one and 400 the turn whenever this fallback catalog is
+    // in effect. Must match capabilitiesOf() in the served catalog
+    // (apps/api/src/llm-gateway/models/catalog-models.ts).
+    temperature: false,
     limit: { context: 1_050_000, output: 64_000 },
   },
   'google/gemini-3.5-flash': {

--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -46,6 +46,40 @@ describe('buildUpstreamRequest', () => {
 });
 
 describe('callUpstream', () => {
+  // Pins the WIRE body for the exact shape the gateway playground endpoint
+  // sends (apps/api/src/projects/routes/gateway.ts hardcodes `max_tokens: 512`
+  // and calls this same callUpstream): for a genuine api.openai.com descriptor
+  // the openai-compat transport must rename it to `max_completion_tokens`
+  // (OpenAI's current chat models 400 on `max_tokens`), while every other
+  // openai-compat upstream keeps `max_tokens` verbatim.
+  test('sends max_completion_tokens on the wire to genuine OpenAI, max_tokens elsewhere', async () => {
+    const bodies: string[] = [];
+    const capturingFetch: FetchImpl = async (_input, init) => {
+      bodies.push(String(init.body));
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+    const playgroundRequest = {
+      model: 'openai/gpt-5.5',
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: false,
+      max_tokens: 512,
+    };
+    await callUpstream(
+      playgroundRequest,
+      { ...descriptor, provider: 'openai', baseUrl: 'https://api.openai.com/v1', resolvedModel: 'gpt-5.5' },
+      { retry: fastRetry, fetchImpl: capturingFetch },
+    );
+    await callUpstream(playgroundRequest, descriptor, { retry: fastRetry, fetchImpl: capturingFetch });
+
+    const toOpenAi = JSON.parse(bodies[0]!);
+    expect(toOpenAi.max_completion_tokens).toBe(512);
+    expect('max_tokens' in toOpenAi).toBe(false);
+
+    const toOpenRouter = JSON.parse(bodies[1]!);
+    expect(toOpenRouter.max_tokens).toBe(512);
+    expect('max_completion_tokens' in toOpenRouter).toBe(false);
+  });
+
   test('retries a 503 then returns the ok response', async () => {
     const fetchMock = makeFetch([{ status: 503, body: 'down' }, { status: 200, body: '{"ok":true}' }]);
     const res = await callUpstream({ model: 'x' }, descriptor, { retry: fastRetry, fetchImpl: fetchMock.impl });


### PR DESCRIPTION
## Summary
Follow-up to #4805 (max_tokens → max_completion_tokens for genuine OpenAI), closing the rest of the reasoning-model param bug class:

- **Playground path proof**: `apps/api/src/projects/routes/gateway.ts`'s `POST /:projectId/gateway/playground` hardcodes `max_tokens: 512` and calls the same `callUpstream` → `buildUpstreamRequest` path #4805 fixed, so it was repaired by that PR with zero extra code. This PR adds a wire-level regression test at the `callUpstream` boundary (the exact function the playground calls, asserting the JSON that hits `fetch`): genuine `api.openai.com` gets `max_completion_tokens: 512` on the wire, OpenRouter keeps `max_tokens: 512`.
- **Fallback catalog metadata bug**: `MINIMAL_FALLBACK_MODELS['openai/gpt-5.5']` in `apps/kortix-sandbox-agent-server/src/opencode.ts` declared `temperature: true`. models.dev (`packages/llm-catalog/src/catalog.generated.json`) says `false` — every OpenAI gpt-5.x/o-series reasoning model rejects a client-sent `temperature` — so whenever this boot fallback is in effect (gateway `/models` fetch AND baked catalog both unavailable), OpenCode would send `temperature` and the turn would 400 at OpenAI. Set to `false`, matching `capabilitiesOf()` in the served catalog, plus a test guarding every `openai/` reasoning entry in the fallback table against regressing.

## Test plan
- [x] `bun test src/http/call-upstream.test.ts` in `packages/llm-gateway` — 7 pass (new wire-shape test included)
- [x] `bun test src/__tests__/fallback-catalog-capabilities.test.ts` in `apps/kortix-sandbox-agent-server` — 2 pass
- [x] `tsc --noEmit` clean in both packages