### PR TITLE
fix(llm-gateway): streaming reliability — abort propagation, mid-stream error surfacing, bounded buffers, deadlines

### DIFF
--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -37,6 +37,10 @@ export function mountLlmGateway(app: OpenAPIHono): void {
       gateway.chatCompletions({
         authorization: c.req.header('authorization'),
         rawBody: await c.req.text(),
+        // `c.req.raw` is the underlying standard Request — its `.signal` fires
+        // when the client disconnects, so the gateway can stop reading (and
+        // billing for) upstream tokens no one is listening for anymore.
+        signal: c.req.raw.signal,
       });
     const models = (c: import('hono').Context) =>
       gateway.listModels(c.req.header('authorization'));

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -163,13 +163,21 @@ export function buildServer(): GatewayServer {
   });
 
   const chatCompletions = async (c: {
-    req: { header: (k: string) => string | undefined; text: () => Promise<string> };
+    req: {
+      header: (k: string) => string | undefined;
+      text: () => Promise<string>;
+      raw?: { signal?: AbortSignal };
+    };
   }) => {
     const requestId = `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
     try {
       const res = await gateway.chatCompletions({
         authorization: c.req.header('authorization'),
         rawBody: await c.req.text(),
+        // `c.req.raw` is Hono's underlying standard Request — its `.signal`
+        // fires on client disconnect, so a caller that goes away mid-request
+        // stops the upstream fetch/stream instead of running to completion.
+        signal: c.req.raw?.signal,
       });
       recordOutcome(res.status);
       return res;

--- a/packages/llm-gateway/src/create-gateway.ts
+++ b/packages/llm-gateway/src/create-gateway.ts
@@ -51,6 +51,7 @@ export function createGateway(
     captureBodies,
     capture,
     breakerFor,
+    maxCapturedBodyBytes: maxBodyBytes,
   };
 
   const jsonResponse = (data: unknown, status = 200): Response =>

--- a/packages/llm-gateway/src/errors.ts
+++ b/packages/llm-gateway/src/errors.ts
@@ -1,10 +1,22 @@
-export type UpstreamErrorKind = 'http' | 'network' | 'timeout' | 'circuit_open';
+export type UpstreamErrorKind = 'http' | 'network' | 'timeout' | 'circuit_open' | 'client_abort';
 
 export class TimeoutError extends Error {
   readonly kind: UpstreamErrorKind = 'timeout';
   constructor(message = 'upstream timed out') {
     super(message);
     this.name = 'TimeoutError';
+  }
+}
+
+// The INBOUND client disconnected (tab closed, stop hit, TCP reset) — distinct
+// from an upstream-side NetworkError/TimeoutError. Never retried (there's no
+// one left to serve) and never counted against the shared provider circuit
+// breaker (the upstream did nothing wrong).
+export class ClientAbortError extends Error {
+  readonly kind: UpstreamErrorKind = 'client_abort';
+  constructor(message = 'client disconnected') {
+    super(message);
+    this.name = 'ClientAbortError';
   }
 }
 
@@ -66,6 +78,7 @@ export class GatewayResolutionError extends Error {
 
 export function defaultIsRetryable(err: unknown): boolean {
   if (err instanceof CircuitOpenError) return false;
+  if (err instanceof ClientAbortError) return false;
   if (err instanceof TimeoutError) return true;
   if (err instanceof NetworkError) return true;
   if (err instanceof UpstreamHttpError) {
@@ -83,6 +96,7 @@ export function defaultIsRetryable(err: unknown): boolean {
 // other tenants whose own keys are fine. A 429 is therefore still retried and
 // failed-over, but it never trips the breaker.
 export function indicatesUpstreamDown(err: unknown): boolean {
+  if (err instanceof ClientAbortError) return false;
   if (err instanceof TimeoutError) return true;
   if (err instanceof NetworkError) return true;
   if (err instanceof UpstreamHttpError) return err.status >= 500 && err.status <= 599;

--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import { callUpstream, type FetchImpl } from './call-upstream';
 import { buildUpstreamRequest } from '../transports';
 import { CircuitBreaker } from '../resilience';
-import { CircuitOpenError, UpstreamHttpError } from '../errors';
+import { ClientAbortError, CircuitOpenError, UpstreamHttpError } from '../errors';
 import type { UpstreamDescriptor } from '../domain';
 
 const descriptor: UpstreamDescriptor = {
@@ -261,5 +261,68 @@ describe('callUpstream — translation sidecar mode', () => {
       { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
     );
     expect(capture.requests[0].headers.authorization).toBeUndefined();
+  });
+});
+
+// Regression coverage for the client-disconnect finding: an inbound abort
+// signal must reach the actual `fetch()` call (so a real upstream fetch is
+// cancelled, not just logically ignored), and must never be retried or trip
+// the shared provider circuit breaker — there's no one left to serve either
+// way, so failing over would only waste more upstream spend for nothing.
+describe('callUpstream client abort propagation', () => {
+  test('an inbound signal is combined into the actual fetch call and aborts it', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const fetchImpl: FetchImpl = async (_url, init) => {
+      receivedSignal = init.signal as AbortSignal;
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+    const ac = new AbortController();
+    await callUpstream({}, descriptor, { retry: fastRetry, fetchImpl, signal: ac.signal });
+    expect(receivedSignal).toBeTruthy();
+    expect(receivedSignal!.aborted).toBe(false);
+    ac.abort();
+    expect(receivedSignal!.aborted).toBe(true);
+  });
+
+  test('an already-aborted inbound signal fails fast as ClientAbortError, never reaching fetch', async () => {
+    let fetchCalls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      fetchCalls += 1;
+      return new Response('{}', { status: 200 });
+    };
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      callUpstream({}, descriptor, { retry: fastRetry, fetchImpl, signal: ac.signal }),
+    ).rejects.toBeInstanceOf(ClientAbortError);
+    expect(fetchCalls).toBe(0);
+  });
+
+  test('a client abort mid-fetch is never retried (unlike a genuine network failure)', async () => {
+    let calls = 0;
+    const ac = new AbortController();
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      ac.abort();
+      throw new DOMException('The operation was aborted', 'AbortError');
+    };
+    await expect(
+      callUpstream({}, descriptor, { retry: fastRetry, fetchImpl, signal: ac.signal }),
+    ).rejects.toBeInstanceOf(ClientAbortError);
+    expect(calls).toBe(1); // no retry attempts spent on a caller that's already gone
+  });
+
+  test('a client abort never trips the shared provider circuit breaker', async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 10_000 });
+    const binding = { provider: descriptor.provider, breaker };
+    const ac = new AbortController();
+    const fetchImpl: FetchImpl = async () => {
+      ac.abort();
+      throw new DOMException('The operation was aborted', 'AbortError');
+    };
+    await callUpstream({}, descriptor, { retry: fastRetry, fetchImpl, signal: ac.signal, binding }).catch(
+      () => {},
+    );
+    expect(breaker.current).toBe('closed');
   });
 });

--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -1,4 +1,4 @@
-import { NetworkError, UpstreamHttpError } from '../errors';
+import { ClientAbortError, NetworkError, UpstreamHttpError } from '../errors';
 import { withResilience, type BreakerBinding, type RetryOptions } from '../resilience';
 import { transportFor } from '../transports';
 import { buildSidecarRequest, isSidecarEligible } from '../transports/sidecar';
@@ -12,6 +12,10 @@ export interface CallUpstreamOptions {
   fetchImpl?: FetchImpl;
   /** See GatewayConfig.translationSidecar. Unset = direct upstream (current behavior). */
   translationSidecar?: TranslationSidecarConfig;
+  /** Inbound client's abort signal — combined with the per-attempt timeout
+   *  signal so a caller disconnect aborts the in-flight upstream fetch too,
+   *  instead of only bounding it by the retry timeout. */
+  signal?: AbortSignal;
 }
 
 export async function callUpstream(
@@ -27,9 +31,15 @@ export async function callUpstream(
       ? buildSidecarRequest(direct, descriptor, opts.translationSidecar)
       : direct;
   const streaming = body.stream === true;
+  const clientSignal = opts.signal;
 
   const raw = await withResilience(
-    async (signal) => {
+    async (attemptSignal) => {
+      if (clientSignal?.aborted) throw new ClientAbortError();
+      // Combine the per-attempt timeout controller with the inbound client's
+      // signal so either one aborts this fetch — `AbortSignal.any` is a plain
+      // union, so whichever fires first wins and the other is simply unused.
+      const signal = clientSignal ? AbortSignal.any([attemptSignal, clientSignal]) : attemptSignal;
       let response: Response;
       try {
         response = await fetchImpl(request.url, {
@@ -39,6 +49,10 @@ export async function callUpstream(
           signal,
         });
       } catch (err) {
+        // Disambiguate WHY the fetch aborted: a client disconnect must never be
+        // retried/failed-over (there's no one left to serve), unlike a genuine
+        // upstream timeout or network failure.
+        if (clientSignal?.aborted) throw new ClientAbortError();
         throw new NetworkError(`fetch to ${descriptor.provider} failed`, err);
       }
       if (!response.ok) {

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -4,7 +4,7 @@ import type {
   ModelFallbackCondition,
   UpstreamDescriptor,
 } from '../domain';
-import { CircuitOpenError, UpstreamHttpError } from '../errors';
+import { ClientAbortError, CircuitOpenError, UpstreamHttpError } from '../errors';
 import { type FetchImpl, callUpstream } from '../http';
 import type { CircuitBreaker } from '../resilience';
 import { gatewayErrorBody } from './error-response';
@@ -77,6 +77,9 @@ export interface FailoverContext {
   trace: Partial<TraceFields>;
   capturedRequest: unknown;
   fallbackOn: ModelFallbackCondition;
+  /** Inbound client's abort signal — aborts an in-flight candidate attempt
+   *  immediately if the caller disconnects before any upstream is chosen. */
+  signal?: AbortSignal;
 }
 
 export interface RoutedUpstreamCandidate {
@@ -97,7 +100,7 @@ export type FailoverResult = { kind: 'response'; response: Response } | { kind: 
 export async function runFailover(ctx: FailoverContext): Promise<FailoverResult> {
   const {
     candidates, payload, config, fetchImpl, breakerFor, emit, logger,
-    requestId, trace, capturedRequest, fallbackOn,
+    requestId, trace, capturedRequest, fallbackOn, signal,
   } = ctx;
   const tried: string[] = [];
   const modelsTried: string[] = [];
@@ -149,6 +152,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
         binding: { provider: descriptor.provider, breaker },
         fetchImpl,
         translationSidecar: config.translationSidecar,
+        signal,
       });
       chosen = candidate;
       debug('upstream_attempt_ok', {
@@ -166,6 +170,36 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
         error: errorMessage(err),
         breakerState: breaker.current,
       });
+      if (err instanceof ClientAbortError) {
+        // The caller is gone — trying the next candidate would only spend more
+        // upstream tokens/money for a response no one will ever receive. Stop
+        // the whole dispatch loop immediately instead of failing over.
+        debug('client_aborted', { provider: descriptor.provider });
+        emit({
+          ...trace, resolvedModel: descriptor.resolvedModel, provider: descriptor.provider,
+          billingMode: descriptor.billingMode, status: 499, ok: false,
+          errorCode: 'client_disconnected', errorMessage: 'Client disconnected before a response was ready',
+          attempts, candidatesTried: tried, request: capturedRequest,
+        });
+        return {
+          kind: 'response',
+          // 499 (nginx's "client closed request") — there's no real HTTP
+          // client left to observe this status, but it keeps the trace/logs
+          // honest about why the dispatch loop stopped.
+          response: json(
+            gatewayErrorBody({
+              message: 'Client disconnected before a response was ready',
+              code: 'client_disconnected',
+              provider: descriptor.provider,
+              requestedModel: trace.requestedModel ?? '',
+              resolvedModel: descriptor.resolvedModel ?? trace.requestedModel ?? '',
+              requestId,
+              suggestion: 'No action needed — the client already disconnected.',
+            }),
+            499,
+          ),
+        };
+      }
       if (err instanceof UpstreamHttpError && err.status >= 400 && err.status < 500) {
         // A rate-limit / quota / billing error (429/402/403) on a candidate that
         // has a fallback behind it — e.g. a user's BYOK key out of quota, with a

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -1202,6 +1202,85 @@ describe("gateway.chatCompletions — request size guard", () => {
   });
 });
 
+// End-to-end regression coverage for the client-disconnect finding: the
+// inbound request's own AbortSignal must reach both the upstream fetch (before
+// any response is chosen) and the streaming relay (after headers are already
+// committed), through the full createGateway → handleChatCompletions →
+// runFailover/relayStream pipeline — not just the lower-level units in
+// isolation.
+describe("gateway.chatCompletions — client abort propagation", () => {
+  test("an already-aborted signal short-circuits before dispatching to the upstream fetch", async () => {
+    const { hooks } = makeHooks({ resolveUpstream: async () => [managed] });
+    let fetchCalls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      fetchCalls += 1;
+      return new Response(JSON.stringify({ choices: [{ message: { content: "x" } }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const ac = new AbortController();
+    ac.abort();
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x"}',
+      signal: ac.signal,
+    });
+
+    expect(res.status).toBe(499);
+    expect((await res.json()).code).toBe("client_disconnected");
+    expect(fetchCalls).toBe(0); // never spent an upstream call on a caller already gone
+  });
+
+  test("an abort mid-stream cancels the upstream reader instead of draining a stream that never closes", async () => {
+    const { hooks } = makeHooks({ resolveUpstream: async () => [managed] });
+    let upstreamCancelled = false;
+    let upstreamController!: ReadableStreamDefaultController<Uint8Array>;
+    const fetchImpl: FetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(c) {
+            upstreamController = c;
+          },
+          cancel() {
+            upstreamCancelled = true;
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+
+    const ac = new AbortController();
+    const resPromise = createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+      signal: ac.signal,
+    });
+    // The probe phase needs at least one content chunk before chatCompletions
+    // resolves with a Response — push it as soon as the mock fetch has handed
+    // back its controller (a handful of hook/auth microtasks upstream of this).
+    for (let i = 0; i < 100 && !upstreamController; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    upstreamController.enqueue(
+      new TextEncoder().encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'),
+    );
+    const res = await resPromise;
+    expect(res.status).toBe(200);
+
+    // Drain the one chunk, then disconnect — the mock upstream never calls
+    // close(), so if the abort weren't honored this would hang forever.
+    const reader = res.body!.getReader();
+    await reader.read();
+    ac.abort();
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+    expect(upstreamCancelled).toBe(true);
+  });
+});
+
 describe("gateway error envelope contract", () => {
   test("all pre-dispatch rejection classes use the complete error envelope", async () => {
     const cases: Array<{ code: string; run: () => Promise<Response> }> = [

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -27,6 +27,15 @@ import { createTraceEmitter } from './trace';
 export interface ChatCompletionRequest {
   authorization: string | undefined;
   rawBody: string;
+  /**
+   * Inbound (client-facing) request's abort signal, when the host surface
+   * exposes one (e.g. Hono's `c.req.raw.signal`). Threaded through to the
+   * upstream fetch and, for streaming, to `relayStream` — so a client that
+   * disconnects mid-request actually stops the upstream from generating (and
+   * the gateway from paying for) tokens nobody will ever see, instead of the
+   * dispatch/stream loops running to completion regardless.
+   */
+  signal?: AbortSignal;
 }
 
 export interface GatewayDeps {
@@ -42,6 +51,10 @@ export interface HandlerRuntime {
   captureBodies: boolean;
   capture: (value: unknown) => unknown;
   breakerFor: (provider: string) => CircuitBreaker;
+  /** Mirrors `config.maxCapturedBodyBytes` — also used to bound the live,
+   *  in-flight streaming response preview (see `relayStream`), not just the
+   *  post-hoc trace truncation. */
+  maxCapturedBodyBytes?: number;
 }
 
 function json(data: unknown, status = 200): Response {
@@ -167,7 +180,8 @@ export async function handleChatCompletions(
   runtime: HandlerRuntime,
   req: ChatCompletionRequest,
 ): Promise<Response> {
-  const { hooks, config, logger, fetchImpl, captureBodies, capture, breakerFor } = runtime;
+  const { hooks, config, logger, fetchImpl, captureBodies, capture, breakerFor, maxCapturedBodyBytes } =
+    runtime;
 
   const requestId = newRequestId();
   const startedAt = new Date().toISOString();
@@ -542,6 +556,7 @@ export async function handleChatCompletions(
       },
       capturedRequest: capture(payload),
       fallbackOn,
+      signal: req.signal,
     });
 
     if (result.kind === 'response') {
@@ -765,6 +780,8 @@ export async function handleChatCompletions(
       resolvedModel: finalDescriptor.resolvedModel ?? requestedModel,
       requestId,
     },
+    signal: req.signal,
+    maxCapturedBodyBytes,
   });
 
   return new Response(readable, {

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -249,3 +249,203 @@ describe('probeStream error frames', () => {
     expect(probe.hasContent).toBe(false);
   });
 });
+
+// Regression coverage for the client-disconnect finding: the gateway must stop
+// reading (and paying for) upstream tokens the instant the caller is gone,
+// instead of draining an upstream that never closes on its own.
+describe('relayStream client abort propagation', () => {
+  function cancellableUpstream() {
+    let cancelled = false;
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    return {
+      stream,
+      push: (s: string) => controller.enqueue(enc.encode(s)),
+      isCancelled: () => cancelled,
+    };
+  }
+
+  test('an inbound abort cancels the upstream reader and ends the relay even though upstream never closes', async () => {
+    const up = cancellableUpstream();
+    const ac = new AbortController();
+    let settleCalls = 0;
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r-abort-1',
+      logger: noop,
+      settle: async () => {
+        settleCalls += 1;
+      },
+      heartbeatMs: 10_000,
+      signal: ac.signal,
+    });
+    const collected = drain(out);
+    up.push('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n');
+    await delay(10);
+    ac.abort();
+    // The mock upstream never calls close() — if the abort weren't honored this
+    // would hang forever (bounded only by the 15-minute default inactivity
+    // deadline). Resolving here proves the relay stopped on its own.
+    await collected;
+    expect(up.isCancelled()).toBe(true);
+    await delay(10);
+    expect(settleCalls).toBe(1);
+  });
+
+  test('a signal already aborted before the relay starts never issues a read, just cancels and settles', async () => {
+    const up = cancellableUpstream();
+    const ac = new AbortController();
+    ac.abort();
+    let settledResponse: unknown = 'unset';
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r-abort-2',
+      logger: noop,
+      settle: async (_usage, response) => {
+        settledResponse = response;
+      },
+      heartbeatMs: 10_000,
+      signal: ac.signal,
+    });
+    await drain(out);
+    expect(up.isCancelled()).toBe(true);
+    await delay(10);
+    expect(settledResponse).toBeNull();
+  });
+});
+
+// Regression coverage for the unbounded-buffer finding: the live preview
+// retained for the trace must stay bounded regardless of total stream size,
+// while usage/error extraction (which needs to see every chunk) stays correct.
+describe('relayStream bounded response buffer', () => {
+  test('caps the retained response preview independent of total stream size, while still relaying everything to the client', async () => {
+    const up = controllableUpstream();
+    let settledPreview: unknown = 'unset';
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: true,
+      requestId: 'r-bounded-1',
+      logger: noop,
+      settle: async (_usage, response) => {
+        settledPreview = response;
+      },
+      heartbeatMs: 10_000,
+      maxCapturedBodyBytes: 32,
+    });
+    const collected = drain(out);
+    const big = 'x'.repeat(5_000);
+    up.push(`data: {"choices":[{"delta":{"content":"${big}"}}]}\n\n`);
+    up.push('data: [DONE]\n\n');
+    up.close();
+    const text = await collected;
+    // The full stream still reaches the client verbatim...
+    expect(text.length).toBeGreaterThan(5_000);
+    await delay(10); // let the detached finally run settle()
+    // ...but the retained preview never grows past the configured cap.
+    expect(typeof settledPreview).toBe('string');
+    expect((settledPreview as string).length).toBe(32);
+  });
+
+  test('extracts usage correctly from a long stream even though the retained preview is capped well below it', async () => {
+    const up = controllableUpstream();
+    let settledUsage: unknown = 'unset';
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: true,
+      requestId: 'r-bounded-2',
+      logger: noop,
+      settle: async (usage) => {
+        settledUsage = usage;
+      },
+      heartbeatMs: 10_000,
+      maxCapturedBodyBytes: 16,
+    });
+    const collected = drain(out);
+    const big = 'y'.repeat(10_000);
+    up.push(`data: {"choices":[{"delta":{"content":"${big}"}}]}\n\n`);
+    up.push(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":22}}\n\n',
+    );
+    up.push('data: [DONE]\n\n');
+    up.close();
+    await collected;
+    await delay(10);
+    expect(settledUsage).toMatchObject({ promptTokens: 11, completionTokens: 22 });
+  });
+});
+
+// Regression coverage for the no-total-deadline finding: a stalled upstream
+// that accepts the connection, sends some bytes, then goes completely silent
+// forever (never closes) must eventually be treated as dead, not propped up
+// by heartbeats indefinitely.
+describe('relayStream inactivity deadline', () => {
+  test('aborts a stalled-but-never-closed upstream after the inactivity budget and surfaces a timeout error', async () => {
+    let cancelled = false;
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    let settledError: unknown = 'unset';
+    const out = relayStream({
+      upstreamBody: stream,
+      captureBodies: false,
+      requestId: 'r-inactive',
+      logger: noop,
+      settle: async (_usage, _response, streamError) => {
+        settledError = streamError;
+      },
+      heartbeatMs: 10,
+      inactivityTimeoutMs: 30,
+    });
+    const collected = drain(out);
+    controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'));
+    // Upstream goes silent forever after this single chunk — never closes.
+    const text = await collected;
+    expect(text).toContain('stream_inactivity_timeout');
+    expect(cancelled).toBe(true);
+    await delay(10);
+    expect(settledError).toMatchObject({ code: 'stream_inactivity_timeout' });
+  });
+
+  test('a slow-thinking model that keeps trickling bytes never trips the inactivity deadline', async () => {
+    const up = controllableUpstream();
+    let settledError: unknown = 'unset';
+    const out = relayStream({
+      upstreamBody: up.stream,
+      captureBodies: false,
+      requestId: 'r-slow-thinker',
+      logger: noop,
+      settle: async (_usage, _response, streamError) => {
+        settledError = streamError;
+      },
+      heartbeatMs: 10,
+      inactivityTimeoutMs: 30,
+    });
+    const collected = drain(out);
+    // Each chunk arrives just under the inactivity budget, resetting the clock.
+    up.push('data: {"choices":[{"delta":{"content":"a"}}]}\n\n');
+    await delay(20);
+    up.push('data: {"choices":[{"delta":{"content":"b"}}]}\n\n');
+    await delay(20);
+    up.push('data: [DONE]\n\n');
+    up.close();
+    const text = await collected;
+    expect(text).not.toContain('stream_inactivity_timeout');
+    await delay(10); // let the detached finally run settle()
+    expect(settledError).toBeNull();
+  });
+});

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -1,7 +1,7 @@
 import {
   type ExtractedUsage,
+  IncrementalSseScanner,
   type SseErrorFrame,
-  extractUsageFromSseBuffer,
   sseErrorFrame,
   sseHasContent,
 } from '../usage';
@@ -28,6 +28,30 @@ export interface StreamRelayOptions {
   };
   /** Keep-alive interval in ms (overridable for tests). */
   heartbeatMs?: number;
+  /**
+   * Inbound (client-facing) request's abort signal. When it fires — the
+   * caller's tab closed, they hit stop, the TCP connection dropped — the
+   * upstream reader is cancelled immediately instead of being drained to
+   * completion for no one, so a disconnected client also stops the upstream
+   * from generating (and us from being billed for) tokens nobody will see.
+   */
+  signal?: AbortSignal;
+  /**
+   * Total time upstream may go completely silent (no bytes at all, not even
+   * a heartbeat-worthy gap) before the stream is treated as stalled and
+   * aborted. Generous by default so a slow-thinking reasoning model is never
+   * mistaken for a dead connection — this only fires when NOTHING has been
+   * read for the whole window, not merely a gap between tokens (that's what
+   * the heartbeat is for). Overridable for tests.
+   */
+  inactivityTimeoutMs?: number;
+  /**
+   * Cap (bytes, pre-JSON-escaping) on the response preview retained for the
+   * trace when `captureBodies` is on. Independent of the stream's actual
+   * duration/size — the preview stops growing once it hits this cap instead
+   * of retaining the full stream text for the whole completion.
+   */
+  maxCapturedBodyBytes?: number;
 }
 
 // How long upstream may go silent before we emit a keep-alive. A reasoning model
@@ -38,6 +62,21 @@ const HEARTBEAT_MS = 10_000;
 // SSE comment line — ignored by every SSE/OpenAI client, so it's invisible
 // payload that just resets each hop's idle timer.
 const HEARTBEAT_FRAME = new TextEncoder().encode(': keep-alive\n\n');
+// Total silence budget before a stalled-but-never-closed upstream connection
+// (accepted the request, sent a 200, then never sent another byte and never
+// closed) is treated as dead rather than propped up by heartbeats forever.
+// Generous — well beyond any legitimate single-turn reasoning pause.
+const INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000;
+// Default cap on the retained response preview when `captureBodies` is on —
+// matches the gateway's default `maxCapturedBodyBytes`.
+const DEFAULT_PREVIEW_CAP_BYTES = 256 * 1024;
+
+class StreamInactivityTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`upstream stream inactivity timeout exceeded (${timeoutMs}ms with no bytes)`);
+    this.name = 'StreamInactivityTimeoutError';
+  }
+}
 
 // A candidate that opens a stream, sends nothing usable, and closes cleanly (the
 // empty-completion bug) fails fast — real models produce their first token well
@@ -118,10 +157,26 @@ function boundedErrorMessage(err: unknown): string {
 export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array> {
   const { captureBodies, requestId, logger, settle } = opts;
   const heartbeatMs = opts.heartbeatMs ?? HEARTBEAT_MS;
+  const inactivityTimeoutMs = opts.inactivityTimeoutMs ?? INACTIVITY_TIMEOUT_MS;
+  const previewCapBytes = opts.maxCapturedBodyBytes ?? DEFAULT_PREVIEW_CAP_BYTES;
   const transform = new TransformStream<Uint8Array, Uint8Array>();
   const writer = transform.writable.getWriter();
   const decoder = new TextDecoder();
-  let sseBuffer = '';
+  // Bounded scanner replaces full-stream buffering: usage/error extraction is
+  // done incrementally per-chunk (memory ~O(1) per stream, not O(total tokens)
+  // streamed) instead of re-scanning one ever-growing string at the end.
+  const scanner = new IncrementalSseScanner();
+  // Separate, small, capped preview retained ONLY for the trace (when
+  // `captureBodies` is on) — independent of the scanner above, and stops
+  // growing once it hits the cap rather than retaining the full stream text.
+  let preview = '';
+  let previewBytes = 0;
+  // Smallest possible state to reproduce the old "are we at an SSE event
+  // boundary" check (`sseBuffer === '' || sseBuffer.endsWith('\n\n')`) without
+  // keeping the whole buffer around — only the last couple of characters ever
+  // written matter for that test.
+  let tailChars = '';
+  let anyBytesWritten = false;
 
   const startMs = Date.now();
   const debug = (event: string, fields?: Record<string, unknown>): void =>
@@ -132,18 +187,32 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
     if (!reader) throw new Error('relayStream requires either `primed` or `upstreamBody`');
     let downstreamAlive = true;
     let firstByteAt = 0;
+    let lastActivityAt = startMs;
     let bytes = 0;
     let chunks = 0;
     let heartbeats = 0;
+    let clientAborted = false;
 
     const writeChunk = async (value: Uint8Array): Promise<void> => {
       if (!firstByteAt) {
         firstByteAt = Date.now();
         debug('stream_first_byte', { ttfbMs: firstByteAt - startMs });
       }
+      lastActivityAt = Date.now();
       chunks += 1;
       bytes += value.byteLength;
-      sseBuffer += decoder.decode(value, { stream: true });
+      const decoded = decoder.decode(value, { stream: true });
+      scanner.push(decoded);
+      if (decoded) {
+        anyBytesWritten = true;
+        tailChars = (tailChars + decoded).slice(-2);
+      }
+      if (captureBodies && previewBytes < previewCapBytes) {
+        const remaining = previewCapBytes - previewBytes;
+        const slice = decoded.length <= remaining ? decoded : decoded.slice(0, remaining);
+        preview += slice;
+        previewBytes += slice.length;
+      }
       if (downstreamAlive) {
         try {
           await writer.write(value);
@@ -164,53 +233,114 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
         for (const value of opts.primed.chunks) await writeChunk(value);
       }
 
-      // Keep exactly one read in flight; race it against a heartbeat timer so a
-      // long token gap emits a keep-alive without ever issuing a second read.
-      let pending = reader.read();
-      while (true) {
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const beat = new Promise<'beat'>((resolve) => {
-          timer = setTimeout(() => resolve('beat'), heartbeatMs);
-        });
-        const next = await Promise.race([pending.then((r) => ({ read: r })), beat]);
-        if (timer) clearTimeout(timer);
-
-        if (next === 'beat') {
-          // Upstream silent for HEARTBEAT_MS. Inject the comment only at an SSE
-          // event boundary (buffer empty, or ends with the \n\n terminator) so we
-          // never split a partial event mid-flight. `pending` stays in flight.
-          if (downstreamAlive && (sseBuffer === '' || sseBuffer.endsWith('\n\n'))) {
-            try {
-              await writer.write(HEARTBEAT_FRAME);
-              heartbeats += 1;
-              debug('stream_heartbeat', { sinceStartMs: Date.now() - startMs, heartbeats });
-            } catch {
-              downstreamAlive = false;
+      // The inbound (client-facing) request's own abort signal — fires when the
+      // caller disconnects (tab closed, stop hit, TCP reset). Racing it below
+      // means a disconnected client stops the upstream read loop immediately
+      // instead of draining an upstream that keeps generating (and billing)
+      // tokens for no one.
+      const clientAbort = opts.signal
+        ? new Promise<'aborted'>((resolve) => {
+            if (opts.signal!.aborted) {
+              resolve('aborted');
+              return;
             }
-          }
-          continue;
-        }
+            opts.signal!.addEventListener('abort', () => resolve('aborted'), { once: true });
+          })
+        : null;
 
-        const { done, value } = next.read;
-        if (done) break;
-        pending = reader.read();
-        if (!value) continue;
-        await writeChunk(value);
+      if (opts.signal?.aborted) {
+        // Already gone before the relay even started (e.g. disconnected during
+        // the probe phase) — never issue a read, just cancel and settle below.
+        clientAborted = true;
+        downstreamAlive = false;
+      } else {
+        // Keep exactly one read in flight; race it against a heartbeat timer so a
+        // long token gap emits a keep-alive without ever issuing a second read,
+        // and against the client-abort signal so a disconnect is noticed even
+        // while a read is still pending.
+        let pending = reader.read();
+        while (true) {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          const beat = new Promise<'beat'>((resolve) => {
+            timer = setTimeout(() => resolve('beat'), heartbeatMs);
+          });
+          const race = clientAbort
+            ? [pending.then((r) => ({ read: r })), beat, clientAbort]
+            : [pending.then((r) => ({ read: r })), beat];
+          const next = await Promise.race(race);
+          if (timer) clearTimeout(timer);
+
+          if (next === 'aborted') {
+            clientAborted = true;
+            downstreamAlive = false;
+            break;
+          }
+
+          if (next === 'beat') {
+            // Upstream has been completely silent (no bytes at all, not even a
+            // heartbeat-worthy gap that later resumed) for the full inactivity
+            // budget — a stalled-but-never-closed connection, not a slow
+            // reasoning pause (which still eventually produces bytes and resets
+            // `lastActivityAt`). Treat it as a dead stream instead of heartbeat-
+            // propping it up forever.
+            if (Date.now() - lastActivityAt >= inactivityTimeoutMs) {
+              try {
+                await reader.cancel();
+              } catch {
+                // already errored/closed — nothing to clean up.
+              }
+              throw new StreamInactivityTimeoutError(inactivityTimeoutMs);
+            }
+            // Inject the comment only at an SSE event boundary (buffer empty, or
+            // ends with the \n\n terminator) so we never split a partial event
+            // mid-flight. `pending` stays in flight.
+            if (downstreamAlive && (!anyBytesWritten || tailChars === '\n\n')) {
+              try {
+                await writer.write(HEARTBEAT_FRAME);
+                heartbeats += 1;
+                debug('stream_heartbeat', { sinceStartMs: Date.now() - startMs, heartbeats });
+              } catch {
+                downstreamAlive = false;
+              }
+            }
+            continue;
+          }
+
+          const { done, value } = next.read;
+          if (done) break;
+          pending = reader.read();
+          if (!value) continue;
+          await writeChunk(value);
+        }
+      }
+
+      if (clientAborted) {
+        // The client is gone — cancelling the reader tells the upstream (fetch
+        // implementation permitting) to stop sending/generating further tokens
+        // rather than have the gateway keep draining and paying for a response
+        // no one will ever see.
+        try {
+          await reader.cancel();
+        } catch {
+          // already errored/closed — nothing to clean up.
+        }
       }
     } catch (err) {
       const message = boundedErrorMessage(err);
+      const inactivityTimeout = err instanceof StreamInactivityTimeoutError;
       logger.warn(`[llm-gateway] stream read error ${requestId}:`, err);
       debug('stream_error', {
         error: message,
         bytes,
         chunks,
+        inactivityTimeout,
       });
       // Once headers are committed, SSE is the only remaining error channel.
       // Emit the standard shape opencode understands instead of silently closing.
       if (downstreamAlive) {
         const frame = `data: ${JSON.stringify(gatewayErrorBody({
           message,
-          code: 'upstream_stream_error',
+          code: inactivityTimeout ? 'stream_inactivity_timeout' : 'upstream_stream_error',
           provider: opts.errorContext?.provider ?? '',
           requestedModel: opts.errorContext?.requestedModel ?? '',
           resolvedModel: opts.errorContext?.resolvedModel ?? '',
@@ -225,11 +355,12 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
       } catch {
         // writer already closed / downstream gone — nothing to do here.
       }
+      scanner.finish();
       // An upstream that dies mid-generation (a stalled model host behind
       // OpenRouter, e.g. "Upstream idle timeout exceeded") reports it as an
       // in-stream error frame on an otherwise clean 200 stream. Surface it so
       // the trace records a failed turn instead of a silent success.
-      const streamError = sseErrorFrame(sseBuffer);
+      const streamError = scanner.error;
       if (streamError) {
         logger.warn(
           `[llm-gateway] upstream error frame in stream ${requestId}: "${streamError.message}"${streamError.code !== undefined ? ` (code ${streamError.code})` : ''}`,
@@ -242,17 +373,14 @@ export function relayStream(opts: StreamRelayOptions): ReadableStream<Uint8Array
         chunks,
         heartbeats,
         downstreamAlive,
+        clientAborted,
         ...(streamError ? { streamError: streamError.message } : {}),
       });
       // Settlement (usage extraction + recordUsage + trace) must never throw out
       // of this detached async task — a failure here would otherwise be an
       // unhandled rejection and silently lose billing/trace for the stream.
       try {
-        await settle(
-          extractUsageFromSseBuffer(sseBuffer),
-          captureBodies ? sseBuffer : null,
-          streamError,
-        );
+        await settle(scanner.usage, captureBodies ? preview : null, streamError);
       } catch (err) {
         logger.warn(`[llm-gateway] stream settle failed ${requestId}:`, err);
       }

--- a/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
+++ b/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
@@ -301,4 +301,55 @@ describe('translateAnthropicResponse (streaming)', () => {
     expect(parsed.error.type).toBe('overloaded_error');
     expect(parsed.error.code).toBe('overloaded_error');
   });
+
+  // Regression coverage for the "no guaranteed terminal frame" finding: Anthropic
+  // never sends a `message_stop` after a mid-stream `error` event, so without an
+  // explicit guarantee the translated stream ends with no [DONE] at all — a
+  // client/proxy waiting on that terminator can hang.
+  test('still terminates with data: [DONE] even though Anthropic sent no message_stop after the error', async () => {
+    const upstream = anthropicSse(
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-6","usage":{"input_tokens":10}}}\n\n',
+      'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+    );
+    const out = await translateAnthropicResponse(upstream, { streaming: true });
+    const text = await new Response(out.body).text();
+    expect(text.trim().endsWith('data: [DONE]')).toBe(true);
+  });
+
+  // Regression coverage for the "mid-stream network failures laundered into a
+  // clean success" finding: a raw read() exception (dropped connection, TLS
+  // reset) previously hit a bare `catch { /* close what we have */ }` that
+  // swallowed it with no trace and no terminal frame.
+  test('a raw read() exception is surfaced as an error frame, not silently swallowed', async () => {
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_2","model":"claude-sonnet-4-6","usage":{"input_tokens":5}}}\n\n' +
+                'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n',
+            ),
+          );
+        },
+        pull() {
+          throw new Error('upstream socket reset');
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    );
+
+    const out = await translateAnthropicResponse(upstream, { streaming: true });
+    const text = await new Response(out.body).text();
+
+    expect(text).toContain('partial'); // whatever streamed before the break is preserved
+    const frame = text
+      .split('\n')
+      .find((l) => l.startsWith('data:') && l.includes('"error"'))!
+      .slice(5)
+      .trim();
+    const parsed = JSON.parse(frame) as { error: { message: string; code: string } };
+    expect(parsed.error.message).toContain('upstream socket reset');
+    expect(parsed.error.code).toBe('upstream_stream_error');
+    expect(text.trim().endsWith('data: [DONE]')).toBe(true);
+  });
 });

