### PR TITLE
fix(llm-gateway): ai-sdk engine parity — response_format, seed, penalties, logit_bias/logprobs/etc

### DIFF
--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, afterEach } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { generateText, jsonSchema, streamText, tool } from 'ai';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
-import { jsonSchema, streamText, tool } from 'ai';
+import type { UpstreamDescriptor } from '../../domain';
+import { NetworkError, UpstreamHttpError, defaultIsRetryable } from '../../errors';
 import { calculateCost, extractUsageFromSseBuffer } from '../../usage';
 import { sseErrorFrame, sseHasContent } from '../../usage/completion-guard';
-import type { UpstreamDescriptor } from '../../domain';
 import { guardAgainstUnhandledResultRejections, mapToolCalls, toTransportError } from './index';
-import { NetworkError, UpstreamHttpError, defaultIsRetryable } from '../../errors';
 import {
   aiSdkFamilyFor,
   clampMaxOutputTokensForBedrock,
@@ -78,9 +78,7 @@ describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
     const f = frames(sse);
     // First delta carries the assistant role.
     expect((f[0] as any).choices[0].delta.role).toBe('assistant');
-    const text = f
-      .map((c: any) => c.choices?.[0]?.delta?.content ?? '')
-      .join('');
+    const text = f.map((c: any) => c.choices?.[0]?.delta?.content ?? '').join('');
     expect(text).toBe('Hello world');
     // Every chunk is a chat.completion.chunk on the right model.
     expect(f.every((c: any) => c.object === 'chat.completion.chunk' || c.usage)).toBe(true);
@@ -100,7 +98,12 @@ describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
           { type: 'tool-input-start', id: 'call_1', toolName: 'get_weather' },
           { type: 'tool-input-delta', id: 'call_1', delta: '{"city":' },
           { type: 'tool-input-delta', id: 'call_1', delta: '"Paris"}' },
-          { type: 'tool-call', toolCallId: 'call_1', toolName: 'get_weather', input: { city: 'Paris' } },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_1',
+            toolName: 'get_weather',
+            input: { city: 'Paris' },
+          },
           { type: 'finish', finishReason: 'tool-calls', totalUsage: usage() },
         ),
         CTX,
@@ -108,8 +111,7 @@ describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
     );
     expect(sseHasContent(sse)).toBe(true);
     const f = frames(sse);
