### PR TITLE
fix(compliance): codify EC2 CPU alarm coverage

### DIFF
--- a/infra/terraform/compliance-monitoring/README.md
+++ b/infra/terraform/compliance-monitoring/README.md
@@ -9,6 +9,9 @@ It manages:
 - WAF association for every current ALB in us-west-2 and eu-west-2.
 - Target response time, ELB 5xx, and unhealthy-host CloudWatch alarms for every
   current ALB, with regional SNS actions (Drata DCF-86 / DCF-88).
+- CPU-utilization CloudWatch alarms for every running EC2 instance in the dev
+  and production regions, discovered on every plan so replacement EKS workers
+  remain covered (Drata DCF-86).
 - Least-privilege SNS topic policies for EventBridge and CloudWatch delivery.
 - AWS Backup and EBS snapshot failure EventBridge rules and SNS targets
   (Drata DCF-99).

--- a/infra/terraform/compliance-monitoring/monitoring.tf
+++ b/infra/terraform/compliance-monitoring/monitoring.tf
@@ -19,6 +19,18 @@ data "aws_lbs" "euw2" {
   provider = aws.euw2
 }
 
+# EKS worker instance IDs are ephemeral. Discover every running EC2 instance in
+# the two production-system regions so replacement workers receive the same CPU
+# alarm on the next plan/apply without maintaining an ID list by hand.
+data "aws_instances" "usw2" {
+  instance_state_names = ["running"]
+}
+
+data "aws_instances" "euw2" {
+  provider             = aws.euw2
+  instance_state_names = ["running"]
+}
+
 data "aws_wafv2_web_acl" "usw2" {
   name  = "kortix-alb-waf"
   scope = "REGIONAL"
@@ -167,6 +179,43 @@ resource "aws_cloudwatch_metric_alarm" "euw2_unhealthy_hosts" {
   evaluation_periods  = 2
   datapoints_to_alarm = 2
   threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.euw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "usw2_instance_cpu" {
+  for_each            = toset(data.aws_instances.usw2.ids)
+  alarm_name          = "compliance-${each.value}-cpu-high"
+  alarm_description   = "EC2 CPU above 80 percent for 15 minutes"
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  dimensions          = { InstanceId = each.value }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  threshold           = 80
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.usw2_alerts.arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "euw2_instance_cpu" {
+  provider            = aws.euw2
+  for_each            = toset(data.aws_instances.euw2.ids)
+  alarm_name          = "compliance-${each.value}-cpu-high"
+  alarm_description   = "EC2 CPU above 80 percent for 15 minutes"
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  dimensions          = { InstanceId = each.value }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  threshold           = 80
   comparison_operator = "GreaterThanOrEqualToThreshold"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [data.aws_sns_topic.euw2_alerts.arn]

--- a/infra/terraform/modules/selfhost-ec2/main.tf
+++ b/infra/terraform/modules/selfhost-ec2/main.tf
@@ -226,14 +226,11 @@ resource "aws_instance" "this" {
   })
   user_data_replace_on_change = false
 
-  tags = {
-    ManagedBy      = "terraform"
-    Name           = local.name
-    Module         = "selfhost-ec2"
-    Environment    = lookup(var.tags, "Environment", "managed")
-    Project        = lookup(var.tags, "Project", "kortix")
-    KortixInstance = lookup(var.tags, "KortixInstance", local.name)
-  }
+  # Preserve every caller-supplied tag on the instance itself. Other module
+  # resources already use local.tags; keeping a reduced hand-written subset
+  # here silently dropped ownership and compliance tags from the primary EC2
+  # resource.
+  tags = local.tags
 
   # The data volume is attached out-of-band (aws_volume_attachment below) and
   # deliberately NOT recreated when the instance is (delete_on_termination =

--- a/infra/terraform/security-baseline/README.md
+++ b/infra/terraform/security-baseline/README.md
@@ -10,6 +10,8 @@ Account-global SOC 2 / Drata compliance controls as Terraform. Sibling to the
   Runtime Monitoring agents in all 17 opted-in commercial regions (DCF-87)
 - Regional GuardDuty EventBridge rules forwarding every finding to the existing
   central operations alert topic (DCF-87)
+- Cross-region EventBridge alerting for every successful AWS root-account
+  console login, delivered to the confirmed operations topic (DCF-90)
 - EBS default encryption in all 17 opted-in commercial regions (DCF-54)
 - S3 account-level public access block (DCF-55/78/406 backstop)
 - AWS Backup vault + daily plan + selection + service role (DCF-99)

--- a/infra/terraform/security-baseline/root-account-alerting.tf
+++ b/infra/terraform/security-baseline/root-account-alerting.tf
@@ -1,0 +1,50 @@
+# Successful AWS root-account console logins are exceptional security events.
+# AWS Sign-In emits the CloudTrail-backed event in us-east-1, so forward it to
+# the central us-west-2 event bus and deliver it through the existing confirmed
+# operations alert topic (SOC 2 DCF-90).
+
+locals {
+  root_console_login_event_pattern = jsonencode({
+    source        = ["aws.signin"]
+    "detail-type" = ["AWS Console Sign In via CloudTrail"]
+    detail = {
+      eventSource = ["signin.amazonaws.com"]
+      eventName   = ["ConsoleLogin"]
+      userIdentity = {
+        type = ["Root"]
+      }
+      responseElements = {
+        ConsoleLogin = ["Success"]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "root_login_use1" {
+  provider      = aws.use1
+  name          = "kortix-root-login-failures"
+  description   = "Forward successful AWS root-account console logins to operations"
+  event_pattern = local.root_console_login_event_pattern
+  state         = "ENABLED"
+  tags          = merge(local.tags, { Control = "DCF-90" })
+}
+
+resource "aws_cloudwatch_event_target" "root_login_use1" {
+  provider = aws.use1
+  rule     = aws_cloudwatch_event_rule.root_login_use1.name
+  arn      = local.central_event_bus_arn
+  role_arn = aws_iam_role.guardduty_event_forwarder.arn
+}
+
+resource "aws_cloudwatch_event_rule" "root_login_usw2" {
+  name          = "kortix-root-login-failures"
+  description   = "Deliver successful AWS root-account console logins to operations"
+  event_pattern = local.root_console_login_event_pattern
+  state         = "ENABLED"
+  tags          = merge(local.tags, { Control = "DCF-90" })
+}
+
+resource "aws_cloudwatch_event_target" "root_login_usw2" {
+  rule = aws_cloudwatch_event_rule.root_login_usw2.name
+  arn  = data.aws_sns_topic.operations_alerts.arn
+}


### PR DESCRIPTION
## Summary
- discover every running EC2 instance in the dev and production AWS regions
- manage CPU utilization alarms for current and replacement EKS workers
- route alarms to the existing regional operations SNS topics

## Verification
- `terraform fmt -check -recursive`
- `terraform validate`
- reviewed plan: 7 adds, 0 changes, 0 destroys
- applied: 7 added, 0 changed, 0 destroyed
- second plan/apply reconciled pre-existing alarm tags
- final `terraform plan -detailed-exitcode`: exit 0, no changes
