### PR TITLE
fix(sandbox): bake Chromium on deterministic layers — fixes the v0.10.11 session-boot regression

### DIFF
--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -163,7 +163,26 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // the v27 full-rebuild path unchanged. (b) Raised
 // PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT to 1800000 (30min, was 300000/5min) as
 // a safety net for that fallback path under a cold cache.
-const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v28';
+// v29: fix the BASE default image rebuild (the gap v27/v28 left open). v27/v28
+// only moved Chromium above the per-project warm-repo clone + instance warm-up,
+// and made per-project bakes inherit Chromium FROM the base — but in the base
+// image's own build (kortixToolchainLayer with no warmRepo) Chromium STILL sat
+// BELOW the opencode install, the `opencode serve` migration-bake, and the
+// config-deps bun install. The migration-bake writes a sqlite db with live
+// timestamps and the config-deps install churns node_modules mtimes — both
+// non-deterministic — so on a content-addressed provider cache (Daytona) they
+// bust the cache for the Chromium layer chained below them. The kortix-agent
+// SOURCE feeds the snapshot fingerprint (AGENT_RUNTIME_ARTIFACTS below), so any
+// agent-server code change mints a brand-new base snapshot name → a full rebuild
+// on Daytona (no agent-swap) → Chromium re-download → the base image never
+// becomes ready inside the session window → "session never starts" (the actual
+// mechanism behind the v0.10.11 rollback: PR #5010 changed the agent-server and
+// re-minted the base hash). Fix: move the Chromium block to sit DIRECTLY on the
+// deterministic apt + pip floors, ABOVE opencode and every non-deterministic
+// layer. Chromium's content hash is now stable across agent-source churn — it is
+// fetched at most once per pinned Playwright/agent-browser version and
+// cache-reused for every base rebuild after.
+const RUNTIME_LAYER_VERSION = 'baked-config-deps-binplugin-v29';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -62,6 +62,26 @@ RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\
         "youtube-transcript-api>=0.6" \\
     && /opt/kortix/pyfloor/bin/python -c 'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")'
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && for pw_try in 1 2 3 4 5; do \\
+        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
+        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
+        sleep $((pw_try*10)); \\
+    done \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
 RUN npm install -g --no-audit --no-fund "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
@@ -97,26 +117,6 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\
     && rm -rf /tmp/opencode-deps-bundle-check \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
