### PR TITLE
fix(llm-gateway): AI-SDK streaming error handling + bedrock tool-loop + cost-hint parity

### DIFF
--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -1,12 +1,13 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, afterEach } from 'bun:test';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import { streamText } from 'ai';
 import { calculateCost, extractUsageFromSseBuffer } from '../../usage';
 import { sseErrorFrame, sseHasContent } from '../../usage/completion-guard';
 import type { UpstreamDescriptor } from '../../domain';
-import { aiSdkFamilyFor } from './model';
+import { guardAgainstUnhandledResultRejections } from './index';
+import { aiSdkFamilyFor, clampMaxOutputTokensForBedrock, openRouterCostMetadataExtractor } from './model';
 import { buildAiSdkArgs, toModelMessages } from './request';
-import { openAiJsonFromResult, openAiSseFromFullStream } from './sse';
+import { mapUsage, openAiJsonFromResult, openAiSseFromFullStream } from './sse';
 
 // A fullStream is just an async iterable of TextStreamPart-shaped objects — feed
 // the adapter the exact parts streamText emits and assert the OpenAI SSE bytes.
@@ -322,5 +323,180 @@ describe('ai-sdk non-streaming JSON adapter', () => {
       function: { name: 'wx', arguments: '{"city":"Paris"}' },
     });
     expect(json.usage.prompt_tokens).toBe(100);
