### PR TITLE
fix(llm-gateway): route genuine-OpenAI reasoning+tools BYOK traffic to /v1/responses

### DIFF
--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { UpstreamDescriptor } from '../domain';
-import { ClientAbortError, CircuitOpenError, UpstreamHttpError } from '../errors';
+import { CircuitOpenError, ClientAbortError, UpstreamHttpError } from '../errors';
 import { CircuitBreaker } from '../resilience';
 import { buildUpstreamRequest } from '../transports';
 import { type FetchImpl, callUpstream } from './call-upstream';
@@ -254,7 +254,12 @@ describe('callUpstream — translation sidecar mode', () => {
     const capture = makeCapturingFetch();
     await callUpstream(
       { model: 'x', messages: [], max_tokens: 4096 },
-      { ...descriptor, provider: 'openai', baseUrl: 'https://api.openai.com/v1', resolvedModel: 'gpt-5.6-sol' },
+      {
+        ...descriptor,
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        resolvedModel: 'gpt-5.6-sol',
+      },
       { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
     );
     expect(capture.requests[0].body).toMatchObject({ max_completion_tokens: 4096 });
@@ -301,12 +306,258 @@ describe('callUpstream — translation sidecar mode', () => {
 
   test('sidecar auth token is optional (no master key configured)', async () => {
     const capture = makeCapturingFetch();
-    await callUpstream(
-      { model: 'x' },
-      descriptor,
-      { fetchImpl: capture.impl, translationSidecar: { url: 'http://litellm.internal:4000' } },
-    );
+    await callUpstream({ model: 'x' }, descriptor, {
+      fetchImpl: capture.impl,
+      translationSidecar: { url: 'http://litellm.internal:4000' },
+    });
     expect(capture.requests[0].headers.authorization).toBeUndefined();
+  });
+});
+
+// Regression coverage for the "gpt-5.5/5.6 BYOK sessions fail with 'Function
+// tools with reasoning_effort are not supported ... in /v1/chat/completions'"
+// incident (essentia.kortix.cloud, session 21c6cfd0-5157-4e78-9d26-4198656b1a81):
+// a genuine api.openai.com reasoning model + function tools + a live
+// reasoning_effort must be dispatched over the Responses API
+// (packages/llm-gateway/src/transports/openai-responses), not chat/completions —
+// see transports/route-kind.ts for the exact gating.
+describe('callUpstream — genuine OpenAI reasoning model auto-routes to /v1/responses', () => {
+  const byokReasoningDescriptor: UpstreamDescriptor = {
+    provider: 'openai',
+    kind: 'openai-compat',
+    baseUrl: 'https://api.openai.com/v1',
+    apiKey: 'sk-byok-test',
+    billingMode: 'platform-fee',
+    markup: 0.1,
+    resolvedModel: 'gpt-5.5',
+    reasoning: true,
+    temperature: false,
+  };
+
+  const weatherTool = {
+    type: 'function',
+    function: { name: 'get_weather', description: 'get weather', parameters: { type: 'object' } },
+  };
+
+  test('the exact failing shape (tools + reasoning_effort) targets /responses with a translated payload', async () => {
+    const capture = makeCapturingFetch(
+      200,
+      JSON.stringify({
+        id: 'resp_1',
+        model: 'gpt-5.5',
+        output: [
+          { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'sunny' }] },
+        ],
+        usage: { input_tokens: 20, output_tokens: 5, total_tokens: 25 },
+      }),
+    );
+    const res = await callUpstream(
+      {
+        model: 'openai/gpt-5.5',
+        messages: [{ role: 'user', content: 'weather in sf?' }],
+        tools: [weatherTool],
+        reasoning_effort: 'medium',
+        stream: false,
+      },
+      byokReasoningDescriptor,
+      { fetchImpl: capture.impl, retry: fastRetry },
+    );
+
+    expect(capture.requests).toHaveLength(1);
+    const req = capture.requests[0];
+    expect(req.url).toBe('https://api.openai.com/v1/responses');
+    expect(req.headers.authorization).toBe('Bearer sk-byok-test');
+    const body = req.body as Record<string, unknown>;
+    expect(body.model).toBe('gpt-5.5');
+    expect(body.input).toEqual([{ role: 'user', content: 'weather in sf?' }]);
+    expect(body.tools).toEqual([
+      {
+        type: 'function',
+        name: 'get_weather',
+        description: 'get weather',
+        parameters: { type: 'object' },
+      },
+    ]);
+    expect(body.reasoning).toEqual({ effort: 'medium' });
+    expect(body.stream).toBe(false);
+
+    // The response comes back translated into an OpenAI chat.completion shape,
+    // not the raw Responses API envelope.
+    const chat = await res.json();
+    expect(chat.object).toBe('chat.completion');
+    expect(chat.choices[0].message.content).toBe('sunny');
+  });
+
+  test('reasoning_effort explicitly "none": stays on chat/completions (OpenAI\'s own documented escape hatch)', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      {
+        model: 'openai/gpt-5.5',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [weatherTool],
+        reasoning_effort: 'none',
+      },
+      byokReasoningDescriptor,
+      { fetchImpl: capture.impl, retry: fastRetry },
+    );
+    expect(capture.requests[0].url).toBe('https://api.openai.com/v1/chat/completions');
+  });
+
+  test('no tools: a plain reasoning-model turn is untouched, still chat/completions', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      {
+        model: 'openai/gpt-5.5',
+        messages: [{ role: 'user', content: 'hi' }],
+        reasoning_effort: 'medium',
+      },
+      byokReasoningDescriptor,
+      { fetchImpl: capture.impl, retry: fastRetry },
+    );
+    expect(capture.requests[0].url).toBe('https://api.openai.com/v1/chat/completions');
+  });
+
+  test('non-reasoning genuine-OpenAI model (capability flag false): tools + reasoning_effort still chat/completions (no regression)', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      {
+        model: 'openai/gpt-4.1',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [weatherTool],
+        reasoning_effort: 'medium',
+      },
+      { ...byokReasoningDescriptor, resolvedModel: 'gpt-4.1', reasoning: false },
+      { fetchImpl: capture.impl, retry: fastRetry },
+    );
+    expect(capture.requests[0].url).toBe('https://api.openai.com/v1/chat/completions');
+  });
+
+  test('a reasoning-flagged model on a different openai-compat host (OpenRouter) is not rerouted', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      {
+        model: 'kortix/o3',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [weatherTool],
+        reasoning_effort: 'medium',
+      },
+      {
+        ...byokReasoningDescriptor,
+        provider: 'openrouter',
+        baseUrl: 'https://openrouter.ai/api/v1',
+      },
+      { fetchImpl: capture.impl, retry: fastRetry },
+    );
+    expect(capture.requests[0].url).toBe('https://openrouter.ai/api/v1/chat/completions');
+  });
+
+  test('the translation sidecar is bypassed for the rerouted request — dispatches directly to api.openai.com/v1/responses', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      {
+        model: 'openai/gpt-5.5',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [weatherTool],
+        reasoning_effort: 'medium',
+      },
+      byokReasoningDescriptor,
+      {
+        fetchImpl: capture.impl,
+        retry: fastRetry,
+        translationSidecar: { url: 'http://litellm.internal:4000', authToken: 'sk-sidecar-master' },
+      },
+    );
+    expect(capture.requests[0].url).toBe('https://api.openai.com/v1/responses');
+    expect(capture.requests[0].body).not.toHaveProperty('api_key');
+    expect(capture.requests[0].body).not.toHaveProperty('api_base');
+  });
+
+  test('a non-rerouted request for the SAME reasoning model (no tools) still uses the sidecar when enabled', async () => {
+    const capture = makeCapturingFetch();
+    await callUpstream(
+      {
+        model: 'openai/gpt-5.5',
+        messages: [{ role: 'user', content: 'hi' }],
+        reasoning_effort: 'medium',
+      },
+      byokReasoningDescriptor,
+      {
+        fetchImpl: capture.impl,
+        retry: fastRetry,
+        translationSidecar: { url: 'http://litellm.internal:4000' },
+      },
+    );
+    expect(capture.requests[0].url).toBe('http://litellm.internal:4000/v1/chat/completions');
+    expect(capture.requests[0].body).toMatchObject({
+      api_key: 'sk-byok-test',
+      api_base: 'https://api.openai.com/v1',
+    });
+  });
+
+  test('streaming tool-call round trip: SSE Responses events translate into OpenAI tool_call chunks for a genuine BYOK descriptor', async () => {
+    const encoder = new TextEncoder();
+    const events = [
+      { type: 'response.created', response: { id: 'resp_9', model: 'gpt-5.5' } },
+      {
+        type: 'response.output_item.added',
+        item: { type: 'function_call', id: 'fc_1', call_id: 'call_1', name: 'get_weather' },
+      },
+      { type: 'response.function_call_arguments.delta', item_id: 'fc_1', delta: '{"city":' },
+      { type: 'response.function_call_arguments.delta', item_id: 'fc_1', delta: '"sf"}' },
+      {
+        type: 'response.completed',
+        response: {
+          model: 'gpt-5.5',
+          usage: { input_tokens: 12, output_tokens: 8, total_tokens: 20 },
+        },
+      },
+    ];
+    const fetchImpl: FetchImpl = async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const event of events) {
+            controller.enqueue(
+              encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`),
+            );
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    };
+
+    const res = await callUpstream(
+      {
+        model: 'openai/gpt-5.5',
+        messages: [{ role: 'user', content: 'weather in sf?' }],
+        tools: [weatherTool],
+        reasoning_effort: 'medium',
+        stream: true,
+      },
+      byokReasoningDescriptor,
+      { fetchImpl, retry: fastRetry },
+    );
+
+    const text = await res.text();
+    const chunks = text
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trim())
+      .filter((p) => p && p !== '[DONE]')
+      .map((p) => JSON.parse(p));
+
+    const args = chunks
+      .flatMap((c) => c.choices?.[0]?.delta?.tool_calls ?? [])
+      .map(
+        (tc: Record<string, unknown>) =>
+          (tc.function as Record<string, unknown> | undefined)?.arguments ?? '',
+      )
+      .join('');
+    expect(args).toBe('{"city":"sf"}');
+    expect(chunks.at(-1).choices[0].finish_reason).toBe('tool_calls');
   });
 });
 
@@ -366,9 +617,12 @@ describe('callUpstream client abort propagation', () => {
       ac.abort();
       throw new DOMException('The operation was aborted', 'AbortError');
     };
-    await callUpstream({}, descriptor, { retry: fastRetry, fetchImpl, signal: ac.signal, binding }).catch(
-      () => {},
-    );
+    await callUpstream({}, descriptor, {
+      retry: fastRetry,
+      fetchImpl,
+      signal: ac.signal,
+      binding,
+    }).catch(() => {});
     expect(breaker.current).toBe('closed');
   });
 });

--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -2,6 +2,7 @@ import type { TranslationSidecarConfig, UpstreamDescriptor } from '../domain';
 import { ClientAbortError, NetworkError, UpstreamHttpError } from '../errors';
 import { type BreakerBinding, type RetryOptions, withResilience } from '../resilience';
 import { transportFor } from '../transports';
+import { resolveTransportKind } from '../transports/route-kind';
 import { buildSidecarRequest, isSidecarEligible } from '../transports/sidecar';
 
 export type FetchImpl = (input: string, init: RequestInit) => Promise<Response>;
@@ -30,10 +31,18 @@ export async function callUpstream(
   opts: CallUpstreamOptions = {},
 ): Promise<Response> {
   const fetchImpl: FetchImpl = opts.fetchImpl ?? ((input, init) => fetch(input, init));
-  const transport = transportFor(descriptor.kind);
+  // Resolved per-request (not just from the descriptor's static `kind`): a
+  // genuine-OpenAI reasoning model with function tools + a live reasoning
+  // effort must go out over the Responses API even though descriptor
+  // resolution (apps/api's resolveCandidates, which doesn't see the body)
+  // labeled it 'openai-compat' — see route-kind.ts. Every other request keeps
+  // the descriptor's own kind unchanged.
+  const kind = resolveTransportKind(body, descriptor);
+  const transport = transportFor(kind);
   const direct = transport.buildRequest(body, descriptor);
   const request =
-    opts.translationSidecar && isSidecarEligible(descriptor)
+    opts.translationSidecar &&
+    isSidecarEligible({ kind, omitAuthorization: descriptor.omitAuthorization })
       ? buildSidecarRequest(direct, descriptor, opts.translationSidecar)
       : direct;
   if (opts.requestId) {

--- a/packages/llm-gateway/src/transports/index.ts
+++ b/packages/llm-gateway/src/transports/index.ts
@@ -1,7 +1,8 @@
 export type { Transport } from './transport';
 export { transportFor } from './registry';
+export { resolveTransportKind } from './route-kind';
 
-export { buildUpstreamRequest } from './openai-compat';
+export { buildUpstreamRequest, isGenuineOpenAiUpstream } from './openai-compat';
 export type { UpstreamRequest } from './openai-compat';
 
 export {

--- a/packages/llm-gateway/src/transports/openai-compat/index.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/index.ts
@@ -19,7 +19,10 @@ const GENUINE_OPENAI_HOSTNAME = 'api.openai.com';
 // even though those share `kind: 'openai-compat'` and flow through this same
 // transport. Checked on the resolved base URL rather than `descriptor.provider`
 // so it stays correct even if a future catalog entry mislabels the provider id.
-function isGenuineOpenAiUpstream(baseUrl: string): boolean {
+// Exported: also used by ../route-kind.ts to decide whether a reasoning-model
+// request with function tools must be routed to the openai-responses transport
+// instead (chat/completions rejects that combination — see route-kind.ts).
+export function isGenuineOpenAiUpstream(baseUrl: string): boolean {
   try {
     return new URL(baseUrl).hostname === GENUINE_OPENAI_HOSTNAME;
   } catch {
@@ -125,7 +128,11 @@ function normalizeRoleSequenceForPerplexity(messages: unknown[]): unknown[] {
       continue;
     }
     const prev = out[out.length - 1];
-    if (prev && prev.role !== 'system' && effectiveRole(prev.role) === effectiveRole(message.role)) {
+    if (
+      prev &&
+      prev.role !== 'system' &&
+      effectiveRole(prev.role) === effectiveRole(message.role)
+    ) {
       out[out.length - 1] = mergeSameRoleMessages(prev, message);
       continue;
     }
@@ -182,7 +189,10 @@ export function buildUpstreamRequest(
     }
   }
   if (descriptor.provider === 'perplexity' && Array.isArray(payload.messages)) {
-    payload = { ...payload, messages: normalizeRoleSequenceForPerplexity(payload.messages as unknown[]) };
+    payload = {
+      ...payload,
+      messages: normalizeRoleSequenceForPerplexity(payload.messages as unknown[]),
+    };
   }
 
   return {

--- a/packages/llm-gateway/src/transports/route-kind.test.ts
+++ b/packages/llm-gateway/src/transports/route-kind.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import type { UpstreamDescriptor } from '../domain';
+import { resolveTransportKind } from './route-kind';
+
+const reasoningTool = {
+  type: 'function',
+  function: { name: 'get_weather', description: 'd', parameters: { type: 'object' } },
+};
+
+const genuineOpenAiReasoning: UpstreamDescriptor = {
+  provider: 'openai',
+  kind: 'openai-compat',
+  baseUrl: 'https://api.openai.com/v1',
+  apiKey: 'sk-test',
+  billingMode: 'platform-fee',
+  markup: 0.1,
+  resolvedModel: 'gpt-5.5',
+  reasoning: true,
+  temperature: false,
+};
+
+describe('resolveTransportKind', () => {
+  test('genuine OpenAI reasoning model + function tools + reasoning_effort -> openai-responses', () => {
+    const kind = resolveTransportKind(
+      { model: 'openai/gpt-5.5', messages: [], tools: [reasoningTool], reasoning_effort: 'medium' },
+      genuineOpenAiReasoning,
+    );
+    expect(kind).toBe('openai-responses');
+  });
+
+  test('genuine OpenAI reasoning model + tools, no explicit reasoning_effort (implicit non-none default) -> openai-responses', () => {
+    const kind = resolveTransportKind(
+      { model: 'openai/gpt-5.6', messages: [], tools: [reasoningTool] },
+      genuineOpenAiReasoning,
+    );
+    expect(kind).toBe('openai-responses');
+  });
+
+  test('genuine OpenAI reasoning model + tools + reasoning_effort: "none" -> stays openai-compat (OpenAI\'s own documented escape hatch)', () => {
+    const kind = resolveTransportKind(
+      { model: 'openai/gpt-5.5', messages: [], tools: [reasoningTool], reasoning_effort: 'none' },
+      genuineOpenAiReasoning,
+    );
+    expect(kind).toBe('openai-compat');
+  });
+
+  test('nested reasoning.effort: "none" shape is honored the same as the flat field', () => {
+    const kind = resolveTransportKind(
+      {
+        model: 'openai/gpt-5.5',
+        messages: [],
+        tools: [reasoningTool],
+        reasoning: { effort: 'none' },
+      },
+      genuineOpenAiReasoning,
+    );
+    expect(kind).toBe('openai-compat');
+  });
+
+  test('genuine OpenAI reasoning model, no tools -> stays openai-compat (not the broken combination)', () => {
+    const kind = resolveTransportKind(
+      { model: 'openai/gpt-5.5', messages: [], reasoning_effort: 'medium' },
+      genuineOpenAiReasoning,
+    );
+    expect(kind).toBe('openai-compat');
+  });
+
+  test('genuine OpenAI reasoning model, empty tools array -> stays openai-compat', () => {
+    const kind = resolveTransportKind(
+      { model: 'openai/gpt-5.5', messages: [], tools: [], reasoning_effort: 'medium' },
+      genuineOpenAiReasoning,
+    );
+    expect(kind).toBe('openai-compat');
+  });
+
+  test('non-reasoning OpenAI model (capability flag false) + tools + reasoning_effort -> stays openai-compat (no regression)', () => {
+    const kind = resolveTransportKind(
+      { model: 'openai/gpt-4.1', messages: [], tools: [reasoningTool], reasoning_effort: 'medium' },
+      { ...genuineOpenAiReasoning, resolvedModel: 'gpt-4.1', reasoning: false },
+    );
+    expect(kind).toBe('openai-compat');
+  });
+
+  test('reasoning flag unset (unknown capability) + tools -> stays openai-compat (never guess)', () => {
+    const kind = resolveTransportKind(
+      {
+        model: 'openai/some-model',
+        messages: [],
+        tools: [reasoningTool],
+        reasoning_effort: 'medium',
+      },
+      { ...genuineOpenAiReasoning, reasoning: undefined },
+    );
+    expect(kind).toBe('openai-compat');
+  });
+
+  test('reasoning model + tools on a DIFFERENT openai-compat host (OpenRouter) -> stays openai-compat', () => {
+    const kind = resolveTransportKind(
+      { model: 'kortix/o3', messages: [], tools: [reasoningTool], reasoning_effort: 'medium' },
+      {
+        ...genuineOpenAiReasoning,
+        provider: 'openrouter',
+        baseUrl: 'https://openrouter.ai/api/v1',
+      },
+    );
+    expect(kind).toBe('openai-compat');
+  });
+
+  test('already anthropic/bedrock/openai-responses descriptors are never touched', () => {
+    expect(
+      resolveTransportKind(
+        { tools: [reasoningTool], reasoning_effort: 'medium' },
+        { ...genuineOpenAiReasoning, kind: 'anthropic' },
+      ),
+    ).toBe('anthropic');
+    expect(
+      resolveTransportKind(
+        { tools: [reasoningTool], reasoning_effort: 'medium' },
+        { ...genuineOpenAiReasoning, kind: 'bedrock' },
+      ),
+    ).toBe('bedrock');
+    expect(
+      resolveTransportKind(
+        { tools: [reasoningTool], reasoning_effort: 'medium' },
+        { ...genuineOpenAiReasoning, kind: 'openai-responses', provider: 'openai-codex' },
+      ),
+    ).toBe('openai-responses');
+  });
+});

--- a/packages/llm-gateway/src/transports/route-kind.ts
+++ b/packages/llm-gateway/src/transports/route-kind.ts
@@ -1,0 +1,86 @@
+import type { ProviderKind, UpstreamDescriptor } from '../domain';
+import { isGenuineOpenAiUpstream } from './openai-compat';
+
+type Json = Record<string, unknown>;
+
+function hasFunctionTools(body: Json): boolean {
+  return Array.isArray(body.tools) && body.tools.length > 0;
+}
+
+// The effective reasoning effort the client asked for, whichever shape it was
+// sent in — the OpenAI chat/completions field (`reasoning_effort: string`) or
+// the Responses-style nested object (`reasoning: { effort: string }`), which
+// opencode/callers occasionally send directly. Mirrors
+// openai-responses/request.ts's `reasoningFromBody`.
+function reasoningEffort(body: Json): string | undefined {
+  if (typeof body.reasoning_effort === 'string') return body.reasoning_effort;
+  const reasoning = body.reasoning;
+  if (reasoning && typeof reasoning === 'object') {
+    const effort = (reasoning as Json).effort;
+    if (typeof effort === 'string') return effort;
+  }
+  return undefined;
+}
+
+/**
+ * OpenAI's /v1/chat/completions rejects genuine reasoning-family models
+ * (o-series, gpt-5.x) whenever BOTH function tools and a non-'none' reasoning
+ * effort are present on the request:
+ *
+ *   "Function tools with reasoning_effort are not supported for gpt-5.5 in
+ *   /v1/chat/completions. To use function tools, use /v1/responses or set
+ *   reasoning_effort to 'none'."
+ *
+ * (observed live against api.openai.com — BYOK gpt-5.5/gpt-5.6 agent sessions
+ * on essentia.kortix.cloud, session 21c6cfd0-5157-4e78-9d26-4198656b1a81).
+ *
+ * The openai-responses transport (./openai-responses) already speaks the
+ * Responses API end to end (messages→input, tools, tool_choice,
+ * reasoning_effort, streaming + non-streaming translation back to the
+ * OpenAI-chat wire shape) — it was wired ONLY to the ChatGPT/Codex OAuth path
+ * (`descriptor.provider === 'openai-codex'`, chosen directly in
+ * apps/api/.../descriptors.ts codexDescriptor), but none of its request/
+ * response translation actually depends on that credential type. Reused here
+ * verbatim for genuine BYOK/managed OpenAI traffic rather than standing up a
+ * second translator, or (the smaller-looking but wrong fix) forcing
+ * `reasoning_effort` to 'none' and silently degrading reasoning quality for
+ * every tool-using request.
+ *
+ * Gated narrowly so this only ever affects the exact broken combination:
+ *  - `descriptor.kind === 'openai-compat'` — never touches anthropic/bedrock/
+ *    custom, and never an already-'openai-responses' descriptor (Codex
+ *    chooses its own transport independently in descriptors.ts).
+ *  - `descriptor.reasoning === true` — the SAME models.dev-derived capability
+ *    flag #4814 uses to strip reasoning-restricted sampling params, so a
+ *    non-reasoning OpenAI model (gpt-4o, gpt-4.1, ...) is never routed here.
+ *  - `isGenuineOpenAiUpstream(descriptor.baseUrl)` — never for an OpenAI-
+ *    compatible-but-not-genuine-OpenAI upstream (OpenRouter, Groq, Azure
+ *    OpenAI, self-hosted vLLM/LiteLLM/Ollama), whose `/responses` surface (if
+ *    it even has one) isn't this same wire contract.
+ *  - the request actually hits the failing shape: function tools present AND
+ *    reasoning_effort isn't explicitly 'none' (OpenAI's own error message
+ *    says 'none' keeps chat/completions working) — so a plain reasoning-model
+ *    turn with no tools, which already works fine today on chat/completions,
+ *    is left completely alone, minimizing blast radius to exactly the broken
+ *    combination instead of moving every reasoning-model request onto a
+ *    different wire format (Responses doesn't translate every chat/completions
+ *    field this codebase supports, e.g. response_format/json_schema — no
+ *    reason to risk those paths when they aren't the ones that are broken).
+ *
+ * Called per-attempt from `callUpstream` (body is available there; descriptor
+ * resolution in apps/api's resolveCandidates happens before the body's
+ * tools/reasoning_effort are known to that layer) — cheap enough to run on
+ * every dispatch, including each failover retry.
+ */
+export function resolveTransportKind(body: Json, descriptor: UpstreamDescriptor): ProviderKind {
+  if (
+    descriptor.kind === 'openai-compat' &&
+    descriptor.reasoning === true &&
+    isGenuineOpenAiUpstream(descriptor.baseUrl) &&
+    hasFunctionTools(body) &&
+    reasoningEffort(body) !== 'none'
+  ) {
+    return 'openai-responses';
+  }
+  return descriptor.kind;
+}


### PR DESCRIPTION
## Summary
- BYOK gpt-5.5/gpt-5.6 agent sessions on api.openai.com fail with `Function tools with reasoning_effort are not supported for gpt-5.5 in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.` (essentia.kortix.cloud, session `21c6cfd0-5157-4e78-9d26-4198656b1a81`). This is the next layer on top of #4805/#4809 (max_tokens) and #4814 (reasoning-param stripping): OpenAI's reasoning-family models reject chat/completions outright once BOTH function tools and a live `reasoning_effort` are present.
- The `openai-responses` transport (`packages/llm-gateway/src/transports/openai-responses`) already speaks the Responses API end to end — messages→input, tools, tool_choice, reasoning_effort, streaming/non-streaming translation back to the OpenAI chat wire shape — but was wired ONLY to the ChatGPT/Codex OAuth path (`provider === 'openai-codex'`). None of its translation logic actually depends on that credential type.
- `callUpstream` (`packages/llm-gateway/src/http/call-upstream.ts`) now resolves the *effective* transport kind per request via `packages/llm-gateway/src/transports/route-kind.ts`, instead of trusting the descriptor's static `kind` alone. A request is rerouted to `openai-responses` only when **all** of:
  - `descriptor.kind === 'openai-compat'`
  - `descriptor.reasoning === true` (the same models.dev capability flag #4814 uses — never a model-id allowlist)
  - the upstream host is genuinely `api.openai.com` (reusing the existing `isGenuineOpenAiUpstream` check from #4805/#4814, now exported)
  - the request actually carries function tools AND `reasoning_effort` isn't explicitly `'none'` (OpenAI's own documented escape hatch)
- Every other case is untouched: no tools, non-reasoning OpenAI models, other openai-compatible hosts (OpenRouter/Groq/Azure/self-hosted), `reasoning_effort: 'none'`, and the existing Codex path (which already resolves its own `kind: 'openai-responses'` independently).
- The LiteLLM translation sidecar (#4817) is bypassed for rerouted requests — `isSidecarEligible` is now checked against the *effective* kind, and `openai-responses` was never in its eligible set — so the fix is correct whether or not `LLM_TRANSLATION_SIDECAR_ENABLED` is on.

## Root cause
OpenAI's `/v1/chat/completions` structurally cannot serve function tools + a non-`'none'` reasoning effort for gpt-5.x/o-series models; only `/v1/responses` supports that combination. Genuine BYOK OpenAI traffic was hardcoded to `openai-compat` (chat/completions) at descriptor-resolution time, before the request body (tools/reasoning_effort) is known to that layer.

## Test plan
- [x] `bun test` in `packages/llm-gateway` — 244 pass (new: `route-kind.test.ts` unit coverage of every gating condition; `call-upstream.test.ts` end-to-end coverage of endpoint + payload shape, streaming tool-call round-trip through the Responses SSE shape, sidecar bypass, and no-regression cases for non-reasoning models / other hosts / `reasoning_effort:'none'`).
- [x] `tsc --noEmit` clean in `packages/llm-gateway` and `apps/api`.
- [x] Existing `openai-compat`/`openai-responses`/`sidecar` suites still pass unchanged (84/84 in the touched files, 244/244 package-wide).