### PR TITLE
feat(llm-gateway): verify BYOK provider keys live + disclose custom-provider gateway bypass

### DIFF
--- a/apps/api/src/llm-gateway/provider-verify.test.ts
+++ b/apps/api/src/llm-gateway/provider-verify.test.ts
@@ -1,0 +1,258 @@
+/**
+ * GAP C1 — "Connected" today only means a secret row exists; it never proves
+ * the key actually works. verifyProviderConnection makes one cheap, single-
+ * attempt completion against the resolved upstream and classifies the
+ * outcome so the UI can render "Verified" vs "Key rejected" vs "Couldn't
+ * verify" instead of a blind green checkmark. Pure-logic unit tests via
+ * injected deps (mirrors unit-executor-gateway.test.ts's GatewayDeps style)
+ * — no DB, no network.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  GatewayResolutionError,
+  UpstreamHttpError,
+  NetworkError,
+  TimeoutError,
+} from '@kortix/llm-gateway';
+import type { AuthedPrincipal, UpstreamDescriptor } from '@kortix/llm-gateway';
+import { verifyProviderConnection, type ProviderVerifyDeps } from './provider-verify';
+
+function principal(overrides: Partial<AuthedPrincipal> = {}): AuthedPrincipal {
+  return { userId: 'user-1', accountId: 'acct-1', projectId: 'project-1', ...overrides };
+}
+
+function descriptor(overrides: Partial<UpstreamDescriptor> = {}): UpstreamDescriptor {
+  return {
+    provider: 'openai',
+    kind: 'openai-compat',
+    baseUrl: 'https://api.openai.com/v1',
+    apiKey: 'sk-test',
+    billingMode: 'none',
+    markup: 0,
+    resolvedModel: 'gpt-4o-mini',
+    npm: '@ai-sdk/openai',
+    ...overrides,
+  };
+}
+
+function makeDeps(o: Partial<ProviderVerifyDeps> = {}): ProviderVerifyDeps {
+  return {
+    pickVerificationModel: o.pickVerificationModel ?? (() => 'openai/gpt-4o-mini'),
+    resolveCandidates: o.resolveCandidates ?? (async () => [descriptor()]),
+    callUpstream: o.callUpstream ?? (async () => new Response('{}', { status: 200 })),
+  };
+}
+
+describe('verifyProviderConnection', () => {
+  test('no catalog model to verify against -> unknown, never calls resolveCandidates', async () => {
+    let resolveCalled = false;
+    const result = await verifyProviderConnection(
+      principal(),
+      'made-up-provider',
+      makeDeps({
+        pickVerificationModel: () => null,
+        resolveCandidates: async () => {
+          resolveCalled = true;
+          return [];
+        },
+      }),
+    );
+    expect(result.status).toBe('unknown');
+    expect(resolveCalled).toBe(false);
+  });
+
+  test('resolveCandidates throws provider_not_connected -> not_connected, never calls upstream', async () => {
+    let upstreamCalled = false;
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        resolveCandidates: async () => {
+          throw new GatewayResolutionError(
+            'provider_not_connected',
+            'No openai API key is connected for this project.',
+            'Add a key.',
+          );
+        },
+        callUpstream: async () => {
+          upstreamCalled = true;
+          return new Response('{}', { status: 200 });
+        },
+      }),
+    );
+    expect(result.status).toBe('not_connected');
+    expect(result.message).toContain('No openai API key');
+    expect(upstreamCalled).toBe(false);
+  });
+
+  test('resolveCandidates throws provider_reauth_required -> invalid (needs reconnect)', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'codex',
+      makeDeps({
+        resolveCandidates: async () => {
+          throw new GatewayResolutionError(
+            'provider_reauth_required',
+            'Your Codex session has expired or was revoked.',
+            'Reconnect.',
+          );
+        },
+      }),
+    );
+    expect(result.status).toBe('invalid');
+  });
+
+  test('resolveCandidates throws a non-credential resolution error (e.g. model_not_found) -> unknown', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        resolveCandidates: async () => {
+          throw new GatewayResolutionError(
+            'model_not_found',
+            '"foo" is not a recognized model.',
+            'Check the id.',
+          );
+        },
+      }),
+    );
+    expect(result.status).toBe('unknown');
+  });
+
+  test('resolveCandidates returns no candidates -> unknown', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({ resolveCandidates: async () => [] }),
+    );
+    expect(result.status).toBe('unknown');
+  });
+
+  test('upstream call succeeds (2xx) -> verified', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({ callUpstream: async () => new Response('{"choices":[]}', { status: 200 }) }),
+    );
+    expect(result.status).toBe('verified');
+  });
+
+  test('upstream call sends a single-attempt, low-token request (cheap ping)', async () => {
+    let seenBody: Record<string, unknown> | null = null;
+    let seenRetry: unknown = null;
+    await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        callUpstream: async (body, _descriptor, opts) => {
+          seenBody = body;
+          seenRetry = opts?.retry;
+          return new Response('{}', { status: 200 });
+        },
+      }),
+    );
+    expect(seenBody).toBeTruthy();
+    expect((seenBody as any).stream).toBe(false);
+    expect((seenRetry as any)?.maxAttempts).toBe(1);
+  });
+
+  test('upstream throws UpstreamHttpError 401 -> invalid, surfaces the provider error body as a hint', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        callUpstream: async () => {
+          throw new UpstreamHttpError(
+            401,
+            JSON.stringify({ error: { message: 'Incorrect API key provided' } }),
+            'openai',
+          );
+        },
+      }),
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.message).toContain('Incorrect API key provided');
+  });
+
+  test('upstream throws UpstreamHttpError 403 -> invalid', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'anthropic',
+      makeDeps({
+        callUpstream: async () => {
+          throw new UpstreamHttpError(403, '', 'anthropic');
+        },
+      }),
+    );
+    expect(result.status).toBe('invalid');
+  });
+
+  test('upstream throws UpstreamHttpError 429 -> unknown (rate limited, not proof the key is bad)', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        callUpstream: async () => {
+          throw new UpstreamHttpError(429, '', 'openai');
+        },
+      }),
+    );
+    expect(result.status).toBe('unknown');
+  });
+
+  test('upstream throws UpstreamHttpError 400 (bad request unrelated to auth) -> unknown, never invalid', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        callUpstream: async () => {
+          throw new UpstreamHttpError(
+            400,
+            JSON.stringify({ error: { message: 'model requires more tokens' } }),
+            'openai',
+          );
+        },
+      }),
+    );
+    expect(result.status).toBe('unknown');
+  });
+
+  test('upstream throws UpstreamHttpError 500 -> unknown', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        callUpstream: async () => {
+          throw new UpstreamHttpError(500, '', 'openai');
+        },
+      }),
+    );
+    expect(result.status).toBe('unknown');
+  });
+
+  test('upstream throws TimeoutError -> unknown, not invalid', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        callUpstream: async () => {
+          throw new TimeoutError('attempt 1 exceeded 8000ms');
+        },
+      }),
+    );
+    expect(result.status).toBe('unknown');
+  });
+
+  test('upstream throws NetworkError -> unknown, not invalid', async () => {
+    const result = await verifyProviderConnection(
+      principal(),
+      'openai',
+      makeDeps({
+        callUpstream: async () => {
+          throw new NetworkError('ai-sdk call to openai failed');
+        },
+      }),
+    );
+    expect(result.status).toBe('unknown');
+  });
+});

--- a/apps/api/src/llm-gateway/provider-verify.ts
+++ b/apps/api/src/llm-gateway/provider-verify.ts
@@ -1,0 +1,185 @@
+// GAP C1 — "Connected" in the provider UI today only means a secret row
+// exists in project_secrets; it never proves the key actually works against
+// the provider. This module makes ONE cheap, single-attempt, non-streaming
+// completion through the exact same resolution + upstream path a real turn
+// uses (resolveCandidates -> callUpstream), and classifies the outcome into a
+// small state the UI can render directly:
+//
+//   verified      — the provider accepted the key.
+//   invalid       — the provider rejected the key (401/403, or a reauth-
+//                    required resolution error like an expired Codex
+//                    session). Safe to show red.
+//   not_connected — no key is configured for this project/provider at all.
+//   unknown        — we couldn't get a clean answer either way (timeout,
+//                    network error, 429 rate limit, 5xx, or a resolution
+//                    failure unrelated to credentials like "model not
+//                    found"). NEVER reported as "invalid" — a transient or
+//                    unrelated failure must not read as "your key is dead".
+//
+// Deliberately non-blocking: nothing here writes to gateway_request_logs or
+// spend, and a project's "Connected" state never depends on this succeeding
+// — connecting a key always works exactly as it does today; verification is
+// a separate, additive signal layered on top.
+import {
+  GatewayResolutionError,
+  callUpstream as realCallUpstream,
+  type AuthedPrincipal,
+  type UpstreamDescriptor,
+} from '@kortix/llm-gateway';
+import { resolveCandidates as realResolveCandidates } from './resolution/resolve-candidates';
+import { runtimeModelCatalog } from './models/runtime-catalog';
+
+export type ProviderVerifyStatus = 'verified' | 'invalid' | 'unknown' | 'not_connected';
+
+export interface ProviderVerifyResult {
+  status: ProviderVerifyStatus;
+  message: string;
+}
+
+export interface ProviderVerifyDeps {
+  resolveCandidates: typeof realResolveCandidates;
+  callUpstream: typeof realCallUpstream;
+  pickVerificationModel: (providerId: string) => string | null;
+}
+
+// Heuristic for "the cheapest model this provider publishes" — the catalog
+// carries no live pricing per model (see runtime-catalog.ts's Catalog shape),
+// so this is a naming heuristic, not a cost lookup. Cost is bounded anyway:
+// the ping below sends a two-word prompt and caps output at 16 tokens, so
+// even a full-size flagship model costs fractions of a cent to verify.
+// Preferring an explicitly "small" model id when one exists just also avoids
+// tripping any model-specific quirks (long cold-start, stricter capacity
+// limits) a flagship reasoning model might have.
+const CHEAP_MODEL_HINTS = ['nano', 'mini', 'flash', 'haiku', 'lite', 'small'];
+
+function defaultPickVerificationModel(providerId: string): string | null {
+  const provider = runtimeModelCatalog.snapshot().providers.find((p) => p.id === providerId);
+  const models = provider?.models ?? [];
+  if (models.length === 0) return null;
+  const cheap = models.find((m) =>
+    CHEAP_MODEL_HINTS.some((hint) => m.id.toLowerCase().includes(hint)),
+  );
+  const chosen = cheap ?? models[0]!;
+  return `${providerId}/${chosen.id}`;
+}
+
+const DEFAULT_DEPS: ProviderVerifyDeps = {
+  resolveCandidates: realResolveCandidates,
+  callUpstream: realCallUpstream,
+  pickVerificationModel: defaultPickVerificationModel,
+};
+
+// Single attempt only — a verification ping must never burn the gateway's
+// normal 3x retry budget against a key that's about to fail the same way
+// every time. Short timeout so a hung/rate-limited provider fails the check
+// fast instead of leaving the UI's "Verifying…" state spinning.
+const VERIFY_RETRY = { maxAttempts: 1, timeoutMs: 8_000, deadlineMs: 9_000 } as const;
+
+function upstreamErrorHint(body: string | undefined): string | undefined {
+  if (!body) return undefined;
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string }; message?: string };
+    const msg = parsed?.error?.message ?? parsed?.message;
+    return typeof msg === 'string' && msg.trim() ? msg.trim() : undefined;
+  } catch {
+    const trimmed = body.trim();
+    return trimmed.length > 0 && trimmed.length < 300 ? trimmed : undefined;
+  }
+}
+
+/**
+ * Attempt to verify that the credential connected for `providerId` on this
+ * project actually works, via one cheap live completion. Never throws — any
+ * unexpected failure classifies as `unknown` rather than propagating, since
+ * this is a best-effort signal layered on top of "Connected", not a gate on
+ * it.
+ */
+export async function verifyProviderConnection(
+  principal: AuthedPrincipal,
+  providerId: string,
+  overrides: Partial<ProviderVerifyDeps> = {},
+): Promise<ProviderVerifyResult> {
+  const deps: ProviderVerifyDeps = { ...DEFAULT_DEPS, ...overrides };
+
+  const modelId = deps.pickVerificationModel(providerId);
+  if (!modelId) {
+    return {
+      status: 'unknown',
+      message: `No catalog model is known for "${providerId}" to verify against.`,
+    };
+  }
+
+  let candidates: UpstreamDescriptor[];
+  try {
+    candidates = await deps.resolveCandidates(principal, modelId);
+  } catch (err) {
+    if (err instanceof GatewayResolutionError) {
+      if (err.code === 'provider_not_connected') {
+        return { status: 'not_connected', message: err.message };
+      }
+      // A session that was connected but is now expired/revoked (Codex OAuth)
+      // reads the same as an invalid key to the user — either way, the thing
+      // they connected no longer works and needs re-connecting.
+      if (err.code === 'provider_reauth_required') {
+        return { status: 'invalid', message: err.message };
+      }
+      // model_not_found / model_disabled_on_deployment / plan_upgrade_required
+      // are catalog/entitlement issues with the model we PICKED to test with,
+      // not evidence the credential itself is bad.
+      return { status: 'unknown', message: err.message };
+    }
+    return {
+      status: 'unknown',
+      message: err instanceof Error ? err.message : "Couldn't resolve an upstream to verify.",
+    };
+  }
+
+  const descriptor = candidates[0];
+  if (!descriptor) {
+    return { status: 'unknown', message: 'No upstream candidate was resolved for this provider.' };
+  }
+
+  try {
+    await deps.callUpstream(
+      {
+        model: modelId,
+        messages: [{ role: 'user', content: 'ping' }],
+        stream: false,
+        max_tokens: 16,
+      },
+      descriptor,
+      { retry: VERIFY_RETRY },
+    );
+    return { status: 'verified', message: 'The provider accepted the key.' };
+  } catch (err) {
+    const status = (err as { status?: number } | undefined)?.status;
+    const body = (err as { body?: string } | undefined)?.body;
+    if (status === 401 || status === 403) {
+      return {
+        status: 'invalid',
+        message: upstreamErrorHint(body) ?? `The provider rejected the key (HTTP ${status}).`,
+      };
+    }
+    if (status === 429) {
+      return {
+        status: 'unknown',
+        message: "Rate limited while verifying — couldn't confirm the key.",
+      };
+    }
+    if (typeof status === 'number') {
+      return {
+        status: 'unknown',
+        message:
+          upstreamErrorHint(body) ?? `The provider returned HTTP ${status} — couldn't confirm.`,
+      };
+    }
+    const kind = (err as { kind?: string } | undefined)?.kind;
+    if (kind === 'timeout') {
+      return { status: 'unknown', message: "Verification timed out — couldn't confirm the key." };
+    }
+    return {
+      status: 'unknown',
+      message: err instanceof Error ? err.message : "Couldn't reach the provider to verify.",
+    };
+  }
+}

