### PR TITLE
fix(llm-gateway): agent-scope model pins now apply to sessions on the 'default' sentinel

### DIFF
--- a/apps/api/src/__tests__/e2e-projects-provision.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-provision.test.ts
@@ -24,6 +24,7 @@ const TEST_AUTH_KEY = '__KORTIX_E2E_AUTH__';
 
 let insertedProject: any | null;
 let grantedProjectRole: any | null;
+let updatedProjectSets: any[];
 let seedFilePaths: string[];
 let seedBaseFilePaths: string[];
 let seedFilesByPath: Map<string, string>;
@@ -308,7 +309,23 @@ mock.module('../shared/db', () => ({
         },
       }),
     }),
-    update: () => ({ set: () => ({ where: () => ({ returning: async () => [] }) }) }),
+    update: (table: unknown) => ({
+      set: (values: any) => ({
+        where: () => {
+          if (table === projects) updatedProjectSets.push(values);
+          // Real drizzle's UPDATE builder is thenable at every chain step
+          // (a caller may `.catch()` it directly without `.returning()` —
+          // see r1.ts's best-effort default_agent metadata mirror write, and
+          // the several other `.where(...).catch(() => {})` call sites this
+          // mirrors), so this stub must be too: a real Promise (which
+          // supplies `.then`/`.catch`) that ALSO exposes `.returning()` for
+          // callers that chain it.
+          const result: any = Promise.resolve([]);
+          result.returning = async () => [];
+          return result;
+        },
+      }),
+    }),
     delete: () => ({ where: async () => {} }),
   },
 }));
