### PR TITLE
fix: manage regional compliance monitoring

### DIFF
--- a/infra/terraform/compliance-monitoring/README.md
+++ b/infra/terraform/compliance-monitoring/README.md
@@ -1,0 +1,37 @@
+# compliance-monitoring
+
+Regional, discovery-based SOC 2 monitoring for the Kortix AWS account. This
+stack has its own state so it cannot accidentally adopt or mutate the legacy
+`security-baseline` stack.
+
+It manages:
+
+- WAF association for every current ALB in us-west-2 and eu-west-2.
+- Target response time, ELB 5xx, and unhealthy-host CloudWatch alarms for every
+  current ALB, with regional SNS actions (Drata DCF-86 / DCF-88).
+- Least-privilege SNS topic policies for EventBridge and CloudWatch delivery.
+- AWS Backup and EBS snapshot failure EventBridge rules and SNS targets
+  (Drata DCF-99).
+
+Kubernetes-managed ALB names contain generated hashes, so the stack discovers
+all current ALB ARNs. Re-run plan/apply after adding or replacing a load
+balancer to bring the new ARN under management.
+
+## First adoption
+
+The resources were created live before this stack was introduced. Initialize
+and run `scripts/import-live.sh` to adopt WAF associations, which cannot be
+upserted. CloudWatch alarms, EventBridge rules/targets, and SNS policies use
+idempotent AWS put operations and are adopted by the first apply. Then require
+a zero-destroy plan:
+
+```bash
+terraform init
+./scripts/import-live.sh
+terraform plan -out=tfplan
+terraform show -json tfplan | jq -e '[.resource_changes[]? | select(.change.actions | index("delete"))] | length == 0'
+terraform apply tfplan
+```
+
+Email SNS subscriptions remain a human confirmation step; Terraform must not
+pretend an unconfirmed subscription is a working alert channel.

