### PR TITLE
feat(llm-gateway): absorb OpenAI Responses API into the ai-sdk engine

### DIFF
--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -45,7 +45,11 @@ export async function callUpstream(
   // breaker + gateway retry apply identically. Non-streaming awaits inside (a
   // 4xx/5xx throws → retry/failover); streaming returns immediately (errors
   // surface as an in-stream frame the pipeline probe handles), matching native
-  // timing. A provider the engine can't serve (Codex) falls through to native.
+  // timing. `isAiSdkServable` is unconditionally true today (every descriptor
+  // kind, including Codex/openai-responses, is now servable — see ai-sdk/
+  // model.ts) but stays as an explicit gate here rather than being inlined
+  // away, so a future descriptor kind the engine genuinely can't serve has an
+  // obvious place to opt back out to native.
   if (opts.engine === 'ai-sdk' && isAiSdkServable(descriptor)) {
     return withResilience(
       async (attemptSignal) => {

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it, afterEach } from 'bun:test';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
-import { streamText } from 'ai';
+import { jsonSchema, streamText, tool } from 'ai';
 import { calculateCost, extractUsageFromSseBuffer } from '../../usage';
 import { sseErrorFrame, sseHasContent } from '../../usage/completion-guard';
 import type { UpstreamDescriptor } from '../../domain';
-import { guardAgainstUnhandledResultRejections } from './index';
-import { aiSdkFamilyFor, clampMaxOutputTokensForBedrock, openRouterCostMetadataExtractor } from './model';
+import { guardAgainstUnhandledResultRejections, mapToolCalls } from './index';
+import {
+  aiSdkFamilyFor,
+  clampMaxOutputTokensForBedrock,
+  isCodexDescriptor,
+  needsResponsesApi,
+  openRouterCostMetadataExtractor,
+  resolveAiModel,
+} from './model';
 import { buildAiSdkArgs, toModelMessages } from './request';
 import { mapUsage, openAiJsonFromResult, openAiSseFromFullStream } from './sse';
 
@@ -499,4 +506,277 @@ describe('cost-hint threading — defect 3 (OpenRouter usage.cost parity)', () =
     streamExtractor.processChunk({ usage: { prompt_tokens: 10, completion_tokens: 5, cost: 0.0011 } });
     expect(streamExtractor.buildMetadata()).toEqual({ openrouterCost: { cost: 0.0011 } });
   });
+});
+
+// Piece A (2026-07-17): absorbs the OpenAI Responses API into the ai-sdk
+// engine itself, so Codex + genuine-OpenAI reasoning-with-tools no longer
+// need to fall through to the native openai-responses transport. The routing
+// decision (needsResponsesApi) is the exact same predicate route-kind.ts's
+// resolveTransportKind already uses for the native path — see route-kind.test.ts
+// for the exhaustive truth table this reuses; the tests here focus on what's
+// NEW: the AI SDK model that decision builds, and Codex's forced-streaming
+// wrinkle (its backend 400s on `stream:false`, which is all `generateText`
+// ever sends).
+describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () => {
+  const reasoningTool = {
+    type: 'function',
+    function: { name: 'get_weather', description: 'd', parameters: { type: 'object' } },
+  };
+
+  const genuineOpenAiReasoning: UpstreamDescriptor = {
+    provider: 'openai',
+    kind: 'openai-compat',
+    baseUrl: 'https://api.openai.com/v1',
+    apiKey: 'sk-test',
+    billingMode: 'platform-fee',
+    markup: 0.1,
+    resolvedModel: 'gpt-5.6',
+    reasoning: true,
+    temperature: false,
+    npm: '@ai-sdk/openai',
+  };
+
+  // Mirrors apps/api's descriptors.ts codexDescriptor shape (no `npm` field —
+  // it's hand-built for the ChatGPT OAuth backend, never catalog-resolved).
+  const codex: UpstreamDescriptor = {
+    provider: 'openai-codex',
+    kind: 'openai-responses',
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    apiKey: 'oat_test',
+    billingMode: 'none',
+    markup: 0,
+    resolvedModel: 'gpt-5-codex',
+    headers: { 'ChatGPT-Account-ID': 'acct_1' },
+  };
+
+  describe('needsResponsesApi — reused verbatim from resolveTransportKind', () => {
+    it('is true for a genuine OpenAI reasoning model with function tools and a live effort', () => {
+      expect(
+        needsResponsesApi(
+          { messages: [], tools: [reasoningTool], reasoning_effort: 'medium' },
+          genuineOpenAiReasoning,
+        ),
+      ).toBe(true);
+    });
+
+    it('is false for the same descriptor with no tools (not the broken combination)', () => {
+      expect(
+        needsResponsesApi({ messages: [], reasoning_effort: 'medium' }, genuineOpenAiReasoning),
+      ).toBe(false);
+    });
+
+    it("is false when reasoning_effort is explicitly 'none' (OpenAI's documented escape hatch)", () => {
+      expect(
+        needsResponsesApi(
+          { messages: [], tools: [reasoningTool], reasoning_effort: 'none' },
+          genuineOpenAiReasoning,
+        ),
+      ).toBe(false);
+    });
+
+    it('is true for a Codex descriptor no matter what the body contains', () => {
+      expect(needsResponsesApi({}, codex)).toBe(true);
+      expect(needsResponsesApi({ messages: [], stream: false }, codex)).toBe(true);
+    });
+  });
+
+  it('aiSdkFamilyFor resolves a Codex descriptor to the openai family (Responses-capable), not generic openai-compatible', () => {
+    expect(aiSdkFamilyFor(codex)).toBe('openai');
+  });
+
+  describe('resolveAiModel — .chat() vs .responses() selection', () => {
+    // `LanguageModel` (the return type) is a union that also admits a bare
+    // model-id string (a global-registry reference) — narrow to the object
+    // shape resolveAiModel actually returns to read `.provider` off it.
+    const providerOf = (model: ReturnType<typeof resolveAiModel>): string =>
+      (model as { provider: string }).provider;
+
+    it('builds a .responses() model for genuine OpenAI reasoning + tools + a live effort', () => {
+      const model = resolveAiModel(genuineOpenAiReasoning, {
+        messages: [],
+        tools: [reasoningTool],
+        reasoning_effort: 'medium',
+      });
+      expect(providerOf(model)).toBe('openai.responses');
+    });
+
+    it('keeps using .chat() for a plain non-reasoning-blocked openai request (no tools)', () => {
+      const model = resolveAiModel(genuineOpenAiReasoning, { messages: [], reasoning_effort: 'medium' });
+      expect(providerOf(model)).toBe('openai.chat');
+    });
+
+    it('keeps using .chat() when no body is passed at all (default {})', () => {
+      expect(providerOf(resolveAiModel(genuineOpenAiReasoning))).toBe('openai.chat');
+    });
+
+    it('always builds a .responses() model for Codex, regardless of what the body says', () => {
+      expect(providerOf(resolveAiModel(codex, { messages: [] }))).toBe('openai.responses');
+      expect(providerOf(resolveAiModel(codex, { messages: [], stream: false }))).toBe('openai.responses');
+    });
+  });
+
+  describe('buildAiSdkArgs — reasoning-effort mapping onto providerOptions.openai', () => {
+    it('maps the nested reasoning.effort shape the same as the flat reasoning_effort field', () => {
+      const args = buildAiSdkArgs({ messages: [], reasoning: { effort: 'high' } }, 'openai');
+      expect(args.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+    });
+
+    it("applies defaultReasoningEffort (Codex's 'low') only when the body carries none of its own", () => {
+      const defaulted = buildAiSdkArgs({ messages: [] }, 'openai', { defaultReasoningEffort: 'low' });
+      expect(defaulted.providerOptions).toEqual({ openai: { reasoningEffort: 'low' } });
+
+      const explicitWins = buildAiSdkArgs(
+        { messages: [], reasoning_effort: 'high' },
+        'openai',
+        { defaultReasoningEffort: 'low' },
+      );
+      expect(explicitWins.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+
+      const noDefaultNoEffort = buildAiSdkArgs({ messages: [] }, 'openai');
+      expect(noDefaultNoEffort.providerOptions).toBeUndefined();
+    });
+  });
+
+  // Codex's backend is stream-only (`stream:false` 400s — see
+  // openai-responses/request.ts's chatToResponses comment). The AI SDK's
+  // non-streaming `doGenerate` always sends `stream:false`, so
+  // callUpstreamViaAiSdk drives Codex through `streamText` (`doStream`, which
+  // DOES force `stream:true` on the wire — see @ai-sdk/openai's
+  // OpenAIResponsesLanguageModel) even for a client that asked for a
+  // non-streaming completion, then collapses the settled result into one JSON
+  // response. This exercises that exact sequence — streamText + guard +
+  // Promise.all + mapToolCalls + openAiJsonFromResult — against a real
+  // streamText() result (mock model, no network) instead of hand-rolling the
+  // JSON shape, so a regression in how callUpstreamViaAiSdk assembles it would
+  // very likely break this too.
+  describe('Codex non-streaming client request over a stream-only upstream (collapse path)', () => {
+    it('collapses a streamText() tool-call result into the same JSON shape generateText would produce', async () => {
+      const mock = new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
+              { type: 'tool-input-delta', id: 'call_1', delta: '{"city":"sf"}' },
+              { type: 'tool-input-end', id: 'call_1' },
+              {
+                type: 'tool-call',
+                toolCallId: 'call_1',
+                toolName: 'get_weather',
+                input: JSON.stringify({ city: 'sf' }),
+              },
+              {
+                type: 'finish',
+                // LanguageModelV4's finish reason is `{unified, raw}`, not a bare
+                // string (see @ai-sdk/provider's LanguageModelV4FinishReason) —
+                // a plain string here silently degrades to 'other'.
+                finishReason: { unified: 'tool-calls', raw: undefined },
+                usage: {
+                  inputTokens: { total: 4, noCache: 4, cacheRead: 0, cacheWrite: 0 },
+                  outputTokens: { total: 6, reasoning: 0 },
+                  totalTokens: 10,
+                },
+              },
+            ] as any,
+          }),
+        }),
+      });
+
+      // The same tool the gateway builds via request.ts's `toToolSet` — no
+      // `execute`, so the SDK surfaces the call and stops instead of running it.
+      const result = streamText({
+        model: mock,
+        prompt: 'weather?',
+        maxRetries: 0,
+        tools: {
+          get_weather: tool({
+            description: 'd',
+            inputSchema: jsonSchema({ type: 'object', properties: {} }),
+          }),
+        },
+      });
+      guardAgainstUnhandledResultRejections(result);
+
+      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] = await Promise.all([
+        result.text,
+        result.reasoningText,
+        result.toolCalls,
+        result.finishReason,
+        result.usage,
+        result.providerMetadata,
+      ]);
+      const json = openAiJsonFromResult(
+        {
+          text,
+          reasoningText,
+          toolCalls: mapToolCalls(toolCalls as any),
+          finishReason,
+          usage,
+          providerMetadata,
+        },
+        { model: 'codex/gpt-5-codex', provider: 'openai-codex' },
+      ) as any;
+
+      expect(json.object).toBe('chat.completion');
+      expect(json.choices[0].finish_reason).toBe('tool_calls');
+      expect(json.choices[0].message.tool_calls[0]).toMatchObject({
+        id: 'call_1',
+        function: { name: 'get_weather', arguments: '{"city":"sf"}' },
+      });
+      expect(json.usage.prompt_tokens).toBe(4);
+      expect(json.usage.completion_tokens).toBe(6);
+    });
+
+    it('collapses a plain-text streamText() result the same way, with no tool_calls key', async () => {
+      const mock = new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: '0' },
+              { type: 'text-delta', id: '0', delta: 'low-effort answer' },
+              { type: 'text-end', id: '0' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: undefined },
+                usage: {
+                  inputTokens: { total: 3, noCache: 3, cacheRead: 0, cacheWrite: 0 },
+                  outputTokens: { total: 2, reasoning: 0 },
+                  totalTokens: 5,
+                },
+              },
+            ] as any,
+          }),
+        }),
+      });
+
+      const result = streamText({ model: mock, prompt: 'hi', maxRetries: 0 });
+      guardAgainstUnhandledResultRejections(result);
+      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] = await Promise.all([
+        result.text,
+        result.reasoningText,
+        result.toolCalls,
+        result.finishReason,
+        result.usage,
+        result.providerMetadata,
+      ]);
+      const json = openAiJsonFromResult(
+        { text, reasoningText, toolCalls: mapToolCalls(toolCalls as any), finishReason, usage, providerMetadata },
+        { model: 'codex/gpt-5-codex', provider: 'openai-codex' },
+      ) as any;
+
+      expect(json.object).toBe('chat.completion');
+      expect(json.choices[0].finish_reason).toBe('stop');
+      expect(json.choices[0].message.content).toBe('low-effort answer');
+      expect(json.choices[0].message.tool_calls).toBeUndefined();
+    });
+  });
+
+  // Codex OAuth cannot be driven live in this environment (no OAuth creds
+  // available here) — the routing (needsResponsesApi/resolveAiModel/
+  // aiSdkFamilyFor above) and the forced-streaming collapse path (this
+  // describe block) are covered by code path + unit test only, matching the
+  // native openai-responses transport's own existing Codex test coverage
+  // (openai-responses/request.test.ts, response.test.ts), which is unchanged
+  // by this piece.
 });

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -1,11 +1,22 @@
 import { generateText, streamText } from 'ai';
 import { NetworkError, UpstreamHttpError } from '../../errors';
 import type { UpstreamDescriptor } from '../../domain';
