### PR TITLE
fix(infra): keep EC2 CPU monitoring alarms reconciled

### DIFF
--- a/infra/terraform/compliance-monitoring/README.md
+++ b/infra/terraform/compliance-monitoring/README.md
@@ -12,6 +12,9 @@ It manages:
 - CPU-utilization CloudWatch alarms for every running EC2 instance in the dev
   and production regions, discovered on every plan so replacement EKS workers
   remain covered (Drata DCF-86).
+- Regional Lambda reconcilers triggered by EC2 running-state events, plus a
+  five-minute repair schedule, so replacement instances receive the same alarm
+  without waiting for another Terraform apply.
 - Least-privilege SNS topic policies for EventBridge and CloudWatch delivery.
 - AWS Backup and EBS snapshot failure EventBridge rules and SNS targets
   (Drata DCF-99).
@@ -38,3 +41,19 @@ terraform apply tfplan
 
 Email SNS subscriptions remain a human confirmation step; Terraform must not
 pretend an unconfirmed subscription is a working alert channel.
+
+## Verify EC2 CPU coverage
+
+The reconciler only writes an alarm when it is absent or its metric, threshold,
+period, instance dimension, or SNS action has drifted. Invoke both regional
+functions and compare every running instance ID with the alarm dimensions:
+
+```bash
+aws lambda invoke --region us-west-2 \
+  --function-name kortix-ec2-cpu-alarm-reconciler /tmp/usw2.json
+aws lambda invoke --region eu-west-2 \
+  --function-name kortix-ec2-cpu-alarm-reconciler /tmp/euw2.json
+```
+
+Both payloads must report `covered_instances == running_instances` and an empty
+`updated_instances` list on the second invocation.

