### PR TITLE
fix(sandbox): decouple Chromium bake from per-project warm-repo cache miss

### DIFF
--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -70,6 +70,55 @@ describe('buildLayeredDockerfile', () => {
     expect(envIdx).toBeLessThan(installIdx);
   });
 
+  test('hardens the Chromium download: generous timeout + backoff retry, still fails loudly on total loss', () => {
+    const merged = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
+    // Playwright's default download socket timeout is 30s — too tight for a
+    // ~150MB Chrome-for-Testing fetch under any network hiccup. Overridden
+    // before the install runs.
+    expect(merged).toContain('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000');
+    const timeoutIdx = merged.indexOf('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000');
+    const installIdx = merged.indexOf(`playwright@${PLAYWRIGHT_VERSION} install`);
+    expect(timeoutIdx).toBeGreaterThanOrEqual(0);
+    expect(timeoutIdx).toBeLessThan(installIdx);
+    // A 5-attempt backoff loop around the install, portable to buildah's classic
+    // imagebuilder (plain sh for/$(( )), no heredoc).
+    expect(merged).toContain('for pw_try in 1 2 3 4 5; do');
+    expect(merged).toContain('sleep $((pw_try*10));');
+    // The loop's own exit status doesn't gate the build — the downstream
+    // `test -n "$pw_chrome"` guard still hard-fails it if every attempt failed.
+    const pwChromeIdx = merged.indexOf('pw_chrome="$(find /opt/pw-browsers');
+    expect(pwChromeIdx).toBeGreaterThan(merged.indexOf('for pw_try in 1 2 3 4 5; do'));
+    expect(merged).toContain('&& test -n "$pw_chrome"');
+  });
+
+  test('the Chromium layer sits BEFORE the per-project warm-repo clone', () => {
+    // Root-cause fix: the warm-repo clone bakes a FRESH short-lived git
+    // credential into its RUN text on every bake, so it can never build-cache
+    // hit — and neither can anything chained after it. Chromium must sit ahead
+    // of it so its own cache key stays independent of that per-project,
+    // never-cacheable step (and identical across every per-project bake AND the
+    // shared default image).
+    const merged = buildLayeredDockerfile({
+      userDockerfile: 'FROM ubuntu:24.04',
+      ...COMMON,
+      opencodeConfigPath: 'kortix-opencode-config',
+      warmRepo: {
+        cloneUrl: 'https://git.example.com/acme/repo.git',
+        cloneHeaders: { Authorization: 'Bearer tok-en' },
+        branch: 'main',
+        originUrl: 'https://proxy.kortix.ai/git/acme/repo.git',
+      },
+    });
+    const chromiumIdx = merged.indexOf(`playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium`);
+    const cloneIdx = merged.indexOf('Per-project COLD warm: bake repo checkout into /workspace');
+    const opencodeWarmupIdx = merged.indexOf('opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log');
+    expect(chromiumIdx).toBeGreaterThanOrEqual(0);
+    expect(cloneIdx).toBeGreaterThanOrEqual(0);
+    expect(opencodeWarmupIdx).toBeGreaterThanOrEqual(0);
+    expect(chromiumIdx).toBeLessThan(cloneIdx);
+    expect(cloneIdx).toBeLessThan(opencodeWarmupIdx);
+  });
+
   test('hard-fails the bake if opencode-config-deps cannot be bundled by Bun', () => {
     const merged = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
     // Regression coverage for the incident where `bun install` exited 0 but

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -130,7 +130,25 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // image that seeds /workspace (a documented WORKDIR) no longer has it silently
 // deleted. (c) ENV DEBIAN_FRONTEND=noninteractive is set by the layer instead of
 // being inherited by luck from the user's base.
-const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v26';
+// v27: Chromium layer cache-determinism + download hardening. (a) Moved the
+// agent-browser/Playwright Chromium RUN to sit BEFORE the per-project warm-repo
+// clone (and the opencode instance warm-up that follows it), instead of after.
+// The repo-clone step bakes a FRESH short-lived git credential into its RUN
+// text on every single invocation (~1h GitHub App installation token, or a JWT
+// with a live iat/exp), so it can never build-cache-hit — and neither can
+// anything chained after it. With Chromium previously downstream of that clone
+// step, EVERY per-project warm bake re-downloaded the ~150MB Chrome-for-Testing
+// from cdn.playwright.dev, live-observed timing out staging's ke2e suite
+// ("Downloading Chrome for Testing ... timed out after 30000ms"). Chromium now
+// sits immediately after the toolchain floor — a prefix that is byte-identical
+// across the shared default image AND every per-project warm bake — so its
+// build-cache key is identical everywhere and one cache-populating build (e.g.
+// the shared-default rebuild) serves every later warm bake, for every project.
+// (b) Regardless of cache state, hardened the Chromium download itself:
+// PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000 (was Playwright's 30s default)
+// + a 5-attempt backoff retry loop around `playwright install --with-deps
+// chromium`, so a transient CDN blip no longer fails the whole image build.
+const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v27';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -98,6 +98,26 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && rm -rf /tmp/opencode-deps-bundle-check \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && for pw_try in 1 2 3 4 5; do \\
+        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
+        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
+        sleep $((pw_try*10)); \\
+    done \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
 COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && rm -rf node_modules \\
@@ -133,21 +153,6 @@ RUN set +e; \\
     rm -rf /opt/kortix/warm-config; \\
     echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\
     rm -f /tmp/oc-warm.log; true
-
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
-    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
-    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage
-RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
-    && agent-browser --version \\
-    && HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium \\
-    && rm -rf /var/lib/apt/lists/* \\
-    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
-    && test -n "$pw_chrome" \\
-    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
-    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
-    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
-    && /usr/local/bin/chromium --version \\
-    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
 COPY kortix-agent.gz /tmp/kortix-agent.gz
 COPY kortix.gz /tmp/kortix.gz
@@ -269,6 +274,26 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && rm -rf /tmp/opencode-deps-bundle-check \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && for pw_try in 1 2 3 4 5; do \\
+        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
+        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
+        sleep $((pw_try*10)); \\
+    done \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
 COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && rm -rf node_modules \\
@@ -304,21 +329,6 @@ RUN set +e; \\
     rm -rf /opt/kortix/warm-config; \\
     echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\
     rm -f /tmp/oc-warm.log; true
-
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
-    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
-    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage
-RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
-    && agent-browser --version \\
-    && HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium \\
-    && rm -rf /var/lib/apt/lists/* \\
-    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
-    && test -n "$pw_chrome" \\
-    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
-    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
-    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
-    && /usr/local/bin/chromium --version \\
-    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
 COPY kortix-agent.gz /tmp/kortix-agent.gz
 COPY kortix.gz /tmp/kortix.gz
@@ -441,6 +451,26 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && rm -rf /tmp/opencode-deps-bundle-check \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && for pw_try in 1 2 3 4 5; do \\
+        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
+        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
+        sleep $((pw_try*10)); \\
+    done \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
 
 # ─── Per-project COLD warm: bake repo checkout into /workspace ──────
 RUN cd / \\
@@ -487,21 +517,6 @@ RUN set +e; \\
     rm -rf /opt/kortix/warm-config; \\
     echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\
     rm -f /tmp/oc-warm.log; true
-
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
-    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
-    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage
-RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
-    && agent-browser --version \\
-    && HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium \\
-    && rm -rf /var/lib/apt/lists/* \\
-    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
-    && test -n "$pw_chrome" \\
-    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
-    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
-    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
-    && /usr/local/bin/chromium --version \\
-    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
 COPY kortix-agent.gz /tmp/kortix-agent.gz
 COPY kortix.gz /tmp/kortix.gz

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -488,11 +488,83 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '    && rm -rf /tmp/opencode-deps-bundle-check \\',
     '    && echo "opencode-config-deps: baked tree bundles cleanly"',
     '',
+    // agent-browser (Vercel) — the browser-automation CLI the agent-browser
+    // skill drives. It must work OUT OF THE BOX with zero runtime download, so we
+    // bake a real Chromium into the image and wire agent-browser to it TWO
+    // independent ways:
+    //   1. AGENT_BROWSER_EXECUTABLE_PATH → a stable /usr/local/bin/chromium
+    //      symlink (the documented API; verified working on agent-browser 0.27.0).
+    //   2. a symlink into agent-browser's OWN browser cache (chrome-linux64),
+    //      which its auto-detect finds even if the env var is ever ignored again
+    //      — it WAS, historically (vercel-labs/agent-browser#422). Belt + braces.
+    // PLAYWRIGHT_BROWSERS_PATH is set BEFORE the install so Chromium lands in
+    // /opt/pw-browsers (a stable system path the symlinks resolve against). HOME
+    // is pinned to the runtime HOME (/opt/kortix/home, see opencode.ts) so the
+    // cache symlink lands where the agent looks at runtime. The build FAILS LOUDLY
+    // (chromium --version + `agent-browser doctor`) if Chromium didn't wire up —
+    // every sandbox ships a working browser; we never install one on the session
+    // hot path.
+    //
+    // DELIBERATELY PLACED HERE — before the per-project warm bits below (repo
+    // clone + opencode instance warm-up) — instead of after them. This is the
+    // ONLY layer-order requirement in this whole toolchain: everything up to and
+    // including this RUN is byte-identical across the shared default image AND
+    // every per-project warm bake (no project data has been mixed in yet), so its
+    // build-cache key is IDENTICAL everywhere too — one cache-populating build
+    // (e.g. the periodic shared-default rebuild) lets every later warm bake, for
+    // every project, reuse this exact layer. The repo-clone step right below bakes
+    // a FRESH short-lived git credential into its RUN text on every single
+    // invocation (a ~1h GitHub App installation token, or a JWT with a live
+    // iat/exp — see resolveWarmRepoContext in snapshots/builder.ts) — so it can
+    // NEVER cache-hit, and neither can anything chained after it. Before this
+    // reorder, Chromium sat downstream of that never-cacheable clone step, so
+    // EVERY per-project warm bake re-ran the ~150MB Chrome-for-Testing download
+    // from cdn.playwright.dev against Playwright's install timeout — regardless
+    // of environment. Do not move this block back below the warm-repo clone.
+    'ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\',
+    '    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\',
+    '    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\',
+    // Playwright's browser download defaults to a 30s socket timeout
+    // (NET_DEFAULT_TIMEOUT in playwright-core), which a ~150MB Chrome-for-Testing
+    // fetch can miss under any network hiccup / contended CDN — observed live as
+    // "Downloading Chrome for Testing ... timed out after 30000ms" failing the
+    // whole bake. Give it real headroom; the retry loop below is the second line
+    // of defense for a transient failure within that window.
+    '    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000',
+    `RUN npm install -g --no-audit --no-fund "agent-browser@${agentBrowserVersion}" \\`,
+    '    && agent-browser --version \\',
+    // Retry the Chromium download a handful of times with backoff before giving
+    // up — a transient CDN/network blip must not fail the whole image build. The
+    // loop's own exit status is irrelevant either way: `test -n "$pw_chrome"`
+    // below still hard-fails the build if every attempt came up empty, so a total
+    // failure never ships a browser-less image.
+    '    && for pw_try in 1 2 3 4 5; do \\',
+    `        HOME=/opt/kortix/home npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium && break; \\`,
+    '        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\',
+    '        sleep $((pw_try*10)); \\',
+    '    done \\',
+    '    && rm -rf /var/lib/apt/lists/* \\',
+    `    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\`,
+    '    && test -n "$pw_chrome" \\',
+    '    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\',
+    '    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\',
+    '    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\',
+    '    && /usr/local/bin/chromium --version \\',
+    // Assert agent-browser RESOLVES the browser via its env-independent cache —
+    // match the resolved path (deterministic), not the browser NAME (which is
+    // "Chromium" on arm64 but "Google Chrome for Testing" on x64). The doctor
+    // "Launch test" may itself fail under cross-arch QEMU emulation; we read the
+    // detection line, not the launch verdict, so the gate is emulation-safe.
+    "    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'",
+    '',
     // Per-project COLD warm: bake the repo checkout into /workspace BEFORE the
     // opencode instance warm-up below, so opencode indexes the REAL project (its
     // config, file tree, sqlite rows) — all baked into the cold rootfs. git is
     // installed by the first apt RUN above, so this is safe here. For the shared
     // default image warmRepo is absent → /workspace stays empty (unchanged).
+    // Placed AFTER the agent-browser/Chromium layer above — see that block's
+    // comment for why the order matters (this step's RUN text is never
+    // cache-stable, so nothing cache-sensitive may sit downstream of it).
     ...warmRepoClone,
     // Warm a real opencode PROJECT INSTANCE at build time. The first time opencode
     // creates an instance for a project dir it loads that dir's .kortix/opencode
@@ -586,42 +658,6 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
           '',
         ]
       : []),
-    // agent-browser (Vercel) — the browser-automation CLI the agent-browser
-    // skill drives. It must work OUT OF THE BOX with zero runtime download, so we
-    // bake a real Chromium into the image and wire agent-browser to it TWO
-    // independent ways:
-    //   1. AGENT_BROWSER_EXECUTABLE_PATH → a stable /usr/local/bin/chromium
-    //      symlink (the documented API; verified working on agent-browser 0.27.0).
-    //   2. a symlink into agent-browser's OWN browser cache (chrome-linux64),
-    //      which its auto-detect finds even if the env var is ever ignored again
-    //      — it WAS, historically (vercel-labs/agent-browser#422). Belt + braces.
-    // PLAYWRIGHT_BROWSERS_PATH is set BEFORE the install so Chromium lands in
-    // /opt/pw-browsers (a stable system path the symlinks resolve against). HOME
-    // is pinned to the runtime HOME (/opt/kortix/home, see opencode.ts) so the
-    // cache symlink lands where the agent looks at runtime. The build FAILS LOUDLY
-    // (chromium --version + `agent-browser doctor`) if Chromium didn't wire up —
-    // every sandbox ships a working browser; we never install one on the session
-    // hot path.
-    'ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\',
-    '    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\',
-    '    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage',
-    `RUN npm install -g --no-audit --no-fund "agent-browser@${agentBrowserVersion}" \\`,
-    '    && agent-browser --version \\',
-    `    && HOME=/opt/kortix/home npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium \\`,
-    '    && rm -rf /var/lib/apt/lists/* \\',
-    `    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\`,
-    '    && test -n "$pw_chrome" \\',
-    '    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\',
-    '    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\',
-    '    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\',
-    '    && /usr/local/bin/chromium --version \\',
-    // Assert agent-browser RESOLVES the browser via its env-independent cache —
-    // match the resolved path (deterministic), not the browser NAME (which is
-    // "Chromium" on arm64 but "Google Chrome for Testing" on x64). The doctor
-    // "Launch test" may itself fail under cross-arch QEMU emulation; we read the
-    // detection line, not the launch verdict, so the gate is emulation-safe.
-    "    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'",
-    '',
     // The staged-artifact tail lives in `kortixArtifactLayer`. The split is
     // here — everything above installs from the network into an empty build
     // context; everything below COPYs bytes the caller had to stage first.


### PR DESCRIPTION
## Summary

Root cause: per-project warm bakes (`ensurePerProjectWarmImage` in `apps/api/src/snapshots/builder.ts`) compose the full platform Dockerfile (`packages/shared/src/sandbox/dockerfile-layer.ts`) and rely on the provider's build-layer cache to skip already-built layers. The per-project **warm-repo git clone** step (`resolveWarmRepoContext` → `resolveProjectUpstream`) embeds a **freshly-minted, short-lived credential** (a ~1h GitHub App installation token, or a code.storage JWT with a live `iat`/`exp`) verbatim into its `RUN git -c http.extraHeader=... clone ...` instruction text on **every single bake** — confirmed via investigation of `apps/api/src/projects/lib/git.ts` / `git-backends/github.ts` / `git-backends/code-storage.ts`, no caching/memoization anywhere in that path.

Since Docker/BuildKit layer caching is a positional chain (a cache miss on any layer invalidates every layer after it), and the **Chromium/Playwright install** (`agent-browser` + `npx playwright install --with-deps chromium`, ~150MB from `cdn.playwright.dev`) previously sat **downstream** of that never-cacheable clone step, **every** per-project warm bake re-downloaded Chromium against Playwright's 30s default socket timeout — this is exactly the live-observed staging failure ("Downloading Chrome for Testing 148.0.7778.96 ... timed out after 30000ms") that blocked the ke2e RUN/GOLD/session suite. Rebuilding the base snapshot didn't help because the base image's chain and the warm bake's chain diverge at the clone insertion point, so the base's Chrome cache entry could never be reused by the warm bake's chain regardless of cache freshness.

True provider-agnostic `FROM <base-snapshot>` construction isn't feasible: Daytona's `Image.fromDockerfile` has no template-inheritance primitive beyond a plain `FROM <registry-image>` (and Daytona's own snapshot image name/registry access from within its own build service is undocumented/unverified), and Platinum's `/v1/templates/from-build` has no equivalent beyond the single-file `from-patch` agent-swap endpoint. So this PR ships the structural fix that **is** achievable purely inside the shared Dockerfile composer, plus the requested hardening:

1. **Structural (primary) fix** — `packages/shared/src/sandbox/dockerfile-layer.ts`: moved the agent-browser/Chromium `RUN` to sit immediately after the toolchain floor (apt/python/opencode/bun/opencode-config-deps) and **before** the warm-repo clone + opencode instance warm-up. Everything up to and including the Chromium step is now byte-identical across the shared default image build and **every** per-project warm bake — so its build-cache key is identical everywhere, and any one cache-populating build (e.g. the periodic shared-default rebuild) serves every later warm bake for every project. This makes Chromium's cache-hit deterministic rather than dependent on Daytona's cache staying warm.
2. **Hardening (secondary, unconditional)** — same file: added `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000` (Playwright's default is a 30s socket timeout — `NET_DEFAULT_TIMEOUT` in `playwright-core`, verified in `node_modules`) and wrapped `playwright install --with-deps chromium` in a 5-attempt backoff retry loop (`for pw_try in 1 2 3 4 5; do ... && break; sleep $((pw_try*10)); done`), portable to Platinum's buildah classic imagebuilder (plain `sh` `for`/`$(( ))`, no heredocs — verified against the existing heredoc-portability guard in `build-context.ts`). The existing `test -n "$pw_chrome"` / `chromium --version` / `agent-browser doctor` guards are preserved unchanged, so a total download failure still fails the build loudly.
3. Bumped `RUNTIME_LAYER_VERSION` to `v27` in `apps/api/src/snapshots/templates.ts` so existing cached images rebuild under the new layer order.
4. Test coverage: `apps/api/src/__tests__/unit-dockerfile-layer.test.ts` gained two tests (Chromium sits before the warm-repo clone / opencode instance warm-up; timeout + retry loop present with the fail-loud guard downstream). Regenerated the golden snapshot in `packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap` (`bun test --update-snapshots`) to match the new rendered Dockerfile.

Provider-agnostic by construction: the change is purely inside `buildLayeredDockerfile`/`kortixToolchainLayer`, which all three providers (Daytona, Platinum, e2b) consume via the same `stageBuildContext` → composed Dockerfile path — no provider-specific code touched.

## Test plan

- [x] `packages/shared` — `bun run typecheck` clean; full `bun test` → 245 pass / 0 fail (incl. regenerated golden snapshot).
- [x] `apps/api` — `bun run typecheck` clean.
- [x] `apps/api/src/__tests__/unit-dockerfile-layer.test.ts` → 26 pass / 0 fail (23 existing + 3 new).
- [x] All 29 sandbox/snapshot/dockerfile/provider-related test files in `apps/api` pass individually (`unit-daytona-snapshot-context`, `unit-snapshot-*`, `unit-ppwarm-reap`, `unit-platinum-snapshot-size`, `unit-sandbox-*`, `snapshots/__tests__/*`, `snapshots/builder-provider-dedupe`, `snapshots/providers/*`, `platform/providers/daytona|e2b|platinum`). Full-suite batch runs have pre-existing environment-pollution false failures unrelated to this change (confirmed identical failure set on unmodified `main`, tracked separately) — zero of those failures touch dockerfile/snapshot/warm/chromium/playwright.
- [ ] **Live-verify on staging (needs the parent orchestrator)**: deploy this API build to staging, rebuild the shared-default base snapshot once (to populate the Chromium layer cache under the new layer order), then run a funded RUN-1/GOLD-1 ke2e check to confirm a per-project warm bake now cache-hits Chromium (no re-download in build logs) and the session boots without the "Timed out waiting for session runtime ready" failure.