### PR TITLE
fix(llm-gateway): strip Bedrock cross-region prefix for pricing lookup

### DIFF
--- a/apps/api/src/llm-gateway/resolution/descriptors.test.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Minimal config stub — none of the functions under test here read config
+// fields, but descriptors.ts imports `config` at module scope (other
+// exports in the file use it), so it must resolve to something.
+const config: Record<string, unknown> = {};
+mock.module('../../config', () => ({ config }));
+
+// Stand in for the live models.dev pricing cache (router/config/model-pricing)
+// with a tiny fixed catalog keyed by BASE (unprefixed) Bedrock model ids —
+// mirrors what models.dev actually publishes for Bedrock: it has never heard
+// of a cross-region inference-profile id like `us.anthropic.claude-...`.
+const CATALOG: Record<string, { inputPer1M: number; outputPer1M: number }> = {
+  'anthropic.claude-opus-4-8': { inputPer1M: 15, outputPer1M: 75 },
+  'amazon.nova-micro-v1:0': { inputPer1M: 0.035, outputPer1M: 0.14 },
+};
+const getModelPricing = mock((modelId: string) => CATALOG[modelId] ?? null);
+mock.module('../../router/config/model-pricing', () => ({ getModelPricing }));
+
+const { livePricing, stripBedrockInferenceProfilePrefix } = await import('./descriptors');
+
+beforeEach(() => {
+  getModelPricing.mockClear();
+});
+
+describe('stripBedrockInferenceProfilePrefix', () => {
+  test('strips the us. cross-region inference-profile prefix', () => {
+    expect(stripBedrockInferenceProfilePrefix('us.anthropic.claude-opus-4-8')).toBe(
+      'anthropic.claude-opus-4-8',
+    );
+  });
+
+  test('strips the eu. prefix', () => {
+    expect(stripBedrockInferenceProfilePrefix('eu.amazon.nova-micro-v1:0')).toBe(
+      'amazon.nova-micro-v1:0',
+    );
+  });
+
+  test('strips the apac. prefix', () => {
+    expect(stripBedrockInferenceProfilePrefix('apac.anthropic.claude-sonnet-4-6')).toBe(
+      'anthropic.claude-sonnet-4-6',
+    );
+  });
+
+  test('strips the us-gov. prefix', () => {
+    expect(stripBedrockInferenceProfilePrefix('us-gov.anthropic.claude-opus-4-8')).toBe(
+      'anthropic.claude-opus-4-8',
+    );
+  });
+
+  test('leaves a base id with no region prefix untouched', () => {
+    expect(stripBedrockInferenceProfilePrefix('anthropic.claude-opus-4-8')).toBe(
+      'anthropic.claude-opus-4-8',
+    );
+  });
+
+  test('does not strip a look-alike id that merely starts with a prefix code but no matching dot boundary', () => {
+    // "use." / "usa." aren't in the known-prefix set and don't match "us."
+    // (the char after "us" isn't a dot), so they must pass through unchanged.
+    expect(stripBedrockInferenceProfilePrefix('use.something')).toBe('use.something');
+    expect(stripBedrockInferenceProfilePrefix('usa.something')).toBe('usa.something');
+  });
+
+  test('does not strip an unrelated region-like prefix outside the known AWS set', () => {
+    expect(stripBedrockInferenceProfilePrefix('us-west-2.anthropic.claude-opus-4-8')).toBe(
+      'us-west-2.anthropic.claude-opus-4-8',
+    );
+  });
+
+  test('a bare prefix with nothing after the dot is left untouched (no empty result)', () => {
+    expect(stripBedrockInferenceProfilePrefix('us.')).toBe('us.');
+  });
+});
+
+describe('livePricing + stripBedrockInferenceProfilePrefix — the actual $0 bug', () => {
+  test('a cross-region-prefixed id misses the catalog on its own (reproduces the bug)', () => {
+    expect(livePricing('us.anthropic.claude-opus-4-8')).toBeUndefined();
+  });
+
+  test('stripping the prefix first resolves the same catalog price as the base id', () => {
+    const stripped = stripBedrockInferenceProfilePrefix('us.anthropic.claude-opus-4-8');
+    expect(livePricing(stripped)).toEqual({
+      inputPerMillion: 15,
+      outputPerMillion: 75,
+      cachedInputPerMillion: undefined,
+      cacheWritePerMillion: undefined,
+    });
+    expect(livePricing(stripped)).toEqual(livePricing('anthropic.claude-opus-4-8'));
+  });
+
+  test('amazon.nova-micro cross-region id resolves via apac. prefix too', () => {
+    const stripped = stripBedrockInferenceProfilePrefix('apac.amazon.nova-micro-v1:0');
+    expect(livePricing(stripped)).toEqual(livePricing('amazon.nova-micro-v1:0'));
+  });
+});

