### PR TITLE
docs(llm-gateway): register inference routes in OpenAPI spec

### DIFF
--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -1,9 +1,286 @@
-import type { OpenAPIHono } from '@hono/zod-openapi';
+import { type OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
 import { createGateway } from '@kortix/llm-gateway';
-import { Hono } from 'hono';
 import { config } from '../config';
+import { auth, errors, json, makeOpenApiApp } from '../openapi';
 import { createInProcessGatewayHooks } from './hooks';
 import { createInternalGatewayRoutes } from './internal-routes';
+
+// ─── OpenAPI documentation for the inference surface ────────────────────────
+//
+// These endpoints are OpenAI/Anthropic *compatibility* surfaces: the gateway
+// forwards the request body to an upstream provider close to verbatim, so the
+// schemas below are intentionally permissive (`.passthrough()` / `z.any()`)
+// rather than a strict re-implementation of the OpenAI/Anthropic wire format.
+// They exist to make the Scalar page genuinely useful (documented fields +
+// examples), not to gate what the proxy accepts.
+//
+// IMPORTANT: these routes are registered with `openAPIRegistry.registerPath()`
+// directly — NOT `llm.openapi(route, handler)` — for the POST/body-bearing ones.
+// `.openapi()` would wire `@hono/zod-openapi`'s zValidator("json", schema)
+// middleware in front of the handler, and a validation failure there returns
+// the SHARED `{error:true,message:"Validation failed",...}` envelope instead of
+// the gateway's own OpenAI/Anthropic-shaped error body — changing the wire
+// contract for a compatibility surface whose whole point is to match those
+// SDKs' expectations (see `/v1/router/chat/completions` in router/routes/llm.ts,
+// which avoids attaching a body schema for the same reason). `registerPath()`
+// adds the operation (incl. the documented request body below) to the SAME
+// OpenAPI registry `.openapi()` would have, WITHOUT touching request handling
+// at all — the actual runtime route is still a plain `llm.post()/get()` with
+// the original, unmodified handler.
+const GATEWAY_INFERENCE_TAG = 'gateway-inference';
+
+const AUTH_DESCRIPTION =
+  'Bearer token: a project gateway key (`kortix_gw_…`, created via ' +
+  'POST /v1/projects/{projectId}/gateway/keys) or a Kortix account token ' +
+  '(PAT `kortix_pat_…`, API key, or sandbox key). Unlike most of the API, the ' +
+  'raw Supabase user JWT is NOT accepted here — mint a gateway key or PAT first.';
+
+const ChatMessageSchema = z
+  .object({
+    role: z.enum(['system', 'user', 'assistant', 'tool']).openapi({ example: 'user' }),
+    content: z
+      .union([z.string(), z.array(z.record(z.string(), z.any()))])
+      .openapi({ example: 'Hello!' }),
+  })
+  .passthrough()
+  .openapi('GatewayChatMessage');
+
+const ChatCompletionRequestExampleSchema = z
+  .object({
+    model: z.string().openapi({ example: 'claude-sonnet-4-5' }),
+    messages: z.array(ChatMessageSchema).min(1),
+    stream: z.boolean().optional().openapi({
+      description:
+        'When true, the response is `text/event-stream` SSE of `chat.completion.chunk` events instead of a single JSON object.',
+    }),
+    tools: z.array(z.record(z.string(), z.any())).optional(),
+    tool_choice: z.union([z.string(), z.record(z.string(), z.any())]).optional(),
+    temperature: z.number().optional(),
+    top_p: z.number().optional(),
+    max_tokens: z.number().optional().openapi({
+      description: 'Legacy alias for max_completion_tokens, honored for compatibility.',
+    }),
+    max_completion_tokens: z.number().optional(),
+    response_format: z.record(z.string(), z.any()).optional(),
+    seed: z.number().optional(),
+    stop: z.union([z.string(), z.array(z.string())]).optional(),
+    reasoning_effort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+  })
+  .passthrough()
+  .openapi('GatewayChatCompletionRequest', {
+    example: {
+      model: 'claude-sonnet-4-5',
+      messages: [{ role: 'user', content: 'Say hello in one word.' }],
+      stream: false,
+      max_completion_tokens: 128,
+    },
+  });
+
+const ChatCompletionResponseSchema = z
+  .object({
+    id: z.string(),
+    object: z.literal('chat.completion'),
+    created: z.number(),
+    model: z.string(),
+    choices: z.array(z.record(z.string(), z.any())),
+    usage: z.record(z.string(), z.any()).optional(),
+  })
+  .passthrough()
+  .openapi('GatewayChatCompletionResponse', {
+    example: {
+      id: 'chatcmpl_abc123',
+      object: 'chat.completion',
+      created: 1737072000,
+      model: 'claude-sonnet-4-5',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'Hello!' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+    },
+  });
+
+const CHAT_COMPLETIONS_RESPONSES = {
+  200: {
+    description:
+      'Chat completion. A single `chat.completion` JSON object when `stream` is falsy; ' +
+      'a `text/event-stream` SSE stream of `chat.completion.chunk` frames (terminated by ' +
+      '`data: [DONE]`) when `stream: true`.',
+    content: {
+      'application/json': { schema: ChatCompletionResponseSchema },
+      'text/event-stream': {
+        schema: z.string().openapi({
+          example:
+            'data: {"id":"chatcmpl_abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello"}}]}\n\ndata: [DONE]\n\n',
+        }),
+      },
+    },
+  },
+  ...errors(400, 401, 402, 413, 429, 502),
+};
+
+function chatCompletionsRoute(path: string) {
+  const fullPath = `/v1/llm${path}`;
+  return createRoute({
+    method: 'post' as const,
+    path,
+    tags: [GATEWAY_INFERENCE_TAG],
+    summary: `POST ${fullPath}`,
+    description: `OpenAI-compatible chat completions, proxied through the Kortix LLM gateway (model routing/failover, budgets, usage billing, and request tracing all apply). The body is forwarded close to verbatim to the resolved upstream provider.\n\nAuth: ${AUTH_DESCRIPTION}\n\n\`\`\`\ncurl -sS $KORTIX_API_URL${fullPath} \\\n  -H "Authorization: Bearer $KORTIX_GATEWAY_KEY" \\\n  -H "Content-Type: application/json" \\\n  -d \'{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"Say hello in one word."}]}\'\n\`\`\``,
+    ...auth,
+    request: {
+      body: {
+        required: true,
+        content: { 'application/json': { schema: ChatCompletionRequestExampleSchema } },
+      },
+    },
+    responses: CHAT_COMPLETIONS_RESPONSES,
+  });
+}
+
+const AnthropicMessageSchema = z
+  .object({
+    role: z.enum(['user', 'assistant']).openapi({ example: 'user' }),
+    content: z
+      .union([z.string(), z.array(z.record(z.string(), z.any()))])
+      .openapi({ example: 'Hello!' }),
+  })
+  .passthrough()
+  .openapi('GatewayAnthropicMessage');
+
+const MessagesRequestExampleSchema = z
+  .object({
+    model: z.string().openapi({ example: 'claude-sonnet-4-5' }),
+    system: z.union([z.string(), z.array(z.record(z.string(), z.any()))]).optional(),
+    messages: z.array(AnthropicMessageSchema).min(1),
+    max_tokens: z.number().openapi({ example: 1024 }),
+    tools: z.array(z.record(z.string(), z.any())).optional(),
+    tool_choice: z.union([z.string(), z.record(z.string(), z.any())]).optional(),
+    temperature: z.number().optional(),
+    top_p: z.number().optional(),
+    stop_sequences: z.array(z.string()).optional(),
+    stream: z.boolean().optional().openapi({
+      description:
+        'When true, the response is Anthropic-shaped SSE: message_start, content_block_delta*, message_delta, message_stop.',
+    }),
+  })
+  .passthrough()
+  .openapi('GatewayMessagesRequest', {
+    example: {
+      model: 'claude-sonnet-4-5',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Say hello in one word.' }],
+    },
+  });
+
+const MessagesResponseSchema = z
+  .object({
+    id: z.string(),
+    type: z.literal('message'),
+    role: z.literal('assistant'),
+    model: z.string(),
+    content: z.array(z.record(z.string(), z.any())),
+    stop_reason: z.string().nullable().optional(),
+    usage: z.record(z.string(), z.any()).optional(),
+  })
+  .passthrough()
+  .openapi('GatewayMessagesResponse', {
+    example: {
+      id: 'msg_abc123',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [{ type: 'text', text: 'Hello!' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 12, output_tokens: 3 },
+    },
+  });
+
+const MESSAGES_RESPONSES = {
+  200: {
+    description:
+      'Anthropic Messages response. A single `message` JSON object when `stream` is falsy; ' +
+      'Anthropic-shaped `text/event-stream` SSE (`message_start` → `content_block_delta`* → ' +
+      '`message_delta` → `message_stop`) when `stream: true`.',
+    content: {
+      'application/json': { schema: MessagesResponseSchema },
+      'text/event-stream': {
+        schema: z.string().openapi({
+          example:
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_abc123","role":"assistant"}}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n',
+        }),
+      },
+    },
+  },
+  ...errors(400, 401, 402, 413, 429, 502),
+};
+
+function messagesRoute(path: string) {
+  const fullPath = `/v1/llm${path}`;
+  return createRoute({
+    method: 'post' as const,
+    path,
+    tags: [GATEWAY_INFERENCE_TAG],
+    summary: `POST ${fullPath}`,
+    description: `Anthropic-Messages-compatible ingress. Translated at the edges only — the request is converted to the gateway\'s internal chat.completions shape, driven through the SAME auth/billing/routing/failover/trace pipeline as chat completions, then the response (or SSE stream) is translated back to the Anthropic Messages wire format.\n\nAuth: ${AUTH_DESCRIPTION}\n\n\`\`\`\ncurl -sS $KORTIX_API_URL${fullPath} \\\n  -H "Authorization: Bearer $KORTIX_GATEWAY_KEY" \\\n  -H "Content-Type: application/json" \\\n  -d \'{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"Say hello in one word."}]}\'\n\`\`\``,
+    ...auth,
+    request: {
+      body: {
+        required: true,
+        content: { 'application/json': { schema: MessagesRequestExampleSchema } },
+      },
+    },
+    responses: MESSAGES_RESPONSES,
+  });
+}
+
+const GatewayModelSchema = z
+  .object({
+    name: z.string(),
+    released: z.string().nullable().optional(),
+    release_date: z.string().nullable().optional(),
+    family: z.string().optional(),
+    reasoning: z.boolean().optional(),
+    tool_call: z.boolean().optional(),
+    attachment: z.boolean().optional(),
+    temperature: z.boolean().optional(),
+    limit: z.object({ context: z.number().optional(), output: z.number().optional() }).optional(),
+  })
+  .openapi('GatewayModel');
+
+const ModelsResponseSchema = z
+  .object({ models: z.record(z.string(), GatewayModelSchema) })
+  .openapi('GatewayModelCatalog', {
+    example: {
+      models: {
+        'claude-sonnet-4-5': {
+          name: 'Claude Sonnet 4.5',
+          family: 'claude',
+          reasoning: true,
+          tool_call: true,
+          attachment: true,
+          temperature: true,
+          limit: { context: 200000, output: 64000 },
+        },
+      },
+    },
+  });
+
+function modelsRoute(path: string) {
+  const fullPath = `/v1/llm${path}`;
+  return createRoute({
+    method: 'get' as const,
+    path,
+    tags: [GATEWAY_INFERENCE_TAG],
+    summary: `GET ${fullPath}`,
+    description: `Servable model catalog for the caller\'s account/project — a keyed object (NOT the OpenAI \`{object:"list",data:[...]}\` array shape) mapping model id → capabilities.\n\nAuth: ${AUTH_DESCRIPTION}\n\n\`\`\`\ncurl -sS $KORTIX_API_URL${fullPath} -H "Authorization: Bearer $KORTIX_GATEWAY_KEY"\n\`\`\``,
+    ...auth,
+    responses: { 200: json(ModelsResponseSchema, 'Servable model catalog'), ...errors(401, 502) },
+  });
+}
 
 // Single place that wires every LLM-gateway surface onto the API:
 //
@@ -23,7 +300,11 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     const gateway = createGateway(createInProcessGatewayHooks(), {
       captureBodies: true,
     });
-    const llm = new Hono();
+    // OpenAPIHono (not a plain Hono) so the inference surface below registers
+    // in the shared OpenAPI registry — `.route()` merges a child OpenAPIHono's
+    // registry into the parent, path-prefixed, the same way `projectsApp` does
+    // for the gateway MANAGEMENT ops in projects/routes/gateway.ts.
+    const llm = makeOpenApiApp();
     llm.get('/health', (c) =>
       c.json({ status: 'ok', service: 'kortix-llm-gateway', mode: 'in-process' }),
     );
@@ -42,6 +323,8 @@ export function mountLlmGateway(app: OpenAPIHono): void {
         authorization: c.req.header('authorization'),
         rawBody: await c.req.text(),
       });
+    // Runtime routes are unchanged plain Hono mounts — same handlers, same
+    // signatures, same streaming behavior as before this OpenAPI registration.
     llm.post('/chat/completions', chat);
     llm.get('/models', models);
     // Anthropic-Messages-compatible ingress: a client speaking the Anthropic
@@ -59,6 +342,15 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     llm.post('/v1/chat/completions', chat);
     llm.get('/v1/models', models);
     llm.post('/v1/messages', messages);
+
+    // OpenAPI documentation ONLY — see the big comment above for why these are
+    // `registerPath()` (registry-only) instead of `llm.openapi(route, handler)`.
+    llm.openAPIRegistry.registerPath(chatCompletionsRoute('/chat/completions'));
+    llm.openAPIRegistry.registerPath(modelsRoute('/models'));
+    llm.openAPIRegistry.registerPath(messagesRoute('/messages'));
+    llm.openAPIRegistry.registerPath(chatCompletionsRoute('/v1/chat/completions'));
+    llm.openAPIRegistry.registerPath(modelsRoute('/v1/models'));
+    llm.openAPIRegistry.registerPath(messagesRoute('/v1/messages'));
     app.route('/v1/llm', llm);
   }
 

