### PR TITLE
feat(web): overhaul LLM gateway + provider/key manager UX

### DIFF
--- a/apps/web/src/features/providers/provider-branding.test.ts
+++ b/apps/web/src/features/providers/provider-branding.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+
+import { providerIconSrc } from './provider-branding';
+
+// Regression coverage for the models.dev id → logo mapping. The connect flow
+// renders provider logos by their VERBATIM models.dev id (live catalog), so the
+// map must be keyed on those ids — the old map keyed Bedrock/Fireworks on short
+// aliases and pointed Moonshot (China) at a moonshotai-cn.svg that never
+// existed, so those rows rendered a broken image.
+
+describe('providerIconSrc', () => {
+  test('resolves the featured models.dev provider ids to real assets', () => {
+    expect(providerIconSrc('anthropic')).toBe('/provider-icons/anthropic.svg');
+    expect(providerIconSrc('openai')).toBe('/provider-icons/openai.svg');
+    expect(providerIconSrc('amazon-bedrock')).toBe('/provider-icons/amazon-bedrock.svg');
+    expect(providerIconSrc('fireworks-ai')).toBe('/provider-icons/fireworks-ai.svg');
+    expect(providerIconSrc('google-vertex')).toBe('/provider-icons/google.svg');
+    expect(providerIconSrc('google-vertex-anthropic')).toBe('/provider-icons/anthropic.svg');
+    expect(providerIconSrc('cohere-platform')).toBe('/provider-icons/cohere.svg');
+  });
+
+  test('renders the three distinct Moonshot providers with the Moonshot mark', () => {
+    // All three share one mark (no separate -cn / kimi asset exists) but each is
+    // a distinct provider id, and none may point at the non-existent
+    // moonshotai-cn.svg.
+    for (const id of ['moonshotai', 'moonshotai-cn', 'kimi-for-coding']) {
+      expect(providerIconSrc(id)).toBe('/provider-icons/moonshotai.svg');
+    }
+  });
+
+  test('keeps legacy short aliases working', () => {
+    expect(providerIconSrc('bedrock')).toBe('/provider-icons/amazon-bedrock.svg');
+    expect(providerIconSrc('fireworks')).toBe('/provider-icons/fireworks-ai.svg');
+  });
+
+  test('returns undefined for an unmapped id (caller falls back to initials)', () => {
+    expect(providerIconSrc('some-brand-new-provider')).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/providers/provider-branding.tsx
+++ b/apps/web/src/features/providers/provider-branding.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import {
   MODEL_SELECTOR_PROVIDER_IDS as SHARED_MODEL_SELECTOR_PROVIDER_IDS,
   PROVIDER_LABELS as SHARED_PROVIDER_LABELS,
 } from '@kortix/llm-catalog';
+import Image from 'next/image';
 
 export const POPULAR_PROVIDER_IDS = [
   'anthropic',
@@ -47,28 +47,47 @@ const PROVIDER_ICON_MAP: Record<string, { src?: string; fallback: string }> = {
   vercel: { src: '/provider-icons/vercel.svg', fallback: 'VE' },
   groq: { src: '/provider-icons/groq.svg', fallback: 'GQ' },
   xai: { src: '/provider-icons/xai.svg', fallback: 'XA' },
+  // Bedrock: models.dev's canonical id is `amazon-bedrock`; keep the short
+  // `bedrock` alias for any legacy call site that still passes it.
+  'amazon-bedrock': { src: '/provider-icons/amazon-bedrock.svg', fallback: 'AW' },
   bedrock: { src: '/provider-icons/amazon-bedrock.svg', fallback: 'AW' },
+  // Moonshot ships as three distinct providers on models.dev — Moonshot AI,
+  // Moonshot AI (China), and the Kimi For Coding plan. They share the one
+  // Moonshot mark (no separate -cn / kimi asset exists), but their VERBATIM
+  // names keep them readable apart in the list.
   moonshotai: { src: '/provider-icons/moonshotai.svg', fallback: 'MS' },
-  'moonshotai-cn': { src: '/provider-icons/moonshotai-cn.svg', fallback: 'MS' },
+  'moonshotai-cn': { src: '/provider-icons/moonshotai.svg', fallback: 'MS' },
+  'kimi-for-coding': { src: '/provider-icons/moonshotai.svg', fallback: 'KI' },
   deepseek: { src: '/provider-icons/deepseek.svg', fallback: 'DS' },
   mistral: { src: '/provider-icons/mistral.svg', fallback: 'MI' },
   cohere: { src: '/provider-icons/cohere.svg', fallback: 'CO' },
+  'cohere-platform': { src: '/provider-icons/cohere.svg', fallback: 'CO' },
   llama: { src: '/provider-icons/llama.svg', fallback: 'LL' },
   huggingface: { src: '/provider-icons/huggingface.svg', fallback: 'HF' },
   cerebras: { src: '/provider-icons/cerebras.svg', fallback: 'CE' },
   togetherai: { src: '/provider-icons/togetherai.svg', fallback: 'TA' },
+  // Fireworks: `fireworks-ai` is the models.dev id; `firepass` is its
+  // pass-through variant; keep `fireworks` as a legacy alias.
+  'fireworks-ai': { src: '/provider-icons/fireworks-ai.svg', fallback: 'FW' },
+  firepass: { src: '/provider-icons/fireworks-ai.svg', fallback: 'FW' },
   fireworks: { src: '/provider-icons/fireworks-ai.svg', fallback: 'FW' },
   deepinfra: { src: '/provider-icons/deepinfra.svg', fallback: 'DI' },
   nvidia: { src: '/provider-icons/nvidia.svg', fallback: 'NV' },
+  // Google Vertex reuses the Google mark; the Anthropic-on-Vertex variant
+  // reuses the Anthropic mark so it reads as what it actually serves.
+  'google-vertex': { src: '/provider-icons/google.svg', fallback: 'GV' },
+  'google-vertex-anthropic': { src: '/provider-icons/anthropic.svg', fallback: 'GV' },
   cloudflare: { src: '/provider-icons/cloudflare-workers-ai.svg', fallback: 'CF' },
+  'cloudflare-workers-ai': { src: '/provider-icons/cloudflare-workers-ai.svg', fallback: 'CF' },
   azure: { src: '/provider-icons/azure.svg', fallback: 'AZ' },
   ollama: { src: '/provider-icons/ollama-cloud.svg', fallback: 'OL' },
   perplexity: { src: '/provider-icons/perplexity.svg', fallback: 'PE' },
+  'perplexity-agent': { src: '/provider-icons/perplexity.svg', fallback: 'PE' },
   lmstudio: { src: '/provider-icons/lmstudio.svg', fallback: 'LM' },
   v0: { src: '/provider-icons/v0.svg', fallback: 'V0' },
   wandb: { src: '/provider-icons/wandb.svg', fallback: 'WB' },
   baseten: { src: '/provider-icons/baseten.svg', fallback: 'BT' },
-  // Add all other icons - they fallback to initials if not mapped
+  // Everything else falls back to monochrome initials.
 };
 
 function initialsFor(providerID: string, name?: string) {
@@ -82,7 +101,12 @@ function initialsFor(providerID: string, name?: string) {
   }
   const source = (name || providerID).replace(/[^a-zA-Z0-9 ]/g, ' ').trim();
   const parts = source.split(/\s+/).filter(Boolean);
-  return (parts.slice(0, 2).map((part) => part[0]).join('') || providerID.slice(0, 2)).toUpperCase();
+  return (
+    parts
+      .slice(0, 2)
+      .map((part) => part[0])
+      .join('') || providerID.slice(0, 2)
+  ).toUpperCase();
 }
 
 export function ProviderLogo({
@@ -128,10 +152,12 @@ export function ProviderLogo({
           className="object-contain dark:invert"
         />
       ) : (
-        <span className={cn(
-          'font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300',
-          size === 'small' ? 'text-xs' : size === 'large' ? 'text-xs' : 'text-xs'
-        )}>
+        <span
+          className={cn(
+            'font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300',
+            size === 'small' ? 'text-xs' : size === 'large' ? 'text-xs' : 'text-xs',
+          )}
+        >
           {initialsFor(providerID, name)}
         </span>
       )}

--- a/apps/web/src/features/providers/provider-branding.tsx
+++ b/apps/web/src/features/providers/provider-branding.tsx
@@ -90,6 +90,16 @@ const PROVIDER_ICON_MAP: Record<string, { src?: string; fallback: string }> = {
   // Everything else falls back to monochrome initials.
 };
 
+/**
+ * Resolve a provider id to its logo asset path, or `undefined` when the id has
+ * no mapped mark (the caller falls back to monochrome initials). Keyed on the
+ * VERBATIM models.dev provider ids so live-catalog entries resolve — see the
+ * icon-map notes above for the Moonshot trio / Bedrock / Vertex cases.
+ */
+export function providerIconSrc(providerID: string): string | undefined {
+  return PROVIDER_ICON_MAP[providerID]?.src;
+}
+
 function initialsFor(providerID: string, name?: string) {
   const label = PROVIDER_LABELS[providerID];
   if (label) {

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
@@ -8,10 +10,9 @@ import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import type { LlmProviderEntry } from '@/lib/llm-providers';
-import { cn } from '@/lib/utils';
 import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ChevronLeft, ExternalLink, Info } from 'lucide-react';
+import { ChevronLeft, ExternalLink, Info, ShieldCheck, TriangleAlert } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, useMemo, useState } from 'react';
 
@@ -62,23 +63,20 @@ export function ApiKeyConnectForm({
 
   const allFilled = provider.envVars.every((envVar) => values[envVar]?.trim());
   const helpHostname = useMemo(() => helpHostnameFromUrl(provider.helpUrl), [provider.helpUrl]);
+  const fieldCount = provider.envVars.length;
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
     if (!allFilled) {
-      setError(
-        provider.envVars.length === 1
-          ? 'API key is required'
-          : `All ${provider.envVars.length} fields are required`,
-      );
+      setError(fieldCount === 1 ? 'API key is required' : `All ${fieldCount} fields are required`);
       return;
     }
     upsert.mutate();
   }
 
   return (
-    <div className="space-y-3 px-5 pt-3 pb-5">
+    <div className="space-y-4 px-5 pt-3 pb-5">
       <Button
         type="button"
         variant="ghost"
@@ -86,21 +84,24 @@ export function ApiKeyConnectForm({
         className="text-muted-foreground -ml-2 h-7 gap-1 px-2 text-xs"
         onClick={onBack}
       >
-        <ChevronLeft className="h-3.5 w-3.5" />
+        <ChevronLeft className="size-3.5 shrink-0" />
         {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line767JsxTextBackToProviders')}
       </Button>
 
-      <div className="border-border/50 bg-muted/20 flex items-center gap-3 rounded-2xl border px-3.5 py-3">
+      {/* Provider identity — logo, name, and exactly what gets stored. */}
+      <div className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3">
         <ProviderLogo providerID={provider.id} name={provider.label} size="default" />
         <div className="min-w-0 flex-1">
           <div className="text-foreground truncate text-sm font-medium">{provider.label}</div>
-          <div className="text-muted-foreground mt-0.5 truncate text-xs">
-            Stored as{' '}
-            {provider.envVars.map((envVar, index) => (
-              <span key={envVar}>
-                {index > 0 && ' · '}
-                <code className="bg-background rounded px-1 py-0.5 font-mono">{envVar}</code>
-              </span>
+          <div className="text-muted-foreground mt-0.5 flex flex-wrap items-center gap-1 text-xs">
+            <span>Stored as</span>
+            {provider.envVars.map((envVar) => (
+              <code
+                key={envVar}
+                className="bg-muted text-foreground/80 rounded px-1 py-0.5 font-mono text-[11px]"
+              >
+                {envVar}
+              </code>
             ))}
           </div>
         </div>
@@ -110,76 +111,93 @@ export function ApiKeyConnectForm({
         <ChatGptSubscriptionConnect projectId={projectId} onConnected={onConnected} />
       )}
 
-      <form
-        onSubmit={handleSubmit}
-        className={cn('border-border/50 bg-muted/20 space-y-3 rounded-2xl border p-4')}
-      >
-        {provider.envVars.map((envVar, index) => (
-          <div key={envVar}>
-            <label
-              htmlFor={`provider-${provider.id}-${envVar}`}
-              className="text-muted-foreground mb-1.5 block text-xs font-medium"
-            >
-              {prettyFieldLabel(envVar)}
-            </label>
-            <Input
-              id={`provider-${provider.id}-${envVar}`}
-              type="text"
-              value={values[envVar] ?? ''}
-              onChange={(e) => setValues((current) => ({ ...current, [envVar]: e.target.value }))}
-              placeholder={envVarPlaceholder(provider, envVar)}
-              className="h-9 text-sm"
-              autoFocus={index === 0}
-              autoComplete="off"
-            />
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="bg-popover space-y-5 rounded-md border px-4 py-5">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-foreground text-sm font-medium">
+              {fieldCount === 1 ? 'Credential' : 'Credentials'}
+            </span>
+            {fieldCount > 1 && (
+              <Badge variant="outline" size="sm">
+                {fieldCount} fields
+              </Badge>
+            )}
           </div>
-        ))}
 
-        <p className="text-muted-foreground text-xs">
-          Project-wide — every member of this project can use this provider.
-        </p>
+          <FieldGroup className="gap-5">
+            {provider.envVars.map((envVar, index) => (
+              <Field key={envVar}>
+                <FieldLabel htmlFor={`provider-${provider.id}-${envVar}`}>
+                  {prettyFieldLabel(envVar)}
+                </FieldLabel>
+                <Input
+                  id={`provider-${provider.id}-${envVar}`}
+                  type="text"
+                  value={values[envVar] ?? ''}
+                  onChange={(e) =>
+                    setValues((current) => ({ ...current, [envVar]: e.target.value }))
+                  }
+                  placeholder={envVarPlaceholder(provider, envVar)}
+                  autoFocus={index === 0}
+                  autoComplete="off"
+                />
+              </Field>
+            ))}
+          </FieldGroup>
 
-        {provider.helpUrl && helpHostname && (
-          <a
-            href={provider.helpUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-1 text-xs"
+          <FieldDescription className="text-xs">
+            Project-wide — every member of this project can use this provider.
+          </FieldDescription>
+
+          {provider.helpUrl && helpHostname && (
+            <a
+              href={provider.helpUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-1.5 text-xs transition-colors"
+            >
+              <ExternalLink className="size-3 shrink-0" />
+              {tHardcodedUi.raw(
+                'componentsProjectsProjectProviderModal.line827JsxTextGetCredentialsFrom',
+              )}{' '}
+              {helpHostname}
+            </a>
+          )}
+
+          <Button
+            type="submit"
+            size="sm"
+            className="w-full"
+            disabled={upsert.isPending || !allFilled}
           >
-            <ExternalLink className="h-3 w-3" />
-            {tHardcodedUi.raw(
-              'componentsProjectsProjectProviderModal.line827JsxTextGetCredentialsFrom',
-            )}{' '}
-            {helpHostname}
-          </a>
-        )}
+            {upsert.isPending ? (
+              <>
+                <Loading className="size-3.5 shrink-0" />
+                {tHardcodedUi.raw(
+                  'componentsProjectsProjectProviderModal.line847JsxTextConnecting',
+                )}
+              </>
+            ) : (
+              'Connect'
+            )}
+          </Button>
+        </div>
 
         {error && (
-          <div className="bg-destructive/5 text-destructive flex items-start gap-2 rounded-2xl px-3 py-2 text-xs">
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
-            <span>{error}</span>
-          </div>
+          <InfoBanner tone="destructive" icon={TriangleAlert} title="Couldn't connect">
+            {error}
+          </InfoBanner>
         )}
 
-        <InfoBanner tone="warning" icon={Info} className="rounded-2xl">
+        <InfoBanner tone="warning" icon={Info}>
           {tHardcodedUi.raw(
             'autoComponentsProjectsProjectProviderModalJsxTextASandboxPicks96cfb428',
           )}
         </InfoBanner>
-
-        <Button type="submit" size="sm" className="px-4" disabled={upsert.isPending || !allFilled}>
-          {upsert.isPending ? (
-            <>
-              <Loading className="mr-1.5 size-3.5 shrink-0" />
-              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line847JsxTextConnecting')}
-            </>
-          ) : (
-            'Connect'
-          )}
-        </Button>
       </form>
 
-      <p className="text-muted-foreground px-1 text-xs">
+      <p className="text-muted-foreground flex items-center gap-1.5 px-1 text-xs">
+        <ShieldCheck className="size-3.5 shrink-0" />
         {tHardcodedUi.raw(
           'componentsProjectsProjectProviderModal.line856JsxTextValuesAreEncryptedAtRestAes256Gcm',
         )}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
@@ -16,7 +16,7 @@ import type { CatalogSubview } from './types';
 import { helpHostnameFromUrl, providerCredentialSummary, releasedAgo } from './utils';
 
 const ROW =
-  'group bg-popover hover:bg-muted/40 flex w-full items-center gap-3 rounded-md border px-4 py-2.5 text-left transition-colors';
+  'group bg-popover hover:bg-muted/40 flex w-full items-center gap-3 rounded-md border px-4 py-2.5 text-left transition-colors active:scale-[0.995]';
 
 export function CatalogTab({
   projectId,

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { InfoBanner } from '@/components/ui/info-banner';
 import Loading from '@/components/ui/loading';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
-import {
-  pollProjectProviderOAuth,
-  startProjectProviderOAuth,
-} from '@kortix/sdk/projects-client';
+import { pollProjectProviderOAuth, startProjectProviderOAuth } from '@kortix/sdk/projects-client';
 import { useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ExternalLink } from 'lucide-react';
+import { CheckCircle2, ExternalLink, TriangleAlert } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -109,7 +107,7 @@ export function ChatGptSubscriptionConnect({
   const waiting = phase === 'waiting';
 
   return (
-    <div className="border-border/50 bg-muted/20 rounded-2xl border p-4">
+    <div className="bg-popover rounded-md border px-4 py-4">
       <div className="flex items-start gap-3">
         <ProviderLogo providerID="openai" name="OpenAI" size="default" />
         <div className="min-w-0 flex-1">
@@ -127,7 +125,7 @@ export function ChatGptSubscriptionConnect({
       </div>
 
       {waiting && (
-        <div className="border-border/50 bg-background/70 mt-3 rounded-2xl border p-3">
+        <div className="border-border bg-muted/30 mt-3 rounded-md border p-3">
           {challenge ? (
             <>
               <div className="text-foreground text-xs font-medium">
@@ -156,7 +154,7 @@ export function ChatGptSubscriptionConnect({
                       'autoComponentsProjectsProjectProviderModalJsxTextEnterThisCodee346992b',
                     )}
                   </div>
-                  <div className="border-border/60 bg-muted text-foreground mt-1 w-fit rounded-2xl border px-3 py-2 font-mono text-lg font-semibold tracking-normal">
+                  <div className="border-border bg-muted text-foreground mt-1 w-fit rounded-md border px-3 py-2 font-mono text-lg font-semibold tracking-widest tabular-nums">
                     {challenge.code}
                   </div>
                 </div>
@@ -177,18 +175,17 @@ export function ChatGptSubscriptionConnect({
       )}
 
       {phase === 'done' && (
-        <div className="text-foreground/80 border-kortix-green/20 bg-kortix-green/[0.06] mt-3 flex items-start gap-2 rounded-2xl border px-3 py-2.5 text-xs">
+        <InfoBanner tone="success" icon={CheckCircle2} className="mt-3 text-xs">
           {tHardcodedUi.raw(
             'autoComponentsProjectsProjectProviderModalJsxTextChatGPTSubscriptionConnectedcf12bc87',
           )}
-        </div>
+        </InfoBanner>
       )}
 
       {error && (
-        <div className="bg-destructive/5 text-destructive mt-3 flex items-start gap-2 rounded-2xl px-3 py-2 text-xs">
-          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
-          <span>{error}</span>
-        </div>
+        <InfoBanner tone="destructive" icon={TriangleAlert} className="mt-3 text-xs">
+          {error}
+        </InfoBanner>
       )}
 
       <div className="mt-3 flex flex-wrap gap-2">

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
@@ -12,7 +12,7 @@ import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import { LLM_PROVIDER_BY_ID, type LlmProviderEntry } from '@/lib/llm-providers';
 import { deleteProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plug, Unplug } from 'lucide-react';
+import { Plug, Plus, Unplug } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 import { CODEX_AUTH_JSON_SECRET_NAME, LEGACY_OPENCODE_AUTH_JSON_SECRET_NAME } from './constants';
@@ -79,9 +79,15 @@ export function ConnectedTab({
           title={tHardcodedUi.raw(
             'componentsProjectsProjectProviderModal.line300JsxTextNoProvidersConnectedYet',
           )}
+          description={
+            canWrite
+              ? 'Connect an LLM provider to give this project its own models. Keys are encrypted and shared with everyone on the project.'
+              : 'No LLM providers have been connected to this project yet.'
+          }
           action={
             canWrite ? (
-              <Button variant="outline" size="sm" onClick={onAddProvider}>
+              <Button variant="outline" size="sm" className="gap-1.5" onClick={onAddProvider}>
+                <Plus className="size-3.5 shrink-0" />
                 {tHardcodedUi.raw(
                   'componentsProjectsProjectProviderModal.line302JsxTextAddProvider',
                 )}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { InfoBanner } from '@/components/ui/info-banner';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ChevronLeft, Copy } from 'lucide-react';
+import { Check, ChevronLeft, Copy, Plus, TriangleAlert } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, useState } from 'react';
 
@@ -117,7 +120,7 @@ export function CustomProviderForm({
   }
 
   return (
-    <div className="space-y-3 px-5 pt-3 pb-5">
+    <div className="space-y-4 px-5 pt-3 pb-5">
       <Button
         type="button"
         variant="ghost"
@@ -125,141 +128,162 @@ export function CustomProviderForm({
         className="text-muted-foreground -ml-2 h-7 gap-1 px-2 text-xs"
         onClick={onBack}
       >
-        <ChevronLeft className="h-3.5 w-3.5" />
+        <ChevronLeft className="size-3.5 shrink-0" />
         {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line983JsxTextBackToProviders')}
       </Button>
 
-      <div className="border-border/50 bg-muted/20 rounded-2xl border px-3.5 py-3">
-        <div className="text-foreground text-sm font-medium">
-          {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line987JsxTextCustomProvider')}
+      <div className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3">
+        <span className="border-border/60 text-muted-foreground/70 flex size-9 shrink-0 items-center justify-center rounded-sm border border-dashed">
+          <Plus className="size-4 shrink-0" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-foreground text-sm font-medium">
+            {tHardcodedUi.raw(
+              'componentsProjectsProjectProviderModal.line987JsxTextCustomProvider',
+            )}
+          </div>
+          <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+            {tHardcodedUi.raw(
+              'componentsProjectsProjectProviderModal.line989JsxTextConnectAnyOpenaiCompatibleEndpointTheApiKey',
+            )}{' '}
+            <code className="bg-muted rounded px-1 py-0.5 font-mono text-[11px]">
+              .opencode/opencode.jsonc
+            </code>
+            .
+          </p>
         </div>
-        <p className="text-muted-foreground mt-0.5 text-xs">
-          {tHardcodedUi.raw(
-            'componentsProjectsProjectProviderModal.line989JsxTextConnectAnyOpenaiCompatibleEndpointTheApiKey',
-          )}{' '}
-          <code className="bg-background rounded px-1 py-0.5 font-mono">
-            .opencode/opencode.jsonc
-          </code>
-          .
-        </p>
       </div>
 
-      <form
-        onSubmit={handleSubmit}
-        className="border-border/50 bg-muted/20 space-y-3 rounded-2xl border p-4"
-      >
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="text-muted-foreground mb-1.5 block text-xs font-medium">
-              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1002JsxTextProviderId')}
-            </label>
-            <Input
-              type="text"
-              value={form.providerId}
-              onChange={(e) =>
-                setField('providerId', e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ''))
-              }
-              placeholder="my-llm"
-              className="h-9 font-mono text-xs"
-              autoFocus
-            />
-          </div>
-          <div>
-            <label className="text-muted-foreground mb-1.5 block text-xs font-medium">
-              {tHardcodedUi.raw(
-                'componentsProjectsProjectProviderModal.line1020JsxTextDisplayName',
-              )}
-            </label>
-            <Input
-              type="text"
-              value={form.name}
-              onChange={(e) => setField('name', e.target.value)}
-              placeholder={tHardcodedUi.raw(
-                'componentsProjectsProjectProviderModal.line1026JsxAttrPlaceholderMyLlm',
-              )}
-              className="h-9 text-sm"
-            />
-          </div>
-        </div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="bg-popover space-y-5 rounded-md border px-4 py-5">
+          <FieldGroup className="gap-5">
+            <div className="grid gap-5 sm:grid-cols-2">
+              <Field>
+                <FieldLabel htmlFor="custom-provider-id">
+                  {tHardcodedUi.raw(
+                    'componentsProjectsProjectProviderModal.line1002JsxTextProviderId',
+                  )}
+                </FieldLabel>
+                <Input
+                  id="custom-provider-id"
+                  type="text"
+                  value={form.providerId}
+                  onChange={(e) =>
+                    setField('providerId', e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ''))
+                  }
+                  placeholder="my-llm"
+                  className="font-mono text-xs"
+                  autoFocus
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="custom-display-name">
+                  {tHardcodedUi.raw(
+                    'componentsProjectsProjectProviderModal.line1020JsxTextDisplayName',
+                  )}
+                </FieldLabel>
+                <Input
+                  id="custom-display-name"
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setField('name', e.target.value)}
+                  placeholder={tHardcodedUi.raw(
+                    'componentsProjectsProjectProviderModal.line1026JsxAttrPlaceholderMyLlm',
+                  )}
+                />
+              </Field>
+            </div>
 
-        {form.apiKey.trim() && (
-          <p className="text-muted-foreground text-xs">
-            Project-wide — every member of this project can use this provider.
-          </p>
-        )}
-        <div>
-          <label className="text-muted-foreground mb-1.5 block text-xs font-medium">
-            {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1033JsxTextBaseUrl')}
-          </label>
-          <Input
-            type="text"
-            value={form.baseURL}
-            onChange={(e) => setField('baseURL', e.target.value)}
-            placeholder="https://api.example.com/v1"
-            className="h-9 font-mono text-xs"
-          />
-        </div>
-        <div>
-          <label className="text-muted-foreground mb-1.5 block text-xs font-medium">
-            {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1045JsxTextApiKey')}{' '}
-            <span className="text-muted-foreground/60 font-normal">(optional)</span>
-          </label>
-          <Input
-            type="text"
-            value={form.apiKey}
-            onChange={(e) => setField('apiKey', e.target.value)}
-            placeholder={tHardcodedUi.raw(
-              'componentsProjectsProjectProviderModal.line1052JsxAttrPlaceholderSkSavedAsAProjectSecret',
-            )}
-            className="h-9 font-mono text-xs"
-          />
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="text-muted-foreground mb-1.5 block text-xs font-medium">
-              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1059JsxTextModelId')}
-            </label>
-            <Input
-              type="text"
-              value={form.modelId}
-              onChange={(e) => setField('modelId', e.target.value)}
-              placeholder="my-llm/foo-7b"
-              className="h-9 font-mono text-xs"
-            />
-          </div>
-          <div>
-            <label className="text-muted-foreground mb-1.5 block text-xs font-medium">
-              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1071JsxTextModelName')}
-            </label>
-            <Input
-              type="text"
-              value={form.modelName}
-              onChange={(e) => setField('modelName', e.target.value)}
-              placeholder={tHardcodedUi.raw(
-                'componentsProjectsProjectProviderModal.line1077JsxAttrPlaceholderFoo7b',
+            <Field>
+              <FieldLabel htmlFor="custom-base-url">
+                {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1033JsxTextBaseUrl')}
+              </FieldLabel>
+              <Input
+                id="custom-base-url"
+                type="text"
+                value={form.baseURL}
+                onChange={(e) => setField('baseURL', e.target.value)}
+                placeholder="https://api.example.com/v1"
+                className="font-mono text-xs"
+              />
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor="custom-api-key">
+                {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1045JsxTextApiKey')}{' '}
+                <span className="text-muted-foreground/60 font-normal">(optional)</span>
+              </FieldLabel>
+              <Input
+                id="custom-api-key"
+                type="text"
+                value={form.apiKey}
+                onChange={(e) => setField('apiKey', e.target.value)}
+                placeholder={tHardcodedUi.raw(
+                  'componentsProjectsProjectProviderModal.line1052JsxAttrPlaceholderSkSavedAsAProjectSecret',
+                )}
+                className="font-mono text-xs"
+              />
+              {form.apiKey.trim() && (
+                <FieldDescription className="text-xs">
+                  Project-wide — every member of this project can use this provider.
+                </FieldDescription>
               )}
-              className="h-9 text-sm"
-            />
-          </div>
+            </Field>
+
+            <div className="grid gap-5 sm:grid-cols-2">
+              <Field>
+                <FieldLabel htmlFor="custom-model-id">
+                  {tHardcodedUi.raw(
+                    'componentsProjectsProjectProviderModal.line1059JsxTextModelId',
+                  )}
+                </FieldLabel>
+                <Input
+                  id="custom-model-id"
+                  type="text"
+                  value={form.modelId}
+                  onChange={(e) => setField('modelId', e.target.value)}
+                  placeholder="my-llm/foo-7b"
+                  className="font-mono text-xs"
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="custom-model-name">
+                  {tHardcodedUi.raw(
+                    'componentsProjectsProjectProviderModal.line1071JsxTextModelName',
+                  )}
+                </FieldLabel>
+                <Input
+                  id="custom-model-name"
+                  type="text"
+                  value={form.modelName}
+                  onChange={(e) => setField('modelName', e.target.value)}
+                  placeholder={tHardcodedUi.raw(
+                    'componentsProjectsProjectProviderModal.line1077JsxAttrPlaceholderFoo7b',
+                  )}
+                />
+              </Field>
+            </div>
+          </FieldGroup>
+
+          <Button type="submit" size="sm" className="w-full" disabled={save.isPending}>
+            {save.isPending ? (
+              <>
+                <Loading className="size-3.5 shrink-0" />
+                {tHardcodedUi.raw(
+                  'componentsProjectsProjectProviderModal.line1094JsxTextGenerating',
+                )}
+              </>
+            ) : (
+              'Generate snippet'
+            )}
+          </Button>
         </div>
 
         {error && (
-          <div className="bg-destructive/5 text-destructive flex items-start gap-2 rounded-2xl px-3 py-2 text-xs">
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
-            <span>{error}</span>
-          </div>
+          <InfoBanner tone="destructive" icon={TriangleAlert} title="Check the fields">
+            {error}
+          </InfoBanner>
         )}
-
-        <Button type="submit" size="sm" className="px-4" disabled={save.isPending}>
-          {save.isPending ? (
-            <>
-              <Loading className="mr-1.5 size-3.5 shrink-0" />
-              {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1094JsxTextGenerating')}
-            </>
-          ) : (
-            'Generate snippet'
-          )}
-        </Button>
       </form>
     </div>
   );
@@ -289,57 +313,73 @@ function CustomProviderSnippetView({
   }
 
   return (
-    <div className="space-y-3 px-5 pt-3 pb-5">
-      <div className="border-kortix-green/30 bg-kortix-green/[0.04] rounded-2xl border px-3.5 py-3">
-        <div className="text-foreground text-sm font-medium">
-          {secretName ? 'API key saved' : 'Snippet ready'}
-        </div>
-        <p className="text-muted-foreground mt-0.5 text-xs">
-          {secretName ? (
-            <>
-              {tHardcodedUi.raw(
-                'componentsProjectsProjectProviderModal.line1136JsxTextYourKeyIsStoredAs',
-              )}{' '}
-              <code className="bg-background rounded px-1 py-0.5 font-mono">{secretName}</code>{' '}
-              {tHardcodedUi.raw(
-                'componentsProjectsProjectProviderModal.line1138JsxTextAndWillBeInjectedIntoSessionsAsAn',
-              )}
-            </>
-          ) : (
-            tHardcodedUi.raw(
-              'componentsProjectsProjectProviderModal.line1141JsxTextNoApiKeyWasProvidedTheSnippetBelow',
-            )
-          )}
-        </p>
-      </div>
+    <div className="space-y-4 px-5 pt-3 pb-5">
+      <InfoBanner
+        tone="success"
+        icon={Check}
+        title={secretName ? 'API key saved' : 'Snippet ready'}
+      >
+        {secretName ? (
+          <>
+            {tHardcodedUi.raw(
+              'componentsProjectsProjectProviderModal.line1136JsxTextYourKeyIsStoredAs',
+            )}{' '}
+            <code className="bg-muted rounded px-1 py-0.5 font-mono text-[11px]">{secretName}</code>{' '}
+            {tHardcodedUi.raw(
+              'componentsProjectsProjectProviderModal.line1138JsxTextAndWillBeInjectedIntoSessionsAsAn',
+            )}
+          </>
+        ) : (
+          tHardcodedUi.raw(
+            'componentsProjectsProjectProviderModal.line1141JsxTextNoApiKeyWasProvidedTheSnippetBelow',
+          )
+        )}
+      </InfoBanner>
 
-      <div>
-        <div className="mb-1.5 flex items-center justify-between px-1">
-          <span className="text-muted-foreground/60 text-xs font-medium tracking-wide uppercase">
+      <div className="bg-popover overflow-hidden rounded-md border">
+        <div className="border-border/60 flex items-center justify-between gap-3 border-b px-4 py-2.5">
+          <span className="text-muted-foreground text-xs">
             {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line1149JsxTextAddTo')}
-            <code className="font-mono normal-case">.opencode/opencode.jsonc</code>
+            <code className="font-mono">.opencode/opencode.jsonc</code>
           </span>
-          <Button
+          <button
             type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1.5 px-2 text-xs"
             onClick={handleCopy}
+            aria-label={copied ? 'Copied' : 'Copy snippet'}
+            className="text-muted-foreground hover:text-foreground hover:bg-muted-foreground/10 inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors active:scale-[0.97]"
           >
-            <Copy className="h-3 w-3" />
-            {copied ? 'Copied' : 'Copy'}
-          </Button>
+            <span className="relative inline-flex size-3.5 items-center justify-center">
+              <AnimatePresence initial={false} mode="popLayout">
+                <motion.span
+                  key={copied ? 'check' : 'copy'}
+                  initial={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+                  animate={{ scale: 1, opacity: 1, filter: 'blur(0px)' }}
+                  exit={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+                  transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+                  className="absolute inset-0 inline-flex items-center justify-center"
+                >
+                  {copied ? (
+                    <Check className="text-kortix-green size-3.5" />
+                  ) : (
+                    <Copy className="size-3.5" />
+                  )}
+                </motion.span>
+              </AnimatePresence>
+            </span>
+          </button>
         </div>
-        <pre className="border-border/40 bg-muted/20 text-foreground max-h-[280px] overflow-auto rounded-2xl border px-3 py-2.5 font-mono text-xs leading-snug">
+        <pre className="text-foreground max-h-[280px] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed">
           {snippet}
         </pre>
       </div>
 
-      <p className="text-muted-foreground px-1 text-xs">
+      <p className="text-muted-foreground px-1 text-xs text-pretty">
         {tHardcodedUi.raw(
           'componentsProjectsProjectProviderModal.line1168JsxTextPasteThisIntoYourProjectRepoAposS',
         )}{' '}
-        <code className="bg-muted rounded px-1 py-0.5 font-mono">.opencode/opencode.jsonc</code>{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-[11px]">
+          .opencode/opencode.jsonc
+        </code>{' '}
         {tHardcodedUi.raw(
           'componentsProjectsProjectProviderModal.line1170JsxTextAndCommitRestartAnyRunningSessionForThe',
         )}


### PR DESCRIPTION
## What

Overhauls the LLM-gateway / provider-connect UX in `apps/web` to the Kortix design system. Highest-priority target: the **provider connect flow** Marko flagged as horrendous.

Pure presentation layer — consumes the existing hooks/endpoints (`use-connected-providers`, the live llm-catalog, gateway keys API). No backend contract or data-shape changes.

## Surfaces redesigned

**Provider connect flow (priority)**
- `api-key-connect-form` rebuilt on `Field` / `FieldLabel` / `FieldGroup` + `InfoBanner` — replaces raw `<label>`s, `h-9` inputs, and hand-rolled `bg-destructive/5` / warning banners. Panels are `rounded-md` (were `rounded-2xl`, banned by the DS). Multi-field providers now show a clear field count (the #4893 any-of contract means **Bedrock shows its 2 fields**, labelled). Full-width Connect button, encrypted-at-rest reassurance line.
- `custom-provider-form` given the same `Field`/`InfoBanner`/`rounded-md` treatment; the generated-snippet copy control is now the buttery blur+scale+opacity icon-swap button from the DS.
- `chatgpt-subscription-connect`: `rounded-md`, `InfoBanner` success/error states, tabular device code.

**Connected state**
- `connected-tab` empty state now has a real description + `Plus` CTA instead of the bare "No providers connected yet" line.

**Provider display / branding**
- `provider-branding` icon map keyed on the **verbatim models.dev provider ids** so logos actually resolve: `amazon-bedrock`, `fireworks-ai`/`firepass`, `google-vertex`(`-anthropic`), `cohere-platform`, `cloudflare-workers-ai`, `perplexity-agent`, and the **three distinct Moonshot providers** — `moonshotai` / `moonshotai-cn` / `kimi-for-coding`. Fixes the broken `moonshotai-cn.svg` reference (asset never existed → broken image). Legacy short aliases (`bedrock`, `fireworks`) kept.

## Design-system adherence
Tokens/components only — `Field`, `InfoBanner`, `Badge`, `Loading`, `rounded-md` panels, `kortix-*` accents, `motion/react` icon-swap per the polish skill. No banned primitives, no raw palette, no nested rounding. Theme-aware + accessible (label/htmlFor pairing, aria-labels, focus states from the primitives).

## Verification
- `tsc --noEmit` clean (only the pre-existing `@/.source` fumadocs-codegen errors remain, unrelated).
- `bun test` — `llm-providers.test.ts` + `gateway-routing.test.ts` green (21/21).
- Biome-formatted.