### PR TITLE
Restore canonical Dotenv Armor team

### DIFF
--- a/.claude/skills/dotenvx-secrets/SKILL.md
+++ b/.claude/skills/dotenvx-secrets/SKILL.md
@@ -9,7 +9,7 @@ API secrets are **encrypted in git** with [dotenvx](https://dotenvx.com); the de
 
 ## Armor organization and access boundary
 
-The canonical Armor organization is **`kortix-ai`**. All API and web keypairs
+The canonical Armor organization is **`go-marko-kortix-ai`**. All API and web keypairs
 must be pushed to and pulled from that team explicitly; never rely on the CLI's
 personal-team default.
 
@@ -69,8 +69,8 @@ This re-encrypts the file in place (value becomes `KEY=encrypted:…`). Then com
 | Verify all 4 envs decrypt + are separated | `pnpm test:envs` |
 | Read a secret | `dotenvx get KEY -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`) |
 | Add / change a secret | `dotenvx set KEY value -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`), then commit |
-| First time / new machine | `dotenvx armor login` then `cd apps/api && for f in .env .env.dev .env.staging .env.prod; do dotenvx armor pull --team kortix-ai -f "$f"; done` |
-| Share a NEW profile / rotated key | `dotenvx armor push --team kortix-ai -f <file>` |
+| First time / new machine | `dotenvx armor login` then `cd apps/api && for f in .env .env.dev .env.staging .env.prod; do dotenvx armor pull --team go-marko-kortix-ai -f "$f"; done` |
+| Share a NEW profile / rotated key | `dotenvx armor push --team go-marko-kortix-ai -f <file>` |
 | Remove a key from the cloud | `dotenvx armor down -f <file>` |
 
 ## Armor login security
@@ -98,7 +98,7 @@ login/push/pull use the current global CLI.
 `rotate --no-armor` deliberately leaves a transitional `old,new` value in
 `.env.keys`. Armor accepts exactly one private key, so **never push that combined
 value**. After proving the new ciphertext decrypts, retain only the new private
-key, push it explicitly to `kortix-ai`, then prove a clean Armor pull matches all
+key, push it explicitly to `go-marko-kortix-ai`, then prove a clean Armor pull matches all
 eight keys before merging. Remove the old armored keys only after the rotated
 ciphertext is merged and available to every consumer.
 
@@ -117,7 +117,7 @@ If a guard fires, the fix is to **encrypt the value**, never to bypass it.
 
 ## The web app (apps/web) — same setup
 
-`apps/web` has the **same four encrypted profiles** (`apps/web/.env` / `.env.dev` / `.env.staging` / `.env.prod`), own keypairs in `apps/web/.env.keys`, armored under `kortix-ai`. Decrypted the same way: `pnpm dev` (via `load_local_env`) and the environment-specific web scripts. Pull on a new machine: `cd apps/web && for f in .env .env.dev .env.staging .env.prod; do dotenvx armor pull --team kortix-ai -f "$f"; done`.
+`apps/web` has the **same four encrypted profiles** (`apps/web/.env` / `.env.dev` / `.env.staging` / `.env.prod`), own keypairs in `apps/web/.env.keys`, armored under `go-marko-kortix-ai`. Decrypted the same way: `pnpm dev` (via `load_local_env`) and the environment-specific web scripts. Pull on a new machine: `cd apps/web && for f in .env .env.dev .env.staging .env.prod; do dotenvx armor pull --team go-marko-kortix-ai -f "$f"; done`.
 
 Maintenance flags are **DB-backed** now (was Vercel Edge Config): stored in `kortix.platform_settings['maintenance_config']`, read via public `GET /v1/system/maintenance`, written via admin-only `PUT /v1/system/maintenance`, set from `/admin/utils`. The `EDGE_CONFIG`/`EDGE_CONFIG_ID`/`VERCEL_API_TOKEN` secrets + the `@vercel/edge-config` dep are gone.
 

--- a/apps/web/content/docs/development.mdx
+++ b/apps/web/content/docs/development.mdx
@@ -49,7 +49,7 @@ Each environment is a [dotenvx](https://dotenvx.com)-encrypted file, committed t
 Every value is AES-encrypted (`KEY=encrypted:…`). The **public key** that encrypts sits in the file and is safe to commit; the **private key** that decrypts never touches git — it lives off your machine in [Dotenv Armor](https://dotenvx.com/armor). At runtime `dotenvx run --overload -f <file>` decrypts **in memory** and injects the vars — nothing plaintext is ever written to disk. `--overload` is intentional for env-specific runs so exported local cloud credentials cannot override the selected profile.
 
 All eight keypairs (API + web, four environments each) belong to the canonical
-Armor organization **`kortix-ai`**. Always pass `--team kortix-ai` when pushing
+Armor organization **`go-marko-kortix-ai`**. Always pass `--team go-marko-kortix-ai` when pushing
 or pulling; do not rely on a personal-team default. The prod API and web keys
 are separate keypairs so production access can be restricted independently.
 
@@ -78,7 +78,7 @@ Armor token moves from the settings file into the native OS secret store.
 ### Pull the keys from the cloud
 ```sh
 for app in api web; do
-  (cd "apps/$app" && for f in .env .env.dev .env.staging .env.prod; do dotenvx armor pull --team kortix-ai -f "$f"; done)
+  (cd "apps/$app" && for f in .env .env.dev .env.staging .env.prod; do dotenvx armor pull --team go-marko-kortix-ai -f "$f"; done)
 done
 ```
 </Step>
@@ -101,13 +101,13 @@ The pre-commit hook **auto-encrypts** the profile files (`.env` / `.env.dev` / `
 | Verify all envs decrypt | `pnpm test:envs` |
 | Read a secret | `dotenvx get KEY -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`) |
 | Add / change a secret | `dotenvx set KEY value -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`), then commit |
-| Share a new/rotated key with the team | `dotenvx armor push --team kortix-ai -f <file>` (one file at a time) |
+| Share a new/rotated key with the team | `dotenvx armor push --team go-marko-kortix-ai -f <file>` (one file at a time) |
 
 The repo-pinned dotenvx 1.75.x still provides `rotate`; dotenvx 2.x temporarily
 removed that command. Use `pnpm exec dotenvx rotate`, not the global binary.
 `rotate --no-armor` creates a transitional comma-separated `old,new` private-key
 value locally. Do not push that combined value to Armor. Retain only the new key
-after decryption verification, push it to `kortix-ai`, and prove a clean pull
+after decryption verification, push it to `go-marko-kortix-ai`, and prove a clean pull
 before merging the rotated ciphertext.
 
 <Callout type="warn">


### PR DESCRIPTION
## Summary
- restore `go-marko-kortix-ai` as the canonical Armor team in the secrets skill and development docs
- keep all eight tracked dotenvx ciphertext profiles unchanged

## Verification
- `pnpm test:envs`
- clean Armor pulls match all eight local keypairs
- all eight pulls succeed from `go-marko-kortix-ai` and return 404 from `kortix-ai`
- active automation token decrypts all eight profiles via `dotenvx run --token` without writing `.env.keys`
- tracked dotenv files: 8; plaintext values: 0