-import { clampMaxOutputTokensForBedrock, resolveAiModel, aiSdkFamilyFor } from './model';
+import {
+  clampMaxOutputTokensForBedrock,
+  resolveAiModel,
+  aiSdkFamilyFor,
+  isCodexDescriptor,
+} from './model';
 import { buildAiSdkArgs } from './request';
 import { openAiJsonFromResult, openAiSseFromFullStream } from './sse';
 
-export { aiSdkFamilyFor, isAiSdkServable, resolveAiModel } from './model';
+export {
+  aiSdkFamilyFor,
+  isAiSdkServable,
+  isCodexDescriptor,
+  needsResponsesApi,
+  resolveAiModel,
+} from './model';
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -75,6 +86,19 @@ export function guardAgainstUnhandledResultRejections(result: {
   }
 }
 
+// Both `generateText`'s and `streamText`'s settled results expose tool calls
+// as an array of `{toolCallId, toolName, input}` (plus provider-specific
+// fields we don't need) — normalize either into what openAiJsonFromResult
+// wants, once, instead of duplicating the `.map` at both call sites below.
+// Exported so ai-sdk.test.ts can drive the exact same collapse sequence
+// callUpstreamViaAiSdk's Codex/non-streaming branch runs, against a real
+// `streamText()` result from a mock model, without needing network access.
+export function mapToolCalls(
+  toolCalls: ReadonlyArray<{ toolCallId: string; toolName: string; input?: unknown }> | undefined,
+): Array<{ toolCallId: string; toolName: string; input: unknown }> | undefined {
+  return toolCalls?.map((tc) => ({ toolCallId: tc.toolCallId, toolName: tc.toolName, input: tc.input }));
+}
+
 // The AI-SDK transport engine. Given the same OpenAI chat.completions body and
 // descriptor the native path receives, drive the AI SDK provider package and
 // return a Response in the SAME OpenAI-compatible shape (SSE for stream, JSON
