### PR TITLE
chore: remove 11 unused imports flagged by CodeQL js/unused-local-variable

### DIFF
--- a/apps/api/src/oauth/token-hash.test.ts
+++ b/apps/api/src/oauth/token-hash.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 
 mock.module('../config', () => ({ config: { API_KEY_SECRET: 'test-pepper' } }));
 

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -49,7 +49,6 @@ import {
   parseSessionConnectorBindings,
   validateSessionConnectorBindings,
 } from './session-connector-bindings';
-import { allocateSessionRuntime } from './session-runtime-allocator';
 import {
   buildSessionRuntimeContextEnv,
   mergeSessionSandboxEnv,

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -9,7 +9,7 @@ import { getBackend, hasBackend, managedGithubOwner, managedGithubToken, type Gi
 import { seedRepoViaGitPush } from '../git-backends/seed';
 import { createRepo, getGitHubAppInstallation, verifyGitHubAppInstallStatePayload } from '../github';
 import { getProjectSecretValue } from '../secrets';
-import { buildStarterFiles, normalizeStarterTemplateId } from '../starter';
+import { normalizeStarterTemplateId } from '../starter';
 import {
   buildProjectSeedFiles,
   buildProjectSeedFilesFromItem,

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -17,7 +17,6 @@ import { registerGitHubLinkedProject, registerPatLinkedProject } from '../lib/pr
 import { PAT_MANAGED_GIT_INSTALLATION_ID, deriveProjectName, isRepoNameTakenError, normalizeString, readBody, requestAuditContext, serializeBuildSummary, serializeProject, serializeProjectGitConnection, serializeTemplate } from '../lib/serializers';
 import { createProjectSession, sendSessionCreateError } from '../lib/sessions';
 import { resolveManifestValidateFormat } from '../lib/manifest-format';
-import { config } from '../../config';
 import { resolveConfiguredProjectProviderPin } from '../../snapshots/provider-coverage';
 import { runProviderActions } from '../../snapshots/provider-actions';
 

--- a/apps/api/src/router/index.ts
+++ b/apps/api/src/router/index.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { config } from '../config';
 import { apiKeyAuth } from '../middleware/auth';
 import { makeOpenApiApp, json } from '../openapi';
 import { webSearch } from './routes/search-web';

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -34,7 +34,6 @@ import {
 import { DEFAULT_SANDBOX_SLUG } from './dockerfile-layer';
 import { classifySnapshotError } from './error-classify';
 import type { WarmRepoContext } from './build-context';
-import { createHash } from 'node:crypto';
 import {
   enabledTemplateBuildProviders,
   observeTemplateProviderCoverage,

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -26,7 +26,6 @@ import {
   CATEGORY_LABELS,
   groupSecretsByCategory,
   isUpdaterManagedKey,
-  maskSecretValue,
   ROTATABLE_GENERATED_KEYS,
   SECRET_DEFS,
   secretDefFor,

--- a/apps/mobile/components/pages/TunnelPage.tsx
+++ b/apps/mobile/components/pages/TunnelPage.tsx
@@ -36,7 +36,6 @@ import {
 } from 'lucide-react-native';
 import { useColorScheme } from 'nativewind';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Ionicons } from '@expo/vector-icons';
 import { haptics } from '@/lib/haptics';
 import { buildTunnelConnectCommand } from '@/lib/tunnel-connect-command';
 import * as Clipboard from 'expo-clipboard';

--- a/apps/web/src/components/ui/agent-avatar.tsx
+++ b/apps/web/src/components/ui/agent-avatar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { KortixLogo } from '@/components/sidebar/kortix-logo';
 import { DynamicIcon } from 'lucide-react/dynamic';
 import { Bot } from 'lucide-react';
 import { cn } from '@/lib/utils';

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -31,7 +31,6 @@ import { type MenuItemDef, type SettingsTabId, getItemsForSurface } from '@/lib/
 import { cn } from '@/lib/utils';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
 import { useCustomizeStore } from '@/stores/customize-store';
-import { useKortixComputerStore } from '@/stores/kortix-computer-store';
 import { useProjectSessionTabsStore } from '@/stores/project-session-tabs-store';
 import { featureFlags } from '@kortix/sdk/feature-flags';
 import { normalizeAppPathname } from '@kortix/sdk/instance-routes';

--- a/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-playground.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/gateway/gateway-playground.tsx
@@ -13,7 +13,7 @@ import { useMemo, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
+import { Disclosure, DisclosureContent } from '@/components/ui/disclosure';
 import Hint from '@/components/ui/hint';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';

--- a/apps/whitelabel-demo/src/components/chat/tool-call.tsx
+++ b/apps/whitelabel-demo/src/components/chat/tool-call.tsx
@@ -39,7 +39,6 @@ import {
   Loader2,
   type LucideIcon,
   Pencil,
-  Search,
   SquareTerminal,
   Wrench,
 } from 'lucide-react';


### PR DESCRIPTION
## What

Removes 11 genuinely-unused imports flagged by CodeQL `js/unused-local-variable` (severity: note). Pure mechanical cleanup; no behavior change.

## Why

CodeQL flags ~75 `js/unused-local-variable` alerts across the repo (severity: note). They're not blockers, but they're noise that obscures real findings in code-scanning dashboards, and a few surfaced as the "warnings" count on the v0.10.11 release PR (#4950). This PR clears the verified-safe subset.

## Verification — each removal checked individually

For each name, I ran a whole-file word-boundary search **after stripping import statements** to confirm `uses_outside_imports = 0`:

```
uses_outside_imports=0  buildStarterFiles       in  apps/api/src/projects/routes/r1.ts
uses_outside_imports=0  maskSecretValue         in  apps/cli/src/commands/self-host.ts
uses_outside_imports=0  DisclosureTrigger       in  apps/web/.../gateway-playground.tsx
uses_outside_imports=0  useKortixComputerStore  in  apps/web/.../command-palette.tsx
uses_outside_imports=0  createHash              in  apps/api/src/snapshots/builder.ts
uses_outside_imports=0  config                  in  apps/api/src/projects/routes/r2.ts
uses_outside_imports=0  config                  in  apps/api/src/router/index.ts
uses_outside_imports=0  KortixLogo              in  apps/web/src/components/ui/agent-avatar.tsx
uses_outside_imports=0  Ionicons                in  apps/mobile/components/pages/TunnelPage.tsx
uses_outside_imports=0  beforeEach              in  apps/api/src/oauth/token-hash.test.ts
uses_outside_imports=0  Search                  in  apps/whitelabel-demo/src/components/chat/tool-call.tsx
uses_outside_imports=0  allocateSessionRuntime  in  apps/api/src/projects/lib/sessions.ts
```

Post-removal re-verified: all 11 names now appear 0 times in their files.

## Skipped false positives (CodeQL wrong)

Same alert set, but these ARE used — left untouched:
- `GitOperationError` in `apps/api/src/index.ts` (3 uses outside imports)
- `config` in `apps/api/src/sandbox-proxy/backend.ts` (6 uses)
- `auth` in `apps/api/src/projects/lib/sessions.ts` (6 uses)

## Scope

12 files, +3/-12. No test change needed (import-only). The remaining ~60 alerts (unused local variables / unused functions) need more careful per-case review and aren't in this PR.

Mirko AGI cycle 19.