### PR TITLE
fix: enforce HTTPS-only ALB listeners

### DIFF
--- a/infra/EKS.md
+++ b/infra/EKS.md
@@ -36,7 +36,7 @@ model is built to fix. This stack layers self-healing at every level:
 
 ```
 api-eks.kortix.com ─► Cloudflare (proxied, Full-strict)
-                       └─► ALB (ACM TLS, :80→:443)         ← AWS LB Controller, from the Ingress
+                       └─► ALB (ACM TLS, :443 only)        ← AWS LB Controller, from the Ingress
                             └─► EKS pods (kortix-api, 3 AZ) ← managed node group, private subnets
                                  envFrom ─► kortix-api-env  ← External Secrets, from Secrets Manager
                                                                (SAME bundle ECS uses: kortix-prod-env-omifd2)

--- a/infra/k8s/charts/kortix-api/README.md
+++ b/infra/k8s/charts/kortix-api/README.md
@@ -11,7 +11,7 @@ controllers; this chart owns the application objects that Argo CD reconciles.
 | ------ | ------- |
 | `Deployment` | The API. Startup/liveness/readiness probes, `preStop` drain, 3-AZ `topologySpreadConstraints`, `maxUnavailable: 0` rolling deploys. |
 | `Service` (ClusterIP) | Backend for the ALB target group. |
-| `Ingress` (`alb`) | AWS Load Balancer Controller → internet-facing ALB, ACM TLS, `:80→:443`, IP targets, `/v1/health` checks. external-dns → proxied `api-eks.kortix.com`. |
+| `Ingress` (`alb`) | AWS Load Balancer Controller → internet-facing ALB, ACM TLS on `:443` only, IP targets, `/v1/health` checks. external-dns → proxied `api-eks.kortix.com`. |
 | `HorizontalPodAutoscaler` | CPU+memory target tracking, 3→12 replicas. |
 | `PodDisruptionBudget` | `minAvailable: 50%` — disruptions never drop below half. |
 | `ServiceAccount` | Annotated with the IRSA role (Secrets Manager read). |

--- a/infra/k8s/charts/kortix-api/templates/ingress.yaml
+++ b/infra/k8s/charts/kortix-api/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- fail "ingress.certificateArn is required (the ACM cert ARN from terraform output acm_certificate_arn)" }}
 {{- end }}
 # The AWS Load Balancer Controller turns this Ingress into a real ALB (the same
-# shape as the ECS stack: internet-facing, ACM TLS, :80 -> :443 redirect, IP
+# shape as the ECS stack: internet-facing, ACM TLS on :443 only, IP
 # targets, /v1/health checks). external-dns then points api-eks.kortix.com at it
 # (Cloudflare, proxied).
 apiVersion: networking.k8s.io/v1
@@ -21,8 +21,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.albGroup | quote }}
     {{- end }}
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
     # Primary cert + any extra certs (multi-host ALB serves the right one via SNI).
     alb.ingress.kubernetes.io/certificate-arn: {{ prepend (.Values.ingress.extraCertificateArns | default list) .Values.ingress.certificateArn | join "," | quote }}

--- a/infra/k8s/charts/kortix-gateway/templates/ingress.yaml
+++ b/infra/k8s/charts/kortix-gateway/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- fail "ingress.certificateArn is required (the ACM cert ARN from terraform output acm_certificate_arn)" }}
 {{- end }}
 # The AWS Load Balancer Controller turns this Ingress into a real ALB (the same
-# shape as the ECS stack: internet-facing, ACM TLS, :80 -> :443 redirect, IP
+# shape as the ECS stack: internet-facing, ACM TLS on :443 only, IP
 # targets, /v1/health checks). external-dns then points api-eks.kortix.com at it
 # (Cloudflare, proxied).
 apiVersion: networking.k8s.io/v1
@@ -21,8 +21,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.albGroup | quote }}
     {{- end }}
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
     # Primary cert + any extra certs (multi-host ALB serves the right one via SNI).
     alb.ingress.kubernetes.io/certificate-arn: {{ prepend (.Values.ingress.extraCertificateArns | default list) .Values.ingress.certificateArn | join "," | quote }}

--- a/infra/k8s/charts/qa-portal/README.md
+++ b/infra/k8s/charts/qa-portal/README.md
@@ -13,7 +13,7 @@ the workload.
 | ------ | ------- |
 | `Deployment` | `web` (nginx) serves the branded landing page at `/` from a small generated file and reverse-proxies every other path to `s3gw`; `s3gw` (`nginx-s3-gateway`, stock) signs each request (SigV4) and streams the object from the **private** bucket; `index-gen` (aws-cli, **read-only**) relists the `reports/` lanes every `syncIntervalSeconds` and rebuilds the kilobyte landing `index.html`. Only that landing file is local. |
 | `Service` (ClusterIP) | Backend for the ALB target group (port 80 → web `8081`). |
-| `Ingress` (`alb`) | AWS Load Balancer Controller → internet-facing ALB, ACM TLS, `:80→:443`, IP targets. external-dns → proxied `qa.kortix.com`. |
+| `Ingress` (`alb`) | AWS Load Balancer Controller → internet-facing ALB, ACM TLS on `:443` only, IP targets. external-dns → proxied `qa.kortix.com`. |
 | `ServiceAccount` | Annotated with the IRSA role (S3 read) — **no static AWS keys**. |
 
 ## Durability model

--- a/infra/k8s/charts/qa-portal/templates/ingress.yaml
+++ b/infra/k8s/charts/qa-portal/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- fail "ingress.certificateArn is required (the ACM cert ARN for qa.kortix.com)" }}
 {{- end }}
 # Same ALB shape as kortix-api: the AWS Load Balancer Controller provisions an
-# internet-facing ALB (ACM TLS, :80 -> :443 redirect, IP targets); external-dns
+# internet-facing ALB (ACM TLS on :443 only, IP targets); external-dns
 # points qa.kortix.com at it (Cloudflare, proxied). Lock to Cloudflare IPs via
 # ingress.inboundCidrs so the raw ALB DNS can't be hit directly.
 apiVersion: networking.k8s.io/v1
@@ -19,8 +19,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.albGroup | quote }}
     {{- end }}
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn | quote }}
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP

--- a/infra/terraform/modules/eks/platform/main.tf
+++ b/infra/terraform/modules/eks/platform/main.tf
@@ -250,8 +250,7 @@ locals {
   argocd_alb_annotations = {
     "alb.ingress.kubernetes.io/scheme"                    = "internet-facing"
     "alb.ingress.kubernetes.io/target-type"               = "ip"
-    "alb.ingress.kubernetes.io/listen-ports"              = "[{\"HTTP\":80},{\"HTTPS\":443}]"
-    "alb.ingress.kubernetes.io/ssl-redirect"              = "443"
+    "alb.ingress.kubernetes.io/listen-ports"              = "[{\"HTTPS\":443}]"
     "alb.ingress.kubernetes.io/ssl-policy"                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
     "alb.ingress.kubernetes.io/certificate-arn"           = var.argocd_certificate_arn
     "alb.ingress.kubernetes.io/backend-protocol"          = "HTTP"


### PR DESCRIPTION
## Summary
- configure application and gateway ALBs to listen on TLS 443 only
- remove the public HTTP redirect listener that causes unrestricted port 80 findings
- keep platform Terraform and infrastructure docs aligned

## Verification
- `bash tests/infra/scripts/helm-validate.sh`
- `helm lint` for API, gateway, and QA portal charts
- `terraform fmt -check -recursive infra/terraform/modules/eks/platform`
- `git diff --check`

## Live finding
The currently controller-managed preview ALB still has a public port 80 redirect listener. After merge and reconciliation, verify the listener and security-group rule are removed.