### PR TITLE
fix(terminal): compile sandbox PTYs with supported Bun

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,13 +4,19 @@
 # Build from repo root: docker build --build-arg SERVICE=apps/api -f apps/api/Dockerfile .
 
 ARG BUN_VERSION=1.2
+# Bun 1.2 silently accepts `Bun.spawn({ terminal: ... })` but closes the child
+# shell's stdin immediately in the compiled sandbox agent. The REST create then
+# returns a pid while the shell exits 0 before its WebSocket can attach, surfacing
+# as `pty not found`. Keep this exact pin synchronized with the agent package's
+# `engines.bun`; that package metadata is also part of the snapshot fingerprint.
+ARG SANDBOX_AGENT_BUN_VERSION=1.3.11
 FROM oven/bun:${BUN_VERSION}-slim AS base
 
 # ---- Sandbox Agent Stage ----
 # The API builds Daytona layered snapshots at runtime. Those snapshots bake the
 # sandbox-side daemon from this repo, so the deployable API image must carry the
 # latest compiled Linux binary even though we no longer publish a sandbox image.
-FROM oven/bun:${BUN_VERSION}-slim AS sandbox-agent
+FROM oven/bun:${SANDBOX_AGENT_BUN_VERSION}-slim AS sandbox-agent
 
 WORKDIR /agent
 

--- a/apps/api/src/__tests__/unit-sandbox-agent-compiler.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-agent-compiler.test.ts
@@ -1,0 +1,36 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+function versionTuple(value: string): [number, number, number] {
+  const [major = 0, minor = 0, patch = 0] = value.split('.').map(Number);
+  return [major, minor, patch];
+}
+
+function isAtLeast(actual: string, minimum: string): boolean {
+  const left = versionTuple(actual);
+  const right = versionTuple(minimum);
+  return left[0] > right[0]
+    || (left[0] === right[0] && left[1] > right[1])
+    || (left[0] === right[0] && left[1] === right[1] && left[2] >= right[2]);
+}
+
+describe('sandbox agent compiler runtime', () => {
+  test('pins a Bun runtime with stable subprocess terminal support and fingerprints the pin', async () => {
+    const dockerfile = await readFile(resolve(import.meta.dir, '../../Dockerfile'), 'utf8');
+    const agentPackage = JSON.parse(
+      await readFile(
+        resolve(import.meta.dir, '../../../kortix-sandbox-agent-server/package.json'),
+        'utf8',
+      ),
+    ) as { engines?: { bun?: string } };
+
+    const dockerPin = dockerfile.match(
+      /^ARG SANDBOX_AGENT_BUN_VERSION=(\d+\.\d+\.\d+)$/m,
+    )?.[1];
+    expect(dockerPin).toBeDefined();
+    expect(dockerPin).toBe(agentPackage.engines?.bun);
+    expect(isAtLeast(dockerPin!, '1.3.0')).toBe(true);
+  });
+});

--- a/apps/kortix-sandbox-agent-server/package.json
+++ b/apps/kortix-sandbox-agent-server/package.json
@@ -4,6 +4,9 @@
   "description": "Consolidated sandbox-side daemon: OpenCode supervisor + Kortix API surface.",
   "type": "module",
   "main": "src/main.ts",
+  "engines": {
+    "bun": "1.3.11"
+  },
   "bin": {
     "kortix-agent": "./dist/kortix-agent"
   },

--- a/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
@@ -188,6 +188,35 @@ describe('kortix-native pty', () => {
     }
   })
 
+  it('keeps the default interactive shell alive until its first viewer attaches', async () => {
+    const proxy = startTestProxy()
+    try {
+      const created = await createPty(proxy.port, {})
+      await Bun.sleep(50)
+
+      const list = (await (
+        await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty`, { headers: authHeaders() })
+      ).json()) as PtyMeta[]
+      expect(list.find((pty) => pty.id === created.id)?.status).toBe('running')
+
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${proxy.port}/kortix/pty/${created.id}/connect`,
+        { headers: { [KORTIX_USER_CONTEXT_HEADER]: signCtx() } } as any,
+      )
+      await waitForOpen(ws)
+      ws.send("printf 'DEFAULT_SHELL_MARKER\\n'\n")
+      await waitForData(ws, (acc) => acc.includes('DEFAULT_SHELL_MARKER'))
+      ws.close()
+
+      await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty/${created.id}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      })
+    } finally {
+      await proxy.stop()
+    }
+  })
+
   it('streams real command output over the websocket', async () => {
     const proxy = startTestProxy()
     try {


### PR DESCRIPTION
Follow-up to #4808 after live dev verification exposed the final Platinum failure.

## Root cause
The API Docker build compiled `kortix-agent` with Bun 1.2.23. That runtime accepts `Bun.spawn({ terminal })` but the compiled Linux agent closes the PTY child input: `/bin/bash -l` exits 0 before WebSocket attachment, yielding `pty not found`.

## Fix
- compile only the sandbox-agent stage with Bun 1.3.11 (API/CLI stay on their existing runtime)
- fingerprint the compiler pin through the agent package metadata so snapshots cannot reuse the Bun 1.2 binary
- add regression coverage for the default shell surviving until first attachment
- add a synchronization guard between Docker and snapshot-fingerprinted package metadata

## Proof
- Bun 1.2.23 Linux container: default shell test fails (`expected running`, received `exited`); PTY streaming/replay also time out
- Bun 1.3.11 Linux container: 9/9 PTY tests pass, including default shell attach/output
- focused tests: 10 pass
- API typecheck: pass
- sandbox-agent typecheck: pass
- Docker sandbox-agent target build: pass; compiled `bun-linux-x64-v1.3.11`

The branch was rebased onto latest `origin/main` (`0b3b2eb68`) before push.