### PR TITLE
fix(sandbox): per-project warm bakes FROM the built default image — Chromium never re-downloads

### DIFF
--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -74,9 +74,11 @@ describe('buildLayeredDockerfile', () => {
     const merged = buildLayeredDockerfile({ userDockerfile: 'FROM ubuntu:24.04', ...COMMON });
     // Playwright's default download socket timeout is 30s — too tight for a
     // ~150MB Chrome-for-Testing fetch under any network hiccup. Overridden
-    // before the install runs.
-    expect(merged).toContain('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000');
-    const timeoutIdx = merged.indexOf('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000');
+    // before the install runs. 30 minutes: headroom for a cold-cache build
+    // under contention (the fallback full-rebuild path only — the primary fix
+    // is the FROM-base fast path, which never re-runs this install at all).
+    expect(merged).toContain('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000');
+    const timeoutIdx = merged.indexOf('PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000');
     const installIdx = merged.indexOf(`playwright@${PLAYWRIGHT_VERSION} install`);
     expect(timeoutIdx).toBeGreaterThanOrEqual(0);
     expect(timeoutIdx).toBeLessThan(installIdx);

--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -21,7 +21,7 @@ import { createGzip } from 'node:zlib';
 import { AGENT_BROWSER_VERSION, OPENCODE_VERSION } from '@kortix/shared';
 import { gatewayModelCatalog } from '../llm-gateway/models/catalog-models';
 import { tmpdir } from 'node:os';
-import { buildLayeredDockerfile } from './dockerfile-layer';
+import { buildLayeredDockerfile, buildPerProjectWarmFromBaseDockerfile } from './dockerfile-layer';
 import { buildStarterFiles, DEFAULT_STARTER_TEMPLATE_ID } from '../projects/starter';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -197,16 +197,81 @@ export async function stageBuildContext(
     warmRepo,
   });
 
-  // ── Buildah-portability guard ──────────────────────────────────────────────
-  // The SAME composed context ships to BOTH providers. Daytona builds with
-  // BuildKit (supports `# syntax=docker/dockerfile:1.7` + RUN heredocs); Platinum
-  // builds with podman/buildah's classic imagebuilder, which supports NEITHER — it
-  // parses a heredoc body's first line (e.g. `import importlib`) as a Dockerfile
-  // instruction and aborts EVERY build ("Unknown instruction: IMPORT"), failing
-  // all Platinum sessions. This exact regression (a `<<'PY'` python verify added
-  // 2026-06-27) took dev down for hours because Daytona silently tolerated it.
-  // Reject it at the SOURCE with a clear error instead of an opaque remote build
-  // failure minutes later — and keep the Dockerfile portable to both builders.
+  await guardBuildahPortable(composed);
+  await writeComposedDockerfile(composedPath, composed);
+  // Fail-loud completeness guard: a context missing scaffold.git / the agent
+  // binary / the composed Dockerfile reaches the provider as a confusing remote
+  // "Path does not exist", and the auto-build can't tell it's a staging miss to
+  // recover from. Assert at the source so a miss is caught here AND is retryable
+  // (the daytona adapter re-stages on "staging incomplete").
+  await assertContextComplete(contextDir, dockerfileName);
+  console.info(`[snapshots] ${snapshotName}: build context staged at ${contextDir}`);
+  return { contextDir, composedPath, dockerfileName };
+}
+
+/**
+ * Stage a MINIMAL build context for the per-project warm FAST PATH: a
+ * Dockerfile that `FROM`s an already-built runtime image (the shared default's
+ * provider-reported image ref) and only adds the warm-repo clone + opencode
+ * instance re-warm on top — see `buildPerProjectWarmFromBaseDockerfile`
+ * (dockerfile-layer.ts) for why this is the actual fix for the Chromium
+ * re-download bug: nothing here re-installs the toolchain, so there's no
+ * Chromium download to lose a cache race on.
+ *
+ * Unlike `stageBuildContext`, this does NOT stage the agent/CLI binaries,
+ * entrypoint, slack-cli, executor-sdk, catalog, or scaffold.git — none of the
+ * artifact tail is re-COPY'd; it's inherited from `baseImageRef`. Only the
+ * starter opencode config (if present) is staged, for the instance re-warm.
+ *
+ * The caller (daytona.ts) is responsible for verifying `baseImageRef` points
+ * at an `active` snapshot before calling this — a `FROM` of a missing or
+ * still-building image fails the build immediately.
+ */
+export async function stageWarmFromBaseContext(
+  snapshotName: string,
+  baseImageRef: string,
+  warmRepo: WarmRepoContext,
+): Promise<StagedContext> {
+  const OPENCODE_CONFIG_SRC_PATH = opencodeConfigSrcPath();
+  const contextDir = await mkdtemp(join(tmpdir(), 'kortix-snap-warm-'));
+  let opencodeConfigPath: string | undefined;
+  if (await isDir(OPENCODE_CONFIG_SRC_PATH)) {
+    await cp(OPENCODE_CONFIG_SRC_PATH, join(contextDir, 'kortix-opencode-config'), {
+      recursive: true,
+    });
+    opencodeConfigPath = 'kortix-opencode-config';
+  }
+
+  const dockerfileName = '.kortix-snapshot.Dockerfile';
+  const composedPath = join(contextDir, dockerfileName);
+  const composed = buildPerProjectWarmFromBaseDockerfile({
+    baseImageRef,
+    warmRepo,
+    opencodeConfigPath,
+  });
+
+  await guardBuildahPortable(composed);
+  await writeComposedDockerfile(composedPath, composed);
+  try {
+    await stat(composedPath);
+  } catch {
+    throw new Error(`build context staging incomplete: ${dockerfileName} missing in ${contextDir}`);
+  }
+  console.info(`[snapshots] ${snapshotName}: FROM-base warm context staged at ${contextDir} (base=${baseImageRef})`);
+  return { contextDir, composedPath, dockerfileName };
+}
+
+// ── Buildah-portability guard ──────────────────────────────────────────────
+// The SAME composed context ships to BOTH providers. Daytona builds with
+// BuildKit (supports `# syntax=docker/dockerfile:1.7` + RUN heredocs); Platinum
+// builds with podman/buildah's classic imagebuilder, which supports NEITHER — it
+// parses a heredoc body's first line (e.g. `import importlib`) as a Dockerfile
+// instruction and aborts EVERY build ("Unknown instruction: IMPORT"), failing
+// all Platinum sessions. This exact regression (a `<<'PY'` python verify added
+// 2026-06-27) took dev down for hours because Daytona silently tolerated it.
+// Reject it at the SOURCE with a clear error instead of an opaque remote build
+// failure minutes later — and keep the Dockerfile portable to both builders.
+async function guardBuildahPortable(composed: string): Promise<void> {
   const heredocLine = composed
     .split('\n')
     .find((l) => !/^\s*#/.test(l) && /<<-?['"]?[A-Za-z_]\w*['"]?\s*\\?\s*$/.test(l));
@@ -218,21 +283,15 @@ export async function stageBuildContext(
         `directives work on Daytona but silently break every Platinum template build.`,
     );
   }
+}
 
