### PR TITLE
ci(self-host): bump fast e2e per-test timeout to 30s (fix release-blocker flake)

### DIFF
--- a/.github/workflows/self-host-e2e.yml
+++ b/.github/workflows/self-host-e2e.yml
@@ -77,7 +77,14 @@ jobs:
         env:
           npm_config_engine_strict: "false"
       - name: Fast self-host CLI tests (no Docker)
-        run: bun test tests/self-host-e2e/fast/
+        # --timeout 30000: every test in this suite spawns the real CLI binary
+        # (cold bun + TypeScript startup) at least once, often twice (init +
+        # env set). On a loaded ubuntu-latest runner that legitimately exceeds
+        # bun's 5s default — seen as a flaky 5001ms timeout on
+        # "re-enabling the landing page is a plain env set" that blocked the
+        # v0.10.11 release PR. 30s is generous (the whole 40-test suite runs
+        # in ~22s) and won't mask a real hang.
+        run: bun test --timeout 30000 tests/self-host-e2e/fast/
 
   # Tier 2 — unchanged heavyweight full-stack e2e. Nightly + manual only.
   full-e2e:


### PR DESCRIPTION
## What

One-line fix: `bun test --timeout 30000` for the fast self-host e2e tier (`.github/workflows/self-host-e2e.yml`).

## Why (grounded)

The fast self-host e2e suite spawns the **real CLI binary** (cold bun + TypeScript startup) per test — often twice (`init` + `env set`). On a loaded `ubuntu-latest` runner that legitimately exceeds bun's 5s default, surfacing as a flaky `5001ms` timeout.

**This exact flake blocked the v0.10.11 release PR (#4950) on 2026-07-18:**
- Failing test: `re-enabling the landing page is a plain env set, no dedicated flag` (`tests/self-host-e2e/fast/feature-flags.test.ts:42`) — timed out after 5001ms.
- **39/40 tests passed**; the one failure was a timeout, not an assertion.
- The same workflow had gone **green on the same release branch 8h earlier** (run 29626146686, 2026-07-18T01:56) and passes on `main`.
- The test body is trivial: `init` + `env set` + read .env. No real regression — just two CLI spawns under the 5s wire.

## The fix

```diff
-        run: bun test tests/self-host-e2e/fast/
+        run: bun test --timeout 30000 tests/self-host-e2e/fast/
```

30s is generous (the whole 40-test suite runs in ~22s total) and won't mask a real hang — the workflow's existing `timeout-minutes: 10` still caps the job. Full-e2e and live tiers unchanged (they shell out to bash scripts with their own timeouts, not `bun:test`).

## Impact

Unblocks the self-host check on release PRs (currently blocking v0.10.11). Does NOT touch test logic — only the timeout budget.

## Verification

- Confirmed `bun test --timeout` is supported (`bun test --help` → `--timeout=<val>  Set the per-test timeout in milliseconds, default is 5000`; bun 1.3.14).
- Pulled the failing run logs (`gh run view 29638894645 --log-failed`): the only failure is the 5001ms timeout on the landing-page test, 39 pass.
- Cross-checked run history: same workflow green on the same branch 8h before the failure → confirmed flake, not regression.
- Could not run the suite locally (sandbox node is 22.11, repo requires 22.13+); CI is the proof.

## Note on the OTHER v0.10.11 blockers

The release PR (#4950) also fails `full suite + quality gates` (staging-api 502s — infra, not code) and `CodeQL`. This PR only addresses the self-host flake. The staging 502s need infra triage; flagging in the PR for the release owner.

Mirko AGI cycle 5.