### PR TITLE
fix(github-app): install-callback no longer 500s on a bare hit (no state)

### DIFF
--- a/apps/api/src/__tests__/unit-github-app-install-state.test.ts
+++ b/apps/api/src/__tests__/unit-github-app-install-state.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the GitHub App install-state token (apps/api/src/projects/
+ * github.ts): buildGitHubAppInstallState / verifyGitHubAppInstallStatePayload.
+ *
+ * These are the state tokens GitHub round-trips through the browser on the
+ * App install flow (buildGitHubAppInstallUrl → GitHub → GET /install-callback
+ * → verifyGitHubAppInstallStatePayload). They correlate an installation back
+ * to the initiating Kortix account and carry a 30-minute TTL.
+ *
+ * Regression coverage for a real bug the ke2e suite surfaced (GHA-2): a bare
+ * GET /install-callback with NO `state` query param used to 500 because
+ * `verifyGitHubAppInstallStatePayload` called `.split('.')` on `undefined`.
+ * The function now mirrors `verifyManifestStartState`'s null-on-non-string
+ * contract; these tests pin that contract so it can't regress.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  buildGitHubAppInstallState,
+  verifyGitHubAppInstallStatePayload,
+} from '../projects/github';
+// buildGitHubAppInstallState is exported from github.ts for testability (it's
+// a pure HMAC-base64url function with no side effects; the only caller is
+// buildGitHubAppInstallUrl, which feeds the token into a GitHub URL).
+
+const ORIG_SECRET = process.env.SUPABASE_JWT_SECRET;
+beforeEach(() => {
+  process.env.SUPABASE_JWT_SECRET = 'test-supabase-jwt-secret';
+});
+afterEach(() => {
+  if (ORIG_SECRET === undefined) delete process.env.SUPABASE_JWT_SECRET;
+  else process.env.SUPABASE_JWT_SECRET = ORIG_SECRET;
+});
+
+describe('verifyGitHubAppInstallStatePayload — defensive input handling', () => {
+  test('returns null for undefined (the bare-callback regression)', () => {
+    // This is the exact shape that used to 500: GET /install-callback with no
+    // query at all → query.state is undefined → .split('.') crashed.
+    expect(verifyGitHubAppInstallStatePayload(undefined)).toBeNull();
+  });
+
+  test('returns null for null', () => {
+    expect(verifyGitHubAppInstallStatePayload(null)).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(verifyGitHubAppInstallStatePayload('')).toBeNull();
+  });
+
+  test('returns null for non-string types', () => {
+    // The zod schema is `z.string().optional()`, so a non-string can't reach
+    // the handler in practice — but the function's contract is now
+    // null-on-non-string regardless, defensive against any future caller.
+    expect(verifyGitHubAppInstallStatePayload(123 as unknown as string)).toBeNull();
+    expect(verifyGitHubAppInstallStatePayload({} as unknown as string)).toBeNull();
+  });
+});
+
+describe('verifyGitHubAppInstallStatePayload — malformed/foreign tokens', () => {
+  test('rejects a token with the wrong version prefix', () => {
+    const good = buildGitHubAppInstallState('acct-1');
+    const tampered = `v2${good.slice(2)}`;
+    expect(verifyGitHubAppInstallStatePayload(tampered)).toBeNull();
+  });
+
+  test('rejects a token with too few parts', () => {
+    expect(verifyGitHubAppInstallStatePayload('v1.payload')).toBeNull();
+    expect(verifyGitHubAppInstallStatePayload('not-a-token')).toBeNull();
+  });
+
+  test('rejects a token with too many parts', () => {
+    expect(verifyGitHubAppInstallStatePayload('v1.payload.sig.extra')).toBeNull();
+  });
+
+  test('rejects a token whose signature was tampered with', () => {
+    const good = buildGitHubAppInstallState('acct-1');
+    const parts = good.split('.');
+    // Flip the last character of the signature — base64url is forgiving, so
+    // mutate until the HMAC differs (a single-char swap almost always does).
+    const sig = parts[2]!;
+    const tamperedSig = sig.endsWith('A') ? sig.slice(0, -1) + 'B' : sig.slice(0, -1) + 'A';
+    const tampered = `${parts[0]}.${parts[1]}.${tamperedSig}`;
+    expect(verifyGitHubAppInstallStatePayload(tampered)).toBeNull();
+  });
+
+  test('rejects a token whose payload was tampered with (signature no longer matches)', () => {
+    const good = buildGitHubAppInstallState('acct-1');
+    const parts = good.split('.');
+    // Decode, swap the account_id, re-encode — signature is over the ORIGINAL
+    // payload, so this must fail.
+    const payloadJson = JSON.parse(
+      Buffer.from(parts[1]!, 'base64url').toString('utf8'),
+    ) as { account_id: string; nonce?: string; iat: number };
+    payloadJson.account_id = 'attacker-acct';
+    const tamperedPayload = Buffer.from(JSON.stringify(payloadJson)).toString('base64url');
+    const tampered = `${parts[0]}.${tamperedPayload}.${parts[2]}`;
+    expect(verifyGitHubAppInstallStatePayload(tampered)).toBeNull();
+  });
+});
+
+describe('verifyGitHubAppInstallStatePayload — TTL + happy path', () => {
+  test('accepts a freshly-minted token and returns the accountId', () => {
+    const token = buildGitHubAppInstallState('acct-1');
+    const verified = verifyGitHubAppInstallStatePayload(token);
+    expect(verified?.accountId).toBe('acct-1');
+  });
+
+  test('accepts a token just inside the 30-minute TTL', () => {
+    const twentyNineMinAgo = Date.now() - 29 * 60 * 1000;
+    const token = buildGitHubAppInstallState('acct-1', {}, twentyNineMinAgo);
+    const verified = verifyGitHubAppInstallStatePayload(token, Date.now());
+    expect(verified?.accountId).toBe('acct-1');
+  });
+
+  test('rejects a token past the 30-minute TTL', () => {
+    const thirtyOneMinAgo = Date.now() - 31 * 60 * 1000;
+    const token = buildGitHubAppInstallState('acct-1', {}, thirtyOneMinAgo);
+    expect(verifyGitHubAppInstallStatePayload(token, Date.now())).toBeNull();
+  });
+
+  test('rejects a token with an iat too far in the future (clock skew guard)', () => {
+    const twoMinInFuture = Date.now() + 2 * 60 * 1000;
+    const token = buildGitHubAppInstallState('acct-1', {}, twoMinInFuture);
+    expect(verifyGitHubAppInstallStatePayload(token, Date.now())).toBeNull();
+  });
+
+  test('round-trips the nonce when one is provided', () => {
+    const token = buildGitHubAppInstallState('acct-1', { nonce: 'nonce-abc' });
+    const verified = verifyGitHubAppInstallStatePayload(token);
+    expect(verified?.accountId).toBe('acct-1');
+    expect(verified?.nonce).toBe('nonce-abc');
+  });
+});

