### PR TITLE
fix(cli): label 'vision model' as the conditional fallback it is

### DIFF
--- a/apps/cli/src/commands/gateway.ts
+++ b/apps/cli/src/commands/gateway.ts
@@ -26,11 +26,13 @@ OpenAI-compatible endpoint. (Connect provider credentials with
 
 Routing:
   routing [get]                     Show the effective default model, fallback
-                                    chain, and vision model (+ where each
+                                    chain, and vision fallback (+ where each
                                     resolves from). --json.
   routing set [flags]               Update the project routing policy:
     --default-model <id>              Default model ("" to clear).
-    --vision-model <id>               Model for image-bearing requests.
+    --vision-model <id>               Vision FALLBACK — only used on `auto` when
+                                      an image is sent and the default model
+                                      can't see images. Ignored otherwise.
     --fallback <id,id,…>              Fallback chain ("" to clear).
     --fallback-on transient|any-error
     --file <path|->                   Full policy JSON (stdin with -).
@@ -265,7 +267,7 @@ function renderRouting(doc: RoutingPolicyDoc): number {
   process.stdout.write(
     `\n  ${C.dim}EFFECTIVE ROUTING${C.reset}\n` +
       `  default model   ${C.bold}${e.defaultModel}${C.reset} ${C.dim}(${e.defaultModelSource})${C.reset}\n` +
-      `  vision model    ${e.visionModel}\n` +
+      `  vision fallback ${e.visionModel} ${C.dim}(auto only — used only when the default model can't see images)${C.reset}\n` +
       `  fallback        ${fb}\n`,
   );
   if (doc.project.rules.length) {

--- a/apps/cli/src/commands/gateway.ts
+++ b/apps/cli/src/commands/gateway.ts
@@ -30,9 +30,9 @@ Routing:
                                     resolves from). --json.
   routing set [flags]               Update the project routing policy:
     --default-model <id>              Default model ("" to clear).
-    --vision-model <id>               Vision FALLBACK — only used on `auto` when
+    --vision-model <id>               Vision FALLBACK — only used on 'auto' when
                                       an image is sent and the default model
-                                      can't see images. Ignored otherwise.
+                                      cannot see images. Ignored otherwise.
     --fallback <id,id,…>              Fallback chain ("" to clear).
     --fallback-on transient|any-error
     --file <path|->                   Full policy JSON (stdin with -).


### PR DESCRIPTION
The CLI's `routing` output showed `vision model` as an unconditional peer row under EFFECTIVE ROUTING, implying every image turn uses it. It doesn't: it's a fallback used ONLY on `kortix/auto` when an image is sent AND the resolved default model lacks image support (`resolve-route.ts`). A pinned model or a vision-capable default never triggers it. The web UI already removed the peer-looking control (#38dcf7ee4); this brings the CLL in line — relabels the row to `vision fallback … (auto only — used only when the default model can't see images)` and clarifies the `--vision-model` flag. Copy only, no behavior change.