--- a/packages/llm-gateway/src/transports/anthropic/response.ts
+++ b/packages/llm-gateway/src/transports/anthropic/response.ts
@@ -92,6 +92,7 @@ function translateStreaming(response: Response): Response {
     controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
   };
 
+  let doneSent = false;
   const stream = new ReadableStream({
     async start(controller) {
       const reader = response.body!.getReader();
@@ -180,12 +181,31 @@ function translateStreaming(response: Response): Response {
               };
               controller.enqueue(encoder.encode(`data: ${JSON.stringify(finalChunk)}\n\n`));
               controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+              doneSent = true;
             }
           }
         }
-      } catch {
-        // upstream stream broke; close what we have
+      } catch (err) {
+        // A network-level failure while reading the upstream body (dropped
+        // connection, timeout, TLS reset) must not be laundered into a clean
+        // stop — surface it as an OpenAI-shaped error frame (matching the
+        // `t === 'error'` handling above) so probeStream/relayStream — and
+        // settle() — see a real failure instead of a silent empty completion.
+        const message = err instanceof Error ? err.message : String(err);
+        const errChunk = {
+          error: {
+            message: message || 'anthropic upstream stream failed',
+            type: 'upstream_stream_error',
+            code: 'upstream_stream_error',
+          },
+        };
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
       } finally {
+        // Every path out of this stream — a clean `message_stop`, a mid-flight
+        // `error` event with no following `message_stop`, or a raw read
+        // exception above — must end with a terminal [DONE] so a client (or
+        // the probe/relay layer) waiting on that frame never hangs.
+        if (!doneSent) controller.enqueue(encoder.encode('data: [DONE]\n\n'));
         controller.close();
       }
     },