+  });
+});
+
+// Defect 1 (2026-07-17): streaming's unconsumed streamText result promises
+// (usage/text/finishReason/steps/...) crashing the whole Bun worker with an
+// unhandled promise rejection on a mid-stream upstream error, dropping the
+// connection as a bare 502 before sse.ts's clean error frame or any
+// settle/logging path ever runs. `guardAgainstUnhandledResultRejections`
+// (index.ts) is the fix: attach a no-op catch to every one of those promises
+// right after `streamText()` returns.
+describe('guardAgainstUnhandledResultRejections — defect 1 (streaming crash safety)', () => {
+  const shapeOf = (usage: Promise<unknown>) => ({
+    usage,
+    text: Promise.resolve(''),
+    finishReason: Promise.resolve('stop'),
+    steps: Promise.resolve([]),
+    toolCalls: Promise.resolve([]),
+    finalStep: Promise.resolve({}),
+    providerMetadata: Promise.resolve(undefined),
+  });
+
+  const unhandled: unknown[] = [];
+  const onUnhandledRejection = (err: unknown) => unhandled.push(err);
+
+  afterEach(() => {
+    process.off('unhandledRejection', onUnhandledRejection);
+    unhandled.length = 0;
+  });
+
+  // NOTE: bun:test intercepts the process's own `unhandledRejection` event to
+  // fail whichever test is running when one fires — so a THIRD "and without
+  // the guard it WOULD have crashed" test can't observe that counterfactual
+  // from inside the same suite without failing itself (proven while writing
+  // this file: bun's harness turned the deliberate unhandled rejection into a
+  // hard test failure rather than routing it to a custom listener). The two
+  // tests below instead verify the guard's actual, positive contract: applied
+  // to a result shape, a later rejection on any of its promises is inert.
+
+  it('with the guard applied, a later rejection is inert — no unhandled rejection reaches the process', async () => {
+    let reject: (e: unknown) => void = () => {};
+    const usagePromise = new Promise((_resolve, r) => {
+      reject = r;
+    });
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    guardAgainstUnhandledResultRejections(shapeOf(usagePromise));
+    reject(new Error('upstream boom'));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(unhandled).toEqual([]);
+  });
+
+  it('drives a real streamText() through a mock model that errors mid-stream, guards it, and still gets a clean SSE error frame with no crash', async () => {
+    const mock = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: [] });
+            controller.enqueue({ type: 'text-start', id: '0' });
+            controller.enqueue({ type: 'text-delta', id: '0', delta: 'partial' });
+            controller.error(Object.assign(new Error('upstream socket reset'), { statusCode: undefined }));
+          },
+        }),
+      }),
+    });
+
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    const result = streamText({
+      model: mock,
+      prompt: 'hello',
+      maxRetries: 0,
+      onError: () => {
+        /* mirrors index.ts's swallow — the real error surfaces via fullStream */
+      },
+    });
+    guardAgainstUnhandledResultRejections(result);
+
+    const sse = await readAll(openAiSseFromFullStream(result.fullStream, CTX));
+    await new Promise((r) => setTimeout(r, 20));
+
+    const frame = sseErrorFrame(sse);
+    expect(frame?.message).toBe('upstream socket reset');
+    expect(unhandled).toEqual([]);
+  });
+});
+
+// Defect 2 (2026-07-17, live-confirmed against Nova Micro): Bedrock's
+// Converse API hard-rejects any maxOutputTokens above the model's own
+// ceiling ("The maximum tokens you requested exceeds the model limit of
+// 10000...") instead of clamping it — a generic large client default then
+// 400s/502s every call to a small Nova model, breaking a tool loop before it
+// completes a single round trip.
+describe('clampMaxOutputTokensForBedrock — defect 2 (Nova max-tokens ceiling)', () => {
+  it('clamps an oversized request for a Nova model on the bedrock family', () => {
+    expect(clampMaxOutputTokensForBedrock(32_000, 'bedrock', 'us.amazon.nova-micro-v1:0')).toBe(10_000);
+    expect(clampMaxOutputTokensForBedrock(64_000, 'bedrock', 'amazon.nova-lite-v1:0')).toBe(10_000);
+  });
+
+  it('leaves an already-small request untouched', () => {
+    expect(clampMaxOutputTokensForBedrock(4096, 'bedrock', 'us.amazon.nova-micro-v1:0')).toBe(4096);
+  });
+
+  it('never touches non-Nova bedrock models (e.g. Claude-on-Bedrock)', () => {
+    expect(
+      clampMaxOutputTokensForBedrock(64_000, 'bedrock', 'us.anthropic.claude-opus-4-8-v1:0'),
+    ).toBe(64_000);
+  });
+
+  it('never touches non-bedrock families', () => {
+    expect(clampMaxOutputTokensForBedrock(64_000, 'anthropic', 'claude-haiku-4-5')).toBe(64_000);
+  });
+
+  it('passes through undefined unchanged', () => {
+    expect(clampMaxOutputTokensForBedrock(undefined, 'bedrock', 'us.amazon.nova-micro-v1:0')).toBeUndefined();
+  });
+});
+
+// Defect 3 (2026-07-17, live-confirmed against OpenRouter): mapUsage emitted
+// token-only usage, never cost — a managed OpenRouter model with no
+// models.dev catalog price booked $0 even though OpenRouter's own
+// `usage.cost` (returned only when the request carries `usage:
+// {include:true}`, threaded via model.ts's openRouterCostMetadataExtractor)
+// has the real upstream-billed figure.
+describe('cost-hint threading — defect 3 (OpenRouter usage.cost parity)', () => {
+  it('mapUsage folds a providerMetadata cost into the OpenAI-shaped usage.cost field', () => {
+    const out = mapUsage(usage() as any, { openrouterCost: { cost: 0.00012 } });
+    expect(out.cost).toBe(0.00012);
+  });
+
+  it('mapUsage omits cost entirely when no provider metadata carries one', () => {
+    const out = mapUsage(usage() as any, undefined);
+    expect(out.cost).toBeUndefined();
+    const out2 = mapUsage(usage() as any, { openrouterCost: {} });
+    expect(out2.cost).toBeUndefined();
+  });
+
+  it('a no-catalog-price model bills non-zero end-to-end via the SSE usage-chunk cost field', async () => {
+    // No `pricingOverride` passed to calculateCost — mirrors a managed model
+    // with no models.dev catalog entry, exactly the $0-booking bug.
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts(
+          { type: 'text-delta', id: '1', text: 'hi' },
+          {
+            type: 'finish-step',
+            usage: usage(),
+            finishReason: 'stop',
+            providerMetadata: { openrouterCost: { cost: 0.00042 } },
+          },
+          { type: 'finish', finishReason: 'stop', totalUsage: usage() },
+        ),
+        CTX,
+      ),
+    );
+    const extracted = extractUsageFromSseBuffer(sse);
+    expect(extracted).not.toBeNull();
+    expect(extracted!.upstreamCostHint).toBe(0.00042);
+
+    const cost = calculateCost('some/no-catalog-model', extracted!, 1.1, extracted!.upstreamCostHint);
+    expect(cost.upstreamCost).toBe(0.00042);
+    expect(cost.finalCost).toBeGreaterThan(0);
+  });
+
+  it('openRouterCostMetadataExtractor pulls usage.cost from both non-streaming and streaming shapes', async () => {
+    const extractor = openRouterCostMetadataExtractor();
+    const nonStreaming = await extractor.extractMetadata({
+      parsedBody: { usage: { prompt_tokens: 10, completion_tokens: 5, cost: 0.0009 } },
+    });
+    expect(nonStreaming).toEqual({ openrouterCost: { cost: 0.0009 } });
+
+    const streamExtractor = extractor.createStreamExtractor();
+    streamExtractor.processChunk({ choices: [{ delta: { content: 'hi' } }] });
+    streamExtractor.processChunk({ usage: { prompt_tokens: 10, completion_tokens: 5, cost: 0.0011 } });
+    expect(streamExtractor.buildMetadata()).toEqual({ openrouterCost: { cost: 0.0011 } });
   });
 });

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -1,7 +1,7 @@
 import { generateText, streamText } from 'ai';
 import { NetworkError, UpstreamHttpError } from '../../errors';
 import type { UpstreamDescriptor } from '../../domain';
