### PR TITLE
fix(llm-gateway): stop forwarding temperature/top_p when Anthropic thinking is enabled

### DIFF
--- a/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
+++ b/packages/llm-gateway/src/transports/anthropic/anthropic.test.ts
@@ -221,6 +221,93 @@ describe('buildAnthropicRequest — reasoning/thinking passthrough', () => {
     expect(req.payload.max_tokens).toBe(2000);
     expect((req.payload.thinking as any).budget_tokens).toBeLessThan(2000);
   });
+
+  test('drops temperature/top_p when thinking is enabled (Anthropic 400s on any non-default value)', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [{ role: 'user', content: 'hi' }],
+        reasoning_effort: 'high',
+        temperature: 0.7,
+        top_p: 0.9,
+      },
+      descriptor,
+    );
+    expect(req.payload.thinking).toBeTruthy();
+    expect(req.payload.temperature).toBeUndefined();
+    expect(req.payload.top_p).toBeUndefined();
+  });
+
+  test('a raw Anthropic-shaped thinking block also suppresses temperature/top_p', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [{ role: 'user', content: 'hi' }],
+        thinking: { type: 'enabled', budget_tokens: 4096 },
+        temperature: 1,
+        top_p: 0.5,
+      },
+      descriptor,
+    );
+    expect(req.payload.temperature).toBeUndefined();
+    expect(req.payload.top_p).toBeUndefined();
+  });
+
+  test('temperature/top_p still forwarded normally when thinking is not requested', () => {
+    const req = buildAnthropicRequest(
+      { messages: [{ role: 'user', content: 'hi' }], temperature: 0.3, top_p: 0.8 },
+      descriptor,
+    );
+    expect(req.payload.thinking).toBeUndefined();
+    expect(req.payload.temperature).toBe(0.3);
+    expect(req.payload.top_p).toBe(0.8);
+  });
+});
+
+describe('buildAnthropicRequest — vision content-part translation', () => {
+  test('translates a base64 data-URL image_url part into a native Anthropic image block', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'what is this?' },
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/png;base64,AAAA' },
+              },
+            ],
+          },
+        ],
+      },
+      descriptor,
+    );
+    const messages = req.payload.messages as any[];
+    const content = messages[0].content as any[];
+    expect(content[0]).toEqual({ type: 'text', text: 'what is this?' });
+    // Last content block also carries the prompt-cache breakpoint (existing
+    // applyPromptCaching behavior) — assert the image translation itself,
+    // not the cache_control tail-stamping.
+    expect(content[1].type).toBe('image');
+    expect(content[1].source).toEqual({ type: 'base64', media_type: 'image/png', data: 'AAAA' });
+  });
+
+  test('translates a remote-URL image_url part into a native Anthropic url-sourced image block', () => {
+    const req = buildAnthropicRequest(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'image_url', image_url: { url: 'https://example.com/cat.png' } }],
+          },
+        ],
+      },
+      descriptor,
+    );
+    const messages = req.payload.messages as any[];
+    const content = messages[0].content as any[];
+    expect(content[0].type).toBe('image');
+    expect(content[0].source).toEqual({ type: 'url', url: 'https://example.com/cat.png' });
+  });
 });
 
 describe('translateAnthropicResponse (non-streaming)', () => {

--- a/packages/llm-gateway/src/transports/anthropic/request.ts
+++ b/packages/llm-gateway/src/transports/anthropic/request.ts
@@ -204,8 +204,16 @@ export function buildAnthropicCorePayload(body: Record<string, any>): Record<str
     messages,
   };
   if (system) payload.system = system;
-  if (body.temperature != null) payload.temperature = body.temperature;
-  if (body.top_p != null) payload.top_p = body.top_p;
+  // Anthropic rejects temperature/top_p entirely once extended thinking is
+  // enabled ("`temperature` may only be set to 1 when thinking is enabled" —
+  // top_p is rejected outright too) — a client that sets both a sampling
+  // param and reasoning_effort/thinking would otherwise 400 upstream. Thinking
+  // already picks its own randomness, so drop both rather than forwarding a
+  // combination Anthropic never accepts.
+  if (!thinking) {
+    if (body.temperature != null) payload.temperature = body.temperature;
+    if (body.top_p != null) payload.top_p = body.top_p;
+  }
   if (body.stop != null) payload.stop_sequences = Array.isArray(body.stop) ? body.stop : [body.stop];
 
   const tools = translateTools(body.tools);

--- a/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
@@ -59,6 +59,20 @@ describe('buildBedrockRequest — reasoning/thinking (inherits the anthropic cor
     );
     expect((req.payload as any).thinking).toEqual({ type: 'enabled', budget_tokens: 16000 });
   });
