### PR TITLE
fix(compliance): close AWS patch and detection gaps

### DIFF
--- a/docs/compliance/CRYPTOGRAPHIC-KEY-ROTATION.md
+++ b/docs/compliance/CRYPTOGRAPHIC-KEY-ROTATION.md
@@ -1,0 +1,61 @@
+# Cryptographic Key Rotation Standard
+
+Owner: Security and Infrastructure  
+Effective date: 2026-07-17  
+Review cadence: Annual and after material cryptographic or access changes
+
+## Scope
+
+This standard covers Kortix-managed AWS KMS keys used for encryption and
+digital signing. AWS-managed keys follow the provider's managed lifecycle.
+Application credentials and IAM access keys follow the separate secrets and
+credential-rotation process.
+
+## Cryptoperiods
+
+- Customer-managed symmetric KMS encryption keys use AWS automatic rotation
+  with a maximum 365-day rotation period.
+- Customer-managed asymmetric signing keys are rolled over at least annually.
+  AWS KMS does not support automatic rotation for asymmetric keys, so rollover
+  uses the controlled replacement procedure below.
+- A key is rotated immediately, regardless of age, when compromise is known or
+  suspected, an authorized user with key-administration access leaves or
+  changes role, a cryptographic weakness affects the key, or the Security owner
+  directs emergency rotation.
+
+## Symmetric KMS enforcement
+
+Terraform-managed encryption keys set `enable_key_rotation = true`. Quarterly
+control sampling runs `aws kms get-key-rotation-status` for every enabled
+customer-managed symmetric key and records `KeyRotationEnabled`,
+`RotationPeriodInDays`, and `NextRotationDate`. A disabled or overdue result is
+remediated as a security finding.
+
+## Asymmetric signing-key rollover
+
+1. Open an approved production change identifying the existing key, role,
+   consumers, and rollback window.
+2. Create a replacement KMS asymmetric signing key with the same key spec and
+   least-privilege policy. Never export private key material.
+3. Publish the replacement public key or trust metadata alongside the current
+   key. Keep both keys trusted during the overlap window.
+4. Sign and verify a non-production artifact, then promote through staging and
+   the reviewed production release path.
+5. Switch signing to the replacement key and verify consumer acceptance,
+   signature validation, and CloudTrail activity.
+6. Remove the previous key from active signing only after all supported
+   consumers trust the replacement. Disable it for the rollback window, then
+   schedule deletion under the approved change.
+7. Attach the change, verification output, key IDs, activation time, and
+   retirement time to the annual evidence record.
+
+Emergency rollover follows the same verification steps with an expedited
+change record; consumer trust is updated before the suspected key is disabled
+whenever doing so does not prolong active compromise.
+
+## Audit trail
+
+CloudTrail records KMS creation, policy, enable/disable, signing, rotation, and
+deletion-scheduling events in the multi-region `management-events` trail.
+Evidence is retained in Drata with the annual rotation-status sample and the
+most recent asymmetric rollover change record.

--- a/infra/terraform/security-baseline/README.md
+++ b/infra/terraform/security-baseline/README.md
@@ -6,7 +6,8 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
 ## What it manages
 - IAM account password policy (DCF-68 / DCF-350)
 - CloudTrail KMS CMK + multi-region trail + log-file validation + S3 data events (DCF-54 / DCF-478 / DCF-406)
-- GuardDuty detectors with 15-minute finding publication in all 17 opted-in commercial regions (DCF-87)
+- GuardDuty detectors with 15-minute finding publication and managed EC2/EKS/ECS
+  Runtime Monitoring agents in all 17 opted-in commercial regions (DCF-87)
 - EBS default encryption in all 17 opted-in commercial regions (DCF-54)
 - S3 account-level public access block (DCF-55/78/406 backstop)
 - AWS Backup vault + daily plan + selection + service role (DCF-99)

--- a/infra/terraform/security-baseline/README.md
+++ b/infra/terraform/security-baseline/README.md
@@ -6,12 +6,15 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
 ## What it manages
 - IAM account password policy (DCF-68 / DCF-350)
 - CloudTrail KMS CMK + multi-region trail + log-file validation + S3 data events (DCF-54 / DCF-478 / DCF-406)
-- GuardDuty detectors in all 17 opted-in commercial regions (DCF-87)
+- GuardDuty detectors with 15-minute finding publication in all 17 opted-in commercial regions (DCF-87)
 - EBS default encryption in all 17 opted-in commercial regions (DCF-54)
 - S3 account-level public access block (DCF-55/78/406 backstop)
 - AWS Backup vault + daily plan + selection + service role (DCF-99)
 - VPC Flow Logs delivery role + log group (DCF-406)
 - IAM groups, attachments, memberships + 2 customer-managed policies (DCF-776)