--- a/apps/api/src/llm-gateway/resolution/descriptors.ts
+++ b/apps/api/src/llm-gateway/resolution/descriptors.ts
@@ -35,6 +35,38 @@ export function bedrockByokBaseUrl(region: string | null | undefined): string {
   return `https://bedrock-runtime.${trimmed || DEFAULT_BEDROCK_BYOK_REGION}.amazonaws.com`;
 }
 
+// Bedrock cross-region ("global") inference profiles prepend a geography code
+// to the base model id so a single logical model can route across multiple
+// AWS regions — e.g. `us.anthropic.claude-sonnet-4-20250514-v1:0` instead of
+// the base `anthropic.claude-sonnet-4-20250514-v1:0` (see AWS's "cross-region
+// inference" docs; the same base model can also appear as `eu.` or `apac.`).
+// The models.dev catalog only ever carries the base (unprefixed) id, so a
+// pricing lookup keyed by the prefixed id silently misses and produces a $0
+// upstream-cost hint. This list is intentionally exhaustive over AWS's
+// published prefixes, not just the first path segment before a dot, so it
+// never mis-strips a legitimate base id that happens to start with one of
+// these codes (there is no `us.*` or `eu.*` Bedrock model family today, but
+// checking the known set instead of "any leading `xx.`" keeps that true).
+const BEDROCK_INFERENCE_PROFILE_PREFIXES = ['us-gov', 'us', 'eu', 'apac'] as const;
+
+/**
+ * Strip a Bedrock cross-region inference-profile prefix (`us.`, `eu.`,
+ * `apac.`, `us-gov.`) from a model id, for PRICING lookups only — never for
+ * the id actually sent to the Bedrock InvokeModel API, which still needs the
+ * full profile id to route correctly. Bedrock-scoped: only ever call this for
+ * `kind === 'bedrock'` descriptors; other providers' ids never carry these
+ * prefixes and shouldn't be run through this heuristic.
+ */
+export function stripBedrockInferenceProfilePrefix(modelId: string): string {
+  for (const prefix of BEDROCK_INFERENCE_PROFILE_PREFIXES) {
+    const withDot = `${prefix}.`;
+    if (modelId.startsWith(withDot) && modelId.length > withDot.length) {
+      return modelId.slice(withDot.length);
+    }
+  }
+  return modelId;
+}
+
 export function livePricing(modelId: string): UpstreamDescriptor['pricing'] | undefined {
   const p = getModelPricing(modelId);
   if (!p) return undefined;

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -56,6 +56,14 @@ const resolveCodexCredential = mock(async () => {
 });
 mock.module('../credentials/codex', () => ({ resolveCodexCredential, CodexRefreshError }));
 
+// Captures every id `livePricing` is called with, in call order — lets tests
+// assert resolveCandidates strips the Bedrock cross-region inference-profile
+// prefix (`us.`/`eu.`/`apac.`/`us-gov.`) before the PRICING lookup while
+// still keeping the full profile id as `resolvedModel` (the id actually sent
+// upstream). Mirrors the real stripBedrockInferenceProfilePrefix (descriptors.ts)
+// closely enough to exercise the call site; the prefix-stripping logic itself
+// is unit-tested directly in descriptors.test.ts.
+let livePricingCalls: string[] = [];
 mock.module('./descriptors', () => ({
   codexDescriptor: (credential: { access: string }, model: string) => ({
     provider: 'openai-codex',
@@ -66,7 +74,12 @@ mock.module('./descriptors', () => ({
     markup: 0,
     resolvedModel: model,
   }),
-  livePricing: () => undefined,
+  livePricing: (modelId: string) => {
+    livePricingCalls.push(modelId);
+    return undefined;
+  },
+  stripBedrockInferenceProfilePrefix: (modelId: string) =>
+    modelId.replace(/^(us-gov|us|eu|apac)\.(?=.)/, ''),
   managedCandidates: (managed: { id: string }) => [
     {
       provider: 'kortix-managed',
@@ -132,6 +145,7 @@ beforeEach(() => {
   runtimeManagedModel = undefined;
   knownManagedModelId = null;
   capabilities = { reasoning: false, temperature: true };
+  livePricingCalls = [];
   getAccountTier.mockClear();
   getCachedAccountTier.mockClear();
   getProjectSecretValue.mockClear();
@@ -226,6 +240,38 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
     expect(candidates[0]).toMatchObject({
       baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
     });
+  });
+
+  // Regression coverage for the $0 upstream-cost-hint bug: models.dev only
+  // catalogs the BASE Bedrock model id, never the cross-region
+  // inference-profile id the user actually requests — so the PRICING lookup
+  // must strip the `us./eu./apac./us-gov.` prefix while `resolvedModel` (what
+  // actually gets invoked) keeps the full profile id untouched.
+  test('BYOK Bedrock: pricing lookup strips the cross-region inference-profile prefix, resolvedModel keeps it', async () => {
+    catalogUpstream = { envVar: 'AWS_BEARER_TOKEN_BEDROCK', kind: 'bedrock' };
+    secretsByName = { AWS_BEARER_TOKEN_BEDROCK: 'bedrock-bearer-key', AWS_REGION: 'eu-west-1' };
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(p, 'amazon-bedrock/us.anthropic.claude-opus-4-8');
+
+    expect(candidates[0]).toMatchObject({ resolvedModel: 'us.anthropic.claude-opus-4-8' });
+    expect(livePricingCalls).toEqual(['anthropic.claude-opus-4-8']);
+  });
+
+  test('BYOK non-Bedrock provider: pricing lookup is never run through the Bedrock prefix-strip', async () => {
+    catalogUpstream = {
+      baseUrl: 'https://api.anthropic.com/v1',
+      envVar: 'ANTHROPIC_API_KEY',
+      kind: 'anthropic',
+    };
+    resolvedSecret = 'sk-user-key';
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    await resolveCandidates(p, 'anthropic/claude-sonnet-4.6');
+
+    expect(livePricingCalls).toEqual(['claude-sonnet-4.6']);
   });
 
   test('Bedrock with no project key connected: provider_not_connected (never a silent managed fallback)', async () => {

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.ts
@@ -12,7 +12,13 @@ import { capabilitiesForModel } from '../models/catalog-models';
 import { getRuntimeManagedModel, isKnownManagedModelId } from '../models/managed-models';
 import { resolveCatalogUpstream } from '../models/provider-registry';
 import { resolveGatewayRoute } from '../routing';
-import { bedrockByokBaseUrl, codexDescriptor, livePricing, managedCandidates } from './descriptors';
+import {
+  bedrockByokBaseUrl,
+  codexDescriptor,
+  livePricing,
+  managedCandidates,
+  stripBedrockInferenceProfilePrefix,
+} from './descriptors';
 
 const PLATFORM_FEE_MARKUP = 0.1;
 
@@ -169,7 +175,16 @@ export async function resolveCandidates(
           config.KORTIX_BILLING_INTERNAL_ENABLED && !isFreeTier ? 'platform-fee' : 'none',
         markup: isFreeTier ? 0 : PLATFORM_FEE_MARKUP,
         resolvedModel: resolvedModelId,
-        pricing: livePricing(resolvedModelId),
+        // Bedrock-only: the id used to INVOKE stays the full cross-region
+        // inference-profile id (resolvedModel above) — only the id used to
+        // LOOK UP pricing gets the geography prefix stripped, since the
+        // models.dev catalog only knows the base model id. See
+        // stripBedrockInferenceProfilePrefix's doc comment.
+        pricing: livePricing(
+          byok.kind === 'bedrock'
+            ? stripBedrockInferenceProfilePrefix(resolvedModelId)
+            : resolvedModelId,
+        ),
         reasoning: capabilities.reasoning,
         temperature: capabilities.temperature,
       };


### PR DESCRIPTION
## Summary
- Bedrock models resolved via a cross-region inference-profile id (`us.`/`eu.`/`apac.`/`us-gov.` prefix — e.g. `us.anthropic.claude-sonnet-4-6`, `us.amazon.nova-micro-v1:0`) priced to **$0** for the upstream-cost hint: the pricing lookup was keyed by the prefixed id, but the models.dev catalog only ever carries the **base** model id (`anthropic.claude-sonnet-4-6`), so `getModelPricing` silently missed.
- Root cause: `apps/api/src/llm-gateway/resolution/resolve-candidates.ts` (BYOK path, ~line 172 pre-fix) passed the raw, prefixed model id straight to `livePricing()`.
- **Not purely cosmetic.** BYOK on a paid Kortix Cloud tier (`KORTIX_BILLING_INTERNAL_ENABLED` on, non-free tier) gets `billingMode: 'platform-fee'`, and `finalCost = upstreamCost * markup`. Bedrock never supplies an `upstreamCostHint` from usage (unlike OpenRouter, which reports its own cost), so `upstreamCost` falls back entirely to the catalog-priced `pricingOverride` — pinned at 0 by the catalog miss. That means the 10% Kortix platform fee was **silently under-billed to $0** for cross-region BYOK Bedrock usage on paid cloud tiers, not just displayed wrong.
- Self-host / free-tier BYOK is `billingMode: 'none'` (markup forced to 0 regardless of `upstreamCost`), so there the bug was cosmetic-only (informational upstream-cost figure), matching the original assumption for that case.
- Managed (Kortix-credits) Bedrock routes are unaffected — they already price off a curated `pricingRef` (e.g. `anthropic/claude-opus-4.8`) separate from the invoke-time `upstreamModelId`, so they never hit the catalog with a prefixed id.

## Fix
- Added `stripBedrockInferenceProfilePrefix()` in `apps/api/src/llm-gateway/resolution/descriptors.ts`: strips a known AWS cross-region prefix (`us-gov.`, `us.`, `eu.`, `apac.`) from a model id, for **pricing lookups only**.
- Applied it at the one call site in `resolve-candidates.ts`, scoped to `byok.kind === 'bedrock'` — every other BYOK provider's pricing lookup is untouched. `resolvedModel` (the id actually sent to Bedrock's `InvokeModel` API) keeps the full profile id; only the pricing-catalog lookup uses the stripped id.

## Parity / field audit
| Field | Before | After |
|---|---|---|
| `resolvedModel` (sent to Bedrock invoke) | full profile id (`us.anthropic...`) | **unchanged** — still full profile id |
| `pricing` lookup key (Bedrock BYOK only) | full profile id → catalog miss → `undefined` | base id (prefix stripped) → catalog hit |
| `pricing` lookup key (all other BYOK providers) | unchanged | unchanged (no stripping applied) |
| Managed Bedrock pricing (`pricingRef`) | unaffected (already base id) | unaffected |

## Test plan
- [x] New unit tests for `stripBedrockInferenceProfilePrefix` + `livePricing` interaction (`apps/api/src/llm-gateway/resolution/descriptors.test.ts`) — covers `us.`/`eu.`/`apac.`/`us-gov.` stripping, no-op on unprefixed ids, and non-matching look-alikes (`use.`, `usa.`, `us-west-2.`) left untouched.
- [x] New integration tests in `resolve-candidates.test.ts`: BYOK Bedrock strips the prefix for the pricing call while `resolvedModel` keeps the full id; a non-Bedrock BYOK provider's pricing call is never run through the strip.
- [x] `bun test apps/api/src/llm-gateway/resolution/descriptors.test.ts apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts` — 33 pass, 0 fail.
- [x] `bun test packages/llm-gateway` — 381 pass, 0 fail (unrelated to this change, run per task instructions).
- [x] `tsc --noEmit` clean in both `apps/api` and `packages/llm-gateway`.
- [x] Biome clean on all touched lines (one pre-existing, unrelated formatting issue on an untouched line in `resolve-candidates.ts` — confirmed present before this change via `git stash`; `apps/api/src` isn't in CI's biome check scope anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)