### PR TITLE
chore: remove 27 more unused imports (CodeQL js/unused-local-variable batch 2)

### DIFF
--- a/apps/api/src/__tests__/integration-token-revocation.test.ts
+++ b/apps/api/src/__tests__/integration-token-revocation.test.ts
@@ -5,7 +5,7 @@
  * sandbox session tokens) is revoked so they can't keep acting on a bearer.
  */
 import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { accountTokens, accounts, projects } from '@kortix/db';
 import { db } from '../shared/db';
 import { revokeAllAccountTokensForUser } from '../repositories/account-tokens';

--- a/apps/api/src/billing/index.ts
+++ b/apps/api/src/billing/index.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { AUTO_TOPUP_DEFAULT_AMOUNT, AUTO_TOPUP_DEFAULT_THRESHOLD } from '@kortix/shared';
 import { timingSafeEqual } from 'node:crypto';
 import type { Context } from 'hono';
 import { config } from '../config';

--- a/apps/api/src/billing/services/webhooks.ts
+++ b/apps/api/src/billing/services/webhooks.ts
@@ -16,7 +16,6 @@ import {
   getTierByPriceId,
   getMonthlyCredits,
   grantForSeats,
-  isUpgrade,
   mapRevenueCatProductToTier,
   getRevenueCatPeriodType,
   isRevenueCatAnonymous,

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -1,12 +1,10 @@
 import {
-  executorConnectionProfiles,
   executorConnectorActions,
   executorConnectorPolicies,
   executorConnectors,
   executorExecutions,
   executorProjectPolicies,
   executorProjectSettings,
-  projectSessions,
   projects,
   sessionToolApprovals,
 } from '@kortix/db';

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -49,11 +49,11 @@ import { eq } from 'drizzle-orm';
 import { ensureSchema } from './ensure-schema';
 import { initModelPricing, stopModelPricing } from './router/config/model-pricing';
 import { runtimeModelCatalog } from './llm-gateway/models/runtime-catalog';
-import { tunnelApp, wsHandlers as tunnelWsHandlers, startTunnelService, stopTunnelService, getTunnelServiceStatus } from './tunnel';
+import { tunnelApp, wsHandlers as tunnelWsHandlers, startTunnelService, stopTunnelService } from './tunnel';
 import { accessControlApp } from './access-control';
 import { startAccessControlCache, stopAccessControlCache } from './shared/access-control-cache';
 import { startTmpReaper, stopTmpReaper } from './snapshots/tmp-reaper';
-import { startLeaderElection, stopLeaderElection, isLeader, runsSingletonWorkers } from './shared/leader-election';
+import { startLeaderElection, stopLeaderElection, runsSingletonWorkers } from './shared/leader-election';
 import { marketplaceApp } from './marketplace';
 import { oauthApp } from './oauth';
 import {
@@ -61,8 +61,6 @@ import {
   projectsApp,
   startProjectTriggerScheduler,
   stopProjectTriggerScheduler,
-  getTriggerSchedulerHealth,
-  schedulerSweepIsStale,
 } from './projects';
 import { startProjectMaintenance, stopProjectMaintenance } from './projects/maintenance';
 import { kickStartupPreBuild } from './snapshots/builder';

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -40,7 +40,7 @@ import {
   parseManifestText,
   serializeManifestObject,
 } from '@kortix/manifest-schema';
-import { type GitBackedProject, readManifestFromRepo, readRepoFile } from './git';
+import { type GitBackedProject, readManifestFromRepo } from './git';
 
 /** Where the manifest lives. Same path the rest of the platform looks for.
  *  A project may instead use `kortix.yaml` ({@link MANIFEST_FILENAME_YAML}) —

--- a/apps/mobile/components/session/GroupedReasoningCard.tsx
+++ b/apps/mobile/components/session/GroupedReasoningCard.tsx
@@ -36,7 +36,6 @@ import Animated, {
   withSequence,
   Easing,
   FadeIn,
-  FadeOut,
 } from 'react-native-reanimated';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {

--- a/apps/mobile/components/session/ReasoningSection.tsx
+++ b/apps/mobile/components/session/ReasoningSection.tsx
@@ -22,11 +22,8 @@ import {
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
-  withRepeat,
   withTiming,
-  withSequence,
   Easing,
-  interpolate,
   FadeIn,
   FadeOut,
 } from 'react-native-reanimated';

--- a/apps/mobile/components/session/SessionPage.tsx
+++ b/apps/mobile/components/session/SessionPage.tsx
@@ -29,7 +29,6 @@ import { useColorScheme } from 'nativewind';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { Menu as MenuIcon, X as CloseIcon } from 'lucide-react-native';
-import { Icon } from '@/components/ui/icon';
 import { Text as RNText } from 'react-native';
 
 import { useSyncStore } from '@/lib/opencode/sync-store';

--- a/apps/mobile/components/session/SessionTurn.tsx
+++ b/apps/mobile/components/session/SessionTurn.tsx
@@ -12,7 +12,6 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import { SelectableMarkdownText } from '@/components/ui/selectable-markdown';
 import { SandboxPreviewCard, detectLocalhostUrls } from '@/components/session/SandboxPreviewCard';
-import { ReasoningSection } from '@/components/session/ReasoningSection';
 import { GroupedReasoningCard } from '@/components/session/GroupedReasoningCard';
 import { SessionErrorBanner } from './SessionErrorBanner';
 import ReAnimated, {
@@ -89,7 +88,6 @@ import {
   getRetryInfo,
   getRetryMessage,
   splitUserParts,
-  isFilePart,
 } from '@kortix/sdk/turns';
 
 // Enable LayoutAnimation on Android

--- a/apps/mobile/components/shared/MarkdownRenderer.tsx
+++ b/apps/mobile/components/shared/MarkdownRenderer.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@/components/ui/text';
 import type React from 'react';
-import { ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 
 interface MarkdownRendererProps {
   content: string;

--- a/apps/mobile/hooks/media/useAudioRecordingHandlers.ts
+++ b/apps/mobile/hooks/media/useAudioRecordingHandlers.ts
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import * as Haptics from 'expo-haptics';
 import type { useAudioRecorder } from './useAudioRecorder';
 import type { useAgentManager } from '../ui/useAgentManager';
-import { saveAudioToFileSystem, deleteCachedAudio } from '@/lib/transcription';
 import { log } from '@/lib/logger';
 
 /**

--- a/apps/web/src/features/file-renderers/presentation/FullScreenPresentationViewer.tsx
+++ b/apps/web/src/features/file-renderers/presentation/FullScreenPresentationViewer.tsx
@@ -2,7 +2,6 @@ import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import {
   X,
   ChevronLeft,

--- a/apps/web/src/features/session/tool/shared/error-and-executor.tsx
+++ b/apps/web/src/features/session/tool/shared/error-and-executor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { STATUS_BG, STATUS_BORDER, STATUS_TEXT } from '@/components/ui/status';
+import { STATUS_TEXT } from '@/components/ui/status';
 import { OutputBlock } from '@/features/session/tool/shared/output-block';
 import { cn } from '@/lib/utils';
 

--- a/apps/web/src/features/session/tool/tool-part-renderer.tsx
+++ b/apps/web/src/features/session/tool/tool-part-renderer.tsx
@@ -5,8 +5,6 @@ import { ToolError } from '@/features/session/tool/tool-error';
 import {
   BasicTool,
   BoundActivateContext,
-  partInput,
-  shouldShowToolPartInActionsPanel,
   StalePendingContext,
   ToolActivateContext,
   ToolDurationContext,
@@ -20,7 +18,7 @@ import { Button } from '@/components/ui/button';
 import { STATUS_TEXT } from '@/components/ui/status';
 import { PERMISSION_LABELS, type PermissionRequest, type QuestionRequest, type ToolPart } from '@/ui';
 import { CircleAlert } from 'lucide-react';
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 


### PR DESCRIPTION
## What

Second batch of verified-safe unused-import removals flagged by CodeQL `js/unused-local-variable`. 15 files, +7/-24. Pure mechanical; no behavior change.

Follows #5025 (batch 1, 11 removals). Together these two PRs clear 38 of the ~75 CodeQL `js/unused-local-variable` notes.

## Verification

Each name checked with a whole-file word-boundary search after stripping import statements (`uses_outside_imports = 0`). Post-removal re-verified all 27 names now appear 0 times in their files.

## Skipped false positives (CodeQL wrong)

Same set as #5025 — these ARE used, left untouched: `auth`/`json` in sessions.ts, `GitOperationError` in index.ts, `Webhook` in audit-webhooks-card.tsx, `createRepo` in r1.ts, `config` in backend.ts, `and`/`projects`/`deleteProjectSession` in 3 test/sdk files.

Mirko AGI cycle 20.