### PR TITLE
feat(cli): kortix gateway — full LLM-gateway control-plane

### DIFF
--- a/apps/cli/src/__tests__/gateway.test.ts
+++ b/apps/cli/src/__tests__/gateway.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const CLI_ROOT = resolve(import.meta.dir, '..', '..');
+const CLI_ENTRY = join(CLI_ROOT, 'src', 'index.ts');
+const ORIGINAL_ENV = { ...process.env };
+const SANDBOX_ENV_OVERRIDES = [
+  'KORTIX_API_URL',
+  'KORTIX_CLI_TOKEN',
+  'KORTIX_EXECUTOR_TOKEN',
+  'KORTIX_FRONTEND_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_TOKEN',
+  'BASH_ENV',
+] as const;
+
+const PROJECT = 'gw_proj';
+
+let tmp: string;
+let server: ReturnType<typeof Bun.serve> | null = null;
+let requests: Array<{ method: string; path: string; body?: unknown }> = [];
+
+function writeConfig(apiBase: string): string {
+  const path = join(tmp, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      active: 'test',
+      hosts: {
+        test: {
+          url: apiBase,
+          token: 'tok_gw',
+          user_id: 'user_1',
+          user_email: 'user@example.test',
+          account_id: 'account_1',
+          logged_in_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+  return path;
+}
+
+// A routing policy the mock mutates on PUT so a set→get round-trip is observable.
+let routingProject = {
+  defaultModel: null as string | null,
+  visionModel: null as string | null,
+  defaultFallback: null as { models: string[]; fallbackOn: string } | null,
+  rules: [] as unknown[],
+};
+
+function routingDoc() {
+  return {
+    version: 1,
+    project: routingProject,
+    effective: {
+      defaultModel: routingProject.defaultModel ?? 'kortix/auto',
+      defaultModelSource: routingProject.defaultModel ? 'project' : 'platform',
+      visionModel: routingProject.visionModel ?? 'claude-sonnet-4.6',
+      defaultFallback: routingProject.defaultFallback ?? { models: [], fallbackOn: 'transient' },
+    },
+    capabilities: { write: true },
+  };
+}
+
+function startServer(): string {
+  server = Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      const entry: { method: string; path: string; body?: unknown } = {
+        method: req.method,
+        path: `${url.pathname}${url.search}`,
+      };
+      if (!['GET', 'HEAD'].includes(req.method)) {
+        const text = await req.text();
+        if (text) entry.body = JSON.parse(text);
+      }
+      requests.push(entry);
+      const base = `/v1/projects/${PROJECT}/gateway`;
+
+      if (url.pathname === `${base}/routing-policy`) {
+        if (req.method === 'PUT') routingProject = entry.body as typeof routingProject;
+        if (req.method === 'DELETE')
+          routingProject = {
+            defaultModel: null,
+            visionModel: null,
+            defaultFallback: null,
+            rules: [],
+          };
+        return Response.json(routingDoc());
+      }
+      if (url.pathname === `${base}/budgets` && req.method === 'GET') {
+        return Response.json({
+          project_spend: { requests: 4, cost: 1.23 },
+          budgets: [],
+          members: [],
+        });
+      }
+      if (url.pathname === `${base}/budgets` && req.method === 'PUT') {
+        return Response.json({ ok: true });
+      }
+      if (url.pathname === `${base}/keys` && req.method === 'GET') {
+        return Response.json({ gateway_url: 'https://gw.test/v1/llm', keys: [] });
+      }
+      if (url.pathname === `${base}/keys` && req.method === 'POST') {
+        return Response.json({
+          key_id: 'key_1',
+          name: (entry.body as { name: string }).name,
+          key_prefix: 'kortix_gw_ab',
+          secret_key: 'kortix_gw_secretshownonce',
+        });
+      }
+      if (url.pathname === `${base}/overview`) {
+        return Response.json({
+          window_days: 30,
+          requests: 10,
+          errors: 1,
+          total_cost: 0.5,
+          input_tokens: 100,
+          output_tokens: 50,
+        });
+      }
+      if (url.pathname === `${base}/breakdown`) {
+        return Response.json({
+          window_days: 30,
+          models: [
+            {
+              model: 'openai/gpt-5.5',
+              provider: 'openai',
+              requests: 7,
+              errors: 0,
+              cost: 0.42,
+              tokens: 120,
+            },
+          ],
+        });
+      }
+      if (url.pathname === `${base}/logs`) {
+        return Response.json({
+          logs: [
+            {
+              request_id: 'req_1',
+              requested_model: 'openai/gpt-5.5',
+              status: 200,
+              ok: true,
+              latency_ms: 900,
+            },
+          ],
+          next_offset: null,
+        });
+      }
+      if (url.pathname === `${base}/playground` && req.method === 'POST') {
+        const models = (entry.body as { models: string[] }).models;
+        return Response.json({
+          results: models.map((m) => ({
+            model: m,
+            ok: true,
+            latency_ms: 100,
+            output: 'pong',
+            input_tokens: 3,
+            output_tokens: 1,
+          })),
+        });
+      }
+      return Response.json({ error: 'not found', path: url.pathname }, { status: 404 });
+    },
+  });
+  return `http://127.0.0.1:${server.port}`;
+}
+
+async function runCli(args: string[], configFile: string) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    KORTIX_NO_UPDATE_CHECK: '1',
+    NO_COLOR: '1',
+    FORCE_COLOR: '0',
+    KORTIX_DISABLE_SANDBOX_ENV_FILE: '1',
+    KORTIX_CONFIG_FILE: configFile,
+  };
+  for (const key of SANDBOX_ENV_OVERRIDES) delete env[key];
+  const proc = Bun.spawn({
+    cmd: [process.execPath, CLI_ENTRY, ...args],
+    cwd: tmp,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const timeout = setTimeout(() => proc.kill(), 10_000);
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]).finally(() => clearTimeout(timeout));
+  return { code, stdout, stderr };
+}
+
+describe('kortix gateway command', () => {
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'kortix-gw-'));
+    requests = [];
+    routingProject = { defaultModel: null, visionModel: null, defaultFallback: null, rules: [] };
+    process.env = { ...ORIGINAL_ENV };
+    for (const key of SANDBOX_ENV_OVERRIDES) delete process.env[key];
+  });
+  afterEach(() => {
+    server?.stop(true);
+    server = null;
+    rmSync(tmp, { recursive: true, force: true });
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test('routing get: hits routing-policy and emits the effective policy as JSON', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(['gateway', 'routing', '--json', '--project', PROJECT], cfg);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout).effective.defaultModel).toBe('kortix/auto');
+    expect(requests).toEqual([
+      { method: 'GET', path: `/v1/projects/${PROJECT}/gateway/routing-policy` },
+    ]);
+  }, 15_000);
+
+  test('routing set: reads current then PUTs a merged body (one field changed, rest preserved)', async () => {
+    const cfg = writeConfig(startServer());
+    routingProject = {
+      defaultModel: null,
+      visionModel: 'claude-sonnet-4.6',
+      defaultFallback: null,
+      rules: [],
+    };
+    const r = await runCli(
+      ['gateway', 'routing', 'set', '--default-model', 'openai/gpt-5.5', '--project', PROJECT],
+      cfg,
+    );
+    expect(r.code).toBe(0);
+    const put = requests.find((q) => q.method === 'PUT');
+    expect(put?.path).toBe(`/v1/projects/${PROJECT}/gateway/routing-policy`);
+    // The unrelated visionModel is preserved; only defaultModel changes.
+    expect(put?.body).toMatchObject({
+      defaultModel: 'openai/gpt-5.5',
+      visionModel: 'claude-sonnet-4.6',
+    });
+  }, 15_000);
+
+  test('budget set: PUTs limit/scope with the expected shape', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(
+      ['gateway', 'budget', 'set', '--limit', '25', '--period', 'month', '--project', PROJECT],
+      cfg,
+    );
+    expect(r.code).toBe(0);
+    const put = requests.find((q) => q.method === 'PUT');
+    expect(put?.body).toMatchObject({ scope: 'project', limit_usd: 25, period: 'month' });
+  }, 15_000);
+
+  test('keys new: POSTs the name and surfaces the one-time secret', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(['gateway', 'keys', 'new', 'ci-key', '--project', PROJECT], cfg);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('kortix_gw_secretshownonce');
+    expect(requests.find((q) => q.method === 'POST')?.body).toMatchObject({ name: 'ci-key' });
+  }, 15_000);
+
+  test('usage: aggregates overview + breakdown', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(
+      ['gateway', 'usage', '--json', '--days', '30', '--project', PROJECT],
+      cfg,
+    );
+    expect(r.code).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.overview.requests).toBe(10);
+    expect(out.breakdown.models[0].model).toBe('openai/gpt-5.5');
+    expect(requests.map((q) => q.path).sort()).toEqual([
+      `/v1/projects/${PROJECT}/gateway/breakdown?days=30`,
+      `/v1/projects/${PROJECT}/gateway/overview?days=30`,
+    ]);
+  }, 15_000);
+
+  test('logs --limit N: the value is a query param, never mistaken for a logId (regression)', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(['gateway', 'logs', '--limit', '3', '--project', PROJECT], cfg);
+    expect(r.code).toBe(0);
+    // The list endpoint with ?limit=3 — NOT /logs/3 (which 400s "Invalid log id").
+    expect(requests).toEqual([
+      { method: 'GET', path: `/v1/projects/${PROJECT}/gateway/logs?limit=3` },
+    ]);
+  }, 15_000);
+
+  test('logs --failed: filters to ok=false', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(['gateway', 'logs', '--failed', '--json', '--project', PROJECT], cfg);
+    expect(r.code).toBe(0);
+    expect(requests[0].path).toBe(`/v1/projects/${PROJECT}/gateway/logs?ok=false`);
+  }, 15_000);
+
+  test('test: POSTs prompt + models to the playground', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(
+      [
+        'gateway',
+        'test',
+        'openai/gpt-5.5',
+        'openai/gpt-4o',
+        '--prompt',
+        'ping',
+        '--json',
+        '--project',
+        PROJECT,
+      ],
+      cfg,
+    );
+    expect(r.code).toBe(0);
+    const post = requests.find((q) => q.method === 'POST');
+    expect(post?.path).toBe(`/v1/projects/${PROJECT}/gateway/playground`);
+    expect(post?.body).toMatchObject({
+      prompt: 'ping',
+      models: ['openai/gpt-5.5', 'openai/gpt-4o'],
+    });
+    expect(JSON.parse(r.stdout).results).toHaveLength(2);
+  }, 15_000);
+
+  test('routing reset: DELETEs the policy', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(['gateway', 'routing', 'reset', '--project', PROJECT], cfg);
+    expect(r.code).toBe(0);
+    expect(
+      requests.some(
+        (q) => q.method === 'DELETE' && q.path === `/v1/projects/${PROJECT}/gateway/routing-policy`,
+      ),
+    ).toBe(true);
+  }, 15_000);
+
+  test('bare `gateway` prints help and exits non-zero', async () => {
+    const cfg = writeConfig(startServer());
+    const r = await runCli(['gateway'], cfg);
+    expect(r.code).toBe(2);
+    expect(r.stdout).toContain('kortix gateway <subcommand>');
+  }, 15_000);
+});

