### PR TITLE
fix(sandbox-proxy): stop 502ing healthy long reasoning/tool turns on blocking POST /session/:id/message

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -1261,6 +1261,103 @@ describe('Preview proxy: retry exhaustion', () => {
   });
 });
 
+// A blocking session turn (`POST /session/:id/message`) can legitimately run
+// long (reasoning + tool calls) — the upstream never sends response headers
+// until it's fully done. That must NOT be treated like a stalled connection:
+// no wake, no resend of the (non-idempotent) message, and a distinct,
+// honest signal instead of the generic "sandbox unreachable" 502. See
+// preview-retry-budget.ts (proxyAttemptTimeoutMs) and forwardToSandbox's
+// catch block in routes/preview.ts.
+describe('Preview proxy: long-turn completion timeout', () => {
+  test('a connect-timer abort on POST /session/:id/message returns 504 LONG_TURN_PROXY_TIMEOUT — no wake, no resend', async () => {
+    const savedFetch = globalThis.fetch;
+    const origSetTimeout = globalThis.setTimeout;
+    let callCount = 0;
+
+    // Simulate a healthy upstream that is still computing: fetch never
+    // resolves on its own, only rejects once the connect-timer aborts it —
+    // exactly what a real long reasoning/tool turn looks like from the
+    // proxy's perspective (TCP alive, no bytes yet).
+    globalThis.fetch = ((_url: any, init?: RequestInit) => {
+      callCount++;
+      const signal = init?.signal;
+      return new Promise((_resolve, reject) => {
+        const abortWith = () =>
+          reject((signal as any)?.reason ?? new DOMException('aborted', 'TimeoutError'));
+        if (signal?.aborted) {
+          abortWith();
+          return;
+        }
+        signal?.addEventListener('abort', abortWith);
+      });
+    }) as any;
+    // Fire the connect-timer (and any retry delay) synchronously instead of
+    // waiting out the real ~49.5s budget.
+    globalThis.setTimeout = ((fn: any) => {
+      fn();
+      return 0 as any;
+    }) as any;
+
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/sandbox-long-turn-001/${TEST_PORT}/session/sess-1/message`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer test', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parts: [{ type: 'text', text: 'do a long thing' }] }),
+    });
+
+    globalThis.setTimeout = origSetTimeout;
+    globalThis.fetch = savedFetch;
+
+    expect(res.status).toBe(504);
+    const body = await res.json();
+    expect(body.code).toBe('LONG_TURN_PROXY_TIMEOUT');
+    // Exactly one attempt: the exempted class gets ~the whole budget on
+    // attempt 0, and a timeout there must NOT resend the (non-idempotent)
+    // message — resending would duplicate the user's turn.
+    expect(callCount).toBe(1);
+    // The sandbox is healthy and still working — waking it is both wrong
+    // and wasted (an extra provider call to an already-running box).
+    expect(mockWakeCalls.length).toBe(0);
+  });
+
+  test('an ordinary connect-timer abort (non-message path) still wakes + retries as before', async () => {
+    const savedFetch = globalThis.fetch;
+    const origSetTimeout = globalThis.setTimeout;
+    let callCount = 0;
+    globalThis.fetch = ((_url: any, init?: RequestInit) => {
+      callCount++;
+      const signal = init?.signal;
+      return new Promise((_resolve, reject) => {
+        const abortWith = () =>
+          reject((signal as any)?.reason ?? new DOMException('aborted', 'TimeoutError'));
+        if (signal?.aborted) {
+          abortWith();
+          return;
+        }
+        signal?.addEventListener('abort', abortWith);
+      });
+    }) as any;
+    globalThis.setTimeout = ((fn: any) => {
+      fn();
+      return 0 as any;
+    }) as any;
+
+    const app = createProxyTestApp();
+    const res = await app.request(`/v1/p/sandbox-long-turn-002/${TEST_PORT}/`, {
+      headers: { Authorization: 'Bearer test' },
+    });
+
+    globalThis.setTimeout = origSetTimeout;
+    globalThis.fetch = savedFetch;
+
+    // Unchanged prior behavior: a plain GET that never gets bytes is a real
+    // stall, not a long-turn completion — full retry/wake path still applies.
+    expect(res.status).toBe(502);
+    expect(callCount).toBe(4);
+    expect(mockWakeCalls.length).toBe(1);
+  });
+});
+
 describe('Preview proxy: no-trailing-slash', () => {
   test('handles /:sandboxId/:port without trailing slash (proxies or redirects)', async () => {
     const app = createProxyTestApp();

--- a/apps/api/src/sandbox-proxy/preview-retry-budget.test.ts
+++ b/apps/api/src/sandbox-proxy/preview-retry-budget.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  PROXY_ATTEMPT_TIMEOUT_MS,
+  isLongTurnCompletionRequest,
+  proxyAttemptTimeoutMs,
+} from './preview-retry-budget';
+
+// `POST /session/:id/message` is OpenCode's synchronous, blocking turn
+// endpoint: it doesn't emit response headers until the whole reasoning +
+// tool-call turn is done. It must get the same "remaining budget, not the
+// generic 15s connect cap" treatment as a multipart upload, or a perfectly
+// healthy 20-40s turn gets aborted and its non-idempotent body gets resent.
+describe('isLongTurnCompletionRequest', () => {
+  test('POST /session/:id/message matches', () => {
+    expect(isLongTurnCompletionRequest({ method: 'POST', path: '/session/abc123/message' })).toBe(
+      true,
+    );
+    expect(isLongTurnCompletionRequest({ method: 'post', path: '/session/abc-123/message' })).toBe(
+      true,
+    );
+    expect(
+      isLongTurnCompletionRequest({ method: 'POST', path: '/session/abc123/message?x=1' }),
+    ).toBe(true);
+  });
+
+  test('GET (fetch transcript) does not match, only the blocking POST does', () => {
+    expect(isLongTurnCompletionRequest({ method: 'GET', path: '/session/abc123/message' })).toBe(
+      false,
+    );
+  });
+
+  test('the async sibling endpoint does not match — it already returns immediately', () => {
+    expect(
+      isLongTurnCompletionRequest({ method: 'POST', path: '/session/abc123/prompt_async' }),
+    ).toBe(false);
+  });
+
+  test('an unrelated path with "/message" elsewhere does not match', () => {
+    expect(
+      isLongTurnCompletionRequest({ method: 'POST', path: '/not-session/abc123/message' }),
+    ).toBe(false);
+    expect(isLongTurnCompletionRequest({ method: 'POST', path: '/session/abc123/messages' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('proxyAttemptTimeoutMs', () => {
+  test('an ordinary GET is capped at the generic 15s connect window', () => {
+    expect(proxyAttemptTimeoutMs(40_000, { method: 'GET', path: '/session/abc123/status' })).toBe(
+      PROXY_ATTEMPT_TIMEOUT_MS,
+    );
+  });
+
+  test('with no request info at all, still caps at the generic window', () => {
+    expect(proxyAttemptTimeoutMs(40_000)).toBe(PROXY_ATTEMPT_TIMEOUT_MS);
+  });
+
+  test('a blocking session-message POST gets ~the whole remaining budget, not the 15s cap', () => {
+    expect(proxyAttemptTimeoutMs(40_000, { method: 'POST', path: '/session/abc123/message' })).toBe(
+      39_500,
+    );
+  });
+
+  test('an upload keeps its existing remaining-budget treatment (no regression)', () => {
+    expect(proxyAttemptTimeoutMs(40_000, { method: 'POST', path: '/file/upload' })).toBe(39_500);
+  });
+
+  test('a blocking session-message POST never drops below the 1s floor', () => {
+    expect(proxyAttemptTimeoutMs(200, { method: 'POST', path: '/session/abc123/message' })).toBe(
+      1_000,
+    );
+  });
+
+  test('a blocking session-message POST is still bounded by whatever budget remains', () => {
+    // Near the end of the outer 50s budget, the exempted class must shrink
+    // with it — it never gets MORE than the remaining wall-clock budget, only
+    // the generic 15s floor is what it's exempt from.
+    expect(proxyAttemptTimeoutMs(5_000, { method: 'POST', path: '/session/abc123/message' })).toBe(
+      4_500,
+    );
+    expect(
+      proxyAttemptTimeoutMs(5_000, { method: 'POST', path: '/session/abc123/message' }),
+    ).toBeLessThan(PROXY_ATTEMPT_TIMEOUT_MS);
+  });
+});

--- a/apps/api/src/sandbox-proxy/preview-retry-budget.ts
+++ b/apps/api/src/sandbox-proxy/preview-retry-budget.ts
@@ -7,6 +7,27 @@
 export const PROXY_RETRY_BUDGET_MS = 50_000;
 export const PROXY_ATTEMPT_TIMEOUT_MS = 15_000;
 
+// OpenCode's synchronous send-message endpoint: the daemon holds the response
+// open until the ENTIRE reasoning + tool-call turn finishes, then emits headers
+// + body together — there is no early flush. (`prompt_async` is the sibling
+// endpoint that returns immediately and streams progress over the
+// `/global/event` SSE channel instead; that's the path the web UI uses
+// precisely to avoid ever blocking on a turn's full duration.) A caller that
+// blocks on this endpoint directly is structurally exposed to the same
+// interval as a multipart upload, just mirrored: uploads can't emit headers
+// until the client finishes WRITING the body, this can't emit headers until
+// the server finishes COMPUTING it.
+export function isLongTurnCompletionRequest(request: { method: string; path: string }): boolean {
+  return (
+    request.method.toUpperCase() === 'POST' &&
+    /^\/session\/[^/]+\/message(?:$|[/?#])/.test(request.path)
+  );
+}
+
+function isUploadRequest(request: { method: string; path: string }): boolean {
+  return request.method.toUpperCase() === 'POST' && /^\/file\/upload(?:$|[/?#])/.test(request.path);
+}
+
 // Per-attempt upstream fetch timeout, shrunk to whatever budget remains so the
 // retry loop can never run past PROXY_RETRY_BUDGET_MS even if an attempt hangs.
 export function proxyAttemptTimeoutMs(
@@ -18,10 +39,15 @@ export function proxyAttemptTimeoutMs(
   // stall aborts every sufficiently large upload at 15s, then retries the same
   // body until the outer 50s budget is exhausted. Give an upload the remaining
   // request budget; the outer budget still keeps us below the ALB idle timeout.
-  if (
-    request?.method.toUpperCase() === 'POST' &&
-    /^\/file\/upload(?:$|[/?#])/.test(request.path)
-  ) {
+  //
+  // A blocking session-message turn gets the exact same treatment and for the
+  // exact same reason: capping it at the generic 15s connect window aborts a
+  // perfectly healthy, still-reasoning turn, then the retry loop resubmits the
+  // SAME (non-idempotent — it re-sends the user's message) request against
+  // whatever budget is left, repeatedly, until the budget runs out — turning
+  // an ordinary 20-40s turn into a manufactured 502 well before either the
+  // outer budget or the ALB's idle timeout actually required one.
+  if (request && (isUploadRequest(request) || isLongTurnCompletionRequest(request))) {
     return Math.max(1_000, budgetRemainingMs - 500);
   }
   return Math.max(1_000, Math.min(PROXY_ATTEMPT_TIMEOUT_MS, budgetRemainingMs));

--- a/apps/api/src/sandbox-proxy/routes/preview.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { shouldAutoResumeStoppedSandbox } from './preview';
+import { longTurnTimeoutResponse, shouldAutoResumeStoppedSandbox } from './preview';
 
 // The data-path proxy may only wake a stopped box on ACTIVE user traffic to the
 // OpenCode daemon (port 8000, principal). Everything else must still 503 so we
@@ -27,5 +27,36 @@ describe('shouldAutoResumeStoppedSandbox', () => {
     expect(shouldAutoResumeStoppedSandbox('archived', 8000, 'principal')).toBe(false);
     expect(shouldAutoResumeStoppedSandbox('active', 8000, 'principal')).toBe(false);
     expect(shouldAutoResumeStoppedSandbox('provisioning', 8000, 'principal')).toBe(false);
+  });
+});
+
+// A long reasoning+tool turn on the blocking `POST /session/:id/message` path
+// can legitimately outrun the proxy's retry budget while the sandbox is
+// perfectly healthy. That must surface as a distinct, honest signal — never
+// the generic "sandbox unreachable" 502 (which implies the box is dead and
+// invites the caller to retry the exact same non-idempotent request).
+describe('longTurnTimeoutResponse', () => {
+  test('reports 504 with a distinct machine-readable code, not a generic 502', async () => {
+    const res = longTurnTimeoutResponse('');
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as { code: string; error: string };
+    expect(body.code).toBe('LONG_TURN_PROXY_TIMEOUT');
+    expect(body.error).toMatch(/prompt_async/);
+  });
+
+  test('is never cached — a retry must always re-evaluate the upstream', () => {
+    const res = longTurnTimeoutResponse('');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  test('reflects CORS origin like every other proxy response', () => {
+    const res = longTurnTimeoutResponse('https://app.kortix.ai');
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://app.kortix.ai');
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  test('omits CORS headers when there is no Origin', () => {
+    const res = longTurnTimeoutResponse('');
+    expect(res.headers.has('Access-Control-Allow-Origin')).toBe(false);
   });
 });

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -18,7 +18,11 @@ import {
   routeSandboxIngress,
   wakeSandbox,
 } from '../backend';
-import { PROXY_RETRY_BUDGET_MS, proxyAttemptTimeoutMs } from '../preview-retry-budget';
+import {
+  PROXY_RETRY_BUDGET_MS,
+  isLongTurnCompletionRequest,
+  proxyAttemptTimeoutMs,
+} from '../preview-retry-budget';
 
 // `userId` is set by combinedAuth (mounted in ../index.ts) before this route.
 const preview = new Hono<{ Variables: { userId: string; userEmail: string } }>();
@@ -225,6 +229,35 @@ function portUnreachableResponse(opts: {
   }
   headers.set('Content-Type', 'application/json');
   return new Response(JSON.stringify({ error: reason, port, status }), { status, headers });
+}
+
+// Response for a blocking session-turn (`POST /session/:id/message`) that
+// outran the proxy's retry budget while the upstream was still actively
+// computing — i.e. NOT the "sandbox is unreachable/dead" case portUnreachableResponse
+// describes. Conflating the two is actively misleading: it makes a healthy,
+// still-working sandbox look down, and it invites a naive caller to retry the
+// exact same (non-idempotent — it would resubmit the user's message) request
+// against a connection shape that can never fit it. 504 + a distinct machine
+// code let a caller branch on "this call structurally cannot block for that
+// long over this connection" and switch to `prompt_async` + the `/global/event`
+// SSE stream instead (what the web UI already does). No-store: a retry should
+// always re-evaluate the upstream, never replay a cached verdict.
+export function longTurnTimeoutResponse(origin: string): Response {
+  const headers = new Headers({ 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+  if (origin) {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Credentials', 'true');
+  }
+  return new Response(
+    JSON.stringify({
+      error:
+        'Turn is still running and outran this connection’s budget. Blocking POST /session/:id/message ' +
+        'cannot wait out a long reasoning/tool turn (the ALB idle-times a stalled connection); use ' +
+        'prompt_async and consume /global/event (SSE) instead of blocking on this endpoint.',
+      code: 'LONG_TURN_PROXY_TIMEOUT',
+    }),
+    { status: 504, headers },
+  );
 }
 
 // Rewrite an upstream redirect Location so the user stays on the preview.
@@ -499,6 +532,12 @@ export async function forwardToSandbox(
   // providers there is no such signal, so the preview proxy never errors the row;
   // liveness is owned by the health-check loop + reconciler, not a port request.
   let sawDeadSignal = false;
+  // A blocking session-turn (`POST /session/:id/message`) whose single attempt
+  // (it gets ~the whole remaining budget, see proxyAttemptTimeoutMs) still hit
+  // the connect-timer. That's a legitimately long-running, healthy turn, not a
+  // stalled connection — see the giveup branch below for why it gets its own
+  // response instead of the generic "sandbox unreachable" one.
+  let sawLongTurnTimeout = false;
 
   // Wall-clock budget so a cold/dead sandbox returns our friendly page BEFORE
   // the 60s ALB idle timeout severs the connection (→ Cloudflare's bare 502).
@@ -781,6 +820,21 @@ export async function forwardToSandbox(
         `[PREVIEW] Attempt ${attempt + 1}/${MAX_RETRIES + 1} failed for ${sandboxId}:${port}: ${(err as Error).message || err}`,
       );
 
+      // A connect-timer abort on a long-turn completion request means the
+      // upstream was still actively computing when its (near-full-budget)
+      // attempt ran out of room — not that it's stalled or dead. Waking an
+      // already-healthy sandbox is a no-op-but-wasted provider call, and
+      // retrying would resubmit the user's message a second time (this
+      // endpoint isn't idempotent). Stop here and report it honestly instead.
+      if (
+        err instanceof DOMException &&
+        err.name === 'TimeoutError' &&
+        isLongTurnCompletionRequest({ method, path: remainingPath })
+      ) {
+        sawLongTurnTimeout = true;
+        break;
+      }
+
       if (!wakeTriggered) {
         await wakeSandbox(sandboxId);
         wakeTriggered = true;
@@ -790,6 +844,10 @@ export async function forwardToSandbox(
         await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
       }
     }
+  }
+
+  if (sawLongTurnTimeout) {
+    return longTurnTimeoutResponse(origin);
   }
 
   // All retries exhausted. Only error the row when the provider CONFIRMED the


### PR DESCRIPTION
## Summary

**Bug**: A blocking `POST /session/:id/message` through the sandbox proxy could 502 on long reasoning+tool turns.

**Root cause** (in `apps/api/src/sandbox-proxy/preview-retry-budget.ts` / `routes/preview.ts`): `proxyAttemptTimeoutMs()` capped every request except `POST /file/upload` at a **15s connect window**, regardless of whether `fetch()` had actually failed to connect. `POST /session/:id/message` is OpenCode's *synchronous* turn-completion endpoint — it cannot emit response headers until the entire reasoning+tool-call turn is finished, so for this endpoint "time to headers" == "total turn duration." Any turn slower than 15s got aborted mid-flight by the connect-timer, and the generic `catch` handler then **resent the same (non-idempotent) message** on retry. Three churns of this ate almost the whole 50s outer retry budget, then the proxy gave up with a misleading `"sandbox upstream unreachable"` 502 — well before the ALB's 60s idle timeout was even the binding constraint, and while the sandbox was perfectly healthy and still computing.

**Fix**:
- `proxyAttemptTimeoutMs()` now gives `POST /session/:id/message` the same "remaining budget, not the 15s cap" treatment already used for multipart uploads (new `isLongTurnCompletionRequest`) — the two cases are structurally identical, just mirrored: server can't emit headers until done computing vs. client can't finish until done writing.
- A connect-timer abort on that endpoint no longer triggers `wakeSandbox` or a retry/resend (it can't be a stall — the attempt already got ~the whole budget, so retrying would just duplicate the user's message). It now returns a distinct `504 LONG_TURN_PROXY_TIMEOUT` instead of the generic `"sandbox unreachable"` 502, telling callers to use `prompt_async` + `/global/event` SSE — exactly what the web UI already does to avoid this class of call entirely.
- Every other path (uploads, ordinary GETs, genuine connection stalls) is unchanged — verified via a same-shape "non-message path still wakes+retries as before" test.

**Where this is architecturally bound, not fixable in-repo**: turns that genuinely exceed ~50s still cannot complete over this blocking connection shape. That's the AWS ALB's ~60s idle timeout (infra, not in this repo) — the proxy's ~50s budget exists specifically to return a controlled response before the ALB severs the connection uncleanly. Extending the budget past ~50s would just move the failure to the ALB's raw/branded error; holding the connection open unboundedly is explicitly the wrong tradeoff. The only real fix for turns that long is what the web UI already does: `prompt_async` + SSE/poll instead of blocking. This PR makes that boundary *correct and legible* (a proper timeout signal) instead of a misleading 502 that looks like the sandbox died.

## Test plan
- [x] New unit tests: `apps/api/src/sandbox-proxy/preview-retry-budget.test.ts` — `isLongTurnCompletionRequest` classification + `proxyAttemptTimeoutMs` budget math for the exempted class (no regression for uploads/ordinary requests).
- [x] New unit tests: `apps/api/src/sandbox-proxy/routes/preview.test.ts` — `longTurnTimeoutResponse` shape (504, `LONG_TURN_PROXY_TIMEOUT`, no-store, CORS).
- [x] New integration tests in `apps/api/src/__tests__/e2e-preview-proxy.test.ts` exercising the real `forwardToSandbox` path end-to-end: (1) a connect-timer abort on `POST /session/:id/message` returns 504 with exactly one upstream attempt and zero wake calls; (2) the same abort shape on an ordinary path is unchanged (502, 4 attempts, 1 wake) — proving no regression to existing stall handling.
- [x] `KORTIX_URL=https://example.com dotenvx run -- bun test src/sandbox-proxy/ src/__tests__/e2e-preview-proxy.test.ts src/__tests__/unit-preview-proxy-budget.test.ts src/__tests__/unit-preview-retry-budget.test.ts` → 82 pass, 0 fail.
- [x] `pnpm run typecheck` (apps/api) → clean.
- [x] `biome check` on all touched files → identical pre-existing error count (0 new files: 0 errors; existing files: same baseline count as main, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)