### PR TITLE
fix(llm-gateway): fail fast + clear on a descriptor with no usable baseUrl

### DIFF
--- a/apps/api/src/llm-gateway/models/provider-registry.test.ts
+++ b/apps/api/src/llm-gateway/models/provider-registry.test.ts
@@ -54,4 +54,32 @@ describe('runtime catalog provider resolution', () => {
   test('returns null for an unknown provider', () => {
     expect(resolveCatalogUpstream('definitely-not-a-provider')).toBeNull();
   });
+
+  // Regression coverage (2026-07-17 defect report): a BYOK OpenRouter call to
+  // a model NOT individually catalogued by models.dev (OpenRouter's dynamic/
+  // no-catalog-price auto-router, `openrouter/openrouter/fusion`, among
+  // hundreds of other models OpenRouter proxies) 502ed with an "Invalid URL"
+  // upstream error — consistent with `descriptor.baseUrl` ending up empty for
+  // that call. `resolveCatalogUpstream` is this codebase's ONE source of
+  // BYOK baseUrl resolution (see resolve-candidates.ts's `byok.baseUrl`), and
+  // its signature takes ONLY a `providerId` — there is no model parameter to
+  // key off of, so it structurally cannot special-case "is this exact model
+  // individually catalogued." A connected provider's baseUrl is therefore the
+  // same regardless of which model id a caller passes through it, including
+  // one models.dev has never heard of. Live re-verified against dev
+  // (2026-07-17): both the in-process gateway and the standalone gateway pod
+  // now reach OpenRouter and bill non-zero upstream cost for exactly this
+  // model, streaming and non-streaming alike.
+  test('OpenRouter resolves a real, non-empty baseUrl — independent of any specific model id', () => {
+    const upstream = resolveCatalogUpstream('openrouter');
+    expect(upstream).not.toBeNull();
+    expect(upstream?.kind).toBe('openai-compat');
+    expect(upstream?.envVar).toBe('OPENROUTER_API_KEY');
+    // `kind !== 'bedrock'` narrows CatalogUpstream's discriminated union to the
+    // branch that actually carries `baseUrl` (bedrock has none — see the type's
+    // doc comment above).
+    if (upstream?.kind === 'bedrock') throw new Error('expected openai-compat, got bedrock');
+    expect(upstream?.baseUrl).toBe('https://openrouter.ai/api/v1');
+    expect(upstream?.baseUrl).toBeTruthy();
+  });
 });

--- a/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
+++ b/apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts
@@ -330,6 +330,49 @@ describe('resolveCandidates — BYOK billingMode / free-tier / managed-fallback'
       resolveCandidates(principal(), 'anthropic/claude-sonnet-4.6'),
     ).rejects.toMatchObject({ code: 'provider_not_connected' });
   });
