### PR TITLE
fix(compliance): codify all-region AWS controls

### DIFF
--- a/infra/terraform/security-baseline/README.md
+++ b/infra/terraform/security-baseline/README.md
@@ -6,7 +6,8 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
 ## What it manages
 - IAM account password policy (DCF-68 / DCF-350)
 - CloudTrail KMS CMK + multi-region trail + log-file validation + S3 data events (DCF-54 / DCF-478 / DCF-406)
-- GuardDuty detectors, us-west-2 + us-east-1 (DCF-87)
+- GuardDuty detectors in all 17 opted-in commercial regions (DCF-87)
+- EBS default encryption in all 17 opted-in commercial regions (DCF-54)
 - S3 account-level public access block (DCF-55/78/406 backstop)
 - AWS Backup vault + daily plan + selection + service role (DCF-99)
 - VPC Flow Logs delivery role + log group (DCF-406)
@@ -15,9 +16,8 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
   sibling `compliance-monitoring` stack and state.
 
 ## Applied via CLI (not in this stack — by design)
-These were one-time or region-spanning and live outside the stack; documented
+These were one-time resource cleanup/remediation actions and live outside the stack; documented
 in `../../compliance/SOC2-DRATA-REMEDIATION.md`:
-- GuardDuty in the other 15 regions
 - Deletion of 15 empty regional default VPCs
 - Per-VPC flow logs, default-SG stripping, and NACL deny (22/3389) for the 5 us-west-2 VPCs
 - S3 per-bucket versioning / TLS-deny policy / access-logging

