### PR TITLE
fix(api): model-defaults (and read endpoints) degrade gracefully when no provider key connected — stop 500

### DIFF
--- a/apps/api/src/llm-gateway/resolution/default-model.test.ts
+++ b/apps/api/src/llm-gateway/resolution/default-model.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { GatewayResolutionError } from '@kortix/llm-gateway';
+import * as resolveCandidatesModule from './resolve-candidates';
+import * as modelPreferencesModule from '../../repositories/model-preferences';
+import * as secretsModule from '../../projects/secrets';
+import {
+  invalidateAccountModelDefaults,
+  isModelServableForAccount,
+  resolveDefaultModelForPrincipal,
+  resolveEffectiveModel,
+} from './default-model';
+
+// The regression this whole file guards against: tonight's error-taxonomy
+// change made resolveCandidates THROW a typed GatewayResolutionError
+// (provider_not_connected, etc.) instead of returning `[]` when a model isn't
+// servable. That's correct for an actual generation request, but every
+// caller in default-model.ts (isModelServableForAccount, and everything that
+// probes through it — resolveDefaultModelForPrincipal used at auth time for
+// EVERY gateway request, and resolveEffectiveModel used by the
+// /model-defaults GET route + the model picker) was built against the old
+// return-`[]` contract.
+//
+// This spies on the individual named exports (spyOn + mock.restore()) rather
+// than replacing the whole modules with mock.module() — `./resolve-candidates`
+// is itself the system-under-test of resolve-candidates.test.ts, and
+// `../../repositories/model-preferences` / `../../projects/secrets` are each
+// mocked wholesale by OTHER sibling test files (seed-default.test.ts,
+// resolve-candidates.test.ts) with different shapes; mock.module() replaces a
+// module for the whole bun test PROCESS (every *.test.ts file runs together —
+// see scripts/test.sh), so it would corrupt those files' runs. spyOn+restore
+// is scoped to this file's own test lifecycle instead.
+
+let resolveCandidatesImpl: (model: string) => Promise<Array<{ provider: string }>> = async () => [];
+let accountDefaults: { account: string | null; agents: Record<string, string>; projects: Record<string, string> } = {
+  account: null,
+  agents: {},
+  projects: {},
+};
+let connectedSecretNames: string[] = [];
+
+beforeEach(() => {
+  resolveCandidatesImpl = async () => [];
+  accountDefaults = { account: null, agents: {}, projects: {} };
+  connectedSecretNames = [];
+  // resolveDefaultModelForPrincipal reads through a module-level 30s-TTL cache
+  // (cachedAccountDefaults) keyed by accountId — every test below reuses the
+  // same PRINCIPAL_BASE.accountId, so without this the FIRST test's defaults
+  // would silently serve every later test regardless of the fresh
+  // `accountDefaults` set above (a test-isolation footgun, not a prod bug: a
+  // real accountId is never reused cross-request within 30s in production).
+  invalidateAccountModelDefaults(PRINCIPAL_BASE.accountId);
+
+  spyOn(resolveCandidatesModule, 'resolveCandidates').mockImplementation(
+    // The real return is Promise<UpstreamDescriptor[]>; these tests only care
+    // about the LENGTH of the candidate list (servable = length > 0) and the
+    // typed-error throw path, so a minimal { provider } stub is enough — cast
+    // through the resolver's signature so tsc accepts the narrowed test double.
+    ((_principal: unknown, model: string) => resolveCandidatesImpl(model)) as typeof resolveCandidatesModule.resolveCandidates,
+  );
+  spyOn(modelPreferencesModule, 'getAccountModelDefaults').mockImplementation(async () => accountDefaults);
+  spyOn(modelPreferencesModule, 'getSessionAgentContext').mockImplementation(async () => null);
+  spyOn(secretsModule, 'listProjectSecretsSnapshot').mockImplementation(async () => ({
+    env: {},
+    names: connectedSecretNames,
+    revision: 'test',
+  }));
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+const PRINCIPAL_BASE = { userId: 'u1', accountId: 'a1', projectId: 'p1' };
+
+describe('isModelServableForAccount — never 500s a passive servability check', () => {
+  test('resolveCandidates throwing a typed GatewayResolutionError → false, not a throw', async () => {
+    resolveCandidatesImpl = async () => {
+      throw new GatewayResolutionError(
+        'provider_not_connected',
+        'No openrouter API key is connected for this project.',
+        'Add an openrouter API key in project settings, then retry.',
+      );
+    };
+    await expect(
+      isModelServableForAccount({ ...PRINCIPAL_BASE, freeModelsOnly: false, model: 'openrouter/some-model' }),
+    ).resolves.toBe(false);
+  });
+
+  test('every GatewayResolutionError reason collapses to false (model_not_found, plan_upgrade_required, ...)', async () => {
+    for (const reason of ['model_not_found', 'plan_upgrade_required', 'model_disabled_on_deployment'] as const) {
+      resolveCandidatesImpl = async () => {
+        throw new GatewayResolutionError(reason, 'nope', 'do something');
+      };
+      await expect(
+        isModelServableForAccount({ ...PRINCIPAL_BASE, freeModelsOnly: false, model: 'x/y' }),
+      ).resolves.toBe(false);
+    }
+  });
+
+  test('a non-GatewayResolutionError bug still propagates (never silently swallowed)', async () => {
+    resolveCandidatesImpl = async () => {
+      throw new Error('unexpected DB failure');
+    };
+    await expect(
+      isModelServableForAccount({ ...PRINCIPAL_BASE, freeModelsOnly: false, model: 'x/y' }),
+    ).rejects.toThrow('unexpected DB failure');
+  });
+
+  test('a real candidate list → true', async () => {
+    resolveCandidatesImpl = async () => [{ provider: 'openai' }];
+    await expect(
+      isModelServableForAccount({ ...PRINCIPAL_BASE, freeModelsOnly: false, model: 'openai/gpt-5.5' }),
+    ).resolves.toBe(true);
+  });
+});
+
+describe('resolveEffectiveModel — the /model-defaults GET + picker resolution path', () => {
+  test('nothing configured → platform default, no resolution/secrets calls at all', async () => {
+    const result = await resolveEffectiveModel({
+      ...PRINCIPAL_BASE,
+      freeModelsOnly: false,
+    });
+    expect(result).toEqual({ model: null, source: 'platform' });
+    expect(resolveCandidatesModule.resolveCandidates).not.toHaveBeenCalled();
+    expect(secretsModule.listProjectSecretsSnapshot).not.toHaveBeenCalled();
+  });
+
+  test('a servable configured project default is returned as-is (real source, no degrade)', async () => {
+    accountDefaults = { account: null, agents: {}, projects: { p1: 'openai/gpt-5.5' } };
+    resolveCandidatesImpl = async () => [{ provider: 'openai' }];
+    const result = await resolveEffectiveModel({ ...PRINCIPAL_BASE, freeModelsOnly: false });
+    expect(result).toEqual({ model: 'openai/gpt-5.5', source: 'project' });
+  });
+
+  test('THE ESSENTIA BUG: a stale/unservable configured default (e.g. disconnected openrouter) never 500s, and degrades to a provider the project HAS connected', async () => {
+    accountDefaults = { account: null, agents: {}, projects: { p1: 'openrouter/some-model' } };
+    // The configured openrouter default is no longer servable — no key connected.
+    resolveCandidatesImpl = async (model) => {
+      if (model === 'openrouter/some-model') {
+        throw new GatewayResolutionError(
+          'provider_not_connected',
+          'No openrouter API key is connected for this project.',
+          'Add an openrouter API key in project settings, then retry.',
+        );
+      }
+      return [{ provider: 'x' }];
+    };
+    // But the project HAS OpenAI (and Bedrock) BYOK connected.
+    connectedSecretNames = ['OPENAI_API_KEY', 'AWS_BEARER_TOKEN_BEDROCK'];
+
+    const result = await resolveEffectiveModel({ ...PRINCIPAL_BASE, freeModelsOnly: false });
+
+    // Never throws/500s, AND never surfaces the dead openrouter ref.
+    expect(result.model).not.toBeNull();
+    expect(result.model).not.toBe('openrouter/some-model');
+    expect(result.model?.startsWith('openrouter/')).toBe(false);
+    // Resolves to a model on a provider the project actually has a key for.
+    expect(result.model?.startsWith('openai/') || result.model?.startsWith('amazon-bedrock/')).toBe(true);
+    expect(result.source).toBe('platform');
+  });
+
+  test('stale configured default AND nothing connected → degrades to plain platform default (unchanged pre-existing behavior), still no throw', async () => {
+    accountDefaults = { account: null, agents: {}, projects: { p1: 'openrouter/some-model' } };
+    resolveCandidatesImpl = async () => {
+      throw new GatewayResolutionError('provider_not_connected', 'nope', 'connect it');
+    };
+    connectedSecretNames = [];
+
+    const result = await resolveEffectiveModel({ ...PRINCIPAL_BASE, freeModelsOnly: false });
+    expect(result).toEqual({ model: null, source: 'platform' });
+  });
+
+  test('an explicit pin that is unservable degrades through the same chain (never throws)', async () => {
+    accountDefaults = { account: null, agents: {}, projects: {} };
+    resolveCandidatesImpl = async () => {
+      throw new GatewayResolutionError('provider_not_connected', 'nope', 'connect it');
+    };
+    const result = await resolveEffectiveModel({
+      ...PRINCIPAL_BASE,
+      explicit: 'openrouter/some-model',
+      freeModelsOnly: false,
+    });
+    expect(result).toEqual({ model: null, source: 'platform' });
+  });
+});
+
+describe('resolveDefaultModelForPrincipal — the real "auto" resolution used at generation time', () => {
+  test('nothing configured → undefined (fast path, unchanged — never touches resolveCandidates)', async () => {
+    const result = await resolveDefaultModelForPrincipal({ ...PRINCIPAL_BASE, freeModelsOnly: false });
+    expect(result).toBeUndefined();
+    expect(resolveCandidatesModule.resolveCandidates).not.toHaveBeenCalled();
+  });
+
+  test('a stale/unservable configured default degrades to a CONNECTED provider, not an unconnected platform default, for a real chat/generation request', async () => {
+    accountDefaults = { account: 'openrouter/some-model', agents: {}, projects: {} };
+    resolveCandidatesImpl = async (model) => {
+      if (model === 'openrouter/some-model') {
+        throw new GatewayResolutionError('provider_not_connected', 'nope', 'connect it');
+      }
+      return [{ provider: 'x' }];
+    };
+    connectedSecretNames = ['OPENAI_API_KEY'];
+
+    const result = await resolveDefaultModelForPrincipal({ ...PRINCIPAL_BASE, freeModelsOnly: false });
+    expect(result).toBeDefined();
+    expect(result).not.toBe('openrouter/some-model');
+    expect(result?.startsWith('openai/')).toBe(true);
+  });
+
+  test('a stale configured default with nothing connected degrades to undefined (platform default applies), never throws', async () => {
+    accountDefaults = { account: 'openrouter/some-model', agents: {}, projects: {} };
+    resolveCandidatesImpl = async () => {
+      throw new GatewayResolutionError('provider_not_connected', 'nope', 'connect it');
+    };
+    connectedSecretNames = [];
+
+    const result = await resolveDefaultModelForPrincipal({ ...PRINCIPAL_BASE, freeModelsOnly: false });
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/api/src/llm-gateway/resolution/default-model.ts
+++ b/apps/api/src/llm-gateway/resolution/default-model.ts
@@ -1,5 +1,7 @@
-import type { AuthedPrincipal } from '@kortix/llm-gateway';
+import { type AuthedPrincipal, GatewayResolutionError } from '@kortix/llm-gateway';
 import { AUTO_MODEL_ID } from '@kortix/llm-catalog';
+import { connectedByokPickerModels } from '../models/picker-catalog';
+import { listProjectSecretsSnapshot } from '../../projects/secrets';
 import {
   type AccountModelDefaults,
   getAccountModelDefaults,
@@ -47,6 +49,29 @@ export function invalidateAccountModelDefaults(accountId: string): void {
   prefsCache.delete(accountId);
 }
 
+/**
+ * Last-resort degrade target when a configured default (or the platform
+ * default itself) turns out unservable: the flagship model of any BYOK
+ * provider the PROJECT has actually connected a key for. Reuses the exact
+ * connected-provider lookup the model picker uses (picker-catalog's
+ * connectedByokPickerModels) so "the default that's resolved/shown" and "the
+ * models a project can pick from" never disagree — a self-host project that
+ * connected OpenAI/Bedrock but not Codex/OpenRouter should land on ITS
+ * connected provider, never get stuck pointing at a provider it never
+ * connected. Returns null (→ the caller's unmodified platform default) when
+ * the project has no BYOK key connected at all, or has no project context.
+ */
+async function connectedByokFallback(projectId: string | undefined): Promise<string | null> {
+  if (!projectId) return null;
+  try {
+    const snapshot = await listProjectSecretsSnapshot(projectId);
+    const connected = new Set(snapshot.names.map((n) => n.toUpperCase()));
+    return connectedByokPickerModels(connected)[0]?.id ?? null;
+  } catch {
+    return null; // never let a secrets-read hiccup break default resolution
+  }
+}
+
 export async function resolveDefaultModelForPrincipal(
   principal: AuthedPrincipal,
 ): Promise<string | undefined> {
@@ -81,6 +106,7 @@ export async function resolveDefaultModelForPrincipal(
         freeModelsOnly: principal.freeModelsOnly ?? false,
         model: chosen as string,
       }),
+    () => connectedByokFallback(principal.projectId),
   );
   return kept ?? undefined;
 }
@@ -92,6 +118,19 @@ export async function resolveDefaultModelForPrincipal(
  * resolvable at request time (managed only when the tier grants it, BYOK only
  * when the provider key is connected, codex only when the credential exists).
  * `auto` is rejected: a stored default must be concrete.
+ *
+ * `resolveCandidates` THROWS a typed `GatewayResolutionError` (provider_not_
+ * connected, provider_reauth_required, model_disabled_on_deployment,
+ * model_not_found, plan_upgrade_required, ...) instead of returning `[]`
+ * whenever it can pin down WHY there's no upstream — the right shape for an
+ * actual generation request, where the caller wants the specific reason
+ * surfaced. This function answers a narrower yes/no question for every READ/
+ * defaults/picker/servability caller in this file (and r4.ts's PUT), so every
+ * one of those typed reasons collapses to "not servable" here — exactly the
+ * old return-`[]` behavior these callers were built against, restored. A
+ * passive "what's the default" read must never fail just because a provider
+ * key isn't connected; only an actual generation attempt should. Anything
+ * that ISN'T a GatewayResolutionError (a real bug) still propagates.
  */
 export async function isModelServableForAccount(params: {
   userId: string;
@@ -104,16 +143,21 @@ export async function isModelServableForAccount(params: {
   // Accept either the opencode ref (`kortix/<id>`) or the bare wire id — the
   // gateway resolves the bare id, so normalize before probing candidates.
   const wire = toWireModel(params.model);
-  const candidates = await resolveCandidates(
-    {
-      userId: params.userId,
-      accountId: params.accountId,
-      projectId: params.projectId,
-      freeModelsOnly: params.freeModelsOnly,
-    },
-    wire,
-  );
-  return candidates.length > 0;
+  try {
+    const candidates = await resolveCandidates(
+      {
+        userId: params.userId,
+        accountId: params.accountId,
+        projectId: params.projectId,
+        freeModelsOnly: params.freeModelsOnly,
+      },
+      wire,
+    );
+    return candidates.length > 0;
+  } catch (err) {
+    if (err instanceof GatewayResolutionError) return false;
+    throw err;
+  }
 }
 
 /**
@@ -153,16 +197,28 @@ export async function resolveEffectiveModel(params: {
     freeModelsOnly: params.freeModelsOnly,
   });
   // Degrade a stale/unservable resolved default (e.g. a BYOK model whose key was
-  // disconnected) to the platform default, so the UI's "resolved" model reflects
-  // what the gateway will actually serve rather than a dead ref.
-  const kept = await degradeUnservableDefault(chain.model, { hasProject: true }, () =>
-    isModelServableForAccount({
-      userId: params.userId,
-      accountId: params.accountId,
-      projectId: params.projectId,
-      freeModelsOnly: params.freeModelsOnly,
-      model: chain.model as string,
-    }),
+  // disconnected) to something the project can actually use right now, so the
+  // UI's "resolved" model reflects what the gateway will actually serve rather
+  // than a dead ref: first try any OTHER BYOK provider the project has
+  // connected (connectedByokFallback), then finally the bare platform default.
+  const kept = await degradeUnservableDefault(
+    chain.model,
+    { hasProject: true },
+    () =>
+      isModelServableForAccount({
+        userId: params.userId,
+        accountId: params.accountId,
+        projectId: params.projectId,
+        freeModelsOnly: params.freeModelsOnly,
+        model: chain.model as string,
+      }),
+    () => connectedByokFallback(params.projectId),
   );
-  return kept ? chain : { model: null, source: 'platform' };
+  if (!kept) return { model: null, source: 'platform' };
+  // kept === chain.model means the originally-configured default WAS servable
+  // (probe passed) — return it with its real source (agent/project/account).
+  // Any other value is the connected-provider fallback degrade target, which
+  // isn't the account's configured choice, so it's labeled 'platform' like
+  // every other degrade-to-something-usable case.
+  return kept === chain.model ? chain : { model: kept, source: 'platform' };
 }

--- a/apps/api/src/llm-gateway/resolution/effective.test.ts
+++ b/apps/api/src/llm-gateway/resolution/effective.test.ts
@@ -147,4 +147,59 @@ describe('degradeUnservableDefault — stale default guard', () => {
       ),
     ).toBeNull();
   });
+
+  test('unservable default + no fallback supplied → platform (omitting fallback preserves old behavior exactly)', async () => {
+    expect(
+      await degradeUnservableDefault('openrouter/some-model', { hasProject: true }, async () => false),
+    ).toBeNull();
+  });
+
+  test('unservable default + a fallback that finds nothing → still platform', async () => {
+    expect(
+      await degradeUnservableDefault(
+        'openrouter/some-model',
+        { hasProject: true },
+        async () => false,
+        async () => null,
+      ),
+    ).toBeNull();
+  });
+
+  test('unservable default + a fallback that finds a connected provider → the fallback model, not platform (the essentia bug)', async () => {
+    // A stale/disconnected openrouter default degrades to whatever the project
+    // ACTUALLY has connected (e.g. its own OpenAI BYOK key) instead of silently
+    // falling all the way to a platform default that may ALSO be unusable
+    // (e.g. Codex, also unconnected).
+    expect(
+      await degradeUnservableDefault(
+        'openrouter/some-model',
+        { hasProject: true },
+        async () => false,
+        async () => 'openai/gpt-5.5',
+      ),
+    ).toBe('openai/gpt-5.5');
+  });
+
+  test('a servable default never calls the fallback at all', async () => {
+    const neverFallback = () => {
+      throw new Error('fallback must not be called when the probe passes');
+    };
+    expect(
+      await degradeUnservableDefault(
+        'anthropic/claude-opus-4-8',
+        { hasProject: true },
+        async () => true,
+        neverFallback,
+      ),
+    ).toBe('anthropic/claude-opus-4-8');
+  });
+
+  test('a managed default never calls probe or fallback', async () => {
+    const neverFallback = () => {
+      throw new Error('fallback must not be called for a trusted managed ref');
+    };
+    expect(await degradeUnservableDefault('glm-5.2', { hasProject: true }, neverProbe, neverFallback)).toBe(
+      'glm-5.2',
+    );
+  });
 });

--- a/apps/api/src/llm-gateway/resolution/effective.ts
+++ b/apps/api/src/llm-gateway/resolution/effective.ts
@@ -88,16 +88,28 @@ export function chooseEffectiveModel(params: {
  * a per-request probe — only BYOK/codex defaults are probed. An unservable one
  * degrades to the platform default (`null`), never a dead turn. The `probe` is
  * injected so the decision stays pure and unit-testable without a DB.
+ *
+ * `fallback` is a second, optional degrade step tried ONLY when the configured
+ * default itself turns out unservable (probe() is false) — e.g. a BYOK model
+ * whose provider key was disconnected/rotated away. Rather than silently
+ * dropping straight to the (possibly ALSO unservable, e.g. an unconnected
+ * platform default like Codex) platform default, a caller can supply a
+ * best-effort "something this project can actually run right now" lookup
+ * (see default-model.ts's connectedByokFallback). Returning null from
+ * `fallback` (or omitting it) preserves the original platform-default
+ * behavior exactly.
  */
 export async function degradeUnservableDefault(
   model: string | null | undefined,
   ctx: { hasProject: boolean },
   probe: () => Promise<boolean>,
+  fallback?: () => Promise<string | null>,
 ): Promise<string | null> {
   if (!model) return null;
   if (isManagedRef(model)) return model;
   if (!ctx.hasProject) return null; // BYOK resolves its key from a project secret
-  return (await probe()) ? model : null;
+  if (await probe()) return model;
+  return fallback ? await fallback() : null;
 }
 
 /**

--- a/apps/api/src/projects/routes/gateway.ts
+++ b/apps/api/src/projects/routes/gateway.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, sql } from 'drizzle-orm';
 import { createRoute, z } from '@hono/zod-openapi';
 import { gatewayBudgets, gatewayRequestLogs, sandboxComputeSessions, sessionSandboxes } from '@kortix/db';
-import { calculateCost, callUpstream, type AuthedPrincipal } from '@kortix/llm-gateway';
+import { calculateCost, callUpstream, GatewayResolutionError, type AuthedPrincipal } from '@kortix/llm-gateway';
 import { resolveCandidates } from '../../llm-gateway/resolution/resolve-candidates';
 import { db } from '../../shared/db';
 import { auth, errors, json } from '../../openapi';
@@ -1147,10 +1147,21 @@ projectsApp.openapi(
       requires: { imageInput: body.imageInput === true },
     });
     const models = [route.primaryModel, ...(route.fallbackModels ?? [])];
-    const availability = await Promise.all(models.map(async (model) => ({
-      model,
-      available: (await resolveCandidates(principal, model)).length > 0,
-    })));
+    // This is an AVAILABILITY PREVIEW, not a generation request: its whole
+    // contract is "tell me which of these models are usable right now",
+    // per-model. resolveCandidates THROWS a typed GatewayResolutionError
+    // (e.g. provider_not_connected) instead of returning [] when a model
+    // isn't servable — correct for an actual generation call, but here it
+    // must degrade to `available: false` for JUST that model rather than
+    // fail the whole Promise.all/response for every model in the list.
+    const availability = await Promise.all(models.map(async (model) => {
+      try {
+        return { model, available: (await resolveCandidates(principal, model)).length > 0 };
+      } catch (err) {
+        if (err instanceof GatewayResolutionError) return { model, available: false };
+        throw err;
+      }
+    }));
     return c.json({ version: 1, route, models: availability });
   },
 );

--- a/apps/web/src/hooks/legacy/use-legacy-machine-migration.ts
+++ b/apps/web/src/hooks/legacy/use-legacy-machine-migration.ts
@@ -40,6 +40,18 @@ function eligibilityKey(accountId?: string | null) {
   return [...ELIGIBILITY_KEY, accountId ?? null] as const;
 }
 
+// "Not eligible" fallback for a deployment that doesn't carry this route at
+// all (e.g. self-host, or an environment ahead of the backend rollout) — same
+// shape react-query would otherwise be handed as an error, but treated as a
+// normal "nothing to migrate" result instead of a query error. Mirrors
+// use-account-deletion.ts's isUnsupportedEndpoint fallback for the same class
+// of "this backend route may legitimately not exist here" 404.
+const NOT_ELIGIBLE: LegacyEligibility = { eligible: false, sandboxes: [] };
+
+function isUnsupportedEndpoint(error: { status?: number; code?: string } | undefined): boolean {
+  return error?.status === 404 || error?.code === '404';
+}
+
 function unwrap<T>(response: { data?: T; success: boolean; error?: Error }): T {
   if (!response.success || response.data === undefined) {
     throw response.error ?? new Error('Legacy migration request failed');
@@ -58,14 +70,23 @@ export function useLegacyMachines(opts?: { enabled?: boolean; accountId?: string
     queryKey: eligibilityKey(accountId),
     queryFn: async () => {
       const qs = accountId ? `?account_id=${encodeURIComponent(accountId)}` : '';
-      return unwrap(
-        // Background eligibility probe on the projects grid — a user who just
-        // joined (or left) an account can race the account switch and 403;
-        // the Migrate card simply doesn't render, never a global toast.
-        await backendApi.get<LegacyEligibility>(`/projects/legacy-migration/eligibility${qs}`, {
-          showErrors: false,
-        }),
+      // Background eligibility probe on the projects grid — a user who just
+      // joined (or left) an account can race the account switch and 403;
+      // the Migrate card simply doesn't render, never a global toast.
+      const response = await backendApi.get<LegacyEligibility>(
+        `/projects/legacy-migration/eligibility${qs}`,
+        { showErrors: false },
       );
+      // A deployment without this route (self-host, or ahead of the backend
+      // rollout) 404s here on every poll. That is an EXPECTED "nothing to
+      // migrate" outcome, not a query error — surfacing it as a thrown/error
+      // query state spams the console/devtools on every 15s refetch for no
+      // actionable reason. Degrade to the same shape a real 200 "not
+      // eligible" response would carry.
+      if (!response.success && isUnsupportedEndpoint(response.error as { status?: number; code?: string } | undefined)) {
+        return NOT_ELIGIBLE;
+      }
+      return unwrap(response);
     },
     enabled: opts?.enabled ?? true,
     staleTime: 15_000,


### PR DESCRIPTION
## Problem

Tonight's error-taxonomy change (#4820) made `resolveCandidates` **throw** a typed `GatewayResolutionError` (`provider_not_connected`, `model_not_found`, `plan_upgrade_required`, `model_disabled_on_deployment`, …) instead of returning `[]` when a model has no usable upstream. That is correct for an actual **generation** request — the caller wants the specific reason. But the passive **READ / defaults / picker** endpoints probe servability through `isModelServableForAccount` → `resolveCandidates`, and were built against the old return-`[]` contract. They now **500** whenever a project's default-model provider has no key connected.

Observed on essentia (self-host): `GET /v1/projects/:id/model-defaults` → 500 `GatewayResolutionError: No openrouter API key is connected for this project` (a stale/auto-seeded `openrouter/*` default on a project that actually has OpenAI/Bedrock BYOK). A defaults/read endpoint must never 500 because a provider key isn't connected.

## Fix

- **`isModelServableForAccount`**: catch `GatewayResolutionError` → `false` (a passive servability check must never throw). Non-typed errors (real bugs) still propagate. This is the single choke point every read/defaults/picker/servability caller funnels through, so `GET /model-defaults`, the model picker, channel-binding resolution, PUT-validation, and seed-on-connect all degrade gracefully.
- **`degradeUnservableDefault`**: optional `fallback` step so a stale/unservable configured default degrades to a model the project **has** connected (its own OpenAI/Bedrock BYOK flagship, via `connectedByokFallback` which reuses the picker's connected-provider lookup) instead of an unconnected platform default (Codex). `resolveEffectiveModel` + `resolveDefaultModelForPrincipal` wired to it.
- **`gateway routing-policy/preview`**: per-model `try/catch` so a typed error on one model degrades to `available:false` for just that model, not a whole-response 500.
- **frontend `legacy-migration/eligibility`**: treat 404 as a normal "not eligible" result (mirrors `use-account-deletion`'s `isUnsupportedEndpoint`) instead of surfacing a query error / console spam on every 15s poll on deployments without the route.

**CHAT/completion path is unchanged** — an actual generation request still throws the specific `GatewayResolutionError` (intended #4820 behavior). The distinction: generation errors clearly; passive reads degrade gracefully.

## Tests

- New `default-model.test.ts` (12): `isModelServableForAccount` returns `false` (never throws) for every `GatewayResolutionError` reason and still propagates real bugs; `resolveEffectiveModel` / `resolveDefaultModelForPrincipal` return 200-shaped results and prefer a connected provider over a dead openrouter ref.
- Extended `effective.test.ts`: `degradeUnservableDefault` fallback behavior (connected → fallback model; nothing connected → platform; servable → never calls fallback).
- `tsc` clean (apps/api). Touched web file typechecks clean.