### PR TITLE
Preserve staging secrets during deployment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -138,11 +138,26 @@ jobs:
             exit 1
           fi
 
-          base="$(aws secretsmanager get-secret-value \
-            --secret-id kortix-dev-env \
-            --region "$AWS_REGION" \
-            --query SecretString \
-            --output text)"
+          # Preserve staging-only integrations (Stripe, managed Git, alerting,
+          # and any future operator-managed keys) across rollouts. Rebuilding
+          # this payload from kortix-dev-env silently replaces those values
+          # with dev credentials on every deploy. The dev bundle is only a
+          # first-creation bootstrap; an existing staging bundle is canonical.
+          if aws secretsmanager describe-secret --secret-id kortix-staging-env --region "$AWS_REGION" >/dev/null 2>&1; then
+            staging_secret_exists=true
+            base="$(aws secretsmanager get-secret-value \
+              --secret-id kortix-staging-env \
+              --region "$AWS_REGION" \
+              --query SecretString \
+              --output text)"
+          else
+            staging_secret_exists=false
+            base="$(aws secretsmanager get-secret-value \
+              --secret-id kortix-dev-env \
+              --region "$AWS_REGION" \
+              --query SecretString \
+              --output text)"
+          fi
 
           payload="$(jq -cn \
             --argjson base "$base" \
@@ -171,7 +186,7 @@ jobs:
               KORTIX_WARM_SNAPSHOT_ENABLED: "false"
             }')"
 
-          if aws secretsmanager describe-secret --secret-id kortix-staging-env --region "$AWS_REGION" >/dev/null 2>&1; then
+          if [ "$staging_secret_exists" = true ]; then
             aws secretsmanager put-secret-value \
               --secret-id kortix-staging-env \
               --region "$AWS_REGION" \

--- a/tests/unit/staging-secret-workflow.test.ts
+++ b/tests/unit/staging-secret-workflow.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('staging secret synchronization', () => {
+  it('preserves the existing staging bundle and uses dev only for first creation', () => {
+    const workflow = readFileSync(
+      resolve(import.meta.dirname, '../../.github/workflows/deploy-staging.yml'),
+      'utf8',
+    );
+
+    const preserveStart = workflow.indexOf('if aws secretsmanager describe-secret --secret-id kortix-staging-env');
+    const payloadStart = workflow.indexOf('payload="$(jq -cn');
+    const preservationBlock = workflow.slice(preserveStart, payloadStart);
+
+    expect(preserveStart).toBeGreaterThan(-1);
+    expect(payloadStart).toBeGreaterThan(preserveStart);
+    expect(preservationBlock).toContain('--secret-id kortix-staging-env');
+    expect(preservationBlock).toContain('staging_secret_exists=true');
+    expect(preservationBlock).toContain('else');
+    expect(preservationBlock).toContain('--secret-id kortix-dev-env');
+    expect(preservationBlock).toContain('staging_secret_exists=false');
+    expect(workflow).toContain('if [ "$staging_secret_exists" = true ]; then');
+  });
+});


### PR DESCRIPTION
## Summary
- retain the existing staging secret bundle during each staging rollout
- use the dev bundle only to bootstrap the first staging secret
- add a regression test for the workflow contract

## Verification
- `make lint typecheck unit`
- focused workflow regression test passed