@@ -89,9 +113,20 @@ export async function callUpstreamViaAiSdk(
   opts: { signal?: AbortSignal } = {},
 ): Promise<Response> {
   const family = aiSdkFamilyFor(descriptor);
-  const model = resolveAiModel(descriptor);
-  const args = buildAiSdkArgs(body, family);
-  const streaming = body.stream === true;
+  const isCodex = isCodexDescriptor(descriptor);
+  // `body` decides chat.completions vs Responses for the 'openai' family (see
+  // model.ts's needsResponsesApi) — Codex/genuine-OpenAI-reasoning-with-tools
+  // only, everything else keeps using .chat().
+  const model = resolveAiModel(descriptor, body);
+  const args = buildAiSdkArgs(body, family, {
+    // The ChatGPT Codex backend always expects a reasoning effort; the native
+    // transport defaults to 'low' when the caller sends none (see
+    // openai-responses/request.ts's `chatToResponses`) — mirrored here via
+    // buildAiSdkArgs's opt-in default rather than in buildAiSdkArgs itself, so
+    // every non-Codex caller's "no default effort" behavior is untouched.
+    defaultReasoningEffort: isCodex ? 'low' : undefined,
+  });
+  const clientWantsStream = body.stream === true;
   const ctx = { model: descriptor.resolvedModel || String(body.model ?? ''), provider: descriptor.provider };
 
   const shared = {
@@ -118,7 +153,19 @@ export async function callUpstreamViaAiSdk(
     abortSignal: opts.signal,
   } as const;
 
-  if (streaming) {
+  // Codex's backend is stream-only — a non-streaming Responses call
+  // (`stream:false`, what `generateText`'s `doGenerate` always sends) 400s
+  // there (same constraint the native transport works around by forcing
+  // `stream: true` in chatToResponses regardless of what the client asked
+  // for — see its comment). The AI SDK has no equivalent per-call override:
+  // the only way to get `stream:true` on the wire is to drive the model
+  // through `streamText` (`doStream`). So a Codex call ALWAYS goes through
+  // streamText below, even when the client itself asked for a non-streaming
+  // completion — that settled result is then collapsed into one JSON response
+  // instead of relayed as SSE, matching openai-responses/response.ts's
+  // `collectStreamAsChat` for the identical client-non-streaming/
+  // upstream-stream-only combination.
+  if (clientWantsStream || isCodex) {
     const result = streamText({
       ...shared,
       onError: () => {
@@ -127,7 +174,32 @@ export async function callUpstreamViaAiSdk(
       },
     });
     guardAgainstUnhandledResultRejections(result);
-    return sseResponse(openAiSseFromFullStream(result.fullStream, ctx));
+
+    if (clientWantsStream) {
+      return sseResponse(openAiSseFromFullStream(result.fullStream, ctx));
+    }
+
+    // Codex + a client that wants JSON: await the same settled-result promises
+    // `guardAgainstUnhandledResultRejections` already made safe to await, and
+    // build the identical JSON shape `generateText`'s branch below produces.
+    try {
+      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] = await Promise.all([
+        result.text,
+        result.reasoningText,
+        result.toolCalls,
+        result.finishReason,
+        result.usage,
+        result.providerMetadata,
+      ]);
+      return jsonResponse(
+        openAiJsonFromResult(
+          { text, reasoningText, toolCalls: mapToolCalls(toolCalls), finishReason, usage, providerMetadata },
+          ctx,
+        ),
+      );
+    } catch (err) {
+      throw toTransportError(err, descriptor.provider);
+    }
   }
 
   try {
@@ -137,11 +209,7 @@ export async function callUpstreamViaAiSdk(
         {
           text: result.text,
           reasoningText: result.reasoningText,
-          toolCalls: result.toolCalls?.map((tc) => ({
-            toolCallId: tc.toolCallId,
-            toolName: tc.toolName,
-            input: (tc as { input?: unknown }).input,
-          })),
+          toolCalls: mapToolCalls(result.toolCalls),
           finishReason: result.finishReason,
           usage: result.usage,
           providerMetadata: result.providerMetadata,

--- a/packages/llm-gateway/src/transports/ai-sdk/model.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/model.ts
@@ -4,6 +4,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible, type MetadataExtractor } from '@ai-sdk/openai-compatible';
 import type { LanguageModel } from 'ai';
 import type { UpstreamDescriptor } from '../../domain';
+import { resolveTransportKind } from '../route-kind';
 
 // Which AI SDK provider package a descriptor maps to. Prefer the models.dev
 // `npm` field (verbatim from the live catalog, #4893); fall back to the transport
@@ -14,11 +15,26 @@ const OPENAI_NPM = '@ai-sdk/openai';
 const ANTHROPIC_NPM = '@ai-sdk/anthropic';
 const BEDROCK_NPM = '@ai-sdk/amazon-bedrock';
 
+// Codex descriptors (apps/api's descriptors.ts `codexDescriptor`) never carry a
+// models.dev `npm` field — they're built by hand for the ChatGPT OAuth backend,
+// not resolved from the catalog — so they're identified by shape instead:
+// `kind: 'openai-responses'` (nothing else uses that kind) or, redundantly,
+// `provider: 'openai-codex'`. Either is sufficient on its own; checking both
+// costs nothing and survives either field changing independently.
+export function isCodexDescriptor(descriptor: UpstreamDescriptor): boolean {
+  return descriptor.provider === 'openai-codex' || descriptor.kind === 'openai-responses';
+}
+
 export function aiSdkFamilyFor(descriptor: UpstreamDescriptor): AiSdkFamily {
   const npm = descriptor.npm;
   if (npm === OPENAI_NPM) return 'openai';
   if (npm === ANTHROPIC_NPM) return 'anthropic';
   if (npm === BEDROCK_NPM) return 'bedrock';
+  // Codex speaks the same OpenAI Responses API as genuine OpenAI — route it
+  // through the `@ai-sdk/openai` package (resolveAiModel's `.responses()`
+  // branch below), not the generic openai-compatible provider, which has no
+  // Responses surface at all.
+  if (isCodexDescriptor(descriptor)) return 'openai';
   // Fall back to the transport kind. `openai-compat`/`custom` → the generic
   // OpenAI-compatible provider (the safe default for any /v1/chat/completions
   // upstream, e.g. OpenRouter). anthropic/bedrock map to their native packages.
@@ -32,10 +48,27 @@ export function aiSdkFamilyFor(descriptor: UpstreamDescriptor): AiSdkFamily {
   }
 }
 
-// AI-SDK-native model families the engine can serve. `openai-responses` (Codex)
-// is intentionally excluded — it keeps the native transport regardless of engine.
-export function isAiSdkServable(descriptor: UpstreamDescriptor): boolean {
-  return descriptor.kind !== 'openai-responses';
+// Every descriptor kind the gateway resolves is now servable by the ai-sdk
+// engine, including Codex/openai-responses — resolveAiModel's `needsResponsesApi`
+// check (below) drives those through the AI SDK's own `.responses()` model
+// instead of falling through to the native openai-responses transport.
+export function isAiSdkServable(_descriptor: UpstreamDescriptor): boolean {
+  return true;
+}
+
+// Whether this call must go out over OpenAI's /v1/responses instead of
+// /v1/chat/completions — exactly the same predicate `resolveTransportKind`
+// (route-kind.ts) uses to pick the native openai-responses transport: a
+// genuine-OpenAI reasoning model with function tools and a live reasoning
+// effort, or a Codex descriptor (which route-kind.ts also resolves to
+// 'openai-responses', since that's already `descriptor.kind`). Reusing the
+// exact same function keeps the two engines' routing decisions identical by
+// construction instead of by two hand-kept copies of the predicate.
+export function needsResponsesApi(
+  body: Record<string, unknown>,
+  descriptor: UpstreamDescriptor,
+): boolean {
+  return resolveTransportKind(body, descriptor) === 'openai-responses';
 }
 
 function trimTrailingSlash(url: string): string {
@@ -136,8 +169,14 @@ export function openRouterCostMetadataExtractor(): MetadataExtractor {
 // Build the AI SDK language model for this descriptor. The provider package owns
 // every provider-specific wire quirk (endpoint shape, param names, tool schema
 // translation, prompt caching, SSE decoding) — we only supply credentials, base
-// URL, and the resolved model id.
-export function resolveAiModel(descriptor: UpstreamDescriptor): LanguageModel {
+// URL, and the resolved model id. `body` is only consulted for the 'openai'
+// family, to decide chat.completions vs Responses (needsResponsesApi) — every
+// other family ignores it; defaults to `{}` so existing non-openai call sites
+// (and tests) that never pass a body keep working unchanged.
+export function resolveAiModel(
+  descriptor: UpstreamDescriptor,
+  body: Record<string, unknown> = {},
+): LanguageModel {
   const modelId = descriptor.resolvedModel || '';
   const baseURL = descriptor.baseUrl ? trimTrailingSlash(descriptor.baseUrl) : undefined;
   const headers = descriptor.headers;
@@ -146,12 +185,16 @@ export function resolveAiModel(descriptor: UpstreamDescriptor): LanguageModel {
   switch (family) {
     case 'openai': {
       const provider = createOpenAI({ baseURL, apiKey: descriptor.apiKey, headers });
-      // Use the Responses API, not chat.completions. OpenAI's reasoning models
-      // (gpt-5.x, o-series) reject function tools alongside reasoning_effort on
-      // /v1/chat/completions — the SDK injects reasoning_effort for them, so a
-      // real gpt-5.6 tool-call turn 400s there. /v1/responses supports reasoning
-      // + tools together, and the adapter output is identical either way.
-      return provider.responses(modelId);
+      // OpenAI's /v1/chat/completions rejects function tools alongside a live
+      // reasoning_effort on reasoning models (gpt-5.x, o-series) — see
+      // route-kind.ts's big comment for the live-confirmed error. /v1/responses
+      // supports reasoning + tools together, so ONLY that exact broken
+      // combination (plus Codex, which is Responses-only end to end) uses
+      // `.responses()` here; every other openai-family call keeps using
+      // `.chat()` — the better-trodden, narrower-surface path — exactly like
+      // the native transports keep genuine reasoning-only or tool-only traffic
+      // on openai-compat instead of moving everything to Responses.
+      return needsResponsesApi(body, descriptor) ? provider.responses(modelId) : provider.chat(modelId);
     }
     case 'anthropic': {
       const provider = createAnthropic({ baseURL, apiKey: descriptor.apiKey, headers });

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -1,4 +1,5 @@
 import { jsonSchema, tool, type ModelMessage, type ToolChoice, type ToolSet } from 'ai';
+import { reasoningEffort as reasoningEffortFromBody } from '../route-kind';
 import type { AiSdkFamily } from './model';
 
 // Everything the AI-SDK engine needs to drive `streamText`/`generateText`,
@@ -171,6 +172,14 @@ const REASONING_FAMILY_KEY: Record<AiSdkFamily, string> = {
 export function buildAiSdkArgs(
   body: Record<string, unknown>,
   family: AiSdkFamily,
+  opts: {
+    // Applied only when the request carries no explicit reasoning effort of
+    // its own (flat `reasoning_effort` or nested `reasoning.effort`) — Codex
+    // always sends a reasoning effort (native transport's `chatToResponses`
+    // defaults to 'low'; see openai-responses/request.ts), so callUpstreamViaAiSdk
+    // passes this for Codex descriptors instead of duplicating that default here.
+    defaultReasoningEffort?: string;
+  } = {},
 ): AiSdkCallArgs {
   const { system, messages } = toModelMessages(body.messages);
   const tools = toToolSet(body.tools);
@@ -186,7 +195,11 @@ export function buildAiSdkArgs(
     typeof stop === 'string' ? [stop] : Array.isArray(stop) ? (stop as string[]) : undefined;
 
   const providerOptions: Record<string, Record<string, string>> = {};
-  const reasoningEffort = body.reasoning_effort;
+  // Accepts both the chat/completions field (`reasoning_effort: string`) and
+  // the Responses-style nested shape (`reasoning: { effort: string }`) some
+  // callers (opencode) send directly — same helper route-kind.ts uses to make
+  // the identical decision for the native transport.
+  const reasoningEffort = reasoningEffortFromBody(body) ?? opts.defaultReasoningEffort;
   if (typeof reasoningEffort === 'string') {
     // The AI SDK's OpenAI provider strips temperature and other unsupported params
     // for reasoning models on its own — we only forward the effort. openai-compatible

--- a/packages/llm-gateway/src/transports/route-kind.ts
+++ b/packages/llm-gateway/src/transports/route-kind.ts
@@ -12,7 +12,7 @@ function hasFunctionTools(body: Json): boolean {
 // the Responses-style nested object (`reasoning: { effort: string }`), which
 // opencode/callers occasionally send directly. Mirrors
 // openai-responses/request.ts's `reasoningFromBody`.
-function reasoningEffort(body: Json): string | undefined {
+export function reasoningEffort(body: Json): string | undefined {
   if (typeof body.reasoning_effort === 'string') return body.reasoning_effort;
   const reasoning = body.reasoning;
   if (reasoning && typeof reasoning === 'object') {
@@ -71,6 +71,13 @@ function reasoningEffort(body: Json): string | undefined {
  * resolution in apps/api's resolveCandidates happens before the body's
  * tools/reasoning_effort are known to that layer) — cheap enough to run on
  * every dispatch, including each failover retry.
+ *
+ * Also reused verbatim by the ai-sdk engine (ai-sdk/model.ts's
+ * `needsResponsesApi`) to decide when to build a `.responses()` LanguageModel
+ * instead of `.chat()` — the exact same broken combination, just served by
+ * the AI SDK's own OpenAI Responses model instead of the native transport in
+ * ./openai-responses. Both engines therefore route the same request the same
+ * way; only the transport code speaking the wire protocol differs.
  */
 export function resolveTransportKind(body: Json, descriptor: UpstreamDescriptor): ProviderKind {
   if (


### PR DESCRIPTION
## Summary

Piece A of completing the ai-sdk transport engine: the ai-sdk engine now drives OpenAI's Responses API itself (`@ai-sdk/openai`'s `.responses()` model) for exactly the cases `route-kind.ts` already forces onto the native `openai-responses` transport, instead of falling through to native for them:

- a genuine-OpenAI reasoning model + function tools + a live `reasoning_effort` (the combination that 400s on `/v1/chat/completions`)
- Codex descriptors (`provider: 'openai-codex'` / `kind: 'openai-responses'`)

The native `openai-responses` transport is **untouched** — it's still there and still used by the native engine (`LLM_TRANSPORT_ENGINE` unset/`native`). This only changes behavior for requests already on `LLM_TRANSPORT_ENGINE=ai-sdk` (dev). Prod is on native and is unaffected.

### What changed

- **`model.ts`**
  - `needsResponsesApi(body, descriptor)` reuses `resolveTransportKind` verbatim, so both engines make the exact same routing decision by construction, not two hand-kept copies of the predicate.
  - `isCodexDescriptor(descriptor)` — Codex descriptors carry no `npm` field (hand-built for the ChatGPT OAuth backend, never catalog-resolved), so `aiSdkFamilyFor` now special-cases them onto the `openai` family (so they build a real `@ai-sdk/openai` model with a `.responses()` method, not the generic openai-compatible provider, which has no Responses surface at all).
  - `resolveAiModel(descriptor, body)` now takes the request body and picks `.chat()` vs `.responses()` per-request via `needsResponsesApi` — narrowly gated, not a blanket "always Responses" (every other openai-family request keeps using `.chat()`, the narrower/better-trodden surface).
  - `isAiSdkServable` is now unconditionally `true` (previously excluded `openai-responses`/Codex).
- **`request.ts`**: `buildAiSdkArgs` now maps the nested `reasoning: { effort }` body shape (not just the flat `reasoning_effort` field) via `route-kind.ts`'s `reasoningEffort` helper, and accepts an opt-in `defaultReasoningEffort` (used for Codex's always-on reasoning default, mirroring the native transport's `chatToResponses`).
- **`index.ts`**: Codex's backend is stream-only — `stream:false` 400s there, and the AI SDK's `generateText` (`doGenerate`) always sends `stream:false` with no per-call override. So a Codex call now always drives `streamText` (`doStream`, which forces `stream:true`) even when the **client** asked for a non-streaming completion, then collapses the settled result into one JSON response — mirroring the native transport's `collectStreamAsChat` for the identical situation.
- **`call-upstream.ts` / `route-kind.ts`**: comments updated to describe the new routing; `reasoningEffort` exported for reuse.

### Tests

New unit tests in `ai-sdk.test.ts` (mirrors existing file style/mocking patterns):
- `needsResponsesApi` truth table (reasoning+tools+live-effort → true, no tools → false, `reasoning_effort:'none'` → false, Codex → always true)
- `aiSdkFamilyFor` maps a Codex-shaped descriptor to the `openai` family
- `resolveAiModel` builds `.responses()` for the reasoning+tools case and for Codex (regardless of body), `.chat()` for everything else (including the no-body default)
- `buildAiSdkArgs` maps nested `reasoning.effort`, and applies/overrides `defaultReasoningEffort` correctly
- Codex's forced-streaming/non-streaming-client collapse path, driven against a real `streamText()` result from a mock model (not hand-rolled JSON) — both a tool-call turn and a plain-text turn

All 354 existing + new tests pass; `tsc --noEmit` is clean.

### Live verification (real OpenAI, not mocked)

Drove `callUpstreamViaAiSdk` directly against `api.openai.com` with `gpt-5.5` + a function tool + `reasoning_effort:'medium'` using a freshly-confirmed-working `OPENAI_API_KEY`:

- Plain `/v1/chat/completions` with this exact combo: **400** — `"Function tools with reasoning_effort are not supported for gpt-5.5 in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'."`
- `callUpstreamViaAiSdk` (non-streaming): **200**, real tool call (`get_weather` / `{"city":"Paris"}`), `finish_reason: "tool_calls"`.
- `callUpstreamViaAiSdk` (streaming): **200**, valid OpenAI-shaped SSE with incremental `tool_calls` deltas and a final `finish_reason: "tool_calls"` + usage chunk.

Codex OAuth was **not** exercised live — no Codex credentials available in this environment. That path is covered by unit test + code path only, per the task instructions.

## Test plan

- [x] `bun test packages/llm-gateway` — 354 pass, 0 fail
- [x] `bunx tsc --noEmit` (package `typecheck` script) — clean
- [x] Live-verified against real OpenAI (see above) — reasoning+tools combo returns 200 via the Responses path for both streaming and non-streaming
- [ ] Codex OAuth path — not live-verifiable here (no creds); unit-tested only