@@ -331,6 +348,7 @@ describe('POST /v1/projects/provision (managed git)', () => {
   beforeEach(() => {
     setTestAuth();
     insertedProject = null;
+    updatedProjectSets = [];
     grantedProjectRole = null;
     seedFilePaths = [];
     seedBaseFilePaths = [];
@@ -480,6 +498,15 @@ describe('POST /v1/projects/provision (managed git)', () => {
     expect(seedBaseFilePaths).toContain('.kortix/opencode/tools/web_search.ts');
     expect(seedBaseFilePaths).toContain('.kortix/opencode/tools/lib/get-env.ts');
     expect(seedBaseFilePaths).not.toContain('registry-lock.json');
+
+    // The bug this route fix closes: the base template's kortix.yaml declares
+    // `default_agent: kortix`, but project.metadata.default_agent was never
+    // mirrored from it — so every session silently stored the non-binding
+    // 'default' sentinel and any agent-scope model pin set on 'kortix' was
+    // never applied (see llm-gateway/resolution/default-model.ts). Provision
+    // must now stamp the mirror at creation time.
+    expect(updatedProjectSets).toHaveLength(1);
+    expect(updatedProjectSets[0]).toMatchObject({ metadata: { default_agent: 'kortix' } });
   });
 
   test('returns 503 when managed git is not configured', async () => {

--- a/apps/api/src/llm-gateway/resolution/default-model.test.ts
+++ b/apps/api/src/llm-gateway/resolution/default-model.test.ts
@@ -218,3 +218,108 @@ describe('resolveDefaultModelForPrincipal — the real "auto" resolution used at
     expect(result).toBeUndefined();
   });
 });
+
+// Regression coverage for the "agent-scope model pins silently never apply"
+// bug: session creation stores the non-binding 'default' sentinel in
+// project_sessions.agent_name whenever project.metadata.default_agent wasn't
+// populated at the time (common — e.g. a brand-new project whose kortix.yaml
+// declares `default_agent: kortix` but whose DB metadata mirror never learned
+// it). Before this fix, resolveDefaultModelForPrincipal looked up
+// `agentDefaults['default']` — which never matches a pin set on the real
+// agent name ('kortix') — and silently fell through to the project/account/
+// platform default instead of the pinned (possibly pricier / provider-
+// mismatched) model, with no error anywhere. cachedSessionAgent now resolves
+// the sentinel to the project's declared default agent (getSessionAgentContext's
+// projectDefaultAgent, mirroring kortix.yaml/PUT-default-agent) before doing
+// the agentDefaults lookup.
+describe('resolveDefaultModelForPrincipal — agent-scope pin applies to a session stuck on the "default" sentinel', () => {
+  test('THE BUG: session.agent_name is the sentinel, but the project declares "kortix" as its default agent and "kortix" has a pin → the pin applies', async () => {
+    accountDefaults = {
+      account: null,
+      agents: { kortix: 'anthropic/claude-opus-4.8' },
+      projects: {},
+    };
+    spyOn(modelPreferencesModule, 'getSessionAgentContext').mockImplementation(async () => ({
+      agentName: 'default',
+      opencodeModel: null,
+      projectDefaultAgent: 'kortix',
+    }));
+    resolveCandidatesImpl = async () => [{ provider: 'anthropic' }];
+
+    const result = await resolveDefaultModelForPrincipal({
+      ...PRINCIPAL_BASE,
+      sessionId: 'sess-pin-applies',
+      freeModelsOnly: false,
+    });
+
+    expect(result).toBe('anthropic/claude-opus-4.8');
+  });
+
+  test('an explicit (non-sentinel) session agent still wins over the project default, even when both have pins', async () => {
+    accountDefaults = {
+      account: null,
+      agents: { kortix: 'anthropic/claude-opus-4.8', 'release-bot': 'openai/gpt-5.5' },
+      projects: {},
+    };
+    spyOn(modelPreferencesModule, 'getSessionAgentContext').mockImplementation(async () => ({
+      agentName: 'release-bot',
+      opencodeModel: null,
+      projectDefaultAgent: 'kortix',
+    }));
+    resolveCandidatesImpl = async () => [{ provider: 'openai' }];
+
+    const result = await resolveDefaultModelForPrincipal({
+      ...PRINCIPAL_BASE,
+      sessionId: 'sess-explicit-wins',
+      freeModelsOnly: false,
+    });
+
+    expect(result).toBe('openai/gpt-5.5');
+  });
+
+  test('sentinel with no project default configured falls through to project/account/platform (unchanged pre-existing behavior)', async () => {
+    accountDefaults = {
+      account: 'openai/gpt-5.5',
+      agents: { kortix: 'anthropic/claude-opus-4.8' },
+      projects: {},
+    };
+    spyOn(modelPreferencesModule, 'getSessionAgentContext').mockImplementation(async () => ({
+      agentName: 'default',
+      opencodeModel: null,
+      projectDefaultAgent: null,
+    }));
+    resolveCandidatesImpl = async () => [{ provider: 'openai' }];
+
+    const result = await resolveDefaultModelForPrincipal({
+      ...PRINCIPAL_BASE,
+      sessionId: 'sess-no-project-default',
+      freeModelsOnly: false,
+    });
+
+    // No agent pin matched (neither 'default' nor any resolved name) → falls
+    // through to the account default.
+    expect(result).toBe('openai/gpt-5.5');
+  });
+
+  test('sentinel resolves to a project default that has NO pin of its own → still falls through to account default', async () => {
+    accountDefaults = {
+      account: 'openai/gpt-5.5',
+      agents: { 'some-other-agent': 'anthropic/claude-opus-4.8' },
+      projects: {},
+    };
+    spyOn(modelPreferencesModule, 'getSessionAgentContext').mockImplementation(async () => ({
+      agentName: 'default',
+      opencodeModel: null,
+      projectDefaultAgent: 'kortix',
+    }));
+    resolveCandidatesImpl = async () => [{ provider: 'openai' }];
+
+    const result = await resolveDefaultModelForPrincipal({
+      ...PRINCIPAL_BASE,
+      sessionId: 'sess-project-default-no-pin',
+      freeModelsOnly: false,
+    });
+
+    expect(result).toBe('openai/gpt-5.5');
+  });
+});

--- a/apps/api/src/llm-gateway/resolution/default-model.ts
+++ b/apps/api/src/llm-gateway/resolution/default-model.ts
@@ -2,13 +2,20 @@ import { type AuthedPrincipal, GatewayResolutionError } from '@kortix/llm-gatewa
 import { AUTO_MODEL_ID } from '@kortix/llm-catalog';
 import { connectedByokPickerModels } from '../models/picker-catalog';
 import { listProjectSecretsSnapshot } from '../../projects/secrets';
+import { DEFAULT_AGENT_SENTINEL } from '../../projects/agents';
 import {
   type AccountModelDefaults,
   getAccountModelDefaults,
   getSessionAgentContext,
 } from '../../repositories/model-preferences';
 import { chooseDefaultModel } from './choose-default-model';
-import { type ModelSource, chooseEffectiveModel, degradeUnservableDefault, toWireModel } from './effective';
+import {
+  chooseEffectiveAgent,
+  type ModelSource,
+  chooseEffectiveModel,
+  degradeUnservableDefault,
+  toWireModel,
+} from './effective';
 import { resolveCandidates } from './resolve-candidates';
 
 // Resolves the account/agent/project-configured default model for a gateway
@@ -35,11 +42,29 @@ async function cachedAccountDefaults(accountId: string): Promise<AccountModelDef
   return value;
 }
 
+// A session's `agent_name` column defaults to the non-binding `'default'`
+// sentinel whenever session creation didn't resolve a concrete agent (see
+// `createProjectSession` in projects/lib/sessions.ts) — most commonly because
+// `project.metadata.default_agent` wasn't populated even though the project's
+// kortix.yaml declares one (that mirror is only written by the explicit PUT
+// /default-agent route; provisioning + a CLI's first push don't always stamp
+// it). Left unresolved, an agent-scope model pin set on the project's REAL
+// default agent name is silently never looked up — the session falls through
+// to the project/account/platform default with no error anywhere. Resolve the
+// sentinel to the project's declared default agent here (reusing the same
+// `chooseEffectiveAgent` precedence the channel-bindings/Slack surfaces
+// already use) so the pin applies to the sessions that actually run it, even
+// when the session row itself still says 'default'.
 async function cachedSessionAgent(sessionId: string): Promise<string | null> {
   const cached = sessionAgentCache.get(sessionId);
   if (cached && cached.expiresAt > Date.now()) return cached.agentName;
   const ctx = await getSessionAgentContext(sessionId);
-  const agentName = ctx?.agentName ?? null;
+  const agentName = ctx
+    ? chooseEffectiveAgent({
+        explicit: ctx.agentName === DEFAULT_AGENT_SENTINEL ? null : ctx.agentName,
+        projectDefault: ctx.projectDefaultAgent,
+      }).agent
+    : null;
   sessionAgentCache.set(sessionId, { agentName, expiresAt: Date.now() + SESSION_AGENT_TTL_MS });
   return agentName;
 }

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -10,7 +10,12 @@ import { seedRepoViaGitPush } from '../git-backends/seed';
 import { createRepo, getGitHubAppInstallation, verifyGitHubAppInstallStatePayload } from '../github';
 import { getProjectSecretValue } from '../secrets';
 import { buildStarterFiles, normalizeStarterTemplateId } from '../starter';
-import { buildProjectSeedFiles, buildProjectSeedFilesFromItem, normalizeMarketplaceItems } from '../seed-files';
+import {
+  buildProjectSeedFiles,
+  buildProjectSeedFilesFromItem,
+  defaultAgentFromSeedFiles,
+  normalizeMarketplaceItems,
+} from '../seed-files';
 import { getCatalogItemDetail } from '../../marketplace/catalog';
 import { loadProjectTriggers } from '../triggers';
 import { createRoute, z } from '@hono/zod-openapi';
@@ -589,6 +594,23 @@ projectsApp.openapi(
         });
       }
       seeded = true;
