### PR TITLE
fix(web): stop approve/deny resolve from double-toasting a generic 'Failed to perform action: not found'

### DIFF
--- a/apps/web/src/features/review-center/hooks/use-review-items.ts
+++ b/apps/web/src/features/review-center/hooks/use-review-items.ts
@@ -95,5 +95,17 @@ export function useResolveReviewApproval() {
     mutationFn: ({ executionId, decision }) =>
       resolveApproval(projectId, executionId, decision, 'once'),
     onSuccess: invalidate,
+    // Every call site (review-center-connected.tsx) passes its own call-time
+    // `onError` to `resolve.mutate(vars, { onError })` and shows a specific
+    // toast. Without this no-op, TanStack Query's `defaultMutationOptions()`
+    // merge falls back to the QueryClient's global default mutation
+    // `onError` (apps/web/src/app/react-query-provider.tsx), which ALSO
+    // fires — producing a second, generic "Failed to perform action:
+    // <message>" toast alongside the intended one. Same fix, same reasoning,
+    // as `resolveApprovalMutationOptions` in session-audit-shared.tsx, which
+    // this hook mirrors (same underlying `resolveApproval` action/endpoint —
+    // a stale inbox row can 404 with "not found" if it was already resolved
+    // elsewhere before the poll caught up).
+    onError: () => {},
   });
 }

--- a/apps/web/src/features/session/session-audit-shared.test.ts
+++ b/apps/web/src/features/session/session-audit-shared.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { MutationObserver, QueryClient } from '@tanstack/react-query';
+
+/**
+ * Regression coverage for the "Failed to perform action: not found" toast
+ * bug (reported firing near the chat composer / approval prompt, seemingly
+ * at random).
+ *
+ * Root cause: `resolveApprovalMutationOptions` (used by `useResolveApproval`)
+ * had no hook-level `onError`. Every call site
+ * (`SessionApprovalPrompt`, `SessionAuditPanel`,
+ * `SessionPendingApprovalsIndicator`) already passes its own call-time
+ * `onError` to `resolve.mutate(vars, { onError })` for a specific, actionable
+ * toast — but TanStack Query's `defaultMutationOptions()` does a plain
+ * `{...defaultOptions.mutations, ...hookOptions}` merge
+ * (`node_modules/@tanstack/query-core/.../queryClient.js`). Since the hook
+ * didn't set its own `onError`, the merge fell through to the QueryClient's
+ * global default mutation `onError`
+ * (`apps/web/src/app/react-query-provider.tsx`), which ALSO fires — in
+ * addition to, not instead of, the call-time one
+ * (`query-core/build/modern/mutation.js`: `this.options.onError` fires from
+ * `Mutation.execute()` independently of the `MutationObserver`-level
+ * call-time callbacks). That produced a confusing second toast — the global
+ * default's generic "Failed to <operation>: <message>" — most visibly when
+ * the resolve endpoint 404s with a bare "not found" (e.g. the target
+ * execution was already resolved elsewhere before the audit poll caught up;
+ * `apps/api` allows resolving with zero browsers open — see
+ * `session-chat.tsx`'s note on server-side `continueSession` delivery).
+ *
+ * This test drives the REAL exported mutation options through a real
+ * `MutationObserver` against a `QueryClient` configured exactly like
+ * `react-query-provider.tsx`'s global default, so it fails if the
+ * hook-level `onError: () => {}` opt-out is ever removed.
+ */
+
+const resolveApprovalMock = mock(async () => {
+  throw new Error('not found');
+});
+
+mock.module('@kortix/sdk/projects-client', () => ({
+  getSessionAudit: mock(async () => ({ actions: [] })),
+  listSessionsNeedingInput: mock(async () => ({ sessions: {}, total: 0 })),
+  resolveApproval: resolveApprovalMock,
+}));
+
+const { resolveApprovalMutationOptions } = await import('./session-audit-shared');
+
+/** Mirrors `apps/web/src/app/react-query-provider.tsx`'s global default
+ *  mutation `onError` shape closely enough to prove (or disprove) that it
+ *  fires — the exact toast text isn't the point, just whether the global
+ *  default handler runs at all for a given mutation. */
+function queryClientWithGlobalDefault(onGlobalError: (error: unknown) => void) {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: {
+        onError: onGlobalError,
+      },
+    },
+  });
+}
+
+describe('resolveApprovalMutationOptions', () => {
+  test('opts out of the QueryClient global default mutation onError', async () => {
+    const globalErrors: unknown[] = [];
+    const callSiteErrors: unknown[] = [];
+    const queryClient = queryClientWithGlobalDefault((e) => globalErrors.push(e));
+
+    const options = resolveApprovalMutationOptions('proj-1', 'session-1', queryClient);
+    const observer = new MutationObserver(queryClient, options);
+    // `useMutation()` subscribes internally via `useSyncExternalStore` — a
+    // live subscriber is required for the MutationObserver's call-time
+    // (`.mutate(vars, { onError })`) callbacks to fire at all.
+    const unsubscribe = observer.subscribe(() => {});
+
+    await observer
+      .mutate(
+        { executionId: 'exec-1', decision: 'approve' },
+        {
+          onError: (e) => callSiteErrors.push(e),
+        },
+      )
+      .catch(() => {
+        // The mutation is expected to reject — the call-site (and, if the
+        // fix regresses, the global default) handles it via callbacks.
+      });
+
+    unsubscribe();
+
+    // The call site's own error handling still runs — this hook must keep
+    // that working.
+    expect(callSiteErrors).toHaveLength(1);
+    expect((callSiteErrors[0] as Error).message).toBe('not found');
+
+    // The QueryClient's global default onError must NOT also fire — that
+    // extra, generic "Failed to perform action: not found" toast is exactly
+    // the reported bug.
+    expect(globalErrors).toHaveLength(0);
+  });
+
+  test('still invalidates the shared audit query on settle after a failed resolve', async () => {
+    const queryClient = queryClientWithGlobalDefault(() => {});
+    const invalidateSpy = mock(() => Promise.resolve());
+    queryClient.invalidateQueries = invalidateSpy as typeof queryClient.invalidateQueries;
+
+    const options = resolveApprovalMutationOptions('proj-1', 'session-1', queryClient);
+    const observer = new MutationObserver(queryClient, options);
+    const unsubscribe = observer.subscribe(() => {});
+
+    await observer.mutate({ executionId: 'exec-1', decision: 'deny' }).catch(() => {});
+
+    unsubscribe();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['session-audit', 'proj-1', 'session-1'],
+    });
+  });
+});

