### PR TITLE
fix(sandbox-agent-server): terminal lookup-or-create pty, stop 'pty not found' close

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
@@ -291,17 +291,136 @@ describe('kortix-native pty', () => {
     }
   })
 
-  it('closes the websocket with pty-not-found for an unknown id', async () => {
+  it('lookup-or-create: mints a fresh, working pty for an unknown id instead of closing', async () => {
+    const proxy = startTestProxy()
+    try {
+      const unknownId = 'kpty_does_not_exist'
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${proxy.port}/kortix/pty/${unknownId}/connect`,
+        { headers: { [KORTIX_USER_CONTEXT_HEADER]: signCtx() } } as any,
+      )
+      await waitForOpen(ws)
+      // The new pty reuses the requested id, so the client's existing
+      // tab/URL/list-cache key keeps working with zero protocol changes.
+      const listRes = await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty`, { headers: authHeaders() })
+      const list = (await listRes.json()) as PtyMeta[]
+      expect(list.some((p) => p.id === unknownId && p.status === 'running')).toBe(true)
+
+      // It's a genuine live shell, not a stub — commands actually execute.
+      ws.send("printf 'LOOKUP_OR_CREATE_MARKER\\n'\n")
+      await waitForData(ws, (acc) => acc.includes('LOOKUP_OR_CREATE_MARKER'))
+      ws.close()
+
+      await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty/${unknownId}`, { method: 'DELETE', headers: authHeaders() })
+    } finally {
+      await proxy.stop()
+    }
+  })
+
+  it('lookup-or-create: mints a fresh pty when the client supplies no id at all', async () => {
     const proxy = startTestProxy()
     try {
       const ws = new WebSocket(
-        `ws://127.0.0.1:${proxy.port}/kortix/pty/kpty_does_not_exist/connect`,
+        `ws://127.0.0.1:${proxy.port}/kortix/pty/connect`,
+        { headers: { [KORTIX_USER_CONTEXT_HEADER]: signCtx() } } as any,
+      )
+      await waitForOpen(ws)
+      ws.send("printf 'NO_ID_MARKER\\n'\n")
+      await waitForData(ws, (acc) => acc.includes('NO_ID_MARKER'))
+      ws.close()
+
+      const listRes = await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty`, { headers: authHeaders() })
+      const list = (await listRes.json()) as PtyMeta[]
+      expect(list.some((p) => p.status === 'running')).toBe(true)
+    } finally {
+      await proxy.stop()
+    }
+  })
+
+  it('lookup-or-create: reattaches to a valid running id instead of recreating (reconnect semantics preserved)', async () => {
+    const proxy = startTestProxy()
+    try {
+      const created = await createPty(proxy.port, { command: 'bash', args: ['-c', 'sleep 5'] })
+      const url = `ws://127.0.0.1:${proxy.port}/kortix/pty/${created.id}/connect`
+      const headers = { [KORTIX_USER_CONTEXT_HEADER]: signCtx() }
+
+      const first = new WebSocket(url, { headers } as any)
+      await waitForOpen(first)
+      first.send("printf 'REATTACH_MARKER\\n'\n")
+      await waitForData(first, (acc) => acc.includes('REATTACH_MARKER'))
+      first.close()
+      await waitForClose(first)
+
+      // Reconnecting with the same still-running id resumes the SAME shell
+      // (same pid) rather than spawning a new one.
+      const second = new WebSocket(url, { headers } as any)
+      await waitForOpen(second)
+      second.close()
+
+      const listRes = await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty`, { headers: authHeaders() })
+      const list = (await listRes.json()) as PtyMeta[]
+      expect(list.find((p) => p.id === created.id)?.pid).toBe(created.pid)
+
+      await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty/${created.id}`, { method: 'DELETE', headers: authHeaders() })
+    } finally {
+      await proxy.stop()
+    }
+  })
+
+  it('lookup-or-create: a known-exited pty closes cleanly instead of being silently reincarnated', async () => {
+    const proxy = startTestProxy()
+    try {
+      // A command that exits immediately — entry stays in the registry with
+      // status 'exited' until an explicit DELETE (see finish() in pty.ts).
+      const created = await createPty(proxy.port, { command: 'bash', args: ['-c', 'exit 7'] })
+
+      // Wait for the process to actually exit.
+      await Bun.sleep(200)
+      const listRes = await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty`, { headers: authHeaders() })
+      const list = (await listRes.json()) as PtyMeta[]
+      expect(list.find((p) => p.id === created.id)?.status).toBe('exited')
+
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${proxy.port}/kortix/pty/${created.id}/connect`,
         { headers: { [KORTIX_USER_CONTEXT_HEADER]: signCtx() } } as any,
       )
       const closed = await waitForClose(ws)
-      expect(closed.reason).toBe('pty not found')
+      expect(closed.reason).toContain('pty exited')
+
+      await fetch(`http://127.0.0.1:${proxy.port}/kortix/pty/${created.id}`, { method: 'DELETE', headers: authHeaders() })
     } finally {
       await proxy.stop()
+    }
+  })
+
+  it('lookup-or-create: survives a daemon-restart-like registry loss — reconnecting with the old id gets a working shell', async () => {
+    // Simulates exactly the reported bug: a client holds a ptyId minted by a
+    // previous daemon process. A full daemon/container restart wipes the
+    // in-memory registry (unlike an opencode-only restart, which the pty
+    // registry is designed to survive). The client then reconnects with the
+    // now-unknown id — it must get a working terminal, not a hard failure.
+    const firstProxy = startTestProxy()
+    let staleId: string
+    try {
+      const created = await createPty(firstProxy.port, { command: 'bash', args: ['-c', 'sleep 5'] })
+      staleId = created.id
+    } finally {
+      await firstProxy.stop()
+    }
+
+    // A brand-new daemon process (fresh in-memory registry), same port range.
+    const secondProxy = startTestProxy()
+    try {
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${secondProxy.port}/kortix/pty/${staleId}/connect`,
+        { headers: { [KORTIX_USER_CONTEXT_HEADER]: signCtx() } } as any,
+      )
+      await waitForOpen(ws)
+      ws.send("printf 'RESTART_RECOVERY_MARKER\\n'\n")
+      await waitForData(ws, (acc) => acc.includes('RESTART_RECOVERY_MARKER'))
+      ws.close()
+    } finally {
+      await secondProxy.stop()
     }
   })
 

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -32,7 +32,10 @@ const STRIP_REQUEST_HEADERS = new Set([
 
 const STRIP_RESPONSE_HEADERS = new Set(['transfer-encoding', 'connection'])
 
-const KORTIX_PTY_WS_PATH_RE = /^\/kortix\/pty\/([^/]+)\/connect\/?$/
+// The id segment is optional: connecting with no id (or an id the daemon
+// doesn't recognize) still opens a working terminal — see the lookup-or-
+// create handling in the `open` websocket handler below.
+const KORTIX_PTY_WS_PATH_RE = /^\/kortix\/pty(?:\/([^/]+))?\/connect\/?$/
 const KORTIX_USER_CONTEXT_QUERY_PARAM = '__kortix_user_context'
 
 // Bound on waiting for opencode to respond to a proxied request. Applied only
@@ -50,7 +53,9 @@ const KORTIX_USER_CONTEXT_QUERY_PARAM = '__kortix_user_context'
 const UPSTREAM_RESPONSE_TIMEOUT_MS = 10_000
 
 type OpencodeWsData = {
-  ptyId: string
+  // Absent when the client connects without an id — lookup-or-create then
+  // mints a brand new pty (see `websocket.open` below).
+  ptyId?: string
   handle?: PtyAttachHandle
 }
 
@@ -74,7 +79,9 @@ function prepareKortixPtyWsUpgrade(
   if (!match) {
     return { ok: false, response: jsonError(404, { error: 'unsupported websocket path' }) }
   }
-  const ptyId = match[1]!
+  // Absent when the client connects with no id segment at all (e.g.
+  // `/kortix/pty/connect`) — lookup-or-create mints a fresh pty either way.
+  const ptyId = match[1]
 
   if (!cfg.sandboxToken) {
     logger.warn('[pty] rejecting websocket: KORTIX_TOKEN not configured')
@@ -355,9 +362,20 @@ export function startProxy(
       return app.fetch(req, srv)
     },
     websocket: {
+      // Lookup-or-create: a normal "open a terminal" must always succeed
+      // with a working shell. A requested id that names a running pty
+      // reattaches (a genuine reconnect resumes the same shell +
+      // scrollback). A missing/unknown/absent id — the daemon restarted
+      // and forgot its in-memory registry, a stale id survived a reload, or
+      // no id was supplied at all — mints a fresh pty instead of hard-
+      // closing with "pty not found". Only a *known-exited* pty (the shell
+      // itself ended, e.g. the user typed `exit`) closes without recreating
+      // — that's a real end-of-session the client should surface, not
+      // silently paper over.
       open(ws: ServerWebSocket<OpencodeWsData>) {
         const state = ws.data
-        const handle = ptyRegistry.attach(state.ptyId, {
+        const requestedId = state.ptyId
+        const result = ptyRegistry.attachOrCreate(requestedId, {
           onData: (chunk) => {
             try { ws.send(chunk) } catch {}
           },
@@ -365,13 +383,22 @@ export function startProxy(
             try { ws.close(1000, `pty exited${exitCode === null ? '' : ` (${exitCode})`}`) } catch {}
           },
         })
-        if (!handle) {
-          try { ws.close(1011, 'pty not found') } catch {}
+        if (result.kind === 'exited') {
+          try {
+            ws.close(1000, `pty exited${result.meta.exitCode === undefined ? '' : ` (${result.meta.exitCode})`}`)
+          } catch {}
           return
         }
-        state.handle = handle
-        if (handle.replay) {
-          try { ws.send(handle.replay) } catch {}
+        state.ptyId = result.meta.id
+        state.handle = result.handle
+        if (result.kind === 'created') {
+          logger.info('[proxy] pty websocket lookup-or-create minted a new pty', {
+            requestedId: requestedId ?? null,
+            id: result.meta.id,
+          })
+        }
+        if (result.handle.replay) {
+          try { ws.send(result.handle.replay) } catch {}
         }
       },
       message(ws: ServerWebSocket<OpencodeWsData>, message: string | Buffer) {

--- a/apps/kortix-sandbox-agent-server/src/routes/pty.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/pty.ts
@@ -55,7 +55,27 @@ export interface PtyRegistry {
   remove(id: string): boolean
   /** Attach a live viewer to a running pty — used by the WS bridge in proxy.ts. */
   attach(id: string, viewer: Viewer): PtyAttachHandle | null
+  /**
+   * Lookup-or-create: the WS bridge's single entry point for "open a
+   * terminal". A requested id that names a *running* entry reattaches (a
+   * genuine reconnect resumes the same shell + scrollback). A requested id
+   * that names an *exited* entry reports that explicitly so the caller can
+   * tell the client the session really ended (never silently reincarnated —
+   * the user may have typed `exit` on purpose). Every other case — id
+   * missing from the registry entirely (daemon restarted and forgot it, a
+   * stale id from a reload, a create/attach race) or no id supplied at all —
+   * mints a fresh pty and attaches to it instead of failing. When a
+   * requested id is supplied but unknown, the new entry reuses that exact
+   * id so the caller's existing bookkeeping (tab/URL/list-cache key) keeps
+   * working with zero protocol changes.
+   */
+  attachOrCreate(id: string | undefined, viewer: Viewer): AttachOrCreateResult
 }
+
+export type AttachOrCreateResult =
+  | { kind: 'attached'; meta: KortixPtyMeta; handle: PtyAttachHandle }
+  | { kind: 'created'; meta: KortixPtyMeta; handle: PtyAttachHandle }
+  | { kind: 'exited'; meta: KortixPtyMeta }
 
 /**
  * In-memory PTY registry, owned for the life of the daemon process (a
@@ -88,59 +108,87 @@ export function createPtyRegistry(cfg: Config): PtyRegistry {
     entry.viewers.clear()
   }
 
+  // Shared by `create()` (HTTP — always mints a fresh id) and
+  // `attachOrCreate()` (WS lookup-or-create — reuses the requested id when
+  // one was supplied, so a caller reconnecting after a registry loss keeps
+  // its existing tab/URL/list-cache key working unmodified).
+  function spawnEntry(
+    id: string,
+    opts: { command?: string; args?: string[]; cwd?: string; title?: string; env?: Record<string, string> },
+  ): PtyEntry {
+    const command = opts.command?.trim() || process.env.SHELL || '/bin/bash'
+    const args = opts.args ?? (opts.command ? [] : ['-l'])
+    const cwd = opts.cwd || cfg.workspace
+    const env = {
+      ...process.env,
+      TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
+      ...(opts.env ?? {}),
+    }
+
+    const entry: PtyEntry = {
+      meta: {
+        id,
+        title: opts.title?.trim() || command,
+        command,
+        args,
+        cwd,
+        status: 'running',
+        pid: 0,
+      },
+      proc: undefined as unknown as ReturnType<typeof Bun.spawn>,
+      scrollback: [],
+      scrollbackBytes: 0,
+      viewers: new Set(),
+    }
+
+    const proc = Bun.spawn([command, ...args], {
+      cwd,
+      env,
+      onExit: (_subprocess, exitCode) => {
+        finish(entry, exitCode)
+      },
+      terminal: {
+        cols: 80,
+        rows: 24,
+        name: 'xterm-256color',
+        data: (_terminal, data) => {
+          broadcast(entry, Buffer.from(data).toString())
+        },
+      },
+    })
+
+    entry.proc = proc
+    entry.meta.pid = proc.pid
+    entries.set(id, entry)
+    return entry
+  }
+
+  function buildHandle(entry: PtyEntry, viewer: Viewer): PtyAttachHandle {
+    entry.viewers.add(viewer)
+    return {
+      replay: entry.scrollback.join(''),
+      write: (data) => {
+        try { entry.proc.terminal?.write(data) } catch {}
+      },
+      resize: (cols, rows) => {
+        try { entry.proc.terminal?.resize(cols, rows) } catch {}
+      },
+      detach: () => {
+        entry.viewers.delete(viewer)
+      },
+    }
+  }
+
   return {
     list() {
       return [...entries.values()].map((e) => ({ ...e.meta }))
     },
 
     create(opts) {
-      const command = opts.command?.trim() || process.env.SHELL || '/bin/bash'
-      const args = opts.args ?? (opts.command ? [] : ['-l'])
-      const cwd = opts.cwd || cfg.workspace
       const id = `kpty_${randomUUID().replace(/-/g, '')}`
-      const env = {
-        ...process.env,
-        TERM: 'xterm-256color',
-        COLORTERM: 'truecolor',
-        ...(opts.env ?? {}),
-      }
-
-      const entry: PtyEntry = {
-        meta: {
-          id,
-          title: opts.title?.trim() || command,
-          command,
-          args,
-          cwd,
-          status: 'running',
-          pid: 0,
-        },
-        proc: undefined as unknown as ReturnType<typeof Bun.spawn>,
-        scrollback: [],
-        scrollbackBytes: 0,
-        viewers: new Set(),
-      }
-
-      const proc = Bun.spawn([command, ...args], {
-        cwd,
-        env,
-        onExit: (_subprocess, exitCode) => {
-          finish(entry, exitCode)
-        },
-        terminal: {
-          cols: 80,
-          rows: 24,
-          name: 'xterm-256color',
-          data: (_terminal, data) => {
-            broadcast(entry, Buffer.from(data).toString())
-          },
-        },
-      })
-
-      entry.proc = proc
-      entry.meta.pid = proc.pid
-      entries.set(id, entry)
-      logger.info('[pty] created', { id, command, args, cwd, pid: proc.pid })
+      const entry = spawnEntry(id, opts)
+      logger.info('[pty] created', { id, command: entry.meta.command, args: entry.meta.args, cwd: entry.meta.cwd, pid: entry.meta.pid })
       return { ...entry.meta }
     },
 
@@ -165,19 +213,34 @@ export function createPtyRegistry(cfg: Config): PtyRegistry {
     attach(id, viewer) {
       const entry = entries.get(id)
       if (!entry || entry.meta.status !== 'running') return null
-      entry.viewers.add(viewer)
-      return {
-        replay: entry.scrollback.join(''),
-        write: (data) => {
-          try { entry.proc.terminal?.write(data) } catch {}
-        },
-        resize: (cols, rows) => {
-          try { entry.proc.terminal?.resize(cols, rows) } catch {}
-        },
-        detach: () => {
-          entry.viewers.delete(viewer)
-        },
+      return buildHandle(entry, viewer)
+    },
+
+    attachOrCreate(id, viewer) {
+      const entry = id ? entries.get(id) : undefined
+      if (entry) {
+        if (entry.meta.status === 'running') {
+          return { kind: 'attached', meta: { ...entry.meta }, handle: buildHandle(entry, viewer) }
+        }
+        // Present but exited: the shell really ended (e.g. the user typed
+        // `exit`). Report it plainly instead of silently reincarnating a
+        // session the user may have deliberately closed.
+        return { kind: 'exited', meta: { ...entry.meta } }
       }
+
+      // Id missing entirely (never existed, a stale id surviving a registry
+      // loss, a create/attach race) or no id supplied at all — a normal
+      // "open a terminal" always succeeds with a working shell. Reuse the
+      // requested id when present so the caller's existing bookkeeping
+      // (tab/URL/list-cache key) keeps working with zero protocol changes.
+      const newId = id || `kpty_${randomUUID().replace(/-/g, '')}`
+      const created = spawnEntry(newId, {})
+      logger.info('[pty] lookup-or-create minted a new pty', {
+        requestedId: id ?? null,
+        id: newId,
+        pid: created.meta.pid,
+      })
+      return { kind: 'created', meta: { ...created.meta }, handle: buildHandle(created, viewer) }
     },
   }
 }


### PR DESCRIPTION
## Summary

- Root cause: the daemon's in-memory PTY registry is process-local and wiped on a full daemon/container restart (unlike an opencode-only restart, which it's designed to survive). Any client reconnecting after that loss — or connecting with any id the daemon simply doesn't recognize (stale id from a reload, create/attach race) — hit a hard `ws.close(1011, 'pty not found')` in the WS `open` handler in `apps/kortix-sandbox-agent-server/src/proxy.ts`, with no server-side recovery. This surfaced as "Connection closed (…): pty not found" and a terminal that never worked.
- Fix: `PtyRegistry.attachOrCreate()` (new, in `apps/kortix-sandbox-agent-server/src/routes/pty.ts`) gives the WS bridge lookup-or-create semantics:
  - requested id names a **running** entry → reattach (genuine reconnect resumes the same shell + scrollback, unchanged behavior)
  - requested id names a **known-exited** entry → close explicitly with `pty exited …` (never silently reincarnate a session the user may have ended on purpose, e.g. typed `exit`)
  - id missing/unknown/absent entirely → mint a fresh pty and attach. When a requested id was supplied but unknown, the new entry **reuses that exact id**, so an existing client's tab/URL/list-cache key keeps working with zero wire-protocol changes.
- `apps/kortix-sandbox-agent-server/src/proxy.ts`'s WS route regex now also accepts a connect with no id segment at all (`/kortix/pty/connect`), which mints a brand new pty the same way.
- The web client already had a defensive replace-on-"pty not found" path from #4808 (`apps/web/src/features/session/pty-connection.ts` / `terminal-tab-content.tsx`); left untouched — it's a useful fallback for sandboxes still running the pre-fix daemon image during rollout, and now becomes mostly dead-weight-but-harmless once the new image is everywhere.

## Ship note — this requires a sandbox image rebuild

`apps/kortix-sandbox-agent-server` is the daemon baked into the sandbox snapshot/template, **not** deployed like `apps/api`/`apps/web`. This change only reaches running sessions once the sandbox image/snapshot is rebuilt and republished, and only for **sandboxes created after that** (existing running sandboxes keep the old daemon binary until they're recreated/restarted onto the new image — there is no live daemon hot-patch). No apps/api or apps/web changes were needed, so this PR alone does not require an API/web deploy; it needs whatever the standard "rebuild + publish default sandbox template" step is.

## Test plan
- [x] `bunx tsc --noEmit` clean in `apps/kortix-sandbox-agent-server`
- [x] `bun test` — 203 pass / 0 fail across the package, including 5 new/updated cases in `pty.test.ts`:
  - unknown id → mints a working pty reusing the requested id
  - no id supplied at all → mints a working pty
  - valid running id → reattaches to the *same* shell (pid unchanged), reconnect semantics preserved
  - known-exited id → still closes explicitly instead of being silently recreated
  - simulated daemon restart (fresh registry, second `startProxy` on a stale id from a first) → reconnect gets a working shell