### PR TITLE
test(release): authenticate protected metrics coverage

### DIFF
--- a/tests/src/flows/new-routes-coverage.flow.ts
+++ b/tests/src/flows/new-routes-coverage.flow.ts
@@ -17,8 +17,14 @@ flow(
     routes: ['GET /metrics', 'GET /v1/router/health'],
   },
   async (ctx) => {
-    await ctx.step('metrics endpoint is mounted or explicitly disabled', async () => {
+    await ctx.step('metrics endpoint rejects anonymous callers', async () => {
       const r = await ctx.client.as(ctx.P.ANON).get('/metrics');
+      r.status(401);
+    });
+    await ctx.step('internal metrics endpoint is mounted or explicitly disabled', async () => {
+      const r = await ctx.client
+        .withBearer(ctx.env.internalServiceKey!, 'INTERNAL_OBSERVABILITY')
+        .get('/metrics');
       r.status([200, 404]);
     });
     await ctx.step('LLM gateway health endpoint is mounted', async () => {


### PR DESCRIPTION
## What changed
- assert anonymous access to `/metrics` is rejected
- exercise the protected metrics endpoint with the staging internal service credential

## Verification
- `npm --prefix tests run test:unit` (13/13)
- `npm --prefix tests run typecheck`
- live staging `COV-1` (1/1)
- live staging free-tier rotation cron returned 200 with zero errors