### PR TITLE
fix(llm-gateway): transport correctness — tool_choice safety, param quirks, role normalization, bedrock frames

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.ts
@@ -92,6 +92,22 @@ function capabilitiesOf(
   };
 }
 
+// Model-level capability lookup for descriptor-building code (BYOK resolution),
+// as opposed to the list-shaped `gatewayModelsAll` above which serves the
+// models API. Single source of truth for "does this model reject a
+// non-default temperature / is it a reasoning model" so transports never need
+// to hardcode a model-id list — see UpstreamDescriptor.reasoning/temperature.
+export function capabilitiesForModel(
+  providerId: string,
+  modelId: string,
+  catalog: Catalog = runtimeModelCatalog.snapshot(),
+): { reasoning: boolean; temperature: boolean } {
+  const provider = catalog.providers.find((p) => p.id === providerId);
+  const model = provider?.models.find((m) => m.id === modelId);
+  const caps = capabilitiesOf(model);
+  return { reasoning: !!caps.reasoning, temperature: !!caps.temperature };
+}
+
 export function managedModels(): Record<string, GatewayModel> {
   const out: Record<string, GatewayModel> = {};
   // RUNTIME_MANAGED_MODELS is already empty when KORTIX_MANAGED_PROVIDER_ENABLED

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -9,6 +9,7 @@ import { getResolvedProjectSecretValue } from '../../projects/secrets';
 import { resolveCodexCredential } from '../credentials/codex';
 import { codexDescriptor, livePricing, managedCandidates } from './descriptors';
 import { resolveCatalogUpstream } from '../models/provider-registry';
+import { capabilitiesForModel } from '../models/catalog-models';
 import { resolveGatewayRoute } from '../routing';
 import { getRuntimeManagedModel } from '../models/managed-models';
 
@@ -78,6 +79,11 @@ export async function resolveCandidates(
         ? await resolveCachedAccountTier(principal.accountId)
         : 'self-hosted';
       const isFreeTier = config.KORTIX_BILLING_INTERNAL_ENABLED && tier === 'free';
+      const resolvedModelId = effectiveModel.slice(provider.length + 1);
+      // Capability flags from the catalog (models.dev enrichment) so the
+      // transport can decide which params a reasoning-restricted model
+      // actually rejects, instead of hardcoding a model-id list.
+      const capabilities = capabilitiesForModel(provider, resolvedModelId);
       const byokDescriptor: UpstreamDescriptor = {
         provider,
         kind: byok.kind,
@@ -86,8 +92,10 @@ export async function resolveCandidates(
         billingMode:
           config.KORTIX_BILLING_INTERNAL_ENABLED && !isFreeTier ? 'platform-fee' : 'none',
         markup: isFreeTier ? 0 : PLATFORM_FEE_MARKUP,
-        resolvedModel: effectiveModel.slice(provider.length + 1),
-        pricing: livePricing(effectiveModel.slice(provider.length + 1)),
+        resolvedModel: resolvedModelId,
+        pricing: livePricing(resolvedModelId),
+        reasoning: capabilities.reasoning,
+        temperature: capabilities.temperature,
       };
       // Queue a managed model behind the BYOK key: if the user's key hits a
       // rate-limit / quota / billing error, the failover loop falls over to it

--- a/packages/llm-gateway/src/domain/descriptor.ts
+++ b/packages/llm-gateway/src/domain/descriptor.ts
@@ -26,6 +26,16 @@ export interface UpstreamDescriptor {
   headers?: Record<string, string>;
   omitAuthorization?: boolean;
   pricing?: UpstreamPricing;
+  // Model capability flags mirrored from the catalog (models.dev enrichment,
+  // see apps/api/src/llm-gateway/models/catalog-models.ts capabilitiesOf).
+  // Transports use these to decide whether to translate/strip params the
+  // target model actually rejects, instead of hardcoding a model-id list.
+  // `reasoning` = the model is a reasoning/o-series-style model.
+  // `temperature` = the model accepts a non-default temperature/top_p/etc.
+  // Left undefined for upstreams that don't carry catalog capability data
+  // (managed models, custom/self-hosted) — treated as "unknown, don't guess".
+  reasoning?: boolean;
+  temperature?: boolean;
   // Upstream-specific fields merged into the outgoing request body, overriding
   // any same-named client fields (e.g. OpenRouter's `provider` routing
   // preferences pinning managed models to reliable hosts). openai-compat only.

--- a/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
+++ b/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
@@ -64,6 +64,49 @@ describe('buildAnthropicRequest', () => {
   });
 });
 
+describe('buildAnthropicRequest — tool_choice (SAFETY: none must not become auto)', () => {
+  const withTools = (tool_choice: unknown) => ({
+    messages: [{ role: 'user', content: 'go' }],
+    tools: [
+      { type: 'function', function: { name: 'search', description: 'd', parameters: { type: 'object' } } },
+    ],
+    tool_choice,
+  });
+
+  test("'none' maps to the explicit Anthropic {type:'none'} value, not omitted", () => {
+    const req = buildAnthropicRequest(withTools('none'), descriptor);
+    // Omitting tool_choice while `tools` is present defaults to Anthropic's own
+    // 'auto' — so 'none' must be sent explicitly or Claude could call a
+    // forbidden tool.
+    expect(req.payload.tool_choice).toEqual({ type: 'none' });
+  });
+
+  test("'auto' omits tool_choice (Anthropic's own default when tools are present)", () => {
+    const req = buildAnthropicRequest(withTools('auto'), descriptor);
+    expect(req.payload.tool_choice).toBeUndefined();
+  });
+
+  test('omitted/null tool_choice also omits it from the payload', () => {
+    const req = buildAnthropicRequest(withTools(undefined), descriptor);
+    expect(req.payload.tool_choice).toBeUndefined();
+    const req2 = buildAnthropicRequest(withTools(null), descriptor);
+    expect(req2.payload.tool_choice).toBeUndefined();
+  });
+
+  test("'required' maps to {type:'any'}", () => {
+    const req = buildAnthropicRequest(withTools('required'), descriptor);
+    expect(req.payload.tool_choice).toEqual({ type: 'any' });
+  });
+
+  test('a named function tool_choice maps to {type:"tool", name}', () => {
+    const req = buildAnthropicRequest(
+      withTools({ type: 'function', function: { name: 'search' } }),
+      descriptor,
+    );
+    expect(req.payload.tool_choice).toEqual({ type: 'tool', name: 'search' });
+  });
+});
+
 describe('buildAnthropicRequest — prompt caching', () => {
   test('marks system, the last tool, and the conversation tail as cacheable', () => {
     const req = buildAnthropicRequest(
@@ -114,6 +157,69 @@ describe('buildAnthropicRequest — prompt caching', () => {
     const tail = (req.payload as any).messages.at(-1).content;
     expect(tail[0].cache_control).toBeUndefined();
     expect(tail[1].cache_control).toEqual({ type: 'ephemeral' });
+  });
+});
+
+describe('buildAnthropicRequest — reasoning/thinking passthrough', () => {
+  test('reasoning_effort maps to a thinking.budget_tokens block instead of being dropped', () => {
+    const req = buildAnthropicRequest(
+      { messages: [{ role: 'user', content: 'hi' }], reasoning_effort: 'high' },
+      descriptor,
+    );
+    expect(req.payload.thinking).toEqual({ type: 'enabled', budget_tokens: 16000 });
+  });
+
+  test('an OpenAI-shaped reasoning object with an effort level translates too', () => {
+    const req = buildAnthropicRequest(
+      { messages: [{ role: 'user', content: 'hi' }], reasoning: { effort: 'medium' } },
+      descriptor,
+    );
+    expect(req.payload.thinking).toEqual({ type: 'enabled', budget_tokens: 8192 });
+  });
+
+  test('an explicit budget_tokens on reasoning wins over the effort table', () => {
+    const req = buildAnthropicRequest(
+      { messages: [{ role: 'user', content: 'hi' }], reasoning: { budget_tokens: 5000 } },
+      descriptor,
+    );
+    expect(req.payload.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+  });
+
+  test('a raw Anthropic-shaped thinking block passes through verbatim', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'enabled', budget_tokens: 10000 },
+      },
+      descriptor,
+    );
+    expect(req.payload.thinking).toEqual({ type: 'enabled', budget_tokens: 10000 });
+  });
+
+  test('no reasoning field at all omits thinking entirely (default behavior unchanged)', () => {
+    const req = buildAnthropicRequest({ messages: [{ role: 'user', content: 'hi' }] }, descriptor);
+    expect(req.payload.thinking).toBeUndefined();
+  });
+
+  test('bumps the default max_tokens ceiling so the thinking budget has room when the client set neither', () => {
+    const req = buildAnthropicRequest(
+      { messages: [{ role: 'user', content: 'hi' }], reasoning_effort: 'max' },
+      descriptor,
+    );
+    expect(req.payload.max_tokens).toBeGreaterThan((req.payload.thinking as any).budget_tokens);
+  });
+
+  test('clamps budget_tokens below an explicit, smaller client max_tokens rather than 400ing upstream', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [{ role: 'user', content: 'hi' }],
+        reasoning_effort: 'max',
+        max_tokens: 2000,
+      },
+      descriptor,
+    );
+    expect(req.payload.max_tokens).toBe(2000);
+    expect((req.payload.thinking as any).budget_tokens).toBeLessThan(2000);
   });
 });
 