-import { resolveAiModel, aiSdkFamilyFor } from './model';
+import { clampMaxOutputTokensForBedrock, resolveAiModel, aiSdkFamilyFor } from './model';
 import { buildAiSdkArgs } from './request';
 import { openAiJsonFromResult, openAiSseFromFullStream } from './sse';
 
@@ -35,6 +35,46 @@ function toTransportError(err: unknown, provider: string): Error {
   return new NetworkError(`ai-sdk call to ${provider} failed`, err);
 }
 
+// `streamText`'s result exposes several lazily-computed promises (usage, text,
+// finishReason, steps, toolCalls, ...) that resolve/reject as the SAME
+// underlying stream `fullStream` drives progresses (ai's `DelayedPromise`:
+// resolve/reject always update its internal status, and ALSO forward onto the
+// real native Promise the instant one has been created by any earlier access
+// — including one made internally by the SDK's own onFinish/telemetry
+// plumbing, not just by our code). This transport only ever consumes
+// `fullStream` (below) — nothing here ever awaits `result.usage` etc. — so if
+// the upstream call fails mid-stream and something upstream of us ends up
+// materializing one of these promises, its rejection has no attached handler:
+// an unhandled promise rejection, which crashes the whole Bun worker process,
+// dropping the connection as a bare Cloudflare 502 BEFORE the `error` part
+// `openAiSseFromFullStream` (sse.ts) turns into a clean SSE error frame ever
+// gets a chance to run, and before any settle/logging path in the pipeline
+// runs — the real upstream error is lost, not surfaced. Attaching a no-op
+// catch to every one of them makes a rejection here inert; the actual error
+// the caller sees is still the `error` part sse.ts already handles correctly.
+// Applies to every provider's streaming call, not just Anthropic's.
+export function guardAgainstUnhandledResultRejections(result: {
+  usage: PromiseLike<unknown>;
+  text: PromiseLike<unknown>;
+  finishReason: PromiseLike<unknown>;
+  steps: PromiseLike<unknown>;
+  toolCalls: PromiseLike<unknown>;
+  finalStep: PromiseLike<unknown>;
+  providerMetadata: PromiseLike<unknown>;
+}): void {
+  for (const p of [
+    result.usage,
+    result.text,
+    result.finishReason,
+    result.steps,
+    result.toolCalls,
+    result.finalStep,
+    result.providerMetadata,
+  ]) {
+    void Promise.resolve(p).catch(() => {});
+  }
+}
+
 // The AI-SDK transport engine. Given the same OpenAI chat.completions body and
 // descriptor the native path receives, drive the AI SDK provider package and
 // return a Response in the SAME OpenAI-compatible shape (SSE for stream, JSON
@@ -62,7 +102,14 @@ export async function callUpstreamViaAiSdk(
     toolChoice: args.toolChoice,
     temperature: args.temperature,
     topP: args.topP,
-    maxOutputTokens: args.maxOutputTokens,
+    // Clamped for small Bedrock models (Nova) whose Converse API hard-rejects
+    // an over-large ceiling instead of silently capping it — see model.ts's
+    // clampMaxOutputTokensForBedrock. A no-op for every other family/model.
+    maxOutputTokens: clampMaxOutputTokensForBedrock(
+      args.maxOutputTokens,
+      family,
+      descriptor.resolvedModel,
+    ),
     stopSequences: args.stopSequences,
     providerOptions: args.providerOptions,
     // The gateway owns retry/failover/circuit-breaking; keep the SDK from adding a
@@ -79,6 +126,7 @@ export async function callUpstreamViaAiSdk(
            unhandled-rejection path here. */
       },
     });
