### PR TITLE
release: promote authenticated release coverage

### DIFF
--- a/tests/src/flows/new-routes-coverage.flow.ts
+++ b/tests/src/flows/new-routes-coverage.flow.ts
@@ -17,8 +17,14 @@ flow(
     routes: ['GET /metrics', 'GET /v1/router/health'],
   },
   async (ctx) => {
-    await ctx.step('metrics endpoint is mounted or explicitly disabled', async () => {
+    await ctx.step('metrics endpoint rejects anonymous callers', async () => {
       const r = await ctx.client.as(ctx.P.ANON).get('/metrics');
+      r.status(401);
+    });
+    await ctx.step('internal metrics endpoint is mounted or explicitly disabled', async () => {
+      const r = await ctx.client
+        .withBearer(ctx.env.internalServiceKey!, 'INTERNAL_OBSERVABILITY')
+        .get('/metrics');
       r.status([200, 404]);
     });
     await ctx.step('LLM gateway health endpoint is mounted', async () => {


### PR DESCRIPTION
Promotes the final release-gate coverage correction from `main` to `staging`.

This changes only `tests/src/flows/new-routes-coverage.flow.ts`: anonymous `/metrics` remains required to return 401, while the authenticated internal-service request must return 200 (or the explicit disabled 404 contract).

Local/live proof before promotion:
- tests unit suite: 13/13 passed
- tests typecheck: passed
- focused staging COV-1: 1/1 passed
- source PR #4966: all executable checks passed
- `main` merge SHA: `a28db4c3aad3d97f73bf9d26026eee6f3735dbc9`