--- a/packages/llm-gateway/src/transports/anthropic/request.ts
+++ b/packages/llm-gateway/src/transports/anthropic/request.ts
@@ -3,6 +3,12 @@ import type { UpstreamRequest } from '../openai-compat';
 
 const ANTHROPIC_VERSION = '2023-06-01';
 const DEFAULT_MAX_TOKENS = 4096;
+// When the client asks for extended thinking but doesn't set its own
+// max_tokens, the default above (4096) is too small to hold both the
+// thinking budget and a real answer — Anthropic requires
+// `thinking.budget_tokens < max_tokens`. Give thinking requests a generous
+// default ceiling instead of silently clamping the budget down to near-zero.
+const DEFAULT_MAX_TOKENS_WITH_THINKING = 32_000;
 
 function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '');
@@ -100,8 +106,61 @@ function translateTools(tools: any[]): any[] | undefined {
 
 function translateToolChoice(tc: unknown): unknown {
   if (tc === 'required') return { type: 'any' };
-  if (tc === 'auto' || tc === 'none' || tc == null) return undefined;
+  // 'auto' (and omitted/null) map to `undefined` because Anthropic's own
+  // default when `tools` are present is already `{type:'auto'}` — no need to
+  // send it explicitly. 'none' must NOT collapse the same way: Anthropic has
+  // no implicit "don't use tools" default, so omitting tool_choice here while
+  // `tools` is still attached would silently let Claude call a tool the
+  // caller explicitly forbade (SAFETY: gateway audit finding, tool_choice:'none'
+  // regression). `{type:'none'}` is a distinct, documented Anthropic value.
+  if (tc === 'auto' || tc == null) return undefined;
+  if (tc === 'none') return { type: 'none' };
   if (typeof tc === 'object' && (tc as any).function?.name) return { type: 'tool', name: (tc as any).function.name };
+  return undefined;
+}
+
+// Client-supplied `reasoning_effort` (OpenAI/opencode-shaped) maps to a
+// concrete Anthropic `thinking.budget_tokens`. Coarse but documented — an
+// explicit `budget_tokens`/`max_tokens` on `body.reasoning`, or a raw
+// Anthropic-shaped `body.thinking` block, always wins over this table.
+const REASONING_EFFORT_BUDGET_TOKENS: Record<string, number> = {
+  minimal: 1024,
+  low: 2048,
+  medium: 8192,
+  high: 16000,
+  max: 32000,
+};
+
+// Client-requested reasoning/extended-thinking previously vanished silently
+// for Anthropic (and Bedrock, which shares this payload builder): the gateway
+// only forwarded it for the openai-responses transport. Translate whatever
+// shape the client sent into Anthropic's `thinking: {type:'enabled',
+// budget_tokens}` block instead of dropping it.
+function translateThinking(body: Record<string, any>): { type: 'enabled'; budget_tokens: number } | undefined {
+  // Already Anthropic-shaped — pass through verbatim (still subject to the
+  // budget_tokens < max_tokens clamp applied by the caller).
+  if (body.thinking && typeof body.thinking === 'object') {
+    const budget = (body.thinking as any).budget_tokens;
+    if ((body.thinking as any).type === 'enabled' && typeof budget === 'number' && budget > 0) {
+      return { type: 'enabled', budget_tokens: budget };
+    }
+    return undefined;
+  }
+
+  const reasoning = body.reasoning;
+  if (reasoning && typeof reasoning === 'object') {
+    const explicit = (reasoning as any).budget_tokens ?? (reasoning as any).max_tokens;
+    if (typeof explicit === 'number' && explicit > 0) return { type: 'enabled', budget_tokens: explicit };
+    const effort = (reasoning as any).effort;
+    if (typeof effort === 'string' && REASONING_EFFORT_BUDGET_TOKENS[effort] != null) {
+      return { type: 'enabled', budget_tokens: REASONING_EFFORT_BUDGET_TOKENS[effort] };
+    }
+  }
+
+  if (typeof body.reasoning_effort === 'string' && REASONING_EFFORT_BUDGET_TOKENS[body.reasoning_effort] != null) {
+    return { type: 'enabled', budget_tokens: REASONING_EFFORT_BUDGET_TOKENS[body.reasoning_effort] };
+  }
+
   return undefined;
 }
 
@@ -135,8 +194,13 @@ function applyPromptCaching(payload: Record<string, any>): void {
 export function buildAnthropicCorePayload(body: Record<string, any>): Record<string, unknown> {
   const { system, messages } = translateMessages(body.messages ?? []);
 
+  const explicitMaxTokens = body.max_tokens ?? body.max_completion_tokens;
+  const thinking = translateThinking(body);
+  const maxTokens =
+    explicitMaxTokens ?? (thinking ? DEFAULT_MAX_TOKENS_WITH_THINKING : DEFAULT_MAX_TOKENS);
+
   const payload: Record<string, unknown> = {
-    max_tokens: body.max_tokens ?? body.max_completion_tokens ?? DEFAULT_MAX_TOKENS,
+    max_tokens: maxTokens,
     messages,
   };
   if (system) payload.system = system;
@@ -148,6 +212,12 @@ export function buildAnthropicCorePayload(body: Record<string, any>): Record<str
   if (tools) payload.tools = tools;
   const toolChoice = translateToolChoice(body.tool_choice);
   if (toolChoice) payload.tool_choice = toolChoice;
+
+  if (thinking) {
+    // Anthropic requires budget_tokens < max_tokens; clamp instead of 400ing
+    // on a client-set combination that doesn't leave room for the answer.
+    payload.thinking = { ...thinking, budget_tokens: Math.min(thinking.budget_tokens, Math.max(1024, maxTokens - 1024)) };
+  }
 
   applyPromptCaching(payload);
   return payload;

--- a/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
@@ -50,3 +50,51 @@ describe('buildBedrockRequest', () => {
     });
   });
 });
