### PR TITLE
Fix release QA staging environment isolation

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -18,6 +18,10 @@ on:
         description: "Staging frontend URL"
         required: false
         type: string
+      gateway_base_url:
+        description: "Staging LLM gateway origin without /v1"
+        required: false
+        type: string
       dast_target_url:
         description: "Staging DAST target origin without /v1"
         required: false
@@ -47,15 +51,16 @@ jobs:
       QA_REPORTS_PUBLIC_BASE_URL: ${{ vars.QA_REPORTS_PUBLIC_BASE_URL }}
       API_BASE_URL_INPUT: ${{ inputs.api_base_url || vars.QA_API_BASE_URL || vars.QA_TARGET_URL }}
       WEB_BASE_URL_INPUT: ${{ inputs.web_base_url || vars.QA_WEB_BASE_URL || vars.E2E_BASE_URL }}
+      GATEWAY_BASE_URL_INPUT: ${{ inputs.gateway_base_url || vars.QA_GATEWAY_URL || 'https://gateway-staging.kortix.com' }}
       DAST_TARGET_URL_INPUT: ${{ inputs.dast_target_url || vars.QA_DAST_TARGET_URL }}
       PENTEST_TARGET_URL_INPUT: ${{ inputs.pentest_target_url || vars.QA_PENTEST_TARGET_URL }}
       KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}
       KE2E_OWNER_PASSWORD: ${{ secrets.KE2E_OWNER_PASSWORD }}
-      KE2E_SUPABASE_URL: ${{ secrets.KE2E_SUPABASE_URL }}
-      KE2E_SUPABASE_ANON_KEY: ${{ secrets.KE2E_SUPABASE_ANON_KEY }}
-      KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.KE2E_SUPABASE_SERVICE_ROLE_KEY }}
-      KE2E_ADMIN_TOKEN: ${{ secrets.KE2E_ADMIN_TOKEN }}
-      KE2E_DATABASE_URL: ${{ secrets.KE2E_DATABASE_URL }}
+      KE2E_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      KE2E_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
+      KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+      KE2E_ADMIN_TOKEN: ${{ secrets.STAGING_KORTIX_ADMIN_API_KEY }}
+      KE2E_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
       KE2E_STRIPE_SECRET_KEY: ${{ secrets.KE2E_STRIPE_SECRET_KEY }}
       KE2E_STRIPE_WEBHOOK_SECRET: ${{ secrets.KE2E_STRIPE_WEBHOOK_SECRET }}
       # staging.kortix.com sits behind Vercel deployment protection (SSO); the
@@ -76,6 +81,7 @@ jobs:
           set -euo pipefail
           api="${API_BASE_URL_INPUT%/}"
           web="${WEB_BASE_URL_INPUT%/}"
+          gateway="${GATEWAY_BASE_URL_INPUT%/}"
           dast="${DAST_TARGET_URL_INPUT:-}"
           pentest="${PENTEST_TARGET_URL_INPUT:-}"
           if [ -z "$dast" ] && [ -n "$api" ]; then
@@ -84,13 +90,13 @@ jobs:
           if [ -z "$pentest" ] && [ -n "$api" ]; then
             pentest="${api%/v1}"
           fi
-          if [ -z "$api" ] || [ -z "$web" ] || [ -z "$dast" ] || [ -z "$pentest" ]; then
-            echo "::error::Release QA requires QA_API_BASE_URL, QA_WEB_BASE_URL, QA_DAST_TARGET_URL, and QA_PENTEST_TARGET_URL (or matching workflow inputs)."
+          if [ -z "$api" ] || [ -z "$web" ] || [ -z "$gateway" ] || [ -z "$dast" ] || [ -z "$pentest" ]; then
+            echo "::error::Release QA requires staging API, web, gateway, DAST, and pentest targets."
             exit 1
           fi
-          case "$dast $pentest" in
+          case "$gateway $dast $pentest" in
             *prod*|*production*|https://api.kortix.com*|https://kortix.com*)
-              echo "::error::Refusing to run DAST/pentest against production-looking target: dast=$dast pentest=$pentest"
+              echo "::error::Refusing production-looking release targets: gateway=$gateway dast=$dast pentest=$pentest"
               exit 1
               ;;
           esac
@@ -99,6 +105,8 @@ jobs:
             echo "KE2E_API_URL=$api"
             echo "BASE_URL=$api"
             echo "E2E_BASE_URL=$web"
+            echo "KE2E_GATEWAY_URL=$gateway"
+            echo "KE2E_TARGET=staging"
             echo "TARGET_URL=$dast"
             echo "PENTEST_TARGET_URL=$pentest"
             echo "PENTEST_LIVE_CONFIRM=ci"
@@ -106,6 +114,7 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "Release API target: $api"
           echo "Release web target: $web"
+          echo "Release gateway target: $gateway"
           echo "Release DAST target: $dast"
           echo "Release pentest target: $pentest"
 