--- a/packages/llm-gateway/src/transports/bedrock/response.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock/response.test.ts
@@ -147,6 +147,27 @@ describe('bedrockEventStreamToSse', () => {
     const sse = await collectSse(bedrockEventStreamToSse(upstream));
     expect(sse).toContain('event: error');
   });
+
+  // Regression coverage for the mid-stream-network-failure-laundered-into-a-
+  // clean-success finding: a raw `reader.read()` exception on the event-stream
+  // body itself (not an AWS exception FRAME, an actual dropped connection) hit
+  // a bare `catch { close } finally { close }` with no error ever surfaced —
+  // the client saw a clean, silently truncated 200 stream.
+  test('a raw read() exception on the event-stream body is surfaced as an error, not silently closed', async () => {
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        pull() {
+          throw new Error('bedrock socket reset');
+        },
+      }),
+      { status: 200 },
+    );
+    const sse = await collectSse(bedrockEventStreamToSse(upstream));
+    expect(sse).toContain('event: error');
+    const dataLine = sse.split('\n').find((l) => l.startsWith('data:'))!;
+    const parsed = JSON.parse(dataLine.slice(5).trim());
+    expect(parsed.error.message).toContain('bedrock socket reset');
+  });
 });
 
 describe('translateBedrockResponse (streaming) — end to end through the Anthropic SSE translator', () => {

--- a/packages/llm-gateway/src/transports/bedrock/response.ts
+++ b/packages/llm-gateway/src/transports/bedrock/response.ts
@@ -176,8 +176,18 @@ function bedrockEventStreamToSse(response: Response): Response {
             }
           }
         }