+async function writeComposedDockerfile(composedPath: string, composed: string): Promise<void> {
   if (typeof (globalThis as any).Bun?.write === 'function') {
     await (globalThis as any).Bun.write(composedPath, composed);
   } else {
     const fs = await import('node:fs/promises');
     await fs.writeFile(composedPath, composed);
   }
-  // Fail-loud completeness guard: a context missing scaffold.git / the agent
-  // binary / the composed Dockerfile reaches the provider as a confusing remote
-  // "Path does not exist", and the auto-build can't tell it's a staging miss to
-  // recover from. Assert at the source so a miss is caught here AND is retryable
-  // (the daytona adapter re-stages on "staging incomplete").
-  await assertContextComplete(contextDir, dockerfileName);
-  console.info(`[snapshots] ${snapshotName}: build context staged at ${contextDir}`);
-  return { contextDir, composedPath, dockerfileName };
 }
 
 /**

--- a/apps/api/src/snapshots/builder-warm-from-base.test.ts
+++ b/apps/api/src/snapshots/builder-warm-from-base.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from 'bun:test';
+import { resolveWarmBaseImageRef, shouldAttemptWarmFromBase } from './builder';
+
+test('only an active base snapshot is eligible for the FROM-base fast path', () => {
+  expect(shouldAttemptWarmFromBase('active')).toBe(true);
+  expect(shouldAttemptWarmFromBase('building')).toBe(false);
+  expect(shouldAttemptWarmFromBase('missing')).toBe(false);
+  expect(shouldAttemptWarmFromBase('build_failed')).toBe(false);
+  expect(shouldAttemptWarmFromBase('removing')).toBe(false);
+  expect(shouldAttemptWarmFromBase('unknown')).toBe(false);
+});
+
+test('resolves the base image ref when the base snapshot is active', async () => {
+  const ref = await resolveWarmBaseImageRef(
+    {
+      getSnapshotState: async () => 'active',
+      getSnapshotImageRef: async () => 'registry.example/kortix-default-abc:latest',
+    },
+    'kortix-default-abc',
+  );
+  expect(ref).toBe('registry.example/kortix-default-abc:latest');
+});
+
+test('never attempts the fast path when the base snapshot is not active', async () => {
+  let imageRefCalls = 0;
+  const ref = await resolveWarmBaseImageRef(
+    {
+      getSnapshotState: async () => 'building',
+      getSnapshotImageRef: async () => {
+        imageRefCalls += 1;
+        return 'registry.example/kortix-default-abc:latest';
+      },
+    },
+    'kortix-default-abc',
+  );
+  expect(ref).toBeUndefined();
+  expect(imageRefCalls).toBe(0);
+});
+
+test('falls back to undefined when the provider has no getSnapshotImageRef capability', async () => {
+  const ref = await resolveWarmBaseImageRef(
+    { getSnapshotState: async () => 'active' },
+    'kortix-default-abc',
+  );
+  expect(ref).toBeUndefined();
+});
+
+test('falls back to undefined when getSnapshotState rejects', async () => {
+  const ref = await resolveWarmBaseImageRef(
+    {
+      getSnapshotState: async () => {
+        throw new Error('network blip');
+      },
+      getSnapshotImageRef: async () => 'registry.example/kortix-default-abc:latest',
+    },
+    'kortix-default-abc',
+  );
+  expect(ref).toBeUndefined();
+});
+
+test('falls back to undefined when getSnapshotImageRef rejects', async () => {
+  const ref = await resolveWarmBaseImageRef(
+    {
+      getSnapshotState: async () => 'active',
+      getSnapshotImageRef: async () => {
+        throw new Error('lookup failed');
+      },
+    },
+    'kortix-default-abc',
+  );
+  expect(ref).toBeUndefined();
+});
+
+test('falls back to undefined when getSnapshotImageRef resolves null', async () => {
+  const ref = await resolveWarmBaseImageRef(
+    {
+      getSnapshotState: async () => 'active',
+      getSnapshotImageRef: async () => null,
+    },
+    'kortix-default-abc',
+  );
+  expect(ref).toBeUndefined();
+});

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -1148,6 +1148,16 @@ export async function ensurePerProjectWarmImage(
 
   const warmRepo = await resolveWarmRepoContext(project);
 
+  // FAST PATH: FROM the already-built shared default image instead of
+  // recomposing + rebuilding the full ~15-layer toolchain (apt/pip/opencode/
+  // bun/agent-browser+Chromium). This is what actually stops per-project warm
+  // bakes from re-downloading Chromium under concurrency — see
+  // buildPerProjectWarmFromBaseDockerfile (dockerfile-layer.ts) for the full
+  // rationale. Only attempted when the provider can report a usable image ref
+  // AND the base snapshot is confirmed `active`; a `FROM` of a not-yet-built
+  // image would fail the whole bake, so this must never guess.
+  const baseImageRef = await resolveWarmBaseImageRef(provider, baseIdentity.snapshotName);
+
   const buildId = opts.accountId
     ? await openBuildLog({
         accountId: opts.accountId,
@@ -1164,12 +1174,15 @@ export async function ensurePerProjectWarmImage(
   try {
     console.log(
       `[snapshots] per-project warm: baking ${snapshotName} (project ${project.projectId.slice(0, 8)}, ` +
-      `tip ${tip.slice(0, 8)}, base ${baseIdentity.snapshotName}, provider=${buildProvider})`,
+      `tip ${tip.slice(0, 8)}, base ${baseIdentity.snapshotName}, provider=${buildProvider}, ` +
+      `fastPath=${baseImageRef ? 'from-base' : 'full-rebuild'})`,
     );
     // COLD build (capture:'none' — buildSnapshot on this branch never captures a
-    // memory snapshot). The ONLY delta from the shared default build is warmRepo,
-    // which bakes /workspace at build time.
-    await provider.buildSnapshot({
+    // memory snapshot). The only per-project delta over the shared default is
+    // warmRepo, which bakes /workspace at build time — either on top of a full
+    // rebuild of the toolchain, or (fast path) on top of the base image FROM'd
+    // verbatim.
+    const fullRebuildInput = {
       snapshotName,
       image: template.image ?? undefined,
       userDockerfile: baseIdentity.userDockerfile,
@@ -1178,7 +1191,25 @@ export async function ensurePerProjectWarmImage(
       slug: warmBuildSlug(template.slug),
       isShared: false,
       warmRepo,
-    });
+    };
+    if (baseImageRef) {
+      try {
+        await provider.buildSnapshot({ ...fullRebuildInput, image: undefined, userDockerfile: undefined, baseImageRef });
+      } catch (fastPathErr) {
+        // Never let a fast-path failure (a stale/unpullable base ref, a
+        // provider-side hiccup building FROM it, …) take down session boot —
+        // fall back to the always-correct full rebuild. This keeps the fast
+        // path strictly additive: worst case is the pre-existing behavior.
+        const msg = fastPathErr instanceof Error ? fastPathErr.message : String(fastPathErr);
+        console.warn(
+          `[snapshots] per-project warm: FROM-base fast path failed for ${snapshotName} ` +
+          `(base=${baseImageRef}) — falling back to full rebuild: ${msg.slice(0, 200)}`,
+        );
+        await provider.buildSnapshot(fullRebuildInput);
+      }
+    } else {
+      await provider.buildSnapshot(fullRebuildInput);
+    }
     if (buildId) await closeBuildLogReady(buildId);
     await reapOldPerProjectWarm(project.projectId, snapshotName, buildProvider);
     return { snapshotName, tip, built: true, provider: buildProvider };
@@ -1187,6 +1218,36 @@ export async function ensurePerProjectWarmImage(
     if (buildId) await closeBuildLogFailed(buildId, message);
     throw new SnapshotBuildError(message, err);
   }
+}
+
+/** `true` iff a snapshot's provider state means it's safe to `FROM` its image
+ *  — anything short of a confirmed `active` snapshot risks a `FROM` of a
+ *  not-yet-built or vanished image, which would fail the whole warm bake
+ *  outright instead of falling back cleanly. */
+export function shouldAttemptWarmFromBase(baseState: ProviderState): boolean {
+  return baseState === 'active';
+}
+
+/**
+ * Resolve a registry-addressable ref for the already-built base (shared
+ * default) image, for use as `BuildableTemplate.baseImageRef` — the
+ * per-project warm fast path. Returns undefined (never throws) whenever the
+ * fast path isn't available: the provider doesn't implement
+ * `getSnapshotImageRef`, the base snapshot isn't `active` yet, or the lookup
+ * itself fails. Every one of those is a normal, expected condition (a fresh
+ * region where the default hasn't built yet, a provider without a registry
+ * concept, a transient lookup hiccup) — the caller always has the full
+ * rebuild path to fall back to.
+ */
+export async function resolveWarmBaseImageRef(
+  provider: Pick<SandboxProviderAdapter, 'getSnapshotState' | 'getSnapshotImageRef'>,
+  baseSnapshotName: string,
+): Promise<string | undefined> {
+  if (!provider.getSnapshotImageRef) return undefined;
+  const baseState = await provider.getSnapshotState(baseSnapshotName).catch((): ProviderState => 'unknown');
+  if (!shouldAttemptWarmFromBase(baseState)) return undefined;
+  const ref = await provider.getSnapshotImageRef(baseSnapshotName).catch(() => null);
+  return ref ?? undefined;
 }
 
 /**

--- a/apps/api/src/snapshots/providers/daytona-errors.test.ts
+++ b/apps/api/src/snapshots/providers/daytona-errors.test.ts
@@ -19,7 +19,7 @@ setTestEnv('FRONTEND_URL', 'http://localhost:3000');
 setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
 setTestEnv('RECALL_BASE_URL', 'https://us-west-2.recall.ai/api/v1');
 
-const { isDaytonaSnapshotNotFoundError } = await import('./daytona');
+const { daytonaProvider, isDaytonaSnapshotNotFoundError } = await import('./daytona');
 
 describe('Daytona snapshot not-found classifier', () => {
   test.each([
@@ -43,5 +43,25 @@ describe('Daytona snapshot not-found classifier', () => {
     ['imprecise snapshot text', new Error('snapshot lookup not found')],
   ])('rejects %s as an unconfirmed not-found', (_label, err) => {
     expect(isDaytonaSnapshotNotFoundError(err)).toBe(false);
+  });
+});
+
+describe('DaytonaAdapter.buildSnapshot input validation (FROM-base fast path)', () => {
+  const BASE_SPEC = { spec: {}, slug: 'default-warm' };
+
+  test('rejects when none of image, userDockerfile, baseImageRef are set', async () => {
+    await expect(
+      daytonaProvider.buildSnapshot({ snapshotName: 'kortix-tpl-x', ...BASE_SPEC }),
+    ).rejects.toThrow('none of image, userDockerfile, baseImageRef set');
+  });
+
+  test('rejects baseImageRef without warmRepo before touching the network', async () => {
+    await expect(
+      daytonaProvider.buildSnapshot({
+        snapshotName: 'kortix-ppwarm-x',
+        baseImageRef: 'registry.example/kortix-default-abc:latest',
+        ...BASE_SPEC,
+      }),
+    ).rejects.toThrow('baseImageRef requires warmRepo');
   });
 });

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -17,7 +17,9 @@ import {
   DEFAULT_DISK_GB,
   DEFAULT_MEMORY_GB,
   KORTIX_ENTRYPOINT,
+  type StagedContext,
   stageBuildContext,
+  stageWarmFromBaseContext,
 } from '../build-context';
 import { type InvalidatableObservation, shortLivedObservation } from '../observation-cache';
 import type {
@@ -91,8 +93,10 @@ class DaytonaAdapter implements SandboxProviderAdapter {
   }
 
   async buildSnapshot(input: BuildableTemplate, tap?: BuildLogTap): Promise<void> {
-    if (!input.image && !input.userDockerfile) {
-      throw new Error('DaytonaAdapter.buildSnapshot: neither image nor userDockerfile set');
+    if (!input.image && !input.userDockerfile && !input.baseImageRef) {
+      throw new Error(
+        'DaytonaAdapter.buildSnapshot: none of image, userDockerfile, baseImageRef set',
+      );
     }
     invalidateSnapshotState(input.snapshotName);
     const daytona = getDaytona();
@@ -114,7 +118,24 @@ class DaytonaAdapter implements SandboxProviderAdapter {
       // reports as "Path does not exist: …/scaffold.git". Re-staging self-heals
       // it so the auto/background build recovers on its own instead of needing a
       // manual rebuild (the "always have to manually start" symptom).
-      const ctx = await stageBuildContext(input.snapshotName, userDockerfile, input.warmRepo, input.isShared);
+      let ctx: StagedContext;
+      if (input.baseImageRef) {
+        if (!input.warmRepo) {
+          throw new Error('DaytonaAdapter.buildSnapshot: baseImageRef requires warmRepo');
+        }
+        ctx = await stageWarmFromBaseContext(
+          input.snapshotName,
+          input.baseImageRef,
+          input.warmRepo,
+        );
+      } else {
+        ctx = await stageBuildContext(
+          input.snapshotName,
+          userDockerfile,
+          input.warmRepo,
+          input.isShared,
+        );
+      }
       const buildLogs: string[] = [];
       try {
         await daytona.snapshot.create(
@@ -181,6 +202,32 @@ class DaytonaAdapter implements SandboxProviderAdapter {
     // the rare race where an `active` snapshot disappears between our check
     // and the actual sandbox.create.
     return observeSnapshotState(snapshotName)();
+  }
+
+  /**
+   * Resolve the registry image ref backing an already-built Daytona snapshot
+   * (`Snapshot.imageName` in the SDK — Daytona snapshots ARE registry images
+   * under the hood: `CreateSnapshotParams.image` accepts a plain string
+   * "available on some registry" as an alternative to an `Image` build spec).
+   * Used by the per-project warm fast path to `FROM` the shared default image
+   * instead of rebuilding its whole toolchain — see builder.ts
+   * `ensurePerProjectWarmImage`. Returns null on ANY failure (not found, no
+   * imageName, network error, unconfigured) — every caller treats null as
+   * "fall back to the full rebuild", never as fatal.
+   */
+  async getSnapshotImageRef(snapshotName: string): Promise<string | null> {
+    if (!isDaytonaConfigured()) return null;
+    try {
+      const snap = await withTimeout(
+        getDaytona().snapshot.get(snapshotName),
+        SNAPSHOT_STATE_TIMEOUT_MS,
+        `Daytona snapshot.get(${snapshotName})`,
+      );
+      const imageName = (snap as { imageName?: unknown } | null | undefined)?.imageName;
+      return typeof imageName === 'string' && imageName.trim() ? imageName : null;
+    } catch {
+      return null;
+    }
   }
 
   async deleteSnapshot(snapshotName: string): Promise<void> {

--- a/apps/api/src/snapshots/providers/index.ts
+++ b/apps/api/src/snapshots/providers/index.ts
@@ -24,9 +24,24 @@ interface SandboxResourceSpec {
 export interface BuildableTemplate {
   /** Snapshot name the provider should write under. */
   snapshotName: string;
-  /** Either `image` OR `userDockerfile` is set (not both). */
+  /**
+   * Exactly one of `image`, `userDockerfile`, or `baseImageRef` is set.
+   */
   image?: string;
   userDockerfile?: string;
+  /**
+   * Per-project warm FAST PATH: a registry-addressable ref to an
+   * already-built, active runtime image (the shared default) to `FROM`
+   * instead of composing the full toolchain Dockerfile. When set, the
+   * provider stages a minimal Dockerfile (see `stageWarmFromBaseContext`)
+   * that only adds `warmRepo` on top — the toolchain (including the
+   * Chromium install that per-project bakes could otherwise re-download
+   * under a build-cache miss) is INHERITED, not re-run. Only meaningful
+   * together with `warmRepo`; providers that don't support this (no
+   * `getSnapshotImageRef`) never receive it — the caller falls back to
+   * `userDockerfile` instead.
+   */
+  baseImageRef?: string;
   /** Optional entrypoint override; null means use the provider default. */
   entrypoint?: string[];
   /** Resource spec. */
@@ -37,10 +52,11 @@ export interface BuildableTemplate {
   isShared?: boolean;
   /**
    * Per-project COLD warm: bake the project's repo checkout into /workspace at
-   * build time. Threaded straight to `stageBuildContext` → the Dockerfile layer,
-   * which clones the repo (build-time creds) and keeps /workspace. The image
-   * stays capture:'none' (no memory snapshot) — BOTH providers boot it cold.
-   * Absent for the shared default image (workspace stays empty).
+   * build time. Threaded straight to `stageBuildContext` (or, on the
+   * `baseImageRef` fast path, `stageWarmFromBaseContext`) → the Dockerfile
+   * layer, which clones the repo (build-time creds) and keeps /workspace. The
+   * image stays capture:'none' (no memory snapshot) — BOTH providers boot it
+   * cold. Absent for the shared default image (workspace stays empty).
    */
   warmRepo?: WarmRepoContext;
 }
@@ -77,6 +93,19 @@ export interface SandboxProviderAdapter {
   deleteSnapshot(snapshotName: string): Promise<void>;
   /** List provider snapshots/templates owned by the current account. */
   listSnapshots(): Promise<Array<{ name: string }>>;
+
+  /**
+   * Optional: resolve a registry-addressable image reference for an
+   * ALREADY-BUILT snapshot, for use as `BuildableTemplate.baseImageRef` on a
+   * later build (the per-project warm FAST PATH — see builder.ts
+   * `ensurePerProjectWarmImage`). Returns null when the snapshot doesn't exist,
+   * the provider has no such reference to give, or on any lookup error — every
+   * caller treats null as "fall back to the full rebuild path", never as a
+   * hard failure. Absent on providers that don't expose an image reference at
+   * all (Platinum, E2B, local-docker); callers must null-check the method
+   * itself, not just its return value.
+   */
+  getSnapshotImageRef?(snapshotName: string): Promise<string | null>;
 
   /**
    * Optional agent-only fast path: produce `newSnapshotName` from a predecessor

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -148,7 +148,22 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000 (was Playwright's 30s default)
 // + a 5-attempt backoff retry loop around `playwright install --with-deps
 // chromium`, so a transient CDN blip no longer fails the whole image build.
-const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v27';
+// v28: v27's cache-order fix made the Chromium RUN text byte-identical across
+// bakes, but under concurrency (3+ simultaneous per-project bakes) the
+// opportunistic build-cache STILL did not reliably hit — the provider's
+// build-cache is not something we can observe or guarantee from here, so
+// per-project warm bakes kept re-downloading Chromium and saturating egress
+// (root cause of the v0.10.11 prod rollback). Two changes: (a) per-project warm
+// bakes now prefer building FROM the already-built default image
+// (buildPerProjectWarmFromBaseDockerfile in dockerfile-layer.ts, wired through
+// ensurePerProjectWarmImage) — Chromium is INHERITED, not re-installed, so
+// there is no download to miss, no matter what the provider's cache does. This
+// requires the default image to already be `active` on the provider; when it
+// isn't (or the provider can't report an image ref), the builder falls back to
+// the v27 full-rebuild path unchanged. (b) Raised
+// PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT to 1800000 (30min, was 300000/5min) as
+// a safety net for that fallback path under a cold cache.
+const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v28';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -101,7 +101,7 @@ RUN cd /opt/kortix/opencode-config-deps \\
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
     AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
     AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
-    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
 RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
     && agent-browser --version \\
     && for pw_try in 1 2 3 4 5; do \\
@@ -277,7 +277,7 @@ RUN cd /opt/kortix/opencode-config-deps \\
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
     AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
     AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
-    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
 RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
     && agent-browser --version \\
     && for pw_try in 1 2 3 4 5; do \\
@@ -454,7 +454,7 @@ RUN cd /opt/kortix/opencode-config-deps \\
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
     AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
     AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
-    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
 RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
     && agent-browser --version \\
     && for pw_try in 1 2 3 4 5; do \\
@@ -538,5 +538,67 @@ RUN mkdir -p /workspace /opt/kortix/home /ephemeral/kortix-master/opencode
 WORKDIR /workspace
 EXPOSE 8000
 ENTRYPOINT ["/usr/local/bin/kortix-entrypoint"]
+"
+`;
+
+exports[`buildPerProjectWarmFromBaseDockerfile (FROM-base fast path) golden 1`] = `
+"FROM registry.daytona.internal/kortix-default-abc123:latest
+
+# ─── Per-project COLD warm (FROM-base fast path, auto-injected) ─────
+# Everything above this line is INHERITED from the already-built default
+# runtime image (apt/pip/opencode/bun/agent-browser + Chromium are already
+# baked in) — nothing below re-installs any of it. This is what makes the
+# Chromium install a guaranteed inherit instead of an opportunistic
+# build-cache hit. Do not add toolchain RUNs here — they belong in
+# kortixToolchainLayer, which this stage deliberately skips.
+
+USER root
+
+# ─── Per-project COLD warm: bake repo checkout into /workspace ──────
+RUN cd / \\
+    && rm -rf /tmp/kortix-warm-repo && mkdir -p /tmp/kortix-warm-repo /workspace \\
+    && git -c http.extraHeader='Authorization: Bearer redacted' clone --depth 1 --branch 'main' 'https://git.example.com/acme/app.git' /tmp/kortix-warm-repo \\
+    && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} + \\
+    && (shopt -s dotglob 2>/dev/null || true) && cp -a /tmp/kortix-warm-repo/. /workspace/ \\
+    && rm -rf /tmp/kortix-warm-repo \\
+    && git -C /workspace remote set-url origin 'https://kortix.example.com/v1/git/proj.git' \\
+    && echo "warm-repo: baked $(git -C /workspace rev-parse HEAD) on main"
+
+COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
+RUN cd /opt/kortix/warm-config/.kortix/opencode \\
+    && rm -rf node_modules \\
+    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\
+    && HOME=/opt/kortix/home bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \\
+    && rm -rf /tmp/opencode-tools-bundle-check \\
+    && echo "opencode-config-deps: starter tool files bundle cleanly"
+
+RUN set +e; \\
+    export HOME=/opt/kortix/home \\
+        XDG_DATA_HOME=/opt/kortix/home/.local/share \\
+        XDG_CONFIG_HOME=/opt/kortix/home/.config \\
+        XDG_CACHE_HOME=/opt/kortix/home/.cache \\
+        BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache; \\
+    mkdir -p /workspace/.kortix; \\
+    staged_starter_config=0; \\
+    [ -d /workspace/.kortix/opencode ] || { cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode && staged_starter_config=1; }; \\
+    rm -rf /workspace/.kortix/opencode/node_modules; \\
+    ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules; \\
+    export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode; \\
+    cd /workspace; \\
+    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log 2>&1 & oc_pid=$!; \\
+    ready=0; \\
+    for i in $(seq 1 300); do \\
+        code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:4096/session?directory=/workspace" 2>/dev/null); \\
+        case "$code" in 200|204|301|302) ready=1; break;; esac; \\
+        kill -0 "$oc_pid" 2>/dev/null || break; \\
+        sleep 1; \\
+    done; \\
+    echo "=== instance-warm: ready=$ready ==="; \\
+    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\
+    echo "warm-repo: keeping baked /workspace checkout"; \\
+    rm -rf /opt/kortix/warm-config; \\
+    echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\
+    rm -f /tmp/oc-warm.log; true
+
 "
 `;

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -19,10 +19,11 @@
 import { describe, expect, test } from 'bun:test';
 import { AGENT_BROWSER_VERSION, OPENCODE_VERSION } from '../../runtime-versions';
 import {
-  buildLayeredDockerfile,
   type BuildLayeredDockerfileOpts,
-  kortixToolchainLayer,
   PLATFORM_DEFAULT_USER_DOCKERFILE,
+  buildLayeredDockerfile,
+  buildPerProjectWarmFromBaseDockerfile,
+  kortixToolchainLayer,
 } from '../dockerfile-layer';
 
 const COMMON = {
@@ -163,5 +164,89 @@ describe('the /workspace wipe is scoped to the shared default image', () => {
   test('warmRepo outranks isSharedDefault — a baked checkout is never wiped', () => {
     const both = buildLayeredDockerfile({ ...CASES[2]!.opts, isSharedDefault: true });
     expect(both).not.toContain(WIPE);
+  });
+});
+
+describe('buildPerProjectWarmFromBaseDockerfile (FROM-base fast path)', () => {
+  const FROM_BASE_OPTS = {
+    baseImageRef: 'registry.daytona.internal/kortix-default-abc123:latest',
+    opencodeConfigPath: 'kortix-opencode-config',
+    warmRepo: {
+      cloneUrl: 'https://git.example.com/acme/app.git',
+      cloneHeaders: { Authorization: 'Bearer redacted' },
+      branch: 'main',
+      originUrl: 'https://kortix.example.com/v1/git/proj.git',
+    },
+  };
+
+  test('golden', () => {
+    expect(buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS)).toMatchSnapshot();
+  });
+
+  test('FROMs the base image ref as the very first line', () => {
+    const rendered = buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS);
+    expect(rendered.startsWith(`FROM ${FROM_BASE_OPTS.baseImageRef}\n`)).toBe(true);
+  });
+
+  test('never re-installs the toolchain — Chromium is inherited, not re-run', () => {
+    const rendered = buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS);
+    expect(rendered).not.toContain('apt-get');
+    expect(rendered).not.toContain('opencode-ai@');
+    expect(rendered).not.toContain('playwright');
+    expect(rendered).not.toContain('chromium');
+    expect(rendered).not.toContain('agent-browser@');
+    expect(rendered).not.toContain('pip install');
+    expect(rendered).not.toContain('bun.com/install');
+  });
+
+  test('bakes the repo checkout and re-warms the opencode instance against it', () => {
+    const rendered = buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS);
+    expect(rendered).toContain('Per-project COLD warm: bake repo checkout into /workspace');
+    expect(rendered).toContain(FROM_BASE_OPTS.warmRepo.cloneUrl);
+    expect(rendered).toContain('opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log');
+    expect(rendered).toContain('warm-repo: keeping baked /workspace checkout');
+  });
+
+  test('renders the clone + warm-up steps byte-identically to the monolithic build', () => {
+    const monolithic = buildLayeredDockerfile({
+      userDockerfile: PLATFORM_DEFAULT_USER_DOCKERFILE,
+      ...COMMON,
+      warmRepo: FROM_BASE_OPTS.warmRepo,
+    });
+    const fromBase = buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS);
+    const startMarker = 'RUN cd / \\\n    && rm -rf /tmp/kortix-warm-repo';
+    const endMarker = 'rm -f /tmp/oc-warm.log; true';
+    const slice = (text: string) =>
+      text.slice(text.indexOf(startMarker), text.indexOf(endMarker) + endMarker.length);
+    expect(slice(fromBase)).toBe(slice(monolithic));
+  });
+
+  test('does not COPY or reference any staged artifact paths — everything is inherited', () => {
+    const rendered = buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS);
+    expect(rendered).not.toContain('COPY kortix-agent.gz');
+    expect(rendered).not.toContain('COPY kortix.gz');
+    expect(rendered).not.toContain('scaffold.git');
+    expect(rendered).not.toContain('ENTRYPOINT');
+  });
+
+  test('with no opencodeConfigPath, only the clone step is added on top of the base', () => {
+    const rendered = buildPerProjectWarmFromBaseDockerfile({
+      baseImageRef: FROM_BASE_OPTS.baseImageRef,
+      warmRepo: FROM_BASE_OPTS.warmRepo,
+    });
+    expect(rendered).not.toContain('COPY ');
+    expect(rendered).toContain('Per-project COLD warm: bake repo checkout into /workspace');
+  });
+
+  test('is portable — no buildah-unsupported heredocs', () => {
+    const rendered = buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS);
+    const heredocLine = rendered
+      .split('\n')
+      .find((l) => !/^\s*#/.test(l) && /<<-?['"]?[A-Za-z_]\w*['"]?\s*\\?\s*$/.test(l));
+    expect(heredocLine).toBeUndefined();
+  });
+
+  test('result ends with a trailing newline', () => {
+    expect(buildPerProjectWarmFromBaseDockerfile(FROM_BASE_OPTS).endsWith('\n')).toBe(true);
   });
 });

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -128,24 +128,32 @@ export interface KortixToolchainLayerOpts {
    * NOT wipe /workspace afterward. Omit for the shared, project-independent
    * default image (workspace stays empty; the daemon clones at boot).
    */
-  warmRepo?: {
-    /** Upstream URL to clone from at BUILD time (real git host or proxy). */
-    cloneUrl: string;
-    /**
-     * Auth headers for the build-time clone, passed via `git -c
-     * http.extraHeader` inside a RUN that deletes the script in the same
-     * invocation — nothing credential-shaped survives into the image layer.
-     */
-    cloneHeaders: Record<string, string>;
-    /** Branch to check out (the default branch tip is baked). */
-    branch: string;
-    /**
-     * The Kortix git-proxy origin the baked checkout's `origin` is reset to, so
-     * the daemon's per-session credential helper re-auths pushes/fetches at
-     * runtime (the build credential is never persisted).
-     */
-    originUrl: string;
-  };
+  warmRepo?: WarmRepoConfig;
+}
+
+/**
+ * Build-time git-clone inputs for a per-project COLD warm bake. Shared between
+ * `kortixToolchainLayer` (the full monolithic build) and
+ * `buildPerProjectWarmFromBaseDockerfile` (the FROM-base fast path) so both
+ * render the identical clone RUN — see `buildWarmRepoCloneLines`.
+ */
+export interface WarmRepoConfig {
+  /** Upstream URL to clone from at BUILD time (real git host or proxy). */
+  cloneUrl: string;
+  /**
+   * Auth headers for the build-time clone, passed via `git -c
+   * http.extraHeader` inside a RUN that deletes the script in the same
+   * invocation — nothing credential-shaped survives into the image layer.
+   */
+  cloneHeaders: Record<string, string>;
+  /** Branch to check out (the default branch tip is baked). */
+  branch: string;
+  /**
+   * The Kortix git-proxy origin the baked checkout's `origin` is reset to, so
+   * the daemon's per-session credential helper re-auths pushes/fetches at
+   * runtime (the build credential is never persisted).
+   */
+  originUrl: string;
 }
 
 /**
@@ -213,6 +221,156 @@ export interface BuildLayeredDockerfileOpts
  * Renders against an EMPTY build context — it stages nothing. Ends with a
  * trailing newline so it concatenates directly onto `kortixArtifactLayer`.
  */
+// Single-quote a value for safe embedding in a build-time bash RUN.
+const shq = (v: string) => `'${String(v).replace(/'/g, `'\\''`)}'`;
+
+/**
+ * The per-project COLD warm clone RUN: clones `warmRepo` into /workspace at
+ * BUILD time. The auth header goes through `git -c http.extraHeader` (never
+ * written to git config) and the whole step is one RUN, so no credential-shaped
+ * bytes persist. origin is reset to the Kortix proxy so the daemon re-auths per
+ * session at runtime.
+ *
+ * Shared verbatim between `kortixToolchainLayer` (the monolithic build) and
+ * `buildPerProjectWarmFromBaseDockerfile` (the FROM-base fast path) — the two
+ * MUST render byte-identical clone text so the baked checkout is the same
+ * either way. Returns `[]` when there's no repo to bake (the shared,
+ * project-independent default image).
+ */
+function buildWarmRepoCloneLines(warmRepo: WarmRepoConfig | undefined): string[] {
+  if (!warmRepo) return [];
+  return [
+    '',
+    '# ─── Per-project COLD warm: bake repo checkout into /workspace ──────',
+    // Clone the default-branch tip into /workspace. --depth 1 keeps the layer
+    // small; the daemon fast-paths the baked .git and deepens on demand.
+    // NOTE: an earlier layer sets `WORKDIR /workspace` (either this image's own
+    // toolchain layer, or — on the FROM-base fast path — the inherited base
+    // image), so the build shell's CWD IS /workspace. We must NOT `rm -rf
+    // /workspace` (that orphans the CWD inode → git dies with "Unable to read
+    // current working directory"). Instead `cd /`, clone into a scratch dir,
+    // then move the contents into the (emptied) /workspace so the CWD inode
+    // stays valid.
+    `RUN cd / \\`,
+    `    && rm -rf /tmp/kortix-warm-repo && mkdir -p /tmp/kortix-warm-repo /workspace \\`,
+    `    && git ${Object.entries(warmRepo.cloneHeaders)
+      .map(([k, v]) => `-c http.extraHeader=${shq(`${k}: ${v}`)}`)
+      .join(' ')} clone --depth 1 --branch ${shq(warmRepo.branch)} ${shq(warmRepo.cloneUrl)} /tmp/kortix-warm-repo \\`,
+    `    && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} + \\`,
+    `    && (shopt -s dotglob 2>/dev/null || true) && cp -a /tmp/kortix-warm-repo/. /workspace/ \\`,
+    `    && rm -rf /tmp/kortix-warm-repo \\`,
+    `    && git -C /workspace remote set-url origin ${shq(warmRepo.originUrl)} \\`,
+    `    && echo "warm-repo: baked $(git -C /workspace rev-parse HEAD) on ${warmRepo.branch}"`,
+    '',
+  ];
+}
+
+/**
+ * Warm a real opencode PROJECT INSTANCE at build time. The first time opencode
+ * creates an instance for a project dir it loads that dir's .kortix/opencode
+ * surface — importing the pty plugin + tools — which makes Bun auto-install /
+ * transpile the plugin dep tree and opencode fetch its model catalog +
+ * ripgrep. On a fresh VM that's a one-time ~6s stall (up to ~60s when npm /
+ * GitHub are contended) that gates runtimeReady right on the session hot path.
+ * We pay it ONCE here, against the canonical starter config staged at the SAME
+ * runtime path (/workspace) so Bun's content-addressed transpile cache hits at
+ * boot. For the SHARED default image we then wipe /workspace (the session
+ * clones into it). For a PER-PROJECT COLD warm (warmRepo set) the repo is
+ * already baked at /workspace and we KEEP it — the daemon boots off the baked
+ * checkout with NO clone. For a CUSTOM template we remove only the config we
+ * staged: /workspace is the user's. Either way the warmed caches under
+ * /opt/kortix/home persist in the image layer. Measured: cold first-instance
+ * 6–60s → ~2–4s after this bake. Requires opencode + bun + the baked config
+ * deps to already be present in the image (either from the toolchain layer
+ * above, or inherited via FROM on the fast path), so it must come after them.
+ * Best effort: a build without network (or a warm-up failure) just falls back
+ * to the runtime cost — set +e + trailing `true` keep the image build green.
+ *
+ * Shared between `kortixToolchainLayer` and `buildPerProjectWarmFromBaseDockerfile`
+ * so both render byte-identical warm-up text. Returns `[]` when there's no
+ * starter config to warm against.
+ */
+function buildOpencodeInstanceWarmupLines(opts: {
+  opencodeConfigPath?: string;
+  warmRepo?: WarmRepoConfig;
+  isSharedDefault?: boolean;
+}): string[] {
+  const { opencodeConfigPath, warmRepo, isSharedDefault } = opts;
+  if (!opencodeConfigPath) return [];
+  return [
+    `COPY ${opencodeConfigPath}/ /opt/kortix/warm-config/.kortix/opencode/`,
+    // Same "does it actually bundle" check as the opencode-config-deps
+    // verification above, but exercised against the REAL starter tool
+    // files (web_search / scrape_webpage / image_search / memory / show)
+    // instead of just their axios/form-data override targets — this is
+    // what actually walks the full transitive dependency tree
+    // (firecrawl-js, tavily-core, replicate) that ToolRegistry resolves
+    // on a session's first prompt. Deliberately its own RUN step (not
+    // folded into the `set +e` warm-up below): a tool that can't bundle
+    // breaks every session's first prompt, not just startup latency, so
+    // it must fail the build — the warm-up readiness probe below stays
+    // best-effort as before.
+    'RUN cd /opt/kortix/warm-config/.kortix/opencode \\',
+    '    && rm -rf node_modules \\',
+    '    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\',
+    '    && HOME=/opt/kortix/home bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \\',
+    '    && rm -rf /tmp/opencode-tools-bundle-check \\',
+    '    && echo "opencode-config-deps: starter tool files bundle cleanly"',
+    '',
+    'RUN set +e; \\',
+    '    export HOME=/opt/kortix/home \\',
+    '        XDG_DATA_HOME=/opt/kortix/home/.local/share \\',
+    '        XDG_CONFIG_HOME=/opt/kortix/home/.config \\',
+    '        XDG_CACHE_HOME=/opt/kortix/home/.cache \\',
+    '        BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache; \\',
+    '    mkdir -p /workspace/.kortix; \\',
+    // Stage the canonical starter opencode config so the instance warm-up
+    // has the pty plugin + tools to load. For a per-project warm the baked
+    // repo may already ship its own .kortix/opencode — keep it (its config
+    // is what the session actually resolves at runtime) and only fall back
+    // to the staged starter when the repo has none.
+    // `staged_starter_config` records whether the starter config in
+    // /workspace is OURS (we copied it) or the image's own — it decides what
+    // the non-shared cleanup below is allowed to delete.
+    '    staged_starter_config=0; \\',
+    '    [ -d /workspace/.kortix/opencode ] || { cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode && staged_starter_config=1; }; \\',
+    '    rm -rf /workspace/.kortix/opencode/node_modules; \\',
+    '    ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules; \\',
+    '    export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode; \\',
+    '    cd /workspace; \\',
+    '    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log 2>&1 & oc_pid=$!; \\',
+    '    ready=0; \\',
+    '    for i in $(seq 1 300); do \\',
+    `        code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:4096/session?directory=/workspace" 2>/dev/null); \\`,
+    '        case "$code" in 200|204|301|302) ready=1; break;; esac; \\',
+    '        kill -0 "$oc_pid" 2>/dev/null || break; \\',
+    '        sleep 1; \\',
+    '    done; \\',
+    '    echo "=== instance-warm: ready=$ready ==="; \\',
+    '    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\',
+    // Three cases, and only one of them may delete indiscriminately:
+    //  • per-project COLD warm (warmRepo): KEEP the baked repo checkout so
+    //    the daemon boots off it with no clone.
+    //  • SHARED default: /workspace contains only what this warm-up put
+    //    there (the base is `PLATFORM_DEFAULT_USER_DOCKERFILE` — a FROM and a
+    //    WORKDIR), so wiping it is exact, and it also clears anything opencode
+    //    itself dropped while serving. The session clones into it at boot.
+    //  • CUSTOM template: the user's Dockerfile owns /workspace. Remove ONLY
+    //    the starter config we staged (and the .kortix dir if that leaves it
+    //    empty) — never their bytes. `rmdir` is the no-op-unless-empty form on
+    //    purpose; a user's own /workspace/.kortix survives untouched.
+    warmRepo
+      ? '    echo "warm-repo: keeping baked /workspace checkout"; \\'
+      : isSharedDefault
+        ? '    find /workspace -mindepth 1 -delete 2>/dev/null; \\'
+        : '    [ "$staged_starter_config" = 1 ] && rm -rf /workspace/.kortix/opencode; rmdir /workspace/.kortix 2>/dev/null; \\',
+    '    rm -rf /opt/kortix/warm-config; \\',
+    '    echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\',
+    '    rm -f /tmp/oc-warm.log; true',
+    '',
+  ];
+}
+
 export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
   const {
     opencodeVersion,
@@ -222,36 +380,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     warmRepo,
   } = opts;
 
-  // Single-quote a value for safe embedding in a build-time bash RUN.
-  const shq = (v: string) => `'${String(v).replace(/'/g, `'\\''`)}'`;
-  // Per-project COLD warm: clone the repo into /workspace at BUILD time. The auth
-  // header goes through `git -c http.extraHeader` (never written to git config)
-  // and the whole step is one RUN, so no credential-shaped bytes persist. origin
-  // is reset to the Kortix proxy so the daemon re-auths per session at runtime.
-  const warmRepoClone = warmRepo
-    ? [
-        '',
-        '# ─── Per-project COLD warm: bake repo checkout into /workspace ──────',
-        // Clone the default-branch tip into /workspace. --depth 1 keeps the layer
-        // small; the daemon fast-paths the baked .git and deepens on demand.
-        // NOTE: an earlier base layer sets `WORKDIR /workspace`, so the build
-        // shell's CWD IS /workspace. We must NOT `rm -rf /workspace` (that orphans
-        // the CWD inode → git dies with "Unable to read current working
-        // directory"). Instead `cd /`, clone into a scratch dir, then move the
-        // contents into the (emptied) /workspace so the CWD inode stays valid.
-        `RUN cd / \\`,
-        `    && rm -rf /tmp/kortix-warm-repo && mkdir -p /tmp/kortix-warm-repo /workspace \\`,
-        `    && git ${Object.entries(warmRepo.cloneHeaders)
-          .map(([k, v]) => `-c http.extraHeader=${shq(`${k}: ${v}`)}`)
-          .join(' ')} clone --depth 1 --branch ${shq(warmRepo.branch)} ${shq(warmRepo.cloneUrl)} /tmp/kortix-warm-repo \\`,
-        `    && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} + \\`,
-        `    && (shopt -s dotglob 2>/dev/null || true) && cp -a /tmp/kortix-warm-repo/. /workspace/ \\`,
-        `    && rm -rf /tmp/kortix-warm-repo \\`,
-        `    && git -C /workspace remote set-url origin ${shq(warmRepo.originUrl)} \\`,
-        `    && echo "warm-repo: baked $(git -C /workspace rev-parse HEAD) on ${warmRepo.branch}"`,
-        '',
-      ]
-    : [];
+  const warmRepoClone = buildWarmRepoCloneLines(warmRepo);
 
   return [
     '',
@@ -528,9 +657,15 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // (NET_DEFAULT_TIMEOUT in playwright-core), which a ~150MB Chrome-for-Testing
     // fetch can miss under any network hiccup / contended CDN — observed live as
     // "Downloading Chrome for Testing ... timed out after 30000ms" failing the
-    // whole bake. Give it real headroom; the retry loop below is the second line
-    // of defense for a transient failure within that window.
-    '    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=300000',
+    // whole bake. 30 minutes gives real headroom for a cold-cache build under
+    // contention (staging observed this stalling on slower Daytona egress); the
+    // retry loop below is the second line of defense for a transient failure
+    // within that window. This is a SAFETY NET, not the primary fix — the
+    // primary fix is that per-project warm bakes now build FROM the already-baked
+    // default image (see buildPerProjectWarmFromBaseDockerfile below) and so
+    // never re-run this install at all when that fast path is available; this
+    // timeout only matters for the fallback full rebuild path.
+    '    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000',
     `RUN npm install -g --no-audit --no-fund "agent-browser@${agentBrowserVersion}" \\`,
     '    && agent-browser --version \\',
     // Retry the Chromium download a handful of times with backoff before giving
@@ -566,98 +701,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // comment for why the order matters (this step's RUN text is never
     // cache-stable, so nothing cache-sensitive may sit downstream of it).
     ...warmRepoClone,
-    // Warm a real opencode PROJECT INSTANCE at build time. The first time opencode
-    // creates an instance for a project dir it loads that dir's .kortix/opencode
-    // surface — importing the pty plugin + tools — which makes Bun auto-install /
-    // transpile the plugin dep tree and opencode fetch its model catalog +
-    // ripgrep. On a fresh VM that's a one-time ~6s stall (up to ~60s when npm /
-    // GitHub are contended) that gates runtimeReady right on the session hot path.
-    // We pay it ONCE here, against the canonical starter config staged at the SAME
-    // runtime path (/workspace) so Bun's content-addressed transpile cache hits at
-    // boot. For the SHARED default image we then wipe /workspace (the session
-    // clones into it). For a PER-PROJECT COLD warm (warmRepo set) the repo is
-    // already baked at /workspace and we KEEP it — the daemon boots off the baked
-    // checkout with NO clone. For a CUSTOM template we remove only the config we
-    // staged: /workspace is the user's. Either way the warmed caches under /opt/kortix/home
-    // persist in the image layer. Measured: cold first-instance 6–60s → ~2–4s
-    // after this bake. Requires opencode + bun + the
-    // baked config deps above, so it must come after them. Best effort: a build
-    // without network (or a warm-up failure) just falls back to the runtime cost —
-    // set +e + trailing `true` keep the image build green.
-    ...(opencodeConfigPath
-      ? [
-          `COPY ${opencodeConfigPath}/ /opt/kortix/warm-config/.kortix/opencode/`,
-          // Same "does it actually bundle" check as the opencode-config-deps
-          // verification above, but exercised against the REAL starter tool
-          // files (web_search / scrape_webpage / image_search / memory / show)
-          // instead of just their axios/form-data override targets — this is
-          // what actually walks the full transitive dependency tree
-          // (firecrawl-js, tavily-core, replicate) that ToolRegistry resolves
-          // on a session's first prompt. Deliberately its own RUN step (not
-          // folded into the `set +e` warm-up below): a tool that can't bundle
-          // breaks every session's first prompt, not just startup latency, so
-          // it must fail the build — the warm-up readiness probe below stays
-          // best-effort as before.
-          'RUN cd /opt/kortix/warm-config/.kortix/opencode \\',
-          '    && rm -rf node_modules \\',
-          '    && ln -s /opt/kortix/opencode-config-deps/node_modules node_modules \\',
-          '    && HOME=/opt/kortix/home bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \\',
-          '    && rm -rf /tmp/opencode-tools-bundle-check \\',
-          '    && echo "opencode-config-deps: starter tool files bundle cleanly"',
-          '',
-          'RUN set +e; \\',
-          '    export HOME=/opt/kortix/home \\',
-          '        XDG_DATA_HOME=/opt/kortix/home/.local/share \\',
-          '        XDG_CONFIG_HOME=/opt/kortix/home/.config \\',
-          '        XDG_CACHE_HOME=/opt/kortix/home/.cache \\',
-          '        BUN_INSTALL_CACHE_DIR=/opt/kortix/home/.bun/install/cache; \\',
-          '    mkdir -p /workspace/.kortix; \\',
-          // Stage the canonical starter opencode config so the instance warm-up
-          // has the pty plugin + tools to load. For a per-project warm the baked
-          // repo may already ship its own .kortix/opencode — keep it (its config
-          // is what the session actually resolves at runtime) and only fall back
-          // to the staged starter when the repo has none.
-          // `staged_starter_config` records whether the starter config in
-          // /workspace is OURS (we copied it) or the image's own — it decides what
-          // the non-shared cleanup below is allowed to delete.
-          '    staged_starter_config=0; \\',
-          '    [ -d /workspace/.kortix/opencode ] || { cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode && staged_starter_config=1; }; \\',
-          '    rm -rf /workspace/.kortix/opencode/node_modules; \\',
-          '    ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules; \\',
-          '    export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode; \\',
-          '    cd /workspace; \\',
-          '    opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log 2>&1 & oc_pid=$!; \\',
-          '    ready=0; \\',
-          '    for i in $(seq 1 300); do \\',
-          `        code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:4096/session?directory=/workspace" 2>/dev/null); \\`,
-          '        case "$code" in 200|204|301|302) ready=1; break;; esac; \\',
-          '        kill -0 "$oc_pid" 2>/dev/null || break; \\',
-          '        sleep 1; \\',
-          '    done; \\',
-          '    echo "=== instance-warm: ready=$ready ==="; \\',
-          '    kill "$oc_pid" 2>/dev/null; wait "$oc_pid" 2>/dev/null; \\',
-          // Three cases, and only one of them may delete indiscriminately:
-          //  • per-project COLD warm (warmRepo): KEEP the baked repo checkout so
-          //    the daemon boots off it with no clone.
-          //  • SHARED default: /workspace contains only what this warm-up put
-          //    there (the base is `PLATFORM_DEFAULT_USER_DOCKERFILE` — a FROM and a
-          //    WORKDIR), so wiping it is exact, and it also clears anything opencode
-          //    itself dropped while serving. The session clones into it at boot.
-          //  • CUSTOM template: the user's Dockerfile owns /workspace. Remove ONLY
-          //    the starter config we staged (and the .kortix dir if that leaves it
-          //    empty) — never their bytes. `rmdir` is the no-op-unless-empty form on
-          //    purpose; a user's own /workspace/.kortix survives untouched.
-          warmRepo
-            ? '    echo "warm-repo: keeping baked /workspace checkout"; \\'
-            : isSharedDefault
-              ? '    find /workspace -mindepth 1 -delete 2>/dev/null; \\'
-              : '    [ "$staged_starter_config" = 1 ] && rm -rf /workspace/.kortix/opencode; rmdir /workspace/.kortix 2>/dev/null; \\',
-          '    rm -rf /opt/kortix/warm-config; \\',
-          '    echo "=== instance-warm: opencode log tail ==="; tail -20 /tmp/oc-warm.log; \\',
-          '    rm -f /tmp/oc-warm.log; true',
-          '',
-        ]
-      : []),
+    ...buildOpencodeInstanceWarmupLines({ opencodeConfigPath, warmRepo, isSharedDefault }),
     // The staged-artifact tail lives in `kortixArtifactLayer`. The split is
     // here — everything above installs from the network into an empty build
     // context; everything below COPYs bytes the caller had to stage first.
