### PR TITLE
fix(web): show dev CLI installer in Git settings

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/view/git-view.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/git-view.test.ts
@@ -22,3 +22,12 @@ test('copy control keeps both icons in an animated fixed-size box', () => {
   expect(source).toContain("filter: 'blur(4px)'");
   expect(source).toContain('duration: 0.3, bounce: 0');
 });
+
+test('develop locally includes the environment-aware CLI installer before clone', () => {
+  const source = readFileSync(join(import.meta.dir, 'git-view.tsx'), 'utf8');
+  expect(source).toContain('getKortixCliInstallCommand(getEnv().VERSION)');
+  expect(source).toContain('label="Install command"');
+  expect(source.indexOf('label="Install command"')).toBeLessThan(
+    source.indexOf('label="Clone command"'),
+  );
+});

--- a/apps/web/src/features/workspace/customize/sections/view/git-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/git-view.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { getEnv } from '@/lib/env-config';
+import { getKortixCliInstallCommand } from '@/lib/kortix-cli';
 import { getProjectDetail, type KortixProject, type ProjectGitConnection } from '@kortix/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { Check, Copy, ExternalLink, GitBranch, GitFork, Github, RefreshCw } from 'lucide-react';
@@ -166,6 +167,7 @@ function SummaryRow({
 }
 
 export function GitView({ projectId }: { projectId: string }) {
+  const installCommand = getKortixCliInstallCommand(getEnv().VERSION);
   const detail = useQuery({
     queryKey: ['project-detail', projectId],
     queryFn: () => getProjectDetail(projectId),
@@ -212,9 +214,11 @@ export function GitView({ projectId }: { projectId: string }) {
             <div>
               <h3 className="text-foreground text-sm font-medium">Develop locally</h3>
               <p className="text-muted-foreground mt-0.5 text-xs">
-                The CLI authenticates the clone without saving a token in the URL or Git config.
+                Install the CLI, then clone through the authenticated Kortix proxy. Tokens are never
+                saved in the URL or Git config.
               </p>
             </div>
+            <CopyValue value={installCommand} label="Install command" />
             <CopyValue value={`kortix projects clone ${projectId}`} label="Clone command" />
             <p className="text-muted-foreground text-xs">
               Then run <code className="text-foreground font-mono">kortix init --force</code> and{' '}

--- a/apps/web/src/lib/kortix-cli.test.ts
+++ b/apps/web/src/lib/kortix-cli.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'bun:test';
+
+import {
+  getKortixCliInstallCommand,
+  KORTIX_CLI_DEV_INSTALL_COMMAND,
+  KORTIX_CLI_INSTALL_COMMAND,
+} from './kortix-cli';
+
+test('uses the mutable dev CLI channel on dev builds', () => {
+  expect(getKortixCliInstallCommand('0.10.13-dev.fca20702')).toBe(KORTIX_CLI_DEV_INSTALL_COMMAND);
+  expect(getKortixCliInstallCommand('dev')).toBe(KORTIX_CLI_DEV_INSTALL_COMMAND);
+});
+
+test('keeps stable installs on staging and production releases', () => {
+  expect(getKortixCliInstallCommand('0.10.13')).toBe(KORTIX_CLI_INSTALL_COMMAND);
+  expect(getKortixCliInstallCommand(undefined)).toBe(KORTIX_CLI_INSTALL_COMMAND);
+});

--- a/apps/web/src/lib/kortix-cli.ts
+++ b/apps/web/src/lib/kortix-cli.ts
@@ -1,1 +1,10 @@
 export const KORTIX_CLI_INSTALL_COMMAND = 'curl -fsSL https://kortix.com/install | bash';
+
+export const KORTIX_CLI_DEV_INSTALL_COMMAND =
+  'curl -fsSL https://kortix.com/install | KORTIX_CHANNEL=dev bash';
+
+export function getKortixCliInstallCommand(version: string | undefined): string {
+  return version?.includes('-dev.') || version === 'dev'
+    ? KORTIX_CLI_DEV_INSTALL_COMMAND
+    : KORTIX_CLI_INSTALL_COMMAND;
+}


### PR DESCRIPTION
## Summary
- show CLI installation before the authenticated clone command in Manage → Git
- select the `dev-latest` CLI installer on dev builds
- keep the stable installer for staging and production

## Verification
- `bun test src/lib/kortix-cli.test.ts src/features/workspace/customize/sections/view/git-view.test.ts` (6 passed)
- `pnpm exec eslint src/lib/kortix-cli.ts src/lib/kortix-cli.test.ts src/features/workspace/customize/sections/view/git-view.tsx src/features/workspace/customize/sections/view/git-view.test.ts`
- `pnpm exec tsc --noEmit`

## Live discovery
The post-deploy Code Storage smoke test proved that stable CLI v0.10.12 cannot service the new URL-scoped `git-credential` helper, while `dev-latest` at merge SHA `fca20702` passes clone/fetch/push. This makes the dev-only install requirement explicit in the UI.