### PR TITLE
test(ke2e): refresh two stale flow assertions for v0.10.11 (staging)

### DIFF
--- a/tests/src/flows/llm-gateway.flow.ts
+++ b/tests/src/flows/llm-gateway.flow.ts
@@ -148,6 +148,10 @@ flow(
         },
       ],
     };
+    // The stored/read-back project policy always carries the per-model
+    // generation-config map (defaults to {} when unset), so the round-trip
+    // assertions compare against the policy plus that field.
+    const savedProject = { ...policy, modelGenerationConfig: {} };
 
     await ctx.step('inherited routing policy is readable', async () => {
       const r = await ctx.client
@@ -194,14 +198,14 @@ flow(
       saved
         .status(200)
         .body()
-        .has('$.project', policy)
+        .has('$.project', savedProject)
         .has('$.effective.defaultModel', 'codex/gpt-5.6-sol')
         .has('$.effective.defaultFallback.models', ['glm-5.2']);
 
       const read = await ctx.client
         .as(ctx.P.OWNER)
         .get('/v1/projects/:projectId/gateway/routing-policy', { params });
-      read.status(200).body().has('$.project', policy);
+      read.status(200).body().has('$.project', savedProject);
     });
 
     await ctx.step('preview resolves ordered default and exact-model routes', async () => {
@@ -254,7 +258,7 @@ flow(
       const read = await ctx.client
         .as(ctx.P.OWNER)
         .get('/v1/projects/:projectId/gateway/routing-policy', { params });
-      read.status(200).body().has('$.project', policy);
+      read.status(200).body().has('$.project', savedProject);
     });
 
     await ctx.step('project access boundaries are enforced', async () => {

--- a/tests/src/flows/projects-misc.flow.ts
+++ b/tests/src/flows/projects-misc.flow.ts
@@ -298,13 +298,11 @@ flow(
 // docs/specs/2026-07-05-agent-first-config-unification.md §2.2). GET reports the
 // agent's full block + the manifest schema version (the UI's v1-vs-v2 branch);
 // PUT replaces the whole block, validating it through the manifest-schema
-// validator before the kortix.yaml commit. A bare provisioned project has no
-// v2 manifest (loadManifestForEdit synthesizes a v1 TOML), so this pins the
-// achievable boundaries: GET degrades cleanly to schema_version 1 / editable
-// false; PUT on that v1 project is refused with a 400 upgrade pointer; the
-// editor-tier gate holds. The v2 happy-path commit needs a project whose
-// kortix.yaml is already v2 — out of reach for a bare repo here (same
-// limitation IAM-31's scope flow documents).
+// validator before the kortix.yaml commit. A bare provisioned project now
+// synthesizes a v2 manifest (synthesizeBlankManifest, kortix_version 2 — see
+// PR #4980), so GET reports schema_version 2 and editable:true. PUT still
+// validates the block shape strictly: a body with unrecognized top-level keys
+// (or a bad enum) is refused with a 400; the editor-tier gate holds.
 flow(
   "PROJ-19",
   {
@@ -318,16 +316,16 @@ flow(
     const team = await ctx.fixtures.team();
     const project = await team.project();
 
-    await ctx.step("GET degrades to schema_version 1 / editable false for a v1 (or empty) manifest", async () => {
+    await ctx.step("GET reports schema_version 2 / editable true for a synthesized blank manifest", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .get("/v1/projects/:projectId/agents/:agentName/config", {
           params: { projectId: project.id, agentName: "kortix" },
         });
-      r.status(200).body().has("$.editable", false);
+      r.status(200).body().has("$.schema_version", 2).has("$.editable", true);
     });
 
-    await ctx.step("PUT a full block on a v1 project → 400 (v2-only, upgrade pointer)", async () => {
+    await ctx.step("PUT a body with unrecognized top-level keys → 400", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .put(


### PR DESCRIPTION
Same test-only fix as #5017 (merged to main), applied to staging so the v0.10.11 release candidate promotes cleanly from staging with green flows.

- GW-4: routing-policy response now carries `modelGenerationConfig` (defaults to `{}`).
- PROJ-19: blank projects synthesize a v2 manifest (#4980) → `schema_version:2`/`editable:true`.

Both verified live against staging-api. No runtime change.