### PR TITLE
fix(cli): avoid long-lived chat proxy requests

### DIFF
--- a/apps/cli/src/__tests__/sandbox-proxy-chat.test.ts
+++ b/apps/cli/src/__tests__/sandbox-proxy-chat.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import type { Auth } from '../api/auth.ts';
+import { ApiError } from '../api/client.ts';
+import { opencodeClient } from '../api/sandbox-proxy.ts';
+
+const SESSION_ID = 'ses_chat';
+
+let server: ReturnType<typeof Bun.serve> | null = null;
+
+afterEach(() => {
+  server?.stop(true);
+  server = null;
+});
+
+function auth(): Auth {
+  return {
+    api_base: `http://127.0.0.1:${server!.port}`,
+    token: 'kortix_pat_test',
+    user_id: 'user_test',
+    user_email: 'test@kortix.local',
+    account_id: 'account_test',
+    logged_in_at: '2026-07-19T00:00:00.000Z',
+  };
+}
+
+function completedReply(parentID: string) {
+  return {
+    info: {
+      id: 'msg_reply',
+      role: 'assistant',
+      sessionID: SESSION_ID,
+      parentID,
+      time: { created: 2, completed: 3 },
+    },
+    parts: [{ type: 'text', text: 'done' }],
+  };
+}
+
+function idleStatus(req: Request): Response | null {
+  const url = new URL(req.url);
+  if (req.method === 'GET' && url.pathname.endsWith('/session/status')) {
+    return Response.json({});
+  }
+  return null;
+}
+
+describe('OpenCode CLI chat transport', () => {
+  test('submits with prompt_async and polls for the matching completed reply', async () => {
+    const requests: Array<{ method: string; path: string }> = [];
+    let submittedMessageID = '';
+    let messageReads = 0;
+
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const status = idleStatus(req);
+        if (status) return status;
+        const url = new URL(req.url);
+        requests.push({ method: req.method, path: url.pathname });
+        if (req.method === 'POST' && url.pathname.endsWith(`/session/${SESSION_ID}/prompt_async`)) {
+          const body = await req.json() as { messageID?: string };
+          submittedMessageID = body.messageID ?? '';
+          return new Response(null, { status: 204 });
+        }
+        if (req.method === 'GET' && url.pathname.endsWith(`/session/${SESSION_ID}/message`)) {
+          messageReads += 1;
+          if (messageReads === 1) {
+            return Response.json([
+              {
+                info: { id: submittedMessageID, role: 'user', sessionID: SESSION_ID, time: { created: 1 } },
+                parts: [{ type: 'text', text: 'hello' }],
+              },
+            ]);
+          }
+          return Response.json([
+            completedReply('msg_unrelated'),
+            {
+              info: { id: submittedMessageID, role: 'user', sessionID: SESSION_ID, time: { created: 1 } },
+              parts: [{ type: 'text', text: 'hello' }],
+            },
+            completedReply(submittedMessageID),
+          ]);
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    const client = opencodeClient({ auth: auth(), sandboxId: 'sbx_test' });
+    const reply = await client.sendPrompt(SESSION_ID, [{ type: 'text', text: 'hello' }], undefined, 2_000);
+
+    expect(submittedMessageID).toMatch(/^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
+    expect(reply.parts).toEqual([{ type: 'text', text: 'done' }]);
+    expect(requests.some((r) => r.method === 'POST' && r.path.endsWith('/message'))).toBe(false);
+    expect(messageReads).toBeGreaterThanOrEqual(2);
+  });
+
+  test('retries a transient prompt_async 502 with the same idempotency message id', async () => {
+    const submittedIDs: string[] = [];
+
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const status = idleStatus(req);
+        if (status) return status;
+        const url = new URL(req.url);
+        if (req.method === 'POST' && url.pathname.endsWith(`/session/${SESSION_ID}/prompt_async`)) {
+          const body = await req.json() as { messageID: string };
+          submittedIDs.push(body.messageID);
+          if (submittedIDs.length === 1) return new Response('transient', { status: 502 });
+          return new Response(null, { status: 204 });
+        }
+        if (req.method === 'GET' && url.pathname.endsWith(`/session/${SESSION_ID}/message`)) {
+          return Response.json([completedReply(submittedIDs[0]!)]);
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    const client = opencodeClient({ auth: auth(), sandboxId: 'sbx_test' });
+    const reply = await client.sendPrompt(SESSION_ID, [{ type: 'text', text: 'hello' }], undefined, 2_000);
+
+    expect(submittedIDs).toHaveLength(2);
+    expect(new Set(submittedIDs).size).toBe(1);
+    expect(reply.info.parentID).toBe(submittedIDs[0]);
+  });
+
+  test('does not resubmit when a 502 lost the prompt_async acceptance response', async () => {
+    let promptCalls = 0;
+    let submittedMessageID = '';
+
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const status = idleStatus(req);
+        if (status) return status;
+        const url = new URL(req.url);
+        if (req.method === 'POST' && url.pathname.endsWith(`/session/${SESSION_ID}/prompt_async`)) {
+          promptCalls += 1;
+          submittedMessageID = ((await req.json()) as { messageID: string }).messageID;
+          return new Response('upstream response lost', { status: 502 });
+        }
+        if (req.method === 'GET' && url.pathname.endsWith(`/session/${SESSION_ID}/message/${submittedMessageID}`)) {
+          return Response.json({
+            info: { id: submittedMessageID, role: 'user', sessionID: SESSION_ID, time: { created: 1 } },
+            parts: [{ type: 'text', text: 'hello' }],
+          });
+        }
+        if (req.method === 'GET' && url.pathname.endsWith(`/session/${SESSION_ID}/message`)) {
+          return Response.json([completedReply(submittedMessageID)]);
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    const client = opencodeClient({ auth: auth(), sandboxId: 'sbx_test' });
+    const reply = await client.sendPrompt(SESSION_ID, [{ type: 'text', text: 'hello' }], undefined, 2_000);
+
+    expect(promptCalls).toBe(1);
+    expect(reply.info.parentID).toBe(submittedMessageID);
+  });
+
+  test('absorbs a transient 502 while polling without resubmitting the prompt', async () => {
+    let promptCalls = 0;
+    let messageReads = 0;
+    let submittedMessageID = '';
+
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const status = idleStatus(req);
+        if (status) return status;
+        const url = new URL(req.url);
+        if (req.method === 'POST' && url.pathname.endsWith(`/session/${SESSION_ID}/prompt_async`)) {
+          promptCalls += 1;
+          submittedMessageID = ((await req.json()) as { messageID: string }).messageID;
+          return new Response(null, { status: 204 });
+        }
+        if (req.method === 'GET' && url.pathname.endsWith(`/session/${SESSION_ID}/message`)) {
+          messageReads += 1;
+          if (messageReads === 1) return new Response('transient', { status: 502 });
+          return Response.json([completedReply(submittedMessageID)]);
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    const client = opencodeClient({ auth: auth(), sandboxId: 'sbx_test' });
+    const reply = await client.sendPrompt(SESSION_ID, [{ type: 'text', text: 'hello' }], undefined, 2_000);
+
+    expect(promptCalls).toBe(1);
+    expect(messageReads).toBe(2);
+    expect(reply.info.id).toBe('msg_reply');
+  });
+
+  test('waits for an idle turn and returns the final assistant message after a tool step', async () => {
+    let submittedMessageID = '';
+    let messageReads = 0;
+    let statusReads = 0;
+
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (req.method === 'POST' && url.pathname.endsWith(`/session/${SESSION_ID}/prompt_async`)) {
+          submittedMessageID = ((await req.json()) as { messageID: string }).messageID;
+          return new Response(null, { status: 204 });
+        }
+        if (req.method === 'GET' && url.pathname.endsWith(`/session/${SESSION_ID}/message`)) {
+          messageReads += 1;
+          const messages: Array<{ info: Record<string, unknown>; parts: Array<Record<string, unknown>> }> = [
+            {
+              info: {
+                id: 'msg_tool_step',
+                role: 'assistant',
+                sessionID: SESSION_ID,
+                parentID: submittedMessageID,
+                finish: 'tool-calls',
+                time: { created: 2, completed: 3 },
+              },
+              parts: [{ type: 'tool', tool: 'bash', state: { status: 'completed' } }],
+            },
+          ];
+          if (messageReads >= 2) {
+            messages.push({
+              info: {
+                id: 'msg_final',
+                role: 'assistant',
+                sessionID: SESSION_ID,
+                parentID: submittedMessageID,
+                finish: 'stop',
+                time: { created: 4, completed: 5 },
+              },
+              parts: [{ type: 'text', text: 'final answer' }],
+            });
+          }
+          return Response.json(messages);
+        }
+        if (req.method === 'GET' && url.pathname.endsWith('/session/status')) {
+          statusReads += 1;
+          return Response.json(statusReads === 1 ? { [SESSION_ID]: { type: 'busy' } } : {});
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    const client = opencodeClient({ auth: auth(), sandboxId: 'sbx_test' });
+    const reply = await client.sendPrompt(SESSION_ID, [{ type: 'text', text: 'hello' }], undefined, 2_000);
+
+    expect(messageReads).toBe(3);
+    expect(statusReads).toBe(2);
+    expect(reply.info.id).toBe('msg_final');
+    expect(reply.parts).toEqual([{ type: 'text', text: 'final answer' }]);
+  });
+
+  test('surfaces a terminal 4xx without retrying or polling', async () => {
+    let promptCalls = 0;
+    let messageReads = 0;
+
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const status = idleStatus(req);
+        if (status) return status;
+        const url = new URL(req.url);
+        if (req.method === 'POST' && url.pathname.endsWith(`/session/${SESSION_ID}/prompt_async`)) {
+          promptCalls += 1;
+          return Response.json({ message: 'unknown model' }, { status: 400 });
+        }
+        if (req.method === 'GET') messageReads += 1;
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    const client = opencodeClient({ auth: auth(), sandboxId: 'sbx_test' });
+    const result = client.sendPrompt(SESSION_ID, [{ type: 'text', text: 'hello' }], undefined, 2_000);
+
+    await expect(result).rejects.toMatchObject({ status: 400, message: 'unknown model' });
+    expect(promptCalls).toBe(1);
+    expect(messageReads).toBe(0);
+  });
+
+  test('keeps the overall wait bounded with a clear timeout error', async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const status = idleStatus(req);
+        if (status) return status;
+        const url = new URL(req.url);
+        if (req.method === 'POST' && url.pathname.endsWith(`/session/${SESSION_ID}/prompt_async`)) {
+          return new Response(null, { status: 204 });
+        }
+        if (req.method === 'GET' && url.pathname.endsWith(`/session/${SESSION_ID}/message`)) {
+          return Response.json([]);
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    const client = opencodeClient({ auth: auth(), sandboxId: 'sbx_test' });
+    const started = Date.now();
+    const result = client.sendPrompt(SESSION_ID, [{ type: 'text', text: 'hello' }], undefined, 100);
+
+    await expect(result).rejects.toEqual(new ApiError(0, 'agent reply timed out after 100ms'));
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+});

--- a/apps/cli/src/api/sandbox-proxy.ts
+++ b/apps/cli/src/api/sandbox-proxy.ts
@@ -1,6 +1,11 @@
 import type { Auth } from './auth.ts';
 import { ApiError } from './client.ts';
 
+const TRANSIENT_SANDBOX_STATUSES = new Set([408, 429]);
+const PROMPT_ACCEPT_BACKOFF_MS = [250, 500, 1_000];
+const PROMPT_POLL_INTERVAL_MS = 500;
+const PROMPT_MESSAGE_LIMIT = 100;
+
 /**
  * The sandbox daemon exposes OpenCode and PTY helpers on this port. Older CLI
  * builds talked to OpenCode's internal 4096 port directly, but live sessions are
@@ -23,8 +28,7 @@ interface RequestOpts {
   method?: string;
   body?: unknown;
   query?: Record<string, string | undefined>;
-  /** Per-request timeout. OpenCode prompt calls block for the AI to finish,
-   *  so callers can override to e.g. 5 minutes. */
+  /** Per-request timeout. */
   timeoutMs?: number;
 }
 
@@ -97,6 +101,181 @@ export async function sandboxRequest<T>(opts: RequestOpts): Promise<T> {
   return payload as T;
 }
 
+function isTransientSandboxError(error: unknown): boolean {
+  return error instanceof ApiError &&
+    (error.status === 0 || error.status >= 500 || TRANSIENT_SANDBOX_STATUSES.has(error.status));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let lastPromptIdTimestamp = 0;
+let promptIdCounter = 0;
+
+/** Generate the ascending OpenCode message-id shape accepted by prompt_async.
+ * Reusing this stable id across a transient submit retry makes the logical
+ * prompt idempotent even if the proxy lost the first 204 response. */
+function promptMessageId(): string {
+  const now = Date.now();
+  if (now !== lastPromptIdTimestamp) {
+    lastPromptIdTimestamp = now;
+    promptIdCounter = 0;
+  }
+  promptIdCounter += 1;
+  const encoded = BigInt(now) * BigInt(0x1000) + BigInt(promptIdCounter);
+  // OpenCode writes the encoded value into six bytes, retaining the low
+  // 48 bits. slice(-12) mirrors that Buffer behavior exactly.
+  const timestamp = encoded.toString(16).padStart(12, '0').slice(-12);
+  const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  const bytes = crypto.getRandomValues(new Uint8Array(14));
+  let random = '';
+  for (const byte of bytes) random += chars[byte % chars.length];
+  return `msg_${timestamp}${random}`;
+}
+
+function completedReplyFor(
+  messages: OpencodeMessageWithParts[],
+  parentID: string,
+): OpencodeMessageWithParts | null {
+  let latest: OpencodeMessageWithParts | null = null;
+  for (const message of messages) {
+    if (message.info.role !== 'assistant' || message.info.parentID !== parentID) continue;
+    if (message.info.time?.completed === undefined && !message.info.error) continue;
+    if (!message.info.error && (message.info.finish === 'tool-calls' || message.info.finish === 'unknown')) continue;
+    if (!latest) {
+      latest = message;
+      continue;
+    }
+    const created = message.info.time?.created ?? 0;
+    const latestCreated = latest.info.time?.created ?? 0;
+    if (created > latestCreated || (created === latestCreated && message.info.id > latest.info.id)) {
+      latest = message;
+    }
+  }
+  return latest;
+}
+
+async function sessionIsIdle(
+  base: Pick<RequestOpts, 'apiBase' | 'token' | 'sandboxId' | 'port'>,
+  sessionId: string,
+  deadline: number,
+): Promise<boolean> {
+  const statuses = await sandboxRequest<Record<string, { type?: string }>>({
+    ...base,
+    path: '/session/status',
+    timeoutMs: Math.max(1, Math.min(5_000, deadline - Date.now())),
+  });
+  const status = statuses[sessionId];
+  // OpenCode may omit idle sessions from the active-status map.
+  return status === undefined || status.type === 'idle';
+}
+
+async function promptWasAccepted(
+  base: Pick<RequestOpts, 'apiBase' | 'token' | 'sandboxId' | 'port'>,
+  sessionId: string,
+  messageID: string,
+  deadline: number,
+): Promise<boolean> {
+  try {
+    const message = await sandboxRequest<OpencodeMessageWithParts>({
+      ...base,
+      path: `/session/${sessionId}/message/${messageID}`,
+      timeoutMs: Math.max(1, Math.min(5_000, deadline - Date.now())),
+    });
+    return message.info.role === 'user' && message.info.id === messageID;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return false;
+    if (isTransientSandboxError(error)) return false;
+    throw error;
+  }
+}
+
+async function submitPromptAsync(
+  base: Pick<RequestOpts, 'apiBase' | 'token' | 'sandboxId' | 'port'>,
+  sessionId: string,
+  body: Record<string, unknown>,
+  deadline: number,
+): Promise<void> {
+  let lastSubmitError: unknown;
+
+  for (let attempt = 0; attempt <= PROMPT_ACCEPT_BACKOFF_MS.length; attempt += 1) {
+    try {
+      await sandboxRequest<null>({
+        ...base,
+        path: `/session/${sessionId}/prompt_async`,
+        method: 'POST',
+        body,
+        timeoutMs: Math.max(1, Math.min(30_000, deadline - Date.now())),
+      });
+      return;
+    } catch (error) {
+      lastSubmitError = error;
+      const backoff = PROMPT_ACCEPT_BACKOFF_MS[attempt];
+      if (!isTransientSandboxError(error) || backoff === undefined || Date.now() + backoff >= deadline) {
+        throw error;
+      }
+      // A proxy may have delivered the initial request but lost OpenCode's
+      // 204. Check the new stable user-message id before retrying so an
+      // ambiguous 502 cannot enqueue the logical prompt twice.
+      if (await promptWasAccepted(base, sessionId, String(body.messageID), deadline)) {
+        return;
+      }
+      await sleep(backoff);
+    }
+  }
+  if (lastSubmitError) throw lastSubmitError;
+}
+
+/**
+ * Submit a CLI chat turn through OpenCode's short-lived prompt_async endpoint,
+ * then wait for the exact assistant reply using idempotent message reads.
+ *
+ * The previous synchronous POST /message kept the API→sandbox proxy request
+ * open for the whole model/tool turn. Cloud load balancers close that request
+ * around 60–70 seconds with a 502 even though OpenCode continues working.
+ * prompt_async returns 204 immediately, so no long-lived proxy request exists;
+ * transient gateway errors while accepting or polling are absorbed within the
+ * caller's existing five-minute turn deadline.
+ */
+async function sendPromptAsyncAndWait(
+  base: Pick<RequestOpts, 'apiBase' | 'token' | 'sandboxId' | 'port'>,
+  sessionId: string,
+  parts: OpencodePromptPart[],
+  extra: { agent?: string; model?: { providerID: string; modelID: string } } | undefined,
+  timeoutMs: number,
+): Promise<{ info: OpencodeAssistantMessage; parts: OpencodePart[] }> {
+  const deadline = Date.now() + timeoutMs;
+  const messageID = promptMessageId();
+  const body = { parts, messageID, ...(extra ?? {}) };
+  await submitPromptAsync(base, sessionId, body, deadline);
+
+  while (Date.now() < deadline) {
+    try {
+      const messages = await sandboxRequest<OpencodeMessageWithParts[]>({
+        ...base,
+        path: `/session/${sessionId}/message`,
+        query: { limit: String(PROMPT_MESSAGE_LIMIT) },
+        timeoutMs: Math.max(1, Math.min(30_000, deadline - Date.now())),
+      });
+      const reply = completedReplyFor(messages, messageID);
+      // Tool turns can emit several completed assistant messages with the same
+      // parent user id. Only return once the run is idle, then select the most
+      // recent one so the CLI prints the final answer instead of an empty
+      // completed tool step.
+      if (reply && await sessionIsIdle(base, sessionId, deadline)) {
+        return { info: reply.info as OpencodeAssistantMessage, parts: reply.parts };
+      }
+    } catch (error) {
+      if (!isTransientSandboxError(error)) throw error;
+    }
+    const remaining = deadline - Date.now();
+    if (remaining > 0) await sleep(Math.min(PROMPT_POLL_INTERVAL_MS, remaining));
+  }
+
+  throw new ApiError(0, `agent reply timed out after ${timeoutMs}ms`);
+}
+
 /** Build the WebSocket URL for a raw terminal (PTY) session, mirroring what
  *  the web app's browser client connects to — same host, same `?token=`
  *  query auth (WebSocket can't set custom headers). Reaches Kortix's own
@@ -162,23 +341,14 @@ export function opencodeClient(opts: SandboxOpencodeOpts) {
         path: `/session/${sessionId}/message`,
         query: { limit: limit ? String(limit) : undefined },
       }),
-    /**
-     * Send a prompt. This BLOCKS until OpenCode finishes generating —
-     * pass a generous timeout (`timeoutMs`) for long completions.
-     */
+    /** Submit a prompt asynchronously, then poll for its completed reply. */
     sendPrompt: (
       sessionId: string,
       parts: OpencodePromptPart[],
       extra?: { agent?: string; model?: { providerID: string; modelID: string } },
       timeoutMs?: number,
     ) =>
-      sandboxRequest<{ info: OpencodeAssistantMessage; parts: OpencodePart[] }>({
-        ...base,
-        path: `/session/${sessionId}/message`,
-        method: 'POST',
-        body: { parts, ...(extra ?? {}) },
-        timeoutMs: timeoutMs ?? 5 * 60_000,
-      }),
+      sendPromptAsyncAndWait(base, sessionId, parts, extra, timeoutMs ?? 5 * 60_000),
     abortSession: (sessionId: string) =>
       sandboxRequest<boolean>({
         ...base,
@@ -273,8 +443,11 @@ export interface OpencodeAssistantMessage {
   id: string;
   role: 'assistant';
   sessionID: string;
+  /** User message that started this turn. */
+  parentID?: string;
   time?: { created?: number; completed?: number };
   error?: { name?: string; message?: string } | null;
+  finish?: string;
   modelID?: string;
   providerID?: string;
 }

--- a/apps/cli/src/api/sandbox-proxy.ts
+++ b/apps/cli/src/api/sandbox-proxy.ts
@@ -128,9 +128,17 @@ function promptMessageId(): string {
   // 48 bits. slice(-12) mirrors that Buffer behavior exactly.
   const timestamp = encoded.toString(16).padStart(12, '0').slice(-12);
   const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-  const bytes = crypto.getRandomValues(new Uint8Array(14));
   let random = '';
-  for (const byte of bytes) random += chars[byte % chars.length];
+  while (random.length < 14) {
+    const bytes = crypto.getRandomValues(new Uint8Array(14 - random.length));
+    for (const byte of bytes) {
+      // 248 is the largest multiple of 62 below 256. Rejecting the remaining
+      // byte values and dividing each accepted bucket by four gives every
+      // base62 character exactly the same probability.
+      if (byte >= 248) continue;
+      random += chars[Math.floor(byte / 4)];
+    }
+  }
   return `msg_${timestamp}${random}`;
 }
 
@@ -199,7 +207,7 @@ async function submitPromptAsync(
 ): Promise<void> {
   let lastSubmitError: unknown;
 
-  for (let attempt = 0; attempt <= PROMPT_ACCEPT_BACKOFF_MS.length; attempt += 1) {
+  for (const backoff of [...PROMPT_ACCEPT_BACKOFF_MS, undefined]) {
     try {
       await sandboxRequest<null>({
         ...base,
@@ -211,7 +219,6 @@ async function submitPromptAsync(
       return;
     } catch (error) {
       lastSubmitError = error;
-      const backoff = PROMPT_ACCEPT_BACKOFF_MS[attempt];
       if (!isTransientSandboxError(error) || backoff === undefined || Date.now() + backoff >= deadline) {
         throw error;
       }

--- a/apps/cli/src/api/sandbox-proxy.ts
+++ b/apps/cli/src/api/sandbox-proxy.ts
@@ -127,18 +127,9 @@ function promptMessageId(): string {
   // OpenCode writes the encoded value into six bytes, retaining the low
   // 48 bits. slice(-12) mirrors that Buffer behavior exactly.
   const timestamp = encoded.toString(16).padStart(12, '0').slice(-12);
-  const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-  let random = '';
-  while (random.length < 14) {
-    const bytes = crypto.getRandomValues(new Uint8Array(14 - random.length));
-    for (const byte of bytes) {
-      // 248 is the largest multiple of 62 below 256. Rejecting the remaining
-      // byte values and dividing each accepted bucket by four gives every
-      // base62 character exactly the same probability.
-      if (byte >= 248) continue;
-      random += chars[Math.floor(byte / 4)];
-    }
-  }
+  // Hex is a valid subset of OpenCode's alphanumeric suffix alphabet. UUID
+  // entropy avoids hand-rolling arithmetic over secure random bytes.
+  const random = crypto.randomUUID().replaceAll('-', '').slice(0, 14);
   return `msg_${timestamp}${random}`;
 }
 


### PR DESCRIPTION
## What changed
- submit `kortix chat` prompts through OpenCode `prompt_async` instead of holding `POST /message` open for the full agent turn
- poll idempotent message reads for the exact assistant response and wait through multi-message tool turns
- retry transient submit/read failures with a stable OpenCode-compatible user message ID
- confirm ambiguous submit 502s before retrying so a lost 204 cannot duplicate a prompt

## Why
The production proxy closes long-lived synchronous chat requests around 60–70 seconds and returns 502 even though OpenCode continues the turn. `prompt_async` ACKs immediately, so the model/tool duration no longer sits inside one gateway request.

## Verification
- `pnpm --filter @kortix/cli test`
- `pnpm --filter @kortix/cli typecheck`
- `pnpm --filter @kortix/cli build`
- `git diff --check`
- production cloud / Platinum black-box run from the source CLI: intentional 75-second bash tool, final CLI elapsed 84.06s, exit 0, exact reply `CLI_502_FINAL_PASS`
- persisted transcript: exactly 1 matching user prompt and 1 final matching assistant reply (3 messages total including the tool-step assistant)
