### PR TITLE
fix(projects): synthesize v2 manifest w/ declared agent for blank projects

### DIFF
--- a/apps/api/src/projects/lib/triggers.test.ts
+++ b/apps/api/src/projects/lib/triggers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { parseManifestText, validateManifest } from '@kortix/manifest-schema';
+
+// `loadManifestForEdit`'s only I/O is git: `readManifest` (imported from
+// `../triggers`) calls `readManifestFromRepo` — resolved from `../git`
+// relative to THIS file, the same absolute module `../triggers.ts` itself
+// resolves `./git` to. `withProjectGitAuth` is `./git` relative to this file,
+// the same module `../lib/triggers.ts` imports it from. Mocking both lets the
+// synthesis path (no manifest committed yet) run with zero DB/network, same
+// pattern as `./compile-agent-config.test.ts`.
+let manifestFile: { path: string; content: string } | null = null;
+
+// `../git` and `./git` are heavily-imported modules (session-lifecycle,
+// github, etc. all pull other exports off them) — spread the REAL module and
+// override only `readManifestFromRepo`/`withProjectGitAuth`, rather than
+// replacing the whole module, so unrelated named exports the rest of
+// `lib/triggers.ts`'s import graph needs stay intact.
+const realProjectsGit = await import('../git');
+mock.module('../git', () => ({
+  ...realProjectsGit,
+  readManifestFromRepo: async () => manifestFile,
+}));
+
+const realLibGit = await import('./git');
+mock.module('./git', () => ({
+  ...realLibGit,
+  withProjectGitAuth: async (project: unknown) => ({
+    ...(project as Record<string, unknown>),
+    gitAuthToken: null,
+  }),
+}));
+
+const { loadManifestForEdit } = await import('./triggers');
+const { serializeManifest } = await import('../triggers');
+const { DEFAULT_AGENT_SENTINEL, extractAgents, resolveGovernedAgentGrant } = await import(
+  '../agents'
+);
+
+const fakeProject = (overrides: Record<string, unknown> = {}) =>
+  ({
+    projectId: 'proj_blank',
+    name: 'blank-project',
+    manifestPath: 'kortix.toml',
+    defaultBranch: 'main',
+    metadata: { require_declared_agents: true },
+    ...overrides,
+  }) as unknown as Parameters<typeof loadManifestForEdit>[0];
+
+describe('loadManifestForEdit — blank managed project (no kortix.yaml on disk yet)', () => {
+  test('synthesizes a valid v2 manifest with a declared, resolvable default agent', async () => {
+    manifestFile = null; // "brand-new repo" — nothing committed yet
+
+    const manifest = await loadManifestForEdit(fakeProject());
+
+    // The bug: this used to synthesize schemaVersion 1 (KNOWN_SCHEMA_VERSION),
+    // which the v2-only agent-config writers (applyAgentBlockV2 /
+    // applyDefaultAgentV2) hard-refuse — every write 400'd before a real
+    // manifest could ever land in git, so the project was permanently stuck
+    // un-declarable.
+    expect(manifest.schemaVersion).toBe(2);
+    expect(manifest.format).toBe('yaml');
+
+    const defaultAgent = manifest.raw.default_agent;
+    expect(typeof defaultAgent).toBe('string');
+    expect((defaultAgent as string).length).toBeGreaterThan(0);
+
+    const agents = manifest.raw.agents as Record<string, unknown> | undefined;
+    expect(agents).toBeTruthy();
+    expect(agents?.[defaultAgent as string]).toBeTruthy();
+
+    // Prove it end-to-end through the same serialize → re-parse → validate
+    // pipeline `commitManifest` actually runs (not just shape-poking the
+    // in-memory `raw`, which omits `kortix_version` by construction — see
+    // `serializeManifest`'s doc comment): a v2 manifest must declare >=1
+    // agent AND a default_agent that resolves to one of them
+    // (validateAgentsV2 / validateDefaultAgentV2) — exactly the two facts
+    // the declared-agent session-create check needs.
+    const committedText = serializeManifest(manifest);
+    const reparsed = parseManifestText(committedText, manifest.format);
+    const result = validateManifest(reparsed, manifest.format);
+    const errors = result.issues.filter((issue) => issue.severity === 'error');
+    expect(errors).toEqual([]);
+
+    // Close the loop all the way to the actual session-create gate: the
+    // 'default' sentinel must resolve to a real, enabled grant — never
+    // AGENT_NOT_DECLARED — the moment this manifest exists, with zero writes.
+    const loadedAgents = extractAgents(manifest);
+    const governed = resolveGovernedAgentGrant(DEFAULT_AGENT_SENTINEL, loadedAgents, {
+      subject: true,
+      projectDefaultAgent: null,
+    });
+    expect(governed.ok).toBe(true);
+  });
+
+  test('an already-committed manifest is read as-is, untouched (v1 stays v1)', async () => {
+    manifestFile = {
+      path: 'kortix.toml',
+      content: 'kortix_version = 1\n\n[project]\nname = "legacy"\n',
+    };
+
+    const manifest = await loadManifestForEdit(fakeProject({ metadata: {} }));
+
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest.format).toBe('toml');
+    expect(manifest.raw.agents).toBeUndefined();
+  });
+});

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -22,7 +22,6 @@ import {
 import {
   type GitTriggerSessionMode,
   type GitTriggerSpec,
-  KNOWN_SCHEMA_VERSION,
   MANIFEST_FILENAME,
   type ParsedManifest,
   loadProjectTriggers,
@@ -1274,6 +1273,16 @@ export function draftToSpec(draft: TriggerDraft, manifestPath: string = MANIFEST
 }
 
 /**
+ * The agent name a synthesized (no-manifest-yet) v2 manifest declares as its
+ * default — same name `@kortix/starter`'s `base` template seeds (see
+ * packages/starter/templates/base/kortix.yaml's `default_agent: kortix` +
+ * `agents.kortix`). Keeping the two in sync means a blank managed-git project
+ * (provisioned WITHOUT `seed_starter:true`, so no kortix.yaml ever lands on
+ * disk) self-heals into the exact shape a seeded one would already have.
+ */
+const SYNTHESIZED_DEFAULT_AGENT_NAME = 'kortix';
+
+/**
  * Read the project's manifest. If the manifest doesn't exist yet (brand-new
  * repo), synthesize a minimal valid one so the first POST /triggers can
  * scaffold it on save.
@@ -1287,12 +1296,45 @@ export async function loadManifestForEdit(project: ProjectRow): Promise<ParsedMa
   // whatever manifestPath is configured (defaults to `kortix`'s stem) rather
   // than trusting a stale/legacy `.toml` value literally, so format and path
   // stay in sync on commit.
+  //
+  // MUST be kortix_version 2, not KNOWN_SCHEMA_VERSION (which deliberately
+  // stays pinned at 1 — see its own doc comment in ../triggers.ts). Every
+  // project created through POST /projects/provision (seeded or not) is
+  // stamped `metadata.require_declared_agents: true` and reads/writes
+  // through the v2-only agent-config API (`applyAgentBlockV2`/
+  // `applyDefaultAgentV2` in ./agent-config-v2.ts hard-refuse a v1
+  // manifest). A blank project (no `seed_starter`, so no kortix.yaml ever
+  // got pushed) synthesizing v1 here meant every agent-config write 400'd
+  // with "upgrade to kortix_version 2" before it could ever commit a real
+  // manifest — a self-inflicted catch-22 that left the project permanently
+  // un-declarable (AGENT_NOT_DECLARED on every session-create) short of a
+  // force-pushed kortix.yaml or a full re-provision with `seed_starter:true`.
+  //
+  // Also pre-declare ONE default agent (not just bump the version number):
+  // a v2 manifest must have `agents` non-empty AND `default_agent` resolving
+  // to a declared, enabled entry in the SAME write (validateAgentsV2 /
+  // validateDefaultAgentV2 in @kortix/manifest-schema), so a caller can't
+  // bootstrap the very first agent from a genuinely empty v2 shell either —
+  // declaring the agent needs `default_agent` already set, and setting
+  // `default_agent` needs the agent already declared. Seeding both together
+  // here (mirroring exactly what `seed_starter` would have committed) breaks
+  // that cycle: a session can start immediately even with zero writes, and
+  // any subsequent agent-config PUT is a normal upsert against an
+  // already-valid v2 manifest.
   return {
-    schemaVersion: KNOWN_SCHEMA_VERSION,
+    schemaVersion: 2,
     raw: {
       project: { name: project.name, description: '' },
-      runtime: { root: '.opencode' },
       env: { required: [], optional: [] },
+      default_agent: SYNTHESIZED_DEFAULT_AGENT_NAME,
+      agents: {
+        [SYNTHESIZED_DEFAULT_AGENT_NAME]: {
+          connectors: 'all',
+          secrets: 'all',
+          kortix_cli: 'all',
+          skills: 'all',
+        },
+      },
     },
     format: 'yaml',
     path: manifestCandidatePaths(project.manifestPath)[0].path,


### PR DESCRIPTION
## Summary

**Bug:** A blank managed-git project (`POST /v1/projects/provision` WITHOUT `seed_starter:true`) is stamped `metadata.require_declared_agents:true`, but was permanently un-declarable via the agent-config API.

**Root cause:** `loadManifestForEdit` (`apps/api/src/projects/lib/triggers.ts:1282`) synthesized an in-memory fallback manifest at `schemaVersion: KNOWN_SCHEMA_VERSION` (= 1) whenever no `kortix.yaml`/`kortix.toml` was committed yet. But every project from `POST /projects/provision` (seeded or not) is stamped `require_declared_agents:true` and reads/writes through the **v2-only** agent-config API — `applyAgentBlockV2`/`applyDefaultAgentV2` (`apps/api/src/projects/lib/agent-config-v2.ts`) hard-refuse a `schemaVersion !== 2` manifest with `"Upgrade to kortix_version 2..."`. So on a blank project, every agent-config write 400'd *before a real manifest could ever land in git* — a catch-22 that left every `session-create` 400ing `AGENT_NOT_DECLARED` until the repo was re-provisioned with `seed_starter:true` or a `kortix.yaml` force-pushed by hand.

**Fix:** synthesize `kortix_version: 2` instead, pre-declaring one default agent (`kortix`, full grants) — the exact shape `seed_starter`'s `base` template (`packages/starter/templates/base/kortix.yaml`) would already have committed. This isn't just a version bump: a v2 manifest requires `agents` non-empty **and** `default_agent` resolving to a declared entry in the *same* write (`validateAgentsV2`/`validateDefaultAgentV2`), so a genuinely-empty v2 shell can't bootstrap its first agent via the API either (declaring the agent needs `default_agent` set; setting `default_agent` needs the agent already declared). Seeding both together breaks that cycle — a blank project now satisfies the declared-agent check immediately (zero writes needed), and any subsequent `agent-config` PUT is a normal upsert against an already-valid manifest.

Also dropped the stale `runtime: { root: '.opencode' }` field from the synthesized fallback (unused anywhere in the codebase — v2's actual config-dir field is `opencode.config_dir`, which already defaults to `.kortix/opencode` when absent).

## Test plan
- [x] New `apps/api/src/projects/lib/triggers.test.ts`: mocks the two git-IO seams `loadManifestForEdit` touches, then proves the synthesized manifest end-to-end:
  - `schemaVersion === 2`, `format === 'yaml'`
  - declares a non-empty `default_agent` that resolves inside `agents`
  - round-trips through the **real** `serializeManifest → parseManifestText → validateManifest` pipeline (same one `commitManifest` uses) with zero errors
  - resolves through the **real** `extractAgents` + `resolveGovernedAgentGrant` — the exact function `session-create`'s declared-agent gate calls — for the `'default'` sentinel, `ok: true`
  - a second test proves an already-committed v1 manifest is read as-is (unaffected — this only changes the *no-file-yet* fallback)
- [x] `bun test src/projects/lib/ src/projects/routes/agent-config.ts src/projects/routes/agent-scope.ts src/projects/agents.ts src/__tests__/unit-yaml-config-roundtrip.test.ts src/__tests__/unit-trigger-pause.test.ts` — 108 pass (1 unrelated pre-existing `KORTIX_URL` env-decrypt false-failure in `sandbox-env-sync.test.ts`, confirmed present on `main` too, unrelated to this diff)
- [x] `pnpm run typecheck` (apps/api) — clean
- [x] `biome check` on both changed files — clean (pre-existing `noExplicitAny` findings elsewhere in `triggers.ts` confirmed present on `main` baseline, untouched by this diff)
- [ ] CI (opened, awaiting checks)