### PR TITLE
fix(self-host): isolate black-box compose probes

### DIFF
--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -2092,22 +2092,20 @@ async function ensurePort(
 
 function composeHasRunningServices(instance: string): boolean {
   if (!existsSync(composePath(instance)) || !existsSync(envPath(instance))) return false;
+  // `docker compose ps` reparses the entire generated stack and can take long
+  // enough to hit the CLI/test timeout even when this project has no
+  // containers. Compose already labels every container with the project name,
+  // so a bounded `docker ps` label lookup is the exact, cheaper question here:
+  // "does this instance currently have at least one running container?"
   const result = spawnSync(
     'docker',
     [
-      'compose',
-      '--project-name',
-      composeProject(instance),
-      '--env-file',
-      envPath(instance),
-      '-f',
-      composePath(instance),
       'ps',
-      '--services',
+      '--quiet',
       '--filter',
-      'status=running',
+      `label=com.docker.compose.project=${composeProject(instance)}`,
     ],
-    { cwd: instanceDir(instance), encoding: 'utf8' },
+    { cwd: instanceDir(instance), encoding: 'utf8', timeout: 3_000 },
   );
   return result.status === 0 && result.stdout.trim().length > 0;
 }

--- a/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
+++ b/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -17,20 +18,30 @@ import { parse } from 'yaml';
 // warning behavior.
 const CLI_ENTRY = resolve(import.meta.dir, '..', '..', 'index.ts');
 
+// Several black-box cases intentionally execute more than one bounded Docker
+// liveness probe. Keep the suite above Bun's 5s default while production probes
+// remain individually capped at 3s.
+setDefaultTimeout(15_000);
+
 describe('kortix self-host (generic Docker CLI)', () => {
   let tmp: string;
   let configRoot: string;
+  let instance: string;
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'kortix-self-host-cli-'));
     configRoot = join(tmp, 'self-host');
+    // Compose project identity is based only on --instance. Never let a test
+    // that exercises `env set` inspect or recreate a developer's real
+    // `kortix-default` services merely because its files use a temp root.
+    instance = `kortixtest${randomUUID().replaceAll('-', '')}`;
   });
 
   afterEach(() => rmSync(tmp, { recursive: true, force: true }));
 
   async function run(args: string[], extraEnv: Record<string, string> = {}) {
     const proc = Bun.spawn({
-      cmd: [process.execPath, CLI_ENTRY, 'self-host', ...args],
+      cmd: [process.execPath, CLI_ENTRY, 'self-host', ...args, '--instance', instance],
       cwd: tmp,
       env: {
         ...process.env,
@@ -52,8 +63,8 @@ describe('kortix self-host (generic Docker CLI)', () => {
     return { code, stdout, stderr };
   }
 
-  function readEnv(instance = 'default'): Record<string, string> {
-    const content = readFileSync(join(configRoot, instance, '.env'), 'utf8');
+  function readEnv(instanceName = instance): Record<string, string> {
+    const content = readFileSync(join(configRoot, instanceName, '.env'), 'utf8');
     const out: Record<string, string> = {};
     for (const line of content.split(/\r?\n/)) {
       if (!line.trim() || !line.includes('=')) continue;
@@ -63,8 +74,8 @@ describe('kortix self-host (generic Docker CLI)', () => {
     return out;
   }
 
-  function readCompose(instance = 'default'): { services: Record<string, unknown> } {
-    return parse(readFileSync(join(configRoot, instance, 'docker-compose.yml'), 'utf8'));
+  function readCompose(instanceName = instance): { services: Record<string, unknown> } {
+    return parse(readFileSync(join(configRoot, instanceName, 'docker-compose.yml'), 'utf8'));
   }
 
   test('init defaults to the shared auth+sandbox defaults and the stable channel', async () => {
@@ -223,7 +234,7 @@ describe('kortix self-host (generic Docker CLI)', () => {
     // is KORTIX_INSTANCE_DIR — recomputed from the real on-disk instance dir
     // on every render (see normalizeFullSupabaseEnv in commands/self-host.ts).
     await run(['init', '--yes']);
-    const instanceDir = join(configRoot, 'default');
+    const instanceDir = join(configRoot, instance);
     expect(readEnv().KORTIX_INSTANCE_DIR).toBe(instanceDir);
 
     const compose = readCompose() as { services: Record<string, {
@@ -512,7 +523,7 @@ describe('kortix self-host (generic Docker CLI)', () => {
     // init/start/update/configure/env-set render — hand-edit .env the way
     // `env set` itself refuses to (see secrets.test.ts's updater-managed
     // refusal coverage for KORTIX_INSTANCE_DIR).
-    const envFile = join(configRoot, 'default', '.env');
+    const envFile = join(configRoot, instance, '.env');
     writeFileSync(
       envFile,
       readFileSync(envFile, 'utf8').replace(

--- a/tests/self-host-e2e/fast/feature-flags.test.ts
+++ b/tests/self-host-e2e/fast/feature-flags.test.ts
@@ -41,6 +41,7 @@ describe('self-host feature-flag matrix (fast, no Docker)', () => {
   // if they genuinely want it back — see the default-off assertion above.
   test('re-enabling the landing page is a plain `env set`, no dedicated flag', async () => {
     await sandbox.run(['init', '--yes']);
+    expect(sandbox.instance).not.toBe('default');
     expect(sandbox.readEnv().KORTIX_PUBLIC_DISABLE_LANDING_PAGE).toBe('true');
 
     const { code } = await sandbox.run(['env', 'set', 'KORTIX_PUBLIC_DISABLE_LANDING_PAGE=false']);

--- a/tests/self-host-e2e/support/cli.ts
+++ b/tests/self-host-e2e/support/cli.ts
@@ -13,6 +13,7 @@
 // entrypoint, so it can't collide with the sibling agents editing
 // apps/cli/src/** in parallel.
 
+import { randomUUID } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -40,17 +41,26 @@ export interface RunResult {
 export class SelfHostSandbox {
   readonly tmp: string;
   readonly configRoot: string;
+  readonly instance: string;
   private readonly cliConfigFile: string;
 
   constructor() {
     this.tmp = mkdtempSync(join(tmpdir(), 'kortix-self-host-e2e-'));
     this.configRoot = join(this.tmp, 'self-host');
     this.cliConfigFile = join(this.tmp, 'cli-config.json');
+    // Compose identity is derived only from --instance, not configRoot. Using
+    // the default instance here would make `env set` inspect (and potentially
+    // recreate) a developer's real `kortix-default` stack even though every
+    // file lives in this throwaway directory. Keep every black-box sandbox on
+    // a globally unique Compose project so the no-Docker suite is truly inert.
+    this.instance = `kortixtest${randomUUID().replaceAll('-', '')}`;
   }
 
   async run(args: string[], extraEnv: Record<string, string> = {}): Promise<RunResult> {
+    const instanceArgs = args.includes('--instance') ? [] : ['--instance', this.instance];
     const proc = Bun.spawn({
-      cmd: [process.execPath, CLI_ENTRY, 'self-host', ...args],
+      cmd: [process.execPath, CLI_ENTRY, 'self-host', ...args, ...instanceArgs],
+      cwd: this.tmp,
       env: {
         ...process.env,
         KORTIX_SELF_HOST_CONFIG_DIR: this.configRoot,
@@ -84,7 +94,7 @@ export class SelfHostSandbox {
    *  (not a real dotenv parser): this repo's self-host `.env` never quotes or
    *  multi-lines a value (see writeEnv() in commands/self-host.ts), so a
    *  naive split is exact and dependency-free. */
-  readEnv(instance = 'default'): Record<string, string> {
+  readEnv(instance = this.instance): Record<string, string> {
     const content = readFileSync(join(this.configRoot, instance, '.env'), 'utf8');
     const out: Record<string, string> = {};
     for (const line of content.split(/\r?\n/)) {
@@ -95,7 +105,7 @@ export class SelfHostSandbox {
     return out;
   }
 
-  readComposeText(instance = 'default'): string {
+  readComposeText(instance = this.instance): string {
     return readFileSync(join(this.configRoot, instance, 'docker-compose.yml'), 'utf8');
   }
 


### PR DESCRIPTION
## Summary
- give every self-host black-box sandbox a unique Compose project identity
- replace slow full-Compose liveness parsing with a bounded Docker label lookup
- keep multi-probe CLI tests within an explicit bounded timeout

## Verification
- `bun test tests/self-host-e2e/fast/` (40 pass)
- `bun test apps/cli/src/self-host/__tests__/` (166 pass)
- 20 repeated landing-page env-set black-box runs (20 pass)
- `pnpm --filter @kortix/cli typecheck`
- existing `kortix-default` API container ID and real config path unchanged after stress run