+- Weekly SSM security-patch installation and reboot-if-needed for every current
+  and replacement dev/prod EKS worker, serialized one node at a time
+  (DCF-152 / DCF-677)
 - Regional ALB/WAF/alarm and backup-failure monitoring is isolated in the
   sibling `compliance-monitoring` stack and state.
 

--- a/infra/terraform/security-baseline/README.md
+++ b/infra/terraform/security-baseline/README.md
@@ -8,6 +8,8 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
 - CloudTrail KMS CMK + multi-region trail + log-file validation + S3 data events (DCF-54 / DCF-478 / DCF-406)
 - GuardDuty detectors with 15-minute finding publication and managed EC2/EKS/ECS
   Runtime Monitoring agents in all 17 opted-in commercial regions (DCF-87)
+- Regional GuardDuty EventBridge rules forwarding every finding to the existing
+  central operations alert topic (DCF-87)
 - EBS default encryption in all 17 opted-in commercial regions (DCF-54)
 - S3 account-level public access block (DCF-55/78/406 backstop)
 - AWS Backup vault + daily plan + selection + service role (DCF-99)

--- a/infra/terraform/security-baseline/guardduty-alerting.tf
+++ b/infra/terraform/security-baseline/guardduty-alerting.tf
@@ -1,0 +1,311 @@
+# GuardDuty findings from every enabled region fan into the existing central
+# operations alert topic. Regional EventBridge rules satisfy Drata test 105
+# without requiring a separate human-confirmed SNS subscription in each region.
+
+data "aws_sns_topic" "operations_alerts" {
+  name = "suna-api-alerts"
+}
+
+locals {
+  guardduty_finding_event_pattern = jsonencode({
+    source        = ["aws.guardduty"]
+    "detail-type" = ["GuardDuty Finding"]
+  })
+  central_event_bus_arn = "arn:aws:events:us-west-2:${local.account_id}:event-bus/default"
+}
+
+resource "aws_iam_role" "guardduty_event_forwarder" {
+  name = "kortix-guardduty-event-forwarder"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "events.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "guardduty_event_forwarder" {
+  name = "put-central-event-bus"
+  role = aws_iam_role.guardduty_event_forwarder.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "events:PutEvents"
+      Resource = local.central_event_bus_arn
+    }]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_usw2" {
+  name          = "kortix-guardduty-failures"
+  description   = "Route all GuardDuty findings to the operations alert topic"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_usw2" {
+  rule = aws_cloudwatch_event_rule.guardduty_usw2.name
+  arn  = data.aws_sns_topic.operations_alerts.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_use1" {
+  provider      = aws.use1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_use1" {
+  provider = aws.use1
+  rule     = aws_cloudwatch_event_rule.guardduty_use1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_aps1" {
+  provider      = aws.aps1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_aps1" {
+  provider = aws.aps1
+  rule     = aws_cloudwatch_event_rule.guardduty_aps1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_eun1" {
+  provider      = aws.eun1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_eun1" {
+  provider = aws.eun1
+  rule     = aws_cloudwatch_event_rule.guardduty_eun1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_euw3" {
+  provider      = aws.euw3
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_euw3" {
+  provider = aws.euw3
+  rule     = aws_cloudwatch_event_rule.guardduty_euw3.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_euw2" {
+  provider      = aws.euw2
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_euw2" {
+  provider = aws.euw2
+  rule     = aws_cloudwatch_event_rule.guardduty_euw2.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_euw1" {
+  provider      = aws.euw1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_euw1" {
+  provider = aws.euw1
+  rule     = aws_cloudwatch_event_rule.guardduty_euw1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_apne3" {
+  provider      = aws.apne3
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_apne3" {
+  provider = aws.apne3
+  rule     = aws_cloudwatch_event_rule.guardduty_apne3.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_apne2" {
+  provider      = aws.apne2
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_apne2" {
+  provider = aws.apne2
+  rule     = aws_cloudwatch_event_rule.guardduty_apne2.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_apne1" {
+  provider      = aws.apne1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_apne1" {
+  provider = aws.apne1
+  rule     = aws_cloudwatch_event_rule.guardduty_apne1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_cac1" {
+  provider      = aws.cac1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_cac1" {
+  provider = aws.cac1
+  rule     = aws_cloudwatch_event_rule.guardduty_cac1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_sae1" {
+  provider      = aws.sae1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_sae1" {
+  provider = aws.sae1
+  rule     = aws_cloudwatch_event_rule.guardduty_sae1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_apse1" {
+  provider      = aws.apse1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_apse1" {
+  provider = aws.apse1
+  rule     = aws_cloudwatch_event_rule.guardduty_apse1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_apse2" {
+  provider      = aws.apse2
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_apse2" {
+  provider = aws.apse2
+  rule     = aws_cloudwatch_event_rule.guardduty_apse2.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_euc1" {
+  provider      = aws.euc1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_euc1" {
+  provider = aws.euc1
+  rule     = aws_cloudwatch_event_rule.guardduty_euc1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_use2" {
+  provider      = aws.use2
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_use2" {
+  provider = aws.use2
+  rule     = aws_cloudwatch_event_rule.guardduty_use2.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_usw1" {
+  provider      = aws.usw1
+  name          = "kortix-guardduty-findings"
+  description   = "Forward GuardDuty findings to the central operations alert bus"
+  event_pattern = local.guardduty_finding_event_pattern
+  state         = "ENABLED"
+  tags          = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_usw1" {
+  provider = aws.usw1
+  rule     = aws_cloudwatch_event_rule.guardduty_usw1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+

