### PR TITLE
fix(api): block sandbox agent tokens from account-scoped usage + gateway forensics reads

### DIFF
--- a/apps/api/src/middleware/reject-sandbox-tokens.test.ts
+++ b/apps/api/src/middleware/reject-sandbox-tokens.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import { rejectSandboxTokens } from './reject-sandbox-tokens';
+
+// Minimal Hono context stub: only `c.get` is read by rejectSandboxTokens.
+// `next` is a spy so we can assert it was/wasn't called.
+function ctx(overrides: Record<string, unknown> = {}) {
+  const store: Record<string, unknown> = { authType: undefined, sandboxId: undefined, ...overrides };
+  let nextCalled = false;
+  return {
+    c: {
+      get: (key: string) => store[key],
+    } as never,
+    next: async () => {
+      nextCalled = true;
+    },
+    nextCalled: () => nextCalled,
+  };
+}
+
+describe('rejectSandboxTokens', () => {
+  test('rejects a sandbox agent token (authType=apiKey + sandboxId) with 403', async () => {
+    const { c, next, nextCalled } = ctx({ authType: 'apiKey', sandboxId: 'sb_123' });
+    let caught: unknown;
+    try {
+      await rejectSandboxTokens(c, next);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as { message: string }).message).toMatch(/Sandbox tokens/);
+    expect((caught as { status?: number }).status).toBe(403);
+    expect(nextCalled()).toBe(false);
+  });
+
+  test('allows a PAT (authType=pat)', async () => {
+    const { c, next, nextCalled } = ctx({ authType: 'pat', userId: 'u_1' });
+    await rejectSandboxTokens(c, next);
+    expect(nextCalled()).toBe(true);
+  });
+
+  test('allows a service account (authType=service_account)', async () => {
+    const { c, next, nextCalled } = ctx({ authType: 'service_account', accountId: 'acc_1' });
+    await rejectSandboxTokens(c, next);
+    expect(nextCalled()).toBe(true);
+  });
+
+  test('allows a Supabase session (authType=supabase)', async () => {
+    const { c, next, nextCalled } = ctx({ authType: 'supabase', userId: 'u_2' });
+    await rejectSandboxTokens(c, next);
+    expect(nextCalled()).toBe(true);
+  });
+
+  test('allows a non-sandbox kortix_ API key (apiKey without sandboxId)', async () => {
+    // Operator account API key — no sandboxId, so not an agent token.
+    const { c, next, nextCalled } = ctx({ authType: 'apiKey', accountId: 'acc_1' });
+    await rejectSandboxTokens(c, next);
+    expect(nextCalled()).toBe(true);
+  });
+
+  test('allows when authType is unset (defensive — combinedAuth would 401 first)', async () => {
+    const { c, next, nextCalled } = ctx({});
+    await rejectSandboxTokens(c, next);
+    expect(nextCalled()).toBe(true);
+  });
+});

--- a/apps/api/src/middleware/reject-sandbox-tokens.ts
+++ b/apps/api/src/middleware/reject-sandbox-tokens.ts
@@ -1,0 +1,32 @@
+import { Context, Next } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+/**
+ * Rejects sandbox-agent tokens (the `kortix_` API keys an agent runs with
+ * inside ONE project/session sandbox) from account-scoped read routes they
+ * have no legitimate reason to hit.
+ *
+ * Why this exists: `combinedAuth` accepts sandbox `kortix_` tokens and sets
+ * `authType: 'apiKey'` + `accountId` + `sandboxId`. Routes that scope only by
+ * `accountId` (e.g. `/v1/usage`, `/v1/generation`) would otherwise let a
+ * sandbox agent read the ENTIRE account's usage/cost rollup and per-call
+ * gateway forensics across every project/session on that account — a
+ * cross-project info leak on multi-user accounts. Found by Strix (MEDIUM)
+ * on the v0.10.11 release PR.
+ *
+ * What passes through unchanged: PATs (`authType: 'pat'`), service accounts
+ * (`'service_account'`), and Supabase sessions (`'supabase'`). A non-sandbox
+ * `kortix_` API key (no `sandboxId`) is also allowed — those are operator
+ * account keys, not agent tokens. Only `authType === 'apiKey'` WITH a
+ * `sandboxId` is blocked.
+ *
+ * MUST run AFTER `combinedAuth` (it reads context `combinedAuth` populates).
+ */
+export async function rejectSandboxTokens(c: Context, next: Next) {
+  if (c.get('authType') === 'apiKey' && c.get('sandboxId')) {
+    throw new HTTPException(403, {
+      message: 'Sandbox tokens cannot access account-scoped read endpoints',
+    });
+  }
+  await next();
+}