-
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
-    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
-    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
-    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
-RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
-    && agent-browser --version \\
-    && for pw_try in 1 2 3 4 5; do \\
-        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
-        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
-        sleep $((pw_try*10)); \\
-    done \\
-    && rm -rf /var/lib/apt/lists/* \\
-    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
-    && test -n "$pw_chrome" \\
-    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
-    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
-    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
-    && /usr/local/bin/chromium --version \\
-    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
 COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
@@ -238,6 +238,26 @@ RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\
         "youtube-transcript-api>=0.6" \\
     && /opt/kortix/pyfloor/bin/python -c 'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")'
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && for pw_try in 1 2 3 4 5; do \\
+        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
+        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
+        sleep $((pw_try*10)); \\
+    done \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
 RUN npm install -g --no-audit --no-fund "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
@@ -273,26 +293,6 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\
     && rm -rf /tmp/opencode-deps-bundle-check \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
-
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
-    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
-    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
-    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
-RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
-    && agent-browser --version \\
-    && for pw_try in 1 2 3 4 5; do \\
-        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
-        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
-        sleep $((pw_try*10)); \\
-    done \\
-    && rm -rf /var/lib/apt/lists/* \\
-    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
-    && test -n "$pw_chrome" \\
-    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
-    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
-    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
-    && /usr/local/bin/chromium --version \\
-    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
 COPY kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
 RUN cd /opt/kortix/warm-config/.kortix/opencode \\
@@ -415,6 +415,26 @@ RUN /opt/kortix/pyfloor/bin/pip install --no-cache-dir \\
         "youtube-transcript-api>=0.6" \\
     && /opt/kortix/pyfloor/bin/python -c 'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")'
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
+    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
+    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
+RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
+    && agent-browser --version \\
+    && for pw_try in 1 2 3 4 5; do \\
+        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
+        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
+        sleep $((pw_try*10)); \\
+    done \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
+    && test -n "$pw_chrome" \\
+    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
+    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
+    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
+    && /usr/local/bin/chromium --version \\
+    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
+
 RUN npm install -g --no-audit --no-fund "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
@@ -450,26 +470,6 @@ RUN cd /opt/kortix/opencode-config-deps \\
     && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\
     && rm -rf /tmp/opencode-deps-bundle-check \\
     && echo "opencode-config-deps: baked tree bundles cleanly"
-
-ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\
-    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\
-    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\
-    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000
-RUN npm install -g --no-audit --no-fund "agent-browser@0.27.0" \\
-    && agent-browser --version \\
-    && for pw_try in 1 2 3 4 5; do \\
-        HOME=/opt/kortix/home npx -y playwright@1.60.0 install --with-deps chromium && break; \\
-        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\
-        sleep $((pw_try*10)); \\
-    done \\
-    && rm -rf /var/lib/apt/lists/* \\
-    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\
-    && test -n "$pw_chrome" \\
-    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\
-    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\
-    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\
-    && /usr/local/bin/chromium --version \\
-    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
 
 # ─── Per-project COLD warm: bake repo checkout into /workspace ──────

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -132,6 +132,54 @@ describe('the Python floor is venv-isolated from dpkg', () => {
   });
 });
 
+describe('Chromium sits on deterministic parents (cache order is load-bearing)', () => {
+  // Regression guard for the v0.10.11 "session never starts" incident. The
+  // provider build caches are CONTENT-ADDRESSED (Daytona has no instruction-text
+  // cache, no agent-swap), so a non-deterministic layer above the ~150MB Chromium
+  // download busts its cache and forces a re-download on every rebuild. An
+  // agent-server code change re-mints the base snapshot hash → a full Daytona
+  // rebuild → if Chromium sat below the `opencode serve` migration-bake (sqlite
+  // with live timestamps) or the warm-repo clone (fresh credential in the RUN
+  // text), it re-downloaded and overran the session-ready window. Chromium must
+  // stay directly on the deterministic apt + pip floors, ABOVE all of them.
+  const chromiumAt = (t: string) =>
+    t.indexOf('npx -y playwright@');
+  const opencodeInstallAt = (t: string) =>
+    t.indexOf('"opencode-ai@');
+  const migrationBakeAt = (t: string) => t.indexOf('/tmp/oc-bake.log');
+
+  test('the base default image installs Chromium before opencode + the migration-bake', () => {
+    const base = kortixToolchainLayer({
+      opencodeVersion: OPENCODE_VERSION,
+      agentBrowserVersion: AGENT_BROWSER_VERSION,
+      opencodeConfigPath: 'kortix-opencode-config',
+      isSharedDefault: true,
+    });
+    const chromium = chromiumAt(base);
+    expect(chromium).toBeGreaterThan(-1);
+    expect(chromium).toBeLessThan(opencodeInstallAt(base));
+    expect(chromium).toBeLessThan(migrationBakeAt(base));
+  });
+
+  test('a per-project warm bake installs Chromium before the credential-bearing clone', () => {
+    const warm = kortixToolchainLayer({
+      opencodeVersion: OPENCODE_VERSION,
+      agentBrowserVersion: AGENT_BROWSER_VERSION,
+      opencodeConfigPath: 'kortix-opencode-config',
+      warmRepo: {
+        cloneUrl: 'https://git.example.com/acme/app.git',
+        cloneHeaders: { Authorization: 'Bearer redacted' },
+        branch: 'main',
+        originUrl: 'https://kortix.example.com/v1/git/proj.git',
+      },
+    });
+    const chromium = chromiumAt(warm);
+    expect(chromium).toBeGreaterThan(-1);
+    // the credential-bearing clone RUN must come strictly after Chromium
+    expect(chromium).toBeLessThan(warm.indexOf('/tmp/kortix-warm-repo'));
+  });
+});
+
 describe('the /workspace wipe is scoped to the shared default image', () => {
   const WIPE = 'find /workspace -mindepth 1 -delete';
 

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -529,6 +529,85 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // equivalent (still fails the layer if any module is missing) and portable.
     '    && /opt/kortix/pyfloor/bin/python -c \'import importlib; [importlib.import_module(m) for m in ["bs4", "lxml", "markitdown", "matplotlib", "numpy", "openpyxl", "pandas", "pdf2docx", "pdf2image", "pdfplumber", "PIL", "playwright", "plotly", "fitz", "pypdf", "pypdfium2", "pytesseract", "docx", "pptx", "reportlab", "requests", "sklearn", "scipy", "seaborn", "youtube_transcript_api"]]; print("starter Python package floor OK")\'',
     '',
+    // agent-browser (Vercel) — the browser-automation CLI the agent-browser
+    // skill drives. It must work OUT OF THE BOX with zero runtime download, so we
+    // bake a real Chromium into the image and wire agent-browser to it TWO
+    // independent ways:
+    //   1. AGENT_BROWSER_EXECUTABLE_PATH → a stable /usr/local/bin/chromium
+    //      symlink (the documented API; verified working on agent-browser 0.27.0).
+    //   2. a symlink into agent-browser's OWN browser cache (chrome-linux64),
+    //      which its auto-detect finds even if the env var is ever ignored again
+    //      — it WAS, historically (vercel-labs/agent-browser#422). Belt + braces.
+    // PLAYWRIGHT_BROWSERS_PATH is set BEFORE the install so Chromium lands in
+    // /opt/pw-browsers (a stable system path the symlinks resolve against). HOME
+    // is pinned to the runtime HOME (/opt/kortix/home, see opencode.ts) so the
+    // cache symlink lands where the agent looks at runtime. The build FAILS LOUDLY
+    // (chromium --version + `agent-browser doctor`) if Chromium didn't wire up —
+    // every sandbox ships a working browser; we never install one on the session
+    // hot path.
+    //
+    // ── LAYER ORDER IS LOAD-BEARING — DO NOT MOVE THIS DOWN ───────────────────
+    // This ~150MB Chromium download sits DIRECTLY on top of the deterministic
+    // apt + pip floors and DELIBERATELY ABOVE everything below it: the opencode
+    // install, the `opencode serve` migration-bake, the config-deps bun install,
+    // the per-project warm-repo clone, and the opencode instance warm-up. Several
+    // of those layers are NON-DETERMINISTIC by construction — the migration-bake
+    // writes a sqlite db with live timestamps, the config-deps install churns
+    // node_modules mtimes, and the warm-repo clone bakes a fresh short-lived git
+    // credential into its RUN text on every single invocation. The providers'
+    // build caches are CONTENT-ADDRESSED (Daytona especially — it has no
+    // Docker-style instruction-text cache and no `swapAgent` fast path), so ANY
+    // non-deterministic layer BUSTS the cache for everything chained BELOW it.
+    //
+    // The kortix-agent SOURCE feeds the snapshot fingerprint (see
+    // AGENT_RUNTIME_ARTIFACTS in apps/api/src/snapshots/templates.ts), so any
+    // agent-server code change mints a BRAND-NEW snapshot name → a full rebuild on
+    // Daytona (no agent-swap). If Chromium sat below the migration-bake (as it did
+    // through v0.10.11), every such rebuild MISSED cache and re-downloaded ~150MB
+    // from cdn.playwright.dev — overrunning the session-ready window and breaking
+    // fresh-sandbox boots (the v0.10.11 "session never starts" incident). Keeping
+    // Chromium on purely deterministic parents makes its content hash stable
+    // across agent-source churn: it is fetched at most ONCE per pinned Playwright/
+    // agent-browser version and cache-reused for every rebuild after. The retry
+    // loop + 30-min timeout below are the SAFETY NET for that one cold fetch.
+    'ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\',
+    '    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\',
+    '    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\',
+    // Playwright's browser download defaults to a 30s socket timeout
+    // (NET_DEFAULT_TIMEOUT in playwright-core), which a ~150MB Chrome-for-Testing
+    // fetch can miss under any network hiccup / contended CDN — observed live as
+    // "Downloading Chrome for Testing ... timed out after 30000ms" failing the
+    // whole bake. 30 minutes gives real headroom for the one cold-cache fetch
+    // under contention (staging observed this stalling on slower Daytona egress);
+    // the retry loop below is the second line of defense for a transient failure
+    // within that window.
+    '    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000',
+    `RUN npm install -g --no-audit --no-fund "agent-browser@${agentBrowserVersion}" \\`,
+    '    && agent-browser --version \\',
+    // Retry the Chromium download a handful of times with backoff before giving
+    // up — a transient CDN/network blip must not fail the whole image build. The
+    // loop's own exit status is irrelevant either way: `test -n "$pw_chrome"`
+    // below still hard-fails the build if every attempt came up empty, so a total
+    // failure never ships a browser-less image.
+    '    && for pw_try in 1 2 3 4 5; do \\',
+    `        HOME=/opt/kortix/home npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium && break; \\`,
+    '        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\',
+    '        sleep $((pw_try*10)); \\',
+    '    done \\',
+    '    && rm -rf /var/lib/apt/lists/* \\',
+    `    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\`,
+    '    && test -n "$pw_chrome" \\',
+    '    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\',
+    '    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\',
+    '    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\',
+    '    && /usr/local/bin/chromium --version \\',
+    // Assert agent-browser RESOLVES the browser via its env-independent cache —
+    // match the resolved path (deterministic), not the browser NAME (which is
+    // "Chromium" on arm64 but "Google Chrome for Testing" on x64). The doctor
+    // "Launch test" may itself fail under cross-arch QEMU emulation; we read the
+    // detection line, not the launch verdict, so the gate is emulation-safe.
+    "    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'",
+    '',
     `RUN npm install -g --no-audit --no-fund "opencode-ai@${opencodeVersion}" \\`,
     '    && command -v opencode \\',
     '    && opencode --version',
@@ -616,81 +695,6 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '    && HOME=/opt/kortix/home bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\',
     '    && rm -rf /tmp/opencode-deps-bundle-check \\',
     '    && echo "opencode-config-deps: baked tree bundles cleanly"',
-    '',
-    // agent-browser (Vercel) — the browser-automation CLI the agent-browser
-    // skill drives. It must work OUT OF THE BOX with zero runtime download, so we
-    // bake a real Chromium into the image and wire agent-browser to it TWO
-    // independent ways:
-    //   1. AGENT_BROWSER_EXECUTABLE_PATH → a stable /usr/local/bin/chromium
-    //      symlink (the documented API; verified working on agent-browser 0.27.0).
-    //   2. a symlink into agent-browser's OWN browser cache (chrome-linux64),
-    //      which its auto-detect finds even if the env var is ever ignored again
-    //      — it WAS, historically (vercel-labs/agent-browser#422). Belt + braces.
-    // PLAYWRIGHT_BROWSERS_PATH is set BEFORE the install so Chromium lands in
-    // /opt/pw-browsers (a stable system path the symlinks resolve against). HOME
-    // is pinned to the runtime HOME (/opt/kortix/home, see opencode.ts) so the
-    // cache symlink lands where the agent looks at runtime. The build FAILS LOUDLY
-    // (chromium --version + `agent-browser doctor`) if Chromium didn't wire up —
-    // every sandbox ships a working browser; we never install one on the session
-    // hot path.
-    //
-    // DELIBERATELY PLACED HERE — before the per-project warm bits below (repo
-    // clone + opencode instance warm-up) — instead of after them. This is the
-    // ONLY layer-order requirement in this whole toolchain: everything up to and
-    // including this RUN is byte-identical across the shared default image AND
-    // every per-project warm bake (no project data has been mixed in yet), so its
-    // build-cache key is IDENTICAL everywhere too — one cache-populating build
-    // (e.g. the periodic shared-default rebuild) lets every later warm bake, for
-    // every project, reuse this exact layer. The repo-clone step right below bakes
-    // a FRESH short-lived git credential into its RUN text on every single
-    // invocation (a ~1h GitHub App installation token, or a JWT with a live
-    // iat/exp — see resolveWarmRepoContext in snapshots/builder.ts) — so it can
-    // NEVER cache-hit, and neither can anything chained after it. Before this
-    // reorder, Chromium sat downstream of that never-cacheable clone step, so
-    // EVERY per-project warm bake re-ran the ~150MB Chrome-for-Testing download
-    // from cdn.playwright.dev against Playwright's install timeout — regardless
-    // of environment. Do not move this block back below the warm-repo clone.
-    'ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \\',
-    '    AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/chromium \\',
-    '    AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage \\',
-    // Playwright's browser download defaults to a 30s socket timeout
-    // (NET_DEFAULT_TIMEOUT in playwright-core), which a ~150MB Chrome-for-Testing
-    // fetch can miss under any network hiccup / contended CDN — observed live as
-    // "Downloading Chrome for Testing ... timed out after 30000ms" failing the
-    // whole bake. 30 minutes gives real headroom for a cold-cache build under
-    // contention (staging observed this stalling on slower Daytona egress); the
-    // retry loop below is the second line of defense for a transient failure
-    // within that window. This is a SAFETY NET, not the primary fix — the
-    // primary fix is that per-project warm bakes now build FROM the already-baked
-    // default image (see buildPerProjectWarmFromBaseDockerfile below) and so
-    // never re-run this install at all when that fast path is available; this
-    // timeout only matters for the fallback full rebuild path.
-    '    PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=1800000',
-    `RUN npm install -g --no-audit --no-fund "agent-browser@${agentBrowserVersion}" \\`,
-    '    && agent-browser --version \\',
-    // Retry the Chromium download a handful of times with backoff before giving
-    // up — a transient CDN/network blip must not fail the whole image build. The
-    // loop's own exit status is irrelevant either way: `test -n "$pw_chrome"`
-    // below still hard-fails the build if every attempt came up empty, so a total
-    // failure never ships a browser-less image.
-    '    && for pw_try in 1 2 3 4 5; do \\',
-    `        HOME=/opt/kortix/home npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium && break; \\`,
-    '        echo "playwright chromium install attempt $pw_try failed, retrying..."; \\',
-    '        sleep $((pw_try*10)); \\',
-    '    done \\',
-    '    && rm -rf /var/lib/apt/lists/* \\',
-    `    && pw_chrome="$(find /opt/pw-browsers -type f -path '*chrome-linux*/chrome' | head -n1)" \\`,
-    '    && test -n "$pw_chrome" \\',
-    '    && ln -sf "$pw_chrome" /usr/local/bin/chromium \\',
-    '    && mkdir -p /opt/kortix/home/.agent-browser/browsers \\',
-    '    && ln -sf "$(dirname "$pw_chrome")" /opt/kortix/home/.agent-browser/browsers/chrome-linux64 \\',
-    '    && /usr/local/bin/chromium --version \\',
-    // Assert agent-browser RESOLVES the browser via its env-independent cache —
-    // match the resolved path (deterministic), not the browser NAME (which is
-    // "Chromium" on arm64 but "Google Chrome for Testing" on x64). The doctor
-    // "Launch test" may itself fail under cross-arch QEMU emulation; we read the
-    // detection line, not the launch verdict, so the gate is emulation-safe.
-    "    && env -u AGENT_BROWSER_EXECUTABLE_PATH HOME=/opt/kortix/home agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'",
     '',
     // Per-project COLD warm: bake the repo checkout into /workspace BEFORE the
     // opencode instance warm-up below, so opencode indexes the REAL project (its