@@ -732,6 +776,75 @@ export function kortixArtifactLayer(opts: KortixArtifactLayerOpts): string {
 export function buildLayeredDockerfile(opts: BuildLayeredDockerfileOpts): string {
   const trimmed = normalizeUserDockerfileForSnapshot(opts.userDockerfile).trimEnd();
   return `${trimmed}\n${kortixToolchainLayer(opts)}${kortixArtifactLayer(opts)}`;
+}
+
+/** Inputs for the FROM-base per-project warm fast path — see
+ *  {@link buildPerProjectWarmFromBaseDockerfile}. */
+export interface PerProjectWarmFromBaseOpts {
+  /**
+   * Registry-addressable reference to an ALREADY-BUILT, ACTIVE image that has
+   * the full Kortix runtime layer baked in (apt/pip/opencode/bun/agent-browser
+   * + Chromium + the artifact tail) — in practice the shared default image's
+   * provider-reported image ref (e.g. Daytona `Snapshot.imageName`). The
+   * caller (ensurePerProjectWarmImage in apps/api/src/snapshots/builder.ts) is
+   * responsible for resolving this and MUST verify the source snapshot is
+   * `active` first; a `FROM` of a not-yet-built or missing image fails the
+   * whole bake immediately (no opportunistic retry-as-full-rebuild happens
+   * inside this function — that fallback lives in the caller).
+   */
+  baseImageRef: string;
+  /** Repo to bake into /workspace — always set; a per-project warm with no
+   *  repo to clone has nothing for this fast path to add over the base. */
+  warmRepo: WarmRepoConfig;
+  /** Same meaning as {@link KortixToolchainLayerOpts.opencodeConfigPath}. */
+  opencodeConfigPath?: string;
+}
+
+/**
+ * Per-project COLD warm, FAST PATH: `FROM` an already-built runtime image
+ * (the shared default) instead of re-running the ~15-layer toolchain install
+ * (apt/pip/opencode/bun/agent-browser+Chromium) from scratch.
+ *
+ * THIS is the actual fix for the Chromium re-download bug (prod incident,
+ * v0.10.11 rollback): `kortixToolchainLayer`'s comment already establishes
+ * that the toolchain RUN text up to and including the Chromium install is
+ * byte-identical between the shared default build and every per-project warm
+ * bake — so in principle a build-cache hit should always be available. In
+ * practice it was not reliable enough under concurrency (3+ simultaneous
+ * per-project bakes), and a full monolithic rebuild is fundamentally an
+ * OPPORTUNISTIC cache hit — the provider's build backend is free to evict,
+ * shard across builder nodes, or otherwise not share that cache, and there is
+ * no way to observe or guarantee it from here. `FROM <baseImageRef>` removes
+ * the dependency on that cache entirely: Chromium (and everything else in the
+ * toolchain) is INHERITED, not re-executed, so there is no download to miss.
+ *
+ * Only adds the two per-project-specific steps on top of the base — the
+ * warm-repo clone and the opencode instance re-warm against the real project
+ * — using the EXACT SAME line-builders as the monolithic path
+ * (`buildWarmRepoCloneLines` / `buildOpencodeInstanceWarmupLines`), so the
+ * resulting /workspace content is equivalent to what the full rebuild would
+ * have produced. Everything else — WORKDIR, ENV, ENTRYPOINT, EXPOSE, the
+ * baked agent/CLI binaries — is inherited from the base image, since Docker
+ * FROM semantics carry those forward automatically; this function does not
+ * (and must not) re-declare them.
+ */
+export function buildPerProjectWarmFromBaseDockerfile(opts: PerProjectWarmFromBaseOpts): string {
+  const { baseImageRef, warmRepo, opencodeConfigPath } = opts;
+  return [
+    `FROM ${baseImageRef}`,
+    '',
+    '# ─── Per-project COLD warm (FROM-base fast path, auto-injected) ─────',
+    '# Everything above this line is INHERITED from the already-built default',
+    '# runtime image (apt/pip/opencode/bun/agent-browser + Chromium are already',
+    '# baked in) — nothing below re-installs any of it. This is what makes the',
+    '# Chromium install a guaranteed inherit instead of an opportunistic',
+    '# build-cache hit. Do not add toolchain RUNs here — they belong in',
+    '# kortixToolchainLayer, which this stage deliberately skips.',
+    '',
+    'USER root',
+    ...buildWarmRepoCloneLines(warmRepo),
+    ...buildOpencodeInstanceWarmupLines({ opencodeConfigPath, warmRepo, isSharedDefault: false }),
+  ].join('\n') + '\n';
 }
 
 export function normalizeUserDockerfileForSnapshot(dockerfile: string): string {


### PR DESCRIPTION
## Summary

Root-cause fix for the Chromium re-download bug that caused the v0.10.11 prod rollback: per-project warm bakes (`ensurePerProjectWarmImage`) still re-downloaded the ~150MB Chromium install under concurrency even after #5042 reordered the Chromium layer ahead of the credential-bearing warm-repo clone.

**Why #5042 wasn't sufficient**: that fix made the toolchain RUN text byte-identical across the shared default build and every per-project bake, so in principle the provider's build-cache should always hit. But a monolithic rebuild depends entirely on that cache being *opportunistically* available — the provider is free to evict entries, shard builds across different builder nodes, or otherwise miss under load, and the caller has no way to observe or guarantee a hit. Under 3+ concurrent per-project bakes this saturated Daytona egress with parallel 150MB downloads → slow sandbox boot → "runtime never ready" → the rollback.

**The fix**: `ensurePerProjectWarmImage` now resolves the already-built shared default image's registry ref (Daytona `Snapshot.imageName` — Daytona snapshots are registry images under the hood; `CreateSnapshotParams.image` accepts a plain registry string as an alternative to a Dockerfile build) and, when that base snapshot is confirmed `active`, builds the per-project warm image `FROM` it (`buildPerProjectWarmFromBaseDockerfile` in `dockerfile-layer.ts`) instead of recomposing the full ~15-layer toolchain. Chromium — and everything else in the toolchain (apt/pip/opencode/bun/agent-browser) — is **inherited** via Docker `FROM` semantics, not re-executed. There is no download to lose a cache race on, no matter what the provider's build-cache does. Only the warm-repo clone + opencode instance re-warm are added on top, reusing the exact same line-builders as the monolithic path (`buildWarmRepoCloneLines` / `buildOpencodeInstanceWarmupLines`) so the baked `/workspace` is equivalent either way.

**Strictly additive / safe**: the fast path is only attempted when the provider exposes `getSnapshotImageRef` (Daytona only — Platinum/E2B/local-docker are completely unchanged) and the base snapshot is verified `active` first (never guesses). Any fast-path build failure (stale ref, provider hiccup, …) is caught and falls back to the full rebuild automatically — this can never make a bake worse than the pre-existing behavior, only better.

**Also**: raises `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT` 300000 → 1800000 (matches staging's #5044 cherry-pick, which never landed on main) as a safety net for the fallback full-rebuild path under a cold cache. Bumps `RUNTIME_LAYER_VERSION` v27 → v28 since that timeout change touches the rendered toolchain text baked into `kortix-default-*`.

## Files changed
- `packages/shared/src/sandbox/dockerfile-layer.ts` — extracted `buildWarmRepoCloneLines` / `buildOpencodeInstanceWarmupLines` (pure refactor, byte-identical output, verified by the golden snapshot); added `buildPerProjectWarmFromBaseDockerfile` (the new FROM-base composer); bumped the Playwright download timeout.
- `apps/api/src/snapshots/build-context.ts` — new `stageWarmFromBaseContext` (minimal context: only the starter opencode config, no agent/CLI/scaffold staging — everything else is inherited).
- `apps/api/src/snapshots/providers/index.ts` — `BuildableTemplate.baseImageRef` + optional `SandboxProviderAdapter.getSnapshotImageRef`.
- `apps/api/src/snapshots/providers/daytona.ts` — `getSnapshotImageRef` (reads `Snapshot.imageName`); `buildSnapshot` branches to the FROM-base staging path when `baseImageRef` is set.
- `apps/api/src/snapshots/builder.ts` — `resolveWarmBaseImageRef` / `shouldAttemptWarmFromBase` (exported, unit-tested); `ensurePerProjectWarmImage` tries the fast path first with automatic fallback to the full rebuild.
- `apps/api/src/snapshots/templates.ts` — `RUNTIME_LAYER_VERSION` v27 → v28 + changelog comment.
- Tests: new golden + invariant coverage for `buildPerProjectWarmFromBaseDockerfile` (packages/shared), new `builder-warm-from-base.test.ts` (pure decision-logic + fallback unit tests), new Daytona input-validation guard tests, updated golden snapshots + the 300000→1800000 assertion.

## Test plan
- [x] `packages/shared` full suite green (254 tests, including regenerated golden snapshots — the ONLY diff versus origin/main is the intentional timeout bump, confirming the extraction refactor is byte-identical).
- [x] `apps/api` snapshots/dockerfile-layer-related suites green (~104 tests across 13 files), scoped per this repo's documented "isolated runs" convention (the full local batch run has pre-existing cross-file mock leakage unrelated to this change — confirmed via `git stash` on `main`).
- [x] `tsc --noEmit` green for both `@kortix/shared` and `kortix-api`.
- [x] Biome: net-zero new violations introduced (verified file-by-file against `git stash` baseline; two new violations from this change were fixed, pre-existing violations in touched files were left alone to keep the diff focused).
- [ ] **Live verification (parent to run, not done here)**: deploy the API to staging, rebuild the base image, run the funded RUN-1/RUN-2/GOLD-1 suite with `--workers 3`, and confirm the ppwarm bake logs show `fastPath=from-base` and **no** "Downloading Chrome" line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)