+
+describe('buildBedrockRequest — reasoning/thinking (inherits the anthropic core payload)', () => {
+  test('reasoning_effort translates to a thinking.budget_tokens block, not silently dropped', () => {
+    const req = buildBedrockRequest(
+      { messages: [{ role: 'user', content: 'hi' }], reasoning_effort: 'high' },
+      descriptor,
+    );
+    expect((req.payload as any).thinking).toEqual({ type: 'enabled', budget_tokens: 16000 });
+  });
+});
+
+describe('buildBedrockRequest — tool_choice (SAFETY: inherits the anthropic core payload)', () => {
+  const withTools = (tool_choice: unknown) => ({
+    messages: [{ role: 'user', content: 'go' }],
+    tools: [{ type: 'function', function: { name: 'search', parameters: { type: 'object' } } }],
+    tool_choice,
+  });
+
+  test("'none' maps to the explicit {type:'none'} value, not omitted", () => {
+    const req = buildBedrockRequest(withTools('none'), descriptor);
+    expect((req.payload as any).tool_choice).toEqual({ type: 'none' });
+  });
+
+  test("'auto' omits tool_choice", () => {
+    const req = buildBedrockRequest(withTools('auto'), descriptor);
+    expect((req.payload as any).tool_choice).toBeUndefined();
+  });
+
+  test('omitted/null tool_choice omits it from the payload', () => {
+    const req = buildBedrockRequest(withTools(undefined), descriptor);
+    expect((req.payload as any).tool_choice).toBeUndefined();
+    const req2 = buildBedrockRequest(withTools(null), descriptor);
+    expect((req2.payload as any).tool_choice).toBeUndefined();
+  });
+
+  test("'required' maps to {type:'any'}", () => {
+    const req = buildBedrockRequest(withTools('required'), descriptor);
+    expect((req.payload as any).tool_choice).toEqual({ type: 'any' });
+  });
+
+  test('a named function tool_choice maps to {type:"tool", name}', () => {
+    const req = buildBedrockRequest(
+      withTools({ type: 'function', function: { name: 'search' } }),
+      descriptor,
+    );
+    expect((req.payload as any).tool_choice).toEqual({ type: 'tool', name: 'search' });
+  });
+});

