### PR TITLE
fix(web): don't reveal the resolved sandbox provider when project provider is Automatic

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { ProjectSnapshotBuild } from '@kortix/sdk/projects-client';
+
+import { BuildRow } from './sandbox-view';
+import type { SandboxProviderMode } from './sandbox-provider-coverage';
+
+const build = (overrides: Partial<ProjectSnapshotBuild> = {}): ProjectSnapshotBuild => ({
+  build_id: 'build-1',
+  slug: 'essentia',
+  template_slug: 'essentia',
+  snapshot_name: 'kortix-tpl-abc123',
+  content_hash: 'abc123',
+  status: 'failed',
+  error: null,
+  error_category: null,
+  fixable_by_agent: false,
+  source: 'manual',
+  provider: 'daytona',
+  started_at: '2026-07-13T10:00:00.000Z',
+  finished_at: '2026-07-13T10:05:00.000Z',
+  ...overrides,
+});
+
+function renderBuildRow(providerMode: SandboxProviderMode, overrides?: Partial<ProjectSnapshotBuild>) {
+  return renderToStaticMarkup(createElement(BuildRow, { build: build(overrides), providerMode }));
+}
+
+describe('sandbox template build row provider disclosure', () => {
+  test('never names the resolved provider when the project is on Automatic', () => {
+    const html = renderBuildRow('automatic');
+
+    expect(html).not.toContain('Daytona');
+    // Everything else about the build should still render.
+    expect(html).toContain('essentia');
+    expect(html).toContain('kortix-tpl-abc123');
+    expect(html).toContain('Manual rebuild');
+  });
+
+  test('names the resolved provider once the project has explicitly pinned one', () => {
+    const html = renderBuildRow('pinned');
+
+    expect(html).toContain('Daytona');
+  });
+
+  test('does not render a provider badge when the build predates provider tracking', () => {
+    const html = renderBuildRow('pinned', { provider: null });
+
+    expect(html).not.toContain('Daytona');
+    expect(html).not.toContain('Platinum');
+    expect(html).not.toContain('E2B');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -162,7 +162,14 @@ function formatBuildDuration(startedAt: string, finishedAt: string | null): stri
   return `${hours}h`;
 }
 
-function BuildRow({ build }: { build: ProjectSnapshotBuild }) {
+export function BuildRow({
+  build,
+  providerMode,
+}: {
+  build: ProjectSnapshotBuild;
+  /** Only reveal the resolved provider when the project has explicitly pinned one. */
+  providerMode: SandboxProviderMode;
+}) {
   const status = BUILD_STATUS_TILE[build.status];
   const { Icon } = status;
   const duration = formatBuildDuration(build.started_at, build.finished_at);
@@ -183,7 +190,7 @@ function BuildRow({ build }: { build: ProjectSnapshotBuild }) {
           <Badge variant={status.badgeVariant} size="xs">
             {status.label}
           </Badge>
-          <ProviderBadge provider={build.provider} />
+          {providerMode === 'pinned' ? <ProviderBadge provider={build.provider} /> : null}
         </div>
         <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
           <span className="truncate font-mono">{build.snapshot_name}</span>
@@ -709,7 +716,7 @@ export function SandboxView({ projectId }: { projectId: string }) {
                   ) : (
                     <ul className="space-y-2">
                       {builds.slice(0, 10).map((b) => (
-                        <BuildRow key={b.build_id} build={b} />
+                        <BuildRow key={b.build_id} build={b} providerMode={providerMode} />
                       ))}
                     </ul>
                   )}


### PR DESCRIPTION
## Summary
- Marko: when a project's sandbox-provider override is "Automatic," the UI must not name the resolved underlying provider (e.g. "Daytona") anywhere — only an explicit pin should show the concrete provider name.
- Root cause: `SandboxView`'s `BuildRow` (apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx) rendered `<ProviderBadge provider={build.provider} />` unconditionally in the "Recent builds" list, regardless of the project's `provider_mode`. That's the leak Marko saw ("essentia · failed · Daytona · kortix-tpl-… · Manual rebuild · 5h ago").
- The sibling per-template provider-coverage matrix (`sandbox-provider-coverage.tsx`) already gated concrete provider names on `providerMode === 'pinned'` — this PR applies the same rule to the build-history row.
- Scanned other provider-name surfaces (admin fleet ops filter, legacy-machine cards, code comments) — those are either admin-only global tooling or historical/archived-resource facts unrelated to the project's current Automatic/pinned setting, so left unchanged.
- Display-layer only: Automatic still resolves to the platform default and all activated providers still receive builds; only the label is gated now.

## Test plan
- [x] Added `sandbox-view.test.tsx` covering `BuildRow`: Automatic → no provider name (and unaffected fields still render); Pinned → provider name shown; Pinned + build predating provider tracking → no provider badge.
- [x] `bun test src/features/workspace/customize/sections/view/` — 43 pass, 0 fail.
- [x] `npx tsc --noEmit` — no new errors introduced (4 pre-existing, unrelated fumadocs `.source` codegen errors only).