-    const toolDeltas = f
-      .flatMap((c: any) => c.choices?.[0]?.delta?.tool_calls ?? []);
+    const toolDeltas = f.flatMap((c: any) => c.choices?.[0]?.delta?.tool_calls ?? []);
     // One opening delta (index 0, id, name) + two argument deltas; the terminal
     // `tool-call` for the same id is NOT re-emitted (already streamed).
     expect(toolDeltas[0]).toMatchObject({
@@ -145,7 +147,10 @@ describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
   it('surfaces an upstream error as an OpenAI error frame the probe detects', async () => {
     const sse = await readAll(
       openAiSseFromFullStream(
-        parts({ type: 'error', error: Object.assign(new Error('overloaded'), { statusCode: 529 }) }),
+        parts({
+          type: 'error',
+          error: Object.assign(new Error('overloaded'), { statusCode: 529 }),
+        }),
         CTX,
       ),
     );
@@ -185,7 +190,16 @@ describe('ai-sdk billing parity vs native openai-compat', () => {
       openAiSseFromFullStream(
         parts(
           { type: 'text-delta', id: '1', text: 'hi' },
-          { type: 'finish', finishReason: 'stop', totalUsage: usage({ inputTokens: 1000, outputTokens: 400, totalTokens: 1400, inputTokenDetails: { cacheReadTokens: 250 } }) },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            totalUsage: usage({
+              inputTokens: 1000,
+              outputTokens: 400,
+              totalTokens: 1400,
+              inputTokenDetails: { cacheReadTokens: 250 },
+            }),
+          },
         ),
         CTX,
       ),
@@ -209,7 +223,13 @@ describe('ai-sdk billing parity vs native openai-compat', () => {
       cachedTokens: u.cachedTokens,
     });
     const aiCost = calculateCost('gpt', counts(aiUsage), 1.1, aiUsage!.upstreamCostHint, pricing);
-    const nativeCost = calculateCost('gpt', counts(nativeUsage), 1.1, nativeUsage!.upstreamCostHint, pricing);
+    const nativeCost = calculateCost(
+      'gpt',
+      counts(nativeUsage),
+      1.1,
+      nativeUsage!.upstreamCostHint,
+      pricing,
+    );
     expect(aiCost.upstreamCost).toBe(nativeCost.upstreamCost);
     expect(aiCost.finalCost).toBe(nativeCost.finalCost);
     expect(aiCost.upstreamCost).toBeGreaterThan(0);
@@ -219,7 +239,13 @@ describe('ai-sdk billing parity vs native openai-compat', () => {
 describe('ai-sdk request conversion', () => {
   it('resolves the provider family from npm then kind', () => {
     const d = (over: Partial<UpstreamDescriptor>): UpstreamDescriptor => ({
-      provider: 'p', kind: 'openai-compat', baseUrl: '', apiKey: '', billingMode: 'none', markup: 0, ...over,
+      provider: 'p',
+      kind: 'openai-compat',
+      baseUrl: '',
+      apiKey: '',
+      billingMode: 'none',
+      markup: 0,
+      ...over,
     });
     expect(aiSdkFamilyFor(d({ npm: '@ai-sdk/openai' }))).toBe('openai');
     expect(aiSdkFamilyFor(d({ npm: '@ai-sdk/anthropic' }))).toBe('anthropic');
@@ -235,7 +261,11 @@ describe('ai-sdk request conversion', () => {
     const { system, messages } = toModelMessages([
       { role: 'system', content: 'be brief' },
       { role: 'user', content: 'weather?' },
-      { role: 'assistant', content: '', tool_calls: [{ id: 'c1', function: { name: 'wx', arguments: '{"city":"Paris"}' } }] },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{ id: 'c1', function: { name: 'wx', arguments: '{"city":"Paris"}' } }],
+      },
       { role: 'tool', tool_call_id: 'c1', name: 'wx', content: 'sunny' },
     ]);
     expect(system).toBe('be brief');
@@ -246,13 +276,21 @@ describe('ai-sdk request conversion', () => {
     });
     expect(messages[2]).toMatchObject({
       role: 'tool',
-      content: [{ type: 'tool-result', toolCallId: 'c1', output: { type: 'text', value: 'sunny' } }],
+      content: [
+        { type: 'tool-result', toolCallId: 'c1', output: { type: 'text', value: 'sunny' } },
+      ],
     });
   });
 
   it('translates image_url user parts', () => {
     const { messages } = toModelMessages([
-      { role: 'user', content: [{ type: 'text', text: 'what is this' }, { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } }] },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+        ],
+      },
     ]);
     expect(messages[0]).toMatchObject({
       role: 'user',
@@ -264,12 +302,23 @@ describe('ai-sdk request conversion', () => {
   });
 
   it('defaults maxOutputTokens for anthropic/bedrock, maps reasoning_effort + tool_choice', () => {
-    const anthropic = buildAiSdkArgs({ messages: [], reasoning_effort: 'high', tools: [{ function: { name: 't', parameters: {} } }], tool_choice: 'required' }, 'anthropic');
+    const anthropic = buildAiSdkArgs(
+      {
+        messages: [],
+        reasoning_effort: 'high',
+        tools: [{ function: { name: 't', parameters: {} } }],
+        tool_choice: 'required',
+      },
+      'anthropic',
+    );
     expect(anthropic.maxOutputTokens).toBe(4096);
     expect(anthropic.toolChoice).toBe('required');
     expect(anthropic.tools).toBeTruthy();
 
-    const openai = buildAiSdkArgs({ messages: [], reasoning_effort: 'high', max_tokens: 2000 }, 'openai');
+    const openai = buildAiSdkArgs(
+      { messages: [], reasoning_effort: 'high', max_tokens: 2000 },
+      'openai',
+    );
     expect(openai.maxOutputTokens).toBe(2000);
     expect(openai.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
   });
@@ -280,7 +329,8 @@ describe('ai-sdk end-to-end via streamText + mock model', () => {
     const mock = new MockLanguageModelV4({
       doStream: async () => ({
         stream: simulateReadableStream({
-          chunks: [ /* LanguageModelV4StreamPart[]; cast to skip union narrowing */
+          chunks: [
+            /* LanguageModelV4StreamPart[]; cast to skip union narrowing */
             { type: 'stream-start', warnings: [] },
             { type: 'text-start', id: '0' },
             { type: 'text-delta', id: '0', delta: 'Hi ' },
@@ -302,10 +352,14 @@ describe('ai-sdk end-to-end via streamText + mock model', () => {
     });
 
     const result = streamText({ model: mock, prompt: 'hello', maxRetries: 0 });
-    const sse = await readAll(openAiSseFromFullStream(result.fullStream, { model: 'mock/x', provider: 'mock' }));
+    const sse = await readAll(
+      openAiSseFromFullStream(result.fullStream, { model: 'mock/x', provider: 'mock' }),
+    );
 
     expect(sseHasContent(sse)).toBe(true);
-    const text = frames(sse).map((c: any) => c.choices?.[0]?.delta?.content ?? '').join('');
+    const text = frames(sse)
+      .map((c: any) => c.choices?.[0]?.delta?.content ?? '')
+      .join('');
     expect(text).toBe('Hi there');
     const u = extractUsageFromSseBuffer(sse);
     expect(u!.promptTokens).toBe(12);
@@ -391,7 +445,9 @@ describe('guardAgainstUnhandledResultRejections — defect 1 (streaming crash sa
             controller.enqueue({ type: 'stream-start', warnings: [] });
             controller.enqueue({ type: 'text-start', id: '0' });
             controller.enqueue({ type: 'text-delta', id: '0', delta: 'partial' });
-            controller.error(Object.assign(new Error('upstream socket reset'), { statusCode: undefined }));
+            controller.error(
+              Object.assign(new Error('upstream socket reset'), { statusCode: undefined }),
+            );
           },
         }),
       }),
@@ -426,7 +482,9 @@ describe('guardAgainstUnhandledResultRejections — defect 1 (streaming crash sa
 // completes a single round trip.
 describe('clampMaxOutputTokensForBedrock — defect 2 (Nova max-tokens ceiling)', () => {
   it('clamps an oversized request for a Nova model on the bedrock family', () => {
-    expect(clampMaxOutputTokensForBedrock(32_000, 'bedrock', 'us.amazon.nova-micro-v1:0')).toBe(10_000);
+    expect(clampMaxOutputTokensForBedrock(32_000, 'bedrock', 'us.amazon.nova-micro-v1:0')).toBe(
+      10_000,
+    );
     expect(clampMaxOutputTokensForBedrock(64_000, 'bedrock', 'amazon.nova-lite-v1:0')).toBe(10_000);
   });
 
@@ -445,7 +503,9 @@ describe('clampMaxOutputTokensForBedrock — defect 2 (Nova max-tokens ceiling)'
   });
 
   it('passes through undefined unchanged', () => {
-    expect(clampMaxOutputTokensForBedrock(undefined, 'bedrock', 'us.amazon.nova-micro-v1:0')).toBeUndefined();
+    expect(
+      clampMaxOutputTokensForBedrock(undefined, 'bedrock', 'us.amazon.nova-micro-v1:0'),
+    ).toBeUndefined();
   });
 });
 
@@ -490,7 +550,12 @@ describe('cost-hint threading — defect 3 (OpenRouter usage.cost parity)', () =
     expect(extracted).not.toBeNull();
     expect(extracted!.upstreamCostHint).toBe(0.00042);
 
-    const cost = calculateCost('some/no-catalog-model', extracted!, 1.1, extracted!.upstreamCostHint);
+    const cost = calculateCost(
+      'some/no-catalog-model',
+      extracted!,
+      1.1,
+      extracted!.upstreamCostHint,
+    );
     expect(cost.upstreamCost).toBe(0.00042);
     expect(cost.finalCost).toBeGreaterThan(0);
   });
@@ -504,7 +569,9 @@ describe('cost-hint threading — defect 3 (OpenRouter usage.cost parity)', () =
 
     const streamExtractor = extractor.createStreamExtractor();
     streamExtractor.processChunk({ choices: [{ delta: { content: 'hi' } }] });
-    streamExtractor.processChunk({ usage: { prompt_tokens: 10, completion_tokens: 5, cost: 0.0011 } });
+    streamExtractor.processChunk({
+      usage: { prompt_tokens: 10, completion_tokens: 5, cost: 0.0011 },
+    });
     expect(streamExtractor.buildMetadata()).toEqual({ openrouterCost: { cost: 0.0011 } });
   });
 });
@@ -602,7 +669,10 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
     });
 
     it('keeps using .chat() for a plain non-reasoning-blocked openai request (no tools)', () => {
-      const model = resolveAiModel(genuineOpenAiReasoning, { messages: [], reasoning_effort: 'medium' });
+      const model = resolveAiModel(genuineOpenAiReasoning, {
+        messages: [],
+        reasoning_effort: 'medium',
+      });
       expect(providerOf(model)).toBe('openai.chat');
     });
 
@@ -612,7 +682,9 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
 
     it('always builds a .responses() model for Codex, regardless of what the body says', () => {
       expect(providerOf(resolveAiModel(codex, { messages: [] }))).toBe('openai.responses');
-      expect(providerOf(resolveAiModel(codex, { messages: [], stream: false }))).toBe('openai.responses');
+      expect(providerOf(resolveAiModel(codex, { messages: [], stream: false }))).toBe(
+        'openai.responses',
+      );
     });
   });
 
@@ -623,14 +695,14 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
     });
 
     it("applies defaultReasoningEffort (Codex's 'low') only when the body carries none of its own", () => {
-      const defaulted = buildAiSdkArgs({ messages: [] }, 'openai', { defaultReasoningEffort: 'low' });
+      const defaulted = buildAiSdkArgs({ messages: [] }, 'openai', {
+        defaultReasoningEffort: 'low',
+      });
       expect(defaulted.providerOptions).toEqual({ openai: { reasoningEffort: 'low' } });
 
-      const explicitWins = buildAiSdkArgs(
-        { messages: [], reasoning_effort: 'high' },
-        'openai',
-        { defaultReasoningEffort: 'low' },
-      );
+      const explicitWins = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'openai', {
+        defaultReasoningEffort: 'low',
+      });
       expect(explicitWins.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
 
       const noDefaultNoEffort = buildAiSdkArgs({ messages: [] }, 'openai');
@@ -698,14 +770,15 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
       });
       guardAgainstUnhandledResultRejections(result);
 
-      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] = await Promise.all([
-        result.text,
-        result.reasoningText,
-        result.toolCalls,
-        result.finishReason,
-        result.usage,
-        result.providerMetadata,
-      ]);
+      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] =
+        await Promise.all([
+          result.text,
+          result.reasoningText,
+          result.toolCalls,
+          result.finishReason,
+          result.usage,
+          result.providerMetadata,
+        ]);
       const json = openAiJsonFromResult(
         {
           text,
@@ -753,16 +826,24 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
 
       const result = streamText({ model: mock, prompt: 'hi', maxRetries: 0 });
       guardAgainstUnhandledResultRejections(result);
-      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] = await Promise.all([
-        result.text,
-        result.reasoningText,
-        result.toolCalls,
-        result.finishReason,
-        result.usage,
-        result.providerMetadata,
-      ]);
+      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] =
+        await Promise.all([
+          result.text,
+          result.reasoningText,
+          result.toolCalls,
+          result.finishReason,
+          result.usage,
+          result.providerMetadata,
+        ]);
       const json = openAiJsonFromResult(
-        { text, reasoningText, toolCalls: mapToolCalls(toolCalls as any), finishReason, usage, providerMetadata },
+        {
+          text,
+          reasoningText,
+          toolCalls: mapToolCalls(toolCalls as any),
+          finishReason,
+          usage,
+          providerMetadata,
+        },
         { model: 'codex/gpt-5-codex', provider: 'openai-codex' },
       ) as any;
 
@@ -904,5 +985,313 @@ describe('ai-sdk streaming error frame — defect 4 (401 surfaces cleanly, no ha
     // handling, verified above. This still confirms doStream itself is
     // invoked exactly once, not retried internally.
     expect(calls).toBe(1);
+  });
+});
+
+// Piece B (2026-07-17): AI-SDK ⇄ native request PARITY AUDIT + fix.
+//
+// CONFIRMED DEFECT: buildAiSdkArgs never read `body.response_format` at all
+// — JSON mode / structured output was silently dropped on the ai-sdk
+// engine (plain prose back instead of JSON) even though native
+// (openai-compat) forwards the whole body, response_format included,
+// verbatim to the upstream. Fixed in request.ts by
+// responseFormatFromBody + buildResponseFormatOutput, threaded through as
+// streamText/generateText's `output` param (the ONLY hook that drives
+// LanguageModelV4CallOptions.responseFormat — see request.ts's big comment
+// on buildResponseFormatOutput, which cites the exact ai/dist/index.js call
+// sites where `output.responseFormat` is awaited).
+describe('Piece B — response_format parity (CONFIRMED DEFECT fix)', () => {
+  it('maps response_format:{type:"json_object"} to a plain JSON output (no schema) for the openai family', async () => {
+    const args = buildAiSdkArgs(
+      { messages: [], response_format: { type: 'json_object' } },
+      'openai',
+    );
+    expect(args.output).toBeDefined();
+    await expect(args.output!.responseFormat).resolves.toEqual({ type: 'json' });
+  });
+
+  it('maps response_format:{type:"json_schema",...} to a JSON output carrying the schema/name/description verbatim', async () => {
+    const schema = { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] };
+    const args = buildAiSdkArgs(
+      {
+        messages: [],
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'thing', description: 'd', schema },
+        },
+      },
+      'openai',
+    );
+    await expect(args.output!.responseFormat).resolves.toEqual({
+      type: 'json',
+      schema,
+      name: 'thing',
+      description: 'd',
+    });
+  });
+
+  it('maps response_format for the openai-compatible family too (OpenRouter etc.) — native forwards it there identically', async () => {
+    const args = buildAiSdkArgs(
+      { messages: [], response_format: { type: 'json_object' } },
+      'openai-compatible',
+      { providerName: 'openrouter' },
+    );
+    await expect(args.output!.responseFormat).resolves.toEqual({ type: 'json' });
+  });
+
+  it('honors an explicit strict:true from the client via providerOptions.openai.strictJsonSchema', () => {
+    const args = buildAiSdkArgs(
+      {
+        messages: [],
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'x', schema: {}, strict: true },
+        },
+      },
+      'openai',
+    );
+    expect(args.providerOptions).toMatchObject({ openai: { strictJsonSchema: true } });
+  });
+
+  // @ai-sdk/openai and @ai-sdk/openai-compatible both default
+  // strictJsonSchema to `true` (OpenAI's Structured Outputs mode) when the
+  // key is absent from providerOptions — but native forwards the client's
+  // body verbatim, so an omitted `strict` field reaches OpenAI as OpenAI's
+  // OWN default for chat/completions json_schema mode (`false`), not the AI
+  // SDK provider package's default. Only an EXPLICIT `strict:true` may ever
+  // escalate this — see the previous test.
+  it("defaults strictJsonSchema to false when the client omits strict (native's implicit behavior), NOT the AI-SDK package's own default of true", () => {
+    const args = buildAiSdkArgs(
+      {
+        messages: [],
+        response_format: { type: 'json_schema', json_schema: { name: 'x', schema: {} } },
+      },
+      'openai',
+    );
+    expect(args.providerOptions).toMatchObject({ openai: { strictJsonSchema: false } });
+  });
+
+  it('drops response_format for anthropic/bedrock — matches native, whose anthropic/request.ts (shared by bedrock) never reads body.response_format either', () => {
+    const anthropic = buildAiSdkArgs(
+      { messages: [], response_format: { type: 'json_object' } },
+      'anthropic',
+    );
+    expect(anthropic.output).toBeUndefined();
+    const bedrock = buildAiSdkArgs(
+      { messages: [], response_format: { type: 'json_object' } },
+      'bedrock',
+    );
+    expect(bedrock.output).toBeUndefined();
+  });
+
+  it('ignores an unrecognized/empty response_format (no output built, no throw)', () => {
+    expect(buildAiSdkArgs({ messages: [], response_format: {} }, 'openai').output).toBeUndefined();
+    expect(buildAiSdkArgs({ messages: [] }, 'openai').output).toBeUndefined();
+  });
+});
+
+// Live-observed regression this whole piece exists to fix: a
+// response_format:{type:'json_object'} request got plain prose back on the
+// ai-sdk engine. These two tests drive the EXACT sequence
+// callUpstreamViaAiSdk runs (buildAiSdkArgs → generateText with the built
+// `output`) against a mock model that records what LanguageModelV4CallOptions
+// it actually received — proving the fix reaches the wire-level call, not
+// just buildAiSdkArgs's own return value.
+describe('response_format end-to-end — the built model call actually receives the structured-output arg', () => {
+  const usage = {
+    inputTokens: { total: 5, noCache: 5, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 5, text: 5, reasoning: 0 },
+    totalTokens: 10,
+  };
+
+  it('a json_object request reaches doGenerate as responseFormat:{type:"json"} (no schema) and the model text is valid JSON', async () => {
+    let seenResponseFormat: unknown;
+    const mock = new MockLanguageModelV4({
+      doGenerate: async (options) => {
+        seenResponseFormat = options.responseFormat;
+        return {
+          content: [{ type: 'text', text: '{"ok":true}' }],
+          finishReason: { unified: 'stop', raw: undefined },
+          usage,
+          warnings: [],
+        };
+      },
+    });
+
+    const args = buildAiSdkArgs(
+      {
+        messages: [{ role: 'user', content: 'give me json' }],
+        response_format: { type: 'json_object' },
+      },
+      'openai',
+    );
+    const result = await generateText({
+      model: mock,
+      system: args.system,
+      messages: args.messages,
+      output: args.output,
+      maxRetries: 0,
+    });
+
+    expect(seenResponseFormat).toEqual({ type: 'json' });
+    expect(result.text).toBe('{"ok":true}');
+    expect(() => JSON.parse(result.text)).not.toThrow();
+  });
+
+  it('a json_schema request reaches doGenerate carrying the schema verbatim', async () => {
+    let seenResponseFormat: unknown;
+    const schema = { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] };
+    const mock = new MockLanguageModelV4({
+      doGenerate: async (options) => {
+        seenResponseFormat = options.responseFormat;
+        return {
+          content: [{ type: 'text', text: '{"name":"kortix"}' }],
+          finishReason: { unified: 'stop', raw: undefined },
+          usage,
+          warnings: [],
+        };
+      },
+    });
+
+    const args = buildAiSdkArgs(
+      {
+        messages: [{ role: 'user', content: 'x' }],
+        response_format: { type: 'json_schema', json_schema: { name: 'person', schema } },
+      },
+      'openai',
+    );
+    await generateText({
+      model: mock,
+      system: args.system,
+      messages: args.messages,
+      output: args.output,
+      providerOptions: args.providerOptions,
+      maxRetries: 0,
+    });
+
+    expect(seenResponseFormat).toEqual({
+      type: 'json',
+      schema,
+      name: 'person',
+      description: undefined,
+    });
+  });
+});
+
+describe('buildAiSdkArgs — sampling/penalty parity (seed, stop, frequency/presence penalty)', () => {
+  it('maps seed, frequency_penalty, presence_penalty to CallSettings top-level fields', () => {
+    const args = buildAiSdkArgs(
+      { messages: [], seed: 42, frequency_penalty: 0.4, presence_penalty: -0.2 },
+      'openai',
+    );
+    expect(args.seed).toBe(42);
+    expect(args.frequencyPenalty).toBe(0.4);
+    expect(args.presencePenalty).toBe(-0.2);
+  });
+
+  it('maps a single stop string and an array of stop sequences the same way native does', () => {
+    expect(buildAiSdkArgs({ messages: [], stop: 'STOP' }, 'openai').stopSequences).toEqual([
+      'STOP',
+    ]);
+    expect(buildAiSdkArgs({ messages: [], stop: ['A', 'B'] }, 'openai').stopSequences).toEqual([
+      'A',
+      'B',
+    ]);
+  });
+
+  it('leaves seed/penalties undefined when absent from the body (never invents a value)', () => {
+    const args = buildAiSdkArgs({ messages: [] }, 'openai');
+    expect(args.seed).toBeUndefined();
+    expect(args.frequencyPenalty).toBeUndefined();
+    expect(args.presencePenalty).toBeUndefined();
+  });
+});
+
+describe('buildAiSdkArgs — extra OpenAI-only fields via providerOptions (logit_bias, logprobs, parallel_tool_calls, user, service_tier, metadata, prediction)', () => {
+  const body = {
+    messages: [],
+    logit_bias: { '123': -100 },
+    logprobs: true,
+    top_logprobs: 3,
+    parallel_tool_calls: false,
+    user: 'user-1',
+    service_tier: 'flex',
+    metadata: { k: 'v' },
+    prediction: { type: 'content', content: 'hi' },
+  };
+
+  it("maps to camelCase keys under providerOptions.openai for the openai family (matches @ai-sdk/openai's own schema)", () => {
+    const args = buildAiSdkArgs(body, 'openai');
+    expect(args.providerOptions).toEqual({
+      openai: {
+        logitBias: { '123': -100 },
+        // top_logprobs count wins over the bare `logprobs:true` boolean —
+        // @ai-sdk/openai encodes both OpenAI wire fields as one option.
+        logprobs: 3,
+        parallelToolCalls: false,
+        user: 'user-1',
+        serviceTier: 'flex',
+        metadata: { k: 'v' },
+        prediction: { type: 'content', content: 'hi' },
+      },
+    });
+  });
+
+  it('maps to raw wire (snake_case) keys under providerOptions[<configured provider name>] for openai-compatible, since that package spreads any key outside its own small schema verbatim onto the wire request', () => {
+    const args = buildAiSdkArgs(body, 'openai-compatible', { providerName: 'openrouter' });
+    expect(args.providerOptions).toEqual({
+      openrouter: {
+        logit_bias: { '123': -100 },
+        logprobs: true,
+        top_logprobs: 3,
+        parallel_tool_calls: false,
+        user: 'user-1',
+        service_tier: 'flex',
+        metadata: { k: 'v' },
+        prediction: { type: 'content', content: 'hi' },
+      },
+    });
+  });
+
+  it('never maps these OpenAI-only fields for anthropic/bedrock — matches native, which has no equivalent for either transport', () => {
+    expect(buildAiSdkArgs(body, 'anthropic').providerOptions).toBeUndefined();
+    expect(buildAiSdkArgs(body, 'bedrock').providerOptions).toBeUndefined();
+  });
+
+  it('omits every key that the body did not set (no false/0/empty invented values)', () => {
+    const args = buildAiSdkArgs({ messages: [] }, 'openai');
+    expect(args.providerOptions).toBeUndefined();
+  });
+});
+
+// Defect 5 (2026-07-17, found auditing this parity piece): buildAiSdkArgs
+// previously keyed reasoning_effort's providerOptions entry as
+// `providerOptions.openai` for EVERY family including 'openai-compatible' —
+// but @ai-sdk/openai-compatible's chat model never reads a bare 'openai'
+// key back out (its `providerOptionsName` getter resolves to whatever
+// `name` model.ts passed to `createOpenAICompatible`, i.e.
+// `descriptor.provider`, e.g. 'openrouter' — confirmed by reading
+// @ai-sdk/openai-compatible's chat-language-model.js getArgs, which parses
+// only `providerOptions['openai-compatible']`, `['openaiCompatible']`,
+// `[this.providerOptionsName]`, and the camelCase of the last one — never a
+// literal `'openai'`). reasoning_effort was therefore silently dropped for
+// every OpenRouter-class request that set one — undetected because the only
+// prior reasoning_effort test drove family:'openai'.
+describe("buildAiSdkArgs — defect 5 (reasoning_effort keyed under the wrong providerOptions entry for 'openai-compatible')", () => {
+  it('keys reasoningEffort under providerOptions[<configured provider name>], not the literal "openai"', () => {
+    const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'openai-compatible', {
+      providerName: 'openrouter',
+    });
+    expect(args.providerOptions).toEqual({ openrouter: { reasoningEffort: 'high' } });
+  });
+
+  it('falls back to the literal "openai-compatible" key when no providerName is supplied, matching model.ts\'s own createOpenAICompatible default', () => {
+    const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'openai-compatible');
+    expect(args.providerOptions).toEqual({ 'openai-compatible': { reasoningEffort: 'high' } });
+  });
+
+  it('still keys genuine openai family calls under providerOptions.openai (unchanged behavior)', () => {
+    const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'openai');
+    expect(args.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
   });
 });

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -1,11 +1,11 @@
 import { generateText, streamText } from 'ai';
