### PR TITLE
feat(session): reasoning-effort selector in the chat composer

### DIFF
--- a/apps/web/src/features/session/composer-chat-input.tsx
+++ b/apps/web/src/features/session/composer-chat-input.tsx
@@ -118,6 +118,7 @@ export function ComposerChatInput({
       toolbarSlot={toolbarSlot}
       cardClassName={cardClassName}
       sessionId={sessionId}
+      projectId={projectId}
       providers={providers}
       agents={local.agent.list}
       selectedAgent={lockedAgentName ?? local.agent.current?.name ?? null}

--- a/apps/web/src/features/session/reasoning-effort-selector.test.ts
+++ b/apps/web/src/features/session/reasoning-effort-selector.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+
+import { applyReasoningEffort, reasoningEffortValuesFor } from './reasoning-effort-selector';
+
+describe('reasoningEffortValuesFor — composer show/hide source of truth', () => {
+  test('no model selected → hidden', () => {
+    expect(reasoningEffortValuesFor(undefined)).toEqual([]);
+  });
+
+  test('unknown wire model → hidden', () => {
+    expect(reasoningEffortValuesFor('nonexistent-provider/nonexistent-model')).toEqual([]);
+  });
+
+  test('a reasoning model with explicit reasoning_options exposes its OWN values (never hardcoded)', () => {
+    // Real catalog entry — same fixture `catalogModelForGateway` (#4995) is
+    // tested against. gpt-5.6-sol's effort ladder includes xhigh/max, which a
+    // generic low/medium/high fallback would never surface.
+    const values = reasoningEffortValuesFor('openai/gpt-5.6-sol');
+    expect(values.length).toBeGreaterThan(0);
+    expect(values).toContain('xhigh');
+  });
+
+  test('the synthetic auto pseudo-model is never treated as reasoning-capable → hidden', () => {
+    expect(reasoningEffortValuesFor('auto')).toEqual([]);
+  });
+
+  test('a managed model resolves through its pricingRef to real reasoning_options', () => {
+    const values = reasoningEffortValuesFor('claude-opus-4.8');
+    expect(values).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+  });
+});
+
+describe('applyReasoningEffort — the exact PUT-body merge the composer sends', () => {
+  test('setting a value on an empty config creates just that model entry', () => {
+    const next = applyReasoningEffort(undefined, 'openai/gpt-5.6-sol', 'high');
+    expect(next).toEqual({ 'openai/gpt-5.6-sol': { reasoningEffort: 'high' } });
+  });
+
+  test('clearing (null) on an empty config is a no-op — no entry created', () => {
+    const next = applyReasoningEffort(undefined, 'openai/gpt-5.6-sol', null);
+    expect(next).toEqual({});
+  });
+
+  test('clearing the ONLY configured field drops the model key entirely', () => {
+    const next = applyReasoningEffort(
+      { 'openai/gpt-5.6-sol': { reasoningEffort: 'high' } },
+      'openai/gpt-5.6-sol',
+      null,
+    );
+    expect(next).toEqual({});
+  });
+
+  test('clearing reasoningEffort PRESERVES other generation-config fields already set for the model', () => {
+    const next = applyReasoningEffort(
+      { 'openai/gpt-5.6-sol': { reasoningEffort: 'high', maxOutputTokens: 4096 } },
+      'openai/gpt-5.6-sol',
+      null,
+    );
+    expect(next).toEqual({ 'openai/gpt-5.6-sol': { maxOutputTokens: 4096 } });
+  });
+
+  test('changing the value overwrites only reasoningEffort, keeps sibling fields', () => {
+    const next = applyReasoningEffort(
+      { 'openai/gpt-5.6-sol': { reasoningEffort: 'low', temperature: 0.4 } },
+      'openai/gpt-5.6-sol',
+      'xhigh',
+    );
+    expect(next).toEqual({ 'openai/gpt-5.6-sol': { reasoningEffort: 'xhigh', temperature: 0.4 } });
+  });
+
+  test('other models in the project config are left completely untouched', () => {
+    const next = applyReasoningEffort(
+      {
+        'anthropic/claude-sonnet-4.6': { reasoningEffort: 'medium' },
+        'openai/gpt-5.6-sol': { reasoningEffort: 'low' },
+      },
+      'openai/gpt-5.6-sol',
+      'max',
+    );
+    expect(next).toEqual({
+      'anthropic/claude-sonnet-4.6': { reasoningEffort: 'medium' },
+      'openai/gpt-5.6-sol': { reasoningEffort: 'max' },
+    });
+  });
+});

--- a/apps/web/src/features/session/reasoning-effort-selector.tsx
+++ b/apps/web/src/features/session/reasoning-effort-selector.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+/**
+ * Reasoning-effort control for the session chat composer — shown only for a
+ * model that actually exposes a tunable effort knob, driven off the SAME
+ * live models.dev capability data (`@kortix/llm-catalog`'s
+ * `generationControlCapabilities`) that gates the gateway settings'
+ * Generation Controls panel (`generation-controls.tsx`, #4995). Never a
+ * hardcoded per-model list — a reasoning model with no `reasoning_options`
+ * entry still gets the generic low/medium/high fallback, a model that isn't
+ * `reasoning: true` at all gets nothing.
+ *
+ * *** WHY THIS WRITES A PROJECT-LEVEL SETTING, NOT A PER-MESSAGE ONE ***
+ * OpenCode's own message-send payload (`SendMessageOptions` in
+ * `@kortix/sdk`'s `use-opencode-sessions/keys.ts`, consumed by
+ * `promptOpenCodeMessage`) only ever carries `model` / `agent` / `variant` /
+ * `directory` — there is no per-message reasoning-effort field to set on a
+ * chat send today. Separately, models.dev-sourced models don't populate
+ * OpenCode's legacy per-model `variant` map, which is why the composer's
+ * `VariantSelector` renders nothing for a model like `openai/gpt-5.6-sol`
+ * even though it's very much a reasoning model.
+ *
+ * The one path that reliably reaches the wire today is the per-project
+ * **model_generation_config** the gateway injects at resolution time —
+ * `packages/llm-gateway/src/pipeline/generation-defaults.ts` merges it into
+ * the outbound OpenAI-shaped body (`reasoning_effort`) for any field the
+ * client didn't already set, and `apps/api/src/llm-gateway/routing/
+ * resolve-route.ts` re-clamps + supplies it per request from
+ * `project_llm_routing_policies.model_generation_config` (same table/API the
+ * Gateway → Routing settings page's "Generation defaults" panel writes).
+ * This component reads/writes that same config, scoped to
+ * (this project, this exact wire model) — every session in the project
+ * sending to this model picks up the change immediately, and an explicit
+ * per-request value (should OpenCode ever grow one) would still win, since
+ * injection only ever fills a field the client left unset.
+ *
+ * Writing requires the `gateway.routing-policy` PUT's capability gate
+ * (`PROJECT_CUSTOMIZE_WRITE`, editor+) — a plain project member can see the
+ * currently configured effort but not change it; the control disables with
+ * an explanatory tooltip in that case rather than hiding outright, so it
+ * stays discoverable.
+ */
+
+import { Brain, Check, ChevronDown } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import {
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandPopover,
+  CommandPopoverContent,
+  CommandPopoverTrigger,
+} from '@/components/ui/command';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { catalogModelForGateway } from '@/features/workspace/customize/sections/view/gateway/generation-controls';
+import { modelKeyToWire } from '@/hooks/opencode/use-model-store';
+import { cn } from '@/lib/utils';
+import { generationControlCapabilities } from '@kortix/llm-catalog';
+import type { GatewayProjectRoutingPolicy } from '@kortix/sdk/projects-client';
+import { useGatewayRoutingPolicy } from '@kortix/sdk/react';
+
+export interface ReasoningEffortModelKey {
+  providerID: string;
+  modelID: string;
+}
+
+export interface ReasoningEffortControl {
+  /** False when the model has no reasoning-effort knob, or there's no
+   *  project to scope the setting to — render nothing. */
+  visible: boolean;
+  /** The model's own effort labels (e.g. ['none','low','medium','high','xhigh','max']). */
+  values: string[];
+  /** Currently configured effort for this (project, model), or null = model default. */
+  current: string | null;
+  /** Whether the current user can change it (editor+ on the project). */
+  canWrite: boolean;
+  /** Initial load or a write in flight. */
+  pending: boolean;
+  wireModel: string | undefined;
+  setEffort: (next: string | null) => void;
+}
+
+/**
+ * The model's own effort labels for the composer to offer — the show/hide
+ * source of truth. Pure wrapper around `@kortix/llm-catalog`'s
+ * `generationControlCapabilities` so it's testable without mounting React or
+ * a query client; a model with no reasoning-effort knob returns `[]`, which
+ * is exactly what makes the control render nothing.
+ */
+export function reasoningEffortValuesFor(wireModel: string | undefined): string[] {
+  if (!wireModel) return [];
+  const catalogModel = catalogModelForGateway(wireModel);
+  return generationControlCapabilities(catalogModel).reasoningEffort?.values ?? [];
+}
+
+/**
+ * Merge a new (or cleared) reasoning-effort choice for `wireModel` into a
+ * project's `modelGenerationConfig`, preserving any other generation-config
+ * fields already set for that model (temperature, topP, maxOutputTokens) and
+ * every OTHER model's entry untouched. `next: null` clears the override back
+ * to "model default"; if that empties the model's entry entirely, the key is
+ * dropped rather than left as `{}`. Pure — no network, no React — so the
+ * exact object the PUT would send is directly assertable in a test.
+ */
+export function applyReasoningEffort(
+  modelGenerationConfig: GatewayProjectRoutingPolicy['modelGenerationConfig'],
+  wireModel: string,
+  next: string | null,
+): GatewayProjectRoutingPolicy['modelGenerationConfig'] {
+  const current = modelGenerationConfig ?? {};
+  const { reasoningEffort: _currentEffort, ...restForModel } = current[wireModel] ?? {};
+  const entry = next ? { ...restForModel, reasoningEffort: next } : restForModel;
+  const otherEntries = Object.entries(current).filter(([key]) => key !== wireModel);
+  return Object.fromEntries(
+    Object.keys(entry).length > 0 ? [...otherEntries, [wireModel, entry]] : otherEntries,
+  );
+}
+
+/**
+ * Derive show/hide + values + current value + write mechanics for the
+ * reasoning-effort control on a given (model, project). Thin React/query
+ * wiring over the two pure functions above.
+ */
+export function useReasoningEffortControl(
+  model: ReasoningEffortModelKey | null | undefined,
+  projectId: string | undefined,
+): ReasoningEffortControl {
+  const wireModel = model ? modelKeyToWire(model) : undefined;
+  const values = useMemo(() => reasoningEffortValuesFor(wireModel), [wireModel]);
+  const routing = useGatewayRoutingPolicy(projectId);
+
+  const current =
+    wireModel && routing.data
+      ? (routing.data.project.modelGenerationConfig?.[wireModel]?.reasoningEffort ?? null)
+      : null;
+  const canWrite = routing.data?.capabilities?.write ?? false;
+
+  const setEffort = (next: string | null) => {
+    if (!wireModel || !projectId || !routing.data) return;
+    const policy: GatewayProjectRoutingPolicy = routing.data.project;
+    routing.set.mutate({
+      ...policy,
+      modelGenerationConfig: applyReasoningEffort(policy.modelGenerationConfig, wireModel, next),
+    });
+  };
+
+  return {
+    visible: !!projectId && values.length > 0,
+    values,
+    current,
+    canWrite,
+    pending: !!projectId && (routing.isLoading || routing.set.isPending),
+    wireModel,
+    setEffort,
+  };
+}
+
+export function ReasoningEffortSelector({
+  model,
+  projectId,
+}: {
+  model: ReasoningEffortModelKey | null;
+  projectId: string | undefined;
+}) {
+  const [open, setOpen] = useState(false);
+  const { visible, values, current, canWrite, pending, wireModel, setEffort } =
+    useReasoningEffortControl(model, projectId);
+
+  if (!visible) return null;
+
+  const locked = !canWrite;
+  const displayValue = current ?? 'auto';
+
+  return (
+    <CommandPopover open={open} onOpenChange={(next) => setOpen(locked || pending ? false : next)}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CommandPopoverTrigger>
+            <button
+              type="button"
+              aria-disabled={locked || pending || undefined}
+              aria-label="Reasoning effort"
+              className={cn(
+                'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full px-2.5 text-xs font-medium capitalize transition-colors duration-200',
+                open && 'bg-muted text-foreground',
+                current && 'text-foreground',
+                (locked || pending) &&
+                  'hover:text-muted-foreground cursor-not-allowed opacity-70 hover:bg-transparent',
+              )}
+            >
+              <Brain className="size-3.5 shrink-0" />
+              <span className="max-w-[80px] truncate">{displayValue}</span>
+              <ChevronDown
+                className={cn(
+                  'size-3 opacity-50 transition-transform duration-200',
+                  open && 'rotate-180',
+                )}
+              />
+            </button>
+          </CommandPopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[240px]">
+          {locked ? (
+            <p>Only project editors can change reasoning effort for this model.</p>
+          ) : (
+            <p>
+              Reasoning effort for <span className="font-mono">{wireModel}</span> — applies to every
+              session in this project using this model.
+            </p>
+          )}
+        </TooltipContent>
+      </Tooltip>
+
+      <CommandPopoverContent side="top" align="start" sideOffset={8} className="w-[180px]">
+        <CommandList>
+          <CommandGroup heading="Reasoning effort">
+            <CommandItem
+              value="reasoning-effort-default"
+              onSelect={() => {
+                setEffort(null);
+                setOpen(false);
+              }}
+            >
+              <span className="flex-1 truncate">Model default</span>
+              {current === null && <Check className="text-foreground size-3.5 shrink-0" />}
+            </CommandItem>
+            {values.map((value) => (
+              <CommandItem
+                key={value}
+                value={`reasoning-effort-${value}`}
+                onSelect={() => {
+                  setEffort(value);
+                  setOpen(false);
+                }}
+              >
+                <span className="flex-1 truncate capitalize">{value}</span>
+                {current === value && <Check className="text-foreground size-3.5 shrink-0" />}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </CommandPopoverContent>
+    </CommandPopover>
+  );
+}

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -57,6 +57,7 @@ import {
 } from './model-availability';
 import { ModelConnectionBar } from './model-connection-gate';
 import { type ModelDefaultControls, ModelSelector } from './model-selector';
+import { ReasoningEffortSelector } from './reasoning-effort-selector';
 import { useModelConnectionGate } from './use-model-connection-gate';
 import { VoiceRecorder } from './voice-recorder';
 
@@ -1146,6 +1147,9 @@ export interface SessionChatInputProps {
   messages?: MessageWithParts[];
   /** Session ID — used for message queue, todo chip, and mention filtering */
   sessionId?: string;
+  /** Project ID — lets the reasoning-effort control read/write this
+   *  project's per-model generation config (see reasoning-effort-selector.tsx). */
+  projectId?: string;
   /** If true, disables the input (e.g. during session creation redirect) */
   disabled?: boolean;
   /**
@@ -1246,6 +1250,7 @@ export function SessionChatInput({
   onVariantChange,
   messages,
   sessionId,
+  projectId,
   disabled = false,
   clearOnSend = true,
   modelRequired = false,
@@ -2359,6 +2364,13 @@ export function SessionChatInput({
                   onSelect={onVariantChange}
                 />
               )}
+              {/* Reasoning-effort control — independent of the legacy opencode
+                  variant list above. Renders nothing unless the selected
+                  model actually exposes a reasoning_options effort knob (see
+                  reasoning-effort-selector.tsx for why this is capability-
+                  gated off the live catalog rather than the empty variant
+                  list models.dev models never populate). */}
+              <ReasoningEffortSelector model={selectedModel} projectId={projectId} />
             </div>
 
             {/* RIGHT: TokenProgress + Voice + Submit/Stop */}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -5370,6 +5370,7 @@ export function SessionChat({
           onVariantChange={(v) => local.model.variant.set(v ?? undefined)}
           messages={messages}
           sessionId={sessionId}
+          projectId={projectId}
           onFileSearch={handleFileSearch}
           providers={providers}
           modelRequired


### PR DESCRIPTION
## Summary
- The chat composer's `VariantSelector` only shows OpenCode's legacy per-model `variant` list, which models.dev-sourced models (e.g. reasoning models like `openai/gpt-5.6-sol`) never populate — so reasoning-capable models got no effort control at all.
- Adds a capability-gated **reasoning-effort selector** to the session chat composer (`session-chat-input.tsx`), shown only when the currently selected model actually exposes a `reasoning_options` effort knob — driven off the exact same live models.dev capability data PR #4995 introduced (`generationControlCapabilities` / `catalogModelForGateway`), never hardcoded per model.
- The legacy `VariantSelector` is untouched and keeps working for any model that genuinely has OpenCode variants.

## Traced data flow
- Composer model data comes from `local.model.list` / `local.model.currentKey` (`useOpenCodeLocal`, backed by the live `providers` catalog). The legacy `variants` prop (`local.model.variant.list`) is OpenCode's own per-model variant map — models.dev models never populate it, which is why reasoning models showed nothing.
- Verified against the vendored `@opencode-ai/sdk` v2 types (`node_modules/.pnpm/@opencode-ai+sdk*/dist/v2/gen/types.gen.d.ts`) and the SDK's `SendMessageOptions` (`packages/sdk/src/react/use-opencode-sessions/keys.ts`) that a chat send **only** carries `model` / `agent` / `variant` / `directory` — there is no per-message reasoning-effort field today. Path (a) from the task (per-message effort) is closed.
- The reliable path (b): the gateway injects a per-project **`model_generation_config`** at resolution time — `packages/llm-gateway/src/pipeline/generation-defaults.ts`'s `applyGenerationDefaults` merges `reasoning_effort` into the outbound body for any field the client didn't set, and `apps/api/src/llm-gateway/routing/resolve-route.ts` re-clamps + supplies it per request from `project_llm_routing_policies.model_generation_config` — the exact same config the Gateway → Routing settings page's "Generation defaults" panel (`generation-controls.tsx`, #4995) already writes via `PUT /projects/:id/gateway/routing-policy`.

## What was built
- `apps/web/src/features/session/reasoning-effort-selector.tsx`:
  - `reasoningEffortValuesFor(wireModel)` — pure show/hide source of truth (empty array ⇒ hidden), wrapping `@kortix/llm-catalog`'s `generationControlCapabilities`.
  - `applyReasoningEffort(modelGenerationConfig, wireModel, next)` — pure merge producing the exact PUT-body patch (preserves sibling fields like `temperature`, drops the model's key entirely when its only field is cleared, leaves every other model's entry untouched).
  - `useReasoningEffortControl` — thin wiring over `useGatewayRoutingPolicy(projectId)` (GET the current policy, PUT the merged one on change).
  - `ReasoningEffortSelector` — compact composer pill (matches `VariantSelector`/`AgentSelector` styling: `CommandPopover`, `Tooltip`, `Brain` icon) listing the model's own effort values plus "Model default".
- Threaded a new `projectId` prop through `SessionChatInput` → wired from `SessionChat` (existing `projectId` prop) and `ComposerChatInput` (existing `projectId` prop), so both the live session composer and the new-session home composer get the control.

## Scoping / permission caveat (read before live-testing)
- The setting is **project + model scoped**, not per-message or per-session: setting effort from one session's composer applies to every session in that project sending to that exact wire model, matching how the gateway's injection is keyed (`principal.projectId` + `input.requestedModel`).
- Writing requires `PROJECT_CUSTOMIZE_WRITE` (editor+ role) — the same gate the Routing settings page's PUT already enforces. A plain project member sees the currently configured effort (read-only) but the control disables with an explanatory tooltip rather than silently no-op'ing or hiding.

## Tests
- `apps/web/src/features/session/reasoning-effort-selector.test.ts` (new, 11 tests, all passing): show/hide against real catalog wire models (`openai/gpt-5.6-sol`, `claude-opus-4.8`, `auto`, unknown model), and the PUT-body merge logic (set/clear/overwrite, sibling-field preservation, other-model isolation).
- `apps/web` `tsc --noEmit`: clean (only 2 pre-existing, unrelated `@/.source` fumadocs codegen errors remain, present before this change).
- `apps/api` `tsc --noEmit`: clean (no API changes in this PR).
- `biome check`: clean on all new/touched files.
- Re-ran `generation-controls.test.ts`, `model-wire.test.ts`, `gateway-routing.test.ts` individually — all still pass.

## Not done here / deferred to parent's live verification
- No live/browser verification against a real deployed session — this branch isn't deployed yet. Parent should pick a reasoning model (e.g. `gpt-5.6`) in a real chat, set an effort, and confirm via `gateway_request_logs` that `reasoning_effort` was applied on the outbound request, per the task's own instruction.
- If OpenCode ever grows a genuine per-message reasoning-effort field, `promptOpenCodeMessage`/`SendMessageOptions` would need a vendored-SDK change to carry it — out of scope here; the project-level generation-config path was chosen specifically because it needs no OpenCode-side change and is provably wired end-to-end today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)