### PR TITLE
fix(projects): honor explicit managed repo purge

### DIFF
--- a/apps/api/src/__tests__/e2e-projects-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-contract.test.ts
@@ -43,6 +43,7 @@ let readRepoFileCalls: any[];
 let archiveCalls: any[];
 let deleteManagedRepoCalls: any[];
 let deleteManagedRepoError: Error | null;
+let deleteManagedRepoResult: boolean;
 let rejectedBranch: string | null;
 
 function setCurrentUser(userId: string, userEmail: string) {
@@ -96,6 +97,7 @@ function resetState() {
   archiveCalls = [];
   deleteManagedRepoCalls = [];
   deleteManagedRepoError = null;
+  deleteManagedRepoResult = false;
   rejectedBranch = null;
 }
 
@@ -215,7 +217,7 @@ mock.module('../projects/lib/project-deletion', () => ({
   deleteManagedProjectRepo: async (project: ProjectRow) => {
     deleteManagedRepoCalls.push(project);
     if (deleteManagedRepoError) throw deleteManagedRepoError;
-    return false;
+    return deleteManagedRepoResult;
   },
 }));
 
@@ -614,19 +616,35 @@ describe('projects API contract', () => {
 
     const del = await app.request(`/v1/projects/${PROJECT_ID}`, { method: 'DELETE' });
     expect(del.status).toBe(200);
-    expect(await del.json()).toEqual({ ok: true });
-    expect(deleteManagedRepoCalls.map((project) => project.projectId)).toEqual([PROJECT_ID]);
+    expect(await del.json()).toEqual({ ok: true, archived: true, repo_deleted: false });
+    expect(deleteManagedRepoCalls).toEqual([]);
     expect(dbState.projectRows.find((project) => project.projectId === PROJECT_ID)?.status).toBe('archived');
 
     const after = await app.request(`/v1/projects/${PROJECT_ID}`);
     expect(after.status).toBe(404);
   });
 
+  test('purges a managed repository only when explicitly requested', async () => {
+    const app = createApp();
+    deleteManagedRepoResult = true;
+
+    const del = await app.request(`/v1/projects/${PROJECT_ID}?purge=true`, {
+      method: 'DELETE',
+    });
+
+    expect(del.status).toBe(200);
+    expect(await del.json()).toEqual({ ok: true, archived: true, repo_deleted: true });
+    expect(deleteManagedRepoCalls.map((project) => project.projectId)).toEqual([PROJECT_ID]);
+    expect(dbState.projectRows.find((project) => project.projectId === PROJECT_ID)?.status).toBe(
+      'archived',
+    );
+  });
+
   test('does not archive a project when managed repository deletion fails', async () => {
     const app = createApp();
     deleteManagedRepoError = new Error('provider unavailable');
 
-    const del = await app.request(`/v1/projects/${PROJECT_ID}`, { method: 'DELETE' });
+    const del = await app.request(`/v1/projects/${PROJECT_ID}?purge=true`, { method: 'DELETE' });
 
     expect(del.status).toBe(502);
     expect(await del.json()).toEqual({ error: 'Failed to delete managed project repository' });

--- a/apps/api/src/projects/routes/r6.ts
+++ b/apps/api/src/projects/routes/r6.ts
@@ -95,6 +95,7 @@ projectsApp.openapi(
     ...auth,
       request: {
         params: z.object({ projectId: z.string() }),
+        query: z.object({ purge: z.enum(['true', 'false']).optional() }),
       },
     responses: {
         200: json(z.any(), 'OK'),
@@ -110,15 +111,19 @@ projectsApp.openapi(
   // editors through via project.write.
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_DELETE);
 
-  // A project archive is the terminal lifecycle event for a Kortix-managed
-  // upstream. Delete it before hiding the project so a provider outage remains
-  // visible and retryable instead of silently leaking an orphan repository.
-  // User-connected/BYO repositories are deliberately left untouched.
-  try {
-    await deleteManagedProjectRepo(loaded.row);
-  } catch (error) {
-    console.error(`[projects] failed to delete managed repo for ${projectId}:`, error);
-    return c.json({ error: 'Failed to delete managed project repository' }, 502);
+  // Archiving is recoverable by default. Only an explicit purge permanently
+  // deletes a Kortix-managed upstream; user-connected/BYO repositories are
+  // always left untouched. Delete before hiding the project so provider
+  // failures remain visible and retryable.
+  const purge = c.req.query('purge') === 'true';
+  let repoDeleted = false;
+  if (purge) {
+    try {
+      repoDeleted = await deleteManagedProjectRepo(loaded.row);
+    } catch (error) {
+      console.error(`[projects] failed to delete managed repo for ${projectId}:`, error);
+      return c.json({ error: 'Failed to delete managed project repository' }, 502);
+    }
   }
 
   const [row] = await db
@@ -128,7 +133,7 @@ projectsApp.openapi(
     .returning();
 
   if (!row) return c.json({ error: 'Not found' }, 404);
-  return c.json({ ok: true });
+  return c.json({ ok: true, archived: true, repo_deleted: repoDeleted });
 },
 );
 

--- a/apps/cli/src/__tests__/cli-blackbox.test.ts
+++ b/apps/cli/src/__tests__/cli-blackbox.test.ts
@@ -638,6 +638,7 @@ console.log(JSON.stringify({ cmd, args, body }));
     const removeProject = await runCli(['projects', 'rm', 'proj_e2e', '--purge', '--yes'], root, { KORTIX_CONFIG_FILE: configFile });
     expect(removeProject.code).toBe(0);
     expect(removeProject.stdout).toContain('Archived');
+    expect(removeProject.stdout).toContain('managed git repo deleted');
     expect(existsSync(join(root, '.kortix', 'link.json'))).toBe(false);
 
     expect(requests.map((r) => [r.method, r.path, r.body ?? null])).toEqual([

--- a/apps/web/src/lib/kortix-cli.test.ts
+++ b/apps/web/src/lib/kortix-cli.test.ts
@@ -7,6 +7,9 @@ import {
 } from './kortix-cli';
 
 test('uses the mutable dev CLI channel on dev builds', () => {
+  expect(KORTIX_CLI_DEV_INSTALL_COMMAND).toBe(
+    'curl -fsSL https://kortix.com/install | KORTIX_CHANNEL=dev bash',
+  );
   expect(getKortixCliInstallCommand('0.10.13-dev.fca20702')).toBe(KORTIX_CLI_DEV_INSTALL_COMMAND);
   expect(getKortixCliInstallCommand('dev')).toBe(KORTIX_CLI_DEV_INSTALL_COMMAND);
 });


### PR DESCRIPTION
## Summary
- keep ordinary project archive recoverable and leave its managed repo intact
- delete managed Code Storage/GitHub repos only for explicit `?purge=true`
- return the `{ archived, repo_deleted }` contract already consumed by the CLI and managed-flow E2E
- assert the CLI reports successful managed-repo deletion
- retain the dev CLI installer assertion so this merge rebuilds the previously superseded frontend artifact

## Verification
- API project contract: 13 passed
- API managed deletion unit tests: 2 passed
- CLI black-box suite: 18 passed
- API typecheck: passed
- CLI typecheck: passed
- Web CLI-install test: 2 passed

## Live discovery
`kortix projects rm <id> --purge --yes` returned 200 and archived the disposable Code Storage project, but the API omitted `repo_deleted`, causing the CLI to falsely report that no managed repo existed. The route also ignored the `purge` query and deleted managed repositories on ordinary archive. This restores the explicit, safer contract already documented and exercised by the CLI/E2E runner.