--- a/apps/api/src/router/routes/generation.ts
+++ b/apps/api/src/router/routes/generation.ts
@@ -3,6 +3,7 @@ import { gatewayRequestLogs } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { combinedAuth } from '../../middleware/auth';
+import { rejectSandboxTokens } from '../../middleware/reject-sandbox-tokens';
 import { auth, errors, json, makeOpenApiApp } from '../../openapi';
 import { db } from '../../shared/db';
 import { resolveScopedAccountId } from '../../shared/resolve-account';
@@ -12,6 +13,10 @@ import { mapGatewayLogToGeneration } from './generation-mapper';
 const generationApp = makeOpenApiApp<AppEnv>();
 
 generationApp.use('*', combinedAuth);
+// Sandbox agent tokens (kortix_ keys with a sandboxId) must not read gateway
+// call forensics across the whole account — prompts/cost/latency for any
+// requestId. See reject-sandbox-tokens.ts.
+generationApp.use('*', rejectSandboxTokens);
 
 const GenerationDataSchema = z
   .object({

--- a/apps/api/src/router/routes/usage.ts
+++ b/apps/api/src/router/routes/usage.ts
@@ -3,6 +3,7 @@ import { usageEvents } from '@kortix/db';
 import { type SQL, and, desc, eq, gte, lte, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { combinedAuth } from '../../middleware/auth';
+import { rejectSandboxTokens } from '../../middleware/reject-sandbox-tokens';
 import { auth, errors, json, makeOpenApiApp } from '../../openapi';
 import { db } from '../../shared/db';
 import { resolveScopedAccountId } from '../../shared/resolve-account';
@@ -18,6 +19,10 @@ import {
 const usageApp = makeOpenApiApp<AppEnv>();
 
 usageApp.use('*', combinedAuth);
+// Sandbox agent tokens (kortix_ keys with a sandboxId) have no legitimate
+// reason to read account-wide usage/cost rollups — without this they'd see
+// every project's spend on multi-user accounts. See reject-sandbox-tokens.ts.
+usageApp.use('*', rejectSandboxTokens);
 
 const UsageTotalsSchema = z
   .object({


### PR DESCRIPTION
## What

New `rejectSandboxTokens` middleware, wired into `/v1/usage` and `/v1/generation`, that blocks sandbox agent tokens from account-scoped read endpoints.

## Why — verified Strix MEDIUM from PR #4950

Strix flagged: **"Sandbox service tokens can read account-wide usage and gateway forensics"** at `apps/api/src/router/routes/usage.ts:20`. I verified it real against both `main` and the `release/v0.10.11` branch:

- `usageApp.use('*', combinedAuth)` and `generationApp.use('*', combinedAuth)` both accept sandbox `kortix_` agent tokens (`apps/api/src/middleware/auth.ts` branch 2 → sets `authType: 'apiKey'`, `accountId`, `sandboxId`).
- The handlers scope ONLY by `accountId`:
  - `usage.ts`: `const accountId = c.get('accountId') ?? ...` → `eq(usageEvents.accountId, accountId)` — whole-account usage/cost rollup.
  - `generation.ts`: same → `eq(gatewayRequestLogs.accountId, accountId)` — per-call forensics (prompt/completion tokens, cost, latency, attempts, status) for ANY `requestId` on the account.
- So a sandbox agent running inside ONE project/session can read every project's spend + every gateway call's forensics across the whole account. Cross-project info leak on multi-user (enterprise) accounts.

**Doesn't weaken OpenRouter parity.** OpenRouter's usage/generation endpoints are keyed on account API keys, not sandbox-internal agent tokens. Rejecting sandbox tokens *enforces* parity rather than weakening it.

## The fix

```ts
// apps/api/src/middleware/reject-sandbox-tokens.ts
export async function rejectSandboxTokens(c, next) {
  if (c.get('authType') === 'apiKey' && c.get('sandboxId')) {
    throw new HTTPException(403, { message: 'Sandbox tokens cannot access account-scoped read endpoints' });
  }
  await next();
}
```

- `authType === 'apiKey' && sandboxId` is exactly the sandbox-agent token shape.
- **Passes through unchanged:** PATs (`'pat'`), service accounts (`'service_account'`), Supabase sessions (`'supabase'`), and operator `kortix_` API keys (no `sandboxId`).
- Wired after `combinedAuth` in both `usage.ts` and `generation.ts`.

## Tests

Unit tests in `reject-sandbox-tokens.test.ts` cover the reject path (403, `next` not called) + each allow path (PAT, service account, Supabase session, operator API key, unset authType).

## Scope / gate

- Ships to `main` (autonomous — main is not prod). If the release owner wants this in v0.10.11, cherry-pick is trivial.
- Posted the verified finding + this fix pointer as a comment on #4950 (https://github.com/kortix-ai/suna/pull/4950#issuecomment-5012333943); this PR is the "ship to main" path I offered there.

Mirko AGI cycle 8.