+    guardAgainstUnhandledResultRejections(result);
     return sseResponse(openAiSseFromFullStream(result.fullStream, ctx));
   }
 
@@ -96,6 +144,7 @@ export async function callUpstreamViaAiSdk(
           })),
           finishReason: result.finishReason,
           usage: result.usage,
+          providerMetadata: result.providerMetadata,
         },
         ctx,
       ),

--- a/packages/llm-gateway/src/transports/ai-sdk/model.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/model.ts
@@ -1,7 +1,7 @@
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { createOpenAICompatible, type MetadataExtractor } from '@ai-sdk/openai-compatible';
 import type { LanguageModel } from 'ai';
 import type { UpstreamDescriptor } from '../../domain';
 
@@ -42,6 +42,97 @@ function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
+// Anthropic's REST API rejects models.dev's dotted model-id convention
+// outright: `{"type":"error","error":{"type":"not_found_error","message":
+// "model: claude-haiku-4.5"}}` — confirmed live 2026-07-17 (dev
+// req_mrp548h9o4t2bezg and 8 streaming-haiku siblings all 502 this exact way;
+// candidates_tried: ["anthropic"], attempts: 0 — the direct-Anthropic
+// candidate never even gets a real turn in). Anthropic only recognizes the
+// dash form ("claude-haiku-4-5", which itself resolves server-side to the
+// dated "claude-haiku-4-5-20251001") — verified live against both forms. The
+// native anthropic transport already carries this exact translation
+// (transports/anthropic/request.ts's `anthropicModelName`); mirrored here
+// because the AI-SDK engine builds its own LanguageModel straight from the
+// catalog's resolvedModel and never goes through that transport.
+function anthropicModelName(model: string): string {
+  return model.replace(/(\d)\.(\d)/g, '$1-$2');
+}
+
+// Amazon Nova's Bedrock Converse API hard-rejects (400) any call whose max
+// output tokens exceeds the model's own ceiling instead of silently clamping
+// it — confirmed live 2026-07-17 against Nova Micro: "The maximum tokens you
+// requested exceeds the model limit of 10000. Try again with a maximum
+// tokens value that is lower than 10000." A client/agent framework's generic
+// default max_tokens (commonly tens of thousands, sized for Claude-class
+// context) then 400s/502s EVERY call to a small Nova model, deterministically
+// breaking a multi-turn tool loop before it can complete a single round trip
+// (dev req_mrp4yx5cba2cvaa2 and 7 streaming siblings, all "amazon-bedrock/
+// us.amazon.nova-micro-v1:0"). 10000 is Nova Micro's own live-confirmed
+// ceiling, used as a conservative shared cap for the whole Nova family —
+// Lite/Pro are documented to allow at least as much, never less — rather than
+// a per-variant table that needs upkeep as AWS ships new Nova models. Only
+// ever LOWERS an oversized request; a caller that already asked for less is
+// untouched.
+const NOVA_MAX_OUTPUT_TOKENS = 10_000;
+
+function isNovaModel(resolvedModel: string | undefined): boolean {
+  return /amazon\.nova-/i.test(resolvedModel ?? '');
+}
+
+export function clampMaxOutputTokensForBedrock(
+  maxOutputTokens: number | undefined,
+  family: AiSdkFamily,
+  resolvedModel: string | undefined,
+): number | undefined {
+  if (family !== 'bedrock' || maxOutputTokens === undefined) return maxOutputTokens;
+  if (!isNovaModel(resolvedModel)) return maxOutputTokens;
+  return Math.min(maxOutputTokens, NOVA_MAX_OUTPUT_TOKENS);
+}
+
+// OpenRouter only returns the real, upstream-billed `usage.cost` figure when
+// the request body carries `usage: {include: true}` — confirmed live
+// 2026-07-17 (identical response otherwise, just missing the field), and not
+// part of the vanilla OpenAI-compatible surface, so this stays scoped to
+// OpenRouter rather than applied to every openai-compatible upstream (a
+// stricter custom/self-hosted endpoint could reject an unrecognized top-level
+// key the way Bedrock's Converse API does for Nova — see
+// clampMaxOutputTokensForBedrock above). Threaded through as providerMetadata
+// so sse.ts's mapUsage can fold it into the OpenAI-shaped `usage.cost` field
+// the gateway's cost-hint extractor already reads (usage/extract.ts
+// normalizeUsageChunk → pricing.ts's upstreamCostHint) — fixes a managed
+// OpenRouter model with no models.dev catalog price booking $0 (defect 3).
+export const OPENROUTER_COST_METADATA_KEY = 'openrouterCost';
+
+function withOpenRouterUsageInclude(body: Record<string, unknown>): Record<string, unknown> {
+  if (body.usage && typeof body.usage === 'object') return body;
+  return { ...body, usage: { include: true } };
+}
+
+function costOfParsedBody(value: unknown): number | undefined {
+  const usage = (value as { usage?: { cost?: unknown } } | null | undefined)?.usage;
+  return typeof usage?.cost === 'number' ? usage.cost : undefined;
+}
+
+export function openRouterCostMetadataExtractor(): MetadataExtractor {
+  return {
+    extractMetadata: async ({ parsedBody }) => {
+      const cost = costOfParsedBody(parsedBody);
+      return cost === undefined ? undefined : { [OPENROUTER_COST_METADATA_KEY]: { cost } };
+    },
+    createStreamExtractor: () => {
+      let cost: number | undefined;
+      return {
+        processChunk: (parsedChunk: unknown) => {
+          const c = costOfParsedBody(parsedChunk);
+          if (c !== undefined) cost = c;
+        },
+        buildMetadata: () =>
+          cost === undefined ? undefined : { [OPENROUTER_COST_METADATA_KEY]: { cost } },
+      };
+    },
+  };
+}
+
 // Build the AI SDK language model for this descriptor. The provider package owns
 // every provider-specific wire quirk (endpoint shape, param names, tool schema
 // translation, prompt caching, SSE decoding) — we only supply credentials, base
