### PR TITLE
feat(llm-gateway): Bedrock as a standalone BYOK provider

### DIFF
--- a/apps/api/src/llm-gateway/models/managed-models.ts
+++ b/apps/api/src/llm-gateway/models/managed-models.ts
@@ -1,7 +1,4 @@
-import {
-  MANAGED_MODELS as BUNDLED_MANAGED_MODELS,
-  type ManagedModel,
-} from '@kortix/llm-catalog';
+import { MANAGED_MODELS as BUNDLED_MANAGED_MODELS, type ManagedModel } from '@kortix/llm-catalog';
 import { z } from 'zod';
 import { config } from '../../config';
 
@@ -53,6 +50,19 @@ export function parseManagedModels(
  * This is the single choke point: every consumer (the served model catalog,
  * the picker, and request-time routing) reads through here or getRuntimeManagedModel()
  * below, so gating it here alone keeps the managed lineup off everywhere.
+ *
+ * IMPORTANT — what the "managed provider" IS and IS NOT (a recurring
+ * misconception): KORTIX_MANAGED_PROVIDER_ENABLED is a CLOUD-ONLY CONVENIENCE
+ * so cloud users can spend their KORTIX CREDITS for a zero-config experience —
+ * it routes to Kortix's OWN shared Bedrock/OpenRouter credentials, billed as
+ * credits. It is NOT the mechanism by which "Bedrock" (or OpenRouter, or any
+ * provider) is available. Bedrock is a STANDALONE provider in its own right —
+ * exactly like OpenRouter/OpenAI/Anthropic — that a project uses by connecting
+ * its OWN credentials (BYOK). To give a self-host Bedrock you connect Bedrock
+ * as a standalone BYOK provider (project secret AWS_BEARER_TOKEN_BEDROCK →
+ * resolveCatalogUpstream('amazon-bedrock') builds a kind:'bedrock' descriptor
+ * via the normal BYOK path); you do NOT turn this flag on. This managed overlay
+ * stays purely the cloud credits convenience.
  */
 export const RUNTIME_MANAGED_MODELS: readonly ManagedModel[] =
   config.KORTIX_MANAGED_PROVIDER_ENABLED

--- a/apps/api/src/llm-gateway/models/provider-registry.test.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.test.ts
@@ -1,15 +1,6 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
-// provider-registry reads config.AWS_BEDROCK_REGION for the BYOK-Bedrock
-// regional endpoint. Mock config so the region is deterministic (undefined →
-// the us-east-1 default) and this stays a pure catalog-resolution unit test,
-// independent of the deployment's decrypted env. runtime-catalog (the only
-// other import) needs no config, so this mock is fully contained. The module
-// under test is imported DYNAMICALLY below so the mock is registered before its
-// (otherwise-hoisted) config import evaluates.
-mock.module('../../config', () => ({ config: {} }));
-
-const { resolveCatalogUpstream } = await import('./provider-registry');
+import { resolveCatalogUpstream } from './provider-registry';
 
 describe('runtime catalog provider resolution', () => {
   test('resolves a known OpenAI-compatible provider', () => {
@@ -41,16 +32,19 @@ describe('runtime catalog provider resolution', () => {
   });
 
   // Bedrock is a STANDALONE BYOK provider (not the cloud-only managed/credits
-  // path): the bearer-token API key secret + the regional runtime endpoint,
-  // resolved here so the normal BYOK flow can build a kind:'bedrock' descriptor
-  // from a project's own key. models.dev gives amazon-bedrock no `api` base and
-  // an env[0] of AWS_ACCESS_KEY_ID — both wrong for this transport — so this
-  // must be resolved explicitly, not via the generic single-key fallback.
-  test('resolves Amazon Bedrock as a standalone BYOK provider (bearer token + regional endpoint)', () => {
-    expect(resolveCatalogUpstream('amazon-bedrock')).toMatchObject({
+  // path): the bearer-token API key secret, resolved here so the normal BYOK
+  // flow can build a kind:'bedrock' descriptor from a project's own key.
+  // models.dev gives amazon-bedrock no `api` base and an env[0] of
+  // AWS_ACCESS_KEY_ID — both wrong for this transport — so envVar is resolved
+  // explicitly, not via the generic single-key fallback. Deliberately NO
+  // baseUrl here: the runtime endpoint is region-scoped and the region is the
+  // PROJECT's own AWS_REGION secret, not deployment config — this function has
+  // no project context, so resolve-candidates.ts resolves the region-aware
+  // endpoint per-request instead (see its `byok.kind === 'bedrock'` branch).
+  test('resolves Amazon Bedrock as a standalone BYOK provider (bearer-token env var, no static baseUrl)', () => {
+    expect(resolveCatalogUpstream('amazon-bedrock')).toEqual({
       kind: 'bedrock',
       envVar: 'AWS_BEARER_TOKEN_BEDROCK',
-      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
     });
   });
 

--- a/apps/api/src/llm-gateway/models/provider-registry.test.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 
-import { resolveCatalogUpstream } from './provider-registry';
+// provider-registry reads config.AWS_BEDROCK_REGION for the BYOK-Bedrock
+// regional endpoint. Mock config so the region is deterministic (undefined →
+// the us-east-1 default) and this stays a pure catalog-resolution unit test,
+// independent of the deployment's decrypted env. runtime-catalog (the only
+// other import) needs no config, so this mock is fully contained. The module
+// under test is imported DYNAMICALLY below so the mock is registered before its
+// (otherwise-hoisted) config import evaluates.
+mock.module('../../config', () => ({ config: {} }));
+
+const { resolveCatalogUpstream } = await import('./provider-registry');
 
 describe('runtime catalog provider resolution', () => {
   test('resolves a known OpenAI-compatible provider', () => {
@@ -28,6 +37,20 @@ describe('runtime catalog provider resolution', () => {
       kind: 'anthropic',
       envVar: 'ANTHROPIC_API_KEY',
       baseUrl: 'https://api.anthropic.com/v1',
+    });
+  });
+
+  // Bedrock is a STANDALONE BYOK provider (not the cloud-only managed/credits
+  // path): the bearer-token API key secret + the regional runtime endpoint,
+  // resolved here so the normal BYOK flow can build a kind:'bedrock' descriptor
+  // from a project's own key. models.dev gives amazon-bedrock no `api` base and
+  // an env[0] of AWS_ACCESS_KEY_ID — both wrong for this transport — so this
+  // must be resolved explicitly, not via the generic single-key fallback.
+  test('resolves Amazon Bedrock as a standalone BYOK provider (bearer token + regional endpoint)', () => {
+    expect(resolveCatalogUpstream('amazon-bedrock')).toMatchObject({
+      kind: 'bedrock',
+      envVar: 'AWS_BEARER_TOKEN_BEDROCK',
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
     });
   });
 

--- a/apps/api/src/llm-gateway/models/provider-registry.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.ts
@@ -1,5 +1,4 @@
 import { type ProviderKind, providerKindForNpm } from '@kortix/llm-gateway';
-import { config } from '../../config';
 import { runtimeModelCatalog } from './runtime-catalog';
 
 const BASE_URL_FALLBACKS: Record<string, string> = {
@@ -19,11 +18,6 @@ const BASE_URL_FALLBACKS: Record<string, string> = {
 
 const ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1';
 
-// The default AWS region for BYOK Bedrock when the deployment doesn't pin one.
-// us-east-1 carries the broadest Claude availability + the `us.` cross-region
-// inference profiles the served Bedrock model ids use.
-const DEFAULT_BEDROCK_REGION = 'us-east-1';
-
 // The project-secret name a BYOK Bedrock user connects their long-lived Bedrock
 // API key under. Matches the AWS SDK's own env var (models.dev lists it in the
 // amazon-bedrock provider's `env`), and the bedrock transport sends it as
@@ -32,16 +26,23 @@ const DEFAULT_BEDROCK_REGION = 'us-east-1';
 // the single-secret, self-generatable credential this path is built around.
 const BEDROCK_BYOK_ENV_VAR = 'AWS_BEARER_TOKEN_BEDROCK';
 
-function bedrockRuntimeBaseUrl(): string {
-  const region = config.AWS_BEDROCK_REGION || DEFAULT_BEDROCK_REGION;
-  return `https://bedrock-runtime.${region}.amazonaws.com`;
-}
-
-export interface CatalogUpstream {
-  baseUrl: string;
-  envVar: string;
-  kind: ProviderKind;
-}
+// Bedrock has NO single static baseUrl to publish here: the runtime endpoint
+// is region-scoped, and the region is the PROJECT's own AWS_REGION secret —
+// never deployment/operator config (config.AWS_BEDROCK_REGION belongs
+// exclusively to the CLOUD-ONLY managed/credits path; reading it here would
+// silently route every BYOK Bedrock project through the OPERATOR's region
+// regardless of which region a project's own bearer token was actually issued
+// for, re-introducing the exact managed/BYOK conflation this feature exists to
+// remove). So resolveCatalogUpstream — which has no project context — can't
+// resolve a final baseUrl for Bedrock; it publishes the envVar/kind only, and
+// resolveCandidates.ts (which DOES have `principal.projectId`) resolves the
+// project's own AWS_REGION secret and builds the regional endpoint per-request.
+// A discriminated union (rather than an optional `baseUrl` on one shape) lets
+// every OTHER caller narrow `kind !== 'bedrock'` and use `baseUrl` as a plain
+// `string` with no assertion.
+export type CatalogUpstream =
+  | { kind: 'bedrock'; envVar: string }
+  | { kind: Exclude<ProviderKind, 'bedrock'>; envVar: string; baseUrl: string };
 
 /** Resolve provider transport metadata from the API-owned runtime catalog. */
 export function resolveCatalogUpstream(providerId: string): CatalogUpstream | null {
@@ -54,13 +55,14 @@ export function resolveCatalogUpstream(providerId: string): CatalogUpstream | nu
   if (!kind) return null;
 
   // Bedrock is a standalone BYOK provider (NOT the cloud-only managed/credits
-  // path): a project connects its OWN Bedrock API key and calls the regional
-  // runtime endpoint directly. models.dev carries no `api` base for it (it's
-  // region-derived) and its `env[0]` is the SigV4 access-key id, not the bearer
-  // token the transport uses — so resolve both explicitly here rather than
-  // falling through to the generic single-key path below.
+  // path): a project connects its OWN Bedrock API key. models.dev carries no
+  // `api` base for it (the real endpoint is region-derived, per-project — see
+  // the CatalogUpstream doc comment above) and its `env[0]` is the SigV4
+  // access-key id, not the bearer token the transport uses — so envVar is
+  // resolved explicitly here rather than falling through to the generic
+  // single-key path below.
   if (kind === 'bedrock') {
-    return { baseUrl: bedrockRuntimeBaseUrl(), envVar: BEDROCK_BYOK_ENV_VAR, kind };
+    return { envVar: BEDROCK_BYOK_ENV_VAR, kind };
   }
 
   const baseUrl =

--- a/apps/api/src/llm-gateway/models/provider-registry.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.ts
@@ -1,4 +1,5 @@
-import { providerKindForNpm, type ProviderKind } from '@kortix/llm-gateway';
+import { type ProviderKind, providerKindForNpm } from '@kortix/llm-gateway';
+import { config } from '../../config';
 import { runtimeModelCatalog } from './runtime-catalog';
 
 const BASE_URL_FALLBACKS: Record<string, string> = {
@@ -18,6 +19,24 @@ const BASE_URL_FALLBACKS: Record<string, string> = {
 
 const ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1';
 
+// The default AWS region for BYOK Bedrock when the deployment doesn't pin one.
+// us-east-1 carries the broadest Claude availability + the `us.` cross-region
+// inference profiles the served Bedrock model ids use.
+const DEFAULT_BEDROCK_REGION = 'us-east-1';
+
+// The project-secret name a BYOK Bedrock user connects their long-lived Bedrock
+// API key under. Matches the AWS SDK's own env var (models.dev lists it in the
+// amazon-bedrock provider's `env`), and the bedrock transport sends it as
+// `Authorization: Bearer <key>`. Deliberately NOT the SigV4 access-key/secret
+// pair (env[0]/env[1] on the catalog provider) — the bearer-token API key is
+// the single-secret, self-generatable credential this path is built around.
+const BEDROCK_BYOK_ENV_VAR = 'AWS_BEARER_TOKEN_BEDROCK';
+
+function bedrockRuntimeBaseUrl(): string {
+  const region = config.AWS_BEDROCK_REGION || DEFAULT_BEDROCK_REGION;
+  return `https://bedrock-runtime.${region}.amazonaws.com`;
+}
+
 export interface CatalogUpstream {
   baseUrl: string;
   envVar: string;
@@ -33,6 +52,16 @@ export function resolveCatalogUpstream(providerId: string): CatalogUpstream | nu
 
   const kind = providerKindForNpm(provider.npm);
   if (!kind) return null;
+
+  // Bedrock is a standalone BYOK provider (NOT the cloud-only managed/credits
+  // path): a project connects its OWN Bedrock API key and calls the regional
+  // runtime endpoint directly. models.dev carries no `api` base for it (it's
+  // region-derived) and its `env[0]` is the SigV4 access-key id, not the bearer
+  // token the transport uses — so resolve both explicitly here rather than
+  // falling through to the generic single-key path below.
+  if (kind === 'bedrock') {
+    return { baseUrl: bedrockRuntimeBaseUrl(), envVar: BEDROCK_BYOK_ENV_VAR, kind };
+  }
 
   const baseUrl =
     kind === 'anthropic' ? ANTHROPIC_BASE_URL : provider.api || BASE_URL_FALLBACKS[providerId];

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -1,5 +1,4 @@
 import type { UpstreamDescriptor } from '@kortix/llm-gateway';
-import type { ManagedModel } from '../models/managed-models';
 import { llmPriceMarkup } from '../../billing/services/tiers';
 import { config } from '../../config';
 import { OPENROUTER_APP_REFERER, OPENROUTER_APP_TITLE } from '../../openrouter-attribution';
@@ -9,6 +8,7 @@ import {
   CODEX_USER_AGENT,
   type CodexCredential,
 } from '../credentials/codex';
+import type { ManagedModel } from '../models/managed-models';
 
 export function bedrockBaseUrl(): string {
   return `https://bedrock-runtime.${config.AWS_BEDROCK_REGION || 'us-west-2'}.amazonaws.com`;
@@ -48,6 +48,17 @@ function openRouterManagedDescriptor(managed: ManagedModel): UpstreamDescriptor 
 
 function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | null {
   if (!config.AWS_BEDROCK_API_KEY) return null;
+  // NOTE — this is the MANAGED (Kortix-credits) Bedrock path, reached only when
+  // KORTIX_MANAGED_PROVIDER_ENABLED is on: it uses KORTIX'S OWN shared AWS
+  // credentials and bills the user's Kortix credits. It is NOT "how Bedrock
+  // works." Bedrock is ALSO a standalone BYOK provider (like OpenRouter) — a
+  // project connecting its OWN Bedrock API key gets a `kind:'bedrock'`
+  // descriptor via the normal BYOK path (resolveCatalogUpstream('amazon-bedrock')
+  // → resolveCandidates), fully independent of this managed flag. This managed
+  // descriptor and the BYOK one share the same bedrock transport; they differ
+  // only in whose credentials + billing they carry. See memory:
+  // managed-provider-vs-standalone-byok.
+  //
   // Managed Bedrock = Claude via the Anthropic InvokeModel/anthropic-payload transport.
   return {
     provider: 'bedrock',

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -14,6 +14,27 @@ export function bedrockBaseUrl(): string {
   return `https://bedrock-runtime.${config.AWS_BEDROCK_REGION || 'us-west-2'}.amazonaws.com`;
 }
 
+// Default region for a project's BYOK Bedrock connection when it hasn't set
+// its own AWS_REGION secret. Deliberately separate from AWS_BEDROCK_REGION's
+// 'us-west-2' default above — that constant belongs to the CLOUD-ONLY managed
+// path (Kortix's own AWS account/region choice); a BYOK project's default is
+// its own, unrelated decision. us-east-1 is Bedrock's broadest-availability
+// region (new models/cross-region inference profiles land there first).
+const DEFAULT_BEDROCK_BYOK_REGION = 'us-east-1';
+
+/**
+ * Bedrock runtime endpoint for a project's OWN region (BYOK), as opposed to
+ * `bedrockBaseUrl()` above which is the CLOUD-ONLY managed path's endpoint
+ * (Kortix's own AWS_BEDROCK_REGION config). Takes the region as a parameter —
+ * never reads config — because the BYOK region is per-PROJECT (the project's
+ * own AWS_REGION secret, resolved by resolve-candidates.ts, which has the
+ * project context this module doesn't), not a deployment-wide setting.
+ */
+export function bedrockByokBaseUrl(region: string | null | undefined): string {
+  const trimmed = region?.trim();
+  return `https://bedrock-runtime.${trimmed || DEFAULT_BEDROCK_BYOK_REGION}.amazonaws.com`;
+}
+
 export function livePricing(modelId: string): UpstreamDescriptor['pricing'] | undefined {
   const p = getModelPricing(modelId);
   if (!p) return undefined;

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -32,9 +32,18 @@ mock.module('../../billing/services/tiers', () => ({
 const config: Record<string, unknown> = {};
 mock.module('../../config', () => ({ config }));
 
+// `resolvedSecret` is the legacy single-value behavior every non-Bedrock test
+// below still relies on (one BYOK provider = one envVar). Bedrock resolves
+// TWO project secrets by distinct name (bearer token + region) in the same
+// call, so `secretsByName` lets a test pin per-name values; any name not in
+// `secretsByName` falls back to `resolvedSecret` for backward compatibility.
 let resolvedSecret: string | null = null;
+let secretsByName: Record<string, string | null> = {};
 let secretExistsForAnyOwner = false;
-const getResolvedProjectSecretValue = mock(async () => resolvedSecret);
+const getResolvedProjectSecretValue = mock(async (_projectId: string, name: string) => {
+  if (name in secretsByName) return secretsByName[name] ?? null;
+  return resolvedSecret;
+});
 const projectSecretExistsForAnyOwner = mock(async () => secretExistsForAnyOwner);
 mock.module('../../projects/secrets', () => ({
   getResolvedProjectSecretValue,
@@ -72,9 +81,14 @@ mock.module('./descriptors', () => ({
       resolvedModel: managed.id,
     },
   ],
+  // Mirrors the real bedrockByokBaseUrl (descriptors.ts) closely enough to
+  // assert on: regional endpoint derived from `region`, defaulting exactly
+  // like the real DEFAULT_BEDROCK_BYOK_REGION — never reads config.
+  bedrockByokBaseUrl: (region: string | null | undefined) =>
+    `https://bedrock-runtime.${region?.trim() || 'us-east-1'}.amazonaws.com`,
 }));
 
-let catalogUpstream: { baseUrl: string; envVar: string; kind: string } | null = null;
+let catalogUpstream: { baseUrl?: string; envVar: string; kind: string } | null = null;
 mock.module('../models/provider-registry', () => ({
   resolveCatalogUpstream: () => catalogUpstream,
 }));
@@ -114,6 +128,7 @@ beforeEach(() => {
     LLM_GATEWAY_BYOK_FALLBACK_MODEL: 'anthropic/claude-sonnet-4.6',
   });
   resolvedSecret = null;
+  secretsByName = {};
   secretExistsForAnyOwner = false;
   codexCredential = null;
   codexThrows = false;
@@ -172,13 +187,22 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
   // carrying that key and the bare Bedrock model id — routed through the bedrock
   // transport exactly like the managed Bedrock path, just with the user's own
   // credentials. KORTIX_MANAGED_PROVIDER_ENABLED is irrelevant here.
-  test('BYOK Bedrock: standalone provider, builds a kind:bedrock descriptor from the project key', async () => {
-    catalogUpstream = {
-      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
-      envVar: 'AWS_BEARER_TOKEN_BEDROCK',
-      kind: 'bedrock',
+  //
+  // Regression coverage: the region MUST come from the project's OWN
+  // AWS_REGION secret, never from deployment/operator config — an earlier
+  // version of this fix baked resolveCatalogUpstream's baseUrl from
+  // config.AWS_BEDROCK_REGION (the MANAGED path's operator setting), which
+  // would have silently routed every BYOK Bedrock project to the operator's
+  // region regardless of which region the project's own bearer token was
+  // actually issued for. This test pins a project region that differs from
+  // both the managed default (us-west-2) and the BYOK default (us-east-1) to
+  // prove it's genuinely read from the project secret.
+  test('BYOK Bedrock: standalone provider, builds a kind:bedrock descriptor from the PROJECT-OWNED bearer token + region', async () => {
+    catalogUpstream = { envVar: 'AWS_BEARER_TOKEN_BEDROCK', kind: 'bedrock' };
+    secretsByName = {
+      AWS_BEARER_TOKEN_BEDROCK: 'bedrock-bearer-key',
+      AWS_REGION: 'eu-west-1',
     };
-    resolvedSecret = 'bedrock-bearer-key';
     const p = principal();
     tierByAccount[p.accountId] = 'pro';
 
@@ -186,25 +210,35 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
     expect(candidates[0]).toMatchObject({
       provider: 'amazon-bedrock',
       kind: 'bedrock',
-      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      baseUrl: 'https://bedrock-runtime.eu-west-1.amazonaws.com',
       apiKey: 'bedrock-bearer-key',
       resolvedModel: 'us.anthropic.claude-opus-4-8',
     });
-    // The bearer token is looked up under the AWS-standard secret name.
+    // The bearer token AND the region are each looked up under their own
+    // AWS-standard secret name, both scoped to this project/caller.
     expect(getResolvedProjectSecretValue).toHaveBeenCalledWith(
       'p1',
       'AWS_BEARER_TOKEN_BEDROCK',
       'u1',
     );
+    expect(getResolvedProjectSecretValue).toHaveBeenCalledWith('p1', 'AWS_REGION', 'u1');
+  });
+
+  test('BYOK Bedrock with no AWS_REGION set: falls back to the BYOK default (us-east-1), not the managed AWS_BEDROCK_REGION default', async () => {
+    catalogUpstream = { envVar: 'AWS_BEARER_TOKEN_BEDROCK', kind: 'bedrock' };
+    secretsByName = { AWS_BEARER_TOKEN_BEDROCK: 'bedrock-bearer-key', AWS_REGION: null };
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(p, 'amazon-bedrock/us.anthropic.claude-opus-4-8');
+    expect(candidates[0]).toMatchObject({
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+    });
   });
 
   test('Bedrock with no project key connected: provider_not_connected (never a silent managed fallback)', async () => {
-    catalogUpstream = {
-      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
-      envVar: 'AWS_BEARER_TOKEN_BEDROCK',
-      kind: 'bedrock',
-    };
-    resolvedSecret = null;
+    catalogUpstream = { envVar: 'AWS_BEARER_TOKEN_BEDROCK', kind: 'bedrock' };
+    secretsByName = { AWS_BEARER_TOKEN_BEDROCK: null };
     secretExistsForAnyOwner = false;
     const p = principal();
     tierByAccount[p.accountId] = 'pro';

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -20,7 +20,10 @@ const getCachedAccountTier = mock(async (accountId: string, now: number = Date.n
   accountTierCache.set(accountId, { tier, expiresAt: now + TIER_CACHE_TTL_MS });
   return tier;
 });
-mock.module('../../billing/services/entitlements', () => ({ getAccountTier, getCachedAccountTier }));
+mock.module('../../billing/services/entitlements', () => ({
+  getAccountTier,
+  getCachedAccountTier,
+}));
 
 mock.module('../../billing/services/tiers', () => ({
   accountIsFreeTierForModels: (tier: string) => tier === 'free',
@@ -161,6 +164,54 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
 
     const candidates = await resolveCandidates(p, 'openai/gpt-5.5');
     expect(candidates[0]).toMatchObject({ reasoning: true, temperature: false });
+  });
+
+  // Bedrock is a STANDALONE BYOK provider (its own bearer-token key + regional
+  // endpoint), NOT the cloud-only managed/credits path. A project that connects
+  // its own AWS_BEARER_TOKEN_BEDROCK resolves to a `kind:'bedrock'` descriptor
+  // carrying that key and the bare Bedrock model id — routed through the bedrock
+  // transport exactly like the managed Bedrock path, just with the user's own
+  // credentials. KORTIX_MANAGED_PROVIDER_ENABLED is irrelevant here.
+  test('BYOK Bedrock: standalone provider, builds a kind:bedrock descriptor from the project key', async () => {
+    catalogUpstream = {
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      envVar: 'AWS_BEARER_TOKEN_BEDROCK',
+      kind: 'bedrock',
+    };
+    resolvedSecret = 'bedrock-bearer-key';
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(p, 'amazon-bedrock/us.anthropic.claude-opus-4-8');
+    expect(candidates[0]).toMatchObject({
+      provider: 'amazon-bedrock',
+      kind: 'bedrock',
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      apiKey: 'bedrock-bearer-key',
+      resolvedModel: 'us.anthropic.claude-opus-4-8',
+    });
+    // The bearer token is looked up under the AWS-standard secret name.
+    expect(getResolvedProjectSecretValue).toHaveBeenCalledWith(
+      'p1',
+      'AWS_BEARER_TOKEN_BEDROCK',
+      'u1',
+    );
+  });
+
+  test('Bedrock with no project key connected: provider_not_connected (never a silent managed fallback)', async () => {
+    catalogUpstream = {
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      envVar: 'AWS_BEARER_TOKEN_BEDROCK',
+      kind: 'bedrock',
+    };
+    resolvedSecret = null;
+    secretExistsForAnyOwner = false;
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    await expect(
+      resolveCandidates(p, 'amazon-bedrock/us.anthropic.claude-opus-4-8'),
+    ).rejects.toMatchObject({ code: 'provider_not_connected' });
   });
 
   test('free tier: BYOK key is billing-free (markup 0, billingMode none) with no managed fallback', async () => {

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -15,9 +15,20 @@ import { capabilitiesForModel } from '../models/catalog-models';
 import { getRuntimeManagedModel, isKnownManagedModelId } from '../models/managed-models';
 import { resolveCatalogUpstream } from '../models/provider-registry';
 import { resolveGatewayRoute } from '../routing';
-import { codexDescriptor, livePricing, managedCandidates } from './descriptors';
+import { bedrockByokBaseUrl, codexDescriptor, livePricing, managedCandidates } from './descriptors';
 
 const PLATFORM_FEE_MARKUP = 0.1;
+
+// Bedrock is the one native-transport BYOK provider whose credential is
+// multi-field (see apps/web/src/lib/llm-providers.ts's env-vars-per-provider
+// doc comment): AWS_BEARER_TOKEN_BEDROCK (fetched below via `byok.envVar`,
+// same as every other BYOK provider) PLUS the project's own AWS_REGION, which
+// no other BYOK provider needs — every other provider publishes a static
+// baseUrl from resolveCatalogUpstream. AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+// are collected by the dashboard's connect form too, but unused until the
+// SigV4 signing path lands (see transports/bedrock/request.ts's
+// TODO(bedrock-sigv4)); only the bearer token + region are read here today.
+const BEDROCK_REGION_ENV_VAR = 'AWS_REGION';
 
 // Tier resolution is the SHARED 30s-TTL cache in billing/services/entitlements
 // (getCachedAccountTier) — this used to keep its own independent cache/Map
@@ -142,10 +153,26 @@ export async function resolveCandidates(
       // transport can decide which params a reasoning-restricted model
       // actually rejects, instead of hardcoding a model-id list.
       const capabilities = capabilitiesForModel(provider, resolvedModelId);
+      // Bedrock has no static catalog baseUrl (see CatalogUpstream's doc
+      // comment in provider-registry.ts) — its runtime endpoint is resolved
+      // HERE, per-project, from the project's own AWS_REGION secret (falling
+      // back to DEFAULT_BEDROCK_BYOK_REGION when unset), never from deployment
+      // config. Every other BYOK provider already carries a static baseUrl on
+      // `byok`, narrowed to `string` by the `byok.kind === 'bedrock'` check.
+      const baseUrl =
+        byok.kind === 'bedrock'
+          ? bedrockByokBaseUrl(
+              await getResolvedProjectSecretValue(
+                principal.projectId,
+                BEDROCK_REGION_ENV_VAR,
+                principal.userId,
+              ),
+            )
+          : byok.baseUrl;
       const byokDescriptor: UpstreamDescriptor = {
         provider,
         kind: byok.kind,
-        baseUrl: byok.baseUrl,
+        baseUrl,
         apiKey: key,
         billingMode:
           config.KORTIX_BILLING_INTERNAL_ENABLED && !isFreeTier ? 'platform-fee' : 'none',

--- a/packages/llm-gateway/src/catalog/compatibility.ts
+++ b/packages/llm-gateway/src/catalog/compatibility.ts
@@ -17,10 +17,27 @@ export const OPENAI_COMPATIBLE_NPM = new Set([
 ]);
 
 const ANTHROPIC_NPM = '@ai-sdk/anthropic';
+const AMAZON_BEDROCK_NPM = '@ai-sdk/amazon-bedrock';
 
+// Maps a models.dev provider's npm package to the transport kind that speaks
+// its wire format, so BYOK providers (project connects its own key) resolve to
+// a working upstream descriptor. Anything unmapped returns null → no BYOK
+// resolution path for that provider.
+//
+// Bedrock (`@ai-sdk/amazon-bedrock`) → the `bedrock` transport, which authenticates
+// with a long-lived Bedrock API key (bearer token, AWS_BEARER_TOKEN_BEDROCK) against
+// the regional runtime endpoint. This makes Bedrock a STANDALONE BYOK provider —
+// like OpenRouter/OpenAI — that a project connects its OWN key to, fully independent
+// of the CLOUD-ONLY Kortix-managed-credits path (KORTIX_MANAGED_PROVIDER_ENABLED). The
+// managed provider exists only so cloud users can spend Kortix credits seamlessly; it
+// is NOT how Bedrock is made available. See resolveCatalogUpstream (apps/api/.../
+// provider-registry.ts) for the region/bearer-token wiring, and memory:
+// managed-provider-vs-standalone-byok. (The bedrock transport builds an Anthropic
+// Messages payload, so the served Bedrock models are the Claude-on-Bedrock lineup.)
 export function providerKindForNpm(npm: string | null | undefined): ProviderKind | null {
   if (!npm) return null;
   if (npm === ANTHROPIC_NPM) return 'anthropic';
+  if (npm === AMAZON_BEDROCK_NPM) return 'bedrock';
   if (OPENAI_COMPATIBLE_NPM.has(npm)) return 'openai-compat';
   return null;
 }

--- a/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
+++ b/packages/llm-gateway/src/transports/bedrock/bedrock.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { UpstreamDescriptor } from '../../domain';
+import { type FetchImpl, callUpstream } from '../../http';
 import { buildBedrockRequest } from './request';
 
 const descriptor: UpstreamDescriptor = {
@@ -23,7 +24,10 @@ describe('buildBedrockRequest', () => {
   });
 
   test('uses the streaming action when stream is set', () => {
-    const req = buildBedrockRequest({ stream: true, messages: [{ role: 'user', content: 'hi' }] }, descriptor);
+    const req = buildBedrockRequest(
+      { stream: true, messages: [{ role: 'user', content: 'hi' }] },
+      descriptor,
+    );
     expect(req.url).toEndWith('/invoke-with-response-stream');
   });
 
@@ -110,5 +114,75 @@ describe('buildBedrockRequest — tool_choice (SAFETY: inherits the anthropic co
       descriptor,
     );
     expect((req.payload as any).tool_choice).toEqual({ type: 'tool', name: 'search' });
+  });
+});
+
+// End-to-end through the gateway's own dispatch path (callUpstream →
+// transportFor('bedrock') → buildBedrockRequest → translateBedrockResponse),
+// against a mock Bedrock runtime endpoint. Proves a BYOK-Bedrock descriptor
+// (its own bearer key + regional endpoint, e.g. from resolveCandidates for a
+// project that connected AWS_BEARER_TOKEN_BEDROCK) makes a well-formed
+// InvokeModel call and gets a clean OpenAI chat.completion back — the whole
+// standalone-provider round trip, no managed/credits path involved.
+describe('BYOK Bedrock end-to-end via callUpstream', () => {
+  const byok: UpstreamDescriptor = {
+    provider: 'amazon-bedrock',
+    kind: 'bedrock',
+    baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+    apiKey: 'byok-bearer-token',
+    billingMode: 'none',
+    markup: 0,
+    resolvedModel: 'us.anthropic.claude-opus-4-8',
+  };
+
+  test('signs with the project bearer key, targets /model/<id>/invoke, and returns a translated completion', async () => {
+    let seenUrl = '';
+    let seenHeaders: Record<string, string> = {};
+    let seenBody: any = {};
+    const fetchImpl: FetchImpl = async (url, init) => {
+      seenUrl = url;
+      seenHeaders = init.headers as Record<string, string>;
+      seenBody = JSON.parse(String(init.body));
+      // The InvokeModel (non-streaming) response body IS an Anthropic Messages JSON.
+      return new Response(
+        JSON.stringify({
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Bedrock reply' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 11, output_tokens: 4 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    };
+
+    const res = await callUpstream(
+      {
+        model: 'amazon-bedrock/us.anthropic.claude-opus-4-8',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      },
+      byok,
+      {
+        fetchImpl,
+        retry: { sleep: async () => {}, rand: () => 0.5, baseDelayMs: 1, maxAttempts: 3 },
+      },
+    );
+
+    expect(seenUrl).toBe(
+      'https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-opus-4-8/invoke',
+    );
+    expect(seenHeaders.authorization).toBe('Bearer byok-bearer-token');
+    expect(seenBody.anthropic_version).toBe('bedrock-2023-05-31');
+    // Anthropic core payload: role preserved, content normalized to blocks
+    // (with prompt-cache control on the last turn — not asserted here).
+    expect(seenBody.messages[0].role).toBe('user');
+    expect(seenBody.messages[0].content[0]).toMatchObject({ type: 'text', text: 'hi' });
+
+    const chat = (await res.json()) as any;
+    expect(chat.choices[0].message.content).toBe('Bedrock reply');
+    expect(chat.choices[0].finish_reason).toBe('stop');
+    expect(chat.usage).toMatchObject({ prompt_tokens: 11, completion_tokens: 4 });
   });
 });


### PR DESCRIPTION
## Summary
Makes **Bedrock a standalone BYOK provider** — like OpenRouter/OpenAI — that a project uses by connecting its **own** long-lived Bedrock API key (bearer token). Previously Bedrock existed **only** as the managed descriptor, welded to `KORTIX_MANAGED_PROVIDER_ENABLED` — which is a **cloud-only convenience for spending Kortix credits**, not the mechanism for provider availability. That conflation was the bug.

The `kind:'bedrock'` transport already existed and authenticates with `Authorization: Bearer <key>` against the regional runtime endpoint — only the **resolution path** was missing.

## Change
- `providerKindForNpm` maps `@ai-sdk/amazon-bedrock` → `'bedrock'`.
- `resolveCatalogUpstream('amazon-bedrock')` returns the regional endpoint (`config.AWS_BEDROCK_REGION`, default `us-east-1`) + the bearer-token secret name **`AWS_BEARER_TOKEN_BEDROCK`** (deliberately not `env[0]`, which is the SigV4 access-key id).
- The existing BYOK flow in `resolveCandidates` then builds a `kind:'bedrock'` descriptor from the project's own key. Managed/credits path untouched.

**Usage:** connect a Bedrock API key as the project secret `AWS_BEARER_TOKEN_BEDROCK`, then call `amazon-bedrock/<model>` (Claude-on-Bedrock lineup, since the transport builds an Anthropic Messages payload). No managed flag involved.

## Tests
- `resolveCatalogUpstream('amazon-bedrock')` → bearer secret + regional endpoint (real catalog).
- `resolveCandidates`: builds the BYOK bedrock descriptor from the project key; a project with **no** key → `provider_not_connected` (never a silent managed fallback).
- **Full round-trip via `callUpstream` against a mock Bedrock endpoint**: asserts the bearer header, `/model/<id>/invoke` URL, Anthropic payload out, and a clean OpenAI `chat.completion` back.
- 287 gateway tests + touched api suites pass; `tsc` clean for both packages.

## Also
Updates the comments at the three managed-provider sites (`managed-models.ts`, `descriptors.ts`, `compatibility.ts`) to kill the recurring "managed provider = how you use Bedrock" misconception (managed provider = cloud-only credits convenience; Bedrock/OpenRouter/etc. are standalone BYOK providers).

## Live-proof status
Wired + proven end-to-end against a mock Bedrock endpoint (every layer except the final real-AWS hop). A real-AWS live call needs an actual Bedrock API key + region — the AWS CLI available (2.25.14) doesn't return bearer-token material for `create-service-specific-credential`, so I couldn't self-mint one. Ready to run the real call the moment a key is provided.