### PR TITLE
fix: remove legacy ECS HTTP listeners

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -103,8 +103,7 @@ module "api" {
 
   image           = var.api_image
   container_port  = var.container_port
-  enable_https    = var.enable_https
-  certificate_arn = var.enable_https ? one(module.acm[*].certificate_arn) : ""
+  certificate_arn = one(module.acm[*].certificate_arn)
   environment     = var.api_environment
   secrets         = var.api_secrets
 
@@ -141,12 +140,11 @@ module "gateway" {
   container_name    = "gateway"
   container_port    = 8090
   health_check_path = "/health/live"
-  enable_https      = var.enable_https
   # The gateway origin hostname (gateway-<env>-ecs-fargate) must pass Cloudflare
   # Full(strict) origin verification, so it needs a cert covering THAT host — the
   # api cert (module.acm, dev-api-ecs-fargate only) does not. Use the *.kortix.com
   # wildcard, which covers every origin alias.
-  certificate_arn = var.enable_https ? var.gateway_certificate_arn : ""
+  certificate_arn = var.gateway_certificate_arn
   # PORT is auto-injected by the module; the gateway also needs to call back to
   # the API, which on Fargate is the public (Cloudflare-fronted) dev-api host.
   environment = merge(var.gateway_environment, { KORTIX_API_URL = "https://dev-api.kortix.com" })

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -73,9 +73,14 @@ variable "api_secrets" {
 }
 
 variable "enable_https" {
-  description = "Create the ACM cert + HTTPS listener (needs the Cloudflare token for DNS validation). false = HTTP-only ALB, e.g. for parallel validation."
+  description = "Compliance guard for the existing ACM module state address. Must remain true; ECS ALBs are HTTPS-only."
   type        = bool
   default     = true
+
+  validation {
+    condition     = var.enable_https
+    error_message = "enable_https must remain true; ECS ALBs are HTTPS-only."
+  }
 }
 
 variable "manage_dns" {

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -95,7 +95,6 @@ module "api" {
 
   image           = var.api_image
   container_port  = var.container_port
-  enable_https    = true
   certificate_arn = module.acm.certificate_arn
   environment     = var.api_environment
   secrets         = var.api_secrets
@@ -153,7 +152,6 @@ module "gateway" {
   container_name    = "gateway"
   container_port    = 8090
   health_check_path = "/health/live"
-  enable_https      = true
   certificate_arn   = module.acm_gateway.certificate_arn
   environment       = merge(var.gateway_environment, { KORTIX_API_URL = "https://api.kortix.com" })
   secrets           = var.api_secrets

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -78,8 +78,7 @@ module "api" {
 
   image           = var.api_image
   container_port  = var.container_port
-  enable_https    = var.enable_https
-  certificate_arn = var.enable_https ? var.wildcard_certificate_arn : ""
+  certificate_arn = var.wildcard_certificate_arn
   environment     = var.api_environment
   secrets         = var.api_secrets
 
@@ -110,8 +109,7 @@ module "gateway" {
   container_name    = "gateway"
   container_port    = 8090
   health_check_path = "/health/live"
-  enable_https      = var.enable_https
-  certificate_arn   = var.enable_https ? var.wildcard_certificate_arn : ""
+  certificate_arn   = var.wildcard_certificate_arn
   environment       = merge(var.gateway_environment, { KORTIX_API_URL = "https://staging-api.kortix.com" })
   secrets           = var.api_secrets
 

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -72,12 +72,6 @@ variable "api_secrets" {
   default     = {}
 }
 
-variable "enable_https" {
-  description = "Create the ACM cert + HTTPS listener (needs the Cloudflare token for DNS validation). false = HTTP-only ALB, e.g. for parallel validation."
-  type        = bool
-  default     = true
-}
-
 variable "manage_dns" {
   description = "Manage the staging Cloudflare origin records (CNAME -> ALB). Default false — records are created out-of-band so the apply needs no Cloudflare creds."
   type        = bool

--- a/infra/terraform/modules/ecs-api/README.md
+++ b/infra/terraform/modules/ecs-api/README.md
@@ -11,8 +11,8 @@ same thing with bigger numbers and `min_capacity >= 2`".
 - ECS cluster (Container Insights optional) + Fargate service, on `FARGATE` or
   `FARGATE_SPOT` (`use_fargate_spot`, good for dev).
 - ALB in public subnets; tasks in private subnets (SG locks tasks to ALB only).
-- HTTPS listener when `certificate_arn` is set (HTTP→HTTPS redirect); plain HTTP
-  otherwise.
+- HTTPS-only listener backed by the required `certificate_arn`; no HTTP listener
+  or redirect is exposed.
 - Target-tracking autoscaling: CPU (`cpu_target`) + memory (`memory_target`),
   between `min_capacity` and `max_capacity`.
 - Rolling deploys with the ECS **deployment circuit breaker** (auto-rollback on

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -4,7 +4,7 @@
 # "the same thing with bigger numbers and min_capacity >= 2".
 #
 # Inputs: a VPC + subnets (from modules/network), a container image, env/secrets,
-# and an optional ACM cert. Outputs the ALB DNS name so the environment can point
+# and an ACM cert. Outputs the ALB DNS name so the environment can point
 # Cloudflare DNS at it.
 
 terraform {
@@ -21,9 +21,6 @@ locals {
   name = var.name
   # PORT is always injected so the app binds the port the target group checks.
   environment = merge(var.environment, { PORT = tostring(var.container_port) })
-  # Gate the HTTPS listener on a STATIC flag (count can't depend on the ACM
-  # cert ARN, which is unknown until apply).
-  https = var.enable_https
 }
 
 # ── Logs ──────────────────────────────────────────────────────────────────────
@@ -95,13 +92,6 @@ resource "aws_security_group" "alb" {
   description = "Ingress to the ${local.name} ALB"
   vpc_id      = var.vpc_id
 
-  ingress {
-    description = "HTTP"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = var.alb_ingress_cidrs
-  }
   ingress {
     description = "HTTPS"
     from_port   = 443
@@ -196,35 +186,7 @@ resource "aws_lb_target_group" "this" {
   tags                 = var.tags
 }
 
-resource "aws_lb_listener" "http" {
-  load_balancer_arn = aws_lb.this.arn
-  port              = 80
-  protocol          = "HTTP"
-
-  # With a cert, force HTTPS; without one, serve HTTP directly (e.g. behind a
-  # TLS-terminating proxy like Cloudflare in dev).
-  dynamic "default_action" {
-    for_each = local.https ? [1] : []
-    content {
-      type = "redirect"
-      redirect {
-        port        = "443"
-        protocol    = "HTTPS"
-        status_code = "HTTP_301"
-      }
-    }
-  }
-  dynamic "default_action" {
-    for_each = local.https ? [] : [1]
-    content {
-      type             = "forward"
-      target_group_arn = aws_lb_target_group.this.arn
-    }
-  }
-}
-
 resource "aws_lb_listener" "https" {
-  count             = local.https ? 1 : 0
   load_balancer_arn = aws_lb.this.arn
   port              = 443
   protocol          = "HTTPS"
@@ -344,12 +306,9 @@ resource "aws_ecs_service" "this" {
     ignore_changes = [task_definition, desired_count]
   }
 
-  # Both listeners must exist before the service: the HTTPS listener (when
-  # enabled) is what associates the target group with the load balancer, and ECS
-  # rejects CreateService against a target group that has no associated LB.
-  # Without this, the service can race ahead of the HTTPS listener on a fresh
-  # apply ("target group ... does not have an associated load balancer").
-  depends_on = [aws_lb_listener.http, aws_lb_listener.https]
+  # The selected listener must exist before the service so the target group is
+  # associated with the load balancer before ECS validates CreateService.
+  depends_on = [aws_lb_listener.https]
   tags = {
     ManagedBy   = "terraform"
     Name        = local.name

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -124,15 +124,13 @@ variable "requests_per_target_target" {
 
 # ── Options ───────────────────────────────────────────────────────────────────
 variable "certificate_arn" {
-  description = "ACM cert ARN for the HTTPS listener (used when enable_https = true)."
+  description = "ACM cert ARN for the required HTTPS listener."
   type        = string
-  default     = ""
-}
 
-variable "enable_https" {
-  description = "Create the HTTPS :443 listener (certificate_arn) and make :80 redirect to it. false = HTTP-only :80 forward. Must be a static value (gates count)."
-  type        = bool
-  default     = false
+  validation {
+    condition     = length(trimspace(var.certificate_arn)) > 0
+    error_message = "certificate_arn is required; the ecs-api module is HTTPS-only."
+  }
 }
 
 variable "use_fargate_spot" {


### PR DESCRIPTION
## Summary
- make the shared ECS API module HTTPS-only
- remove the legacy port 80 ALB listener and security-group ingress
- require a non-empty ACM certificate and prevent dev from disabling HTTPS

## Verification
- terraform fmt -check for the module and dev/staging/prod environments
- terraform validate for dev, staging, and prod
- Checkov no longer reports the port-80 or non-HTTPS listener findings

## Compliance evidence
Live AWS reconciliation and endpoint verification are tracked in the SOC 2 monitor audit.