+
+  test('drops temperature/top_p when thinking is enabled, same as the anthropic transport', () => {
+    const req = buildBedrockRequest(
+      {
+        messages: [{ role: 'user', content: 'hi' }],
+        reasoning_effort: 'high',
+        temperature: 0.7,
+        top_p: 0.9,
+      },
+      descriptor,
+    );
+    expect((req.payload as any).temperature).toBeUndefined();
+    expect((req.payload as any).top_p).toBeUndefined();
+  });
 });
 
 describe('buildBedrockRequest — tool_choice (SAFETY: inherits the anthropic core payload)', () => {


### PR DESCRIPTION
## Summary\n\nFollow-up to the gateway capability-matrix audit (docs/specs/2026-07-16-gateway-capability-matrix.md). Anthropic's Messages API rejects any non-default / once extended thinking is enabled ( must be 1,  unset) — confirmed live against real Bedrock Claude traffic during the audit: sending  alongside  400s.\n\n (shared by both the  and  transports) forwarded client-supplied / unconditionally regardless of whether  was present, so any caller combining / with an explicit sampling param would 400 on real Claude/Bedrock traffic. This mirrors the same-shaped bug #4814 already fixed for genuine-OpenAI reasoning models (strip incompatible sampling params rather than let the upstream reject the whole request) — same structural fix, applied to the other transport that has the same class of restriction.\n\nAlso fills a real test-coverage gap found during the audit: the anthropic transport's  → native Anthropic  content-block translation (base64 data-URL and remote URL) was correct and working but had zero test assertions — a regression here would have shipped silently.\n\n## Changes\n- : drop / from the payload when  is enabled (both the reasoning_effort-derived and raw Anthropic-shaped paths).\n- : 3 new tests for the temperature/top_p-drop behavior + 2 new tests for image_url translation (base64 + remote URL).\n- : 1 new test confirming Bedrock inherits the fix via the shared core payload builder.\n\n## Test plan\n- [x] bun test v1.3.11 (af24e281)
stage-npm-publish.test: 24 assertions passed
DO
DO
DO
DO
DO

> @kortix/db@1.0.0 migrate /Users/markokraemer/Projects/kortix/suna-gw-thinking-sampling/packages/db
> bun scripts/migrate.ts up

node-pg-migrate up  DB: postgresql://postgres:***@127.0.0.1:55440/postgres
> Migrating files:
> - 20260621094136410_baseline
> - 20260621094136411_storage_avatars
> - 20260622073727110_drop-discontinued-tables
> - 20260622153054773_executor_computer_provider
> - 20260622154500000_reconcile_faked_baseline_drift
> - 20260622185000000_executor_channel_provider
> - 20260624113021202_template_swap_key
> - 20260625184318399_slack_user_identity
> - 20260626012000000_tunnel_relay_ownership
> - 20260628010205205_account_model_preferences
> - 20260628053000000_slack_thread_participants
> - 20260628060000000_iam_roles_policies
> - 20260628060000001_d2_agent_service_account_identity
> - 20260628060000002_add_iam_resource_grants
> - 20260628140000000_project_role_user_tier
> - 20260629120000000_project_role_user_floor
> - 20260629130000000_drop_shadow_account_members
> - 20260629140000000_drop_server_entries
> - 20260701201651600_demo-enterprise-flag
> - 20260702120000000_unify_secret_access_share_model
> - 20260703160000000_add-review-items
> - 20260704120000000_project_role_member_rename
> - 20260704130000000_session_tool_approvals
> - 20260704140000000_secret_agent_scope
> - 20260704150000000_connector_agent_scope
> - 20260704160000000_reassert_kortix_runtime_grants
> - 20260706120000000_retire_basejump
> - 20260706130000000_remove_per_user_credential_mode
> - 20260706130001000_secrets_v2_identifier_model
> - 20260706130002000_retire-connector-share-scope
> - 20260706130003000_drop-project-role-manager-check
> - 20260706180000000_executor_executions_session_audit_index
> - 20260706190000000_sandbox_provider_add_managed
> - 20260706203000000_account_session_limit_override
> - 20260707170000000_sso_auto_provision_groups
> - 20260708023648000_manifest_path_default_yaml
> - 20260708154500000_sandbox_provider_add_platinum
> - 20260711210000000_session_sandbox_identity_immutability
> - 20260712160000000_session_runtime_context
> - 20260712160001000_atomic_use_credits_balance_guard
> - 20260712190000000_session_connector_profiles
> - 20260712200000000_allow_missing_runtime_recovery
> - 20260712210000000_revoke_automatic_runtime_identity_recovery
> - 20260712220000000_invite_accept_identity
> - 20260712230000000_teams_schema
> - 20260712230001000_widen_chat_turn_channel
> - 20260713000000000_widen_chat_channel_thread_ids
> - 20260713130000000_project_group_default_base_ref
> - 20260713152327797_drop_hosted_deployments
> - 20260713180000000_project_llm_routing_policies
> - 20260713220000000_e2b_provider_set
> - 20260713220001000_project_branch_environments
> - 20260714150000000_project_trigger_runtime_pinned_session
> - 20260715235932684_add-enforce-sso-to-account-sso-providers
> - 20260716122532312_sandbox_provider_add_local_docker
### MIGRATION 20260621094136410_baseline (UP) ###
### MIGRATION 20260621094136411_storage_avatars (UP) ###
### MIGRATION 20260622073727110_drop-discontinued-tables (UP) ###
### MIGRATION 20260622153054773_executor_computer_provider (UP) ###
### MIGRATION 20260622154500000_reconcile_faked_baseline_drift (UP) ###
### MIGRATION 20260622185000000_executor_channel_provider (UP) ###
### MIGRATION 20260624113021202_template_swap_key (UP) ###
### MIGRATION 20260625184318399_slack_user_identity (UP) ###
### MIGRATION 20260626012000000_tunnel_relay_ownership (UP) ###
### MIGRATION 20260628010205205_account_model_preferences (UP) ###
### MIGRATION 20260628053000000_slack_thread_participants (UP) ###
### MIGRATION 20260628060000000_iam_roles_policies (UP) ###
### MIGRATION 20260628060000001_d2_agent_service_account_identity (UP) ###
### MIGRATION 20260628060000002_add_iam_resource_grants (UP) ###
### MIGRATION 20260628140000000_project_role_user_tier (UP) ###
### MIGRATION 20260629120000000_project_role_user_floor (UP) ###
### MIGRATION 20260629130000000_drop_shadow_account_members (UP) ###
### MIGRATION 20260629140000000_drop_server_entries (UP) ###
### MIGRATION 20260701201651600_demo-enterprise-flag (UP) ###
### MIGRATION 20260702120000000_unify_secret_access_share_model (UP) ###
### MIGRATION 20260703160000000_add-review-items (UP) ###
### MIGRATION 20260704120000000_project_role_member_rename (UP) ###
### MIGRATION 20260704130000000_session_tool_approvals (UP) ###
### MIGRATION 20260704140000000_secret_agent_scope (UP) ###
### MIGRATION 20260704150000000_connector_agent_scope (UP) ###
### MIGRATION 20260704160000000_reassert_kortix_runtime_grants (UP) ###
### MIGRATION 20260706120000000_retire_basejump (UP) ###
### MIGRATION 20260706130000000_remove_per_user_credential_mode (UP) ###
### MIGRATION 20260706130001000_secrets_v2_identifier_model (UP) ###
### MIGRATION 20260706130002000_retire-connector-share-scope (UP) ###
### MIGRATION 20260706130003000_drop-project-role-manager-check (UP) ###
### MIGRATION 20260706180000000_executor_executions_session_audit_index (UP) ###
### MIGRATION 20260706190000000_sandbox_provider_add_managed (UP) ###
### MIGRATION 20260706203000000_account_session_limit_override (UP) ###
### MIGRATION 20260707170000000_sso_auto_provision_groups (UP) ###
### MIGRATION 20260708023648000_manifest_path_default_yaml (UP) ###
### MIGRATION 20260708154500000_sandbox_provider_add_platinum (UP) ###
### MIGRATION 20260711210000000_session_sandbox_identity_immutability (UP) ###
### MIGRATION 20260712160000000_session_runtime_context (UP) ###
### MIGRATION 20260712160001000_atomic_use_credits_balance_guard (UP) ###
### MIGRATION 20260712190000000_session_connector_profiles (UP) ###
### MIGRATION 20260712200000000_allow_missing_runtime_recovery (UP) ###
### MIGRATION 20260712210000000_revoke_automatic_runtime_identity_recovery (UP) ###
### MIGRATION 20260712220000000_invite_accept_identity (UP) ###
### MIGRATION 20260712230000000_teams_schema (UP) ###
### MIGRATION 20260712230001000_widen_chat_turn_channel (UP) ###
### MIGRATION 20260713000000000_widen_chat_channel_thread_ids (UP) ###
### MIGRATION 20260713130000000_project_group_default_base_ref (UP) ###
### MIGRATION 20260713152327797_drop_hosted_deployments (UP) ###
### MIGRATION 20260713180000000_project_llm_routing_policies (UP) ###
### MIGRATION 20260713220000000_e2b_provider_set (UP) ###
### MIGRATION 20260713220001000_project_branch_environments (UP) ###
### MIGRATION 20260714150000000_project_trigger_runtime_pinned_session (UP) ###
### MIGRATION 20260715235932684_add-enforce-sso-to-account-sso-providers (UP) ###
### MIGRATION 20260716122532312_sandbox_provider_add_local_docker (UP) ###
DO
DO
DO
DO
DO

> @kortix/db@1.0.0 migrate /Users/markokraemer/Projects/kortix/suna-gw-thinking-sampling/packages/db
> bun scripts/migrate.ts up

node-pg-migrate up  DB: postgresql://postgres:***@127.0.0.1:55440/postgres
No migrations to run!
{"t":"2026-07-16T21:55:35.137Z","level":"info","msg":"[static-web] listening","port":51197,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:35.487Z","level":"info","msg":"[git] cloning repo","repoUrl":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-credential-4AwICb/remote.git","base":"main","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-credential-4AwICb/workspace","filter":"none"}
{"t":"2026-07-16T21:55:35.527Z","level":"info","msg":"[git] configured default repo identity","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-credential-4AwICb/workspace","name":"Kortix Agent","email":"agent@kortix.ai"}
{"t":"2026-07-16T21:55:35.550Z","level":"info","msg":"[git] cloning repo","repoUrl":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-empty-RVbRmt/remote.git","base":"main","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-empty-RVbRmt/workspace","filter":"none"}
{"t":"2026-07-16T21:55:35.599Z","level":"info","msg":"[git] initialized fresh local repo at base (empty upstream)","base":"main","dir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-empty-RVbRmt/.kortix-clone-4730-1784238935550"}
{"t":"2026-07-16T21:55:35.612Z","level":"info","msg":"[git] remote session branch not ready; creating local branch from base checkout","branch":"session-abc","stderr":"fatal: couldn't find remote ref refs/heads/session-abc\n"}
{"t":"2026-07-16T21:55:35.620Z","level":"info","msg":"[git] created local session branch","branch":"session-abc"}
{"t":"2026-07-16T21:55:35.638Z","level":"info","msg":"[git] configured default repo identity","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-empty-RVbRmt/workspace","name":"Kortix Agent","email":"agent@kortix.ai"}
{"t":"2026-07-16T21:55:35.780Z","level":"info","msg":"[git] configured safe git directory","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-baked-checkout-ZaAmwh/workspace"}
{"t":"2026-07-16T21:55:35.785Z","level":"info","msg":"[git] using baked repo checkout (warm)","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-baked-checkout-ZaAmwh/workspace","head":"08de94f71692b421cf8d589ac2cb8ec1da31d270"}
{"t":"2026-07-16T21:55:35.798Z","level":"info","msg":"[git] created local session branch from baked checkout","branch":"session-branch"}
{"t":"2026-07-16T21:55:35.816Z","level":"info","msg":"[git] configured default repo identity","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-baked-checkout-ZaAmwh/workspace","name":"Kortix Agent","email":"agent@kortix.ai"}
{"t":"2026-07-16T21:55:35.861Z","level":"info","msg":"[git] configured default global identity","home":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-git-home-nGmtPx","name":"Kortix Agent","email":"agent@kortix.ai"}
{"t":"2026-07-16T21:55:36.167Z","level":"info","msg":"[env] project env changed; refreshing live agent env file","revision":"rev-1","names":3}
{"t":"2026-07-16T21:55:36.167Z","level":"info","msg":"[env] project env changed; refreshing live agent env file","revision":"rev-gateway-on","names":0}
{"t":"2026-07-16T21:55:36.167Z","level":"info","msg":"[env] model-affecting env changed; restarting opencode","projectRevision":"rev-gateway-on","projectEnvChanged":true,"opencodeEnvNames":["KORTIX_LLM_API_KEY","KORTIX_LLM_BASE_URL"]}
{"t":"2026-07-16T21:55:36.167Z","level":"info","msg":"[env] project env changed; refreshing live agent env file","revision":"rev-gateway-off","names":0}
{"t":"2026-07-16T21:55:36.167Z","level":"info","msg":"[env] model-affecting env changed; restarting opencode","projectRevision":"rev-gateway-off","projectEnvChanged":true,"opencodeEnvNames":["KORTIX_LLM_API_KEY","KORTIX_LLM_BASE_URL"]}
{"t":"2026-07-16T21:55:36.168Z","level":"info","msg":"[env] project env changed; refreshing live agent env file","revision":"rev-on","names":0}
{"t":"2026-07-16T21:55:36.168Z","level":"info","msg":"[env] model-affecting env changed; restarting opencode","projectRevision":"rev-on","projectEnvChanged":true,"opencodeEnvNames":["KORTIX_LLM_API_KEY","KORTIX_LLM_BASE_URL","KORTIX_OPENCODE_DENY_ENV"]}
{"t":"2026-07-16T21:55:36.168Z","level":"info","msg":"[env] project env changed; refreshing live agent env file","revision":"rev-off","names":0}
{"t":"2026-07-16T21:55:36.168Z","level":"info","msg":"[env] model-affecting env changed; restarting opencode","projectRevision":"rev-off","projectEnvChanged":true,"opencodeEnvNames":["KORTIX_LLM_API_KEY","KORTIX_LLM_BASE_URL","KORTIX_OPENCODE_DENY_ENV"]}
{"t":"2026-07-16T21:55:36.170Z","level":"info","msg":"[git] cloning repo","repoUrl":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-fail-O1ZFxz/missing.git","base":"main","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-clone-fail-O1ZFxz/workspace","filter":"none"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_root","attempt":1,"backoffMs":5000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_root","attempt":1}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_root","attempt":1,"backoffMs":5000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_root","attempt":1}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_root","attempt":2,"backoffMs":15000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_root","attempt":2}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_root","attempt":3,"backoffMs":45000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_root","attempt":3}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_root","attempt":1,"backoffMs":5000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_root","attempt":1}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_a","attempt":1,"backoffMs":5000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_a","attempt":1}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_a","attempt":2,"backoffMs":15000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_a","attempt":2}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_a","attempt":3,"backoffMs":45000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_a","attempt":3}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_b","attempt":1,"backoffMs":5000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] resume prompt delivered","sessionId":"ses_b","attempt":1}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_root","attempt":1,"backoffMs":5000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] session moved on during backoff — skipping resume","sessionId":"ses_root","lastRole":"user"}
{"t":"2026-07-16T21:55:36.178Z","level":"info","msg":"[turn-auto-resume] transient turn error — resuming after backoff","sessionId":"ses_root","attempt":1,"backoffMs":5000,"errorName":"UnknownError","errorMessage":"Upstream idle timeout exceeded"}
{"t":"2026-07-16T21:55:36.181Z","level":"info","msg":"[proxy] listening","port":51210,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:36.181Z","level":"info","msg":"[proxy] listening","port":51211,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:36.183Z","level":"info","msg":"[proxy] listening","port":51212,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:36.184Z","level":"info","msg":"[proxy] listening","port":51213,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:36.237Z","level":"info","msg":"[proxy] listening","port":51214,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:41.240Z","level":"info","msg":"[proxy] listening","port":51224,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:46.241Z","level":"info","msg":"[proxy] listening","port":51239,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:51.243Z","level":"info","msg":"[proxy] listening","port":51247,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:51.244Z","level":"info","msg":"[proxy] listening","port":51249,"hostname":"0.0.0.0"}
{"t":"2026-07-16T21:55:51.265Z","level":"info","msg":"[boot] linked baked opencode config deps","configDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/oc-deps-EnmHsg/config","from":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/oc-deps-EnmHsg/baked/node_modules"}
{"t":"2026-07-16T21:55:51.283Z","level":"info","msg":"[env] project env changed; refreshing live agent env file","revision":"rev-curl-1","names":2}
{"t":"2026-07-16T21:55:51.298Z","level":"info","msg":"[env] project env changed; refreshing live agent env file","revision":"rev-curl-2","names":2}
{"t":"2026-07-16T21:55:51.298Z","level":"info","msg":"[env] model-affecting env changed; restarting opencode","projectRevision":"rev-curl-2","projectEnvChanged":true,"opencodeEnvNames":[]}
{"t":"2026-07-16T21:55:51.308Z","level":"info","msg":"[presentation] starting conversion","format":"pdf","presDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-pres-test-vWM4Fh/presentations/deck"}
{"t":"2026-07-16T21:55:51.308Z","level":"info","msg":"[presentation] conversion complete","format":"pdf","presDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-pres-test-vWM4Fh/presentations/deck"}
{"t":"2026-07-16T21:55:51.309Z","level":"info","msg":"[presentation] starting conversion","format":"pptx","presDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-pres-test-zIplrn/presentations/deck"}
{"t":"2026-07-16T21:55:51.309Z","level":"info","msg":"[presentation] conversion complete","format":"pptx","presDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-pres-test-zIplrn/presentations/deck"}
{"t":"2026-07-16T21:55:51.315Z","level":"info","msg":"[presentation] starting conversion","format":"pdf","presDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-pres-test-RWd4Dp/presentations/deck"}
{"t":"2026-07-16T21:55:51.322Z","level":"info","msg":"[presentation] starting conversion","format":"pdf","presDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-pres-test-RWd4Dp/presentations/deck"}
{"t":"2026-07-16T21:55:51.347Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:51.348Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:51.348Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:51.348Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:51.348Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.850Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.850Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetching gateway models from https://api.kortix.test/v1/llm/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:54.851Z","level":"info","msg":"[opencode] fetched 5 gateway models from https://api.kortix.test/v1/llm/models"}
{"t":"2026-07-16T21:55:54.921Z","level":"info","msg":"[opencode-events] subscribed"}
{"t":"2026-07-16T21:55:55.126Z","level":"info","msg":"[opencode-events] subscribed"}
{"t":"2026-07-16T21:55:55.190Z","level":"info","msg":"[opencode-events] subscribed"}
{"t":"2026-07-16T21:55:55.377Z","level":"info","msg":"[opencode-events] subscribed"}
{"t":"2026-07-16T21:55:55.396Z","level":"info","msg":"[boot] injected managed kortix skills","configDir":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/inj-skills-P8GCHV/config","from":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/inj-skills-P8GCHV/baked","injected":2}
{"t":"2026-07-16T21:55:55.415Z","level":"info","msg":"[git] configured managed credential helper (global)","host":"https://git.example.test"}
{"t":"2026-07-16T21:55:55.435Z","level":"info","msg":"[git] configured managed credential helper (global)","host":"https://git.example.test"}
{"t":"2026-07-16T21:55:55.444Z","level":"info","msg":"[git] configured managed credential helper (global)","host":"https://git.example.test"}
{"t":"2026-07-16T21:55:55.468Z","level":"info","msg":"[git] configured managed credential helper (repo-local)","host":"https://git.example.test","target":"/var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/kortix-cred-repo-HHAHiH"}
{"t":"2026-07-16T21:55:55.500Z","level":"info","msg":"[llm-proxy] listening","port":14319,"hasUpstream":true}
{"t":"2026-07-16T21:55:55.502Z","level":"info","msg":"[llm-proxy] listening","port":14319,"hasUpstream":true}
{"t":"2026-07-16T21:55:55.504Z","level":"info","msg":"[executor-proxy] listening","port":14320,"hasUpstream":true}
{"t":"2026-07-16T21:55:55.505Z","level":"info","msg":"[opencode] loaded 1 gateway models from baked catalog /var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/cat-FCSpRK/catalog.json"}
{"t":"2026-07-16T21:55:55.505Z","level":"info","msg":"[opencode] loaded 1 gateway models from baked catalog /var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/cat-FCSpRK/catalog.json"}
{"t":"2026-07-16T21:55:55.505Z","level":"info","msg":"[opencode] loaded 1 gateway models from baked catalog /var/folders/4b/k94fgt8575n7lh1hsrywfm5w0000gn/T/cat-FCSpRK/catalog.json"}
{"t":"2026-07-16T21:55:55.507Z","level":"info","msg":"[opencode] fetching gateway models from http://127.0.0.1:51277/models (timeout 6000ms)"}
{"t":"2026-07-16T21:55:55.878Z","level":"info","msg":"[opencode-events] subscribed"}
{"t":"2026-07-16T21:55:56.880Z","level":"info","msg":"[opencode-events] subscribed"}
{"t":"2026-07-16T21:55:58.881Z","level":"info","msg":"[opencode-events] subscribed"}
{"t":"2026-07-16T21:55:59.020Z","level":"info","msg":"[opencode] fetching gateway models from http://127.0.0.1:51299/models (timeout 6000ms)"} in  — 268 pass, 0 fail (was 262 before this change)\n- [x]  (tsc --noEmit) clean for \n- [x] No  call sites reference these functions directly — no touched-API tests needed