--- a/apps/web/src/features/session/session-audit-shared.tsx
+++ b/apps/web/src/features/session/session-audit-shared.tsx
@@ -23,7 +23,13 @@ import {
   listSessionsNeedingInput,
   resolveApproval,
 } from '@kortix/sdk/projects-client';
-import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type QueryClient,
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 /**
@@ -116,10 +122,33 @@ export function useSessionAudit(
   });
 }
 
-/** Approve/deny mutation that invalidates the shared audit query on settle. */
-export function useResolveApproval(projectId: string | undefined, sessionId: string | undefined) {
-  const queryClient = useQueryClient();
-  return useMutation({
+/**
+ * Mutation options for approve/deny, extracted out of `useResolveApproval` so
+ * this is directly testable without rendering a component (see
+ * `session-audit-shared.test.ts`).
+ *
+ * Every call site (`SessionApprovalPrompt`, `SessionAuditPanel`,
+ * `SessionPendingApprovalsIndicator`) passes its own call-time `onError` to
+ * `resolve.mutate(vars, { onError })` and shows a specific, actionable toast
+ * (e.g. "Failed to resolve approval"). Without a hook-level `onError` here,
+ * TanStack Query's `defaultMutationOptions()` merge falls back to the
+ * QueryClient's global default mutation `onError`
+ * (`apps/web/src/app/react-query-provider.tsx`) — which ALSO fires, in
+ * addition to (not instead of) the call-time one. That produced a confusing
+ * SECOND toast — the generic "Failed to perform action: <message>" — anytime
+ * a resolve failed, most visibly when the target execution had already been
+ * resolved elsewhere (the resolve endpoint can be hit with zero browsers
+ * open, and the audit poll can lag a few seconds behind), which 404s with a
+ * bare "not found". The no-op `onError` below opts this mutation out of the
+ * global default, matching the same pattern already used by
+ * `useAbortOpenCodeSession` — every consumer already owns its own error UX.
+ */
+export function resolveApprovalMutationOptions(
+  projectId: string | undefined,
+  sessionId: string | undefined,
+  queryClient: QueryClient,
+) {
+  return {
     mutationFn: ({
       executionId,
       decision,
@@ -132,10 +161,22 @@ export function useResolveApproval(projectId: string | undefined, sessionId: str
       if (!projectId) throw new Error('No project in context');
       return resolveApproval(projectId, executionId, decision, scope);
     },
+    // See the jsdoc above `useResolveApproval` — opts out of the global
+    // default mutation `onError` so it doesn't double-toast alongside each
+    // call site's own, more specific error handling.
+    onError: () => {},
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: sessionAuditKey(projectId, sessionId) });
     },
-  });
+  };
+}
+
+/** Approve/deny mutation that invalidates the shared audit query on settle —
+ *  see `resolveApprovalMutationOptions` above for why it opts out of the
+ *  global default mutation `onError`. */
+export function useResolveApproval(projectId: string | undefined, sessionId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation(resolveApprovalMutationOptions(projectId, sessionId, queryClient));
 }
 
 export function riskTone(risk: string | null): 'destructive' | 'warning' | 'muted' {


### PR DESCRIPTION
## Summary
- Root cause: `useResolveApproval` (`apps/web/src/features/session/session-audit-shared.tsx`) had no hook-level `onError`. Every call site (`SessionApprovalPrompt` — pinned above the composer, `SessionAuditPanel`, `SessionPendingApprovalsIndicator`) already passes its own call-time `onError` to `resolve.mutate(vars, { onError })` and shows a specific toast. TanStack Query's `defaultMutationOptions()` does a plain `{...defaultOptions.mutations, ...hookOptions}` merge, so when the hook doesn't set its own `onError`, it falls back to the QueryClient's *global default* mutation `onError` (`apps/web/src/app/react-query-provider.tsx`, `operation: 'perform action'`) — which fires **in addition to**, not instead of, the call-time one (verified directly against `@tanstack/query-core`'s `Mutation.execute()`/`MutationObserver` — both callbacks run independently). That's the generic "Failed to perform action: `<message>`" toast — most visible when the resolve endpoint 404s with a bare "not found" because the target execution was already resolved elsewhere (server-side `continueSession` delivery can resolve an approval with zero browsers open) before the 15–20s audit poll caught up.
- This is a **double-toast bug**, not an ambient/optional 404 — the approve/deny action itself is correct and every surface already has dedicated error UX; the extra generic toast was pure noise from the framework-level merge.
- Fix: add a no-op `onError: () => {}` to the mutation (same pattern already used by `useAbortOpenCodeSession`) so it opts out of the global default and only the call site's own error handling runs. Applied to both `resolveApproval` consumers: `session-audit-shared.tsx` and the Review Center inbox's `useResolveReviewApproval` (`apps/web/src/features/review-center/hooks/use-review-items.ts`), which mirrors the same underlying action/endpoint and had the identical bug.
- Extracted `resolveApprovalMutationOptions` out of `useResolveApproval` so the fix is directly testable without rendering a component.

## Test plan
- [x] New `apps/web/src/features/session/session-audit-shared.test.ts`: drives the real exported mutation options through a real `MutationObserver`/`QueryClient` (configured like the app's global default) and asserts the global default `onError` does **not** fire while the call-site `onError` still does, plus that `onSettled` still invalidates the audit query. Manually verified this test fails without the fix (reverted the `onError: () => {}` line locally, saw the exact double-fire) and passes with it.
- [x] `bun test src/features/session/session-audit-shared.test.ts` — 2 pass.
- [x] `tsc --noEmit` on `apps/web` — no new errors (4 pre-existing, unrelated errors in generated `.source` files / markdown components).
- [x] `biome check` clean on all touched files.