### PR TITLE
fix(web): session panel stuck-shifted layout + show tool's inline carousel

### DIFF
--- a/apps/web/src/features/session/action-panel/browser-panel.tsx
+++ b/apps/web/src/features/session/action-panel/browser-panel.tsx
@@ -16,6 +16,7 @@ import { useAuthenticatedPreviewUrl } from '@/hooks/use-authenticated-preview-ur
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { INTERACTIVE_PREVIEW_IFRAME_SANDBOX } from '@/lib/security/iframe-sandbox';
 import { cn } from '@/lib/utils';
+import { focusWithoutScroll } from '@/lib/utils/focus-without-scroll';
 import {
   buildWebProxyUrl,
   isExternalUrl,
@@ -112,6 +113,17 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
   );
   const [isAddressEditing, setIsAddressEditing] = useState(false);
   const addressInputRef = useRef<HTMLInputElement>(null);
+
+  // Empty landing gets the cursor, like `autoFocus` did — but through
+  // `focusWithoutScroll`, because React's `autoFocus` is a bare focus() at
+  // mount, and mount can happen while the panel is mid enter-animation: the
+  // reveal scroll shoves a permanent sideways offset onto the panel's
+  // overflow-hidden ancestors. Mount-only on purpose (`autoFocus` semantics —
+  // a later navigation clearing the URL must not steal the cursor).
+  const autoFocusAddressRef = useRef(!rawPreviewUrl);
+  useEffect(() => {
+    if (autoFocusAddressRef.current) focusWithoutScroll(addressInputRef.current);
+  }, []);
 
   const isExternalBrowsing = useMemo(() => {
     return (
@@ -549,7 +561,6 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
                 // isAddressEditing && !!addressValue && 'font-mono',
                 urlParts && 'text-transparent',
               )}
-              autoFocus={!rawPreviewUrl}
             />
             {urlParts && (
               <span

--- a/apps/web/src/features/session/action-panel/easy/app-preview.tsx
+++ b/apps/web/src/features/session/action-panel/easy/app-preview.tsx
@@ -30,6 +30,7 @@ import { useIsMobile } from '@/hooks/utils';
 import { INTERACTIVE_PREVIEW_IFRAME_SANDBOX } from '@/lib/security/iframe-sandbox';
 import { track } from '@/lib/track';
 import { cn } from '@/lib/utils';
+import { focusWithoutScroll } from '@/lib/utils/focus-without-scroll';
 import { parseLocalhostUrl, toInternalUrl } from '@/lib/utils/sandbox-url';
 import { recentDisplayLabel, useBrowserRecentsStore } from '@/stores/browser-recents-store';
 import { useIsExpanded, useToggleExpanded } from '@/stores/kortix-computer-store';
@@ -163,9 +164,12 @@ export function AppPreview({
   }, [isLoading, refreshKey, clearLoadTimeout, noApp]);
 
   // Nothing to load, so land the cursor on the address bar — the fastest way
-  // in once you know the port.
+  // in once you know the port. `focusWithoutScroll`: this fires while the
+  // detail card is still sliding in from x:100%, and a bare focus() would
+  // scroll the panel's overflow-hidden ancestors sideways to reveal it —
+  // the stuck-shifted-layout bug.
   useEffect(() => {
-    if (noApp) addressRef.current?.focus();
+    if (noApp) focusWithoutScroll(addressRef.current);
   }, [noApp]);
 
   const reload = useCallback(() => {

--- a/apps/web/src/features/session/action-panel/easy/detail-view.tsx
+++ b/apps/web/src/features/session/action-panel/easy/detail-view.tsx
@@ -23,6 +23,7 @@ import Hint from '@/components/ui/hint';
 import { useOptionalSidebar } from '@/components/ui/sidebar';
 import { useIsMobile } from '@/hooks/utils';
 import { cn } from '@/lib/utils';
+import { focusWithoutScroll } from '@/lib/utils/focus-without-scroll';
 import { useKortixComputerStore } from '@/stores/kortix-computer-store';
 import type { ToolPart } from '@/ui';
 import { ChevronLeft, ChevronRight, PanelLeft, X } from 'lucide-react';
@@ -418,6 +419,11 @@ export function DetailLayer({
   // `document.activeElement` then would overwrite the invoking row with
   // whatever the nav button itself was, losing the way home. Harmless on
   // mobile: the desktop `detailRef` never mounts there, so `.focus()` no-ops.
+  // Both focuses go through `focusWithoutScroll`: they land while a layer is
+  // still translated by the slide (card entering at x:100%, home returning
+  // from -12%), and a bare focus() scrolls the panel's overflow-hidden
+  // ancestors sideways to "reveal" it — permanently, once the keep-alive
+  // terminal layer's parked x:100% keeps the overflow from shrinking back.
   useEffect(() => {
     const wasOpen = wasOpenRef.current;
     wasOpenRef.current = detail !== null;
@@ -425,9 +431,9 @@ export function DetailLayer({
       if (!wasOpen) {
         restoreFocusRef.current = document.activeElement as HTMLElement | null;
       }
-      requestAnimationFrame(() => detailRef.current?.focus());
+      requestAnimationFrame(() => focusWithoutScroll(detailRef.current));
     } else if (wasOpen) {
-      restoreFocusRef.current?.focus?.();
+      focusWithoutScroll(restoreFocusRef.current);
       restoreFocusRef.current = null;
     }
   }, [detail?.key]);

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -388,14 +388,19 @@ export const SessionLayout = memo(function SessionLayout({
 
   return (
     <SessionWallpaperLayerContext.Provider value={wallpaperLayer}>
+      {/* `overflow-clip` (not -hidden) on the layout wrappers below: hidden
+          boxes still accept a programmatic scrollLeft — a focus() aimed at a
+          mid-animation (translated) panel layer scrolled them sideways and the
+          layout stuck there, with no scrollbar to undo it. Clip makes them
+          categorically unscrollable; the visual clipping is identical. */}
       <div
-        className="bg-background relative flex h-full flex-col overflow-hidden"
+        className="bg-background relative flex h-full flex-col overflow-clip"
         data-testid="session-layout"
       >
         <div
           ref={panelGroupRef}
           className={cn(
-            'relative flex min-h-0 flex-1 overflow-hidden',
+            'relative flex min-h-0 flex-1 overflow-clip',
             // Fullscreen detail: the shell's floating sidebar toggle sits at
             // z-30 in the same stacking context this wrapper competes in, and
             // this wrapper is the panel subtree's stacking-context root — so
@@ -458,14 +463,14 @@ export const SessionLayout = memo(function SessionLayout({
               >
                 <div
                   className={cn(
-                    'border-border flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden',
+                    'border-border flex h-full min-h-0 w-full min-w-0 flex-col overflow-clip',
                     // Easy mode is chrome-free — the cards carry their own
                     // borders, so a panel border would just box a box.
                     !isEasy && 'border-l',
                   )}
                 >
                   {effectivePanelHeader}
-                  <div className="min-h-0 flex-1 overflow-hidden">{effectivePanelBody}</div>
+                  <div className="min-h-0 flex-1 overflow-clip">{effectivePanelBody}</div>
                 </div>
               </div>
             </ResizablePanel>

--- a/apps/web/src/features/session/tool/shared/infrastructure.test.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { BasicTool, ToolSurfaceContext } from '@/features/session/tool/shared/infrastructure';
+import {
+  BasicTool,
+  BoundActivateContext,
+  ToolSurfaceContext,
+} from '@/features/session/tool/shared/infrastructure';
 
 describe('BasicTool panel surface — node trigger', () => {
   test('wraps a JSX-node trigger in the standard sticky panel header', () => {
@@ -28,5 +32,34 @@ describe('BasicTool panel surface — node trigger', () => {
 
     // The node's own content must render inside that header, not the shrunken fallback row.
     expect(html).toContain('Generating slides');
+  });
+});
+
+describe('BasicTool inline surface — activate context vs defaultOpen', () => {
+  const activate = () => {};
+
+  test('defaultOpen renders the body inline even when an activate context is bound', () => {
+    // The regression: chat binds BoundActivateContext for every tool row, and
+    // the activate branch discarded `defaultOpen` — collapsing `show`'s
+    // carousel to a bare "Show · N items" line with no content anywhere inline.
+    const html = renderToStaticMarkup(
+      <BoundActivateContext.Provider value={activate}>
+        <BasicTool trigger={{ title: 'Show', subtitle: '4 items' }} defaultOpen>
+          <div>carousel body</div>
+        </BasicTool>
+      </BoundActivateContext.Provider>,
+    );
+    expect(html).toContain('carousel body');
+  });
+
+  test('without defaultOpen the activate row still wins (no inline body)', () => {
+    const html = renderToStaticMarkup(
+      <BoundActivateContext.Provider value={activate}>
+        <BasicTool trigger={{ title: 'Read', subtitle: 'file.ts' }}>
+          <div>file contents</div>
+        </BasicTool>
+      </BoundActivateContext.Provider>,
+    );
+    expect(html).not.toContain('file contents');
   });
 });

--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -1182,8 +1182,12 @@ export function BasicTool({
     return <ClickableToolRow header={header} locked={locked} onClick={onClick} />;
   }
 
-  // A bound "activate" context opens this tool in the side panel instead of expanding inline.
-  if (activate && !locked && !forceOpen) {
+  // A bound "activate" context opens this tool in the side panel instead of
+  // expanding inline. `defaultOpen` opts out the same way `forceOpen` does: a
+  // tool that asks to start expanded is saying its payload belongs inline —
+  // `show`'s whole purpose is presenting the carousel/content IN the chat, and
+  // this row was collapsing it to a one-line "Show · 4 items" instead.
+  if (activate && !locked && !forceOpen && !defaultOpen) {
     return <ActivatableToolRow header={header} activate={activate} />;
   }
 

--- a/apps/web/src/lib/utils/focus-without-scroll.test.ts
+++ b/apps/web/src/lib/utils/focus-without-scroll.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { focusWithoutScroll } from './focus-without-scroll';
+
+describe('focusWithoutScroll', () => {
+  // The contract that fixes the stuck-sideways-layout bug: every programmatic
+  // focus aimed at an animated panel layer must carry preventScroll, or the
+  // browser scrolls the panel's overflow-hidden ancestors to reveal the
+  // still-translated target and the offset sticks.
+  test('always passes preventScroll', () => {
+    let received: FocusOptions | undefined | 'never-called' = 'never-called';
+    focusWithoutScroll({
+      focus: (opts) => {
+        received = opts;
+      },
+    });
+    expect(received).toEqual({ preventScroll: true });
+  });
+
+  test('tolerates null, undefined, and focus-less targets', () => {
+    expect(() => focusWithoutScroll(null)).not.toThrow();
+    expect(() => focusWithoutScroll(undefined)).not.toThrow();
+    expect(() => focusWithoutScroll({})).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/utils/focus-without-scroll.ts
+++ b/apps/web/src/lib/utils/focus-without-scroll.ts
@@ -1,0 +1,20 @@
+/**
+ * Programmatic focus that never scrolls ancestors into view.
+ *
+ * A plain `.focus()` makes the browser scroll EVERY scrollable ancestor —
+ * including `overflow: hidden` ones, which accept a programmatic
+ * `scrollLeft` — to reveal the focused element. The session panel focuses
+ * elements while they're still translated off-panel by an enter animation
+ * (the detail card slides in from `x: 100%`), so that reveal shoved a
+ * permanent sideways scroll onto the panel's `overflow-hidden` wrappers:
+ * with the keep-alive terminal layer parked at `translateX(100%)`, the
+ * overflow never shrinks back and the layout stayed shifted with no
+ * scrollbar to undo it.
+ *
+ * Every focus aimed at (or inside) an animated layer must go through here.
+ */
+export function focusWithoutScroll(
+  el: { focus?: (opts?: FocusOptions) => void } | null | undefined,
+): void {
+  el?.focus?.({ preventScroll: true });
+}


### PR DESCRIPTION
## Summary

Two production UI fixes in the session surface:

### 1. Layout stuck shifted sideways after opening the browser/terminal (`f5f405f15`)

Programmatic focus aimed at panel layers still translated by their enter animation — the detail card focused one rAF after opening (while at `x:100%`), AppPreview's/BrowserPanel's address-bar autofocus, and the focus restore on close — made the browser scroll the layout's `overflow-hidden` ancestors sideways to reveal the target (hidden boxes still accept a programmatic `scrollLeft`). Once the keep-alive terminal layer is parked at `translateX(100%)`, the overflow never shrinks back, so the scroll stuck permanently: chat and Easy-panel cards clipped at the left, dead space at the right, no scrollbar to undo it.

- New `focusWithoutScroll` helper (`focus({ preventScroll: true })`); every focus that targets an animated layer routes through it. `BrowserPanel`'s `autoFocus` attribute becomes a mount effect (React's `autoFocus` is a bare `focus()` at mount).
- Defense in depth: the session-layout wrappers switch from `overflow-hidden` to `overflow-clip` — visually identical, but categorically unscrollable, so no future reveal/`scrollIntoView` can shift the layout again.

### 2. `show` tool never rendered its carousel/content inline in chat (`423490670`)

Since the Easy-panel rebuild (#4120), `BasicTool`'s bound-activate branch turned every chat tool row into a one-line open-in-panel trigger and silently discarded `defaultOpen` — so a `show` call with `items` collapsed to a bare "Show · 4 items" row with no carousel anywhere inline. `defaultOpen` now opts out of the activate row the same way `forceOpen` does; all other tools keep the one-line open-in-panel behavior.

## Test plan

- [x] Live repro before the fix (Playwright, real session): terminal open → close → "Open browser" left `scrollLeft=479.5` frozen on the panel wrapper, matching the reported screenshots pixel-for-pixel.
- [x] Live verify after: same sequence (plus rapid Escape-and-reopen interrupt) keeps `scrollLeft=0` on every ancestor at every phase; address bar still receives focus.
- [x] Live verify: a `show` call with 4 file items now renders the carousel inline in the transcript (item tabs, 1/4 pager, PDF viewer); clicking through to the panel detail still works.
- [x] New unit tests: `focus-without-scroll.test.ts` (preventScroll contract, null-safety) and `infrastructure.test.tsx` (defaultOpen renders inline under a bound activate context; without it the activate row still wins).
- [x] `bun test --isolate src/features/session src/lib/utils`: 539 pass, 0 fail. Typecheck clean (remaining errors are pre-existing stale `.next/types` artifacts for a deleted route).