### PR DESCRIPTION
## Root cause (verified from git + code, not assumed)

The v0.10.11 prod rollback was caused by fresh sandboxes whose daemon never became reachable ("session never starts"). Verified chain:

1. The snapshot fingerprint hashes the **kortix-agent SOURCE** (`AGENT_RUNTIME_ARTIFACTS` in `apps/api/src/snapshots/templates.ts`). PR #5010 edited `apps/kortix-sandbox-agent-server/src/opencode.ts` → the base default snapshot **hash changed → a new snapshot name**, even though the Dockerfile text and `RUNTIME_LAYER_VERSION` were byte-identical to v0.10.10 (which is why the diff looked empty).
2. A new snapshot name forces a **full rebuild on Daytona** — the primary provider, which has **no agent-swap fast path** (`builder.ts`: "Daytona has no `swapAgent`").
3. In the base image build, the ~150MB Chromium download still sat **below** the `opencode serve` migration-bake (sqlite w/ live timestamps) and the config-deps bun install (node_modules mtimes) — both non-deterministic. Provider build caches are **content-addressed** (Daytona has no instruction-text cache), so those layers bust the cache for the Chromium layer beneath them.
4. → every agent-source-driven base rebuild **re-downloaded Chromium**, overran the session-ready window, the base image never went `active`, and the fire-and-forget startup pre-build never closed the gap → fresh sessions time out.

