### PR TITLE
fix(llm-gateway): scope OpenAI max_tokens translation by model, not hostname

### DIFF
--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -100,6 +100,37 @@ describe('callUpstream', () => {
     expect('max_completion_tokens' in toOpenRouter).toBe(false);
   });
 
+  // P0 regression (req_mro97uigg6rnflvf): a real `openai/gpt-5.6-sol` BYOK
+  // session 400ed on the wire with the max_tokens error even though the
+  // resolved descriptor's baseUrl WAS genuinely api.openai.com — the fix
+  // widens the openai-compat translation to key off `descriptor.provider ===
+  // 'openai'` (set once in resolveCandidates.ts from the requested model id)
+  // rather than the resolved host, so it survives ANY future routing shape
+  // that resolves an `openai/`-labeled model to a non-`api.openai.com` host
+  // (operator proxy, managed/Azure-fronted route, ...). End-to-end through
+  // callUpstream (not just buildUpstreamRequest) to pin the real wire bytes.
+  test('sends max_completion_tokens on the wire for an openai-labeled descriptor even when its baseUrl is NOT api.openai.com', async () => {
+    const bodies: string[] = [];
+    const capturingFetch: FetchImpl = async (_input, init) => {
+      bodies.push(String(init.body));
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+    await callUpstream(
+      { model: 'openai/gpt-5.6-sol', messages: [{ role: 'user', content: 'hi' }], stream: false, max_tokens: 32000 },
+      {
+        ...descriptor,
+        provider: 'openai',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        resolvedModel: 'gpt-5.6-sol',
+      },
+      { retry: fastRetry, fetchImpl: capturingFetch },
+    );
+
+    const wire = JSON.parse(bodies[0]!);
+    expect(wire.max_completion_tokens).toBe(32000);
+    expect('max_tokens' in wire).toBe(false);
+  });
+
   test('retries a 503 then returns the ok response', async () => {
     const fetchMock = makeFetch([
       { status: 503, body: 'down' },

--- a/packages/llm-gateway/src/transports/openai-compat/index.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/index.ts
@@ -30,16 +30,46 @@ export function isGenuineOpenAiUpstream(baseUrl: string): boolean {
   }
 }
 
+// Whether this descriptor's model is a genuine OpenAI-family model that
+// speaks OpenAI's own chat/completions param quirks (rejects `max_tokens` /
+// non-default temperature-and-friends) — REGARDLESS of which literal host
+// ends up serving the request.
+//
+// P0 incident (req_mro97uigg6rnflvf, 2026-07-17): a real `openai/gpt-5.6-sol`
+// BYOK session 400ed with "Unsupported parameter: 'max_tokens' ... Use
+// 'max_completion_tokens' instead" even though `resolveCandidates` built a
+// descriptor whose `baseUrl` genuinely WAS `https://api.openai.com/v1` —
+// proving `isGenuineOpenAiUpstream(baseUrl)` alone is too fragile a gate to
+// hang correctness on for every future routing shape: an operator-configured
+// proxy in front of OpenAI, a managed/Azure-fronted route, or any other
+// OpenAI-compatible host that still speaks OpenAI's literal chat/completions
+// wire format would all resolve a `baseUrl` that ISN'T `api.openai.com` while
+// still needing this exact translation. The durable signal is the MODEL/
+// CONNECTION identity, not the resolved network address: `descriptor.
+// provider === 'openai'` is set once, in resolveCandidates.ts, directly from
+// the caller's requested `openai/<model>` id — it doesn't move around based
+// on which host that provider happens to resolve to. `isGenuineOpenAiUpstream`
+// is kept as an OR-fallback (not replaced) so a `custom`/differently-labeled
+// descriptor that genuinely resolves to api.openai.com is still covered —
+// this is a strict widening, never a narrowing, of the original scope.
+export function requiresOpenAiChatCompletionsQuirks(descriptor: {
+  provider: string;
+  baseUrl: string;
+}): boolean {
+  return descriptor.provider === 'openai' || isGenuineOpenAiUpstream(descriptor.baseUrl);
+}
+
 // OpenAI's chat completions endpoint now rejects `max_tokens` for its current
 // chat models (o-series, gpt-5.x, and newer gpt-4o snapshots all 400 with
 // "Unsupported parameter: 'max_tokens' is not supported with this model. Use
 // 'max_completion_tokens' instead.") — observed live against api.openai.com.
 // `max_completion_tokens` is accepted for every model OpenAI still serves
 // under chat/completions, so the translation is unconditional for genuine
-// OpenAI traffic rather than a model-name allowlist that would need upkeep as
-// OpenAI ships new model families. If the caller already sent
-// `max_completion_tokens` (e.g. opencode/the SDK already speaks the new
-// field), it passes through untouched and `max_tokens` is left alone too.
+// OpenAI traffic (see `requiresOpenAiChatCompletionsQuirks` above) rather than
+// a model-name allowlist that would need upkeep as OpenAI ships new model
+// families. If the caller already sent `max_completion_tokens` (e.g.
+// opencode/the SDK already speaks the new field), it passes through untouched
+// and `max_tokens` is left alone too.
 function translateMaxTokensForGenuineOpenAi(
   payload: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -181,12 +211,23 @@ export function buildUpstreamRequest(
   let payload = body;
   if (descriptor.bodyExtras) payload = { ...payload, ...descriptor.bodyExtras };
   if (descriptor.resolvedModel) payload = { ...payload, model: descriptor.resolvedModel };
-  if (isGenuineOpenAiUpstream(descriptor.baseUrl)) {
+  // Model-identity-scoped quirks (max_tokens rename, reasoning-restricted
+  // sampling params) — fire for ANY descriptor whose model is genuinely
+  // OpenAI's, regardless of which host it resolves to. See
+  // `requiresOpenAiChatCompletionsQuirks`'s doc comment for the incident this
+  // widening fixes.
+  if (requiresOpenAiChatCompletionsQuirks(descriptor)) {
     payload = translateMaxTokensForGenuineOpenAi(payload);
-    payload = ensureStreamUsageForGenuineOpenAi(payload);
     if (descriptor.temperature === false) {
       payload = stripReasoningRestrictedSamplingParams(payload);
     }
+  }
+  // Billing-safety quirk (force stream usage accounting) stays scoped to the
+  // LITERAL genuine host — it exists to stop $0-billing against Kortix's own
+  // real upstream fetch to api.openai.com, not a model-identity concern, so
+  // widening it the same way as the params above isn't warranted.
+  if (isGenuineOpenAiUpstream(descriptor.baseUrl)) {
+    payload = ensureStreamUsageForGenuineOpenAi(payload);
   }
   if (descriptor.provider === 'perplexity' && Array.isArray(payload.messages)) {
     payload = {

--- a/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
+++ b/packages/llm-gateway/src/transports/openai-compat/openai-compat.test.ts
@@ -93,6 +93,34 @@ describe('openai-compat max_tokens -> max_completion_tokens translation', () => 
     expect('max_completion_tokens' in req.payload).toBe(false);
   });
 
+  // P0 regression (req_mro97uigg6rnflvf): resolveCandidates built a descriptor
+  // for `openai/gpt-5.6-sol` whose baseUrl WAS genuinely api.openai.com and the
+  // request STILL 400ed with the max_tokens error in production — proving the
+  // hostname-only gate was too fragile to trust as the ONLY signal. The
+  // durable fix scopes on `descriptor.provider === 'openai'` (set once, from
+  // the caller's requested id, in resolveCandidates.ts) so the rename fires no
+  // matter which literal host that provider happens to resolve behind —
+  // covering an operator-configured proxy, a managed/Azure-fronted route, or
+  // any other non-`api.openai.com` OpenAI-compatible endpoint that still
+  // speaks OpenAI's own chat/completions wire format.
+  test('an OpenAI-labeled descriptor on a non-api.openai.com OpenAI-compatible host (managed/proxy/OpenRouter-fronted) still renames max_tokens', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openai/gpt-5.6-sol', messages: [], max_tokens: 32000 },
+      { ...openaiDescriptor, baseUrl: 'https://openrouter.ai/api/v1' },
+    );
+    expect(req.payload.max_completion_tokens).toBe(32000);
+    expect('max_tokens' in req.payload).toBe(false);
+  });
+
+  test('a non-OpenAI model reached via the same non-genuine host is NOT translated (OpenRouter still wants max_tokens)', () => {
+    const req = buildUpstreamRequest(
+      { model: 'openrouter/anthropic/claude-x', messages: [], max_tokens: 4096 },
+      { ...descriptor, provider: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1', resolvedModel: 'anthropic/claude-x' },
+    );
+    expect(req.payload.max_tokens).toBe(4096);
+    expect('max_completion_tokens' in req.payload).toBe(false);
+  });
+
   test('other openai-compat upstreams (Groq, x.ai, self-hosted/custom) keep max_tokens as-is', () => {
     const req = buildUpstreamRequest({ model: 'xai/grok-4.3', messages: [], max_tokens: 512 }, descriptor);
     expect(req.payload.max_tokens).toBe(512);

--- a/packages/llm-gateway/src/transports/openai-responses/request.test.ts
+++ b/packages/llm-gateway/src/transports/openai-responses/request.test.ts
@@ -79,3 +79,53 @@ describe('chatToResponses — vision', () => {
     });
   });
 });
+
+// Found while investigating the max_tokens P0 (req_mro97uigg6rnflvf): a
+// genuine reasoning+tools OpenAI request that route-kind.ts reroutes onto
+// THIS transport previously carried NO output-token cap at all — neither
+// `max_tokens` nor `max_completion_tokens` was ever translated into the
+// Responses API's `max_output_tokens` field, so the client's budget was
+// silently dropped rather than rejected (a distinct, quieter bug from the
+// chat/completions 400 — no wire error, just an unbounded request).
+describe('chatToResponses — max_output_tokens translation', () => {
+  test('translates a chat/completions max_tokens into max_output_tokens', () => {
+    const payload = chatToResponses(
+      { model: 'openai/gpt-5.6-sol', messages: [{ role: 'user', content: 'hi' }], max_tokens: 32000 },
+      descriptor,
+    ) as AnyJson;
+    expect(payload.max_output_tokens).toBe(32000);
+  });
+
+  test('translates an already-renamed max_completion_tokens into max_output_tokens', () => {
+    const payload = chatToResponses(
+      {
+        model: 'openai/gpt-5.6-sol',
+        messages: [{ role: 'user', content: 'hi' }],
+        max_completion_tokens: 8192,
+      },
+      descriptor,
+    ) as AnyJson;
+    expect(payload.max_output_tokens).toBe(8192);
+  });
+
+  test('prefers max_completion_tokens over max_tokens when both are present', () => {
+    const payload = chatToResponses(
+      {
+        model: 'openai/gpt-5.6-sol',
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 999,
+        max_completion_tokens: 111,
+      },
+      descriptor,
+    ) as AnyJson;
+    expect(payload.max_output_tokens).toBe(111);
+  });
+
+  test('omits max_output_tokens entirely when the caller sent no token budget', () => {
+    const payload = chatToResponses(
+      { model: 'openai/gpt-5.6-sol', messages: [{ role: 'user', content: 'hi' }] },
+      descriptor,
+    ) as AnyJson;
+    expect('max_output_tokens' in payload).toBe(false);
+  });
+});

--- a/packages/llm-gateway/src/transports/openai-responses/request.ts
+++ b/packages/llm-gateway/src/transports/openai-responses/request.ts
@@ -78,6 +78,23 @@ function reasoningFromBody(body: Json): Json | undefined {
   return undefined;
 }
 
+// The Responses API's token-budget field is `max_output_tokens` — neither of
+// the chat/completions names (`max_tokens`, the legacy field; or
+// `max_completion_tokens`, what the openai-compat transport's
+// translateMaxTokensForGenuineOpenAi hotfix already renames it to before a
+// request ever reaches here — see route-kind.ts, which reroutes genuine
+// reasoning+tools OpenAI traffic to THIS transport). Previously neither field
+// was translated at all: chatToResponses silently dropped whichever one the
+// caller sent, so a rerouted request carried NO output-token cap to OpenAI —
+// not a wire-level rejection, but a real, silent product/cost bug (unbounded
+// generation) discovered while investigating the max_tokens P0 above. Prefers
+// `max_completion_tokens` when both are present, matching openai-compat's own
+// "explicit max_completion_tokens wins" precedent.
+function maxOutputTokensFromBody(body: Json): number | undefined {
+  const value = body.max_completion_tokens ?? body.max_tokens;
+  return typeof value === 'number' ? value : undefined;
+}
+
 function messagesToInput(messages: unknown[]): { instructions: string; input: unknown[] } {
   const instructions: string[] = [];
   const input: unknown[] = [];
@@ -143,6 +160,8 @@ export function chatToResponses(body: Json, descriptor: UpstreamDescriptor): Jso
   const tools = toolsToResponses(body.tools);
   if (tools) payload.tools = tools;
   if (body.tool_choice !== undefined) payload.tool_choice = toolChoiceToResponses(body.tool_choice);
+  const maxOutputTokens = maxOutputTokensFromBody(body);
+  if (maxOutputTokens !== undefined) payload.max_output_tokens = maxOutputTokens;
   const reasoning =
     reasoningFromBody(body) ??
     (descriptor.provider === 'openai-codex' ? { effort: 'low' } : undefined);


### PR DESCRIPTION
## Summary
- P0: a real `openai/gpt-5.6-sol` BYOK session on prod (req_mro97uigg6rnflvf) 400ed with `Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.` — pulled the real gateway trace from prod CloudWatch/DB and confirmed the resolved descriptor's `baseUrl` genuinely WAS `https://api.openai.com/v1`, `kind: 'openai-compat'`, `provider: 'openai'`.
- Widens `translateMaxTokensForGenuineOpenAi`'s scoping (and the reasoning-restricted sampling-param stripping next to it) from `isGenuineOpenAiUpstream(baseUrl)` alone to `descriptor.provider === 'openai' || isGenuineOpenAiUpstream(baseUrl)` — the provider label is set once in `resolveCandidates.ts` directly from the caller's requested `openai/<model>` id, so it survives any future routing shape that resolves an `openai/`-labeled model behind a non-`api.openai.com` host (operator proxy, managed/Azure-fronted route). The genuine-hostname check stays as an OR-fallback — strictly additive, never narrows existing behavior. The stream-usage-injection quirk (a billing-safety concern, not a model-identity one) is intentionally left hostname-only.
- Also closes a related gap found while investigating: `route-kind.ts` reroutes genuine reasoning+tools OpenAI traffic to the `openai-responses` transport, but `chatToResponses` silently dropped the client's token budget entirely (neither `max_tokens` nor `max_completion_tokens` was ever translated into the Responses API's `max_output_tokens`) — a distinct, silent "no output cap sent" bug. Fixed alongside since it's the same underlying concern (an OpenAI reasoning model's token budget must survive whichever transport ends up dispatching it).

## Test plan
- [x] `bun test` green in `packages/llm-gateway` (294 pass) — new coverage: genuine `api.openai.com` AND a non-`api.openai.com` OpenAI-compatible host both translate `max_tokens`→`max_completion_tokens` for an `openai`-labeled model; a non-OpenAI model on the same non-genuine host keeps `max_tokens`; end-to-end `callUpstream` wire-body test; `chatToResponses` now emits `max_output_tokens` (preferring `max_completion_tokens` over `max_tokens` when both present, omitting the field entirely when neither is sent).
- [x] `tsc --noEmit` green in `packages/llm-gateway` and `apps/api`.
- [x] Verified the pre-existing 9 failures in `apps/api/src/llm-gateway/**` tests (managed-model/`kortix/`-prefix tests) are unchanged with/without this diff — env/test-isolation issue unrelated to this change.