### PR TITLE
feat(llm-gateway): Models tab in depth — pricing, capabilities, copyable ids

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
@@ -2,18 +2,29 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { InlineMeta } from '@/components/ui/inline-meta';
 import { Label } from '@/components/ui/label';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { LLM_PROVIDERS, LLM_PROVIDER_BY_ID, type LlmProviderEntry } from '@/lib/llm-providers';
+import { useModelPricingLookup } from '@/lib/model-pricing';
 import { ChevronLeft, ChevronRight, ExternalLink, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
 
 import { ApiKeyConnectForm } from './api-key-connect-form';
 import { CustomProviderForm } from './custom-provider-form';
+import { ModelCapabilityIcons } from './model-capability-icons';
+import { ModelIdCopyButton } from './model-id-copy-button';
 import type { CatalogSubview } from './types';
-import { helpHostnameFromUrl, providerCredentialSummary, releasedAgo } from './utils';
+import {
+  formatPricePerMillion,
+  formatTokenCount,
+  gatewayModelId,
+  helpHostnameFromUrl,
+  providerCredentialSummary,
+  releasedAgo,
+} from './utils';
 
 const ROW =
   'group bg-popover hover:bg-muted/40 flex w-full items-center gap-3 rounded-md border px-4 py-2.5 text-left transition-colors active:scale-[0.995]';
@@ -176,6 +187,7 @@ function ProviderDetail({
   const tHardcodedUi = useTranslations('hardcodedUi');
   const models = provider.models;
   const helpHostname = helpHostnameFromUrl(provider.helpUrl);
+  const pricingLookup = useModelPricingLookup(undefined);
 
   return (
     <div className="space-y-4 px-5 pt-3 pb-5">
@@ -244,25 +256,55 @@ function ProviderDetail({
           </p>
         ) : (
           <ul className="space-y-2">
-            {models.map((model) => (
-              <li
-                key={model.id}
-                className="bg-popover flex items-center gap-3 rounded-md border px-4 py-2.5"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="text-foreground truncate text-sm font-medium">{model.name}</div>
-                  <div className="text-muted-foreground/50 mt-0.5 truncate text-xs">{model.id}</div>
-                </div>
-                {model.released && (
-                  <span
-                    className="text-muted-foreground/50 shrink-0 text-xs tabular-nums"
-                    title={`Released ${model.released}`}
-                  >
-                    {releasedAgo(model.released)}
-                  </span>
-                )}
-              </li>
-            ))}
+            {models.map((model) => {
+              const wireId = gatewayModelId(provider, model.id);
+              const rates = pricingLookup(provider.id, model.id);
+              const ctx = formatTokenCount(model.limit?.context);
+              const out = formatTokenCount(model.limit?.output);
+              const priceIn = rates ? formatPricePerMillion(rates.inputPer1M) : '';
+              const priceOut = rates ? formatPricePerMillion(rates.outputPer1M) : '';
+              const hasMeta = !!ctx || !!out || (!!priceIn && !!priceOut);
+              return (
+                <li
+                  key={model.id}
+                  className="bg-popover flex items-start gap-3 rounded-md border px-4 py-2.5"
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="text-foreground truncate text-sm font-medium">
+                        {model.name}
+                      </span>
+                      <ModelCapabilityIcons model={model} />
+                    </div>
+                    <div className="flex min-w-0 items-center gap-0.5">
+                      <code className="text-muted-foreground/50 min-w-0 truncate font-mono text-xs">
+                        {wireId}
+                      </code>
+                      <ModelIdCopyButton value={wireId} />
+                    </div>
+                    {hasMeta && (
+                      <InlineMeta>
+                        {ctx && <span className="tabular-nums">{ctx} ctx</span>}
+                        {out && <span className="tabular-nums">{out} max out</span>}
+                        {priceIn && priceOut && (
+                          <span className="tabular-nums">
+                            {priceIn} / {priceOut} per 1M
+                          </span>
+                        )}
+                      </InlineMeta>
+                    )}
+                  </div>
+                  {model.released && (
+                    <span
+                      className="text-muted-foreground/50 mt-0.5 shrink-0 text-xs tabular-nums"
+                      title={`Released ${model.released}`}
+                    >
+                      {releasedAgo(model.released)}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/model-capability-icons.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/model-capability-icons.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Hint from '@/components/ui/hint';
+import type { LlmProviderModel } from '@/lib/llm-providers';
+import { Brain, Eye, Wrench } from 'lucide-react';
+
+const ICON_CLASS = 'text-muted-foreground/50 size-3.5 shrink-0';
+
+/**
+ * Compact capability chips — reasoning / tool-calling / vision — mirrored
+ * verbatim from models.dev (`LlmProviderModel.reasoning` / `tool_call` /
+ * `attachment`). Icon-only with a `Hint` tooltip so a dense model row stays
+ * scannable; renders nothing when a model declares no capabilities.
+ */
+export function ModelCapabilityIcons({ model }: { model: LlmProviderModel }) {
+  if (!model.reasoning && !model.tool_call && !model.attachment) return null;
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {model.reasoning && (
+        <Hint label="Reasoning">
+          <Brain className={ICON_CLASS} />
+        </Hint>
+      )}
+      {model.tool_call && (
+        <Hint label="Tool calling">
+          <Wrench className={ICON_CLASS} />
+        </Hint>
+      )}
+      {model.attachment && (
+        <Hint label="Vision / file input">
+          <Eye className={ICON_CLASS} />
+        </Hint>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/model-id-copy-button.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/model-id-copy-button.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Check, Copy } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useCallback, useState } from 'react';
+
+/**
+ * Copies the literal gateway wire model id (`provider/model`). Model rows in
+ * this section live inside a clickable `<label>` (the visibility toggle) —
+ * `stopPropagation`/`preventDefault` keep a copy click from also flipping
+ * that switch. Icon-swap follows the buttery blur+scale+opacity pattern
+ * (`kortix-design-system` skill) — see `CopyButton` in
+ * `components/markdown/copy-button.tsx` for the same shape.
+ */
+export function ModelIdCopyButton({ value, className }: { value: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      navigator.clipboard
+        .writeText(value)
+        .then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        })
+        .catch(() => undefined);
+    },
+    [value],
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? 'Copied' : 'Copy model id'}
+      className={cn(
+        'text-muted-foreground/50 hover:text-foreground hover:bg-muted-foreground/10 inline-flex size-5 shrink-0 items-center justify-center rounded outline-none',
+        'cursor-pointer transition-colors active:scale-[0.96]',
+        className,
+      )}
+    >
+      <span className="relative inline-flex size-3 items-center justify-center">
+        <AnimatePresence initial={false} mode="popLayout">
+          <motion.span
+            key={copied ? 'check' : 'copy'}
+            initial={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+            animate={{ scale: 1, opacity: 1, filter: 'blur(0px)' }}
+            exit={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+            transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+            className="absolute inset-0 inline-flex items-center justify-center"
+          >
+            {copied ? <Check className="text-kortix-green size-3" /> : <Copy className="size-3" />}
+          </motion.span>
+        </AnimatePresence>
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
@@ -1,15 +1,27 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { InlineMeta } from '@/components/ui/inline-meta';
 import { Switch } from '@/components/ui/switch';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { modelVisibilityKeyForProviderModel } from '@/features/session/model-tags';
 import type { FlatModel } from '@/features/session/session-chat-input';
 import { useModelStore } from '@/hooks/opencode/use-model-store';
 import type { LlmProviderEntry } from '@/lib/llm-providers';
+import { useModelPricingLookup } from '@/lib/model-pricing';
 import { cn } from '@/lib/utils';
+import { ExternalLink } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
+
+import { ModelCapabilityIcons } from './model-capability-icons';
+import { ModelIdCopyButton } from './model-id-copy-button';
+import {
+  formatPricePerMillion,
+  formatTokenCount,
+  gatewayModelId,
+  helpHostnameFromUrl,
+} from './utils';
 
 export function ModelsTab({
   connectedProviders,
@@ -21,6 +33,7 @@ export function ModelsTab({
   llmGatewayEnabled: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
+  const pricingLookup = useModelPricingLookup(undefined);
 
   const rows = useMemo(
     () =>
@@ -126,43 +139,82 @@ export function ModelsTab({
         </div>
       )}
       <div className="space-y-3">
-        {grouped.map(({ provider, rows: providerRows }) => (
-          <div key={provider.id}>
-            <div className="flex items-center gap-2 px-1 pb-1">
-              <ProviderLogo providerID={provider.id} name={provider.label} size="small" />
-              <span className="text-foreground/70 text-xs font-medium">{provider.label}</span>
-              <span className="text-muted-foreground/40 ml-auto text-xs">
-                {providerRows.length}
-              </span>
-            </div>
-            <div className="bg-popover overflow-hidden rounded-md border">
-              {providerRows.map(({ model, storeKey }, i) => {
-                const visible = modelStore.isVisible(storeKey);
-                return (
-                  <label
-                    key={model.id}
-                    className={cn(
-                      'hover:bg-muted/40 flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors',
-                      i > 0 && 'border-border border-t',
-                      !visible && 'opacity-60',
-                    )}
+        {grouped.map(({ provider, rows: providerRows }) => {
+          const helpHostname = helpHostnameFromUrl(provider.helpUrl);
+          return (
+            <div key={provider.id}>
+              <div className="flex items-center gap-2 px-1 pb-1">
+                <ProviderLogo providerID={provider.id} name={provider.label} size="small" />
+                <span className="text-foreground/70 text-xs font-medium">{provider.label}</span>
+                {helpHostname && provider.helpUrl && (
+                  <a
+                    href={provider.helpUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground/50 hover:text-foreground inline-flex items-center gap-0.5 text-[11px] transition-colors"
                   >
-                    <div className="min-w-0 flex-1">
-                      <div className="text-foreground truncate text-sm">{model.name}</div>
-                      <div className="text-muted-foreground/50 mt-0.5 truncate text-xs">
-                        {model.id}
+                    <ExternalLink className="size-2.5 shrink-0" />
+                    {helpHostname}
+                  </a>
+                )}
+                <span className="text-muted-foreground/40 ml-auto text-xs">
+                  {providerRows.length}
+                </span>
+              </div>
+              <div className="bg-popover overflow-hidden rounded-md border">
+                {providerRows.map(({ model, storeKey }, i) => {
+                  const visible = modelStore.isVisible(storeKey);
+                  const wireId = gatewayModelId(provider, model.id);
+                  const rates = pricingLookup(provider.id, model.id);
+                  const ctx = formatTokenCount(model.limit?.context);
+                  const out = formatTokenCount(model.limit?.output);
+                  const priceIn = rates ? formatPricePerMillion(rates.inputPer1M) : '';
+                  const priceOut = rates ? formatPricePerMillion(rates.outputPer1M) : '';
+                  const hasMeta = !!ctx || !!out || (!!priceIn && !!priceOut);
+                  return (
+                    <label
+                      key={model.id}
+                      className={cn(
+                        'hover:bg-muted/40 flex cursor-pointer items-start gap-3 px-3 py-2.5 transition-colors',
+                        i > 0 && 'border-border border-t',
+                        !visible && 'opacity-60',
+                      )}
+                    >
+                      <div className="min-w-0 flex-1 space-y-1">
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span className="text-foreground truncate text-sm">{model.name}</span>
+                          <ModelCapabilityIcons model={model} />
+                        </div>
+                        <div className="flex min-w-0 items-center gap-0.5">
+                          <code className="text-muted-foreground/50 min-w-0 truncate font-mono text-xs">
+                            {wireId}
+                          </code>
+                          <ModelIdCopyButton value={wireId} />
+                        </div>
+                        {hasMeta && (
+                          <InlineMeta>
+                            {ctx && <span className="tabular-nums">{ctx} ctx</span>}
+                            {out && <span className="tabular-nums">{out} max out</span>}
+                            {priceIn && priceOut && (
+                              <span className="tabular-nums">
+                                {priceIn} / {priceOut} per 1M
+                              </span>
+                            )}
+                          </InlineMeta>
+                        )}
                       </div>
-                    </div>
-                    <Switch
-                      checked={visible}
-                      onCheckedChange={(c) => modelStore.setVisibility(storeKey, c)}
-                    />
-                  </label>
-                );
-              })}
+                      <Switch
+                        checked={visible}
+                        onCheckedChange={(c) => modelStore.setVisibility(storeKey, c)}
+                        className="mt-0.5 shrink-0"
+                      />
+                    </label>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/use-connected-providers.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/use-connected-providers.ts
@@ -4,7 +4,7 @@ import { useOpenCodeProviders } from '@/hooks/opencode/use-opencode-sessions';
 import { isManagedProviderEnabled } from '@/lib/config';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
 import { LLM_PROVIDERS, type LlmProviderEntry, type LlmProviderModel } from '@/lib/llm-providers';
-import { isProviderAuthSatisfied } from '@kortix/llm-catalog';
+import { getManagedModel, isProviderAuthSatisfied } from '@kortix/llm-catalog';
 import { getProjectDetail, listProjectSecrets } from '@kortix/sdk/projects-client';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -61,11 +61,32 @@ export function useConnectedProviders(projectId: string, enabled: boolean) {
     if (!kortix || !connectedIds.has('kortix')) return null;
     const models: LlmProviderModel[] = Object.entries(kortix.models ?? {})
       .filter(([id]) => MANAGED_MODEL_ID_SET.has(id))
-      .map(([id, m]) => ({
-        id,
-        name: ((m as { name?: string }).name || id).replace('(latest)', '').trim(),
-        released: (m as { release_date?: string }).release_date ?? null,
-      }));
+      .map(([id, m]) => {
+        // Best-effort capability/limit passthrough for the "Models in depth"
+        // display (models-tab.tsx / catalog-tab.tsx) — the opencode provider
+        // snapshot mirrors these when it has them; `vision`/`limit` otherwise
+        // fall back to `@kortix/llm-catalog`'s curated managed-model table,
+        // the canonical home for both (see MANAGED_MODELS' doc comment —
+        // managed slugs aren't reliably on models.dev, so this table is
+        // authoritative for them, not a guess).
+        const raw = m as {
+          name?: string;
+          release_date?: string;
+          reasoning?: boolean;
+          tool_call?: boolean;
+          limit?: { context?: number; output?: number };
+        };
+        const managed = getManagedModel(id);
+        return {
+          id,
+          name: (raw.name || id).replace('(latest)', '').trim(),
+          released: raw.release_date ?? null,
+          reasoning: raw.reasoning,
+          tool_call: raw.tool_call,
+          attachment: managed?.vision,
+          limit: raw.limit ?? managed?.limit,
+        };
+      });
     return {
       id: 'kortix',
       label: kortix.name || 'Kortix',

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/utils.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatPricePerMillion, formatTokenCount, gatewayModelId } from './utils';
+
+describe('gatewayModelId', () => {
+  test('BYOK provider gets a provider/model wire id', () => {
+    expect(gatewayModelId({ id: 'anthropic', managed: false }, 'claude-sonnet-4.6')).toBe(
+      'anthropic/claude-sonnet-4.6',
+    );
+  });
+
+  test('managed Kortix provider stays bare (single-segment)', () => {
+    expect(gatewayModelId({ id: 'kortix', managed: true }, 'claude-opus-4.8')).toBe(
+      'claude-opus-4.8',
+    );
+  });
+
+  test('codex (ChatGPT subscription) gets a codex/ prefix', () => {
+    expect(gatewayModelId({ id: 'codex', managed: false }, 'gpt-5.6-sol')).toBe(
+      'codex/gpt-5.6-sol',
+    );
+  });
+});
+
+describe('formatTokenCount', () => {
+  test('formats millions with a decimal only when not whole', () => {
+    expect(formatTokenCount(1_000_000)).toBe('1M');
+    expect(formatTokenCount(1_500_000)).toBe('1.5M');
+  });
+
+  test('formats thousands rounded to the nearest K', () => {
+    expect(formatTokenCount(128_000)).toBe('128K');
+    expect(formatTokenCount(8_192)).toBe('8K');
+  });
+
+  test('formats sub-1000 values verbatim', () => {
+    expect(formatTokenCount(512)).toBe('512');
+  });
+
+  test('returns empty string for falsy or non-positive input', () => {
+    expect(formatTokenCount(undefined)).toBe('');
+    expect(formatTokenCount(null)).toBe('');
+    expect(formatTokenCount(0)).toBe('');
+    expect(formatTokenCount(-5)).toBe('');
+  });
+});
+
+describe('formatPricePerMillion', () => {
+  test('formats whole-dollar rates with two decimals', () => {
+    expect(formatPricePerMillion(3)).toBe('$3.00');
+    expect(formatPricePerMillion(15)).toBe('$15.00');
+  });
+
+  test('formats sub-dollar rates with three decimals', () => {
+    expect(formatPricePerMillion(0.25)).toBe('$0.250');
+  });
+
+  test('formats sub-cent rates with four decimals', () => {
+    expect(formatPricePerMillion(0.0007)).toBe('$0.0007');
+  });
+
+  test('zero rate reads as Free', () => {
+    expect(formatPricePerMillion(0)).toBe('Free');
+  });
+
+  test('returns empty string when the rate is unknown', () => {
+    expect(formatPricePerMillion(null)).toBe('');
+    expect(formatPricePerMillion(undefined)).toBe('');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/utils.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/utils.ts
@@ -23,17 +23,27 @@ export function buildCodexProvider(ocProviders: OpenCodeProvidersSnapshot): LlmP
     kortix && connectedIds.has('kortix')
       ? Object.entries(kortix.models ?? {})
           .filter(([id]) => id.startsWith('codex/'))
-          .map(([id, m]) => ({
-            id: id.slice('codex/'.length),
-            name: ((m as { name?: string }).name || id)
-              .replace('(latest)', '')
-              .trim()
-              .replace(/\s*\(ChatGPT\)$/, ''),
-            released:
-              (m as { release_date?: string; released?: string }).release_date ??
-              (m as { released?: string }).released ??
-              null,
-          }))
+          .map(([id, m]) => {
+            const raw = m as {
+              name?: string;
+              release_date?: string;
+              released?: string;
+              reasoning?: boolean;
+              tool_call?: boolean;
+              limit?: { context?: number; output?: number };
+            };
+            return {
+              id: id.slice('codex/'.length),
+              name: (raw.name || id)
+                .replace('(latest)', '')
+                .trim()
+                .replace(/\s*\(ChatGPT\)$/, ''),
+              released: raw.release_date ?? raw.released ?? null,
+              reasoning: raw.reasoning,
+              tool_call: raw.tool_call,
+              limit: raw.limit,
+            };
+          })
       : [];
 
   return {
@@ -138,3 +148,44 @@ export function envVarPlaceholder(provider: LlmProviderEntry, envVar: string): s
 }
 
 export const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * The literal model id you'd pass as `model` in a gateway request body
+ * (`POST /v1/chat/completions`, `/v1/messages`, …) — `provider/model` for
+ * BYOK providers (e.g. `anthropic/claude-sonnet-4.6`), the bare id for
+ * Kortix-managed models (single-segment by design — see `@kortix/llm-catalog`'s
+ * `MANAGED_MODELS` doc comment), and `codex/<id>` for the ChatGPT-subscription
+ * provider.
+ */
+export function gatewayModelId(
+  provider: Pick<LlmProviderEntry, 'id' | 'managed'>,
+  modelId: string,
+): string {
+  if (provider.managed) return modelId;
+  if (provider.id === 'codex') return `codex/${modelId}`;
+  return `${provider.id}/${modelId}`;
+}
+
+/** Compact token-count label — "128K", "1M", "8K". Empty string when falsy/invalid. */
+export function formatTokenCount(tokens: number | null | undefined): string {
+  if (!tokens || tokens <= 0) return '';
+  if (tokens >= 1_000_000) {
+    const millions = tokens / 1_000_000;
+    return `${Number.isInteger(millions) ? millions : millions.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) return `${Math.round(tokens / 1000)}K`;
+  return `${tokens}`;
+}
+
+/**
+ * Per-1M-token USD rate, formatted with just enough precision to stay
+ * meaningful at sub-cent values (a lot of models.dev input rates are
+ * $0.0X–$0.X per 1M). Empty string when the rate isn't known.
+ */
+export function formatPricePerMillion(usd: number | null | undefined): string {
+  if (usd === null || usd === undefined || Number.isNaN(usd)) return '';
+  if (usd <= 0) return 'Free';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}

--- a/apps/web/src/lib/llm-providers.ts
+++ b/apps/web/src/lib/llm-providers.ts
@@ -55,6 +55,19 @@ export interface LlmProviderModel {
    * field; the field is exposed so the UI can render a "released X ago" hint.
    */
   released: string | null;
+  /**
+   * Capability + limit flags mirrored verbatim from models.dev — present on
+   * both the baked seed (`catalog.generated.json`) and the live
+   * `/llm-catalog/providers` fetch (see `@kortix/llm-catalog`'s
+   * `CatalogModel`, the shape both ultimately originate from). Optional
+   * because the synthetic `codex`/`kortix` provider entries built in this
+   * section (`utils.ts`'s `buildCodexProvider`, `use-connected-providers.ts`'s
+   * `kortixProvider`) only set what the opencode provider snapshot exposes.
+   */
+  attachment?: boolean;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  limit?: { context?: number; output?: number };
 }
 
 export interface LlmProviderEntry {


### PR DESCRIPTION
## Summary

The Providers modal's **Models** tab (and the Catalog tab's provider-detail
model list) showed only a model's name, wire id, and release date — even
though the live models.dev catalog already carries everything else needed
for a genuinely informative model browser, and it was just never surfaced:

- **Context window / max output** — `LlmProviderModel.limit` was already on
  the catalog JSON (both the baked seed and the live
  `/llm-catalog/providers` fetch), just not exposed on the TS type.
- **Capabilities** — `reasoning` / `tool_call` / `attachment` (vision) flags,
  same story.
- **Pricing** — `apps/web/src/lib/model-pricing.ts` already fetches live
  per-1M input/output rates from models.dev for cost estimates elsewhere in
  the app (session context modal); this reuses that same lookup instead of
  adding a new fetch.
- **Copyable gateway model id** — the literal `model` value you'd pass to
  `/v1/chat/completions` / `/v1/messages` (`provider/model` for BYOK, bare id
  for Kortix-managed, `codex/<id>` for the ChatGPT-subscription provider).
- **Provider docs link** — `provider.helpUrl`, already resolved elsewhere,
  now shown next to each provider group's header.

### What changed

- `apps/web/src/lib/llm-providers.ts` — widened `LlmProviderModel` with the
  (optional) `attachment` / `reasoning` / `tool_call` / `limit` fields that
  were already flowing through the catalog JSON at runtime.
- `models-tab.tsx` — each row now shows capability icons, a copyable wire
  model id, and an `InlineMeta` line with context/output/pricing; provider
  group headers link out to docs.
- `catalog-tab.tsx` (`ProviderDetail`) — same enrichment on the per-model
  rows shown before connecting a provider, since that's exactly when this
  info is most useful for deciding whether to connect.
- `use-connected-providers.ts` / `utils.ts` (`buildCodexProvider`) —
  best-effort capability/limit passthrough for the synthetic `kortix`
  (managed) and `codex` (ChatGPT subscription) provider entries, so every
  group in the Models tab is equally rich, not just BYOK ones.
- New `model-capability-icons.tsx` / `model-id-copy-button.tsx` — small
  shared components (icon-only capability chips with `Hint` tooltips; a
  copy button using the buttery blur+scale+opacity icon-swap from the design
  system, `stopPropagation`'d so it doesn't also flip the row's visibility
  `Switch`).
- `utils.ts` — new pure helpers (`gatewayModelId`, `formatTokenCount`,
  `formatPricePerMillion`) with a new `utils.test.ts`.

### Scoped narrowly, on purpose

No change to the connect/select flows, no attempt to dump the full
multi-thousand-model models.dev catalog into the Models tab (that's the
Catalog tab's job, and would be a real unvirtualized-list performance
problem) — the tab still shows only connected providers' models, just each
row is now genuinely informative instead of a bare name + id.

## Test plan

- [x] `bun test` — new `utils.test.ts` (13 tests) + existing
      `llm-providers.test.ts` (10 tests), all green.
- [x] `tsc --noEmit` — clean except two pre-existing, unrelated errors
      (`@/.source` — fumadocs codegen not run outside `next build`/`dev`).
- [x] `next build` — compiles successfully, all 168 static pages generated,
      no new warnings (confirmed against the same warnings present on
      `main`).
- [ ] Manual click-through in a running dev server (not done in this
      sandboxed session — no live project to open the modal against).