### PR TITLE
fix(llm-gateway): fail fast on terminal upstream auth errors instead of hanging

### DIFF
--- a/packages/llm-gateway/src/errors.test.ts
+++ b/packages/llm-gateway/src/errors.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  NetworkError,
+  TimeoutError,
+  UpstreamHttpError,
+  defaultIsRetryable,
+  indicatesUpstreamDown,
+  looksLikeTerminalAuthFailure,
+} from './errors';
+
+// Defect (2026-07-17, live-confirmed): an invalid upstream key retried 11+
+// times over 2+ minutes with no error ever surfacing to the session — a
+// terminal client-auth failure must fail fast on attempt one, both when it
+// carries a clean HTTP status and when it doesn't (see toTransportError in
+// transports/ai-sdk/index.ts for the statusCode-less case this guards).
+describe('looksLikeTerminalAuthFailure', () => {
+  test('recognizes OpenAI/Anthropic-shaped auth error wording', () => {
+    expect(looksLikeTerminalAuthFailure('Incorrect API key provided')).toBe(true);
+    expect(looksLikeTerminalAuthFailure('invalid_api_key')).toBe(true);
+    expect(looksLikeTerminalAuthFailure('invalid x-api-key')).toBe(true);
+    expect(looksLikeTerminalAuthFailure('authentication_error: invalid key')).toBe(true);
+  });
+
+  test('recognizes AWS SigV4/STS credential exception names (Bedrock)', () => {
+    expect(
+      looksLikeTerminalAuthFailure(
+        'UnrecognizedClientException: The security token included in the request is invalid',
+      ),
+    ).toBe(true);
+    expect(looksLikeTerminalAuthFailure('InvalidSignatureException: bad signature')).toBe(true);
+    expect(looksLikeTerminalAuthFailure('AccessDeniedException: not authorized')).toBe(true);
+  });
+
+  test('does not flag an unrelated/transient message', () => {
+    expect(looksLikeTerminalAuthFailure('socket hang up')).toBe(false);
+    expect(looksLikeTerminalAuthFailure('upstream overloaded, try again')).toBe(false);
+    expect(looksLikeTerminalAuthFailure(undefined)).toBe(false);
+    expect(looksLikeTerminalAuthFailure('')).toBe(false);
+  });
+});
+
+describe('defaultIsRetryable — terminal client-auth errors', () => {
+  test('401 is never retryable', () => {
+    expect(defaultIsRetryable(new UpstreamHttpError(401, 'invalid_api_key'))).toBe(false);
+  });
+
+  test('403 is never retryable', () => {
+    expect(defaultIsRetryable(new UpstreamHttpError(403, 'forbidden'))).toBe(false);
+  });
+
+  test('a clearly-terminal 400 invalid_api_key is never retryable', () => {
+    expect(
+      defaultIsRetryable(
+        new UpstreamHttpError(
+          400,
+          '{"error":{"code":"invalid_api_key","message":"Incorrect API key provided"}}',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  test('a statusCode-less error whose message is a terminal auth failure is never retryable', () => {
+    expect(
+      defaultIsRetryable(new NetworkError('UnrecognizedClientException: invalid security token')),
+    ).toBe(false);
+  });
+
+  test('500 and 429 stay retryable', () => {
+    expect(defaultIsRetryable(new UpstreamHttpError(500, 'boom'))).toBe(true);
+    expect(defaultIsRetryable(new UpstreamHttpError(429, 'slow down'))).toBe(true);
+  });
+
+  test('timeouts and genuine network errors stay retryable', () => {
+    expect(defaultIsRetryable(new TimeoutError())).toBe(true);
+    expect(defaultIsRetryable(new NetworkError('ECONNRESET'))).toBe(true);
+  });
+});
+
+describe('indicatesUpstreamDown — terminal auth errors never trip the shared breaker', () => {
+  test('a statusCode-less terminal auth failure does not count as upstream-down', () => {
+    expect(indicatesUpstreamDown(new NetworkError('AccessDeniedException: not authorized'))).toBe(
+      false,
+    );
+  });
+
+  test('a 401/403 UpstreamHttpError does not count as upstream-down (unchanged)', () => {
+    expect(indicatesUpstreamDown(new UpstreamHttpError(401, 'invalid_api_key'))).toBe(false);
+    expect(indicatesUpstreamDown(new UpstreamHttpError(403, 'forbidden'))).toBe(false);
+  });
+
+  test('5xx and genuine network/timeout errors still count as upstream-down', () => {
+    expect(indicatesUpstreamDown(new UpstreamHttpError(503, 'down'))).toBe(true);
+    expect(indicatesUpstreamDown(new NetworkError('ECONNRESET'))).toBe(true);
+    expect(indicatesUpstreamDown(new TimeoutError())).toBe(true);
+  });
+});

--- a/packages/llm-gateway/src/errors.ts
+++ b/packages/llm-gateway/src/errors.ts
@@ -75,14 +75,64 @@ export class GatewayResolutionError extends Error {
   }
 }
 
+function errorText(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return typeof err === 'string' ? err : '';
+}
+
+// Substrings that reliably indicate a TERMINAL, permanent client-auth failure
+// across every provider shape this gateway talks to — OpenAI/Anthropic-style
+// JSON error codes, AWS SigV4/STS credential exceptions (Bedrock), and generic
+// "Unauthorized" wording. Matched case-insensitively against an error's
+// `.message`.
+//
+// Exists because not every upstream failure carries a clean numeric HTTP
+// status by the time it reaches `defaultIsRetryable`/`indicatesUpstreamDown`:
+// an AWS credential/SigV4 resolution error can throw before any HTTP response
+// ever exists, and some AI-SDK error classes don't expose `.statusCode` at
+// all (see transports/ai-sdk/index.ts's `toTransportError`). Without this
+// fallback those errors collapse to a generic retryable NetworkError, and a
+// dead credential gets retried into a permanently empty, hung turn instead of
+// failing fast (2026-07-17 incident: invalid upstream key retried 11+ times
+// over 2+ minutes with no error ever surfaced to the session).
+const TERMINAL_AUTH_FAILURE_MARKERS = [
+  'invalid_api_key',
+  'invalid x-api-key',
+  'incorrect api key',
+  'authentication_error',
+  'invalid api key',
+  'unrecognizedclientexception',
+  'invalidsignatureexception',
+  'accessdeniedexception',
+  'security token included in the request is invalid',
+];
+
+export function looksLikeTerminalAuthFailure(message: string | undefined | null): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return TERMINAL_AUTH_FAILURE_MARKERS.some((marker) => lower.includes(marker));
+}
+
 export function defaultIsRetryable(err: unknown): boolean {
   if (err instanceof CircuitOpenError) return false;
   if (err instanceof ClientAbortError) return false;
-  if (err instanceof TimeoutError) return true;
-  if (err instanceof NetworkError) return true;
   if (err instanceof UpstreamHttpError) {
+    // 401/403 are a dead credential or a permission the caller doesn't have —
+    // never a transient host issue, so never worth retrying. Called out
+    // explicitly (rather than left to fall through to `false` below it) so
+    // the intent is documented and independently testable — see
+    // TERMINAL_AUTH_FAILURE_MARKERS above for the same rule applied when no
+    // clean status is available at all.
+    if (err.status === 401 || err.status === 403) return false;
     return err.status === 429 || (err.status >= 500 && err.status <= 599);
   }
+  // A generic/NetworkError-shaped error can still be a terminal auth failure in
+  // disguise (see TERMINAL_AUTH_FAILURE_MARKERS) — check before the
+  // TimeoutError/NetworkError defaults below ever get a chance to call it
+  // retryable.
+  if (looksLikeTerminalAuthFailure(errorText(err))) return false;
+  if (err instanceof TimeoutError) return true;
+  if (err instanceof NetworkError) return true;
   return true;
 }
 
@@ -96,6 +146,11 @@ export function defaultIsRetryable(err: unknown): boolean {
 // failed-over, but it never trips the breaker.
 export function indicatesUpstreamDown(err: unknown): boolean {
   if (err instanceof ClientAbortError) return false;
+  // A dead credential is this caller's problem, not the host's — same
+  // reasoning as the 429/402/403 carve-out above, extended to the
+  // statusCode-less shape (see TERMINAL_AUTH_FAILURE_MARKERS): must never trip
+  // the shared breaker for every other tenant on this provider.
+  if (looksLikeTerminalAuthFailure(errorText(err))) return false;
   if (err instanceof TimeoutError) return true;
   if (err instanceof NetworkError) return true;
   if (err instanceof UpstreamHttpError) return err.status >= 500 && err.status <= 599;

--- a/packages/llm-gateway/src/index.ts
+++ b/packages/llm-gateway/src/index.ts
@@ -29,6 +29,7 @@ export {
   UpstreamHttpError,
   defaultIsRetryable,
   indicatesUpstreamDown,
+  looksLikeTerminalAuthFailure,
 } from './errors';
 export type { NoUpstreamReasonCode, UpstreamErrorKind } from './errors';
 

--- a/packages/llm-gateway/src/resilience/retry.test.ts
+++ b/packages/llm-gateway/src/resilience/retry.test.ts
@@ -74,6 +74,42 @@ describe('withRetry', () => {
     expect(calls).toBe(1);
   });
 
+  // Defect (2026-07-17, live-confirmed): an invalid upstream key retried 11+
+  // times over 2+ minutes and the session turn hung permanently empty — a
+  // terminal client-auth failure must make exactly one attempt, never retry.
+  test('does not retry a 401 (dead credential) — fails fast in one attempt', async () => {
+    let calls = 0;
+    await expect(
+      withRetry(async () => {
+        calls++;
+        throw new UpstreamHttpError(401, 'invalid_api_key');
+      }, fastOpts()),
+    ).rejects.toBeInstanceOf(UpstreamHttpError);
+    expect(calls).toBe(1);
+  });
+
+  test('does not retry a 403 (forbidden credential) — fails fast in one attempt', async () => {
+    let calls = 0;
+    await expect(
+      withRetry(async () => {
+        calls++;
+        throw new UpstreamHttpError(403, 'forbidden');
+      }, fastOpts()),
+    ).rejects.toBeInstanceOf(UpstreamHttpError);
+    expect(calls).toBe(1);
+  });
+
+  test('a 500/timeout-shaped failure still retries as before (contrast with the 401 case above)', async () => {
+    let calls = 0;
+    const r = await withRetry(async () => {
+      calls++;
+      if (calls < 3) throw new UpstreamHttpError(500, 'boom');
+      return 'recovered';
+    }, fastOpts({ maxAttempts: 3 }));
+    expect(r).toBe('recovered');
+    expect(calls).toBe(3);
+  });
+
   test('retries 429 rate-limit', async () => {
     let calls = 0;
     const r = await withRetry(async () => {

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -4,7 +4,8 @@ import { jsonSchema, streamText, tool } from 'ai';
 import { calculateCost, extractUsageFromSseBuffer } from '../../usage';
 import { sseErrorFrame, sseHasContent } from '../../usage/completion-guard';
 import type { UpstreamDescriptor } from '../../domain';
-import { guardAgainstUnhandledResultRejections, mapToolCalls } from './index';
+import { guardAgainstUnhandledResultRejections, mapToolCalls, toTransportError } from './index';
+import { NetworkError, UpstreamHttpError, defaultIsRetryable } from '../../errors';
 import {
   aiSdkFamilyFor,
   clampMaxOutputTokensForBedrock,
@@ -779,4 +780,129 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
   // native openai-responses transport's own existing Codex test coverage
   // (openai-responses/request.test.ts, response.test.ts), which is unchanged
   // by this piece.
+});
+
+// Defect 4 (2026-07-17, live-confirmed): an invalid upstream key was retried
+// 11+ times over 2+ minutes and the session turn stayed permanently empty —
+// no clean error was ever surfaced. Root cause: toTransportError only ever
+// inspected `.statusCode`; provider errors that never populate one (an AWS
+// credential/SigV4 resolution failure thrown before any HTTP response exists,
+// or an AI-SDK error class without `.statusCode`) fell through to a generic
+// NetworkError, which `defaultIsRetryable` treats as retryable — so a dead
+// credential got retried instead of failing fast. Fixed by classifying a
+// statusCode-less error's MESSAGE via `looksLikeTerminalAuthFailure` (errors.ts)
+// as a terminal 401 UpstreamHttpError.
+describe('toTransportError — terminal auth classification (defect 4: 401 retried into a hang)', () => {
+  it('maps a clean statusCode straight through as an UpstreamHttpError with that status', () => {
+    const err = Object.assign(new Error('Incorrect API key provided'), {
+      statusCode: 401,
+      responseBody: '{"error":{"code":"invalid_api_key"}}',
+    });
+    const mapped = toTransportError(err, 'openai');
+    expect(mapped).toBeInstanceOf(UpstreamHttpError);
+    expect((mapped as UpstreamHttpError).status).toBe(401);
+    expect(defaultIsRetryable(mapped)).toBe(false);
+  });
+
+  it('reads a statusCode nested under `.cause` when the top-level error lacks one', () => {
+    const err = Object.assign(new Error('wrapped'), { cause: { statusCode: 403 } });
+    const mapped = toTransportError(err, 'anthropic');
+    expect(mapped).toBeInstanceOf(UpstreamHttpError);
+    expect((mapped as UpstreamHttpError).status).toBe(403);
+  });
+
+  it('classifies a statusCode-less AWS credential failure as a terminal 401, not a retryable NetworkError', () => {
+    const err = new Error(
+      'UnrecognizedClientException: The security token included in the request is invalid',
+    );
+    const mapped = toTransportError(err, 'bedrock');
+    expect(mapped).toBeInstanceOf(UpstreamHttpError);
+    expect((mapped as UpstreamHttpError).status).toBe(401);
+    expect(defaultIsRetryable(mapped)).toBe(false);
+  });
+
+  it('still falls back to a retryable NetworkError for a genuine statusCode-less transient failure', () => {
+    const err = new Error('socket hang up');
+    const mapped = toTransportError(err, 'openai');
+    expect(mapped).toBeInstanceOf(NetworkError);
+    expect(defaultIsRetryable(mapped)).toBe(true);
+  });
+
+  it('a 500-shaped error still maps to a retryable UpstreamHttpError (contrast with the 401 case above)', () => {
+    const err = Object.assign(new Error('internal error'), { statusCode: 500 });
+    const mapped = toTransportError(err, 'openai');
+    expect(mapped).toBeInstanceOf(UpstreamHttpError);
+    expect(defaultIsRetryable(mapped)).toBe(true);
+  });
+});
+
+describe('ai-sdk streaming error frame — defect 4 (401 surfaces cleanly, no hang)', () => {
+  it('a statusCode-carrying auth error surfaces its real code in the SSE error frame', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts({
+          type: 'error',
+          error: Object.assign(new Error('Incorrect API key provided'), { statusCode: 401 }),
+        }),
+        CTX,
+      ),
+    );
+    const frame = sseErrorFrame(sse);
+    expect(frame?.message).toBe('Incorrect API key provided');
+    expect(frame?.code).toBe(401);
+    // No content was ever produced — a same-candidate empty-completion retry
+    // would otherwise be indistinguishable from this terminal failure.
+    expect(sseHasContent(sse)).toBe(false);
+  });
+
+  it('a statusCode-less terminal auth error message is still classified as a 401 error frame', async () => {
+    const sse = await readAll(
+      openAiSseFromFullStream(
+        parts({
+          type: 'error',
+          error: new Error('AccessDeniedException: not authorized to invoke model'),
+        }),
+        CTX,
+      ),
+    );
+    const frame = sseErrorFrame(sse);
+    expect(frame?.code).toBe(401);
+  });
+
+  it('drives a real streamText() through a mock model whose doStream rejects with a 401 — exactly one call, one clean error frame, no retry storm', async () => {
+    let calls = 0;
+    const mock = new MockLanguageModelV4({
+      doStream: async () => {
+        calls++;
+        throw Object.assign(new Error('Incorrect API key provided'), {
+          statusCode: 401,
+          responseBody: '{"error":{"code":"invalid_api_key"}}',
+        });
+      },
+    });
+
+    const result = streamText({
+      model: mock,
+      prompt: 'hello',
+      maxRetries: 0,
+      onError: () => {
+        /* mirrors index.ts's swallow — the real error surfaces via fullStream */
+      },
+    });
+    guardAgainstUnhandledResultRejections(result);
+
+    const sse = await readAll(openAiSseFromFullStream(result.fullStream, CTX));
+    const frame = sseErrorFrame(sse);
+    expect(frame?.code).toBe(401);
+    expect(sseHasContent(sse)).toBe(false);
+    // The mock model's doStream is called once by streamText itself — the
+    // gateway's own resilience layer (withResilience wrapping
+    // callUpstreamViaAiSdk) never gets a chance to retry a streaming call in
+    // the first place, since it resolves as soon as the SSE Response is built
+    // (see index.ts's callUpstreamViaAiSdk); the terminal classification that
+    // matters for streaming lives in the pipeline's probeStream/errorFrame
+    // handling, verified above. This still confirms doStream itself is
+    // invoked exactly once, not retried internally.
+    expect(calls).toBe(1);
+  });
 });

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -1,5 +1,5 @@
 import { generateText, streamText } from 'ai';
-import { NetworkError, UpstreamHttpError } from '../../errors';
+import { NetworkError, UpstreamHttpError, looksLikeTerminalAuthFailure } from '../../errors';
 import type { UpstreamDescriptor } from '../../domain';
 import {
   clampMaxOutputTokensForBedrock,
@@ -38,10 +38,37 @@ function sseResponse(stream: ReadableStream<Uint8Array>): Response {
 
 // Map an AI SDK error into the gateway's transport error taxonomy so failover,
 // retry, and the circuit breaker behave identically to the native path.
-function toTransportError(err: unknown, provider: string): Error {
-  const e = err as { statusCode?: number; responseBody?: string; message?: string; url?: string };
-  if (typeof e?.statusCode === 'number') {
-    return new UpstreamHttpError(e.statusCode, e.responseBody ?? e.message ?? '', provider);
+//
+// Defect (2026-07-17, live-confirmed): not every AI-SDK provider error carries
+// a numeric `.statusCode` — an AWS credential/SigV4 resolution failure
+// (Bedrock) can throw before any HTTP response ever exists, and some AI-SDK
+// error classes don't expose one at all. Without the message-based fallback
+// below, those errors always fell through to a generic NetworkError — which
+// `defaultIsRetryable` treats as retryable — so an invalid/dead upstream key
+// got retried into a permanently empty, hung session turn (11+ attempts over
+// 2+ minutes, no error ever surfaced) instead of failing fast on attempt one.
+export function toTransportError(err: unknown, provider: string): Error {
+  const e = err as {
+    statusCode?: number;
+    responseBody?: string;
+    message?: string;
+    url?: string;
+    cause?: { statusCode?: number };
+  };
+  // A `cause`-wrapped statusCode (some AI-SDK error classes nest the original
+  // API-call error there) counts the same as a top-level one.
+  const statusCode =
+    typeof e?.statusCode === 'number'
+      ? e.statusCode
+      : typeof e?.cause?.statusCode === 'number'
+        ? e.cause.statusCode
+        : undefined;
+  if (typeof statusCode === 'number') {
+    return new UpstreamHttpError(statusCode, e.responseBody ?? e.message ?? '', provider);
+  }
+  const message = e?.message ?? (err instanceof Error ? err.message : String(err));
+  if (looksLikeTerminalAuthFailure(message)) {
+    return new UpstreamHttpError(401, message, provider);
   }
   return new NetworkError(`ai-sdk call to ${provider} failed`, err);
 }

--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -1,4 +1,5 @@
 import type { FinishReason, LanguageModelUsage, ProviderMetadata } from 'ai';
+import { looksLikeTerminalAuthFailure } from '../../errors';
 
 // Adapts the AI SDK's provider-neutral stream/result back into the OpenAI
 // chat.completions SSE + JSON shapes the gateway pipeline (probe, relay, usage
@@ -222,8 +223,15 @@ export function openAiSseFromFullStream(
               const err = part.error;
               const message =
                 err instanceof Error ? err.message : typeof err === 'string' ? err : 'Upstream error';
-              const code = (err as { statusCode?: number; code?: string })?.statusCode ??
-                (err as { code?: string })?.code;
+              // Some provider errors (AWS credential/SigV4 failures, an AI-SDK
+              // error class without a `.statusCode`) never carry a numeric code —
+              // fall back to classifying the message itself so a terminal auth
+              // failure is still recognizable as one downstream, same as
+              // toTransportError (index.ts) does for the non-streaming path.
+              const code =
+                (err as { statusCode?: number; code?: string })?.statusCode ??
+                (err as { code?: string })?.code ??
+                (looksLikeTerminalAuthFailure(message) ? 401 : undefined);
               emit(sse({ error: { message, ...(code != null ? { code } : {}) } }));
               break;
             }
@@ -233,7 +241,9 @@ export function openAiSseFromFullStream(
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        const code = (err as { statusCode?: number })?.statusCode;
+        const code =
+          (err as { statusCode?: number })?.statusCode ??
+          (looksLikeTerminalAuthFailure(message) ? 401 : undefined);
         emit(sse({ error: { message, ...(code != null ? { code } : {}) } }));
       }
 


### PR DESCRIPTION
## Summary
- Fixes a live-observed hang: with an invalid upstream key, the gateway retried 11+ times over 2+ minutes (each a 502 `upstream_error`) and the session turn stayed permanently empty — no clean error ever surfaced.
- Root cause: the ai-sdk transport's `toTransportError` only classified an error as an `UpstreamHttpError` (correctly non-retryable for 401/403 via the shared `defaultIsRetryable` predicate) when it carried a numeric `.statusCode`. Any error that didn't — an AWS credential/SigV4 resolution failure thrown before any HTTP response exists (Bedrock), or an AI-SDK error class without one — fell through to a generic `NetworkError`, which `defaultIsRetryable` treats as retryable, so a dead credential got retried into a hang instead of failing fast.
- The native engine (`http/call-upstream.ts`) already builds `UpstreamHttpError` from the real HTTP response status, so it was already correctly non-retryable for 401/403 — this PR makes that explicit/documented in the one shared predicate and closes the gap that only existed on the ai-sdk engine's statusCode-less fallback path. Both engines now benefit from the same hardened classification.

## Changes
- `packages/llm-gateway/src/errors.ts` — extend the shared `defaultIsRetryable`/`indicatesUpstreamDown` predicate: explicit 401/403 terminal case (documented, not just an implicit fallthrough) + a new `looksLikeTerminalAuthFailure(message)` fallback that classifies a statusCode-less error by message content (OpenAI/Anthropic-shaped auth wording, AWS SigV4/STS credential exception names) so it isn't misclassified as a retryable network blip, and so it never trips the shared circuit breaker for other tenants on the same provider.
- `packages/llm-gateway/src/transports/ai-sdk/index.ts` — `toTransportError` now also checks `.cause.statusCode` for a nested status, and classifies a statusCode-less terminal-auth message as `UpstreamHttpError(401)` instead of a retryable `NetworkError`.
- `packages/llm-gateway/src/transports/ai-sdk/sse.ts` — the streaming error-frame path applies the same message-based classification so a statusCode-less auth failure still surfaces a recognizable `code` (401) in the SSE error frame the pipeline probe/completion-guard already turns into a visible session error.
- `packages/llm-gateway/src/index.ts` — export `looksLikeTerminalAuthFailure`.

## Test plan
- [x] `packages/llm-gateway/src/errors.test.ts` (new) — `looksLikeTerminalAuthFailure`, `defaultIsRetryable`, `indicatesUpstreamDown` for 401/403/terminal-400/message-classified auth failures vs. genuine 5xx/timeout/network errors.
- [x] `packages/llm-gateway/src/resilience/retry.test.ts` — a 401/403 makes exactly one attempt (`withRetry`); a 500-shaped failure still retries as before.
- [x] `packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts` — `toTransportError` unit tests (statusCode, nested `.cause.statusCode`, statusCode-less AWS credential message → terminal 401, statusCode-less transient message → still retryable `NetworkError`, 500 stays retryable); SSE error-frame tests (statusCode-carrying and statusCode-less auth failures both surface `code: 401`, no content); an end-to-end `streamText()` + mock model test proving a single `doStream` call and a clean error frame, no retry storm.
- [x] `bun test packages/llm-gateway` — 364 pass, 0 fail.
- [x] `bunx tsc --noEmit` in `packages/llm-gateway` — clean.
- No pipeline/routing logic changed — streaming's terminal-error handling (`probeStream`/`exhaustedCandidates`, no same-candidate retry on a structured error frame) was already correct; this PR closes the upstream classification gap that fed it a misclassified retryable error in the first place.