### PR TITLE
test(llm-gateway): close coverage gaps + backlog hygiene (correlation id, key validation)

### DIFF
--- a/apps/api/src/llm-gateway/RELIABILITY-BACKLOG.md
+++ b/apps/api/src/llm-gateway/RELIABILITY-BACKLOG.md
@@ -57,8 +57,7 @@ managed fallback with tier gating), real unit tests on the core pipeline.
    cross-referenced against a provider's own request logs instead of manual
    timestamp/payload matching. requestId was already in logs/traces
    (`pipeline/trace.ts`) — only the wire hop to the provider was missing.
-   *(test: call-upstream.test.ts)* — PR test(llm-gateway): close coverage gaps
-   + backlog hygiene (correlation id, key validation).
+   *(test: call-upstream.test.ts)* — PR #4815.
 
 10. **`GATEWAY_INTERNAL_TOKEN` weak-secret boot warning** — `internal-auth.ts`
     + `internal-routes.ts`. `weakInternalTokenWarnings()` logs a loud
@@ -68,7 +67,7 @@ managed fallback with tier gating), real unit tests on the core pipeline.
     mTLS/HMAC upgrade should ever refuse traffic — it just makes a
     trivial/default static bearer secret impossible to leave unnoticed in a
     prod config. *(test: internal-auth.test.ts)* — cheap hardening only; see 7b
-    for the real gap this doesn't close.
+    for the real gap this doesn't close. PR #4815.
 
 11. **Gateway-key validation test coverage** — `gateway-keys.ts`.
     `validateGatewayKey` (the sole auth gate for every `kgw_...` request through
@@ -77,7 +76,7 @@ managed fallback with tier gating), real unit tests on the core pipeline.
     accepts, revoked rejects, past-expiry rejects, the exact expiry-boundary
     instant, `createdBy` null → `userId` falls back to `accountId`, an unknown
     secret, and the fire-and-forget `lastUsedAt` stamp. *(test:
-    gateway-keys.test.ts)*
+    gateway-keys.test.ts)* — PR #4815.
 
 12. **Tier gating + BYOK free-tier `billingMode` test coverage** —
     `resolution/resolve-candidates.ts`. `resolveCandidates` (BYOK markup/
@@ -86,7 +85,7 @@ managed fallback with tier gating), real unit tests on the core pipeline.
     TTL cache now takes an injectable `now` (defaults to `Date.now()`, every
     production call site unaffected) so the TTL boundary and the "tier change
     during the cache window" bug shape are both unit-testable without a real
-    wall-clock sleep. *(test: resolution/resolve-candidates.test.ts)*
+    wall-clock sleep. *(test: resolution/resolve-candidates.test.ts)* — PR #4815.
 
 ## ◻️ Remaining (need design / infra, not a code tweak)
 

--- a/apps/api/src/llm-gateway/RELIABILITY-BACKLOG.md
+++ b/apps/api/src/llm-gateway/RELIABILITY-BACKLOG.md
@@ -42,11 +42,51 @@ managed fallback with tier gating), real unit tests on the core pipeline.
    `internal-auth.ts` + `internal-routes.ts`
    `GATEWAY_INTERNAL_TOKEN` accepts a comma-separated list (zero-downtime
    rotation) and is compared with `crypto.timingSafeEqual`. *(test:
-   internal-auth.test.ts)* — full mTLS/HMAC remains infra work (below).
+   internal-auth.test.ts)* — full mTLS/HMAC remains infra work (see 7b below).
 
 8. **Missing-pricing no longer silently bills $0** — `pipeline/handler.ts`
    A billable request that prices to $0 (stale catalog → no pricing for the
    resolved model) now logs a warning so the revenue leak is visible.
+
+9. **Correlation ID threaded to the upstream call** — `http/call-upstream.ts` +
+   `pipeline/failover.ts`. `callUpstream()` now accepts a `requestId` and sends
+   it as `x-kortix-request-id` on every outbound provider request (all
+   transports — set centrally after `transport.buildRequest()`, not per
+   transport, so it can't drift out of sync with them); `runFailover` passes
+   its existing `requestId` through. A failed/slow completion can now be
+   cross-referenced against a provider's own request logs instead of manual
+   timestamp/payload matching. requestId was already in logs/traces
+   (`pipeline/trace.ts`) — only the wire hop to the provider was missing.
+   *(test: call-upstream.test.ts)* — PR test(llm-gateway): close coverage gaps
+   + backlog hygiene (correlation id, key validation).
+
+10. **`GATEWAY_INTERNAL_TOKEN` weak-secret boot warning** — `internal-auth.ts`
+    + `internal-routes.ts`. `weakInternalTokenWarnings()` logs a loud
+    `[gateway-internal-auth]` warning at boot when the configured token (or any
+    entry in the rotation CSV) is under 24 chars or matches a known-weak/default
+    value (`test`, `changeme`, etc.). This does not block startup — only a real
+    mTLS/HMAC upgrade should ever refuse traffic — it just makes a
+    trivial/default static bearer secret impossible to leave unnoticed in a
+    prod config. *(test: internal-auth.test.ts)* — cheap hardening only; see 7b
+    for the real gap this doesn't close.
+
+11. **Gateway-key validation test coverage** — `gateway-keys.ts`.
+    `validateGatewayKey` (the sole auth gate for every `kgw_...` request through
+    the standalone/out-of-process `/internal/gateway` RPC path) had zero tests.
+    Added a real-DB suite covering: active/no-expiry accepts, future-expiry
+    accepts, revoked rejects, past-expiry rejects, the exact expiry-boundary
+    instant, `createdBy` null → `userId` falls back to `accountId`, an unknown
+    secret, and the fire-and-forget `lastUsedAt` stamp. *(test:
+    gateway-keys.test.ts)*
+
+12. **Tier gating + BYOK free-tier `billingMode` test coverage** —
+    `resolution/resolve-candidates.ts`. `resolveCandidates` (BYOK markup/
+    free-tier billing-mode branch, managed-model tier gating, managed-fallback
+    queuing, codex routing) had zero tests. `resolveCachedAccountTier`'s 30s
+    TTL cache now takes an injectable `now` (defaults to `Date.now()`, every
+    production call site unaffected) so the TTL boundary and the "tier change
+    during the cache window" bug shape are both unit-testable without a real
+    wall-clock sleep. *(test: resolution/resolve-candidates.test.ts)*
 
 ## ◻️ Remaining (need design / infra, not a code tweak)
 
@@ -56,25 +96,75 @@ managed fallback with tier gating), real unit tests on the core pipeline.
    (hold) row or a DB-level atomic decrement — a schema + billing-path change
    that should land on its own, reviewed, with its own tests. Overshoot is
    bounded and the gateway is otherwise correct, so this is deferred deliberately.
+   Status as of this pass: still open — tracked separately from tonight's
+   `checkBudget` warn-action fix (item below), which does not change the
+   check-then-act race.
 
-7b. **Mutual auth API ↔ standalone pod** — beyond the rotation/timing-safe fix
-   above, real hardening (mTLS or HMAC request signing) is an infra/deployment
-   change, not a code edit. Tracked here.
+7b. **Mutual auth API ↔ standalone pod — threat model & scoped follow-up.**
+   Current state after items 7 and 10: `GATEWAY_INTERNAL_TOKEN` is a shared
+   static bearer, comma-rotatable, compared timing-safe, with a boot-time
+   weak-secret warning. There is still no host/identity binding — anything
+   holding the token can call the full `/internal/gateway/*` surface
+   (authenticate, authorize, resolve-route, resolve-upstream, budget-check,
+   record-usage, persist-trace) from anywhere on the network.
+   - **Threat model:** the credential is a single Kubernetes/ECS secret shared
+     between exactly two known hosts (the API and the standalone gateway pod).
+     The realistic exposure is credential leakage (env dump, log line,
+     misconfigured secrets sync — the same class of incident as the prior
+     `CLOUDFLARE_GLOBAL_API_KEY` plaintext-rotation incident), not on-path
+     interception (both hops are already inside the cluster's private network,
+     TLS-terminated at the ingress). A leaked token lets an attacker read/mint
+     usage records and drive routing decisions for any principal it can name,
+     but cannot itself exfiltrate provider credentials (those stay resolved
+     server-side, never returned over this RPC) or bypass the per-request
+     account/project auth done upstream of these routes.
+   - **Why not tonight:** a real fix is mTLS (both hosts already have a
+     private DNS identity + the cluster's own CA — this is provisioning/infra
+     work, not app code) or HMAC-signed requests (needs a signing-key
+     distribution + clock-skew/replay-window design — a small protocol change
+     that deserves its own review and tests, not a same-night addition next to
+     five other fixes). Neither is a "cheap" change; both are real scope.
+   - **Recommended next step:** HMAC request signing is the lower-lift of the
+     two (no infra/cert-issuance dependency) — sign `{method, path, body-hash,
+     timestamp}` with a key distributed the same way `GATEWAY_INTERNAL_TOKEN`
+     is today, reject requests outside a small clock-skew window. Rough size:
+     similar to item 7 (a `internal-auth.ts`-sized module + tests) plus a
+     client-side signer in `apps/llm-gateway/src/clients/api-client.ts`.
+     Tracked here as the next infra-adjacent pass on this RPC boundary, not
+     scheduled.
 
