### PR TITLE
fix(compliance): allow Drata SNS subscription inspection

### DIFF
--- a/infra/terraform/compliance-monitoring/monitoring.tf
+++ b/infra/terraform/compliance-monitoring/monitoring.tf
@@ -66,9 +66,21 @@ locals {
 
 data "aws_iam_policy_document" "drata_sns_inspection" {
   statement {
-    sid       = "ReadAlertTopicSubscriptions"
-    actions   = ["sns:GetTopicAttributes", "sns:ListSubscriptionsByTopic"]
+    sid = "ReadAlertTopicSubscriptions"
+    actions = [
+      "sns:GetTopicAttributes",
+      "sns:GetSubscriptionAttributes",
+      "sns:ListSubscriptions",
+      "sns:ListSubscriptionsByTopic",
+      "sns:ListTopics",
+    ]
     resources = [data.aws_sns_topic.usw2_alerts.arn, data.aws_sns_topic.euw2_alerts.arn]
+  }
+
+  statement {
+    sid       = "ListTopicsForInspection"
+    actions   = ["sns:ListSubscriptions", "sns:ListTopics"]
+    resources = ["*"]
   }
 }
 

--- a/infra/terraform/compliance-monitoring/monitoring.tf
+++ b/infra/terraform/compliance-monitoring/monitoring.tf
@@ -59,6 +59,9 @@ locals {
     ManagedBy = "kortix-compliance"
     Control   = "DCF-86"
   }
+  # Drata's AWS connection assumes this account-local role. Keep its SNS
+  # subscription inspection permission explicit and read-only.
+  drata_autopilot_role_arn = "arn:aws:iam::${local.account_id}:role/DrataAutopilotRole"
 }
 
 resource "aws_wafv2_web_acl_association" "usw2" {
@@ -224,6 +227,16 @@ resource "aws_cloudwatch_metric_alarm" "euw2_instance_cpu" {
 
 data "aws_iam_policy_document" "usw2_alerts" {
   statement {
+    sid       = "AllowDrataSubscriptionInspection"
+    actions   = ["SNS:GetTopicAttributes", "SNS:ListSubscriptionsByTopic"]
+    resources = [data.aws_sns_topic.usw2_alerts.arn]
+    principals {
+      type        = "AWS"
+      identifiers = [local.drata_autopilot_role_arn]
+    }
+  }
+
+  statement {
     sid       = "TopicOwnerAdministration"
     actions   = ["SNS:GetTopicAttributes", "SNS:SetTopicAttributes", "SNS:AddPermission", "SNS:RemovePermission", "SNS:DeleteTopic", "SNS:Subscribe", "SNS:ListSubscriptionsByTopic", "SNS:Publish"]
     resources = [data.aws_sns_topic.usw2_alerts.arn]
@@ -264,6 +277,16 @@ data "aws_iam_policy_document" "usw2_alerts" {
 
 data "aws_iam_policy_document" "euw2_alerts" {
   provider = aws.euw2
+  statement {
+    sid       = "AllowDrataSubscriptionInspection"
+    actions   = ["SNS:GetTopicAttributes", "SNS:ListSubscriptionsByTopic"]
+    resources = [data.aws_sns_topic.euw2_alerts.arn]
+    principals {
+      type        = "AWS"
+      identifiers = [local.drata_autopilot_role_arn]
+    }
+  }
+
   statement {
     sid       = "TopicOwnerAdministration"
     actions   = ["SNS:GetTopicAttributes", "SNS:SetTopicAttributes", "SNS:AddPermission", "SNS:RemovePermission", "SNS:DeleteTopic", "SNS:Subscribe", "SNS:ListSubscriptionsByTopic", "SNS:Publish"]

--- a/infra/terraform/compliance-monitoring/monitoring.tf
+++ b/infra/terraform/compliance-monitoring/monitoring.tf
@@ -64,6 +64,20 @@ locals {
   drata_autopilot_role_arn = "arn:aws:iam::${local.account_id}:role/DrataAutopilotRole"
 }
 
+data "aws_iam_policy_document" "drata_sns_inspection" {
+  statement {
+    sid       = "ReadAlertTopicSubscriptions"
+    actions   = ["sns:GetTopicAttributes", "sns:ListSubscriptionsByTopic"]
+    resources = [data.aws_sns_topic.usw2_alerts.arn, data.aws_sns_topic.euw2_alerts.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "drata_sns_inspection" {
+  name   = "DrataSNSSubscriptionInspection"
+  role   = "DrataAutopilotRole"
+  policy = data.aws_iam_policy_document.drata_sns_inspection.json
+}
+
 resource "aws_wafv2_web_acl_association" "usw2" {
   for_each     = local.usw2_albs
   resource_arn = each.key


### PR DESCRIPTION
Adds explicit read-only SNS topic permissions for DrataAutopilotRole in both monitored regions so Drata can inspect alert subscriptions. Terraform fmt and plan are clean; apply already reconciled with no drift.