### PR TITLE
feat(llm-gateway): gen_ai.* OTel span per gateway call

### DIFF
--- a/apps/api/src/llm-gateway/hooks.otel.test.ts
+++ b/apps/api/src/llm-gateway/hooks.otel.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { GatewayTrace } from '@kortix/llm-gateway';
+import { runWithContext, setContextField } from '../lib/request-context';
+import { emitGatewayGenAiSpan } from './hooks';
+
+interface OtelAttributeValue {
+  stringValue?: string;
+  intValue?: string;
+  doubleValue?: number;
+  boolValue?: boolean;
+}
+
+interface OtelAttribute {
+  key: string;
+  value: OtelAttributeValue;
+}
+
+interface OtelSpan {
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: OtelAttribute[];
+}
+
+interface OtlpBody {
+  resourceSpans: Array<{ scopeSpans: Array<{ spans: OtelSpan[] }> }>;
+}
+
+const originalFetch = globalThis.fetch;
+const fetchCalls: Array<{ url: string; body: OtlpBody }> = [];
+
+function baseTrace(overrides: Partial<GatewayTrace> = {}): GatewayTrace {
+  return {
+    requestId: 'req_gw_1',
+    startedAt: new Date().toISOString(),
+    accountId: 'acc_1',
+    actorUserId: 'user_1',
+    projectId: 'proj_1',
+    sessionId: 'sess_1',
+    requestedModel: 'claude-sonnet',
+    resolvedModel: 'claude-sonnet-4-5',
+    provider: 'bedrock',
+    billingMode: 'credits',
+    streaming: false,
+    status: 200,
+    ok: true,
+    latencyMs: 850,
+    attempts: 1,
+    candidatesTried: ['claude-sonnet-4-5'],
+    usage: { promptTokens: 120, completionTokens: 45, cachedTokens: 10 },
+    upstreamCost: 0.002,
+    finalCost: 0.003,
+    request: {},
+    response: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function lastSpan(): OtelSpan {
+  const call = fetchCalls[fetchCalls.length - 1];
+  return call.body.resourceSpans[0].scopeSpans[0].spans[0];
+}
+
+function attr(span: OtelSpan, key: string): OtelAttributeValue | undefined {
+  return span.attributes.find((a) => a.key === key)?.value;
+}
+
+function attrScalar(span: OtelSpan, key: string): unknown {
+  const value = attr(span, key);
+  if (!value) return undefined;
+  return value.stringValue ?? value.intValue ?? value.doubleValue ?? value.boolValue;
+}
+
+async function emitAndFlush(trace: GatewayTrace) {
+  await runWithContext('POST', '/v1/llm/chat/completions', async () => {
+    setContextField('accountId', 'acc_1');
+    emitGatewayGenAiSpan(trace);
+    // emitGatewayGenAiSpan is fire-and-forget; give the microtask queue a turn
+    // so the underlying emitOtelSpan() promise's fetch() call resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('emitGatewayGenAiSpan', () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = 'https://otel.example.test/v1/traces';
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as OtlpBody;
+      fetchCalls.push({ url: String(url), body });
+      return new Response('', { status: 204 });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  });
+
+  test('emits a gen_ai span with OTel semantic-convention + kortix custom attributes', async () => {
+    await emitAndFlush(baseTrace());
+
+    expect(fetchCalls).toHaveLength(1);
+    const span = lastSpan();
+    expect(span.name).toBe('chat claude-sonnet-4-5');
+    expect(span.kind).toBe(1);
+
+    expect(attrScalar(span, 'gen_ai.system')).toBe('bedrock');
+    expect(attrScalar(span, 'gen_ai.operation.name')).toBe('chat');
+    expect(attrScalar(span, 'gen_ai.request.model')).toBe('claude-sonnet');
+    expect(attrScalar(span, 'gen_ai.response.model')).toBe('claude-sonnet-4-5');
+    expect(attrScalar(span, 'gen_ai.usage.input_tokens')).toBe('120');
+    expect(attrScalar(span, 'gen_ai.usage.output_tokens')).toBe('45');
+
+    expect(attrScalar(span, 'kortix.cost_usd')).toBe(0.003);
+    expect(attrScalar(span, 'kortix.upstream_cost_usd')).toBe(0.002);
+    expect(attrScalar(span, 'kortix.provider')).toBe('bedrock');
+    expect(attrScalar(span, 'kortix.cached_tokens')).toBe('10');
+    expect(attrScalar(span, 'kortix.streaming')).toBe(false);
+    expect(attrScalar(span, 'kortix.billing_mode')).toBe('credits');
+    expect(attrScalar(span, 'kortix.request_id')).toBe('req_gw_1');
+    expect(attrScalar(span, 'kortix.attempts')).toBe('1');
+    expect(attrScalar(span, 'kortix.gateway_status')).toBe('200');
+    expect(attrScalar(span, 'kortix.ok')).toBe(true);
+    expect(attr(span, 'kortix.error_code')).toBeUndefined();
+  });
+
+  test('falls back gen_ai.response.model to the requested model when unresolved', async () => {
+    await emitAndFlush(baseTrace({ resolvedModel: '' }));
+
+    const span = lastSpan();
+    expect(span.name).toBe('chat claude-sonnet');
+    expect(attrScalar(span, 'gen_ai.response.model')).toBe('claude-sonnet');
+  });
+
+  test('includes kortix.error_code for a failed gateway call', async () => {
+    await emitAndFlush(baseTrace({ ok: false, status: 502, errorCode: 'upstream_error' }));
+
+    const span = lastSpan();
+    expect(attrScalar(span, 'kortix.error_code')).toBe('upstream_error');
+    expect(attrScalar(span, 'kortix.ok')).toBe(false);
+  });
+
+  test('computes the span time window from latencyMs', async () => {
+    const before = Date.now();
+    await emitAndFlush(baseTrace({ latencyMs: 500 }));
+    const after = Date.now();
+
+    const span = lastSpan();
+    const startMs = Number(BigInt(span.startTimeUnixNano) / 1_000_000n);
+    const endMs = Number(BigInt(span.endTimeUnixNano) / 1_000_000n);
+    expect(endMs - startMs).toBe(500);
+    expect(endMs).toBeGreaterThanOrEqual(before);
+    expect(endMs).toBeLessThanOrEqual(after + 5);
+  });
+
+  test('never throws and does not export when no OTLP endpoint is configured', () => {
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+    expect(() => emitGatewayGenAiSpan(baseTrace())).not.toThrow();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test('never throws when there is no request context, even if the exporter is configured', () => {
+    expect(() => emitGatewayGenAiSpan(baseTrace())).not.toThrow();
+  });
+});

--- a/apps/api/src/llm-gateway/hooks.ts
+++ b/apps/api/src/llm-gateway/hooks.ts
@@ -12,6 +12,7 @@ import { accountIsFreeTierForModels, llmPriceMarkup } from '../billing/services/
 import { attributeYoloToken } from '../billing/services/yolo-tokens';
 import { config } from '../config';
 import { logger } from '../lib/logger';
+import { emitOtelSpan, isOtelTraceExporterConfigured } from '../lib/otel';
 import { isPureHoldRefund, reconcileBillingHold } from './billing-hold-reconciliation';
 import { validateAccountToken } from '../repositories/account-tokens';
 import { isGatewayKey } from '../shared/crypto';
@@ -253,6 +254,59 @@ export async function recordGatewayUsage(event: UsageEvent): Promise<void> {
   });
 }
 
+/**
+ * Build + fire a standard OTel `gen_ai.*` span for one gateway call.
+ *
+ * Best-effort telemetry only: gated on isOtelTraceExporterConfigured() so we
+ * skip building the attributes object entirely when no OTLP endpoint is
+ * configured (the common self-host case), fire-and-forget (never awaited by
+ * the caller), and guarded so a span-emission failure can never throw into —
+ * or block — trace persistence or billing.
+ */
+export function emitGatewayGenAiSpan(trace: GatewayTrace): void {
+  if (!isOtelTraceExporterConfigured()) return;
+  try {
+    const endTimeMs = Date.now();
+    const startTimeMs = endTimeMs - Math.max(0, trace.latencyMs || 0);
+    const resolvedModel = trace.resolvedModel || trace.requestedModel;
+    void emitOtelSpan({
+      name: `chat ${resolvedModel}`,
+      kind: 'INTERNAL',
+      startTimeMs,
+      endTimeMs,
+      attributes: {
+        'gen_ai.system': trace.provider,
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.request.model': trace.requestedModel,
+        'gen_ai.response.model': resolvedModel,
+        'gen_ai.usage.input_tokens': trace.usage.promptTokens,
+        'gen_ai.usage.output_tokens': trace.usage.completionTokens,
+        'kortix.cost_usd': trace.finalCost,
+        'kortix.upstream_cost_usd': trace.upstreamCost,
+        'kortix.provider': trace.provider,
+        'kortix.cached_tokens': trace.usage.cachedTokens,
+        'kortix.streaming': trace.streaming,
+        'kortix.billing_mode': trace.billingMode,
+        'kortix.request_id': trace.requestId,
+        'kortix.attempts': trace.attempts,
+        'kortix.gateway_status': trace.status,
+        'kortix.ok': trace.ok,
+        ...(trace.errorCode ? { 'kortix.error_code': trace.errorCode } : {}),
+      },
+    }).catch((error) => {
+      console.warn(
+        '[otel] gen_ai span emit failed:',
+        error instanceof Error ? error.message : error,
+      );
+    });
+  } catch (error) {
+    console.warn(
+      '[otel] gen_ai span build failed:',
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
 /** Persist a request trace to gateway_request_logs (skips unauthenticated traces). */
 export async function persistGatewayTrace(trace: GatewayTrace): Promise<void> {
   // Pre-auth failures (401) carry no accountId — nothing useful to attribute.
@@ -289,6 +343,8 @@ export async function persistGatewayTrace(trace: GatewayTrace): Promise<void> {
     // (finalCost/upstreamCost) already reflects the cache-write premium.
     metadata: { ...trace.metadata, cacheWriteTokens: trace.usage.cacheWriteTokens },
   });
+  // Non-blocking: never let telemetry delay the caller or affect the trace write.
+  emitGatewayGenAiSpan(trace);
 }
 
 /** The full set of hooks the pipeline needs, bound to the in-process control plane. */


### PR DESCRIPTION
## Summary

Emits a standard OpenTelemetry `gen_ai.*` span for every LLM gateway call, from the gateway's post-request trace hook (`persistGatewayTrace` in `apps/api/src/llm-gateway/hooks.ts`), reusing the existing `emitOtelSpan` helper in `apps/api/src/lib/otel.ts` — no new OTLP plumbing.

- Extracted `emitGatewayGenAiSpan(trace: GatewayTrace)` for testability. It:
  - No-ops early via `isOtelTraceExporterConfigured()` when no OTLP endpoint is configured (the default self-host case) — skips building the attributes object entirely.
  - Is fire-and-forget (never awaited by `persistGatewayTrace`) so telemetry never delays the request or the trace write.
  - Is fully guarded (`try/catch` + `.catch()`) so a span-emission failure can never throw into — or affect — trace persistence or billing.
  - Derives the span window from `Date.now() - trace.latencyMs` → `Date.now()`.
  - Span name: `chat ${resolvedModel || requestedModel}` (OTel GenAI convention), kind `INTERNAL`.

- Attributes — standard OTel GenAI semantic conventions:
  - `gen_ai.system` = `trace.provider`
  - `gen_ai.operation.name` = `'chat'`
  - `gen_ai.request.model` = `trace.requestedModel`
  - `gen_ai.response.model` = `trace.resolvedModel || trace.requestedModel`
  - `gen_ai.usage.input_tokens` = `trace.usage.promptTokens`
  - `gen_ai.usage.output_tokens` = `trace.usage.completionTokens`

- Plus namespaced Kortix custom attributes:
  - `kortix.cost_usd`, `kortix.upstream_cost_usd`, `kortix.provider`, `kortix.cached_tokens`, `kortix.streaming`, `kortix.billing_mode`, `kortix.request_id`, `kortix.attempts`, `kortix.gateway_status`, `kortix.ok`, and `kortix.error_code` (only when the call errored).

`emitOtelSpan` already injects ambient request-context attributes (request_id, account_id, session_id, etc.) via `AsyncLocalStorage`, so those aren't duplicated here.

No new HTTP route — no ke2e/route-manifest changes needed.

## Test plan

- [x] New `apps/api/src/llm-gateway/hooks.test.ts` (co-located `bun:test`) covers `emitGatewayGenAiSpan`: full attribute set + span name/kind, the `resolvedModel` fallback, `kortix.error_code` on failure, the latency-derived time window, no-op (no fetch call, no throw) when the OTLP exporter is unconfigured, and no-throw when there's no request context.
- [x] `KORTIX_URL=http://localhost:23908 dotenvx run -- bun test src/llm-gateway/hooks.test.ts` → 6 pass, 0 fail.
- [x] `bun run typecheck` (tsc --noEmit) → clean.
- [x] `bunx biome check apps/api/src/llm-gateway/hooks.ts apps/api/src/llm-gateway/hooks.test.ts` → clean.

Note: a pre-existing, unrelated cross-file test-pollution issue (`bun test`'s `mock.module()` isn't actually process-isolated per the `bunfig.toml` `isolation = true` setting — see the comment in `apps/api/src/projects/disk-quota-guard.test.ts`) causes `managed-provider-disabled.test.ts` to fail when run in the same process as certain other `llm-gateway` test files. Verified this reproduces identically on a clean `main` checkout with zero changes from this PR — not introduced or worsened here.