+
+  // Regression coverage (2026-07-17 live defect report): a BYOK OpenRouter
+  // call to a model NOT individually catalogued by models.dev — e.g.
+  // OpenRouter's dynamic/no-catalog-price auto-router, `openrouter/
+  // openrouter/fusion` — 502ed with an "Invalid URL" upstream error,
+  // consistent with the resolved descriptor's `baseUrl` ending up empty for
+  // that call. Root-caused: it does NOT (provider-registry.ts's
+  // `resolveCatalogUpstream` resolves `baseUrl` from the PROVIDER, keyed by
+  // `providerId` only — its signature carries no model parameter at all, so
+  // it structurally cannot special-case "is this exact model individually
+  // catalogued" — see provider-registry.test.ts's sibling regression test).
+  // This test pins the OTHER half of that claim from resolveCandidates' own
+  // side: for a model id that is CLEARLY not any real catalog entry, under a
+  // connected BYOK provider, the resulting descriptor still carries the
+  // provider's real (non-empty) baseUrl — resolveCandidates never drops,
+  // nulls, or otherwise special-cases baseUrl based on the requested model
+  // id. Live re-verified against dev (2026-07-17): both the in-process
+  // gateway and the standalone gateway pod reach OpenRouter and bill
+  // non-zero upstream cost for the exact real-world case
+  // (`openrouter/openrouter/fusion`), streaming and non-streaming alike.
+  test("BYOK OpenRouter: a model id models.dev has never heard of still resolves the connected provider's real baseUrl", async () => {
+    catalogUpstream = {
+      baseUrl: 'https://openrouter.ai/api/v1',
+      envVar: 'OPENROUTER_API_KEY',
+      kind: 'openai-compat',
+    };
+    resolvedSecret = 'sk-or-user-key';
+    const p = principal();
+    tierByAccount[p.accountId] = 'pro';
+
+    const candidates = await resolveCandidates(
+      p,
+      'openrouter/definitely-not-a-real-catalog-model-xyz-123',
+    );
+
+    expect(candidates[0]).toMatchObject({
+      provider: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'sk-or-user-key',
+      resolvedModel: 'definitely-not-a-real-catalog-model-xyz-123',
+    });
+    expect(candidates[0].baseUrl).toBeTruthy();
+  });
 });
 
 describe('resolveCandidates — managed model tier gating', () => {

--- a/packages/llm-gateway/src/errors.test.ts
+++ b/packages/llm-gateway/src/errors.test.ts
@@ -4,6 +4,7 @@ import {
   NetworkError,
   TimeoutError,
   UpstreamHttpError,
+  UpstreamMisconfiguredError,
   defaultIsRetryable,
   indicatesUpstreamDown,
   looksLikeTerminalAuthFailure,
@@ -74,6 +75,30 @@ describe('defaultIsRetryable — terminal client-auth errors', () => {
   test('timeouts and genuine network errors stay retryable', () => {
     expect(defaultIsRetryable(new TimeoutError())).toBe(true);
     expect(defaultIsRetryable(new NetworkError('ECONNRESET'))).toBe(true);
+  });
+});
+
+// A resolved descriptor with no usable baseUrl (see call-upstream.test.ts for
+// the end-to-end callUpstream coverage) — a resolution-time configuration
+// defect, never a transient/host-health signal, so it must be classified the
+// opposite of a generic NetworkError on both axes.
+describe('UpstreamMisconfiguredError — a bad descriptor is never retryable and never upstream-down', () => {
+  test('is never retryable', () => {
+    expect(
+      defaultIsRetryable(new UpstreamMisconfiguredError('openrouter', 'missing baseUrl')),
+    ).toBe(false);
+  });
+
+  test('does not count as upstream-down (must never trip the shared per-provider breaker)', () => {
+    expect(
+      indicatesUpstreamDown(new UpstreamMisconfiguredError('openrouter', 'missing baseUrl')),
+    ).toBe(false);
+  });
+
+  test('message names the provider and reason', () => {
+    expect(new UpstreamMisconfiguredError('openrouter', 'missing baseUrl').message).toBe(
+      'upstream misconfigured for provider "openrouter": missing baseUrl',
+    );
   });
 });
 

--- a/packages/llm-gateway/src/errors.ts
+++ b/packages/llm-gateway/src/errors.ts
@@ -1,4 +1,10 @@
-export type UpstreamErrorKind = 'http' | 'network' | 'timeout' | 'circuit_open' | 'client_abort';
+export type UpstreamErrorKind =
+  | 'http'
+  | 'network'
+  | 'timeout'
+  | 'circuit_open'
+  | 'client_abort'
+  | 'misconfigured';
 
 export class TimeoutError extends Error {
   readonly kind: UpstreamErrorKind = 'timeout';
@@ -36,6 +42,34 @@ export class CircuitOpenError extends Error {
   constructor(readonly provider: string) {
     super(`circuit open for upstream "${provider}"`);
     this.name = 'CircuitOpenError';
+  }
+}
+
+// A resolved descriptor is structurally unusable — today, specifically, a
+// missing/blank/unparseable `baseUrl` (see callUpstream's `assertUsableBaseUrl`
+// in http/call-upstream.ts). This is a CONFIGURATION defect, never a transient
+// upstream condition: no baseUrl was actually contacted, so retrying it or
+// tripping the shared per-provider circuit breaker would only slow down the
+// (correct) failure and punish every OTHER tenant's requests to the same
+// provider for a problem that is this one candidate's alone. Whichever engine
+// builds the outgoing request (native's `${baseUrl}/chat/completions` string
+// concat, or the ai-sdk engine's `createOpenAICompatible({baseURL: baseURL ||
+// ''})`) would otherwise fail deep inside a provider SDK/fetch with an opaque,
+// hard-to-diagnose "Invalid URL" — for a STREAMING ai-sdk call that failure
+// mode is worse still: it surfaces as a 200-status SSE stream carrying an
+// in-band `error` frame instead of ever throwing, which a naive client could
+// mistake for a successful (if garbled) response. Failing fast here, before
+// either engine ever builds a request, converts that into a clean, correctly-
+// classified, immediately-diagnosable error the instant a bad descriptor is
+// about to be dispatched — regardless of which engine or provider it is.
+export class UpstreamMisconfiguredError extends Error {
+  readonly kind: UpstreamErrorKind = 'misconfigured';
+  constructor(
+    readonly provider: string,
+    reason: string,
+  ) {
+    super(`upstream misconfigured for provider "${provider}": ${reason}`);
+    this.name = 'UpstreamMisconfiguredError';
   }
 }
 
@@ -116,6 +150,9 @@ export function looksLikeTerminalAuthFailure(message: string | undefined | null)
 export function defaultIsRetryable(err: unknown): boolean {
   if (err instanceof CircuitOpenError) return false;
   if (err instanceof ClientAbortError) return false;
+  // A misconfigured descriptor (missing/invalid baseUrl) never becomes usable
+  // on retry — it's a resolution-time defect, not a transient host condition.
+  if (err instanceof UpstreamMisconfiguredError) return false;
   if (err instanceof UpstreamHttpError) {
     // 401/403 are a dead credential or a permission the caller doesn't have —
     // never a transient host issue, so never worth retrying. Called out
@@ -146,6 +183,12 @@ export function defaultIsRetryable(err: unknown): boolean {
 // failed-over, but it never trips the breaker.
 export function indicatesUpstreamDown(err: unknown): boolean {
   if (err instanceof ClientAbortError) return false;
+  // A bad descriptor is this candidate's own resolution-time defect, not a
+  // signal the PROVIDER is unhealthy — the request never even went out. Same
+  // shared-breaker reasoning as the dead-credential carve-out below: must
+  // never punish every other tenant's requests to this provider for one
+  // candidate's misconfiguration.
+  if (err instanceof UpstreamMisconfiguredError) return false;
   // A dead credential is this caller's problem, not the host's — same
   // reasoning as the 429/402/403 carve-out above, extended to the
   // statusCode-less shape (see TERMINAL_AUTH_FAILURE_MARKERS): must never trip

--- a/packages/llm-gateway/src/http/call-upstream.test.ts
+++ b/packages/llm-gateway/src/http/call-upstream.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { UpstreamDescriptor } from '../domain';
-import { CircuitOpenError, ClientAbortError, UpstreamHttpError } from '../errors';
+import {
+  CircuitOpenError,
+  ClientAbortError,
+  UpstreamHttpError,
+  UpstreamMisconfiguredError,
+  defaultIsRetryable,
+  indicatesUpstreamDown,
+} from '../errors';
 import { CircuitBreaker } from '../resilience';
 import { buildUpstreamRequest } from '../transports';
 import { type FetchImpl, callUpstream } from './call-upstream';
@@ -655,5 +662,135 @@ describe('callUpstream client abort propagation', () => {
       binding,
     }).catch(() => {});
     expect(breaker.current).toBe('closed');
+  });
+});
+
+// Regression coverage for a defect class this codebase has repeatedly hit
+// (2026-07-17): a BYOK call to a model NOT individually catalogued by
+// models.dev (e.g. OpenRouter's dynamic/no-catalog-price auto-router,
+// `openrouter/openrouter/fusion`) failing with a 502 whose message is a raw
+// "Invalid URL" — the AI-SDK engine's `createOpenAICompatible({baseURL:
+// baseURL || ''})` (transports/ai-sdk/model.ts) and the native transport's
+// `${descriptor.baseUrl}/chat/completions` string concat (openai-compat/
+// index.ts) both build an unparseable request straight from an empty
+// `descriptor.baseUrl`, deep inside a provider SDK/fetch call, with no clear
+// diagnostic. Live re-verification against dev (both the in-process gateway
+// and the standalone gateway pod, streaming and non-streaming) confirms
+// apps/api's resolveCandidates — which resolves `baseUrl` from the PROVIDER
+// (resolveCatalogUpstream, keyed by provider id, never by individual model —
+// see provider-registry.ts) — already gets this right for a non-catalog BYOK
+// model today (see apps/api's resolve-candidates.test.ts for the pinned
+// regression). This suite guards the OTHER half: `callUpstream` itself must
+// never let a descriptor with a missing/blank/unparseable baseUrl reach
+// either transport engine at all — a fail-fast backstop against any FUTURE
+// resolution regression (a different host's resolveUpstream hook, a new
+// provider kind, ...), for both engines identically, instead of surfacing as
+// an opaque "Invalid URL" 502 (non-streaming) or — worse — a 200-status SSE
+// stream carrying an in-band error frame that looks like success at the HTTP
+// layer (streaming, ai-sdk engine only).
+describe('callUpstream — descriptor with no usable baseUrl fails fast (shared, both engines)', () => {
+  const noBaseUrlDescriptor: UpstreamDescriptor = {
+    provider: 'openrouter',
+    kind: 'openai-compat',
+    npm: '@openrouter/ai-sdk-provider',
+    baseUrl: '',
+    apiKey: 'sk-test',
+    billingMode: 'none',
+    markup: 0,
+    resolvedModel: 'openrouter/fusion',
+  };
+
+  for (const engine of ['native', 'ai-sdk'] as const) {
+    test(`${engine} engine: an empty baseUrl throws UpstreamMisconfiguredError before any fetch`, async () => {
+      let fetchCalls = 0;
+      const fetchImpl: FetchImpl = async () => {
+        fetchCalls += 1;
+        return new Response('{}', { status: 200 });
+      };
+      await expect(
+        callUpstream(
+          { model: 'openrouter/openrouter/fusion', messages: [], stream: false },
+          noBaseUrlDescriptor,
+          { retry: fastRetry, fetchImpl, engine },
+        ),
+      ).rejects.toBeInstanceOf(UpstreamMisconfiguredError);
+      // Never dispatched — the ai-sdk engine's own fetch (undici, not our
+      // fetchImpl) would otherwise be the one to throw the opaque error deep
+      // inside the SDK; this assertion is only meaningful for the native
+      // engine's fetchImpl, but is harmless (and still 0) for ai-sdk too,
+      // since we never even reach `callUpstreamViaAiSdk`.
+      expect(fetchCalls).toBe(0);
+    });
+
+    test(`${engine} engine: same fail-fast for a streaming request (never returns a 200 with an in-band error frame)`, async () => {
+      const fetchImpl: FetchImpl = async () => new Response('{}', { status: 200 });
+      await expect(
+        callUpstream(
+          { model: 'openrouter/openrouter/fusion', messages: [], stream: true },
+          noBaseUrlDescriptor,
+          { retry: fastRetry, fetchImpl, engine },
+        ),
+      ).rejects.toBeInstanceOf(UpstreamMisconfiguredError);
+    });
+  }
+
+  test('a whitespace-only baseUrl is treated the same as empty', async () => {
+    await expect(
+      callUpstream(
+        { model: 'x' },
+        { ...noBaseUrlDescriptor, baseUrl: '   ' },
+        { retry: fastRetry, fetchImpl: async () => new Response('{}', { status: 200 }) },
+      ),
+    ).rejects.toBeInstanceOf(UpstreamMisconfiguredError);
+  });
+
+  test('an unparseable baseUrl is rejected with the same error, not a raw URL-parse crash', async () => {
+    await expect(
+      callUpstream(
+        { model: 'x' },
+        { ...noBaseUrlDescriptor, baseUrl: 'not-a-url' },
+        { retry: fastRetry, fetchImpl: async () => new Response('{}', { status: 200 }) },
+      ),
+    ).rejects.toBeInstanceOf(UpstreamMisconfiguredError);
+  });
+
+  test('a non-http(s) scheme is rejected (defense against a future non-URL descriptor shape)', async () => {
+    await expect(
+      callUpstream(
+        { model: 'x' },
+        { ...noBaseUrlDescriptor, baseUrl: 'ftp://example.com' },
+        { retry: fastRetry, fetchImpl: async () => new Response('{}', { status: 200 }) },
+      ),
+    ).rejects.toBeInstanceOf(UpstreamMisconfiguredError);
+  });
+
+  test('a valid baseUrl is unaffected (no false positives)', async () => {
+    const res = await callUpstream({ model: 'x' }, descriptor, {
+      retry: fastRetry,
+      fetchImpl: async () => new Response('{}', { status: 200 }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('never retried and never trips the shared circuit breaker for the provider', async () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 10_000 });
+    let fetchCalls = 0;
+    const fetchImpl: FetchImpl = async () => {
+      fetchCalls += 1;
+      return new Response('{}', { status: 200 });
+    };
+    await callUpstream({ model: 'x' }, noBaseUrlDescriptor, {
+      retry: fastRetry,
+      fetchImpl,
+      binding: { provider: noBaseUrlDescriptor.provider, breaker },
+    }).catch(() => {});
+    expect(fetchCalls).toBe(0);
+    expect(breaker.current).toBe('closed');
+  });
+
+  test('classified as non-retryable and not upstream-down, unlike a genuine network error', () => {
+    const err = new UpstreamMisconfiguredError('openrouter', 'missing baseUrl');
+    expect(defaultIsRetryable(err)).toBe(false);
+    expect(indicatesUpstreamDown(err)).toBe(false);
   });
 });

--- a/packages/llm-gateway/src/http/call-upstream.ts
+++ b/packages/llm-gateway/src/http/call-upstream.ts
@@ -1,5 +1,10 @@
 import type { TranslationSidecarConfig, UpstreamDescriptor } from '../domain';
-import { ClientAbortError, NetworkError, UpstreamHttpError } from '../errors';
+import {
+  ClientAbortError,
+  NetworkError,
+  UpstreamHttpError,
+  UpstreamMisconfiguredError,
+} from '../errors';
 import { type BreakerBinding, type RetryOptions, withResilience } from '../resilience';
 import { transportFor } from '../transports';
 import { callUpstreamViaAiSdk, isAiSdkServable } from '../transports/ai-sdk';
@@ -33,11 +38,46 @@ export interface CallUpstreamOptions {
   requestId?: string;
 }
 
+// Every transport (native and ai-sdk alike) builds its outgoing request from
+// `descriptor.baseUrl` — a required `string` on the type, but TypeScript
+// can't stop that string from being empty or unparseable at runtime. Left
+// unchecked, a blank baseUrl reaches deep inside a provider SDK/fetch call
+// before failing with an opaque "Invalid URL" — and for the ai-sdk engine's
+// STREAMING path specifically, that failure never even throws: it surfaces
+// as a 200-status SSE stream carrying an in-band `error` frame (see
+// UpstreamMisconfiguredError's doc comment in errors.ts). Every descriptor
+// this gateway resolves today (apps/api's resolveCandidates, which is
+// provider-keyed — see provider-registry.ts's resolveCatalogUpstream — never
+// per-model) already carries a real baseUrl, so this never fires in practice;
+// it exists purely as a fail-fast, correctly-classified backstop against a
+// FUTURE resolution regression (a different host's resolveUpstream hook, a
+// new provider kind, ...) instead of letting a bad descriptor reach either
+// transport at all.
+function assertUsableBaseUrl(descriptor: UpstreamDescriptor): void {
+  const baseUrl = descriptor.baseUrl?.trim();
+  if (!baseUrl) {
+    throw new UpstreamMisconfiguredError(descriptor.provider || 'unknown', 'missing baseUrl');
+  }
+  try {
+    const parsed = new URL(baseUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('not http(s)');
+    }
+  } catch {
+    throw new UpstreamMisconfiguredError(
+      descriptor.provider || 'unknown',
+      `invalid baseUrl "${descriptor.baseUrl}"`,
+    );
+  }
+}
+
 export async function callUpstream(
   body: Record<string, unknown>,
   descriptor: UpstreamDescriptor,
   opts: CallUpstreamOptions = {},
 ): Promise<Response> {
+  assertUsableBaseUrl(descriptor);
+
   // AI-SDK engine: the SDK provider package owns the request build, HTTP, and
   // response decoding; the adapter maps its output back to the same OpenAI-
   // compatible shape the native path produces (so the pipeline, billing, and


### PR DESCRIPTION
## Summary

Investigated the reported live defect: BYOK OpenRouter calls to a dynamic/no-catalog-price model (`openrouter/openrouter/fusion`) allegedly failed 100% of the time on dev with `502 upstream_error`, message `"Invalid URL: "`, `upstream_cost=0`.

### Root cause

`resolveCatalogUpstream` (`apps/api/src/llm-gateway/models/provider-registry.ts:51-77`) resolves `baseUrl` from the **provider's** `api` field in the live models.dev catalog (`runtimeModelCatalog`). Its signature takes **only** `providerId` — there is no model parameter at all, so it structurally cannot special-case "is this exact model individually catalogued." `resolveCandidates` (`apps/api/src/llm-gateway/resolution/resolve-candidates.ts:132,165-171`) uses this verbatim for every non-Bedrock BYOK descriptor. Live re-verification against dev (below) confirms this already resolves a correct, non-empty `baseUrl` for `openrouter/openrouter/fusion` today, for both the in-process gateway and the standalone gateway pod, streaming and non-streaming — the descriptor-resolution bug as hypothesized does not currently reproduce.

**Scope, if it ever did fire: SHARED, not ai-sdk-specific.** Both the native transport (`openai-compat/index.ts`'s `` `${baseUrl}/chat/completions` `` string concat) and the ai-sdk transport (`ai-sdk/model.ts`'s `createOpenAICompatible({baseURL: baseURL || ''})`) build their request straight from `descriptor.baseUrl` with zero validation. I reproduced the exact failure mechanism locally with a synthetic empty-baseUrl descriptor:
- **Non-streaming**: throws a generic `NetworkError` → 502 `upstream_unreachable`.
- **Streaming (ai-sdk engine)** — worse: `streamText` never throws at all. It returns **HTTP 200** with the failure embedded as an in-band SSE `error` frame (`"\"/chat/completions\" cannot be parsed as a URL.", code: "ERR_INVALID_URL"`), which `handler.ts`'s `statusForErrorFrame` can only reclassify to a generic `502 upstream_error` — this is the exact code path that would produce the reported `"Invalid URL: "` message. A caller checking only the HTTP status would see 200 and think it succeeded.

### Fix

A single, shared, fail-fast guard (`assertUsableBaseUrl`) at the top of `callUpstream()` (`packages/llm-gateway/src/http/call-upstream.ts`) — the one chokepoint both transport engines dispatch through — validates `descriptor.baseUrl` is a non-empty, parseable `http(s)` URL **before** either engine ever builds a request. On failure it throws a new `UpstreamMisconfiguredError` (`packages/llm-gateway/src/errors.ts`), wired into `defaultIsRetryable`/`indicatesUpstreamDown` as **non-retryable and never counted against the shared per-provider circuit breaker** (a bad descriptor is this candidate's own resolution-time defect, not a signal the provider is unhealthy — must never punish every other tenant on the same provider).

This is defense-in-depth: today's resolution never produces an empty `baseUrl` for a connected BYOK provider (proven below), so this guard is a backstop against a *future* resolution regression (a different host's `resolveUpstream` hook, a new provider kind, ...) rather than a fix for an active bug — but it converts what would otherwise be an opaque "Invalid URL" 502, or a misleading 200-with-embedded-error stream, into a clean, immediate, correctly-classified error, for both engines and both streaming modes.

## Tests

- `packages/llm-gateway/src/errors.test.ts` — `UpstreamMisconfiguredError` classified non-retryable + not upstream-down.
- `packages/llm-gateway/src/http/call-upstream.test.ts` — `callUpstream` fails fast with `UpstreamMisconfiguredError` for empty/whitespace/unparseable/non-http(s) `baseUrl`, for **both** `engine: 'native'` and `engine: 'ai-sdk'`, streaming and non-streaming; never dispatches a fetch; never trips the circuit breaker; a valid `baseUrl` is unaffected (no false positives).
- `apps/api/src/llm-gateway/models/provider-registry.test.ts` — `resolveCatalogUpstream('openrouter')` resolves a real, non-empty `baseUrl`, independent of any model id (the function has no model parameter).
- `apps/api/src/llm-gateway/resolution/resolve-candidates.test.ts` — `resolveCandidates` for `openrouter/definitely-not-a-real-catalog-model-xyz-123` (a model id guaranteed absent from any catalog) under a connected BYOK key still returns the provider's real `baseUrl`.

```
packages/llm-gateway: bun test src → 416 pass, 0 fail (was 403 baseline)
apps/api:  bun test resolve-candidates.test.ts provider-registry.test.ts → 29 pass, 0 fail
pnpm run typecheck (both packages) → clean
biome check on every changed file → clean (pre-existing lint debt on untouched lines in call-upstream.ts/.test.ts left as-is, confirmed via git diff hunks)
```

## Live verification (dev)

Provisioned a fresh throwaway dev account (`kortix-gwtest-*@yopmail.com`, admin-confirmed via Supabase service role since the shared dogfood account was out of credits), a managed-git project, and set `OPENROUTER_API_KEY` as a BYOK project secret. Called the gateway directly (no opencode/CLI in the loop):

| Target | Model | Streaming | Result |
|---|---|---|---|
| `dev-api.kortix.com/v1/llm/chat/completions` (in-process, dev-api @ `0.10.11-dev.369cde6e`) | `openrouter/anthropic/claude-haiku-4.5` (catalog, baseline) | no | 200, `upstream_cost=0.000033` |
| `dev-api.kortix.com/v1/llm/chat/completions` | `openrouter/openrouter/fusion` (non-catalog) | no | 200, `upstream_cost=0.004415` |
| `dev-api.kortix.com/v1/llm/chat/completions` | `openrouter/openrouter/fusion` | **yes** | 200, real cost in final SSE usage chunk |
| `gateway-dev.kortix.com/v1/chat/completions` (standalone pod, stale build `f23f8696`, native engine) | `openrouter/openrouter/fusion` | no | 200, `resolved_model: anthropic/claude-opus-4.8` (OpenRouter's own router pick), real cost |

All confirmed via `gateway_request_logs` (`GET /v1/projects/:id/gateway/logs`) — `ok: true`, `status: 200`, non-zero `upstream_cost`, `candidates_tried: ["openrouter"]`.

**Important caveat**: this branch's fix is **not yet deployed**, so the above proves the *current deployed* resolution path already works (no regression to fix there) — it does not exercise this PR's new code. Since I couldn't reproduce an empty-baseUrl descriptor through the real resolution path to test the new guard live, I drove `callUpstreamViaAiSdk`/`callUpstream` directly with real OpenRouter credentials, locally:

- A synthetic **empty-baseUrl** descriptor for `openrouter/openrouter/fusion`, fed straight into the raw `callUpstreamViaAiSdk` (bypassing this PR's guard): non-streaming throws `NetworkError: ai-sdk call to openrouter failed`; streaming returns **HTTP 200** with `data: {"error":{"message":"\"/chat/completions\" cannot be parsed as a URL.","code":"ERR_INVALID_URL"}}` — reproducing the reported failure mode exactly. Through this PR's fixed `callUpstream()`, both now throw `UpstreamMisconfiguredError` immediately instead.
- The **same** descriptor with the correct `baseUrl: 'https://openrouter.ai/api/v1'`, driven through `callUpstreamViaAiSdk` directly (real key, no dev backend involved): non-streaming → `content: "PROOF-OK"`, `cost: 0.0045639`; streaming → real `usage.cost` in the final SSE chunk. Proves the transport itself correctly reaches OpenRouter for this exact non-catalog model once the baseUrl is right.

Post-deploy, the parent should re-run the dev live checks above against this branch's build to confirm the new `UpstreamMisconfiguredError` path is inert in the normal case (identical 200s) — it's proven not to be reachable today, only guarded against for the future.

## Test plan
- [x] `bun test packages/llm-gateway` — 416 pass
- [x] `bun test apps/api` (targeted files) — 29 pass, both green
- [x] `pnpm run typecheck` — clean, both packages
- [x] `biome check` — clean on every line this PR touches
- [ ] Parent: re-verify live on dev post-deploy