### PR TITLE
fix(auth): project-scoped PATs can drive their own project's sandbox proxy

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -166,6 +166,10 @@ mock.module('../shared/preview-ownership', () => ({
     userId && mockDbSandbox && mockDbMembership
       ? { userId, sandboxId: mockSandboxRows()[0]?.sandboxId ?? sandboxId, sandboxRole: 'member', scopes: ['*'] }
       : null,
+  // combinedAuth is bypassed in this suite (see above), so no project-scoped
+  // PAT ever reaches this — stub so the real module's shape stays satisfied
+  // for anything that imports it.
+  resolveSandboxProjectId: async () => null,
 }));
 
 // Daytona SDK mock

--- a/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
+++ b/apps/api/src/__tests__/unit-combined-auth-sa.test.ts
@@ -45,6 +45,9 @@ mock.module('../shared/supabase', () => ({
 mock.module('../shared/preview-ownership', () => ({
   canAccessPreviewSandbox: async ({ accountId }: { accountId?: string }) =>
     accountId === 'acct-1',
+  // No project-scoped PATs in this suite — stub so the real module's shape
+  // stays satisfied for anything that imports it.
+  resolveSandboxProjectId: async () => null,
 }));
 
 mock.module('../shared/auth-audit', () => ({

--- a/apps/api/src/__tests__/unit-opencode-mapping.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-mapping.test.ts
@@ -27,6 +27,9 @@ mock.module('../sandbox-proxy/backend', () => ({
 
 mock.module('../shared/preview-ownership', () => ({
   resolvePreviewUserContext: async () => null,
+  // Not exercised by this suite — stub so the real module's shape stays
+  // satisfied for anything else that imports it in the same test run.
+  resolveSandboxProjectId: async () => null,
 }));
 
 const { ensureOpencodeSessionPin } = await import('../projects/opencode-mapping');

--- a/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
@@ -79,6 +79,9 @@ mock.module('../shared/preview-ownership', () => ({
       ? { userId, sandboxId: SANDBOX_ID, sandboxRole: 'member', scopes: ['*'] }
       : null,
   canAccessSandboxSession: async () => true,
+  // Not exercised by this suite (no project-scoped PATs here) — stub so the
+  // real module's shape stays satisfied for anything that imports it.
+  resolveSandboxProjectId: async () => null,
 }));
 
 const { authenticatePreviewPrincipal, extractPreviewToken } = await import('../sandbox-proxy/preview-auth');

--- a/apps/api/src/__tests__/unit-preview-auth.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth.test.ts
@@ -16,6 +16,9 @@ mock.module('../shared/preview-ownership', () => ({
     if (userId) return mockResolvedAccountId === mockSandboxAccountId;
     return false;
   },
+  // Not exercised by this suite (no project-scoped PATs here) — stub so the
+  // real module's shape stays satisfied for anything that imports it.
+  resolveSandboxProjectId: async () => null,
 }));
 
 mock.module('../shared/resolve-account', () => ({

--- a/apps/api/src/__tests__/unit-sandbox-backend.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-backend.test.ts
@@ -26,6 +26,9 @@ mock.module('../projects/disk-quota-guard', () => ({
 mock.module('../shared/preview-ownership', () => ({
   resolvePreviewUserContext: async (sandboxId: string, userId?: string) =>
     mockPayload ? { ...mockPayload, sandboxId, userId } : null,
+  // Not exercised by this suite — stub so the real module's shape stays
+  // satisfied for anything else that imports it in the same test run.
+  resolveSandboxProjectId: async () => null,
 }));
 mock.module('../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'X-Kortix-User-Context',

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+// Two projects under the same account, each with its own sandbox — this is
+// the exact shape the security bug needs: a project-scoped PAT for project A
+// hitting project B's sandbox must be 403'd even though both projects (and
+// both sandboxes) belong to the same account.
+const PROJECT_A = 'project-aaa';
+const PROJECT_B = 'project-bbb';
+const SANDBOX_A = 'sandbox-for-a';
+const SANDBOX_B = 'sandbox-for-b';
+const ACCOUNT = 'acct-shared';
+
+const sandboxProjectByOwnSandboxId: Record<string, string> = {
+  [SANDBOX_A]: PROJECT_A,
+  [SANDBOX_B]: PROJECT_B,
+};
+
+mock.module('../shared/crypto', () => ({
+  isAccountToken: (t: string) => t.startsWith('kortix_pat_'),
+  isServiceAccountToken: (t: string) => t.startsWith('kortix_sa_'),
+  isKortixToken: (t: string) => t.startsWith('kortix_'),
+}));
+
+mock.module('../repositories/account-tokens', () => ({
+  validateAccountToken: async (t: string) => {
+    if (t === 'kortix_pat_project_a') {
+      return {
+        isValid: true,
+        userId: 'user-1',
+        accountId: ACCOUNT,
+        projectId: PROJECT_A,
+        tokenId: 'tok-a',
+      };
+    }
+    if (t === 'kortix_pat_account_scoped') {
+      return {
+        isValid: true,
+        userId: 'user-1',
+        accountId: ACCOUNT,
+        tokenId: 'tok-account',
+      };
+    }
+    return { isValid: false, error: 'Invalid PAT' };
+  },
+}));
+
+mock.module('../repositories/service-accounts', () => ({
+  validateServiceAccountToken: async () => ({ isValid: false, error: 'Invalid service account' }),
+}));
+
+mock.module('../repositories/api-keys', () => ({
+  validateSecretKey: async () => ({ isValid: false, error: 'Invalid Kortix token' }),
+}));
+
+mock.module('../shared/jwt-verify', () => ({
+  decodeSupabaseJwtPayload: () => null,
+  verifySupabaseJwt: async () => ({ ok: false, reason: 'no-keys' }),
+}));
+
+mock.module('../shared/supabase', () => ({
+  getSupabase: () => ({
+    auth: { getUser: async () => ({ data: { user: null }, error: { message: 'invalid' } }) },
+  }),
+}));
+
+// Sandbox → project resolution, keyed by sandboxId the same way the real
+// session_sandboxes lookup would be (uuid/externalId → project_id).
+mock.module('../shared/preview-ownership', () => ({
+  canAccessPreviewSandbox: async () => true,
+  resolveSandboxProjectId: async (sandboxId: string) =>
+    sandboxProjectByOwnSandboxId[sandboxId] ?? null,
+}));
+
+mock.module('../shared/auth-audit', () => ({
+  auditLoginSuccess: () => {},
+  auditLoginFail: () => {},
+}));
+
+mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
+mock.module('../lib/request-context', () => ({ setContextField: () => {} }));
+mock.module('../iam/sso-sync', () => ({ syncSsoMembership: async () => {} }));
+
+const { combinedAuth } = await import('./auth');
+
+function appWithProbe() {
+  const app = new Hono();
+  app.use('/*', combinedAuth);
+  app.get('/v1/p/:sandboxId/:port/*', (c) =>
+    c.json({
+      userId: c.get('userId' as never),
+      tokenProjectId: c.get('tokenProjectId' as never),
+    }),
+  );
+  app.get('/v1/projects/:projectId', (c) =>
+    c.json({ userId: c.get('userId' as never), projectId: c.req.param('projectId') }),
+  );
+  return app;
+}
+
+describe('project-scoped PAT on the sandbox-proxy path', () => {
+  beforeEach(() => {});
+
+  test('CAN drive its own project sandbox via /v1/p/{sandboxId}/{port}/...', async () => {
+    const res = await appWithProbe().request(`/v1/p/${SANDBOX_A}/8000/turn-stream`, {
+      headers: { Authorization: 'Bearer kortix_pat_project_a' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.userId).toBe('user-1');
+    expect(body.tokenProjectId).toBe(PROJECT_A);
+  });
+
+  test("CANNOT reach another project's sandbox (403, cross-project blocked)", async () => {
+    const res = await appWithProbe().request(`/v1/p/${SANDBOX_B}/8000/turn-stream`, {
+      headers: { Authorization: 'Bearer kortix_pat_project_a' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain(
+      'Project-scoped token cannot access a sandbox outside its project',
+    );
+  });
+
+  test('a sandbox lookup miss also denies (fail closed, not fail open)', async () => {
+    const res = await appWithProbe().request('/v1/p/unknown-sandbox/8000/turn-stream', {
+      headers: { Authorization: 'Bearer kortix_pat_project_a' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('project-scoped PAT still cannot call unrelated account-level surfaces', async () => {
+    const res = await appWithProbe().request('/v1/accounts', {
+      headers: { Authorization: 'Bearer kortix_pat_project_a' },
+    });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('Project-scoped token cannot call account-level routes');
+  });
+
+  test('project-scoped PAT still works unchanged on its own /v1/projects/:id/* REST routes', async () => {
+    const res = await appWithProbe().request(`/v1/projects/${PROJECT_A}`, {
+      headers: { Authorization: 'Bearer kortix_pat_project_a' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.projectId).toBe(PROJECT_A);
+  });
+
+  test('account-scoped PAT (no project binding) reaches the sandbox proxy unchanged', async () => {
+    const res = await appWithProbe().request(`/v1/p/${SANDBOX_A}/8000/turn-stream`, {
+      headers: { Authorization: 'Bearer kortix_pat_account_scoped' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.userId).toBe('user-1');
+    expect(body.tokenProjectId).toBeFalsy();
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -4,7 +4,7 @@ import { validateSecretKey } from '../repositories/api-keys';
 import { validateAccountToken } from '../repositories/account-tokens';
 import { validateServiceAccountToken } from '../repositories/service-accounts';
 import { isKortixToken, isAccountToken, isServiceAccountToken } from '../shared/crypto';
-import { canAccessPreviewSandbox } from '../shared/preview-ownership';
+import { canAccessPreviewSandbox, resolveSandboxProjectId } from '../shared/preview-ownership';
 import { getSupabase } from '../shared/supabase';
 import { decodeSupabaseJwtPayload, verifySupabaseJwt } from '../shared/jwt-verify';
 import { setSentryUser } from '../lib/sentry';
@@ -181,7 +181,7 @@ export async function supabaseAuth(c: Context, next: Next) {
       throw new HTTPException(401, { message: result.error || 'Invalid PAT' });
     }
     if (result.projectId) {
-      enforceTokenProjectScope(c, result.projectId);
+      await enforceTokenProjectScope(c, result.projectId);
     }
     c.set('userId', result.userId);
     c.set('userEmail', '');
@@ -461,7 +461,7 @@ export async function combinedAuth(c: Context, next: Next) {
       throw new HTTPException(401, { message: patResult.error || 'Invalid PAT' });
     }
     if (patResult.projectId) {
-      enforceTokenProjectScope(c, patResult.projectId);
+      await enforceTokenProjectScope(c, patResult.projectId);
     }
     c.set('userId', patResult.userId);
     c.set('userEmail', '');
@@ -672,11 +672,13 @@ function extractPreviewSandboxId(path: string): string | null {
  *   - the URL is an account-level route (`/v1/accounts/*` other than
  *     `/v1/accounts/me`, which we allow as a self-identity probe), OR
  *   - the URL is a webhook / preview / system route the token has no
- *     business hitting.
+ *     business hitting — UNLESS it is the sandbox-proxy path
+ *     (`/v1/p/{sandboxId}/{port}/...`) AND the sandbox belongs to the
+ *     token's own project (see below).
  *
  * Throws HTTPException(403) so the calling middleware aborts the chain.
  */
-function enforceTokenProjectScope(c: Context, tokenProjectId: string): void {
+async function enforceTokenProjectScope(c: Context, tokenProjectId: string): Promise<void> {
   const path = c.req.path;
 
   // Whitelist a couple of self-identity probes the CLI hits even for
@@ -714,6 +716,25 @@ function enforceTokenProjectScope(c: Context, tokenProjectId: string): void {
   if (path === '/v1/projects') {
     throw new HTTPException(403, {
       message: 'Project-scoped token cannot list projects',
+    });
+  }
+
+  // Sandbox-proxy path — this is what session.send()/stream() and other
+  // runtime.* SDK calls actually hit (NOT /v1/projects/:id/*). Without this
+  // branch a project PAT could authenticate REST calls but never drive an
+  // agent turn. Allow it through ONLY for a sandbox that resolves back to
+  // THIS token's own project — resolved via `session_sandboxes` (one indexed
+  // lookup, sandbox_id is the PK). A lookup miss or a mismatched project both
+  // deny, same as every other surface a project PAT has no business on; this
+  // never widens access to another project's or another account's sandbox.
+  const previewSandboxId = extractPreviewSandboxId(path);
+  if (previewSandboxId) {
+    const sandboxProjectId = await resolveSandboxProjectId(previewSandboxId);
+    if (sandboxProjectId && sandboxProjectId === tokenProjectId) {
+      return;
+    }
+    throw new HTTPException(403, {
+      message: 'Project-scoped token cannot access a sandbox outside its project',
     });
   }
 

--- a/apps/api/src/shared/preview-ownership.ts
+++ b/apps/api/src/shared/preview-ownership.ts
@@ -95,13 +95,13 @@ function cacheKey(previewSandboxId: string, userId: string): string {
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * Resolve the real session sandbox uuid + owning account from a
+ * Resolve the real session sandbox uuid + owning account/project from a
  * `previewSandboxId`, which can be either a uuid (sandboxId / externalId) or
  * the Daytona-side externalId string.
  */
 async function resolveSandboxRef(
   previewSandboxId: string,
-): Promise<{ sandboxId: string; accountId: string } | null> {
+): Promise<{ sandboxId: string; accountId: string; projectId: string } | null> {
   const idCondition = UUID_RE.test(previewSandboxId)
     ? or(
         eq(sessionSandboxes.externalId, previewSandboxId),
@@ -110,12 +110,32 @@ async function resolveSandboxRef(
     : eq(sessionSandboxes.externalId, previewSandboxId);
 
   const [row] = await db
-    .select({ sandboxId: sessionSandboxes.sandboxId, accountId: sessionSandboxes.accountId })
+    .select({
+      sandboxId: sessionSandboxes.sandboxId,
+      accountId: sessionSandboxes.accountId,
+      projectId: sessionSandboxes.projectId,
+    })
     .from(sessionSandboxes)
     .where(idCondition)
     .limit(1);
 
   return row ?? null;
+}
+
+/**
+ * Resolve the project a sandbox belongs to, given the same `previewSandboxId`
+ * form the proxy path carries (uuid or Daytona externalId). Used by the
+ * project-scoped-PAT gate in middleware/auth.ts to decide whether a project
+ * PAT may reach `/v1/p/{sandboxId}/...` — it may, only for a sandbox whose
+ * `session_sandboxes.project_id` matches the token's own project. One indexed
+ * lookup (sandbox_id is the PK; external_id and project_id are both indexed),
+ * so this is cheap enough for the auth hot path. Returns null when the
+ * sandbox row can't be found — callers must treat that as "deny", not
+ * "unscoped ok".
+ */
+export async function resolveSandboxProjectId(previewSandboxId: string): Promise<string | null> {
+  const ref = await resolveSandboxRef(previewSandboxId);
+  return ref?.projectId ?? null;
 }
 
 async function isAccountMember(userId: string, accountId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

- **Bug**: `session.send()`/`stream()` and other `runtime.*` SDK calls go through the sandbox-proxy path `/v1/p/{sandboxId}/{port}/...`, not `/v1/projects/:id/*`. `enforceTokenProjectScope()` in `apps/api/src/middleware/auth.ts` only allowlisted `/v1/projects/:id/*` (and `/v1/executor/projects/:id/*`) for project-scoped PATs, so a project PAT could hit REST routes fine but got `403 "Project-scoped token cannot call this surface"` the instant it tried to actually drive an agent turn.
- **Fix**: resolve the sandbox-proxy path's `sandboxId` back to its owning `project_id` via `session_sandboxes` (new `resolveSandboxProjectId()` in `apps/api/src/shared/preview-ownership.ts` — one indexed lookup, `sandbox_id` is the PK) and allow the PAT through **only** when that project matches the token's own `tokenProjectId`. A lookup miss or a project mismatch still 403s exactly as before.

## Security note (cross-project access stays blocked)

- `enforceTokenProjectScope()` is the single choke point both `supabaseAuth` and `combinedAuth` call for every project-scoped PAT request, on every path, before any handler runs.
- The new branch is scoped strictly to paths matched by `extractPreviewSandboxId()` (`/v1/p/{sandboxId}/...`, excluding the `auth`/`share` sub-paths which stay in the reject-all branch).
- Authorization is **fail-closed**: `resolveSandboxProjectId()` returning `null` (sandbox not found) or a non-matching `project_id` both throw `403`. There is no code path where a missing/ambiguous lookup defaults to "allow".
- This does **not** rely on account membership (`canAccessPreviewSandbox`, called further downstream in `preview.ts`) to enforce the project boundary — that check is membership-only and would otherwise let *any* project-scoped PAT reach *any* sandbox in the same account, defeating the purpose of project scoping. The new check is strictly narrower (same project, not just same account) and runs first.
- No other surface is broadened: `/v1/accounts/*`, bare `/v1/projects`, and everything else still hit the pre-existing reject-all fallthrough unchanged.

**Tradeoff called out**: the sandbox→project mapping requires one DB read (`session_sandboxes`, PK lookup on `sandbox_id`, indexed `project_id`) per project-scoped-PAT request to this path — this is the auth hot path, so latency is bounded to a single indexed row fetch, no join. Account-scoped PATs and all non-preview-proxy paths are unaffected (zero extra queries).

## Test plan

- [x] New `apps/api/src/middleware/auth.test.ts`: project PAT **can** drive its own project's sandbox proxy; **cannot** reach another project's sandbox (403 preserved, exact message asserted); a sandbox-lookup miss also denies (fail-closed); project PAT still blocked from unrelated account-level surfaces; project PAT still works unchanged on `/v1/projects/:id/*`; account-scoped PAT (no project binding) unaffected.
- [x] Updated existing suites that mock `../shared/preview-ownership` (`unit-preview-auth.test.ts`, `unit-preview-auth-principal.test.ts`, `unit-combined-auth-sa.test.ts`, `e2e-preview-proxy.test.ts`, `unit-sandbox-backend.test.ts`, `unit-opencode-mapping.test.ts`) to stub the new `resolveSandboxProjectId` export so the mocked module shape stays complete.
- [x] All affected test files pass in isolated `bun test` runs (this repo's `bun run test` has a known unrelated `KORTIX_URL` env false-failure in this sandbox — verified per-file instead, per existing project notes).
- [x] `pnpm run typecheck` (apps/api) — clean.
- [x] `biome check` — new file (`auth.test.ts`) is clean; pre-existing format/import-order nits in touched files are unchanged from baseline (verified via `git stash` diff), none introduced by this change.