### PR TITLE
fix: make ALB WAF ownership durable

### DIFF
--- a/infra/k8s/charts/kortix-api/templates/ingress.yaml
+++ b/infra/k8s/charts/kortix-api/templates/ingress.yaml
@@ -2,6 +2,9 @@
 {{- if not .Values.ingress.certificateArn }}
 {{- fail "ingress.certificateArn is required (the ACM cert ARN from terraform output acm_certificate_arn)" }}
 {{- end }}
+{{- if not .Values.ingress.wafAclArn }}
+{{- fail "ingress.wafAclArn is required so the AWS Load Balancer Controller preserves the WAF association" }}
+{{- end }}
 # The AWS Load Balancer Controller turns this Ingress into a real ALB (the same
 # shape as the ECS stack: internet-facing, ACM TLS on :443 only, IP
 # targets, /v1/health checks). external-dns then points api-eks.kortix.com at it
@@ -23,6 +26,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn | quote }}
     # Primary cert + any extra certs (multi-host ALB serves the right one via SNI).
     alb.ingress.kubernetes.io/certificate-arn: {{ prepend (.Values.ingress.extraCertificateArns | default list) .Values.ingress.certificateArn | join "," | quote }}
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP

--- a/infra/k8s/charts/kortix-api/values.yaml
+++ b/infra/k8s/charts/kortix-api/values.yaml
@@ -146,6 +146,8 @@ ingress:
   host: api-eks.kortix.com
   # ACM cert ARN for the ALB HTTPS listener (from TF output acm_certificate_arn).
   certificateArn: ""
+  # Regional WAFv2 Web ACL ARN. Required when ingress is enabled.
+  wafAclArn: ""
   # Extra hostnames this ALB should also serve (each gets an Ingress rule), and
   # the extra ACM cert ARNs to attach for them (ALB picks the right cert by SNI).
   # Used for cutover: serve the real domain (e.g. dev-api.kortix.com) alongside

--- a/infra/k8s/charts/kortix-gateway/templates/ingress.yaml
+++ b/infra/k8s/charts/kortix-gateway/templates/ingress.yaml
@@ -2,6 +2,9 @@
 {{- if not .Values.ingress.certificateArn }}
 {{- fail "ingress.certificateArn is required (the ACM cert ARN from terraform output acm_certificate_arn)" }}
 {{- end }}
+{{- if not .Values.ingress.wafAclArn }}
+{{- fail "ingress.wafAclArn is required so the AWS Load Balancer Controller preserves the WAF association" }}
+{{- end }}
 # The AWS Load Balancer Controller turns this Ingress into a real ALB (the same
 # shape as the ECS stack: internet-facing, ACM TLS on :443 only, IP
 # targets, /v1/health checks). external-dns then points api-eks.kortix.com at it
@@ -23,6 +26,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn | quote }}
     # Primary cert + any extra certs (multi-host ALB serves the right one via SNI).
     alb.ingress.kubernetes.io/certificate-arn: {{ prepend (.Values.ingress.extraCertificateArns | default list) .Values.ingress.certificateArn | join "," | quote }}
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP

--- a/infra/k8s/charts/kortix-gateway/values.yaml
+++ b/infra/k8s/charts/kortix-gateway/values.yaml
@@ -89,6 +89,8 @@ ingress:
   enabled: true
   host: gateway-eks.kortix.com
   certificateArn: ""
+  # Regional WAFv2 Web ACL ARN. Required when ingress is enabled.
+  wafAclArn: ""
   extraHosts: []
   extraCertificateArns: []
   albGroup: ""

--- a/infra/k8s/charts/qa-portal/templates/ingress.yaml
+++ b/infra/k8s/charts/qa-portal/templates/ingress.yaml
@@ -2,6 +2,9 @@
 {{- if not .Values.ingress.certificateArn }}
 {{- fail "ingress.certificateArn is required (the ACM cert ARN for qa.kortix.com)" }}
 {{- end }}
+{{- if not .Values.ingress.wafAclArn }}
+{{- fail "ingress.wafAclArn is required so the AWS Load Balancer Controller preserves the WAF association" }}
+{{- end }}
 # Same ALB shape as kortix-api: the AWS Load Balancer Controller provisions an
 # internet-facing ALB (ACM TLS on :443 only, IP targets); external-dns
 # points qa.kortix.com at it (Cloudflare, proxied). Lock to Cloudflare IPs via