--- a/infra/terraform/compliance-monitoring/backend.tf
+++ b/infra/terraform/compliance-monitoring/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "kortix-terraform-state"
+    key            = "security/compliance-monitoring.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/compliance-monitoring/monitoring.tf
+++ b/infra/terraform/compliance-monitoring/monitoring.tf
@@ -1,0 +1,335 @@
+# Regional alert delivery and ALB coverage — Drata DCF-86 / DCF-88 / DCF-99.
+#
+# ALBs are discovered instead of named because the AWS Load Balancer Controller
+# includes a generated hash in Kubernetes-managed load balancer names. A plan
+# therefore adds coverage for a new ALB without a hand-maintained name list.
+
+data "aws_sns_topic" "usw2_alerts" {
+  name = "suna-api-alerts"
+}
+
+data "aws_sns_topic" "euw2_alerts" {
+  provider = aws.euw2
+  name     = "kortix-compliance-alerts"
+}
+
+data "aws_lbs" "usw2" {}
+
+data "aws_lbs" "euw2" {
+  provider = aws.euw2
+}
+
+data "aws_wafv2_web_acl" "usw2" {
+  name  = "kortix-alb-waf"
+  scope = "REGIONAL"
+}
+
+data "aws_wafv2_web_acl" "euw2" {
+  provider = aws.euw2
+  name     = "kortix-alb-waf"
+  scope    = "REGIONAL"
+}
+
+locals {
+  usw2_albs = {
+    for arn in data.aws_lbs.usw2.arns : arn => {
+      name      = split("/", arn)[2]
+      dimension = replace(arn, "/^.*:loadbalancer\\//", "")
+    }
+  }
+  euw2_albs = {
+    for arn in data.aws_lbs.euw2.arns : arn => {
+      name      = split("/", arn)[2]
+      dimension = replace(arn, "/^.*:loadbalancer\\//", "")
+    }
+  }
+  alarm_tags = {
+    ManagedBy = "kortix-compliance"
+    Control   = "DCF-86"
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "usw2" {
+  for_each     = local.usw2_albs
+  resource_arn = each.key
+  web_acl_arn  = data.aws_wafv2_web_acl.usw2.arn
+}
+
+resource "aws_wafv2_web_acl_association" "euw2" {
+  provider     = aws.euw2
+  for_each     = local.euw2_albs
+  resource_arn = each.key
+  web_acl_arn  = data.aws_wafv2_web_acl.euw2.arn
+}
+
+resource "aws_cloudwatch_metric_alarm" "usw2_target_response_time" {
+  for_each            = local.usw2_albs
+  alarm_name          = "kortix-alb-${each.value.name}-target-response-time"
+  alarm_description   = "SOC2 DCF-86: ALB target response time is elevated"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "TargetResponseTime"
+  dimensions          = { LoadBalancer = each.value.dimension }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 2
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.usw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "usw2_elb_5xx" {
+  for_each            = local.usw2_albs
+  alarm_name          = "kortix-alb-${each.value.name}-elb-5xx"
+  alarm_description   = "SOC2 DCF-86: ALB server errors detected"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  dimensions          = { LoadBalancer = each.value.dimension }
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 5
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.usw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "usw2_unhealthy_hosts" {
+  for_each            = local.usw2_albs
+  alarm_name          = "kortix-alb-${each.value.name}-unhealthy-hosts"
+  alarm_description   = "SOC2 DCF-86: ALB has unhealthy targets"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "UnHealthyHostCount"
+  dimensions          = { LoadBalancer = each.value.dimension }
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.usw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "euw2_target_response_time" {
+  provider            = aws.euw2
+  for_each            = local.euw2_albs
+  alarm_name          = "kortix-alb-${each.value.name}-target-response-time"
+  alarm_description   = "SOC2 DCF-86: ALB target response time is elevated"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "TargetResponseTime"
+  dimensions          = { LoadBalancer = each.value.dimension }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 2
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.euw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "euw2_elb_5xx" {
+  provider            = aws.euw2
+  for_each            = local.euw2_albs
+  alarm_name          = "kortix-alb-${each.value.name}-elb-5xx"
+  alarm_description   = "SOC2 DCF-86: ALB server errors detected"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  dimensions          = { LoadBalancer = each.value.dimension }
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 5
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.euw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "euw2_unhealthy_hosts" {
+  provider            = aws.euw2
+  for_each            = local.euw2_albs
+  alarm_name          = "kortix-alb-${each.value.name}-unhealthy-hosts"
+  alarm_description   = "SOC2 DCF-86: ALB has unhealthy targets"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "UnHealthyHostCount"
+  dimensions          = { LoadBalancer = each.value.dimension }
+  statistic           = "Maximum"
+  period              = 300
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.euw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+data "aws_iam_policy_document" "usw2_alerts" {
+  statement {
+    sid       = "TopicOwnerAdministration"
+    actions   = ["SNS:GetTopicAttributes", "SNS:SetTopicAttributes", "SNS:AddPermission", "SNS:RemovePermission", "SNS:DeleteTopic", "SNS:Subscribe", "SNS:ListSubscriptionsByTopic", "SNS:Publish"]
+    resources = [data.aws_sns_topic.usw2_alerts.arn]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+    }
+  }
+  statement {
+    sid       = "AllowEventBridgeComplianceAlerts"
+    actions   = ["SNS:Publish"]
+    resources = [data.aws_sns_topic.usw2_alerts.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:events:us-west-2:${local.account_id}:rule/kortix-*failures"]
+    }
+  }
+  statement {
+    sid       = "AllowCloudWatchAlarmPublish"
+    actions   = ["SNS:Publish"]
+    resources = [data.aws_sns_topic.usw2_alerts.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudwatch:us-west-2:${local.account_id}:alarm:*"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "euw2_alerts" {
+  provider = aws.euw2
+  statement {
+    sid       = "TopicOwnerAdministration"
+    actions   = ["SNS:GetTopicAttributes", "SNS:SetTopicAttributes", "SNS:AddPermission", "SNS:RemovePermission", "SNS:DeleteTopic", "SNS:Subscribe", "SNS:ListSubscriptionsByTopic", "SNS:Publish"]
+    resources = [data.aws_sns_topic.euw2_alerts.arn]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+    }
+  }
+  statement {
+    sid       = "AllowEventBridgeComplianceAlerts"
+    actions   = ["SNS:Publish"]
+    resources = [data.aws_sns_topic.euw2_alerts.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:events:eu-west-2:${local.account_id}:rule/kortix-*failures"]
+    }
+  }
+  statement {
+    sid       = "AllowCloudWatchAlarmPublish"
+    actions   = ["SNS:Publish"]
+    resources = [data.aws_sns_topic.euw2_alerts.arn]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudwatch:eu-west-2:${local.account_id}:alarm:*"]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "usw2_alerts" {
+  arn    = data.aws_sns_topic.usw2_alerts.arn
+  policy = data.aws_iam_policy_document.usw2_alerts.json
+}
+
+resource "aws_sns_topic_policy" "euw2_alerts" {
+  provider = aws.euw2
+  arn      = data.aws_sns_topic.euw2_alerts.arn
+  policy   = data.aws_iam_policy_document.euw2_alerts.json
+}
+
+locals {
+  backup_failure_pattern = jsonencode({
+    source        = ["aws.backup"]
+    "detail-type" = ["Backup Job State Change"]
+    detail        = { state = ["FAILED", "ABORTED", "EXPIRED"] }
+  })
+  snapshot_failure_pattern = jsonencode({
+    source        = ["aws.ec2"]
+    "detail-type" = ["EBS Snapshot Notification"]
+    detail        = { result = ["failed"] }
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "usw2_backup_failures" {
+  name          = "kortix-backup-job-failures"
+  description   = "Alert on failed, aborted, or expired AWS Backup jobs"
+  event_pattern = local.backup_failure_pattern
+  tags          = merge(local.tags, { Control = "DCF-99" })
+}
+
+resource "aws_cloudwatch_event_rule" "usw2_snapshot_failures" {
+  name          = "kortix-ebs-snapshot-failures"
+  description   = "Alert on failed EBS snapshot operations"
+  event_pattern = local.snapshot_failure_pattern
+  tags          = merge(local.tags, { Control = "DCF-99" })
+}
+
+resource "aws_cloudwatch_event_target" "usw2_backup_failures" {
+  rule      = aws_cloudwatch_event_rule.usw2_backup_failures.name
+  target_id = "compliance-sns"
+  arn       = data.aws_sns_topic.usw2_alerts.arn
+}
+
+resource "aws_cloudwatch_event_target" "usw2_snapshot_failures" {
+  rule      = aws_cloudwatch_event_rule.usw2_snapshot_failures.name
+  target_id = "compliance-sns"
+  arn       = data.aws_sns_topic.usw2_alerts.arn
+}
+
+resource "aws_cloudwatch_event_rule" "euw2_backup_failures" {
+  provider      = aws.euw2
+  name          = "kortix-backup-job-failures"
+  description   = "Alert on failed, aborted, or expired AWS Backup jobs"
+  event_pattern = local.backup_failure_pattern
+  tags          = merge(local.tags, { Control = "DCF-99" })
+}
+
+resource "aws_cloudwatch_event_rule" "euw2_snapshot_failures" {
+  provider      = aws.euw2
+  name          = "kortix-ebs-snapshot-failures"
+  description   = "Alert on failed EBS snapshot operations"
+  event_pattern = local.snapshot_failure_pattern
+  tags          = merge(local.tags, { Control = "DCF-99" })
+}
+
+resource "aws_cloudwatch_event_target" "euw2_backup_failures" {
+  provider  = aws.euw2
+  rule      = aws_cloudwatch_event_rule.euw2_backup_failures.name
+  target_id = "compliance-sns"
+  arn       = data.aws_sns_topic.euw2_alerts.arn
+}
+
+resource "aws_cloudwatch_event_target" "euw2_snapshot_failures" {
+  provider  = aws.euw2
+  rule      = aws_cloudwatch_event_rule.euw2_snapshot_failures.name
+  target_id = "compliance-sns"
+  arn       = data.aws_sns_topic.euw2_alerts.arn
+}

--- a/infra/terraform/compliance-monitoring/providers.tf
+++ b/infra/terraform/compliance-monitoring/providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+provider "aws" {
+  alias  = "euw2"
+  region = "eu-west-2"
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  tags = {
+    ManagedBy  = "terraform"
+    Stack      = "compliance-monitoring"
+    Compliance = "soc2"
+  }
+}

--- a/infra/terraform/compliance-monitoring/scripts/import-live.sh
+++ b/infra/terraform/compliance-monitoring/scripts/import-live.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+import_if_missing() {
+  local address="$1"
+  local id="$2"
+  terraform state show "$address" >/dev/null 2>&1 || terraform import "$address" "$id"
+}
+
+import_region() {
+  local region="$1"
+  local prefix="$2"
+  local web_acl="$3"
+
+  while IFS=$'\t' read -r arn name; do
+    local quoted_arn
+    quoted_arn=$(printf '%s' "$arn" | sed 's/"/\\"/g')
+    import_if_missing "aws_wafv2_web_acl_association.${prefix}[\"${quoted_arn}\"]" "$web_acl,$arn"
+  done < <(aws elbv2 describe-load-balancers --region "$region" --output json |
+    jq -r '.LoadBalancers[] | select(.Type == "application") | [.LoadBalancerArn, .LoadBalancerName] | @tsv')
+}
+
+account_id=$(aws sts get-caller-identity --query Account --output text)
+import_region "us-west-2" "usw2" "arn:aws:wafv2:us-west-2:${account_id}:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65"
+import_region "eu-west-2" "euw2" "arn:aws:wafv2:eu-west-2:${account_id}:regional/webacl/kortix-alb-waf/8ac41166-f4f0-4a53-9d23-f4aae0963a22"

--- a/infra/terraform/security-baseline/README.md
+++ b/infra/terraform/security-baseline/README.md
@@ -11,6 +11,8 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
 - AWS Backup vault + daily plan + selection + service role (DCF-99)
 - VPC Flow Logs delivery role + log group (DCF-406)
 - IAM groups, attachments, memberships + 2 customer-managed policies (DCF-776)
+- Regional ALB/WAF/alarm and backup-failure monitoring is isolated in the
+  sibling `compliance-monitoring` stack and state.
 
 ## Applied via CLI (not in this stack — by design)
 These were one-time or region-spanning and live outside the stack; documented
@@ -19,9 +21,11 @@ in `../../compliance/SOC2-DRATA-REMEDIATION.md`:
 - Deletion of 15 empty regional default VPCs
 - Per-VPC flow logs, default-SG stripping, and NACL deny (22/3389) for the 5 us-west-2 VPCs
 - S3 per-bucket versioning / TLS-deny policy / access-logging
-- ALB CloudWatch alarms + WAFv2 WebACL (app-tier; candidates to fold into the `ecs-api` module)
-  - WebACL `kortix-alb-waf` (REGIONAL, us-west-2) is associated with BOTH `kortix-prod-alb`
-    and `kortix-dev-alb`, and fronts `api(-prod)/dev-api.kortix.com` behind Cloudflare.
+- The WAFv2 WebACL definitions themselves. This stack discovers all ALBs and
+  manages their associations, but reads the existing regional
+  `kortix-alb-waf` WebACLs as data sources.
+  - WebACL `kortix-alb-waf` exists in us-west-2 and eu-west-2 and is associated
+    with every current ALB in those regions.
   - DO NOT block on the `*_BODY` managed sub-rules: this is an API that legitimately carries
     arbitrary user/agent payloads (prompts full of code, file paths like `/etc/passwd`, IPs
     like `127.0.0.1`, git binary thin-packs, bodies well over 8 KB). On 2026-06-04 the


### PR DESCRIPTION
## What changed
- add an isolated Terraform stack/state for regional compliance monitoring
- discover every ALB in us-west-2 and eu-west-2 and manage WAF association
- manage target-response-time, ELB 5xx, and unhealthy-host alarms with SNS actions
- manage scoped SNS policies plus failed AWS Backup/EBS snapshot EventBridge alerts
- document/import already-live associations without touching the legacy baseline state

## Verification
- terraform fmt -check -recursive
- terraform validate: success
- Checkov: 30 passed, 0 failed
- first live plan: 48 add, 7 update, 15 no-op, 0 destroy, 0 replace
- apply: 48 added, 7 changed, 0 destroyed
- convergence apply: 0 added, 4 tag-only changes, 0 destroyed
- final terraform plan: No changes
- live: 15/15 ALBs have WAF
- live: 15/15 ALBs have all three alarms with correct app/name/id dimensions and active SNS actions

SNS email subscriptions still require recipient confirmation; pending is not represented as working delivery.