### PR TITLE
docs(self-host): correct stale ':stable not yet published' claim

### DIFF
--- a/apps/web/content/docs/reference/self-hosting-architecture.mdx
+++ b/apps/web/content/docs/reference/self-hosting-architecture.mdx
@@ -132,13 +132,17 @@ or **`latest`** — or an explicit pinned version (`--tag <version>`). The
 `kortix-updater` service and `kortix self-host update`/`reconcile` both
 resolve the same way: an explicit pin wins, otherwise the configured channel.
 
-This is a **release-pipeline contract**, not a self-host CLI concern: the
-Kortix release flow must publish/repoint the moving `stable` tag on all three
-app images (`kortix-api`, `kortix-frontend`, `kortix-gateway`) on every
-production release, the same way it already republishes `latest` and the
-exact `X.Y.Z` tag. Self-host installs — evaluation or production — consume
-whatever that pipeline publishes; they never build or sign anything
-themselves.
+This is a **release-pipeline contract**, not a self-host CLI concern. A prod
+release automatically retags `:latest` and the exact `:X.Y.Z` on all three
+app images (`kortix-api`, `kortix-frontend`, `kortix-gateway`). The moving
+`:stable` tag is promoted **separately and deliberately** — a human runs the
+`Promote Self-Host Stable` workflow (workflow_dispatch, picks a version) to
+repoint `:stable` → that version's digest. Curation is intentional: not
+every prod release is pushed to every self-hosted box overnight; only proven
+versions reach `:stable`. Self-host installs — evaluation or production —
+consume whatever that pipeline has promoted; they never build or sign
+anything themselves. To get a release that hasn't been promoted to `:stable`
+yet, use `--channel latest` or pin `--tag <version>`.
 
 ## What changed from the old enterprise-VPC design
 

--- a/docs/runbooks/self-hosting.md
+++ b/docs/runbooks/self-hosting.md
@@ -372,16 +372,20 @@ tag to the concrete version it currently points to, via Docker Hub) and
 whether a newer release is available.
 
 > **Release-flow contract this depends on:** the self-host default channel is
-> `stable`, meaning the Kortix release pipeline (`deploy-prod.yml` /
-> `Promote` → GitHub Release) must publish/repoint a moving `:stable` tag on
-> all three app images (`kortix-api`, `kortix-frontend`, `kortix-gateway`) on
-> every production release, the same way it already retags `:latest` and the
-> exact `:X.Y.Z`. **As of this writing the release workflow retags `:latest`
-> and `:X.Y.Z` only — it does not yet publish `:stable`.** Until that's added,
-> self-host installs tracking the (default) `stable` channel will not see new
-> versions from the auto-updater; use `--channel latest` or pin `--tag
-> <version>` in the meantime, and treat wiring up `:stable` publishing as a
-> release-pipeline follow-up, not a self-host CLI change.
+> `stable`. A prod release (`deploy-prod.yml` → GitHub Release) retags
+> `:latest` and the exact `:X.Y.Z` on all three app images (`kortix-api`,
+> `kortix-frontend`, `kortix-gateway`) automatically. The moving `:stable`
+> tag is promoted **separately and deliberately**, not on every release: a
+> human runs the
+> [`Promote Self-Host Stable`](https://github.com/kortix-ai/suna/actions/workflows/promote-self-host-stable.yml)
+> workflow (`workflow_dispatch`, picks a version) to repoint `:stable` →
+> that version's digest (`docker buildx imagetools create`) on all three
+> images. Curation is intentional — we don't push every prod release to
+> every self-hosted box overnight; only proven versions reach `:stable`.
+> From the moment a version is promoted, self-host installs tracking the
+> (default) `stable` channel pick it up on their next auto-updater cycle.
+> To get a release that hasn't been promoted to `:stable` yet, use
+> `--channel latest` or pin `--tag <version>`.
 
 ## Configuring SMTP, Daytona, and other integrations later
 


### PR DESCRIPTION
## What

The self-host runbook (`docs/runbooks/self-hosting.md`) and architecture doc (`apps/web/content/docs/reference/self-hosting-architecture.mdx`) claimed the release workflow "does not yet publish `:stable`" and called wiring it up "a release-pipeline follow-up."

## Why it's wrong (grounded verification)

That claim is stale. [`promote-self-host-stable.yml`](https://github.com/kortix-ai/suna/blob/main/.github/workflows/promote-self-host-stable.yml) exists, works, and has been run repeatedly — last 7 runs all green, most recent 2026-07-17T12:07 UTC:

```
completed success Promote Self-Host Stable workflow_dispatch 2026-07-17T12:07:26Z
completed success Promote Self-Host Stable workflow_dispatch 2026-07-17T08:53:32Z
completed success Promote Self-Host Stable workflow_dispatch 2026-07-17T01:25:09Z
... (4 more)
```

It repoints `:stable` → a chosen version's digest on all three app images via `docker buildx imagetools create`.

## Why it's curated, not automatic

`:stable` is promoted **deliberately, not on every release** — by design, so not every prod release is pushed to every self-hosted box overnight. A human runs the `Promote Self-Host Stable` workflow (`workflow_dispatch`, picks a version) after a release is proven. `deploy-prod.yml` already documents this (line 11): *"self-host `:stable` channel is promoted SEPARATELY and manually."*

## The fix

Replaced the false "not yet wired" text in both files with the actual contract:
- `":latest"` and `:X.Y.Z` retag automatically on every prod release.
- `:stable` is curated via the `Promote Self-Host Stable` workflow (manual dispatch, picks a proven version).
- Self-host installs on the default `stable` channel pick up whatever was last promoted, on their next auto-updater cycle.
- To get a release not yet promoted to `:stable`, use `--channel latest` or pin `--tag <version>`.

## Impact

Removes a false "not yet wired" claim that would mislead enterprise/Essentia onboarding against goal §1 (seamless enterprise self-host with easy continuous updates). Docs-only; no code or behavior change.

## Verification

- \`grep -rn "does not yet publish" docs/ apps/web/content/\` → no remaining instances after this PR.
- Confirmed `promote-self-host-stable.yml` run history via `gh run list --workflow=promote-self-host-stable.yml`.
- Confirmed `deploy-prod.yml:11` documents the separate-manual-promote contract.

Mirko AGI cycle 3 (T-5 grounded re-audit of the current generic self-host system).