### PR TITLE
fix(security): remediate Trivy base-image npm CVEs (remove/patch bundled npm) + justify residual

### DIFF
--- a/apps/llm-gateway/Dockerfile
+++ b/apps/llm-gateway/Dockerfile
@@ -56,4 +56,7 @@ USER bun
 # Chart sets PORT from containerPort (8090); the server reads it from config.
 EXPOSE 8090
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD bun -e "fetch('http://localhost:'+(process.env.PORT||8090)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["bun", "run", "src/main.ts"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,6 +34,19 @@ LABEL org.opencontainers.image.title="kortix-frontend" \
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
+# This image only ever runs the pre-built Next.js standalone server
+# (`node apps/web/server.js` — see the ENTRYPOINT below and
+# docker-entrypoint.sh, which shells out to node/sed/grep/find, never npm).
+# The node:22-slim base bundles a global npm CLI whose OWN vendored
+# dependencies periodically carry CVEs (sigstore, picomatch, tar,
+# @sigstore/core, ip-address, brace-expansion — see CVE-2026-48815,
+# CVE-2026-33671/33672, CVE-2026-48758, CVE-2026-53655, CVE-2026-42338,
+# CVE-2026-33750). Since npm/npx/corepack are never invoked at build or
+# runtime in this stage, drop them entirely: real remediation instead of
+# an ignore-list entry, and it shrinks the image.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+    /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
+
 # License
 COPY LICENSE /LICENSE
 