--- a/apps/api/src/openapi/index.ts
+++ b/apps/api/src/openapi/index.ts
@@ -73,7 +73,7 @@ export function mountOpenApiDocs(app: OpenAPIHono<any, any, any>, version: strin
     type: "http",
     scheme: "bearer",
     description:
-      "Supabase user JWT, or a Kortix token: PAT (`kortix_pat_…`), API key (`kortix_…`), or service account (`kortix_sa_…`).",
+      "Supabase user JWT, or a Kortix token: PAT (`kortix_pat_…`), API key (`kortix_…`), service account (`kortix_sa_…`), or (LLM Gateway inference routes only) a project gateway key (`kortix_gw_…`).",
   });
 
   app.doc31("/v1/openapi.json", (c) => ({


### PR DESCRIPTION
## Summary
- Registers the LLM Gateway's **inference** endpoints (chat completions, Anthropic messages, models) in the core API's OpenAPI registry, so they now appear in `/v1/openapi.json` and the Scalar page at `/v1/docs` — closing the gap where only the gateway **management** ops (`projects/routes/gateway.ts`, tag `gateway`) were documented.
- New tag `gateway-inference`, adjacent (alphabetically and in the doc) to the existing `gateway` management tag.
- Covers all 6 real mounted paths: `POST /v1/llm/chat/completions` (+ `/v1/llm/v1/chat/completions` alias), `POST /v1/llm/messages` (+ `/v1/llm/v1/messages` alias), `GET /v1/llm/models` (+ `/v1/llm/v1/models` alias). Each has a documented request/response shape, an example, a runnable curl snippet, and clarified auth (gateway key `kortix_gw_…` or Kortix account token — the raw Supabase JWT is *not* accepted here, unlike most of the API).
- Also extends the shared `bearerAuth` security-scheme description to mention gateway keys.

## Why `registerPath()` instead of `llm.openapi(route, handler)`
The runtime handlers (`chat`, `messages`, `models`) are unchanged plain `llm.post()/get()` mounts with the exact same handler functions as before. Documentation is added via `llm.openAPIRegistry.registerPath(...)` — the same registry `.openapi()` writes to — rather than binding the route through `.openapi()` itself, because `.openapi()` would wire `@hono/zod-openapi`'s `zValidator("json", schema)` in front of the handler. A validation failure there returns the shared `{error:true,message:"Validation failed",...}` envelope instead of the gateway's own OpenAI/Anthropic-shaped error body — silently changing the wire contract for a compatibility surface whose entire point is matching those SDKs' expectations. `/v1/router/chat/completions` (`router/routes/llm.ts`) already avoids attaching a body schema for this same reason; this PR documents a full request-body schema safely by keeping it registry-only.

Net effect: zero runtime/streaming behavior change, fully documented request/response shapes.

## Verification
- `apps/api`: `pnpm run typecheck` — clean.
- `biome check` on the touched file — clean (no new lint/format issues).
- Booted the real Hono `app` in-process (`app.request(...)`) with `LLM_GATEWAY_ENABLED=true` and confirmed `/v1/openapi.json` now includes all 6 `/v1/llm/*` inference paths, tagged `gateway-inference`, with `GatewayChatCompletionRequest/Response`, `GatewayMessagesRequest/Response`, and `GatewayModelCatalog` schemas registered.
- Regenerated the route manifest (`bun run apps/api/scripts/dump-routes.ts`) and diffed against the pre-change route table: **identical** set of `/v1/llm/*` method+path pairs — confirms zero runtime route changes. (Left `tests/spec/routes.generated.json` untouched — it's already stale on `main` for unrelated routes and the ke2e coverage gate is explicitly WIP/not-enforced per `tests/spec` conventions; regenerating it here would just add unrelated churn.)
- Sent live requests through the in-process app to `/v1/llm/chat/completions`, `/v1/llm/v1/messages`, and `/v1/llm/models` with no/invalid auth and confirmed the gateway's own native error envelopes are returned unchanged (OpenAI-style for chat/models, Anthropic-style `{"type":"error",...}` for messages) — proving the new request-body doc schema never intercepts real requests.

## Test plan
- [x] `apps/api` typecheck green
- [x] Biome clean on touched file
- [x] `/v1/openapi.json` contains the 3 inference endpoints (6 paths incl. aliases) under `gateway-inference`
- [x] Route table (`app.routes`) unchanged before/after
- [x] Live in-process requests confirm untouched error contracts (no zod-validator interception)
- [ ] Visual check of `/v1/docs` Scalar page (not run in this sandbox — no way to render the browser UI here; JSON spec inspected directly instead)