v0.10.10 works only because its old-hash snapshot is already warm.

## Why v27/v28 (#5042/#5050) didn't cover this

Those fixed the **per-project warm** path only (moved Chromium above the warm-repo clone; made warm bakes inherit Chromium `FROM` the base). The **base default image's own build** still had Chromium below the non-deterministic opencode layers.

## Fix

Move the agent-browser + Playwright Chromium install to sit directly on the deterministic **apt + pip** floors, **above** opencode and every non-deterministic layer. Chromium's content hash is now stable across agent-source churn → fetched at most **once per pinned Playwright/agent-browser version**, cache-reused for every rebuild after. The retry loop + 30-min timeout stay as the safety net for that one cold fetch.

- Bumps `RUNTIME_LAYER_VERSION` **v28 → v29** (rendered Dockerfile text isn't hashed, so the reorder needs the bump to invalidate cached images).
- Adds a hard **cache-order invariant test** (`layer-render.test.ts`) so Chromium-below-a-non-deterministic-layer can't silently regress.
- `buildPerProjectWarmFromBaseDockerfile` still inherits Chromium via `FROM` (0 re-installs) — unchanged.

## Verification

- Rendered the platform-default layer: agent-browser + Chromium now precede opencode install + migration-bake; exactly 1 of each (no dup/drop); FROM-base = 0 Chromium installs.
- `bun test packages/shared/src/sandbox` → 45 pass (golden re-baselined + 2 new invariants).

## Next

Merge → promote to staging → **load-test fresh sessions under concurrency** (RUN/GOLD --workers 3, watch for no "Downloading Chrome" in base-rebuild logs) → v0.10.12 to prod.