### PR TITLE
feat(gateway): add Playground tab for comparing models side by side

### DIFF
--- a/apps/api/src/projects/routes/gateway.ts
+++ b/apps/api/src/projects/routes/gateway.ts
@@ -804,6 +804,7 @@ projectsApp.openapi(
             schema: z.object({
               prompt: z.string().min(1).max(8000),
               models: z.array(z.string()).min(1).max(6),
+              system: z.string().max(4000).optional(),
             }),
           },
         },
@@ -826,6 +827,7 @@ projectsApp.openapi(
     const body = await c.req.json();
     const prompt = typeof body.prompt === 'string' ? body.prompt : '';
     const models: string[] = Array.isArray(body.models) ? body.models.slice(0, 6) : [];
+    const system = typeof body.system === 'string' && body.system.trim() ? body.system : undefined;
     if (!prompt || models.length === 0) {
       return c.json({ error: 'prompt and models are required' }, 400);
     }
@@ -842,7 +844,10 @@ projectsApp.openapi(
         const requestId = crypto.randomUUID();
         const request = {
           model,
-          messages: [{ role: 'user', content: prompt }],
+          messages: [
+            ...(system ? [{ role: 'system', content: system }] : []),
+            { role: 'user', content: prompt },
+          ],
           stream: false,
           max_tokens: 512,
         };
@@ -927,6 +932,9 @@ projectsApp.openapi(
             output: data?.choices?.[0]?.message?.content ?? '',
             input_tokens: promptTokens,
             output_tokens: completionTokens,
+            cost: finalCost,
+            resolved_model: resolvedModel,
+            provider: descriptor.provider,
           };
         } catch (err) {
           return { model, ok: false, error: err instanceof Error ? err.message : 'Request failed' };

--- a/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
@@ -26,6 +26,7 @@ import { GatewayBudgets } from '@/features/workspace/customize/sections/view/gat
 import { GatewayKeys } from '@/features/workspace/customize/sections/view/gateway/gateway-keys';
 import { GatewayLogs } from '@/features/workspace/customize/sections/view/gateway/gateway-logs';
 import { GatewayOverview } from '@/features/workspace/customize/sections/view/gateway/gateway-overview';
+import { GatewayPlayground } from '@/features/workspace/customize/sections/view/gateway/gateway-playground';
 import { GatewayRouting } from '@/features/workspace/customize/sections/view/gateway/gateway-routing';
 import { useModelDefaults } from '@/hooks/opencode/use-model-defaults';
 import { useGatewayKeys } from '@/hooks/projects/use-project-gateway';
@@ -36,11 +37,20 @@ import { useCustomizeStore } from '@/stores/customize-store';
 import { gatewayRoutingPolicyKey, useProjectModels } from '@kortix/sdk/react';
 import { useIsMutating } from '@tanstack/react-query';
 
-type LlmTab = 'providers' | 'routing' | 'overview' | 'logs' | 'budgets' | 'keys' | 'api';
+type LlmTab =
+  | 'providers'
+  | 'routing'
+  | 'playground'
+  | 'overview'
+  | 'logs'
+  | 'budgets'
+  | 'keys'
+  | 'api';
 
 const LLM_TABS: { id: LlmTab; label: string }[] = [
   { id: 'providers', label: 'Providers' },
   { id: 'routing', label: 'Routing' },
+  { id: 'playground', label: 'Playground' },
   { id: 'overview', label: 'Overview' },
   { id: 'logs', label: 'Logs' },
   { id: 'budgets', label: 'Budgets' },
@@ -153,6 +163,9 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
           canWrite={canWrite}
           projectDefaultPending={modelDefaults.isUpdating}
         />
+      </TabsContent>
+      <TabsContent value="playground" className="min-h-0 overflow-y-auto">
+        <GatewayPlayground projectId={projectId} />
       </TabsContent>
       <TabsContent value="logs" className="min-h-0 overflow-y-auto">
         <GatewayLogs projectId={projectId} />

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-playground.test.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-playground.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { GatewayPlaygroundResult } from '@/lib/projects-gateway-client';
+
+import { fmtLatency, PlaygroundResultCard } from './gateway-playground';
+
+const result = (overrides: Partial<GatewayPlaygroundResult> = {}): GatewayPlaygroundResult => ({
+  model: 'gpt-4o',
+  ok: true,
+  latency_ms: 842,
+  output: 'Hello from the model.',
+  input_tokens: 12,
+  output_tokens: 34,
+  cost: 0.0031,
+  resolved_model: 'gpt-4o-2026-01-01',
+  provider: 'openrouter',
+  ...overrides,
+});
+
+function render(r: GatewayPlaygroundResult) {
+  return renderToStaticMarkup(createElement(PlaygroundResultCard, { result: r }));
+}
+
+describe('fmtLatency', () => {
+  test('renders sub-second latency in milliseconds', () => {
+    expect(fmtLatency(842)).toBe('842ms');
+  });
+
+  test('renders one-second-plus latency in seconds with one decimal', () => {
+    expect(fmtLatency(1500)).toBe('1.5s');
+    expect(fmtLatency(12345)).toBe('12.3s');
+  });
+});
+
+describe('PlaygroundResultCard', () => {
+  test('a successful run shows the output, usage, cost, and latency', () => {
+    const html = render(result());
+
+    expect(html).toContain('Hello from the model.');
+    expect(html).toContain('842ms');
+    expect(html).toContain('12 in');
+    expect(html).toContain('34 out');
+    expect(html).toContain('OK');
+    expect(html).not.toContain('Failed');
+  });
+
+  test('shows the resolved upstream model alongside the requested id when they differ', () => {
+    const html = render(result({ model: 'auto/gpt', resolved_model: 'gpt-4o-2026-01-01' }));
+
+    expect(html).toContain('auto/gpt');
+  });
+
+  test('a failed run shows the error instead of output, with no usage row', () => {
+    const html = render(
+      result({
+        ok: false,
+        output: undefined,
+        input_tokens: undefined,
+        output_tokens: undefined,
+        cost: undefined,
+        error: 'No upstream configured for this model',
+      }),
+    );
+
+    expect(html).toContain('No upstream configured for this model');
+    expect(html).toContain('Failed');
+    expect(html).not.toContain('Hello from the model.');
+  });
+
+  test('an empty successful response still reads as ok, not an error', () => {
+    const html = render(result({ output: '' }));
+
+    expect(html).toContain('Empty response.');
+    expect(html).toContain('OK');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-playground.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-playground.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+/**
+ * Playground — run one prompt against several models side by side and compare
+ * output, tokens, cost, and latency. Thin client over the gateway's built-in
+ * `POST /gateway/playground` endpoint (see `useGatewayPlayground`); the
+ * backend runs every model concurrently and returns once all finish, so there
+ * is a single "running" state rather than per-model streaming.
+ */
+
+import { AlertTriangle, Clock, Coins, Play, Plus, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { InfoBanner } from '@/components/ui/info-banner';
+import { InlineMeta } from '@/components/ui/inline-meta';
+import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { errorToast } from '@/components/ui/toast';
+import { ModelSelector } from '@/features/session/model-selector';
+import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
+import { modelKeyToWire, wireToModelKey } from '@/hooks/opencode/use-model-store';
+import { useGatewayPlayground } from '@/hooks/projects/use-project-gateway';
+import type { GatewayPlaygroundResult } from '@/lib/projects-gateway-client';
+import { cn } from '@/lib/utils';
+import { useProjectModels } from '@kortix/sdk/react';
+
+import { displayModel } from './_shared';
+import { fmtUsd } from './_metrics';
+
+const MAX_MODELS = 6;
+
+type PlaygroundModel = ReturnType<typeof useProjectModels>[number];
+
+function PlaygroundModelSelector({
+  value,
+  models,
+  exclude = [],
+  unsetLabel = 'Choose model',
+  disabled,
+  onChange,
+}: {
+  value: string | null;
+  models: PlaygroundModel[];
+  exclude?: string[];
+  unsetLabel?: string;
+  disabled?: boolean;
+  onChange: (value: string | null) => void;
+}) {
+  const options = models.filter((model) => {
+    const wire = modelKeyToWire(model);
+    return !exclude.includes(wire) || wire === value;
+  });
+  return (
+    <ModelSelector
+      models={options}
+      selectedModel={value ? wireToModelKey(value) : null}
+      unsetLabel={unsetLabel}
+      disabled={disabled}
+      onSelect={(model) => onChange(model ? modelKeyToWire(model) : null)}
+    />
+  );
+}
+
+export function fmtLatency(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+}
+
+/** One model's result — output, usage, cost, latency, or the error it hit.
+ *  Exported standalone (no hooks) so it renders and tests without a query
+ *  client. */
+export function PlaygroundResultCard({ result }: { result: GatewayPlaygroundResult }) {
+  const title = displayModel(result.resolved_model ?? result.model);
+  return (
+    <section className="bg-popover flex flex-col overflow-hidden rounded-md border">
+      <div className="border-border/60 flex items-center justify-between gap-2 border-b px-4 py-3">
+        <div className="min-w-0">
+          <p className="text-foreground truncate text-sm font-medium">{title}</p>
+          {result.resolved_model && result.resolved_model !== result.model ? (
+            <p className="text-muted-foreground truncate font-mono text-xs">{result.model}</p>
+          ) : null}
+        </div>
+        <Badge variant={result.ok ? 'success' : 'destructive'} size="sm" className="shrink-0">
+          {result.ok ? 'OK' : 'Failed'}
+        </Badge>
+      </div>
+      <div className="flex-1 space-y-3 px-4 py-4">
+        {result.ok ? (
+          <p className="text-foreground max-h-64 overflow-y-auto text-sm whitespace-pre-wrap text-pretty">
+            {result.output?.trim() || <span className="text-muted-foreground">Empty response.</span>}
+          </p>
+        ) : (
+          <InfoBanner tone="destructive" icon={AlertTriangle} title="Request failed">
+            {result.error ?? 'Unknown error.'}
+          </InfoBanner>
+        )}
+        <InlineMeta className="border-border/60 border-t pt-3">
+          {result.latency_ms != null ? (
+            <span className="inline-flex items-center gap-1 tabular-nums">
+              <Clock className="size-3 shrink-0" />
+              {fmtLatency(result.latency_ms)}
+            </span>
+          ) : null}
+          {result.input_tokens != null || result.output_tokens != null ? (
+            <span className="tabular-nums">
+              {result.input_tokens ?? 0} in · {result.output_tokens ?? 0} out
+            </span>
+          ) : null}
+          {result.cost != null ? (
+            <span className="inline-flex items-center gap-1 tabular-nums">
+              <Coins className="size-3 shrink-0" />
+              {fmtUsd(result.cost)}
+            </span>
+          ) : null}
+        </InlineMeta>
+      </div>
+    </section>
+  );
+}
+
+export function GatewayPlayground({ projectId }: { projectId: string }) {
+  const catalogModels = useProjectModels(projectId);
+  const playground = useGatewayPlayground(projectId);
+
+  const [prompt, setPrompt] = useState('');
+  const [system, setSystem] = useState('');
+  const [showSystem, setShowSystem] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const models = useMemo(
+    () => catalogModels.filter((model) => modelKeyToWire(model) !== 'auto'),
+    [catalogModels],
+  );
+
+  const canAddMore =
+    selected.length < MAX_MODELS && models.some((model) => !selected.includes(modelKeyToWire(model)));
+  const canRun = prompt.trim().length > 0 && selected.length > 0 && !playground.isPending;
+  const results = playground.data?.results ?? null;
+
+  const run = () => {
+    playground.mutate(
+      { prompt: prompt.trim(), models: selected, system: system.trim() || undefined },
+      {
+        onError: (error) =>
+          errorToast(error instanceof Error ? error.message : 'Playground run failed'),
+      },
+    );
+  };
+
+  return (
+    <CustomizeSectionWrapper
+      title="Playground"
+      description="Run one prompt across several models and compare output, cost, and latency side by side."
+    >
+      <div className="space-y-8">
+        <section className="space-y-4">
+          <Label>Prompt</Label>
+          <div className="bg-popover space-y-3 rounded-md border px-4 py-5">
+            <Textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Ask something to compare across models…"
+              minHeight={96}
+              maxHeight={280}
+              disabled={playground.isPending}
+            />
+            {showSystem ? (
+              <div className="space-y-1.5">
+                <Label className="text-muted-foreground text-xs font-normal">System prompt</Label>
+                <Textarea
+                  value={system}
+                  onChange={(e) => setSystem(e.target.value)}
+                  placeholder="Optional system instructions sent to every model"
+                  minHeight={60}
+                  maxHeight={160}
+                  variant="secondary"
+                  disabled={playground.isPending}
+                />
+              </div>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground -ml-2 w-fit"
+                onClick={() => setShowSystem(true)}
+                disabled={playground.isPending}
+              >
+                <Plus className="size-3.5 shrink-0" />
+                Add system prompt
+              </Button>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Label>
+            Models
+            <span className="text-muted-foreground font-normal">
+              {' '}
+              ({selected.length}/{MAX_MODELS})
+            </span>
+          </Label>
+
+          {selected.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              Choose up to {MAX_MODELS} models to compare on this prompt.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {selected.map((wire, index) => (
+                <li
+                  key={`${wire}-${index}`}
+                  className="bg-popover flex items-center gap-2 rounded-md border px-3 py-2"
+                >
+                  <div className="min-w-0 flex-1">
+                    <PlaygroundModelSelector
+                      value={wire}
+                      models={models}
+                      exclude={selected.filter((_, i) => i !== index)}
+                      disabled={playground.isPending}
+                      onChange={(next) => {
+                        if (!next) return;
+                        setSelected((current) => current.map((m, i) => (i === index ? next : m)));
+                      }}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    size="icon-sm"
+                    variant="ghost"
+                    aria-label="Remove model"
+                    disabled={playground.isPending}
+                    onClick={() => setSelected((current) => current.filter((_, i) => i !== index))}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {canAddMore ? (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs">Add model</span>
+              <PlaygroundModelSelector
+                value={null}
+                models={models}
+                exclude={selected}
+                unsetLabel="Choose model"
+                disabled={playground.isPending}
+                onChange={(next) => next && setSelected((current) => [...current, next])}
+              />
+            </div>
+          ) : null}
+        </section>
+
+        <div className="bg-background/95 sticky bottom-0 -mx-4 flex items-center justify-between gap-4 border-t px-4 py-4 backdrop-blur">
+          <div className="text-muted-foreground text-xs">
+            {playground.isPending
+              ? `Running against ${selected.length} model${selected.length === 1 ? '' : 's'}…`
+              : results
+                ? `Last run · ${results.length} result${results.length === 1 ? '' : 's'}`
+                : 'Nothing run yet'}
+          </div>
+          <Button type="button" disabled={!canRun} onClick={run}>
+            {playground.isPending ? (
+              <Loading className="size-4 shrink-0" />
+            ) : (
+              <Play className="size-3.5 shrink-0" />
+            )}
+            Run
+          </Button>
+        </div>
+
+        {playground.isPending ? (
+          <div className={cn('grid gap-4', selected.length > 1 && 'lg:grid-cols-2')}>
+            {selected.map((wire) => (
+              <Skeleton key={wire} className="h-48 rounded-md" />
+            ))}
+          </div>
+        ) : results && results.length > 0 ? (
+          <div className={cn('grid gap-4', results.length > 1 && 'lg:grid-cols-2')}>
+            {results.map((result, index) => (
+              <PlaygroundResultCard key={`${result.model}-${index}`} result={result} />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </CustomizeSectionWrapper>
+  );
+}

--- a/apps/web/src/hooks/projects/use-project-gateway.ts
+++ b/apps/web/src/hooks/projects/use-project-gateway.ts
@@ -15,7 +15,9 @@ import {
   getGatewaySessions,
   listGatewayLogs,
   revokeGatewayKey,
+  runGatewayPlayground,
   setGatewayBudget,
+  type GatewayPlaygroundResponse,
   type SetGatewayBudgetInput,
 } from '@/lib/projects-gateway-client';
 
@@ -128,5 +130,19 @@ export function useRevokeGatewayKey(projectId: string | undefined) {
   return useMutation({
     mutationFn: (keyId: string) => revokeGatewayKey(projectId!, keyId),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['project-gateway-keys', projectId] }),
+  });
+}
+
+export interface RunGatewayPlaygroundInput {
+  prompt: string;
+  models: string[];
+  system?: string;
+}
+
+/** Run one prompt across up to 6 models side by side — no cache, always a fresh run. */
+export function useGatewayPlayground(projectId: string | undefined) {
+  return useMutation<GatewayPlaygroundResponse, Error, RunGatewayPlaygroundInput>({
+    mutationFn: ({ prompt, models, system }) =>
+      runGatewayPlayground(projectId!, prompt, models, system),
   });
 }

--- a/apps/web/src/lib/projects-gateway-client.ts
+++ b/apps/web/src/lib/projects-gateway-client.ts
@@ -17,6 +17,7 @@ export {
   getGatewayKeys,
   createGatewayKey,
   revokeGatewayKey,
+  runGatewayPlayground,
   type GatewayLogRow,
   type GatewayLogDetail,
   type GatewayLogsResponse,
@@ -35,4 +36,6 @@ export {
   type SetGatewayBudgetInput,
   type GatewayKeyRow,
   type CreatedGatewayKey,
+  type GatewayPlaygroundResult,
+  type GatewayPlaygroundResponse,
 } from '@kortix/sdk/projects-client';

--- a/packages/sdk/API-MAP.md
+++ b/packages/sdk/API-MAP.md
@@ -101,7 +101,7 @@ try/catching every call.
 - catalog/budget: `GET /v1/llm/models`, `GET /v1/projects/:id/llm-catalog`
 - selection + persistence: `useOpenCodeLocal`, `useModelStore` ✅
 - **gateway observability** (`/v1/projects/:id/gateway/{overview,logs,keys,budgets,series,errors}`) → client fully in SDK (`projects-client/gateway.ts`) ✅; hooks still web-local 🟡
-- **gateway playground** — `project(id).gateway.playground(prompt, models)` → `POST /v1/projects/:id/gateway/playground` (run one prompt against up to 6 models side by side) ✅
+- **gateway playground** — `project(id).gateway.playground(prompt, models, system?)` → `POST /v1/projects/:id/gateway/playground` (run one prompt, plus an optional system prompt, against up to 6 models side by side) ✅; UI: Playground tab in `gateway-view.tsx` (`useGatewayPlayground` hook) ✅
 
 ### 8. Agents · commands · tools · skills · MCP
 | op | runtime | SDK |

--- a/packages/sdk/src/core/client/kortix.ts
+++ b/packages/sdk/src/core/client/kortix.ts
@@ -538,8 +538,8 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
             P.previewGatewayRoute(projectId, input),
         },
         /** Run one prompt against up to 6 models side by side (a model-comparison playground). */
-        playground: (prompt: string, models: string[]) =>
-          P.runGatewayPlayground(projectId, prompt, models),
+        playground: (prompt: string, models: string[], system?: string) =>
+          P.runGatewayPlayground(projectId, prompt, models, system),
       },
 
       /** Slack + email + Meet channel integrations. */

--- a/packages/sdk/src/core/rest/projects-client/gateway.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/gateway.test.ts
@@ -98,11 +98,39 @@ test('getGatewayKeys returns the keys list', async () => {
 test('runGatewayPlayground posts prompt + models and returns per-model results', async () => {
   nextResponse = {
     status: 200,
-    body: { results: [{ model: 'gpt-4o', ok: true, latency_ms: 120, output: 'hi' }] },
+    body: {
+      results: [
+        {
+          model: 'gpt-4o',
+          ok: true,
+          latency_ms: 120,
+          output: 'hi',
+          input_tokens: 5,
+          output_tokens: 2,
+          cost: 0.0012,
+          resolved_model: 'gpt-4o-2026-01-01',
+          provider: 'openrouter',
+        },
+      ],
+    },
   };
   const result = await runGatewayPlayground('P1', 'Say hi', ['gpt-4o', 'claude-3']);
   expect(last().url).toContain('/projects/P1/gateway/playground');
   expect(last().method).toBe('POST');
   expect(last().body).toEqual({ prompt: 'Say hi', models: ['gpt-4o', 'claude-3'] });
   expect(result.results[0]?.model).toBe('gpt-4o');
+  expect(result.results[0]?.cost).toBe(0.0012);
+  expect(result.results[0]?.resolved_model).toBe('gpt-4o-2026-01-01');
+});
+
+test('runGatewayPlayground includes an optional system prompt in the request body', async () => {
+  nextResponse = { status: 200, body: { results: [] } };
+  await runGatewayPlayground('P1', 'Say hi', ['gpt-4o'], 'Be terse.');
+  expect(last().body).toEqual({ prompt: 'Say hi', models: ['gpt-4o'], system: 'Be terse.' });
+});
+
+test('runGatewayPlayground omits system from the body when not provided', async () => {
+  nextResponse = { status: 200, body: { results: [] } };
+  await runGatewayPlayground('P1', 'Say hi', ['gpt-4o']);
+  expect(last().body).toEqual({ prompt: 'Say hi', models: ['gpt-4o'] });
 });

--- a/packages/sdk/src/core/rest/projects-client/gateway.ts
+++ b/packages/sdk/src/core/rest/projects-client/gateway.ts
@@ -374,6 +374,11 @@ export interface GatewayPlaygroundResult {
   output?: string;
   input_tokens?: number;
   output_tokens?: number;
+  /** Final (post-markup) cost in USD, present only when the request succeeded. */
+  cost?: number;
+  /** The concrete upstream model the requested id resolved to. */
+  resolved_model?: string;
+  provider?: string;
   error?: string;
 }
 
@@ -386,11 +391,13 @@ export async function runGatewayPlayground(
   projectId: string,
   prompt: string,
   models: string[],
+  system?: string,
 ): Promise<GatewayPlaygroundResponse> {
   return unwrap(
     await backendApi.post<GatewayPlaygroundResponse>(`/projects/${projectId}/gateway/playground`, {
       prompt,
       models,
+      ...(system ? { system } : {}),
     }),
     'Gateway request failed',
   );


### PR DESCRIPTION
## Summary

The gateway's built-in multi-model Playground (`POST /v1/projects/:id/gateway/playground`) had a working backend and SDK client but zero UI. This adds a real "compare models on this gateway" surface.

- New **Playground** tab in `gateway-view.tsx` (placed after Routing, before Overview) — a prompt box, optional system prompt, up to 6 models picked from the project's servable catalog (`useProjectModels` + the same `ModelSelector` used elsewhere in the gateway), and a Run button.
- Results render side by side as cards: output text, input/output tokens, cost, latency, and per-model errors. The endpoint runs every model concurrently and returns once all finish (no SSE), so there's a single "running" state with skeleton placeholders rather than per-model streaming — matches the backend's actual `Promise.all` semantics.
- **Backend** (`apps/api/src/projects/routes/gateway.ts`): the playground endpoint now accepts an optional `system` prompt (prepended as a system message to every model call) and returns `cost`, `resolved_model`, and `provider` on success — all additive, so this doesn't disturb the existing 400/403 e2e coverage for the route.
- **SDK** (`packages/sdk`): `runGatewayPlayground(projectId, prompt, models, system?)` gained the optional `system` param; `GatewayPlaygroundResult` gained `cost?`/`resolved_model?`/`provider?`. Facade binding in `kortix.ts` updated to match. Both changes are additive (no renamed/removed exports — the type-surface snapshot is untouched).
- New `useGatewayPlayground` mutation hook in `apps/web/src/hooks/projects/use-project-gateway.ts`, following the existing gateway hook conventions.

## Test plan
- [x] `pnpm --filter @kortix/sdk typecheck` — clean
- [x] `pnpm --filter @kortix/sdk test` — 1122 pass, 0 fail (extended `gateway.test.ts` with cases for the new `system` param and the new response fields)
- [x] `apps/api` — `pnpm typecheck` clean (full local `bun test` needs `KORTIX_URL`/live infra not available in this worktree — known local-only gap, see repo notes)
- [x] `apps/web` — new co-located `gateway-playground.test.tsx` (6 tests, `renderToStaticMarkup` pattern matching `sandbox-view.test.tsx`) covering the result card's success/error/empty states and latency formatting
- [x] `apps/web` — full `tsc --noEmit` clean (0 errors) and `next build` completes successfully (production route manifest generated)

## UI
Playground tab: prompt + optional system prompt → pick up to 6 models (reuses the gateway's model picker) → Run → side-by-side result cards with output, token usage, cost, latency, or error per model. Matches the gateway's existing panel/card styling (`bg-popover rounded-md border`, `Badge`, `InfoBanner`, `Loading`, `Skeleton`).