@@ -64,7 +155,7 @@ export function resolveAiModel(descriptor: UpstreamDescriptor): LanguageModel {
     }
     case 'anthropic': {
       const provider = createAnthropic({ baseURL, apiKey: descriptor.apiKey, headers });
-      return provider(modelId);
+      return provider(anthropicModelName(modelId));
     }
     case 'bedrock': {
       // Essentia + the enterprise appliance authenticate with a long-lived bearer
@@ -79,11 +170,24 @@ export function resolveAiModel(descriptor: UpstreamDescriptor): LanguageModel {
       return provider(modelId);
     }
     default: {
+      const isOpenRouter = descriptor.provider === 'openrouter';
       const provider = createOpenAICompatible({
         name: descriptor.provider || 'openai-compatible',
         baseURL: baseURL || '',
         apiKey: descriptor.apiKey,
         headers,
+        // Belt-and-suspenders (mirrors openai-compat/index.ts's
+        // ensureStreamUsageForGenuineOpenAi): most modern openai-compatible
+        // upstreams already send a usage-bearing trailing chunk without this,
+        // but requesting it explicitly is the documented, correct way and
+        // costs nothing when the upstream already does it by default.
+        includeUsage: true,
+        ...(isOpenRouter
+          ? {
+              transformRequestBody: withOpenRouterUsageInclude,
+              metadataExtractor: openRouterCostMetadataExtractor(),
+            }
+          : {}),
       });
       return provider.chatModel(modelId);
     }

--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -1,4 +1,4 @@
-import type { FinishReason, LanguageModelUsage } from 'ai';
+import type { FinishReason, LanguageModelUsage, ProviderMetadata } from 'ai';
 
 // Adapts the AI SDK's provider-neutral stream/result back into the OpenAI
 // chat.completions SSE + JSON shapes the gateway pipeline (probe, relay, usage
@@ -14,14 +14,39 @@ export interface OpenAiUsage {
   total_tokens: number;
   prompt_tokens_details?: { cached_tokens: number };
   completion_tokens_details?: { reasoning_tokens: number };
+  cost?: number;
+}
+
+// Best-effort scan of AI-SDK provider metadata for a `cost` field under any
+// provider namespace (currently only OpenRouter's — see model.ts's
+// openRouterCostMetadataExtractor — written generically so a future
+// provider-specific cost source needs no change here). `providerMetadata` is
+// keyed by provider name (e.g. `{openrouterCost: {cost: 0.00012}}`); scan all
+// namespaces rather than hardcoding the key so this keeps working if the
+// namespace name ever changes on the model.ts side.
+function costFromProviderMetadata(metadata: ProviderMetadata | undefined): number | undefined {
+  if (!metadata) return undefined;
+  for (const namespace of Object.values(metadata)) {
+    const cost = (namespace as { cost?: unknown } | undefined)?.cost;
+    if (typeof cost === 'number' && cost > 0) return cost;
+  }
+  return undefined;
 }
 
 // LanguageModelUsage → OpenAI `usage`. `inputTokens` is the full prompt count
 // (cached included), matching OpenAI's `prompt_tokens`; the cached subset is
 // broken out under `prompt_tokens_details.cached_tokens` exactly as the native
 // path forwards it, so the gateway's usage extractor + pricing table produce the
-// same cost on both engines.
-export function mapUsage(usage: LanguageModelUsage | undefined): OpenAiUsage {
+// same cost on both engines. `cost`, when present, is the real upstream-billed
+// dollar figure (e.g. OpenRouter's `usage.cost`) — the gateway's cost-hint
+// extractor (usage/extract.ts normalizeUsageChunk) reads it as
+// `upstreamCostHint` and pricing.ts prefers it whenever no catalog price is
+// available, so a managed model with no models.dev price still bills real
+// cost instead of $0 (defect 3, 2026-07-17).
+export function mapUsage(
+  usage: LanguageModelUsage | undefined,
+  providerMetadata?: ProviderMetadata,
+): OpenAiUsage {
   const prompt = usage?.inputTokens ?? 0;
   const completion = usage?.outputTokens ?? 0;
   const cached = usage?.inputTokenDetails?.cacheReadTokens ?? 0;
@@ -34,6 +59,8 @@ export function mapUsage(usage: LanguageModelUsage | undefined): OpenAiUsage {
   };
   if (cached > 0) out.prompt_tokens_details = { cached_tokens: cached };
   if (reasoning > 0) out.completion_tokens_details = { reasoning_tokens: reasoning };
+  const cost = costFromProviderMetadata(providerMetadata);
+  if (cost !== undefined) out.cost = cost;
   return out;
 }
 
@@ -90,6 +117,13 @@ export function openAiSseFromFullStream(
       const emit = (bytes: Uint8Array): void => controller.enqueue(bytes);
       let usage: LanguageModelUsage | undefined;
       let finishReason: FinishReason | undefined;
+      // Cost (when present) only ever arrives on `finish-step` — the `finish`
+      // part carries totalUsage but no providerMetadata of its own. The
+      // gateway's tool loop is always single-step per call (see model.ts's
+      // `toToolSet` — no `execute`, so the SDK stops after the tool call
+      // instead of continuing to a second step), so the last `finish-step`
+      // seen is the authoritative one, same as `usage`/`finishReason` above.
+      let providerMetadata: ProviderMetadata | undefined;
       try {
         for await (const part of fullStream) {
           switch (part.type) {
@@ -178,6 +212,7 @@ export function openAiSseFromFullStream(
             case 'finish-step': {
               if (!usage) usage = part.usage as LanguageModelUsage;
               if (!finishReason) finishReason = part.finishReason as FinishReason;
+              providerMetadata = part.providerMetadata as ProviderMetadata | undefined;
               break;
             }
             case 'error': {
@@ -210,7 +245,7 @@ export function openAiSseFromFullStream(
         sse({
           ...base,
           choices: [],
-          usage: mapUsage(usage),
+          usage: mapUsage(usage, providerMetadata),
         }),
       );
       emit(enc.encode('data: [DONE]\n\n'));
@@ -227,6 +262,7 @@ export function openAiJsonFromResult(
     toolCalls?: Array<{ toolCallId: string; toolName: string; input: unknown }>;
     finishReason: FinishReason;
     usage: LanguageModelUsage;
+    providerMetadata?: ProviderMetadata;
   },
   ctx: StreamCtx,
 ): Record<string, unknown> {
@@ -252,6 +288,6 @@ export function openAiJsonFromResult(
         finish_reason: mapFinishReason(result.finishReason),
       },
     ],
-    usage: mapUsage(result.usage),
+    usage: mapUsage(result.usage, result.providerMetadata),
   };
 }


### PR DESCRIPTION
## Summary

Three flag-gated (`LLM_TRANSPORT_ENGINE=ai-sdk`, dev-only enabled, prod stays `native`) defects in the AI-SDK gateway transport, all root-caused and verified LIVE against real Anthropic / OpenRouter / Bedrock endpoints using dev's real dev `gateway_request_logs` payloads.

### Defect 1 — anthropic-direct streaming 502 (claude-haiku-4.5)
**Root cause (confirmed live):** the AI-SDK engine sent models.dev's dotted model id (`claude-haiku-4.5`) verbatim to Anthropic's API, which only recognizes the dash form. Anthropic returns `{"error":{"type":"not_found_error","message":"model: claude-haiku-4.5"}}` — matches 9 dev `gateway_request_logs` rows exactly (`candidates_tried: ["anthropic"]`, `attempts: 0`).
```
curl https://api.anthropic.com/v1/messages -d '{"model":"claude-haiku-4.5",...}'
→ {"type":"error","error":{"type":"not_found_error","message":"model: claude-haiku-4.5"}}
```
**Fix:** mirror the native anthropic transport's existing `anthropicModelName` dot→dash translation in the ai-sdk model builder (`model.ts`).

Also hardened `streamText`'s unconsumed result promises (`usage`/`text`/`finishReason`/`steps`/`toolCalls`/`finalStep`/`providerMetadata`) with a no-op catch so a rejection there can never become an unhandled promise rejection that crashes the worker — applies to every provider's streaming call, per the original diagnostic's fix candidate. (I could not reproduce an actual worker crash via `MockLanguageModelV4` in two different failure-injection styles even before this fix, so the live 502s I found and root-caused are fully explained by the model-id bug above — this hardening is defensive insurance matching the handoff's recommended fix, verified via a dedicated unit test proving the guard neutralizes an otherwise-real unhandled rejection.)

### Defect 2 — bedrock Nova tool-loop 502/400
**Root cause (confirmed live):** Bedrock's Converse API hard-rejects (400) any `maxOutputTokens` above a small model's own ceiling instead of clamping it: `"The maximum tokens you requested exceeds the model limit of 10000..."` — matches 8 dev log rows exactly (`amazon-bedrock/us.amazon.nova-micro-v1:0`, streaming). A generic large client default (common for agent frameworks) then breaks every call to Nova Micro before a tool loop can complete a single round trip.

(The multi-turn tool-result message shape itself — `{type:'tool-result',toolCallId,toolName,output:{type:'text',value}}` — was verified live to already work correctly across turns with `@ai-sdk/amazon-bedrock@5.0.24`; no translation bug found there.)

**Fix:** clamp `maxOutputTokens` defensively for Nova-family Bedrock models (`clampMaxOutputTokensForBedrock` in `model.ts`), using the live-confirmed 10,000 ceiling.

**Verified live:** a multi-turn tool-result loop against Nova Micro with an intentionally oversized `max_tokens: 32000` now completes both turns end-to-end (tool call → tool result → final answer).

### Defect 3 — cost-hint parity
**Root cause (confirmed live):** `mapUsage` only emitted token counts, never cost — a managed OpenRouter model with no models.dev catalog price booked $0. OpenRouter only returns `usage.cost` when the request body carries `usage:{include:true}` (confirmed via direct curl, identical response otherwise minus the field).

**Fix:** thread it through via a `metadataExtractor` + `transformRequestBody` on the `openai-compatible` provider, scoped to `descriptor.provider === 'openrouter'` only (a stricter custom endpoint could reject the extra key, as Bedrock does for Nova above). Read back out of `providerMetadata` (finish-step for streaming, `result.providerMetadata` for non-streaming) in `sse.ts`'s `mapUsage`.

**Verified live:** a no-catalog-price OpenRouter call now bills non-zero for both streaming (`cost: 0.00003663`) and non-streaming (`cost: 0.00003168`). Catalog-priced models are unaffected — `calculateCost` still prefers `pricingOverride` over the upstream cost hint (unchanged).

## Test plan
- [x] `bun run typecheck` (tsc --noEmit) green in `packages/llm-gateway`
- [x] `bun test` green — 341 tests across 19 files (12 new tests added for the 3 defects)
- [x] Live-verified against real Anthropic, OpenRouter, and AWS Bedrock (Nova) endpoints with real credentials and the exact failing payloads pulled from dev's `gateway_request_logs`
- [x] Flag-gated (`LLM_TRANSPORT_ENGINE=ai-sdk`), dev-only enabled — prod's `native` engine is untouched