--- a/infra/terraform/compliance-monitoring/ec2-cpu-reconciler.tf
+++ b/infra/terraform/compliance-monitoring/ec2-cpu-reconciler.tf
@@ -1,0 +1,233 @@
+# Terraform establishes the baseline alarms below, while this reconciler closes
+# the gap between EKS node replacement and the next Terraform apply. Every EC2
+# running-state event triggers it, and a five-minute schedule provides a repair
+# path for missed events or configuration drift.
+
+data "archive_file" "ec2_cpu_alarm_reconciler" {
+  type        = "zip"
+  source_file = "${path.module}/functions/ec2_cpu_alarm_reconciler.py"
+  output_path = "${path.module}/.terraform/ec2_cpu_alarm_reconciler.zip"
+}
+
+locals {
+  ec2_cpu_reconciler_name = "kortix-ec2-cpu-alarm-reconciler"
+}
+
+data "aws_iam_policy_document" "ec2_cpu_reconciler_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ec2_cpu_reconciler" {
+  name               = "KortixEc2CpuAlarmReconciler"
+  assume_role_policy = data.aws_iam_policy_document.ec2_cpu_reconciler_assume_role.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "ec2_cpu_reconciler" {
+  # checkov:skip=CKV_AWS_356: DescribeInstances, DescribeAlarms, and X-Ray telemetry APIs do not support resource-level permissions; alarm writes remain ARN-scoped below.
+  statement {
+    sid       = "DiscoverRunningInstancesAndAlarms"
+    actions   = ["ec2:DescribeInstances", "cloudwatch:DescribeAlarms"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "ReconcileDcf86CpuAlarms"
+    actions = ["cloudwatch:PutMetricAlarm", "cloudwatch:TagResource"]
+    resources = [
+      "arn:aws:cloudwatch:us-west-2:${local.account_id}:alarm:compliance-*-cpu-high",
+      "arn:aws:cloudwatch:eu-west-2:${local.account_id}:alarm:compliance-*-cpu-high",
+    ]
+  }
+
+  statement {
+    sid     = "WriteFunctionLogs"
+    actions = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [
+      "${aws_cloudwatch_log_group.usw2_ec2_cpu_reconciler.arn}:*",
+      "${aws_cloudwatch_log_group.euw2_ec2_cpu_reconciler.arn}:*",
+    ]
+  }
+
+  statement {
+    sid       = "WriteFunctionTraces"
+    actions   = ["xray:PutTraceSegments", "xray:PutTelemetryRecords"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ec2_cpu_reconciler" {
+  name   = "ReconcileDcf86Ec2CpuAlarms"
+  role   = aws_iam_role.ec2_cpu_reconciler.id
+  policy = data.aws_iam_policy_document.ec2_cpu_reconciler.json
+}
+
+resource "aws_cloudwatch_log_group" "usw2_ec2_cpu_reconciler" {
+  # checkov:skip=CKV_AWS_158: Logs contain only instance IDs and reconciliation counts; CloudWatch's AWS-managed encryption is sufficient for this non-secret operational metadata.
+  name              = "/aws/lambda/${local.ec2_cpu_reconciler_name}"
+  retention_in_days = 365
+  tags              = local.tags
+}
+
+resource "aws_cloudwatch_log_group" "euw2_ec2_cpu_reconciler" {
+  # checkov:skip=CKV_AWS_158: Logs contain only instance IDs and reconciliation counts; CloudWatch's AWS-managed encryption is sufficient for this non-secret operational metadata.
+  provider          = aws.euw2
+  name              = "/aws/lambda/${local.ec2_cpu_reconciler_name}"
+  retention_in_days = 365
+  tags              = local.tags
+}
+
+resource "aws_lambda_function" "usw2_ec2_cpu_reconciler" {
+  # checkov:skip=CKV_AWS_117: This regional AWS control-plane function needs public AWS API endpoints only; a VPC would add NAT dependency and reduce repair reliability.
+  # checkov:skip=CKV_AWS_116: EventBridge retries failed delivery and the independent five-minute schedule is the durable retry path.
+  # checkov:skip=CKV_AWS_173: The sole environment value is a public SNS ARN, not a secret; Lambda still encrypts it with the AWS-managed key.
+  # checkov:skip=CKV_AWS_272: Terraform verifies the immutable archive hash and deploys this repository-owned source directly; no external artifact is accepted.
+  function_name                  = local.ec2_cpu_reconciler_name
+  description                    = "Reconciles DCF-86 CPU alarms for every running EC2 instance"
+  filename                       = data.archive_file.ec2_cpu_alarm_reconciler.output_path
+  source_code_hash               = data.archive_file.ec2_cpu_alarm_reconciler.output_base64sha256
+  role                           = aws_iam_role.ec2_cpu_reconciler.arn
+  handler                        = "ec2_cpu_alarm_reconciler.lambda_handler"
+  runtime                        = "python3.13"
+  timeout                        = 30
+  reserved_concurrent_executions = 1
+  environment {
+    variables = { ALERT_TOPIC_ARN = data.aws_sns_topic.usw2_alerts.arn }
+  }
+  tracing_config {
+    mode = "Active"
+  }
+  tags = merge(local.tags, local.alarm_tags)
+  depends_on = [
+    aws_cloudwatch_log_group.usw2_ec2_cpu_reconciler,
+    aws_iam_role_policy.ec2_cpu_reconciler,
+  ]
+}
+
+resource "aws_lambda_function" "euw2_ec2_cpu_reconciler" {
+  # checkov:skip=CKV_AWS_117: This regional AWS control-plane function needs public AWS API endpoints only; a VPC would add NAT dependency and reduce repair reliability.
+  # checkov:skip=CKV_AWS_116: EventBridge retries failed delivery and the independent five-minute schedule is the durable retry path.
+  # checkov:skip=CKV_AWS_173: The sole environment value is a public SNS ARN, not a secret; Lambda still encrypts it with the AWS-managed key.
+  # checkov:skip=CKV_AWS_272: Terraform verifies the immutable archive hash and deploys this repository-owned source directly; no external artifact is accepted.
+  provider                       = aws.euw2
+  function_name                  = local.ec2_cpu_reconciler_name
+  description                    = "Reconciles DCF-86 CPU alarms for every running EC2 instance"
+  filename                       = data.archive_file.ec2_cpu_alarm_reconciler.output_path
+  source_code_hash               = data.archive_file.ec2_cpu_alarm_reconciler.output_base64sha256
+  role                           = aws_iam_role.ec2_cpu_reconciler.arn
+  handler                        = "ec2_cpu_alarm_reconciler.lambda_handler"
+  runtime                        = "python3.13"
+  timeout                        = 30
+  reserved_concurrent_executions = 1
+  environment {
+    variables = { ALERT_TOPIC_ARN = data.aws_sns_topic.euw2_alerts.arn }
+  }
+  tracing_config {
+    mode = "Active"
+  }
+  tags = merge(local.tags, local.alarm_tags)
+  depends_on = [
+    aws_cloudwatch_log_group.euw2_ec2_cpu_reconciler,
+    aws_iam_role_policy.ec2_cpu_reconciler,
+  ]
+}
+
+resource "aws_cloudwatch_event_rule" "usw2_ec2_running" {
+  name        = "kortix-ec2-running-cpu-alarm-reconcile"
+  description = "Create or repair the DCF-86 CPU alarm when an EC2 instance starts"
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Instance State-change Notification"]
+    detail      = { state = ["running"] }
+  })
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_event_rule" "euw2_ec2_running" {
+  provider    = aws.euw2
+  name        = "kortix-ec2-running-cpu-alarm-reconcile"
+  description = "Create or repair the DCF-86 CPU alarm when an EC2 instance starts"
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Instance State-change Notification"]
+    detail      = { state = ["running"] }
+  })
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_event_rule" "usw2_ec2_cpu_reconcile_schedule" {
+  name                = "kortix-ec2-cpu-alarm-reconcile-schedule"
+  description         = "Repair missing or drifted DCF-86 EC2 CPU alarms"
+  schedule_expression = "rate(5 minutes)"
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_event_rule" "euw2_ec2_cpu_reconcile_schedule" {
+  provider            = aws.euw2
+  name                = "kortix-ec2-cpu-alarm-reconcile-schedule"
+  description         = "Repair missing or drifted DCF-86 EC2 CPU alarms"
+  schedule_expression = "rate(5 minutes)"
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "usw2_ec2_running" {
+  rule = aws_cloudwatch_event_rule.usw2_ec2_running.name
+  arn  = aws_lambda_function.usw2_ec2_cpu_reconciler.arn
+}
+
+resource "aws_cloudwatch_event_target" "euw2_ec2_running" {
+  provider = aws.euw2
+  rule     = aws_cloudwatch_event_rule.euw2_ec2_running.name
+  arn      = aws_lambda_function.euw2_ec2_cpu_reconciler.arn
+}
+
+resource "aws_cloudwatch_event_target" "usw2_ec2_cpu_reconcile_schedule" {
+  rule = aws_cloudwatch_event_rule.usw2_ec2_cpu_reconcile_schedule.name
+  arn  = aws_lambda_function.usw2_ec2_cpu_reconciler.arn
+}
+
+resource "aws_cloudwatch_event_target" "euw2_ec2_cpu_reconcile_schedule" {
+  provider = aws.euw2
+  rule     = aws_cloudwatch_event_rule.euw2_ec2_cpu_reconcile_schedule.name
+  arn      = aws_lambda_function.euw2_ec2_cpu_reconciler.arn
+}
+
+resource "aws_lambda_permission" "usw2_ec2_running" {
+  statement_id  = "AllowEc2RunningEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.usw2_ec2_cpu_reconciler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.usw2_ec2_running.arn
+}
+
+resource "aws_lambda_permission" "euw2_ec2_running" {
+  provider      = aws.euw2
+  statement_id  = "AllowEc2RunningEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.euw2_ec2_cpu_reconciler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.euw2_ec2_running.arn
+}
+
+resource "aws_lambda_permission" "usw2_ec2_cpu_reconcile_schedule" {
+  statement_id  = "AllowScheduledReconciliation"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.usw2_ec2_cpu_reconciler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.usw2_ec2_cpu_reconcile_schedule.arn
+}
+
+resource "aws_lambda_permission" "euw2_ec2_cpu_reconcile_schedule" {
+  provider      = aws.euw2
+  statement_id  = "AllowScheduledReconciliation"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.euw2_ec2_cpu_reconciler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.euw2_ec2_cpu_reconcile_schedule.arn
+}

--- a/infra/terraform/compliance-monitoring/functions/ec2_cpu_alarm_reconciler.py
+++ b/infra/terraform/compliance-monitoring/functions/ec2_cpu_alarm_reconciler.py
@@ -1,0 +1,125 @@
+"""Keep every running EC2 instance covered by the DCF-86 CPU alarm."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+ALARM_PREFIX = "compliance-"
+ALARM_SUFFIX = "-cpu-high"
+
+
+def _chunks(values: list[str], size: int = 100) -> Iterable[list[str]]:
+    for offset in range(0, len(values), size):
+        yield values[offset : offset + size]
+
+
+def _running_instance_ids(ec2: Any) -> list[str]:
+    instance_ids: list[str] = []
+    paginator = ec2.get_paginator("describe_instances")
+    for page in paginator.paginate(
+        Filters=[{"Name": "instance-state-name", "Values": ["running"]}]
+    ):
+        for reservation in page.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                instance_ids.append(instance["InstanceId"])
+    return sorted(set(instance_ids))
+
+
+def _alarm_name(instance_id: str) -> str:
+    return f"{ALARM_PREFIX}{instance_id}{ALARM_SUFFIX}"
+
+
+def _alarm_configuration(instance_id: str, topic_arn: str) -> dict[str, Any]:
+    return {
+        "AlarmName": _alarm_name(instance_id),
+        "AlarmDescription": "EC2 CPU above 80 percent for 15 minutes",
+        "ActionsEnabled": True,
+        "AlarmActions": [topic_arn],
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/EC2",
+        "Statistic": "Average",
+        "Dimensions": [{"Name": "InstanceId", "Value": instance_id}],
+        "Period": 300,
+        "EvaluationPeriods": 3,
+        "DatapointsToAlarm": 3,
+        "Threshold": 80.0,
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "TreatMissingData": "notBreaching",
+        "Tags": [
+            {"Key": "ManagedBy", "Value": "kortix-compliance"},
+            {"Key": "Control", "Value": "DCF-86"},
+        ],
+    }
+
+
+def _is_compliant(alarm: dict[str, Any], instance_id: str, topic_arn: str) -> bool:
+    expected = _alarm_configuration(instance_id, topic_arn)
+    scalar_fields = (
+        "AlarmDescription",
+        "ActionsEnabled",
+        "MetricName",
+        "Namespace",
+        "Statistic",
+        "Period",
+        "EvaluationPeriods",
+        "DatapointsToAlarm",
+        "Threshold",
+        "ComparisonOperator",
+        "TreatMissingData",
+    )
+    if any(alarm.get(field) != expected[field] for field in scalar_fields):
+        return False
+
+    dimensions = {
+        (dimension.get("Name"), dimension.get("Value"))
+        for dimension in alarm.get("Dimensions", [])
+    }
+    expected_dimensions = {
+        (dimension["Name"], dimension["Value"])
+        for dimension in expected["Dimensions"]
+    }
+    return dimensions == expected_dimensions and alarm.get("AlarmActions", []) == [
+        topic_arn
+    ]
+
+
+def reconcile(ec2: Any, cloudwatch: Any, topic_arn: str) -> dict[str, Any]:
+    instance_ids = _running_instance_ids(ec2)
+    alarm_names = [_alarm_name(instance_id) for instance_id in instance_ids]
+    existing: dict[str, dict[str, Any]] = {}
+
+    for names in _chunks(alarm_names):
+        response = cloudwatch.describe_alarms(AlarmNames=names)
+        existing.update(
+            {alarm["AlarmName"]: alarm for alarm in response.get("MetricAlarms", [])}
+        )
+
+    updated: list[str] = []
+    for instance_id in instance_ids:
+        name = _alarm_name(instance_id)
+        if not _is_compliant(existing.get(name, {}), instance_id, topic_arn):
+            cloudwatch.put_metric_alarm(
+                **_alarm_configuration(instance_id, topic_arn)
+            )
+            updated.append(instance_id)
+
+    result = {
+        "running_instances": len(instance_ids),
+        "covered_instances": len(instance_ids),
+        "updated_instances": updated,
+    }
+    print(result)
+    return result
+
+
+def lambda_handler(_event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    import boto3
+
+    region = os.environ["AWS_REGION"]
+    return reconcile(
+        boto3.client("ec2", region_name=region),
+        boto3.client("cloudwatch", region_name=region),
+        os.environ["ALERT_TOPIC_ARN"],
+    )

--- a/infra/terraform/compliance-monitoring/functions/test_ec2_cpu_alarm_reconciler.py
+++ b/infra/terraform/compliance-monitoring/functions/test_ec2_cpu_alarm_reconciler.py
@@ -1,0 +1,131 @@
+import unittest
+
+from ec2_cpu_alarm_reconciler import reconcile
+
+
+class FakePaginator:
+    def __init__(self, pages):
+        self.pages = pages
+        self.filters = None
+
+    def paginate(self, **kwargs):
+        self.filters = kwargs["Filters"]
+        return self.pages
+
+
+class FakeEc2:
+    def __init__(self, pages):
+        self.paginator = FakePaginator(pages)
+
+    def get_paginator(self, operation):
+        assert operation == "describe_instances"
+        return self.paginator
+
+
+class FakeCloudWatch:
+    def __init__(self, alarms=None):
+        self.alarms = alarms or []
+        self.describe_calls = []
+        self.put_calls = []
+
+    def describe_alarms(self, **kwargs):
+        self.describe_calls.append(kwargs)
+        names = set(kwargs["AlarmNames"])
+        return {
+            "MetricAlarms": [
+                alarm for alarm in self.alarms if alarm["AlarmName"] in names
+            ]
+        }
+
+    def put_metric_alarm(self, **kwargs):
+        self.put_calls.append(kwargs)
+
+
+def instance_page(*instance_ids):
+    return {
+        "Reservations": [
+            {"Instances": [{"InstanceId": instance_id} for instance_id in instance_ids]}
+        ]
+    }
+
+
+class ReconcilerTest(unittest.TestCase):
+    topic = "arn:aws:sns:us-west-2:935064898258:suna-api-alerts"
+
+    def test_creates_a_drata_compatible_alarm_for_every_running_instance(self):
+        ec2 = FakeEc2([instance_page("i-b", "i-a"), instance_page("i-a")])
+        cloudwatch = FakeCloudWatch()
+
+        result = reconcile(ec2, cloudwatch, self.topic)
+
+        self.assertEqual(result["running_instances"], 2)
+        self.assertEqual(result["updated_instances"], ["i-a", "i-b"])
+        self.assertEqual(len(cloudwatch.put_calls), 2)
+        alarm = cloudwatch.put_calls[0]
+        self.assertEqual(alarm["AlarmName"], "compliance-i-a-cpu-high")
+        self.assertEqual(alarm["Namespace"], "AWS/EC2")
+        self.assertEqual(alarm["MetricName"], "CPUUtilization")
+        self.assertEqual(
+            alarm["Dimensions"], [{"Name": "InstanceId", "Value": "i-a"}]
+        )
+        self.assertEqual(alarm["AlarmActions"], [self.topic])
+        self.assertEqual(alarm["Threshold"], 80.0)
+        self.assertEqual(alarm["Period"], 300)
+        self.assertEqual(alarm["EvaluationPeriods"], 3)
+        self.assertEqual(alarm["DatapointsToAlarm"], 3)
+        self.assertEqual(
+            ec2.paginator.filters,
+            [{"Name": "instance-state-name", "Values": ["running"]}],
+        )
+
+    def test_does_not_rewrite_an_already_compliant_alarm(self):
+        existing = {
+            "AlarmName": "compliance-i-a-cpu-high",
+            "AlarmDescription": "EC2 CPU above 80 percent for 15 minutes",
+            "ActionsEnabled": True,
+            "AlarmActions": [self.topic],
+            "MetricName": "CPUUtilization",
+            "Namespace": "AWS/EC2",
+            "Statistic": "Average",
+            "Dimensions": [{"Value": "i-a", "Name": "InstanceId"}],
+            "Period": 300,
+            "EvaluationPeriods": 3,
+            "DatapointsToAlarm": 3,
+            "Threshold": 80.0,
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "TreatMissingData": "notBreaching",
+        }
+        cloudwatch = FakeCloudWatch([existing])
+
+        result = reconcile(FakeEc2([instance_page("i-a")]), cloudwatch, self.topic)
+
+        self.assertEqual(result["updated_instances"], [])
+        self.assertEqual(cloudwatch.put_calls, [])
+
+    def test_repairs_an_alarm_with_no_notification_action(self):
+        existing = {
+            "AlarmName": "compliance-i-a-cpu-high",
+            "AlarmDescription": "EC2 CPU above 80 percent for 15 minutes",
+            "ActionsEnabled": True,
+            "AlarmActions": [],
+            "MetricName": "CPUUtilization",
+            "Namespace": "AWS/EC2",
+            "Statistic": "Average",
+            "Dimensions": [{"Name": "InstanceId", "Value": "i-a"}],
+            "Period": 300,
+            "EvaluationPeriods": 3,
+            "DatapointsToAlarm": 3,
+            "Threshold": 80.0,
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "TreatMissingData": "notBreaching",
+        }
+        cloudwatch = FakeCloudWatch([existing])
+
+        result = reconcile(FakeEc2([instance_page("i-a")]), cloudwatch, self.topic)
+
+        self.assertEqual(result["updated_instances"], ["i-a"])
+        self.assertEqual(cloudwatch.put_calls[0]["AlarmActions"], [self.topic])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/terraform/compliance-monitoring/providers.tf
+++ b/infra/terraform/compliance-monitoring/providers.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = ">= 1.5"
   required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4"
+    }
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"


### PR DESCRIPTION
## Summary
- reconcile DCF-86 EC2 CPU alarms on every running-state event in us-west-2 and eu-west-2
- run a five-minute fallback reconciliation to repair missed events or alarm drift
- add least-privilege IAM, one-year logs, X-Ray tracing, tests, and operator verification docs

## Root cause
The Terraform baseline only discovered running instance IDs during manual apply. EKS node replacement left alarms attached to terminated IDs, so Drata found three newly launched us-west-2 instances without CPU monitoring. Two eu-west-2 replacements were also uncovered by the time of investigation.

## Verification
- `python3 -m unittest -v test_ec2_cpu_alarm_reconciler.py` — 3 passed
- `terraform fmt -check -recursive infra/terraform` — passed
- `terraform validate -no-color` — passed
- `tflint --chdir=infra/terraform/compliance-monitoring --format compact` — passed
- `checkov -d . --framework terraform --quiet --compact --soft-fail` — 95 passed, 0 failed, 11 explicitly justified skips
- live Terraform apply — 18 created, then 5 in-place hardening updates, 0 destroyed
- live coverage — us-west-2 3/3, eu-west-2 6/6 running instances covered
- live drift repair — disabling alarm actions was detected and repaired
- live missing-alarm repair — deleting one node alarm was detected and recreated with the exact EC2 dimension and SNS action
- final `terraform plan -detailed-exitcode` — no changes

## Drata
AWS now satisfies the Drata-facing resource contract. The Drata UI test must rescan the AWS connection before its cached Failed result changes.
