### PR TITLE
fix(llm-gateway): catch GatewayResolutionError in /resolve-upstream — stop "Connect Codex" spike (incident 991624588)

### DIFF
--- a/apps/api/src/llm-gateway/internal-routes.test.ts
+++ b/apps/api/src/llm-gateway/internal-routes.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { GatewayResolutionError } from '@kortix/llm-gateway';
+
+// resolveCandidates is the only internal-routes dep whose behavior matters
+// here; mock it (and the logger) so the route loads in isolation without
+// dragging in config/db/billing.
+mock.module('../lib/logger', () => ({
+  logger: {
+    warn: mock(() => {}),
+    info: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+  },
+}));
+mock.module('../billing/services/billing-gate', () => ({
+  assertBillingActive: async () => undefined,
+}));
+mock.module('./budgets', () => ({ checkBudget: async () => ({ exceeded: false }) }));
+mock.module('./hooks', () => ({
+  authenticatePrincipal: async () => null,
+  authorizeRequest: async () => ({ ok: true }),
+  persistGatewayTrace: async () => {},
+  recordGatewayUsage: async () => {},
+}));
+mock.module('./models/catalog-models', () => ({
+  gatewayModelCatalog: () => ({}),
+}));
+mock.module('./routing', () => ({
+  resolveGatewayRoute: async () => ({
+    policyId: 'auto',
+    primaryModel: 'codex/gpt-5.6-sol',
+    fallbackModels: [],
+    fallbackOn: 'transient',
+  }),
+}));
+
+// The thrower is swapped per-test via resolveCandidatesMock.
+const resolveCandidatesMock = mock<
+  (principal: unknown, model: string) => Promise<unknown[]>
+>();
+mock.module('./resolution/resolve-candidates', () => ({
+  resolveCandidates: resolveCandidatesMock,
+}));
+
+const { createInternalGatewayRoutes } = await import('./internal-routes');
+
+const TOKEN = 'test-internal-token-aaaaaaaaaaaaaaaaaaaaaaaa';
+
+function app() {
+  process.env.GATEWAY_INTERNAL_TOKEN = TOKEN;
+  return createInternalGatewayRoutes();
+}
+
+function authedRequest(body: unknown) {
+  // createInternalGatewayRoutes() mounts routes at /resolve-upstream etc. — the
+  // /internal/gateway prefix is added by the parent mount in wire.ts.
+  return new Request('http://test/resolve-upstream', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${TOKEN}` },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /internal/gateway/resolve-upstream — GatewayResolutionError contract', () => {
+  test('returns candidates in a 200 when resolution succeeds', async () => {
+    resolveCandidatesMock.mockResolvedValueOnce([{ provider: 'openrouter' }]);
+    const res = await app().request(authedRequest({ principal: { userId: 'u' }, model: 'auto' }));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { candidates: unknown[] };
+    expect(json.candidates).toHaveLength(1);
+  });
+
+  test('returns a 200 with resolutionError (NOT a 500) when resolveCandidates throws GatewayResolutionError', async () => {
+    // The "Connect Codex to use this model." spike (incident 991624588):
+    // resolveCandidates throws a deliberate, user-facing resolution error for
+    // a codex/* model with no connected Codex credential. The route MUST catch
+    // it and return it in a 200 body — letting it propagate produces a 500 to
+    // the gateway pod, a Sentry/Better Stack error event, and a 3x retry.
+    resolveCandidatesMock.mockRejectedValueOnce(
+      new GatewayResolutionError(
+        'provider_not_connected',
+        'Connect Codex to use this model.',
+        'Connect your ChatGPT/Codex account in project settings, then retry.',
+      ),
+    );
+    const res = await app().request(
+      authedRequest({ principal: { userId: 'u' }, model: 'codex/gpt-5.6-sol' }),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      candidates: unknown[];
+      resolutionError: { code: string; message: string; suggestion: string };
+    };
+    expect(json.candidates).toEqual([]);
+    expect(json.resolutionError).toEqual({
+      code: 'provider_not_connected',
+      message: 'Connect Codex to use this model.',
+      suggestion: 'Connect your ChatGPT/Codex account in project settings, then retry.',
+    });
+  });
+
+  test('still surfaces other (unexpected) errors as a 500 — only GatewayResolutionError is caught', async () => {
+    resolveCandidatesMock.mockRejectedValueOnce(new Error('boom: real bug'));
+    const res = await app().request(
+      authedRequest({ principal: { userId: 'u' }, model: 'auto' }),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/api/src/llm-gateway/internal-routes.ts
+++ b/apps/api/src/llm-gateway/internal-routes.ts
@@ -4,6 +4,7 @@ import type {
   ModelRouteInput,
   UsageEvent,
 } from '@kortix/llm-gateway';
+import { GatewayResolutionError } from '@kortix/llm-gateway';
 import { Hono } from 'hono';
 import { assertBillingActive } from '../billing/services/billing-gate';
 import { logger } from '../lib/logger';
@@ -62,11 +63,36 @@ export function createInternalGatewayRoutes() {
 
   app.post('/resolve-upstream', async (c) => {
     const { principal, model } = await c.req.json();
-    const candidates = await resolveCandidates(
-      principal as AuthedPrincipal,
-      typeof model === 'string' ? model : '',
-    );
-    return c.json({ candidates });
+    try {
+      const candidates = await resolveCandidates(
+        principal as AuthedPrincipal,
+        typeof model === 'string' ? model : '',
+      );
+      return c.json({ candidates });
+    } catch (err) {
+      // resolveCandidates throws a GatewayResolutionError (instead of returning
+      // []) when it can pin down WHY there's no upstream — provider_not_connected
+      // ("Connect Codex to use this model."), plan_upgrade_required, expired
+      // Codex OAuth, model_disabled_on_deployment, model_not_found. These are
+      // EXPECTED, user-facing resolution outcomes the gateway pipeline is
+      // designed to catch and surface as a clean 400 with an actionable
+      // suggestion (see packages/llm-gateway/src/pipeline/handler.ts's dispatch
+      // loop, which treats a thrown GatewayResolutionError as "no candidates,
+      // with a reason"). Letting it propagate here would (a) turn an expected
+      // 4xx into a 500 to the gateway pod, (b) get captured to Sentry/Better
+      // Stack Errors as an unhandled exception (the "Connect Codex" spike,
+      // incident 991624588), and (c) be retried 3x by the api-client. Instead,
+      // return the typed error in a 200 body so the api-client can re-throw it
+      // as a GatewayResolutionError and the in-process hook contract holds.
+      if (err instanceof GatewayResolutionError) {
+        logger.warn(`[gateway-internal] resolution failed for "${model}": ${err.code} — ${err.message}`);
+        return c.json({
+          candidates: [],
+          resolutionError: { code: err.code, message: err.message, suggestion: err.suggestion },
+        });
+      }
+      throw err;
+    }
   });
 
   app.post('/resolve-route', async (c) => {

--- a/apps/llm-gateway/src/clients/api-client.test.ts
+++ b/apps/llm-gateway/src/clients/api-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { GatewayResolutionError } from '@kortix/llm-gateway';
 
 import { ApiUnavailableError, type FetchLike, createApiClient } from './api-client';
 
@@ -43,6 +44,51 @@ describe('ApiClient', () => {
       'm',
     );
     expect(result).toHaveLength(2);
+  });
+
+  test('resolveUpstream re-throws a typed GatewayResolutionError from the body (not a 5xx ApiUnavailableError)', async () => {
+    // The API catches GatewayResolutionError in /resolve-upstream and returns
+    // it in a 200 body. The client must reconstruct the typed error so the
+    // pipeline's dispatch loop surfaces a clean 400 — and must NOT treat it as
+    // a 5xx (which would retry 3x and lose the actionable suggestion).
+    const c = client(async () =>
+      jsonResponse({
+        candidates: [],
+        resolutionError: {
+          code: 'provider_not_connected',
+          message: 'Connect Codex to use this model.',
+          suggestion: 'Connect your ChatGPT/Codex account in project settings, then retry.',
+        },
+      }),
+    );
+    await expect(c.resolveUpstream(principal, 'codex/gpt-5.6-sol')).rejects.toMatchObject({
+      name: 'GatewayResolutionError',
+      code: 'provider_not_connected',
+      message: 'Connect Codex to use this model.',
+      suggestion: 'Connect your ChatGPT/Codex account in project settings, then retry.',
+    });
+    await expect(c.resolveUpstream(principal, 'codex/gpt-5.6-sol')).rejects.toBeInstanceOf(
+      GatewayResolutionError,
+    );
+  });
+
+  test('resolveUpstream does NOT retry a resolutionError response (expected 4xx outcome, not a transient 5xx)', async () => {
+    let calls = 0;
+    const c = client(async () => {
+      calls += 1;
+      return jsonResponse({
+        candidates: [],
+        resolutionError: {
+          code: 'provider_not_connected',
+          message: 'Connect Codex to use this model.',
+          suggestion: 'Connect your ChatGPT/Codex account in project settings, then retry.',
+        },
+      });
+    });
+    await expect(c.resolveUpstream(principal, 'codex/gpt-5.6-sol')).rejects.toBeInstanceOf(
+      GatewayResolutionError,
+    );
+    expect(calls).toBe(1);
   });
 
   test('resolveRoute obtains the model plan from the API control plane', async () => {

--- a/apps/llm-gateway/src/clients/api-client.ts
+++ b/apps/llm-gateway/src/clients/api-client.ts
@@ -1,13 +1,14 @@
 import { withRetry } from '@kortix/llm-gateway';
-import type {
-  AuthedPrincipal,
-  AuthorizeResult,
-  GatewayTrace,
-  ModelCatalog,
-  ModelRouteInput,
-  ModelRoutePlan,
-  UpstreamDescriptor,
-  UsageEvent,
+import {
+  GatewayResolutionError,
+  type AuthedPrincipal,
+  type AuthorizeResult,
+  type GatewayTrace,
+  type ModelCatalog,
+  type ModelRouteInput,
+  type ModelRoutePlan,
+  type UpstreamDescriptor,
+  type UsageEvent,
 } from '@kortix/llm-gateway';
 
 export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
@@ -108,13 +109,29 @@ export function createApiClient(opts: ApiClientOptions): ApiClient {
       return result.route ?? null;
     },
     resolveUpstream: async (principal, model) => {
-      const result = await post<{ candidates: UpstreamDescriptor[] }>(
-        '/internal/gateway/resolve-upstream',
-        {
-          principal,
-          model,
-        },
-      );
+      const result = await post<{
+        candidates?: UpstreamDescriptor[];
+        resolutionError?: {
+          code: 'model_not_found' | 'model_disabled_on_deployment' | 'plan_upgrade_required' | 'provider_not_connected' | 'provider_reauth_required';
+          message: string;
+          suggestion: string;
+        };
+      }>('/internal/gateway/resolve-upstream', {
+        principal,
+        model,
+      });
+      // The API catches GatewayResolutionError in /resolve-upstream and returns
+      // it in a 200 body instead of letting it propagate as a 500 (which would
+      // be captured to Sentry AND retried 3x here). Re-throw it as the typed
+      // error so the pipeline's dispatch loop (handler.ts) sees the same
+      // contract as the in-process hook (hooks.ts: resolveUpstream:
+      // resolveCandidates) — a thrown GatewayResolutionError it can surface as
+      // a clean 400 with the actionable suggestion, rather than a generic
+      // ApiUnavailableError 5xx.
+      if (result.resolutionError) {
+        const { code, message, suggestion } = result.resolutionError;
+        throw new GatewayResolutionError(code, message, suggestion);
+      }
       return result.candidates ?? [];
     },
     assertBillingActive: async (accountId) => {


### PR DESCRIPTION
## Root cause — incident 991624588 (Better Stack, dev)

`POST /internal/gateway/resolve-upstream` (`apps/api/src/llm-gateway/internal-routes.ts`) called `resolveCandidates` with **no try/catch**. When `resolveCandidates` throws a deliberate, user-facing `GatewayResolutionError` (e.g. `provider_not_connected` -> "Connect Codex to use this model."), it propagated as an unhandled exception:

1. `apps/api/src/index.ts`'s generic error handler captured it to Sentry/Better Stack **Errors** as a 500 (`level=error, mechanism=generic, handled=true`) — the spike source.
2. The gateway pod's `api-client` saw a non-2xx -> threw `ApiUnavailableError` -> **retried 3x** (each retry = another Sentry event, ~3x amplification).
3. The typed-error contract `packages/llm-gateway/src/pipeline/handler.ts:467` is designed to catch (and surface as a clean 400 with the actionable "Connect your ChatGPT/Codex account" suggestion) was broken for the standalone-gateway path -> users got a generic 5xx instead.

### Why now (the spike)
PR #4535 made `codex/gpt-5.6-sol` — a project-scoped BYOK model — the default. Every `auto` request from a project without Codex connected now throws at resolution time. Volume crossed the Better Stack spike threshold on 2026-07-17 00:18 UTC; incident opened 2026-07-18 03:42 UTC. Better Stack metadata confirms: `url = http://staging-api-ecs-fargate.kortix.com/internal/gateway/resolve-upstream`, `user = anonymous`, `handled = true`, env `staging`/`dev`.

## Fix

**`apps/api/src/llm-gateway/internal-routes.ts`** — `/resolve-upstream` catches `GatewayResolutionError` and returns it in a **200** body: `{ candidates: [], resolutionError: { code, message, suggestion } }`. No 500 -> no Sentry capture -> no retry. (A 200 is semantically correct: the *RPC* succeeded — it resolved and reached a definitive "no upstream, for this reason"; the error is in the resolution *result*, not the RPC. This mirrors the existing contract where `resolveUpstream` may return `[]` for "no candidates", now enriched with a reason.) Logs at `warn` for ops visibility.

**`apps/llm-gateway/src/clients/api-client.ts`** — `resolveUpstream` re-throws the typed `GatewayResolutionError` from the response body, so the pipeline's dispatch loop (`handler.ts`) sees the same contract as the in-process hook (`hooks.ts: resolveUpstream: resolveCandidates`) and surfaces the clean 400 with the actionable suggestion.

## Tests
- `apps/llm-gateway/src/clients/api-client.test.ts` — 3 new: re-throws typed `GatewayResolutionError` from body (not a 5xx `ApiUnavailableError`); does **not** retry (expected 4xx outcome, not transient 5xx); existing success path unchanged.
- `apps/api/src/llm-gateway/internal-routes.test.ts` — new file: 200+candidates on success; **200+`resolutionError` (not 500)** when `resolveCandidates` throws `GatewayResolutionError`; unexpected errors still surface as 500 (only `GatewayResolutionError` is caught).

## Verification
- `tsc --noEmit` clean for both `apps/api` and `apps/llm-gateway`.
- `bun test apps/llm-gateway/src apps/api/src/llm-gateway/internal-routes.test.ts` — 17/17 new + existing pass.
- Pre-existing failures in `resolve-candidates.test.ts` / `default-model.test.ts` confirmed present on `main` (unchanged by this PR).

## Confirming it stays fixed
After promote, the Better Stack error group `d75886c3...` ("Connect Codex to use this model." from `resolveCandidates`) should go quiet, and `kortix_api_dev` logs should show `warn`-level `[gateway-internal] resolution failed ...` lines instead of `error`-level 500s. End users requesting `codex/*` without Codex connected will see the clean 400 suggestion instead of a 5xx.