### PR TITLE
feat(llm-gateway): models.dev-capability-gated request building (step 2, reuse canonical clamp)

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.ts
@@ -5,8 +5,7 @@ import {
   type CatalogModalities,
   type CatalogModel,
   type CatalogReasoningOption,
-  getManagedModel,
-  pricingRefLookupCandidates,
+  catalogModelForWireModel as catalogModelForWireModelCanonical,
 } from "@kortix/llm-catalog";
 import { resolveCatalogUpstream } from './provider-registry';
 import { codexModelIds } from "./codex-models";
@@ -173,64 +172,19 @@ export function capabilitiesForModel(
 // `@kortix/llm-catalog`'s generation-controls capability functions
 // (`generationControlCapabilities`/`clampGenerationConfig`) need but
 // `capabilitiesForModel` above doesn't carry (it only ever returned the two
-// booleans transports needed). Single source of truth for "what model does
-// this wire id actually resolve to, capability-wise" — used by the
-// generation-controls UI's server-side clamp (routing/resolve-route.ts) so
-// a configured per-model default is never sent to a model that can't honor
-// it, whether it's a BYOK catalog entry, a `codex/<id>`, or a managed slug.
-export function catalogModelForWireModel(
+// booleans transports needed). Used by the generation-controls UI's
+// server-side clamp (routing/resolve-route.ts) so a configured per-model
+// default is never sent to a model that can't honor it, whether it's a BYOK
+// catalog entry, a `codex/<id>`, or a managed slug.
+//
+// The wire-id → CatalogModel resolution itself lives in @kortix/llm-catalog
+// (the single source of truth, reachable by the standalone gateway transport
+// too); this is a thin wrapper that only supplies the LIVE models.dev snapshot
+// as the catalog default, so the host-side clamp sees fresh capabilities.
+export const catalogModelForWireModel = (
   wireModel: string,
   catalog: Catalog = runtimeModelCatalog.snapshot(),
-): CatalogModel | undefined {
-  if (wireModel.startsWith('codex/')) {
-    return modelsById(catalog).get(`openai/${wireModel.slice('codex/'.length)}`);
-  }
-  const slash = wireModel.indexOf('/');
-  if (slash > 0) {
-    const providerId = wireModel.slice(0, slash);
-    const modelId = wireModel.slice(slash + 1);
-    return catalog.providers
-      .find((provider) => provider.id === providerId)
-      ?.models.find((model) => model.id === modelId);
-  }
-  const managed = getManagedModel(wireModel);
-  if (managed) {
-    // Managed slugs are curated and don't always exist on models.dev under
-    // their own id, but `pricingRef` (used for live pricing lookup) usually
-    // IS a real models.dev id — reuse it here so e.g. claude-opus-4.8 gets
-    // Claude's real reasoning_options instead of the generic fallback.
-    // Try dot/dash id variants (see `pricingRefLookupCandidates`) so a
-    // dotted-vs-dashed slip in `pricingRef` degrades gracefully instead of
-    // silently losing real capability data.
-    const catalogById = modelsById(catalog);
-    const byPricingRef = pricingRefLookupCandidates(managed.pricingRef)
-      .map((ref) => catalogById.get(ref))
-      .find((entry): entry is CatalogModel => entry !== undefined);
-    if (byPricingRef) return byPricingRef;
-    // No models.dev entry to borrow from — synthesize a minimal capability
-    // record from what managedModels() below already asserts about every
-    // managed model (reasoning/tool_call/temperature all true).
-    return {
-      id: managed.id,
-      name: managed.name,
-      reasoning: true,
-      tool_call: true,
-      temperature: true,
-      limit: managed.limit,
-    };
-  }
-  if (wireModel === AUTO_MODEL_ID || wireModel === `kortix/${AUTO_MODEL_ID}`) {
-    return {
-      id: AUTO_MODEL_ID,
-      name: 'Auto',
-      reasoning: false,
-      tool_call: true,
-      temperature: true,
-      limit: { context: 1_000_000, output: 128_000 },
-    };
-  }
-  return undefined;
-}
+): CatalogModel | undefined => catalogModelForWireModelCanonical(wireModel, catalog);
 
 export function managedModels(): Record<string, GatewayModel> {
   const out: Record<string, GatewayModel> = {};

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -645,6 +645,79 @@ export function pickAutoModel(
   return target;
 }
 
+function modelsByWireId(catalog: Catalog): Map<string, CatalogModel> {
+  const byId = new Map<string, CatalogModel>();
+  for (const provider of catalog.providers) {
+    for (const model of provider.models) byId.set(`${provider.id}/${model.id}`, model);
+  }
+  return byId;
+}
+
+/**
+ * Resolve a gateway WIRE model id to its full `CatalogModel` — the capability
+ * record `generationControlCapabilities`/`clampGenerationConfig` gate against.
+ * The CANONICAL wire-id → model resolver: it stitches together the three id
+ * shapes a gateway request can carry, so a caller never has to string-split
+ * `<provider>/<model>` or special-case managed slugs itself.
+ *
+ *   - `codex/<id>`      → the genuine OpenAI catalog entry (`openai/<id>`).
+ *   - `<provider>/<id>` → that provider's catalog entry (BYOK models).
+ *   - bare `<id>`       → a managed slug, resolved via its `pricingRef` (the
+ *                         model's real models.dev id) so e.g. `claude-opus-4.8`
+ *                         gets Claude's real `reasoning_options`/`limit` instead
+ *                         of a permissive fallback; a synthesized minimal record
+ *                         (reasoning/tool_call/temperature all true) when the
+ *                         managed slug has no models.dev entry to borrow from.
+ *
+ * `catalog` defaults to the bundled static `CATALOG`. apps/api passes the LIVE
+ * models.dev snapshot instead (its own thin wrapper of the same name) so the
+ * host-side generation-controls clamp sees fresh capabilities; the standalone
+ * gateway transport, which has no runtime snapshot, uses the bundled catalog.
+ */
+export function catalogModelForWireModel(
+  wireModel: string,
+  catalog: Catalog = CATALOG,
+): CatalogModel | undefined {
+  if (wireModel.startsWith('codex/')) {
+    return modelsByWireId(catalog).get(`openai/${wireModel.slice('codex/'.length)}`);
+  }
+  const slash = wireModel.indexOf('/');
+  if (slash > 0) {
+    const providerId = wireModel.slice(0, slash);
+    const modelId = wireModel.slice(slash + 1);
+    return catalog.providers
+      .find((provider) => provider.id === providerId)
+      ?.models.find((model) => model.id === modelId);
+  }
+  const managed = getManagedModel(wireModel);
+  if (managed) {
+    const catalogById = modelsByWireId(catalog);
+    const byPricingRef = pricingRefLookupCandidates(managed.pricingRef)
+      .map((ref) => catalogById.get(ref))
+      .find((entry): entry is CatalogModel => entry !== undefined);
+    if (byPricingRef) return byPricingRef;
+    return {
+      id: managed.id,
+      name: managed.name,
+      reasoning: true,
+      tool_call: true,
+      temperature: true,
+      limit: managed.limit,
+    };
+  }
+  if (wireModel === AUTO_MODEL_ID || wireModel === `kortix/${AUTO_MODEL_ID}`) {
+    return {
+      id: AUTO_MODEL_ID,
+      name: 'Auto',
+      reasoning: false,
+      tool_call: true,
+      temperature: true,
+      limit: { context: 1_000_000, output: 128_000 },
+    };
+  }
+  return undefined;
+}
+
 export const MODEL_SELECTOR_PROVIDER_IDS = [
   'kortix',
   'opencode',

--- a/packages/llm-gateway/package.json
+++ b/packages/llm-gateway/package.json
@@ -17,6 +17,7 @@
     "@ai-sdk/anthropic": "4.0.16",
     "@ai-sdk/openai": "4.0.16",
     "@ai-sdk/openai-compatible": "3.0.12",
+    "@kortix/llm-catalog": "workspace:*",
     "@kortix/shared": "workspace:*",
     "ai": "7.0.31"
   },

--- a/packages/llm-gateway/src/domain/catalog.ts
+++ b/packages/llm-gateway/src/domain/catalog.ts
@@ -1,7 +1,12 @@
 // One entry of models.dev's `reasoning_options` (mirrors
-// `@kortix/llm-catalog`'s `CatalogReasoningOption` — duplicated rather than
-// imported so this package stays dependency-free of `@kortix/llm-catalog`;
-// keep the shape identical). Three real shapes: `effort` (values), `toggle`
+// `@kortix/llm-catalog`'s `CatalogReasoningOption` — kept as a local shape for
+// this domain's descriptor capability flags; keep it identical). This package
+// DOES depend on `@kortix/llm-catalog` now (the ai-sdk transport reuses its
+// canonical `clampGenerationConfig`/`catalogModelForWireModel` to gate
+// per-request generation params — see transports/ai-sdk/request.ts), so this
+// duplication is no longer a dependency-avoidance measure; it just avoids
+// coupling this domain type to the catalog's evolving surface. Three real
+// shapes: `effort` (values), `toggle`
 // (neither), `budget_tokens` (min/max, no values — this is mainline
 // Anthropic's shape). All fields but `type` are optional so every shape
 // round-trips through this type without narrowing.

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test';
+import type { CatalogModel } from '@kortix/llm-catalog';
 import { generateText, jsonSchema, streamText, tool } from 'ai';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import type { UpstreamDescriptor } from '../../domain';
@@ -320,6 +321,86 @@ describe('ai-sdk request conversion', () => {
     );
     expect(openai.maxOutputTokens).toBe(2000);
     expect(openai.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+  });
+});
+
+// buildAiSdkArgs is now models.dev-capability-driven: when the caller passes
+// the resolved CatalogModel (index.ts resolves it via @kortix/llm-catalog's
+// `catalogModelForWireModel`), the four generation params are clamped ONCE in
+// normalizeRequest through the CANONICAL `clampGenerationConfig` — the exact
+// same gate the host runs on route defaults, now also applied to the
+// client-supplied values that path never touched. With NO model the clamp is a
+// deliberate NO-OP (permissive parity), which is why every test above still
+// passes a body with no model and sees pre-gating behavior verbatim.
+describe('ai-sdk per-request capability gating (reuses @kortix/llm-catalog clampGenerationConfig)', () => {
+  // Fixtures use only capability shapes that derive identically in every
+  // catalog version (an explicit `effort` reasoning_options entry, a literal
+  // `temperature` flag, an explicit `limit.output`) — never a bare
+  // `reasoning:true`-with-no-options, whose effort-control synthesis is a
+  // catalog-internal heuristic, not the contract under test here.
+  const effortModel = (over: Partial<CatalogModel> = {}): CatalogModel => ({
+    id: 'test-model',
+    name: 'Test Model',
+    reasoning: true,
+    reasoning_options: [{ type: 'effort', values: ['low', 'medium', 'high'] }],
+    temperature: true,
+    limit: { output: 8000 },
+    ...over,
+  });
+
+  it('(a) drops a client temperature (and top_p) for a temperature:false model, keeps them for a capable one', () => {
+    const fixed = buildAiSdkArgs({ messages: [], temperature: 0.7, top_p: 0.9 }, 'openai', {
+      model: effortModel({ temperature: false }),
+    });
+    expect(fixed.temperature).toBeUndefined();
+    expect(fixed.topP).toBeUndefined();
+
+    const tunable = buildAiSdkArgs({ messages: [], temperature: 0.7, top_p: 0.9 }, 'openai', {
+      model: effortModel({ temperature: true }),
+    });
+    expect(tunable.temperature).toBe(0.7);
+    expect(tunable.topP).toBe(0.9);
+  });
+
+  it('(b) drops a reasoning_effort the model does not publish, keeps a published one, and clamps max_tokens to limit.output', () => {
+    // 'xhigh' is NOT in the model's effort values → dropped, so no reasoningEffort
+    // reaches providerOptions at all (providerOptions ends up empty → undefined).
+    const rejected = buildAiSdkArgs(
+      { messages: [], reasoning_effort: 'xhigh', max_tokens: 100000 },
+      'openai',
+      { model: effortModel() },
+    );
+    expect(rejected.providerOptions).toBeUndefined();
+    // max_tokens clamped down to the model's real output ceiling.
+    expect(rejected.maxOutputTokens).toBe(8000);
+
+    // A published tier survives verbatim.
+    const accepted = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'openai', {
+      model: effortModel(),
+    });
+    expect(accepted.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+  });
+
+  it('(c) a non-reasoning model suppresses thinking/reasoningEffort entirely (anthropic family)', () => {
+    // reasoning:false + no reasoning_options → the effort tier is dropped, so
+    // resolveThinkingRequest never turns extended thinking on and maxOutputTokens
+    // falls back to the plain (non-thinking) 4096 default, not the thinking bump.
+    const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'anthropic', {
+      model: effortModel({ reasoning: false, reasoning_options: undefined }),
+    });
+    expect(args.providerOptions).toBeUndefined();
+    expect(args.maxOutputTokens).toBe(4096);
+  });
+
+  it('(d) parity: with NO model passed, gating is a no-op — output matches the pre-gating result exactly', () => {
+    const body = { messages: [], temperature: 1.5, top_p: 0.2, reasoning_effort: 'xhigh' };
+    const ungated = buildAiSdkArgs({ ...body }, 'openai');
+    // Every capability-relevant field passes through untouched — no model, no gate.
+    expect(ungated.temperature).toBe(1.5);
+    expect(ungated.topP).toBe(0.2);
+    // 'xhigh' would be dropped by a temperature:true/effort-limited model above,
+    // but with no model it survives verbatim — the exact permissive parity contract.
+    expect(ungated.providerOptions).toEqual({ openai: { reasoningEffort: 'xhigh' } });
   });
 });
 

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -1,3 +1,4 @@
+import { CATALOG, catalogModelForWireModel } from '@kortix/llm-catalog';
 import { InvalidPromptError, generateText, streamText } from 'ai';
 import type { UpstreamDescriptor } from '../../domain';
 import { NetworkError, UpstreamHttpError, looksLikeTerminalAuthFailure } from '../../errors';