--- a/apps/api/src/projects/routes/gateway.ts
+++ b/apps/api/src/projects/routes/gateway.ts
@@ -18,6 +18,7 @@ import {
   recordGatewayUsage,
 } from '../../llm-gateway/hooks';
 import { publicGatewayBaseUrl } from '../../llm-gateway/public-url';
+import { verifyProviderConnection } from '../../llm-gateway/provider-verify';
 import { config } from '../../config';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
 import { accountIsFreeTierForModels } from '../../billing/services/tiers';
@@ -935,6 +936,61 @@ projectsApp.openapi(
     );
 
     return c.json({ results });
+  },
+);
+
+// GAP C1 — "Connected" (a secret row exists) is not the same claim as "the
+// key works". This makes ONE cheap, single-attempt completion through the
+// same resolveCandidates -> callUpstream path a real turn uses and reports
+// verified/invalid/unknown/not_connected — see provider-verify.ts for the
+// full classification rationale. Gated on PROJECT_SECRET_READ (same leaf as
+// GET /secrets): it never exposes the key itself, only whether it works, so
+// any member who can already see that the provider is connected can check
+// whether it's actually usable.
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/gateway/providers/{providerId}/verify',
+    tags: ['gateway'],
+    summary: 'POST /:projectId/gateway/providers/:providerId/verify',
+    ...auth,
+    request: { params: z.object({ projectId: z.string(), providerId: z.string() }) },
+    responses: { 200: json(z.any(), 'Provider credential verification result'), ...errors(403, 404) },
+  }),
+  async (c: any) => {
+    const projectId = c.req.param('projectId');
+    const providerId = c.req.param('providerId');
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_SECRET_READ,
+    );
+
+    const principal: AuthedPrincipal = {
+      userId: c.get('userId'),
+      accountId: loaded.row.accountId,
+      projectId,
+    };
+    // The ping is a real (if tiny) paid upstream call for a platform-fee-billed
+    // BYOK project — it must respect an already-exceeded project budget like
+    // any other gateway call (see playground's identical guard above). Caught
+    // rather than left to propagate: a budget block is exactly the "couldn't
+    // verify" case this endpoint already models, not a hard failure.
+    try {
+      await assertGatewayBudget(principal);
+    } catch (err) {
+      return c.json({
+        status: 'unknown',
+        message: err instanceof Error ? err.message : 'Project budget exceeded — try again later.',
+        checked_at: new Date().toISOString(),
+      });
+    }
+    const result = await verifyProviderConnection(principal, providerId);
+    return c.json({ ...result, checked_at: new Date().toISOString() });
   },
 );
 

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/connected-tab.tsx
@@ -5,18 +5,46 @@ import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import Hint from '@/components/ui/hint';
 import Loading from '@/components/ui/loading';
