### PR TITLE
feat(llm-gateway): AI-SDK transport engine (flag-gated) behind LLM_TRANSPORT_ENGINE

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -357,6 +357,15 @@ const envSchema = z.object({
   // technically run with no master key; self-host always sets one (see
   // kortix-compose.yml).
   LLM_TRANSLATION_SIDECAR_AUTH_TOKEN: optStr,
+  // Transport engine for upstream LLM calls. 'native' (default) uses the
+  // hand-written per-provider transports (optionally fronted by the LiteLLM
+  // translation sidecar above). 'ai-sdk' routes replaceable providers
+  // (openai-compat / anthropic / bedrock) through the Vercel AI SDK provider
+  // packages, which own the provider quirks, adapting back to the same
+  // OpenAI-compatible /v1/llm contract. Codex (openai-responses) always stays
+  // native. Flag-gated for a proven, staged rollout and, ultimately, retiring
+  // the sidecar.
+  LLM_TRANSPORT_ENGINE:        optStrDefault('native'),
   // AWS Bedrock — the managed ("Kortix") models route here via a Bedrock API key
   // (bearer). Region selects the bedrock-runtime endpoint; the key is an IAM
   // service-specific credential for bedrock.amazonaws.com.
@@ -818,6 +827,7 @@ export const config = {
   LLM_GATEWAY_PROXY_TARGET: env.LLM_GATEWAY_PROXY_TARGET,
   LLM_TRANSLATION_SIDECAR_URL: env.LLM_TRANSLATION_SIDECAR_URL,
   LLM_TRANSLATION_SIDECAR_AUTH_TOKEN: env.LLM_TRANSLATION_SIDECAR_AUTH_TOKEN,
+  LLM_TRANSPORT_ENGINE: env.LLM_TRANSPORT_ENGINE,
   AWS_BEDROCK_REGION: env.AWS_BEDROCK_REGION,
   AWS_BEDROCK_API_KEY: env.AWS_BEDROCK_API_KEY,
   ANTHROPIC_API_URL: env.ANTHROPIC_API_URL,

--- a/apps/api/src/llm-gateway/models/provider-registry.test.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.test.ts
@@ -45,6 +45,9 @@ describe('runtime catalog provider resolution', () => {
     expect(resolveCatalogUpstream('amazon-bedrock')).toEqual({
       kind: 'bedrock',
       envVar: 'AWS_BEARER_TOKEN_BEDROCK',
+      // models.dev `npm` (for the ai-sdk engine's provider selection); still NO
+      // static baseUrl — the region-scoped endpoint is resolved per-request.
+      npm: '@ai-sdk/amazon-bedrock',
     });
   });
 

--- a/apps/api/src/llm-gateway/models/provider-registry.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.ts
@@ -40,9 +40,12 @@ const BEDROCK_BYOK_ENV_VAR = 'AWS_BEARER_TOKEN_BEDROCK';
 // A discriminated union (rather than an optional `baseUrl` on one shape) lets
 // every OTHER caller narrow `kind !== 'bedrock'` and use `baseUrl` as a plain
 // `string` with no assertion.
+// `npm` is the models.dev `npm` field (verbatim) — it selects the AI SDK
+// provider package under the 'ai-sdk' transport engine; ignored by the native
+// transports.
 export type CatalogUpstream =
-  | { kind: 'bedrock'; envVar: string }
-  | { kind: Exclude<ProviderKind, 'bedrock'>; envVar: string; baseUrl: string };
+  | { kind: 'bedrock'; envVar: string; npm?: string }
+  | { kind: Exclude<ProviderKind, 'bedrock'>; envVar: string; baseUrl: string; npm?: string };
 
 /** Resolve provider transport metadata from the API-owned runtime catalog. */
 export function resolveCatalogUpstream(providerId: string): CatalogUpstream | null {
@@ -62,7 +65,7 @@ export function resolveCatalogUpstream(providerId: string): CatalogUpstream | nu
   // resolved explicitly here rather than falling through to the generic
   // single-key path below.
   if (kind === 'bedrock') {
-    return { envVar: BEDROCK_BYOK_ENV_VAR, kind };
+    return { envVar: BEDROCK_BYOK_ENV_VAR, kind, npm: provider.npm ?? undefined };
   }
 
   const baseUrl =
@@ -70,5 +73,5 @@ export function resolveCatalogUpstream(providerId: string): CatalogUpstream | nu
   const envVar = provider.env?.[0];
   if (!baseUrl || !envVar) return null;
 
-  return { baseUrl, envVar, kind };
+  return { baseUrl, envVar, kind, npm: provider.npm ?? undefined };
 }

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -86,6 +86,10 @@ function bedrockManagedDescriptor(managed: ManagedModel): UpstreamDescriptor | n
     kind: 'bedrock',
     baseUrl: bedrockBaseUrl(),
     apiKey: config.AWS_BEDROCK_API_KEY,
+    // Region for the AI-SDK engine's Bedrock provider (bearer-token auth still
+    // comes from apiKey; region only picks the endpoint host). Ignored by the
+    // native path, which bakes the region into baseUrl.
+    region: config.AWS_BEDROCK_REGION || 'us-west-2',
     billingMode: 'credits',
     markup: llmPriceMarkup(),
     resolvedModel: managed.upstreamModelId,

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -150,16 +150,20 @@ export async function resolveCandidates(
       // back to DEFAULT_BEDROCK_BYOK_REGION when unset), never from deployment
       // config. Every other BYOK provider already carries a static baseUrl on
       // `byok`, narrowed to `string` by the `byok.kind === 'bedrock'` check.
-      const baseUrl =
+      // Bedrock's project-scoped region also feeds the AI-SDK engine's Bedrock
+      // provider (descriptor.region); resolve it once for both baseUrl + region.
+      const bedrockRegion =
         byok.kind === 'bedrock'
-          ? bedrockByokBaseUrl(
-              await getProjectSecretValue(principal.projectId, BEDROCK_REGION_ENV_VAR),
-            )
-          : byok.baseUrl;
+          ? await getProjectSecretValue(principal.projectId, BEDROCK_REGION_ENV_VAR)
+          : undefined;
+      const baseUrl =
+        byok.kind === 'bedrock' ? bedrockByokBaseUrl(bedrockRegion) : byok.baseUrl;
       const byokDescriptor: UpstreamDescriptor = {
         provider,
         kind: byok.kind,
+        npm: byok.npm,
         baseUrl,
+        ...(bedrockRegion ? { region: bedrockRegion } : {}),
         apiKey: key,
         billingMode:
           config.KORTIX_BILLING_INTERNAL_ENABLED && !isFreeTier ? 'platform-fee' : 'none',

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -28,6 +28,7 @@ export function mountLlmGateway(app: OpenAPIHono): void {
             authToken: config.LLM_TRANSLATION_SIDECAR_AUTH_TOKEN || undefined,
           }
         : undefined,
+      transportEngine: config.LLM_TRANSPORT_ENGINE === 'ai-sdk' ? 'ai-sdk' : 'native',
     });
     const llm = new Hono();
     llm.get('/health', (c) =>

--- a/packages/llm-gateway/package.json
+++ b/packages/llm-gateway/package.json
@@ -13,7 +13,12 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@kortix/shared": "workspace:*"
+    "@ai-sdk/amazon-bedrock": "5.0.24",
+    "@ai-sdk/anthropic": "4.0.16",
+    "@ai-sdk/openai": "4.0.16",
+    "@ai-sdk/openai-compatible": "3.0.12",
+    "@kortix/shared": "workspace:*",
+    "ai": "7.0.31"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/packages/llm-gateway/src/domain/config.ts
+++ b/packages/llm-gateway/src/domain/config.ts
@@ -36,4 +36,12 @@ export interface GatewayConfig {
    * behavior — required for old self-host boxes and a gradual rollout.
    */
   translationSidecar?: TranslationSidecarConfig;
+  // Which transport engine executes upstream calls. 'native' (default) uses the
+  // hand-written per-provider transports (optionally fronted by the translation
+  // sidecar above). 'ai-sdk' routes replaceable providers (openai-compat /
+  // anthropic / bedrock) through the Vercel AI SDK provider packages, which own
+  // the provider quirks, adapting the result back to the same OpenAI-compatible
+  // /v1/llm contract. Codex (openai-responses) always stays native. Flag-gated
+  // for a proven, staged rollout and, ultimately, retiring the LiteLLM sidecar.
+  transportEngine?: 'native' | 'ai-sdk';
 }

--- a/packages/llm-gateway/src/domain/descriptor.ts
+++ b/packages/llm-gateway/src/domain/descriptor.ts
@@ -45,4 +45,13 @@ export interface UpstreamDescriptor {
   // any same-named client fields (e.g. OpenRouter's `provider` routing
   // preferences pinning managed models to reliable hosts). openai-compat only.
   bodyExtras?: Record<string, unknown>;
+  // The models.dev `npm` field for the provider (e.g. '@ai-sdk/openai',
+  // '@ai-sdk/anthropic', '@ai-sdk/amazon-bedrock'). Selects the AI SDK provider
+  // package under the 'ai-sdk' transport engine. Optional: when absent the engine
+  // falls back to `kind`. Ignored by the native transports.
+  npm?: string;
+  // AWS region for the Bedrock provider under the 'ai-sdk' engine (bearer-token
+  // auth still comes from `apiKey`; region only selects the endpoint host).
+  // Ignored by every other provider/engine.
+  region?: string;
 }

--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -2,15 +2,23 @@ import type { TranslationSidecarConfig, UpstreamDescriptor } from '../domain';
 import { ClientAbortError, NetworkError, UpstreamHttpError } from '../errors';
 import { type BreakerBinding, type RetryOptions, withResilience } from '../resilience';
 import { transportFor } from '../transports';
+import { callUpstreamViaAiSdk, isAiSdkServable } from '../transports/ai-sdk';
 import { resolveTransportKind } from '../transports/route-kind';
 import { buildSidecarRequest, isSidecarEligible } from '../transports/sidecar';
 
 export type FetchImpl = (input: string, init: RequestInit) => Promise<Response>;
 
+export type TransportEngine = 'native' | 'ai-sdk';
+
 export interface CallUpstreamOptions {
   retry?: RetryOptions;
   binding?: BreakerBinding;
   fetchImpl?: FetchImpl;
+  // Which transport engine executes this call. Defaults to 'native'. 'ai-sdk'
+  // routes replaceable providers through the Vercel AI SDK; a provider the
+  // AI-SDK engine cannot serve (openai-responses/Codex) transparently falls back
+  // to native regardless of this flag.
+  engine?: TransportEngine;
   /** See GatewayConfig.translationSidecar. Unset = direct upstream (current behavior). */
   translationSidecar?: TranslationSidecarConfig;
   /** Inbound client's abort signal — combined with the per-attempt timeout
@@ -30,6 +38,27 @@ export async function callUpstream(
   descriptor: UpstreamDescriptor,
   opts: CallUpstreamOptions = {},
 ): Promise<Response> {
+  // AI-SDK engine: the SDK provider package owns the request build, HTTP, and
+  // response decoding; the adapter maps its output back to the same OpenAI-
+  // compatible shape the native path produces (so the pipeline, billing, and
+  // opencode see no difference). Still wrapped in withResilience so the circuit
+  // breaker + gateway retry apply identically. Non-streaming awaits inside (a
+  // 4xx/5xx throws → retry/failover); streaming returns immediately (errors
+  // surface as an in-stream frame the pipeline probe handles), matching native
+  // timing. A provider the engine can't serve (Codex) falls through to native.
+  if (opts.engine === 'ai-sdk' && isAiSdkServable(descriptor)) {
+    return withResilience(
+      async (attemptSignal) => {
+        const signal = opts.signal
+          ? AbortSignal.any([attemptSignal, opts.signal])
+          : attemptSignal;
+        return callUpstreamViaAiSdk(body, descriptor, { signal });
+      },
+      opts.retry ?? {},
+      opts.binding,
+    );
+  }
+
   const fetchImpl: FetchImpl = opts.fetchImpl ?? ((input, init) => fetch(input, init));
   // Resolved per-request (not just from the descriptor's static `kind`): a
   // genuine-OpenAI reasoning model with function tools + a live reasoning

--- a/packages/llm-gateway/src/http/index.ts
+++ b/packages/llm-gateway/src/http/index.ts
@@ -1,2 +1,2 @@
 export { callUpstream } from './call-upstream';
-export type { CallUpstreamOptions, FetchImpl } from './call-upstream';
+export type { CallUpstreamOptions, FetchImpl, TransportEngine } from './call-upstream';

--- a/packages/llm-gateway/src/index.ts
+++ b/packages/llm-gateway/src/index.ts
@@ -4,7 +4,7 @@ export { gatewayErrorBody, gatewayErrorResponse } from './pipeline/error-respons
 export type { GatewayErrorContext } from './pipeline/error-response';
 
 export { callUpstream } from './http';
-export type { CallUpstreamOptions, FetchImpl } from './http';
+export type { CallUpstreamOptions, FetchImpl, TransportEngine } from './http';
 
 export {
   CircuitBreaker,

--- a/packages/llm-gateway/src/pipeline/failover.ts
+++ b/packages/llm-gateway/src/pipeline/failover.ts
@@ -162,6 +162,7 @@ export async function runFailover(ctx: FailoverContext): Promise<FailoverResult>
         binding: { provider: descriptor.provider, breaker },
         fetchImpl,
         translationSidecar: config.translationSidecar,
+        engine: config.transportEngine ?? 'native',
         signal,
         requestId,
       });

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from 'bun:test';
+import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
+import { streamText } from 'ai';
+import { calculateCost, extractUsageFromSseBuffer } from '../../usage';
+import { sseErrorFrame, sseHasContent } from '../../usage/completion-guard';
+import type { UpstreamDescriptor } from '../../domain';
+import { aiSdkFamilyFor } from './model';
+import { buildAiSdkArgs, toModelMessages } from './request';
+import { openAiJsonFromResult, openAiSseFromFullStream } from './sse';
+
+// A fullStream is just an async iterable of TextStreamPart-shaped objects — feed
+// the adapter the exact parts streamText emits and assert the OpenAI SSE bytes.
+async function* parts(...items: Array<Record<string, unknown>>) {
+  for (const item of items) yield item as { type: string; [k: string]: unknown };
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+// Parse `data: {...}` frames (ignoring [DONE] + heartbeats) — the same view the
+// gateway's probe/relay/usage-extraction take of the stream.
+function frames(sse: string): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const line of sse.split('\n')) {
+    if (!line.startsWith('data:')) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === '[DONE]') continue;
+    out.push(JSON.parse(payload));
+  }
+  return out;
+}
+
+const usage = (over: Record<string, unknown> = {}) => ({
+  inputTokens: 100,
+  outputTokens: 50,
+  totalTokens: 150,
+  inputTokenDetails: { cacheReadTokens: 20 },
+  outputTokenDetails: { reasoningTokens: 10 },
+  ...over,
+});
+
+const CTX = { model: 'openai/gpt-5.6', provider: 'openai' };
+
+describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
+  it('streams text as OpenAI chat.completion.chunk deltas + usage + [DONE]', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts(
+          { type: 'text-delta', id: '1', text: 'Hello' },
+          { type: 'text-delta', id: '1', text: ' world' },
+          { type: 'finish', finishReason: 'stop', totalUsage: usage() },
+        ),
+        CTX,
+      ),
+    );
+
+    expect(sse.endsWith('data: [DONE]\n\n')).toBe(true);
+    expect(sseHasContent(sse)).toBe(true);
+
+    const f = frames(sse);
+    // First delta carries the assistant role.
+    expect((f[0] as any).choices[0].delta.role).toBe('assistant');
+    const text = f
+      .map((c: any) => c.choices?.[0]?.delta?.content ?? '')
+      .join('');
+    expect(text).toBe('Hello world');
+    // Every chunk is a chat.completion.chunk on the right model.
+    expect(f.every((c: any) => c.object === 'chat.completion.chunk' || c.usage)).toBe(true);
+    // Terminal finish_reason then usage-only chunk.
+    const finishChunk = f.find((c: any) => c.choices?.[0]?.finish_reason);
+    expect((finishChunk as any).choices[0].finish_reason).toBe('stop');
+    const usageChunk = f.find((c: any) => c.usage);
+    expect((usageChunk as any).usage.prompt_tokens).toBe(100);
+    expect((usageChunk as any).usage.completion_tokens).toBe(50);
+    expect((usageChunk as any).usage.prompt_tokens_details.cached_tokens).toBe(20);
+  });
+
+  it('streams tool calls as incremental OpenAI tool_calls deltas', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts(
+          { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
+          { type: 'tool-input-delta', id: 'call_1', delta: '{"city":' },
+          { type: 'tool-input-delta', id: 'call_1', delta: '"Paris"}' },
+          { type: 'tool-call', toolCallId: 'call_1', toolName: 'get_weather', input: { city: 'Paris' } },
+          { type: 'finish', finishReason: 'tool-calls', totalUsage: usage() },
+        ),
+        CTX,
+      ),
+    );
+    expect(sseHasContent(sse)).toBe(true);
+    const f = frames(sse);
+    const toolDeltas = f
+      .flatMap((c: any) => c.choices?.[0]?.delta?.tool_calls ?? []);
+    // One opening delta (index 0, id, name) + two argument deltas; the terminal
+    // `tool-call` for the same id is NOT re-emitted (already streamed).
+    expect(toolDeltas[0]).toMatchObject({
+      index: 0,
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'get_weather', arguments: '' },
+    });
+    const args = toolDeltas.map((t: any) => t.function?.arguments ?? '').join('');
+    expect(args).toBe('{"city":"Paris"}');
+    const finishChunk = f.find((c: any) => c.choices?.[0]?.finish_reason);
+    expect((finishChunk as any).choices[0].finish_reason).toBe('tool_calls');
+  });
+
+  it('emits a full tool_call when the provider gives no input-start/delta', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts(
+          { type: 'tool-call', toolCallId: 'c2', toolName: 'search', input: { q: 'hi' } },
+          { type: 'finish', finishReason: 'tool-calls', totalUsage: usage() },
+        ),
+        CTX,
+      ),
+    );
+    const tc = frames(sse).flatMap((c: any) => c.choices?.[0]?.delta?.tool_calls ?? [])[0];
+    expect(tc).toMatchObject({
+      index: 0,
+      id: 'c2',
+      function: { name: 'search', arguments: '{"q":"hi"}' },
+    });
+  });
+
+  it('surfaces an upstream error as an OpenAI error frame the probe detects', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts({ type: 'error', error: Object.assign(new Error('overloaded'), { statusCode: 529 }) }),
+        CTX,
+      ),
+    );
+    const frame = sseErrorFrame(sse);
+    expect(frame?.message).toBe('overloaded');
+    expect(frame?.code).toBe(529);
+  });
+
+  it('maps reasoning deltas to delta.reasoning (counts as content)', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts(
+          { type: 'reasoning-delta', id: 'r', text: 'thinking...' },
+          { type: 'text-delta', id: '1', text: 'answer' },
+          { type: 'finish', finishReason: 'stop', totalUsage: usage() },
+        ),
+        CTX,
+      ),
+    );
+    expect(sseHasContent(sse)).toBe(true);
+    const reasoning = frames(sse)
+      .map((c: any) => c.choices?.[0]?.delta?.reasoning ?? '')
+      .join('');
+    expect(reasoning).toBe('thinking...');
+  });
+});
+
+describe('ai-sdk billing parity vs native openai-compat', () => {
+  // The native path forwards the provider's OpenAI-shaped usage verbatim; the
+  // AI-SDK path maps LanguageModelUsage → the same shape. For any given token
+  // counts, extract + cost must be identical on both engines.
+  const pricing = { inputPerMillion: 3, outputPerMillion: 15, cachedInputPerMillion: 0.3 };
+
+  it('extracts identical token counts + cost from both engines', async () => {
+    // AI-SDK engine output.
+    const aiSse = await readAll(
+      openAiSseFromFullStream(
+        parts(
+          { type: 'text-delta', id: '1', text: 'hi' },
+          { type: 'finish', finishReason: 'stop', totalUsage: usage({ inputTokens: 1000, outputTokens: 400, totalTokens: 1400, inputTokenDetails: { cacheReadTokens: 250 } }) },
+        ),
+        CTX,
+      ),
+    );
+    // Equivalent native OpenAI SSE (what openai-compat forwards verbatim).
+    const nativeSse =
+      `data: ${JSON.stringify({ model: 'openai/gpt-5.6', choices: [{ delta: { content: 'hi' } }] })}\n\n` +
+      `data: ${JSON.stringify({ model: 'openai/gpt-5.6', choices: [], usage: { prompt_tokens: 1000, completion_tokens: 400, total_tokens: 1400, prompt_tokens_details: { cached_tokens: 250 } } })}\n\n` +
+      'data: [DONE]\n\n';
+
+    const aiUsage = extractUsageFromSseBuffer(aiSse);
+    const nativeUsage = extractUsageFromSseBuffer(nativeSse);
+    expect(aiUsage).not.toBeNull();
+    expect(aiUsage!.promptTokens).toBe(nativeUsage!.promptTokens);
+    expect(aiUsage!.completionTokens).toBe(nativeUsage!.completionTokens);
+    expect(aiUsage!.cachedTokens).toBe(nativeUsage!.cachedTokens);
+
+    const counts = (u: any) => ({
+      promptTokens: u.promptTokens,
+      completionTokens: u.completionTokens,
+      cachedTokens: u.cachedTokens,
+    });
+    const aiCost = calculateCost('gpt', counts(aiUsage), 1.1, aiUsage!.upstreamCostHint, pricing);
+    const nativeCost = calculateCost('gpt', counts(nativeUsage), 1.1, nativeUsage!.upstreamCostHint, pricing);
+    expect(aiCost.upstreamCost).toBe(nativeCost.upstreamCost);
+    expect(aiCost.finalCost).toBe(nativeCost.finalCost);
+    expect(aiCost.upstreamCost).toBeGreaterThan(0);
+  });
+});
+
+describe('ai-sdk request conversion', () => {
+  it('resolves the provider family from npm then kind', () => {
+    const d = (over: Partial<UpstreamDescriptor>): UpstreamDescriptor => ({
+      provider: 'p', kind: 'openai-compat', baseUrl: '', apiKey: '', billingMode: 'none', markup: 0, ...over,
+    });
+    expect(aiSdkFamilyFor(d({ npm: '@ai-sdk/openai' }))).toBe('openai');
+    expect(aiSdkFamilyFor(d({ npm: '@ai-sdk/anthropic' }))).toBe('anthropic');
+    expect(aiSdkFamilyFor(d({ npm: '@ai-sdk/amazon-bedrock' }))).toBe('bedrock');
+    // Fallback to kind when npm is absent/unknown.
+    expect(aiSdkFamilyFor(d({ kind: 'anthropic' }))).toBe('anthropic');
+    expect(aiSdkFamilyFor(d({ kind: 'bedrock' }))).toBe('bedrock');
+    expect(aiSdkFamilyFor(d({ kind: 'openai-compat' }))).toBe('openai-compatible');
+    expect(aiSdkFamilyFor(d({ npm: 'unknown', kind: 'custom' }))).toBe('openai-compatible');
+  });
+
+  it('hoists system, translates tool calls + tool results', () => {
+    const { system, messages } = toModelMessages([
+      { role: 'system', content: 'be brief' },
+      { role: 'user', content: 'weather?' },
+      { role: 'assistant', content: '', tool_calls: [{ id: 'c1', function: { name: 'wx', arguments: '{"city":"Paris"}' } }] },
+      { role: 'tool', tool_call_id: 'c1', name: 'wx', content: 'sunny' },
+    ]);
+    expect(system).toBe('be brief');
+    expect(messages[0]).toEqual({ role: 'user', content: 'weather?' });
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'c1', toolName: 'wx', input: { city: 'Paris' } }],
+    });
+    expect(messages[2]).toMatchObject({
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'c1', output: { type: 'text', value: 'sunny' } }],
+    });
+  });
+
+  it('translates image_url user parts', () => {
+    const { messages } = toModelMessages([
+      { role: 'user', content: [{ type: 'text', text: 'what is this' }, { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } }] },
+    ]);
+    expect(messages[0]).toMatchObject({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'what is this' },
+        { type: 'image', image: 'data:image/png;base64,AAAA' },
+      ],
+    });
+  });
+
+  it('defaults maxOutputTokens for anthropic/bedrock, maps reasoning_effort + tool_choice', () => {
+    const anthropic = buildAiSdkArgs({ messages: [], reasoning_effort: 'high', tools: [{ function: { name: 't', parameters: {} } }], tool_choice: 'required' }, 'anthropic');
+    expect(anthropic.maxOutputTokens).toBe(4096);
+    expect(anthropic.toolChoice).toBe('required');
+    expect(anthropic.tools).toBeTruthy();
+
+    const openai = buildAiSdkArgs({ messages: [], reasoning_effort: 'high', max_tokens: 2000 }, 'openai');
+    expect(openai.maxOutputTokens).toBe(2000);
+    expect(openai.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+  });
+});
+
+describe('ai-sdk end-to-end via streamText + mock model', () => {
+  it('drives streamText through a mock provider and emits valid OpenAI SSE', async () => {
+    const mock = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [ /* LanguageModelV4StreamPart[]; cast to skip union narrowing */
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: '0' },
+            { type: 'text-delta', id: '0', delta: 'Hi ' },
+            { type: 'text-delta', id: '0', delta: 'there' },
+            { type: 'text-end', id: '0' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              // LanguageModelV4 provider-level usage shape (nested totals).
+              usage: {
+                inputTokens: { total: 12, noCache: 12, cacheRead: 0, cacheWrite: 0 },
+                outputTokens: { total: 3, reasoning: 0 },
+                totalTokens: 15,
+              },
+            },
+          ] as any,
+        }),
+      }),
+    });
+
+    const result = streamText({ model: mock, prompt: 'hello', maxRetries: 0 });
+    const sse = await readAll(openAiSseFromFullStream(result.fullStream, { model: 'mock/x', provider: 'mock' }));
+
+    expect(sseHasContent(sse)).toBe(true);
+    const text = frames(sse).map((c: any) => c.choices?.[0]?.delta?.content ?? '').join('');
+    expect(text).toBe('Hi there');
+    const u = extractUsageFromSseBuffer(sse);
+    expect(u!.promptTokens).toBe(12);
+    expect(u!.completionTokens).toBe(3);
+  });
+});
+
+describe('ai-sdk non-streaming JSON adapter', () => {
+  it('produces a chat.completion with tool_calls + usage jsonHasContent sees', () => {
+    const json = openAiJsonFromResult(
+      {
+        text: '',
+        toolCalls: [{ toolCallId: 'c1', toolName: 'wx', input: { city: 'Paris' } }],
+        finishReason: 'tool-calls',
+        usage: usage() as any,
+      },
+      CTX,
+    ) as any;
+    expect(json.object).toBe('chat.completion');
+    expect(json.choices[0].finish_reason).toBe('tool_calls');
+    expect(json.choices[0].message.tool_calls[0]).toMatchObject({
+      id: 'c1',
+      function: { name: 'wx', arguments: '{"city":"Paris"}' },
+    });
+    expect(json.usage.prompt_tokens).toBe(100);
+  });
+});

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -1,0 +1,106 @@
+import { generateText, streamText } from 'ai';
+import { NetworkError, UpstreamHttpError } from '../../errors';
+import type { UpstreamDescriptor } from '../../domain';
+import { resolveAiModel, aiSdkFamilyFor } from './model';
+import { buildAiSdkArgs } from './request';
+import { openAiJsonFromResult, openAiSseFromFullStream } from './sse';
+
+export { aiSdkFamilyFor, isAiSdkServable, resolveAiModel } from './model';
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function sseResponse(stream: ReadableStream<Uint8Array>): Response {
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    },
+  });
+}
+
+// Map an AI SDK error into the gateway's transport error taxonomy so failover,
+// retry, and the circuit breaker behave identically to the native path.
+function toTransportError(err: unknown, provider: string): Error {
+  const e = err as { statusCode?: number; responseBody?: string; message?: string; url?: string };
+  if (typeof e?.statusCode === 'number') {
+    return new UpstreamHttpError(e.statusCode, e.responseBody ?? e.message ?? '', provider);
+  }
+  return new NetworkError(`ai-sdk call to ${provider} failed`, err);
+}
+
+// The AI-SDK transport engine. Given the same OpenAI chat.completions body and
+// descriptor the native path receives, drive the AI SDK provider package and
+// return a Response in the SAME OpenAI-compatible shape (SSE for stream, JSON
+// otherwise) — so the pipeline, billing, and opencode see no difference.
+//
+// Streaming returns immediately (matching native): errors then surface as an
+// in-stream OpenAI error frame the pipeline probe already handles. Non-streaming
+// awaits the call so a 4xx/5xx throws here and drives the same failover.
+export async function callUpstreamViaAiSdk(
+  body: Record<string, unknown>,
+  descriptor: UpstreamDescriptor,
+  opts: { signal?: AbortSignal } = {},
+): Promise<Response> {
+  const family = aiSdkFamilyFor(descriptor);
+  const model = resolveAiModel(descriptor);
+  const args = buildAiSdkArgs(body, family);
+  const streaming = body.stream === true;
+  const ctx = { model: descriptor.resolvedModel || String(body.model ?? ''), provider: descriptor.provider };
+
+  const shared = {
+    model,
+    system: args.system,
+    messages: args.messages,
+    tools: args.tools,
+    toolChoice: args.toolChoice,
+    temperature: args.temperature,
+    topP: args.topP,
+    maxOutputTokens: args.maxOutputTokens,
+    stopSequences: args.stopSequences,
+    providerOptions: args.providerOptions,
+    // The gateway owns retry/failover/circuit-breaking; keep the SDK from adding a
+    // second, opaque retry layer on top.
+    maxRetries: 0,
+    abortSignal: opts.signal,
+  } as const;
+
+  if (streaming) {
+    const result = streamText({
+      ...shared,
+      onError: () => {
+        /* error is surfaced through fullStream as an `error` part; swallow the
+           unhandled-rejection path here. */
+      },
+    });
+    return sseResponse(openAiSseFromFullStream(result.fullStream, ctx));
+  }
+
+  try {
+    const result = await generateText(shared);
+    return jsonResponse(
+      openAiJsonFromResult(
+        {
+          text: result.text,
+          reasoningText: result.reasoningText,
+          toolCalls: result.toolCalls?.map((tc) => ({
+            toolCallId: tc.toolCallId,
+            toolName: tc.toolName,
+            input: (tc as { input?: unknown }).input,
+          })),
+          finishReason: result.finishReason,
+          usage: result.usage,
+        },
+        ctx,
+      ),
+    );
+  } catch (err) {
+    throw toTransportError(err, descriptor.provider);
+  }
+}