@@ -238,6 +239,16 @@ export async function callUpstreamViaAiSdk(
     // model.ts passed to createOpenAICompatible for this descriptor — see
     // request.ts's providerOptionsKeyFor / defect 5 comment.
     providerName: descriptor.provider,
+    // The resolved catalog model for the WIRE model id (managed slug, BYOK
+    // `provider/id`, or `codex/id` — `catalogModelForWireModel` stitches all
+    // three), so buildAiSdkArgs can gate reasoning_effort/temperature/top_p/
+    // max_tokens against its real models.dev capabilities (see request.ts's
+    // normalizeRequest). `undefined` for an unknown/unresolvable id → no gating
+    // (permissive parity). Keyed off the client wire id, not descriptor
+    // .resolvedModel (which is the UPSTREAM id — a Bedrock/OpenRouter slug that
+    // wouldn't resolve here). The bundled static CATALOG is authoritative for
+    // capability shape; the transport has no live snapshot.
+    model: catalogModelForWireModel(String(body.model ?? ''), CATALOG),
   });
   const clientWantsStream = body.stream === true;
   const ctx = {

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -1,6 +1,7 @@
 import type { BedrockProviderOptions } from '@ai-sdk/amazon-bedrock';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import type { OpenAIChatLanguageModelOptions } from '@ai-sdk/openai';
+import { type CatalogModel, clampGenerationConfig } from '@kortix/llm-catalog';
 import {
   type JSONValue,
   type ModelMessage,
@@ -643,10 +644,13 @@ function applyAnthropicPromptCaching(
 
 // ---------------------------------------------------------------------------
 // Normalization: the incoming OpenAI chat.completions body, translated ONCE
-// into the family-agnostic shape every adapter below reads from. Sampling
-// params with a direct AI-SDK CallSettings equivalent (temperature/top_p/
-// stop/seed/penalties) have no per-family behaviour at all, so they're read
-// straight off `raw` in the orchestrator instead of being duplicated here.
+// into the family-agnostic shape every adapter below reads from. The four
+// capability-gated generation params (reasoning effort, temperature, top_p,
+// max output tokens) are ALSO clamped here, in one place, against the resolved
+// model's real models.dev capabilities — so adapters and the orchestrator only
+// ever read already-gated values. The remaining CallSettings-equivalent params
+// (stop/seed/penalties) carry no per-model capability, so they stay read
+// straight off `raw` in the orchestrator.
 interface NormalizedRequest {
   // The original parsed body — adapters read family-specific raw fields
   // (`thinking`, `reasoning`, `response_format`, the openai-only extra
@@ -661,25 +665,65 @@ interface NormalizedRequest {
   // the Responses-style nested shape (`reasoning: { effort: string }`) some
   // callers (opencode) send directly, folded with the caller's own default
   // (Codex always sends a reasoning effort — see buildAiSdkArgs's opts doc).
+  // Dropped when a resolved model publishes no matching effort tier (gating).
   reasoningEffort: string | undefined;
+  // Client-supplied sampling params. Dropped when the resolved model rejects a
+  // custom temperature/top_p (models.dev `temperature:false`, e.g. gpt-5.6-sol);
+  // clamped to [0,2]/[0,1] otherwise — read by the orchestrator instead of the
+  // raw body so gating lives in exactly one place.
+  temperature: number | undefined;
+  topP: number | undefined;
   // `max_tokens` / `max_completion_tokens`, whichever is present — always
   // wins over any family default (see each adapter's `defaultMaxTokens`).
+  // Clamped to the model's `limit.output` ceiling when one is known.
   explicitMaxTokens: number | undefined;
 }
 
 function normalizeRequest(
   body: Record<string, unknown>,
-  opts: { defaultReasoningEffort?: string },
+  opts: { defaultReasoningEffort?: string; model?: CatalogModel },
 ): NormalizedRequest {
   const { system, messages } = toModelMessages(body.messages);
   const tools = toToolSet(body.tools);
   const toolChoice = tools ? toToolChoice(body.tool_choice) : undefined;
-  const reasoningEffort = reasoningEffortFromBody(body) ?? opts.defaultReasoningEffort;
-  const explicitMaxTokens =
+
+  // Raw per-request generation params, before capability gating.
+  let reasoningEffort = reasoningEffortFromBody(body) ?? opts.defaultReasoningEffort;
+  let temperature = typeof body.temperature === 'number' ? body.temperature : undefined;
+  let topP = typeof body.top_p === 'number' ? body.top_p : undefined;
+  let explicitMaxTokens =
     (typeof body.max_tokens === 'number' ? body.max_tokens : undefined) ??
     (typeof body.max_completion_tokens === 'number' ? body.max_completion_tokens : undefined);
 
-  return { raw: body, system, messages, tools, toolChoice, reasoningEffort, explicitMaxTokens };
+  // Gate ONCE against the resolved model's real capabilities, REUSING the
+  // canonical clamp from @kortix/llm-catalog — the exact gate the host already
+  // runs on route DEFAULTS (see routing/resolve-route.ts), now applied to the
+  // client-supplied values that path never touched. Only when a model is known:
+  // `clampGenerationConfig` treats an unknown model as "supports nothing" and
+  // would drop every field, so absence is a deliberate NO-OP (permissive —
+  // preserves the pre-gating behavior every existing caller relies on).
+  if (opts.model) {
+    const gated = clampGenerationConfig(
+      { reasoningEffort, temperature, topP, maxOutputTokens: explicitMaxTokens },
+      opts.model,
+    );
+    reasoningEffort = gated.reasoningEffort;
+    temperature = gated.temperature;
+    topP = gated.topP;
+    explicitMaxTokens = gated.maxOutputTokens;
+  }
+
+  return {
+    raw: body,
+    system,
+    messages,
+    tools,
+    toolChoice,
+    reasoningEffort,
+    temperature,
+    topP,
+    explicitMaxTokens,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -851,6 +895,12 @@ export function buildAiSdkArgs(
     // the 'openai-compatible' family (see the ProviderAdapter interface doc
     // comment above). Ignored for every other family.
     providerName?: string;
+    // The resolved catalog model for this wire request (see index.ts, which
+    // resolves it via @kortix/llm-catalog's `catalogModelForWireModel`). When
+    // present, the four capability-gated generation params are clamped against
+    // its real models.dev capabilities in `normalizeRequest`. OPTIONAL: absent
+    // → no gating (permissive parity — every param passes through unchanged).
+    model?: CatalogModel;
   } = {},
 ): AiSdkCallArgs {
   const req = normalizeRequest(body, opts);
@@ -894,8 +944,11 @@ export function buildAiSdkArgs(
     messages: req.messages,
     tools,
     toolChoice: req.toolChoice,
-    temperature: typeof body.temperature === 'number' ? body.temperature : undefined,
-    topP: typeof body.top_p === 'number' ? body.top_p : undefined,
+    // Already capability-gated in normalizeRequest (dropped/clamped per the
+    // resolved model) — read off `req`, never the raw body, so a model that
+    // rejects a custom temperature/top_p never sees one.
+    temperature: req.temperature,
+    topP: req.topP,
     maxOutputTokens: maxTokens,
     stopSequences,
     seed: typeof body.seed === 'number' ? body.seed : undefined,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,6 +1376,9 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: 3.0.12
         version: 3.0.12(zod@3.25.76)
+      '@kortix/llm-catalog':
+        specifier: workspace:*
+        version: link:../llm-catalog
       '@kortix/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
Completes the unified mapping (spec #5077, after the #5085 adapter refactor). Makes `buildAiSdkArgs` **models.dev-driven by REUSE** — no parallel capability system.

## What
- `normalizeRequest` clamps the four capability-gated params (reasoning_effort, temperature, top_p, max_tokens) via the **canonical `clampGenerationConfig`/`generationControlCapabilities`** from `@kortix/llm-catalog` — only when a resolved model is supplied.
- `index.ts` resolves the `CatalogModel` from the wire model id (`catalogModelForWireModel`) and threads it in.

## Parity
Model input is **optional**; gating is behind `if (opts.model)` → the no-model path is a strict no-op. **All 317 existing gateway tests pass byte-identically.** +4 new tests (temperature:false drop; unpublished-effort drop + max_tokens clamp; non-reasoning model suppresses thinking; no-model parity guard).

## Thermonuclear (ran as part of the build)
Review caught that the new resolver duplicated a pre-existing apps/api `catalogModelForWireModel`. Applied: hoisted it into `@kortix/llm-catalog` as the single wire-id→CatalogModel resolver and **collapsed apps/api's copy into a one-line delegator (−~50 lines)** — one source of truth. `request.ts` stays 963 lines (no bloat).

## Verified
321 gateway + 74 catalog tests pass; `tsc` clean (gateway + apps/api). apps/api model tests can only run in CI (worktree module-resolution).