-import { errorToast, successToast } from '@/components/ui/toast';
+import { errorToast, successToast, warningToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import { LLM_PROVIDER_BY_ID, type LlmProviderEntry } from '@/lib/llm-providers';
-import { deleteProjectSecret } from '@kortix/sdk/projects-client';
+import { cn } from '@/lib/utils';
+import {
+  deleteProjectSecret,
+  type GatewayProviderVerifyResult,
+  verifyGatewayProvider,
+} from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plug, Plus, Unplug } from 'lucide-react';
+import { Plug, Plus, ShieldAlert, ShieldCheck, ShieldQuestion, Unplug } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 import { CODEX_AUTH_JSON_SECRET_NAME, LEGACY_OPENCODE_AUTH_JSON_SECRET_NAME } from './constants';
 import { providerCredentialSummary } from './utils';
+
+// GAP C1 — "Connected" only means a secret row exists in project_secrets; it
+// never proves the key actually works. This row action calls the gateway's
+// cheap one-request verify endpoint (POST .../gateway/providers/:id/verify)
+// on demand and renders the classification inline — never on mount, so
+// connecting stays exactly as fast/cheap as it is today and verification is
+// purely opt-in. Not offered for `codex` (a ChatGPT OAuth subscription, not
+// an API key — no catalog model exists to ping it against) or managed rows
+// (no BYOK credential to verify).
+function verifyAffordanceIcon(status: GatewayProviderVerifyResult['status'] | undefined) {
+  if (status === 'verified') return { Icon: ShieldCheck, className: 'text-kortix-green' };
+  if (status === 'invalid' || status === 'not_connected') {
+    return { Icon: ShieldAlert, className: 'text-kortix-red' };
+  }
+  if (status === 'unknown') return { Icon: ShieldQuestion, className: 'text-kortix-yellow' };
+  return { Icon: ShieldQuestion, className: 'text-muted-foreground/40' };
+}
+
+function verifyAffordanceLabel(result: GatewayProviderVerifyResult | undefined): string {
+  if (!result) return 'Verify this key works';
+  if (result.status === 'verified') return 'Verified — the provider accepted the key';
+  return result.message || 'Verify this key works';
+}
 
 export function ConnectedTab({
   projectId,
@@ -34,6 +62,25 @@ export function ConnectedTab({
   const tHardcodedUi = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
   const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [verifyResults, setVerifyResults] = useState<Record<string, GatewayProviderVerifyResult>>(
+    {},
+  );
+
+  const verify = useMutation({
+    mutationFn: (provider: LlmProviderEntry) => verifyGatewayProvider(projectId, provider.id),
+    onSuccess: (result, provider) => {
+      setVerifyResults((current) => ({ ...current, [provider.id]: result }));
+      if (result.status === 'verified') {
+        successToast(`${provider.label} key verified`);
+      } else if (result.status === 'invalid' || result.status === 'not_connected') {
+        errorToast(result.message || `${provider.label} key rejected`);
+      } else {
+        warningToast(result.message || `Couldn't verify ${provider.label}`);
+      }
+    },
+    onError: (err) =>
+      errorToast(err instanceof Error ? err.message : "Couldn't verify — try again"),
+  });
 
   const disconnect = useMutation({
     mutationFn: async (provider: LlmProviderEntry) => {
@@ -121,6 +168,12 @@ export function ConnectedTab({
       <ul className="space-y-2 px-5 pt-3 pb-4">
         {filtered.map((provider) => {
           const busy = disconnect.isPending && disconnect.variables?.id === provider.id;
+          const verifyBusy = verify.isPending && verify.variables?.id === provider.id;
+          const verifyResult = verifyResults[provider.id];
+          const verifyOffered = !provider.managed && provider.id !== 'codex';
+          const { Icon: VerifyIcon, className: verifyIconClassName } = verifyAffordanceIcon(
+            verifyResult?.status,
+          );
           return (
             <li
               key={provider.id}
@@ -144,6 +197,25 @@ export function ConnectedTab({
                     : `${providerCredentialSummary(provider)} · ${provider.models.length} model${provider.models.length === 1 ? '' : 's'}`}
                 </p>
               </div>
+              {verifyOffered && (
+                <Hint label={verifyAffordanceLabel(verifyResult)}>
+                  <Button
+                    type="button"
+                    onClick={() => verify.mutate(provider)}
+                    disabled={verify.isPending}
+                    variant="ghost"
+                    size="icon-sm"
+                    className={cn('hover:text-foreground shrink-0', verifyIconClassName)}
+                    aria-label="Verify key"
+                  >
+                    {verifyBusy ? (
+                      <Loading className="size-3.5 shrink-0" />
+                    ) : (
+                      <VerifyIcon className="size-3.5 shrink-0" />
+                    )}
+                  </Button>
+                </Hint>
+              )}
               {canWrite && !provider.managed && (
                 <Hint label="Disconnect">
                   <Button

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-form.tsx
@@ -9,7 +9,7 @@ import { errorToast, successToast } from '@/components/ui/toast';
 import { refreshProjectProviderState } from '@/hooks/opencode/provider-refresh';
 import { upsertProjectSecret } from '@kortix/sdk/projects-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Check, ChevronLeft, Copy, Plus, TriangleAlert } from 'lucide-react';
+import { Check, ChevronLeft, Copy, Info, Plus, TriangleAlert } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useTranslations } from 'next-intl';
 import { type FormEvent, useState } from 'react';
@@ -284,6 +284,18 @@ export function CustomProviderForm({
             {error}
           </InfoBanner>
         )}
+
+        {/* GAP C2 — a custom provider's traffic goes straight to `baseURL`
+            (see buildCustomProviderSnippet's `options.baseURL`), never through
+            the Kortix gateway — so it never appears in gateway logs, never
+            counts against gateway budgets, and never participates in routing
+            policy/fallback. Disclosed here since nothing else in this flow
+            says so. */}
+        <InfoBanner tone="warning" icon={Info}>
+          Requests to a custom provider go straight to its own endpoint — they don&apos;t pass
+          through the Kortix gateway, so they&apos;re not covered by gateway budgets, logs, or
+          routing.
+        </InfoBanner>
       </form>
     </div>
   );
@@ -334,6 +346,11 @@ function CustomProviderSnippetView({
             'componentsProjectsProjectProviderModal.line1141JsxTextNoApiKeyWasProvidedTheSnippetBelow',
           )
         )}
+      </InfoBanner>
+
+      <InfoBanner tone="warning" icon={Info}>
+        This provider talks directly to its own endpoint, bypassing the Kortix gateway — no budgets,
+        logs, or routing apply to it.
       </InfoBanner>
 
       <div className="bg-popover overflow-hidden rounded-md border">

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -958,3 +958,26 @@ installed, imported, and constructed `@kortix/sdk` successfully.
 
 **Shippable to production: YES** for the SDK surface. Repository PR, Deploy Dev,
 and live-dev verification remain part of the parent feature lifecycle.
+
+---
+
+### 2026-07-18 — session `gateway-provider-key-verify` (completion)
+
+Self-contained addition (not part of the Now chain — outside its own PR/plan):
+`verifyGatewayProvider(projectId, providerId)` client fn +
+`GatewayProviderVerifyResult`/`GatewayProviderVerifyStatus` types, backing a new
+`POST /projects/:id/gateway/providers/:providerId/verify` endpoint that runs one
+cheap live completion through a connected BYOK provider's credential and
+classifies it `verified`/`invalid`/`unknown`/`not_connected` (closes the LLM
+provider UI's "Connected ≠ proven working" gap). No exported name renamed or
+removed — additive only.
+
+**Final SDK gates:** `pnpm --filter @kortix/sdk typecheck` exited 0; the full SDK
+suite reported **1122 pass / 2 skip / 0 fail** across 84 files with 5009
+assertions; and `pnpm --filter @kortix/sdk run smoke:install` built, packed,
+installed, imported, and constructed `@kortix/sdk` successfully. Public-surface
+snapshots re-recorded — diff is additive only (`verifyGatewayProvider`,
+`GatewayProviderVerifyResult`, `GatewayProviderVerifyStatus`).
+
+**Shippable to production: YES** for the SDK surface. apps/api route + apps/web
+UI land in the same PR (#4990); see that PR for backend/frontend evidence.

--- a/packages/sdk/src/core/rest/projects-client/gateway.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/gateway.test.ts
@@ -10,6 +10,7 @@ import {
   revokeGatewayKey,
   runGatewayPlayground,
   setGatewayBudget,
+  verifyGatewayProvider,
 } from './gateway';
 
 let calls: { url: string; method: string; body: unknown }[] = [];
@@ -105,4 +106,28 @@ test('runGatewayPlayground posts prompt + models and returns per-model results',
   expect(last().method).toBe('POST');
   expect(last().body).toEqual({ prompt: 'Say hi', models: ['gpt-4o', 'claude-3'] });
   expect(result.results[0]?.model).toBe('gpt-4o');
+});
+
+test('verifyGatewayProvider posts to the provider verify endpoint and returns the classification', async () => {
+  nextResponse = {
+    status: 200,
+    body: {
+      status: 'verified',
+      message: 'The provider accepted the key.',
+      checked_at: '2026-07-18T00:00:00Z',
+    },
+  };
+  const result = await verifyGatewayProvider('P1', 'openai');
+  expect(last().url).toContain('/projects/P1/gateway/providers/openai/verify');
+  expect(last().method).toBe('POST');
+  expect(result.status).toBe('verified');
+});
+
+test('verifyGatewayProvider URL-encodes the provider id', async () => {
+  nextResponse = {
+    status: 200,
+    body: { status: 'unknown', message: 'x', checked_at: '2026-07-18T00:00:00Z' },
+  };
+  await verifyGatewayProvider('P1', 'weird/id');
+  expect(last().url).toContain('/projects/P1/gateway/providers/weird%2Fid/verify');
 });

--- a/packages/sdk/src/core/rest/projects-client/gateway.ts
+++ b/packages/sdk/src/core/rest/projects-client/gateway.ts
@@ -395,3 +395,34 @@ export async function runGatewayPlayground(
     'Gateway request failed',
   );
 }
+
+/**
+ * Whether a connected provider's credential actually works — "Connected"
+ * only means a secret row exists (see api-key-connect-form.tsx); this makes
+ * one cheap live check through the gateway and classifies the result.
+ * `not_connected` means no key is configured at all; `unknown` covers every
+ * inconclusive outcome (timeout, rate limit, unrelated resolution failure) —
+ * never collapsed into `invalid`, which is reserved for a confirmed
+ * provider-side credential rejection.
+ */
+export type GatewayProviderVerifyStatus = 'verified' | 'invalid' | 'unknown' | 'not_connected';
+
+export interface GatewayProviderVerifyResult {
+  status: GatewayProviderVerifyStatus;
+  message: string;
+  checked_at: string;
+}
+
+/** Verify a connected provider's credential with one cheap live completion. */
+export async function verifyGatewayProvider(
+  projectId: string,
+  providerId: string,
+): Promise<GatewayProviderVerifyResult> {
+  return unwrap(
+    await backendApi.post<GatewayProviderVerifyResult>(
+      `/projects/${projectId}/gateway/providers/${encodeURIComponent(providerId)}/verify`,
+      {},
+    ),
+    'Gateway provider verification failed',
+  );
+}

--- a/packages/sdk/src/public-surface.snapshot.json
+++ b/packages/sdk/src/public-surface.snapshot.json
@@ -527,7 +527,8 @@
     "upsertProjectGitCredential",
     "upsertProjectSecret",
     "validateProjectManifest",
-    "validateToken"
+    "validateToken",
+    "verifyGatewayProvider"
   ],
   "./react": [
     "BillingError",
@@ -1166,7 +1167,8 @@
     "upsertProjectGitCredential",
     "upsertProjectSecret",
     "validateProjectManifest",
-    "validateToken"
+    "validateToken",
+    "verifyGatewayProvider"
   ],
   "./feature-flags": [
     "featureFlags",

--- a/packages/sdk/src/public-type-surface.snapshot.json
+++ b/packages/sdk/src/public-type-surface.snapshot.json
@@ -460,6 +460,8 @@
     "GatewayPlaygroundResponse",
     "GatewayPlaygroundResult",
     "GatewayProjectRoutingPolicy",
+    "GatewayProviderVerifyResult",
+    "GatewayProviderVerifyStatus",
     "GatewayRoutePreview",
     "GatewayRoutePreviewInput",
     "GatewayRoutingPolicyDocument",
@@ -2331,7 +2333,8 @@
     "upsertProjectGitCredential",
     "upsertProjectSecret",
     "validateProjectManifest",
-    "validateToken"
+    "validateToken",
+    "verifyGatewayProvider"
   ],
   "./react": [
     "ActorType",
@@ -4339,6 +4342,8 @@
     "GatewayPlaygroundResponse",
     "GatewayPlaygroundResult",
     "GatewayProjectRoutingPolicy",
+    "GatewayProviderVerifyResult",
+    "GatewayProviderVerifyStatus",
     "GatewayRoutePreview",
     "GatewayRoutePreviewInput",
     "GatewayRoutingPolicyDocument",
@@ -4756,7 +4761,8 @@
     "upsertProjectGitCredential",
     "upsertProjectSecret",
     "validateProjectManifest",
-    "validateToken"
+    "validateToken",
+    "verifyGatewayProvider"
   ],
   "./feature-flags": [
     "FeatureFlags",

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 492,
+  "count": 493,
   "routes": [
     {
       "method": "GET",
@@ -1305,6 +1305,10 @@
     {
       "method": "POST",
       "path": "/v1/projects/:projectId/gateway/playground"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/gateway/providers/:providerId/verify"
     },
     {
       "method": "DELETE",

--- a/tests/src/flows/new-routes-coverage.flow.ts
+++ b/tests/src/flows/new-routes-coverage.flow.ts
@@ -92,6 +92,7 @@ flow(
       'POST /v1/projects/:projectId/gateway/keys',
       'DELETE /v1/projects/:projectId/gateway/keys/:keyId',
       'POST /v1/projects/:projectId/gateway/playground',
+      'POST /v1/projects/:projectId/gateway/providers/:providerId/verify',
     ],
   },
   async (ctx) => {
@@ -148,6 +149,17 @@ flow(
       const r = await owner.post('/v1/projects/:projectId/gateway/playground', {}, { params });
       r.status([400, 403]);
     });
+    await ctx.step(
+      'gateway provider verify reports not_connected for an unconnected provider, no upstream call',
+      async () => {
+        const r = await owner.post(
+          '/v1/projects/:projectId/gateway/providers/:providerId/verify',
+          {},
+          { params: { ...params, providerId: 'openai' } },
+        );
+        r.status([200, 403]);
+      },
+    );
   },
 );
 


### PR DESCRIPTION
## Summary

Closes the two provider-trust gaps in the LLM provider UI.

**GAP C1 (key/credential validation)** — "Connected" today only means a secret row exists in `project_secrets`; it never proves the key actually works.

- New endpoint `POST /v1/projects/:projectId/gateway/providers/:providerId/verify` — makes **one cheap, single-attempt, non-streaming completion** (max 16 tokens) through the exact same `resolveCandidates -> callUpstream` path a real turn uses, gated on `PROJECT_SECRET_READ` (never exposes the key itself).
- Classifies the outcome into `verified` / `invalid` / `unknown` / `not_connected`:
  - `verified` — provider accepted the key.
  - `invalid` — a confirmed 401/403 rejection, or an expired/revoked Codex session.
  - `unknown` — everything inconclusive (timeout, 429 rate limit, 5xx, unrelated resolution failure like "model not found") — **never** collapsed into `invalid`.
  - `not_connected` — no key configured at all.
- Respects an already-exceeded project budget (mirrors the playground endpoint's guard) since it's a real, if tiny, paid upstream call.
- Wired into `connected-tab.tsx` as an opt-in per-row "Verify key" icon action (Shield icon that turns green/red/yellow + tooltip with the provider's error hint). Not offered for managed (Kortix) or `codex` (ChatGPT OAuth subscription, no catalog model to ping) rows. Verification never runs automatically on connect/mount — connecting stays exactly as fast as it is today.

**GAP C2 (custom-provider disclosure)** — verified against the backend that a custom (BYOK openai-compatible) provider's `baseURL` is called directly by the sandbox's AI SDK provider (`buildCustomProviderSnippet`'s `options.baseURL`), never through the Kortix gateway — so it never appears in gateway logs, never counts against gateway budgets, and never participates in routing/fallback policy.

- Added a one-line `InfoBanner` disclosure to `custom-provider-form.tsx`'s connect form and to the post-save snippet/"connected" view.

## Implementation

- `apps/api/src/llm-gateway/provider-verify.ts` — the classification logic, dependency-injected (`resolveCandidates` / `callUpstream` / `pickVerificationModel`) for pure unit testing, no DB. Picks a "cheap" model per provider via a naming heuristic (`nano`/`mini`/`flash`/`haiku`/`lite`/`small`) falling back to the catalog's first model.
- `apps/api/src/projects/routes/gateway.ts` — route wiring, `PROJECT_SECRET_READ` capability check, budget guard.
- `packages/sdk` — `verifyGatewayProvider` client fn + `GatewayProviderVerifyResult`/`GatewayProviderVerifyStatus` types (additive-only; public-surface snapshots re-recorded, diff is pure additions).
- `apps/web` — `connected-tab.tsx` (verify affordance), `custom-provider-form.tsx` (disclosure banners).
- `tests/` — new route registered in `routes.generated.json`, covered by `COV-4` in `new-routes-coverage.flow.ts` (asserts `not_connected` for an unconnected provider, no live upstream cost); `ke2e coverage` gate passes.

## Test plan

- [x] `apps/api`: new `provider-verify.test.ts` — 14 unit tests (resolution errors, 401/403 → invalid, 429/5xx/timeout/network → unknown, no catalog model → unknown, cheap single-attempt request shape). `pnpm typecheck` clean.
- [x] `packages/sdk`: `gateway.test.ts` — 2 new tests (POST shape, provider-id URL-encoding). Full suite: `pnpm typecheck` clean, `pnpm test` 1122 pass / 0 fail, `pnpm run smoke:install` passed. Public-surface snapshots re-recorded (additive only — verified diff).
- [x] `apps/web`: `tsc --noEmit` clean, `next build` succeeds (full static/dynamic route manifest generated, no errors).
- [x] `tests/`: `bun run coverage` → gate passed; `bun run typecheck` clean.
- [x] Biome format-checked all touched/new files (single-quote convention; pre-existing unrelated drift in touched files left untouched).

Pre-existing, unrelated-to-this-change items observed during verification (documented for the record, not touched here): `resolve-candidates.test.ts` has a pre-existing cross-file `mock.module` pollution issue when run alongside the rest of `src/llm-gateway/` (reproduces identically on `main`); `routes.generated.json`'s committed route count already drifts from a from-scratch regen in this environment (pre-existing, unrelated to this PR — only my one new route was hand-added to the manifest rather than doing a full regen, to avoid unrelated churn).