--- a/apps/api/src/projects/github.ts
+++ b/apps/api/src/projects/github.ts
@@ -148,7 +148,7 @@ export interface GitHubAppInstallState {
   issuedAt: number;
 }
 
-function buildGitHubAppInstallState(
+export function buildGitHubAppInstallState(
   accountId: string,
   options: { nonce?: string } = {},
   nowMs = Date.now(),
@@ -161,7 +161,21 @@ function buildGitHubAppInstallState(
   return `v1.${payload}.${signGitHubAppStatePayload(payload)}`;
 }
 
-export function verifyGitHubAppInstallStatePayload(state: string, nowMs = Date.now()): GitHubAppInstallState | null {
+export function verifyGitHubAppInstallStatePayload(
+  state: string | undefined | null,
+  nowMs = Date.now(),
+): GitHubAppInstallState | null {
+  // Defensive against bare/missing `state` query params — the install-callback
+  // route (apps/api/src/platform/routes/github-app.ts) calls this with
+  // `query.state`, which is `string | undefined` (zod schema marks it
+  // `optional()`). Without this guard, `undefined.split('.')` throws a
+  // TypeError that surfaces as a 500 on a bare GET /install-callback hit —
+  // observed live on staging (ke2e GHA-2). Mirrors verifyManifestStartState's
+  // own null-on-non-string-input contract. Every real GitHub redirect always
+  // includes a `state` param, so this is a robustness fix, not a security
+  // change — a missing state was always meant to be rejected (→ null → 302
+  // redirect), just not by crashing.
+  if (typeof state !== 'string' || state.length === 0) return null;
   const parts = state.split('.');
   if (parts.length !== 3 || parts[0] !== 'v1') return null;
   const payload = parts[1]!;

--- a/tests/src/flows/github-app.flow.ts
+++ b/tests/src/flows/github-app.flow.ts
@@ -10,16 +10,17 @@
  *   - admin-gated routes: ANON → 401, authed non-admin (OWNER) → 403.
  *   - missing required fields → 400 (admin token, when available — fails
  *     BEFORE any GitHub API call, so it's safe and non-mutating).
- *   - public callbacks: a PRESENT-but-invalid state/code/installation_id →
- *     302 redirect to the frontend with an `error` reason (never a store).
+ *   - public callbacks: ANY malformed input (no query at all, present-but-
+ *     invalid state, missing code, missing installation_id, GitHub ?error=)
+ *     → 302 redirect to the frontend with an `error` reason (never a store,
+ *     never a 500).
  *
- * KNOWN BUG (asserted, not hidden — GHA-2): a truly bare hit on
- * install-callback (no query at all) 500s — `verifyGitHubAppInstallStatePayload`
- * calls `.split()` on `undefined` when `state` is absent entirely, before the
- * route's own `!installationId` guard runs. Every real GitHub redirect always
- * includes `state`, so this is a low-severity robustness gap, not a security
- * issue — but the test asserts the REAL observed 500, not the docblock's
- * original claim of a graceful redirect for that exact shape.
+ * The bare install-callback hit (no query at all) used to 500 —
+ * `verifyGitHubAppInstallStatePayload` called `.split()` on `undefined` when
+ * `state` was absent entirely. Fixed in apps/api/src/projects/github.ts
+ * (defensive null-on-non-string input, mirroring verifyManifestStartState);
+ * the GHA-2 assertion now pins the correct 302 redirect, with a unit test
+ * (unit-github-app-install-state.test.ts) guarding the regression.
  *
  * We NEVER call POST /app, POST /pat, POST /manifest-start (happy path) or
  * DELETE / with real creds — those mutate the single shared platform_settings
@@ -226,16 +227,21 @@ flow(
     });
 
     await ctx.step(
-      'install-callback with a truly bare hit (no query at all) → 500, a REAL pre-existing bug, ' +
-        'not an assertion of desired behavior: verifyGitHubAppInstallStatePayload(query.state) ' +
-        'calls .split() on undefined when `state` is absent entirely, crashing before the route\'s ' +
-        'own !installationId guard ever runs. Confirmed live against staging-api.kortix.com. ' +
-        'Never asserted as [302] here — that would silently paper over the bug.',
+      'install-callback with a truly bare hit (no query at all) → 302 (graceful redirect, ' +
+        'not a 500): verifyGitHubAppInstallStatePayload now returns null on undefined state ' +
+        '(defensive null-on-non-string input, mirroring verifyManifestStartState), so the ' +
+        'route falls through to its !installationId guard and redirects. This used to 500 ' +
+        '— a real bug the ke2e suite surfaced (GHA-2); fixed in apps/api/src/projects/github.ts, ' +
+        'regression-guard unit test in unit-github-app-install-state.test.ts.',
       async () => {
         const r = await ctx.client
           .as(ctx.P.ANON)
           .get('/v1/platform/github-app/install-callback');
-        r.status(500);
+        r.status(302).headerExists('location');
+        const loc = r.header('location') ?? '';
+        if (!loc.includes('github=error')) {
+          throw new Error(`expected redirect to carry github=error, got: ${loc}`);
+        }
       },
     );
 
@@ -274,5 +280,60 @@ flow(
         throw new Error(`expected an http redirect or empty, got: ${loc}`);
       }
     });
+
+    await ctx.step(
+      'install-callback with installation_id but NO state param → 302 (not 500)',
+      async () => {
+        // The exact regression-guard for the bug the suite surfaced: an
+        // installation_id present but `state` entirely absent used to crash
+        // verifyGitHubAppInstallStatePayload (undefined.split). With the fix
+        // the function returns null on non-string input and the route
+        // redirects. A confused browser stripping query params, or a direct
+        // hit with only the installation_id, is the realistic shape.
+        const r = await ctx.client
+          .as(ctx.P.ANON)
+          .get('/v1/platform/github-app/install-callback', {
+            query: { installation_id: '12345', setup_action: 'install' },
+          });
+        r.status(302);
+        const loc = r.header('location') ?? '';
+        if (!loc.includes('github=error')) {
+          throw new Error(`expected redirect to carry github=error, got: ${loc}`);
+        }
+      },
+    );
+
+    await ctx.step('install-callback with empty-string state → 302 (not 500)', async () => {
+      // Boundary: `state` is present but empty. The zod schema allows any
+      // string, so `?state=` reaches the handler as `''`. Must redirect, not
+      // crash — verifyGitHubAppInstallStatePayload now returns null on
+      // empty strings too (mirroring verifyManifestStartState).
+      const r = await ctx.client
+        .as(ctx.P.ANON)
+        .get('/v1/platform/github-app/install-callback', {
+          query: { state: '', installation_id: '12345' },
+        });
+      r.status(302);
+      const loc = r.header('location') ?? '';
+      if (!loc.includes('github=error')) {
+        throw new Error(`expected redirect to carry github=error, got: ${loc}`);
+      }
+    });
+
+    await ctx.step(
+      'install-callback with a state carrying the wrong version prefix → 302',
+      async () => {
+        // A state token shaped `v2.payload.sig` (wrong version) must be
+        // rejected, not crash. Guards against a future version bump silently
+        // accepting old-shape tokens, and against an attacker crafting
+        // plausible-looking but foreign tokens.
+        const r = await ctx.client
+          .as(ctx.P.ANON)
+          .get('/v1/platform/github-app/install-callback', {
+            query: { state: 'v2.payload.sig', installation_id: '12345' },
+          });
+        r.status(302);
+      },
+    );
   },
 );