--- a/infra/terraform/security-baseline/imports.tf
+++ b/infra/terraform/security-baseline/imports.tf
@@ -19,7 +19,7 @@ import {
 }
 import {
   to = aws_cloudtrail.management_events
-  id = "management-events"
+  id = "arn:aws:cloudtrail:us-east-1:935064898258:trail/management-events"
 }
 import {
   to = aws_guardduty_detector.usw2
@@ -28,6 +28,66 @@ import {
 import {
   to = aws_guardduty_detector.use1
   id = "c4cf47395e33e146a188d9a061f25c0f"
+}
+import {
+  to = aws_guardduty_detector.aps1
+  id = "48cf47392817ef3fdf6841bf156b8e97"
+}
+import {
+  to = aws_guardduty_detector.eun1
+  id = "80cf47392cd5a5f04acf3d8241e1d070"
+}
+import {
+  to = aws_guardduty_detector.euw3
+  id = "aecf47392fbccdeea9d8e7a675d730cb"
+}
+import {
+  to = aws_guardduty_detector.euw2
+  id = "f2cf473932e9e3135c033f395a4a8e09"
+}
+import {
+  to = aws_guardduty_detector.euw1
+  id = "c8cf473935f2098f92cd348ce457a876"
+}
+import {
+  to = aws_guardduty_detector.apne3
+  id = "c6cf47393b49f00d86993fa2f8d935c4"
+}
+import {
+  to = aws_guardduty_detector.apne2
+  id = "96cf47394043a5e0cac7e695bac98307"
+}
+import {
+  to = aws_guardduty_detector.apne1
+  id = "96cf473945687ac9917af8e2f67d20bb"
+}
+import {
+  to = aws_guardduty_detector.cac1
+  id = "8ccf4739494abaaecd7c1039c4e0308b"
+}
+import {
+  to = aws_guardduty_detector.sae1
+  id = "e6cf47394de6eb5b4572e8f969c837c0"
+}
+import {
+  to = aws_guardduty_detector.apse1
+  id = "90cf473952467ffb9f2c1d900106b5d3"
+}
+import {
+  to = aws_guardduty_detector.apse2
+  id = "e8cf4739581ddd4d866fd1034e98e406"
+}
+import {
+  to = aws_guardduty_detector.euc1
+  id = "16cf47395ad7d2a0f7de56805fb76881"
+}
+import {
+  to = aws_guardduty_detector.use2
+  id = "5ccf473961e8fd4cf9a328fb8b5f0670"
+}
+import {
+  to = aws_guardduty_detector.usw1
+  id = "b8cf473965d80b5fd3748b4c8fd8111e"
 }
 import {
   to = aws_s3_account_public_access_block.this

--- a/infra/terraform/security-baseline/main.tf
+++ b/infra/terraform/security-baseline/main.tf
@@ -76,21 +76,229 @@ resource "aws_cloudtrail" "management_events" {
 }
 
 # ════════════════════════════════════════════════════════════════════════════
-# GuardDuty — Drata DCF-87 (threat detection). Enabled in ALL 17 regions via CLI;
-# the two active regions are codified here. Add provider aliases for the rest if
-# you want full Terraform coverage.
+# GuardDuty — Drata DCF-87 (threat detection). GuardDuty is regional, so every
+# opted-in commercial region is managed even when it currently has no workload.
 # ════════════════════════════════════════════════════════════════════════════
 resource "aws_guardduty_detector" "usw2" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   enable                       = true
   finding_publishing_frequency = "SIX_HOURS"
   tags                         = local.tags
 }
 
 resource "aws_guardduty_detector" "use1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.use1
   enable                       = true
   finding_publishing_frequency = "SIX_HOURS"
   tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "aps1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.aps1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "eun1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.eun1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "euw3" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.euw3
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "euw2" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.euw2
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "euw1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.euw1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "apne3" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.apne3
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "apne2" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.apne2
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "apne1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.apne1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "cac1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.cac1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "sae1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.sae1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "apse1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.apse1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "apse2" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.apse2
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "euc1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.euc1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "use2" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.use2
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+resource "aws_guardduty_detector" "usw1" {
+  #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
+  provider                     = aws.usw1
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+  tags                         = local.tags
+}
+
+# EBS default encryption — Drata DCF-54. This account-level regional default is
+# enforced everywhere, including empty regions, so future volumes are encrypted
+# before a workload can make that region part of the compliance scope.
+resource "aws_ebs_encryption_by_default" "usw2" {
+  enabled = true
+}
+
+resource "aws_ebs_encryption_by_default" "use1" {
+  provider = aws.use1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "aps1" {
+  provider = aws.aps1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "eun1" {
+  provider = aws.eun1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "euw3" {
+  provider = aws.euw3
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "euw2" {
+  provider = aws.euw2
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "euw1" {
+  provider = aws.euw1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "apne3" {
+  provider = aws.apne3
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "apne2" {
+  provider = aws.apne2
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "apne1" {
+  provider = aws.apne1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "cac1" {
+  provider = aws.cac1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "sae1" {
+  provider = aws.sae1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "apse1" {
+  provider = aws.apse1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "apse2" {
+  provider = aws.apse2
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "euc1" {
+  provider = aws.euc1
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "use2" {
+  provider = aws.use2
+  enabled  = true
+}
+
+resource "aws_ebs_encryption_by_default" "usw1" {
+  provider = aws.usw1
+  enabled  = true
 }
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/infra/terraform/security-baseline/providers.tf
+++ b/infra/terraform/security-baseline/providers.tf
@@ -7,9 +7,9 @@
 # pipeline (.github/workflows/drata-compliance.yml) scans.
 #
 # State is isolated from the app envs (own key security/baseline.tfstate).
-# Region-spanning / one-time actions (GuardDuty in all 17 regions, deletion of
-# 15 empty default VPCs, per-VPC flow logs + NACL deny entries) were applied via
-# CLI — see README.md for why and how to reconcile.
+# One-time cleanup actions (deletion of 15 empty default VPCs, per-VPC flow logs
+# + NACL deny entries) were applied via CLI. Regional account controls such as
+# GuardDuty and EBS default encryption are managed here in all 17 regions.
 #
 # Adopt the already-live resources with `terraform plan` + the import blocks in
 # imports.tf, review the (should-be-empty) diff, then `terraform apply`.
@@ -32,6 +32,84 @@ provider "aws" {
 provider "aws" {
   alias  = "use1"
   region = "us-east-1"
+}
+
+# Every opted-in commercial region is explicit here because GuardDuty and EBS
+# default encryption are regional account controls. Keeping them in Terraform
+# prevents an unused region from silently drifting out of the security baseline.
+provider "aws" {
+  alias  = "aps1"
+  region = "ap-south-1"
+}
+
+provider "aws" {
+  alias  = "eun1"
+  region = "eu-north-1"
+}
+
+provider "aws" {
+  alias  = "euw3"
+  region = "eu-west-3"
+}
+
+provider "aws" {
+  alias  = "euw2"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "euw1"
+  region = "eu-west-1"
+}
+
+provider "aws" {
+  alias  = "apne3"
+  region = "ap-northeast-3"
+}
+
+provider "aws" {
+  alias  = "apne2"
+  region = "ap-northeast-2"
+}
+
+provider "aws" {
+  alias  = "apne1"
+  region = "ap-northeast-1"
+}
+
+provider "aws" {
+  alias  = "cac1"
+  region = "ca-central-1"
+}
+
+provider "aws" {
+  alias  = "sae1"
+  region = "sa-east-1"
+}
+
+provider "aws" {
+  alias  = "apse1"
+  region = "ap-southeast-1"
+}
+
+provider "aws" {
+  alias  = "apse2"
+  region = "ap-southeast-2"
+}
+
+provider "aws" {
+  alias  = "euc1"
+  region = "eu-central-1"
+}
+
+provider "aws" {
+  alias  = "use2"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "usw1"
+  region = "us-west-1"
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
## Summary
- manage GuardDuty and EBS default encryption in every opted-in AWS region
- import all live GuardDuty detectors into the security-baseline state
- fix the CloudTrail import identifier to use its required ARN
- document the Checkov organization-level exception for the reseller-owned billing organization

## Verification
- `terraform fmt -check`
- `terraform validate`
- `tflint --format compact`
- focused Checkov: 0 failed, 17 documented skips for CKV2_AWS_3
- targeted Terraform apply: 17 imported, 17 added, 17 changed, 0 destroyed
- post-apply targeted plan: no changes
- live AWS: 17/17 GuardDuty detectors ENABLED; 17/17 regions EBS default encryption true
- SNS email subscriptions confirmed in us-west-2 and eu-west-2

## Safety
The targeted apply excluded all unrelated pre-existing security-baseline drift. No customer or demo resources are introduced.