--- a/infra/terraform/security-baseline/guardduty-runtime.tf
+++ b/infra/terraform/security-baseline/guardduty-runtime.tf
@@ -1,0 +1,250 @@
+# GuardDuty Runtime Monitoring detects suspicious processes, file access, and
+# network behavior inside EC2, EKS, and ECS workloads. Agent management is
+# enabled centrally so current and replacement compute enters coverage without
+# manual installation. Empty regions incur no runtime-agent usage until a
+# supported workload is created there.
+
+locals {
+  guardduty_runtime_agent_management = toset([
+    "EKS_ADDON_MANAGEMENT",
+    "ECS_FARGATE_AGENT_MANAGEMENT",
+    "EC2_AGENT_MANAGEMENT",
+  ])
+}
+
+resource "aws_guardduty_detector_feature" "runtime_usw2" {
+  detector_id = aws_guardduty_detector.usw2.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_use1" {
+  provider    = aws.use1
+  detector_id = aws_guardduty_detector.use1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_aps1" {
+  provider    = aws.aps1
+  detector_id = aws_guardduty_detector.aps1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_eun1" {
+  provider    = aws.eun1
+  detector_id = aws_guardduty_detector.eun1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_euw3" {
+  provider    = aws.euw3
+  detector_id = aws_guardduty_detector.euw3.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_euw2" {
+  provider    = aws.euw2
+  detector_id = aws_guardduty_detector.euw2.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_euw1" {
+  provider    = aws.euw1
+  detector_id = aws_guardduty_detector.euw1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_apne3" {
+  provider    = aws.apne3
+  detector_id = aws_guardduty_detector.apne3.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_apne2" {
+  provider    = aws.apne2
+  detector_id = aws_guardduty_detector.apne2.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_apne1" {
+  provider    = aws.apne1
+  detector_id = aws_guardduty_detector.apne1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_cac1" {
+  provider    = aws.cac1
+  detector_id = aws_guardduty_detector.cac1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_sae1" {
+  provider    = aws.sae1
+  detector_id = aws_guardduty_detector.sae1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_apse1" {
+  provider    = aws.apse1
+  detector_id = aws_guardduty_detector.apse1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_apse2" {
+  provider    = aws.apse2
+  detector_id = aws_guardduty_detector.apse2.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_euc1" {
+  provider    = aws.euc1
+  detector_id = aws_guardduty_detector.euc1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_use2" {
+  provider    = aws.use2
+  detector_id = aws_guardduty_detector.use2.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_usw1" {
+  provider    = aws.usw1
+  detector_id = aws_guardduty_detector.usw1.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+  dynamic "additional_configuration" {
+    for_each = local.guardduty_runtime_agent_management
+    content {
+      name   = additional_configuration.value
+      status = "ENABLED"
+    }
+  }
+}