--- a/tests/src/core/env.ts
+++ b/tests/src/core/env.ts
@@ -8,7 +8,7 @@
  * Bun auto-loads a `.env` in the cwd, so local runs can drop secrets there.
  */
 
-export type TargetName = "local" | "dev" | "prod" | "custom";
+export type TargetName = 'local' | 'dev' | 'staging' | 'prod' | 'custom';
 
 export interface Capabilities {
   /** Real Daytona sandbox provisioning available. */
@@ -64,31 +64,46 @@ export interface Env {
 function pick(...names: string[]): string | null {
   for (const n of names) {
     const v = process.env[n];
-    if (v != null && v.trim() !== "") return v.trim();
+    if (v != null && v.trim() !== '') return v.trim();
   }
   return null;
 }
 
 function stripTrailingSlash(u: string): string {
-  return u.replace(/\/+$/, "");
+  return u.replace(/\/+$/, '');
 }
 
-function inferTarget(apiUrl: string): TargetName {
-  const explicit = pick("KE2E_TARGET", "E2E_TARGET");
-  if (explicit === "local" || explicit === "dev" || explicit === "prod" || explicit === "custom") {
+export function inferTarget(apiUrl: string): TargetName {
+  const explicit = pick('KE2E_TARGET', 'E2E_TARGET');
+  if (
+    explicit === 'local' ||
+    explicit === 'dev' ||
+    explicit === 'staging' ||
+    explicit === 'prod' ||
+    explicit === 'custom'
+  ) {
     return explicit;
   }
   const host = (() => {
     try {
       return new URL(apiUrl).hostname;
     } catch {
-      return "";
+      return '';
     }
   })();
-  if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost")) return "local";
-  if (host.startsWith("dev-api.") || host.startsWith("dev-")) return "dev";
-  if (host === "api.kortix.com" || host.startsWith("api-prod.") || host === "kortix.com") return "prod";
-  return "custom";
+  if (host === 'localhost' || host === '127.0.0.1' || host.endsWith('.localhost')) return 'local';
+  if (host.startsWith('dev-api.') || host.startsWith('dev-')) return 'dev';
+  if (host.startsWith('staging-api.') || host.startsWith('staging-')) return 'staging';
+  if (host === 'api.kortix.com' || host.startsWith('api-prod.') || host === 'kortix.com')
+    return 'prod';
+  return 'custom';
+}
+
+export function defaultGatewayUrl(target: TargetName): string {
+  if (target === 'prod') return 'https://gateway.kortix.com';
+  if (target === 'staging') return 'https://gateway-staging.kortix.com';
+  if (target === 'dev') return 'https://gateway-dev.kortix.com';
+  return 'http://localhost:8009';
 }
 
 let cached: Env | null = null;
@@ -97,49 +112,43 @@ export function loadEnv(): Env {
   if (cached) return cached;
 
   const apiUrl = stripTrailingSlash(
-    pick("KE2E_API_URL", "E2E_API_URL", "NEXT_PUBLIC_BACKEND_URL") || "http://localhost:8008/v1",
+    pick('KE2E_API_URL', 'E2E_API_URL', 'NEXT_PUBLIC_BACKEND_URL') || 'http://localhost:8008/v1',
   );
   const baseUrl = stripTrailingSlash(
-    pick("KE2E_BASE_URL", "E2E_BASE_URL") || apiUrl.replace(/\/v1$/, "").replace("://api.", "://").replace("://dev-api.", "://dev."),
+    pick('KE2E_BASE_URL', 'E2E_BASE_URL') ||
+      apiUrl.replace(/\/v1$/, '').replace('://api.', '://').replace('://dev-api.', '://dev.'),
   );
   const supabaseUrl = stripTrailingSlash(
-    pick("KE2E_SUPABASE_URL", "E2E_SUPABASE_URL", "SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_URL") ||
-      "http://127.0.0.1:54321",
+    pick('KE2E_SUPABASE_URL', 'E2E_SUPABASE_URL', 'SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_URL') ||
+      'http://127.0.0.1:54321',
   );
   const supabaseAnonKey = pick(
-    "KE2E_SUPABASE_ANON_KEY",
-    "SUPABASE_ANON_KEY",
-    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    'KE2E_SUPABASE_ANON_KEY',
+    'SUPABASE_ANON_KEY',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
   );
   const supabaseServiceRoleKey = pick(
-    "KE2E_SUPABASE_SERVICE_ROLE_KEY",
-    "SUPABASE_SERVICE_ROLE_KEY",
+    'KE2E_SUPABASE_SERVICE_ROLE_KEY',
+    'SUPABASE_SERVICE_ROLE_KEY',
   );
-  const databaseUrl = pick("KE2E_DATABASE_URL", "E2E_DATABASE_URL");
-  const ownerEmail = pick("KE2E_OWNER_EMAIL", "E2E_OWNER_EMAIL");
-  const ownerPassword = pick("KE2E_OWNER_PASSWORD", "E2E_OWNER_PASSWORD");
-  const adminToken = pick("KE2E_ADMIN_TOKEN", "E2E_ADMIN_TOKEN", "ADMIN_TOKEN");
-  const stripeSecretKey = pick("KE2E_STRIPE_SECRET_KEY");
-  const stripeWebhookSecret = pick("KE2E_STRIPE_WEBHOOK_SECRET");
-  const liveConfirm = pick("KE2E_LIVE_CONFIRM");
+  const databaseUrl = pick('KE2E_DATABASE_URL', 'E2E_DATABASE_URL');
+  const ownerEmail = pick('KE2E_OWNER_EMAIL', 'E2E_OWNER_EMAIL');
+  const ownerPassword = pick('KE2E_OWNER_PASSWORD', 'E2E_OWNER_PASSWORD');
+  const adminToken = pick('KE2E_ADMIN_TOKEN', 'E2E_ADMIN_TOKEN', 'ADMIN_TOKEN');
+  const stripeSecretKey = pick('KE2E_STRIPE_SECRET_KEY');
+  const stripeWebhookSecret = pick('KE2E_STRIPE_WEBHOOK_SECRET');
+  const liveConfirm = pick('KE2E_LIVE_CONFIRM');
   const target = inferTarget(apiUrl);
-  const gatewayUrl = stripTrailingSlash(
-    pick("KE2E_GATEWAY_URL") ||
-      (target === "prod"
-        ? "https://gateway.kortix.com"
-        : target === "dev"
-          ? "https://gateway-dev.kortix.com"
-          : "http://localhost:8009"),
-  );
+  const gatewayUrl = stripTrailingSlash(pick('KE2E_GATEWAY_URL') || defaultGatewayUrl(target));
 
   const capabilities: Capabilities = {
-    daytona: pick("KE2E_CAP_DAYTONA") !== "0",
-    managedGit: pick("KE2E_CAP_MANAGED_GIT") !== "0",
+    daytona: pick('KE2E_CAP_DAYTONA') !== '0',
+    managedGit: pick('KE2E_CAP_MANAGED_GIT') !== '0',
     stripe: stripeSecretKey != null,
     supabaseAdmin: supabaseServiceRoleKey != null,
     database: databaseUrl != null,
     admin: adminToken != null,
-    funded: pick("KE2E_CAP_FUNDED") === "1",
+    funded: pick('KE2E_CAP_FUNDED') === '1',
   };
 
   cached = {
@@ -158,7 +167,7 @@ export function loadEnv(): Env {
     liveConfirm,
     target,
     capabilities,
-    testEmailDomain: pick("KE2E_EMAIL_DOMAIN") || "ke2e.kortix.test",
+    testEmailDomain: pick('KE2E_EMAIL_DOMAIN') || 'ke2e.kortix.test',
   };
   return cached;
 }
@@ -167,6 +176,6 @@ export function describeEnv(env: Env): string {
   const caps = Object.entries(env.capabilities)
     .filter(([, v]) => v)
     .map(([k]) => k)
-    .join(", ");
+    .join(', ');
   return `target=${env.target} api=${env.apiUrl} caps=[${caps}]`;
 }

--- a/tests/unit/env-target.test.ts
+++ b/tests/unit/env-target.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { defaultGatewayUrl, inferTarget } from '../src/core/env';
+
+describe('release target inference', () => {
+  it('classifies the staging API and selects the staging gateway', () => {
+    expect(inferTarget('https://staging-api.kortix.com/v1')).toBe('staging');
+    expect(defaultGatewayUrl('staging')).toBe('https://gateway-staging.kortix.com');
+  });
+
+  it('keeps dev, prod, and local gateway defaults isolated', () => {
+    expect(defaultGatewayUrl('dev')).toBe('https://gateway-dev.kortix.com');
+    expect(defaultGatewayUrl('prod')).toBe('https://gateway.kortix.com');
+    expect(defaultGatewayUrl('local')).toBe('http://localhost:8009');
+  });
+});


### PR DESCRIPTION
## Summary
- use staging Supabase, database, and admin credentials in the production release gate
- set the staging gateway target explicitly and classify staging as its own ke2e target
- add a focused regression test for staging target and gateway inference

## Verification
- `pnpm exec biome check tests/src/core/env.ts tests/unit/env-target.test.ts`
- `cd tests && npm run test:unit -- --run unit/env-target.test.ts`
- `cd tests && bunx tsc --noEmit`
- workflow YAML parse + `git diff --check`

## Live failure corrected
Release QA run 29625376922 paired staging-api with dev-only KE2E credentials (401 Invalid or expired token) and defaulted gateway flows to localhost:8009. This change keeps all release-QA dependencies on staging.