### PR DESCRIPTION
## What

Fixes a real product bug the ke2e suite surfaced. `verifyGitHubAppInstallStatePayload(state: string)` did `state.split('.')` with no input guard. The `install-callback` route calls it with `query.state`, which the zod schema marks `optional()` — so a **bare `GET /install-callback` (no query at all)**, or a hit with `installation_id` but no `state`, crashed with `TypeError: Cannot read properties of undefined (reading 'split')` and surfaced as a **500**.

Observed live on `staging-api.kortix.com` by the ke2e suite (GHA-2 in `tests/src/flows/github-app.flow.ts`), which had been asserting the real 500 rather than papering over it. PR #5024 documented the bug inline; this PR fixes it.

## The fix

Mirrors `verifyManifestStartState`'s own null-on-non-string-input contract (that sibling function was already unit-tested for `undefined`/empty/malformed input; `verifyGitHubAppInstallStatePayload` was not). Widens the param type to `string | undefined | null` and returns `null` for any non-string or empty input before touching `.split()`.

Every real GitHub redirect always includes a `state` param, so this is a **robustness fix, not a security change** — a missing state was always meant to be rejected (→ `null` → the route's `!installationId` guard → 302 redirect), just not by crashing. No behavior change for any well-formed request.

Also exports `buildGitHubAppInstallState` (previously private) so the install-state token can be unit-tested directly. It's a pure HMAC-base64url function with no side effects; the only caller is `buildGitHubAppInstallUrl`, which feeds the token into a GitHub URL.

## Tests

- **New** `apps/api/src/__tests__/unit-github-app-install-state.test.ts` (14 tests):
  - defensive input handling (`undefined`/`null`/`empty`/`non-string` — the exact regression)
  - malformed/foreign tokens (wrong version prefix, wrong part count, tampered signature, tampered payload)
  - TTL + future-`iat` rejection
  - happy-path round trip + nonce preservation
- **Flips** the ke2e GHA-2 assertion from asserting-the-bug-500 to asserting the correct 302 redirect, and adds three new boundary assertions:
  - `installation_id` with no `state` (the exact regression shape, with an installation_id present)
  - empty-string `state` (`?state=`)
  - a wrong-version state token (`v2.payload.sig`)

## Verification

- `bun test` on the 6 github-app unit test files → **68 pass, 0 fail** (14 new + 54 existing)
- `bun test src/__tests__/e2e-github-app-projects.test.ts` → **5 pass**
- `tsc --noEmit` (apps/api) → clean
- `tsc --noEmit` (tests) → clean
- `bun bin/ke2e.ts coverage` → gate green (**98.2%, 0 uncovered**)
- ⚠️ Could not run the flipped GHA-2 e2e flow against live staging in this sandbox (no `KE2E_SUPABASE_*` / `KE2E_ADMIN_TOKEN` creds); CI runs it against `staging-api.kortix.com`. The unit test pins the regression at the function level regardless.

## Why this matters for the gate

The ke2e suite's job is to make the pre-prod gate impossible to pass unless staging genuinely works. A 500 on a public callback route is exactly the kind of failure the gate exists to catch — and it did. PR #5024 asserted the real (broken) behavior so the bug couldn't be silently hidden; this PR fixes the bug and tightens the assertion to the correct contract, with a unit-test regression guard so it can't come back.

🤖 Generated by the daily ke2e coverage maintainer (run 2, 2026-07-19).