### PR TITLE
fix(llm-gateway): terminal upstream auth errors surface as non-retryable, not silent 502

### DIFF
--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -1141,6 +1141,91 @@ describe("gateway.chatCompletions — empty-completion failover", () => {
     expect(traces[0].candidatesTried).toEqual(["openrouter"]);
   });
 
+  // A dead BYOK credential is one of the providers (e.g. OpenAI) that reports
+  // an invalid-key failure as a 200-status stream carrying a `data:
+  // {"error":{...}}` frame rather than a non-2xx HTTP response — so this never
+  // throws an UpstreamHttpError, it lands here via probeStream's error-frame
+  // detection. A blanket 502 (this branch's default for every other in-band
+  // error frame — "Overloaded", request-too-large, ...) tells an OpenAI-
+  // compatible client "transient, retry me", and a dead key never stops being
+  // dead: the 2026-07-17 incident this guards against saw exactly that client-
+  // side retry loop end in an empty, error-free turn with nothing surfaced to
+  // the session. 401 is non-retryable to any spec-compliant client (retry
+  // eligibility is keyed off HTTP status, not body), so the failure reaches
+  // the session's error-surfacing path on the first attempt instead.
+  const authErrorSse =
+    'data: {"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key"}}\n\n' +
+    "data: [DONE]\n\n";
+
+  test("streaming: a terminal-auth error frame (dead BYOK key) surfaces as 401, not a retryable 502", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    let calls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      calls += 1;
+      return sseResponse(authErrorSse);
+    };
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.code).toBe("upstream_error");
+    expect(body.message).toBe("Incorrect API key provided");
+    expect(body.upstream_code).toBe("invalid_api_key");
+    expect(calls).toBe(1); // no same-candidate retry storm on a dead key
+    await flush();
+    expect(traces[0].ok).toBe(false);
+    expect(traces[0].status).toBe(401);
+    expect(traces[0].errorCode).toBe("upstream_error");
+  });
+
+  // The ai-sdk transport (transports/ai-sdk/sse.ts) pre-classifies its own
+  // upstream errors and embeds the real HTTP-equivalent status as a NUMERIC
+  // `code` on the frame — e.g. a genuine 429 the provider itself returned
+  // mid-stream, not just an auth failure. This branch must trust that
+  // pre-computed status verbatim instead of falling back to a blanket 502.
+  const numericCodeSse =
+    'data: {"error":{"message":"Rate limit exceeded","code":429}}\n\n' + "data: [DONE]\n\n";
+
+  test("streaming: a numeric error-frame code (ai-sdk transport's own classification) is trusted verbatim", async () => {
+    const { hooks, traces } = makeHooks({ resolveUpstream: async () => [managed] });
+    const fetchImpl: FetchImpl = async () => sseResponse(numericCodeSse);
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.message).toBe("Rate limit exceeded");
+    expect(body.upstream_code).toBe(429);
+    await flush();
+    expect(traces[0].status).toBe(429);
+  });
+
+  // A numeric code OUTSIDE the 4xx range (e.g. a provider that reports its own
+  // 5xx mid-stream) must NOT override the branch's generic "transient" 502 —
+  // trusting an arbitrary 5xx here wouldn't change anything meaningful, so the
+  // classifier deliberately only trusts 4xx.
+  const numeric5xxSse =
+    'data: {"error":{"message":"Upstream had an internal error","code":503}}\n\n' + "data: [DONE]\n\n";
+
+  test("streaming: a numeric 5xx error-frame code stays the branch's generic 502", async () => {
+    const { hooks } = makeHooks({ resolveUpstream: async () => [managed] });
+    const fetchImpl: FetchImpl = async () => sseResponse(numeric5xxSse);
+
+    const res = await createGateway(hooks, { retry: fastRetry }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"x","stream":true}',
+    });
+
+    expect(res.status).toBe(502);
+  });
+
   test("streaming: an error frame from candidate A still fails over to a healthy candidate B", async () => {
     const a: UpstreamDescriptor = { ...managed, provider: "a", baseUrl: "https://a.test/v1" };
     const b: UpstreamDescriptor = { ...managed, provider: "b", baseUrl: "https://b.test/v1" };

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -9,7 +9,7 @@ import type {
   UpstreamDescriptor,
   UsageEvent,
 } from '../domain';
-import { GatewayResolutionError } from '../errors';
+import { GatewayResolutionError, looksLikeTerminalAuthFailure } from '../errors';
 import type { FetchImpl } from '../http';
 import { type CircuitBreaker, backoffDelay, realSleep } from '../resilience';
 import {
@@ -77,6 +77,41 @@ function newRequestId(): string {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+// A dead credential (or other terminal, client-side-fixable failure) can reach
+// the gateway as a 200-status stream carrying a `data: {"error":{...}}` frame
+// instead of a non-2xx HTTP response — every OpenAI-compatible-shaped upstream
+// this gateway talks to can do this for a streaming call, so `callUpstream`
+// never throws and `probeStream`/`sseErrorFrame` exist to catch it in-band
+// instead. Blanket-502ing every one of those (this function's caller's old
+// behavior) tells an OpenAI-compatible client "transient, retry me" about a
+// failure that will NEVER succeed on retry — exactly what let a dead upstream
+// key retry silently (client-side, past the gateway's own control) until a
+// session gave up with no visible error surfaced (2026-07-17 incident; see
+// `looksLikeTerminalAuthFailure`'s doc comment for the sibling fix on the
+// THROWN-error side of the same class of bug — this is the in-band-SSE-frame
+// side). Reclassifying the response status makes it non-retryable to any
+// spec-compliant client (retry eligibility is keyed off HTTP status, not
+// response body) instead of silently retried into an empty, error-free turn.
+function statusForErrorFrame(frame: SseErrorFrame): number {
+  // The ai-sdk transport (transports/ai-sdk/sse.ts) already classifies its own
+  // upstream errors and, when it recognizes a terminal failure, embeds the
+  // real HTTP-equivalent status as a NUMERIC `code` on the frame (e.g. `401`
+  // for a dead credential, or a genuine `429`/`403` the provider itself
+  // returned mid-stream) — trust that pre-computed classification verbatim
+  // rather than re-deriving it from the message a second time. Restricted to
+  // the 4xx range: a 4xx is unambiguously "don't retry this", whereas trusting
+  // an arbitrary numeric 5xx here wouldn't change this branch's already-
+  // reasonable "transient, generic 502" default.
+  if (typeof frame.code === 'number' && frame.code >= 400 && frame.code < 500) {
+    return frame.code;
+  }
+  // Other transports (native openai-compat, OpenRouter, ...) embed a STRING
+  // code/type instead (`invalid_api_key`, `authentication_error`) — no
+  // numeric status to trust, so fall back to the same message-based
+  // classifier `toTransportError` uses for the thrown-error side.
+  return looksLikeTerminalAuthFailure(frame.message) ? 401 : 502;
 }
 
 function concatChunks(chunks: Uint8Array[]): Uint8Array {
@@ -607,6 +642,7 @@ export async function handleChatCompletions(
       const message = lastErrorFrame
         ? lastErrorFrame.message
         : 'All upstream candidates returned an empty completion';
+      const status = lastErrorFrame ? statusForErrorFrame(lastErrorFrame) : 502;
       const failedCandidate = [...candidates].reverse().find((candidate) =>
         exhaustedCandidates.has(candidateKey(candidate)),
       );
@@ -616,7 +652,7 @@ export async function handleChatCompletions(
         requestedModel,
         resolvedModel: routedModel,
         streaming,
-        status: 502,
+        status,
         ok: false,
         errorCode,
         errorMessage: message,
@@ -633,9 +669,12 @@ export async function handleChatCompletions(
           requestedModel,
           resolvedModel: failedDescriptor?.resolvedModel ?? routedModel,
           requestId,
-          suggestion: 'Retry the request. If the error continues, switch to another model.',
+          suggestion:
+            status === 401
+              ? 'Check the provider credentials, or switch to another model.'
+              : 'Retry the request. If the error continues, switch to another model.',
         }),
-        502,
+        status,
       );
     }
 


### PR DESCRIPTION
## Summary

PIECE 2 of the LLM-gateway session-layer error-propagation investigation
(prerequisite for deleting the native transports).

**Investigated:** the path from a gateway streaming error to a visible
session-turn error — API `/v1/llm` proxy → the sandbox's opencode agent →
turn finalization. Reproduced gap: dev, invalid BYOK `OPENAI_API_KEY`,
`error_code=upstream_error` / `502` in `gateway_request_logs` — the gateway
itself fails fast and cleanly (per #4923), but the **session turn completes
with an empty assistant message and no visible error** (a silent hang from
the user's POV), whereas `provider_not_connected` (400, no key configured at
all) surfaces correctly.

**Root cause (in-repo half):** when every routed candidate for a `stream:
true` request comes back as a 200-status stream carrying an in-band `data:
{"error":{...}}` frame and no content — the exact shape `probeStream`/
`sseErrorFrame` exist to catch, because `callUpstream` never throws in this
case — `handler.ts`'s `all_candidates_empty` branch unconditionally returned
`502`. To any spec-compliant OpenAI-compatible HTTP client (retry eligibility
is keyed off HTTP status, not response body), `502` means "transient, retry
me." For a dead credential that's false: it will never succeed on retry. This
is precisely the failure class `looksLikeTerminalAuthFailure` (added for the
*thrown*-error side of the same incident, `errors.ts`) exists to prevent, but
that classifier was never applied to this *in-band SSE frame* sibling path.

**Fix:** `statusForErrorFrame()` — when the frame carries a numeric `code` (the
ai-sdk transport's own `sse.ts` already pre-classifies terminal auth failures
as `401`, and passes through any real 4xx a provider reports mid-stream),
trust it verbatim. Otherwise fall back to the same message-based
`looksLikeTerminalAuthFailure` classifier the thrown-error path already uses.
Only 4xx codes override the branch's `502` default; an arbitrary 5xx is left
alone. Engine-agnostic (`packages/llm-gateway/src/pipeline/handler.ts`, no
flag) — applies identically to native and ai-sdk transports, per the task
brief.

**Session-layer / opencode remainder (documented, NOT patched here — see
Risks):** the actual "assistant message finalizes empty with no `.error` set"
defect lives in the vendored opencode agent runtime baked into the sandbox
image, outside this git repo. Evidence trail below. This PR removes the false
"retryable" signal that was feeding that external retry-then-swallow path for
the *specific, reproduced* auth-failure case; it cannot patch the runtime
itself.

## Investigation trail (for the follow-up)

- `apps/kortix-sandbox-agent-server/src/opencode-events.ts` /
  `main.ts#relayTurnEndToApi` — the ONLY in-repo consumer of opencode's
  `session.error` / `AssistantMessage.error`; gated on `slackRelayContext()`,
  so it's a Slack-only finalization path, not the general session/turn path.
- `apps/api/src/projects/lib/session-transcript.ts` and
  `packages/sdk/src/core/turns/state.ts#getTurnError` faithfully forward
  `AssistantMessage.info.error` wherever it's present — confirming the
  in-repo consumers are correct; the gap is opencode never *setting* `.error`
  for this failure class in the first place.
- `packages/sdk/src/react/use-opencode-events/handle-event.ts`'s
  `session.error` handler already patches the error onto the last assistant
  message defensively, with an explicit comment that "some error paths ...
  never emit `message.updated` with `.error` at all" — i.e. the client SDK
  already knows this opencode-side gap exists and works around it where it
  can, but has nothing to patch onto when neither `session.error` nor
  `AssistantMessage.error` ever fires.

## Test plan
- [x] `bun test packages/llm-gateway` — 384 pass, 0 fail (3 new tests: dead-key
      401, ai-sdk-transport numeric-code trust, numeric-5xx-stays-502 boundary)
- [x] `bun run typecheck` (packages/llm-gateway) — clean
- [x] Existing `502 upstream_error` ("Overloaded" / read-error) tests
      unaffected — confirmed no accidental status regression on genuinely
      transient failures