-- **Correlation ID to upstream** — propagate `requestId` as a header for
-  cross-provider tracing (minor; needs threading requestId into `callUpstream`).
 - **Heartbeat read loop after client disconnect** — currently we keep draining
   upstream to capture full usage even when the client is gone. Intentional
   (billing completeness > the minor wasted read); revisit only if it shows up in
   profiles.
 - **Gateway-key `lastUsedAt`** is fire-and-forget (stale admin view only).
-- **Idempotency key** — client retries can double-record usage; needs a client
-  contract.
-- **Per-model / per-request-count rate limit** — only global spend budget today.
+- **Idempotency key** *(flagged, not implemented — feature, not a fix)* —
+  client retries still double-record and double-bill usage
+  (`pipeline/handler.ts` / `hooks.ts` `recordGatewayUsage`, confirmed still
+  absent in tonight's audit). Needs an `Idempotency-Key` header contract +
+  a keyed cache/table to short-circuit `recordGatewayUsage` on a replay within
+  a bounded window, plus a documented client contract (opencode and any other
+  caller must actually send the header on retry). Scoped follow-up, not a
+  same-night addition.
+- **Per-model / per-key rate limit** *(flagged, not implemented — feature, not
+  a fix)* — only a global $ spend budget exists; a runaway well-behaved caller
+  (e.g. a stuck retry loop on a free/cheap model) has no request-count throttle
+  and can collaterally trip the shared per-provider circuit breaker for every
+  other tenant. Needs a lightweight per-principal (project/key) token-bucket
+  limiter ahead of dispatch, independent of the $ budget. Scoped follow-up, not
+  a same-night addition.
 
-## Test gaps still open (need a DB-backed harness)
+## Test gaps
 
-- Budget enforcement (`checkBudget`) — block vs warn, period rollover.
-- Account tier gating + 30s tier-cache TTL.
-- BYOK markup / free-tier `billingMode` + managed-fallback resolution.
-- Gateway-key expiration in `validateGatewayKey`.
+- ~~Gateway-key expiration in `validateGatewayKey`~~ — closed, see item 11
+  above.
+- ~~Account tier gating + 30s tier-cache TTL~~ / ~~BYOK markup / free-tier
+  `billingMode` + managed-fallback resolution~~ — closed, see item 12 above.
+- Budget enforcement (`checkBudget`) — block vs warn, period rollover. Status
+  as of this pass: **not covered by this PR** — `checkBudget` and its
+  `calculateCost`/pricing counterpart are being fixed and tested by a parallel
+  billing pass the same night (checkBudget currently only ever queries
+  `action='block'`, silently never evaluating `warn`-scoped budgets — a
+  correctness bug, not just a test gap). If that lands separately, this line
+  should be struck; if it hasn't landed, `budgets.ts`/`pricing.ts` still have
+  zero tests and this remains open.

--- a/apps/api/src/llm-gateway/RELIABILITY-BACKLOG.md
+++ b/apps/api/src/llm-gateway/RELIABILITY-BACKLOG.md
@@ -87,6 +87,27 @@ managed fallback with tier gating), real unit tests on the core pipeline.
     during the cache window" bug shape are both unit-testable without a real
     wall-clock sleep. *(test: resolution/resolve-candidates.test.ts)* — PR #4815.
 
+### Also landed this wave (sibling PRs, all with tests)
+
+- **max_tokens → max_completion_tokens for genuine OpenAI** — #4805 (+ the
+  gpt-5.5 fallback-temperature / playground wire-shape follow-up #4809).
+- **Transport correctness** — #4814: `tool_choice:'none'` no longer silently
+  becomes Anthropic's default `auto` (safety-critical), plus reasoning-model
+  param quirks (temperature/top_p), role normalization, and Bedrock
+  event-stream error/exception frame surfacing.
+- **LiteLLM stateless translation sidecar** — #4817: per-request translation
+  routing behind the control plane (the `translationSidecar` option on
+  `callUpstream`).
+- **Honest, actionable error taxonomy** — #4820: `resolveCandidates` now throws
+  a typed `GatewayResolutionError` (distinct `code` + suggestion:
+  `provider_not_connected` / `provider_key_private` / `provider_reauth_required`
+  / `plan_upgrade_required` / `model_disabled_on_deployment` / `model_not_found`)
+  instead of collapsing every no-upstream case into one generic message; this
+  PR's tier-gating/BYOK tests (item 12) assert that taxonomy.
+- **Streaming reliability** — #4821: client-disconnect abort propagation
+  (see the heartbeat item below), mid-stream error surfacing, bounded buffers,
+  and stream deadlines.
+
 ## ◻️ Remaining (need design / infra, not a code tweak)
 
 2. **Atomic budget check + deduction** — `hooks.ts` / `budgets.ts`
@@ -132,10 +153,15 @@ managed fallback with tier gating), real unit tests on the core pipeline.
      Tracked here as the next infra-adjacent pass on this RPC boundary, not
      scheduled.
 
-- **Heartbeat read loop after client disconnect** — currently we keep draining
-  upstream to capture full usage even when the client is gone. Intentional
-  (billing completeness > the minor wasted read); revisit only if it shows up in
-  profiles.
+- ~~**Heartbeat read loop after client disconnect**~~ — **addressed by #4821.**
+  The old behavior kept draining the upstream to capture full usage even after
+  the client was gone (accepted as "billing completeness > the minor wasted
+  read"). #4821 (streaming reliability) threads the inbound request's
+  `AbortSignal` through the dispatch/relay pipeline: on a client disconnect the
+  upstream reader is cancelled (a new `ClientAbortError` stops the failover loop
+  and `relayStream` cancels the in-flight read), so a departed client no longer
+  keeps spending upstream tokens — plus a stream inactivity deadline bounds a
+  silently-stalled upstream.
 - **Gateway-key `lastUsedAt`** is fire-and-forget (stale admin view only).
 - **Idempotency key** *(flagged, not implemented — feature, not a fix)* —
   client retries still double-record and double-bill usage

--- a/apps/api/src/llm-gateway/gateway-keys.test.ts
+++ b/apps/api/src/llm-gateway/gateway-keys.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
 import { accounts, gatewayApiKeys, projects } from '@kortix/db';
-import { db } from '../shared/db';
+import { eq } from 'drizzle-orm';
 import { hashSecretKey } from '../shared/crypto';
+import { db } from '../shared/db';
 import { validateGatewayKey } from './gateway-keys';
 
 const ACCOUNT = crypto.randomUUID();

--- a/apps/api/src/llm-gateway/gateway-keys.test.ts
+++ b/apps/api/src/llm-gateway/gateway-keys.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { accounts, gatewayApiKeys, projects } from '@kortix/db';
+import { db } from '../shared/db';
+import { hashSecretKey } from '../shared/crypto';
+import { validateGatewayKey } from './gateway-keys';
+
+const ACCOUNT = crypto.randomUUID();
+const PROJECT = crypto.randomUUID();
+const CREATOR = crypto.randomUUID();
+
+let n = 0;
+async function seedKey(opts: {
+  status?: 'active' | 'revoked';
+  expiresAt?: Date | null;
+  createdBy?: string | null;
+}) {
+  n += 1;
+  const secretKey = `kortix_gw_test_${n}_${crypto.randomUUID()}`;
+  const [row] = await db
+    .insert(gatewayApiKeys)
+    .values({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      name: `test-key-${n}`,
+      keyPrefix: secretKey.slice(0, 14),
+      secretKeyHash: hashSecretKey(secretKey),
+      status: opts.status ?? 'active',
+      expiresAt: opts.expiresAt ?? null,
+      createdBy: opts.createdBy === undefined ? CREATOR : opts.createdBy,
+    })
+    .returning({ keyId: gatewayApiKeys.keyId });
+  return { secretKey, keyId: row!.keyId };
+}
+
+beforeAll(async () => {
+  await db.insert(accounts).values({ accountId: ACCOUNT, name: 'gateway-key-test-acct' });
+  await db.insert(projects).values({
+    projectId: PROJECT,
+    accountId: ACCOUNT,
+    name: 'gateway-key-test-project',
+    repoUrl: 'https://example.test/gw-key.git',
+  });
+});
+
+afterAll(async () => {
+  await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
+  await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT));
+});
+
+describe('validateGatewayKey', () => {
+  test('accepts an active key with no expiry', async () => {
+    const { secretKey, keyId } = await seedKey({ expiresAt: null });
+    expect(await validateGatewayKey(secretKey)).toEqual({
+      accountId: ACCOUNT,
+      projectId: PROJECT,
+      userId: CREATOR,
+      keyId,
+    });
+  });
+
+  test('accepts an active key whose expiry is in the future', async () => {
+    const { secretKey } = await seedKey({ expiresAt: new Date(Date.now() + 60_000) });
+    expect(await validateGatewayKey(secretKey)).not.toBeNull();
+  });
+
+  test('rejects a revoked key', async () => {
+    const { secretKey } = await seedKey({ status: 'revoked' });
+    expect(await validateGatewayKey(secretKey)).toBeNull();
+  });
+
+  test('rejects a key past its expiry', async () => {
+    const { secretKey } = await seedKey({ expiresAt: new Date(Date.now() - 1) });
+    expect(await validateGatewayKey(secretKey)).toBeNull();
+  });
+
+  test('rejects exactly at the expiry boundary instant', async () => {
+    const now = new Date();
+    const { secretKey } = await seedKey({ expiresAt: now });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(await validateGatewayKey(secretKey)).toBeNull();
+  });
+
+  test('falls back userId to accountId when createdBy is null', async () => {
+    const { secretKey } = await seedKey({ createdBy: null });
+    expect((await validateGatewayKey(secretKey))?.userId).toBe(ACCOUNT);
+  });
+
+  test('rejects an unknown secret', async () => {
+    expect(await validateGatewayKey(`kortix_gw_${crypto.randomUUID()}`)).toBeNull();
+  });
+
+  test('stamps lastUsedAt on a successful validation (fire-and-forget)', async () => {
+    const { secretKey, keyId } = await seedKey({});
+    expect(await validateGatewayKey(secretKey)).not.toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const [row] = await db
+      .select({ lastUsedAt: gatewayApiKeys.lastUsedAt })
+      .from(gatewayApiKeys)
+      .where(eq(gatewayApiKeys.keyId, keyId));
+    expect(row?.lastUsedAt).toBeTruthy();
+  });
+});