-import { NetworkError, UpstreamHttpError, looksLikeTerminalAuthFailure } from '../../errors';
 import type { UpstreamDescriptor } from '../../domain';
+import { NetworkError, UpstreamHttpError, looksLikeTerminalAuthFailure } from '../../errors';
 import {
-  clampMaxOutputTokensForBedrock,
-  resolveAiModel,
   aiSdkFamilyFor,
+  clampMaxOutputTokensForBedrock,
   isCodexDescriptor,
+  resolveAiModel,
 } from './model';
 import { buildAiSdkArgs } from './request';
 import { openAiJsonFromResult, openAiSseFromFullStream } from './sse';
@@ -123,7 +123,11 @@ export function guardAgainstUnhandledResultRejections(result: {
 export function mapToolCalls(
   toolCalls: ReadonlyArray<{ toolCallId: string; toolName: string; input?: unknown }> | undefined,
 ): Array<{ toolCallId: string; toolName: string; input: unknown }> | undefined {
-  return toolCalls?.map((tc) => ({ toolCallId: tc.toolCallId, toolName: tc.toolName, input: tc.input }));
+  return toolCalls?.map((tc) => ({
+    toolCallId: tc.toolCallId,
+    toolName: tc.toolName,
+    input: tc.input,
+  }));
 }
 
 // The AI-SDK transport engine. Given the same OpenAI chat.completions body and
@@ -152,9 +156,16 @@ export async function callUpstreamViaAiSdk(
     // buildAiSdkArgs's opt-in default rather than in buildAiSdkArgs itself, so
     // every non-Codex caller's "no default effort" behavior is untouched.
     defaultReasoningEffort: isCodex ? 'low' : undefined,
+    // Needed so buildAiSdkArgs keys providerOptions under the SAME name
+    // model.ts passed to createOpenAICompatible for this descriptor — see
+    // request.ts's providerOptionsKeyFor / defect 5 comment.
+    providerName: descriptor.provider,
   });
   const clientWantsStream = body.stream === true;
-  const ctx = { model: descriptor.resolvedModel || String(body.model ?? ''), provider: descriptor.provider };
+  const ctx = {
+    model: descriptor.resolvedModel || String(body.model ?? ''),
+    provider: descriptor.provider,
+  };
 
   const shared = {
     model,
@@ -173,6 +184,14 @@ export async function callUpstreamViaAiSdk(
       descriptor.resolvedModel,
     ),
     stopSequences: args.stopSequences,
+    seed: args.seed,
+    frequencyPenalty: args.frequencyPenalty,
+    presencePenalty: args.presencePenalty,
+    // Drives response_format (JSON mode / structured output) — see
+    // request.ts's buildResponseFormatOutput. `undefined` here is exactly
+    // streamText/generateText's own default (plain text), so a request with
+    // no response_format is completely unaffected by this field existing.
+    output: args.output,
     providerOptions: args.providerOptions,
     // The gateway owns retry/failover/circuit-breaking; keep the SDK from adding a
     // second, opaque retry layer on top.
@@ -210,17 +229,25 @@ export async function callUpstreamViaAiSdk(
     // `guardAgainstUnhandledResultRejections` already made safe to await, and
     // build the identical JSON shape `generateText`'s branch below produces.
     try {
-      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] = await Promise.all([
-        result.text,
-        result.reasoningText,
-        result.toolCalls,
-        result.finishReason,
-        result.usage,
-        result.providerMetadata,
-      ]);
+      const [text, reasoningText, toolCalls, finishReason, usage, providerMetadata] =
+        await Promise.all([
+          result.text,
+          result.reasoningText,
+          result.toolCalls,
+          result.finishReason,
+          result.usage,
+          result.providerMetadata,
+        ]);
       return jsonResponse(
         openAiJsonFromResult(
-          { text, reasoningText, toolCalls: mapToolCalls(toolCalls), finishReason, usage, providerMetadata },
+          {
+            text,
+            reasoningText,
+            toolCalls: mapToolCalls(toolCalls),
+            finishReason,
+            usage,
+            providerMetadata,
+          },
           ctx,
         ),
       );

--- a/packages/llm-gateway/src/transports/ai-sdk/model.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/model.ts
@@ -231,9 +231,9 @@ export function resolveAiModel(
         // verbatim regardless of what the upstream actually supports — this
         // package instead SILENTLY drops the schema (downgrading to plain
         // `json_object`) unless told the upstream supports Structured
-        // Outputs (see model.ts's request.ts buildResponseFormatOutput /
-        // extraOpenAiFields comment, and @ai-sdk/openai-compatible's
-        // getArgs: `supportsStructuredOutputs === true && schema != null`).
+        // Outputs (see request.ts's buildResponseFormatOutput comment, and
+        // @ai-sdk/openai-compatible's getArgs:
+        // `supportsStructuredOutputs === true && schema != null`).
         // Forced true here so an openai-compatible upstream (OpenRouter,
         // Groq, self-hosted...) that DOES support it isn't silently
         // downgraded — matches native's assume-it-works passthrough; an

--- a/packages/llm-gateway/src/transports/ai-sdk/model.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/model.ts
@@ -1,7 +1,7 @@
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
-import { createOpenAICompatible, type MetadataExtractor } from '@ai-sdk/openai-compatible';
+import { type MetadataExtractor, createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { LanguageModel } from 'ai';
 import type { UpstreamDescriptor } from '../../domain';
 import { resolveTransportKind } from '../route-kind';
@@ -194,7 +194,9 @@ export function resolveAiModel(
       // `.chat()` — the better-trodden, narrower-surface path — exactly like
       // the native transports keep genuine reasoning-only or tool-only traffic
       // on openai-compat instead of moving everything to Responses.
-      return needsResponsesApi(body, descriptor) ? provider.responses(modelId) : provider.chat(modelId);
+      return needsResponsesApi(body, descriptor)
+        ? provider.responses(modelId)
+        : provider.chat(modelId);
     }
     case 'anthropic': {
       const provider = createAnthropic({ baseURL, apiKey: descriptor.apiKey, headers });
@@ -225,6 +227,19 @@ export function resolveAiModel(
         // but requesting it explicitly is the documented, correct way and
         // costs nothing when the upstream already does it by default.
         includeUsage: true,
+        // Native forwards a client's `response_format:{type:'json_schema',...}`
+        // verbatim regardless of what the upstream actually supports — this
+        // package instead SILENTLY drops the schema (downgrading to plain
+        // `json_object`) unless told the upstream supports Structured
+        // Outputs (see model.ts's request.ts buildResponseFormatOutput /
+        // extraOpenAiFields comment, and @ai-sdk/openai-compatible's
+        // getArgs: `supportsStructuredOutputs === true && schema != null`).
+        // Forced true here so an openai-compatible upstream (OpenRouter,
+        // Groq, self-hosted...) that DOES support it isn't silently
+        // downgraded — matches native's assume-it-works passthrough; an
+        // upstream that genuinely doesn't support it 400s the same way
+        // native's verbatim forward would have.
+        supportsStructuredOutputs: true,
         ...(isOpenRouter
           ? {
               transformRequestBody: withOpenRouterUsageInclude,

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -1,4 +1,11 @@
-import { jsonSchema, tool, type ModelMessage, type ToolChoice, type ToolSet } from 'ai';
+import {
+  type JSONValue,
+  type ModelMessage,
+  type ToolChoice,
+  type ToolSet,
+  jsonSchema,
+  tool,
+} from 'ai';
 import { reasoningEffort as reasoningEffortFromBody } from '../route-kind';
 import type { AiSdkFamily } from './model';
 
@@ -14,7 +21,14 @@ export interface AiSdkCallArgs {
   topP?: number;
   maxOutputTokens?: number;
   stopSequences?: string[];
-  providerOptions?: Record<string, Record<string, string>>;
+  seed?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  providerOptions?: Record<string, Record<string, JSONValue>>;
+  // Drives structured-output (response_format) — see buildResponseFormatOutput
+  // below. `undefined` means "plain text", matching streamText/generateText's
+  // own default when no `output` is passed.
+  output?: AiSdkOutput;
 }
 
 function safeParseJson(value: unknown): unknown {
@@ -40,9 +54,7 @@ function textOf(content: unknown): string {
   return '';
 }
 
-type UserContentPart =
-  | { type: 'text'; text: string }
-  | { type: 'image'; image: URL | string };
+type UserContentPart = { type: 'text'; text: string } | { type: 'image'; image: URL | string };
 
 function translateUserContent(content: unknown): string | UserContentPart[] {
   if (typeof content === 'string') return content;
@@ -68,7 +80,10 @@ interface OpenAiToolCall {
 // hoisted into `system` (kept separate so provider prompt-caching works). The
 // role/tool-call/tool-result shape mirrors what the native transports build, but
 // in the neutral AI-SDK core format the provider package then re-serializes.
-export function toModelMessages(rawMessages: unknown): { system?: string; messages: ModelMessage[] } {
+export function toModelMessages(rawMessages: unknown): {
+  system?: string;
+  messages: ModelMessage[];
+} {
   const messages = Array.isArray(rawMessages) ? rawMessages : [];
   const systemParts: string[] = [];
   const out: ModelMessage[] = [];
@@ -162,12 +177,209 @@ function toToolChoice(raw: unknown): ToolChoice<ToolSet> | undefined {
   return undefined;
 }
 
-const REASONING_FAMILY_KEY: Record<AiSdkFamily, string> = {
-  openai: 'openai',
-  'openai-compatible': 'openai',
-  anthropic: 'anthropic',
-  bedrock: 'bedrock',
-};
+// Which `providerOptions` key each family's AI-SDK provider PACKAGE itself
+// reads back out — NOT an arbitrary label. Getting this wrong means the
+// options object is built but never consumed (silently inert):
+//  - 'openai'/'anthropic'/'bedrock': each package's own name.
+//  - 'openai-compatible': `createOpenAICompatible`'s chat model reads
+//    `providerOptions[<the exact `name` model.ts passed to
+//    createOpenAICompatible>]` (its `providerOptionsName` getter — see
+//    @ai-sdk/openai-compatible's chat-language-model.js), i.e.
+//    `descriptor.provider` (e.g. 'openrouter'), never the literal string
+//    'openai'.
+//
+// Defect 5 (2026-07-17, found auditing this parity piece): the previous
+// version of this map sent 'openai-compatible' calls' reasoningEffort to
+// providerOptions.openai — a key @ai-sdk/openai-compatible's chat model
+// NEVER reads (it only parses `providerOptions['openai-compatible']`,
+// `['openaiCompatible']`, `[providerOptionsName]`, and the camelCase of the
+// last one — never a bare `'openai'`). reasoning_effort was therefore
+// silently dropped for every OpenRouter-class (openai-compatible) request
+// carrying one — a real request ↔ upstream-call parity gap, never caught
+// because the only existing reasoning_effort test drove family:'openai'.
+function providerOptionsKeyFor(family: AiSdkFamily, providerName: string | undefined): string {
+  if (family === 'openai-compatible') return providerName || 'openai-compatible';
+  if (family === 'anthropic') return 'anthropic';
+  if (family === 'bedrock') return 'bedrock';
+  return 'openai';
+}
+
+function mergeProviderOptions(
+  target: Record<string, Record<string, unknown>>,
+  key: string,
+  fields: Record<string, unknown>,
+): void {
+  const entries = Object.entries(fields).filter(([, value]) => value !== undefined);
+  if (!entries.length) return;
+  target[key] = { ...target[key], ...Object.fromEntries(entries) };
+}
+
+// OpenAI wire fields that carry no AI-SDK top-level CallSettings equivalent
+// (unlike temperature/topP/stopSequences/seed/frequencyPenalty/
+// presencePenalty, which the SDK core exposes directly — see the seed/
+// penalty mapping in buildAiSdkArgs below) but that native's openai-compat
+// forwards completely verbatim to the upstream (openai-compat/index.ts:
+// `payload = body`, untouched unless one of its few named rewrites fires).
+// Threaded through providerOptions instead of CallSettings:
+//  - 'openai' family: @ai-sdk/openai's own schema
+//    (openaiLanguageModelChatOptions) recognizes each of these under
+//    providerOptions.openai by CAMELCASE name and re-serializes them back to
+//    the identical wire field (see its chat getArgs `baseArgs`).
+//  - 'openai-compatible' family: its schema only recognizes
+//    user/reasoningEffort/textVerbosity/strictJsonSchema — any OTHER key
+//    under providerOptions[<provider name>] rides straight onto the wire
+//    request UNMODIFIED (getArgs spreads everything not in its own schema's
+//    `.shape` verbatim) — so these are set using the RAW WIRE (snake_case)
+//    field names here, not the openai package's camelCase ones, since no
+//    schema ever translates them for this family.
+// Deliberately NOT mapped: `n` (multiple choices) — even forwarded onto the
+// wire, this transport only ever reconstructs ONE choice from AI-SDK's
+// single-result `streamText`/`generateText` (see sse.ts/index.ts), so
+// setting n>1 would silently bill for completions the client never receives
+// instead of doing nothing; and `modalities` (audio output) — no current
+// caller (opencode/agents) requests non-text output and AI SDK core has no
+// hook for it on streamText/generateText.
+function extraOpenAiFields(
+  body: Record<string, unknown>,
+  family: AiSdkFamily,
+): Record<string, unknown> {
+  if (family !== 'openai' && family !== 'openai-compatible') return {};
+
+  const logitBias = body.logit_bias;
+  const logprobs = body.logprobs;
+  const topLogprobs = body.top_logprobs;
+  const parallelToolCalls = body.parallel_tool_calls;
+  const user = body.user;
+  const serviceTier = body.service_tier;
+  const metadata = body.metadata;
+  const prediction = body.prediction;
+
+  if (family === 'openai') {
+    return {
+      logitBias: logitBias && typeof logitBias === 'object' ? logitBias : undefined,
+      // @ai-sdk/openai encodes "how many top logprobs" as the VALUE of a
+      // single `logprobs` option (boolean → just the chosen token; number →
+      // that many alternatives) — collapse OpenAI's two wire fields
+      // (`logprobs: boolean`, `top_logprobs: number`) into it.
+      logprobs:
+        typeof topLogprobs === 'number'
+          ? topLogprobs
+          : typeof logprobs === 'boolean'
+            ? logprobs
+            : undefined,
+      parallelToolCalls: typeof parallelToolCalls === 'boolean' ? parallelToolCalls : undefined,
+      user: typeof user === 'string' ? user : undefined,
+      serviceTier: typeof serviceTier === 'string' ? serviceTier : undefined,
+      metadata: metadata && typeof metadata === 'object' ? metadata : undefined,
+      prediction: prediction && typeof prediction === 'object' ? prediction : undefined,
+    };
+  }
+
+  return {
+    logit_bias: logitBias && typeof logitBias === 'object' ? logitBias : undefined,
+    logprobs: typeof logprobs === 'boolean' ? logprobs : undefined,
+    top_logprobs: typeof topLogprobs === 'number' ? topLogprobs : undefined,
+    parallel_tool_calls: typeof parallelToolCalls === 'boolean' ? parallelToolCalls : undefined,
+    user: typeof user === 'string' ? user : undefined,
+    service_tier: typeof serviceTier === 'string' ? serviceTier : undefined,
+    metadata: metadata && typeof metadata === 'object' ? metadata : undefined,
+    prediction: prediction && typeof prediction === 'object' ? prediction : undefined,
+  };
+}
+
+type AiSdkResponseFormat =
+  | { type: 'text' }
+  | { type: 'json'; schema?: unknown; name?: string; description?: string };
+
+// A hand-built AI-SDK `Output` (see ai's `Output.text()`/`Output.object()`)
+// carrying an EXACT wire-level responseFormat, instead of the one those two
+// factories produce. Needed because:
+//  - `Output.text()` always resolves `{type:'text'}` — no way to request JSON.
+//  - `Output.object()` ALWAYS attaches a schema (a required param), so it can
+//    only ever produce OpenAI's 'json_schema' wire variant — never plain
+//    'json_object' (no schema). OpenAI's `response_format:{type:'json_object'}`
+//    is a real, commonly used, DIFFERENT mode (looser, no Structured-Outputs
+//    validation) from 'json_schema'; forcing every such request through
+//    Output.object with a dummy/empty schema would silently switch modes,
+//    which is not the parity fix this is meant to be — see
+//    responseFormatFromBody below, which preserves the client's exact choice
+//    of mode by only ever attaching a schema when the client's own
+//    response_format was `json_schema`.
+// Confirmed by reading ai's source (ai/dist/index.js): streamText/generateText
+// await ONLY `output.responseFormat` before calling doGenerate/doStream —
+// `parseCompleteOutput`/`parsePartialOutput`/`createElementStreamTransform`
+// feed `result.experimental_output`, which this transport never reads (it
+// always reads `.text`/`.reasoningText` and forwards those as the OpenAI
+// `message.content` string — see index.ts/sse.ts), so those three are inert
+// stubs here, not a functional gap.
+function buildResponseFormatOutput(responseFormat: AiSdkResponseFormat) {
+  return {
+    name: 'response_format',
+    // `schema`, when present, is the client's own already-supplied JSON
+    // Schema object, forwarded verbatim — exactly what native does. Typed
+    // `unknown` here (rather than importing @ai-sdk/provider's JSONSchema7
+    // just for this cast) keeps this module decoupled from that package's
+    // exact type surface; the AI SDK only ever JSON-serializes this value
+    // onto the wire, it never validates its TS shape at runtime.
+    // biome-ignore lint: cast crosses into @ai-sdk/provider's JSONSchema7
+    // type, which this module deliberately doesn't import (see comment
+    // above) — the AI SDK only ever JSON-serializes this value onto the
+    // wire, it never validates it against that type at runtime.
+    responseFormat: Promise.resolve(responseFormat) as any,
+    async parseCompleteOutput({ text }: { text: string }): Promise<string> {
+      return text;
+    },
+    async parsePartialOutput({ text }: { text: string }): Promise<{ partial: string } | undefined> {
+      return { partial: text };
+    },
+    createElementStreamTransform(): undefined {
+      return undefined;
+    },
+  };
+}
+
+export type AiSdkOutput = ReturnType<typeof buildResponseFormatOutput>;
+
+// Only the two families whose NATIVE transport is openai-compat (the
+// verbatim body-forwarding path — see openai-compat/index.ts) ever actually
+// deliver `response_format` to an upstream today: genuine OpenAI and any
+// generic OpenAI-compatible upstream (OpenRouter, Groq, self-hosted...).
+// anthropic/bedrock's native transports (anthropic/request.ts's
+// buildAnthropicCorePayload, shared by bedrock) never read
+// `body.response_format` at all — it's silently dropped there too — so NOT
+// mapping it for those two families here is matching parity, not a gap.
+const RESPONSE_FORMAT_FAMILIES: ReadonlySet<AiSdkFamily> = new Set(['openai', 'openai-compatible']);
+
+interface OpenAiResponseFormatBody {
+  type?: string;
+  json_schema?: { schema?: unknown; name?: string; description?: string; strict?: boolean };
+}
+
+// CONFIRMED DEFECT fix (2026-07-17, live-observed): buildAiSdkArgs never
+// read `body.response_format` at all — JSON mode / structured output was
+// silently dropped on the ai-sdk engine (plain prose back instead of JSON),
+// a parity regression vs native (openai-compat forwards the whole body,
+// response_format included, verbatim). Reduces both OpenAI response_format
+// wire variants down to what buildResponseFormatOutput needs: `json_object`
+// (no schema) and `json_schema` (schema attached) both map onto AI SDK's
+// `{type:'json', schema?}`* — schema presence/absence is what tells the
+// downstream provider package which of the two to actually emit back onto
+// the wire (see @ai-sdk/openai's and @ai-sdk/openai-compatible's chat
+// getArgs: `schema != null ? {type:'json_schema',...} : {type:'json_object'}`).
+function responseFormatFromBody(body: Record<string, unknown>): AiSdkResponseFormat | undefined {
+  const raw = body.response_format as OpenAiResponseFormatBody | undefined;
+  if (!raw || typeof raw !== 'object') return undefined;
+  if (raw.type === 'json_object') return { type: 'json' };
+  if (raw.type === 'json_schema' && raw.json_schema) {
+    return {
+      type: 'json',
+      schema: raw.json_schema.schema,
+      name: raw.json_schema.name,
+      description: raw.json_schema.description,
+    };
+  }
+  return undefined;
+}
 
 export function buildAiSdkArgs(
   body: Record<string, unknown>,
@@ -179,6 +391,11 @@ export function buildAiSdkArgs(
     // defaults to 'low'; see openai-responses/request.ts), so callUpstreamViaAiSdk
     // passes this for Codex descriptors instead of duplicating that default here.
     defaultReasoningEffort?: string;
+    // The exact provider name model.ts passed to `createOpenAICompatible`
+    // (`descriptor.provider`) — needed to key providerOptions correctly for
+    // the 'openai-compatible' family (see providerOptionsKeyFor above).
+    // Ignored for every other family.
+    providerName?: string;
   } = {},
 ): AiSdkCallArgs {
   const { system, messages } = toModelMessages(body.messages);
@@ -194,7 +411,9 @@ export function buildAiSdkArgs(
   const stopSequences =
     typeof stop === 'string' ? [stop] : Array.isArray(stop) ? (stop as string[]) : undefined;
 
-  const providerOptions: Record<string, Record<string, string>> = {};
+  const providerOptionsKey = providerOptionsKeyFor(family, opts.providerName);
+  const providerOptions: Record<string, Record<string, unknown>> = {};
+
   // Accepts both the chat/completions field (`reasoning_effort: string`) and
   // the Responses-style nested shape (`reasoning: { effort: string }`) some
   // callers (opencode) send directly — same helper route-kind.ts uses to make
@@ -204,8 +423,33 @@ export function buildAiSdkArgs(
     // The AI SDK's OpenAI provider strips temperature and other unsupported params
     // for reasoning models on its own — we only forward the effort. openai-compatible
     // upstreams (OpenRouter) accept the same field under the provider namespace.
-    providerOptions[REASONING_FAMILY_KEY[family]] = { reasoningEffort };
+    mergeProviderOptions(providerOptions, providerOptionsKey, { reasoningEffort });
   }
+
+  const responseFormat = RESPONSE_FORMAT_FAMILIES.has(family)
+    ? responseFormatFromBody(body)
+    : undefined;
+  let output: AiSdkOutput | undefined;
+  if (responseFormat) {
+    output = buildResponseFormatOutput(responseFormat);
+    if (responseFormat.type === 'json' && responseFormat.schema !== undefined) {
+      // Both provider packages default `strictJsonSchema` to `true`
+      // (OpenAI Structured Outputs' stricter validation) when the key is
+      // absent — but native forwards the client's body verbatim, so an
+      // omitted `strict` field reaches OpenAI as ITS OWN default (`false`
+      // for chat/completions' json_schema mode), not the AI SDK's default.
+      // Only ever honor an EXPLICIT `strict:true` from the client; never let
+      // the ai-sdk engine be stricter than native would have been for the
+      // exact same request.
+      const rawStrict = (body.response_format as OpenAiResponseFormatBody | undefined)?.json_schema
+        ?.strict;
+      mergeProviderOptions(providerOptions, providerOptionsKey, {
+        strictJsonSchema: rawStrict === true,
+      });
+    }
+  }
+
+  mergeProviderOptions(providerOptions, providerOptionsKey, extraOpenAiFields(body, family));
 
   return {
     system,
@@ -216,6 +460,19 @@ export function buildAiSdkArgs(
     topP: typeof body.top_p === 'number' ? body.top_p : undefined,
     maxOutputTokens: maxTokens,
     stopSequences,
-    providerOptions: Object.keys(providerOptions).length ? providerOptions : undefined,
+    seed: typeof body.seed === 'number' ? body.seed : undefined,
+    frequencyPenalty:
+      typeof body.frequency_penalty === 'number' ? body.frequency_penalty : undefined,
+    presencePenalty: typeof body.presence_penalty === 'number' ? body.presence_penalty : undefined,
+    output,
+    // The accumulator above is built with `unknown` values (its inputs —
+    // logit_bias, metadata, prediction, a client-supplied JSON Schema — come
+    // straight from an already-parsed JSON request body, so they're
+    // structurally JSON-safe even though the JSON body's declared type is
+    // `Record<string, unknown>`, not `JSONValue`) — cast once at the
+    // boundary rather than threading `JSONValue` through every helper above.
+    providerOptions: (Object.keys(providerOptions).length ? providerOptions : undefined) as
+      | Record<string, Record<string, JSONValue>>
+      | undefined,
   };
 }


### PR DESCRIPTION
## Summary

Prerequisite for Phase 3 (deleting the native transports) — full field-by-field parity audit of `buildAiSdkArgs` (ai-sdk engine request builder) vs what the native transports (mainly `openai-compat`'s verbatim body forward) actually deliver to an upstream.

**CONFIRMED DEFECT (fixed):** `buildAiSdkArgs` never read `body.response_format` — JSON mode / structured output was silently dropped on the ai-sdk engine (plain prose back instead of JSON) even though native forwards the whole body, `response_format` included, verbatim. Fixed via a hand-built AI-SDK `Output` that carries the *exact* wire-level `responseFormat` for both `json_object` (no schema) and `json_schema` (schema forwarded verbatim, `strict` faithfully defaulted to `false` to match native's implicit behavior instead of the AI-SDK package's own default of `true`).

**Live-verified against real `api.openai.com`** (fresh key, HTTP 200) via `callUpstreamViaAiSdk` directly:
- `response_format:{type:'json_object'}` → `{"name":"Zyphara","moons":7}` (valid JSON, parsed OK)
- `response_format:{type:'json_schema', json_schema:{schema,strict:true}}` → `{"name":"Zyphora","moons":3}` (valid JSON matching the schema, parsed OK)

**Rest of the audit, also fixed:**
- `seed`, `frequency_penalty`, `presence_penalty` → AI-SDK's top-level `CallSettings` (`seed`, `frequencyPenalty`, `presencePenalty`).
- `logit_bias`, `logprobs`/`top_logprobs`, `parallel_tool_calls`, `user`, `service_tier`, `metadata`, `prediction` → `providerOptions`, camelCase under `providerOptions.openai` for genuine OpenAI, raw wire snake_case pass-through under `providerOptions[<provider name>]` for `openai-compatible` (that provider package spreads any key outside its own tiny schema straight onto the wire request — confirmed by reading `@ai-sdk/openai-compatible`'s source).
- `n` and `modalities` deliberately left unmapped, documented why: this transport only ever reconstructs ONE choice from `streamText`/`generateText`'s single result (forwarding `n>1` would silently bill for completions never relayed to the client), and no current caller requests non-text output.
- `stop`/`stop_sequences` were already mapped pre-existing; unaffected.

**Defect 5 (found while auditing):** `reasoning_effort` was keyed under `providerOptions.openai` for the `openai-compatible` family too — a key `@ai-sdk/openai-compatible`'s chat model never actually reads back out (it only reads `providerOptions[<the exact provider name passed to createOpenAICompatible>]`, e.g. `'openrouter'`). `reasoning_effort` was therefore silently dropped for every OpenRouter-class request that set one, undetected because the only prior test drove `family:'openai'`. `buildAiSdkArgs` now threads `descriptor.provider` through as `opts.providerName` to key correctly.

`model.ts`: `createOpenAICompatible` now sets `supportsStructuredOutputs: true` so a client's `json_schema` `response_format` isn't silently downgraded to plain `json_object` for OpenRouter/etc upstreams — matches native's assume-it-works verbatim forward.

All changes are inside `packages/llm-gateway/src/transports/ai-sdk/**`, only reachable via the `ai-sdk` transport engine (`LLM_TRANSPORT_ENGINE=ai-sdk`, dev-only) — prod (native transports) is untouched.

### Field-by-field parity table

| Field | Native (openai-compat verbatim forward) | ai-sdk BEFORE this PR | ai-sdk AFTER this PR |
|---|---|---|---|
| `response_format` (json_object) | forwarded verbatim | **dropped (CONFIRMED DEFECT)** | `output` → wire `{type:'json_object'}` |
| `response_format` (json_schema) | forwarded verbatim | **dropped** | `output` → wire `{type:'json_schema',...}`, schema/name/description verbatim, `strict` defaults false unless client set `true` |
| `seed` | forwarded verbatim | dropped | `CallSettings.seed` |
| `stop`/`stop_sequences` | forwarded verbatim | mapped (pre-existing) | unchanged |
| `frequency_penalty` | forwarded verbatim | dropped | `CallSettings.frequencyPenalty` |
| `presence_penalty` | forwarded verbatim | dropped | `CallSettings.presencePenalty` |
| `logit_bias` | forwarded verbatim | dropped | `providerOptions.openai.logitBias` (openai) / raw `logit_bias` (openai-compatible) |
| `logprobs`/`top_logprobs` | forwarded verbatim | dropped | `providerOptions.openai.logprobs` (openai, collapsed per SDK's own encoding) / raw `logprobs`+`top_logprobs` (openai-compatible) |
| `parallel_tool_calls` | forwarded verbatim | dropped | `providerOptions.*.parallelToolCalls` / raw `parallel_tool_calls` |
| `user` | forwarded verbatim | dropped | `providerOptions.*.user` |
| `service_tier` | forwarded verbatim | dropped | `providerOptions.openai.serviceTier` / raw `service_tier` |
| `metadata` | forwarded verbatim | dropped | `providerOptions.openai.metadata` / raw `metadata` |
| `prediction` | forwarded verbatim | dropped | `providerOptions.openai.prediction` / raw `prediction` |
| `n` | forwarded verbatim (dumb proxy relays raw multi-choice SSE) | dropped | still not mapped — documented structural limitation (this engine only ever relays ONE AI-SDK result choice) |
| `modalities` | forwarded verbatim | dropped | still not mapped — no current caller, no AI-SDK core hook |
| `reasoning_effort` (openai-compatible family) | n/a (native has its own translation) | **built but keyed under a providerOptions entry the SDK never reads (Defect 5)** | keyed under `providerOptions[<configured provider name>]` |
| `response_format`/extras for anthropic/bedrock | native's anthropic/request.ts never reads these fields either | dropped | still dropped — **matches native**, not a gap |

## Test plan
- [x] `bun test packages/llm-gateway` — 400 pass, 0 fail (381 pre-existing + 19 new)
- [x] `pnpm run typecheck` (packages/llm-gateway) — clean
- [x] Live-verified `response_format` (both `json_object` and `json_schema`) end-to-end against real `api.openai.com` via `callUpstreamViaAiSdk`, fresh key, HTTP 200, valid parsed JSON both times (see PR description above)
- [x] New unit tests assert the exact `LanguageModelV4CallOptions.responseFormat` a mock model's `doGenerate` receives, not just `buildAiSdkArgs`'s own return value
- [ ] CI (native/prod path untouched — no native transport files changed)