### PR TITLE
fix(snapshots): retry Platinum template builds that never register

### DIFF
--- a/apps/api/src/snapshots/providers/platinum-build-retry.test.ts
+++ b/apps/api/src/snapshots/providers/platinum-build-retry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('ALLOWED_SANDBOX_PROVIDERS', 'platinum');
+setTestEnv('KORTIX_URL', 'https://api.example.test');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+setTestEnv('RECALL_BASE_URL', 'https://us-west-2.recall.ai/api/v1');
+
+const { isRetryablePlatinumBuildError } = await import('./platinum');
+
+describe('Platinum build-error retry classifier', () => {
+  test.each([
+    ['stale staging context', new Error('build context does not exist')],
+    ['S3 upload failure', new Error('build-context S3 upload -> 500 oops')],
+    ['tar failure', new Error('tar build context failed')],
+    ['network blip', new Error('fetch failed: network error')],
+    ['upstream 502', new Error('platinum -> 502 Bad Gateway')],
+    // A `from-build` registration that never surfaced via GET /v1/templates for
+    // the ENTIRE waitForActive poll window — never even 'building', just gone.
+    // Empirically a transient registration-pipeline flake on Platinum's side
+    // (2026-07-18 dev incident), not a real build problem — see the classifier's
+    // own comment for the live evidence. A fresh same-process retry is safe and
+    // bounded (BUILD_ATTEMPTS).
+    [
+      'template never registered (stuck on "missing")',
+      new Error('Platinum template kortix-default-3e3906a27df1 did not become ready (last state: missing)'),
+    ],
+  ])('retries %s', (_label, err) => {
+    expect(isRetryablePlatinumBuildError(err)).toBe(true);
+  });
+
+  test.each([
+    // An EXPLICIT build failure — Platinum registered the template, actually ran
+    // the build, and it failed. Retrying would just fail identically.
+    ['explicit build failure', new Error('Platinum template kortix-default-abc123 build failed')],
+    // Reached a real (non-missing) state before giving up — a genuine stuck
+    // build, not a registration no-show.
+    [
+      'activate timeout after reaching a real state',
+      new Error('Platinum template kortix-default-abc123 did not become ready (last state: building)'),
+    ],
+    ['unrelated application error', new Error('unexpected token in JSON')],
+  ])('does not retry %s', (_label, err) => {
+    expect(isRetryablePlatinumBuildError(err)).toBe(false);
+  });
+});

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -47,17 +47,34 @@ export const PLATINUM_MAX_BUILD_SIZE_MB = 20480;
 /**
  * Retry only stale-context (staging disturbed before the S3 upload — API restart
  * mid-build / tmp sweep) and transient transport (S3 PUT / gateway). A real build
- * failure ('template … build failed') or activate timeout is NOT retried — that's
- * a genuine error, not something a fresh stage would fix.
+ * failure ('template … build failed') is NOT retried — that's a genuine error,
+ * not something a fresh stage would fix.
+ *
+ * One activate-timeout shape IS retried: `waitForActive` throwing "did not
+ * become ready (last state: missing)" means the template NEVER appeared via
+ * `GET /v1/templates` for the entire ACTIVATE_DEADLINE_MS poll window — not
+ * "building", not "failed", just never registered at all. That is distinct
+ * from an explicit 'failed' state (a genuine build error, never retried here)
+ * and points at a registration-pipeline flake on Platinum's side rather than a
+ * real build problem with this content. Verified empirically during a
+ * 2026-07-18 dev incident: a `from-build` registration silently never
+ * produced a template (stuck ~15min on `state: missing`, dev sandbox_id
+ * 5771eb57-b0be-4579-8e33-93776a66f4fe), while a fresh build attempt for a
+ * different content hash minutes later succeeded on its very first try — so a
+ * same-process retry is a real, bounded (BUILD_ATTEMPTS) mitigation, not a
+ * blind retry-forever. A build that reaches any OTHER observed state
+ * ('building', 'pending', …) before failing is a real failure and still
+ * excluded, same as 'failed'.
  */
-function isRetryablePlatinumBuildError(err: unknown): boolean {
+export function isRetryablePlatinumBuildError(err: unknown): boolean {
   const m = (err instanceof Error ? err.message : String(err)).toLowerCase();
   return (
     m.includes('does not exist') || m.includes('staging incomplete') || m.includes('scaffold') ||
     m.includes('no such file') || m.includes('s3 upload') || m.includes('tar build context') ||
     m.includes('timeout') || m.includes('timed out') || m.includes('econnreset') ||
     m.includes('econnrefused') || m.includes('network') || m.includes('gateway') ||
-    m.includes(' 502') || m.includes(' 503') || m.includes(' 504')
+    m.includes(' 502') || m.includes(' 503') || m.includes(' 504') ||
+    m.includes('last state: missing')
   );
 }
 


### PR DESCRIPTION
## Summary
- Diagnoses a live dev incident (2026-07-18, sandbox `5771eb57-b0be-4579-8e33-93776a66f4fe`, project item `kortix-default-3e3906a27df1`): a Platinum `POST /v1/templates/from-build` registration was accepted, but the template never appeared via `GET /v1/templates` for the entire ~12 min `waitForActive` poll window (state stuck on `missing` throughout, never `building`/`ready`/`failed`). Confirmed against the live Platinum dev API — the template name genuinely never registered, while a fresh build minutes later for a *different* content hash succeeded on its first try.
- `isRetryablePlatinumBuildError` (the classifier gating `buildSnapshot`'s existing bounded 3-attempt/backoff retry) did not recognize this failure shape, so a single stuck registration directly failed the whole session provision ("Provisioning failed via platinum") instead of self-healing via a same-process retry — exactly what a fresh content-hash build did moments later.
- Adds `last state: missing` (the exact terminal message `waitForActive` throws when the template never registered) to the retryable set. Deliberately narrow: an explicit `failed` state, or a timeout after reaching any *other* real state (e.g. stuck mid-`building`), is a genuine build problem and stays non-retryable.
- Also explains the reported `initAttempts=0` symptom: this stall happens during per-project image resolution (`ensureSandboxImage`), which runs *before* `session-sandbox.ts`'s own provisioning retry loop ever calls its `onAttemptStart` hook — so the DB row's `initAttempts` metadata never advances past its initial `0` for the whole ~12-14 minute stall, then jumps straight to a misleading `initAttempts=3` on the terminal-failure write (that field is literally the constant `SANDBOX_INIT_MAX_ATTEMPTS`, not the real attempt count, on that code path).

## Root cause split (for the parent diagnostic task)
- **In-repo, fixed here:** our own retry classifier didn't cover this failure shape, so we gave up in one attempt instead of using retry machinery we already have.
- **Infra, NOT fixed here (Platinum-side):** *why* a `from-build` registration occasionally never lands is a reliability gap in Platinum's own template-build pipeline — connectivity/auth/quota are fine (verified live: the Platinum API is reachable, org has 50 templates, plenty of concurrent builds succeeding around the same window). Flagging for whoever owns Platinum/dev-infra to investigate the registration pipeline itself; this PR only makes our side resilient to the flake.

## Test plan
- [x] New co-located test: `apps/api/src/snapshots/providers/platinum-build-retry.test.ts` (9 cases — retryable transient/registration-flake shapes vs. non-retryable genuine failures)
- [x] `dotenvx run -- bun test src/snapshots/ src/__tests__/unit-platinum-snapshot-size.test.ts` → 72/72 pass
- [x] `pnpm run typecheck` (apps/api) → clean