--- a/apps/api/src/llm-gateway/internal-auth.test.ts
+++ b/apps/api/src/llm-gateway/internal-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { matchesInternalToken } from './internal-auth';
+import { matchesInternalToken, weakInternalTokenWarnings } from './internal-auth';
 
 describe('matchesInternalToken', () => {
   test('accepts the configured token', () => {
@@ -31,5 +31,34 @@ describe('matchesInternalToken', () => {
   test('is not fooled by length-prefix differences', () => {
     expect(matchesInternalToken('Bearer secre', 'secret')).toBe(false);
     expect(matchesInternalToken('Bearer secrets', 'secret')).toBe(false);
+  });
+});
+
+describe('weakInternalTokenWarnings', () => {
+  test('no warnings for unconfigured token', () => {
+    expect(weakInternalTokenWarnings(undefined)).toEqual([]);
+    expect(weakInternalTokenWarnings('')).toEqual([]);
+  });
+
+  test('warns on a short token', () => {
+    expect(weakInternalTokenWarnings('short')).toHaveLength(1);
+  });
+
+  test('warns on a known-weak value regardless of case', () => {
+    expect(weakInternalTokenWarnings('ChangeMe')).toHaveLength(1);
+    expect(weakInternalTokenWarnings('secret')).toHaveLength(1);
+  });
+
+  test('no warning for a sufficiently long random-looking token', () => {
+    expect(weakInternalTokenWarnings('a'.repeat(32))).toEqual([]);
+  });
+
+  test('checks every entry in a rotation list independently', () => {
+    const warnings = weakInternalTokenWarnings(`${'a'.repeat(32)}, short`);
+    expect(warnings).toHaveLength(1);
+  });
+
+  test('flags every weak entry when the whole list is weak', () => {
+    expect(weakInternalTokenWarnings('short1, short2')).toHaveLength(2);
   });
 });

--- a/apps/api/src/llm-gateway/internal-auth.ts
+++ b/apps/api/src/llm-gateway/internal-auth.ts
@@ -1,5 +1,17 @@
 import { timingSafeEqual } from 'node:crypto';
 
+const MIN_INTERNAL_TOKEN_LENGTH = 24;
+const KNOWN_WEAK_TOKENS = new Set([
+  'test',
+  'secret',
+  'changeme',
+  'change-me',
+  'password',
+  'internal',
+  'token',
+  'default',
+]);
+
 /**
  * Constant-time check of the internal control-plane bearer token.
  *
@@ -32,4 +44,38 @@ export function matchesInternalToken(
     }
   }
   return ok;
+}
+
+/**
+ * Cheap defense-in-depth for the API↔standalone-gateway-pod control plane,
+ * which is otherwise a single shared static bearer token (see
+ * RELIABILITY-BACKLOG.md item 7b — full mutual auth (mTLS/HMAC) is an
+ * infra-level change, tracked there). This does not reject a weak token —
+ * only a real mTLS/HMAC upgrade should ever do that, and this repo has no
+ * mechanism to safely block a running deployment from serving traffic — it
+ * just surfaces a loud, cheap boot-time signal so a trivial/default/guessable
+ * `GATEWAY_INTERNAL_TOKEN` doesn't sit unnoticed in a production config.
+ */
+export function weakInternalTokenWarnings(tokensCsv: string | undefined): string[] {
+  if (!tokensCsv) return [];
+  const tokens = tokensCsv
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const warnings: string[] = [];
+  for (const token of tokens) {
+    if (token.length < MIN_INTERNAL_TOKEN_LENGTH) {
+      warnings.push(
+        `GATEWAY_INTERNAL_TOKEN entry is only ${token.length} chars (want >= ${MIN_INTERNAL_TOKEN_LENGTH}) — a short static bearer token is brute-forceable.`,
+      );
+      continue;
+    }
+    if (KNOWN_WEAK_TOKENS.has(token.toLowerCase())) {
+      warnings.push(
+        'GATEWAY_INTERNAL_TOKEN entry matches a known-weak/default value — rotate it to a random secret.',
+      );
+    }
+  }
+  return warnings;
 }

--- a/apps/api/src/llm-gateway/internal-routes.ts
+++ b/apps/api/src/llm-gateway/internal-routes.ts
@@ -13,7 +13,7 @@ import {
   persistGatewayTrace,
   recordGatewayUsage,
 } from './hooks';
-import { matchesInternalToken } from './internal-auth';
+import { matchesInternalToken, weakInternalTokenWarnings } from './internal-auth';
 import { gatewayModelCatalog } from './models/catalog-models';
 import { resolveCandidates } from './resolution/resolve-candidates';
 import { resolveGatewayRoute } from './routing';
@@ -26,6 +26,10 @@ import { logger } from '../lib/logger';
 export function createInternalGatewayRoutes() {
   const app = new Hono();
   const internalToken = process.env.GATEWAY_INTERNAL_TOKEN;
+
+  for (const warning of weakInternalTokenWarnings(internalToken)) {
+    logger.warn(`[gateway-internal-auth] ${warning}`);
+  }
 
   app.use('*', async (c, next) => {
     if (!internalToken) return c.json({ error: 'internal gateway disabled' }, 503);

--- a/apps/api/src/llm-gateway/internal-routes.ts
+++ b/apps/api/src/llm-gateway/internal-routes.ts
@@ -6,6 +6,7 @@ import type {
 } from '@kortix/llm-gateway';
 import { Hono } from 'hono';
 import { assertBillingActive } from '../billing/services/billing-gate';
+import { logger } from '../lib/logger';
 import { checkBudget } from './budgets';
 import {
   authenticatePrincipal,
@@ -17,7 +18,6 @@ import { matchesInternalToken, weakInternalTokenWarnings } from './internal-auth
 import { gatewayModelCatalog } from './models/catalog-models';
 import { resolveCandidates } from './resolution/resolve-candidates';
 import { resolveGatewayRoute } from './routing';
-import { logger } from '../lib/logger';
 
 // HTTP control plane for the OUT-OF-PROCESS gateway pod. Every handler is a thin
 // wrapper over the shared in-process hooks in ./hooks — the standalone service
@@ -71,10 +71,7 @@ export function createInternalGatewayRoutes() {
 
   app.post('/resolve-route', async (c) => {
     const { principal, input } = await c.req.json();
-    const route = await resolveGatewayRoute(
-      principal as AuthedPrincipal,
-      input as ModelRouteInput,
-    );
+    const route = await resolveGatewayRoute(principal as AuthedPrincipal, input as ModelRouteInput);
     return c.json({ route });
   });
 

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -19,12 +19,6 @@ let codexCredential: { access: string; accountId?: string } | null = null;
 const resolveCodexCredential = mock(async () => codexCredential);
 mock.module('../credentials/codex', () => ({ resolveCodexCredential }));
 
-const fallbackCandidate = {
-  provider: 'kortix-fallback',
-  kind: 'openai-compat',
-  baseUrl: 'https://fb.test',
-  apiKey: 'fb',
-};
 mock.module('./descriptors', () => ({
   codexDescriptor: (credential: { access: string }, model: string) => ({
     provider: 'openai-codex',

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let tierByAccount: Record<string, string> = {};
+const getAccountTier = mock(async (accountId: string) => tierByAccount[accountId] ?? 'pro');
+mock.module('../../billing/services/entitlements', () => ({ getAccountTier }));
+
+mock.module('../../billing/services/tiers', () => ({
+  accountIsFreeTierForModels: (tier: string) => tier === 'free',
+}));
+
+const config: Record<string, unknown> = {};
+mock.module('../../config', () => ({ config }));
+
+let resolvedSecret: string | null = null;
+const getResolvedProjectSecretValue = mock(async () => resolvedSecret);
+mock.module('../../projects/secrets', () => ({ getResolvedProjectSecretValue }));
+
+let codexCredential: { access: string; accountId?: string } | null = null;
+const resolveCodexCredential = mock(async () => codexCredential);
+mock.module('../credentials/codex', () => ({ resolveCodexCredential }));
+
+const fallbackCandidate = { provider: 'kortix-fallback', kind: 'openai-compat', baseUrl: 'https://fb.test', apiKey: 'fb' };
+mock.module('./descriptors', () => ({
+  codexDescriptor: (credential: { access: string }, model: string) => ({
+    provider: 'openai-codex',
+    kind: 'openai-responses',
+    baseUrl: 'https://codex.test',
+    apiKey: credential.access,
+    billingMode: 'none',
+    markup: 0,
+    resolvedModel: model,
+  }),
+  livePricing: () => undefined,
+  managedCandidates: (managed: { id: string }) => [
+    { provider: 'kortix-managed', kind: 'bedrock', baseUrl: 'https://managed.test', apiKey: 'm', billingMode: 'credits', markup: 1, resolvedModel: managed.id },
+  ],
+}));
+
+let catalogUpstream: { baseUrl: string; envVar: string; kind: string } | null = null;
+mock.module('../models/provider-registry', () => ({
+  resolveCatalogUpstream: () => catalogUpstream,
+}));
+
+mock.module('../routing', () => ({
+  resolveGatewayRoute: async () => ({ primaryModel: 'anthropic/claude-sonnet-4.6' }),
+}));
+
+let runtimeManagedModel: { id: string } | undefined;
+mock.module('../models/managed-models', () => ({
+  getRuntimeManagedModel: (id: string) => (runtimeManagedModel?.id === id ? runtimeManagedModel : undefined),
+}));
+
+const { resolveCandidates, resolveCachedAccountTier } = await import('./resolve-candidates');
+
+function principal(overrides: Record<string, unknown> = {}) {
+  return { userId: 'u1', accountId: crypto.randomUUID(), projectId: 'p1', ...overrides };
+}
+
+beforeEach(() => {
+  tierByAccount = {};
+  for (const key of Object.keys(config)) delete config[key];
+  Object.assign(config, {
+    LLM_GATEWAY_ENABLED: true,
+    KORTIX_MANAGED_PROVIDER_ENABLED: true,
+    KORTIX_BILLING_INTERNAL_ENABLED: true,
+    LLM_GATEWAY_BYOK_FALLBACK_MODEL: 'anthropic/claude-sonnet-4.6',
+  });
+  resolvedSecret = null;
+  codexCredential = null;
+  catalogUpstream = null;
+  runtimeManagedModel = undefined;
+  getAccountTier.mockClear();
+  getResolvedProjectSecretValue.mockClear();
+  resolveCodexCredential.mockClear();
+});
+
+describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback', () => {
+  test('paid tier: platform-fee billing, 10% markup, managed fallback queued behind the BYOK key', async () => {
+    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    resolvedSecret = 'sk-user-key';
+    runtimeManagedModel = { id: 'anthropic/claude-sonnet-4.6' };
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(p, 'anthropic/claude-sonnet-4.6');
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toMatchObject({ billingMode: 'platform-fee', markup: 0.1, apiKey: 'sk-user-key' });
+    expect(candidates[1]).toMatchObject({ provider: 'kortix-managed' });
+  });
+
+  test('free tier: BYOK key is billing-free (markup 0, billingMode none) with no managed fallback', async () => {
+    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    resolvedSecret = 'sk-user-key';
+    const p = principal();
+    tierByAccount[p.accountId] = 'free';
+
+    const candidates = await resolveCandidates(p, 'anthropic/claude-sonnet-4.6');
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({ billingMode: 'none', markup: 0 });
+  });
+
+  test('self-hosted (billing disabled): no tier lookup, still gets the platform markup and a managed fallback', async () => {
+    config.KORTIX_BILLING_INTERNAL_ENABLED = false;
+    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    resolvedSecret = 'sk-user-key';
+    runtimeManagedModel = { id: 'anthropic/claude-sonnet-4.6' };
+
+    const candidates = await resolveCandidates(principal(), 'anthropic/claude-sonnet-4.6');
+
+    expect(getAccountTier).not.toHaveBeenCalled();
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toMatchObject({ billingMode: 'none', markup: 0.1 });
+  });
+
+  test('no BYOK secret configured for the project falls through to the managed/empty path', async () => {
+    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    resolvedSecret = null;
+
+    expect(await resolveCandidates(principal(), 'anthropic/claude-sonnet-4.6')).toEqual([]);
+  });
+});
+
+describe('resolveCandidates — managed model tier gating', () => {
+  test('freeModelsOnly principal short-circuits before any tier lookup', async () => {
+    runtimeManagedModel = { id: 'glm-5.2' };
+
+    expect(await resolveCandidates(principal({ freeModelsOnly: true }), 'glm-5.2')).toEqual([]);
+    expect(getAccountTier).not.toHaveBeenCalled();
+  });
+
+  test('free-tier account gets no managed candidates', async () => {
+    runtimeManagedModel = { id: 'glm-5.2' };
+    const p = principal();
+    tierByAccount[p.accountId] = 'free';
+
+    expect(await resolveCandidates(p, 'glm-5.2')).toEqual([]);
+  });
+
+  test('paid-tier account gets the managed candidates', async () => {
+    runtimeManagedModel = { id: 'glm-5.2' };
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(p, 'glm-5.2');
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({ provider: 'kortix-managed' });
+  });
+
+  test('managed model is gated off entirely when KORTIX_MANAGED_PROVIDER_ENABLED is false', async () => {
+    config.KORTIX_MANAGED_PROVIDER_ENABLED = false;
+    runtimeManagedModel = { id: 'glm-5.2' };
+
+    expect(await resolveCandidates(principal(), 'glm-5.2')).toEqual([]);
+  });
+});
+
+describe('resolveCandidates — codex + unknown provider', () => {
+  test('codex provider requires a projectId', async () => {
+    expect(await resolveCandidates(principal({ projectId: undefined }), 'codex/gpt-5.5')).toEqual([]);
+  });
+
+  test('codex provider resolves to the codex descriptor when a credential exists', async () => {
+    codexCredential = { access: 'codex-token' };
+    const candidates = await resolveCandidates(principal(), 'codex/gpt-5.5');
+    expect(candidates).toEqual([
+      expect.objectContaining({ provider: 'openai-codex', apiKey: 'codex-token', resolvedModel: 'codex/gpt-5.5' }),
+    ]);
+  });
+
+  test('codex provider with no resolvable credential returns nothing', async () => {
+    codexCredential = null;
+    expect(await resolveCandidates(principal(), 'codex/gpt-5.5')).toEqual([]);
+  });
+
+  test('an unroutable provider (no BYOK, no managed, no codex) returns nothing', async () => {
+    expect(await resolveCandidates(principal(), 'made-up-provider/some-model')).toEqual([]);
+  });
+});
+
+describe('resolveCachedAccountTier — 30s TTL boundary', () => {
+  test('caches within the TTL window: a second call inside 30s does not re-query', async () => {
+    const accountId = crypto.randomUUID();
+    tierByAccount[accountId] = 'pro';
+
+    expect(await resolveCachedAccountTier(accountId, 1_000)).toBe('pro');
+    tierByAccount[accountId] = 'free';
+    expect(await resolveCachedAccountTier(accountId, 1_000 + 29_999)).toBe('pro');
+    expect(getAccountTier).toHaveBeenCalledTimes(1);
+  });
+
+  test('a tier change mid-window is invisible until the cache expires (the exact bug shape)', async () => {
+    const accountId = crypto.randomUUID();
+    tierByAccount[accountId] = 'free';
+    expect(await resolveCachedAccountTier(accountId, 5_000)).toBe('free');
+
+    tierByAccount[accountId] = 'pro';
+    expect(await resolveCachedAccountTier(accountId, 5_000 + 15_000)).toBe('free');
+  });
+
+  test('refreshes exactly once the 30s TTL has elapsed', async () => {
+    const accountId = crypto.randomUUID();
+    tierByAccount[accountId] = 'free';
+    await resolveCachedAccountTier(accountId, 10_000);
+
+    tierByAccount[accountId] = 'pro';
+    expect(await resolveCachedAccountTier(accountId, 10_000 + 30_000)).toBe('pro');
+    expect(getAccountTier).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -19,7 +19,12 @@ let codexCredential: { access: string; accountId?: string } | null = null;
 const resolveCodexCredential = mock(async () => codexCredential);
 mock.module('../credentials/codex', () => ({ resolveCodexCredential }));
 
-const fallbackCandidate = { provider: 'kortix-fallback', kind: 'openai-compat', baseUrl: 'https://fb.test', apiKey: 'fb' };
+const fallbackCandidate = {
+  provider: 'kortix-fallback',
+  kind: 'openai-compat',
+  baseUrl: 'https://fb.test',
+  apiKey: 'fb',
+};
 mock.module('./descriptors', () => ({
   codexDescriptor: (credential: { access: string }, model: string) => ({
     provider: 'openai-codex',
@@ -32,7 +37,15 @@ mock.module('./descriptors', () => ({
   }),
   livePricing: () => undefined,
   managedCandidates: (managed: { id: string }) => [
-    { provider: 'kortix-managed', kind: 'bedrock', baseUrl: 'https://managed.test', apiKey: 'm', billingMode: 'credits', markup: 1, resolvedModel: managed.id },
+    {
+      provider: 'kortix-managed',
+      kind: 'bedrock',
+      baseUrl: 'https://managed.test',
+      apiKey: 'm',
+      billingMode: 'credits',
+      markup: 1,
+      resolvedModel: managed.id,
+    },
   ],
 }));
 
@@ -47,7 +60,8 @@ mock.module('../routing', () => ({
 
 let runtimeManagedModel: { id: string } | undefined;
 mock.module('../models/managed-models', () => ({
-  getRuntimeManagedModel: (id: string) => (runtimeManagedModel?.id === id ? runtimeManagedModel : undefined),
+  getRuntimeManagedModel: (id: string) =>
+    runtimeManagedModel?.id === id ? runtimeManagedModel : undefined,
 }));
 
 const { resolveCandidates, resolveCachedAccountTier } = await import('./resolve-candidates');
@@ -76,7 +90,11 @@ beforeEach(() => {
 
 describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback', () => {
   test('paid tier: platform-fee billing, 10% markup, managed fallback queued behind the BYOK key', async () => {
-    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    catalogUpstream = {
+      baseUrl: 'https://api.anthropic.com/v1',
+      envVar: 'ANTHROPIC_API_KEY',
+      kind: 'anthropic',
+    };
     resolvedSecret = 'sk-user-key';
     runtimeManagedModel = { id: 'anthropic/claude-sonnet-4.6' };
     const p = principal();
@@ -85,12 +103,20 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
     const candidates = await resolveCandidates(p, 'anthropic/claude-sonnet-4.6');
 
     expect(candidates).toHaveLength(2);
-    expect(candidates[0]).toMatchObject({ billingMode: 'platform-fee', markup: 0.1, apiKey: 'sk-user-key' });
+    expect(candidates[0]).toMatchObject({
+      billingMode: 'platform-fee',
+      markup: 0.1,
+      apiKey: 'sk-user-key',
+    });
     expect(candidates[1]).toMatchObject({ provider: 'kortix-managed' });
   });
 
   test('free tier: BYOK key is billing-free (markup 0, billingMode none) with no managed fallback', async () => {
-    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    catalogUpstream = {
+      baseUrl: 'https://api.anthropic.com/v1',
+      envVar: 'ANTHROPIC_API_KEY',
+      kind: 'anthropic',
+    };
     resolvedSecret = 'sk-user-key';
     const p = principal();
     tierByAccount[p.accountId] = 'free';
@@ -103,7 +129,11 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
 
   test('self-hosted (billing disabled): no tier lookup, still gets the platform markup and a managed fallback', async () => {
     config.KORTIX_BILLING_INTERNAL_ENABLED = false;
-    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    catalogUpstream = {
+      baseUrl: 'https://api.anthropic.com/v1',
+      envVar: 'ANTHROPIC_API_KEY',
+      kind: 'anthropic',
+    };
     resolvedSecret = 'sk-user-key';
     runtimeManagedModel = { id: 'anthropic/claude-sonnet-4.6' };
 
@@ -115,7 +145,11 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
   });
 
   test('no BYOK secret configured for the project falls through to the managed/empty path', async () => {
-    catalogUpstream = { baseUrl: 'https://api.anthropic.com/v1', envVar: 'ANTHROPIC_API_KEY', kind: 'anthropic' };
+    catalogUpstream = {
+      baseUrl: 'https://api.anthropic.com/v1',
+      envVar: 'ANTHROPIC_API_KEY',
+      kind: 'anthropic',
+    };
     resolvedSecret = null;
 
     expect(await resolveCandidates(principal(), 'anthropic/claude-sonnet-4.6')).toEqual([]);
@@ -158,14 +192,20 @@ describe('resolveCandidates — managed model tier gating', () => {
 
 describe('resolveCandidates — codex + unknown provider', () => {
   test('codex provider requires a projectId', async () => {
-    expect(await resolveCandidates(principal({ projectId: undefined }), 'codex/gpt-5.5')).toEqual([]);
+    expect(await resolveCandidates(principal({ projectId: undefined }), 'codex/gpt-5.5')).toEqual(
+      [],
+    );
   });
 
   test('codex provider resolves to the codex descriptor when a credential exists', async () => {
     codexCredential = { access: 'codex-token' };
     const candidates = await resolveCandidates(principal(), 'codex/gpt-5.5');
     expect(candidates).toEqual([
-      expect.objectContaining({ provider: 'openai-codex', apiKey: 'codex-token', resolvedModel: 'codex/gpt-5.5' }),
+      expect.objectContaining({
+        provider: 'openai-codex',
+        apiKey: 'codex-token',
+        resolvedModel: 'codex/gpt-5.5',
+      }),
     ]);
   });
 

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { GatewayResolutionError } from '@kortix/llm-gateway';
 
 let tierByAccount: Record<string, string> = {};
 const getAccountTier = mock(async (accountId: string) => tierByAccount[accountId] ?? 'pro');
@@ -12,12 +13,22 @@ const config: Record<string, unknown> = {};
 mock.module('../../config', () => ({ config }));
 
 let resolvedSecret: string | null = null;
+let secretExistsForAnyOwner = false;
 const getResolvedProjectSecretValue = mock(async () => resolvedSecret);
-mock.module('../../projects/secrets', () => ({ getResolvedProjectSecretValue }));
+const projectSecretExistsForAnyOwner = mock(async () => secretExistsForAnyOwner);
+mock.module('../../projects/secrets', () => ({
+  getResolvedProjectSecretValue,
+  projectSecretExistsForAnyOwner,
+}));
 
+class CodexRefreshError extends Error {}
 let codexCredential: { access: string; accountId?: string } | null = null;
-const resolveCodexCredential = mock(async () => codexCredential);
-mock.module('../credentials/codex', () => ({ resolveCodexCredential }));
+let codexThrows = false;
+const resolveCodexCredential = mock(async () => {
+  if (codexThrows) throw new CodexRefreshError('codex refresh failed');
+  return codexCredential;
+});
+mock.module('../credentials/codex', () => ({ resolveCodexCredential, CodexRefreshError }));
 
 mock.module('./descriptors', () => ({
   codexDescriptor: (credential: { access: string }, model: string) => ({
@@ -53,11 +64,13 @@ mock.module('../routing', () => ({
 }));
 
 let runtimeManagedModel: { id: string } | undefined;
+let knownManagedModelId: string | null = null;
 mock.module('../models/managed-models', () => ({
   RUNTIME_MANAGED_MODELS: [],
   getRuntimeManagedModel: (id: string) =>
     runtimeManagedModel?.id === id ? runtimeManagedModel : undefined,
   isRuntimeManagedModelId: (id: string) => runtimeManagedModel?.id === id,
+  isKnownManagedModelId: (id: string) => id === knownManagedModelId,
 }));
 
 let capabilities = { reasoning: false, temperature: true };
@@ -81,12 +94,16 @@ beforeEach(() => {
     LLM_GATEWAY_BYOK_FALLBACK_MODEL: 'anthropic/claude-sonnet-4.6',
   });
   resolvedSecret = null;
+  secretExistsForAnyOwner = false;
   codexCredential = null;
+  codexThrows = false;
   catalogUpstream = null;
   runtimeManagedModel = undefined;
+  knownManagedModelId = null;
   capabilities = { reasoning: false, temperature: true };
   getAccountTier.mockClear();
   getResolvedProjectSecretValue.mockClear();
+  projectSecretExistsForAnyOwner.mockClear();
   resolveCodexCredential.mockClear();
 });
 
@@ -161,32 +178,53 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
     expect(candidates[0]).toMatchObject({ billingMode: 'none', markup: 0.1 });
   });
 
-  test('no BYOK secret configured for the project falls through to the managed/empty path', async () => {
+  test('no BYOK key connected for anyone throws provider_not_connected', async () => {
     catalogUpstream = {
       baseUrl: 'https://api.anthropic.com/v1',
       envVar: 'ANTHROPIC_API_KEY',
       kind: 'anthropic',
     };
     resolvedSecret = null;
+    secretExistsForAnyOwner = false;
 
-    expect(await resolveCandidates(principal(), 'anthropic/claude-sonnet-4.6')).toEqual([]);
+    await expect(
+      resolveCandidates(principal(), 'anthropic/claude-sonnet-4.6'),
+    ).rejects.toMatchObject({ code: 'provider_not_connected' });
+  });
+
+  test("a teammate's private key (not shared) throws the distinct provider_key_private", async () => {
+    catalogUpstream = {
+      baseUrl: 'https://api.anthropic.com/v1',
+      envVar: 'ANTHROPIC_API_KEY',
+      kind: 'anthropic',
+    };
+    resolvedSecret = null;
+    secretExistsForAnyOwner = true;
+
+    await expect(
+      resolveCandidates(principal(), 'anthropic/claude-sonnet-4.6'),
+    ).rejects.toMatchObject({ code: 'provider_key_private' });
   });
 });
 
 describe('resolveCandidates — managed model tier gating', () => {
-  test('freeModelsOnly principal short-circuits before any tier lookup', async () => {
+  test('freeModelsOnly principal throws plan_upgrade_required before any tier lookup', async () => {
     runtimeManagedModel = { id: 'glm-5.2' };
 
-    expect(await resolveCandidates(principal({ freeModelsOnly: true }), 'glm-5.2')).toEqual([]);
+    await expect(
+      resolveCandidates(principal({ freeModelsOnly: true }), 'glm-5.2'),
+    ).rejects.toMatchObject({ code: 'plan_upgrade_required' });
     expect(getAccountTier).not.toHaveBeenCalled();
   });
 
-  test('free-tier account gets no managed candidates', async () => {
+  test('free-tier account throws plan_upgrade_required for a managed model', async () => {
     runtimeManagedModel = { id: 'glm-5.2' };
     const p = principal();
     tierByAccount[p.accountId] = 'free';
 
-    expect(await resolveCandidates(p, 'glm-5.2')).toEqual([]);
+    await expect(resolveCandidates(p, 'glm-5.2')).rejects.toMatchObject({
+      code: 'plan_upgrade_required',
+    });
   });
 
   test('paid-tier account gets the managed candidates', async () => {
@@ -199,19 +237,22 @@ describe('resolveCandidates — managed model tier gating', () => {
     expect(candidates[0]).toMatchObject({ provider: 'kortix-managed' });
   });
 
-  test('managed model is gated off entirely when KORTIX_MANAGED_PROVIDER_ENABLED is false', async () => {
+  test('a known managed model with the provider disabled throws model_disabled_on_deployment', async () => {
     config.KORTIX_MANAGED_PROVIDER_ENABLED = false;
     runtimeManagedModel = { id: 'glm-5.2' };
+    knownManagedModelId = 'glm-5.2';
 
-    expect(await resolveCandidates(principal(), 'glm-5.2')).toEqual([]);
+    await expect(resolveCandidates(principal(), 'glm-5.2')).rejects.toMatchObject({
+      code: 'model_disabled_on_deployment',
+    });
   });
 });
 
 describe('resolveCandidates — codex + unknown provider', () => {
-  test('codex provider requires a projectId', async () => {
-    expect(await resolveCandidates(principal({ projectId: undefined }), 'codex/gpt-5.5')).toEqual(
-      [],
-    );
+  test('codex provider without a projectId throws provider_not_connected', async () => {
+    await expect(
+      resolveCandidates(principal({ projectId: undefined }), 'codex/gpt-5.5'),
+    ).rejects.toMatchObject({ code: 'provider_not_connected' });
   });
 
   test('codex provider resolves to the codex descriptor when a credential exists', async () => {
@@ -226,13 +267,24 @@ describe('resolveCandidates — codex + unknown provider', () => {
     ]);
   });
 
-  test('codex provider with no resolvable credential returns nothing', async () => {
+  test('codex with no resolvable credential throws provider_not_connected', async () => {
     codexCredential = null;
-    expect(await resolveCandidates(principal(), 'codex/gpt-5.5')).toEqual([]);
+    await expect(resolveCandidates(principal(), 'codex/gpt-5.5')).rejects.toMatchObject({
+      code: 'provider_not_connected',
+    });
   });
 
-  test('an unroutable provider (no BYOK, no managed, no codex) returns nothing', async () => {
-    expect(await resolveCandidates(principal(), 'made-up-provider/some-model')).toEqual([]);
+  test('codex whose session expired (CodexRefreshError) throws provider_reauth_required', async () => {
+    codexThrows = true;
+    await expect(resolveCandidates(principal(), 'codex/gpt-5.5')).rejects.toMatchObject({
+      code: 'provider_reauth_required',
+    });
+  });
+
+  test('an unroutable provider (no BYOK, no managed, no codex) throws model_not_found', async () => {
+    const promise = resolveCandidates(principal(), 'made-up-provider/some-model');
+    await expect(promise).rejects.toBeInstanceOf(GatewayResolutionError);
+    await expect(promise).rejects.toMatchObject({ code: 'model_not_found' });
   });
 });
 

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -60,8 +60,15 @@ mock.module('../routing', () => ({
 
 let runtimeManagedModel: { id: string } | undefined;
 mock.module('../models/managed-models', () => ({
+  RUNTIME_MANAGED_MODELS: [],
   getRuntimeManagedModel: (id: string) =>
     runtimeManagedModel?.id === id ? runtimeManagedModel : undefined,
+  isRuntimeManagedModelId: (id: string) => runtimeManagedModel?.id === id,
+}));
+
+let capabilities = { reasoning: false, temperature: true };
+mock.module('../models/catalog-models', () => ({
+  capabilitiesForModel: () => capabilities,
 }));
 
 const { resolveCandidates, resolveCachedAccountTier } = await import('./resolve-candidates');
@@ -83,6 +90,7 @@ beforeEach(() => {
   codexCredential = null;
   catalogUpstream = null;
   runtimeManagedModel = undefined;
+  capabilities = { reasoning: false, temperature: true };
   getAccountTier.mockClear();
   getResolvedProjectSecretValue.mockClear();
   resolveCodexCredential.mockClear();
@@ -109,6 +117,21 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
       apiKey: 'sk-user-key',
     });
     expect(candidates[1]).toMatchObject({ provider: 'kortix-managed' });
+  });
+
+  test('BYOK descriptor carries the model capability flags for the transport', async () => {
+    catalogUpstream = {
+      baseUrl: 'https://api.openai.com/v1',
+      envVar: 'OPENAI_API_KEY',
+      kind: 'openai-compat',
+    };
+    resolvedSecret = 'sk-user-key';
+    capabilities = { reasoning: true, temperature: false };
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(p, 'openai/gpt-5.5');
+    expect(candidates[0]).toMatchObject({ reasoning: true, temperature: false });
   });
 
   test('free tier: BYOK key is billing-free (markup 0, billingMode none) with no managed fallback', async () => {

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -1,18 +1,21 @@
 import {
   type AuthedPrincipal,
-  type UpstreamDescriptor,
   GatewayResolutionError,
+  type UpstreamDescriptor,
 } from '@kortix/llm-gateway';
 import { getAccountTier } from '../../billing/services/entitlements';
 import { accountIsFreeTierForModels } from '../../billing/services/tiers';
 import { config } from '../../config';
-import { getResolvedProjectSecretValue, projectSecretExistsForAnyOwner } from '../../projects/secrets';
+import {
+  getResolvedProjectSecretValue,
+  projectSecretExistsForAnyOwner,
+} from '../../projects/secrets';
 import { CodexRefreshError, resolveCodexCredential } from '../credentials/codex';
-import { codexDescriptor, livePricing, managedCandidates } from './descriptors';
-import { resolveCatalogUpstream } from '../models/provider-registry';
 import { capabilitiesForModel } from '../models/catalog-models';
-import { resolveGatewayRoute } from '../routing';
 import { getRuntimeManagedModel, isKnownManagedModelId } from '../models/managed-models';
+import { resolveCatalogUpstream } from '../models/provider-registry';
+import { resolveGatewayRoute } from '../routing';
+import { codexDescriptor, livePricing, managedCandidates } from './descriptors';
 
 const PLATFORM_FEE_MARKUP = 0.1;
 const TIER_CACHE_TTL_MS = 30_000;
@@ -72,12 +75,15 @@ export async function resolveCandidates(
   // resolve it against the same account/agent default the control plane used.
   // Free-tier principals cannot use managed Kortix models, so stale AUTO below
   // resolves to no candidates rather than a paid/default upstream.
-  const effectiveModel = model === 'auto' || model === 'kortix/auto'
-    ? (await resolveGatewayRoute(principal, {
-        requestedModel: model,
-        requires: { imageInput: false },
-      })).primaryModel
-    : model;
+  const effectiveModel =
+    model === 'auto' || model === 'kortix/auto'
+      ? (
+          await resolveGatewayRoute(principal, {
+            requestedModel: model,
+            requires: { imageInput: false },
+          })
+        ).primaryModel
+      : model;
   const provider = effectiveModel.includes('/') ? effectiveModel.split('/')[0] : '';
 
   if (provider === 'codex') {
@@ -127,7 +133,11 @@ export async function resolveCandidates(
     // PRIVATE key (never another member's) so a member who saved a personal
     // provider key isn't left with a "connected" provider that silently
     // routes nothing — see pickResolvedSecretRow's doc comment.
-    const key = await getResolvedProjectSecretValue(principal.projectId, byok.envVar, principal.userId);
+    const key = await getResolvedProjectSecretValue(
+      principal.projectId,
+      byok.envVar,
+      principal.userId,
+    );
     if (key) {
       const tier = config.KORTIX_BILLING_INTERNAL_ENABLED
         ? await resolveCachedAccountTier(principal.accountId)

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -19,12 +19,18 @@ const TIER_CACHE_TTL_MS = 30_000;
 
 const accountTierCache = new Map<string, { tier: string; expiresAt: number }>();
 
-async function resolveCachedAccountTier(accountId: string): Promise<string> {
+// `now` is injectable (defaults to Date.now()) purely so the 30s TTL boundary
+// is unit-testable without a real wall-clock sleep — every production call
+// site leaves it unset and gets the real clock.
+export async function resolveCachedAccountTier(
+  accountId: string,
+  now: number = Date.now(),
+): Promise<string> {
   const cached = accountTierCache.get(accountId);
-  if (cached && cached.expiresAt > Date.now()) return cached.tier;
+  if (cached && cached.expiresAt > now) return cached.tier;
 
   const tier = await getAccountTier(accountId);
-  accountTierCache.set(accountId, { tier, expiresAt: Date.now() + TIER_CACHE_TTL_MS });
+  accountTierCache.set(accountId, { tier, expiresAt: now + TIER_CACHE_TTL_MS });
   return tier;
 }
 

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -170,7 +170,10 @@ export async function resolveCandidates(
     // provider at all" from "a teammate connected their own key but kept it
     // private" — both used to read as the same generic "No upstream
     // configured" message with no clue which of the two applies.
-    const anyOwnerConnected = await projectSecretExistsForAnyOwner(principal.projectId, byok.envVar);
+    const anyOwnerConnected = await projectSecretExistsForAnyOwner(
+      principal.projectId,
+      byok.envVar,
+    );
     byokFailure = anyOwnerConnected
       ? new GatewayResolutionError(
           'provider_key_private',

--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
-import { callUpstream, type FetchImpl } from './call-upstream';
-import { buildUpstreamRequest } from '../transports';
-import { CircuitBreaker } from '../resilience';
-import { ClientAbortError, CircuitOpenError, UpstreamHttpError } from '../errors';
 import type { UpstreamDescriptor } from '../domain';
+import { ClientAbortError, CircuitOpenError, UpstreamHttpError } from '../errors';
+import { CircuitBreaker } from '../resilience';
+import { buildUpstreamRequest } from '../transports';
+import { type FetchImpl, callUpstream } from './call-upstream';
 
 const descriptor: UpstreamDescriptor = {
   provider: 'openrouter',
@@ -37,7 +37,10 @@ function makeRecordingFetch() {
   const seenHeaders: Record<string, string>[] = [];
   const impl: FetchImpl = async (_input, init) => {
     seenHeaders.push({ ...(init.headers as Record<string, string>) });
-    return new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } });
+    return new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
   };
   return { impl, seenHeaders };
 }
@@ -75,10 +78,18 @@ describe('callUpstream', () => {
     };
     await callUpstream(
       playgroundRequest,
-      { ...descriptor, provider: 'openai', baseUrl: 'https://api.openai.com/v1', resolvedModel: 'gpt-5.5' },
+      {
+        ...descriptor,
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        resolvedModel: 'gpt-5.5',
+      },
       { retry: fastRetry, fetchImpl: capturingFetch },
     );
-    await callUpstream(playgroundRequest, descriptor, { retry: fastRetry, fetchImpl: capturingFetch });
+    await callUpstream(playgroundRequest, descriptor, {
+      retry: fastRetry,
+      fetchImpl: capturingFetch,
+    });
 
     const toOpenAi = JSON.parse(bodies[0]!);
     expect(toOpenAi.max_completion_tokens).toBe(512);
@@ -90,8 +101,14 @@ describe('callUpstream', () => {
   });
 
   test('retries a 503 then returns the ok response', async () => {
-    const fetchMock = makeFetch([{ status: 503, body: 'down' }, { status: 200, body: '{"ok":true}' }]);
-    const res = await callUpstream({ model: 'x' }, descriptor, { retry: fastRetry, fetchImpl: fetchMock.impl });
+    const fetchMock = makeFetch([
+      { status: 503, body: 'down' },
+      { status: 200, body: '{"ok":true}' },
+    ]);
+    const res = await callUpstream({ model: 'x' }, descriptor, {
+      retry: fastRetry,
+      fetchImpl: fetchMock.impl,
+    });
     expect(res.status).toBe(200);
     expect(fetchMock.getCalls()).toBe(2);
   });
@@ -121,7 +138,11 @@ describe('callUpstream', () => {
     const fetchMock = makeFetch([{ status: 500, body: 'boom' }]);
     const binding = { provider: descriptor.provider, breaker };
 
-    await callUpstream({}, descriptor, { retry: { ...fastRetry, maxAttempts: 1 }, fetchImpl: fetchMock.impl, binding }).catch(() => {});
+    await callUpstream({}, descriptor, {
+      retry: { ...fastRetry, maxAttempts: 1 },
+      fetchImpl: fetchMock.impl,
+      binding,
+    }).catch(() => {});
     expect(breaker.current).toBe('open');
 
     const callsBefore = fetchMock.getCalls();

--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -33,6 +33,15 @@ function makeFetch(steps: Step[]) {
   return { impl, getCalls: () => calls };
 }
 
+function makeRecordingFetch() {
+  const seenHeaders: Record<string, string>[] = [];
+  const impl: FetchImpl = async (_input, init) => {
+    seenHeaders.push({ ...(init.headers as Record<string, string>) });
+    return new Response('{"ok":true}', { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  return { impl, seenHeaders };
+}
+
 describe('buildUpstreamRequest', () => {
   test('targets /chat/completions with a bearer key', () => {
     const req = buildUpstreamRequest({ model: 'x' }, descriptor);
@@ -120,6 +129,22 @@ describe('callUpstream', () => {
       callUpstream({}, descriptor, { retry: fastRetry, fetchImpl: fetchMock.impl, binding }),
     ).rejects.toBeInstanceOf(CircuitOpenError);
     expect(fetchMock.getCalls()).toBe(callsBefore);
+  });
+
+  test('threads requestId through to the upstream as a correlation header', async () => {
+    const recording = makeRecordingFetch();
+    await callUpstream({ model: 'x' }, descriptor, {
+      retry: fastRetry,
+      fetchImpl: recording.impl,
+      requestId: 'req_abc123',
+    });
+    expect(recording.seenHeaders[0]?.['x-kortix-request-id']).toBe('req_abc123');
+  });
+
+  test('omits the correlation header when no requestId is given', async () => {
+    const recording = makeRecordingFetch();
+    await callUpstream({ model: 'x' }, descriptor, { retry: fastRetry, fetchImpl: recording.impl });
+    expect(recording.seenHeaders[0]).not.toHaveProperty('x-kortix-request-id');
   });
 });
 

--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -1,8 +1,8 @@
+import type { TranslationSidecarConfig, UpstreamDescriptor } from '../domain';
 import { ClientAbortError, NetworkError, UpstreamHttpError } from '../errors';
-import { withResilience, type BreakerBinding, type RetryOptions } from '../resilience';
+import { type BreakerBinding, type RetryOptions, withResilience } from '../resilience';
 import { transportFor } from '../transports';
 import { buildSidecarRequest, isSidecarEligible } from '../transports/sidecar';
-import type { TranslationSidecarConfig, UpstreamDescriptor } from '../domain';
 
 export type FetchImpl = (input: string, init: RequestInit) => Promise<Response>;
 

--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -16,6 +16,12 @@ export interface CallUpstreamOptions {
    *  signal so a caller disconnect aborts the in-flight upstream fetch too,
    *  instead of only bounding it by the retry timeout. */
   signal?: AbortSignal;
+  // Kortix-internal correlation id for this request (see pipeline/handler.ts's
+  // newRequestId()). Sent to the upstream as a best-effort header so a failed
+  // or slow completion can be cross-referenced against the provider's own
+  // request logs/support tooling — every provider here tolerates unknown
+  // headers, so this is safe to always send rather than gated per-transport.
+  requestId?: string;
 }
 
 export async function callUpstream(
@@ -30,6 +36,9 @@ export async function callUpstream(
     opts.translationSidecar && isSidecarEligible(descriptor)
       ? buildSidecarRequest(direct, descriptor, opts.translationSidecar)
       : direct;
+  if (opts.requestId) {
+    request.headers = { ...request.headers, 'x-kortix-request-id': opts.requestId };
+  }
   const streaming = body.stream === true;
   const clientSignal = opts.signal;
 

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -153,6 +153,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
         fetchImpl,
         translationSidecar: config.translationSidecar,
         signal,
+        requestId,
       });
       chosen = candidate;
       debug('upstream_attempt_ok', {

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -4,7 +4,7 @@ import type {
   ModelFallbackCondition,
   UpstreamDescriptor,
 } from '../domain';
-import { ClientAbortError, CircuitOpenError, UpstreamHttpError } from '../errors';
+import { CircuitOpenError, ClientAbortError, UpstreamHttpError } from '../errors';
 import { type FetchImpl, callUpstream } from '../http';
 import type { CircuitBreaker } from '../resilience';
 import { gatewayErrorBody } from './error-response';
@@ -95,12 +95,24 @@ export interface FailoverSuccess {
   attempts: number;
 }
 
-export type FailoverResult = { kind: 'response'; response: Response } | { kind: 'success'; value: FailoverSuccess };
+export type FailoverResult =
+  | { kind: 'response'; response: Response }
+  | { kind: 'success'; value: FailoverSuccess };
 
 export async function runFailover(ctx: FailoverContext): Promise<FailoverResult> {
   const {
-    candidates, payload, config, fetchImpl, breakerFor, emit, logger,
-    requestId, trace, capturedRequest, fallbackOn, signal,
+    candidates,
+    payload,
+    config,
+    fetchImpl,
+    breakerFor,
+    emit,
+    logger,
+    requestId,
+    trace,
+    capturedRequest,
+    fallbackOn,
+    signal,
   } = ctx;
   const tried: string[] = [];
   const modelsTried: string[] = [];
@@ -116,9 +128,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
     const candidate = candidates[i];
     const { descriptor, routeModel } = candidate;
     const hasFallback = i < candidates.length - 1;
-    const hasModelFallback = candidates
-      .slice(i + 1)
-      .some((next) => next.routeModel !== routeModel);
+    const hasModelFallback = candidates.slice(i + 1).some((next) => next.routeModel !== routeModel);
     tried.push(descriptor.provider);
     if (modelsTried.at(-1) !== routeModel) modelsTried.push(routeModel);
     attempts += 1;
@@ -177,10 +187,17 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
         // the whole dispatch loop immediately instead of failing over.
         debug('client_aborted', { provider: descriptor.provider });
         emit({
-          ...trace, resolvedModel: descriptor.resolvedModel, provider: descriptor.provider,
-          billingMode: descriptor.billingMode, status: 499, ok: false,
-          errorCode: 'client_disconnected', errorMessage: 'Client disconnected before a response was ready',
-          attempts, candidatesTried: tried, request: capturedRequest,
+          ...trace,
+          resolvedModel: descriptor.resolvedModel,
+          provider: descriptor.provider,
+          billingMode: descriptor.billingMode,
+          status: 499,
+          ok: false,
+          errorCode: 'client_disconnected',
+          errorMessage: 'Client disconnected before a response was ready',
+          attempts,
+          candidatesTried: tried,
+          request: capturedRequest,
         });
         return {
           kind: 'response',
@@ -217,33 +234,44 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
             fromModel: routeModel,
             status: err.status,
             reason:
-              fallbackOn === 'any-error' && hasModelFallback
-                ? 'model_policy'
-                : 'provider_limit',
+              fallbackOn === 'any-error' && hasModelFallback ? 'model_policy' : 'provider_limit',
           });
           continue;
         }
-        debug('upstream_client_error_return', { provider: descriptor.provider, status: err.status });
+        debug('upstream_client_error_return', {
+          provider: descriptor.provider,
+          status: err.status,
+        });
         const upstreamError = parseUpstreamBody(err.body);
         emit({
-          ...trace, resolvedModel: descriptor.resolvedModel, provider: descriptor.provider,
-          billingMode: descriptor.billingMode, status: err.status, ok: false,
-          errorCode: 'upstream_client_error', errorMessage: upstreamError.message, attempts, candidatesTried: tried,
+          ...trace,
+          resolvedModel: descriptor.resolvedModel,
+          provider: descriptor.provider,
+          billingMode: descriptor.billingMode,
+          status: err.status,
+          ok: false,
+          errorCode: 'upstream_client_error',
+          errorMessage: upstreamError.message,
+          attempts,
+          candidatesTried: tried,
           request: capturedRequest,
         });
         return {
           kind: 'response',
-          response: json(gatewayErrorBody({
-            message: upstreamError.message,
-            code: 'upstream_client_error',
-            upstreamCode: upstreamError.code,
-            upstreamStatus: err.status,
-            provider: descriptor.provider,
-            requestedModel: trace.requestedModel ?? '',
-            resolvedModel: descriptor.resolvedModel ?? trace.requestedModel ?? '',
-            requestId,
-            suggestion: suggestionFor(err.status),
-          }), err.status),
+          response: json(
+            gatewayErrorBody({
+              message: upstreamError.message,
+              code: 'upstream_client_error',
+              upstreamCode: upstreamError.code,
+              upstreamStatus: err.status,
+              provider: descriptor.provider,
+              requestedModel: trace.requestedModel ?? '',
+              resolvedModel: descriptor.resolvedModel ?? trace.requestedModel ?? '',
+              requestId,
+              suggestion: suggestionFor(err.status),
+            }),
+            err.status,
+          ),
         };
       }
     }
@@ -253,33 +281,51 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
     const open = lastError instanceof CircuitOpenError;
     const status = open ? 503 : 502;
     const errorCode = open ? 'upstream_unavailable' : 'upstream_unreachable';
-    const lastCandidate = [...candidates].reverse().find(
-      (candidate) => candidate.descriptor.provider === tried.at(-1),
-    );
+    const lastCandidate = [...candidates]
+      .reverse()
+      .find((candidate) => candidate.descriptor.provider === tried.at(-1));
     const lastDescriptor = lastCandidate?.descriptor;
-    const upstreamError = lastError instanceof UpstreamHttpError
-      ? parseUpstreamBody(lastError.body)
-      : { message: errorMessage(lastError) };
-    debug('all_upstreams_exhausted', { circuitOpen: open, status, tried, attempts, error: upstreamError.message });
+    const upstreamError =
+      lastError instanceof UpstreamHttpError
+        ? parseUpstreamBody(lastError.body)
+        : { message: errorMessage(lastError) };
+    debug('all_upstreams_exhausted', {
+      circuitOpen: open,
+      status,
+      tried,
+      attempts,
+      error: upstreamError.message,
+    });
     emit({
-      ...trace, provider: tried[tried.length - 1] ?? '', status, ok: false,
+      ...trace,
+      provider: tried[tried.length - 1] ?? '',
+      status,
+      ok: false,
       resolvedModel: lastDescriptor?.resolvedModel,
-      errorCode, errorMessage: upstreamError.message, attempts, candidatesTried: tried,
+      errorCode,
+      errorMessage: upstreamError.message,
+      attempts,
+      candidatesTried: tried,
       request: capturedRequest,
     });
     return {
       kind: 'response',
-      response: json(gatewayErrorBody({
-        message: upstreamError.message || 'All upstreams unavailable',
-        code: errorCode,
-        upstreamCode: upstreamError.code,
-        upstreamStatus: lastError instanceof UpstreamHttpError ? lastError.status : undefined,
-        provider: lastDescriptor?.provider ?? tried.at(-1) ?? '',
-        requestedModel: trace.requestedModel ?? '',
-        resolvedModel: lastDescriptor?.resolvedModel ?? trace.requestedModel ?? '',
-        requestId,
-        suggestion: suggestionFor(lastError instanceof UpstreamHttpError ? lastError.status : status),
-      }), status),
+      response: json(
+        gatewayErrorBody({
+          message: upstreamError.message || 'All upstreams unavailable',
+          code: errorCode,
+          upstreamCode: upstreamError.code,
+          upstreamStatus: lastError instanceof UpstreamHttpError ? lastError.status : undefined,
+          provider: lastDescriptor?.provider ?? tried.at(-1) ?? '',
+          requestedModel: trace.requestedModel ?? '',
+          resolvedModel: lastDescriptor?.resolvedModel ?? trace.requestedModel ?? '',
+          requestId,
+          suggestion: suggestionFor(
+            lastError instanceof UpstreamHttpError ? lastError.status : status,
+          ),
+        }),
+        status,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary

Closes the TEST-COVERAGE and RELIABILITY-BACKLOG findings from tonight's adversarially-verified LLM-gateway audit that are NOT owned by the parallel billing/streaming/errors/transports fix PRs.

- **Correlation ID threaded to the upstream call** (`packages/llm-gateway/src/http/call-upstream.ts`, `pipeline/failover.ts`): `callUpstream()` sends `x-kortix-request-id` on every outbound provider request, set centrally after `transport.buildRequest()` so all transports get it without touching each one. `requestId` was already in logs/traces; only the wire hop was missing.
- **`validateGatewayKey` test coverage** (`apps/api/src/llm-gateway/gateway-keys.test.ts`, real-DB): active/no-expiry, future-expiry, revoked, past-expiry, the exact expiry boundary, `createdBy`-null → `accountId` fallback, unknown secret, and the fire-and-forget `lastUsedAt` stamp.
- **`GATEWAY_INTERNAL_TOKEN` weak-secret boot warning** (`internal-auth.ts` + `internal-routes.ts`): loud, non-blocking warning when the configured token (or any rotation-CSV entry) is short or matches a known-weak/default value. Cheap hardening on top of the existing rotation + timing-safe compare; the real mutual-auth gap (no host/identity binding) is written up in the backlog doc as a scoped follow-up with a threat model and a recommended next step (HMAC request signing), not attempted tonight.
- **Tier gating + BYOK free-tier `billingMode` test coverage** (`resolution/resolve-candidates.test.ts`): BYOK markup/free-tier branch, managed-model tier gating, managed-fallback queuing, codex routing. `resolveCachedAccountTier` now takes an injectable `now` (default `Date.now()`, no production behavior change) so its 30s TTL boundary and the "tier change during the cache window" bug shape are both unit-testable.
- **`RELIABILITY-BACKLOG.md` updated**: marks the above closed with this PR; flags `checkBudget`'s warn-action bug as owned by a parallel billing pass tonight (not duplicated here); documents idempotency-key support and per-model/per-key rate limiting as deliberately-deferred *features*, not fixes, for a future pass.

Explicitly **not** touched (owned by the other agents in tonight's wave, verified via `git log origin/main` before writing): `pricing.ts`/`calculateCost`, `budgets.ts`/`checkBudget`, Bedrock stream parser, openai-compat param-shape tests (PR #4809 already landed and was picked up cleanly on rebase).

## Test plan

- [x] `packages/llm-gateway`: `tsc --noEmit` clean
- [x] `apps/api`: `tsc --noEmit` clean
- [x] `bun test packages/llm-gateway/src/http/call-upstream.test.ts` — 9 pass (incl. 2 new correlation-id tests)
- [x] `KORTIX_URL=http://localhost:8008 dotenvx run -f .env.local -f .env -- bun test apps/api/src/llm-gateway/gateway-keys.test.ts apps/api/src/llm-gateway/internal-auth.test.ts apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts` — all pass against a real local Postgres
- [x] Full `apps/api/src/llm-gateway` suite run for regressions — same 3 pre-existing `managed-provider-disabled.test.ts` failures reproduce identically on a clean `origin/main` baseline (env-order/isolation issue, unrelated to this change)
- [x] Rebased onto latest `origin/main` — no conflicts