+
+      // Mirror the seeded manifest's declared default agent into
+      // project.metadata (see defaultAgentFromSeedFiles in ../seed-files.ts)
+      // so session creation resolves it from birth instead of falling back
+      // to the non-binding 'default' sentinel — see
+      // llm-gateway/resolution/default-model.ts's cachedSessionAgent for the
+      // defense-in-depth fallback that also covers pre-existing/CLI-created
+      // projects where this mirror is still stale.
+      const seededDefaultAgent = defaultAgentFromSeedFiles(seed.files, row.manifestPath);
+      if (seededDefaultAgent) {
+        row.metadata = { ...((row.metadata as Record<string, unknown> | null) ?? {}), default_agent: seededDefaultAgent };
+        await db
+          .update(projects)
+          .set({ metadata: row.metadata, updatedAt: new Date() })
+          .where(eq(projects.projectId, row.projectId))
+          .catch(() => {}); // best-effort — a mirror-write hiccup must not fail project creation
+      }
     } catch (error) {
       try { await backend.deleteRepo(connRef); } catch { /* best effort */ }
       await db.delete(projects).where(eq(projects.projectId, row.projectId)).catch(() => {});

--- a/apps/api/src/projects/seed-files.test.ts
+++ b/apps/api/src/projects/seed-files.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { defaultAgentFromSeedFiles } from './seed-files';
+
+// Regression coverage for the "agent-scope model pins silently never apply"
+// bug: POST /projects/provision seeds a starter kortix.yaml that declares
+// `default_agent: kortix`, but never stamped project.metadata.default_agent
+// with it — every session then stored the non-binding 'default' sentinel
+// (see sessions.ts createProjectSession), and an agent-scope model pin set on
+// 'kortix' was never looked up. This helper extracts the seeded manifest's
+// declared default agent so r1.ts's provision route can mirror it into
+// project.metadata at creation time, same as PUT /:projectId/default-agent.
+describe('defaultAgentFromSeedFiles', () => {
+  test('extracts a declared default_agent from the seeded kortix.yaml', () => {
+    const files = [
+      { path: 'kortix.yaml', content: 'kortix_version: 2\ndefault_agent: kortix\nagents:\n  kortix: {}\n' },
+    ];
+    expect(defaultAgentFromSeedFiles(files, 'kortix.yaml')).toBe('kortix');
+  });
+
+  test('no default_agent declared → null (not every project needs one)', () => {
+    const files = [{ path: 'kortix.yaml', content: 'kortix_version: 2\nagents:\n  kortix: {}\n' }];
+    expect(defaultAgentFromSeedFiles(files, 'kortix.yaml')).toBeNull();
+  });
+
+  test('falls back to a literal "kortix.yaml" path when manifestPath differs', () => {
+    const files = [{ path: 'kortix.yaml', content: 'default_agent: release-bot\n' }];
+    expect(defaultAgentFromSeedFiles(files, 'config/kortix.toml')).toBe('release-bot');
+  });
+
+  test('no manifest file in the seed list → null, never throws', () => {
+    const files = [{ path: 'README.md', content: '# hi' }];
+    expect(defaultAgentFromSeedFiles(files, 'kortix.yaml')).toBeNull();
+  });
+
+  test('malformed YAML → null, never throws (project creation must not fail over this)', () => {
+    const files = [{ path: 'kortix.yaml', content: ':::not yaml:::\n  - [unclosed' }];
+    expect(defaultAgentFromSeedFiles(files, 'kortix.yaml')).toBeNull();
+  });
+
+  test('blank/whitespace-only default_agent is treated as unset', () => {
+    const files = [{ path: 'kortix.yaml', content: 'default_agent: "   "\n' }];
+    expect(defaultAgentFromSeedFiles(files, 'kortix.yaml')).toBeNull();
+  });
+
+  test('non-string default_agent (malformed manifest) → null, never throws', () => {
+    const files = [{ path: 'kortix.yaml', content: 'default_agent: 42\n' }];
+    expect(defaultAgentFromSeedFiles(files, 'kortix.yaml')).toBeNull();
+  });
+});

--- a/apps/api/src/projects/seed-files.ts
+++ b/apps/api/src/projects/seed-files.ts
@@ -1,4 +1,5 @@
 import { interpolateVars, type StarterTemplateId } from '@kortix/starter';
+import { parseManifestText } from '@kortix/manifest-schema';
 import { findCatalogEntryByName, getCatalogEntry } from '../marketplace/catalog';
 import { buildStarterFiles } from './starter';
 
@@ -113,4 +114,37 @@ export async function buildProjectSeedFilesFromItem(input: ProjectSeedFilesFromI
   const files = mergeSeedFiles(starterFiles, ownFiles);
 
   return { files, baseFiles };
+}
+
+/**
+ * Best-effort extraction of a seeded `kortix.yaml`'s top-level `default_agent`
+ * from a file list POST /projects/provision is about to push. Used to stamp
+ * `project.metadata.default_agent` (the read-optimized mirror session creation
+ * and the LLM gateway's model-default resolution consult — see
+ * projects/lib/sessions.ts and llm-gateway/resolution/default-model.ts) at
+ * project-creation time, the same value `PUT /:projectId/default-agent`
+ * writes later. Without this, a brand-new project's manifest declares a
+ * default agent (the starter template ships `default_agent: kortix`) that the
+ * DB mirror never learns about — every session then stores the non-binding
+ * `'default'` sentinel instead, and any agent-scope model pin set on the real
+ * agent name is silently never applied (the bug this closes).
+ *
+ * Never throws: a parse failure here must not fail project creation —
+ * session creation's own manifest read (for MANDATORY DECLARED AGENTS
+ * projects) is the actual source of truth and will surface a real error if
+ * the manifest is genuinely broken.
+ */
+export function defaultAgentFromSeedFiles(
+  files: Array<{ path: string; content: string }>,
+  manifestPath: string,
+): string | null {
+  const manifestFile = files.find((f) => f.path === manifestPath) ?? files.find((f) => f.path === 'kortix.yaml');
+  if (!manifestFile) return null;
+  try {
+    const raw = parseManifestText(manifestFile.content, 'yaml');
+    const defaultAgent = raw.default_agent;
+    return typeof defaultAgent === 'string' && defaultAgent.trim() ? defaultAgent.trim() : null;
+  } catch {
+    return null;
+  }
 }

--- a/apps/api/src/repositories/model-preferences.test.ts
+++ b/apps/api/src/repositories/model-preferences.test.ts
@@ -9,7 +9,7 @@ let conflictMode: 'update' | 'nothing' | null = null;
 
 function chain(): any {
   const c: any = {};
-  for (const m of ['select', 'from', 'where', 'update', 'set', 'delete', 'returning', 'limit']) {
+  for (const m of ['select', 'from', 'where', 'update', 'set', 'delete', 'returning', 'limit', 'leftJoin']) {
     c[m] = () => c;
   }
   c.values = (v: any) => {
@@ -32,7 +32,9 @@ mock.module('../shared/db', () => ({
   hasDatabase: () => true,
 }));
 
-const { getAccountModelDefaults, upsertAccountModelPreference } = await import('./model-preferences');
+const { getAccountModelDefaults, getSessionAgentContext, upsertAccountModelPreference } = await import(
+  './model-preferences'
+);
 
 beforeEach(() => {
   selectRows = [];
@@ -80,5 +82,58 @@ describe('upsertAccountModelPreference', () => {
       onlyIfAbsent: true,
     });
     expect(conflictMode).toBe('nothing');
+  });
+});
+
+// The join that lets a caller resolve the 'default' agent-name sentinel to
+// the owning project's declared default agent (see default-model.ts's
+// cachedSessionAgent) — the fix for agent-scope model pins silently never
+// applying to sessions whose agent_name never resolved past 'default'.
+describe('getSessionAgentContext', () => {
+  test('no row for sessionId → null', async () => {
+    selectRows = [];
+    expect(await getSessionAgentContext('s-missing')).toBeNull();
+  });
+
+  test('carries the joined project.metadata.default_agent as projectDefaultAgent', async () => {
+    selectRows = [
+      { agentName: 'default', metadata: {}, projectMetadata: { default_agent: 'kortix' } },
+    ];
+    const ctx = await getSessionAgentContext('s1');
+    expect(ctx).toEqual({ agentName: 'default', opencodeModel: null, projectDefaultAgent: 'kortix' });
+  });
+
+  test('project metadata with no default_agent → projectDefaultAgent null', async () => {
+    selectRows = [{ agentName: 'default', metadata: {}, projectMetadata: { git: {} } }];
+    const ctx = await getSessionAgentContext('s1');
+    expect(ctx?.projectDefaultAgent).toBeNull();
+  });
+
+  test('null project metadata (left join miss / never happens in practice, but must not throw) → projectDefaultAgent null', async () => {
+    selectRows = [{ agentName: 'default', metadata: {}, projectMetadata: null }];
+    const ctx = await getSessionAgentContext('s1');
+    expect(ctx?.projectDefaultAgent).toBeNull();
+  });
+
+  test('blank-string default_agent is treated as unset', async () => {
+    selectRows = [{ agentName: 'default', metadata: {}, projectMetadata: { default_agent: '   ' } }];
+    const ctx = await getSessionAgentContext('s1');
+    expect(ctx?.projectDefaultAgent).toBeNull();
+  });
+
+  test('still surfaces the session-level opencode_model override unchanged', async () => {
+    selectRows = [
+      {
+        agentName: 'release-bot',
+        metadata: { opencode_model: 'anthropic/claude-opus-4.8' },
+        projectMetadata: { default_agent: 'kortix' },
+      },
+    ];
+    const ctx = await getSessionAgentContext('s1');
+    expect(ctx).toEqual({
+      agentName: 'release-bot',
+      opencodeModel: 'anthropic/claude-opus-4.8',
+      projectDefaultAgent: 'kortix',
+    });
   });
 });

--- a/apps/api/src/repositories/model-preferences.ts
+++ b/apps/api/src/repositories/model-preferences.ts
@@ -1,4 +1,4 @@
-import { accountModelPreferences, projectSessions } from '@kortix/db';
+import { accountModelPreferences, projectSessions, projects } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
 import { db } from '../shared/db';
 
@@ -118,18 +118,39 @@ export async function deleteAccountModelPreference(params: {
  * The agent + per-session model a gateway principal's session is bound to.
  * `principal.sessionId === sandbox_id === project_sessions.session_id` (the PK)
  * by construction, so we look up the row by that key.
+ *
+ * Also carries the owning project's `metadata.default_agent` mirror
+ * (`projectDefaultAgent`) so callers can resolve the non-binding `'default'`
+ * sentinel to the project's actually-declared default agent — see
+ * `chooseEffectiveAgent` (llm-gateway/resolution/effective.ts) and its use in
+ * default-model.ts's `cachedSessionAgent`. A session's `agent_name` column
+ * lands on the `'default'` sentinel whenever session creation didn't resolve a
+ * concrete name (see `createProjectSession` in projects/lib/sessions.ts), most
+ * commonly because `project.metadata.default_agent` wasn't populated even
+ * though the project's kortix.yaml declares one — without this fallback, an
+ * agent-scope model pin keyed by that declared name is silently never applied.
  */
 export async function getSessionAgentContext(
   sessionId: string,
-): Promise<{ agentName: string; opencodeModel: string | null } | null> {
+): Promise<{ agentName: string; opencodeModel: string | null; projectDefaultAgent: string | null } | null> {
   const [row] = await db
-    .select({ agentName: projectSessions.agentName, metadata: projectSessions.metadata })
+    .select({
+      agentName: projectSessions.agentName,
+      metadata: projectSessions.metadata,
+      projectMetadata: projects.metadata,
+    })
     .from(projectSessions)
+    .leftJoin(projects, eq(projects.projectId, projectSessions.projectId))
     .where(eq(projectSessions.sessionId, sessionId))
     .limit(1);
   if (!row) return null;
   const metadata = row.metadata as Record<string, unknown> | null;
   const opencodeModel =
     metadata && typeof metadata.opencode_model === 'string' ? metadata.opencode_model : null;
-  return { agentName: row.agentName, opencodeModel };
+  const projectMetadata = row.projectMetadata as Record<string, unknown> | null;
+  const projectDefaultAgent =
+    projectMetadata && typeof projectMetadata.default_agent === 'string' && projectMetadata.default_agent.trim()
+      ? projectMetadata.default_agent.trim()
+      : null;
+  return { agentName: row.agentName, opencodeModel, projectDefaultAgent };
 }

--- a/apps/cli/src/__tests__/sessions.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions.e2e.test.ts
@@ -228,6 +228,22 @@ describe('sessions new CLI flow', () => {
     expect(sessionSha).toBe(baseSha);
   });
 
+  test('--agent forces the session onto an explicit agent instead of the project default', async () => {
+    const code = await runSessions(['new', '--agent', 'release-bot']);
+
+    expect(code).toBe(0);
+    expect(sessionCreateBody).not.toBeNull();
+    expect(sessionCreateBody).toMatchObject({ agent_name: 'release-bot' });
+  });
+
+  test('omitting --agent never sends agent_name (server resolves the project default)', async () => {
+    const code = await runSessions(['new']);
+
+    expect(code).toBe(0);
+    expect(sessionCreateBody).not.toBeNull();
+    expect(sessionCreateBody).not.toHaveProperty('agent_name');
+  });
+
   test('digest uses compact project transcript endpoint', async () => {
     const runningId = '11111111-1111-4111-8111-111111111111';
     const stoppedId = '22222222-2222-4222-8222-222222222222';

--- a/apps/cli/src/commands/sessions.ts
+++ b/apps/cli/src/commands/sessions.ts
@@ -28,9 +28,12 @@ Subcommands:
                                     each agent is doing right now (live).
                                     --all, --json. Aliases: overview, ps.
   new [--prompt "<text>"]           Start a new session, optionally with an
-                                    initial prompt. --wait blocks until it's
-                                    running; --json prints the session object
-                                    (capture session_id to orchestrate).
+                                    initial prompt. --agent <name> pins the
+                                    session to that agent (default: the
+                                    project's declared default agent).
+                                    --wait blocks until it's running; --json
+                                    prints the session object (capture
+                                    session_id to orchestrate).
   chat [<session-id>]               Talk to a session's agent (REPL, or
                                     one-shot with --prompt). --new starts one.
   connect [<session-id>]            Attach local OpenCode to the running
@@ -132,11 +135,13 @@ export async function runSessions(argv: string[]): Promise<number> {
   let promptFlag: string | undefined;
   let hostFlag: string | undefined;
   let portFlag: string | undefined;
+  let agentFlag: string | undefined;
   try {
     projectFlag = takeFlagValue(rest, ['--project']);
     hostFlag = takeFlagValue(rest, ['--host']);
     promptFlag = takeFlagValue(rest, ['--prompt', '-p']);
     portFlag = takeFlagValue(rest, ['--port']);
+    agentFlag = takeFlagValue(rest, ['--agent']);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
@@ -149,7 +154,7 @@ export async function runSessions(argv: string[]): Promise<number> {
       return sessionsLs(ctxOpts, json);
     case 'new':
     case 'create':
-      return sessionsNew(promptFlag, ctxOpts, json, wait);
+      return sessionsNew(promptFlag, ctxOpts, json, wait, agentFlag);
     case 'info':
     case 'show':
       return sessionsInfo(rest[0], ctxOpts, json);
@@ -218,12 +223,18 @@ async function sessionsNew(
   opts: CtxOpts,
   json = false,
   wait = false,
+  agent?: string,
 ): Promise<number> {
   const ctx = await resolveProjectContext(opts);
   if (!ctx) return 1;
 
   const body: Record<string, unknown> = {};
   if (prompt) body.initial_prompt = prompt;
+  // Explicit caller override — the server otherwise falls back to the
+  // project's declared default agent (kortix.yaml's `default_agent`), or the
+  // non-binding 'default' sentinel when none is configured. See
+  // apps/api/src/projects/lib/sessions.ts createProjectSession.
+  if (agent) body.agent_name = agent;
 
   const prepared = await prepareClientCreatedBranch(ctx, body);
   if (prepared === 'error') return 1;


### PR DESCRIPTION
## Summary

Fixes a correctness bug where **agent-scope model pins were silently never applied to sessions**, so a session could run the wrong (pricier / provider-mismatched) model with no error.

### Root cause (confirmed)

- `POST /v1/projects/provision` seeds every new project with the base starter's `kortix.yaml`, which declares `default_agent: kortix` — but the route never mirrored that into `project.metadata.default_agent`.
- `createProjectSession` (`apps/api/src/projects/lib/sessions.ts`) resolves a session's `agent_name` as `explicit ?? project.metadata.default_agent ?? 'default'`. With the mirror unpopulated, every session silently stored the non-binding `'default'` sentinel.
- `resolveDefaultModelForPrincipal` → `cachedSessionAgent` → `getSessionAgentContext` (`apps/api/src/repositories/model-preferences.ts`) looked up `agentDefaults[agentName]` using that raw `'default'` name. An agent-scope pin set via `kortix agents model kortix <model>` (scope=`agent`, key=`kortix`) never matched `'default'`, so the pin was silently ignored and resolution fell through to project/account/platform default — no error anywhere.

This affects essentially every project created through the standard web/CLI provisioning flow, since the base starter template (merged into every template) always declares `default_agent: kortix`.

### Fix

1. **`apps/api/src/projects/routes/r1.ts`** (`POST /projects/provision`) now stamps `project.metadata.default_agent` from the seeded `kortix.yaml` at creation time — the same value `PUT /:projectId/default-agent` writes later. Extraction helper `defaultAgentFromSeedFiles` lives in `apps/api/src/projects/seed-files.ts` (unit tested, never throws).
2. **Defense-in-depth** in `apps/api/src/llm-gateway/resolution/default-model.ts`: `cachedSessionAgent` now resolves the `'default'` sentinel to the project's declared default agent (via `getSessionAgentContext`'s new `projectDefaultAgent`, joined from `projects.metadata`) using the existing `chooseEffectiveAgent` precedence function — before doing the `agentDefaults[...]` lookup. This covers sessions created before this fix, and projects whose metadata mirror is otherwise stale (e.g. a CLI's first `kortix ship` push, which doesn't go through the provision route).
3. **CLI**: `kortix sessions new --agent <name>` now lets a caller force an explicit agent instead of relying on the project default.

### Evaluated, not changed

`account_model_preferences` scope=`agent` pins are keyed by `(account_id, agent_name)` only — no `project_id`. Since `'kortix'` is the conventional default agent name for virtually every project (from the shared starter template), two different projects on the same account both named `'kortix'` currently share one pin. This is a real design question, but:
- Fixing it requires a schema/migration change touching every call site (CLI `kortix agents model`, `PUT /:projectId/model-defaults`, the picker, Slack commands).
- It may be intentional (an account-wide "my kortix agent always uses X" preference is a plausible UX).

Left as-is per the task's guidance to prioritize the concrete wrong-model bug over a broad/risky scope change. Flagging for a follow-up decision.

## Test plan

- [x] `apps/api/src/repositories/model-preferences.test.ts` — new coverage for `getSessionAgentContext`'s joined `projectDefaultAgent`.
- [x] `apps/api/src/llm-gateway/resolution/default-model.test.ts` — new `resolveDefaultModelForPrincipal` coverage: sentinel resolves the pin, explicit agent still wins, no-pin fallthrough unchanged.
- [x] `apps/api/src/projects/seed-files.test.ts` (new file) — unit tests for `defaultAgentFromSeedFiles` (happy path, no manifest, malformed YAML, blank/non-string `default_agent`).
- [x] `apps/api/src/__tests__/e2e-projects-provision.test.ts` — extended to assert `project.metadata.default_agent` is stamped from the seeded manifest on provision (also fixed a pre-existing gap in this test's `db.update` mock that wasn't thenable without `.returning()`, matching real drizzle behavior already relied on elsewhere in the codebase).
- [x] `apps/cli/src/__tests__/sessions.e2e.test.ts` — new coverage for `--agent`.
- [x] `bun run typecheck` clean for `apps/api` and `apps/cli`.
- [x] Isolated `bun test` runs of every touched file pass 100%. Full-suite `scripts/test.sh` shows a net improvement (1280 pass / 472 fail vs baseline 1267 pass / 473 fail) — the remaining failures are pre-existing, unrelated `mock.module()` cross-file test-isolation flakiness (documented in `default-model.test.ts`'s own comments), confirmed identical on `origin/main` before this change.
- [ ] Live dev verification not performed — this PR is not yet deployed to dev (per task instructions, unit-proven only; live proof deferred to post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)