### PR TITLE
fix(routing): routing-policy PUT 500 when defaultModel is set (missed partial-index ON CONFLICT predicate from #4978)

### DIFF
--- a/apps/api/src/repositories/project-routing-policies.ts
+++ b/apps/api/src/repositories/project-routing-policies.ts
@@ -1,5 +1,5 @@
 import { accountModelPreferences, projectLlmRoutingPolicies } from "@kortix/db";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "../shared/db";
 import type {
   ProjectModelGenerationConfig,
@@ -76,6 +76,12 @@ export async function setProjectRoutingPolicy(params: {
             accountModelPreferences.scope,
             accountModelPreferences.scopeKey,
           ],
+          // project-scope default is a project_id-IS-NULL row, so the ON CONFLICT
+          // arbiter must name the GLOBAL partial unique index's predicate (PR #4978
+          // split the old single unique index into two partial indexes). Without
+          // this, Postgres errors "no unique/exclusion constraint matching ON
+          // CONFLICT" and the routing-policy PUT 500s whenever defaultModel is set.
+          targetWhere: sql`project_id is null`,
           set: {
             model: params.policy.defaultModel,
             updatedBy: params.updatedBy,


### PR DESCRIPTION
Live-found regression from #4978: PUT /v1/projects/:id/gateway/routing-policy 500s (DrizzleQueryError, no unique/exclusion constraint matching ON CONFLICT) whenever defaultModel is non-null — #4978 split account_model_preferences' unique index into two partial indexes + fixed model-preferences.ts's upserts with targetWhere, but missed this file's project-default upsert. Adds the global partial-index predicate (targetWhere: project_id is null). Unblocks the routing/generation-config UI save. (Verified by CI — bare worktree can't run @kortix/db tests locally.)