### PR TITLE
test(llm-gateway): remove unused test declarations

### DIFF
--- a/packages/llm-gateway/src/create-gateway.test.ts
+++ b/packages/llm-gateway/src/create-gateway.test.ts
@@ -33,14 +33,6 @@ function makeHooks(over: Partial<GatewayHooks> = {}): GatewayHooks {
   };
 }
 
-function okFetch(data: unknown): FetchImpl {
-  return async () =>
-    new Response(JSON.stringify(data), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    });
-}
-
 describe('gateway.messages (Anthropic Messages ingress)', () => {
   test('401 without a bearer token, in the Anthropic error envelope (not the OpenAI-compat one)', async () => {
     const res = await createGateway(makeHooks(), { retry: fastRetry }).messages({

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -9,7 +9,6 @@ import { guardAgainstUnhandledResultRejections, mapToolCalls, toTransportError }
 import {
   aiSdkFamilyFor,
   clampMaxOutputTokensForBedrock,
-  isCodexDescriptor,
   needsResponsesApi,
   openRouterCostMetadataExtractor,
   resolveAiModel,


### PR DESCRIPTION
Resolves the two CodeQL unused-declaration findings surfaced by the staging promotion candidate.\n\nVerified:\n- `pnpm --filter @kortix/llm-gateway test` (416 passed)\n- `pnpm --filter @kortix/llm-gateway typecheck`\n- `git diff --check`