--- a/packages/llm-gateway/src/transports/bedrock/response.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock/response.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'bun:test';
+
+import { bedrockEventStreamToSse, translateBedrockResponse } from './response';
+
+// ---- AWS event-stream binary frame test helpers -----------------------------
+//
+// Frame layout: [total:u32][headers-len:u32][prelude-crc:u32][headers][payload][message-crc:u32]
+// CRCs are never validated by the parser under test, so placeholder zero
+// bytes are fine here.
+
+function u32(n: number): Uint8Array {
+  return new Uint8Array([(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]);
+}
+
+function concatAll(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+}
+
+function encodeStringHeader(name: string, value: string): Uint8Array {
+  const nameBytes = new TextEncoder().encode(name);
+  const valueBytes = new TextEncoder().encode(value);
+  const out = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
+  let o = 0;
+  out[o++] = nameBytes.length;
+  out.set(nameBytes, o);
+  o += nameBytes.length;
+  out[o++] = 7; // header value type: string
+  out[o++] = (valueBytes.length >> 8) & 0xff;
+  out[o++] = valueBytes.length & 0xff;
+  out.set(valueBytes, o);
+  return out;
+}
+
+function encodeFrame(headers: Record<string, string>, payload: unknown): Uint8Array {
+  const headerBytes = concatAll(...Object.entries(headers).map(([k, v]) => encodeStringHeader(k, v)));
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(payload));
+  const headersLen = headerBytes.length;
+  const total = 4 + 4 + 4 + headersLen + payloadBytes.length + 4;
+  return concatAll(u32(total), u32(headersLen), u32(0), headerBytes, payloadBytes, u32(0));
+}
+
+function chunkFrame(anthropicEvent: unknown): Uint8Array {
+  const bytes = btoa(JSON.stringify(anthropicEvent));
+  return encodeFrame({ ':message-type': 'event', ':event-type': 'chunk' }, { bytes });
+}
+
+function exceptionFrame(exceptionType: string, message: string): Uint8Array {
+  return encodeFrame(
+    { ':message-type': 'exception', ':exception-type': exceptionType },
+    { message },
+  );
+}
+
+function streamResponse(chunks: Uint8Array[]): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(c);
+        controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+async function collectSse(response: Response): Promise<string> {
+  return new Response(response.body).text();
+}
+
+describe('bedrockEventStreamToSse', () => {
+  test('reassembles a normal multi-frame stream into `data:` SSE lines', async () => {
+    const upstream = streamResponse([
+      concatAll(
+        chunkFrame({ type: 'message_start', message: { id: 'm1', model: 'x', usage: { input_tokens: 1 } } }),
+        chunkFrame({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } }),
+      ),
+    ]);
+    const sse = await collectSse(bedrockEventStreamToSse(upstream));
+    const dataLines = sse
+      .split('\n\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => JSON.parse(l.slice(5).trim()));
+    expect(dataLines).toHaveLength(2);
+    expect(dataLines[0].type).toBe('message_start');
+    expect(dataLines[1].type).toBe('content_block_delta');
+    expect(dataLines[1].delta.text).toBe('hi');
+  });
+
+  test('reassembles a frame split across two chunk reads (partial-frame carryover)', async () => {
+    const frame = chunkFrame({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'split-ok' } });
+    const splitAt = Math.floor(frame.length / 2);
+    const upstream = streamResponse([frame.subarray(0, splitAt), frame.subarray(splitAt)]);
+    const sse = await collectSse(bedrockEventStreamToSse(upstream));
+    expect(sse).toContain('split-ok');
+    const dataLine = sse.split('\n\n').find((l) => l.startsWith('data:'))!;
+    const parsed = JSON.parse(dataLine.slice(5).trim());
+    expect(parsed.delta.text).toBe('split-ok');
+  });
+
+  test('surfaces an exception/error frame as a client-facing error SSE event, not just a console.warn', async () => {
+    const upstream = streamResponse([
+      concatAll(
+        chunkFrame({ type: 'message_start', message: { id: 'm1', model: 'x', usage: { input_tokens: 1 } } }),
+        exceptionFrame('ThrottlingException', 'Too many requests, please wait and try again.'),
+      ),
+    ]);
+    const sse = await collectSse(bedrockEventStreamToSse(upstream));
+    expect(sse).toContain('event: error');
+    const frames = sse.split('\n\n').filter(Boolean);
+    const errorFrameText = frames.find((f) => f.includes('event: error'))!;
+    const dataLine = errorFrameText.split('\n').find((l) => l.startsWith('data:'))!;
+    const parsed = JSON.parse(dataLine.slice(5).trim());
+    expect(parsed.type).toBe('error');
+    expect(parsed.error.type).toBe('ThrottlingException');
+    expect(parsed.error.message).toContain('Too many requests');
+  });
+
+  test('a desynced/undersized frame terminates the stream cleanly instead of hanging or spinning', async () => {
+    // total length below the 16-byte minimum frame size => desync.
+    const garbage = concatAll(u32(4), new Uint8Array([1, 2, 3, 4]));
+    const upstream = streamResponse([garbage]);
+    const sse = await Promise.race([
+      collectSse(bedrockEventStreamToSse(upstream)),
+      new Promise<string>((_, reject) => setTimeout(() => reject(new Error('hung')), 2000)),
+    ]);
+    // No data frames emitted, and the call resolved (didn't hang / throw).
+    expect(sse).not.toContain('data:');
+  });
+
+  test('an exception frame with an unparsable payload still surfaces an error, not a silent drop', async () => {
+    // Build a frame whose payload is not valid JSON, but whose headers still
+    // mark it as an exception — the parser must not rely on payload JSON
+    // parsing succeeding to recognize an exception frame.
+    const headerBytes = encodeStringHeader(':message-type', 'exception');
+    const payloadBytes = new TextEncoder().encode('not-json{{{');
+    const total = 4 + 4 + 4 + headerBytes.length + payloadBytes.length + 4;
+    const frame = concatAll(u32(total), u32(headerBytes.length), u32(0), headerBytes, payloadBytes, u32(0));
+
+    const upstream = streamResponse([frame]);
+    const sse = await collectSse(bedrockEventStreamToSse(upstream));
+    expect(sse).toContain('event: error');
+  });
+});
+
+describe('translateBedrockResponse (streaming) — end to end through the Anthropic SSE translator', () => {
+  test('a mid-stream exception frame comes out as an OpenAI-shaped error chunk', async () => {
+    const upstream = streamResponse([
+      concatAll(
+        chunkFrame({ type: 'message_start', message: { id: 'm1', model: 'x', usage: { input_tokens: 1 } } }),
+        exceptionFrame('ModelStreamErrorException', 'Malformed model output'),
+      ),
+    ]);
+    const out = await translateBedrockResponse(upstream, { streaming: true });
+    const text = await new Response((out as Response).body).text();
+    const errorLine = text
+      .split('\n')
+      .find((l) => l.startsWith('data:') && l.includes('"error"'))!;
+    const parsed = JSON.parse(errorLine.slice(5).trim());
+    expect(parsed.error.type).toBe('ModelStreamErrorException');
+    expect(parsed.error.message).toBe('Malformed model output');
+  });
+});

