### PR TITLE
fix(projects): delete managed repo before archive

### DIFF
--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -41,6 +41,8 @@ let commitCalls: any[];
 let listRepoFileCalls: any[];
 let readRepoFileCalls: any[];
 let archiveCalls: any[];
+let deleteManagedRepoCalls: any[];
+let deleteManagedRepoError: Error | null;
 let rejectedBranch: string | null;
 
 function setCurrentUser(userId: string, userEmail: string) {
@@ -92,6 +94,8 @@ function resetState() {
   listRepoFileCalls = [];
   readRepoFileCalls = [];
   archiveCalls = [];
+  deleteManagedRepoCalls = [];
+  deleteManagedRepoError = null;
   rejectedBranch = null;
 }
 
@@ -205,6 +209,14 @@ mock.module('../projects/git', () => ({
   resolveBranchAheadState: async () => ({ ahead: false, commitsAhead: 0 }),
   resolveTreeOid: async () => 'b'.repeat(40),
   materializeRepoContext: async () => '/tmp/fake-snapshot-context',
+}));
+
+mock.module('../projects/lib/project-deletion', () => ({
+  deleteManagedProjectRepo: async (project: ProjectRow) => {
+    deleteManagedRepoCalls.push(project);
+    if (deleteManagedRepoError) throw deleteManagedRepoError;
+    return false;
+  },
 }));
 
 mock.module("../snapshots/builder", () => ({
@@ -603,10 +615,23 @@ describe('projects API contract', () => {
     const del = await app.request(`/v1/projects/${PROJECT_ID}`, { method: 'DELETE' });
     expect(del.status).toBe(200);
     expect(await del.json()).toEqual({ ok: true });
+    expect(deleteManagedRepoCalls.map((project) => project.projectId)).toEqual([PROJECT_ID]);
     expect(dbState.projectRows.find((project) => project.projectId === PROJECT_ID)?.status).toBe('archived');
 
     const after = await app.request(`/v1/projects/${PROJECT_ID}`);
     expect(after.status).toBe(404);
+  });
+
+  test('does not archive a project when managed repository deletion fails', async () => {
+    const app = createApp();
+    deleteManagedRepoError = new Error('provider unavailable');
+
+    const del = await app.request(`/v1/projects/${PROJECT_ID}`, { method: 'DELETE' });
+
+    expect(del.status).toBe(502);
+    expect(await del.json()).toEqual({ error: 'Failed to delete managed project repository' });
+    expect(deleteManagedRepoCalls.map((project) => project.projectId)).toEqual([PROJECT_ID]);
+    expect(dbState.projectRows.find((project) => project.projectId === PROJECT_ID)?.status).toBe('active');
   });
 
   test('lists and manages explicit project access grants without overriding account managers', async () => {

--- a/apps/api/src/__tests__/unit-project-deletion.test.ts
+++ b/apps/api/src/__tests__/unit-project-deletion.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { deleteManagedProjectRepo } from '../projects/lib/project-deletion';
+
+const project = {
+  projectId: '00000000-0000-4000-a000-000000000201',
+  accountId: '00000000-0000-4000-a000-000000000101',
+  name: 'Managed project',
+  repoUrl: 'https://kortix.code.storage/managed-project.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+  status: 'active',
+  metadata: {
+    git: {
+      provider: 'code-storage',
+      managed: true,
+      auth: { method: 'managed' },
+      upstream_url: 'https://kortix.code.storage/managed-project.git',
+      repo_id: 'repo-1',
+      name: 'managed-project',
+    },
+  },
+} as any;
+
+describe('deleteManagedProjectRepo', () => {
+  test('deletes a managed repository through its configured backend', async () => {
+    const deleteRepo = mock(async (_ref: any) => undefined);
+
+    const deleted = await deleteManagedProjectRepo(project, {
+      getConnection: async () => null,
+      getBackend: () => ({ deleteRepo }) as any,
+    });
+
+    expect(deleted).toBe(true);
+    expect(deleteRepo).toHaveBeenCalledTimes(1);
+    expect(deleteRepo.mock.calls[0]?.[0]).toMatchObject({
+      provider: 'code-storage',
+      repoName: 'managed-project',
+      externalRepoId: 'repo-1',
+      managed: true,
+    });
+  });
+
+  test('leaves user-connected repositories untouched', async () => {
+    const deleteRepo = mock(async (_ref: any) => undefined);
+    const byo = {
+      ...project,
+      metadata: {
+        git: {
+          ...(project.metadata.git as Record<string, unknown>),
+          managed: false,
+          auth: { method: 'github_app' },
+        },
+      },
+    };
+
+    const deleted = await deleteManagedProjectRepo(byo, {
+      getConnection: async () => null,
+      getBackend: () => ({ deleteRepo }) as any,
+    });
+
+    expect(deleted).toBe(false);
+    expect(deleteRepo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/projects/lib/project-deletion.ts
+++ b/apps/api/src/projects/lib/project-deletion.ts
@@ -1,0 +1,31 @@
+import { getBackend, type GitHostBackend } from '../git-backends';
+import {
+  buildConnectionRef,
+  getProjectGitConnection,
+  getProjectGitRemote,
+} from './git';
+import type { ProjectGitConnectionRow, ProjectRow } from './serializers';
+
+export interface ProjectDeletionDeps {
+  getConnection(projectId: string): Promise<ProjectGitConnectionRow | null>;
+  getBackend(provider: string): Pick<GitHostBackend, 'deleteRepo'>;
+}
+
+const defaultDeps: ProjectDeletionDeps = {
+  getConnection: getProjectGitConnection,
+  getBackend,
+};
+
+/** Delete only Kortix-managed upstreams; user-connected repositories are never touched. */
+export async function deleteManagedProjectRepo(
+  project: ProjectRow,
+  deps: ProjectDeletionDeps = defaultDeps,
+): Promise<boolean> {
+  const connection = await deps.getConnection(project.projectId);
+  const remote = getProjectGitRemote(project, connection);
+  if (!remote.managed) return false;
+
+  const backend = deps.getBackend(remote.provider);
+  await backend.deleteRepo(buildConnectionRef(project, remote));
+  return true;
+}

--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -21,6 +21,7 @@ import { reconcileChannelConnectors, reconcileComputerConnectors } from '../../e
 import { propagateLlmGatewayModeToActiveSandboxes } from '../lib/sandbox-env-sync';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { config, type SandboxProviderName } from '../../config';
+import { deleteManagedProjectRepo } from '../lib/project-deletion';
 
 function serializeProjectAccessRequest(row: typeof projectAccessRequests.$inferSelect) {
   return {
@@ -97,7 +98,7 @@ projectsApp.openapi(
       },
     responses: {
         200: json(z.any(), 'OK'),
-        ...errors(404),
+        ...errors(404, 502),
     },
   }),
   async (c: any) => {
@@ -108,6 +109,17 @@ projectsApp.openapi(
   // project.delete; loadProjectForUser('manage') would otherwise let
   // editors through via project.write.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_DELETE);
+
+  // A project archive is the terminal lifecycle event for a Kortix-managed
+  // upstream. Delete it before hiding the project so a provider outage remains
+  // visible and retryable instead of silently leaking an orphan repository.
+  // User-connected/BYO repositories are deliberately left untouched.
+  try {
+    await deleteManagedProjectRepo(loaded.row);
+  } catch (error) {
+    console.error(`[projects] failed to delete managed repo for ${projectId}:`, error);
+    return c.json({ error: 'Failed to delete managed project repository' }, 502);
+  }
 
   const [row] = await db
     .update(projects)


### PR DESCRIPTION
## Summary
- delete Kortix-managed upstream repositories before archiving a project
- leave user-connected/BYO repositories untouched
- return 502 and keep the project active when provider cleanup fails, so deletion is visible and retryable

## Verification
- API typecheck: pass
- focused API contracts: **14 passed, 0 failed**
- direct Code Storage cleanup: all repositories created by this dev E2E run are absent

## Demo
Before: `DELETE /projects/:id` returned 200 but the Code Storage repo remained in `GET /api/repos`.
After: the route invokes the configured managed-Git backend before archive; the live dev smoke will re-prove provider-side absence after deployment.