@@ -21,6 +24,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
+    alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn | quote }}
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn | quote }}
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
     alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.health.path | quote }}

--- a/infra/k8s/charts/qa-portal/values.yaml
+++ b/infra/k8s/charts/qa-portal/values.yaml
@@ -104,6 +104,8 @@ ingress:
   host: qa.kortix.com
   # ACM cert ARN for the ALB HTTPS listener. REQUIRED.
   certificateArn: ""
+  # Regional WAFv2 Web ACL ARN. Required when ingress is enabled.
+  wafAclArn: ""
   # Cloudflare proxies the record (orange cloud) — external-dns sets this.
   cloudflareProxied: true
   idleTimeout: 60

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -77,6 +77,7 @@ ingress:
   # cert (a9af6fd8), which is now free for the ECS dev stack alone.
   host: dev-api-eks.kortix.com
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/57eed8f4-cba4-4d6a-94ea-1b948708989b
+  wafAclArn: arn:aws:wafv2:us-west-2:935064898258:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65
   cloudflareProxied: true
   # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
   inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"

--- a/infra/k8s/envs/preview/values.yaml
+++ b/infra/k8s/envs/preview/values.yaml
@@ -59,6 +59,7 @@ ingress:
   host: preview.preview-api.kortix.com # overridden per-PR by the ApplicationSet
   # Wildcard cert *.preview-api.kortix.com (TF module.acm_preview).
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/8e5ec220-77d9-450f-abe9-21d5322afa78
+  wafAclArn: arn:aws:wafv2:us-west-2:935064898258:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65
   # All previews share ONE host-routed ALB (no ALB-per-PR cost/latency).
   albGroup: kortix-previews
   # DNS-only (grey cloud): external-dns creates pr-<n>.preview-api.kortix.com →

--- a/infra/k8s/envs/prod/values.yaml
+++ b/infra/k8s/envs/prod/values.yaml
@@ -89,6 +89,7 @@ ingress:
   enabled: true
   host: api-eks.kortix.com
   certificateArn: arn:aws:acm:eu-west-2:935064898258:certificate/27dd2310-c468-428c-b97a-ec46b1eed6fd
+  wafAclArn: arn:aws:wafv2:eu-west-2:935064898258:regional/webacl/kortix-alb-waf/8ac41166-f4f0-4a53-9d23-f4aae0963a22
   cloudflareProxied: true
   # Lock the origin ALB to Cloudflare's edge ranges so api.kortix.com can only be
   # reached THROUGH Cloudflare — no direct-to-origin WAF/rate-limit bypass. Same

--- a/infra/k8s/envs/qa/values.yaml
+++ b/infra/k8s/envs/qa/values.yaml
@@ -23,6 +23,7 @@ ingress:
   host: qa.kortix.com
   # *.kortix.com wildcard ACM cert in us-west-2 (covers qa.kortix.com).
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755
+  wafAclArn: arn:aws:wafv2:us-west-2:935064898258:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65
   cloudflareProxied: true
   albGroup: kortix-qa-portal
   # Internal tool: lock the ALB to Cloudflare IP ranges so it's only reachable

--- a/infra/k8s/envs/staging/values.yaml
+++ b/infra/k8s/envs/staging/values.yaml
@@ -52,6 +52,7 @@ ingress:
   host: staging-api-eks.kortix.com
   # us-west-2 wildcard cert for *.kortix.com.
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755
+  wafAclArn: arn:aws:wafv2:us-west-2:935064898258:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65
   cloudflareProxied: true
   # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
   inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"


### PR DESCRIPTION
## Summary
- declare the regional WAFv2 ACL on every application, gateway, preview, and QA ingress
- fail Helm rendering when an enabled ingress omits its WAF
- keep the AWS Load Balancer Controller from removing externally-added WAF associations

## Verification
- `bash tests/infra/scripts/helm-validate.sh`
- all chart renders and kubeconform checks passed
- `git diff --check`

## Live finding
Two controller-managed ALBs lost their prior WAF association because their Ingress objects did not declare it. This change makes the controller the durable owner.