--- a/infra/terraform/security-baseline/main.tf
+++ b/infra/terraform/security-baseline/main.tf
@@ -32,7 +32,13 @@ resource "aws_kms_key" "cloudtrail" {
       Condition = { StringLike = { "kms:EncryptionContext:aws:cloudtrail:arn" = "arn:aws:cloudtrail:*:${local.account_id}:trail/*" } } },
       { Sid = "AllowCloudTrailDescribe", Effect = "Allow", Principal = { Service = "cloudtrail.amazonaws.com" }, Action = "kms:DescribeKey", Resource = "*" },
       { Sid = "AllowLogReadersDecrypt", Effect = "Allow", Principal = { AWS = "arn:aws:iam::${local.account_id}:root" }, Action = ["kms:Decrypt", "kms:ReEncryptFrom"], Resource = "*",
-      Condition = { StringEquals = { "kms:CallerAccount" = local.account_id }, StringLike = { "kms:EncryptionContext:aws:cloudtrail:arn" = "arn:aws:cloudtrail:*:${local.account_id}:trail/*" } } }
+      Condition = { StringEquals = { "kms:CallerAccount" = local.account_id }, StringLike = { "kms:EncryptionContext:aws:cloudtrail:arn" = "arn:aws:cloudtrail:*:${local.account_id}:trail/*" } } },
+      # Lets the CloudWatch Logs group the trail delivers to (below) also be
+      # encrypted with this CMK, instead of shipping it unencrypted (Trivy
+      # AWS-0017 / Checkov CKV_AWS_158).
+      { Sid    = "AllowCloudWatchLogsEncrypt", Effect = "Allow", Principal = { Service = "logs.us-east-1.amazonaws.com" },
+        Action = ["kms:Encrypt*", "kms:Decrypt*", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:Describe*"], Resource = "*",
+      Condition = { ArnLike = { "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:us-east-1:${local.account_id}:log-group:*" } } }
     ]
   })
   tags = {
@@ -58,6 +64,13 @@ resource "aws_cloudtrail" "management_events" {
   include_global_service_events = true
   enable_log_file_validation    = true
 
+  # Real-time CloudWatch Logs delivery alongside the durable S3 trail
+  # (Trivy AWS-0162 / avd.aquasec.com/misconfig/aws-0162). S3 stays the
+  # long-term/durable copy; this just adds the searchable, real-time
+  # analysis path CloudTrail's own S3 delivery doesn't provide.
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
+  cloud_watch_logs_role_arn  = aws_iam_role.cloudtrail_cloudwatch_logs.arn
+
   # S3 object-level read+write data events (DCF-406)
   event_selector {
     read_write_type           = "All"
@@ -73,6 +86,48 @@ resource "aws_cloudtrail" "management_events" {
     Stack      = "security-baseline"
     Compliance = "soc2"
   }
+}
+
+# CloudWatch Logs destination + delivery role for the trail above (AWS-0162).
+# Log group lives in us-east-1 alongside the trail's home region — CloudTrail
+# requires the log group and delivery role to be in the same region as the
+# trail itself.
+resource "aws_cloudwatch_log_group" "cloudtrail" {
+  provider          = aws.use1
+  name              = "/aws/cloudtrail/management-events"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.cloudtrail.arn
+  tags = {
+    ManagedBy  = "terraform"
+    Name       = "cloudtrail"
+    Stack      = "security-baseline"
+    Compliance = "soc2"
+  }
+}
+
+resource "aws_iam_role" "cloudtrail_cloudwatch_logs" {
+  name               = "cloudtrail-cloudwatch-logs-role"
+  description        = "CloudTrail -> CloudWatch Logs delivery (SOC2 DCF-406, AWS-0162)"
+  assume_role_policy = jsonencode({ Version = "2012-10-17", Statement = [{ Effect = "Allow", Principal = { Service = "cloudtrail.amazonaws.com" }, Action = "sts:AssumeRole" }] })
+  tags = {
+    ManagedBy  = "terraform"
+    Name       = "cloudtrail-cloudwatch-logs-role"
+    Stack      = "security-baseline"
+    Compliance = "soc2"
+  }
+}
+
+resource "aws_iam_role_policy" "cloudtrail_cloudwatch_logs" {
+  name = "cloudtrail-cloudwatch-logs-delivery"
+  role = aws_iam_role.cloudtrail_cloudwatch_logs.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+      Resource = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
+    }]
+  })
 }
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -386,5 +441,38 @@ resource "aws_iam_role_policy" "flow_logs" {
 resource "aws_cloudwatch_log_group" "flow_logs" {
   name              = "/vpc/flowlogs"
   retention_in_days = 90
+  kms_key_id        = aws_kms_key.cloudwatch_logs.arn
   tags              = local.tags
+}
+
+# CMK for CloudWatch Logs in the default (us-west-2) region — CloudWatch log
+# groups are encrypted at rest by AWS either way, but a dedicated CMK gives us
+# key-rotation + access control (Trivy AWS-0017 / avd.aquasec.com/misconfig/aws-0017).
+resource "aws_kms_key" "cloudwatch_logs" {
+  description             = "CloudWatch Logs encryption, us-west-2 (SOC2 DCF-54)"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "cloudwatch-logs-cmk-policy"
+    Statement = [
+      { Sid    = "EnableRoot", Effect = "Allow", Principal = { AWS = "arn:aws:iam::${local.account_id}:root" },
+        Action = ["kms:Create*", "kms:Describe*", "kms:Enable*", "kms:List*", "kms:Put*", "kms:Update*", "kms:Revoke*", "kms:Disable*", "kms:Get*", "kms:Delete*", "kms:TagResource", "kms:UntagResource", "kms:ScheduleKeyDeletion", "kms:CancelKeyDeletion", "kms:Encrypt", "kms:Decrypt", "kms:ReEncrypt*", "kms:GenerateDataKey*"],
+      Resource = "*" },
+      { Sid    = "AllowCloudWatchLogsEncrypt", Effect = "Allow", Principal = { Service = "logs.us-west-2.amazonaws.com" },
+        Action = ["kms:Encrypt*", "kms:Decrypt*", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:Describe*"], Resource = "*",
+      Condition = { ArnLike = { "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:us-west-2:${local.account_id}:log-group:*" } } }
+    ]
+  })
+  tags = {
+    ManagedBy  = "terraform"
+    Name       = "cloudwatch-logs"
+    Stack      = "security-baseline"
+    Compliance = "soc2"
+  }
+}
+
+resource "aws_kms_alias" "cloudwatch_logs" {
+  name          = "alias/cloudwatch-logs"
+  target_key_id = aws_kms_key.cloudwatch_logs.key_id
 }


### PR DESCRIPTION
## Summary

Remediates the open Trivy code-scanning alerts flagged as blocking the release ("4 new alerts including 1 high severity" + the other open MEDIUM/LOW findings Marko listed). All fixed with real remediation — no `.trivyignore` suppressions were needed.

