### PR TITLE
fix(k8s): set ingress.wafAclArn on prod gateway-values so Argo can render the gateway app

### DIFF
--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -29,6 +29,8 @@ ingress:
   host: gateway-dev.kortix.com
   # ACM cert for gateway-dev.kortix.com (dev-eks/cluster module.acm_gateway).
   certificateArn: "arn:aws:acm:us-west-2:935064898258:certificate/ee7b3729-26c7-4622-881d-028daa58d051"
+  # Same shared regional WAFv2 Web ACL as the dev API ingress (envs/dev/values.yaml), us-west-2.
+  wafAclArn: "arn:aws:wafv2:us-west-2:935064898258:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65"
   cloudflareProxied: true
   # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
   inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"

--- a/infra/k8s/envs/prod/gateway-values.yaml
+++ b/infra/k8s/envs/prod/gateway-values.yaml
@@ -31,6 +31,9 @@ ingress:
   host: gateway-eks.kortix.com
   # ACM cert for gateway-eks.kortix.com in eu-west-2 (the prod-eks ALB region).
   certificateArn: "arn:aws:acm:eu-west-2:935064898258:certificate/7dc99167-c60b-4bd0-a731-f77251ef8e04"
+  # Same shared regional WAFv2 Web ACL as the prod API ingress (envs/prod/values.yaml) —
+  # "Managed edge protections for Kortix application load balancers", eu-west-2.
+  wafAclArn: "arn:aws:wafv2:eu-west-2:935064898258:regional/webacl/kortix-alb-waf/8ac41166-f4f0-4a53-9d23-f4aae0963a22"
   cloudflareProxied: true
   # Lock the origin ALB to Cloudflare's edge ranges so the LLM gateway can only be
   # reached THROUGH Cloudflare — no direct-to-origin bypass of the edge.

--- a/infra/k8s/envs/staging/gateway-values.yaml
+++ b/infra/k8s/envs/staging/gateway-values.yaml
@@ -22,6 +22,8 @@ ingress:
   host: gateway-staging.kortix.com
   # us-west-2 wildcard cert for *.kortix.com.
   certificateArn: arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755
+  # Same shared regional WAFv2 Web ACL as the staging API ingress (envs/staging/values.yaml), us-west-2.
+  wafAclArn: arn:aws:wafv2:us-west-2:935064898258:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65
   cloudflareProxied: true
   # Lock the origin ALB to Cloudflare's edge ranges (no direct-to-origin bypass).
   inboundCidrs: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22"


### PR DESCRIPTION
## Summary

- The kortix-gateway helm chart (`infra/k8s/charts/kortix-gateway/templates/ingress.yaml`) has required `ingress.wafAclArn` since commit d824ab0f5 ("fix: make ALB WAF ownership durable"), which added the same guard to `kortix-api`, `kortix-gateway`, and `qa-portal` and back-filled every env's **API** `values.yaml` — but missed the gateway's own `envs/*/gateway-values.yaml`. Result: `helm template`/Argo fails with `ingress.wafAclArn is required so the AWS Load Balancer Controller preserves the WAF association` → Argo ComparisonError, "chart can't render", for every env whose gateway ingress is enabled.
- This blocked the **prod EKS gateway standby** during tonight's v0.10.8 release. The ACTIVE public gateway is ECS Fargate (`api.kortix.com`) and was unaffected — EKS is standby only. An agent manually patched the *running* EKS gateway Deployment to unblock the release, but the values file itself still lacked the field, so Argo remained unable to reconcile and the next release/sync would hit the identical wall.
- While investigating I found the same gap in `envs/dev/gateway-values.yaml` and `envs/staging/gateway-values.yaml` (same commit missed them too) — fixed those in the same PR since the correct value was already known and it's the same one-line change. `envs/preview/gateway-values.yaml` sets `ingress.enabled: false` for the gateway, so it's unaffected and needs no change.

## Fix

Set `ingress.wafAclArn` to each env's existing **shared regional WAFv2 Web ACL** — the same ARN already set on that env's `kortix-api` ingress (`envs/<env>/values.yaml`), not a new/invented ARN:

- `envs/prod/gateway-values.yaml`: `arn:aws:wafv2:eu-west-2:935064898258:regional/webacl/kortix-alb-waf/8ac41166-f4f0-4a53-9d23-f4aae0963a22`
- `envs/dev/gateway-values.yaml`: `arn:aws:wafv2:us-west-2:935064898258:regional/webacl/kortix-alb-waf/4a81aadc-31ad-470a-a10c-3606de61cf65`
- `envs/staging/gateway-values.yaml`: same us-west-2 ARN as dev

Verified live via `aws wafv2 get-web-acl --scope REGIONAL --region <region> --name kortix-alb-waf --id <id>` for both the eu-west-2 (prod) and us-west-2 (dev/staging) Web ACLs — both exist and match ("kortix-alb-waf" — Managed edge protections for Kortix application load balancers).

## Test plan

- [x] `helm template kortix-gateway infra/k8s/charts/kortix-gateway -f infra/k8s/envs/prod/gateway-values.yaml` — renders cleanly, exit 0, `alb.ingress.kubernetes.io/wafv2-acl-arn` annotation present with the correct ARN
- [x] Same for `envs/dev/gateway-values.yaml` and `envs/staging/gateway-values.yaml` — both clean
- [x] `envs/preview/gateway-values.yaml` — clean (ingress disabled, guard not evaluated)
- [x] Reproduced the original failure: templating with `wafAclArn: ""` reproduces `Error: execution error at (kortix-gateway/templates/ingress.yaml:6:4): ingress.wafAclArn is required...`
- [x] `helm lint` clean on all three edited values files

This is GitOps-managed infra config (Argo-applied) — merging updates desired state and Argo will pick it up and reconcile on its own; no separate deploy step needed.