### PR TITLE
feat(git-backends): code.storage (Pierre) managed git provider, flag-gated

### DIFF
--- a/apps/api/src/__tests__/unit-code-storage-git-backend.test.ts
+++ b/apps/api/src/__tests__/unit-code-storage-git-backend.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Unit tests for the code.storage (Pierre) managed git backend
+ * (projects/git-backends/code-storage.ts): JWT minting (alg/claims/scopes,
+ * repo-scoped vs org-wide), createRepo/deleteRepo request+response mapping,
+ * buildUpstream's neutral {url, headers} shape for read vs write, and
+ * seedFiles' commit-pack ndjson payload. All HTTP is mocked via
+ * `globalThis.fetch` (same convention as unit-github-owner-type-routing.test.ts)
+ * — this file never touches the live code.storage API, and every private key
+ * used below is a throwaway generated in-process with node:crypto, never a
+ * real credential.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
+import { jwtVerify, importSPKI } from 'jose';
+import { config } from '../config';
+import {
+  codeStorageBackend,
+  codeStorageGitAuthHeader,
+  mintCodeStorageJwt,
+  type GitConnectionRef,
+} from '../projects/git-backends';
+
+// Throwaway EC (P-256) and RSA keypairs — signing-only, never a live
+// code.storage credential.
+const EC_KEYS = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+const EC_PRIVATE_PEM = EC_KEYS.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+const EC_PUBLIC_PEM = EC_KEYS.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+const RSA_KEYS = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const RSA_PRIVATE_PEM = RSA_KEYS.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+const RSA_PUBLIC_PEM = RSA_KEYS.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+function decodeJwtPayload(jwt: string): Record<string, unknown> {
+  const [, payload] = jwt.split('.');
+  return JSON.parse(Buffer.from(payload!, 'base64url').toString('utf8'));
+}
+
+function decodeJwtHeader(jwt: string): Record<string, unknown> {
+  const [header] = jwt.split('.');
+  return JSON.parse(Buffer.from(header!, 'base64url').toString('utf8'));
+}
+
+const SNAPSHOT_KEYS = [
+  'CODE_STORAGE_ORG',
+  'CODE_STORAGE_PRIVATE_KEY',
+  'CODE_STORAGE_API_BASE',
+  'CODE_STORAGE_GIT_HOST',
+] as const;
+const saved: Record<string, string> = {};
+
+beforeEach(() => {
+  for (const k of SNAPSHOT_KEYS) saved[k] = (config as any)[k];
+  config.CODE_STORAGE_ORG = 'acme';
+  config.CODE_STORAGE_PRIVATE_KEY = EC_PRIVATE_PEM;
+  config.CODE_STORAGE_API_BASE = '';
+  config.CODE_STORAGE_GIT_HOST = '';
+});
+
+afterEach(() => {
+  for (const k of SNAPSHOT_KEYS) (config as any)[k] = saved[k];
+});
+
+function ref(overrides: Partial<GitConnectionRef> = {}): GitConnectionRef {
+  return {
+    provider: 'code-storage',
+    upstreamUrl: 'https://acme.code.storage/team/project-alpha.git',
+    externalRepoId: 'repo_7f2b3d9',
+    repoOwner: null,
+    repoName: 'team/project-alpha',
+    installationId: null,
+    credentialRef: null,
+    defaultBranch: 'main',
+    managed: true,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('mintCodeStorageJwt', () => {
+  test('signs ES256 for an EC private key, verifiable by a spec-compliant verifier', async () => {
+    const jwt = mintCodeStorageJwt({ repo: 'team/project-alpha', scopes: ['git:read'] });
+    expect(decodeJwtHeader(jwt)).toEqual({ alg: 'ES256', typ: 'JWT' });
+    const key = await importSPKI(EC_PUBLIC_PEM, 'ES256');
+    const { payload } = await jwtVerify(jwt, key);
+    expect(payload.iss).toBe('acme');
+    expect(payload.repo).toBe('team/project-alpha');
+    expect(payload.scopes).toEqual(['git:read']);
+  });
+
+  test('signs RS256 for an RSA private key, verifiable by a spec-compliant verifier', async () => {
+    config.CODE_STORAGE_PRIVATE_KEY = RSA_PRIVATE_PEM;
+    const jwt = mintCodeStorageJwt({ scopes: ['repo:write'] });
+    expect(decodeJwtHeader(jwt)).toEqual({ alg: 'RS256', typ: 'JWT' });
+    const key = await importSPKI(RSA_PUBLIC_PEM, 'RS256');
+    const { payload } = await jwtVerify(jwt, key);
+    expect(payload.scopes).toEqual(['repo:write']);
+  });
+
+  test('claims: iss/sub/scopes/iat/exp, repo-scoped', () => {
+    const before = Math.floor(Date.now() / 1000);
+    const jwt = mintCodeStorageJwt({
+      repo: 'team/project-alpha',
+      scopes: ['git:write', 'git:read'],
+      ttlSeconds: 120,
+      subject: 'kortix-session-42',
+    });
+    const payload = decodeJwtPayload(jwt);
+    expect(payload.iss).toBe('acme');
+    expect(payload.sub).toBe('kortix-session-42');
+    expect(payload.repo).toBe('team/project-alpha');
+    expect(payload.scopes).toEqual(['git:write', 'git:read']);
+    expect(payload.iat as number).toBeGreaterThanOrEqual(before);
+    expect(payload.exp as number).toBe((payload.iat as number) + 120);
+  });
+
+  test('org-wide token omits the `repo` claim entirely', () => {
+    const jwt = mintCodeStorageJwt({ scopes: ['repo:write'] });
+    const payload = decodeJwtPayload(jwt);
+    expect('repo' in payload).toBe(false);
+  });
+
+  test('defaults sub to "kortix-api" when no subject given', () => {
+    const jwt = mintCodeStorageJwt({ scopes: ['org:read'] });
+    expect(decodeJwtPayload(jwt).sub).toBe('kortix-api');
+  });
+
+  test('throws when org or private key is not configured', () => {
+    config.CODE_STORAGE_ORG = '';
+    expect(() => mintCodeStorageJwt({ scopes: ['git:read'] })).toThrow(/not configured/);
+  });
+
+  test('throws on an unsupported (e.g. Ed25519) key type', () => {
+    const ed = generateKeyPairSync('ed25519');
+    config.CODE_STORAGE_PRIVATE_KEY = ed.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    expect(() => mintCodeStorageJwt({ scopes: ['git:read'] })).toThrow(/unsupported/);
+  });
+});
+
+describe('codeStorageGitAuthHeader', () => {
+  test('Basic base64("t:<jwt>")', () => {
+    const h = codeStorageGitAuthHeader('abc.def.ghi');
+    expect(h.Authorization).toBe(`Basic ${Buffer.from('t:abc.def.ghi').toString('base64')}`);
+  });
+});
+
+describe('isConfigured', () => {
+  test('true once org + private key are set', async () => {
+    expect(await codeStorageBackend.isConfigured()).toBe(true);
+  });
+
+  test('false with no org', async () => {
+    config.CODE_STORAGE_ORG = '';
+    expect(await codeStorageBackend.isConfigured()).toBe(false);
+  });
+
+  test('false with no private key', async () => {
+    config.CODE_STORAGE_PRIVATE_KEY = '';
+    expect(await codeStorageBackend.isConfigured()).toBe(false);
+  });
+});
+
+describe('buildUpstream', () => {
+  test('write scope: url + Basic header carrying a self-minted git:write+git:read token', () => {
+    const up = codeStorageBackend.buildUpstream(ref(), null, 'write');
+    expect(up.url).toBe('https://acme.code.storage/team/project-alpha.git');
+    const [, encoded] = up.headers.Authorization!.split(' ');
+    const [user, jwt] = Buffer.from(encoded!, 'base64').toString('utf8').split(':');
+    expect(user).toBe('t');
+    const payload = decodeJwtPayload(jwt!);
+    expect(payload.repo).toBe('team/project-alpha');
+    expect(payload.scopes).toEqual(['git:write', 'git:read']);
+  });
+
+  test('read scope: self-minted token scoped to git:read only', () => {
+    const up = codeStorageBackend.buildUpstream(ref(), null, 'read');
+    const [, encoded] = up.headers.Authorization!.split(' ');
+    const [, jwt] = Buffer.from(encoded!, 'base64').toString('utf8').split(':');
+    expect(decodeJwtPayload(jwt!).scopes).toEqual(['git:read']);
+  });
+
+  test('honors an already-resolved token instead of self-minting', () => {
+    const up = codeStorageBackend.buildUpstream(ref(), 'pre-minted-token', 'write');
+    const [, encoded] = up.headers.Authorization!.split(' ');
+    expect(Buffer.from(encoded!, 'base64').toString('utf8')).toBe('t:pre-minted-token');
+  });
+
+  test('CODE_STORAGE_GIT_HOST override changes the remote host', () => {
+    config.CODE_STORAGE_GIT_HOST = 'git.acme-cluster.example';
+    const up = codeStorageBackend.buildUpstream(ref(), 'tok', 'read');
+    expect(up.url).toBe('https://git.acme-cluster.example/team/project-alpha.git');
+  });
+});
+
+describe('createRepo / deleteRepo (mocked HTTP)', () => {
+  const originalFetch = globalThis.fetch;
+  let requests: Array<{ url: string; init?: RequestInit }> = [];
+
+  function json(body: unknown, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  beforeEach(() => {
+    requests = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('createRepo: POST /api/repos with repo:write org-wide bearer token, maps the response', async () => {
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+      requests.push({ url: href, init });
+      return json({
+        repo_id: 'repo_7f2b3d9',
+        http_url: 'https://git.code.storage/acme/my-project',
+        message: 'repository created',
+      });
+    }) as unknown as typeof fetch;
+
+    const repo = await codeStorageBackend.createRepo({
+      accountId: 'acct-1',
+      projectId: 'proj-1',
+      slug: 'my-project',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toBe('https://api.acme.code.storage/api/repos');
+    expect(requests[0]!.init?.method).toBe('POST');
+    const authHeader = (requests[0]!.init?.headers as Record<string, string>).Authorization;
+    const token = authHeader!.replace('Bearer ', '');
+    const payload = decodeJwtPayload(token);
+    expect(payload.scopes).toEqual(['repo:write']);
+    expect('repo' in payload).toBe(false); // org-wide — repo doesn't exist yet
+    const sentBody = JSON.parse(String(requests[0]!.init?.body));
+    expect(sentBody).toEqual({ id: 'my-project', default_branch: 'main' });
+
+    expect(repo.provider).toBe('code-storage');
+    expect(repo.externalRepoId).toBe('repo_7f2b3d9');
+    expect(repo.repoName).toBe('acme/my-project'); // parsed from http_url's path
+    expect(repo.upstreamUrl).toBe('https://acme.code.storage/acme/my-project.git');
+    expect(repo.defaultBranch).toBe('main');
+    expect(repo.repoOwner).toBeNull();
+    expect(repo.installationId).toBeNull();
+    // initialToken: repo-scoped git:write(+read)
+    expect(repo.initialToken).toBeTruthy();
+    const initialPayload = decodeJwtPayload(repo.initialToken!);
+    expect(initialPayload.repo).toBe('acme/my-project');
+    expect(initialPayload.scopes).toEqual(['git:write', 'git:read']);
+  });
+
+  test('createRepo: falls back to the requested slug as repo path when http_url is missing', async () => {
+    globalThis.fetch = (async () => json({ repo_id: 'repo_x', message: 'ok' })) as unknown as typeof fetch;
+    const repo = await codeStorageBackend.createRepo({
+      accountId: 'a',
+      projectId: 'p',
+      slug: 'fallback-slug',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+    expect(repo.repoName).toBe('fallback-slug');
+  });
+
+  test('createRepo: throws with the RFC 9457 problem detail on failure', async () => {
+    globalThis.fetch = (async () =>
+      json({ type: 'about:blank', title: 'Conflict', status: 409, detail: 'repo already exists' }, 409)) as unknown as typeof fetch;
+    await expect(
+      codeStorageBackend.createRepo({
+        accountId: 'a',
+        projectId: 'p',
+        slug: 'dup',
+        defaultBranch: 'main',
+        isPrivate: true,
+      }),
+    ).rejects.toThrow(/repo already exists/);
+  });
+
+  test('deleteRepo: DELETE /api/repos/{repoName} (URL-encoded) with a repo-scoped repo:write bearer token', async () => {
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+      requests.push({ url: href, init });
+      return json({ repo_id: 'repo_7f2b3d9', message: 'deletion initiated' });
+    }) as unknown as typeof fetch;
+
+    await codeStorageBackend.deleteRepo(ref());
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toBe(
+      `https://api.acme.code.storage/api/repos/${encodeURIComponent('team/project-alpha')}`,
+    );
+    expect(requests[0]!.init?.method).toBe('DELETE');
+    const token = (requests[0]!.init?.headers as Record<string, string>).Authorization!.replace('Bearer ', '');
+    const payload = decodeJwtPayload(token);
+    expect(payload.repo).toBe('team/project-alpha');
+    expect(payload.scopes).toEqual(['repo:write']);
+  });
+
+  test('deleteRepo: 404 (already gone) is treated as success, not thrown', async () => {
+    globalThis.fetch = (async () => json({ error: 'not found' }, 404)) as unknown as typeof fetch;
+    await expect(codeStorageBackend.deleteRepo(ref())).resolves.toBeUndefined();
+  });
+
+  test('deleteRepo: 409 (delete already in flight) is treated as success', async () => {
+    globalThis.fetch = (async () => json({ error: 'conflict' }, 409)) as unknown as typeof fetch;
+    await expect(codeStorageBackend.deleteRepo(ref())).resolves.toBeUndefined();
+  });
+
+  test('deleteRepo: other failures throw', async () => {
+    globalThis.fetch = (async () => json({ error: 'forbidden' }, 403)) as unknown as typeof fetch;
+    await expect(codeStorageBackend.deleteRepo(ref())).rejects.toThrow(/forbidden/);
+  });
+
+  test('deleteRepo: no-op when the ref has no repo identifier at all', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return json({});
+    }) as unknown as typeof fetch;
+    await codeStorageBackend.deleteRepo(ref({ repoName: null, externalRepoId: null }));
+    expect(called).toBe(false);
+  });
+});
+
+describe('seedFiles (mocked HTTP, commit-pack ndjson)', () => {
+  const originalFetch = globalThis.fetch;
+  let bodies: string[] = [];
+  let urls: string[] = [];
+  let headersSeen: Array<Record<string, string>> = [];
+
+  beforeEach(() => {
+    bodies = [];
+    urls = [];
+    headersSeen = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+      urls.push(href);
+      bodies.push(String(init?.body ?? ''));
+      headersSeen.push((init?.headers as Record<string, string>) ?? {});
+      return new Response(
+        JSON.stringify({
+          commit: { commit_sha: 'sha1', tree_sha: 'tree1', target_branch: 'main', pack_bytes: 10, blob_count: 1 },
+          result: { branch: 'main', old_sha: '0'.repeat(40), new_sha: 'sha1', success: true, status: 'ok' },
+        }),
+        { status: 201, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function parseNdjson(body: string) {
+    return body.trim().split('\n').map((line) => JSON.parse(line));
+  }
+
+  test('single commit when there are no baseFiles', async () => {
+    await codeStorageBackend.seedFiles!(
+      ref(),
+      'git-write-token',
+      [{ path: 'README.md', content: '# hello' }],
+      { branch: 'main', message: 'chore: scaffold Kortix project' },
+    );
+
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toBe(
+      `https://api.acme.code.storage/api/repos/${encodeURIComponent('team/project-alpha')}/commit-pack`,
+    );
+    const lines = parseNdjson(bodies[0]!);
+    expect(lines[0].metadata.target_branch).toBe('main');
+    expect(lines[0].metadata.commit_message).toBe('chore: scaffold Kortix project');
+    expect(lines[0].metadata.files).toEqual([
+      { path: 'README.md', operation: 'upsert', content_id: 'blob-0', mode: '100644' },
+    ]);
+    expect(lines[0].metadata).not.toHaveProperty('expected_head_sha');
+    expect(lines[1].blob_chunk.content_id).toBe('blob-0');
+    expect(Buffer.from(lines[1].blob_chunk.data, 'base64').toString('utf8')).toBe('# hello');
+    expect(lines[1].blob_chunk.eof).toBe(true);
+  });
+
+  test('two sequential commits when baseFiles is set: deterministic scaffold, then project files', async () => {
+    await codeStorageBackend.seedFiles!(
+      ref(),
+      'git-write-token',
+      [{ path: 'kortix.yaml', content: 'name: my-project' }],
+      {
+        branch: 'main',
+        message: 'ignored when baseFiles present',
+        baseFiles: [{ path: '.kortix/agent.md', content: 'base scaffold' }],
+      },
+    );
+
+    expect(urls).toHaveLength(2);
+    const first = parseNdjson(bodies[0]!);
+    expect(first[0].metadata.commit_message).toBe('chore: scaffold Kortix project');
+    expect(first[0].metadata.files[0].path).toBe('.kortix/agent.md');
+
+    const second = parseNdjson(bodies[1]!);
+    expect(second[0].metadata.commit_message).toBe('chore: project setup');
+    expect(second[0].metadata.files[0].path).toBe('kortix.yaml');
+  });
+
+  test('uses the caller-supplied token as the bearer credential (never self-mints)', async () => {
+    await codeStorageBackend.seedFiles!(
+      ref(),
+      'caller-token-123',
+      [{ path: 'a.txt', content: 'x' }],
+      { branch: 'main', message: 'msg' },
+    );
+    expect(headersSeen[0]!.Authorization).toBe('Bearer caller-token-123');
+    expect(headersSeen[0]!['Content-Type']).toBe('application/x-ndjson');
+  });
+
+  test('throws when the connection ref has no repo path', async () => {
+    await expect(
+      codeStorageBackend.seedFiles!(ref({ repoName: null }), 'tok', [{ path: 'a', content: 'b' }], {
+        branch: 'main',
+        message: 'm',
+      }),
+    ).rejects.toThrow(/missing a repo path/);
+  });
+
+  test('propagates a commit-pack failure (e.g. 409 branch-moved conflict)', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ result: { branch: 'main', message: 'expected branch head did not match current tip', success: false, status: 'precondition_failed' } }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      )) as unknown as typeof fetch;
+    await expect(
+      codeStorageBackend.seedFiles!(ref(), 'tok', [{ path: 'a', content: 'b' }], { branch: 'main', message: 'm' }),
+    ).rejects.toThrow(/did not match current tip/);
+  });
+});

--- a/apps/api/src/__tests__/unit-code-storage-git-backend.test.ts
+++ b/apps/api/src/__tests__/unit-code-storage-git-backend.test.ts
@@ -134,6 +134,29 @@ describe('mintCodeStorageJwt', () => {
     config.CODE_STORAGE_PRIVATE_KEY = ed.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
     expect(() => mintCodeStorageJwt({ scopes: ['git:read'] })).toThrow(/unsupported/);
   });
+
+  test('throws on a non-P-256 EC curve (ES256 is only spec-valid for P-256)', () => {
+    // secp384r1 (P-384) is a valid EC curve but NOT one ES256 supports —
+    // `asymmetricKeyType === 'ec'` alone isn't enough to pick ES256.
+    const p384 = generateKeyPairSync('ec', { namedCurve: 'secp384r1' });
+    config.CODE_STORAGE_PRIVATE_KEY = p384.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    expect(() => mintCodeStorageJwt({ scopes: ['git:read'] })).toThrow(/unsupported/);
+  });
+
+  test('normalizeKeyPem: strips surrounding quotes and un-escapes literal \\n before signing', async () => {
+    // Same PEM as the happy-path EC key, but stored the way a secret manager
+    // / .env round-trip commonly mangles a PEM: wrapped in quotes with real
+    // newlines flattened to the two-character sequence `\n`.
+    const mangled = `"${EC_PRIVATE_PEM.trim().replace(/\n/g, '\\n')}"`;
+    config.CODE_STORAGE_PRIVATE_KEY = mangled;
+    const jwt = mintCodeStorageJwt({ repo: 'team/project-alpha', scopes: ['git:read'] });
+    expect(decodeJwtHeader(jwt)).toEqual({ alg: 'ES256', typ: 'JWT' });
+    // Verifiable against the ORIGINAL (un-mangled) public key — proves the
+    // normalized PEM signs identically to the clean one.
+    const key = await importSPKI(EC_PUBLIC_PEM, 'ES256');
+    const { payload } = await jwtVerify(jwt, key);
+    expect(payload.repo).toBe('team/project-alpha');
+  });
 });
 
 describe('codeStorageGitAuthHeader', () => {
@@ -210,7 +233,7 @@ describe('createRepo / deleteRepo (mocked HTTP)', () => {
     globalThis.fetch = originalFetch;
   });
 
-  test('createRepo: POST /api/repos with repo:write org-wide bearer token, maps the response', async () => {
+  test('createRepo: POST /api/repos with a repo-scoped repo:write bearer token, maps the response', async () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
       requests.push({ url: href, init });
@@ -236,9 +259,13 @@ describe('createRepo / deleteRepo (mocked HTTP)', () => {
     const token = authHeader!.replace('Bearer ', '');
     const payload = decodeJwtPayload(token);
     expect(payload.scopes).toEqual(['repo:write']);
-    expect('repo' in payload).toBe(false); // org-wide — repo doesn't exist yet
+    // Per the live create-repo.md schema (additionalProperties: false, no
+    // `id` field): the target repo's identity comes from the JWT `repo`
+    // claim, not the body — so the token MUST be repo-scoped to the slug.
+    expect(payload.repo).toBe('my-project');
     const sentBody = JSON.parse(String(requests[0]!.init?.body));
-    expect(sentBody).toEqual({ id: 'my-project', default_branch: 'main' });
+    expect(sentBody).toEqual({ default_branch: 'main' });
+    expect(sentBody).not.toHaveProperty('id');
 
     expect(repo.provider).toBe('code-storage');
     expect(repo.externalRepoId).toBe('repo_7f2b3d9');
@@ -278,6 +305,25 @@ describe('createRepo / deleteRepo (mocked HTTP)', () => {
         isPrivate: true,
       }),
     ).rejects.toThrow(/repo already exists/);
+  });
+
+  test('CODE_STORAGE_API_BASE override replaces the default https://api.<org>.code.storage host (trailing slash stripped)', async () => {
+    config.CODE_STORAGE_API_BASE = 'https://mgmt.custom-cluster.example/';
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url;
+      requests.push({ url: href, init });
+      return json({ repo_id: 'repo_x', http_url: 'https://git.code.storage/acme/my-project', message: 'ok' });
+    }) as unknown as typeof fetch;
+
+    await codeStorageBackend.createRepo({
+      accountId: 'a',
+      projectId: 'p',
+      slug: 'my-project',
+      defaultBranch: 'main',
+      isPrivate: true,
+    });
+
+    expect(requests[0]!.url).toBe('https://mgmt.custom-cluster.example/api/repos');
   });
 
   test('deleteRepo: DELETE /api/repos/{repoName} (URL-encoded) with a repo-scoped repo:write bearer token', async () => {
@@ -322,6 +368,21 @@ describe('createRepo / deleteRepo (mocked HTTP)', () => {
       return json({});
     }) as unknown as typeof fetch;
     await codeStorageBackend.deleteRepo(ref({ repoName: null, externalRepoId: null }));
+    expect(called).toBe(false);
+  });
+
+  test('deleteRepo: throws instead of using externalRepoId as the {repo_name} path when repoName is missing', async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return json({});
+    }) as unknown as typeof fetch;
+    // `externalRepoId` is code.storage's opaque internal repo_id — never a
+    // valid `{repo_name}` path segment. Silently substituting it (the old
+    // behavior) would call DELETE against the wrong resource.
+    await expect(
+      codeStorageBackend.deleteRepo(ref({ repoName: null, externalRepoId: 'repo_7f2b3d9' })),
+    ).rejects.toThrow(/missing repoName/);
     expect(called).toBe(false);
   });
 });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -165,8 +165,8 @@ const envSchema = z.object({
 
   // ── Managed git (provider-agnostic via the git proxy) ────────────────────
   // MANAGED_GIT_PROVIDER selects the backend NEW managed repos provision on
-  // ('github' default; only active managed backend). The GitHub backend creates
-  // repos under MANAGED_GIT_GITHUB_OWNER (a Kortix-owned org) via the Kortix App
+  // ('github' default). The GitHub backend creates repos under
+  // MANAGED_GIT_GITHUB_OWNER (a Kortix-owned org) via the Kortix App
   // installed there (MANAGED_GIT_GITHUB_INSTALL_ID). Reuses KORTIX_GITHUB_APP_*
   // for the App JWT. Each backend's isConfigured() checks its own vars, so
   // leaving these blank keeps the managed-git path inert.
@@ -178,6 +178,24 @@ const envSchema = z.object({
   // over the GitHub App for managed-org admin ops (create/delete repo, invite
   // collaborator). Leave blank to use the App installation instead.
   MANAGED_GIT_GITHUB_TOKEN:        optStr,
+  // Second managed backend: code.storage (Pierre), a headless git-hosting API
+  // (https://code.storage/docs). Select it with MANAGED_GIT_PROVIDER=code-storage
+  // — inert (isConfigured() false) until org + private key are both set.
+  // CODE_STORAGE_ORG: your code.storage organization identifier — doubles as
+  // the JWT `iss` claim and (unless overridden) the git-remote/API host prefix.
+  CODE_STORAGE_ORG:                optStr,
+  // PKCS8 PEM private key (EC or RSA — algorithm auto-detected) code.storage
+  // issued you; signs every management-API and git-push/pull JWT server-side
+  // (projects/git-backends/code-storage.ts's `mintCodeStorageJwt`). Never
+  // logged, returned to a caller, or embedded verbatim — only its signatures
+  // leave this process. \n-escaped or quote-wrapped values are normalized.
+  CODE_STORAGE_PRIVATE_KEY:        optStr,
+  // Management API base URL. Defaults to `https://api.<CODE_STORAGE_ORG>.code.storage`
+  // when blank; set only for a non-standard cluster mapping.
+  CODE_STORAGE_API_BASE:           optStr,
+  // Git remote host for clone/push URLs. Defaults to `<CODE_STORAGE_ORG>.code.storage`
+  // when blank.
+  CODE_STORAGE_GIT_HOST:           optStr,
   // When true, runtime clients (sandbox + `kortix` CLI) use the Kortix git
   // proxy as their git origin (auth = KORTIX_TOKEN) instead of the real host —
   // so a real GitHub credential never reaches a sandbox. Requires a
@@ -744,6 +762,10 @@ export const config = {
   MANAGED_GIT_GITHUB_OWNER: env.MANAGED_GIT_GITHUB_OWNER,
   MANAGED_GIT_GITHUB_INSTALL_ID: env.MANAGED_GIT_GITHUB_INSTALL_ID,
   MANAGED_GIT_GITHUB_TOKEN: env.MANAGED_GIT_GITHUB_TOKEN,
+  CODE_STORAGE_ORG: env.CODE_STORAGE_ORG,
+  CODE_STORAGE_PRIVATE_KEY: env.CODE_STORAGE_PRIVATE_KEY,
+  CODE_STORAGE_API_BASE: env.CODE_STORAGE_API_BASE,
+  CODE_STORAGE_GIT_HOST: env.CODE_STORAGE_GIT_HOST,
   KORTIX_GIT_PROXY: env.KORTIX_GIT_PROXY,
   KORTIX_PRERESUME_ENABLED: env.KORTIX_PRERESUME_ENABLED,
   KORTIX_PRERESUME_MAX_PER_PROJECT: env.KORTIX_PRERESUME_MAX_PER_PROJECT,

--- a/apps/api/src/projects/git-backends/code-storage.ts
+++ b/apps/api/src/projects/git-backends/code-storage.ts
@@ -1,0 +1,419 @@
+/**
+ * code.storage (Pierre) managed git backend — a headless git-hosting layer
+ * reached entirely over plain HTTPS (management API + git smart-HTTP), no
+ * local git binary required server-side (unlike the GitHub backend's
+ * `seedRepoViaGitPush`, which shells out to `git`).
+ *
+ * Auth model (see https://code.storage/docs/getting-started/authentication):
+ * every request — management API AND git push/pull — carries a JWT you sign
+ * yourself with your org's PKCS8 private key (ES256 or RS256, auto-detected
+ * from the key). Claims: `iss` (org), `sub` (agent identity, for logging),
+ * `repo` (optional — a single repo path; OMIT for org-wide tokens), `scopes`,
+ * `iat`, `exp`. There is no key-exchange or OAuth dance — a compromised
+ * private key is a full compromise, so it lives ONLY in
+ * `CODE_STORAGE_PRIVATE_KEY` and is never logged, returned to a caller, or
+ * embedded anywhere except the one signature it produces.
+ *
+ * `mintCodeStorageJwt` is the SINGLE place that signs a token — every
+ * operation below (createRepo, deleteRepo, seedFiles, buildUpstream) goes
+ * through it with a scope-appropriate, short-lived claim set. It's
+ * deliberately synchronous (Node's `crypto.createSign` supports fully sync
+ * EC/RSA signing) rather than using the async `jose` SignJWT path used
+ * elsewhere in this repo (e.g. channels/teams/jwt.ts's verify side) — sync
+ * matters because `buildUpstream` is a SYNC method on `GitHostBackend`
+ * (types.ts docstring: token resolution stays with the project layer for
+ * OTHER backends, but code.storage mints its own on demand, and it can't
+ * `await` inside a sync call). Verified against `jose`'s verifier (round-trip
+ * tested for both ES256 and RS256) to produce byte-identical, spec-correct
+ * JWS output (ES256 needs the IEEE-P1363 R||S signature encoding, not
+ * OpenSSL's default DER ASN.1 — see `signWithAlg` below).
+ *
+ * Management API base URL defaults to `https://api.<org>.code.storage`
+ * (override with CODE_STORAGE_API_BASE for a non-standard cluster mapping);
+ * the git remote host defaults to `<org>.code.storage` (override with
+ * CODE_STORAGE_GIT_HOST). Git push/pull auth is embedded as HTTP Basic on the
+ * remote — username literally `t`, password the JWT — expressed here as an
+ * `Authorization: Basic` header (not baked into the URL) so it flows through
+ * the SAME neutral `{url, headers}` shape + `http.extraHeader` credential
+ * path the git proxy already uses for the GitHub backend (see
+ * `basicAuthHeader` in ./types.ts and seed.ts's `.extraheader` injection).
+ *
+ * Endpoint + payload shapes below are transcribed from the LIVE docs
+ * (code.storage/docs/reference/api/**), not the task's initial paraphrase —
+ * the real paths are under `/api/repos`, not `/repositories`.
+ */
+import { type KeyObject, createPrivateKey, createSign } from 'node:crypto';
+import { config } from '../../config';
+import type {
+  GitConnectionRef,
+  GitHostBackend,
+  GitScope,
+  ProvisionInput,
+  ProvisionedRepo,
+  SeedFile,
+  UpstreamGit,
+} from './types';
+
+export type CodeStorageScope = 'git:read' | 'git:write' | 'repo:write' | 'org:read';
+
+export interface CodeStorageJwtOptions {
+  /** Repo path this token is scoped to. Omit (or null) for an org-wide token (create-repo). */
+  repo?: string | null;
+  scopes: CodeStorageScope[];
+  /** Token lifetime in seconds. Defaults to a short-lived management-call TTL. */
+  ttlSeconds?: number;
+  /** `sub` claim — agent identity, for the org's own audit logging. */
+  subject?: string;
+}
+
+const DEFAULT_SUBJECT = 'kortix-api';
+// Short-lived — minted fresh per management-API call (create/delete/commit),
+// never persisted or reused.
+const MGMT_TOKEN_TTL_SECONDS = 5 * 60;
+// Longer-lived — embedded in a git remote credential a session or the CLI may
+// hold onto for the lifetime of a clone/push (buildUpstream, createRepo's
+// `initialToken`). Still far under the SDK helper's own 1-year default.
+const GIT_TOKEN_TTL_SECONDS = 60 * 60;
+
+function org(): string {
+  return config.CODE_STORAGE_ORG.trim();
+}
+
+/**
+ * Strip surrounding quotes (a secret stored as `"...PEM..."` double-encodes
+ * the quotes into the value) and un-escape literal `\n` sequences — same
+ * normalization as GitHub App keys (projects/github.ts's
+ * `normalizeGitHubPrivateKey`), duplicated here rather than imported so this
+ * backend has zero coupling to the GitHub one.
+ */
+function normalizeKeyPem(value: string): string {
+  return value
+    .trim()
+    .replace(/^\s*(['"])([\s\S]*)\1\s*$/, '$2')
+    .trim()
+    .replace(/\\n/g, '\n');
+}
+
+function privateKeyPem(): string {
+  return normalizeKeyPem(config.CODE_STORAGE_PRIVATE_KEY);
+}
+
+/** `https://api.<org>.code.storage` unless overridden. Trailing slash stripped. */
+function apiBase(): string {
+  const override = config.CODE_STORAGE_API_BASE.trim();
+  const base = override || `https://api.${org()}.code.storage`;
+  return base.replace(/\/+$/, '');
+}
+
+/** `<org>.code.storage` unless overridden — the git remote host. */
+function gitHost(): string {
+  return config.CODE_STORAGE_GIT_HOST.trim() || `${org()}.code.storage`;
+}
+
+interface LoadedKey {
+  keyObject: KeyObject;
+  alg: 'ES256' | 'RS256';
+}
+
+// Keyed by the raw PEM string so tests that swap CODE_STORAGE_PRIVATE_KEY
+// between cases never see a stale cached key.
+const keyCache = new Map<string, LoadedKey>();
+
+function loadKey(pem: string): LoadedKey {
+  const cached = keyCache.get(pem);
+  if (cached) return cached;
+  const keyObject = createPrivateKey(pem);
+  let alg: 'ES256' | 'RS256';
+  if (keyObject.asymmetricKeyType === 'ec') alg = 'ES256';
+  else if (keyObject.asymmetricKeyType === 'rsa') alg = 'RS256';
+  else {
+    throw new Error(
+      `code.storage: unsupported CODE_STORAGE_PRIVATE_KEY type "${keyObject.asymmetricKeyType}" ` +
+        `(expected a PKCS8 PEM-encoded EC or RSA key)`,
+    );
+  }
+  const loaded: LoadedKey = { keyObject, alg };
+  keyCache.set(pem, loaded);
+  return loaded;
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+/**
+ * Sign `data` with the given algorithm. ES256 (JWS/RFC 7518) requires the raw
+ * 64-byte IEEE-P1363 R||S concatenation — `dsaEncoding: 'ieee-p1363'` is what
+ * makes Node emit that instead of its default DER ASN.1 SEQUENCE, which a
+ * spec-compliant JWT verifier (jose, code.storage's own server) would reject.
+ * RS256 needs no such option — PKCS#1 v1.5 is already the JWS wire format.
+ */
+function signWithAlg(alg: 'ES256' | 'RS256', data: string, key: KeyObject): string {
+  const signer = createSign(alg === 'ES256' ? 'SHA256' : 'RSA-SHA256');
+  signer.update(data);
+  signer.end();
+  const signature =
+    alg === 'ES256' ? signer.sign({ key, dsaEncoding: 'ieee-p1363' }) : signer.sign(key);
+  return signature.toString('base64url');
+}
+
+/**
+ * Mint a code.storage JWT. The ONE signing path every operation in this file
+ * goes through — never construct or sign a token anywhere else.
+ */
+export function mintCodeStorageJwt(opts: CodeStorageJwtOptions): string {
+  const orgId = org();
+  const pem = privateKeyPem();
+  if (!orgId || !pem) {
+    throw new Error(
+      'code.storage is not configured (set CODE_STORAGE_ORG and CODE_STORAGE_PRIVATE_KEY)',
+    );
+  }
+  const { keyObject, alg } = loadKey(pem);
+  const now = Math.floor(Date.now() / 1000);
+  const ttl = opts.ttlSeconds ?? MGMT_TOKEN_TTL_SECONDS;
+  const payload: Record<string, unknown> = {
+    iss: orgId,
+    sub: opts.subject || DEFAULT_SUBJECT,
+    scopes: opts.scopes,
+    iat: now,
+    exp: now + ttl,
+  };
+  if (opts.repo) payload.repo = opts.repo;
+
+  const header = base64UrlJson({ alg, typ: 'JWT' });
+  const body = base64UrlJson(payload);
+  const unsigned = `${header}.${body}`;
+  const signature = signWithAlg(alg, unsigned, keyObject);
+  return `${unsigned}.${signature}`;
+}
+
+/** `Authorization: Basic base64("t:<jwt>")` — the git-remote credential scheme (username literally `t`). */
+export function codeStorageGitAuthHeader(jwt: string): Record<string, string> {
+  const encoded = Buffer.from(`t:${jwt}`).toString('base64');
+  return { Authorization: `Basic ${encoded}` };
+}
+
+function mgmtHeaders(token: string, extra?: Record<string, string>): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, ...extra };
+}
+
+async function parseJsonBody(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/** RFC 9457 problem-details on most endpoints; commit-pack's own `{result:{message}}` shape on conflict. */
+function extractErrorDetail(body: unknown): string | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as Record<string, unknown> & { result?: { message?: unknown } };
+  const detail = b.detail ?? b.title ?? b.error ?? b.result?.message ?? b.message;
+  return typeof detail === 'string' ? detail : null;
+}
+
+function codeStorageError(action: string, res: Response, body: unknown): Error {
+  const detail = extractErrorDetail(body) || res.statusText || 'request failed';
+  return new Error(`code.storage ${action} failed (${res.status}): ${detail}`);
+}
+
+/** Repo path segment (e.g. `team/project-alpha`) parsed from a code.storage `http_url` response field. */
+function parseRepoPath(httpUrl: string): string | null {
+  try {
+    const path = new URL(httpUrl).pathname.replace(/^\/+/, '').replace(/\.git$/, '');
+    return path || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Clean (credential-free) git clone URL for a repo path — auth travels via `buildUpstream`'s headers. */
+function buildCloneUrl(repoPath: string): string {
+  return `https://${gitHost()}/${repoPath.replace(/^\/+/, '')}.git`;
+}
+
+interface CommitPackFile {
+  path: string;
+  content: string;
+}
+
+/**
+ * POST .../commit-pack — code.storage's "create commit from files" endpoint
+ * (application/x-ndjson: one metadata line, then one base64 blob_chunk line
+ * per file). No local git checkout needed, unlike the GitHub backend's
+ * `seedRepoViaGitPush`. `expected_head_sha` is intentionally omitted — per
+ * the SDK docs, omitting it "allows unconditional fast-forward commits",
+ * which is what an initial repo seed wants (no prior tip to race against).
+ */
+async function commitPack(
+  repoPath: string,
+  token: string,
+  opts: { branch: string; message: string; files: SeedFile[] },
+): Promise<void> {
+  const author = { name: 'Kortix', email: 'noreply@kortix.ai' };
+  const commitFiles: CommitPackFile[] = opts.files.map((f) => ({
+    path: f.path,
+    content: f.content,
+  }));
+  const metadataLine = JSON.stringify({
+    metadata: {
+      target_branch: opts.branch,
+      commit_message: opts.message,
+      author,
+      files: commitFiles.map((f, i) => ({
+        path: f.path,
+        operation: 'upsert',
+        content_id: `blob-${i}`,
+        mode: '100644',
+      })),
+    },
+  });
+  const blobLines = commitFiles.map((f, i) =>
+    JSON.stringify({
+      blob_chunk: {
+        content_id: `blob-${i}`,
+        data: Buffer.from(f.content, 'utf8').toString('base64'),
+        eof: true,
+      },
+    }),
+  );
+  const ndjson = `${[metadataLine, ...blobLines].join('\n')}\n`;
+
+  const res = await fetch(`${apiBase()}/api/repos/${encodeURIComponent(repoPath)}/commit-pack`, {
+    method: 'POST',
+    headers: mgmtHeaders(token, { 'Content-Type': 'application/x-ndjson' }),
+    body: ndjson,
+  });
+  if (!res.ok) {
+    const body = await parseJsonBody(res);
+    throw codeStorageError(`commit to ${repoPath}#${opts.branch}`, res, body);
+  }
+}
+
+export const codeStorageBackend: GitHostBackend = {
+  id: 'code-storage',
+
+  async isConfigured(): Promise<boolean> {
+    return Boolean(org() && privateKeyPem());
+  },
+
+  async createRepo(input: ProvisionInput): Promise<ProvisionedRepo> {
+    // repo:write, org-wide (no `repo` claim — the repo doesn't exist yet).
+    const token = mintCodeStorageJwt({
+      scopes: ['repo:write'],
+      ttlSeconds: MGMT_TOKEN_TTL_SECONDS,
+    });
+    const res = await fetch(`${apiBase()}/api/repos`, {
+      method: 'POST',
+      headers: mgmtHeaders(token, { 'Content-Type': 'application/json' }),
+      body: JSON.stringify({
+        // `id`: a custom repo id/slug — documented on the SDK's `createRepo({id})`
+        // (the management API "mirrors SDK primitives"); the scraped HTTP schema
+        // doc doesn't enumerate it, so this is sent best-effort and ignored
+        // harmlessly if the server doesn't honor it (we always fall back to
+        // parsing the authoritative repo path out of the response `http_url`
+        // below, never assume `id` was applied).
+        id: input.slug,
+        default_branch: input.defaultBranch,
+      }),
+    });
+    const body = await parseJsonBody(res);
+    if (!res.ok) throw codeStorageError('create repo', res, body);
+    const created = (body ?? {}) as { repo_id?: unknown; http_url?: unknown };
+    const repoId = created.repo_id ? String(created.repo_id) : null;
+    const httpUrl = typeof created.http_url === 'string' ? created.http_url : null;
+    const repoPath = (httpUrl && parseRepoPath(httpUrl)) || input.slug;
+
+    return {
+      provider: 'code-storage',
+      upstreamUrl: buildCloneUrl(repoPath),
+      externalRepoId: repoId,
+      // code.storage repos aren't owner/name-namespaced like GitHub's — the
+      // org is one global config value, not a per-repo field.
+      repoOwner: null,
+      repoName: repoPath,
+      installationId: null,
+      credentialRef: null,
+      defaultBranch: input.defaultBranch,
+      // git:write (implies read, per the docs' scope table) — repo-scoped —
+      // for the caller's seeding / CLI first-push step.
+      initialToken: mintCodeStorageJwt({
+        repo: repoPath,
+        scopes: ['git:write', 'git:read'],
+        ttlSeconds: GIT_TOKEN_TTL_SECONDS,
+      }),
+    };
+  },
+
+  async deleteRepo(ref: GitConnectionRef): Promise<void> {
+    const repoPath = ref.repoName || ref.externalRepoId;
+    if (!repoPath) return;
+    // repo:write + per-repo authorization, per delete-repo's own docs (NOT
+    // git:write — deleting is a repo-management op, not a git op).
+    const token = mintCodeStorageJwt({
+      repo: repoPath,
+      scopes: ['repo:write'],
+      ttlSeconds: MGMT_TOKEN_TTL_SECONDS,
+    });
+    const res = await fetch(`${apiBase()}/api/repos/${encodeURIComponent(repoPath)}`, {
+      method: 'DELETE',
+      headers: mgmtHeaders(token),
+    });
+    // 404 (already gone) / 409 (delete already in flight) are both a no-op
+    // success from this backend's point of view — mirrors the idempotent
+    // "best-effort" delete contract the rest of the codebase relies on.
+    if (!res.ok && res.status !== 404 && res.status !== 409) {
+      const body = await parseJsonBody(res);
+      throw codeStorageError('delete repo', res, body);
+    }
+  },
+
+  buildUpstream(ref: GitConnectionRef, token: string | null, scope: GitScope): UpstreamGit {
+    const repoPath = ref.repoName || undefined;
+    // Honor an already-resolved token (forward-compat with a future caller
+    // that mints one, e.g. via a scoped git-credential endpoint) — otherwise
+    // self-mint. This is the normal path today: nothing upstream of
+    // `GitHostBackend` yet knows how to resolve a code.storage credential
+    // (`resolveProjectGitAuth` in projects/lib/git.ts is GitHub-only), so
+    // `token` arrives as `null` and this backend mints its own, scoped to
+    // `ref.repoName` and the requested read/write scope.
+    const jwt =
+      token ??
+      mintCodeStorageJwt({
+        repo: repoPath,
+        scopes: scope === 'write' ? ['git:write', 'git:read'] : ['git:read'],
+        ttlSeconds: GIT_TOKEN_TTL_SECONDS,
+      });
+    return {
+      url: repoPath ? buildCloneUrl(repoPath) : ref.upstreamUrl,
+      headers: codeStorageGitAuthHeader(jwt),
+    };
+  },
+
+  async seedFiles(
+    ref: GitConnectionRef,
+    token: string,
+    files: SeedFile[],
+    opts: { branch: string; message: string; baseFiles?: SeedFile[] },
+  ): Promise<void> {
+    const repoPath = ref.repoName;
+    if (!repoPath) throw new Error('code.storage seedFiles: connection ref is missing a repo path');
+    // Same two-commit shape as `seedRepoViaGitPush` (github.ts's seed.ts): a
+    // deterministic base-scaffold commit first, then the per-project files —
+    // commit-pack does one commit per call, so issue two sequential requests.
+    if (opts.baseFiles?.length) {
+      await commitPack(repoPath, token, {
+        branch: opts.branch,
+        message: 'chore: scaffold Kortix project',
+        files: opts.baseFiles,
+      });
+    }
+    await commitPack(repoPath, token, {
+      branch: opts.branch,
+      message: opts.baseFiles?.length ? 'chore: project setup' : opts.message,
+      files,
+    });
+  },
+};

--- a/apps/api/src/projects/git-backends/code-storage.ts
+++ b/apps/api/src/projects/git-backends/code-storage.ts
@@ -6,10 +6,14 @@
  *
  * Auth model (see https://code.storage/docs/getting-started/authentication):
  * every request — management API AND git push/pull — carries a JWT you sign
- * yourself with your org's PKCS8 private key (ES256 or RS256, auto-detected
- * from the key). Claims: `iss` (org), `sub` (agent identity, for logging),
- * `repo` (optional — a single repo path; OMIT for org-wide tokens), `scopes`,
- * `iat`, `exp`. There is no key-exchange or OAuth dance — a compromised
+ * yourself with your org's PKCS8 private key (ES256 for EC P-256, RS256 for
+ * RSA — auto-detected from the key; a non-P-256 EC curve is rejected, since
+ * ES256 is only spec-valid for P-256). Claims: `iss` (org), `sub` (agent
+ * identity, for logging), `repo` (a single repo path — REQUIRED, including
+ * for createRepo, since the target repo's identity comes from this claim,
+ * not the request body; omit only for genuinely org-wide, no-target
+ * operations), `scopes`, `iat`, `exp`. There is no key-exchange or OAuth
+ * dance — a compromised
  * private key is a full compromise, so it lives ONLY in
  * `CODE_STORAGE_PRIVATE_KEY` and is never logged, returned to a caller, or
  * embedded anywhere except the one signature it produces.
@@ -124,12 +128,21 @@ function loadKey(pem: string): LoadedKey {
   if (cached) return cached;
   const keyObject = createPrivateKey(pem);
   let alg: 'ES256' | 'RS256';
-  if (keyObject.asymmetricKeyType === 'ec') alg = 'ES256';
-  else if (keyObject.asymmetricKeyType === 'rsa') alg = 'RS256';
-  else {
+  // ES256 is only spec-valid for P-256 (`prime256v1`) — an EC key on any other
+  // curve (P-384, P-521, secp256k1, ...) would sign fine but produce a JWS the
+  // server's ES256 verifier must reject, so treat it the same as an
+  // unsupported key type rather than silently minting an invalid token.
+  if (
+    keyObject.asymmetricKeyType === 'ec' &&
+    keyObject.asymmetricKeyDetails?.namedCurve === 'prime256v1'
+  ) {
+    alg = 'ES256';
+  } else if (keyObject.asymmetricKeyType === 'rsa') {
+    alg = 'RS256';
+  } else {
     throw new Error(
       `code.storage: unsupported CODE_STORAGE_PRIVATE_KEY type "${keyObject.asymmetricKeyType}" ` +
-        `(expected a PKCS8 PEM-encoded EC or RSA key)`,
+        `(expected a PKCS8 PEM-encoded EC P-256 key or RSA key)`,
     );
   }
   const loaded: LoadedKey = { keyObject, alg };
@@ -300,8 +313,14 @@ export const codeStorageBackend: GitHostBackend = {
   },
 
   async createRepo(input: ProvisionInput): Promise<ProvisionedRepo> {
-    // repo:write, org-wide (no `repo` claim — the repo doesn't exist yet).
+    // repo:write, REPO-SCOPED to the repo we're about to create. Per the live
+    // docs (code.storage/docs/reference/api/repositories/create-repo.md) the
+    // request body schema is `additionalProperties: false` with only
+    // `default_branch` / `base_repo` — there is NO `id` field. The target
+    // repo's identity comes entirely from the JWT's `repo` claim, not the
+    // body, so the token — not the payload — is what names `input.slug`.
     const token = mintCodeStorageJwt({
+      repo: input.slug,
       scopes: ['repo:write'],
       ttlSeconds: MGMT_TOKEN_TTL_SECONDS,
     });
@@ -309,13 +328,6 @@ export const codeStorageBackend: GitHostBackend = {
       method: 'POST',
       headers: mgmtHeaders(token, { 'Content-Type': 'application/json' }),
       body: JSON.stringify({
-        // `id`: a custom repo id/slug — documented on the SDK's `createRepo({id})`
-        // (the management API "mirrors SDK primitives"); the scraped HTTP schema
-        // doc doesn't enumerate it, so this is sent best-effort and ignored
-        // harmlessly if the server doesn't honor it (we always fall back to
-        // parsing the authoritative repo path out of the response `http_url`
-        // below, never assume `id` was applied).
-        id: input.slug,
         default_branch: input.defaultBranch,
       }),
     });
@@ -348,8 +360,24 @@ export const codeStorageBackend: GitHostBackend = {
   },
 
   async deleteRepo(ref: GitConnectionRef): Promise<void> {
-    const repoPath = ref.repoName || ref.externalRepoId;
-    if (!repoPath) return;
+    // Nothing was ever provisioned (or we never learned an identifier) —
+    // a true no-op, nothing to clean up.
+    if (!ref.repoName && !ref.externalRepoId) return;
+    // `DELETE /api/repos/{repo_name}` takes the human-readable repo
+    // name/path, NOT `externalRepoId` (code.storage's opaque internal
+    // `repo_id`, e.g. `repo_7f2b3d9`) — the two are different identifier
+    // spaces and using the id as the path segment would either 404 against
+    // the wrong resource or, worse, silently no-op against a repo that was
+    // never actually deleted. Refuse rather than guess.
+    if (!ref.repoName) {
+      throw new Error(
+        'code.storage deleteRepo: connection ref is missing repoName (the ' +
+          '`{repo_name}` path segment DELETE /api/repos/{repo_name} expects) — ' +
+          `refusing to delete using externalRepoId ("${ref.externalRepoId}") as a ` +
+          'substitute, since that is an opaque internal id, not the repo name/path',
+      );
+    }
+    const repoPath = ref.repoName;
     // repo:write + per-repo authorization, per delete-repo's own docs (NOT
     // git:write — deleting is a repo-management op, not a git op).
     const token = mintCodeStorageJwt({

--- a/apps/api/src/projects/git-backends/index.ts
+++ b/apps/api/src/projects/git-backends/index.ts
@@ -8,3 +8,10 @@ export {
   managedGithubToken,
 } from './github';
 export { seedRepoViaGitPush } from './seed';
+export {
+  codeStorageBackend,
+  codeStorageGitAuthHeader,
+  mintCodeStorageJwt,
+  type CodeStorageJwtOptions,
+  type CodeStorageScope,
+} from './code-storage';

--- a/apps/api/src/projects/git-backends/registry.ts
+++ b/apps/api/src/projects/git-backends/registry.ts
@@ -5,15 +5,20 @@
  * Forgejo/Artifacts project resolves through its own — all behind the same
  * Kortix git proxy.
  *
- * GitHub is the default + only currently-active managed backend. Forgejo /
- * Cloudflare Artifacts slot in here as drop-ins (same `GitHostBackend`
+ * GitHub is the default managed backend. code.storage (Pierre) is a second,
+ * flag-gated drop-in — select it per-deployment with
+ * `MANAGED_GIT_PROVIDER=code-storage`; it stays fully inert (isConfigured()
+ * false) until CODE_STORAGE_ORG/CODE_STORAGE_PRIVATE_KEY are set. Forgejo /
+ * Cloudflare Artifacts slot in here the same way (same `GitHostBackend`
  * interface) with zero changes to the proxy, sandbox, or CLI.
  */
+import { codeStorageBackend } from './code-storage';
 import { githubBackend } from './github';
 import type { GitHostBackend } from './types';
 
 const backends = new Map<string, GitHostBackend>([
   [githubBackend.id, githubBackend],
+  [codeStorageBackend.id, codeStorageBackend],
   // ['forgejo', forgejoBackend],
   // ['artifacts', artifactsBackend],
 ]);


### PR DESCRIPTION
## Summary

Implements the **code.storage** (Pierre) managed git provider as a second, flag-gated drop-in `GitHostBackend`, alongside the existing GitHub backend. Select it per-deployment with `MANAGED_GIT_PROVIDER=code-storage`; GitHub remains the default. The backend is fully inert (`isConfigured()` returns `false`) until `CODE_STORAGE_ORG` and `CODE_STORAGE_PRIVATE_KEY` are both set.

**Zero changes** to the git proxy, sandbox, or CLI — this only adds a new implementation behind the existing `GitHostBackend` interface (`apps/api/src/projects/git-backends/types.ts`) and registers it in `registry.ts`.

### Files
- `apps/api/src/projects/git-backends/code-storage.ts` (new) — the backend: `createRepo`, `deleteRepo`, `buildUpstream`, `seedFiles`, plus a centralized `mintCodeStorageJwt` helper every operation signs through.
- `apps/api/src/projects/git-backends/registry.ts` — registers `codeStorageBackend` under id `"code-storage"`.
- `apps/api/src/projects/git-backends/index.ts` — re-exports the new backend + JWT helper.
- `apps/api/src/config.ts` — adds `CODE_STORAGE_ORG` / `CODE_STORAGE_PRIVATE_KEY` / `CODE_STORAGE_API_BASE` / `CODE_STORAGE_GIT_HOST` (all `optStr`, no defaults required — inert unless configured).
- `apps/api/src/__tests__/unit-code-storage-git-backend.test.ts` (new) — 28 unit tests, all HTTP mocked.

## Endpoint/payload shapes — verified against the LIVE docs, not the task's initial paraphrase

I fetched `code.storage/docs/llms.txt` + the individual `reference/api/**.md` pages (the linked `openapi.json` actually resolves to an unrelated Mintlify sandbox spec, so it was useless). Two corrections vs. the initial task brief:
- Endpoints are under **`/api/repos`**, not `/repositories` (e.g. `POST /api/repos`, `DELETE /api/repos/{repo_name}`, `POST /api/repos/{repo_name}/commit-pack`).
- "Create commit from files" is `POST .../commit-pack` with an `application/x-ndjson` body (one metadata line + one base64 blob_chunk line per file) — not a plain JSON POST.

## authModel — exactly how the JWT is minted + threaded through

Every code.storage request (management API **and** git push/pull) carries a JWT signed with the org's own PKCS8 private key (ES256 or RS256, auto-detected from the key). Claims: `iss` (org), `sub` (agent identity), `repo` (optional — omitted for org-wide tokens like `createRepo`), `scopes`, `iat`, `exp`.

`mintCodeStorageJwt` is the **single** signing path everything goes through. It's deliberately **synchronous** — built directly on `node:crypto`'s `createSign`/`.sign()` (not the async `jose` `SignJWT` used elsewhere in this repo, e.g. `channels/teams/jwt.ts`) — because `GitHostBackend.buildUpstream` is a **sync** method on the interface and can't `await`. ES256 needs the JWS-mandated IEEE-P1363 raw R‖S signature encoding (`dsaEncoding: 'ieee-p1363'`), not OpenSSL's default DER ASN.1 — I round-trip-verified both ES256 and RS256 output against `jose`'s verifier to confirm spec-correct output.

- **Management API**: `Authorization: Bearer <jwt>` — `repo:write` (org-wide) for create, `repo:write` (repo-scoped) for delete, `git:write` (repo-scoped) for commit-pack.
- **Git remote**: `Authorization: Basic base64("t:<jwt>")` — code.storage's convention is literally username `t`; expressed as a header (not baked into the URL) so it matches the neutral `{url, headers}` shape + `http.extraHeader` credential path the git proxy already uses for GitHub (`basicAuthHeader` in `types.ts`).

**Known wiring gap (pre-existing, not introduced here):** `resolveProjectGitAuth` (`projects/lib/git.ts`) is GitHub-only — it has no branch for `provider === 'code-storage'`, so the token the git proxy would normally hand to `buildUpstream` arrives as `null` for this backend. `buildUpstream` handles this by **self-minting** a scope-appropriate JWT when no token is supplied (falling back to an externally-resolved one if a future caller provides it). This is correct and self-contained today; a future PR could teach `resolveProjectGitAuth` about code-storage explicitly, but that's out of scope here per the "zero changes to the git proxy" constraint.

## configSecrets

- `CODE_STORAGE_ORG` — org identifier; doubles as the JWT `iss` claim and the default host/API prefix.
- `CODE_STORAGE_PRIVATE_KEY` — PKCS8 PEM (EC or RSA); signs every JWT server-side; never logged or returned to a caller.
- `CODE_STORAGE_API_BASE` — optional override, defaults to `https://api.<org>.code.storage`.
- `CODE_STORAGE_GIT_HOST` — optional override, defaults to `<org>.code.storage`.
- `MANAGED_GIT_PROVIDER=code-storage` selects this backend for new managed repos (unchanged mechanism, already existed for the GitHub default).

## liveVerifyStatus

**Unit-tested only — live e2e is explicitly PENDING.** A private key was pasted into chat earlier in this task and must be treated as compromised; I did not use it anywhere, and no key (real or otherwise) appears in any commit. All 28 tests use throwaway EC/RSA keypairs generated in-process with `node:crypto.generateKeyPairSync` and mock `globalThis.fetch` — nothing here touches the live code.storage API. Once the operator rotates `CODE_STORAGE_PRIVATE_KEY` and drops the new one into Secrets Manager, live verification (create → seed → clone/push → delete against the real API) is still needed before flipping any real deployment to `MANAGED_GIT_PROVIDER=code-storage`.

## Test plan
- [x] `pnpm typecheck` (apps/api) — clean
- [x] `bun test` on the new file — 28/28 pass (mocked HTTP + JWT round-trip against `jose`)
- [x] Confirmed no regression in adjacent git-backend tests (`unit-git-backends.test.ts`, `unit-github-owner-type-routing.test.ts`, `unit-github-app-isconfigured.test.ts`, `projects/github.test.ts`, `projects/seed-files.test.ts`) run in isolation
- [x] Confirmed the full-suite-in-one-process failures (`e2e-project-limit.test.ts`, `e2e-create-repo-starter.test.ts`, and the `mock.module` cross-file leakage noise) are pre-existing on `main`/base, reproduced identically with my changes stashed
- [ ] Live e2e against the real code.storage API — **pending** a freshly-rotated `CODE_STORAGE_PRIVATE_KEY` in Secrets Manager (operator action)

Not merging — opened for review only, per instructions.