**Root cause of the 7 npm CVEs (HIGH: CVE-2026-48815, CVE-2026-33671; MEDIUM: CVE-2026-48758, CVE-2026-53655, CVE-2026-33672, CVE-2026-42338, CVE-2026-33750):** all traced (confirmed via the GH code-scanning API — every alert instance is `category: trivy-image-1`, i.e. the `kortix/kortix-frontend:dev-latest` image scan) to the global `npm` CLI bundled in the `node:22-slim` base image used as the **final** stage of `apps/web/Dockerfile`. npm's own vendored dependencies (sigstore, @sigstore/core, picomatch, tar, ip-address, brace-expansion) carry these CVEs. `kortix-api`'s `node:22-slim` usage is only an intermediate `deps` stage (never shipped — final stage is `oven/bun:slim`), so it was never actually vulnerable; confirmed via `gh api .../code-scanning/alerts` that the `kortix-api` image scan has zero open Trivy alerts.

**Real fix, not a suppression:** `apps/web/docker-entrypoint.sh` and the Dockerfile's `CMD` only ever invoke `node`/`sed`/`grep`/`find` — npm/npx/corepack are never used at build or runtime in the runner stage. Added a `RUN rm -rf` dropping npm/npx/corepack entirely from the final image. Verified locally with `trivy image`: all 6 CVEs present on stock `node:22-slim` (confirmed via `@sigstore/core` etc. showing as vulnerable) are **gone** after the removal, and `node --version` / `fetch()` still work fine post-removal. Also did a full real `docker build` of `apps/web/Dockerfile` (with a smoke-test standalone payload, since a real `next build` OOM'd this sandbox) — build succeeds, entrypoint runs, `npm` is absent, `node` works.

**DS-0026 (`apps/llm-gateway/Dockerfile`, missing HEALTHCHECK):** real fix — added a `HEALTHCHECK` hitting the existing `/health` route, matching the pattern already used in `apps/api/Dockerfile` and `apps/web/Dockerfile`. Built the image and ran it locally; `/health` responds (503 in this env only because `KORTIX_API_URL` isn't reachable — expected without a live backend) and the `HEALTHCHECK` CMD correctly reads that status.

**AWS-0162 / AWS-0017 (`infra/terraform/security-baseline/main.tf`):** real fix, not ignored, despite being LOW/non-blocking:
- AWS-0162: wired `aws_cloudtrail.management_events` to CloudWatch Logs (new log group + delivery IAM role) alongside its existing S3 delivery.
- AWS-0017: added a dedicated CMK for CloudWatch Logs and encrypted both the new CloudTrail log group and the pre-existing `/vpc/flowlogs` group with it.
- Verified with `terraform fmt -check`, `terraform validate`, `tflint --recursive` (all clean), and `checkov` — confirmed via a baseline-vs-after comparison that both `CKV_AWS_158` (log group not KMS-encrypted) and `CKV2_AWS_10` (CloudTrail not integrated with CloudWatch Logs) — the Checkov equivalents of AWS-0017/AWS-0162 — clear, and no new findings were introduced (failed checks 17→15).
- Note: this stack is `terraform apply`'d manually by an operator (not CI), per its own header comment, so this PR only proposes the IaC — nothing auto-applies on merge.

## Other CI health check (per Marko's "any other errors")
Reviewed recent `main` CI runs. Only non-cron-noise failure found was **`Deploy Staging`** (EKS staging rollout-wait timing out on `afd88b2a0`, 3 failures in a row starting today) — that's deploy-pipeline territory (same family as `deploy-prod.yml`, owned by #4863 / the release agent per the coordination note), not a Dockerfile/dependency issue, so left untouched. `DB Drift Sentinel` has been failing on cron daily for a week+ — same pre-existing-noise category as `QA-nightly` / self-host full e2e, left alone.

## Test plan
- [x] `docker build -f apps/web/Dockerfile .` — full build succeeds, entrypoint runs, `npm`/`npx`/`corepack` absent, `node` works
- [x] `trivy image` on a `node:22-slim` test image with the same `rm -rf` — all 6 CVEs (sigstore, @sigstore/core, picomatch, tar, ip-address, brace-expansion) confirmed present before / absent after
- [x] `docker build -f apps/llm-gateway/Dockerfile .` — succeeds; ran container, `/health` reachable, HEALTHCHECK CMD behaves correctly
- [x] `terraform fmt -check`, `terraform validate`, `tflint --recursive` — all clean
- [x] `checkov` before/after comparison — `CKV_AWS_158` and `CKV2_AWS_10` clear, no new findings
- [x] `hadolint` on both changed Dockerfiles — no new warnings vs. `origin/main`