--- a/apps/cli/src/commands/gateway.ts
+++ b/apps/cli/src/commands/gateway.ts
@@ -1,0 +1,542 @@
+import {
+  emitJson,
+  resolveProjectContext,
+  surfaceApiError,
+  takeFlagBool,
+  takeFlagValue,
+} from '../command-helpers.ts';
+import { C, help, pad, status } from '../style.ts';
+
+// The LLM-gateway control-plane for the linked project: how it ROUTES
+// (default model / fallback / vision), METERS (spend budgets), EXPOSES itself
+// (external gateway API keys), and is OBSERVED (usage / request logs) — plus a
+// playground to test a model end to end. Deliberately its own command, not a
+// `providers` subcommand: `providers` connects CREDENTIALS (a one-time input),
+// while this configures ongoing gateway behavior. The split mirrors the API's
+// own taxonomy — `/oauth` + `/secrets` (credentials) vs `/gateway/*` (this).
+// Every handler wraps one `/projects/:id/gateway/*` route 1:1, so the CLI
+// stays a thin, faithful client (see apps/api/src/projects/routes/gateway.ts).
+
+const HELP = help`Usage: kortix gateway <subcommand> [options]
+
+Configure and inspect the LLM gateway for the linked Kortix project — the
+layer that routes every model request, meters spend, and exposes an
+OpenAI-compatible endpoint. (Connect provider credentials with
+\`kortix providers\`; pick per-agent models with \`kortix agents\`.)
+
+Routing:
+  routing [get]                     Show the effective default model, fallback
+                                    chain, and vision model (+ where each
+                                    resolves from). --json.
+  routing set [flags]               Update the project routing policy:
+    --default-model <id>              Default model ("" to clear).
+    --vision-model <id>               Model for image-bearing requests.
+    --fallback <id,id,…>              Fallback chain ("" to clear).
+    --fallback-on transient|any-error
+    --file <path|->                   Full policy JSON (stdin with -).
+  routing reset                     Drop the project policy (fall back to
+                                    account/platform defaults).
+  routing preview <model> [--image] Resolve what a request would route to.
+
+Spend:
+  budget [ls]                       Budgets + this month's spend. --json.
+  budget set --limit <usd> [flags]  Upsert a budget:
+    --scope project|member  --user <id>  --period day|week|month
+    --action block|warn
+  budget rm <budgetId>              Remove a budget.
+
+Access:
+  keys [ls]                         External gateway API keys. --json.
+  keys new <name>                   Mint a key (shown once).
+  keys rm <keyId>                   Revoke a key.
+
+Observability:
+  usage [--days N]                  Request/error/cost totals + by-model. --json.
+  logs [--limit N] [--failed]       Recent gateway requests. --json.
+  logs <logId>                      One request's full detail (JSON).
+  test <model…> [--prompt <text>]   Run a prompt through one or more models.
+
+Global options:
+  --project <id>     Operate on this project id (default: linked or \$KORTIX_PROJECT_ID).
+  --host <name>      Operate against a non-default Kortix host.
+  --json             Machine-readable output (read subcommands).
+  -h, --help         Show this help.
+`;
+
+type CtxOpts = { projectArg?: string; hostArg?: string };
+
+export async function runGateway(argv: string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+    process.stdout.write(HELP);
+    return argv.length === 0 ? 2 : 0;
+  }
+
+  const sub = argv[0];
+  const rest = argv.slice(1);
+  let json = false;
+  let projectFlag: string | undefined;
+  let hostFlag: string | undefined;
+  try {
+    json = takeFlagBool(rest, ['--json']);
+    projectFlag = takeFlagValue(rest, ['--project']);
+    hostFlag = takeFlagValue(rest, ['--host']);
+  } catch (err) {
+    process.stderr.write(`${status.err((err as Error).message)}\n`);
+    return 2;
+  }
+  const ctxOpts: CtxOpts = { projectArg: projectFlag, hostArg: hostFlag };
+
+  switch (sub) {
+    case 'routing':
+      return gatewayRouting(rest, ctxOpts, json);
+    case 'budget':
+    case 'budgets':
+      return gatewayBudget(rest, ctxOpts, json);
+    case 'keys':
+    case 'key':
+      return gatewayKeys(rest, ctxOpts, json);
+    case 'usage':
+    case 'overview':
+      return gatewayUsage(rest, ctxOpts, json);
+    case 'logs':
+    case 'log':
+      return gatewayLogs(rest, ctxOpts, json);
+    case 'test':
+    case 'playground':
+      return gatewayTest(rest, ctxOpts, json);
+    default:
+      process.stderr.write(`${status.err(`unknown subcommand "${sub}"`)}\n\n${HELP}`);
+      return 2;
+  }
+}
+
+function money(n: unknown): string {
+  const v = Number(n ?? 0);
+  return `$${v.toFixed(v < 1 ? 4 : 2)}`;
+}
+
+// Emit JSON and return a success code — keeps the `if (json) return outJson(x)`
+// call sites one line without the (biome-forbidden) comma operator.
+function outJson(data: unknown): number {
+  emitJson(data);
+  return 0;
+}
+
+// Write a usage error and return the arg-error exit code (2).
+function fail(message: string): number {
+  process.stderr.write(`${status.err(message)}\n`);
+  return 2;
+}
+
+// Pull an optional leading positional action (e.g. `routing set`) off argv,
+// defaulting when the next token is a flag or absent. Avoids a non-null
+// assertion on `rest.shift()`.
+function takeAction(rest: string[], fallback: string): string {
+  if (rest[0] && !rest[0].startsWith('-')) return rest.shift() as string;
+  return fallback;
+}
+
+// ── Routing policy ──────────────────────────────────────────────────────────
+// The default model / fallback chain / vision model the gateway applies for
+// this project (GET/PUT/DELETE /gateway/routing-policy). Read shows the
+// EFFECTIVE resolution (project → account → platform) so it's clear where each
+// value comes from.
+
+interface RoutingPolicyDoc {
+  project: {
+    defaultModel: string | null;
+    visionModel: string | null;
+    defaultFallback: { models: string[]; fallbackOn: string } | null;
+    rules: { model: string; fallbackModels: string[]; fallbackOn: string }[];
+  };
+  effective: {
+    defaultModel: string;
+    defaultModelSource: string;
+    visionModel: string;
+    defaultFallback: { models: string[]; fallbackOn: string };
+  };
+  capabilities: { write: boolean };
+}
+
+export async function gatewayRouting(
+  rest: string[],
+  opts: CtxOpts,
+  json: boolean,
+): Promise<number> {
+  const action = takeAction(rest, 'get');
+  const ctx = await resolveProjectContext(opts);
+  if (!ctx) return 1;
+  const base = `/projects/${ctx.projectId}/gateway/routing-policy`;
+
+  try {
+    if (action === 'get' || action === 'show') {
+      const doc = await ctx.client.get<RoutingPolicyDoc>(base);
+      if (json) return outJson(doc);
+      return renderRouting(doc);
+    }
+    if (action === 'reset') {
+      const doc = await ctx.client.delete<RoutingPolicyDoc>(base);
+      if (json) return outJson(doc);
+      process.stdout.write(
+        `\n  ${status.ok('routing policy reset to account/platform defaults')}\n\n`,
+      );
+      return renderRouting(doc);
+    }
+    if (action === 'preview') {
+      const model = rest.find((a) => !a.startsWith('-'));
+      if (!model) return fail('preview needs a model id');
+      const image = rest.includes('--image');
+      const res = await ctx.client.post<unknown>(`${base}/preview`, {
+        requestedModel: model,
+        imageInput: image,
+      });
+      if (json) return outJson(res);
+      return outJson(res); // preview is inherently machine-shaped
+    }
+    if (action === 'set') {
+      // Convenience flags for the common fields; --file/- for a full JSON body.
+      let defaultModel: string | undefined;
+      let visionModel: string | undefined;
+      let fallback: string | undefined;
+      let fallbackOn: string | undefined;
+      let file: string | undefined;
+      try {
+        defaultModel = takeFlagValue(rest, ['--default-model', '--default']);
+        visionModel = takeFlagValue(rest, ['--vision-model', '--vision']);
+        fallback = takeFlagValue(rest, ['--fallback']);
+        fallbackOn = takeFlagValue(rest, ['--fallback-on']);
+        file = takeFlagValue(rest, ['--file']);
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+
+      let body: Record<string, unknown>;
+      if (file !== undefined) {
+        const raw = file === '-' ? await readStdin() : await Bun.file(file).text();
+        body = JSON.parse(raw) as Record<string, unknown>;
+      } else {
+        // Merge onto the current stored policy so a single field can be changed
+        // without clobbering the rest.
+        const current = await ctx.client.get<RoutingPolicyDoc>(base);
+        body = {
+          defaultModel: current.project.defaultModel,
+          visionModel: current.project.visionModel,
+          defaultFallback: current.project.defaultFallback,
+          rules: current.project.rules,
+        };
+        if (defaultModel !== undefined) body.defaultModel = defaultModel || null;
+        if (visionModel !== undefined) body.visionModel = visionModel || null;
+        if (fallback !== undefined) {
+          const models = fallback
+            .split(',')
+            .map((m) => m.trim())
+            .filter(Boolean);
+          body.defaultFallback = models.length
+            ? {
+                models,
+                fallbackOn:
+                  fallbackOn ?? current.project.defaultFallback?.fallbackOn ?? 'transient',
+              }
+            : null;
+        } else if (fallbackOn !== undefined && body.defaultFallback) {
+          (body.defaultFallback as { fallbackOn: string }).fallbackOn = fallbackOn;
+        }
+      }
+
+      const doc = await ctx.client.put<RoutingPolicyDoc>(base, body);
+      if (json) return outJson(doc);
+      process.stdout.write(`\n  ${status.ok('routing policy updated')}\n\n`);
+      return renderRouting(doc);
+    }
+    process.stderr.write(
+      `${status.err(`unknown routing action "${action}"`)} — get | set | reset | preview\n`,
+    );
+    return 2;
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+}
+
+function renderRouting(doc: RoutingPolicyDoc): number {
+  const e = doc.effective;
+  const fb = e.defaultFallback.models.length
+    ? `${e.defaultFallback.models.join(' → ')} (${e.defaultFallback.fallbackOn})`
+    : '—';
+  process.stdout.write(
+    `\n  ${C.dim}EFFECTIVE ROUTING${C.reset}\n` +
+      `  default model   ${C.bold}${e.defaultModel}${C.reset} ${C.dim}(${e.defaultModelSource})${C.reset}\n` +
+      `  vision model    ${e.visionModel}\n` +
+      `  fallback        ${fb}\n`,
+  );
+  if (doc.project.rules.length) {
+    process.stdout.write(`\n  ${C.dim}PER-MODEL RULES${C.reset}\n`);
+    for (const r of doc.project.rules) {
+      process.stdout.write(`  ${r.model} → ${r.fallbackModels.join(' → ')} (${r.fallbackOn})\n`);
+    }
+  }
+  if (!doc.capabilities.write) {
+    process.stdout.write(
+      `\n  ${C.dim}(read-only — you lack customize-write on this project)${C.reset}\n`,
+    );
+  }
+  process.stdout.write('\n');
+  return 0;
+}
+
+// ── Budgets ─────────────────────────────────────────────────────────────────
+
+export async function gatewayBudget(rest: string[], opts: CtxOpts, json: boolean): Promise<number> {
+  const action = takeAction(rest, 'ls');
+  const ctx = await resolveProjectContext(opts);
+  if (!ctx) return 1;
+  const base = `/projects/${ctx.projectId}/gateway/budgets`;
+
+  try {
+    if (action === 'ls' || action === 'list') {
+      const data = await ctx.client.get<any>(base);
+      if (json) return outJson(data);
+      process.stdout.write(
+        `\n  ${C.dim}PROJECT SPEND (this month)${C.reset}  ${money(data.project_spend?.cost)} · ${data.project_spend?.requests ?? 0} req\n`,
+      );
+      if (data.budgets?.length) {
+        process.stdout.write(`\n  ${C.dim}BUDGETS${C.reset}\n`);
+        for (const b of data.budgets) {
+          const who = b.scope === 'member' ? ` ${C.dim}user=${b.subject_user_id}${C.reset}` : '';
+          process.stdout.write(
+            `  ${money(b.limit_usd)}/${b.period} ${b.scope} (${b.action})${who} ${C.faded}${b.budget_id}${C.reset}\n`,
+          );
+        }
+      } else {
+        process.stdout.write(`\n  ${C.dim}No budgets set.${C.reset}\n`);
+      }
+      process.stdout.write('\n');
+      return 0;
+    }
+    if (action === 'set') {
+      let scope: string | undefined;
+      let user: string | undefined;
+      let limit: string | undefined;
+      let period: string | undefined;
+      let actionFlag: string | undefined;
+      try {
+        scope = takeFlagValue(rest, ['--scope']);
+        user = takeFlagValue(rest, ['--user']);
+        limit = takeFlagValue(rest, ['--limit']);
+        period = takeFlagValue(rest, ['--period']);
+        actionFlag = takeFlagValue(rest, ['--action']);
+      } catch (err) {
+        return fail((err as Error).message);
+      }
+      if (!limit) return fail('--limit <usd> is required');
+      const body: Record<string, unknown> = {
+        scope: scope ?? (user ? 'member' : 'project'),
+        limit_usd: Number(limit),
+        ...(period ? { period } : {}),
+        ...(actionFlag ? { action: actionFlag } : {}),
+        ...(user ? { subject_user_id: user } : {}),
+      };
+      await ctx.client.put(base, body);
+      process.stdout.write(
+        `\n  ${status.ok(`budget set: ${money(limit)}/${body.period ?? 'month'} (${body.scope})`)}\n\n`,
+      );
+      return 0;
+    }
+    if (action === 'rm' || action === 'delete') {
+      const id = rest.find((a) => !a.startsWith('-'));
+      if (!id) return fail('budget rm needs a budget id');
+      await ctx.client.delete(`${base}/${encodeURIComponent(id)}`);
+      process.stdout.write(`\n  ${status.ok(`budget ${id} removed`)}\n\n`);
+      return 0;
+    }
+    process.stderr.write(`${status.err(`unknown budget action "${action}"`)} — ls | set | rm\n`);
+    return 2;
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+}
+
+// ── External gateway API keys ───────────────────────────────────────────────
+
+export async function gatewayKeys(rest: string[], opts: CtxOpts, json: boolean): Promise<number> {
+  const action = takeAction(rest, 'ls');
+  const ctx = await resolveProjectContext(opts);
+  if (!ctx) return 1;
+  const base = `/projects/${ctx.projectId}/gateway/keys`;
+
+  try {
+    if (action === 'ls' || action === 'list') {
+      const data = await ctx.client.get<any>(base);
+      if (json) return outJson(data);
+      process.stdout.write(`\n  ${C.dim}Gateway URL: ${data.gateway_url}${C.reset}\n\n`);
+      if (!data.keys?.length) {
+        process.stdout.write(
+          `  ${C.dim}No gateway keys. Create one: kortix gateway keys new <name>${C.reset}\n\n`,
+        );
+        return 0;
+      }
+      const nameW = Math.max(...data.keys.map((k: any) => (k.name ?? '').length), 4);
+      for (const k of data.keys) {
+        const dot = k.status === 'active' ? `${C.green}●${C.reset}` : `${C.faded}○${C.reset}`;
+        process.stdout.write(
+          `  ${dot} ${pad(k.name ?? '', nameW)}  ${C.dim}${k.key_prefix}…  ${k.status}${C.reset}\n`,
+        );
+      }
+      process.stdout.write('\n');
+      return 0;
+    }
+    if (action === 'new' || action === 'create') {
+      const name = rest.find((a) => !a.startsWith('-'));
+      if (!name) return fail('keys new needs a name');
+      const created = await ctx.client.post<any>(base, { name });
+      if (json) return outJson(created);
+      process.stdout.write(
+        `\n  ${status.ok(`created gateway key "${name}"`)}\n\n` +
+          `  ${C.bold}${created.secret_key}${C.reset}\n\n` +
+          `  ${C.dim}Shown once — store it now. Use as the Bearer token against the gateway URL.${C.reset}\n\n`,
+      );
+      return 0;
+    }
+    if (action === 'rm' || action === 'revoke' || action === 'delete') {
+      const id = rest.find((a) => !a.startsWith('-'));
+      if (!id) return fail('keys rm needs a key id');
+      await ctx.client.delete(`${base}/${encodeURIComponent(id)}`);
+      process.stdout.write(`\n  ${status.ok(`gateway key ${id} revoked`)}\n\n`);
+      return 0;
+    }
+    process.stderr.write(`${status.err(`unknown keys action "${action}"`)} — ls | new | rm\n`);
+    return 2;
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+}
+
+// ── Usage / analytics ───────────────────────────────────────────────────────
+
+export async function gatewayUsage(rest: string[], opts: CtxOpts, json: boolean): Promise<number> {
+  const ctx = await resolveProjectContext(opts);
+  if (!ctx) return 1;
+  let days: string | undefined;
+  try {
+    days = takeFlagValue(rest, ['--days']);
+  } catch (err) {
+    return fail((err as Error).message);
+  }
+  const q = days ? `?days=${encodeURIComponent(days)}` : '';
+  try {
+    const [overview, breakdown] = await Promise.all([
+      ctx.client.get<any>(`/projects/${ctx.projectId}/gateway/overview${q}`),
+      ctx.client.get<any>(`/projects/${ctx.projectId}/gateway/breakdown${q}`),
+    ]);
+    if (json) return outJson({ overview, breakdown });
+    process.stdout.write(
+      `\n  ${C.dim}LAST ${overview.window_days}d${C.reset}  ` +
+        `${overview.requests} req · ${overview.errors} err · ${money(overview.total_cost)} · ` +
+        `${overview.input_tokens}/${overview.output_tokens} tok\n`,
+    );
+    if (breakdown.models?.length) {
+      process.stdout.write(`\n  ${C.dim}BY MODEL${C.reset}\n`);
+      for (const m of breakdown.models) {
+        process.stdout.write(
+          `  ${pad(m.model, 28)} ${String(m.requests).padStart(5)} req  ${money(m.cost)}  ${C.dim}${m.provider}${C.reset}\n`,
+        );
+      }
+    }
+    process.stdout.write('\n');
+    return 0;
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+}
+
+export async function gatewayLogs(rest: string[], opts: CtxOpts, json: boolean): Promise<number> {
+  // Pull flags off FIRST so a flag VALUE (e.g. the `3` in `--limit 3`) is never
+  // mistaken for a positional logId.
+  let limit: string | undefined;
+  const failed = takeFlagBool(rest, ['--failed']);
+  try {
+    limit = takeFlagValue(rest, ['--limit']);
+  } catch (err) {
+    return fail((err as Error).message);
+  }
+  const ctx = await resolveProjectContext(opts);
+  if (!ctx) return 1;
+  // `gateway logs <logId>` fetches one row's full request/response detail.
+  const id = rest.find((a) => !a.startsWith('-'));
+  try {
+    if (id) {
+      const row = await ctx.client.get<any>(
+        `/projects/${ctx.projectId}/gateway/logs/${encodeURIComponent(id)}`,
+      );
+      return outJson(row);
+    }
+    const params = new URLSearchParams();
+    if (limit) params.set('limit', limit);
+    if (failed) params.set('ok', 'false');
+    const qs = params.toString();
+    const data = await ctx.client.get<any>(
+      `/projects/${ctx.projectId}/gateway/logs${qs ? `?${qs}` : ''}`,
+    );
+    if (json) return outJson(data);
+    if (!data.logs?.length) {
+      process.stdout.write(`\n  ${C.dim}No gateway requests logged.${C.reset}\n\n`);
+      return 0;
+    }
+    process.stdout.write('\n');
+    for (const l of data.logs) {
+      const dot = l.ok ? `${C.green}●${C.reset}` : `${C.red}●${C.reset}`;
+      const err = l.ok
+        ? ''
+        : ` ${C.red}${l.error_code ?? ''}${C.reset} ${C.dim}${(l.error_message ?? '').slice(0, 80)}${C.reset}`;
+      process.stdout.write(
+        `  ${dot} ${pad(l.requested_model ?? '', 24)} ${String(l.status).padStart(3)} ${String(l.latency_ms ?? 0).padStart(5)}ms  ${C.faded}${l.request_id}${C.reset}${err}\n`,
+      );
+    }
+    process.stdout.write('\n');
+    return 0;
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+}
+
+// ── Playground (test a model end-to-end through the gateway) ─────────────────
+
+export async function gatewayTest(rest: string[], opts: CtxOpts, json: boolean): Promise<number> {
+  let prompt: string | undefined;
+  try {
+    prompt = takeFlagValue(rest, ['--prompt', '-p']);
+  } catch (err) {
+    return fail((err as Error).message);
+  }
+  const models = rest.filter((a) => !a.startsWith('-'));
+  if (!models.length) return fail('pass at least one model id');
+  const ctx = await resolveProjectContext(opts);
+  if (!ctx) return 1;
+  try {
+    const data = await ctx.client.post<any>(`/projects/${ctx.projectId}/gateway/playground`, {
+      prompt: prompt ?? 'Reply with exactly: pong',
+      models,
+    });
+    if (json) return outJson(data);
+    process.stdout.write('\n');
+    for (const r of data.results ?? []) {
+      if (r.ok) {
+        process.stdout.write(
+          `  ${status.ok(r.model)} ${C.dim}${r.latency_ms}ms · ${r.input_tokens}/${r.output_tokens} tok${C.reset}\n` +
+            `    ${String(r.output ?? '').slice(0, 200)}\n`,
+        );
+      } else {
+        process.stdout.write(`  ${status.err(r.model)} ${C.dim}${r.error ?? 'failed'}${C.reset}\n`);
+      }
+    }
+    process.stdout.write('\n');
+    return (data.results ?? []).every((r: any) => r.ok) ? 0 : 1;
+  } catch (err) {
+    return surfaceApiError(err);
+  }
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of Bun.stdin.stream()) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,6 +9,7 @@ import { runCr } from './commands/cr.ts';
 import { runEnv } from './commands/env.ts';
 import { runExecutor } from './commands/executor.ts';
 import { runFiles } from './commands/files.ts';
+import { runGateway } from './commands/gateway.ts';
 import { runGrants } from './commands/grants.ts';
 import { runHosts } from './commands/hosts.ts';
 import { runInit } from './commands/init.ts';
@@ -128,12 +129,25 @@ const TIERS: readonly CommandTier[] = [
         commands: [
           { name: 'agents', args: '<subcommand>', blurb: 'Set which model each agent runs on' },
           {
+            name: 'gateway',
+            args: '<subcommand>',
+            blurb: 'Configure the LLM gateway: routing, budgets, keys, usage, logs, test',
+          },
+          {
             name: 'connectors',
             args: '<subcommand>',
             blurb: 'Manage integrations agents call as tools (Pipedream/MCP/HTTP)',
           },
-          { name: 'secrets', args: '<subcommand>', blurb: 'Manage project secrets (project-scoped)' },
-          { name: 'env', args: '<subcommand>', blurb: 'Pull/push project secrets as a dotenv file' },
+          {
+            name: 'secrets',
+            args: '<subcommand>',
+            blurb: 'Manage project secrets (project-scoped)',
+          },
+          {
+            name: 'env',
+            args: '<subcommand>',
+            blurb: 'Pull/push project secrets as a dotenv file',
+          },
           {
             name: 'channels',
             args: '<subcommand>',
@@ -164,13 +178,21 @@ const TIERS: readonly CommandTier[] = [
       {
         title: 'Sessions & work',
         commands: [
-          { name: 'sessions', args: '<subcommand>', blurb: 'List, create, restart project sessions' },
+          {
+            name: 'sessions',
+            args: '<subcommand>',
+            blurb: 'List, create, restart project sessions',
+          },
           {
             name: 'chat',
             args: '[session-id]',
             blurb: "Talk to a session's agent (REPL or --prompt)",
           },
-          { name: 'files', args: '<subcommand>', blurb: 'Browse repo files, commits, branches, diffs' },
+          {
+            name: 'files',
+            args: '<subcommand>',
+            blurb: 'Browse repo files, commits, branches, diffs',
+          },
           { name: 'cr', args: '<subcommand>', blurb: 'Open, review, merge change requests' },
           { name: 'triggers', args: '<subcommand>', blurb: 'List, fire, enable/disable triggers' },
         ],
@@ -191,7 +213,8 @@ const TIERS: readonly CommandTier[] = [
           {
             name: 'grants',
             args: '<subcommand>',
-            blurb: "Assign agents to members or groups (they inherit the agent's skills/connectors/secrets)",
+            blurb:
+              "Assign agents to members or groups (they inherit the agent's skills/connectors/secrets)",
           },
         ],
       },
@@ -334,6 +357,9 @@ async function main(argv: string[]): Promise<number> {
   if (argv[0] === 'agents') {
     return runAgents(argv.slice(1));
   }
+  if (argv[0] === 'gateway') {
+    return runGateway(argv.slice(1));
+  }
   if (argv[0] === 'self-host') {
     return runSelfHost(argv.slice(1));
   }
@@ -430,6 +456,7 @@ const KNOWN_COMMANDS = [
   'connectors',
   'secrets',
   'env',
+  'gateway',
   'channels',
   'sandboxes',
   'marketplace',
@@ -471,7 +498,11 @@ function closestCommand(input: string): string | undefined {
     const distance = editDistance(needle, name);
     // The distance cap alone lets tiny inputs match anything short ("us" →
     // "cr"), so also require most of the input to survive the edit.
-    if (distance <= 2 && distance < needle.length && (best === undefined || distance < best.distance)) {
+    if (
+      distance <= 2 &&
+      distance < needle.length &&
+      (best === undefined || distance < best.distance)
+    ) {
       best = { name, distance };
     }
   }


### PR DESCRIPTION
## Summary
Adds `kortix gateway`, giving the CLI 100% programmatic control over a project's LLM gateway — routing, spend, external keys, observability, and a playground — as a thin, faithful client of the existing `/projects/:id/gateway/*` API (`apps/api/src/projects/routes/gateway.ts`). No web UI needed to configure the gateway.

```
routing  get | set | reset | preview   default model, fallback chain, vision model, live route preview
budget   ls | set | rm                  spend caps (project / per-member)
keys     ls | new | rm                  external gateway API keys (mint/revoke)
usage    [--days N]                     request/error/cost totals + by-model
logs     [--limit N] [--failed] | <id>  recent requests / one row's full detail
test     <model…> [--prompt <text>]     run a prompt through the playground
```

Every subcommand supports `--json`, `--project <id>`, `--host <name>`.

## Why its own command (not a `providers` subcommand)
The domain has two distinct nouns. `providers` connects **credentials** (a one-time input: OAuth / API keys via `/oauth` + `/secrets`). `gateway` configures **ongoing behavior** (`/gateway/*`, tagged `gateway` in the API). Folding budgets/usage/logs into `providers` would make it a grab-bag where `providers keys` is ambiguous (provider credential vs gateway key). Keeping them separate mirrors the API's own taxonomy and keeps each command cohesive. (`kortix agents` still owns per-agent model selection; `kortix gateway routing` owns the project default/fallback.)

## Test plan
- [x] New black-box suite (`apps/cli/src/__tests__/gateway.test.ts`, 10 tests): spawns the real CLI against a mock API and asserts the endpoint + method + request body for each subcommand, the `--json` output shape, the routing-`set` merge-onto-current behavior, and — as a regression guard — that `logs --limit 3` sends `?limit=3` (not `/logs/3`, which 400s "Invalid log id").
- [x] `tsc` clean for the new/changed files (`gateway.ts`, `index.ts`).
- [x] Biome clean (no comma-operator / non-null-assertion violations; only the same advisory `any` on loose API responses that existing CLI commands use).
- [x] Manually exercised the read paths against the live cloud API (routing / usage / logs render + `--json` parses cleanly; banner stays on stderr).

## Note (separate, pre-existing)
`kortix providers` (`runProviders`) is currently **not wired** into the CLI dispatcher in `apps/cli/src/index.ts` — it exists but is unreachable. Left as-is here (out of scope); flagging for a follow-up if provider-credential management via CLI is desired.