### PR TITLE
seo(aeo): order /api/ai recency-first so freshest content leads

### DIFF
--- a/apps/web/src/app/(system)/api/ai/route.ts
+++ b/apps/web/src/app/(system)/api/ai/route.ts
@@ -85,9 +85,21 @@ export function GET(request: Request): Response {
     );
   }
 
+  // Recency-first ordering: dated content (blog posts + dated use-cases) leads
+  // by lastModified desc so answer-engine crawlers reading top-N see the
+  // freshest high-intent comparison content first; undated content (marketing,
+  // most docs) follows in a stable alphabetical-by-path order. The sort is
+  // deterministic so offset-based pagination stays stable within a snapshot.
   const records = getPublicContentRecords()
     .filter((record) => !requestedKind || record.kind === requestedKind)
-    .sort((a, b) => a.htmlPath.localeCompare(b.htmlPath));
+    .sort((a, b) => {
+      const aDate = a.lastModified ?? null;
+      const bDate = b.lastModified ?? null;
+      if (aDate && bDate) return bDate.localeCompare(aDate);
+      if (aDate) return -1;
+      if (bDate) return 1;
+      return a.htmlPath.localeCompare(b.htmlPath);
+    });
   const page = records.slice(cursor, cursor + limit);
   const nextOffset = cursor + page.length;
 

--- a/apps/web/src/lib/seo/public-content.test.ts
+++ b/apps/web/src/lib/seo/public-content.test.ts
@@ -217,6 +217,34 @@ describe('bounded public agent index', () => {
     }
   });
 
+  test('orders the index recency-first so freshest content leads each kind', async () => {
+    const response = getAgentIndex(
+      new Request('https://kortix.com/api/ai?kind=blog&limit=999', {
+        headers: { 'x-real-ip': '192.0.2.4' },
+      }),
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as any;
+    const dates: string[] = body.data
+      .map((item: any) => item.last_modified)
+      .filter((value: any) => typeof value === 'string');
+    expect(dates.length).toBeGreaterThan(1);
+    // Blog records are recency-desc by last_modified.
+    for (let index = 1; index < dates.length; index += 1) {
+      expect(dates[index - 1] >= dates[index]).toBe(true);
+    }
+    // In the unfiltered index, no dated record ever follows an undated one.
+    const unfiltered = getAgentIndex(
+      new Request('https://kortix.com/api/ai?limit=999', { headers: { 'x-real-ip': '192.0.2.5' } }),
+    );
+    const unfilteredBody = (await unfiltered.json()) as any;
+    let sawUndated = false;
+    for (const item of unfilteredBody.data as any[]) {
+      if (!item.last_modified) sawUndated = true;
+      else expect(sawUndated).toBe(false);
+    }
+  });
+
   test('rejects malformed pagination and enforces the documented rate limit', async () => {
     const invalid = getAgentIndex(
       new Request('https://kortix.com/api/ai?cursor=not-valid!', {


### PR DESCRIPTION
## Why

The public agent index (`/api/ai`, `noindex, follow`) was sorted alphabetically by `htmlPath` (`route.ts:90`), which buried the freshest high-intent comparison posts (`kortix-vs-glean` 2026-07-13, `secure-ai-agent-tool-access` 2026-07-07, `kortix-vs-claude-cowork`) at positions 5/7/9 of the blog slice. An answer-engine crawler reading top-N therefore saw the oldest posts first. SEO-agency-worker AEO shard confirmed: `/api/ai?limit=5` returned only 06-29/06-27/06-06 blog posts, omitting the two July comparison posts from the first page.

## What changed

- `apps/web/src/app/(system)/api/ai/route.ts` — replace `.sort((a, b) => a.htmlPath.localeCompare(b.htmlPath))` with a recency-first sort: `lastModified` desc (nulls last), with `htmlPath` as a deterministic tiebreaker among undated records. Dated content (blog posts + dated use-cases) now leads; undated marketing/docs follow in stable alphabetical order. Deterministic, so offset-based pagination stays stable within a snapshot.
- `apps/web/src/lib/seo/public-content.test.ts` — adds a regression test asserting blog records are recency-desc by `last_modified` and that no dated record ever follows an undated one in the unfiltered index.

## Scope

Public SEO/AEO only. Metadata-only, `noindex, follow` agent index. No auth/billing/runtime/private-data/CI/infra changes. Backward compatible: the response shape is unchanged; only the order changes.

## Verification

- Local: prettier/format clean; local `bun test` cannot run (sandbox node_modules missing `next-intl/server` — same as prior SEO runs; CI runs the suite).
- CI: will verify `bun unit tests (packages + apps)` including the new regression test.
- Exact-head preview: after CI green, will fetch `/api/ai?kind=blog&limit=3` on the Vercel head and assert the freshest blog posts lead.

## Experiment contract

- Hypothesis: recency-first ordering surfaces the freshest comparison content to answer-engine crawlers consuming `/api/ai` top-N.
- Baseline: `/api/ai?kind=blog&limit=5` returns oldest posts first (alphabetical).
- Target: `/api/ai?kind=blog&limit=3` returns the 3 newest blog posts.
- Guardrail: response shape unchanged; no 500s; pagination cursor stays valid.
- Rollback: revert the single commit.