### PR TITLE
feat(gateway): routing availability preview + vision-model override editor

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-routing.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-routing.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
+  collectPreviewTargets,
   editablePolicySignature,
   fallbackModeForPolicy,
   moveFallback,
@@ -80,11 +81,65 @@ describe('gateway routing editor helpers', () => {
     ).toContain('at least one');
   });
 
-  test('uses the shared model selector and removes vision and route-preview configuration', () => {
+  test('uses the shared model selector', () => {
     expect(routingSource).toContain("from '@/features/session/model-selector'");
     expect(routingSource).toContain('<ModelSelector');
-    expect(routingSource).not.toContain('Vision model');
-    expect(routingSource).not.toContain('Route preview');
+  });
+
+  test('renders an editable vision model override saved through the same routing policy', () => {
+    expect(routingSource).toContain('Vision model');
+    expect(routingSource).toContain('draft.visionModel');
+    expect(routingSource).toContain('unsetLabel="Inherit platform"');
+    expect(routingSource).toContain(
+      'onChange={(visionModel) => setDraft({ ...draft, visionModel })}',
+    );
+    // Included in the dirty-check so an edit here enables Save, and shipped
+    // in the same `routing.set.mutate({ ...draft, ... })` payload as the
+    // fallback chain and rules.
+    expect(routingSource).toContain('visionModel: policy.visionModel');
+  });
+
+  test('debounces a routing-policy/preview availability check and surfaces per-entry feedback', () => {
+    expect(routingSource).toContain('routing.preview.mutateAsync');
+    expect(routingSource).toContain('setTimeout');
+    expect(routingSource).toContain('AvailabilityBadge');
+    expect(routingSource).toContain('Not connected');
+  });
+
+  test('collects a deduped preview target list across the primary, vision override, default chain, and rule chains', () => {
+    expect(
+      collectPreviewTargets(
+        {
+          visionModel: 'anthropic/claude-sonnet-4.6',
+          defaultFallback: { models: ['glm-5.2', 'auto'], fallbackOn: 'transient' },
+          rules: [
+            { model: 'codex/gpt-5.6-sol', fallbackModels: ['glm-5.2'], fallbackOn: 'transient' },
+          ],
+        },
+        'anthropic/claude-opus-4.8',
+      ),
+    ).toEqual([
+      'anthropic/claude-opus-4.8',
+      'anthropic/claude-sonnet-4.6',
+      'glm-5.2',
+      'codex/gpt-5.6-sol',
+    ]);
+  });
+
+  test('preview targets skip null/auto entries and dedupe repeats', () => {
+    expect(
+      collectPreviewTargets({ visionModel: null, defaultFallback: null, rules: [] }, null),
+    ).toEqual([]);
+    expect(
+      collectPreviewTargets(
+        {
+          visionModel: 'glm-5.2',
+          defaultFallback: { models: ['glm-5.2'], fallbackOn: 'transient' },
+          rules: [],
+        },
+        'glm-5.2',
+      ),
+    ).toEqual(['glm-5.2']);
   });
 
   test('the header selector reads and writes the project default scope', () => {
@@ -109,9 +164,9 @@ describe('gateway routing editor helpers', () => {
       defaultFallback: { models: ['glm-5.2'], fallbackOn: 'transient' as const },
       rules: [],
     };
-    expect(
-      editablePolicySignature({ ...policy, defaultModel: 'anthropic/claude-opus-4.8' }),
-    ).toBe(editablePolicySignature(policy));
+    expect(editablePolicySignature({ ...policy, defaultModel: 'anthropic/claude-opus-4.8' })).toBe(
+      editablePolicySignature(policy),
+    );
     expect(
       editablePolicySignature({
         ...policy,

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-routing.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-routing.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { ArrowDown, ArrowUp, Plus, RotateCcw, SlidersHorizontal, Trash2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  Plus,
+  RotateCcw,
+  SlidersHorizontal,
+  Trash2,
+} from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
@@ -95,6 +103,31 @@ export function validateRoutingDraft(
   return null;
 }
 
+/**
+ * The deduped, order-stable set of model wire ids the routing draft
+ * references: the resolved primary, the vision override, the default
+ * fallback chain, and every per-model rule's primary + fallback chain.
+ * Feeds the debounced routing-policy/preview availability check so a user
+ * can't unknowingly save a chain that routes to a disconnected provider.
+ */
+export function collectPreviewTargets(
+  policy: Pick<GatewayProjectRoutingPolicy, 'visionModel' | 'defaultFallback' | 'rules'>,
+  primaryModel: string | null,
+): string[] {
+  const targets = new Set<string>();
+  const track = (model: string | null | undefined) => {
+    if (model && model !== 'auto') targets.add(model);
+  };
+  track(primaryModel);
+  track(policy.visionModel);
+  if (policy.defaultFallback) policy.defaultFallback.models.forEach(track);
+  for (const rule of policy.rules) {
+    track(rule.model);
+    rule.fallbackModels.forEach(track);
+  }
+  return [...targets];
+}
+
 function clonePolicy(policy: GatewayProjectRoutingPolicy): GatewayProjectRoutingPolicy {
   return {
     ...policy,
@@ -107,9 +140,8 @@ function clonePolicy(policy: GatewayProjectRoutingPolicy): GatewayProjectRouting
 
 export function editablePolicySignature(policy: GatewayProjectRoutingPolicy): string {
   // The shared header owns defaultModel. A successful header change refetches
-  // this document, but must not replace unsaved fallback edits in this screen.
-  // Vision stays in the signature because it remains a backwards-compatible
-  // field that another client could still update even though this UI hides it.
+  // this document, but must not replace unsaved fallback (or vision) edits
+  // made on this screen.
   return JSON.stringify({
     visionModel: policy.visionModel,
     defaultFallback: policy.defaultFallback,
@@ -155,6 +187,19 @@ function RoutingModelSelector({
   );
 }
 
+/** Warns inline when the routing-policy preview reports a model's provider isn't connected. */
+function AvailabilityBadge({ available }: { available: boolean | undefined }) {
+  if (available !== false) return null;
+  return (
+    <Hint label="This model's provider isn't connected for this project — requests routed here fail over immediately">
+      <Badge variant="warning" size="xs" className="shrink-0 gap-1">
+        <AlertTriangle className="size-3" />
+        Not connected
+      </Badge>
+    </Hint>
+  );
+}
+
 function ConditionSelect({
   value,
   onChange,
@@ -191,12 +236,14 @@ function ChainEditor({
   models,
   onChange,
   disabled,
+  availability,
 }: {
   primary: string | null;
   chain: GatewayFallbackChain;
   models: RoutingModel[];
   onChange: (chain: GatewayFallbackChain) => void;
   disabled?: boolean;
+  availability?: Record<string, boolean>;
 }) {
   const unavailable = [primary ?? '', ...chain.models];
   const canAdd = models.some((model) => !unavailable.includes(modelKeyToWire(model)));
@@ -244,6 +291,7 @@ function ChainEditor({
                   disabled={disabled}
                 />
               </div>
+              <AvailabilityBadge available={availability?.[model]} />
               <Hint label="Move up">
                 <Button
                   type="button"
@@ -332,7 +380,9 @@ export function GatewayRouting({
   const [fallbackMode, setFallbackMode] = useState<FallbackMode>('inherit');
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
+  const [availability, setAvailability] = useState<Record<string, boolean>>({});
   const hydratedPolicySignature = useRef<string | null>(null);
+  const previewRequestId = useRef(0);
 
   useEffect(() => {
     if (!routing.data?.project) return;
@@ -345,6 +395,50 @@ export function GatewayRouting({
     setDraft(clonePolicy(routing.data.project));
     setFallbackMode(fallbackModeForPolicy(routing.data.project.defaultFallback));
   }, [routing.data]);
+
+  // Debounced availability preview: whenever the draft's referenced models
+  // change, ask the gateway which of them currently have a connected
+  // provider so the chain editor can flag a dead fallback before save.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: routing.preview's mutateAsync is a stable handle from useGatewayRoutingPolicy and shouldn't retrigger this debounce.
+  useEffect(() => {
+    if (!draft || !routing.data) {
+      setAvailability({});
+      return;
+    }
+    const projectDefaultWire = modelDefaults.projectDefault
+      ? modelKeyToWire(modelDefaults.projectDefault)
+      : null;
+    const primary = projectDefaultWire ?? routing.data.effective.defaultModel;
+    const targets = collectPreviewTargets(draft, primary);
+    if (targets.length === 0) {
+      setAvailability({});
+      return;
+    }
+    const requestId = ++previewRequestId.current;
+    const timer = setTimeout(() => {
+      Promise.all(
+        targets.map(async (model) => {
+          try {
+            const result = await routing.preview.mutateAsync({
+              requestedModel: model,
+              imageInput: false,
+            });
+            const match = result.models.find((entry) => entry.model === model);
+            // Fail open: an unresolved lookup shouldn't paint an unrelated model as broken.
+            return [model, match?.available ?? true] as const;
+          } catch {
+            // A preview request failure (network, auth) isn't evidence the
+            // provider is disconnected — don't surface a false warning.
+            return [model, true] as const;
+          }
+        }),
+      ).then((entries) => {
+        if (previewRequestId.current !== requestId) return; // superseded by a newer edit
+        setAvailability(Object.fromEntries(entries));
+      });
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [draft, routing.data, modelDefaults.projectDefault]);
 
   const models = useMemo(() => {
     const byWire = new Map<string, RoutingModel>();
@@ -409,6 +503,7 @@ export function GatewayRouting({
     projectDefaultPending ||
     modelDefaults.isLoading;
   const editableState = (policy: GatewayProjectRoutingPolicy) => ({
+    visionModel: policy.visionModel,
     defaultFallback: policy.defaultFallback,
     rules: policy.rules,
   });
@@ -516,6 +611,7 @@ export function GatewayRouting({
                 chain={draft.defaultFallback}
                 models={models}
                 disabled={controlsDisabled}
+                availability={availability}
                 onChange={(defaultFallback) => setDraft({ ...draft, defaultFallback })}
               />
             ) : fallbackMode === 'inherit' ? (
@@ -535,6 +631,42 @@ export function GatewayRouting({
                 </p>
               </div>
             )}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <Label>Vision model</Label>
+          <div className="bg-popover overflow-hidden rounded-md border">
+            <div className="flex flex-col gap-3 px-4 py-5 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-medium">Image-input override</p>
+                <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
+                  Requests that include an image are routed here instead of the default chain.
+                </p>
+              </div>
+              <div className="flex w-full items-center gap-2 sm:w-56">
+                <div className="min-w-0 flex-1">
+                  <RoutingModelSelector
+                    value={draft.visionModel}
+                    models={models}
+                    disabled={controlsDisabled}
+                    unsetLabel="Inherit platform"
+                    onChange={(visionModel) => setDraft({ ...draft, visionModel })}
+                  />
+                </div>
+                <AvailabilityBadge
+                  available={draft.visionModel ? availability[draft.visionModel] : undefined}
+                />
+              </div>
+            </div>
+            {!draft.visionModel ? (
+              <div className="border-t px-4 py-4">
+                <p className="text-muted-foreground text-xs">Current inherited vision model</p>
+                <p className="mt-1 truncate font-mono text-xs">
+                  {routing.data.effective.visionModel}
+                </p>
+              </div>
+            ) : null}
           </div>
         </section>
 
@@ -583,6 +715,7 @@ export function GatewayRouting({
                           onChange={(model) => model && setRule(index, { ...rule, model })}
                         />
                       </div>
+                      <AvailabilityBadge available={availability[rule.model]} />
                       {writable ? (
                         <Hint label="Remove override">
                           <Button
@@ -608,6 +741,7 @@ export function GatewayRouting({
                       chain={{ models: rule.fallbackModels, fallbackOn: rule.fallbackOn }}
                       models={models}
                       disabled={controlsDisabled}
+                      availability={availability}
                       onChange={(chain) =>
                         setRule(index, {
                           ...rule,
@@ -623,9 +757,7 @@ export function GatewayRouting({
                     type="button"
                     size="sm"
                     variant="outline"
-                    disabled={
-                      controlsDisabled || !newRuleModel || draft.rules.length >= MAX_RULES
-                    }
+                    disabled={controlsDisabled || !newRuleModel || draft.rules.length >= MAX_RULES}
                     onClick={() =>
                       newRuleModel &&
                       setDraft({


### PR DESCRIPTION
Closes two LLM Gateway routing-UI feature-parity gaps (found by the parity audit):

- **Availability preview**: the routing UI now calls POST /gateway/routing-policy/preview (debounced) as the default model + fallback chain + rules are edited, and shows a 'Not connected' badge on any model whose provider isn't connected — so a dead fallback can't be configured silently. Fails open (a preview outage never false-flags).
- **Vision-model override editor**: the visionModel routing override was fetched and change-tracked but never rendered/editable — added a 'Vision model' section (routes image-input requests) consistent with the default-fallback editor, saved through the same routing-policy PUT.

Tests: gateway-routing.test.ts extended (14 pass) incl. new collectPreviewTargets unit tests; tsc clean; biome clean. Frontend build confirmed by CI.