### PR TITLE
test(e2e): wait for managed session branch propagation

### DIFF
--- a/tests/e2e/scripts/session-smoke.ts
+++ b/tests/e2e/scripts/session-smoke.ts
@@ -232,7 +232,13 @@ async function main() {
     await sleep(1000);
   }
   if (!ok('sandbox active', startStage === 'ready' && sbStatus === 'active', `stage=${startStage} status=${sbStatus}`) || !ext) return finish({ projectId, sessionId });
-  const branches = await api('GET', `/projects/${projectId}/branches`);
+  const branches = await eventuallyGet(
+    `/projects/${projectId}/branches`,
+    (result) => {
+      const rows = result.json?.branches ?? [];
+      return result.status === 200 && rows.some((branch: any) => branch.name === sessionId);
+    },
+  );
   const branchRows = branches.json?.branches ?? [];
   ok('session branch pushed to managed repo', branches.status === 200 && branchRows.some((branch: any) => branch.name === sessionId), `${branches.status} ${branches.text.slice(0, 160)}`);
 


### PR DESCRIPTION
## Summary
- retry the live managed-session branch assertion until the provider exposes the new branch
- preserve the existing 90 second eventual-consistency bound used by mirror checks

## Verification
- `git diff --check`
- dev Code Storage smoke against `https://dev-api.kortix.com/v1`: **24 passed, 0 failed**
- proved provision/files/manifest/token, snapshot, Daytona session, managed branch, OpenCode runtime/session, and cleanup

## Demo
The live smoke initially observed `200` with only `main`; after this bounded retry it observed the session UUID branch and completed 24/24 assertions.