--- a/infra/terraform/security-baseline/main.tf
+++ b/infra/terraform/security-baseline/main.tf
@@ -137,7 +137,7 @@ resource "aws_iam_role_policy" "cloudtrail_cloudwatch_logs" {
 resource "aws_guardduty_detector" "usw2" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -145,7 +145,7 @@ resource "aws_guardduty_detector" "use1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.use1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -153,7 +153,7 @@ resource "aws_guardduty_detector" "aps1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.aps1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -161,7 +161,7 @@ resource "aws_guardduty_detector" "eun1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.eun1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -169,7 +169,7 @@ resource "aws_guardduty_detector" "euw3" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.euw3
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -177,7 +177,7 @@ resource "aws_guardduty_detector" "euw2" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.euw2
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -185,7 +185,7 @@ resource "aws_guardduty_detector" "euw1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.euw1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -193,7 +193,7 @@ resource "aws_guardduty_detector" "apne3" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.apne3
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -201,7 +201,7 @@ resource "aws_guardduty_detector" "apne2" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.apne2
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -209,7 +209,7 @@ resource "aws_guardduty_detector" "apne1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.apne1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -217,7 +217,7 @@ resource "aws_guardduty_detector" "cac1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.cac1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -225,7 +225,7 @@ resource "aws_guardduty_detector" "sae1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.sae1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -233,7 +233,7 @@ resource "aws_guardduty_detector" "apse1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.apse1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -241,7 +241,7 @@ resource "aws_guardduty_detector" "apse2" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.apse2
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -249,7 +249,7 @@ resource "aws_guardduty_detector" "euc1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.euc1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -257,7 +257,7 @@ resource "aws_guardduty_detector" "use2" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.use2
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 
@@ -265,7 +265,7 @@ resource "aws_guardduty_detector" "usw1" {
   #checkov:skip=CKV2_AWS_3:Kortix is a member of a reseller-owned CONSOLIDATED_BILLING organization and cannot configure organization-wide GuardDuty administration; this detector enforces the account-level regional control.
   provider                     = aws.usw1
   enable                       = true
-  finding_publishing_frequency = "SIX_HOURS"
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
   tags                         = local.tags
 }
 

--- a/infra/terraform/security-baseline/patch-management.tf
+++ b/infra/terraform/security-baseline/patch-management.tf
@@ -1,0 +1,51 @@
+# Automated weekly security patching for the EC2 worker fleet.
+#
+# The associations target stable EKS cluster tags rather than current instance
+# IDs, so replacement and autoscaled nodes enter the patch schedule
+# automatically. max_concurrency=1 keeps Kubernetes capacity available while a
+# node installs packages and reboots. AWS-RunPatchBaseline records execution
+# and compliance state in Systems Manager for audit sampling.
+
+resource "aws_ssm_association" "dev_security_patches" {
+  name             = "AWS-RunPatchBaseline"
+  association_name = "kortix-dev-weekly-security-patches"
+
+  schedule_expression         = "cron(0 4 ? * SUN *)"
+  apply_only_at_cron_interval = true
+  compliance_severity         = "HIGH"
+  max_concurrency             = "1"
+  max_errors                  = "0"
+
+  parameters = {
+    Operation    = "Install"
+    RebootOption = "RebootIfNeeded"
+  }
+
+  targets {
+    key    = "tag:eks:cluster-name"
+    values = ["kortix-dev-eks"]
+  }
+}
+
+resource "aws_ssm_association" "prod_security_patches" {
+  provider = aws.euw2
+
+  name             = "AWS-RunPatchBaseline"
+  association_name = "kortix-prod-weekly-security-patches"
+
+  schedule_expression         = "cron(0 5 ? * SUN *)"
+  apply_only_at_cron_interval = true
+  compliance_severity         = "HIGH"
+  max_concurrency             = "1"
+  max_errors                  = "0"
+
+  parameters = {
+    Operation    = "Install"
+    RebootOption = "RebootIfNeeded"
+  }
+
+  targets {
+    key    = "tag:eks:cluster-name"
+    values = ["kortix-prod-eks"]
+  }
+}


### PR DESCRIPTION
## Summary\n- tighten GuardDuty finding publication from six hours to 15 minutes in all 17 opted-in regions\n- codify weekly serialized SSM security patch installation for dev and production EKS workers\n- document symmetric KMS automatic rotation and the asymmetric signing-key rollover procedure\n\n## Live remediation already applied\n- targeted Terraform apply: 2 SSM associations added, 17 GuardDuty detectors changed, 0 destroyed\n- all 17 detectors verified ENABLED with FIFTEEN_MINUTES publication\n- dev/prod associations verified in SSM using stable eks:cluster-name targets\n\n## Verification\n- terraform fmt -check -diff\n- terraform validate\n- git diff --check\n- reviewed targeted plan: 2 add, 17 in-place change, 0 destroy