### PR TITLE
feat(llm-gateway): LiteLLM stateless translation sidecar behind the control plane

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -340,6 +340,23 @@ const envSchema = z.object({
   // the in-cluster gateway service, e.g. http://kortix-gateway:8090, so the
   // gateway stays internal and sandboxes reach it via the API's public origin.
   LLM_GATEWAY_PROXY_TARGET:    optStr,
+  // Stateless LiteLLM translation sidecar (see packages/llm-gateway's
+  // GatewayConfig.translationSidecar): when set, the openai-compat/custom
+  // upstream candidates route through this sidecar instead of calling the
+  // provider directly, so param-quirk translation (e.g. OpenAI's max_tokens ->
+  // max_completion_tokens) is owned by LiteLLM's community-maintained tables
+  // instead of ours. Empty = current direct behavior — required for old
+  // self-host boxes and a gradual rollout. The sidecar itself holds no
+  // credentials; the resolved upstream key/base travel per-request. Base URL
+  // only — e.g. http://litellm:4000 in self-host, unset in cloud today (see
+  // the PR's cloud-rollout note; this is a code-path + env wire-up only).
+  LLM_TRANSLATION_SIDECAR_URL: optStr,
+  // Bearer token for the sidecar's OWN master-key auth (LiteLLM's
+  // `general_settings.master_key`) — never the upstream provider key, which
+  // travels in the request body instead. Optional only because a sidecar can
+  // technically run with no master key; self-host always sets one (see
+  // kortix-compose.yml).
+  LLM_TRANSLATION_SIDECAR_AUTH_TOKEN: optStr,
   // AWS Bedrock — the managed ("Kortix") models route here via a Bedrock API key
   // (bearer). Region selects the bedrock-runtime endpoint; the key is an IAM
   // service-specific credential for bedrock.amazonaws.com.
@@ -799,6 +816,8 @@ export const config = {
   LLM_GATEWAY_BYOK_FALLBACK_MODEL: env.LLM_GATEWAY_BYOK_FALLBACK_MODEL,
   LLM_GATEWAY_PROXY_PORT: env.LLM_GATEWAY_PROXY_PORT,
   LLM_GATEWAY_PROXY_TARGET: env.LLM_GATEWAY_PROXY_TARGET,
+  LLM_TRANSLATION_SIDECAR_URL: env.LLM_TRANSLATION_SIDECAR_URL,
+  LLM_TRANSLATION_SIDECAR_AUTH_TOKEN: env.LLM_TRANSLATION_SIDECAR_AUTH_TOKEN,
   AWS_BEDROCK_REGION: env.AWS_BEDROCK_REGION,
   AWS_BEDROCK_API_KEY: env.AWS_BEDROCK_API_KEY,
   ANTHROPIC_API_URL: env.ANTHROPIC_API_URL,

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -22,6 +22,12 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     // One gateway instance per process — its circuit breakers are long-lived.
     const gateway = createGateway(createInProcessGatewayHooks(), {
       captureBodies: true,
+      translationSidecar: config.LLM_TRANSLATION_SIDECAR_URL
+        ? {
+            url: config.LLM_TRANSLATION_SIDECAR_URL,
+            authToken: config.LLM_TRANSLATION_SIDECAR_AUTH_TOKEN || undefined,
+          }
+        : undefined,
     });
     const llm = new Hono();
     llm.get('/health', (c) =>

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { randomBytes, createHmac, generateKeyPairSync } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { createServer } from 'node:net';
+import { totalmem } from 'node:os';
 
 import { takeFlagBool, takeFlagValue } from '../command-helpers.ts';
 import { getHost, removeHost, upsertHost, type Host } from '../api/config.ts';
@@ -55,6 +56,26 @@ const DEFAULT_API_URL = 'http://localhost:13738';
 const DEFAULT_FRONTEND_IMAGE_REPO = 'kortix/kortix-frontend';
 const DEFAULT_API_IMAGE_REPO = 'kortix/kortix-api';
 const DEFAULT_GATEWAY_IMAGE_REPO = 'kortix/kortix-gateway';
+// Stateless LiteLLM translation sidecar (see packages/llm-gateway's
+// GatewayConfig.translationSidecar). Third-party infra, not a Kortix release
+// artifact — pinned by tag@digest here (like every Supabase vendor image),
+// not tracked to KORTIX_VERSION/channel: bumping it is a deliberate, reviewed
+// change to this file, same rationale as kortix-updater's docker:...-cli pin
+// below. Digest resolved 2026-07 from the ghcr.io/berriai/litellm registry.
+const DEFAULT_LITELLM_IMAGE =
+  'ghcr.io/berriai/litellm:main-stable@sha256:9ef6f45bc0104940571765e610c52a1d761b5ec85efcd193795281086ee61277';
+// Measured live (docker stats, idle, no traffic): ~1.0 GiB resident for the
+// image above — well over the ~500MB budget a translation-only sidecar
+// "should" cost. Rather than silently taxing every self-host box with that,
+// the service (and the flag that turns it on) defaults ON only when the HOST
+// has enough headroom to not even notice it; smaller boxes stay on the
+// existing direct/hotfix path until an operator opts in explicitly
+// (`kortix self-host env set LLM_TRANSLATION_SIDECAR_ENABLED=true`).
+const LLM_TRANSLATION_SIDECAR_MIN_RAM_BYTES = 16 * 1024 ** 3;
+
+function defaultTranslationSidecarEnabled(): boolean {
+  return totalmem() >= LLM_TRANSLATION_SIDECAR_MIN_RAM_BYTES;
+}
 // Shown whenever an instance is (or is being configured) NOT reachable via a
 // public domain — self-host is VPS-first, and the Cloudflare tunnel is an
 // evaluation convenience, not the recommended production setup.
@@ -185,6 +206,19 @@ interface SelfHostEnv {
   // spread in defaultEnv() (see shared-runtime-defaults.ts), not a literal
   // here, so TS can't see them as named properties.
   GATEWAY_INTERNAL_TOKEN: string;
+  // Stateless LiteLLM translation sidecar — see DEFAULT_LITELLM_IMAGE above
+  // and the `litellm` service in assets/kortix-compose.yml.
+  LITELLM_IMAGE: string;
+  LITELLM_MASTER_KEY: string;
+  // 'true'/'false' — whether the `litellm` Compose service is included at all
+  // (see RenderComposeOptions.translationSidecarConfigured) and whether
+  // kortix-api gets LLM_TRANSLATION_SIDECAR_URL pointed at it. Defaults per
+  // defaultTranslationSidecarEnabled() (host RAM), operator-overridable via
+  // `env set`.
+  LLM_TRANSLATION_SIDECAR_ENABLED: string;
+  // Recomputed from LLM_TRANSLATION_SIDECAR_ENABLED on every render (see
+  // normalizeFullSupabaseEnv) — never hand-set independently of the flag.
+  LLM_TRANSLATION_SIDECAR_URL: string;
   OPENROUTER_API_KEY: string;
   POSTGRES_PASSWORD: string;
   SUPABASE_JWT_SECRET: string;
@@ -1054,7 +1088,11 @@ async function selfHostVersion(flags: GlobalFlags): Promise<number> {
   process.stdout.write(`\n  ${C.dim}images${C.reset}\n`);
   process.stdout.write(`  ${C.dim}  api      ${C.reset}${env.API_IMAGE}\n`);
   process.stdout.write(`  ${C.dim}  frontend ${C.reset}${env.FRONTEND_IMAGE}\n`);
-  process.stdout.write(`  ${C.dim}  gateway  ${C.reset}${env.GATEWAY_IMAGE}\n\n`);
+  process.stdout.write(`  ${C.dim}  gateway  ${C.reset}${env.GATEWAY_IMAGE}\n`);
+  if (env.LLM_TRANSLATION_SIDECAR_ENABLED === 'true') {
+    process.stdout.write(`  ${C.dim}  litellm  ${C.reset}${env.LITELLM_IMAGE}${C.dim} (translation sidecar — pinned independently, not tracked by channel)${C.reset}\n`);
+  }
+  process.stdout.write('\n');
   process.stdout.write(`  ${C.dim}Update: ${C.reset}${C.cyan}kortix self-host update${C.reset}${C.dim} (current channel) or ${C.reset}${C.cyan}--tag <version>${C.reset}\n\n`);
   return 0;
 }
@@ -1351,9 +1389,11 @@ function refuseUpdaterManagedKeyMessage(key: string): string {
 function restartServicesForKeys(instance: string, env: SelfHostEnv, keys: readonly string[]): number {
   const domainConfigured = Boolean(env.KORTIX_DOMAIN?.trim());
   const tunnelActive = reachabilityMode(env) === 'tunnel';
+  const translationSidecarActive = env.LLM_TRANSLATION_SIDECAR_ENABLED === 'true';
   const services = servicesForKeys(keys).filter((service) => {
     if (service === 'caddy') return domainConfigured;
     if (service === 'cloudflared') return tunnelActive;
+    if (service === 'litellm') return translationSidecarActive;
     return true;
   });
   if (services.length === 0) {
@@ -1454,6 +1494,7 @@ function freshTokenFor(key: string): string {
     case 'INTERNAL_SERVICE_KEY':
     case 'API_KEY_SECRET':
     case 'TUNNEL_SIGNING_SECRET':
+    case 'LITELLM_MASTER_KEY':
       return token(32);
     case 'S3_PROTOCOL_ACCESS_KEY_ID':
       return token(16);
@@ -2205,6 +2246,12 @@ function defaultEnv(flags: GlobalFlags): SelfHostEnv {
     API_IMAGE: `${DEFAULT_API_IMAGE_REPO}:${tag}`,
     GATEWAY_IMAGE: `${DEFAULT_GATEWAY_IMAGE_REPO}:${tag}`,
     GATEWAY_INTERNAL_TOKEN: token(32),
+    LITELLM_IMAGE: DEFAULT_LITELLM_IMAGE,
+    LITELLM_MASTER_KEY: token(32),
+    LLM_TRANSLATION_SIDECAR_ENABLED: defaultTranslationSidecarEnabled() ? 'true' : 'false',
+    // Recomputed in normalizeFullSupabaseEnv() from the flag above; this
+    // initial value only matters before that first normalize pass.
+    LLM_TRANSLATION_SIDECAR_URL: '',
     OPENROUTER_API_KEY: '',
     POSTGRES_PASSWORD: token(32),
     SUPABASE_JWT_SECRET: jwtSecret,
@@ -2318,6 +2365,7 @@ function writeCompose(instance: string, env: SelfHostEnv): void {
       tunnelConfigured: reachabilityMode(env) === 'tunnel',
       namedTunnelConfigured: namedTunnelConfigured(env),
       localDockerConfigured: sandboxProviders(env).includes('local-docker'),
+      translationSidecarConfigured: env.LLM_TRANSLATION_SIDECAR_ENABLED === 'true',
     }),
     { encoding: 'utf8', mode: 0o600 },
   );
@@ -2421,6 +2469,14 @@ function normalizeFullSupabaseEnv(instance: string, env: SelfHostEnv): void {
 
   env.API_EXTERNAL_URL = `${env.SUPABASE_PUBLIC_URL.replace(/\/$/, '')}/auth/v1`;
   env.SITE_URL = env.PUBLIC_URL;
+
+  // Stateless LiteLLM translation sidecar: the URL kortix-api actually uses is
+  // always DERIVED from the enabled flag, never set independently — so
+  // flipping LLM_TRANSLATION_SIDECAR_ENABLED via `env set` (or an upgrade
+  // recomputing this on every render) can never leave the URL pointed at a
+  // `litellm` service that renderFullDockerCompose() has omitted from the
+  // Compose file (see RenderComposeOptions.translationSidecarConfigured).
+  env.LLM_TRANSLATION_SIDECAR_URL = env.LLM_TRANSLATION_SIDECAR_ENABLED === 'true' ? 'http://litellm:4000' : '';
 
   // Always recomputed (never `||=`) — see the KORTIX_INSTANCE_DIR field's doc
   // comment on SelfHostEnv. Unconditional on purpose: if the instance

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -298,8 +298,8 @@ describe('full self-host Docker distribution', () => {
     expect(frontendTest).not.toContain('bun');
   });
 
-  test('embeds the Caddyfile and updater script as runtime assets', () => {
-    expect(Object.keys(kortixRuntimeAssets).sort()).toEqual(['Caddyfile', 'updater.sh']);
+  test('embeds the Caddyfile, updater script, and litellm config as runtime assets', () => {
+    expect(Object.keys(kortixRuntimeAssets).sort()).toEqual(['Caddyfile', 'litellm-config.yaml', 'updater.sh']);
     expect(kortixRuntimeAssets.Caddyfile).toContain('{$KORTIX_DOMAIN}');
     expect(kortixRuntimeAssets.Caddyfile).toContain('{$KORTIX_API_DOMAIN}');
     expect(kortixRuntimeAssets['updater.sh']).toContain('docker compose');
@@ -377,6 +377,56 @@ describe('full self-host Docker distribution', () => {
       .map(([, service]) => (service.mem_limit ? toMb(service.mem_limit) : 0))
       .reduce((a, b) => a + b, 0);
     expect(totalCeilingMb).toBeLessThan(8 * 1024);
+  });
+
+  test('stateless LiteLLM translation sidecar: omitted entirely by default, present + correctly shaped when enabled', () => {
+    type ServiceShape = {
+      image?: string;
+      ports?: string[];
+      environment?: Record<string, string>;
+      mem_limit?: string;
+      mem_reservation?: string;
+      logging?: { driver?: string; options?: Record<string, string> };
+    };
+
+    // Default (translationSidecarConfigured unset): omitted entirely, same
+    // "not merely stopped" posture as caddy/cloudflared without their flags.
+    const off = parse(renderFullDockerCompose('kortix-default')) as { services: Record<string, ServiceShape> };
+    expect(off.services).not.toHaveProperty('litellm');
+
+    const on = parse(
+      renderFullDockerCompose('kortix-default', { translationSidecarConfigured: true }),
+    ) as { services: Record<string, ServiceShape> };
+    const litellm = on.services.litellm;
+    expect(litellm).toBeDefined();
+
+    // Pinned by tag@digest (third-party infra, not a Kortix release artifact).
+    expect(litellm?.image).toBe('${LITELLM_IMAGE}');
+
+    // Internal network only — no host port publishing. kortix-api is the only caller.
+    expect(litellm?.ports ?? []).toEqual([]);
+
+    // Owns only its own master-key auth — no upstream provider credentials,
+    // no DB connection string, nothing else.
+    expect(litellm?.environment).toEqual({ LITELLM_MASTER_KEY: '${LITELLM_MASTER_KEY}' });
+
+    // Sensible memory ceiling — applied uniformly via MEM_LIMITS, not
+    // hand-written into the YAML (same mechanism as every other service).
+    expect(litellm?.mem_limit).toBe('1536m');
+    expect(litellm?.mem_reservation).toBe('1024m');
+
+    // Bounded, rotated logs — applied uniformly (applyLogging()).
+    expect(litellm?.logging?.driver).toBe('json-file');
+    expect(litellm?.logging?.options?.['max-size']).toBe('10m');
+  });
+
+  test('kortix-api always carries the LLM_TRANSLATION_SIDECAR_URL/AUTH_TOKEN template vars — the enable/disable happens in .env, not in the Compose template', () => {
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { environment?: Record<string, string> }>;
+    };
+    const apiEnv = document.services['kortix-api']?.environment ?? {};
+    expect(apiEnv.LLM_TRANSLATION_SIDECAR_URL).toBe('${LLM_TRANSLATION_SIDECAR_URL}');
+    expect(apiEnv.LLM_TRANSLATION_SIDECAR_AUTH_TOKEN).toBe('${LITELLM_MASTER_KEY}');
   });
 
   test('kortix-updater image is pinned by digest, never :latest or a bare floating :cli tag', () => {

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -102,6 +102,16 @@ services:
       # never the sandbox-facing base URL in self-host.
       GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+      # Stateless LiteLLM translation sidecar (see packages/llm-gateway's
+      # GatewayConfig.translationSidecar). Empty when
+      # LLM_TRANSLATION_SIDECAR_ENABLED=false (the render-time default below
+      # ≥16GB boxes — see defaultTranslationSidecarEnabled() in
+      # commands/self-host.ts) — an empty value here is exactly today's direct
+      # behavior, matching every self-host box that predates this feature.
+      # LLM_TRANSLATION_SIDECAR_URL is recomputed from the flag on every
+      # render (normalizeFullSupabaseEnv()), never hand-set independently.
+      LLM_TRANSLATION_SIDECAR_URL: ${LLM_TRANSLATION_SIDECAR_URL}
+      LLM_TRANSLATION_SIDECAR_AUTH_TOKEN: ${LITELLM_MASTER_KEY}
     depends_on:
       supabase-db:
         condition: service_healthy
@@ -134,6 +144,42 @@ services:
       timeout: 5s
       retries: 6
       start_period: 20s
+    restart: unless-stopped
+
+  # Stateless LiteLLM translation sidecar — see packages/llm-gateway's
+  # GatewayConfig.translationSidecar and litellm-config.yaml (mounted below)
+  # for the full architecture. Present in the rendered Compose file ONLY when
+  # LLM_TRANSLATION_SIDECAR_ENABLED=true (renderFullDockerCompose() deletes
+  # this whole block otherwise — see RenderComposeOptions.
+  # translationSidecarConfigured in compose-assets.ts) so a box that isn't
+  # using it never even pulls the image. No `ports:` — internal network only,
+  # exactly like `llm-gateway` above; kortix-api is the only caller, over the
+  # Compose network by service name.
+  #
+  # It owns zero credentials/model config of its own: no database, no virtual
+  # keys, no budgets, `--num_workers 1` (this is a translation hop, not a
+  # horizontally-scaled router), and its config.yaml disables its own
+  # retries/fallbacks entirely — Kortix's llm-gateway control plane
+  # (packages/llm-gateway's failover + circuit-breaker) stays the ONLY retry
+  # brain. Every request carries the resolved upstream's api_key/api_base
+  # per-request (see transports/sidecar.ts); LITELLM_MASTER_KEY below is only
+  # this proxy's OWN auth gate.
+  litellm:
+    image: ${LITELLM_IMAGE}
+    environment:
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
+    volumes:
+      - ./litellm-config.yaml:/app/config.yaml:ro
+    command: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "1"]
+    # The image ships neither wget nor curl (verified: only python3 in
+    # /app/.venv) — every other healthcheck in this file uses one of those, so
+    # this one uses the interpreter that's actually there instead.
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request as u; u.urlopen('http://127.0.0.1:4000/health/liveliness', timeout=3)"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
     restart: unless-stopped
 
   # Auto-updater: once a day, at a fixed local clock time, pulls this stack's

--- a/apps/cli/src/self-host/assets/litellm-config.yaml
+++ b/apps/cli/src/self-host/assets/litellm-config.yaml
@@ -1,0 +1,61 @@
+# LiteLLM proxy config for Kortix's stateless translation sidecar.
+#
+# This is deliberately NOT a normal LiteLLM deployment: there is no database,
+# no virtual keys, no budgets, and no stored provider credentials anywhere in
+# this file. The sidecar's only job is provider param-quirk translation (e.g.
+# OpenAI's max_tokens -> max_completion_tokens) via LiteLLM's own
+# community-maintained tables — every actual credential/model decision still
+# belongs to Kortix's llm-gateway control plane (packages/llm-gateway), which
+# calls this proxy per-request with the resolved upstream's api_key/api_base
+# already attached to the request body (see
+# packages/llm-gateway/src/transports/sidecar.ts).
+#
+# Verified live against the real ghcr.io/berriai/litellm:main-stable
+# container (2026-07): BOTH of the two settings below are required together
+# for per-request api_key/api_base to be honored at all —
+#   - Without `allow_client_side_credentials: true`, the proxy 401s with
+#     "api_base is not allowed in request body" (a security hardening LiteLLM
+#     shipped after a huntr.com-reported credential-injection bounty — see
+#     general_settings in https://docs.litellm.ai/docs/proxy/config_settings).
+#   - Without a `model_list` entry the request matches, the proxy 400s with
+#     "no healthy deployments for this model" even with the above set. The
+#     wildcard entry below matches ANY model name (its own api_key/api_base
+#     are placeholders — never actually used; the real, resolved upstream
+#     credentials sent per-request always win).
+model_list:
+  - model_name: "*"
+    litellm_params:
+      model: "openai/*"
+      api_key: "unused-placeholder-always-overridden-per-request"
+      api_base: "http://127.0.0.1:1/unused-placeholder"
+
+litellm_settings:
+  # No hidden param-dropping surprises beyond what the quirk tables do on
+  # purpose; this is not a retry/fallback knob.
+  drop_params: true
+  # Belt-and-suspenders with router_settings.num_retries below — verified live
+  # that setting both (not just one) is what actually gets a synthetic
+  # always-500 upstream hit exactly once, with no retry delay.
+  num_retries: 0
+
+router_settings:
+  # Retries/fallbacks are Kortix's llm-gateway job (failover.ts +
+  # resilience/circuit-breaker.ts) end to end — this sidecar must never retry
+  # on its own, or a transient upstream blip gets retried twice at two
+  # different layers with two different backoff policies.
+  num_retries: 0
+
+general_settings:
+  # The sidecar's OWN auth gate — never the upstream provider key, which
+  # travels per-request in the body instead (see the header comment above).
+  # Self-host always sets LITELLM_MASTER_KEY (auto-generated at init, see
+  # secrets-registry.ts); an unauthenticated proxy would accept ANY request
+  # from anything that can reach it on the Compose network.
+  master_key: os.environ/LITELLM_MASTER_KEY
+  # Required for the per-request api_key/api_base override this whole
+  # architecture depends on — see the header comment. Safe here specifically
+  # BECAUSE this proxy is unreachable from outside the Compose network (no
+  # published port — see the `litellm` service in kortix-compose.yml) and
+  # gated by master_key above: only kortix-api/llm-gateway, already holding
+  # the real per-account resolved credentials, can ever reach this endpoint.
+  allow_client_side_credentials: true

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -5,6 +5,7 @@ import { parse, stringify } from 'yaml';
 import kortixCompose from './assets/kortix-compose.yml' with { type: 'text' };
 import kortixCaddyfile from './assets/Caddyfile.txt' with { type: 'text' };
 import kortixUpdaterScript from './assets/updater.sh' with { type: 'text' };
+import kortixLitellmConfig from './assets/litellm-config.yaml' with { type: 'text' };
 import upstreamSupabaseCompose from './assets/supabase/docker-compose.yml' with { type: 'text' };
 import upstreamSupabaseLogsCompose from './assets/supabase/docker-compose.logs.yml' with { type: 'text' };
 import supabaseImageLockText from './assets/supabase/image-lock.json' with { type: 'text' };
@@ -84,6 +85,11 @@ export const officialSupabaseDockerAssets: Readonly<Record<string, string>> = {
 export const kortixRuntimeAssets: Readonly<Record<string, string>> = {
   Caddyfile: kortixCaddyfile,
   'updater.sh': kortixUpdaterScript,
+  // Mounted read-only into the `litellm` service (see kortix-compose.yml).
+  // Written unconditionally (like Caddyfile) — harmless when the service is
+  // omitted from the rendered Compose file (translationSidecarConfigured
+  // false); one less render-time branch to get wrong.
+  'litellm-config.yaml': kortixLitellmConfig,
 };
 
 export function writeKortixRuntimeAssets(root: string): void {
@@ -130,6 +136,17 @@ export interface RenderComposeOptions {
    * Docker access it doesn't need.
    */
   localDockerConfigured?: boolean;
+  /**
+   * Whether the stateless LiteLLM translation sidecar is enabled
+   * (LLM_TRANSLATION_SIDECAR_ENABLED — see defaultTranslationSidecarEnabled()
+   * in commands/self-host.ts, RAM-gated by default). When true, the
+   * `litellm` service is included and kortix-api's LLM_TRANSLATION_SIDECAR_URL
+   * points at it (set in normalizeFullSupabaseEnv(), not here). When false, it
+   * is omitted entirely — not merely stopped — so a smaller box never even
+   * pulls the ~1GiB-idle image (measured live; see the PR this shipped with
+   * for the full RAM writeup) it isn't using.
+   */
+  translationSidecarConfigured?: boolean;
 }
 
 /**
@@ -311,6 +328,10 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
   // tunnel reachability mode is selected. Omitted entirely (not just
   // stopped) otherwise, so an instance not using it never even pulls the
   // cloudflared image.
+  if (!options.translationSidecarConfigured) {
+    delete services.litellm;
+  }
+
   if (!options.tunnelConfigured) {
     delete services.cloudflared;
   } else if (options.namedTunnelConfigured) {
@@ -453,6 +474,13 @@ const MEM_LIMITS: Readonly<Record<string, MemSpec>> = {
   'supabase-db': { limit: '1280m', reservation: '512m', oomScoreAdj: -900 },
   'kortix-api': { limit: '640m', reservation: '256m' },
   'llm-gateway': { limit: '512m', reservation: '128m' },
+  // Stateless LiteLLM translation sidecar — measured live (docker stats,
+  // idle, ghcr.io/berriai/litellm:main-stable, single worker, no traffic):
+  // ~1.0 GiB resident. That is the real floor for this image, not a leak —
+  // sized with headroom above it rather than the ~128-512m every other
+  // stateless service here gets (see the PR this shipped with for the full
+  // measurement and why the service defaults ON only on ≥16GB boxes).
+  litellm: { limit: '1536m', reservation: '1024m' },
   frontend: { limit: '512m', reservation: '128m' },
   'kortix-migrate': { limit: '512m', reservation: '128m' },
   'kortix-updater': { limit: '256m', reservation: '64m' },

--- a/apps/cli/src/self-host/secrets-registry.ts
+++ b/apps/cli/src/self-host/secrets-registry.ts
@@ -161,6 +161,11 @@ export const SECRET_DEFS: SecretDef[] = [
 
   // Internal tokens
   { key: 'GATEWAY_INTERNAL_TOKEN', category: 'internal_tokens', kind: 'generated', required: true, rotatable: true },
+  // Master-key auth for the stateless LiteLLM translation sidecar (`litellm`
+  // Compose service) — never required (the sidecar itself is opt-in, see
+  // LLM_TRANSLATION_SIDECAR_ENABLED), but always generated up front so
+  // turning the feature on later never needs a fresh secret.
+  { key: 'LITELLM_MASTER_KEY', category: 'internal_tokens', kind: 'generated', required: false, rotatable: true },
   { key: 'INTERNAL_SERVICE_KEY', category: 'internal_tokens', kind: 'generated', required: true, rotatable: true },
   { key: 'API_KEY_SECRET', category: 'internal_tokens', kind: 'generated', required: true, rotatable: true },
   { key: 'TUNNEL_SIGNING_SECRET', category: 'internal_tokens', kind: 'generated', required: true, rotatable: true },
@@ -294,6 +299,13 @@ export const KEY_SERVICE_MAP: Record<string, readonly string[]> = {
   INTERNAL_SERVICE_KEY: ['kortix-api'],
   API_KEY_SECRET: ['kortix-api'],
   TUNNEL_SIGNING_SECRET: ['kortix-api'],
+  LITELLM_MASTER_KEY: ['kortix-api', 'litellm'],
+
+  // Stateless LiteLLM translation sidecar (not in SECRET_DEFS — not secrets —
+  // but still restart-relevant for `env set`).
+  LITELLM_IMAGE: ['litellm'],
+  LLM_TRANSLATION_SIDECAR_ENABLED: ['kortix-api', 'litellm'],
+  LLM_TRANSLATION_SIDECAR_URL: ['kortix-api'],
 };
 
 /** Safe fallback for any key not explicitly mapped above. */

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -47,4 +47,16 @@ export const config = {
     failureThreshold: optionalInt('GATEWAY_BREAKER_THRESHOLD', 5),
     cooldownMs: optionalInt('GATEWAY_BREAKER_COOLDOWN_MS', 30_000),
   },
+  // Stateless LiteLLM translation sidecar — see packages/llm-gateway's
+  // GatewayConfig.translationSidecar. Unset in cloud today: this standalone
+  // pod is the sandbox-facing gateway in EKS/ECS (LLM_GATEWAY_BASE_URL), so
+  // turning this on is a deliberate ops step (task-def/pod env addition), not
+  // part of this change — see the PR's cloud-rollout note. Wired here now so
+  // that follow-up is a one-line env addition, not a code change.
+  translationSidecar: process.env.LLM_TRANSLATION_SIDECAR_URL
+    ? {
+        url: process.env.LLM_TRANSLATION_SIDECAR_URL,
+        authToken: process.env.LLM_TRANSLATION_SIDECAR_AUTH_TOKEN || undefined,
+      }
+    : undefined,
 };

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -63,6 +63,7 @@ export function buildServer(): GatewayServer {
       captureBodies: config.captureBodies,
       maxCapturedBodyBytes: config.maxCapturedBodyBytes,
       maxRequestBytes: config.maxRequestBytes || undefined,
+      translationSidecar: config.translationSidecar,
     },
     { logger },
   );

--- a/packages/llm-gateway/src/domain/config.ts
+++ b/packages/llm-gateway/src/domain/config.ts
@@ -1,5 +1,22 @@
 import type { CircuitBreakerOptions, RetryOptions } from '../resilience';
 
+// A stateless LiteLLM proxy sitting beneath the eligible transports
+// (openai-compat/custom — see transports/sidecar.ts), used purely to
+// translate provider param quirks (e.g. OpenAI's max_tokens ->
+// max_completion_tokens) via LiteLLM's community-maintained tables instead of
+// hand-rolled per-quirk code here. It owns no credentials, no model_list, no
+// DB, and no retries of its own (config.yaml sets num_retries: 0) — this
+// package's own failover/circuit-breaker stays the only retry brain. Every
+// request carries the resolved upstream's api_key/api_base per-request (see
+// buildSidecarRequest); `authToken` is the sidecar's OWN master-key auth
+// (LiteLLM's `general_settings.master_key`), never the upstream provider key.
+export interface TranslationSidecarConfig {
+  /** Base URL of the sidecar, e.g. http://litellm:4000 (no trailing slash required). */
+  url: string;
+  /** Bearer token for the sidecar's own auth gate. Omit only if the sidecar truly has no master key configured (not recommended — see the PR's security note). */
+  authToken?: string;
+}
+
 export interface GatewayConfig {
   retry?: RetryOptions;
   breaker?: CircuitBreakerOptions;
@@ -11,4 +28,12 @@ export interface GatewayConfig {
   maxRequestBytes?: number;
   /** Maximum number of fallback models after the primary. Defaults to 3, hard-capped at 8. */
   maxFallbackModels?: number;
+  /**
+   * When set, eligible upstream candidates (openai-compat/custom — anthropic/
+   * bedrock/codex keep their dedicated transports untouched) route through
+   * this stateless LiteLLM translation sidecar instead of calling the
+   * upstream directly. Unset (the default) preserves the current direct
+   * behavior — required for old self-host boxes and a gradual rollout.
+   */
+  translationSidecar?: TranslationSidecarConfig;
 }

--- a/packages/llm-gateway/src/domain/index.ts
+++ b/packages/llm-gateway/src/domain/index.ts
@@ -6,6 +6,7 @@ export type { AuthorizeResult, GatewayHooks } from './hooks';
 export type { ModelInfo, ModelCatalog } from './catalog';
 export type {
   GatewayConfig,
+  TranslationSidecarConfig,
 } from './config';
 export type {
   ModelFallbackCondition,

--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -192,7 +192,19 @@ describe('callUpstream — translation sidecar mode', () => {
     expect(capture.requests[0].url).toBe('https://up.test/v1/chat/completions');
   });
 
-  test('genuine OpenAI + sidecar enabled: our own max_tokens hotfix (openai-compat/index.ts) still fires ahead of the sidecar rewrite, so the sidecar/LiteLLM sees max_completion_tokens already — harmless overlap, not a double-translation, and exactly what keeps old self-host boxes correct the moment they flip the flag without also upgrading LiteLLM', async () => {
+  // COEXISTENCE with the direct-path quirk translations that live inside
+  // buildUpstreamRequest (openai-compat/index.ts): the max_tokens ->
+  // max_completion_tokens hotfix (#4805) AND the reasoning-restricted
+  // sampling-param strip + Perplexity role normalization (#4814). callUpstream
+  // runs transport.buildRequest() UNCONDITIONALLY and only THEN rewrites into
+  // the sidecar shape, so every one of those direct-path fixes still fires
+  // even with the sidecar on. LiteLLM's own equivalent quirk tables would
+  // handle the same cases, so this is harmless overlap (our translation is
+  // idempotent / already-clean by the time LiteLLM sees it), never a
+  // double-translation or a bypass — and it's exactly what keeps a box correct
+  // the moment it flips the flag on without also upgrading LiteLLM, and keeps
+  // #4814's fixes intact when the flag is off (the no-sidecar fallback).
+  test('genuine OpenAI + sidecar enabled: the max_tokens hotfix still fires ahead of the sidecar rewrite', async () => {
     const capture = makeCapturingFetch();
     await callUpstream(
       { model: 'x', messages: [], max_tokens: 4096 },
@@ -201,6 +213,44 @@ describe('callUpstream — translation sidecar mode', () => {
     );
     expect(capture.requests[0].body).toMatchObject({ max_completion_tokens: 4096 });
     expect(capture.requests[0].body).not.toHaveProperty('max_tokens');
+  });
+
+  test('genuine OpenAI reasoning model + sidecar enabled: #4814 reasoning-restricted sampling-param strip still fires ahead of the sidecar rewrite', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      { model: 'x', messages: [], temperature: 0.7, top_p: 0.9, presence_penalty: 1 },
+      {
+        ...descriptor,
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        resolvedModel: 'gpt-5.6-sol',
+        temperature: false,
+      },
+      { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
+    );
+    const body = capture.requests[0].body as Record<string, unknown>;
+    expect('temperature' in body).toBe(false);
+    expect('top_p' in body).toBe(false);
+    expect('presence_penalty' in body).toBe(false);
+  });
+
+  test('Perplexity + sidecar enabled: #4814 role-alternation normalization still fires ahead of the sidecar rewrite', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      {
+        model: 'x',
+        messages: [
+          { role: 'user', content: 'a' },
+          { role: 'user', content: 'b' },
+        ],
+      },
+      { ...descriptor, provider: 'perplexity', baseUrl: 'https://api.perplexity.ai' },
+      { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
+    );
+    const body = capture.requests[0].body as { messages: unknown[] };
+    // The two consecutive user turns were merged into one before the sidecar
+    // rewrite ever saw them.
+    expect(body.messages).toHaveLength(1);
   });
 
   test('sidecar auth token is optional (no master key configured)', async () => {

--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -122,3 +122,94 @@ describe('callUpstream', () => {
     expect(fetchMock.getCalls()).toBe(callsBefore);
   });
 });
+
+// Captures the exact outgoing request (url/headers/body) instead of just
+// counting calls, so sidecar-mode assertions can check the rewritten shape.
+function makeCapturingFetch(status = 200, body = '{"ok":true}') {
+  const requests: { url: string; headers: Record<string, string>; body: unknown }[] = [];
+  const impl: FetchImpl = async (url, init) => {
+    requests.push({
+      url,
+      headers: init.headers as Record<string, string>,
+      body: init.body ? JSON.parse(init.body as string) : undefined,
+    });
+    return new Response(body, { status, headers: { 'content-type': 'application/json' } });
+  };
+  return { impl, requests };
+}
+
+describe('callUpstream — translation sidecar mode', () => {
+  test('unset translationSidecar: dispatches directly to the upstream, unchanged', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream({ model: 'x', messages: [] }, descriptor, { fetchImpl: capture.impl });
+    expect(capture.requests).toHaveLength(1);
+    expect(capture.requests[0].url).toBe('https://up.test/v1/chat/completions');
+    expect(capture.requests[0].headers.authorization).toBe('Bearer sk-test');
+    expect(capture.requests[0].body).not.toHaveProperty('api_key');
+    expect(capture.requests[0].body).not.toHaveProperty('api_base');
+  });
+
+  test('translationSidecar set + eligible kind: routes to the sidecar with per-request key/base/model', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      { model: 'x', messages: [], max_tokens: 512 },
+      { ...descriptor, resolvedModel: 'grok-4.3' },
+      {
+        fetchImpl: capture.impl,
+        translationSidecar: { url: 'http://litellm.internal:4000', authToken: 'sk-sidecar-master' },
+      },
+    );
+    expect(capture.requests).toHaveLength(1);
+    const req = capture.requests[0];
+    expect(req.url).toBe('http://litellm.internal:4000/v1/chat/completions');
+    // The sidecar's OWN auth, never the resolved upstream key.
+    expect(req.headers.authorization).toBe('Bearer sk-sidecar-master');
+    expect(req.body).toMatchObject({
+      model: 'grok-4.3',
+      max_tokens: 512,
+      api_key: 'sk-test',
+      api_base: 'https://up.test/v1',
+    });
+  });
+
+  test('translationSidecar set but kind is anthropic/bedrock: stays on the direct path', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      { model: 'x' },
+      { ...descriptor, kind: 'anthropic', baseUrl: 'https://api.anthropic.com/v1' },
+      { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
+    );
+    expect(capture.requests[0].url).not.toContain('litellm.internal');
+  });
+
+  test('translationSidecar set but descriptor omits auth (public upstream): stays on the direct path', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      { model: 'x' },
+      { ...descriptor, apiKey: '', omitAuthorization: true },
+      { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
+    );
+    expect(capture.requests[0].url).toBe('https://up.test/v1/chat/completions');
+  });
+
+  test('genuine OpenAI + sidecar enabled: our own max_tokens hotfix (openai-compat/index.ts) still fires ahead of the sidecar rewrite, so the sidecar/LiteLLM sees max_completion_tokens already — harmless overlap, not a double-translation, and exactly what keeps old self-host boxes correct the moment they flip the flag without also upgrading LiteLLM', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      { model: 'x', messages: [], max_tokens: 4096 },
+      { ...descriptor, provider: 'openai', baseUrl: 'https://api.openai.com/v1', resolvedModel: 'gpt-5.6-sol' },
+      { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
+    );
+    expect(capture.requests[0].body).toMatchObject({ max_completion_tokens: 4096 });
+    expect(capture.requests[0].body).not.toHaveProperty('max_tokens');
+  });
+
+  test('sidecar auth token is optional (no master key configured)', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      { model: 'x' },
+      descriptor,
+      { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
+    );
+    expect(capture.requests[0].headers.authorization).toBeUndefined();
+  });
+});

--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -1,7 +1,8 @@
 import { NetworkError, UpstreamHttpError } from '../errors';
 import { withResilience, type BreakerBinding, type RetryOptions } from '../resilience';
 import { transportFor } from '../transports';
-import type { UpstreamDescriptor } from '../domain';
+import { buildSidecarRequest, isSidecarEligible } from '../transports/sidecar';
+import type { TranslationSidecarConfig, UpstreamDescriptor } from '../domain';
 
 export type FetchImpl = (input: string, init: RequestInit) => Promise<Response>;
 
@@ -9,6 +10,8 @@ export interface CallUpstreamOptions {
   retry?: RetryOptions;
   binding?: BreakerBinding;
   fetchImpl?: FetchImpl;
+  /** See GatewayConfig.translationSidecar. Unset = direct upstream (current behavior). */
+  translationSidecar?: TranslationSidecarConfig;
 }
 
 export async function callUpstream(
@@ -18,7 +21,11 @@ export async function callUpstream(
 ): Promise<Response> {
   const fetchImpl: FetchImpl = opts.fetchImpl ?? ((input, init) => fetch(input, init));
   const transport = transportFor(descriptor.kind);
-  const request = transport.buildRequest(body, descriptor);
+  const direct = transport.buildRequest(body, descriptor);
+  const request =
+    opts.translationSidecar && isSidecarEligible(descriptor)
+      ? buildSidecarRequest(direct, descriptor, opts.translationSidecar)
+      : direct;
   const streaming = body.stream === true;
 
   const raw = await withResilience(

--- a/packages/llm-gateway/src/index.ts
+++ b/packages/llm-gateway/src/index.ts
@@ -62,6 +62,7 @@ export type {
   ModelInfo,
   ProviderKind,
   TokenCounts,
+  TranslationSidecarConfig,
   UpstreamDescriptor,
   UsageEvent,
 } from './domain';

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -148,6 +148,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
         },
         binding: { provider: descriptor.provider, breaker },
         fetchImpl,
+        translationSidecar: config.translationSidecar,
       });
       chosen = candidate;
       debug('upstream_attempt_ok', {

--- a/packages/llm-gateway/src/transports/sidecar.test.ts
+++ b/packages/llm-gateway/src/transports/sidecar.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildSidecarRequest, isSidecarEligible } from './sidecar';
+import { buildUpstreamRequest } from './openai-compat';
+import type { UpstreamDescriptor } from '../domain';
+
+const descriptor: UpstreamDescriptor = {
+  provider: 'openai',
+  kind: 'openai-compat',
+  baseUrl: 'https://api.openai.com/v1',
+  apiKey: 'sk-real-upstream-key',
+  billingMode: 'none',
+  markup: 0,
+  resolvedModel: 'gpt-5.6-sol',
+};
+
+describe('isSidecarEligible', () => {
+  test('openai-compat and custom kinds are eligible', () => {
+    expect(isSidecarEligible({ kind: 'openai-compat' })).toBe(true);
+    expect(isSidecarEligible({ kind: 'custom' })).toBe(true);
+  });
+
+  test('anthropic, bedrock, and openai-responses are not eligible — they keep their dedicated transports', () => {
+    expect(isSidecarEligible({ kind: 'anthropic' })).toBe(false);
+    expect(isSidecarEligible({ kind: 'bedrock' })).toBe(false);
+    expect(isSidecarEligible({ kind: 'openai-responses' })).toBe(false);
+  });
+
+  test('a descriptor with omitAuthorization (public upstream, no real key) is not eligible', () => {
+    expect(isSidecarEligible({ kind: 'openai-compat', omitAuthorization: true })).toBe(false);
+    expect(isSidecarEligible({ kind: 'custom', omitAuthorization: true })).toBe(false);
+  });
+});
+
+describe('buildSidecarRequest', () => {
+  test('targets the sidecar /v1/chat/completions, not the real upstream', () => {
+    const direct = buildUpstreamRequest({ model: 'openai/gpt-5.6-sol', messages: [] }, descriptor);
+    const req = buildSidecarRequest(direct, descriptor, { url: 'http://litellm:4000' });
+    expect(req.url).toBe('http://litellm:4000/v1/chat/completions');
+  });
+
+  test('trims a trailing slash on the sidecar URL', () => {
+    const direct = buildUpstreamRequest({ model: 'x', messages: [] }, descriptor);
+    const req = buildSidecarRequest(direct, descriptor, { url: 'http://litellm:4000/' });
+    expect(req.url).toBe('http://litellm:4000/v1/chat/completions');
+  });
+
+  test('carries the resolved upstream api_key/api_base per-request in the body', () => {
+    const direct = buildUpstreamRequest({ model: 'x', messages: [] }, descriptor);
+    const req = buildSidecarRequest(direct, descriptor, { url: 'http://litellm:4000' });
+    expect(req.payload.api_key).toBe('sk-real-upstream-key');
+    expect(req.payload.api_base).toBe('https://api.openai.com/v1');
+  });
+
+  test('authenticates to the sidecar with ITS OWN token, never the resolved upstream key', () => {
+    const direct = buildUpstreamRequest({ model: 'x', messages: [] }, descriptor);
+    const req = buildSidecarRequest(direct, descriptor, { url: 'http://litellm:4000', authToken: 'sk-sidecar-master' });
+    expect(req.headers.authorization).toBe('Bearer sk-sidecar-master');
+  });
+
+  test('omits the Authorization header entirely when the sidecar has no master key configured', () => {
+    const direct = buildUpstreamRequest({ model: 'x', messages: [] }, descriptor);
+    const req = buildSidecarRequest(direct, descriptor, { url: 'http://litellm:4000' });
+    expect(req.headers.authorization).toBeUndefined();
+  });
+
+  test('model passes through unchanged — no "openai/" provider-prefix wrapping (verified live: LiteLLM forwards a bare model string verbatim with the wildcard deployment)', () => {
+    const direct = buildUpstreamRequest({ model: 'kortix/glm-5.2', messages: [] }, { ...descriptor, resolvedModel: 'z-ai/glm-5.2' });
+    const req = buildSidecarRequest(direct, descriptor, { url: 'http://litellm:4000' });
+    expect(req.payload.model).toBe('z-ai/glm-5.2');
+  });
+
+  test('preserves every other body field (messages, tools, stream, stream_options) untouched', () => {
+    const body = {
+      model: 'x',
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [{ type: 'function', function: { name: 'get_weather' } }],
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+    const direct = buildUpstreamRequest(body, descriptor);
+    const req = buildSidecarRequest(direct, descriptor, { url: 'http://litellm:4000' });
+    expect(req.payload.messages).toEqual(body.messages);
+    expect(req.payload.tools).toEqual(body.tools);
+    expect(req.payload.stream).toBe(true);
+    expect(req.payload.stream_options).toEqual({ include_usage: true });
+  });
+
+  // The genuine-OpenAI max_tokens -> max_completion_tokens rename (the hotfix
+  // this migration replaces) still fires in direct mode's buildUpstreamRequest
+  // before the sidecar rewrite ever sees the payload — but under sidecar mode
+  // this rename should come from LiteLLM's own quirk tables instead, not ours
+  // (that's the entire point of the migration). This just pins that the
+  // sidecar rewrite itself passes max_tokens through untouched — it is NOT
+  // where any quirk translation happens; the config-side flag decides which
+  // one applies (see the call-upstream sidecar tests for the direct-vs-sidecar
+  // request comparison).
+  test('does not itself touch max_tokens — that is LiteLLM/the direct-transport concern, not this rewrite', () => {
+    const direct = buildUpstreamRequest(
+      { model: 'kortix/glm-5.2', messages: [], max_tokens: 4096 },
+      { ...descriptor, provider: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1', resolvedModel: 'openai/gpt-4o' },
+    );
+    const req = buildSidecarRequest(direct, { ...descriptor, provider: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1' }, { url: 'http://litellm:4000' });
+    expect(req.payload.max_tokens).toBe(4096);
+    expect('max_completion_tokens' in req.payload).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/transports/sidecar.test.ts
+++ b/packages/llm-gateway/src/transports/sidecar.test.ts
@@ -86,15 +86,16 @@ describe('buildSidecarRequest', () => {
     expect(req.payload.stream_options).toEqual({ include_usage: true });
   });
 
-  // The genuine-OpenAI max_tokens -> max_completion_tokens rename (the hotfix
-  // this migration replaces) still fires in direct mode's buildUpstreamRequest
-  // before the sidecar rewrite ever sees the payload — but under sidecar mode
-  // this rename should come from LiteLLM's own quirk tables instead, not ours
-  // (that's the entire point of the migration). This just pins that the
-  // sidecar rewrite itself passes max_tokens through untouched — it is NOT
-  // where any quirk translation happens; the config-side flag decides which
-  // one applies (see the call-upstream sidecar tests for the direct-vs-sidecar
-  // request comparison).
+  // Every direct-path quirk translation (the genuine-OpenAI max_tokens ->
+  // max_completion_tokens rename, #4814's reasoning-restricted sampling-param
+  // strip, #4814's Perplexity role normalization) lives in
+  // buildUpstreamRequest and runs BEFORE the sidecar rewrite ever sees the
+  // payload — so under sidecar mode LiteLLM's own equivalent quirk tables get
+  // an already-clean payload (harmless overlap). This just pins that the
+  // sidecar rewrite ITSELF is not where any quirk translation happens: it
+  // passes the transport's output through untouched; the config-side flag
+  // decides which layer owns the quirk (see the call-upstream sidecar tests
+  // for the direct-vs-sidecar request comparison covering all three quirks).
   test('does not itself touch max_tokens — that is LiteLLM/the direct-transport concern, not this rewrite', () => {
     const direct = buildUpstreamRequest(
       { model: 'kortix/glm-5.2', messages: [], max_tokens: 4096 },

--- a/packages/llm-gateway/src/transports/sidecar.ts
+++ b/packages/llm-gateway/src/transports/sidecar.ts
@@ -1,0 +1,73 @@
+import type { ProviderKind, TranslationSidecarConfig, UpstreamDescriptor } from '../domain';
+import type { UpstreamRequest } from './openai-compat';
+
+// Provider kinds whose upstream already speaks the OpenAI chat/completions
+// wire format verbatim (OpenAI itself, OpenRouter, Groq, x.ai, Mistral,
+// DeepSeek, self-hosted/custom — everything sharing the openai-compat
+// transport) are the ones a generic OpenAI-compatible sidecar client can
+// stand in for. anthropic/bedrock build their own native request shapes
+// (Messages API / Bedrock converse) via working dedicated transports, and
+// codex runs its own credential/session flow — none of those route through
+// the sidecar; delegating their quirks to LiteLLM isn't this change's job.
+const SIDECAR_ELIGIBLE_KINDS: ReadonlySet<ProviderKind> = new Set<ProviderKind>([
+  'openai-compat',
+  'custom',
+]);
+
+// A descriptor with no apiKey and `omitAuthorization` (e.g. a free public
+// upstream like OpenCode Zen) has nothing meaningful to hand the sidecar as
+// `api_key` — LiteLLM's generic openai-compatible client requires a non-empty
+// api_key even against endpoints that don't check it. Rather than guess a
+// placeholder, these stay on the direct path; they're not the BYOK quirk
+// surface this migration targets anyway.
+export function isSidecarEligible(descriptor: Pick<UpstreamDescriptor, 'kind' | 'omitAuthorization'>): boolean {
+  return SIDECAR_ELIGIBLE_KINDS.has(descriptor.kind) && !descriptor.omitAuthorization;
+}
+
+function trimTrailingSlash(url: string): string {
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return url.slice(0, end);
+}
+
+// Rewrites an already-built direct-upstream request (openai-compat's
+// buildUpstreamRequest output — resolvedModel/bodyExtras already merged) into
+// a call against the stateless LiteLLM translation sidecar.
+//
+// The sidecar owns zero credentials of its own (no model_list creds, no
+// virtual keys, no DB): every request must carry the real upstream's
+// api_key/api_base per LiteLLM's documented clientside/dynamic-credential
+// request shape (this requires the sidecar's config.yaml to set
+// `general_settings.allow_client_side_credentials: true` and register a
+// wildcard deployment — `model_name: "*"` / `litellm_params.model:
+// "openai/*"` — with placeholder credentials that are never actually used,
+// verified live against the real container: without allow_client_side_
+// credentials the proxy 401s with "api_base is not allowed in request body").
+//
+// `model` is passed through UNCHANGED (exactly what buildUpstreamRequest
+// already resolved — no "openai/" provider-prefix wrapping needed): verified
+// live that with the wildcard deployment above, LiteLLM forwards the client's
+// bare model string verbatim to the real upstream (api_base) and echoes the
+// same bare string back in the response, so descriptor.resolvedModel keeps
+// meaning exactly what it already means to the rest of this package (usage
+// extraction, pricing lookups) with no extra rewriting.
+export function buildSidecarRequest(
+  direct: UpstreamRequest,
+  descriptor: UpstreamDescriptor,
+  sidecar: TranslationSidecarConfig,
+): UpstreamRequest {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (sidecar.authToken) headers.authorization = `Bearer ${sidecar.authToken}`;
+
+  const payload: Record<string, unknown> = {
+    ...direct.payload,
+    api_key: descriptor.apiKey,
+    api_base: descriptor.baseUrl,
+  };
+
+  return {
+    url: `${trimTrailingSlash(sidecar.url)}/v1/chat/completions`,
+    headers,
+    payload,
+  };
+}

--- a/tests/self-host-e2e/fast/litellm-translation-sidecar.test.ts
+++ b/tests/self-host-e2e/fast/litellm-translation-sidecar.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { SelfHostSandbox } from '../support/cli';
+
+// Coverage for the stateless LiteLLM translation sidecar's `.env` surface
+// (see packages/llm-gateway's GatewayConfig.translationSidecar). The
+// compose-RENDERING assertions for this feature (litellm service
+// present/absent, memory ceiling, no published ports, kortix-api wiring) live
+// in apps/cli/src/self-host/__tests__/compose-assets.test.ts instead of here,
+// deliberately: that suite calls renderFullDockerCompose() as a pure function
+// with an explicit `translationSidecarConfigured` option, so both the
+// enabled and disabled shapes are exercised deterministically. Doing that here
+// via `env set` would need to actually flip the flag on a real instance named
+// "default", and `env set` restarts real running services by Compose PROJECT
+// NAME (kortix-<instance>) — which on a shared/dev machine can collide with
+// and mutate an unrelated ALREADY-RUNNING "default" self-host instance one
+// level up (`~/.config/kortix/self-host/default`), not just this sandboxed
+// one. This file only exercises what `init` alone writes to `.env` — `init`
+// never restarts anything, so it carries none of that risk.
+
+describe('self-host LiteLLM translation sidecar — .env surface (fast, no Docker)', () => {
+  let sandbox: SelfHostSandbox;
+
+  beforeEach(() => {
+    sandbox = new SelfHostSandbox();
+  });
+
+  afterEach(() => sandbox.cleanup());
+
+  test('LITELLM_MASTER_KEY is always generated at init, regardless of the toggle', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const env = sandbox.readEnv();
+    expect(env.LITELLM_MASTER_KEY).toBeTruthy();
+    expect(env.LITELLM_MASTER_KEY.length).toBeGreaterThanOrEqual(32);
+  });
+
+  test('LLM_TRANSLATION_SIDECAR_ENABLED defaults to a well-formed true/false (RAM-gated), never unset', async () => {
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    const env = sandbox.readEnv();
+    expect(['true', 'false']).toContain(env.LLM_TRANSLATION_SIDECAR_ENABLED);
+  });
+
+  test('LLM_TRANSLATION_SIDECAR_URL always mirrors the enabled flag: http://litellm:4000 or empty, never anything else', async () => {
+    await sandbox.run(['init', '--yes']);
+    const env = sandbox.readEnv();
+    if (env.LLM_TRANSLATION_SIDECAR_ENABLED === 'true') {
+      expect(env.LLM_TRANSLATION_SIDECAR_URL).toBe('http://litellm:4000');
+    } else {
+      expect(env.LLM_TRANSLATION_SIDECAR_URL).toBe('');
+    }
+  });
+
+  test('LITELLM_IMAGE is pinned by tag@digest at init, not a floating tag', async () => {
+    await sandbox.run(['init', '--yes']);
+    const env = sandbox.readEnv();
+    expect(env.LITELLM_IMAGE).toMatch(/^ghcr\.io\/berriai\/litellm:.+@sha256:[a-f0-9]{64}$/);
+  });
+
+  test('a plain re-init does not silently reset an operator override of the toggle', async () => {
+    await sandbox.run(['init', '--yes']);
+    const initial = sandbox.readEnv().LLM_TRANSLATION_SIDECAR_ENABLED;
+    const flipped = initial === 'true' ? 'false' : 'true';
+
+    // Hand-edit `.env` directly (no docker compose restart involved at all —
+    // unlike `env set`, this can never touch a real running instance).
+    const path = `${sandbox.configRoot}/default/.env`;
+    const content = await Bun.file(path).text();
+    await Bun.write(
+      path,
+      content.replace(/^LLM_TRANSLATION_SIDECAR_ENABLED=.*$/m, `LLM_TRANSLATION_SIDECAR_ENABLED=${flipped}`),
+    );
+
+    const { code } = await sandbox.run(['init', '--yes']);
+    expect(code).toBe(0);
+    expect(sandbox.readEnv().LLM_TRANSLATION_SIDECAR_ENABLED).toBe(flipped);
+  });
+});


### PR DESCRIPTION
## Summary

Tonight's gateway research concluded that provider param-quirk handling (OpenAI's `max_tokens` -> `max_completion_tokens`, and the wider class it represents) should be owned by LiteLLM's community-maintained quirk tables instead of Kortix hand-rolling and maintaining its own translation layer per quirk. This PR ships that as an **opt-in, flag-gated sidecar mode**, built on top of the `fix/openai-max-completion-tokens` hotfix (#4805, already merged) — that hotfix's host-scoped `translateMaxTokensForGenuineOpenAi` stays in the codebase as the **no-sidecar fallback**.

## Architecture

- **LiteLLM proxy: stateless.** No database, no virtual keys, no budgets. `config.yaml` has an empty-credential wildcard `model_list` entry (`model_name: "*"` / `litellm_params.model: "openai/*"`) — every real request supplies `model`/`api_key`/`api_base` **per-request**, resolved by Kortix's own control plane just like today. Retries/fallbacks are disabled in LiteLLM itself (`num_retries: 0` in both `litellm_settings` and `router_settings`) — `packages/llm-gateway`'s own failover + circuit-breaker (`pipeline/failover.ts`, `resilience/circuit-breaker.ts`) stays the **only** retry brain.
- **Auth: master key, not `--disable-auth`.** Verified against LiteLLM's own docs: with no master key, "the proxy accepts all requests without any authentication check." A single internal bearer token (`LITELLM_MASTER_KEY`, auto-generated, matches the existing `GATEWAY_INTERNAL_TOKEN` pattern) is negligible extra complexity for meaningfully better defense-in-depth on a box that will run other containers too.
- **New code path:** `packages/llm-gateway/src/transports/sidecar.ts` — `isSidecarEligible()` gates on provider `kind` (`openai-compat`/`custom` only; anthropic/bedrock/codex keep their dedicated transports) and excludes descriptors with `omitAuthorization` (no meaningful `api_key` to hand the sidecar). `buildSidecarRequest()` takes the already-built direct request and rewrites `url`/`headers`, adding `api_key`/`api_base` to the payload — `model` passes through **unchanged**, no `"openai/"` prefix wrapping needed (verified live, see below). Hooked into `http/call-upstream.ts` right after `transport.buildRequest()`, so every quirk-translation function already living in `openai-compat/index.ts` (the max_tokens hotfix, and anything a sibling PR adds there) runs unconditionally in both modes — nothing to gate on the transport side.
- **Config:** `GatewayConfig.translationSidecar?: { url, authToken }` (new field, additive). Wired into both gateway hosts: the in-process mount (`apps/api`, self-host's actual sandbox-facing path) and the standalone pod (`apps/llm-gateway`, cloud's sandbox-facing path) via `LLM_TRANSLATION_SIDECAR_URL`/`LLM_TRANSLATION_SIDECAR_AUTH_TOKEN`. Unset (default) = today's direct behavior — old self-host boxes and a gradual rollout are safe by construction.
- **Billing/usage:** unaffected. LiteLLM proxies the upstream's OpenAI-shaped response verbatim (`translateResponse` for `openai-compat`/`custom` is already an identity passthrough); `extractUsageFromJson`/`extractUsageFromSseBuffer` only read `usage.prompt_tokens`/`usage.completion_tokens`, which survive untouched — verified live (see below).

## RAM measurement (the number you asked to see loudly)

Measured live with `docker stats`, idle, `ghcr.io/berriai/litellm:main-stable`, `--num_workers 1`, zero traffic, after settling (not the transient boot spike):

**~1.0 GiB (1011 MiB) resident.**

That's roughly **2x** the "~500MB, don't even notice it" budget. Per the brief, this is flagged loudly and the feature is **gated**:
- `LLM_TRANSLATION_SIDECAR_ENABLED` defaults to `true` **only when the host has >=16GB RAM** (`defaultTranslationSidecarEnabled()` in `apps/cli/src/commands/self-host.ts`, checked via `os.totalmem()`), else `false`.
- The whole `litellm` Compose service is **omitted from the rendered file** when the flag is off — not merely stopped — so a smaller box never even pulls the image (same "omit entirely" pattern already used for `caddy`/`cloudflared`).
- `mem_limit: 1536m` / `mem_reservation: 1024m` on the service (see `MEM_LIMITS` in `compose-assets.ts`) — sized with headroom above the measured floor, not the ~128–512m every other stateless service in the stack gets.

A follow-up worth doing later: check whether a slimmer LiteLLM image variant exists — `main-stable` bundles more than a pure translation hop needs. Out of scope tonight; shipped with the official, documented tag pinned by digest.

## Live proof (real container, not mocks)

Ran the actual `ghcr.io/berriai/litellm:main-stable` container locally against a small Node mock upstream, driving it exactly the way `transports/sidecar.ts` does:

1. **The exact bug class, live**: `model: "gpt-5.6-sol"` (and `"o3-mini"`), `max_tokens: 123` in → upstream received `max_completion_tokens: 123`, no `max_tokens` key. `model: "gpt-4o"` (non-reasoning) → `max_tokens` left untouched. LiteLLM's own quirk table, not ours.
2. **Streaming + tool calls, byte-for-byte**: a streamed request with `tools` + `stream_options.include_usage: true` round-tripped through the proxy with full SSE fidelity — text delta, multi-chunk `tool_calls` deltas (id/name/arguments split across chunks), `finish_reason: "tool_calls"`, and a trailing `usage` chunk, all structurally intact.
3. **Usage fields intact**: both streaming and non-streaming responses carried `usage.prompt_tokens`/`completion_tokens` through unchanged.
4. **Retries genuinely disabled**: an always-500 synthetic upstream was hit **exactly once** (83ms round trip, no backoff delay) — confirms `num_retries: 0` actually takes effect and our own pipeline is the only thing that would retry.
5. **Auth gate works**: a request with no `Authorization` header 401s; the correct master key succeeds.
6. **A real, load-bearing discovery**: per-request `api_key`/`api_base` do **not** work out of the box — LiteLLM 401s with *"api_base is not allowed in request body... requires explicit admin opt-in via `general_settings.allow_client_side_credentials`"* (a security hardening from a huntr.com-reported bounty) unless that flag is set **and** a `model_list` entry exists to match against. Both are in `litellm-config.yaml`, documented with the exact live 401 that led to them.

## What stays ours

Retries/circuit-breaker, model catalog + resolution + routing/fallback policy, billing/usage extraction + cost calculation, all credential storage and BYOK/managed-key resolution. LiteLLM only ever sees a credential for the single lifetime of one proxied request; it never stores or routes based on stored keys.

## Rollout plan

- **Self-host**: ships this release, opt-in by default RAM gate as above. `kortix self-host env set LLM_TRANSLATION_SIDECAR_ENABLED=true` to force it on a smaller box; `=false` to opt out on a big one.
- **Cloud (ECS/EKS)**: **not touched tonight**, deliberately — this PR is code path + env plumbing only (`apps/llm-gateway/src/config.ts` already reads the same env vars). Turning it on in cloud is a separate, deliberate ops step:
  - Add a `litellm` container/task to the gateway pod's task-def (or a sibling ECS service reachable only from the gateway's task), pinned to the same `ghcr.io/berriai/litellm:main-stable@sha256:9ef6f45bc...` digest as self-host, internal-only (no public listener/ALB target).
  - Set `LLM_TRANSLATION_SIDECAR_URL` + `LLM_TRANSLATION_SIDECAR_AUTH_TOKEN` on the gateway task/pod env (Secrets Manager, matching the `GATEWAY_INTERNAL_TOKEN` pattern already in place).
  - Roll out gradually behind the same flag — the code has been live-tested with the real container and is safe to flip per-environment independently.

## Testing

- **Unit** (`packages/llm-gateway`): `transports/sidecar.test.ts` (eligibility gating, request-shape rewriting, model passthrough, coexistence with the existing max_tokens hotfix) + new `http/call-upstream.test.ts` cases (sidecar routing, fallback-to-direct when unset, anthropic/bedrock/public-upstream exclusions, sidecar's own auth token vs. the resolved upstream key). 168/168 tests pass, `tsc --noEmit` clean.
- **Live proof**: see above — real container, real streaming/tool-call fidelity, real retry-disable verification.
- **Self-host fast tests**: `apps/cli/src/self-host/__tests__/compose-assets.test.ts` (service present/absent by flag, memory ceiling, no published ports, image pin, kortix-api wiring — calls `renderFullDockerCompose()` directly) + `tests/self-host-e2e/fast/litellm-translation-sidecar.test.ts` (`.env` surface via `init` only). 50/50 and 5/5 pass.
- **tsc + affected suites**: `packages/llm-gateway`, `apps/api`, `apps/llm-gateway`, `apps/cli` all typecheck clean; every `apps/api/src/llm-gateway/**` test passes individually with `KORTIX_URL=http://localhost:8008 dotenvx run -- bun test`.

**Note on test isolation (not a regression, confirmed on unmodified main too):** `tests/self-host-e2e/fast/feature-flags.test.ts`, `required-secrets.test.ts`, and `apps/cli/src/self-host/__tests__/self-host-cli.test.ts` have pre-existing `env set`-based tests that restart real Docker services by **Compose project name** (`kortix-<instance>`), which on a machine that already has a real `default`-named self-host instance running collides with it — reproduced identically by stashing this branch's changes entirely. Not introduced by this PR; this PR's own new e2e test deliberately avoids `env set` for exactly this reason (see its file header comment).