### PR TITLE
fix(web): self-host SSO/OAuth redirect lands on 0.0.0.0:3000 instead of the public host

### DIFF
--- a/apps/web/src/app/(auth)/auth/callback/route.ts
+++ b/apps/web/src/app/(auth)/auth/callback/route.ts
@@ -1,7 +1,7 @@
 import { accountHasAppAccess } from '@/lib/auth/account-access';
 import { resolveFirstProjectPathForNewUser } from '@/lib/auth/bootstrap-first-project';
 import { buildDesktopBounceHtml, buildMobileBounceHtml } from '@/lib/auth/desktop-bounce';
-import { isInviteReturnUrl, sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
+import { isInviteReturnUrl, resolveAuthRedirectBaseUrl, sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
 import { ACTIVE_INSTANCE_COOKIE } from '@kortix/sdk/instance-routes';
 import { fetchAccountStateWithToken } from '@kortix/sdk/projects-client';
 import { getServerPublicEnv } from '@/lib/public-env-server';
@@ -58,10 +58,15 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  // Use request origin for redirects (most reliable for local dev)
-  // This ensures localhost:3000 redirects stay on localhost, not staging
+  // Prefer the request origin for redirects (most reliable for local dev — keeps
+  // localhost:3000 on localhost, not a configured staging APP_URL). On self-host
+  // the frontend is a Next standalone server bound to HOSTNAME=0.0.0.0 behind a
+  // reverse proxy, so request.nextUrl.origin can be the internal bind address
+  // (https://0.0.0.0:3000); resolveAuthRedirectBaseUrl falls back to the public
+  // APP_URL in exactly that case so post-auth (incl. SSO) redirects land on the
+  // real host. See lib/auth/return-url.ts.
   const requestOrigin = request.nextUrl.origin;
-  const baseUrl = requestOrigin || runtimeEnv.APP_URL || 'http://localhost:3000';
+  const baseUrl = resolveAuthRedirectBaseUrl(requestOrigin, runtimeEnv.APP_URL);
   const error = searchParams.get('error');
   const errorCode = searchParams.get('error_code');
   const errorDescription = searchParams.get('error_description');

--- a/apps/web/src/lib/auth/return-url.test.ts
+++ b/apps/web/src/lib/auth/return-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { isInviteReturnUrl, sanitizeAuthReturnUrl } from './return-url';
+import { isInviteReturnUrl, resolveAuthRedirectBaseUrl, sanitizeAuthReturnUrl } from './return-url';
 
 describe('sanitizeAuthReturnUrl', () => {
   test('preserves an invite URL verbatim (must survive to reach the dialog)', () => {
@@ -39,5 +39,43 @@ describe('isInviteReturnUrl', () => {
 
   test('the sanitized invite URL is recognized end-to-end', () => {
     expect(isInviteReturnUrl(sanitizeAuthReturnUrl('/invites/xyz'))).toBe(true);
+  });
+});
+
+describe('resolveAuthRedirectBaseUrl', () => {
+  test('prefers the request origin in the normal case (local dev + cloud)', () => {
+    expect(resolveAuthRedirectBaseUrl('http://localhost:3000', 'https://staging.example.com')).toBe(
+      'http://localhost:3000',
+    );
+    expect(resolveAuthRedirectBaseUrl('https://kortix.com', 'https://kortix.com')).toBe('https://kortix.com');
+  });
+
+  test('leaves loopback origins as-is so local dev stays on localhost', () => {
+    expect(resolveAuthRedirectBaseUrl('http://localhost:3000', undefined)).toBe('http://localhost:3000');
+    expect(resolveAuthRedirectBaseUrl('http://127.0.0.1:3000', 'https://app.example.com')).toBe(
+      'http://127.0.0.1:3000',
+    );
+  });
+
+  test('falls back to APP_URL when the origin is a 0.0.0.0 wildcard bind (self-host behind proxy)', () => {
+    // The exact live symptom: SSO on self-host landing on https://0.0.0.0:3000.
+    expect(resolveAuthRedirectBaseUrl('https://0.0.0.0:3000', 'https://essentia.kortix.cloud')).toBe(
+      'https://essentia.kortix.cloud',
+    );
+    expect(resolveAuthRedirectBaseUrl('http://0.0.0.0:3000', 'https://essentia.kortix.cloud/')).toBe(
+      'https://essentia.kortix.cloud',
+    );
+    expect(resolveAuthRedirectBaseUrl('https://[::]:3000', 'https://essentia.kortix.cloud')).toBe(
+      'https://essentia.kortix.cloud',
+    );
+  });
+
+  test('keeps the wildcard origin only if no APP_URL is configured (nothing better to use)', () => {
+    expect(resolveAuthRedirectBaseUrl('https://0.0.0.0:3000', undefined)).toBe('https://0.0.0.0:3000');
+  });
+
+  test('final fallback when everything is empty', () => {
+    expect(resolveAuthRedirectBaseUrl('', undefined)).toBe('http://localhost:3000');
+    expect(resolveAuthRedirectBaseUrl(null, 'https://app.example.com/')).toBe('https://app.example.com');
   });
 });

--- a/apps/web/src/lib/auth/return-url.ts
+++ b/apps/web/src/lib/auth/return-url.ts
@@ -58,4 +58,34 @@ export function isInviteReturnUrl(returnUrl: string | null | undefined): boolean
   return typeof returnUrl === 'string' && returnUrl.startsWith('/invites/');
 }
 
+/**
+ * Resolve the public base URL to use for post-auth redirects (OAuth/SSO/magic
+ * link callbacks).
+ *
+ * `request.nextUrl.origin` is normally the right answer and is preferred so
+ * local dev keeps redirecting to whatever host the browser is actually on
+ * (e.g. http://localhost:3000, not a configured staging APP_URL). But on a
+ * self-host instance the frontend runs as a Next.js standalone server bound to
+ * HOSTNAME=0.0.0.0 behind a reverse proxy (caddy), and the request origin
+ * resolves to the internal wildcard BIND address `https://0.0.0.0:3000` instead
+ * of the public host. Redirecting there drops the user on a dead address right
+ * after they authenticate (observed live: SSO on a self-host landing on
+ * `https://0.0.0.0:3000/projects?auth_event=signup&auth_method=sso:...`).
+ *
+ * A wildcard bind address (0.0.0.0 / [::]) is never a real client-facing
+ * origin, so when we see one we fall back to the configured public APP_URL.
+ * loopback (localhost / 127.0.0.1) is deliberately left as-is so the local-dev
+ * behavior above is preserved.
+ */
+export function resolveAuthRedirectBaseUrl(
+  requestOrigin: string | null | undefined,
+  appUrl: string | null | undefined,
+): string {
+  const origin = requestOrigin || '';
+  const cleanAppUrl = appUrl ? appUrl.replace(/\/+$/, '') : '';
+  const isWildcardBindOrigin = /^https?:\/\/(0\.0\.0\.0|\[::\])(:\d+)?$/i.test(origin);
+  if (isWildcardBindOrigin && cleanAppUrl) return cleanAppUrl;
+  return origin || cleanAppUrl || 'http://localhost:3000';
+}
+
 export { DEFAULT_AUTH_RETURN_URL };


### PR DESCRIPTION
## Summary
After SSO (and any OAuth/magic-link) login on a **self-host** instance, the user is redirected to `https://0.0.0.0:3000/projects?auth_event=signup&auth_method=sso:...` — a dead address — instead of the public host. Reported live on `essentia.kortix.cloud`.

## Root cause
The web auth callback (`apps/web/src/app/(auth)/auth/callback/route.ts`) computes its post-auth redirect base from `request.nextUrl.origin`. On self-host the frontend runs as a Next.js standalone server bound to `HOSTNAME=0.0.0.0` behind caddy (`dynamic a` upstream), so `request.nextUrl.origin` resolves to the internal wildcard **bind** address `https://0.0.0.0:3000` rather than the public host. The runtime `APP_URL` (`KORTIX_PUBLIC_APP_URL`) is correct — it just wasn't being used because the (truthy) request origin was preferred.

Reproduced on essentia:
```
$ curl -sI https://essentia.kortix.cloud/auth/callback?error=diagnostic_test | grep location
location: https://0.0.0.0:3000/auth?error=diagnostic_test
```

Not a regression from any recent release — this logic is longstanding; it only bites self-host behind the proxy.

## Fix
New `resolveAuthRedirectBaseUrl(requestOrigin, appUrl)` in `lib/auth/return-url.ts`:
- **Still prefers the request origin** in the normal case, so local dev keeps redirecting to `localhost:3000` (not a configured staging `APP_URL`) — the reason the origin was preferred in the first place.
- **Only** when the origin is a wildcard **bind** address (`0.0.0.0` / `[::]`) — which is never a real client-facing origin — it falls back to the configured public `APP_URL`.
- Loopback (`localhost` / `127.0.0.1`) is intentionally left as-is.

Wired into the web callback route. Unit-tested (12 cases incl. the exact `https://0.0.0.0:3000 → APP_URL` symptom, localhost preservation, and the no-APP_URL fallback).

## Test plan
- [x] `bun test src/lib/auth/return-url.test.ts` → 12 pass
- [x] tsc clean on the touched files
- [ ] After merge + a self-host frontend update, SSO on essentia lands on `https://essentia.kortix.cloud/projects` (verify with the same curl → `location` should be the public host)
