### PR TITLE
feat(connectors): add first-class Postman ingestion

### DIFF
--- a/apps/api/src/__tests__/unit-connectors-parse.test.ts
+++ b/apps/api/src/__tests__/unit-connectors-parse.test.ts
@@ -95,6 +95,25 @@ connectors:
     expect(specs[0]).toMatchObject({ spec: '.kortix/executor/internal.openapi.json', auth: { type: 'none' } });
   });
 
+  test('postman by public repository URL', () => {
+    const { specs, errors } = parseAndExtract(`
+connectors:
+  - slug: hubspot
+    provider: postman
+    spec: https://github.com/HubSpot/HubSpot-public-api-spec-collection
+`);
+    expect(errors).toEqual([]);
+    expect(specs[0]).toMatchObject({
+      slug: 'hubspot',
+      provider: 'postman',
+      spec: 'https://github.com/HubSpot/HubSpot-public-api-spec-collection',
+    });
+    expect(connectorSpecToTomlEntry(specs[0]!)).toMatchObject({
+      provider: 'postman',
+      spec: 'https://github.com/HubSpot/HubSpot-public-api-spec-collection',
+    });
+  });
+
   test('graphql — endpoint, optional spec, bearer', () => {
     const { specs, errors } = parseAndExtract(`
 connectors:

--- a/apps/api/src/__tests__/unit-connectors-parse.test.ts
+++ b/apps/api/src/__tests__/unit-connectors-parse.test.ts
@@ -114,6 +114,16 @@ connectors:
     });
   });
 
+  test('postman requires a source spec', () => {
+    const { specs, errors } = parseAndExtract(`
+connectors:
+  - slug: hubspot
+    provider: postman
+`);
+    expect(specs).toEqual([]);
+    expect(errors[0]!.error).toContain('provider="postman" requires `spec`');
+  });
+
   test('graphql — endpoint, optional spec, bearer', () => {
     const { specs, errors } = parseAndExtract(`
 connectors:
@@ -566,6 +576,7 @@ describe('connectors: — runtime parser ⇄ schema gate provider agreement', ()
     { name: 'pipedream', accept: true, body: `connectors:\n  - slug: c\n    provider: pipedream\n    app: gmail` },
     { name: 'mcp', accept: true, body: `connectors:\n  - slug: c\n    provider: mcp\n    url: https://e.com` },
     { name: 'openapi', accept: true, body: `connectors:\n  - slug: c\n    provider: openapi\n    spec: https://e.com/o.json` },
+    { name: 'postman', accept: true, body: `connectors:\n  - slug: c\n    provider: postman\n    spec: https://github.com/acme/apis` },
     { name: 'graphql', accept: true, body: `connectors:\n  - slug: c\n    provider: graphql\n    endpoint: https://e.com/graphql` },
     { name: 'http', accept: true, body: `connectors:\n  - slug: c\n    provider: http\n    base_url: https://e.com` },
     { name: 'channel', accept: true, body: `connectors:\n  - slug: kortix_slack\n    provider: channel\n    platform: slack` },

--- a/apps/api/src/__tests__/unit-executor-execute.test.ts
+++ b/apps/api/src/__tests__/unit-executor-execute.test.ts
@@ -170,6 +170,50 @@ describe('HTTP execution request shape', () => {
   });
 });
 
+describe('Postman execution request shape', () => {
+  test('renders URL/header templates, preserves static values, sends body, and attaches connector auth', async () => {
+    const { fetchImpl, calls } = recordingFetch();
+    await executeCall({
+      binding: {
+        kind: 'postman',
+        method: 'POST',
+        url: 'https://api.example.com/contacts/{{contactId}}?archived={{archived}}',
+        headers: { 'X-Client': 'kortix', 'X-Trace': '{{traceId}}' },
+        bodyMode: 'json',
+      },
+      auth: BEARER,
+      secret: 'hubspot-token',
+      args: {
+        contactId: 'a/b',
+        archived: false,
+        traceId: 'trace-1',
+        body: { properties: { email: 'person@example.com' } },
+      },
+      fetchImpl,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://api.example.com/contacts/a%2Fb?archived=false');
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.headers).toMatchObject({
+      Authorization: 'Bearer hubspot-token',
+      'Content-Type': 'application/json',
+      'X-Client': 'kortix',
+      'X-Trace': 'trace-1',
+    });
+    expect(JSON.parse(calls[0]!.body!)).toEqual({ properties: { email: 'person@example.com' } });
+  });
+
+  test('fails closed when a required template variable is missing', async () => {
+    const { fetchImpl } = recordingFetch();
+    await expect(executeCall({
+      binding: { kind: 'postman', method: 'GET', url: 'https://api.example.com/{{id}}', headers: {}, bodyMode: null },
+      args: {},
+      fetchImpl,
+    })).rejects.toThrow('missing Postman variable "id"');
+  });
+});
+
 describe('MCP execution request shape', () => {
   test('builds JSON-RPC tools/call with auth', async () => {
     const { fetchImpl, calls } = recordingFetch();

--- a/apps/api/src/__tests__/unit-executor-materialize.test.ts
+++ b/apps/api/src/__tests__/unit-executor-materialize.test.ts
@@ -47,6 +47,21 @@ account = "work"
     expect(connectorConfig(spec)).toEqual({ app: 'gmail', account: 'work' });
   });
 
+  test('postman stores only its source and credential-free auth shape', () => {
+    const spec = specFrom(`
+[[connectors]]
+slug = "hubspot"
+provider = "postman"
+spec = "https://github.com/HubSpot/HubSpot-public-api-spec-collection"
+  [connectors.auth]
+  type = "bearer"
+`);
+    expect(connectorConfig(spec, 'https://must-not-be-used.example')).toEqual({
+      spec: 'https://github.com/HubSpot/HubSpot-public-api-spec-collection',
+      auth: { type: 'bearer', in: 'header', name: null, prefix: null },
+    });
+  });
+
   test('mcp/graphql/http base URLs', () => {
     const mcp = specFrom(`
 [[connectors]]

--- a/apps/api/src/__tests__/unit-executor-normalize.test.ts
+++ b/apps/api/src/__tests__/unit-executor-normalize.test.ts
@@ -230,6 +230,12 @@ describe('normalizePostmanCollection', () => {
 
   test('rejects non-collection documents precisely', () => {
     expect(() => normalizePostmanCollection({ openapi: '3.0.0', paths: {} })).toThrow('Postman Collection');
+    expect(() => normalizePostmanCollection({
+      info: {
+        schema: 'https://attacker.example/schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      item: [],
+    })).toThrow('Postman Collection');
   });
 });
 

--- a/apps/api/src/__tests__/unit-executor-normalize.test.ts
+++ b/apps/api/src/__tests__/unit-executor-normalize.test.ts
@@ -88,6 +88,44 @@ describe('normalizeOpenApi', () => {
     expect(normalizeOpenApi(null)).toEqual([]);
     expect(normalizeOpenApi({})).toEqual([]);
   });
+
+  test('memoizes repeated schema refs within a large document', () => {
+    const shared = {
+      type: 'object',
+      properties: { id: { type: 'string' }, nested: { $ref: '#/components/schemas/Nested' } },
+    };
+    const actions = normalizeOpenApi({
+      paths: {
+        '/a': { get: { responses: { '200': { content: { 'application/json': { schema: { $ref: '#/components/schemas/Shared' } } } } } } },
+        '/b': { get: { responses: { '200': { content: { 'application/json': { schema: { $ref: '#/components/schemas/Shared' } } } } } } },
+      },
+      components: { schemas: { Shared: shared, Nested: { type: 'object', properties: { value: { type: 'string' } } } } },
+    });
+    expect(actions[0]!.outputSchema).toBe(actions[1]!.outputSchema);
+    expect((actions[0]!.outputSchema as any).properties.nested.properties.value.type).toBe('string');
+  });
+
+  test('bounds serialized schema expansion for deeply shared OpenAPI graphs', () => {
+    const schemas: Record<string, unknown> = {
+      Level0: { type: 'object', properties: { value: { type: 'string' } } },
+    };
+    for (let level = 1; level <= 18; level++) {
+      schemas[`Level${level}`] = {
+        type: 'object',
+        properties: {
+          left: { $ref: `#/components/schemas/Level${level - 1}` },
+          right: { $ref: `#/components/schemas/Level${level - 1}` },
+        },
+      };
+    }
+    const [action] = normalizeOpenApi({
+      paths: { '/tree': { get: { responses: { '200': { content: { 'application/json': { schema: { $ref: '#/components/schemas/Level18' } } } } } } } },
+      components: { schemas },
+    });
+    const serialized = JSON.stringify(action!.outputSchema);
+    expect(serialized.length).toBeLessThan(100_000);
+    expect(serialized).toContain('value');
+  });
 });
 
 describe('normalizePostmanCollection', () => {
@@ -99,6 +137,7 @@ describe('normalizePostmanCollection', () => {
     variable: [
       { key: 'baseUrl', value: 'https://api.hubapi.com', type: 'string' },
       { key: 'privateToken', value: 'must-not-be-imported', type: 'secret' },
+      { key: 'apiKey', value: 'also-must-not-be-imported', type: 'string' },
     ],
     item: [
       {
@@ -111,6 +150,7 @@ describe('normalizePostmanCollection', () => {
               header: [
                 { key: 'X-Trace', value: '{{traceId}}' },
                 { key: 'Authorization', value: 'Bearer {{privateToken}}' },
+                { key: 'X-API-Key', value: '{{apiKey}}' },
               ],
               url: {
                 raw: '{{baseUrl}}/crm/v3/objects/contacts/:contactId?archived={{archived}}',
@@ -156,7 +196,25 @@ describe('normalizePostmanCollection', () => {
     expect((create.inputSchema as any).properties.body).toMatchObject({ type: 'object' });
     expect((create.inputSchema as any).required).toContain('body');
     expect(JSON.stringify(result)).not.toContain('must-not-be-imported');
+    expect(JSON.stringify(result)).not.toContain('also-must-not-be-imported');
     expect(JSON.stringify(result)).not.toContain('Authorization');
+    expect(JSON.stringify(result)).not.toContain('X-API-Key');
+  });
+
+  test('drops credential-like query parameters instead of persisting inline values', () => {
+    const result = normalizePostmanCollection({
+      info: { name: 'credentials', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+      item: [{
+        name: 'list',
+        request: {
+          method: 'GET',
+          url: 'https://example.com/items?hapikey=inline-secret&limit={{limit}}',
+        },
+      }],
+    });
+    expect((result.actions[0]!.binding as any).url).toBe('https://example.com/items?limit={{limit}}');
+    expect(JSON.stringify(result)).not.toContain('inline-secret');
+    expect(result.warnings.join('\n')).toContain('credential-like query parameter');
   });
 
   test('reports scripts and unsupported file bodies without executing them', () => {

--- a/apps/api/src/__tests__/unit-executor-normalize.test.ts
+++ b/apps/api/src/__tests__/unit-executor-normalize.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeHttp,
   normalizeMcp,
   normalizeOpenApi,
+  normalizePostmanCollection,
 } from '../executor/normalize';
 
 describe('normalizeOpenApi', () => {
@@ -86,6 +87,91 @@ describe('normalizeOpenApi', () => {
   test('empty / malformed doc → []', () => {
     expect(normalizeOpenApi(null)).toEqual([]);
     expect(normalizeOpenApi({})).toEqual([]);
+  });
+});
+
+describe('normalizePostmanCollection', () => {
+  const collection = {
+    info: {
+      name: 'HubSpot Contacts',
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+    },
+    variable: [
+      { key: 'baseUrl', value: 'https://api.hubapi.com', type: 'string' },
+      { key: 'privateToken', value: 'must-not-be-imported', type: 'secret' },
+    ],
+    item: [
+      {
+        name: 'Contacts',
+        item: [
+          {
+            name: 'Get contact',
+            request: {
+              method: 'GET',
+              header: [
+                { key: 'X-Trace', value: '{{traceId}}' },
+                { key: 'Authorization', value: 'Bearer {{privateToken}}' },
+              ],
+              url: {
+                raw: '{{baseUrl}}/crm/v3/objects/contacts/:contactId?archived={{archived}}',
+                variable: [{ key: 'contactId', value: '' }],
+                query: [{ key: 'archived', value: '{{archived}}' }],
+              },
+            },
+            response: [{ code: 200, body: '{"id":"123","archived":false}', header: [{ key: 'Content-Type', value: 'application/json' }] }],
+          },
+          {
+            name: 'Create contact',
+            request: {
+              method: 'POST',
+              url: '{{baseUrl}}/crm/v3/objects/contacts',
+              body: { mode: 'raw', raw: '{"properties":{"email":"person@example.com"}}', options: { raw: { language: 'json' } } },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  test('normalizes nested requests, variables, schemas, risk, and safe bindings', () => {
+    const result = normalizePostmanCollection(collection);
+    expect(result.warnings).toEqual([]);
+    expect(result.actions).toHaveLength(2);
+    const byPath = Object.fromEntries(result.actions.map((action) => [action.path, action]));
+
+    const get = byPath['contacts.get_contact']!;
+    expect(get.risk).toBe('read');
+    expect(get.binding).toEqual({
+      kind: 'postman',
+      method: 'GET',
+      url: 'https://api.hubapi.com/crm/v3/objects/contacts/{{contactId}}?archived={{archived}}',
+      headers: { 'X-Trace': '{{traceId}}' },
+      bodyMode: null,
+    });
+    expect((get.inputSchema as any).required.sort()).toEqual(['archived', 'contactId', 'traceId']);
+    expect((get.outputSchema as any).properties.id.type).toBe('string');
+
+    const create = byPath['contacts.create_contact']!;
+    expect(create.risk).toBe('write');
+    expect((create.inputSchema as any).properties.body).toMatchObject({ type: 'object' });
+    expect((create.inputSchema as any).required).toContain('body');
+    expect(JSON.stringify(result)).not.toContain('must-not-be-imported');
+    expect(JSON.stringify(result)).not.toContain('Authorization');
+  });
+
+  test('reports scripts and unsupported file bodies without executing them', () => {
+    const result = normalizePostmanCollection({
+      info: { name: 'unsafe', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+      event: [{ listen: 'prerequest', script: { exec: ['throw new Error("never")'] } }],
+      item: [{ name: 'upload', request: { method: 'POST', url: 'https://example.com/upload', body: { mode: 'file', file: { src: '/tmp/x' } } } }],
+    });
+    expect(result.actions).toHaveLength(1);
+    expect(result.warnings.join('\n')).toContain('pre-request');
+    expect(result.warnings.join('\n')).toContain('file');
+  });
+
+  test('rejects non-collection documents precisely', () => {
+    expect(() => normalizePostmanCollection({ openapi: '3.0.0', paths: {} })).toThrow('Postman Collection');
   });
 });
 

--- a/apps/api/src/__tests__/unit-postman-catalog.test.ts
+++ b/apps/api/src/__tests__/unit-postman-catalog.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizePostmanDocuments } from '../executor/sync';
+
+describe('Postman multi-document catalogs', () => {
+  test('namespaces actions and deterministically suffixes collisions', () => {
+    const openapi = (path: string) => ({
+      openapi: '3.0.0',
+      paths: { [path]: { get: { operationId: 'list', responses: {} } } },
+    });
+    const actions = normalizePostmanDocuments([
+      { namespace: 'crm_contacts_v3', kind: 'openapi', source: 'contacts-a.json', doc: openapi('/contacts') },
+      { namespace: 'crm_contacts_v3', kind: 'openapi', source: 'contacts-b.json', doc: openapi('/contacts/archive') },
+      { namespace: 'crm_companies_v3', kind: 'openapi', source: 'companies.json', doc: openapi('/companies') },
+    ]);
+
+    expect(actions.map((action) => action.path)).toEqual([
+      'crm_contacts_v3.list',
+      'crm_contacts_v3.list_2',
+      'crm_companies_v3.list',
+    ]);
+  });
+
+  test('does not add a namespace to a single exported collection', () => {
+    const actions = normalizePostmanDocuments([{
+      namespace: 'hubspot',
+      kind: 'postman',
+      source: 'hubspot.postman_collection.json',
+      doc: {
+        info: { name: 'HubSpot', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+        item: [{ name: 'Get owner', request: { method: 'GET', url: 'https://api.hubapi.com/owners/v2/owners' } }],
+      },
+    }]);
+    expect(actions.map((action) => action.path)).toEqual(['get_owner']);
+  });
+});

--- a/apps/api/src/__tests__/unit-postman-source.test.ts
+++ b/apps/api/src/__tests__/unit-postman-source.test.ts
@@ -60,4 +60,47 @@ describe('Postman repository metadata', () => {
       {},
     )).rejects.toThrow('POSTMAN_API_KEY');
   });
+
+  test('loads an exported Collection v2 document directly', async () => {
+    const source = 'https://example.com/hubspot.postman_collection.json';
+    const doc = {
+      info: { name: 'HubSpot', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+      item: [],
+    };
+    const documents = await resolvePostmanSource(source, async (loaded) => {
+      expect(loaded).toBe(source);
+      return JSON.stringify(doc);
+    });
+    expect(documents).toEqual([{ namespace: 'hubspot', kind: 'postman', source, doc }]);
+  });
+
+  test('rejects an oversized direct collection before parsing it', async () => {
+    await expect(resolvePostmanSource(
+      'https://example.com/large.postman_collection.json',
+      async () => JSON.stringify({
+        info: { name: 'large', schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json' },
+        item: [],
+        padding: 'x'.repeat(1_000),
+      }),
+      { maxDocumentBytes: 200 },
+    )).rejects.toThrow('exceeds 200 bytes');
+  });
+
+  test('a stale repository relation is warned and skipped without losing healthy APIs', async () => {
+    const warnings: string[] = [];
+    const documents = await resolvePostmanSource(
+      '.postman/api',
+      async (source) => {
+        if (source === '.postman/api') return 'apis[] = {"apiId":"healthy"}\napis[] = {"apiId":"deleted"}';
+        if (source.endsWith('api_healthy')) return '[config.relations.apiDefinition.metaData]\ntype = openapi:3\nrootFiles[] = specs/healthy.json';
+        if (source.endsWith('api_deleted')) throw new Error('HTTP 404');
+        if (source === 'specs/healthy.json') return JSON.stringify({ openapi: '3.0.0', paths: {} });
+        throw new Error(`unexpected ${source}`);
+      },
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+    expect(documents).toHaveLength(1);
+    expect(documents[0]!.source).toBe('specs/healthy.json');
+    expect(warnings).toEqual([expect.stringContaining('deleted')]);
+  });
 });

--- a/apps/api/src/__tests__/unit-postman-source.test.ts
+++ b/apps/api/src/__tests__/unit-postman-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  parsePostmanApiEntity,
+  parsePostmanApiIndex,
+  resolvePostmanSource,
+} from '../executor/postman-source';
+
+describe('Postman repository metadata', () => {
+  test('parses the repeated API ids from .postman/api', () => {
+    expect(parsePostmanApiIndex(`
+      apis[] = {"apiId":"alpha"}
+      apis[] = {"apiId":"beta"}
+      configVersion = 1.0.0
+    `)).toEqual(['alpha', 'beta']);
+  });
+
+  test('prefers original OpenAPI definitions and retains collections as fallback', () => {
+    expect(parsePostmanApiEntity(`
+      [config.relations.collections]
+      rootDirectory = PublicApiSpecs/CRM/Contacts/Collection Directory
+      files[] = {"id":"1","path":"Contacts Collection.json","metaData":{}}
+      [config.relations.apiDefinition]
+      files[] = {"path":"PublicApiSpecs/CRM/Contacts/contacts.json","metaData":{}}
+      [config.relations.apiDefinition.metaData]
+      type = openapi:3
+      rootFiles[] = PublicApiSpecs/CRM/Contacts/contacts.json
+    `)).toEqual({
+      type: 'openapi',
+      files: ['PublicApiSpecs/CRM/Contacts/contacts.json'],
+    });
+  });
+
+  test('resolves a GitHub Postman repository deterministically through raw files', async () => {
+    const loaded: string[] = [];
+    const documents = await resolvePostmanSource(
+      'https://github.com/acme/apis',
+      async (url) => {
+        loaded.push(url);
+        if (url.endsWith('/.postman/api')) return 'apis[] = {"apiId":"contacts"}\napis[] = {"apiId":"companies"}';
+        if (url.endsWith('/.postman/api_contacts')) return '[config.relations.apiDefinition.metaData]\ntype = openapi:3\nrootFiles[] = specs/contacts.json';
+        if (url.endsWith('/.postman/api_companies')) return '[config.relations.apiDefinition.metaData]\ntype = openapi:3\nrootFiles[] = specs/companies.json';
+        if (url.endsWith('/specs/contacts.json')) return JSON.stringify({ openapi: '3.0.0', paths: { '/contacts': { get: { operationId: 'list' } } } });
+        if (url.endsWith('/specs/companies.json')) return JSON.stringify({ openapi: '3.0.0', paths: { '/companies': { get: { operationId: 'list' } } } });
+        throw new Error(`unexpected ${url}`);
+      },
+      { githubDefaultBranch: async () => 'main' },
+    );
+
+    expect(documents.map((doc) => [doc.namespace, doc.kind])).toEqual([
+      ['specs_companies', 'openapi'],
+      ['specs_contacts', 'openapi'],
+    ]);
+    expect(loaded[0]).toBe('https://raw.githubusercontent.com/acme/apis/main/.postman/api');
+  });
+
+  test('public Postman workspace URLs require supported API credentials', async () => {
+    await expect(resolvePostmanSource(
+      'https://www.postman.com/hubspot/hubspot-public-api-workspace/overview',
+      async () => { throw new Error('must not scrape'); },
+      {},
+    )).rejects.toThrow('POSTMAN_API_KEY');
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -488,6 +488,9 @@ const envSchema = z.object({
   PIPEDREAM_PROJECT_ID:        optStr,
   PIPEDREAM_ENVIRONMENT:       optStrDefault('production'),
   PIPEDREAM_WEBHOOK_SECRET:    optStr,
+  // Optional: required only when importing a public Postman workspace URL.
+  // Exported collection JSON and Postman-managed Git repositories need no key.
+  POSTMAN_API_KEY:              optStr,
 
   // ── Tunnel (optional, all have sane defaults) ────────────────────────────
   TUNNEL_SIGNING_SECRET:             optStr,
@@ -735,6 +738,7 @@ export const config = {
   PIPEDREAM_PROJECT_ID: env.PIPEDREAM_PROJECT_ID,
   PIPEDREAM_ENVIRONMENT: env.PIPEDREAM_ENVIRONMENT,
   PIPEDREAM_WEBHOOK_SECRET: env.PIPEDREAM_WEBHOOK_SECRET,
+  POSTMAN_API_KEY: env.POSTMAN_API_KEY,
 
   // ─── Search Providers ──────────────────────────────────────────────────────
   TAVILY_API_URL: env.TAVILY_API_URL,

--- a/apps/api/src/executor/execute.ts
+++ b/apps/api/src/executor/execute.ts
@@ -275,6 +275,68 @@ function appendQuery(query: URLSearchParams, key: string, value: unknown): void 
   }
 }
 
+function renderPostmanTemplate(
+  template: string,
+  args: Record<string, unknown>,
+  encode: boolean,
+): string {
+  return template.replace(/{{\s*([^{}]+?)\s*}}/g, (_whole, rawName: string) => {
+    const name = rawName.trim();
+    const value = args[name];
+    if (value === undefined || value === null) throw new Error(`missing Postman variable "${name}"`);
+    const rendered = String(value);
+    return encode ? encodeURIComponent(rendered) : rendered;
+  });
+}
+
+function setDefaultHeader(headers: Record<string, string>, name: string, value: string): void {
+  if (!Object.keys(headers).some((key) => key.toLowerCase() === name.toLowerCase())) headers[name] = value;
+}
+
+function buildPostmanRequest(opts: {
+  binding: Extract<ActionBinding, { kind: 'postman' }>;
+  auth?: ExecutorAuth;
+  secret?: string | null;
+  args?: Record<string, unknown>;
+}): BuiltRequest {
+  const args = opts.args ?? {};
+  const url = new URL(renderPostmanTemplate(opts.binding.url, args, true));
+  const headers = Object.fromEntries(
+    Object.entries(opts.binding.headers).map(([key, value]) => [key, renderPostmanTemplate(value, args, false)]),
+  );
+  const auth = opts.auth ?? NO_AUTH;
+  if (auth.type === 'oauth1') {
+    const creds = parseOauth1Secret(opts.secret ?? null);
+    if (!creds) {
+      throw new Error(
+        'oauth1 credential must be a JSON object {"consumer_key","consumer_secret","token","token_secret"}',
+      );
+    }
+    headers.Authorization = oauth1Header({
+      method: opts.binding.method,
+      url: `${url.protocol}//${url.host}${url.pathname}`,
+      query: url.searchParams,
+      creds,
+    });
+  } else {
+    applyAuth(headers, url.searchParams, auth, opts.secret ?? null);
+  }
+
+  let body: string | undefined;
+  if (opts.binding.bodyMode === 'json' && args.body !== undefined) {
+    setDefaultHeader(headers, 'Content-Type', 'application/json');
+    body = JSON.stringify(args.body);
+  } else if (opts.binding.bodyMode === 'raw' && args.body !== undefined) {
+    body = typeof args.body === 'string' ? args.body : JSON.stringify(args.body);
+  } else if (opts.binding.bodyMode === 'urlencoded' && args.body && typeof args.body === 'object') {
+    setDefaultHeader(headers, 'Content-Type', 'application/x-www-form-urlencoded');
+    const encoded = new URLSearchParams();
+    for (const [key, value] of Object.entries(args.body as Record<string, unknown>)) appendQuery(encoded, key, value);
+    body = encoded.toString();
+  }
+  return { url: url.href, method: opts.binding.method.toUpperCase(), headers, body };
+}
+
 /** Serialize a JS value to a GraphQL literal (strings/numbers/bools/arrays/objects). */
 function gqlLiteral(v: unknown): string {
   if (v === null || v === undefined) return 'null';
@@ -393,6 +455,15 @@ export async function executeCall(opts: {
   fetchImpl: FetchImpl;
 }): Promise<ExecResult> {
   const { binding } = opts;
+
+  if (binding.kind === 'postman') {
+    return performRequest(buildPostmanRequest({
+      binding,
+      auth: opts.auth,
+      secret: opts.secret,
+      args: opts.args,
+    }), opts.fetchImpl);
+  }
 
   if (binding.kind === 'openapi') {
     const base = opts.baseUrl ?? binding.server;

--- a/apps/api/src/executor/gateway.ts
+++ b/apps/api/src/executor/gateway.ts
@@ -40,7 +40,7 @@ export interface GatewayConnector {
   profileIsDefault?: boolean;
   profileMetadata?: Record<string, unknown>;
   slug: string;
-  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel' | 'computer';
+  provider: 'pipedream' | 'mcp' | 'openapi' | 'postman' | 'graphql' | 'http' | 'channel' | 'computer';
   platform?: string | null;
   /** server / base_url / endpoint / url, per provider (null for some). */
   baseUrl: string | null;

--- a/apps/api/src/executor/manifest-crud.ts
+++ b/apps/api/src/executor/manifest-crud.ts
@@ -28,7 +28,7 @@ import { resolveExperimentalFeature } from '../experimental/features';
 export interface ConnectorDraft {
   slug: string;
   name?: string;
-  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel';
+  provider: 'pipedream' | 'mcp' | 'openapi' | 'postman' | 'graphql' | 'http' | 'channel';
   platform?: 'slack' | 'email';
   app?: string;
   account?: string;
@@ -64,7 +64,7 @@ function draftToEntry(d: ConnectorDraft): Record<string, unknown> {
   } else if (d.provider === 'http') {
     if (d.baseUrl) entry.base_url = d.baseUrl;
     if (d.spec) entry.spec = d.spec;
-  } else if (d.provider === 'openapi') {
+  } else if (d.provider === 'openapi' || d.provider === 'postman') {
     if (d.spec) entry.spec = d.spec;
   } else if (d.provider === 'channel') {
     if (d.platform) entry.platform = d.platform;

--- a/apps/api/src/executor/materialize.ts
+++ b/apps/api/src/executor/materialize.ts
@@ -32,6 +32,10 @@ export function connectorConfig(spec: ConnectorSpec, openapiServer?: string | nu
         return { baseUrl: spec.baseUrl, spec: spec.spec, auth };
       case 'openapi':
         return { spec: spec.spec, server: openapiServer ?? null, auth };
+      case 'postman':
+        // Each Postman request carries its own absolute URL binding; a bundle
+        // can span many upstream servers, so there is intentionally no shared base.
+        return { spec: spec.spec, auth };
       case 'channel':
         // The credential is the platform install token (resolved server-side); the
         // connector carries the platform's API base + its auth placement so

--- a/apps/api/src/executor/normalize.ts
+++ b/apps/api/src/executor/normalize.ts
@@ -58,6 +58,7 @@ export function normalizeOpenApi(doc: any): NormalizedAction[] {
   if (!doc || typeof doc !== 'object' || !doc.paths) return [];
   const server = firstServerUrl(doc);
   const actions: NormalizedAction[] = [];
+  const derefContext: DerefContext = { refs: new Map(), objects: new WeakMap(), bounded: new WeakMap() };
 
   for (const [pathTemplate, pathItem] of Object.entries(doc.paths as Record<string, any>)) {
     if (!pathItem || typeof pathItem !== 'object') continue;
@@ -72,11 +73,11 @@ export function normalizeOpenApi(doc: any): NormalizedAction[] {
         : [seg(pathTemplate) || 'root', method].filter(Boolean).join('.');
 
       const params = [...pathLevelParams, ...(Array.isArray(op.parameters) ? op.parameters : [])]
-        .map((p) => deref(doc, p))
+        .map((p) => deref(doc, p, new Set(), derefContext))
         .filter((p) => p && typeof p === 'object');
 
-      const inputSchema = buildOpenApiInput(doc, params, op.requestBody);
-      const outputSchema = buildOpenApiOutput(doc, op.responses);
+      const inputSchema = buildOpenApiInput(doc, params, op.requestBody, derefContext);
+      const outputSchema = buildOpenApiOutput(doc, op.responses, derefContext);
 
       const binding: ActionBinding = { kind: 'openapi', method: method.toUpperCase(), path: pathTemplate, server };
       actions.push({
@@ -98,26 +99,35 @@ function firstServerUrl(doc: any): string | null {
   return null;
 }
 
-function buildOpenApiInput(doc: any, params: any[], requestBody: any): Record<string, unknown> | null {
+function buildOpenApiInput(
+  doc: any,
+  params: any[],
+  requestBody: any,
+  context: DerefContext,
+): Record<string, unknown> | null {
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
 
   for (const p of params) {
     if (!p?.name) continue;
+    const parameterSchema = boundedSchema(
+      deref(doc, p.schema, new Set(), context) ?? { type: 'string' },
+      context,
+    );
     properties[p.name] = {
-      ...(deref(doc, p.schema) ?? { type: 'string' }),
-      ...(p.description ? { description: String(p.description) } : {}),
+      ...parameterSchema,
+      ...(p.description ? { description: String(p.description).slice(0, 4_000) } : {}),
       'x-in': p.in,
     };
     if (p.required) required.push(p.name);
   }
 
-  const body = deref(doc, requestBody);
+  const body = deref(doc, requestBody, new Set(), context);
   if (body?.content) {
     const json = body.content['application/json'] ?? Object.values(body.content)[0];
-    const bodySchema = deref(doc, (json as any)?.schema);
+    const bodySchema = deref(doc, (json as any)?.schema, new Set(), context);
     if (bodySchema) {
-      properties.body = bodySchema;
+      properties.body = boundedSchema(bodySchema, context);
       if (body.required) required.push('body');
     }
   }
@@ -126,31 +136,88 @@ function buildOpenApiInput(doc: any, params: any[], requestBody: any): Record<st
   return { type: 'object', properties, ...(required.length ? { required } : {}) };
 }
 
-function buildOpenApiOutput(doc: any, responses: any): Record<string, unknown> | null {
+function buildOpenApiOutput(
+  doc: any,
+  responses: any,
+  context: DerefContext,
+): Record<string, unknown> | null {
   if (!responses || typeof responses !== 'object') return null;
   const ok = responses['200'] ?? responses['201'] ?? responses['2XX'] ?? responses.default;
-  const resolved = deref(doc, ok);
+  const resolved = deref(doc, ok, new Set(), context);
   const content = resolved?.content;
   if (!content) return null;
   const json = content['application/json'] ?? Object.values(content)[0];
-  const schema = deref(doc, (json as any)?.schema);
-  return schema ?? null;
+  const schema = deref(doc, (json as any)?.schema, new Set(), context);
+  return schema ? boundedSchema(schema, context) : null;
 }
 
 /** Resolve `$ref` (only `#/...` local refs) recursively, cycle-guarded. */
-function deref(doc: any, node: any, seen: Set<string> = new Set()): any {
+interface DerefContext {
+  refs: Map<string, any>;
+  objects: WeakMap<object, any>;
+  bounded: WeakMap<object, any>;
+}
+
+function deref(
+  doc: any,
+  node: any,
+  seen: Set<string> = new Set(),
+  context: DerefContext = { refs: new Map(), objects: new WeakMap(), bounded: new WeakMap() },
+): any {
   if (!node || typeof node !== 'object') return node;
   if (typeof node.$ref === 'string') {
     const ref = node.$ref;
     if (!ref.startsWith('#/') || seen.has(ref)) return {};
+    if (context.refs.has(ref)) return context.refs.get(ref);
     seen.add(ref);
     const target = resolvePointer(doc, ref.slice(2).split('/'));
-    return deref(doc, target, seen);
+    const resolved = deref(doc, target, seen, context);
+    context.refs.set(ref, resolved);
+    return resolved;
   }
-  if (Array.isArray(node)) return node.map((n) => deref(doc, n, new Set(seen)));
+  if (context.objects.has(node)) return context.objects.get(node);
+  if (Array.isArray(node)) {
+    const out: any[] = [];
+    context.objects.set(node, out);
+    for (const child of node) out.push(deref(doc, child, new Set(seen), context));
+    return out;
+  }
   const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(node)) out[k] = deref(doc, v, new Set(seen));
+  context.objects.set(node, out);
+  for (const [k, v] of Object.entries(node)) out[k] = deref(doc, v, new Set(seen), context);
   return out;
+}
+
+/**
+ * Convert a dereferenced schema graph into a bounded, JSON-safe tree. OpenAPI
+ * documents commonly reuse the same component through several branches; a
+ * naive JSON serialization expands that DAG exponentially even though it is
+ * small in memory. Connector schemas are discovery hints, so keep a generous
+ * first occurrence and replace repeated/deep branches with an empty schema.
+ */
+function boundedSchema(node: any, context: DerefContext): any {
+  if (!node || typeof node !== 'object') return node;
+  const cached = context.bounded.get(node);
+  if (cached) return cached;
+
+  let remaining = 2_000;
+  const seen = new WeakSet<object>();
+  const visit = (value: any, depth: number): any => {
+    if (typeof value === 'string') return value.length > 4_000 ? value.slice(0, 4_000) : value;
+    if (!value || typeof value !== 'object') return value;
+    if (depth >= 64 || remaining-- <= 0 || seen.has(value)) return {};
+    seen.add(value);
+    if (Array.isArray(value)) return value.slice(0, 200).map((entry) => visit(entry, depth + 1));
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value).slice(0, 300)) {
+      out[key] = visit(child, depth + 1);
+    }
+    return out;
+  };
+
+  const bounded = visit(node, 0);
+  context.bounded.set(node, bounded);
+  return bounded;
 }
 
 function resolvePointer(doc: any, parts: string[]): any {

--- a/apps/api/src/executor/normalize.ts
+++ b/apps/api/src/executor/normalize.ts
@@ -14,6 +14,7 @@ import type {
   PipedreamActionLike,
   Risk,
 } from './types';
+export { normalizePostmanCollection } from './postman-normalize';
 
 /* ─── shared helpers ─────────────────────────────────────────────────────── */
 

--- a/apps/api/src/executor/postman-normalize.ts
+++ b/apps/api/src/executor/postman-normalize.ts
@@ -1,0 +1,235 @@
+import type { ActionBinding, NormalizedAction, Risk } from './types';
+
+export interface PostmanNormalizationResult {
+  actions: NormalizedAction[];
+  warnings: string[];
+}
+
+const COLLECTION_SCHEMA = /schema\.getpostman\.com\/json\/collection\/v2(?:\.0|\.1)\.0\/collection\.json/i;
+const TEMPLATE_RE = /{{\s*([^{}]+?)\s*}}/g;
+
+function segment(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+    .toLowerCase();
+}
+
+function riskForMethod(method: string): Risk {
+  const normalized = method.toUpperCase();
+  if (normalized === 'GET' || normalized === 'HEAD' || normalized === 'OPTIONS') return 'read';
+  if (normalized === 'DELETE') return 'destructive';
+  return 'write';
+}
+
+function collectionVariables(raw: unknown): Map<string, string> {
+  const values = new Map<string, string>();
+  if (!Array.isArray(raw)) return values;
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const item = entry as Record<string, unknown>;
+    if (item.disabled === true || String(item.type ?? '').toLowerCase() === 'secret') continue;
+    if (typeof item.key !== 'string') continue;
+    const value = item.value;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      values.set(item.key, String(value));
+    }
+  }
+  return values;
+}
+
+function resolveKnownVariables(value: string, variables: Map<string, string>): string {
+  return value.replace(TEMPLATE_RE, (whole, key: string) => variables.get(key.trim()) ?? whole);
+}
+
+function requestUrl(raw: unknown): string | null {
+  if (typeof raw === 'string') return raw;
+  if (!raw || typeof raw !== 'object') return null;
+  const url = raw as Record<string, unknown>;
+  if (typeof url.raw === 'string') return url.raw;
+  const protocol = typeof url.protocol === 'string' ? `${url.protocol}://` : '';
+  const host = Array.isArray(url.host) ? url.host.join('.') : String(url.host ?? '');
+  const path = Array.isArray(url.path) ? url.path.join('/') : String(url.path ?? '');
+  const query = Array.isArray(url.query)
+    ? url.query
+        .filter((entry: any) => entry && entry.disabled !== true && typeof entry.key === 'string')
+        .map((entry: any) => `${entry.key}=${entry.value ?? ''}`)
+        .join('&')
+    : '';
+  if (!host) return null;
+  return `${protocol}${host}${path ? `/${path}` : ''}${query ? `?${query}` : ''}`;
+}
+
+function templateVariables(value: string): string[] {
+  const out = new Set<string>();
+  for (const match of value.matchAll(TEMPLATE_RE)) out.add(match[1]!.trim());
+  return [...out];
+}
+
+function schemaForValue(value: unknown): Record<string, unknown> {
+  if (value === null) return { type: 'null' };
+  if (Array.isArray(value)) {
+    return {
+      type: 'array',
+      ...(value.length ? { items: schemaForValue(value[0]) } : {}),
+    };
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    return {
+      type: 'object',
+      properties: Object.fromEntries(entries.map(([key, child]) => [key, schemaForValue(child)])),
+      ...(entries.length ? { required: entries.map(([key]) => key) } : {}),
+    };
+  }
+  if (typeof value === 'number') return { type: Number.isInteger(value) ? 'integer' : 'number' };
+  if (typeof value === 'boolean') return { type: 'boolean' };
+  return { type: 'string' };
+}
+
+function jsonSchema(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  try {
+    return schemaForValue(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function responseSchema(responses: unknown): Record<string, unknown> | null {
+  if (!Array.isArray(responses)) return null;
+  const preferred = responses.find((response: any) => {
+    const code = Number(response?.code);
+    return code >= 200 && code < 300 && typeof response?.body === 'string';
+  });
+  return jsonSchema(preferred?.body);
+}
+
+function descriptionText(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object' && typeof (value as any).content === 'string') {
+    return (value as any).content;
+  }
+  return null;
+}
+
+function hasScripts(value: any): boolean {
+  return Array.isArray(value?.event) && value.event.some((event: any) => event?.script);
+}
+
+export function normalizePostmanCollection(doc: any): PostmanNormalizationResult {
+  if (
+    !doc ||
+    typeof doc !== 'object' ||
+    !doc.info ||
+    typeof doc.info !== 'object' ||
+    !COLLECTION_SCHEMA.test(String(doc.info.schema ?? '')) ||
+    !Array.isArray(doc.item)
+  ) {
+    throw new Error('document is not a Postman Collection v2.0 or v2.1');
+  }
+
+  const warnings: string[] = [];
+  const actions: NormalizedAction[] = [];
+  const rootVariables = collectionVariables(doc.variable);
+  if (hasScripts(doc)) warnings.push('collection pre-request/test scripts were ignored');
+
+  const walk = (items: unknown[], folders: string[], inherited: Map<string, string>) => {
+    for (const candidate of items) {
+      if (!candidate || typeof candidate !== 'object') continue;
+      const item = candidate as Record<string, any>;
+      if (item.disabled === true) continue;
+      const name = typeof item.name === 'string' && item.name.trim() ? item.name.trim() : 'request';
+      const variables = new Map([...inherited, ...collectionVariables(item.variable)]);
+      if (hasScripts(item)) warnings.push(`${[...folders, name].join(' / ')} scripts were ignored`);
+
+      if (Array.isArray(item.item)) {
+        walk(item.item, [...folders, name], variables);
+        continue;
+      }
+      if (!item.request || typeof item.request !== 'object') continue;
+
+      const request = item.request as Record<string, any>;
+      if (hasScripts(request)) warnings.push(`${[...folders, name].join(' / ')} scripts were ignored`);
+      const method = String(request.method ?? 'GET').toUpperCase();
+      const unresolvedUrl = requestUrl(request.url);
+      if (!unresolvedUrl) {
+        warnings.push(`${[...folders, name].join(' / ')} has no usable URL and was skipped`);
+        continue;
+      }
+      const url = resolveKnownVariables(unresolvedUrl, variables).replace(
+        /(^|\/)\:([A-Za-z_][A-Za-z0-9_]*)/g,
+        '$1{{$2}}',
+      );
+
+      const headers: Record<string, string> = {};
+      if (Array.isArray(request.header)) {
+        for (const rawHeader of request.header) {
+          if (!rawHeader || rawHeader.disabled === true || typeof rawHeader.key !== 'string') continue;
+          const key = rawHeader.key.trim();
+          if (!key || /^(authorization|proxy-authorization|cookie|set-cookie)$/i.test(key)) continue;
+          headers[key] = resolveKnownVariables(String(rawHeader.value ?? ''), variables);
+        }
+      }
+
+      const properties: Record<string, unknown> = {};
+      const required = new Set<string>();
+      for (const variable of templateVariables(url)) {
+        properties[variable] = { type: 'string', 'x-in': url.includes(`?`) && url.slice(url.indexOf('?')).includes(`{{${variable}}}`) ? 'query' : 'path' };
+        required.add(variable);
+      }
+      for (const [header, value] of Object.entries(headers)) {
+        for (const variable of templateVariables(value)) {
+          properties[variable] = { type: 'string', 'x-in': 'header', description: `Postman header ${header}` };
+          required.add(variable);
+        }
+      }
+
+      let bodyMode: Extract<ActionBinding, { kind: 'postman' }>['bodyMode'] = null;
+      const body = request.body;
+      if (body && typeof body === 'object' && body.disabled !== true) {
+        const mode = String(body.mode ?? '');
+        if (mode === 'raw') {
+          const inferred = jsonSchema(body.raw);
+          bodyMode = inferred ? 'json' : 'raw';
+          properties.body = inferred ?? { type: 'string' };
+          required.add('body');
+        } else if (mode === 'urlencoded' && Array.isArray(body.urlencoded)) {
+          bodyMode = 'urlencoded';
+          const fields = body.urlencoded.filter((entry: any) => entry && entry.disabled !== true && typeof entry.key === 'string');
+          properties.body = {
+            type: 'object',
+            properties: Object.fromEntries(fields.map((entry: any) => [entry.key, { type: 'string' }])),
+          };
+          required.add('body');
+        } else if (mode) {
+          warnings.push(`${[...folders, name].join(' / ')} uses unsupported ${mode} body mode`);
+        }
+      }
+
+      const path = [...folders, name].map(segment).filter(Boolean).join('.') || 'request';
+      actions.push({
+        path,
+        name,
+        description: descriptionText(request.description) ?? `${method} ${url}`,
+        inputSchema: Object.keys(properties).length
+          ? { type: 'object', properties, ...(required.size ? { required: [...required] } : {}) }
+          : null,
+        outputSchema: responseSchema(item.response),
+        risk: riskForMethod(method),
+        binding: { kind: 'postman', method, url, headers, bodyMode },
+      });
+    }
+  };
+
+  walk(doc.item, [], rootVariables);
+
+  const seen = new Map<string, number>();
+  for (const action of actions) {
+    const count = seen.get(action.path) ?? 0;
+    seen.set(action.path, count + 1);
+    if (count > 0) action.path = `${action.path}_${count + 1}`;
+  }
+  return { actions, warnings: [...new Set(warnings)] };
+}

--- a/apps/api/src/executor/postman-normalize.ts
+++ b/apps/api/src/executor/postman-normalize.ts
@@ -8,6 +8,11 @@ export interface PostmanNormalizationResult {
 const COLLECTION_SCHEMA = /schema\.getpostman\.com\/json\/collection\/v2(?:\.0|\.1)\.0\/collection\.json/i;
 const TEMPLATE_RE = /{{\s*([^{}]+?)\s*}}/g;
 
+function isCredentialName(value: string): boolean {
+  const compact = value.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return /(?:apikey|hapikey|accesstoken|authtoken|authorization|password|passwd|secret|credential|cookie)$/.test(compact);
+}
+
 function segment(value: string): string {
   return value
     .replace(/[^a-zA-Z0-9]+/g, '_')
@@ -29,7 +34,11 @@ function collectionVariables(raw: unknown): Map<string, string> {
   for (const entry of raw) {
     if (!entry || typeof entry !== 'object') continue;
     const item = entry as Record<string, unknown>;
-    if (item.disabled === true || String(item.type ?? '').toLowerCase() === 'secret') continue;
+    if (
+      item.disabled === true ||
+      String(item.type ?? '').toLowerCase() === 'secret' ||
+      isCredentialName(String(item.key ?? ''))
+    ) continue;
     if (typeof item.key !== 'string') continue;
     const value = item.value;
     if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
@@ -59,6 +68,30 @@ function requestUrl(raw: unknown): string | null {
     : '';
   if (!host) return null;
   return `${protocol}${host}${path ? `/${path}` : ''}${query ? `?${query}` : ''}`;
+}
+
+function stripCredentialQuery(url: string): { url: string; removed: boolean } {
+  const question = url.indexOf('?');
+  if (question < 0) return { url, removed: false };
+  const hash = url.indexOf('#', question);
+  const suffix = hash >= 0 ? url.slice(hash) : '';
+  const query = url.slice(question + 1, hash >= 0 ? hash : undefined);
+  const kept: string[] = [];
+  let removed = false;
+  for (const part of query.split('&')) {
+    const rawKey = part.split('=', 1)[0] ?? '';
+    let key = rawKey;
+    try { key = decodeURIComponent(rawKey); } catch { /* keep raw */ }
+    if (isCredentialName(key)) {
+      removed = true;
+      continue;
+    }
+    if (part) kept.push(part);
+  }
+  return {
+    url: `${url.slice(0, question)}${kept.length ? `?${kept.join('&')}` : ''}${suffix}`,
+    removed,
+  };
 }
 
 function templateVariables(value: string): string[] {
@@ -134,6 +167,7 @@ export function normalizePostmanCollection(doc: any): PostmanNormalizationResult
   const actions: NormalizedAction[] = [];
   const rootVariables = collectionVariables(doc.variable);
   if (hasScripts(doc)) warnings.push('collection pre-request/test scripts were ignored');
+  if (doc.auth) warnings.push('collection authentication was ignored; configure connector auth in Kortix');
 
   const walk = (items: unknown[], folders: string[], inherited: Map<string, string>) => {
     for (const candidate of items) {
@@ -152,23 +186,29 @@ export function normalizePostmanCollection(doc: any): PostmanNormalizationResult
 
       const request = item.request as Record<string, any>;
       if (hasScripts(request)) warnings.push(`${[...folders, name].join(' / ')} scripts were ignored`);
+      if (request.auth) warnings.push(`${[...folders, name].join(' / ')} authentication was ignored; configure connector auth in Kortix`);
       const method = String(request.method ?? 'GET').toUpperCase();
       const unresolvedUrl = requestUrl(request.url);
       if (!unresolvedUrl) {
         warnings.push(`${[...folders, name].join(' / ')} has no usable URL and was skipped`);
         continue;
       }
-      const url = resolveKnownVariables(unresolvedUrl, variables).replace(
+      const renderedUrl = resolveKnownVariables(unresolvedUrl, variables).replace(
         /(^|\/)\:([A-Za-z_][A-Za-z0-9_]*)/g,
         '$1{{$2}}',
       );
+      const sanitizedUrl = stripCredentialQuery(renderedUrl);
+      const url = sanitizedUrl.url;
+      if (sanitizedUrl.removed) {
+        warnings.push(`${[...folders, name].join(' / ')} credential-like query parameter was ignored; configure connector auth in Kortix`);
+      }
 
       const headers: Record<string, string> = {};
       if (Array.isArray(request.header)) {
         for (const rawHeader of request.header) {
           if (!rawHeader || rawHeader.disabled === true || typeof rawHeader.key !== 'string') continue;
           const key = rawHeader.key.trim();
-          if (!key || /^(authorization|proxy-authorization|cookie|set-cookie)$/i.test(key)) continue;
+          if (!key || /^(authorization|proxy-authorization|cookie|set-cookie)$/i.test(key) || isCredentialName(key)) continue;
           headers[key] = resolveKnownVariables(String(rawHeader.value ?? ''), variables);
         }
       }

--- a/apps/api/src/executor/postman-normalize.ts
+++ b/apps/api/src/executor/postman-normalize.ts
@@ -5,7 +5,7 @@ export interface PostmanNormalizationResult {
   warnings: string[];
 }
 
-const COLLECTION_SCHEMA = /schema\.getpostman\.com\/json\/collection\/v2(?:\.0|\.1)\.0\/collection\.json/i;
+const COLLECTION_SCHEMA = /^https?:\/\/schema\.getpostman\.com\/json\/collection\/v2(?:\.0|\.1)\.0\/collection\.json$/i;
 const TEMPLATE_RE = /{{\s*([^{}]+?)\s*}}/g;
 
 function isCredentialName(value: string): boolean {

--- a/apps/api/src/executor/postman-source.ts
+++ b/apps/api/src/executor/postman-source.ts
@@ -17,6 +17,8 @@ export interface PostmanSourceOptions {
   resolveWorkspace?: (url: string, apiKey: string) => Promise<PostmanSourceDocument[]>;
   maxApis?: number;
   maxDocumentBytes?: number;
+  concurrency?: number;
+  onWarning?: (warning: string) => void;
 }
 
 export interface PostmanApiEntity {
@@ -88,10 +90,12 @@ export function parsePostmanApiEntity(raw: string): PostmanApiEntity {
 
 function namespaceFor(path: string): string {
   const withoutExtension = path.replace(/\.(?:json|ya?ml)$/i, '');
-  return withoutExtension
-    .split('/')
-    .filter(Boolean)
-    .slice(-2)
+  const parts = withoutExtension.split('/').filter(Boolean);
+  const publicApiSpecs = parts.indexOf('PublicApiSpecs');
+  const selected = publicApiSpecs >= 0 && parts.length > publicApiSpecs + 2
+    ? [parts[publicApiSpecs + 1]!, parts[publicApiSpecs + 2]!, parts.at(-2)!]
+    : parts.slice(-2);
+  return selected
     .join('_')
     .replace(/[^a-zA-Z0-9]+/g, '_')
     .replace(/_+/g, '_')
@@ -140,8 +144,8 @@ function resolveRelative(base: string, path: string): string {
     return new URL(path, base).href;
   }
   const slash = base.lastIndexOf('/');
-  const root = base.endsWith('/.postman/api') || /\/\.postman\/api_[^/]+$/.test(base)
-    ? base.replace(/\/\.postman\/api(?:_[^/]+)?$/, '')
+  const root = /(?:^|\/)\.postman\/api(?:_[^/]+)?$/.test(base)
+    ? base.replace(/(?:^|\/)\.postman\/api(?:_[^/]+)?$/, '')
     : slash >= 0 ? base.slice(0, slash) : '';
   return `${root ? `${root}/` : ''}${path.replace(/^\/+/, '')}`;
 }
@@ -167,29 +171,59 @@ async function resolveApiManifest(
   const maxApis = options.maxApis ?? 250;
   if (ids.length > maxApis) throw new Error(`Postman repository contains ${ids.length} APIs; limit is ${maxApis}`);
 
-  const relations = await Promise.all(ids.map(async (id) => {
+  const concurrency = options.concurrency ?? 8;
+  const relations = (await mapConcurrent(ids, concurrency, async (id) => {
     const entitySource = manifestSource.replace(/\/api$/, `/api_${encodeURIComponent(id)}`);
-    return { entitySource, entity: parsePostmanApiEntity(await loader(entitySource)) };
-  }));
+    try {
+      return { entitySource, entity: parsePostmanApiEntity(await loader(entitySource)) };
+    } catch (error) {
+      options.onWarning?.(`skipped Postman API relation ${id}: ${(error as Error).message}`);
+      return null;
+    }
+  })).filter((value): value is NonNullable<typeof value> => value !== null);
   const refs = relations.flatMap(({ entitySource, entity }) =>
     entity.files.map((path) => ({ kind: entity.type, source: resolveRelative(entitySource, path), path })),
   );
   refs.sort((a, b) => a.source.localeCompare(b.source));
 
   const maxBytes = options.maxDocumentBytes ?? 10 * 1024 * 1024;
-  const documents = await Promise.all(refs.map(async (ref) => {
-    const raw = await loader(ref.source);
-    if (new TextEncoder().encode(raw).byteLength > maxBytes) {
-      throw new Error(`Postman source document at ${ref.source} exceeds ${maxBytes} bytes`);
+  const documents = (await mapConcurrent(refs, concurrency, async (ref) => {
+    try {
+      const raw = await loader(ref.source);
+      if (new TextEncoder().encode(raw).byteLength > maxBytes) {
+        throw new Error(`document exceeds ${maxBytes} bytes`);
+      }
+      return {
+        namespace: namespaceFor(ref.path),
+        kind: ref.kind,
+        source: ref.source,
+        doc: parseDocument(raw, ref.source, ref.kind),
+      } satisfies PostmanSourceDocument;
+    } catch (error) {
+      options.onWarning?.(`skipped Postman source ${ref.source}: ${(error as Error).message}`);
+      return null;
     }
-    return {
-      namespace: namespaceFor(ref.path),
-      kind: ref.kind,
-      source: ref.source,
-      doc: parseDocument(raw, ref.source, ref.kind),
-    } satisfies PostmanSourceDocument;
-  }));
+  })).filter((value): value is PostmanSourceDocument => value !== null);
+  if (documents.length === 0) throw new Error('Postman repository contains no usable API definitions or collections');
   return documents;
+}
+
+async function mapConcurrent<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const output = new Array<R>(items.length);
+  let cursor = 0;
+  const run = async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      output[index] = await worker(items[index]!, index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(Math.max(1, limit), items.length) }, run));
+  return output;
 }
 
 export async function resolvePostmanSource(
@@ -217,6 +251,11 @@ export async function resolvePostmanSource(
 
   const raw = await loader(source);
   if (/^\s*apis\[\]\s*=/m.test(raw)) return resolveApiManifest(source, async (ref) => ref === source ? raw : loader(ref), options);
+
+  const maxBytes = options.maxDocumentBytes ?? 10 * 1024 * 1024;
+  if (new TextEncoder().encode(raw).byteLength > maxBytes) {
+    throw new Error(`Postman source document at ${source} exceeds ${maxBytes} bytes`);
+  }
 
   const doc = parseSpecDocument(raw, source);
   if (!String(doc?.info?.schema ?? '').includes('/collection/v2.')) {

--- a/apps/api/src/executor/postman-source.ts
+++ b/apps/api/src/executor/postman-source.ts
@@ -1,0 +1,226 @@
+import { parseSpecDocument } from './spec-doc';
+
+export type PostmanSourceDocumentKind = 'openapi' | 'postman';
+
+export interface PostmanSourceDocument {
+  namespace: string;
+  kind: PostmanSourceDocumentKind;
+  source: string;
+  doc: any;
+}
+
+export type PostmanSourceLoader = (source: string) => Promise<string>;
+
+export interface PostmanSourceOptions {
+  githubDefaultBranch?: (owner: string, repo: string) => Promise<string>;
+  postmanApiKey?: string | null;
+  resolveWorkspace?: (url: string, apiKey: string) => Promise<PostmanSourceDocument[]>;
+  maxApis?: number;
+  maxDocumentBytes?: number;
+}
+
+export interface PostmanApiEntity {
+  type: PostmanSourceDocumentKind;
+  files: string[];
+}
+
+const API_ID_RE = /^\s*apis\[\]\s*=\s*(\{.*\})\s*$/gm;
+const ROOT_FILE_RE = /^\s*rootFiles\[\]\s*=\s*(.+?)\s*$/gm;
+const FILE_RE = /^\s*files\[\]\s*=\s*(\{.*\})\s*$/gm;
+
+export function parsePostmanApiIndex(raw: string): string[] {
+  const ids: string[] = [];
+  for (const match of raw.matchAll(API_ID_RE)) {
+    try {
+      const parsed = JSON.parse(match[1]!) as { apiId?: unknown };
+      if (typeof parsed.apiId === 'string' && parsed.apiId.trim()) ids.push(parsed.apiId.trim());
+    } catch {
+      throw new Error('invalid JSON entry in .postman/api');
+    }
+  }
+  if (ids.length === 0) throw new Error('.postman/api contains no API relations');
+  return [...new Set(ids)];
+}
+
+function section(raw: string, name: string): string {
+  const marker = `[${name}]`;
+  const markerIndex = raw.indexOf(marker);
+  if (markerIndex < 0) return '';
+  const start = raw.indexOf('\n', markerIndex + marker.length);
+  if (start < 0) return '';
+  const tail = raw.slice(start + 1);
+  const nextSection = tail.search(/^\s*\[/m);
+  return nextSection < 0 ? tail : tail.slice(0, nextSection);
+}
+
+function jsonFilePaths(raw: string): string[] {
+  const files: string[] = [];
+  for (const match of raw.matchAll(FILE_RE)) {
+    try {
+      const parsed = JSON.parse(match[1]!) as { path?: unknown };
+      if (typeof parsed.path === 'string' && parsed.path.trim()) files.push(parsed.path.trim());
+    } catch {
+      throw new Error('invalid files[] JSON entry in .postman API entity');
+    }
+  }
+  return files;
+}
+
+export function parsePostmanApiEntity(raw: string): PostmanApiEntity {
+  const definitionMetadata = section(raw, 'config.relations.apiDefinition.metaData');
+  const definitionSection = section(raw, 'config.relations.apiDefinition');
+  const openapi = /^\s*type\s*=\s*openapi:3\s*$/m.test(definitionMetadata);
+  const rootFiles = [...definitionMetadata.matchAll(ROOT_FILE_RE)].map((match) => match[1]!.trim());
+  const definitionFiles = jsonFilePaths(definitionSection);
+  const preferred = rootFiles.length ? rootFiles : definitionFiles;
+  if (openapi && preferred.length) {
+    return { type: 'openapi', files: [...new Set(preferred)] };
+  }
+
+  const collections = section(raw, 'config.relations.collections');
+  const rootDirectory = collections.match(/^\s*rootDirectory\s*=\s*(.+?)\s*$/m)?.[1]?.trim() ?? '';
+  const collectionFiles = jsonFilePaths(collections).map((file) =>
+    rootDirectory && !file.startsWith(rootDirectory) ? `${rootDirectory.replace(/\/$/, '')}/${file}` : file,
+  );
+  if (collectionFiles.length) return { type: 'postman', files: [...new Set(collectionFiles)] };
+  throw new Error('.postman API entity has neither an OpenAPI definition nor a collection');
+}
+
+function namespaceFor(path: string): string {
+  const withoutExtension = path.replace(/\.(?:json|ya?ml)$/i, '');
+  return withoutExtension
+    .split('/')
+    .filter(Boolean)
+    .slice(-2)
+    .join('_')
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+    .toLowerCase() || 'api';
+}
+
+function githubRepository(source: string): { owner: string; repo: string; ref: string | null } | null {
+  try {
+    const url = new URL(source);
+    if (url.hostname.toLowerCase() !== 'github.com') return null;
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    const owner = parts[0]!;
+    const repo = parts[1]!.replace(/\.git$/i, '');
+    const tree = parts[2] === 'tree' && parts[3] ? parts[3] : null;
+    return { owner, repo, ref: tree };
+  } catch {
+    return null;
+  }
+}
+
+function isPostmanWorkspaceUrl(source: string): boolean {
+  try {
+    const url = new URL(source);
+    return /(^|\.)postman\.com$/i.test(url.hostname) && url.pathname.split('/').filter(Boolean).length >= 2;
+  } catch {
+    return false;
+  }
+}
+
+function rawGithubBase(owner: string, repo: string, ref: string): string {
+  return `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(ref)}`;
+}
+
+function resolveRelative(base: string, path: string): string {
+  if (/^https?:\/\//i.test(path)) return path;
+  if (/^https?:\/\//i.test(base)) {
+    const url = new URL(base);
+    const rootMarker = '/.postman/api';
+    if (url.pathname.endsWith(rootMarker) || /\/\.postman\/api_[^/]+$/.test(url.pathname)) {
+      const root = url.pathname.replace(/\/\.postman\/api(?:_[^/]+)?$/, '');
+      url.pathname = `${root}/${path.replace(/^\/+/, '')}`;
+      return url.href;
+    }
+    return new URL(path, base).href;
+  }
+  const slash = base.lastIndexOf('/');
+  const root = base.endsWith('/.postman/api') || /\/\.postman\/api_[^/]+$/.test(base)
+    ? base.replace(/\/\.postman\/api(?:_[^/]+)?$/, '')
+    : slash >= 0 ? base.slice(0, slash) : '';
+  return `${root ? `${root}/` : ''}${path.replace(/^\/+/, '')}`;
+}
+
+function parseDocument(raw: string, source: string, expected: PostmanSourceDocumentKind): any {
+  const doc = parseSpecDocument(raw, source);
+  if (expected === 'openapi' && !String(doc.openapi ?? '').startsWith('3.')) {
+    throw new Error(`Postman API definition at ${source} is not OpenAPI 3`);
+  }
+  if (expected === 'postman' && !String(doc?.info?.schema ?? '').includes('/collection/v2.')) {
+    throw new Error(`Postman collection at ${source} is not Collection v2.0/v2.1`);
+  }
+  return doc;
+}
+
+async function resolveApiManifest(
+  manifestSource: string,
+  loader: PostmanSourceLoader,
+  options: PostmanSourceOptions,
+): Promise<PostmanSourceDocument[]> {
+  const manifest = await loader(manifestSource);
+  const ids = parsePostmanApiIndex(manifest);
+  const maxApis = options.maxApis ?? 250;
+  if (ids.length > maxApis) throw new Error(`Postman repository contains ${ids.length} APIs; limit is ${maxApis}`);
+
+  const relations = await Promise.all(ids.map(async (id) => {
+    const entitySource = manifestSource.replace(/\/api$/, `/api_${encodeURIComponent(id)}`);
+    return { entitySource, entity: parsePostmanApiEntity(await loader(entitySource)) };
+  }));
+  const refs = relations.flatMap(({ entitySource, entity }) =>
+    entity.files.map((path) => ({ kind: entity.type, source: resolveRelative(entitySource, path), path })),
+  );
+  refs.sort((a, b) => a.source.localeCompare(b.source));
+
+  const maxBytes = options.maxDocumentBytes ?? 10 * 1024 * 1024;
+  const documents = await Promise.all(refs.map(async (ref) => {
+    const raw = await loader(ref.source);
+    if (new TextEncoder().encode(raw).byteLength > maxBytes) {
+      throw new Error(`Postman source document at ${ref.source} exceeds ${maxBytes} bytes`);
+    }
+    return {
+      namespace: namespaceFor(ref.path),
+      kind: ref.kind,
+      source: ref.source,
+      doc: parseDocument(raw, ref.source, ref.kind),
+    } satisfies PostmanSourceDocument;
+  }));
+  return documents;
+}
+
+export async function resolvePostmanSource(
+  source: string,
+  loader: PostmanSourceLoader,
+  options: PostmanSourceOptions = {},
+): Promise<PostmanSourceDocument[]> {
+  if (isPostmanWorkspaceUrl(source)) {
+    const apiKey = options.postmanApiKey?.trim();
+    if (!apiKey) {
+      throw new Error('public Postman workspace import requires server-side POSTMAN_API_KEY; web scraping is intentionally unsupported');
+    }
+    if (!options.resolveWorkspace) {
+      throw new Error('public Postman workspace resolver is not configured');
+    }
+    return options.resolveWorkspace(source, apiKey);
+  }
+
+  const github = githubRepository(source);
+  if (github) {
+    const branch = github.ref ?? await (options.githubDefaultBranch?.(github.owner, github.repo) ?? Promise.resolve('main'));
+    const manifestSource = `${rawGithubBase(github.owner, github.repo, branch)}/.postman/api`;
+    return resolveApiManifest(manifestSource, loader, options);
+  }
+
+  const raw = await loader(source);
+  if (/^\s*apis\[\]\s*=/m.test(raw)) return resolveApiManifest(source, async (ref) => ref === source ? raw : loader(ref), options);
+
+  const doc = parseSpecDocument(raw, source);
+  if (!String(doc?.info?.schema ?? '').includes('/collection/v2.')) {
+    throw new Error(`Postman source at ${source} is neither a Collection v2 document nor a .postman/api manifest`);
+  }
+  return [{ namespace: namespaceFor(String(doc.info.name ?? source)), kind: 'postman', source, doc }];
+}

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -23,6 +23,7 @@ import { listAgentMailInstalls, loadSlackInstall } from '../channels/install-sto
 import { resolveExperimentalFeature } from '../experimental/features';
 import { assertAllowedSourceAddress } from '../marketplace/catalog';
 import { safeEgressFetch } from '../shared/ssrf-guard';
+import { config } from '../config';
 import {
   type ConnectorSpec,
   extractConnectors,
@@ -47,8 +48,10 @@ import {
   normalizeMcp,
   normalizeOpenApi,
   normalizePipedream,
+  normalizePostmanCollection,
 } from './normalize';
 import { pipedreamCatalog, pipedreamConfigured } from './pipedream';
+import { resolvePostmanSource, type PostmanSourceDocument } from './postman-source';
 import { parseSpecDocument } from './spec-doc';
 import type { HttpRouteSpec, NormalizedAction } from './types';
 
@@ -433,18 +436,19 @@ async function upsertConnector(
       .delete(executorConnectorActions)
       .where(eq(executorConnectorActions.connectorId, connectorId));
     if (catalog.actions.length > 0) {
-      await db.insert(executorConnectorActions).values(
-        catalog.actions.map((a) => ({
-          connectorId: connectorId!,
-          path: a.path,
-          name: a.name,
-          description: a.description,
-          inputSchema: a.inputSchema,
-          outputSchema: a.outputSchema,
-          risk: a.risk,
-          binding: a.binding as unknown as Record<string, unknown>,
-        })),
-      );
+      const rows = catalog.actions.map((a) => ({
+        connectorId: connectorId!,
+        path: a.path,
+        name: a.name,
+        description: a.description,
+        inputSchema: a.inputSchema,
+        outputSchema: a.outputSchema,
+        risk: a.risk,
+        binding: a.binding as unknown as Record<string, unknown>,
+      }));
+      for (let offset = 0; offset < rows.length; offset += 500) {
+        await db.insert(executorConnectorActions).values(rows.slice(offset, offset + 500));
+      }
     }
   }
 
@@ -487,6 +491,23 @@ export async function resolveCatalog(
         }
         return { actions: normalizeOpenApi(doc), server };
       }
+      case 'postman': {
+        const documents = await resolvePostmanSource(
+          spec.spec!,
+          (source) => loadSourceText(project, source),
+          {
+            githubDefaultBranch: resolveGithubDefaultBranch,
+            postmanApiKey: config.POSTMAN_API_KEY,
+            resolveWorkspace: resolvePostmanWorkspace,
+            onWarning: (warning) => console.warn(`[executor] ${spec.slug}: ${warning}`),
+          },
+        );
+        const actions = normalizePostmanDocuments(documents);
+        if (actions.length > 10_000) {
+          throw new Error(`Postman source produced ${actions.length} actions; limit is 10000`);
+        }
+        return { actions, server: null };
+      }
       case 'http': {
         const routes = await loadHttpRoutes(project, spec.spec);
         return { actions: normalizeHttp(routes), server: spec.baseUrl };
@@ -525,6 +546,10 @@ export async function resolveCatalog(
 }
 
 async function loadSpecDoc(project: GitBackedProject, spec: string): Promise<any> {
+  return parseSpecDocument(await loadSourceText(project, spec), spec);
+}
+
+async function loadSourceText(project: GitBackedProject, spec: string): Promise<string> {
   let raw: string;
   if (/^https?:\/\//i.test(spec)) {
     assertAllowedSourceAddress(spec);
@@ -540,7 +565,84 @@ async function loadSpecDoc(project: GitBackedProject, spec: string): Promise<any
   } else {
     raw = await readRepoFile(project, spec, project.defaultBranch);
   }
-  return parseSpecDocument(raw, spec);
+  return raw;
+}
+
+async function resolveGithubDefaultBranch(owner: string, repo: string): Promise<string> {
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  assertAllowedSourceAddress(url);
+  const response = await safeEgressFetch(url, {
+    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'Kortix-Postman-Importer' },
+  });
+  if (!response.ok) throw new Error(`failed to inspect GitHub repository: HTTP ${response.status}`);
+  const body = await response.json() as { default_branch?: unknown };
+  if (typeof body.default_branch !== 'string' || !body.default_branch) {
+    throw new Error('GitHub repository response has no default_branch');
+  }
+  return body.default_branch;
+}
+
+function sourceSlug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+async function postmanApiJson(path: string, apiKey: string): Promise<any> {
+  const url = `https://api.getpostman.com${path}`;
+  assertAllowedSourceAddress(url);
+  const response = await safeEgressFetch(url, {
+    headers: { Accept: 'application/json', 'X-Api-Key': apiKey },
+  });
+  if (!response.ok) throw new Error(`Postman API ${path} failed: HTTP ${response.status}`);
+  return response.json();
+}
+
+async function resolvePostmanWorkspace(url: string, apiKey: string): Promise<PostmanSourceDocument[]> {
+  const parsed = new URL(url);
+  const parts = parsed.pathname.split('/').filter(Boolean);
+  const requestedSlug = parts[1] ?? parts[0] ?? '';
+  const listed = await postmanApiJson('/workspaces?type=public', apiKey);
+  const workspaces = Array.isArray(listed?.workspaces) ? listed.workspaces : [];
+  const workspace = workspaces.find((entry: any) =>
+    entry && (entry.id === requestedSlug || sourceSlug(String(entry.name ?? '')) === requestedSlug),
+  );
+  if (!workspace?.id) {
+    throw new Error(`POSTMAN_API_KEY cannot access public workspace "${requestedSlug}"; export a collection or use its synchronized Git repository`);
+  }
+  const detail = await postmanApiJson(`/workspaces/${encodeURIComponent(String(workspace.id))}`, apiKey);
+  const collections = Array.isArray(detail?.workspace?.collections) ? detail.workspace.collections : [];
+  const documents = await Promise.all(collections.map(async (entry: any) => {
+    const uid = String(entry?.uid ?? entry?.id ?? '');
+    if (!uid) throw new Error('Postman workspace contains a collection without an id');
+    const response = await postmanApiJson(`/collections/${encodeURIComponent(uid)}`, apiKey);
+    const doc = response?.collection;
+    if (!doc) throw new Error(`Postman API returned no collection for ${uid}`);
+    return {
+      namespace: sourceSlug(String(entry?.name ?? uid)).replace(/-/g, '_') || 'collection',
+      kind: 'postman' as const,
+      source: `postman:${uid}`,
+      doc,
+    };
+  }));
+  return documents.sort((a, b) => a.namespace.localeCompare(b.namespace));
+}
+
+/** Pure multi-document catalog mapper, exported for contract tests. */
+export function normalizePostmanDocuments(documents: PostmanSourceDocument[]): NormalizedAction[] {
+  const multi = documents.length > 1;
+  const actions: NormalizedAction[] = [];
+  const seen = new Map<string, number>();
+  for (const document of documents) {
+    const normalized = document.kind === 'openapi'
+      ? normalizeOpenApi(document.doc)
+      : normalizePostmanCollection(document.doc).actions;
+    for (const action of normalized) {
+      const basePath = multi ? `${document.namespace}.${action.path}` : action.path;
+      const count = seen.get(basePath) ?? 0;
+      seen.set(basePath, count + 1);
+      actions.push({ ...action, path: count ? `${basePath}_${count + 1}` : basePath });
+    }
+  }
+  return actions;
 }
 
 async function loadHttpRoutes(

--- a/apps/api/src/executor/types.ts
+++ b/apps/api/src/executor/types.ts
@@ -29,6 +29,15 @@ export interface NormalizedAction {
 
 export type ActionBinding =
   | { kind: 'openapi'; method: string; path: string; server: string | null }
+  | {
+      kind: 'postman';
+      method: string;
+      /** Fully-qualified request template after safe collection defaults resolve. */
+      url: string;
+      /** Static or templated non-credential headers. */
+      headers: Record<string, string>;
+      bodyMode: 'json' | 'raw' | 'urlencoded' | null;
+    }
   | { kind: 'graphql'; operation: 'query' | 'mutation'; field: string }
   | { kind: 'mcp'; tool: string }
   | { kind: 'http'; method: string; path: string }

--- a/apps/api/src/projects/connectors.ts
+++ b/apps/api/src/projects/connectors.ts
@@ -3,7 +3,7 @@
  * v1 project may instead declare `[[connectors]]` in `kortix.toml`).
  *
  * A connector is one named integration the Executor can call — Pipedream,
- * MCP, OpenAPI, GraphQL, or raw HTTP. The manifest holds the *definition*
+ * MCP, OpenAPI, Postman, GraphQL, or raw HTTP. The manifest holds the *definition*
  * (provider, endpoint/spec, auth method + which project-secret to use) and,
  * for the policy layer, each connector's `policies:` list. The
  * secret *value* and Pipedream OAuth live in the platform, never in git.
@@ -37,8 +37,8 @@ import { MANIFEST_FILENAME, type ParsedManifest } from './triggers';
 import { isValidSecretName } from './secrets';
 import { CHANNEL_PLATFORMS, RESERVED_SLUG_PROVIDERS, SLUG_RE } from '@kortix/manifest-schema';
 
-export type ConnectorProvider = 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel' | 'computer';
-const PROVIDERS: readonly ConnectorProvider[] = ['pipedream', 'mcp', 'openapi', 'graphql', 'http', 'channel', 'computer'];
+export type ConnectorProvider = 'pipedream' | 'mcp' | 'openapi' | 'postman' | 'graphql' | 'http' | 'channel' | 'computer';
+const PROVIDERS: readonly ConnectorProvider[] = ['pipedream', 'mcp', 'openapi', 'postman', 'graphql', 'http', 'channel', 'computer'];
 
 /**
  * Platform-owned slugs and the ONLY provider allowed to use each. These are
@@ -132,7 +132,7 @@ export interface ConnectorSpec {
   baseUrl: string | null;
   /** channel: chat platform (slack | …) — selects the fixed action catalog + API base. */
   platform: ChannelPlatform | null;
-  /** openapi/graphql/http: a URL or repo-relative file path. Optional for graphql. */
+  /** openapi/postman/graphql/http: a URL or repo-relative file path. Optional for graphql. */
   spec: string | null;
   // ── shared ──
   auth: ConnectorAuthSpec;
@@ -232,7 +232,7 @@ export function connectorSpecToTomlEntry(spec: ConnectorSpec): Record<string, un
     if (spec.spec) entry.spec = spec.spec;
   } else if (spec.provider === 'channel') {
     if (spec.platform) entry.platform = spec.platform;
-  } else if (spec.provider === 'openapi') {
+  } else if (spec.provider === 'openapi' || spec.provider === 'postman') {
     if (spec.spec) entry.spec = spec.spec;
   }
 
@@ -389,9 +389,9 @@ function parseProviderFields(
     return { ok: true, value: { ...base, url, transport: t } };
   }
 
-  if (provider === 'openapi') {
+  if (provider === 'openapi' || provider === 'postman') {
     const spec = str(row.spec);
-    if (!spec) return err(slug, 'provider="openapi" requires `spec` (a URL or repo-relative file path)', filename);
+    if (!spec) return err(slug, `provider="${provider}" requires \`spec\` (a URL or repo-relative file path)`, filename);
     return { ok: true, value: { ...base, spec } };
   }
 
@@ -445,7 +445,7 @@ function parseAuth(
   if (provider === 'channel' && type !== 'none') {
     return err(slug, 'provider="channel" authenticates via its platform install token — omit [connectors.auth]', filename);
   }
-  if (type === 'oauth1' && provider !== 'openapi' && provider !== 'http') {
+  if (type === 'oauth1' && provider !== 'openapi' && provider !== 'postman' && provider !== 'http') {
     return err(slug, '[connectors.auth] type="oauth1" is only supported for openapi/http connectors');
   }
 

--- a/apps/cli/src/commands/connectors.ts
+++ b/apps/cli/src/commands/connectors.ts
@@ -16,7 +16,7 @@ import { C, help, pad, status } from '../style.ts';
 
 // ── Shapes (mirror apps/api/src/executor) ───────────────────────────────────
 
-type Provider = 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http';
+type Provider = 'pipedream' | 'mcp' | 'openapi' | 'postman' | 'graphql' | 'http';
 
 interface ConnectorAction {
   path: string;
@@ -43,12 +43,12 @@ interface SyncResult {
   errors: Array<{ slug: string; error: string }>;
 }
 
-const PROVIDERS: readonly Provider[] = ['pipedream', 'mcp', 'openapi', 'graphql', 'http'];
+const PROVIDERS: readonly Provider[] = ['pipedream', 'mcp', 'openapi', 'postman', 'graphql', 'http'];
 
 const HELP = help`Usage: kortix connectors <subcommand> [options]
 
 Manage the project's connectors — the integrations agents call as tools
-(Pipedream apps, MCP servers, OpenAPI/GraphQL/HTTP endpoints). Mirrors the
+(Pipedream apps, MCP servers, OpenAPI/Postman/GraphQL/HTTP endpoints). Mirrors the
 dashboard's Customize → Connectors. Connectors are project-wide visible; the
 only access gate is which AGENTS may call one (\`kortix agents scope\` /
 \`[[agents]].connectors\` in kortix.yaml) — see \`kortix grants\`.
@@ -93,7 +93,7 @@ Add options (provider-specific):
   --transport <http|sse>   MCP transport (provider=mcp).
   --endpoint <url>         GraphQL endpoint (provider=graphql).
   --base-url <url>         HTTP base URL (provider=http).
-  --spec <url|path>        OpenAPI/GraphQL/HTTP spec ref.
+  --spec <url|path>        OpenAPI/Postman/GraphQL/HTTP spec or source ref.
   --auth-type <t>          none|bearer|basic|custom.
   --credential <mode>      shared (the only mode).
 

--- a/apps/cli/src/commands/executor.ts
+++ b/apps/cli/src/commands/executor.ts
@@ -1,6 +1,6 @@
 /**
  * `kortix executor` — the agent's interface to every configured integration
- * (Pipedream / MCP / OpenAPI / GraphQL / HTTP), absorbed from the old in-sandbox
+ * (Pipedream / MCP / OpenAPI / Postman / GraphQL / HTTP), absorbed from the old in-sandbox
  * `executor` shim into the one kortix CLI.
  *
  * Three faces over ONE core (see ../executor/gateway.ts):
@@ -27,7 +27,7 @@ import {
 import { runExecutorMcpServer } from '../executor/mcp.ts';
 import { CliError, out, parseExecArgs } from '../executor/io.ts';
 
-const PROVIDERS = ['pipedream', 'mcp', 'openapi', 'graphql', 'http'];
+const PROVIDERS = ['pipedream', 'mcp', 'openapi', 'postman', 'graphql', 'http'];
 
 // Built-in channels are never added/connected through the executor — the
 // platform materializes their connectors automatically after the channel is
@@ -50,7 +50,7 @@ function rejectBuiltinChannel(slug: string): void {
 // Build a connector draft (ConnectorDraft on the API) from CLI flags.
 function connectorDraftFromFlags(slug: string, flags: Record<string, string | undefined>): Record<string, unknown> {
   const provider = flags.provider;
-  if (!provider) throw new CliError('--provider is required (pipedream|mcp|openapi|graphql|http)', 'USAGE');
+  if (!provider) throw new CliError('--provider is required (pipedream|mcp|openapi|postman|graphql|http)', 'USAGE');
   if (!PROVIDERS.includes(provider)) throw new CliError(`--provider must be one of ${PROVIDERS.join(', ')}`, 'USAGE');
   const draft: Record<string, unknown> = { slug, provider };
   if (flags.name) draft.name = flags.name;

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -358,7 +358,7 @@ async function ensureProjectEnv(
 interface ShipConnector {
   slug: string;
   name: string;
-  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http';
+  provider: 'pipedream' | 'mcp' | 'openapi' | 'postman' | 'graphql' | 'http';
   status: 'active' | 'disabled' | 'needs_auth' | 'error';
   authSecret: string | null;
   secretSet: boolean;

--- a/apps/cli/src/executor/mcp.ts
+++ b/apps/cli/src/executor/mcp.ts
@@ -2,7 +2,7 @@
  * `kortix executor mcp` — the Executor exposed as a stdio MCP server.
  *
  * This is an optional compatibility face for every configured integration
- * (Pipedream / MCP / OpenAPI / GraphQL / HTTP). The default agent path is the
+ * (Pipedream / MCP / OpenAPI / Postman / GraphQL / HTTP). The default agent path is the
  * `kortix executor` CLI; OpenCode only sees this MCP server when the runtime
  * explicitly registers it.
  *
@@ -48,7 +48,7 @@ const META_TOOLS = [
   {
     name: 'connectors',
     description:
-      'List the integration connectors this session can use (Pipedream / MCP / OpenAPI / GraphQL / HTTP), each with its provider, status, and number of tools. Start here to see what is available.',
+      'List the integration connectors this session can use (Pipedream / MCP / OpenAPI / Postman / GraphQL / HTTP), each with its provider, status, and number of tools. Start here to see what is available.',
     inputSchema: { type: 'object', properties: {}, additionalProperties: false },
     readOnly: true,
   },
@@ -173,7 +173,7 @@ const META_TOOLS = [
         slug: { type: 'string', description: 'Connector slug, e.g. "smartlead".' },
         provider: {
           type: 'string',
-          enum: ['pipedream', 'mcp', 'openapi', 'graphql', 'http'],
+          enum: ['pipedream', 'mcp', 'openapi', 'postman', 'graphql', 'http'],
           description: 'Connector provider.',
         },
         app: {
@@ -189,7 +189,7 @@ const META_TOOLS = [
         },
         endpoint: { type: 'string', description: 'GraphQL endpoint (provider=graphql).' },
         base_url: { type: 'string', description: 'HTTP base URL (provider=http).' },
-        spec: { type: 'string', description: 'OpenAPI/GraphQL/HTTP spec ref.' },
+        spec: { type: 'string', description: 'OpenAPI/Postman/GraphQL/HTTP spec or source ref.' },
         credential: {
           type: 'string',
           enum: ['shared'],

--- a/apps/cli/src/self-host/secrets-registry.ts
+++ b/apps/cli/src/self-host/secrets-registry.ts
@@ -150,6 +150,7 @@ export const SECRET_DEFS: SecretDef[] = [
   { key: 'PIPEDREAM_CLIENT_ID', category: 'connectors', kind: 'operator', required: false },
   { key: 'PIPEDREAM_CLIENT_SECRET', category: 'connectors', kind: 'operator', required: false },
   { key: 'PIPEDREAM_PROJECT_ID', category: 'connectors', kind: 'operator', required: false },
+  { key: 'POSTMAN_API_KEY', category: 'connectors', kind: 'operator', required: false },
   { key: 'PIPEDREAM_WEBHOOK_SECRET', category: 'connectors', kind: 'operator', required: false },
 
   // Reachability (tunnel mode only — see self-host/tunnel.ts). Both optional:
@@ -287,6 +288,7 @@ export const KEY_SERVICE_MAP: Record<string, readonly string[]> = {
   PIPEDREAM_CLIENT_ID: ['kortix-api'],
   PIPEDREAM_CLIENT_SECRET: ['kortix-api'],
   PIPEDREAM_PROJECT_ID: ['kortix-api'],
+  POSTMAN_API_KEY: ['kortix-api'],
   PIPEDREAM_ENVIRONMENT: ['kortix-api'],
   PIPEDREAM_WEBHOOK_SECRET: ['kortix-api'],
 

--- a/apps/mobile/components/pages/ConnectorsPage.tsx
+++ b/apps/mobile/components/pages/ConnectorsPage.tsx
@@ -1,7 +1,7 @@
 /**
  * ConnectorsPage — the project's tool connectors (web parity:
  * customize/sections connectors-view). Lists connected connectors (Pipedream
- * apps, MCP servers, custom OpenAPI/GraphQL/HTTP), with a Sync action, a detail
+ * apps, MCP servers, custom OpenAPI/Postman/GraphQL/HTTP), with a Sync action, a detail
  * view of each connector's tools, and delete. Adding/connecting connectors is
  * layered on top in a follow-up.
  *
@@ -108,7 +108,7 @@ const CONNECT_ERROR_URI = 'kortix://connectors/error';
 function providerIcon(provider: ConnectorProvider): LucideIcon {
   if (provider === 'pipedream') return Zap;
   if (provider === 'mcp') return Boxes;
-  return Globe; // openapi | graphql | http
+  return Globe; // openapi | postman | graphql | http
 }
 
 function providerLabel(provider: ConnectorProvider): string {
@@ -601,7 +601,7 @@ function AddConnectorView({
         </TouchableOpacity>
       </View>
 
-      {/* Easy Connect (Pipedream catalogue) vs Custom (MCP / OpenAPI / GraphQL / HTTP) */}
+      {/* Easy Connect (Pipedream catalogue) vs Custom (MCP / OpenAPI / Postman / GraphQL / HTTP) */}
       <View style={{ paddingHorizontal: 16, paddingBottom: 8 }}>
         <Segmented
           isDark={isDark}
@@ -690,7 +690,7 @@ function AddConnectorView({
   );
 }
 
-// ─── Custom connector form (MCP / OpenAPI / GraphQL / HTTP) ───────────────────
+// ─── Custom connector form (MCP / OpenAPI / Postman / GraphQL / HTTP) ─────────
 
 function Segmented<T extends string>({
   options,
@@ -770,6 +770,7 @@ function CustomConnectorForm({
 
   const providerValid =
     (provider === 'openapi' && spec.trim()) ||
+    (provider === 'postman' && spec.trim()) ||
     (provider === 'graphql' && endpoint.trim()) ||
     (provider === 'mcp' && url.trim()) ||
     (provider === 'http' && baseUrl.trim());
@@ -783,7 +784,7 @@ function CustomConnectorForm({
         slug: slug.trim(),
         provider,
         auth: { type: authType, ...(authType === 'custom' ? { name: authName.trim(), in: 'header' } : {}) },
-        ...(provider === 'openapi' ? { spec: spec.trim() } : {}),
+        ...(provider === 'openapi' || provider === 'postman' ? { spec: spec.trim() } : {}),
         ...(provider === 'graphql' ? { endpoint: endpoint.trim(), ...(spec.trim() ? { spec: spec.trim() } : {}) } : {}),
         ...(provider === 'mcp' ? { url: url.trim(), transport } : {}),
         ...(provider === 'http' ? { baseUrl: baseUrl.trim(), ...(spec.trim() ? { spec: spec.trim() } : {}) } : {}),
@@ -821,6 +822,7 @@ function CustomConnectorForm({
             onChange={setProvider}
             options={[
               { value: 'openapi', label: 'OpenAPI' },
+              { value: 'postman', label: 'Postman' },
               { value: 'graphql', label: 'GraphQL' },
               { value: 'mcp', label: 'MCP' },
               { value: 'http', label: 'HTTP' },
@@ -828,9 +830,9 @@ function CustomConnectorForm({
           />
         </FormField>
 
-        {provider === 'openapi' && (
-          <FormField label="Spec URL or repo path" isDark={isDark}>
-            <BottomSheetTextInput value={spec} onChangeText={setSpec} placeholder="https://…/openapi.json" placeholderTextColor={muted} autoCapitalize="none" autoCorrect={false} style={inputStyle} />
+        {(provider === 'openapi' || provider === 'postman') && (
+          <FormField label={provider === 'postman' ? 'Collection, repository, or workspace' : 'Spec URL or repo path'} isDark={isDark}>
+            <BottomSheetTextInput value={spec} onChangeText={setSpec} placeholder={provider === 'postman' ? 'https://github.com/… or collection.json' : 'https://…/openapi.json'} placeholderTextColor={muted} autoCapitalize="none" autoCorrect={false} style={inputStyle} />
           </FormField>
         )}
         {provider === 'graphql' && (

--- a/apps/web/content/docs/concepts/connections.mdx
+++ b/apps/web/content/docs/concepts/connections.mdx
@@ -8,7 +8,7 @@ service — Slack, Gmail, a database, any HTTP/GraphQL API. Connections are
 per-project, and the agent can only use what you connect.
 
 - **Declared as `connectors` in the manifest** — provider is one of
-  **Pipedream, MCP, OpenAPI, GraphQL, HTTP, Channel** (chat platforms like
+  **Pipedream, MCP, OpenAPI, Postman, GraphQL, HTTP, Channel** (chat platforms like
   Slack and Microsoft Teams), or **Computer** (a connected machine). The definition lives in git; the
   **credentials live in the platform, never in the repo**.
 - **Channel + Computer connectors auto-materialize.** Connecting Slack or
@@ -33,7 +33,10 @@ per-project, and the agent can only use what you connect.
 - **Per-call policies** — each tool can be set to run, require approval, or be
   blocked.
 - **Set up in the dashboard** — the project's Connectors page offers Pipedream
-  one-click connect plus a custom path for OpenAPI/GraphQL/MCP/HTTP. See
+  one-click connect plus a custom path for OpenAPI/Postman/GraphQL/MCP/HTTP. A
+  Postman connector turns a Collection v2 document, `.postman/api` repository,
+  synchronized public GitHub repository, or public workspace into namespaced
+  Executor actions. See
   [Connecting your tools](/docs/guides/connecting-tools).
 - **Which agent may use which connector** is a separate, per-agent grant —
   each agent's `connectors` field in the manifest (`all`, `none`, or a list of

--- a/apps/web/content/docs/guides/connecting-tools.mdx
+++ b/apps/web/content/docs/guides/connecting-tools.mdx
@@ -9,7 +9,7 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 
 ## How a connection works
 
-- **Declared as `connectors` in the manifest.** The `provider` is one of `pipedream`, `mcp`, `openapi`, `graphql`, `http`, `channel` (chat platforms like Slack and Microsoft Teams), or `computer` (a connected machine). The definition lives in git; the credential lives on the platform, never in your repo.
+- **Declared as `connectors` in the manifest.** The `provider` is one of `pipedream`, `mcp`, `openapi`, `postman`, `graphql`, `http`, `channel` (chat platforms like Slack and Microsoft Teams), or `computer` (a connected machine). The definition lives in git; the credential lives on the platform, never in your repo.
 - **Connecting is per project**, like [secrets](/docs/guides/managing-secrets). Connecting a tool for one project doesn't make it available to another.
 - **A connector isn't automatically usable by every agent.** Each agent's `connectors` field in the manifest (`all`, `none`, or a list of slugs) grants — or withholds — access to what's connected. Connecting a tool to the project is a separate step from letting a given agent call it.
 - **Each tool call can be policed.** A connector's `policies` mark a tool `always_run`, `require_approval`, or `block`.
@@ -23,7 +23,7 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
 
 From the dashboard, open the project's Connectors page. For apps Pipedream supports (Gmail, Slack, Stripe, and others — searchable from the same page), use **one-click connect** — it walks you through OAuth and finalizes the connection server-side; no manifest edit required.
 
-For anything else, add a connector by hand: an **OpenAPI** or **GraphQL** API by spec URL, a remote **MCP** server, or a raw **HTTP** API with declared routes.
+For anything else, add a connector by hand: an **OpenAPI** or **GraphQL** API by spec URL, a **Postman** collection, workspace, or synchronized repository, a remote **MCP** server, or a raw **HTTP** API with declared routes.
 </Step>
 
 <Step>
@@ -48,6 +48,25 @@ spec     = "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec
 ```
 
 Pipedream connectors round-trip the same way once connected, but you rarely hand-write them — the dashboard's one-click flow creates the entry for you.
+
+Postman can expose an entire API repository as one connector. For example, HubSpot's public Postman-managed repository imports its original OpenAPI definitions and namespaces every action under the source API:
+
+```toml
+[[connectors]]
+slug     = "hubspot"
+name     = "HubSpot REST API"
+provider = "postman"
+spec     = "https://github.com/HubSpot/HubSpot-public-api-spec-collection"
+
+  [connectors.auth]
+  type = "bearer"
+```
+
+You may instead use a Collection v2 JSON URL/path, a `.postman/api` manifest,
+or a public `postman.com/<team>/<workspace>/...` URL. Public workspace URLs are
+resolved through Postman's official API and require the Kortix host operator to
+set `POSTMAN_API_KEY`; no key is needed for public Git repositories or exported
+collections. Imported scripts, cookies, and credential values are ignored.
 
 See the [manifest reference](/docs/reference/manifest#connectors--connectors) for every field, and [Connections](/docs/concepts/connections) for how `channel` and `computer` connectors auto-materialize (connecting Slack, Microsoft Teams, or a machine creates their connector for you — no manifest entry needed).
 </Step>

--- a/apps/web/content/docs/reference/cli.mdx
+++ b/apps/web/content/docs/reference/cli.mdx
@@ -177,7 +177,7 @@ Encrypted env vars stored on the project, injected as plain env into every sessi
 
 ### Connectors
 
-Integrations agents call as tools (Pipedream apps, MCP servers, OpenAPI/GraphQL/HTTP endpoints) — mirrors the dashboard's Customize → Connectors. Connectors are project-wide visible; the access gate is which agents may call one (`[[agents]].connectors` in `kortix.yaml`, see [Grants](#grants)). `add` / `rm` / `policy set` edit the **local** `kortix.yaml` (the source of truth) — run `kortix ship` to apply, then `sync` to reconcile — unless you pass `--apply`, which skips ship/CR and applies on the cloud project immediately.
+Integrations agents call as tools (Pipedream apps, MCP servers, Postman collections/workspaces, and OpenAPI/GraphQL/HTTP endpoints) — mirrors the dashboard's Customize → Connectors. Connectors are project-wide visible; the access gate is which agents may call one (`[[agents]].connectors` in `kortix.yaml`, see [Grants](#grants)). `add` / `rm` / `policy set` edit the **local** `kortix.yaml` (the source of truth) — run `kortix ship` to apply, then `sync` to reconcile — unless you pass `--apply`, which skips ship/CR and applies on the cloud project immediately.
 
 | Command | Effect |
 | --- | --- |
@@ -200,7 +200,7 @@ Integrations agents call as tools (Pipedream apps, MCP servers, OpenAPI/GraphQL/
 | `kortix connectors policy <slug> rm <match>` | Remove a connector rule. |
 | `kortix connectors policy <slug> clear` | Remove all of a connector's rules. |
 
-`add` options: `--name <label>` (default: slug), `--provider <pipedream\|mcp\|openapi\|graphql\|http>`, `--app <slug>` (Pipedream), `--url <url>` (MCP), `--transport <http\|sse>` (MCP), `--endpoint <url>` (GraphQL), `--base-url <url>` (HTTP), `--spec <url\|path>` (OpenAPI/GraphQL/HTTP), `--auth-type <none\|bearer\|basic\|custom>`, `--credential shared`.
+`add` options: `--name <label>` (default: slug), `--provider <pipedream\|mcp\|openapi\|postman\|graphql\|http>`, `--app <slug>` (Pipedream), `--url <url>` (MCP), `--transport <http\|sse>` (MCP), `--endpoint <url>` (GraphQL), `--base-url <url>` (HTTP), `--spec <url\|path>` (OpenAPI/Postman/GraphQL/HTTP), `--auth-type <none\|bearer\|basic\|custom>`, `--credential shared`. A Postman `--spec` may be Collection v2 JSON, a `.postman/api` manifest, a public GitHub repository managed by Postman, or a public Postman workspace URL. Workspace URLs require the host operator to configure `POSTMAN_API_KEY`; repository and collection imports do not.
 
 ### Channels
 

--- a/apps/web/content/docs/reference/manifest.mdx
+++ b/apps/web/content/docs/reference/manifest.mdx
@@ -375,7 +375,7 @@ model: [Connections](/docs/concepts/connections).
 ```yaml
 connectors:
   - slug: gmail-work
-    provider: pipedream     # pipedream | mcp | openapi | graphql | http | channel
+    provider: pipedream     # pipedream | mcp | openapi | postman | graphql | http | channel
     app: gmail               # pipedream app slug
     credential: shared        # shared is the only mode — see below
     policies:
@@ -386,7 +386,7 @@ connectors:
 | Field        | Required | Type   | Notes                                                              |
 | ------------ | -------- | ------ | ------------------------------------------------------------------ |
 | `slug`       | yes      | string | `[a-z0-9][a-z0-9_-]{0,127}`, unique among connectors; the tool namespace. |
-| `provider`   | yes      | string | `pipedream` \| `mcp` \| `openapi` \| `graphql` \| `http` \| `channel`. |
+| `provider`   | yes      | string | `pipedream` \| `mcp` \| `openapi` \| `postman` \| `graphql` \| `http` \| `channel`. |
 | `name`       | no       | string | Display name. Defaults to slug.                                  |
 | `enabled`    | no       | bool   | Defaults to `true`.                                              |
 | `credential` | no       | string | `shared` is the only mode and the default. `per_user` (per-member BYO credential) was removed 2026-07-05 — a legacy manifest that still says `credential: per_user` is tolerated and always resolves to `shared`. |
@@ -396,6 +396,13 @@ Provider-specific fields:
 - **pipedream** — `app` (required), `account` (optional, defaults to slug).
 - **mcp** — `url` (required), `transport` = `http` (default) or `sse`.
 - **openapi** — `spec` (required: URL or repo-relative path).
+- **postman** — `spec` (required): a Collection v2.0/v2.1 JSON URL or repo path,
+  a `.postman/api` manifest, a public Postman-managed GitHub repository, or a
+  public Postman workspace URL. Repository imports prefer their original OpenAPI
+  3 definitions and fall back to collections. Workspace URLs use the official
+  Postman API and require the host operator's `POSTMAN_API_KEY`; Kortix never
+  scrapes the Postman web app. Collection scripts, cookies, and embedded
+  credential values are never imported or executed.
 - **graphql** — `endpoint` (required), `spec` (optional SDL).
 - **http** — `base_url` (required), `spec` (optional).
 - **channel** — `platform` (required) = `slack` \| `teams` \| `email` \| `meet`. Chat

--- a/apps/web/public/schema/kortix.schema.json
+++ b/apps/web/public/schema/kortix.schema.json
@@ -374,6 +374,7 @@
                     "pipedream",
                     "mcp",
                     "openapi",
+                    "postman",
                     "graphql",
                     "http",
                     "channel"
@@ -1326,6 +1327,7 @@
                     "pipedream",
                     "mcp",
                     "openapi",
+                    "postman",
                     "graphql",
                     "http",
                     "channel"

--- a/apps/web/public/schema/kortix.v1.schema.json
+++ b/apps/web/public/schema/kortix.v1.schema.json
@@ -351,6 +351,7 @@
               "pipedream",
               "mcp",
               "openapi",
+              "postman",
               "graphql",
               "http",
               "channel"

--- a/apps/web/public/schema/kortix.v2.schema.json
+++ b/apps/web/public/schema/kortix.v2.schema.json
@@ -506,6 +506,7 @@
               "pipedream",
               "mcp",
               "openapi",
+              "postman",
               "graphql",
               "http",
               "channel"

--- a/apps/web/src/components/projects/project-onboarding-wizard.tsx
+++ b/apps/web/src/components/projects/project-onboarding-wizard.tsx
@@ -85,7 +85,7 @@ const SlackConnectForm = lazy(() =>
   })),
 );
 
-/** Lazy — the full custom-connector form (OpenAPI / GraphQL / MCP / HTTP), reused
+/** Lazy — the full custom-connector form (OpenAPI / Postman / GraphQL / MCP / HTTP), reused
  * verbatim from the Connectors page so onboarding's "Advanced" tab matches it. */
 const CustomConnectorForm = lazy(() =>
   import('@/features/workspace/customize/sections/connectors-view').then((m) => ({
@@ -524,10 +524,10 @@ function ToolsStep({
           </p>
         </TabsContent>
 
-        {/* Custom — wire up any OpenAPI / GraphQL / MCP / HTTP service directly. */}
+        {/* Custom — wire up any OpenAPI / Postman / GraphQL / MCP / HTTP service directly. */}
         <TabsContent value="custom" className="mt-0">
           <p className="text-muted-foreground mb-3 text-sm leading-6">
-            Have your own API? Connect a custom OpenAPI, GraphQL, MCP, or HTTP service so your agent
+            Have your own API? Connect a custom OpenAPI, Postman, GraphQL, MCP, or HTTP service so your agent
             can call it directly.
           </p>
           <div className="max-h-[46vh] overflow-y-auto pr-1">

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -47,7 +47,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
-import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
 import Hint from '@/components/ui/hint';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';
@@ -119,6 +119,7 @@ const PROVIDER_ICON: Record<AdminConnector['provider'], LucideIcon> = {
   pipedream: Zap,
   mcp: Boxes,
   openapi: Globe,
+  postman: Globe,
   graphql: Globe,
   http: Globe,
   channel: MessageSquare,
@@ -139,6 +140,7 @@ function providerLabel(p: AdminConnector['provider']): string {
   if (p === 'pipedream') return 'App';
   if (p === 'channel') return 'Channel';
   if (p === 'computer') return 'Computer';
+  if (p === 'postman') return 'Postman';
   return p.toUpperCase();
 }
 
@@ -3256,6 +3258,7 @@ function ConnectorConfigFields({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="openapi">OpenAPI</SelectItem>
+              <SelectItem value="postman">Postman</SelectItem>
               <SelectItem value="graphql">GraphQL</SelectItem>
               <SelectItem value="mcp">MCP</SelectItem>
               <SelectItem value="http">HTTP</SelectItem>
@@ -3286,22 +3289,29 @@ function ConnectorConfigFields({
           </Select>
         </div>
       )}
-      {p === 'openapi' && (
+      {(p === 'openapi' || p === 'postman') && (
         <Field>
           <FieldLabel htmlFor="connector-spec">
-            {tI18nHardcoded.raw(
-              'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSpec4235864d',
-            )}
+            {p === 'postman'
+              ? 'Collection, repository, or workspace'
+              : tI18nHardcoded.raw(
+                  'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxAttrLabelSpec4235864d',
+                )}
           </FieldLabel>
           <Input
             id="connector-spec"
             value={draft.spec ?? ''}
             onChange={(e) => set({ spec: e.target.value })}
-            placeholder="https://…/openapi.json"
+            placeholder={p === 'postman' ? 'https://github.com/… or collection.json' : 'https://…/openapi.json'}
             variant="popover"
             disabled={readOnly}
             required
           />
+          {p === 'postman' ? (
+            <FieldDescription>
+              Supports Collection v2 JSON, Postman-managed Git repositories, and configured public workspaces.
+            </FieldDescription>
+          ) : null}
         </Field>
       )}
       {p === 'graphql' && (
@@ -3454,6 +3464,7 @@ function connectionValid(d: ConnectorDraftInput, emailChannelEnabled = true): bo
   if (d.auth?.type === 'custom' && !d.auth.name?.trim()) return false;
   if (d.provider === 'mcp') return !!d.url?.trim();
   if (d.provider === 'openapi') return !!d.spec?.trim();
+  if (d.provider === 'postman') return !!d.spec?.trim();
   if (d.provider === 'graphql') return !!d.endpoint?.trim();
   if (d.provider === 'http') return !!d.baseUrl?.trim();
   if (d.provider === 'channel') {

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -442,7 +442,7 @@ export const menuRegistry: MenuItemDef[] = [
     kind: 'navigate',
     href: '/projects/{projectId}/customize/connectors',
     requiresProject: true,
-    keywords: 'connectors integrations pipedream mcp openapi apps executor project customize',
+    keywords: 'connectors integrations pipedream mcp openapi postman collections apps executor project customize',
   },
   {
     id: 'proj-connectors-policies',

--- a/apps/whitelabel-demo/src/components/settings/connectors-tab.tsx
+++ b/apps/whitelabel-demo/src/components/settings/connectors-tab.tsx
@@ -30,7 +30,15 @@ import { Loader2, Plug, RefreshCw, Settings2, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
-type Provider = 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel' | 'computer';
+type Provider =
+  | 'pipedream'
+  | 'mcp'
+  | 'openapi'
+  | 'postman'
+  | 'graphql'
+  | 'http'
+  | 'channel'
+  | 'computer';
 
 const PROVIDERS: Provider[] = [
   'pipedream',

--- a/docs/plans/2026-07-17-postman-connectors.md
+++ b/docs/plans/2026-07-17-postman-connectors.md
@@ -1,0 +1,20 @@
+# Postman connector implementation plan
+
+1. Add RED tests for Collection v2.1 normalization, request execution, source
+   classification, `.postman/api` relation parsing, manifest validation, CRUD
+   round-tripping, SDK typing, and CLI argument acceptance.
+2. Implement a dependency-injected Postman source resolver with strict fetch
+   limits and GitHub/Postman URL adapters.
+3. Implement Collection v2.0/v2.1 normalization and the `postman` execution
+   binding, including template substitution, static headers/query values, body
+   handling, warnings, risk, and schema inference.
+4. Wire `provider: postman` through manifest schema, API sync/materialization,
+   gateway/database shapes, SDK public types/snapshots, CLI/MCP surfaces, web
+   form, JSON schemas, and documentation.
+5. Add integration fixtures for a direct collection and a multi-definition
+   `.postman/api` repository. Run focused tests and all affected package gates.
+6. Run the local stack and prove API, CLI, UI, executor call behavior, the live
+   HubSpot repository, and a raw HubSpot collection with real requests.
+7. Commit, push, open and merge the PR, monitor required checks, verify Deploy
+   Dev contains the merge SHA, then repeat the customer-visible proof on dev.
+

--- a/docs/specs/2026-07-17-postman-connectors.md
+++ b/docs/specs/2026-07-17-postman-connectors.md
@@ -1,0 +1,123 @@
+# Postman connector ingestion
+
+## Goal
+
+Let a Kortix project declare a Postman collection, a Postman-managed Git
+repository, or a public Postman workspace as one connector source. Sync turns
+the source into the same normalized, policy-governed action catalog used by
+OpenAPI, GraphQL, MCP, and HTTP connectors.
+
+The HubSpot public API workspace and its synchronized Git repository are the
+acceptance fixture. The repository currently contains `.postman/api` metadata
+for more than one hundred product APIs, each pointing at an OpenAPI definition
+and (usually) a generated Postman collection.
+
+## Product contract
+
+```yaml
+connectors:
+  - slug: hubspot
+    name: HubSpot
+    provider: postman
+    spec: https://github.com/HubSpot/HubSpot-public-api-spec-collection
+    auth:
+      type: bearer
+      secret: HUBSPOT_ACCESS_TOKEN
+```
+
+`spec` accepts:
+
+1. a URL or repository-relative path to a Postman Collection v2.0/v2.1 JSON
+   document;
+2. a URL or repository-relative path to a `.postman/api` manifest;
+3. a public GitHub repository URL containing `.postman/api`; or
+4. a public Postman workspace URL. Workspace resolution uses Postman's
+   supported API and a server-side `POSTMAN_API_KEY`; it never scrapes the web
+   application or imports credentials embedded in collection content.
+
+The dashboard and CLI expose `postman` beside the existing connector providers.
+Existing OpenAPI behavior and manifests remain backward compatible.
+
+## Ingestion boundary
+
+Postman is a source provider, not an alternate executor. Source resolution
+returns one or more named documents:
+
+- `.postman/api` repositories: follow each `.postman/api_<id>` relation and
+  prefer `apiDefinition.rootFiles` with `type = openapi:3`; fall back to its
+  collection files when no API definition exists;
+- direct collection documents: parse Collection v2.0/v2.1 recursively;
+- public workspaces: list collections through the official Postman API and
+  fetch their exported JSON documents.
+
+Each document becomes normalized actions. When a source contains multiple
+documents, action paths are prefixed with a deterministic document namespace.
+The connector remains one manifest entry and one policy boundary:
+
+```text
+hubspot.crm_contacts.getbyid
+hubspot.crm_companies.getbyid
+```
+
+Document namespaces derive from the repository path or collection name and are
+deduplicated deterministically. Source ordering must not change action paths.
+
+## Direct collection normalization
+
+For every request item:
+
+- folder names plus the request name produce a stable dotted action path;
+- GET/HEAD/OPTIONS are `read`, DELETE is `destructive`, and other methods are
+  `write`;
+- collection and request variables resolve from non-secret collection defaults;
+- unresolved `{{variables}}`, `:pathVariables`, query entries, and non-auth
+  headers become typed string inputs;
+- JSON request examples produce a `body` schema and JSON response examples
+  produce an output schema;
+- static query parameters and headers are retained in the invocation binding;
+- collection/request auth metadata is detected for diagnostics, but token,
+  password, API-key, cookie, and OAuth values are never imported;
+- disabled items are ignored;
+- pre-request scripts, tests, cookies, and `pm.sendRequest` are never executed;
+- unsupported body modes or unresolved dynamic scripts create visible sync
+  warnings instead of silently claiming full fidelity.
+
+Execution uses a dedicated `postman` action binding so request templates and
+static headers/query values survive normalization. It still calls the existing
+HTTP request executor, authentication attachment, audit, approval, and policy
+layers.
+
+## Safety and limits
+
+- Keep the existing outbound-source SSRF checks for every fetched URL.
+- Follow redirects only when every destination is allowed.
+- Limit individual documents, repository API counts, aggregate bytes, and
+  normalized actions; return actionable errors when a limit is exceeded.
+- Bound fetch concurrency and apply timeouts.
+- Reject HTML/login pages and malformed collection schemas precisely.
+- Do not persist source credentials or imported third-party secret values.
+- Do not evaluate JavaScript from Postman content.
+
+## Refresh and hashing
+
+The manifest hash remains the cheap declaration hash. Source content is fetched
+on explicit sync and materialized through the existing catalog hash. A changed
+repository or collection replaces actions atomically; removed actions disappear.
+The connector status exposes the last resolution error and warnings.
+
+## Acceptance criteria
+
+1. Existing connector tests and manifests remain green.
+2. Direct Collection v2.1 JSON imports nested requests and executes a real HTTP
+   request with path/query/header/body/auth behavior intact.
+3. HubSpot's public repository URL resolves `.postman/api`, imports all usable
+   API definitions, produces stable namespaced actions, and does not import its
+   generated Postman collections redundantly.
+4. A raw HubSpot collection imports successfully through the collection parser.
+5. A public Postman workspace URL either resolves through the supported API or
+   returns a precise missing-`POSTMAN_API_KEY` error.
+6. API, SDK, CLI, manifest schema, dashboard, docs, and generated schemas all
+   expose `postman` consistently.
+7. Local black-box API/CLI/UI verification and deployed-dev verification prove
+   creation, sync, catalog visibility, and a real outbound call.
+

--- a/packages/db/drizzle/meta/20260717143135_snapshot.json
+++ b/packages/db/drizzle/meta/20260717143135_snapshot.json
@@ -1,0 +1,14634 @@
+{
+  "id": "5cd51380-d530-4775-8d87-c2e3ee9266ce",
+  "prevId": "875343b7-4266-4cfb-a1d4-ae18b5ad50f3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "kortix.access_allowlist": {
+      "name": "access_allowlist",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_allowlist_type_value": {
+          "name": "idx_access_allowlist_type_value",
+          "columns": [
+            {
+              "expression": "entry_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.access_requests": {
+      "name": "access_requests",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_case": {
+          "name": "use_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "access_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_access_requests_email": {
+          "name": "idx_access_requests_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_access_requests_status": {
+          "name": "idx_access_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_deletion_requests": {
+      "name": "account_deletion_requests",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_github_installation_states": {
+      "name": "account_github_installation_states",
+      "schema": "kortix",
+      "columns": {
+        "state_nonce": {
+          "name": "state_nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_github_installation_states_account": {
+          "name": "idx_account_github_installation_states_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_github_installation_states_expires_at": {
+          "name": "idx_account_github_installation_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_github_installation_states_account_id_accounts_account_id_fk": {
+          "name": "account_github_installation_states_account_id_accounts_account_id_fk",
+          "tableFrom": "account_github_installation_states",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_github_installations": {
+      "name": "account_github_installations",
+      "schema": "kortix",
+      "columns": {
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Organization'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_github_installations_account": {
+          "name": "idx_account_github_installations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_github_installations_account_installation": {
+          "name": "idx_account_github_installations_account_installation",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_github_installations_owner": {
+          "name": "idx_account_github_installations_owner",
+          "columns": [
+            {
+              "expression": "owner_login",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_github_installations_account_id_accounts_account_id_fk": {
+          "name": "account_github_installations_account_id_accounts_account_id_fk",
+          "tableFrom": "account_github_installations",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_group_members": {
+      "name": "account_group_members",
+      "schema": "kortix",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_group_members_user": {
+          "name": "idx_account_group_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_group_members_group_id_account_groups_group_id_fk": {
+          "name": "account_group_members_group_id_account_groups_group_id_fk",
+          "tableFrom": "account_group_members",
+          "tableTo": "account_groups",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "group_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_group_members_group_id_user_id_pk": {
+          "name": "account_group_members_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_groups": {
+      "name": "account_groups",
+      "schema": "kortix",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "account_group_source",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_groups_account": {
+          "name": "idx_account_groups_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_groups_account_name": {
+          "name": "idx_account_groups_account_name",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_groups_account_id_accounts_account_id_fk": {
+          "name": "account_groups_account_id_accounts_account_id_fk",
+          "tableFrom": "account_groups",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_invitations": {
+      "name": "account_invitations",
+      "schema": "kortix",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_role": {
+          "name": "initial_role",
+          "type": "account_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "bootstrap_grants": {
+          "name": "bootstrap_grants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '14 days'"
+        }
+      },
+      "indexes": {
+        "idx_account_invitations_email": {
+          "name": "idx_account_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_invitations_account": {
+          "name": "idx_account_invitations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_invitations_expires_at": {
+          "name": "idx_account_invitations_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_invitations_pending": {
+          "name": "idx_account_invitations_pending",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_invitations_account_id_accounts_account_id_fk": {
+          "name": "account_invitations_account_id_accounts_account_id_fk",
+          "tableFrom": "account_invitations",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_members": {
+      "name": "account_members",
+      "schema": "kortix",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_role": {
+          "name": "account_role",
+          "type": "account_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "scim_external_id": {
+          "name": "scim_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_members_user_id": {
+          "name": "idx_account_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_members_account_id": {
+          "name": "idx_account_members_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_members_user_account": {
+          "name": "idx_account_members_user_account",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_members_account_id_accounts_account_id_fk": {
+          "name": "account_members_account_id_accounts_account_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_members_user_id_account_id_pk": {
+          "name": "account_members_user_id_account_id_pk",
+          "columns": [
+            "user_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_model_preferences": {
+      "name": "account_model_preferences",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_model_preferences_account": {
+          "name": "idx_account_model_preferences_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_model_preferences_scope": {
+          "name": "idx_account_model_preferences_scope",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_model_preferences_account_id_accounts_account_id_fk": {
+          "name": "account_model_preferences_account_id_accounts_account_id_fk",
+          "tableFrom": "account_model_preferences",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_session_activity": {
+      "name": "account_session_activity",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_account_session_activity_account": {
+          "name": "idx_account_session_activity_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_session_activity_user": {
+          "name": "idx_account_session_activity_user",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_session_activity_account_id_accounts_account_id_fk": {
+          "name": "account_session_activity_account_id_accounts_account_id_fk",
+          "tableFrom": "account_session_activity",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_session_activity_account_id_user_id_session_id_pk": {
+          "name": "account_session_activity_account_id_user_id_session_id_pk",
+          "columns": [
+            "account_id",
+            "user_id",
+            "session_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_sso_group_mappings": {
+      "name": "account_sso_group_mappings",
+      "schema": "kortix",
+      "columns": {
+        "mapping_id": {
+          "name": "mapping_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_value": {
+          "name": "claim_value",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_sso_mappings_claim": {
+          "name": "idx_account_sso_mappings_claim",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claim_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_mappings_provider": {
+          "name": "idx_account_sso_mappings_provider",
+          "columns": [
+            {
+              "expression": "sso_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_mappings_group": {
+          "name": "idx_account_sso_mappings_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_sso_group_mappings_account_id_accounts_account_id_fk": {
+          "name": "account_sso_group_mappings_account_id_accounts_account_id_fk",
+          "tableFrom": "account_sso_group_mappings",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_sso_group_mappings_sso_provider_id_account_sso_providers_sso_provider_id_fk": {
+          "name": "account_sso_group_mappings_sso_provider_id_account_sso_providers_sso_provider_id_fk",
+          "tableFrom": "account_sso_group_mappings",
+          "tableTo": "account_sso_providers",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sso_provider_id"
+          ],
+          "columnsTo": [
+            "sso_provider_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_sso_group_mappings_group_id_account_groups_group_id_fk": {
+          "name": "account_sso_group_mappings_group_id_account_groups_group_id_fk",
+          "tableFrom": "account_sso_group_mappings",
+          "tableTo": "account_groups",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "group_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_sso_providers": {
+      "name": "account_sso_providers",
+      "schema": "kortix",
+      "columns": {
+        "sso_provider_id": {
+          "name": "sso_provider_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supabase_sso_provider_id": {
+          "name": "supabase_sso_provider_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_domain": {
+          "name": "primary_domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_claim_name": {
+          "name": "group_claim_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'groups'"
+        },
+        "auto_create_members": {
+          "name": "auto_create_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_provision_groups": {
+          "name": "auto_provision_groups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enforce_sso": {
+          "name": "enforce_sso",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_account_sso_providers_account": {
+          "name": "idx_account_sso_providers_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_providers_supabase": {
+          "name": "idx_account_sso_providers_supabase",
+          "columns": [
+            {
+              "expression": "supabase_sso_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_sso_providers_domain": {
+          "name": "idx_account_sso_providers_domain",
+          "columns": [
+            {
+              "expression": "primary_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_sso_providers_account_id_accounts_account_id_fk": {
+          "name": "account_sso_providers_account_id_accounts_account_id_fk",
+          "tableFrom": "account_sso_providers",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.account_tokens": {
+      "name": "account_tokens",
+      "schema": "kortix",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_hash": {
+          "name": "secret_key_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "api_key_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_grant": {
+          "name": "agent_grant",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_account_tokens_public_key": {
+          "name": "idx_account_tokens_public_key",
+          "columns": [
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_secret_hash": {
+          "name": "idx_account_tokens_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_account": {
+          "name": "idx_account_tokens_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_user": {
+          "name": "idx_account_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_account_tokens_project": {
+          "name": "idx_account_tokens_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_tokens_account_id_accounts_account_id_fk": {
+          "name": "account_tokens_account_id_accounts_account_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_tokens_project_id_projects_project_id_fk": {
+          "name": "account_tokens_project_id_projects_project_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_tokens_service_account_id_service_accounts_service_account_id_fk": {
+          "name": "account_tokens_service_account_id_service_accounts_service_account_id_fk",
+          "tableFrom": "account_tokens",
+          "tableTo": "service_accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "service_account_id"
+          ],
+          "columnsTo": [
+            "service_account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.accounts": {
+      "name": "accounts",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setup_complete_at": {
+          "name": "setup_complete_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_wizard_step": {
+          "name": "setup_wizard_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mfa_required": {
+          "name": "mfa_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "session_max_lifetime_minutes": {
+          "name": "session_max_lifetime_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_idle_timeout_minutes": {
+          "name": "session_idle_timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pat_max_lifetime_days": {
+          "name": "pat_max_lifetime_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pat_require_expiry": {
+          "name": "pat_require_expiry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pat_idle_revoke_days": {
+          "name": "pat_idle_revoke_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.audit_events": {
+      "name": "audit_events",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_events_account_time": {
+          "name": "idx_audit_events_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_actor_time": {
+          "name": "idx_audit_events_actor_time",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_resource": {
+          "name": "idx_audit_events_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_account_id_accounts_account_id_fk": {
+          "name": "audit_events_account_id_accounts_account_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.audit_webhooks": {
+      "name": "audit_webhooks",
+      "schema": "kortix",
+      "columns": {
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "action_prefix": {
+          "name": "action_prefix",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_webhooks_account": {
+          "name": "idx_audit_webhooks_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_webhooks_enabled": {
+          "name": "idx_audit_webhooks_enabled",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_webhooks_account_id_accounts_account_id_fk": {
+          "name": "audit_webhooks_account_id_accounts_account_id_fk",
+          "tableFrom": "audit_webhooks",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.billing_customers": {
+      "name": "billing_customers",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kortix_billing_customers_account_id": {
+          "name": "idx_kortix_billing_customers_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.change_requests": {
+      "name": "change_requests",
+      "schema": "kortix",
+      "columns": {
+        "cr_id": {
+          "name": "cr_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "change_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "head_commit_sha": {
+          "name": "head_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_commit_sha": {
+          "name": "base_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_by": {
+          "name": "merged_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_commit_sha": {
+          "name": "merge_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by": {
+          "name": "closed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_change_requests_account": {
+          "name": "idx_change_requests_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_requests_project": {
+          "name": "idx_change_requests_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_requests_project_status": {
+          "name": "idx_change_requests_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_requests_project_number": {
+          "name": "idx_change_requests_project_number",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_requests_account_id_accounts_account_id_fk": {
+          "name": "change_requests_account_id_accounts_account_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_project_id_projects_project_id_fk": {
+          "name": "change_requests_project_id_projects_project_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "change_requests_origin_session_id_project_sessions_session_id_fk": {
+          "name": "change_requests_origin_session_id_project_sessions_session_id_fk",
+          "tableFrom": "change_requests",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "origin_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_channel_bindings": {
+      "name": "chat_channel_bindings",
+      "schema": "kortix",
+      "columns": {
+        "binding_id": {
+          "name": "binding_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picker_ts": {
+          "name": "picker_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opencode_model": {
+          "name": "opencode_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_policy": {
+          "name": "conversation_policy",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project_open'"
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_channel_bindings_channel": {
+          "name": "idx_chat_channel_bindings_channel",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_channel_bindings_project": {
+          "name": "idx_chat_channel_bindings_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_channel_bindings_project_id_projects_project_id_fk": {
+          "name": "chat_channel_bindings_project_id_projects_project_id_fk",
+          "tableFrom": "chat_channel_bindings",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_event_dedup": {
+      "name": "chat_event_dedup",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_event_dedup_expiry": {
+          "name": "idx_chat_event_dedup_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_installs": {
+      "name": "chat_installs",
+      "schema": "kortix",
+      "columns": {
+        "install_id": {
+          "name": "install_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_installs_workspace_project": {
+          "name": "idx_chat_installs_workspace_project",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_installs_workspace": {
+          "name": "idx_chat_installs_workspace",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_installs_project": {
+          "name": "idx_chat_installs_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_installs_project_id_projects_project_id_fk": {
+          "name": "chat_installs_project_id_projects_project_id_fk",
+          "tableFrom": "chat_installs",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_pending_auth_messages": {
+      "name": "chat_pending_auth_messages",
+      "schema": "kortix",
+      "columns": {
+        "pending_id": {
+          "name": "pending_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slack'"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_response_url": {
+          "name": "slack_response_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_chat_pending_auth_messages_lookup": {
+          "name": "idx_chat_pending_auth_messages_lookup",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_pending_auth_messages_expiry": {
+          "name": "idx_chat_pending_auth_messages_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_pending_auth_messages_project_id_projects_project_id_fk": {
+          "name": "chat_pending_auth_messages_project_id_projects_project_id_fk",
+          "tableFrom": "chat_pending_auth_messages",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_thread_participants": {
+      "name": "chat_thread_participants",
+      "schema": "kortix",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_participants_thread_user": {
+          "name": "idx_chat_thread_participants_thread_user",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_participants_session": {
+          "name": "idx_chat_thread_participants_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_participants_user": {
+          "name": "idx_chat_thread_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_participants_session_id_project_sessions_session_id_fk": {
+          "name": "chat_thread_participants_session_id_project_sessions_session_id_fk",
+          "tableFrom": "chat_thread_participants",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_threads": {
+      "name": "chat_threads",
+      "schema": "kortix",
+      "columns": {
+        "thread_row_id": {
+          "name": "thread_row_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_thread": {
+          "name": "idx_chat_threads_thread",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_project": {
+          "name": "idx_chat_threads_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_threads_session": {
+          "name": "idx_chat_threads_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_project_id_projects_project_id_fk": {
+          "name": "chat_threads_project_id_projects_project_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_session_id_project_sessions_session_id_fk": {
+          "name": "chat_threads_session_id_project_sessions_session_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_turn_streams": {
+      "name": "chat_turn_streams",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_ts": {
+          "name": "trigger_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming": {
+          "name": "streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "placeholder_active": {
+          "name": "placeholder_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "finalized": {
+          "name": "finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "originating_event": {
+          "name": "originating_event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_ref": {
+          "name": "channel_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_turn_streams_expiry": {
+          "name": "idx_chat_turn_streams_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.chat_user_identities": {
+      "name": "chat_user_identities",
+      "schema": "kortix",
+      "columns": {
+        "identity_id": {
+          "name": "identity_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_user_identities_platform_user": {
+          "name": "idx_chat_user_identities_platform_user",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_user_identities_user": {
+          "name": "idx_chat_user_identities_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_accounts": {
+      "name": "credit_accounts",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_granted": {
+          "name": "lifetime_granted",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_purchased": {
+          "name": "lifetime_purchased",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetime_used": {
+          "name": "lifetime_used",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_grant_date": {
+          "name": "last_grant_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'free'"
+        },
+        "billing_cycle_anchor": {
+          "name": "billing_cycle_anchor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_credit_grant": {
+          "name": "next_credit_grant",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiring_credits": {
+          "name": "expiring_credits",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "non_expiring_credits": {
+          "name": "non_expiring_credits",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "daily_credits_balance": {
+          "name": "daily_credits_balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "trial_status": {
+          "name": "trial_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "trial_started_at": {
+          "name": "trial_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_grandfathered_free": {
+          "name": "is_grandfathered_free",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_type": {
+          "name": "commitment_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_start_date": {
+          "name": "commitment_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_end_date": {
+          "name": "commitment_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_price_id": {
+          "name": "commitment_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_cancel_after": {
+          "name": "can_cancel_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_renewal_period_start": {
+          "name": "last_renewal_period_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "last_payment_failure": {
+          "name": "last_payment_failure",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_tier_change": {
+          "name": "scheduled_tier_change",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_tier_change_date": {
+          "name": "scheduled_tier_change_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_price_id": {
+          "name": "scheduled_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'stripe'"
+        },
+        "revenuecat_customer_id": {
+          "name": "revenuecat_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_subscription_id": {
+          "name": "revenuecat_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_cancelled_at": {
+          "name": "revenuecat_cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_cancel_at_period_end": {
+          "name": "revenuecat_cancel_at_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_pending_change_product": {
+          "name": "revenuecat_pending_change_product",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_pending_change_date": {
+          "name": "revenuecat_pending_change_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_pending_change_type": {
+          "name": "revenuecat_pending_change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_product_id": {
+          "name": "revenuecat_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'monthly'"
+        },
+        "stripe_subscription_status": {
+          "name": "stripe_subscription_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_daily_refresh": {
+          "name": "last_daily_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_enabled": {
+          "name": "auto_topup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_threshold": {
+          "name": "auto_topup_threshold",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'5'"
+        },
+        "auto_topup_amount": {
+          "name": "auto_topup_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20'"
+        },
+        "auto_topup_last_charged": {
+          "name": "auto_topup_last_charged",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_model": {
+          "name": "billing_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "seat_count": {
+          "name": "seat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "seat_subscription_item_id": {
+          "name": "seat_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topup_customized": {
+          "name": "auto_topup_customized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_topup_consecutive_failures": {
+          "name": "auto_topup_consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_topup_disabled_reason": {
+          "name": "auto_topup_disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_enterprise": {
+          "name": "demo_enterprise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kortix_credit_accounts_account_id_idx": {
+          "name": "kortix_credit_accounts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_accounts_billing_model": {
+          "name": "idx_credit_accounts_billing_model",
+          "columns": [
+            {
+              "expression": "billing_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_expiring": {
+          "name": "is_expiring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_event_id": {
+          "name": "stripe_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_source": {
+          "name": "processing_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_kortix_credit_ledger_idempotency": {
+          "name": "idx_kortix_credit_ledger_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"credit_ledger\".\"idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kortix_unique_stripe_event": {
+          "name": "kortix_unique_stripe_event",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_purchases": {
+      "name": "credit_purchases",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_dollars": {
+          "name": "amount_dollars",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'stripe'"
+        },
+        "revenuecat_transaction_id": {
+          "name": "revenuecat_transaction_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenuecat_product_id": {
+          "name": "revenuecat_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.credit_usage": {
+      "name": "credit_usage",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_dollars": {
+          "name": "amount_dollars",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_type": {
+          "name": "usage_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'token_overage'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connection_profiles": {
+      "name": "executor_connection_profiles",
+      "schema": "kortix",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "executor_connection_profile_owner_type",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "executor_connection_profile_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connection_profiles_tenant_identity": {
+          "name": "idx_executor_connection_profiles_tenant_identity",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_connector_identity": {
+          "name": "idx_executor_connection_profiles_connector_identity",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_default": {
+          "name": "idx_executor_connection_profiles_default",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_connection_profiles\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_owner": {
+          "name": "idx_executor_connection_profiles_owner",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_connection_profiles\".\"owner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_project": {
+          "name": "idx_executor_connection_profiles_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connection_profiles_connector": {
+          "name": "idx_executor_connection_profiles_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connection_profiles_connector_tenant_fk": {
+          "name": "executor_connection_profiles_connector_tenant_fk",
+          "tableFrom": "executor_connection_profiles",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "connector_id"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "executor_connection_profiles_owner_check": {
+          "name": "executor_connection_profiles_owner_check",
+          "value": "(\"kortix\".\"executor_connection_profiles\".\"owner_type\" = 'project' AND \"kortix\".\"executor_connection_profiles\".\"owner_id\" IS NULL) OR (\"kortix\".\"executor_connection_profiles\".\"owner_type\" <> 'project' AND \"kortix\".\"executor_connection_profiles\".\"owner_id\" IS NOT NULL AND btrim(\"kortix\".\"executor_connection_profiles\".\"owner_id\") <> '')"
+        },
+        "executor_connection_profiles_metadata_check": {
+          "name": "executor_connection_profiles_metadata_check",
+          "value": "jsonb_typeof(\"kortix\".\"executor_connection_profiles\".\"metadata\") = 'object' AND octet_length(\"kortix\".\"executor_connection_profiles\".\"metadata\"::text) <= 16384"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connector_actions": {
+      "name": "executor_connector_actions",
+      "schema": "kortix",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "executor_risk",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "binding": {
+          "name": "binding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connector_actions_connector": {
+          "name": "idx_executor_connector_actions_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connector_actions_path": {
+          "name": "idx_executor_connector_actions_path",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connector_actions_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_connector_actions_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_connector_actions",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connector_grants": {
+      "name": "executor_connector_grants",
+      "schema": "kortix",
+      "columns": {
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "secret_grant_principal",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connector_grants_connector": {
+          "name": "idx_executor_connector_grants_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connector_grants_unique": {
+          "name": "idx_executor_connector_grants_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connector_grants_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_connector_grants_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_connector_grants",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connector_policies": {
+      "name": "executor_connector_policies",
+      "schema": "kortix",
+      "columns": {
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match": {
+          "name": "match",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "executor_policy_action",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connector_policies_connector": {
+          "name": "idx_executor_connector_policies_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connector_policies_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_connector_policies_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_connector_policies",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_connectors": {
+      "name": "executor_connectors",
+      "schema": "kortix",
+      "columns": {
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "executor_connector_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auth_secret": {
+          "name": "auth_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_scope": {
+          "name": "share_scope",
+          "type": "secret_share_scope",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "agent_scope": {
+          "name": "agent_scope",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_mode": {
+          "name": "credential_mode",
+          "type": "executor_credential_mode",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared'"
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "executor_connector_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_connectors_project": {
+          "name": "idx_executor_connectors_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_account": {
+          "name": "idx_executor_connectors_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_project_slug": {
+          "name": "idx_executor_connectors_project_slug",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_tenant_identity": {
+          "name": "idx_executor_connectors_tenant_identity",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_connectors_tenant_alias": {
+          "name": "idx_executor_connectors_tenant_alias",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_connectors_account_id_accounts_account_id_fk": {
+          "name": "executor_connectors_account_id_accounts_account_id_fk",
+          "tableFrom": "executor_connectors",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_connectors_project_id_projects_project_id_fk": {
+          "name": "executor_connectors_project_id_projects_project_id_fk",
+          "tableFrom": "executor_connectors",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_credentials": {
+      "name": "executor_credentials",
+      "schema": "kortix",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret'"
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_credentials_connector": {
+          "name": "idx_executor_credentials_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_credentials_profile": {
+          "name": "idx_executor_credentials_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_credentials_profile_unique": {
+          "name": "idx_executor_credentials_profile_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_credentials\".\"profile_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_credentials_legacy_connector_unique": {
+          "name": "idx_executor_credentials_legacy_connector_unique",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"executor_credentials\".\"profile_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_credentials_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_credentials_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_credentials",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_credentials_connector_profile_fk": {
+          "name": "executor_credentials_connector_profile_fk",
+          "tableFrom": "executor_credentials",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id",
+            "profile_id"
+          ],
+          "columnsTo": [
+            "connector_id",
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_executions": {
+      "name": "executor_executions",
+      "schema": "kortix",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_path": {
+          "name": "action_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acting_user_id": {
+          "name": "acting_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "executor_execution_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk": {
+          "name": "risk",
+          "type": "executor_risk",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_digest": {
+          "name": "request_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_executor_executions_project": {
+          "name": "idx_executor_executions_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_project_session_created": {
+          "name": "idx_executor_executions_project_session_created",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_connector": {
+          "name": "idx_executor_executions_connector",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_profile": {
+          "name": "idx_executor_executions_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executor_executions_status": {
+          "name": "idx_executor_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_executions_account_id_accounts_account_id_fk": {
+          "name": "executor_executions_account_id_accounts_account_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_executions_project_id_projects_project_id_fk": {
+          "name": "executor_executions_project_id_projects_project_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "executor_executions_connector_id_executor_connectors_connector_id_fk": {
+          "name": "executor_executions_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "executor_executions_profile_id_executor_connection_profiles_profile_id_fk": {
+          "name": "executor_executions_profile_id_executor_connection_profiles_profile_id_fk",
+          "tableFrom": "executor_executions",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_project_policies": {
+      "name": "executor_project_policies",
+      "schema": "kortix",
+      "columns": {
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match": {
+          "name": "match",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "executor_policy_action",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executor_project_policies_project": {
+          "name": "idx_executor_project_policies_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "executor_project_policies_project_id_projects_project_id_fk": {
+          "name": "executor_project_policies_project_id_projects_project_id_fk",
+          "tableFrom": "executor_project_policies",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.executor_project_settings": {
+      "name": "executor_project_settings",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "default_mode": {
+          "name": "default_mode",
+          "type": "executor_default_mode",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allow_all'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "executor_project_settings_project_id_projects_project_id_fk": {
+          "name": "executor_project_settings_project_id_projects_project_id_fk",
+          "tableFrom": "executor_project_settings",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.gateway_api_keys": {
+      "name": "gateway_api_keys",
+      "schema": "kortix",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_hash": {
+          "name": "secret_key_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "api_key_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gateway_keys_secret_hash": {
+          "name": "idx_gateway_keys_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_keys_project": {
+          "name": "idx_gateway_keys_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_keys_account": {
+          "name": "idx_gateway_keys_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gateway_api_keys_account_id_accounts_account_id_fk": {
+          "name": "gateway_api_keys_account_id_accounts_account_id_fk",
+          "tableFrom": "gateway_api_keys",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gateway_api_keys_project_id_projects_project_id_fk": {
+          "name": "gateway_api_keys_project_id_projects_project_id_fk",
+          "tableFrom": "gateway_api_keys",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.gateway_budgets": {
+      "name": "gateway_budgets",
+      "schema": "kortix",
+      "columns": {
+        "budget_id": {
+          "name": "budget_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "gateway_budget_scope",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_usd": {
+          "name": "limit_usd",
+          "type": "numeric(12, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "gateway_budget_period",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'month'"
+        },
+        "action": {
+          "name": "action",
+          "type": "gateway_budget_action",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'block'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gateway_budgets_project": {
+          "name": "idx_gateway_budgets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_budgets_lookup": {
+          "name": "idx_gateway_budgets_lookup",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gateway_budgets_project_id_projects_project_id_fk": {
+          "name": "gateway_budgets_project_id_projects_project_id_fk",
+          "tableFrom": "gateway_budgets",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.gateway_request_logs": {
+      "name": "gateway_request_logs",
+      "schema": "kortix",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_model": {
+          "name": "requested_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_model": {
+          "name": "resolved_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "candidates_tried": {
+          "name": "candidates_tried",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_tokens": {
+          "name": "cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upstream_cost": {
+          "name": "upstream_cost",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "final_cost": {
+          "name": "final_cost",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "streaming": {
+          "name": "streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_mode": {
+          "name": "billing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gateway_logs_request_id": {
+          "name": "idx_gateway_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_account_time": {
+          "name": "idx_gateway_logs_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_project_time": {
+          "name": "idx_gateway_logs_project_time",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_model": {
+          "name": "idx_gateway_logs_model",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_account_ok": {
+          "name": "idx_gateway_logs_account_ok",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ok",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gateway_logs_session": {
+          "name": "idx_gateway_logs_session",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gateway_request_logs_account_id_accounts_account_id_fk": {
+          "name": "gateway_request_logs_account_id_accounts_account_id_fk",
+          "tableFrom": "gateway_request_logs",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gateway_request_logs_project_id_projects_project_id_fk": {
+          "name": "gateway_request_logs_project_id_projects_project_id_fk",
+          "tableFrom": "gateway_request_logs",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_policies": {
+      "name": "iam_policies",
+      "schema": "kortix",
+      "columns": {
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_policies_account_principal": {
+          "name": "idx_iam_policies_account_principal",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_policies_scope": {
+          "name": "idx_iam_policies_scope",
+          "columns": [
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_policies_role": {
+          "name": "idx_iam_policies_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iam_policies_account_id_accounts_account_id_fk": {
+          "name": "iam_policies_account_id_accounts_account_id_fk",
+          "tableFrom": "iam_policies",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "iam_policies_role_id_iam_roles_role_id_fk": {
+          "name": "iam_policies_role_id_iam_roles_role_id_fk",
+          "tableFrom": "iam_policies",
+          "tableTo": "iam_roles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_resource_grants": {
+      "name": "iam_resource_grants",
+      "schema": "kortix",
+      "columns": {
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allow'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_iam_resource_grants": {
+          "name": "uq_iam_resource_grants",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_project_type": {
+          "name": "idx_iam_resource_grants_project_type",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_resource": {
+          "name": "idx_iam_resource_grants_resource",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_principal": {
+          "name": "idx_iam_resource_grants_principal",
+          "columns": [
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_resource_grants_account": {
+          "name": "idx_iam_resource_grants_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iam_resource_grants_account_id_accounts_account_id_fk": {
+          "name": "iam_resource_grants_account_id_accounts_account_id_fk",
+          "tableFrom": "iam_resource_grants",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "iam_resource_grants_project_id_projects_project_id_fk": {
+          "name": "iam_resource_grants_project_id_projects_project_id_fk",
+          "tableFrom": "iam_resource_grants",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_role_actions": {
+      "name": "iam_role_actions",
+      "schema": "kortix",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "iam_role_actions_role_id_iam_roles_role_id_fk": {
+          "name": "iam_role_actions_role_id_iam_roles_role_id_fk",
+          "tableFrom": "iam_role_actions",
+          "tableTo": "iam_roles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "role_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "iam_role_actions_role_id_action_pk": {
+          "name": "iam_role_actions_role_id_action_pk",
+          "columns": [
+            "role_id",
+            "action"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.iam_roles": {
+      "name": "iam_roles",
+      "schema": "kortix",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project'"
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iam_roles_account": {
+          "name": "idx_iam_roles_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_iam_roles_account_key": {
+          "name": "idx_iam_roles_account_key",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iam_roles_account_id_accounts_account_id_fk": {
+          "name": "iam_roles_account_id_accounts_account_id_fk",
+          "tableFrom": "iam_roles",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.api_keys": {
+      "name": "api_keys",
+      "schema": "kortix",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_hash": {
+          "name": "secret_key_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "api_key_type",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "status": {
+          "name": "status",
+          "type": "api_key_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kortix_api_keys_public_key": {
+          "name": "idx_kortix_api_keys_public_key",
+          "columns": [
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kortix_api_keys_secret_hash": {
+          "name": "idx_kortix_api_keys_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kortix_api_keys_sandbox": {
+          "name": "idx_kortix_api_keys_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kortix_api_keys_account": {
+          "name": "idx_kortix_api_keys_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.legacy_sandbox_migrations": {
+      "name": "legacy_sandbox_migrations",
+      "schema": "kortix",
+      "columns": {
+        "migration_id": {
+          "name": "migration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dry_run'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rollback": {
+          "name": "rollback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "opencode_archive": {
+          "name": "opencode_archive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_legacy_sandbox_migrations_run": {
+          "name": "idx_legacy_sandbox_migrations_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_sandbox": {
+          "name": "idx_legacy_sandbox_migrations_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_status": {
+          "name": "idx_legacy_sandbox_migrations_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_account": {
+          "name": "idx_legacy_sandbox_migrations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_legacy_sandbox_migrations_heartbeat": {
+          "name": "idx_legacy_sandbox_migrations_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_access_token_hash": {
+          "name": "idx_oauth_access_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_tokens_client": {
+          "name": "idx_oauth_access_tokens_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_access_tokens_user": {
+          "name": "idx_oauth_access_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_codes_code": {
+          "name": "idx_oauth_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_codes_client": {
+          "name": "idx_oauth_codes_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_codes_expires": {
+          "name": "idx_oauth_codes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_authorization_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "kortix",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_id": {
+          "name": "access_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oauth_refresh_token_hash": {
+          "name": "idx_oauth_refresh_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_refresh_tokens_client": {
+          "name": "idx_oauth_refresh_tokens_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_access_token_id_oauth_access_tokens_id_fk": {
+          "name": "oauth_refresh_tokens_access_token_id_oauth_access_tokens_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_access_tokens",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "access_token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.platform_settings": {
+      "name": "platform_settings",
+      "schema": "kortix",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.platform_user_roles": {
+      "name": "platform_user_roles",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "platform_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_user_roles_account_id": {
+          "name": "idx_platform_user_roles_account_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_platform_user_roles_role": {
+          "name": "idx_platform_user_roles_role",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_access_requests": {
+      "name": "project_access_requests",
+      "schema": "kortix",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_access_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_access_requests_project": {
+          "name": "idx_project_access_requests_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_account": {
+          "name": "idx_project_access_requests_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_requester": {
+          "name": "idx_project_access_requests_requester",
+          "columns": [
+            {
+              "expression": "requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_status": {
+          "name": "idx_project_access_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_access_requests_pending_unique": {
+          "name": "idx_project_access_requests_pending_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requester_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"project_access_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_access_requests_account_id_accounts_account_id_fk": {
+          "name": "project_access_requests_account_id_accounts_account_id_fk",
+          "tableFrom": "project_access_requests",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_access_requests_project_id_projects_project_id_fk": {
+          "name": "project_access_requests_project_id_projects_project_id_fk",
+          "tableFrom": "project_access_requests",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_git_connections": {
+      "name": "project_git_connections",
+      "schema": "kortix",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_repo_id": {
+          "name": "external_repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_ref": {
+          "name": "credential_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_git_connections_account": {
+          "name": "idx_project_git_connections_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_connections_project": {
+          "name": "idx_project_git_connections_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_connections_provider_repo": {
+          "name": "idx_project_git_connections_provider_repo",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_repo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_connections_status": {
+          "name": "idx_project_git_connections_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_git_connections_account_id_accounts_account_id_fk": {
+          "name": "project_git_connections_account_id_accounts_account_id_fk",
+          "tableFrom": "project_git_connections",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_git_connections_project_id_projects_project_id_fk": {
+          "name": "project_git_connections_project_id_projects_project_id_fk",
+          "tableFrom": "project_git_connections",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_git_credentials": {
+      "name": "project_git_credentials",
+      "schema": "kortix",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'token'"
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_git_credentials_account": {
+          "name": "idx_project_git_credentials_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_git_credentials_project_provider": {
+          "name": "idx_project_git_credentials_project_provider",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_git_credentials_account_id_accounts_account_id_fk": {
+          "name": "project_git_credentials_account_id_accounts_account_id_fk",
+          "tableFrom": "project_git_credentials",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_git_credentials_project_id_projects_project_id_fk": {
+          "name": "project_git_credentials_project_id_projects_project_id_fk",
+          "tableFrom": "project_git_credentials",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_group_grants": {
+      "name": "project_group_grants",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "project_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_group_grants_project": {
+          "name": "idx_project_group_grants_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_group_grants_group": {
+          "name": "idx_project_group_grants_group",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_group_grants_account": {
+          "name": "idx_project_group_grants_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_group_grants_project_id_projects_project_id_fk": {
+          "name": "project_group_grants_project_id_projects_project_id_fk",
+          "tableFrom": "project_group_grants",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_grants_group_id_account_groups_group_id_fk": {
+          "name": "project_group_grants_group_id_account_groups_group_id_fk",
+          "tableFrom": "project_group_grants",
+          "tableTo": "account_groups",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "group_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_group_grants_account_id_accounts_account_id_fk": {
+          "name": "project_group_grants_account_id_accounts_account_id_fk",
+          "tableFrom": "project_group_grants",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_group_grants_project_id_group_id_pk": {
+          "name": "project_group_grants_project_id_group_id_pk",
+          "columns": [
+            "project_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_llm_routing_policies": {
+      "name": "project_llm_routing_policies",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vision_model": {
+          "name": "vision_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_models": {
+          "name": "default_fallback_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_on": {
+          "name": "default_fallback_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_llm_routing_policies_project_id_projects_project_id_fk": {
+          "name": "project_llm_routing_policies_project_id_projects_project_id_fk",
+          "tableFrom": "project_llm_routing_policies",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_llm_routing_policies_fallback_pair_check": {
+          "name": "project_llm_routing_policies_fallback_pair_check",
+          "value": "(\"kortix\".\"project_llm_routing_policies\".\"default_fallback_models\" IS NULL AND \"kortix\".\"project_llm_routing_policies\".\"default_fallback_on\" IS NULL) OR (\"kortix\".\"project_llm_routing_policies\".\"default_fallback_models\" IS NOT NULL AND \"kortix\".\"project_llm_routing_policies\".\"default_fallback_on\" IN ('transient', 'any-error'))"
+        },
+        "project_llm_routing_policies_rules_array_check": {
+          "name": "project_llm_routing_policies_rules_array_check",
+          "value": "jsonb_typeof(\"kortix\".\"project_llm_routing_policies\".\"rules\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.project_members": {
+      "name": "project_members",
+      "schema": "kortix",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_role": {
+          "name": "project_role",
+          "type": "project_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_members_account_user": {
+          "name": "idx_project_members_account_user",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_members_project": {
+          "name": "idx_project_members_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_members_project_user": {
+          "name": "idx_project_members_project_user",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_account_id_accounts_account_id_fk": {
+          "name": "project_members_account_id_accounts_account_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_project_id_projects_project_id_fk": {
+          "name": "project_members_project_id_projects_project_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_secrets": {
+      "name": "project_secrets",
+      "schema": "kortix",
+      "columns": {
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_enc": {
+          "name": "value_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "project_secret_scope",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runtime'"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_secrets_project": {
+          "name": "idx_project_secrets_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_secrets_project_name": {
+          "name": "idx_project_secrets_project_name",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_secrets_project_identifier_shared": {
+          "name": "idx_project_secrets_project_identifier_shared",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"project_secrets\".\"owner_user_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_secrets_project_name_owner": {
+          "name": "idx_project_secrets_project_name_owner",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"project_secrets\".\"owner_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_secrets_project_id_projects_project_id_fk": {
+          "name": "project_secrets_project_id_projects_project_id_fk",
+          "tableFrom": "project_secrets",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_connector_bindings": {
+      "name": "project_session_connector_bindings",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_alias": {
+          "name": "connector_alias",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "project_session_connector_binding_source",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'request'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_connector_bindings_profile": {
+          "name": "idx_project_session_connector_bindings_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_connector_bindings_project": {
+          "name": "idx_project_session_connector_bindings_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_connector_bindings_session_tenant_fk": {
+          "name": "project_session_connector_bindings_session_tenant_fk",
+          "tableFrom": "project_session_connector_bindings",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "session_id"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_connector_bindings_alias_tenant_fk": {
+          "name": "project_session_connector_bindings_alias_tenant_fk",
+          "tableFrom": "project_session_connector_bindings",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "connector_alias"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "project_session_connector_bindings_profile_tenant_fk": {
+          "name": "project_session_connector_bindings_profile_tenant_fk",
+          "tableFrom": "project_session_connector_bindings",
+          "tableTo": "executor_connection_profiles",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "profile_id"
+          ],
+          "columnsTo": [
+            "account_id",
+            "project_id",
+            "connector_id",
+            "profile_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_session_connector_bindings_session_id_connector_alias_pk": {
+          "name": "project_session_connector_bindings_session_id_connector_alias_pk",
+          "columns": [
+            "session_id",
+            "connector_alias"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_grants": {
+      "name": "project_session_grants",
+      "schema": "kortix",
+      "columns": {
+        "grant_id": {
+          "name": "grant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "secret_grant_principal",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_grants_session": {
+          "name": "idx_project_session_grants_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_grants_unique": {
+          "name": "idx_project_session_grants_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_grants_session_id_project_sessions_session_id_fk": {
+          "name": "project_session_grants_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_session_grants",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_public_shares": {
+      "name": "project_session_public_shares",
+      "schema": "kortix",
+      "columns": {
+        "share_id": {
+          "name": "share_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preview'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'App preview'"
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'/'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'view'"
+        },
+        "allow_websocket": {
+          "name": "allow_websocket",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_public_shares_token_hash": {
+          "name": "idx_project_session_public_shares_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_public_shares_session": {
+          "name": "idx_project_session_public_shares_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_session_public_shares_project": {
+          "name": "idx_project_session_public_shares_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_public_shares_session_id_project_sessions_session_id_fk": {
+          "name": "project_session_public_shares_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_session_public_shares",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_public_shares_project_id_projects_project_id_fk": {
+          "name": "project_session_public_shares_project_id_projects_project_id_fk",
+          "tableFrom": "project_session_public_shares",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_session_public_shares_account_id_accounts_account_id_fk": {
+          "name": "project_session_public_shares_account_id_accounts_account_id_fk",
+          "tableFrom": "project_session_public_shares",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_session_runtime_contexts": {
+      "name": "project_session_runtime_contexts",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_session_runtime_contexts_updated": {
+          "name": "idx_project_session_runtime_contexts_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_session_runtime_contexts_session_id_project_sessions_session_id_fk": {
+          "name": "project_session_runtime_contexts_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_session_runtime_contexts",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "project_session_runtime_contexts_byte_size_check": {
+          "name": "project_session_runtime_contexts_byte_size_check",
+          "value": "\"kortix\".\"project_session_runtime_contexts\".\"byte_size\" >= 2 AND \"kortix\".\"project_session_runtime_contexts\".\"byte_size\" <= 16384"
+        },
+        "project_session_runtime_contexts_object_check": {
+          "name": "project_session_runtime_contexts_object_check",
+          "value": "jsonb_typeof(\"kortix\".\"project_session_runtime_contexts\".\"context\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kortix.project_sessions": {
+      "name": "project_sessions",
+      "schema": "kortix",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "sandbox_provider": {
+          "name": "sandbox_provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_url": {
+          "name": "sandbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opencode_session_id": {
+          "name": "opencode_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "status": {
+          "name": "status",
+          "type": "project_session_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "project_session_visibility",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_sessions_account": {
+          "name": "idx_project_sessions_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_project": {
+          "name": "idx_project_sessions_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_status": {
+          "name": "idx_project_sessions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_created_by": {
+          "name": "idx_project_sessions_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_project_branch": {
+          "name": "idx_project_sessions_project_branch",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_sessions_tenant_identity": {
+          "name": "idx_project_sessions_tenant_identity",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_sessions_account_id_accounts_account_id_fk": {
+          "name": "project_sessions_account_id_accounts_account_id_fk",
+          "tableFrom": "project_sessions",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sessions_project_id_projects_project_id_fk": {
+          "name": "project_sessions_project_id_projects_project_id_fk",
+          "tableFrom": "project_sessions",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_snapshot_builds": {
+      "name": "project_snapshot_builds",
+      "schema": "kortix",
+      "columns": {
+        "build_id": {
+          "name": "build_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "snapshot_name": {
+          "name": "snapshot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_category": {
+          "name": "error_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_project_snapshot_builds_project_recent": {
+          "name": "idx_project_snapshot_builds_project_recent",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_snapshot_builds_status": {
+          "name": "idx_project_snapshot_builds_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_snapshot_builds_account_id_accounts_account_id_fk": {
+          "name": "project_snapshot_builds_account_id_accounts_account_id_fk",
+          "tableFrom": "project_snapshot_builds",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_snapshot_builds_project_id_projects_project_id_fk": {
+          "name": "project_snapshot_builds_project_id_projects_project_id_fk",
+          "tableFrom": "project_snapshot_builds",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.project_trigger_runtime": {
+      "name": "project_trigger_runtime",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_project_trigger_runtime_owner_user": {
+          "name": "idx_project_trigger_runtime_owner_user",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_trigger_runtime_project_id_projects_project_id_fk": {
+          "name": "project_trigger_runtime_project_id_projects_project_id_fk",
+          "tableFrom": "project_trigger_runtime",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_trigger_runtime_session_id_project_sessions_session_id_fk": {
+          "name": "project_trigger_runtime_session_id_project_sessions_session_id_fk",
+          "tableFrom": "project_trigger_runtime",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_trigger_runtime_project_id_slug_pk": {
+          "name": "project_trigger_runtime_project_id_slug_pk",
+          "columns": [
+            "project_id",
+            "slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.projects": {
+      "name": "projects",
+      "schema": "kortix",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "manifest_path": {
+          "name": "manifest_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'kortix.yaml'"
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_account": {
+          "name": "idx_projects_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_status": {
+          "name": "idx_projects_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_updated": {
+          "name": "idx_projects_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_account_repo": {
+          "name": "idx_projects_account_repo",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_account_id_accounts_account_id_fk": {
+          "name": "projects_account_id_accounts_account_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.provider_events": {
+      "name": "provider_events",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_ms": {
+          "name": "total_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marks": {
+          "name": "marks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_events_provider": {
+          "name": "idx_provider_events_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_events_kind": {
+          "name": "idx_provider_events_kind",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_events_outcome": {
+          "name": "idx_provider_events_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_events_created": {
+          "name": "idx_provider_events_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.review_items": {
+      "name": "review_items",
+      "schema": "kortix",
+      "columns": {
+        "review_item_id": {
+          "name": "review_item_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "review_item_kind",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "review_item_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'needs_you'"
+        },
+        "risk": {
+          "name": "risk",
+          "type": "review_item_risk",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "source": {
+          "name": "source",
+          "type": "review_item_source",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agent'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acted_by": {
+          "name": "acted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acted_at": {
+          "name": "acted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_review_items_project": {
+          "name": "idx_review_items_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_review_items_project_status": {
+          "name": "idx_review_items_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_review_items_project_kind": {
+          "name": "idx_review_items_project_kind",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_review_items_created": {
+          "name": "idx_review_items_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_items_account_id_accounts_account_id_fk": {
+          "name": "review_items_account_id_accounts_account_id_fk",
+          "tableFrom": "review_items",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_items_project_id_projects_project_id_fk": {
+          "name": "review_items_project_id_projects_project_id_fk",
+          "tableFrom": "review_items",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_items_origin_session_id_project_sessions_session_id_fk": {
+          "name": "review_items_origin_session_id_project_sessions_session_id_fk",
+          "tableFrom": "review_items",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "origin_session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_compute_sessions": {
+      "name": "sandbox_compute_sessions",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "cpu_cores": {
+          "name": "cpu_cores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_gb": {
+          "name": "memory_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disk_gb": {
+          "name": "disk_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gpu_count": {
+          "name": "gpu_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_billed_at": {
+          "name": "last_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "ledger_id": {
+          "name": "ledger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_compute_sessions_account_time": {
+          "name": "idx_sandbox_compute_sessions_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_compute_sessions_provider_time": {
+          "name": "idx_sandbox_compute_sessions_provider_time",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_compute_sessions_open": {
+          "name": "idx_sandbox_compute_sessions_open",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"sandbox_compute_sessions\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_sandbox_compute_sessions_one_open": {
+          "name": "uniq_sandbox_compute_sessions_one_open",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kortix\".\"sandbox_compute_sessions\".\"ended_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_compute_sessions_last_billed": {
+          "name": "idx_sandbox_compute_sessions_last_billed",
+          "columns": [
+            {
+              "expression": "last_billed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"sandbox_compute_sessions\".\"state\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_invites": {
+      "name": "sandbox_invites",
+      "schema": "kortix",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_role": {
+          "name": "initial_role",
+          "type": "account_role",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '14 days'"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_invites_email": {
+          "name": "idx_sandbox_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_invites_sandbox": {
+          "name": "idx_sandbox_invites_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_invites_expires_at": {
+          "name": "idx_sandbox_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_invites_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "sandbox_invites_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "sandbox_invites",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_member_scopes": {
+      "name": "sandbox_member_scopes",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "scope_effect",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_member_scopes_unique": {
+          "name": "idx_sandbox_member_scopes_unique",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_member_scopes_lookup": {
+          "name": "idx_sandbox_member_scopes_lookup",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_member_scopes_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "sandbox_member_scopes_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "sandbox_member_scopes",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_members": {
+      "name": "sandbox_members",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthly_spend_cap_cents": {
+          "name": "monthly_spend_cap_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_cents": {
+          "name": "current_period_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sandbox_members_unique": {
+          "name": "idx_sandbox_members_unique",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_members_user": {
+          "name": "idx_sandbox_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_members_sandbox": {
+          "name": "idx_sandbox_members_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_members_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "sandbox_members_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "sandbox_members",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandbox_templates": {
+      "name": "sandbox_templates",
+      "schema": "kortix",
+      "columns": {
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'toml'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dockerfile_path": {
+          "name": "dockerfile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrypoint": {
+          "name": "entrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_gb": {
+          "name": "memory_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disk_gb": {
+          "name": "disk_gb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_from_commit": {
+          "name": "built_from_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swap_key": {
+          "name": "swap_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_snapshot_name": {
+          "name": "provider_snapshot_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'missing'"
+        },
+        "last_built_at": {
+          "name": "last_built_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_templates_project": {
+          "name": "idx_sandbox_templates_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_templates_shared": {
+          "name": "idx_sandbox_templates_shared",
+          "columns": [
+            {
+              "expression": "is_shared",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandbox_templates_project_slug": {
+          "name": "idx_sandbox_templates_project_slug",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_templates_project_id_projects_project_id_fk": {
+          "name": "sandbox_templates_project_id_projects_project_id_fk",
+          "tableFrom": "sandbox_templates",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sandbox_templates_account_id_accounts_account_id_fk": {
+          "name": "sandbox_templates_account_id_accounts_account_id_fk",
+          "tableFrom": "sandbox_templates",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.sandboxes": {
+      "name": "sandboxes",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "sandbox_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_included": {
+          "name": "is_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sandboxes_account": {
+          "name": "idx_sandboxes_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_external_id": {
+          "name": "idx_sandboxes_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sandboxes_status": {
+          "name": "idx_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.scim_tokens": {
+      "name": "scim_tokens",
+      "schema": "kortix",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_prefix": {
+          "name": "public_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_scim_tokens_account": {
+          "name": "idx_scim_tokens_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_scim_tokens_secret_hash": {
+          "name": "idx_scim_tokens_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scim_tokens_account_id_accounts_account_id_fk": {
+          "name": "scim_tokens_account_id_accounts_account_id_fk",
+          "tableFrom": "scim_tokens",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.service_accounts": {
+      "name": "service_accounts",
+      "schema": "kortix",
+      "columns": {
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_prefix": {
+          "name": "public_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_service_accounts_account": {
+          "name": "idx_service_accounts_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_service_accounts_secret_hash": {
+          "name": "idx_service_accounts_secret_hash",
+          "columns": [
+            {
+              "expression": "secret_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_service_accounts_account_name": {
+          "name": "idx_service_accounts_account_name",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_name IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_service_accounts_agent": {
+          "name": "idx_service_accounts_agent",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "agent_name IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_accounts_account_id_accounts_account_id_fk": {
+          "name": "service_accounts_account_id_accounts_account_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_accounts_project_id_projects_project_id_fk": {
+          "name": "service_accounts_project_id_projects_project_id_fk",
+          "tableFrom": "service_accounts",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.session_lifecycle_commands": {
+      "name": "session_lifecycle_commands",
+      "schema": "kortix",
+      "columns": {
+        "command_id": {
+          "name": "command_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_lifecycle_command_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_lifecycle_commands_idempotency": {
+          "name": "idx_session_lifecycle_commands_idempotency",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_due": {
+          "name": "idx_session_lifecycle_commands_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_project": {
+          "name": "idx_session_lifecycle_commands_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_session": {
+          "name": "idx_session_lifecycle_commands_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_lifecycle_commands_locked": {
+          "name": "idx_session_lifecycle_commands_locked",
+          "columns": [
+            {
+              "expression": "locked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_lifecycle_commands_project_id_projects_project_id_fk": {
+          "name": "session_lifecycle_commands_project_id_projects_project_id_fk",
+          "tableFrom": "session_lifecycle_commands",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_lifecycle_commands_session_id_project_sessions_session_id_fk": {
+          "name": "session_lifecycle_commands_session_id_project_sessions_session_id_fk",
+          "tableFrom": "session_lifecycle_commands",
+          "tableTo": "project_sessions",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "session_lifecycle_commands_account_id_accounts_account_id_fk": {
+          "name": "session_lifecycle_commands_account_id_accounts_account_id_fk",
+          "tableFrom": "session_lifecycle_commands",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.session_sandboxes": {
+      "name": "session_sandboxes",
+      "schema": "kortix",
+      "columns": {
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "sandbox_provider",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daytona'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "session_sandbox_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_session_sandboxes_session": {
+          "name": "idx_session_sandboxes_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_project": {
+          "name": "idx_session_sandboxes_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_account": {
+          "name": "idx_session_sandboxes_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_status": {
+          "name": "idx_session_sandboxes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_sandboxes_external_id": {
+          "name": "idx_session_sandboxes_external_id",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_sandboxes_session_id_unique": {
+          "name": "session_sandboxes_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.session_tool_approvals": {
+      "name": "session_tool_approvals",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_path": {
+          "name": "action_path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_tool_approvals_unique": {
+          "name": "session_tool_approvals_unique",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_tool_approvals_session_idx": {
+          "name": "session_tool_approvals_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_tool_approvals_project_id_projects_project_id_fk": {
+          "name": "session_tool_approvals_project_id_projects_project_id_fk",
+          "tableFrom": "session_tool_approvals",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_tool_approvals_connector_id_executor_connectors_connector_id_fk": {
+          "name": "session_tool_approvals_connector_id_executor_connectors_connector_id_fk",
+          "tableFrom": "session_tool_approvals",
+          "tableTo": "executor_connectors",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "connector_id"
+          ],
+          "columnsTo": [
+            "connector_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.stripe_webhook_events_processed": {
+      "name": "stripe_webhook_events_processed",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stripe_webhook_events_processed_at": {
+          "name": "idx_stripe_webhook_events_processed_at",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.suna_account_migrations": {
+      "name": "suna_account_migrations",
+      "schema": "kortix",
+      "columns": {
+        "migration_id": {
+          "name": "migration_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'dry_run'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_suna_account_migrations_status": {
+          "name": "idx_suna_account_migrations_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_suna_account_migrations_account": {
+          "name": "idx_suna_account_migrations_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_suna_account_migrations_heartbeat": {
+          "name": "idx_suna_account_migrations_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.teams_pending_uploads": {
+      "name": "teams_pending_uploads",
+      "schema": "kortix",
+      "columns": {
+        "upload_id": {
+          "name": "upload_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_url": {
+          "name": "service_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_teams_pending_uploads_expiry": {
+          "name": "idx_teams_pending_uploads_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_audit_logs": {
+      "name": "tunnel_audit_logs",
+      "schema": "kortix",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "tunnel_capability",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_summary": {
+          "name": "request_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bytes_transferred": {
+          "name": "bytes_transferred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_audit_tunnel": {
+          "name": "idx_tunnel_audit_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_audit_account": {
+          "name": "idx_tunnel_audit_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_audit_capability": {
+          "name": "idx_tunnel_audit_capability",
+          "columns": [
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_audit_created": {
+          "name": "idx_tunnel_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_audit_logs_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_audit_logs_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_audit_logs",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_connections": {
+      "name": "tunnel_connections",
+      "schema": "kortix",
+      "columns": {
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "machine_info": {
+          "name": "machine_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "relay_owner_id": {
+          "name": "relay_owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relay_owner_instance": {
+          "name": "relay_owner_instance",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relay_owner_started_at": {
+          "name": "relay_owner_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relay_owner_heartbeat_at": {
+          "name": "relay_owner_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_token_hash": {
+          "name": "setup_token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_connections_account": {
+          "name": "idx_tunnel_connections_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_connections_sandbox": {
+          "name": "idx_tunnel_connections_sandbox",
+          "columns": [
+            {
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_connections_status": {
+          "name": "idx_tunnel_connections_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_connections_relay_owner": {
+          "name": "idx_tunnel_connections_relay_owner",
+          "columns": [
+            {
+              "expression": "relay_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_connections_sandbox_id_sandboxes_sandbox_id_fk": {
+          "name": "tunnel_connections_sandbox_id_sandboxes_sandbox_id_fk",
+          "tableFrom": "tunnel_connections",
+          "tableTo": "sandboxes",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "sandbox_id"
+          ],
+          "columnsTo": [
+            "sandbox_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_device_auth_requests": {
+      "name": "tunnel_device_auth_requests",
+      "schema": "kortix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_secret_hash": {
+          "name": "device_secret_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_device_auth_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "machine_hostname": {
+          "name": "machine_hostname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_token": {
+          "name": "setup_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_device_auth_code": {
+          "name": "idx_tunnel_device_auth_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_device_auth_status": {
+          "name": "idx_tunnel_device_auth_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_device_auth_expires": {
+          "name": "idx_tunnel_device_auth_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_device_auth_requests_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_device_auth_requests_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_device_auth_requests",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_permission_requests": {
+      "name": "tunnel_permission_requests",
+      "schema": "kortix",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "tunnel_capability",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_scope": {
+          "name": "requested_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_permission_request_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_perm_requests_tunnel": {
+          "name": "idx_tunnel_perm_requests_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_perm_requests_account": {
+          "name": "idx_tunnel_perm_requests_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_perm_requests_status": {
+          "name": "idx_tunnel_perm_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_permission_requests_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_permission_requests_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_permission_requests",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_permissions": {
+      "name": "tunnel_permissions",
+      "schema": "kortix",
+      "columns": {
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "tunnel_capability",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "tunnel_permission_status",
+          "typeSchema": "kortix",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tunnel_permissions_tunnel": {
+          "name": "idx_tunnel_permissions_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_permissions_account": {
+          "name": "idx_tunnel_permissions_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_permissions_capability": {
+          "name": "idx_tunnel_permissions_capability",
+          "columns": [
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_permissions_status": {
+          "name": "idx_tunnel_permissions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_permissions_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_permissions_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_permissions",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.tunnel_rpc_forwards": {
+      "name": "tunnel_rpc_forwards",
+      "schema": "kortix",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_relay_owner_id": {
+          "name": "requester_relay_owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_relay_owner_id": {
+          "name": "target_relay_owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tunnel_rpc_forwards_target_status": {
+          "name": "idx_tunnel_rpc_forwards_target_status",
+          "columns": [
+            {
+              "expression": "target_relay_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_rpc_forwards_expiry": {
+          "name": "idx_tunnel_rpc_forwards_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tunnel_rpc_forwards_tunnel": {
+          "name": "idx_tunnel_rpc_forwards_tunnel",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_rpc_forwards_tunnel_id_tunnel_connections_tunnel_id_fk": {
+          "name": "tunnel_rpc_forwards_tunnel_id_tunnel_connections_tunnel_id_fk",
+          "tableFrom": "tunnel_rpc_forwards",
+          "tableTo": "tunnel_connections",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "tunnel_id"
+          ],
+          "columnsTo": [
+            "tunnel_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.usage_events": {
+      "name": "usage_events",
+      "schema": "kortix",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cached_tokens": {
+          "name": "cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "streaming": {
+          "name": "streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "upstream_status": {
+          "name": "upstream_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_usage_events_account_time": {
+          "name": "idx_usage_events_account_time",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_project_time": {
+          "name": "idx_usage_events_project_time",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_session": {
+          "name": "idx_usage_events_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_events_model": {
+          "name": "idx_usage_events_model",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_events_account_id_accounts_account_id_fk": {
+          "name": "usage_events_account_id_accounts_account_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "accounts",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_events_project_id_projects_project_id_fk": {
+          "name": "usage_events_project_id_projects_project_id_fk",
+          "tableFrom": "usage_events",
+          "tableTo": "projects",
+          "schemaTo": "kortix",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "project_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.worker_leader_lease": {
+      "name": "worker_leader_lease",
+      "schema": "kortix",
+      "columns": {
+        "lock_key": {
+          "name": "lock_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kortix.yolo_member_tokens": {
+      "name": "yolo_member_tokens",
+      "schema": "kortix",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_yolo_member_tokens_prefix": {
+          "name": "idx_yolo_member_tokens_prefix",
+          "columns": [
+            {
+              "expression": "token_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"kortix\".\"yolo_member_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_yolo_member_tokens_account": {
+          "name": "idx_yolo_member_tokens_account",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "yolo_member_tokens_user_id_account_id_pk": {
+          "name": "yolo_member_tokens_user_id_account_id_pk",
+          "columns": [
+            "user_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "kortix.access_request_status": {
+      "name": "access_request_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "kortix.account_group_source": {
+      "name": "account_group_source",
+      "schema": "kortix",
+      "values": [
+        "manual",
+        "scim",
+        "sso"
+      ]
+    },
+    "kortix.account_role": {
+      "name": "account_role",
+      "schema": "kortix",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "kortix.api_key_status": {
+      "name": "api_key_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "revoked",
+        "expired"
+      ]
+    },
+    "kortix.api_key_type": {
+      "name": "api_key_type",
+      "schema": "kortix",
+      "values": [
+        "user",
+        "sandbox"
+      ]
+    },
+    "kortix.change_request_status": {
+      "name": "change_request_status",
+      "schema": "kortix",
+      "values": [
+        "open",
+        "merged",
+        "closed"
+      ]
+    },
+    "kortix.executor_connection_profile_owner_type": {
+      "name": "executor_connection_profile_owner_type",
+      "schema": "kortix",
+      "values": [
+        "project",
+        "agent",
+        "member",
+        "subject",
+        "external"
+      ]
+    },
+    "kortix.executor_connection_profile_status": {
+      "name": "executor_connection_profile_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "revoked",
+        "error"
+      ]
+    },
+    "kortix.executor_connector_provider": {
+      "name": "executor_connector_provider",
+      "schema": "kortix",
+      "values": [
+        "pipedream",
+        "mcp",
+        "openapi",
+        "postman",
+        "graphql",
+        "http",
+        "channel",
+        "computer"
+      ]
+    },
+    "kortix.executor_connector_status": {
+      "name": "executor_connector_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "disabled",
+        "needs_auth",
+        "error"
+      ]
+    },
+    "kortix.executor_credential_mode": {
+      "name": "executor_credential_mode",
+      "schema": "kortix",
+      "values": [
+        "shared",
+        "per_user"
+      ]
+    },
+    "kortix.executor_default_mode": {
+      "name": "executor_default_mode",
+      "schema": "kortix",
+      "values": [
+        "risk",
+        "allow_all"
+      ]
+    },
+    "kortix.executor_execution_status": {
+      "name": "executor_execution_status",
+      "schema": "kortix",
+      "values": [
+        "ok",
+        "error",
+        "denied",
+        "pending_approval"
+      ]
+    },
+    "kortix.executor_policy_action": {
+      "name": "executor_policy_action",
+      "schema": "kortix",
+      "values": [
+        "always_run",
+        "require_approval",
+        "block"
+      ]
+    },
+    "kortix.executor_risk": {
+      "name": "executor_risk",
+      "schema": "kortix",
+      "values": [
+        "read",
+        "write",
+        "destructive"
+      ]
+    },
+    "kortix.gateway_budget_action": {
+      "name": "gateway_budget_action",
+      "schema": "kortix",
+      "values": [
+        "block",
+        "warn"
+      ]
+    },
+    "kortix.gateway_budget_period": {
+      "name": "gateway_budget_period",
+      "schema": "kortix",
+      "values": [
+        "day",
+        "week",
+        "month"
+      ]
+    },
+    "kortix.gateway_budget_scope": {
+      "name": "gateway_budget_scope",
+      "schema": "kortix",
+      "values": [
+        "project",
+        "member"
+      ]
+    },
+    "kortix.platform_role": {
+      "name": "platform_role",
+      "schema": "kortix",
+      "values": [
+        "user",
+        "admin",
+        "super_admin"
+      ]
+    },
+    "kortix.project_access_request_status": {
+      "name": "project_access_request_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "kortix.project_role": {
+      "name": "project_role",
+      "schema": "kortix",
+      "values": [
+        "manager",
+        "editor",
+        "member",
+        "viewer"
+      ]
+    },
+    "kortix.project_secret_scope": {
+      "name": "project_secret_scope",
+      "schema": "kortix",
+      "values": [
+        "runtime",
+        "connector"
+      ]
+    },
+    "kortix.project_session_connector_binding_source": {
+      "name": "project_session_connector_binding_source",
+      "schema": "kortix",
+      "values": [
+        "request",
+        "default"
+      ]
+    },
+    "kortix.project_session_status": {
+      "name": "project_session_status",
+      "schema": "kortix",
+      "values": [
+        "queued",
+        "branching",
+        "provisioning",
+        "running",
+        "stopped",
+        "failed",
+        "completed"
+      ]
+    },
+    "kortix.project_session_visibility": {
+      "name": "project_session_visibility",
+      "schema": "kortix",
+      "values": [
+        "private",
+        "project",
+        "restricted"
+      ]
+    },
+    "kortix.project_status": {
+      "name": "project_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "kortix.review_item_kind": {
+      "name": "review_item_kind",
+      "schema": "kortix",
+      "values": [
+        "change",
+        "approval",
+        "output",
+        "decision",
+        "batch"
+      ]
+    },
+    "kortix.review_item_risk": {
+      "name": "review_item_risk",
+      "schema": "kortix",
+      "values": [
+        "none",
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "kortix.review_item_source": {
+      "name": "review_item_source",
+      "schema": "kortix",
+      "values": [
+        "web",
+        "slack",
+        "agent"
+      ]
+    },
+    "kortix.review_item_status": {
+      "name": "review_item_status",
+      "schema": "kortix",
+      "values": [
+        "needs_you",
+        "waiting",
+        "approved",
+        "changes_requested",
+        "rejected",
+        "done",
+        "dismissed"
+      ]
+    },
+    "kortix.sandbox_provider": {
+      "name": "sandbox_provider",
+      "schema": "kortix",
+      "values": [
+        "daytona",
+        "platinum",
+        "e2b",
+        "local-docker"
+      ]
+    },
+    "kortix.sandbox_status": {
+      "name": "sandbox_status",
+      "schema": "kortix",
+      "values": [
+        "provisioning",
+        "active",
+        "stopped",
+        "archived",
+        "error"
+      ]
+    },
+    "kortix.scope_effect": {
+      "name": "scope_effect",
+      "schema": "kortix",
+      "values": [
+        "grant",
+        "revoke"
+      ]
+    },
+    "kortix.secret_grant_principal": {
+      "name": "secret_grant_principal",
+      "schema": "kortix",
+      "values": [
+        "member",
+        "group"
+      ]
+    },
+    "kortix.secret_share_scope": {
+      "name": "secret_share_scope",
+      "schema": "kortix",
+      "values": [
+        "project",
+        "restricted"
+      ]
+    },
+    "kortix.session_lifecycle_command_status": {
+      "name": "session_lifecycle_command_status",
+      "schema": "kortix",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "dead_lettered"
+      ]
+    },
+    "kortix.session_sandbox_status": {
+      "name": "session_sandbox_status",
+      "schema": "kortix",
+      "values": [
+        "provisioning",
+        "active",
+        "stopped",
+        "error",
+        "archived"
+      ]
+    },
+    "kortix.tunnel_capability": {
+      "name": "tunnel_capability",
+      "schema": "kortix",
+      "values": [
+        "filesystem",
+        "shell",
+        "network",
+        "apps",
+        "hardware",
+        "desktop",
+        "gpu"
+      ]
+    },
+    "kortix.tunnel_device_auth_status": {
+      "name": "tunnel_device_auth_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "kortix.tunnel_permission_request_status": {
+      "name": "tunnel_permission_request_status",
+      "schema": "kortix",
+      "values": [
+        "pending",
+        "approved",
+        "denied",
+        "expired"
+      ]
+    },
+    "kortix.tunnel_permission_status": {
+      "name": "tunnel_permission_status",
+      "schema": "kortix",
+      "values": [
+        "active",
+        "revoked",
+        "expired"
+      ]
+    },
+    "kortix.tunnel_status": {
+      "name": "tunnel_status",
+      "schema": "kortix",
+      "values": [
+        "online",
+        "offline",
+        "connecting"
+      ]
+    }
+  },
+  "schemas": {
+    "kortix": "kortix"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784204732306,
       "tag": "20260716122532_sandbox_provider_add_local_docker",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784298695986,
+      "tag": "20260717143135_executor_postman_provider",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/20260717143000000_executor_postman_provider.sql
+++ b/packages/db/migrations/20260717143000000_executor_postman_provider.sql
@@ -1,0 +1,8 @@
+-- Up Migration
+-- Postman collections and Postman-managed repositories are first-class
+-- connector sources. Enum additions are forward-only in PostgreSQL.
+ALTER TYPE kortix.executor_connector_provider ADD VALUE IF NOT EXISTS 'postman';
+
+-- Down Migration
+-- Intentionally empty: removing an enum value would invalidate existing
+-- executor connector rows and requires a table rewrite.

--- a/packages/db/migrations/20260717143000000_executor_postman_provider.sql
+++ b/packages/db/migrations/20260717143000000_executor_postman_provider.sql
@@ -1,8 +1,0 @@
--- Up Migration
--- Postman collections and Postman-managed repositories are first-class
--- connector sources. Enum additions are forward-only in PostgreSQL.
-ALTER TYPE kortix.executor_connector_provider ADD VALUE IF NOT EXISTS 'postman';
-
--- Down Migration
--- Intentionally empty: removing an enum value would invalidate existing
--- executor connector rows and requires a table rewrite.

--- a/packages/db/migrations/20260717143136006_executor_postman_provider.sql
+++ b/packages/db/migrations/20260717143136006_executor_postman_provider.sql
@@ -1,0 +1,13 @@
+-- Postman collections and Postman-managed repositories are first-class
+-- connector sources. This migration only expands the enum; application rows
+-- use the value in later transactions after deployment.
+--
+-- enum-value-checked: `postman` exists in neither the 2026-07-16 Drizzle
+-- rebaseline nor any earlier executor_connector_provider migration, so an
+-- environment that faked that baseline cannot have silently skipped this
+-- value. This new, post-baseline migration is applied normally in every
+-- environment. The isolated Postman E2E database was also queried after
+-- migration and returned `postman` from pg_enum before connector insertion.
+set statement_timeout = '5s';
+set lock_timeout = '1s';
+ALTER TYPE "kortix"."executor_connector_provider" ADD VALUE IF NOT EXISTS 'postman' BEFORE 'graphql';

--- a/packages/db/src/schema/kortix.ts
+++ b/packages/db/src/schema/kortix.ts
@@ -3213,6 +3213,7 @@ export const executorConnectorProviderEnum = kortixSchema.enum('executor_connect
   'pipedream',
   'mcp',
   'openapi',
+  'postman',
   'graphql',
   'http',
   // Chat platforms (Slack, later Telegram/Teams) as first-class connectors. The

--- a/packages/executor-sdk/package.json
+++ b/packages/executor-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kortix/executor-sdk",
   "version": "0.9.66",
-  "description": "TypeScript SDK for the Kortix Executor — one typed client for every connector (Pipedream / MCP / OpenAPI / GraphQL / HTTP). Calls run server-side through the Kortix Executor gateway; no third-party secret ever touches your code.",
+  "description": "TypeScript SDK for the Kortix Executor — one typed client for every connector (Pipedream / MCP / OpenAPI / Postman / GraphQL / HTTP). Calls run server-side through the Kortix Executor gateway; no third-party secret ever touches your code.",
   "type": "module",
   "license": "Elastic-2.0",
   "homepage": "https://github.com/kortix-ai/suna/tree/main/packages/executor-sdk",

--- a/packages/manifest-schema/src/__tests__/validator.test.ts
+++ b/packages/manifest-schema/src/__tests__/validator.test.ts
@@ -362,6 +362,26 @@ provider = "mcp"
     expect(errorPaths).toContain('connectors[0].url');
   });
 
+  test('postman connector accepts a repository source and requires spec', () => {
+    const accepted = summarize(`
+kortix_version = 1
+[[connectors]]
+slug = "hubspot"
+provider = "postman"
+spec = "https://github.com/HubSpot/HubSpot-public-api-spec-collection"
+`);
+    expect(accepted.errorPaths).toEqual([]);
+    expect(accepted.valid).toBe(true);
+
+    const missing = summarize(`
+kortix_version = 1
+[[connectors]]
+slug = "hubspot"
+provider = "postman"
+`);
+    expect(missing.warningPaths).toContain('connectors[0].spec');
+  });
+
   test('auth.secret is rejected', () => {
     const { errorPaths } = summarize(`
 kortix_version = 1

--- a/packages/manifest-schema/src/constants.ts
+++ b/packages/manifest-schema/src/constants.ts
@@ -25,7 +25,7 @@ export const TRIGGER_TYPES = ['cron', 'webhook'] as const;
 // runtime parser's PROVIDERS in apps/api/src/projects/connectors.ts — enforced
 // by apps/api/src/__tests__/unit-connectors-parse.test.ts. `computer` is
 // deliberately absent: it is synth-only and never written to a manifest.
-export const CONNECTOR_PROVIDERS = ['pipedream', 'mcp', 'openapi', 'graphql', 'http', 'channel'] as const;
+export const CONNECTOR_PROVIDERS = ['pipedream', 'mcp', 'openapi', 'postman', 'graphql', 'http', 'channel'] as const;
 export const CONNECTOR_AUTH_TYPES = ['bearer', 'basic', 'custom', 'oauth1', 'none'] as const;
 /** Platforms a `channel` connector can target — mirrors connectors.ts CHANNEL_PLATFORMS. */
 export const CHANNEL_PLATFORMS = ['slack', 'teams', 'email', 'meet'] as const;

--- a/packages/manifest-schema/src/index.ts
+++ b/packages/manifest-schema/src/index.ts
@@ -1005,11 +1005,11 @@ function validateConnectors(node: unknown, path: string, issues: ManifestIssue[]
         });
       }
     }
-    if (provider === 'openapi' && typeof entry.spec !== 'string') {
+    if ((provider === 'openapi' || provider === 'postman') && typeof entry.spec !== 'string') {
       issues.push({
         path: `${where}.spec`,
         message:
-          'openapi connectors need a `spec` (URL or repo path); without it the connector fails to materialize.',
+          `${provider} connectors need a \`spec\` (URL or repo path); without it the connector fails to materialize.`,
         severity: 'warning',
       });
     }
@@ -1098,10 +1098,10 @@ function validateConnectors(node: unknown, path: string, issues: ManifestIssue[]
             severity: 'error',
           });
         }
-        if (t === 'oauth1' && provider !== 'openapi' && provider !== 'http') {
+        if (t === 'oauth1' && provider !== 'openapi' && provider !== 'postman' && provider !== 'http') {
           issues.push({
             path: `${where}.auth.type`,
-            message: 'auth.type "oauth1" is only supported for openapi/http connectors.',
+            message: 'auth.type "oauth1" is only supported for openapi/postman/http connectors.',
             severity: 'error',
           });
         }

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -825,3 +825,28 @@ Implementation will follow RED -> GREEN -> REFACTOR and finish with the full SDK
 typecheck, test, and packed-install smoke gates.
 
 **Status:** IN PROGRESS.
+
+---
+
+### 2026-07-17 — session `postman-connectors` (completion)
+
+Completed the additive Postman connector provider contract. The published SDK
+now accepts and reports `postman` anywhere the existing connector surfaces
+accept a provider, without renaming or removing an exported symbol.
+
+**TDD evidence:** the focused connector contract initially rejected `postman`,
+then passed after the provider union was widened. **Final SDK gates:**
+`pnpm --filter @kortix/sdk typecheck` exited 0; `pnpm --filter @kortix/sdk test`
+reported **1113 pass / 0 fail** across 82 files with 4995 assertions; and
+`pnpm --filter @kortix/sdk smoke:install` built, packed, installed, imported,
+and constructed `@kortix/sdk` successfully.
+
+**Shippable to production: YES** — the SDK change is additive, its complete
+runtime and type-level public surfaces remain snapshot-locked, and the packed
+consumer install path is verified. The enclosing API/CLI/UI Postman rollout
+retains its own merge, deploy, and live-dev gates.
+
+**Post-rebase gate addendum:** after rebasing onto `origin/main` at
+`bcb2a2afa`, the SDK typecheck remained green; the full suite reported
+**1121 pass / 0 fail** across 84 files with 5005 assertions; and the packed
+install smoke again passed. **Shippable to production: YES.**

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -809,3 +809,19 @@ The exact self-host fast E2E also reported **24 pass / 0 fail**.
 snapshot-locked, install-verified, and the self-host CLI contract is green.
 
 - 2026-07-17 — additive: `PtyMutationOptions` + `ptyMutationOverrides`, `useCreatePty`/`useUpdatePty` accept optional `onError` so hosts can keep pty errors out of global toasts (web terminal UX). Surface snapshot re-recorded (adds only).
+
+---
+
+### 2026-07-17 — session `postman-connectors` (claim)
+
+Claimed the additive Postman connector surface within the user-directed
+end-to-end Postman ingestion rollout. The SDK scope is deliberately narrow: add
+`postman` to existing connector provider unions and preserve the current
+`ConnectorDraftInput` API. No exported name is renamed or removed. Design and
+execution plan: `docs/specs/2026-07-17-postman-connectors.md` and
+`docs/plans/2026-07-17-postman-connectors.md`.
+
+Implementation will follow RED -> GREEN -> REFACTOR and finish with the full SDK
+typecheck, test, and packed-install smoke gates.
+
+**Status:** IN PROGRESS.

--- a/packages/sdk/src/core/rest/projects-client/connectors.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/connectors.test.ts
@@ -45,6 +45,13 @@ beforeEach(() => {
 configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
 const last = () => calls[calls.length - 1];
 
+const postmanDraftTypecheck: import('./connectors').ConnectorDraftInput = {
+  slug: 'hubspot',
+  provider: 'postman',
+  spec: 'https://github.com/HubSpot/HubSpot-public-api-spec-collection',
+};
+void postmanDraftTypecheck;
+
 test('listConnectors GETs the project connectors list', async () => {
   nextResponse = { status: 200, body: { connectors: [] } };
   const result = await listConnectors('P1');

--- a/packages/sdk/src/core/rest/projects-client/connectors.ts
+++ b/packages/sdk/src/core/rest/projects-client/connectors.ts
@@ -18,7 +18,7 @@ export interface ConnectorAction {
 export interface AdminConnector {
   slug: string;
   name: string;
-  provider: 'pipedream' | 'mcp' | 'openapi' | 'graphql' | 'http' | 'channel' | 'computer';
+  provider: 'pipedream' | 'mcp' | 'openapi' | 'postman' | 'graphql' | 'http' | 'channel' | 'computer';
   platform?: 'slack' | 'email' | null;
   status: 'active' | 'disabled' | 'needs_auth' | 'error';
   /** Credential storage model. Always `shared` — `per_user` (each member's


### PR DESCRIPTION
## Summary
- ingest Postman Collection v2.0/v2.1 JSON, `.postman/api`, public GitHub repositories, and public workspaces via optional server-side `POSTMAN_API_KEY`
- prefer synchronized OpenAPI definitions, fall back to collections, namespace multi-document catalogs, and bound schema/catalog persistence
- wire provider support through API, DB migration, manifest/schema, SDK, CLI, web/mobile/whitelabel, self-host config, and docs

## Real HubSpot proof
- source: `https://github.com/HubSpot/HubSpot-public-api-spec-collection`
- resolved: 113 documents / 1,223 actions
- persisted: active `postman` connector / exactly 1,223 action rows
- executor CLI: listed tools, discovered `account details`, and described the selected action
- real Collection execution: GET + POST against postman-echo.com
- missing credential: denied with HTTP 403 `needs_auth`

## Verification
- API Postman focus: 58 pass / 0 fail
- manifest schema: 316 pass / 0 fail
- SDK: 1,121 pass / 0 fail; typecheck; packed-install smoke
- executor SDK: 18 pass / 0 fail; typecheck
- API / CLI / manifest / whitelabel typechecks
- web touched-file ESLint and full typecheck

## Known unrelated baseline
- API `unit-connectors-parse.test.ts` has a pre-existing assertion expecting TOML wording (`array of tables`) for a YAML mapping; runtime correctly reports a YAML `list`.
- CLI self-host subprocess tests intermittently exceed their 5s timeout; the Postman CLI paths were exercised as real processes against the live local API.