### PR TITLE
test(accessibility): scope decorative contrast audit

### DIFF
--- a/apps/web/src/features/marketing/hero.tsx
+++ b/apps/web/src/features/marketing/hero.tsx
@@ -26,7 +26,11 @@ const Hero = () => {
 
   return (
     <section id="hero" className="relative overflow-hidden px-6 pt-32 pb-12 sm:py-36">
-      <div className="pointer-events-none absolute inset-0 z-0 mask-y-to-95%" aria-hidden>
+      <div
+        className="pointer-events-none absolute inset-0 z-0 mask-y-to-95%"
+        aria-hidden
+        data-a11y-decorative
+      >
         <KortixLetterField seed={3382} />
       </div>
       <div className="inset-0 z-0 hidden mask-t-from-70% lg:absolute">

--- a/tests/accessibility/landing.a11y.spec.ts
+++ b/tests/accessibility/landing.a11y.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
@@ -32,10 +32,19 @@ function contrastNodeCount(violations: Violation[]): number {
 }
 
 test.describe('Accessibility — axe-core', () => {
-  test('landing page has no structural serious or critical violations', async ({ page }, testInfo) => {
+  test('landing page has no structural serious or critical violations', async ({
+    page,
+  }, testInfo) => {
     await page.goto('/', { waitUntil: 'networkidle' });
 
-    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+    const decorativeArtwork = page.locator('[data-a11y-decorative]');
+    await expect(decorativeArtwork).toHaveCount(1);
+    await expect(decorativeArtwork).toHaveAttribute('aria-hidden', 'true');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .exclude('[data-a11y-decorative]')
+      .analyze();
     await testInfo.attach('axe-results.json', {
       body: JSON.stringify(results.violations, null, 2),
       contentType: 'application/json',
@@ -51,8 +60,7 @@ test.describe('Accessibility — axe-core', () => {
     });
     expect(
       contrast,
-      `color-contrast debt is ${contrast} nodes, above the tracked ceiling of ${CONTRAST_CEILING}. ` +
-        `Either fix the new low-contrast text or lower/raise A11Y_CONTRAST_MAX deliberately as the design debt is paid down.`,
+      `color-contrast debt is ${contrast} nodes, above the tracked ceiling of ${CONTRAST_CEILING}. Either fix the new low-contrast text or lower/raise A11Y_CONTRAST_MAX deliberately as the design debt is paid down.`,
     ).toBeLessThanOrEqual(CONTRAST_CEILING);
   });
 


### PR DESCRIPTION
## Summary
- mark the landing hero ASCII letter field as explicitly decorative
- exclude only that marker from the Axe contrast audit
- assert the exclusion target is unique and remains aria-hidden

## Verification
- `pnpm exec biome check apps/web/src/features/marketing/hero.tsx tests/accessibility/landing.a11y.spec.ts`
- `cd tests && bun run typecheck`
- `E2E_BASE_URL=http://127.0.0.1:3100 A11Y_CONTRAST_MAX=560 bun run test:a11y -- --project=chromium` (2 passed)
- diagnostic run at ceiling 0 measured 12 remaining audited contrast nodes (down from staging failure at 626); configured ceiling remains 560