--- a/packages/llm-gateway/src/transports/ai-sdk/model.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/model.ts
@@ -1,0 +1,91 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import type { LanguageModel } from 'ai';
+import type { UpstreamDescriptor } from '../../domain';
+
+// Which AI SDK provider package a descriptor maps to. Prefer the models.dev
+// `npm` field (verbatim from the live catalog, #4893); fall back to the transport
+// `kind` so a descriptor that predates npm threading still resolves correctly.
+export type AiSdkFamily = 'openai' | 'openai-compatible' | 'anthropic' | 'bedrock';
+
+const OPENAI_NPM = '@ai-sdk/openai';
+const ANTHROPIC_NPM = '@ai-sdk/anthropic';
+const BEDROCK_NPM = '@ai-sdk/amazon-bedrock';
+
+export function aiSdkFamilyFor(descriptor: UpstreamDescriptor): AiSdkFamily {
+  const npm = descriptor.npm;
+  if (npm === OPENAI_NPM) return 'openai';
+  if (npm === ANTHROPIC_NPM) return 'anthropic';
+  if (npm === BEDROCK_NPM) return 'bedrock';
+  // Fall back to the transport kind. `openai-compat`/`custom` → the generic
+  // OpenAI-compatible provider (the safe default for any /v1/chat/completions
+  // upstream, e.g. OpenRouter). anthropic/bedrock map to their native packages.
+  switch (descriptor.kind) {
+    case 'anthropic':
+      return 'anthropic';
+    case 'bedrock':
+      return 'bedrock';
+    default:
+      return 'openai-compatible';
+  }
+}
+
+// AI-SDK-native model families the engine can serve. `openai-responses` (Codex)
+// is intentionally excluded — it keeps the native transport regardless of engine.
+export function isAiSdkServable(descriptor: UpstreamDescriptor): boolean {
+  return descriptor.kind !== 'openai-responses';
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+// Build the AI SDK language model for this descriptor. The provider package owns
+// every provider-specific wire quirk (endpoint shape, param names, tool schema
+// translation, prompt caching, SSE decoding) — we only supply credentials, base
+// URL, and the resolved model id.
+export function resolveAiModel(descriptor: UpstreamDescriptor): LanguageModel {
+  const modelId = descriptor.resolvedModel || '';
+  const baseURL = descriptor.baseUrl ? trimTrailingSlash(descriptor.baseUrl) : undefined;
+  const headers = descriptor.headers;
+  const family = aiSdkFamilyFor(descriptor);
+
+  switch (family) {
+    case 'openai': {
+      const provider = createOpenAI({ baseURL, apiKey: descriptor.apiKey, headers });
+      // Use the Responses API, not chat.completions. OpenAI's reasoning models
+      // (gpt-5.x, o-series) reject function tools alongside reasoning_effort on
+      // /v1/chat/completions — the SDK injects reasoning_effort for them, so a
+      // real gpt-5.6 tool-call turn 400s there. /v1/responses supports reasoning
+      // + tools together, and the adapter output is identical either way.
+      return provider.responses(modelId);
+    }
+    case 'anthropic': {
+      const provider = createAnthropic({ baseURL, apiKey: descriptor.apiKey, headers });
+      return provider(modelId);
+    }
+    case 'bedrock': {
+      // Essentia + the enterprise appliance authenticate with a long-lived bearer
+      // token (apiKey), not SigV4 — it takes precedence over AWS credentials in the
+      // provider. Region is required by the SDK for the endpoint host.
+      const provider = createAmazonBedrock({
+        baseURL,
+        apiKey: descriptor.apiKey,
+        region: descriptor.region || process.env.AWS_REGION || 'us-east-1',
+        headers,
+      });
+      return provider(modelId);
+    }
+    default: {
+      const provider = createOpenAICompatible({
+        name: descriptor.provider || 'openai-compatible',
+        baseURL: baseURL || '',
+        apiKey: descriptor.apiKey,
+        headers,
+      });
+      return provider.chatModel(modelId);
+    }
+  }
+}

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -1,0 +1,208 @@
+import { jsonSchema, tool, type ModelMessage, type ToolChoice, type ToolSet } from 'ai';
+import type { AiSdkFamily } from './model';
+
+// Everything the AI-SDK engine needs to drive `streamText`/`generateText`,
+// derived once from the incoming OpenAI chat.completions body. The AI SDK owns
+// per-provider quirks from here on (endpoint, param names, tool translation).
+export interface AiSdkCallArgs {
+  system?: string;
+  messages: ModelMessage[];
+  tools?: ToolSet;
+  toolChoice?: ToolChoice<ToolSet>;
+  temperature?: number;
+  topP?: number;
+  maxOutputTokens?: number;
+  stopSequences?: string[];
+  providerOptions?: Record<string, Record<string, string>>;
+}
+
+function safeParseJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value ?? {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function textOf(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && typeof part === 'object' && 'text' in part
+          ? String((part as { text?: unknown }).text ?? '')
+          : '',
+      )
+      .join('');
+  }
+  return '';
+}
+
+type UserContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image'; image: URL | string };
+
+function translateUserContent(content: unknown): string | UserContentPart[] {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return textOf(content);
+  const parts: UserContentPart[] = [];
+  for (const raw of content) {
+    const part = raw as { type?: string; text?: string; image_url?: { url?: string } };
+    if (part?.type === 'text') parts.push({ type: 'text', text: String(part.text ?? '') });
+    else if (part?.type === 'image_url' && part.image_url?.url) {
+      const url = part.image_url.url;
+      parts.push({ type: 'image', image: url });
+    }
+  }
+  return parts.length ? parts : textOf(content);
+}
+
+interface OpenAiToolCall {
+  id?: string;
+  function?: { name?: string; arguments?: string };
+}
+
+// OpenAI chat.completions messages → AI SDK ModelMessage[]. System messages are
+// hoisted into `system` (kept separate so provider prompt-caching works). The
+// role/tool-call/tool-result shape mirrors what the native transports build, but
+// in the neutral AI-SDK core format the provider package then re-serializes.
+export function toModelMessages(rawMessages: unknown): { system?: string; messages: ModelMessage[] } {
+  const messages = Array.isArray(rawMessages) ? rawMessages : [];
+  const systemParts: string[] = [];
+  const out: ModelMessage[] = [];
+
+  for (const raw of messages) {
+    const m = raw as {
+      role?: string;
+      content?: unknown;
+      tool_calls?: OpenAiToolCall[];
+      tool_call_id?: string;
+      name?: string;
+    };
+    if (m.role === 'system' || m.role === 'developer') {
+      systemParts.push(textOf(m.content));
+      continue;
+    }
+    if (m.role === 'tool') {
+      out.push({
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: m.tool_call_id ?? '',
+            toolName: m.name ?? '',
+            output: {
+              type: 'text',
+              value: typeof m.content === 'string' ? m.content : JSON.stringify(m.content ?? ''),
+            },
+          },
+        ],
+      });
+      continue;
+    }
+    if (m.role === 'assistant') {
+      const parts: Array<
+        | { type: 'text'; text: string }
+        | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
+      > = [];
+      const text = textOf(m.content);
+      if (text) parts.push({ type: 'text', text });
+      for (const tc of m.tool_calls ?? []) {
+        parts.push({
+          type: 'tool-call',
+          toolCallId: tc.id ?? '',
+          toolName: tc.function?.name ?? '',
+          input: safeParseJson(tc.function?.arguments),
+        });
+      }
+      out.push({
+        role: 'assistant',
+        content: parts.length ? parts : text,
+      });
+      continue;
+    }
+    out.push({ role: 'user', content: translateUserContent(m.content) });
+  }
+
+  return {
+    system: systemParts.filter(Boolean).join('\n\n') || undefined,
+    messages: out,
+  };
+}
+
+// OpenAI `tools` → an AI SDK ToolSet with NO `execute`. Without an executor the
+// SDK surfaces the model's tool call in the stream and stops the step (it never
+// tries to run the tool), which is exactly the relay-to-client behaviour the
+// gateway needs — opencode executes tools, not us.
+function toToolSet(rawTools: unknown): ToolSet | undefined {
+  if (!Array.isArray(rawTools) || rawTools.length === 0) return undefined;
+  const set: ToolSet = {};
+  for (const raw of rawTools) {
+    const fn = (raw as { function?: { name?: string; description?: string; parameters?: unknown } })
+      .function;
+    if (!fn?.name) continue;
+    set[fn.name] = tool({
+      description: fn.description,
+      inputSchema: jsonSchema((fn.parameters as object) ?? { type: 'object', properties: {} }),
+    });
+  }
+  return Object.keys(set).length ? set : undefined;
+}
+
+function toToolChoice(raw: unknown): ToolChoice<ToolSet> | undefined {
+  if (raw === 'required') return 'required';
+  if (raw === 'auto') return 'auto';
+  if (raw === 'none') return 'none';
+  if (raw && typeof raw === 'object') {
+    const name = (raw as { function?: { name?: string } }).function?.name;
+    if (name) return { type: 'tool', toolName: name };
+  }
+  return undefined;
+}
+
+const REASONING_FAMILY_KEY: Record<AiSdkFamily, string> = {
+  openai: 'openai',
+  'openai-compatible': 'openai',
+  anthropic: 'anthropic',
+  bedrock: 'bedrock',
+};
+
+export function buildAiSdkArgs(
+  body: Record<string, unknown>,
+  family: AiSdkFamily,
+): AiSdkCallArgs {
+  const { system, messages } = toModelMessages(body.messages);
+  const tools = toToolSet(body.tools);
+  const toolChoice = tools ? toToolChoice(body.tool_choice) : undefined;
+
+  const maxTokens =
+    (typeof body.max_tokens === 'number' ? body.max_tokens : undefined) ??
+    (typeof body.max_completion_tokens === 'number' ? body.max_completion_tokens : undefined) ??
+    (family === 'anthropic' || family === 'bedrock' ? 4096 : undefined);
+
+  const stop = body.stop;
+  const stopSequences =
+    typeof stop === 'string' ? [stop] : Array.isArray(stop) ? (stop as string[]) : undefined;
+
+  const providerOptions: Record<string, Record<string, string>> = {};
+  const reasoningEffort = body.reasoning_effort;
+  if (typeof reasoningEffort === 'string') {
+    // The AI SDK's OpenAI provider strips temperature and other unsupported params
+    // for reasoning models on its own — we only forward the effort. openai-compatible
+    // upstreams (OpenRouter) accept the same field under the provider namespace.
+    providerOptions[REASONING_FAMILY_KEY[family]] = { reasoningEffort };
+  }
+
+  return {
+    system,
+    messages,
+    tools,
+    toolChoice,
+    temperature: typeof body.temperature === 'number' ? body.temperature : undefined,
+    topP: typeof body.top_p === 'number' ? body.top_p : undefined,
+    maxOutputTokens: maxTokens,
+    stopSequences,
+    providerOptions: Object.keys(providerOptions).length ? providerOptions : undefined,
+  };
+}