--- a/packages/llm-gateway/src/transports/bedrock/response.ts
+++ b/packages/llm-gateway/src/transports/bedrock/response.ts
@@ -18,6 +18,98 @@ function base64ToBytes(b64: string): Uint8Array {
   return out;
 }
 
+type HeaderValue = string | number | boolean | Uint8Array;
+
+// Minimal parser for AWS event-stream headers (vnd.amazon.event-stream), used
+// by Bedrock's InvokeModelWithResponseStream. Each header is
+// [name-len:1][name][type:1][value...], repeated until `length` bytes are
+// consumed. We only need enough of this to read `:message-type` /
+// `:exception-type` (both type 7 / string), but the other AWS-defined value
+// types are decoded too so an unexpected-but-valid header never desyncs the
+// parse of the headers that follow it.
+function parseHeaders(buf: Uint8Array, offset: number, length: number): Record<string, HeaderValue> {
+  const headers: Record<string, HeaderValue> = {};
+  const decoder = new TextDecoder();
+  const end = offset + length;
+  let p = offset;
+  while (p < end) {
+    if (p + 2 > end) break;
+    const nameLen = buf[p];
+    p += 1;
+    if (p + nameLen + 1 > end) break;
+    const name = decoder.decode(buf.subarray(p, p + nameLen));
+    p += nameLen;
+    const type = buf[p];
+    p += 1;
+    switch (type) {
+      case 0: // bool true
+        headers[name] = true;
+        break;
+      case 1: // bool false
+        headers[name] = false;
+        break;
+      case 2: // byte
+        headers[name] = buf[p];
+        p += 1;
+        break;
+      case 3: // short (int16)
+        headers[name] = (buf[p] << 8) | buf[p + 1];
+        p += 2;
+        break;
+      case 4: // int32
+        headers[name] = readU32(buf, p) | 0;
+        p += 4;
+        break;
+      case 5: {
+        // int64 — best-effort as a JS number; large enough for anything
+        // Bedrock actually sends in a header value.
+        let value = 0;
+        for (let i = 0; i < 8; i += 1) value = value * 256 + buf[p + i];
+        headers[name] = value;
+        p += 8;
+        break;
+      }
+      case 6: {
+        // byte array: 2-byte length prefix + bytes.
+        const len = (buf[p] << 8) | buf[p + 1];
+        p += 2;
+        headers[name] = buf.subarray(p, p + len);
+        p += len;
+        break;
+      }
+      case 7: {
+        // string: 2-byte length prefix + utf8 bytes.
+        const len = (buf[p] << 8) | buf[p + 1];
+        p += 2;
+        headers[name] = decoder.decode(buf.subarray(p, p + len));
+        p += len;
+        break;
+      }
+      case 8: // timestamp (int64 ms) — unused here, skip the bytes.
+        p += 8;
+        break;
+      case 9: // uuid (16 bytes)
+        headers[name] = buf.subarray(p, p + 16);
+        p += 16;
+        break;
+      default:
+        // Unknown/unsupported value type: can't know its width, so stop
+        // reading headers rather than risk misinterpreting subsequent bytes.
+        return headers;
+    }
+  }
+  return headers;
+}
+
+function isExceptionFrame(headers: Record<string, HeaderValue>, frame: { bytes?: string }): boolean {
+  const messageType = headers[':message-type'];
+  if (messageType === 'exception' || messageType === 'error') return true;
+  // Fall back to the shape heuristic (a normal chunk frame always carries
+  // `bytes`) for older/self-hosted Bedrock-compatible endpoints that don't
+  // set `:message-type`.
+  return typeof frame.bytes !== 'string';
+}
+
 function bedrockEventStreamToSse(response: Response): Response {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
@@ -47,23 +139,40 @@ function bedrockEventStreamToSse(response: Response): Response {
             if (total < 16) break outer;
             if (buf.length - pos < total) break;
             const headersLen = readU32(buf, pos + 4);
+            const headers = parseHeaders(buf, pos + 12, headersLen);
             const payload = buf.subarray(pos + 12 + headersLen, pos + total - 4);
             pos += total;
 
-            let frame: { bytes?: string; message?: string };
+            let frame: { bytes?: string; message?: string; Message?: string } = {};
+            let payloadParsed = true;
             try {
               frame = JSON.parse(decoder.decode(payload));
             } catch {
+              payloadParsed = false;
+            }
+
+            if (isExceptionFrame(headers, frame)) {
+              // Exception/error frame (throttling, model stream error, etc.) —
+              // surface it to the client as a canonical error SSE event
+              // instead of only logging it server-side and silently
+              // truncating the stream to a clean-looking 200.
+              const exceptionType =
+                typeof headers[':exception-type'] === 'string'
+                  ? (headers[':exception-type'] as string)
+                  : 'bedrock_stream_exception';
+              const message =
+                (payloadParsed && (frame.message ?? frame.Message)) ||
+                (payloadParsed ? JSON.stringify(frame) : decoder.decode(payload)) ||
+                'bedrock event-stream error frame';
+              console.warn('[bedrock] event-stream error frame:', exceptionType, message);
+              const errorEvent = { type: 'error', error: { type: exceptionType, message } };
+              controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify(errorEvent)}\n\n`));
               continue;
             }
+
             if (typeof frame.bytes === 'string') {
               const eventJson = decoder.decode(base64ToBytes(frame.bytes));
               controller.enqueue(encoder.encode(`data: ${eventJson}\n\n`));
-            } else {
-              // Exception/error frame (throttling, model stream error) — no
-              // payload bytes. Surface it instead of silently truncating to a
-              // 200, so the failure is visible upstream.
-              console.warn('[bedrock] event-stream error frame:', frame.message ?? JSON.stringify(frame));
             }
           }
         }
@@ -91,3 +200,5 @@ export function translateBedrockResponse(
   }
   return translateAnthropicResponse(response, { streaming: false });
 }
+
+export { bedrockEventStreamToSse };

--- a/packages/llm-gateway/src/transports/openai-compat/index.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/index.ts
@@ -45,6 +45,95 @@ function translateMaxTokensForGenuineOpenAi(
   return { ...rest, max_completion_tokens: max_tokens };
 }
 
+// OpenAI's chat/completions endpoint rejects several more sampling params
+// outright for the same reasoning-restricted models the max_tokens
+// translation above targets (o-series, gpt-5.x): temperature/top_p only
+// accept the default value ("Unsupported value: temperature does not support
+// ... only the default (1) value"), and logprobs/penalties/logit_bias 400
+// entirely. Gated on `descriptor.temperature === false` — the SAME capability
+// flag the client-facing model picker already uses to grey out the
+// temperature control (mirrored from models.dev via
+// apps/api/.../catalog-models.ts capabilitiesForModel) — rather than a
+// hardcoded model-id list, so it tracks the catalog without needing upkeep as
+// OpenAI ships new reasoning-model families.
+const REASONING_RESTRICTED_SAMPLING_PARAMS = [
+  'temperature',
+  'top_p',
+  'presence_penalty',
+  'frequency_penalty',
+  'logprobs',
+  'top_logprobs',
+  'logit_bias',
+] as const;
+
+function stripReasoningRestrictedSamplingParams(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!REASONING_RESTRICTED_SAMPLING_PARAMS.some((key) => key in payload)) return payload;
+  const next = { ...payload };
+  for (const key of REASONING_RESTRICTED_SAMPLING_PARAMS) delete next[key];
+  return next;
+}
+
+// Perplexity's Sonar chat/completions endpoint enforces strict role
+// alternation after any leading system message(s): two consecutive
+// user/assistant/tool turns 400 with "messages should alternate". Normal
+// opencode tool-calling sessions routinely produce back-to-back same-role
+// turns (e.g. a `tool` result immediately followed by another `user` message,
+// or two consecutive `tool` results), so — scoped to Perplexity only — merge
+// consecutive same-effective-role messages instead of forwarding the raw
+// array untouched. `tool` has no Perplexity-native equivalent, so it's folded
+// into the surrounding `user` turn for alternation purposes.
+function effectiveRole(role: unknown): unknown {
+  return role === 'tool' ? 'user' : role;
+}
+
+function contentToParts(content: unknown): Array<Record<string, unknown>> {
+  if (typeof content === 'string') return content ? [{ type: 'text', text: content }] : [];
+  if (Array.isArray(content)) return content as Array<Record<string, unknown>>;
+  return [];
+}
+
+function mergeContent(a: unknown, b: unknown): unknown {
+  if (typeof a === 'string' && typeof b === 'string') return [a, b].filter(Boolean).join('\n\n');
+  return [...contentToParts(a), ...contentToParts(b)];
+}
+
+function mergeSameRoleMessages(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...a, content: mergeContent(a.content, b.content) };
+  const toolCallsA = Array.isArray(a.tool_calls) ? (a.tool_calls as unknown[]) : undefined;
+  const toolCallsB = Array.isArray(b.tool_calls) ? (b.tool_calls as unknown[]) : undefined;
+  if (toolCallsA || toolCallsB) merged.tool_calls = [...(toolCallsA ?? []), ...(toolCallsB ?? [])];
+  return merged;
+}
+
+function normalizeRoleSequenceForPerplexity(messages: unknown[]): unknown[] {
+  const out: Array<Record<string, unknown>> = [];
+  for (const raw of messages) {
+    if (!raw || typeof raw !== 'object') {
+      out.push(raw as Record<string, unknown>);
+      continue;
+    }
+    const message = raw as Record<string, unknown>;
+    // System messages don't participate in the alternation requirement and
+    // may repeat/lead freely — never merged into or with anything.
+    if (message.role === 'system') {
+      out.push(message);
+      continue;
+    }
+    const prev = out[out.length - 1];
+    if (prev && prev.role !== 'system' && effectiveRole(prev.role) === effectiveRole(message.role)) {
+      out[out.length - 1] = mergeSameRoleMessages(prev, message);
+      continue;
+    }
+    out.push(message);
+  }
+  return out;
+}
+
 export function buildUpstreamRequest(
   body: Record<string, unknown>,
   descriptor: UpstreamDescriptor,
@@ -62,6 +151,12 @@ export function buildUpstreamRequest(
   if (descriptor.resolvedModel) payload = { ...payload, model: descriptor.resolvedModel };
   if (isGenuineOpenAiUpstream(descriptor.baseUrl)) {
     payload = translateMaxTokensForGenuineOpenAi(payload);
+    if (descriptor.temperature === false) {
+      payload = stripReasoningRestrictedSamplingParams(payload);
+    }
+  }
+  if (descriptor.provider === 'perplexity' && Array.isArray(payload.messages)) {
+    payload = { ...payload, messages: normalizeRoleSequenceForPerplexity(payload.messages as unknown[]) };
   }
 
   return {

--- a/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
@@ -109,6 +109,195 @@ describe('openai-compat max_tokens -> max_completion_tokens translation', () => 
   });
 });
 
+describe('openai-compat: reasoning-restricted sampling params for genuine OpenAI', () => {
+  const reasoningModelDescriptor: UpstreamDescriptor = {
+    ...descriptor,
+    provider: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    resolvedModel: 'gpt-5.6-sol',
+    temperature: false,
+  };
+
+  test('strips temperature/top_p/penalties/logprobs for a genuine-OpenAI reasoning model', () => {
+    const req = buildUpstreamRequest(
+      {
+        model: 'openai/gpt-5.6-sol',
+        messages: [],
+        temperature: 0.4,
+        top_p: 0.9,
+        presence_penalty: 0.2,
+        frequency_penalty: 0.1,
+        logprobs: true,
+        top_logprobs: 3,
+        logit_bias: { '123': 1 },
+      },
+      reasoningModelDescriptor,
+    );
+    for (const key of [
+      'temperature',
+      'top_p',
+      'presence_penalty',
+      'frequency_penalty',
+      'logprobs',
+      'top_logprobs',
+      'logit_bias',
+    ]) {
+      expect(key in req.payload).toBe(false);
+    }
+  });
+
+  test('leaves sampling params alone for a non-reasoning genuine-OpenAI model (capability flag true)', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openai/gpt-4.1', messages: [], temperature: 0.4, top_p: 0.9 },
+      { ...reasoningModelDescriptor, resolvedModel: 'gpt-4.1', temperature: true },
+    );
+    expect(req.payload.temperature).toBe(0.4);
+    expect(req.payload.top_p).toBe(0.9);
+  });
+
+  test('leaves sampling params alone when the capability flag is unknown (undefined)', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openai/some-model', messages: [], temperature: 0.4 },
+      { ...reasoningModelDescriptor, temperature: undefined },
+    );
+    expect(req.payload.temperature).toBe(0.4);
+  });
+
+  test('does not strip sampling params for a reasoning-marked model on a DIFFERENT openai-compat host (OpenRouter)', () => {
+    const req = buildUpstreamRequest(
+      { model: 'kortix/o3', messages: [], temperature: 0.4, top_p: 0.9 },
+      {
+        ...descriptor,
+        provider: 'openrouter',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        temperature: false,
+      },
+    );
+    expect(req.payload.temperature).toBe(0.4);
+    expect(req.payload.top_p).toBe(0.9);
+  });
+
+  test('does not touch max_tokens translation behavior (both fixes compose cleanly)', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openai/gpt-5.6-sol', messages: [], max_tokens: 4096, temperature: 0.7 },
+      reasoningModelDescriptor,
+    );
+    expect(req.payload.max_completion_tokens).toBe(4096);
+    expect('max_tokens' in req.payload).toBe(false);
+    expect('temperature' in req.payload).toBe(false);
+  });
+});
+
+describe('openai-compat: Perplexity role-sequence normalization', () => {
+  const perplexityDescriptor: UpstreamDescriptor = {
+    ...descriptor,
+    provider: 'perplexity',
+    baseUrl: 'https://api.perplexity.ai',
+    resolvedModel: 'sonar-pro',
+  };
+
+  test('merges two consecutive user messages into one', () => {
+    const req = buildUpstreamRequest(
+      {
+        model: 'perplexity/sonar-pro',
+        messages: [
+          { role: 'user', content: 'first' },
+          { role: 'user', content: 'second' },
+        ],
+      },
+      perplexityDescriptor,
+    );
+    const messages = req.payload.messages as any[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].content).toBe('first\n\nsecond');
+  });
+
+  test('folds a `tool` result into the preceding user turn (no native tool role on Perplexity)', () => {
+    const req = buildUpstreamRequest(
+      {
+        model: 'perplexity/sonar-pro',
+        messages: [
+          { role: 'user', content: 'question' },
+          { role: 'tool', tool_call_id: 't1', content: 'tool result' },
+        ],
+      },
+      perplexityDescriptor,
+    );
+    const messages = req.payload.messages as any[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].content).toBe('question\n\ntool result');
+  });
+
+  test('a leading system message is preserved and never merged', () => {
+    const req = buildUpstreamRequest(
+      {
+        model: 'perplexity/sonar-pro',
+        messages: [
+          { role: 'system', content: 'be helpful' },
+          { role: 'user', content: 'first' },
+          { role: 'user', content: 'second' },
+        ],
+      },
+      perplexityDescriptor,
+    );
+    const messages = req.payload.messages as any[];
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toEqual({ role: 'system', content: 'be helpful' });
+    expect(messages[1].content).toBe('first\n\nsecond');
+  });
+
+  test('an already-alternating sequence passes through unchanged', () => {
+    const req = buildUpstreamRequest(
+      {
+        model: 'perplexity/sonar-pro',
+        messages: [
+          { role: 'user', content: 'q1' },
+          { role: 'assistant', content: 'a1' },
+          { role: 'user', content: 'q2' },
+        ],
+      },
+      perplexityDescriptor,
+    );
+    const messages = req.payload.messages as any[];
+    expect(messages).toHaveLength(3);
+    expect(messages.map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
+  });
+
+  test('does not touch message sequencing for a non-Perplexity provider, even with same-role runs', () => {
+    const req = buildUpstreamRequest(
+      {
+        model: 'kortix/glm-5.2',
+        messages: [
+          { role: 'user', content: 'first' },
+          { role: 'user', content: 'second' },
+        ],
+      },
+      { ...descriptor, provider: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1' },
+    );
+    const messages = req.payload.messages as any[];
+    expect(messages).toHaveLength(2);
+  });
+
+  test('merges consecutive assistant tool_calls arrays instead of dropping either', () => {
+    const req = buildUpstreamRequest(
+      {
+        model: 'perplexity/sonar-pro',
+        messages: [
+          { role: 'assistant', content: '', tool_calls: [{ id: 'a', type: 'function', function: { name: 'x', arguments: '{}' } }] },
+          { role: 'assistant', content: '', tool_calls: [{ id: 'b', type: 'function', function: { name: 'y', arguments: '{}' } }] },
+        ],
+      },
+      perplexityDescriptor,
+    );
+    const messages = req.payload.messages as any[];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].tool_calls).toHaveLength(2);
+    expect(messages[0].tool_calls.map((t: any) => t.id)).toEqual(['a', 'b']);
+  });
+});
+
 describe('openai-compat bodyExtras', () => {
   test('merges descriptor bodyExtras into the payload, overriding client fields', () => {
     const req = buildUpstreamRequest(


### PR DESCRIPTION
## Summary

Fixes the TRANSPORT-CORRECTNESS findings from the adversarially-verified LLM-gateway audit, including a safety-critical tool_choice bug.

1. **SAFETY-CRITICAL — `tool_choice:'none'` silently became Anthropic's default `auto`.** `translateToolChoice()` mapped OpenAI-shaped `tool_choice:'none'` to `undefined`; omitting `tool_choice` while `tools` is attached defaults to Anthropic's own `{type:'auto'}` — so a caller that explicitly forbade tool use could still have Claude invoke one. Now maps `'none'` to the distinct `{type:'none'}` value. Bedrock inherits the fix via `buildAnthropicCorePayload`. Tests cover all four `tool_choice` shapes on both transports.
2. **HIGH — openai-compat only translated `max_tokens`.** Extended the genuine-OpenAI translation (same `isGenuineOpenAiUpstream`-gated path #4805 added) to also strip `temperature`/`top_p`/`presence_penalty`/`frequency_penalty`/`logprobs`/`top_logprobs`/`logit_bias` for reasoning-restricted models, gated on a new `UpstreamDescriptor.temperature` capability flag sourced from the catalog (`capabilitiesForModel`, models.dev-enriched) rather than a hardcoded model list.
3. **HIGH — no role-sequence normalization**, breaking Perplexity's strict alternating-role requirement. Added a Perplexity-scoped normalizer that merges consecutive same-effective-role messages (folding `tool` into the surrounding `user` turn).
4. **HIGH — Bedrock's binary event-stream parser silently dropped exception frames** (only a `console.warn`, nothing surfaced to the client) and had zero tests. Now parses AWS event-stream headers well enough to read `:message-type`/`:exception-type` and enqueues a translated `event: error` SSE frame that flows through the existing Anthropic error-chunk handling. Added `response.test.ts`: normal multi-frame reassembly, a frame split across chunk reads, an exception frame (asserted to surface as a client-facing error, including end-to-end through `translateBedrockResponse`), a desynced/undersized frame terminating cleanly, and an exception frame with an unparsable JSON payload.
5. **MEDIUM — client-requested reasoning/thinking was silently dropped for Anthropic/Bedrock.** Translates `reasoning` / `reasoning_effort` / a raw Anthropic `thinking` block into `thinking:{type:'enabled', budget_tokens}`, clamped below `max_tokens` (bumping the default ceiling when the client didn't set one).
6. **LOW/MEDIUM — gpt-5.5 fallback `temperature` flag** — already fixed on main by #4809 (verified, no duplicate change needed here).

## Coordination

- Anthropic/Bedrock fixes (1, 4, 5) don't overlap any in-flight work.
- openai-compat fixes (2, 3) live in the same direct-translation path #4805 (`e437e6c02`) used, additive only (no renames of `buildUpstreamRequest`/`isGenuineOpenAiUpstream`/`translateMaxTokensForGenuineOpenAi`) — messaged the `feat/litellm-translation-sidecar` agent before editing to confirm boundaries; proceeded with an additive approach since these changes apply only when the sidecar's flag-gated path is off.
- Rebased onto latest `origin/main` (picked up #4805 and the follow-up #4809, which already fixed finding 6 — dropped the redundant local edit).

## Test plan

- [x] `bun run typecheck` clean for `packages/llm-gateway` and `apps/api`
- [x] `packages/llm-gateway`: `bun test` — 186 pass, 0 fail
- [x] `apps/api` touched files individually (`catalog-models.test.ts`, `unit-tier-model-entitlement.test.ts`, `managed-provider-disabled.test.ts`, `unit-resolve-candidates-free-tier.test.ts`) via `KORTIX_URL=http://localhost:8008 dotenvx run -- bun test <file>` — all pass except 2 pre-existing DB-dependency failures in `unit-resolve-candidates-free-tier.test.ts` (confirmed present on `origin/main` before this change too, unrelated to this diff)