-      } catch {
-        // upstream stream broke; close with what was relayed
+      } catch (err) {
+        // A network-level failure while reading the raw event-stream body
+        // (dropped connection, socket reset) is not an AWS exception FRAME —
+        // it never reaches `isExceptionFrame` above — but must not be
+        // laundered into a clean close either. Surface it the same way,
+        // matching the `event: error` shape used for a genuine exception frame.
+        const message = err instanceof Error ? err.message : String(err);
+        const errorEvent = {
+          type: 'error',
+          error: { type: 'upstream_stream_error', message: message || 'bedrock upstream stream failed' },
+        };
+        controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify(errorEvent)}\n\n`));
       } finally {
         controller.close();
       }

--- a/packages/llm-gateway/src/transports/openai-responses/response.test.ts
+++ b/packages/llm-gateway/src/transports/openai-responses/response.test.ts
@@ -297,6 +297,38 @@ describe('translateResponsesResponse (failure + incomplete events)', () => {
     expect(finishReasons(chunks)).not.toContain('stop');
     expect(extractUsageFromSseBuffer(sse)?.completionTokens).toBe(3);
   });
+
+  // Regression coverage for the "mid-stream network failure laundered into a
+  // clean success" finding: previously a raw `reader.read()` exception hit a
+  // bare `finally { enqueue([DONE]); close(); }` with no `catch` at all — the
+  // exception was fully swallowed and the client saw a clean, silent [DONE].
+  test('a raw read() exception mid-stream is surfaced as an error chunk, not silently swallowed into [DONE]', async () => {
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              `event: response.created\ndata: ${JSON.stringify({ type: 'response.created', response: { id: 'resp_x', model: 'gpt-5.5' } })}\n\n` +
+                `event: response.output_text.delta\ndata: ${JSON.stringify({ type: 'response.output_text.delta', delta: 'partial' })}\n\n`,
+            ),
+          );
+        },
+        pull() {
+          throw new Error('codex upstream socket reset');
+        },
+      }),
+      { status: 200 },
+    );
+
+    const translated = await translateResponsesResponse(upstream, { streaming: true });
+    const sse = await translated.text();
+    const chunks = dataChunks(sse);
+
+    const errors = errorChunks(chunks);
+    expect(errors).toHaveLength(1);
+    expect((errors[0].error as Record<string, unknown>).message).toContain('codex upstream socket reset');
+    expect(sse).toContain('data: [DONE]'); // the finally's terminal frame still fires
+  });
 });
 
 describe('callUpstream with openai-responses transport', () => {

--- a/packages/llm-gateway/src/transports/openai-responses/response.ts
+++ b/packages/llm-gateway/src/transports/openai-responses/response.ts
@@ -214,6 +214,14 @@ function translateStream(upstream: Response): Response {
         }
         const tail = parseFrame(buffer);
         if (tail) for (const out of eventToChunks(tail, state)) send(out);
+      } catch (err) {
+        // A network-level failure while reading the upstream body must not be
+        // laundered into a clean stop by the `finally` below — surface it as
+        // an OpenAI-shaped error frame (matching `response.failed`/`error`
+        // handling above) so probeStream/relayStream see a real failure
+        // instead of a silent empty completion.
+        const message = err instanceof Error ? err.message : String(err);
+        send(errorChunk(message || 'Upstream stream failed', 'upstream_stream_error', 'upstream_stream_error'));
       } finally {
         controller.enqueue(encoder.encode('data: [DONE]\n\n'));
         controller.close();

--- a/packages/llm-gateway/src/usage/extract.ts
+++ b/packages/llm-gateway/src/usage/extract.ts
@@ -5,7 +5,7 @@ export interface ExtractedUsage extends TokenUsage {
   model?: string;
 }
 
-interface UpstreamUsageShape {
+export interface UpstreamUsageShape {
   prompt_tokens?: number;
   completion_tokens?: number;
   cached_tokens?: number;
@@ -13,12 +13,12 @@ interface UpstreamUsageShape {
   cost?: number;
 }
 
-interface UpstreamChunkShape {
+export interface UpstreamChunkShape {
   model?: string;
   usage?: UpstreamUsageShape;
 }
 
-function normalize(raw: UpstreamChunkShape | undefined): ExtractedUsage {
+export function normalizeUsageChunk(raw: UpstreamChunkShape | undefined): ExtractedUsage {
   const usage = raw?.usage;
   const cached = usage?.cached_tokens ?? usage?.prompt_tokens_details?.cached_tokens ?? 0;
   return {
@@ -31,7 +31,7 @@ function normalize(raw: UpstreamChunkShape | undefined): ExtractedUsage {
 }
 
 export function extractUsageFromJson(json: unknown): ExtractedUsage {
-  return normalize(json as UpstreamChunkShape);
+  return normalizeUsageChunk(json as UpstreamChunkShape);
 }
 
 export function extractUsageFromSseBuffer(buffer: string): ExtractedUsage | null {
@@ -45,7 +45,7 @@ export function extractUsageFromSseBuffer(buffer: string): ExtractedUsage | null
     try {
       const chunk = JSON.parse(payload) as UpstreamChunkShape;
       if (chunk?.model) lastModel = chunk.model;
-      if (chunk?.usage) lastUsage = normalize(chunk);
+      if (chunk?.usage) lastUsage = normalizeUsageChunk(chunk);
     } catch {
       continue;
     }

--- a/packages/llm-gateway/src/usage/index.ts
+++ b/packages/llm-gateway/src/usage/index.ts
@@ -6,3 +6,5 @@ export type { CostBreakdown, TokenUsage } from './pricing';
 
 export { jsonHasContent, sseErrorFrame, sseHasContent } from './completion-guard';
 export type { SseErrorFrame } from './completion-guard';
+
+export { IncrementalSseScanner } from './sse-scanner';

--- a/packages/llm-gateway/src/usage/sse-scanner.ts
+++ b/packages/llm-gateway/src/usage/sse-scanner.ts
@@ -1,0 +1,93 @@
+import type { SseErrorFrame } from './completion-guard';
+import { type ExtractedUsage, type UpstreamChunkShape, normalizeUsageChunk } from './extract';
+
+// A well-formed SSE `data:` line for a chat-completion chunk (usage frame,
+// error frame, or content delta) is at most a few KB. An upstream that never
+// terminates a line with `\n` is malformed — carrying an unbounded amount of
+// text forever waiting for a newline that never comes would defeat the whole
+// point of bounding this scanner's memory, so the carry is capped and the
+// oldest bytes are dropped once it's exceeded.
+const DEFAULT_MAX_CARRY_BYTES = 1024 * 1024;
+
+/**
+ * Incrementally scans an SSE token stream for the two things `settle()` needs
+ * at the end of a completion — the final usage frame and the first upstream
+ * error frame — WITHOUT retaining the full stream text for the life of the
+ * request. Memory is bounded by `maxCarryBytes` (the worst case: a single
+ * unterminated "line") rather than growing with total tokens streamed.
+ *
+ * This mirrors exactly what `extractUsageFromSseBuffer`/`sseErrorFrame` did
+ * over a fully-accumulated buffer: last usage frame wins, first error frame
+ * wins, and only `data:` lines are considered.
+ */
+export class IncrementalSseScanner {
+  private carry = '';
+  private lastUsage: ExtractedUsage | null = null;
+  private lastModel: string | undefined;
+  private errorFrame: SseErrorFrame | null = null;
+  private readonly maxCarryBytes: number;
+
+  constructor(maxCarryBytes: number = DEFAULT_MAX_CARRY_BYTES) {
+    this.maxCarryBytes = maxCarryBytes;
+  }
+
+  /** Feed the next decoded text chunk. Call `finish()` once the stream ends. */
+  push(text: string): void {
+    if (!text) return;
+    this.carry += text;
+    let nl = this.carry.indexOf('\n');
+    while (nl >= 0) {
+      this.consumeLine(this.carry.slice(0, nl));
+      this.carry = this.carry.slice(nl + 1);
+      nl = this.carry.indexOf('\n');
+    }
+    if (this.carry.length > this.maxCarryBytes) {
+      this.carry = this.carry.slice(this.carry.length - this.maxCarryBytes);
+    }
+  }
+
+  /** Flush a final unterminated line (upstream closed without a trailing `\n`). */
+  finish(): void {
+    if (this.carry) {
+      this.consumeLine(this.carry);
+      this.carry = '';
+    }
+  }
+
+  private consumeLine(rawLine: string): void {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    if (!line.startsWith('data:')) return;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === '[DONE]') return;
+    let chunk: UpstreamChunkShape & { error?: unknown };
+    try {
+      chunk = JSON.parse(payload) as UpstreamChunkShape & { error?: unknown };
+    } catch {
+      return;
+    }
+    if (chunk?.model) this.lastModel = chunk.model;
+    if (chunk?.usage) this.lastUsage = normalizeUsageChunk(chunk);
+    if (!this.errorFrame && chunk?.error && typeof chunk.error === 'object') {
+      const { message, code } = chunk.error as { message?: unknown; code?: unknown };
+      if (typeof message === 'string' && message.length > 0) {
+        this.errorFrame = {
+          message,
+          ...(typeof code === 'string' || typeof code === 'number' ? { code } : {}),
+        };
+      }
+    }
+  }
+
+  /** Final usage frame seen (last one wins), or null if none carried usage. */
+  get usage(): ExtractedUsage | null {
+    if (this.lastUsage && !this.lastUsage.model && this.lastModel) {
+      this.lastUsage.model = this.lastModel;
+    }
+    return this.lastUsage;
+  }
+
+  /** First upstream error frame seen, or null on a clean stream. */
+  get error(): SseErrorFrame | null {
+    return this.errorFrame;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the STREAMING-RELIABILITY findings from the adversarially-verified LLM-gateway audit (workflow wf_b98bb3a8-1fc), scoped to the streaming relay/probe pipeline (`packages/llm-gateway/src/pipeline/streaming.ts`) and its immediate dependencies (transport response translators, dispatch/failover, call-upstream).

- **CRITICAL — client disconnect never aborts the upstream stream.** The inbound request's `AbortSignal` (from Hono's `c.req.raw.signal`) is now threaded through `ChatCompletionRequest` → `runFailover`/`callUpstream` (aborts the initial fetch, combined via `AbortSignal.any` with the per-attempt timeout signal) and into `relayStream` (cancels the upstream reader mid-stream instead of draining to completion). A new `ClientAbortError` disambiguates "caller is gone" from a genuine upstream failure — never retried, never trips the shared provider circuit breaker, and short-circuits the whole failover loop (499) instead of wasting more upstream spend on the next candidate.
- **CRITICAL — mid-stream network failures laundered into clean, billed successes.** The Anthropic, Bedrock, and OpenAI-Responses translation streams each wrapped the raw upstream body in their own `ReadableStream` and swallowed a raw `reader.read()` exception with a bare `catch { close }` — no error frame was ever enqueued, so `settle()` saw a clean stream. All three now catch the read exception and enqueue an OpenAI-shaped `{error:{...}}` frame before closing, so `sseErrorFrame`/incremental scanner sees a real failure.
- **HIGH — unbounded per-stream buffer.** `relayStream` no longer accumulates the full SSE text for the life of a completion. A new `IncrementalSseScanner` (`usage/sse-scanner.ts`) extracts usage/error frames per-chunk with bounded carry-over state; a separate, small preview (capped at `maxCapturedBodyBytes`, default 256KB) is retained only for the trace when `captureBodies` is on.
- **HIGH — no guaranteed terminal frame.** Anthropic's stream now guarantees a terminating `data: [DONE]` on every exit path (clean stop, mid-flight `error` event with no `message_stop`, or a raw read exception). Bedrock's exception-frame surfacing was already fixed in #4814 (merged concurrently) with full AWS event-stream header parsing — this PR adds the one gap that fix didn't cover (a raw read exception on the event-stream body itself).
- **MEDIUM — no total stream deadline.** `relayStream` now enforces a configurable inactivity deadline (default 15 min of total silence, distinct from the 10s per-token heartbeat) — a stalled-but-never-closed upstream is aborted and surfaced as `stream_inactivity_timeout` instead of being heartbeat-propped-up forever. A slow-thinking model that keeps trickling bytes never trips it.
- **CRITICAL — tool_choice safety**: transport-agent territory, not touched (already fixed in #4814).

## Coordination note

This PR and the concurrent billing PR both touch `packages/llm-gateway/src/pipeline/handler.ts` — my changes there are limited to threading `req.signal`/`maxCapturedBodyBytes` through to `runFailover`/`relayStream` call sites (not `settle()`'s billing body). Whoever merges second should rebase; the overlap should be trivial (different lines).

This branch was already rebased onto `origin/main` after #4814 (transport correctness) merged — the Bedrock exception-frame duplicate fix was resolved in favor of #4814's more thorough AWS-header-parsing implementation, keeping only the net-new raw-read-error coverage.

## Test plan

- [x] `tsc --noEmit` clean on `packages/llm-gateway`, `apps/llm-gateway`, `apps/api`
- [x] `bun test` — 202/202 pass in `packages/llm-gateway` (167 pre-existing/transport-PR tests + regression tests added here for abort propagation, mid-stream error surfacing, bounded buffer, terminal-frame guarantee, inactivity deadline)
- [x] `bun test` — 16/16 pass in `apps/llm-gateway`
- [x] End-to-end regression tests through `createGateway(...).chatCompletions(...)` for both the pre-dispatch abort (499, zero upstream calls) and mid-stream abort (upstream reader cancelled) paths