--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -1,0 +1,257 @@
+import type { FinishReason, LanguageModelUsage } from 'ai';
+
+// Adapts the AI SDK's provider-neutral stream/result back into the OpenAI
+// chat.completions SSE + JSON shapes the gateway pipeline (probe, relay, usage
+// extraction, billing, trace) and opencode both depend on. THIS is the contract
+// boundary — the bytes produced here must be byte-compatible with what the native
+// openai-compat transport emits, so nothing downstream can tell the paths apart.
+
+const enc = new TextEncoder();
+
+export interface OpenAiUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  prompt_tokens_details?: { cached_tokens: number };
+  completion_tokens_details?: { reasoning_tokens: number };
+}
+
+// LanguageModelUsage → OpenAI `usage`. `inputTokens` is the full prompt count
+// (cached included), matching OpenAI's `prompt_tokens`; the cached subset is
+// broken out under `prompt_tokens_details.cached_tokens` exactly as the native
+// path forwards it, so the gateway's usage extractor + pricing table produce the
+// same cost on both engines.
+export function mapUsage(usage: LanguageModelUsage | undefined): OpenAiUsage {
+  const prompt = usage?.inputTokens ?? 0;
+  const completion = usage?.outputTokens ?? 0;
+  const cached = usage?.inputTokenDetails?.cacheReadTokens ?? 0;
+  const reasoning = usage?.outputTokenDetails?.reasoningTokens ?? 0;
+  const total = usage?.totalTokens ?? prompt + completion;
+  const out: OpenAiUsage = {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: total,
+  };
+  if (cached > 0) out.prompt_tokens_details = { cached_tokens: cached };
+  if (reasoning > 0) out.completion_tokens_details = { reasoning_tokens: reasoning };
+  return out;
+}
+
+export function mapFinishReason(reason: FinishReason | undefined): string {
+  switch (reason) {
+    case 'tool-calls':
+      return 'tool_calls';
+    case 'length':
+      return 'length';
+    case 'content-filter':
+      return 'content_filter';
+    case 'stop':
+      return 'stop';
+    default:
+      return 'stop';
+  }
+}
+
+function chatId(): string {
+  return `chatcmpl-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function sse(obj: unknown): Uint8Array {
+  return enc.encode(`data: ${JSON.stringify(obj)}\n\n`);
+}
+
+interface StreamCtx {
+  model: string;
+  provider: string;
+}
+
+// AI SDK `fullStream` (TextStreamPart union) → OpenAI chat.completions SSE.
+export function openAiSseFromFullStream(
+  fullStream: AsyncIterable<{ type: string; [k: string]: unknown }>,
+  ctx: StreamCtx,
+): ReadableStream<Uint8Array> {
+  const id = chatId();
+  const created = Math.floor(Date.now() / 1000);
+  const base = { id, object: 'chat.completion.chunk', created, model: ctx.model };
+
+  // Map AI SDK tool-call ids → dense OpenAI tool_call indices, and remember which
+  // ids already opened a streamed call so a terminal `tool-call` part for the same
+  // id doesn't re-emit the name/arguments.
+  const toolIndex = new Map<string, number>();
+  let nextToolIndex = 0;
+  const streamedTools = new Set<string>();
+  let roleSent = false;
+
+  const delta = (d: Record<string, unknown>, finishReason: string | null = null): Uint8Array =>
+    sse({ ...base, choices: [{ index: 0, delta: d, finish_reason: finishReason }] });
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const emit = (bytes: Uint8Array): void => controller.enqueue(bytes);
+      let usage: LanguageModelUsage | undefined;
+      let finishReason: FinishReason | undefined;
+      try {
+        for await (const part of fullStream) {
+          switch (part.type) {
+            case 'text-delta': {
+              if (!roleSent) {
+                emit(delta({ role: 'assistant', content: '' }));
+                roleSent = true;
+              }
+              const text = part.text as string;
+              if (text) emit(delta({ content: text }));
+              break;
+            }
+            case 'reasoning-delta': {
+              if (!roleSent) {
+                emit(delta({ role: 'assistant', content: '' }));
+                roleSent = true;
+              }
+              const text = part.text as string;
+              if (text) emit(delta({ reasoning: text }));
+              break;
+            }
+            case 'tool-input-start': {
+              if (!roleSent) {
+                emit(delta({ role: 'assistant', content: '' }));
+                roleSent = true;
+              }
+              const tid = part.id as string;
+              const index = nextToolIndex++;
+              toolIndex.set(tid, index);
+              streamedTools.add(tid);
+              emit(
+                delta({
+                  tool_calls: [
+                    {
+                      index,
+                      id: tid,
+                      type: 'function',
+                      function: { name: part.toolName as string, arguments: '' },
+                    },
+                  ],
+                }),
+              );
+              break;
+            }
+            case 'tool-input-delta': {
+              const tid = part.id as string;
+              const index = toolIndex.get(tid);
+              if (index === undefined) break;
+              emit(
+                delta({
+                  tool_calls: [{ index, function: { arguments: (part.delta as string) ?? '' } }],
+                }),
+              );
+              break;
+            }
+            case 'tool-call': {
+              const tid = part.toolCallId as string;
+              if (streamedTools.has(tid)) break; // already streamed via input-start/delta
+              if (!roleSent) {
+                emit(delta({ role: 'assistant', content: '' }));
+                roleSent = true;
+              }
+              const index = nextToolIndex++;
+              emit(
+                delta({
+                  tool_calls: [
+                    {
+                      index,
+                      id: tid,
+                      type: 'function',
+                      function: {
+                        name: part.toolName as string,
+                        arguments: JSON.stringify(part.input ?? {}),
+                      },
+                    },
+                  ],
+                }),
+              );
+              break;
+            }
+            case 'finish': {
+              usage = part.totalUsage as LanguageModelUsage;
+              finishReason = part.finishReason as FinishReason;
+              break;
+            }
+            case 'finish-step': {
+              if (!usage) usage = part.usage as LanguageModelUsage;
+              if (!finishReason) finishReason = part.finishReason as FinishReason;
+              break;
+            }
+            case 'error': {
+              // A structured upstream failure (auth, overloaded, content filter).
+              // Emit the OpenAI-shaped error frame the gateway probe detects so it
+              // fails over / surfaces the real cause instead of a blank stop.
+              const err = part.error;
+              const message =
+                err instanceof Error ? err.message : typeof err === 'string' ? err : 'Upstream error';
+              const code = (err as { statusCode?: number; code?: string })?.statusCode ??
+                (err as { code?: string })?.code;
+              emit(sse({ error: { message, ...(code != null ? { code } : {}) } }));
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const code = (err as { statusCode?: number })?.statusCode;
+        emit(sse({ error: { message, ...(code != null ? { code } : {}) } }));
+      }
+
+      // Terminal finish chunk + usage-only chunk (OpenAI include_usage semantics)
+      // + [DONE]. The usage chunk carries `model` so the SSE usage extractor books
+      // the right model even if no content chunk did.
+      emit(delta({}, mapFinishReason(finishReason)));
+      emit(
+        sse({
+          ...base,
+          choices: [],
+          usage: mapUsage(usage),
+        }),
+      );
+      emit(enc.encode('data: [DONE]\n\n'));
+      controller.close();
+    },
+  });
+}
+
+// generateText result → OpenAI chat.completion JSON (non-streaming).
+export function openAiJsonFromResult(
+  result: {
+    text: string;
+    reasoningText?: string;
+    toolCalls?: Array<{ toolCallId: string; toolName: string; input: unknown }>;
+    finishReason: FinishReason;
+    usage: LanguageModelUsage;
+  },
+  ctx: StreamCtx,
+): Record<string, unknown> {
+  const message: Record<string, unknown> = { role: 'assistant', content: result.text ?? '' };
+  if (result.reasoningText) message.reasoning = result.reasoningText;
+  if (result.toolCalls && result.toolCalls.length > 0) {
+    message.tool_calls = result.toolCalls.map((tc) => ({
+      id: tc.toolCallId,
+      type: 'function',
+      function: { name: tc.toolName, arguments: JSON.stringify(tc.input ?? {}) },
+    }));
+    message.content = result.text || null;
+  }
+  return {
+    id: chatId(),
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: ctx.model,
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: mapFinishReason(result.finishReason),
+      },
+    ],
+    usage: mapUsage(result.usage),
+  };
+}

--- a/packages/llm-gateway/src/transports/index.ts
+++ b/packages/llm-gateway/src/transports/index.ts
@@ -11,3 +11,10 @@ export {
   responsesJsonToChat,
   translateResponsesResponse,
 } from './openai-responses';
+
+export {
+  aiSdkFamilyFor,
+  callUpstreamViaAiSdk,
+  isAiSdkServable,
+  resolveAiModel,
+} from './ai-sdk';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1394,9 +1394,24 @@ importers:
 
   packages/llm-gateway:
     dependencies:
+      '@ai-sdk/amazon-bedrock':
+        specifier: 5.0.24
+        version: 5.0.24(zod@3.25.76)
+      '@ai-sdk/anthropic':
+        specifier: 4.0.16
+        version: 4.0.16(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: 4.0.16
+        version: 4.0.16(zod@3.25.76)
+      '@ai-sdk/openai-compatible':
+        specifier: 3.0.12
+        version: 3.0.12(zod@3.25.76)
       '@kortix/shared':
         specifier: workspace:*
         version: link:../shared
+      ai:
+        specifier: 7.0.31
+        version: 7.0.31(zod@3.25.76)
     devDependencies:
       '@types/bun':
         specifier: ^1.1.0
@@ -1495,6 +1510,87 @@ packages:
     peerDependenciesMeta:
       graphql:
         optional: true
+
+  /@ai-sdk/amazon-bedrock@5.0.24(zod@3.25.76):
+    resolution: {integrity: sha512-DqepS/e0mZfpfFjbCKIG7LzsvrQYeKJT0aoQDC6WyXvR81Vi1VIJVk6IL2q6dq2zwuBNnXIQkUPFF0NTXRXGRQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/anthropic': 4.0.16(zod@3.25.76)
+      '@ai-sdk/openai': 4.0.16(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@3.25.76)
+      '@smithy/eventstream-codec': 4.4.10
+      '@smithy/util-utf8': 4.4.10
+      aws4fetch: 1.0.20
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/anthropic@4.0.16(zod@3.25.76):
+    resolution: {integrity: sha512-vyH4D6Auih5H2xvVzzh2ep5pbdWiaV7JDC+jHUE7zZJ5Kyv0TteLav4DrOgHzRuyv8ptfUSqFF6Y8//f/Ec0fQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@3.25.76)
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/gateway@4.0.23(zod@3.25.76):
+    resolution: {integrity: sha512-f85diFdPMXYJpxCjOYZchMQkRH8h3r6lhK4Q2xmzJ7UA2OQ80L3W7tFu61742xGQK7zHWm5AhxYhNuc50H9SGQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/openai-compatible@3.0.12(zod@3.25.76):
+    resolution: {integrity: sha512-tN9BUb4jUGjqtbRPUsziLxASfogLNICcq/Qrwr55vpnzKvprV6Ukl8ynED2lZaNrAHU5U4zlGnyU/iuYrjQK6g==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@3.25.76)
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/openai@4.0.16(zod@3.25.76):
+    resolution: {integrity: sha512-Yh+PsXaf9NbN7oA3oKwOuyjTiHMPD75phf3SqGbDNNKQ3Yj3oTntp/WhO3nCHIPA6gr5/1lyridQokmOpPf9oQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@3.25.76)
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/provider-utils@5.0.11(zod@3.25.76):
+    resolution: {integrity: sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 3.25.76
+    dev: false
+
+  /@ai-sdk/provider@4.0.3:
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
+    dependencies:
+      json-schema: 0.4.0
+    dev: false
 
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -9717,12 +9813,28 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@smithy/core@3.29.5:
+    resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+    dev: false
+
   /@smithy/credential-provider-imds@4.4.6:
     resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/eventstream-codec@4.4.10:
+    resolution: {integrity: sha512-yG1n59zLQMa979xvXlTQ9+FpNmm4RRPR+2rYZo57wk28E27zmKZN4ST9wc2pKkyspLpDal2/84ST72KLJhbP1w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.29.5
       tslib: 2.8.1
     dev: false
 
@@ -9757,6 +9869,21 @@ packages:
     resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
     engines: {node: '>=18.0.0'}
     dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/types@4.16.1:
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-utf8@4.4.10:
+    resolution: {integrity: sha512-4pWFv2sxrykZqaTixXhkgAsG6+k/VxgAiyZ6M0iLEmsOqcJaR0eidlTCmuKKtMJMIEw8lYwDTvEyR4NyC+V0cw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.29.5
       tslib: 2.8.1
     dev: false
 
@@ -11790,6 +11917,11 @@ packages:
       vue: 3.5.39(typescript@5.9.3)
     dev: false
 
+  /@vercel/oidc@3.2.0:
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+    dev: false
+
   /@vercel/speed-insights@1.3.1(next@15.5.18)(react@19.1.0)(svelte@5.56.4)(vue@3.5.39):
     resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
     peerDependencies:
@@ -12003,6 +12135,10 @@ packages:
     resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
     dev: false
 
+  /@workflow/serde@4.1.0:
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+    dev: false
+
   /@wyw-in-js/processor-utils@0.6.0:
     resolution: {integrity: sha512-5YAZMUmF+S2HaqheKfew6ybbYBMnF10PjIgI7ieyuFxCohyqJNF4xdo6oHftv2z5Z4vCQ0OZHtDOQyDImBYwmg==}
     engines: {node: '>=16.0.0'}
@@ -12171,6 +12307,18 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
     dev: true
+
+  /ai@7.0.31(zod@3.25.76):
+    resolution: {integrity: sha512-pJfwKXjF5kw0rKRTePwYo60EfWb8wfzJAgf3ojln/YkOsVVKttzZAJVcRPsg37Z3a06ZdKkxX+DSrMAFlPm5Mw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/gateway': 4.0.23(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@3.25.76)
+      zod: 3.25.76
+    dev: false
 
   /ajv-formats@2.1.1(ajv@8.18.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -12607,6 +12755,10 @@ packages:
   /awesome-phonenumber@5.11.0:
     resolution: {integrity: sha512-25GfikMIo6CBQIqvjoewo4uiu5Ai7WqEC8gxesH3LDwCY43oEdkLaT15a+8adC7uWIJCGh+YQiBY5bjmDpoQcg==}
     engines: {node: '>=14'}
+    dev: false
+
+  /aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
     dev: false
 
   /axe-core@4.12.1:
@@ -15471,6 +15623,11 @@ packages:
     engines: {node: '>=0.8.x'}
     dev: false
 
+  /eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -18182,6 +18339,10 @@ packages:
   /json-schema-typed@7.0.3:
     resolution: {integrity: sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==}
     dev: true
+
+  /json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}


### PR DESCRIPTION
## What

Phase 3 of the gateway rewrite: an alternative **upstream transport engine** that routes replaceable providers (openai-compat / anthropic / bedrock) through the **Vercel AI SDK provider packages** instead of the hand-written transports. The AI SDK owns every provider param quirk (`max_tokens`/`max_completion_tokens`, `reasoning_effort`, temperature stripping, prompt caching, tool-schema translation). A thin adapter maps the AI SDK's stream/result **back to the exact OpenAI-compatible `/v1/llm` chat.completions SSE + JSON shape** opencode and the pipeline depend on — so probe / relay / usage extraction / billing / trace are **byte-unchanged**. The contract does not move.

This is the in-process alternative to the LiteLLM translation sidecar; once proven at scale it lets us retire that sidecar. **Not done in this PR** — it's the follow-up, gated on the default flip.

## Flag-gated, zero default risk
`LLM_TRANSPORT_ENGINE=native` (default) → no behaviour change. `=ai-sdk` → new path. Codex (`openai-responses`) always stays native.

## Design
- `transports/ai-sdk/model.ts` — models.dev `npm` (or `kind` fallback) → provider package. **OpenAI uses the Responses API** (`.responses()`) so gpt-5.x/o-series reasoning + function tools work; `/chat/completions` 400s on that combo (matches main's native `route-kind.ts` decision, same essentia evidence).
- `transports/ai-sdk/request.ts` — OpenAI body → AI SDK `ModelMessage[]` + `ToolSet` (no executor = tool-calls relayed to the client) + params/providerOptions.
- `transports/ai-sdk/sse.ts` — `fullStream` → OpenAI SSE (role/content/reasoning/tool_calls deltas, finish_reason, `include_usage` chunk, `[DONE]`); `generateText` → chat.completion JSON. Usage maps `inputTokens`→`prompt_tokens` + `cacheRead`→`cached_tokens` so **cost is identical to native** (BYOK uses the pricing table on both paths).
- `callUpstream` branches at the top and still wraps `withResilience` (breaker/retry/failover intact). Descriptor gains `npm`/`region`, threaded from the catalog → resolve-candidates → managed/BYOK descriptors.

## Tests
- Unit: `fullStream`→SSE fidelity (text, streamed tool-calls, reasoning, error frames), **billing parity vs native openai-compat**, request conversion, and an end-to-end `streamText` run via `MockLanguageModelV4`.
- Package: `bun test` 311 pass, `tsc` clean. apps/api gateway resolution tests pass.

## Proven with real live sessions (the "not typecheck-only" bar)
Ran real streaming + non-streaming turns **through the AI-SDK path** with BYOK keys:
| Provider (family) | Model | Result |
|---|---|---|
| OpenAI (openai/Responses) | gpt-5.6 (reasoning) | ✅ streamed `get_weather({"city":"Paris"})`, usage 45/18; ✅ non-stream |
| OpenAI | gpt-4o-mini | ✅ stream+tools, ✅ non-stream |
| OpenRouter (openai-compatible) | openai/gpt-4o-mini | ✅ stream+tools, usage 73/14 |
| Bedrock (bedrock, essentia bearer) | us.amazon.nova-micro-v1:0 | ✅ stream+tools, usage 393/56; ✅ non-stream |

Real-session finding fixed mid-review: the AI SDK's OpenAI `.chat()` injects `reasoning_effort` for gpt-5.x, which `/chat/completions` rejects alongside tools — switched the openai family to `.responses()`, re-proven live.

## Not in this PR (follow-ups, honestly flagged)
- Default flip to `ai-sdk` + LiteLLM sidecar retirement + native dead-code deletion — gated on broader real-session proof.
- Anthropic-direct (`@ai-sdk/anthropic`) exercised only via Bedrock/OpenRouter here (no direct Anthropic key in the test harness); the provider path is the same shape.
- gen_ai.* OTel span + `/v1/generation` + `/v1/usage` + Anthropic `/v1/messages` ingress — separate PRs.