### PR TITLE
feat(iam-web): last-sync indicator for Directory Sync

### DIFF
--- a/apps/api/src/__tests__/unit-bootstrap-group.test.ts
+++ b/apps/api/src/__tests__/unit-bootstrap-group.test.ts
@@ -3,7 +3,7 @@
 // Malformed jsonb must be rejected (null), never fed into account_group_members.
 import { describe, expect, test } from 'bun:test';
 import { validateBootstrapGroup } from '../accounts/invites';
-import { resolveInviteMemberAction, stripGroupGrant } from '../scim/groups';
+import { parseGroupPut, resolveInviteMemberAction, stripGroupGrant } from '../scim/groups';
 
 const UUID = '5888c520-d8f0-489a-a807-d2f8bf007fd1';
 
@@ -35,24 +35,20 @@ describe('validateBootstrapGroup', () => {
 // membership forever. The decision must add live members directly.
 describe('resolveInviteMemberAction', () => {
   test('person already a member (SSO JIT or accepted invite) → add directly', () => {
-    expect(
-      resolveInviteMemberAction({ accepted: false, resolvedMemberUserId: UUID }),
-    ).toBe('add-member');
-    expect(
-      resolveInviteMemberAction({ accepted: true, resolvedMemberUserId: UUID }),
-    ).toBe('add-member');
+    expect(resolveInviteMemberAction({ accepted: false, resolvedMemberUserId: UUID })).toBe(
+      'add-member',
+    );
+    expect(resolveInviteMemberAction({ accepted: true, resolvedMemberUserId: UUID })).toBe(
+      'add-member',
+    );
   });
 
   test('truly pending (no member, not accepted) → park on the invite', () => {
-    expect(resolveInviteMemberAction({ accepted: false, resolvedMemberUserId: null })).toBe(
-      'park',
-    );
+    expect(resolveInviteMemberAction({ accepted: false, resolvedMemberUserId: null })).toBe('park');
   });
 
   test('accepted but membership since removed → skip (not a group PATCH decision)', () => {
-    expect(resolveInviteMemberAction({ accepted: true, resolvedMemberUserId: null })).toBe(
-      'skip',
-    );
+    expect(resolveInviteMemberAction({ accepted: true, resolvedMemberUserId: null })).toBe('skip');
   });
 });
 
@@ -87,5 +83,45 @@ describe('stripGroupGrant', () => {
     expect(stripGroupGrant(null, UUID)).toEqual({ changed: false, remaining: [] });
     expect(stripGroupGrant(undefined, UUID)).toEqual({ changed: false, remaining: [] });
     expect(stripGroupGrant([], UUID)).toEqual({ changed: false, remaining: [] });
+  });
+});
+
+// Group PUT body interpretation — Okta group-push renames arrive as PUT with
+// the full resource. Omitted fields must mean "leave alone" (a partial client
+// must not wipe a group), while a PRESENT members array — even empty — is the
+// IdP's authoritative member list.
+describe('parseGroupPut', () => {
+  test('a rename-only PUT changes the name and leaves members alone', () => {
+    expect(parseGroupPut({ displayName: 'Platform Team' })).toEqual({
+      displayName: 'Platform Team',
+      externalId: null,
+      members: null,
+    });
+  });
+
+  test('a full Okta-style body extracts name + member values', () => {
+    expect(
+      parseGroupPut({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        id: UUID,
+        displayName: 'Engineers',
+        members: [{ value: 'user-1', display: 'A' }, { value: 'user-2' }],
+      }),
+    ).toEqual({ displayName: 'Engineers', externalId: null, members: ['user-1', 'user-2'] });
+  });
+
+  test('an EMPTY members array is authoritative (clears the group), absent is not', () => {
+    expect(parseGroupPut({ displayName: 'X', members: [] }).members).toEqual([]);
+    expect(parseGroupPut({ displayName: 'X' }).members).toBeNull();
+  });
+
+  test('junk member entries and whitespace names are dropped', () => {
+    expect(
+      parseGroupPut({
+        displayName: '   ',
+        externalId: '  ext-9 ',
+        members: [{ value: 42 }, { display: 'no value' }, { value: 'ok' }],
+      }),
+    ).toEqual({ displayName: null, externalId: 'ext-9', members: ['ok'] });
   });
 });

--- a/apps/api/src/scim/groups.ts
+++ b/apps/api/src/scim/groups.ts
@@ -1,5 +1,6 @@
 // SCIM Groups routes: GET (list), GET/:id, POST, PATCH (member add/remove,
-// rename), DELETE. Registers onto the shared scimRouter via side effect.
+// rename), PUT (full-state replace — Okta group-push renames), DELETE.
+// Registers onto the shared scimRouter via side effect.
 
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountInvitations, accountMembers } from '@kortix/db';
@@ -79,10 +80,7 @@ async function addGroupMembersOrDeferInvites(
         .select({ userId: accountMembers.userId })
         .from(accountMembers)
         .where(
-          and(
-            eq(accountMembers.accountId, accountId),
-            eq(accountMembers.userId, resolvedUserId),
-          ),
+          and(eq(accountMembers.accountId, accountId), eq(accountMembers.userId, resolvedUserId)),
         )
         .limit(1);
       resolvedMemberUserId = member?.userId ?? null;
@@ -210,7 +208,10 @@ async function removeGroupMemberValue(
     await db
       .delete(accountGroupMembers)
       .where(
-        and(eq(accountGroupMembers.groupId, groupId), eq(accountGroupMembers.userId, resolvedUserId)),
+        and(
+          eq(accountGroupMembers.groupId, groupId),
+          eq(accountGroupMembers.userId, resolvedUserId),
+        ),
       );
   }
 }
@@ -530,6 +531,150 @@ scimRouter.openapi(
       resourceId: groupId,
       before: { name: group.name },
       after: { operations: operations.length },
+    });
+
+    const [row] = await db
+      .select({
+        groupId: accountGroups.groupId,
+        name: accountGroups.name,
+        externalId: accountGroups.externalId,
+        createdAt: accountGroups.createdAt,
+        updatedAt: accountGroups.updatedAt,
+      })
+      .from(accountGroups)
+      .where(eq(accountGroups.groupId, groupId))
+      .limit(1);
+    return c.json(await buildGroup(accountId, row!));
+  },
+);
+
+/**
+ * Pure: interpret a SCIM Group PUT body as the changes to apply. PUT is
+ * nominally a full-resource replace, but omitted fields are treated as
+ * "leave alone" rather than "clear" — IdPs always send the fields they
+ * manage, and clearing membership because a partial client omitted the key
+ * would wipe a group. A PRESENT members array is authoritative, including
+ * an empty one (that's the IdP saying the group has no members). Mirrors
+ * how users.ts PUT treats the body as a change set. Exported for unit tests.
+ */
+export function parseGroupPut(body: Record<string, unknown>): {
+  displayName: string | null;
+  externalId: string | null;
+  members: string[] | null;
+} {
+  const displayName =
+    typeof body.displayName === 'string' && body.displayName.trim()
+      ? body.displayName.trim()
+      : null;
+  const externalId =
+    typeof body.externalId === 'string' && body.externalId.trim() ? body.externalId.trim() : null;
+  const members = Array.isArray(body.members)
+    ? (body.members as Array<{ value?: unknown }>)
+        .map((m) => (typeof m.value === 'string' ? m.value : null))
+        .filter((v): v is string => !!v)
+    : null;
+  return { displayName, externalId, members };
+}
+
+// PUT — Okta's group push replaces the whole resource via PUT (renames arrive
+// this way). Kortix previously implemented only PATCH, so those calls 404'd —
+// the same gap users.ts closed for Okta's profile pushes. Member values may be
+// user ids OR cached invitation ids; the shared add/remove helpers resolve both.
+scimRouter.openapi(
+  createRoute({
+    method: 'put',
+    path: '/accounts/{accountId}/Groups/{groupId}',
+    tags: ['scim'],
+    summary: 'Replace a SCIM Group (IdP rename / full-state push)',
+    request: {
+      params: z.object({ accountId: z.string(), groupId: z.string() }),
+      body: { content: { 'application/json': { schema: ScimResource } } },
+    },
+    responses: {
+      200: json(ScimResource, 'SCIM Group'),
+      ...errors(400, 401, 403, 404, 409),
+    },
+  }),
+  async (c: any) => {
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+
+    const [group] = await db
+      .select({ groupId: accountGroups.groupId, name: accountGroups.name })
+      .from(accountGroups)
+      .where(and(eq(accountGroups.accountId, accountId), eq(accountGroups.groupId, groupId)))
+      .limit(1);
+    if (!group) return scimError(c, 404, 'Group not found');
+
+    let body: Record<string, unknown>;
+    try {
+      body = await c.req.json();
+    } catch {
+      return scimError(c, 400, 'Body must be JSON');
+    }
+    if (typeof body.displayName === 'string' && body.displayName.trim().length > 128) {
+      return scimError(c, 400, 'displayName too long (max 128 chars)');
+    }
+
+    const changes = parseGroupPut(body);
+
+    // Snapshot the pre-PUT members so removed users' cached roles bust too.
+    const beforeMemberIds = (
+      await db
+        .select({ userId: accountGroupMembers.userId })
+        .from(accountGroupMembers)
+        .where(eq(accountGroupMembers.groupId, groupId))
+    ).map((r) => r.userId);
+
+    if (changes.displayName && changes.displayName !== group.name) {
+      try {
+        await db
+          .update(accountGroups)
+          .set({ name: changes.displayName, updatedAt: new Date() })
+          .where(eq(accountGroups.groupId, groupId));
+      } catch (err: unknown) {
+        // Same unique-name guard as POST — renaming onto an existing group
+        // must 409, not 500.
+        if (err instanceof Error && /unique|duplicate/i.test(err.message)) {
+          return scimError(c, 409, 'A group with this displayName already exists');
+        }
+        throw err;
+      }
+    }
+    if (changes.externalId) {
+      await db
+        .update(accountGroups)
+        .set({ externalId: changes.externalId, updatedAt: new Date() })
+        .where(eq(accountGroups.groupId, groupId));
+    }
+    if (changes.members) {
+      // Full-state member replace — identical semantics to PATCH's Azure-style
+      // replace: drop live rows AND parked invite grants, then re-add so real
+      // members join now and pending invites re-park.
+      await db.delete(accountGroupMembers).where(eq(accountGroupMembers.groupId, groupId));
+      await unparkGroupFromInvites(accountId, groupId);
+      await addGroupMembersOrDeferInvites(accountId, groupId, changes.members);
+    }
+
+    await db
+      .update(accountGroups)
+      .set({ updatedAt: new Date() })
+      .where(eq(accountGroups.groupId, groupId));
+
+    invalidateIamCacheForUsers(beforeMemberIds);
+    await invalidateIamCacheForGroup(groupId);
+
+    await scimAudit(c, {
+      accountId,
+      action: 'scim.group.update',
+      resourceType: 'account_group',
+      resourceId: groupId,
+      before: { name: group.name },
+      after: {
+        via: 'put',
+        name: changes.displayName ?? group.name,
+        members_replaced: changes.members !== null,
+      },
     });
 
     const [row] = await db

--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -46,6 +46,7 @@ import {
   listScimTokens,
   revokeScimToken,
 } from '@/lib/iam-client';
+import { latestScimSyncAt, scimSyncFreshness } from '@/lib/scim-sync';
 
 interface ScimCardProps {
   accountId: string;
@@ -59,7 +60,14 @@ interface ScimCardProps {
  * the wizard's verify-step panel (features/sso-setup/setup-wizard.tsx
  * ProvisionedStatusPanel).
  */
-function ProvisioningHealthPanel({ accountId }: { accountId: string }) {
+function ProvisioningHealthPanel({
+  accountId,
+  lastSyncAt,
+}: {
+  accountId: string;
+  /** Newest last_used_at across active SCIM tokens — when the IdP last called us. */
+  lastSyncAt: string | null;
+}) {
   const membersQuery = useQuery({
     queryKey: ['scim-verify-members', accountId],
     queryFn: () => listAccountMembers(accountId),
@@ -76,6 +84,7 @@ function ProvisioningHealthPanel({ accountId }: { accountId: string }) {
   const scimGroups = (groupsQuery.data ?? []).filter((g) => g.source === 'scim');
   const scimMemberCount = scimGroups.reduce((sum, g) => sum + (g.member_count ?? 0), 0);
   const isLoading = membersQuery.isLoading || groupsQuery.isLoading;
+  const freshness = scimSyncFreshness(lastSyncAt);
 
   return (
     <div className="border-border/60 bg-muted/10 space-y-2 rounded-md border px-3 py-2.5">
@@ -109,6 +118,26 @@ function ProvisioningHealthPanel({ accountId }: { accountId: string }) {
           </span>
         </p>
       )}
+      <p className="flex items-center gap-1.5 text-xs">
+        <span
+          className={cn(
+            'size-1.5 shrink-0 rounded-full',
+            freshness === 'live' && 'bg-kortix-green',
+            freshness === 'recent' && 'bg-kortix-green/60',
+            freshness === 'quiet' && 'bg-muted-foreground/40',
+            freshness === 'never' && 'bg-amber-500',
+          )}
+        />
+        <span className="text-muted-foreground">Last sync activity</span>
+        <span className="text-foreground font-medium">
+          {lastSyncAt ? formatRelative(lastSyncAt) : 'none yet'}
+        </span>
+        <span className="text-muted-foreground">
+          {freshness === 'never'
+            ? '— your IdP hasn’t connected; check provisioning is running there'
+            : '— your IdP pushes on its own schedule (Entra ~every 40 min; most others as changes happen)'}
+        </span>
+      </p>
     </div>
   );
 }
@@ -145,6 +174,9 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
     queryKey: ['scim-tokens', accountId],
     queryFn: () => listScimTokens(accountId),
     staleTime: 30_000,
+    // Poll so "Last sync activity" (last_used_at, stamped by every IdP call)
+    // stays current while the card is open — a sync run shows up live.
+    refetchInterval: 30_000,
   });
   // Same query key SsoCard uses — React Query dedupes this, so checking
   // whether SAML is connected here costs no extra round-trip. Light-touch
@@ -206,7 +238,9 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
 
       <div className="bg-popover rounded-md border">
         <div className="space-y-4 px-4 py-5">
-          {tokens.length > 0 && <ProvisioningHealthPanel accountId={accountId} />}
+          {tokens.length > 0 && (
+            <ProvisioningHealthPanel accountId={accountId} lastSyncAt={latestScimSyncAt(tokens)} />
+          )}
           {/* Endpoint URL */}
           <div className="space-y-1.5">
             <Label className="text-xs">SCIM base URL</Label>

--- a/apps/web/src/features/sso-setup/guides.ts
+++ b/apps/web/src/features/sso-setup/guides.ts
@@ -131,6 +131,11 @@ export interface ProviderConfig {
   metadataSource?: string;
   /** Placeholder for the metadata URL input (only when preferredMetadata is 'url'). */
   metadataUrlPlaceholder?: string;
+  /** SCIM guides: when the IdP pushes changes to Kortix — shown next to the
+   *  "Last sync activity" indicator. We're the SCIM SERVER, so we can't know
+   *  when the next call comes; this states the provider's real cadence
+   *  (Entra: ~40-min scheduled cycle; most others: event-driven pushes). */
+  syncCadenceHint?: string;
 }
 
 export interface ProviderGuide {
@@ -1952,6 +1957,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
       groupClaimName: 'memberOf',
       groupValueHint:
         'Groups pushed via SCIM are created in Kortix under their Entra display names.',
+      syncCadenceHint:
+        'Entra runs its scheduled provisioning cycle roughly every 40 minutes — changes apply on the next cycle, or instantly with "Provision on demand".',
     },
     steps: [
       {
@@ -2102,6 +2109,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
     config: {
       groupClaimName: 'groups',
       groupValueHint: 'Groups pushed via Push Groups are created in Kortix under their Okta names.',
+      syncCadenceHint:
+        'Okta pushes changes as they happen (assignments, profile updates, group pushes) — a quiet period just means nothing changed.',
     },
     steps: [
       {
@@ -2219,6 +2228,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
       groupClaimName: 'groups',
       groupValueHint:
         'Groups pushed from OneLogin Rules are created in Kortix under their OneLogin names.',
+      syncCadenceHint:
+        'OneLogin pushes changes as they happen once provisioning is enabled — a quiet period just means nothing changed (or actions are held in the approval queue).',
     },
     steps: [
       {
@@ -2326,6 +2337,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
       groupClaimName: 'groups',
       groupValueHint:
         'The JumpCloud user groups you bind to the app are created in Kortix under their JumpCloud names.',
+      syncCadenceHint:
+        'JumpCloud pushes changes as they happen (group binds, membership changes) — a quiet period just means nothing changed.',
     },
     steps: [
       {
@@ -2413,6 +2426,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
       groupClaimName: 'groups',
       groupValueHint:
         'The internal PingOne groups you select on the provisioning rule are created in Kortix under their PingOne names.',
+      syncCadenceHint:
+        'PingOne runs an initial full sync when the rule goes Active, then pushes incremental changes as your directory changes.',
     },
     steps: [
       {
@@ -2508,6 +2523,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
     config: {
       groupClaimName: 'groups',
       groupValueHint: 'Pushed groups are created in Kortix under their displayName.',
+      syncCadenceHint:
+        'Cadence depends on your IdP — most push changes as they happen; some run scheduled cycles. Check its provisioning log if nothing arrives.',
     },
     steps: [
       scimConnectStep({

--- a/apps/web/src/features/sso-setup/setup-wizard.tsx
+++ b/apps/web/src/features/sso-setup/setup-wizard.tsx
@@ -50,8 +50,10 @@ import {
   listScimTokens,
 } from '@/lib/iam-client';
 import { type SamlSpUrls, buildSamlSpUrls } from '@/lib/saml-sp';
+import { latestScimSyncAt, scimSyncFreshness } from '@/lib/scim-sync';
 import { buildScimBaseUrl } from '@/lib/scim-url';
 import { cn } from '@/lib/utils';
+import { relativeTime } from '@/lib/utils/date';
 import { listAccountMembers } from '@kortix/sdk/projects-client';
 import {
   type GuideStep,
@@ -1137,7 +1139,14 @@ function SsoTestStatusPanel({
   );
 }
 
-function ProvisionedStatusPanel({ accountId }: { accountId: string }) {
+function ProvisionedStatusPanel({
+  accountId,
+  cadenceHint,
+}: {
+  accountId: string;
+  /** Per-provider "when does the IdP push" copy (guide.config.syncCadenceHint). */
+  cadenceHint?: string;
+}) {
   const membersQuery = useQuery({
     queryKey: ['scim-verify-members', accountId],
     queryFn: () => listAccountMembers(accountId),
@@ -1150,11 +1159,25 @@ function ProvisionedStatusPanel({ accountId }: { accountId: string }) {
     refetchInterval: 8_000,
     staleTime: 4_000,
   });
+  // Same key as the connect step's resume query — this observer just adds
+  // polling so "Last sync activity" ticks while the admin watches the IdP run.
+  const tokensQuery = useQuery({
+    queryKey: ['scim-tokens', accountId],
+    queryFn: () => listScimTokens(accountId),
+    refetchInterval: 8_000,
+    staleTime: 4_000,
+  });
 
   const scimGroups = (groupsQuery.data ?? []).filter((g) => g.source === 'scim');
   const scimMemberCount = scimGroups.reduce((sum, g) => sum + (g.member_count ?? 0), 0);
   const totalMembers = membersQuery.data?.length ?? null;
   const isLoading = membersQuery.isLoading || groupsQuery.isLoading;
+
+  // Kortix is the SCIM server: the freshest signal we own is when the IdP
+  // last made an authenticated SCIM call (stamped on every request, including
+  // no-change reconciliation reads). Active tokens only.
+  const lastSyncAt = latestScimSyncAt(tokensQuery.data ?? []);
+  const freshness = scimSyncFreshness(lastSyncAt);
 
   return (
     <div className="border-border/70 bg-popover space-y-3 rounded-md border p-4">
@@ -1173,11 +1196,32 @@ function ProvisionedStatusPanel({ accountId }: { accountId: string }) {
           onClick={() => {
             membersQuery.refetch();
             groupsQuery.refetch();
+            tokensQuery.refetch();
           }}
         >
           <RefreshCw className={cn('size-3.5', isLoading && 'animate-spin')} />
         </Button>
       </div>
+      <p className="flex items-center gap-1.5 text-xs">
+        <span
+          className={cn(
+            'size-1.5 shrink-0 rounded-full',
+            freshness === 'live' && 'bg-kortix-green',
+            freshness === 'recent' && 'bg-kortix-green/60',
+            freshness === 'quiet' && 'bg-muted-foreground/40',
+            freshness === 'never' && 'bg-amber-500',
+          )}
+        />
+        <span className="text-muted-foreground">Last sync activity</span>
+        <span className="text-foreground font-medium">
+          {lastSyncAt ? relativeTime(lastSyncAt) : 'none yet'}
+        </span>
+        {freshness === 'never' && !tokensQuery.isLoading && (
+          <span className="text-muted-foreground">
+            — your IdP hasn’t connected; check provisioning is running there
+          </span>
+        )}
+      </p>
       {isLoading ? (
         <Skeleton className="h-12 w-full rounded-md" />
       ) : (
@@ -1206,8 +1250,9 @@ function ProvisionedStatusPanel({ accountId }: { accountId: string }) {
         </div>
       )}
       <p className="text-muted-foreground text-xs">
-        Refreshes automatically every few seconds — give Entra's provisioning cycle a minute after
-        you click Start (or use Provision on demand for an instant push).
+        Refreshes automatically every few seconds.{' '}
+        {cadenceHint ??
+          'Your IdP pushes changes on its own schedule — no manual action needed on the Kortix side.'}
       </p>
     </div>
   );
@@ -1352,7 +1397,9 @@ function StepBody({
         />
       ) : step.kind === 'test' ? (
         <div className="space-y-4">
-          {flow === 'scim' && <ProvisionedStatusPanel accountId={accountId} />}
+          {flow === 'scim' && (
+            <ProvisionedStatusPanel accountId={accountId} cadenceHint={config.syncCadenceHint} />
+          )}
           {flow === 'sso' && (
             <SsoTestStatusPanel accountId={accountId} baselineRef={ssoBaselineRef} />
           )}

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -293,6 +293,39 @@ describe('WorkOS-informed guide content, adopted per provider (not copied assets
   });
 });
 
+// "Last sync" indicator — we're the SCIM server, so the honest signal is when
+// the IdP last called us (token last_used_at), paired with the provider's real
+// cadence instead of a made-up "next sync at" prediction.
+describe('SCIM last-sync indicator', () => {
+  test('every SCIM guide states its sync cadence', () => {
+    for (const g of SCIM_PROVIDER_GUIDES) {
+      expect(g.config.syncCadenceHint, `${g.id} missing syncCadenceHint`).toBeTruthy();
+    }
+    // Entra is the one with a real scheduled cycle; the hint must say so.
+    expect(getScimGuide('entra')!.config.syncCadenceHint).toContain('40 minutes');
+    expect(getScimGuide('entra')!.config.syncCadenceHint).toContain('Provision on demand');
+    // Event-driven IdPs must NOT imply a cycle to wait for.
+    expect(getScimGuide('okta')!.config.syncCadenceHint).toContain('as they happen');
+  });
+
+  test('the wizard verify panel shows last sync activity from active-token usage', () => {
+    expect(wizardSource).toContain('latestScimSyncAt');
+    expect(wizardSource).toContain('Last sync activity');
+    // The per-provider cadence replaces the old Entra-hardcoded footer.
+    expect(wizardSource).toContain('cadenceHint={config.syncCadenceHint}');
+    expect(wizardSource).not.toContain("give Entra's provisioning cycle a minute");
+  });
+
+  test('the SCIM card health panel shows last sync activity and polls tokens', () => {
+    expect(scimCardSource).toContain('latestScimSyncAt(tokens)');
+    expect(scimCardSource).toContain('Last sync activity');
+    // The tokens list must poll, or last_used_at goes stale on an open card.
+    expect(scimCardSource).toMatch(
+      /queryFn: \(\) => listScimTokens\(accountId\)[\s\S]{0,200}refetchInterval/,
+    );
+  });
+});
+
 describe('SCIM scope trade-off copy (live confusion: "why only assigned?")', () => {
   test('the Entra configure step explains "sync only assigned" vs "sync all" in plain terms', () => {
     const text = JSON.stringify(getScimGuide('entra')!.steps);

--- a/apps/web/src/lib/scim-sync.test.ts
+++ b/apps/web/src/lib/scim-sync.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+import type { ScimToken } from './iam-client';
+import { latestScimSyncAt, scimSyncFreshness } from './scim-sync';
+
+const token = (over: Partial<ScimToken>): ScimToken => ({
+  token_id: 't1',
+  name: 'Test',
+  public_prefix: 'kortix_scim_AbCd…',
+  status: 'active',
+  created_at: '2026-07-01T00:00:00Z',
+  last_used_at: null,
+  expires_at: null,
+  revoked_at: null,
+  ...over,
+});
+
+describe('latestScimSyncAt', () => {
+  it('returns null with no tokens or no usage', () => {
+    expect(latestScimSyncAt([])).toBeNull();
+    expect(latestScimSyncAt([token({ last_used_at: null })])).toBeNull();
+  });
+
+  it('picks the newest last_used_at across active tokens', () => {
+    const tokens = [
+      token({ token_id: 'a', last_used_at: '2026-07-19T10:00:00Z' }),
+      token({ token_id: 'b', last_used_at: '2026-07-20T09:30:00Z' }),
+      token({ token_id: 'c', last_used_at: '2026-07-18T23:00:00Z' }),
+    ];
+    expect(latestScimSyncAt(tokens)).toBe('2026-07-20T09:30:00Z');
+  });
+
+  it('ignores revoked and expired tokens — a rotated-away token must not fake health', () => {
+    const tokens = [
+      token({ token_id: 'a', status: 'revoked', last_used_at: '2026-07-20T09:30:00Z' }),
+      token({ token_id: 'b', status: 'expired', last_used_at: '2026-07-20T08:00:00Z' }),
+      token({ token_id: 'c', status: 'active', last_used_at: '2026-07-19T10:00:00Z' }),
+    ];
+    expect(latestScimSyncAt(tokens)).toBe('2026-07-19T10:00:00Z');
+    // Only dead tokens → no sync signal at all.
+    expect(latestScimSyncAt(tokens.slice(0, 2))).toBeNull();
+  });
+
+  it('skips unparseable timestamps', () => {
+    expect(latestScimSyncAt([token({ last_used_at: 'not-a-date' })])).toBeNull();
+  });
+});
+
+describe('scimSyncFreshness', () => {
+  const now = new Date('2026-07-20T12:00:00Z').getTime();
+
+  it('never — no usage or unparseable', () => {
+    expect(scimSyncFreshness(null, now)).toBe('never');
+    expect(scimSyncFreshness('not-a-date', now)).toBe('never');
+  });
+
+  it('live under 5 minutes', () => {
+    expect(scimSyncFreshness('2026-07-20T11:56:01Z', now)).toBe('live');
+  });
+
+  it('recent under an hour (covers Entra’s ~40-minute cycle)', () => {
+    expect(scimSyncFreshness('2026-07-20T11:20:00Z', now)).toBe('recent');
+  });
+
+  it('quiet beyond an hour — a fact, not an alarm (event-driven IdPs)', () => {
+    expect(scimSyncFreshness('2026-07-20T09:00:00Z', now)).toBe('quiet');
+    expect(scimSyncFreshness('2026-07-01T00:00:00Z', now)).toBe('quiet');
+  });
+});

--- a/apps/web/src/lib/scim-sync.ts
+++ b/apps/web/src/lib/scim-sync.ts
@@ -1,0 +1,52 @@
+// "Last sync" derivation for Directory Sync surfaces. Kortix is the SCIM
+// SERVER — the IdP calls us — so the honest sync signal we own is "when did
+// the IdP last make an authenticated SCIM request" (the backend stamps
+// last_used_at on every validated call, including no-change reconciliation
+// reads). We can never know when the IdP will call NEXT; the UI pairs this
+// timestamp with a per-provider cadence hint instead of guessing.
+
+import type { ScimToken } from './iam-client';
+
+/**
+ * Newest last_used_at across ACTIVE tokens — the "last sync activity" shown on
+ * the SCIM card and the wizard's verify panel. Revoked/expired tokens are
+ * excluded: their history says nothing about whether the IdP can still reach
+ * us (a rotated-away token's recent use would fake a healthy connection).
+ */
+export function latestScimSyncAt(tokens: ScimToken[]): string | null {
+  let max: string | null = null;
+  for (const t of tokens) {
+    if (t.status !== 'active' || !t.last_used_at) continue;
+    const ts = new Date(t.last_used_at).getTime();
+    if (Number.isNaN(ts)) continue;
+    if (!max || ts > new Date(max).getTime()) max = t.last_used_at;
+  }
+  return max;
+}
+
+/**
+ * Freshness bucket for tinting the indicator. Deliberately conservative:
+ * event-driven IdPs (Okta/OneLogin/JumpCloud) only call when something
+ * CHANGED, so a long quiet period is normal, not an outage — 'quiet' is a
+ * fact to display, never an alarm. Only 'never' (tokens exist but the IdP
+ * has not connected once) suggests a misconfiguration worth flagging.
+ *
+ *  - live:   < 5 min — a sync cycle is happening or just finished
+ *  - recent: < 60 min — within Entra's ~40-minute scheduled cycle + slack
+ *  - quiet:  older — expected for event-driven IdPs with no changes
+ *  - never:  no active token has ever been used
+ */
+export type ScimSyncFreshness = 'live' | 'recent' | 'quiet' | 'never';
+
+export function scimSyncFreshness(
+  lastSyncAt: string | null,
+  now: number = Date.now(),
+): ScimSyncFreshness {
+  if (!lastSyncAt) return 'never';
+  const ts = new Date(lastSyncAt).getTime();
+  if (Number.isNaN(ts)) return 'never';
+  const age = now - ts;
+  if (age < 5 * 60_000) return 'live';
+  if (age < 60 * 60_000) return 'recent';
+  return 'quiet';
+}

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 494,
+  "count": 495,
   "routes": [
     {
       "method": "GET",
@@ -68,6 +68,10 @@
     },
     {
       "method": "PATCH",
+      "path": "/scim/v2/accounts/:accountId/Groups/:groupId"
+    },
+    {
+      "method": "PUT",
       "path": "/scim/v2/accounts/:accountId/Groups/:groupId"
     },
     {

--- a/tests/src/flows/scim.flow.ts
+++ b/tests/src/flows/scim.flow.ts
@@ -230,6 +230,7 @@ flow(
       'POST /scim/v2/accounts/:accountId/Groups',
       'GET /scim/v2/accounts/:accountId/Groups/:groupId',
       'PATCH /scim/v2/accounts/:accountId/Groups/:groupId',
+      'PUT /scim/v2/accounts/:accountId/Groups/:groupId',
       'DELETE /scim/v2/accounts/:accountId/Groups/:groupId',
     ],
   },
@@ -286,11 +287,37 @@ flow(
       r.status(200).body().has('$.displayName', next);
     });
 
+    await ctx.step('PUT full-resource rename (Okta group push) → 200', async () => {
+      // Okta renames pushed groups via PUT with the FULL resource. No members
+      // key here → membership must be left alone (only a present array is
+      // authoritative).
+      const next = ctx.fixtures.name('scim-group-put');
+      const r = await scim.put(
+        '/scim/v2/accounts/:accountId/Groups/:groupId',
+        {
+          schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+          id: groupId,
+          displayName: next,
+        },
+        { params: { accountId: team.id, groupId } },
+      );
+      r.status(200).body().has('$.displayName', next).has('$.id', groupId);
+    });
+
     await ctx.step('GET unknown Group → 404 SCIM error', async () => {
       const r = await scim.get('/scim/v2/accounts/:accountId/Groups/:groupId', {
         params: { accountId: team.id, groupId: '00000000-0000-4000-8000-000000000000' },
       });
       r.status(404).body().exists('$.detail');
+    });
+
+    await ctx.step('PUT unknown Group → 404', async () => {
+      const r = await scim.put(
+        '/scim/v2/accounts/:accountId/Groups/:groupId',
+        { displayName: 'x' },
+        { params: { accountId: team.id, groupId: '00000000-0000-4000-8000-000000000000' } },
+      );
+      r.status(404);
     });
 
     await ctx.step('PATCH unknown Group → 404', async () => {
@@ -411,31 +438,37 @@ flow(
     });
 
     let userId = '';
-    await ctx.step('POST Users for an unknown email → 201 invite (create the real user to PUT)', async () => {
-      const userName = `${ctx.fixtures.name('scim-put-user')}@ke2e.kortix.test`;
-      const r = await scim.post(
-        '/scim/v2/accounts/:accountId/Users',
-        { userName, externalId: 'ext-ke2e-put-1' },
-        { params: { accountId: team.id } },
-      );
-      r.status(201).body().has('$.active', true);
-      userId = r.json<any>().id;
-    });
+    await ctx.step(
+      'POST Users for an unknown email → 201 invite (create the real user to PUT)',
+      async () => {
+        const userName = `${ctx.fixtures.name('scim-put-user')}@ke2e.kortix.test`;
+        const r = await scim.post(
+          '/scim/v2/accounts/:accountId/Users',
+          { userName, externalId: 'ext-ke2e-put-1' },
+          { params: { accountId: team.id } },
+        );
+        r.status(201).body().has('$.active', true);
+        userId = r.json<any>().id;
+      },
+    );
 
-    await ctx.step('PUT full-replace with active:false → 200, actually deactivates (not idempotent 204 on an unknown id)', async () => {
-      const r = await scim.put(
-        '/scim/v2/accounts/:accountId/Users/:userId',
-        {
-          schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
-          userName: 'ke2e-put-replaced@ke2e.kortix.test',
-          active: false,
-        },
-        { params: { accountId: team.id, userId } },
-      );
-      // The pending invite is revoked by this PUT — 200 + active:false confirms
-      // the write landed (distinct from SCIM-2's PUT-on-unknown-id → 204 case).
-      r.status(200).body().has('$.active', false);
-    });
+    await ctx.step(
+      'PUT full-replace with active:false → 200, actually deactivates (not idempotent 204 on an unknown id)',
+      async () => {
+        const r = await scim.put(
+          '/scim/v2/accounts/:accountId/Users/:userId',
+          {
+            schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            userName: 'ke2e-put-replaced@ke2e.kortix.test',
+            active: false,
+          },
+          { params: { accountId: team.id, userId } },
+        );
+        // The pending invite is revoked by this PUT — 200 + active:false confirms
+        // the write landed (distinct from SCIM-2's PUT-on-unknown-id → 204 case).
+        r.status(200).body().has('$.active', false);
+      },
+    );
 
     await ctx.step('DELETE the now-revoked invite → idempotent 204 (cleanup)', async () => {
       const r = await scim.del('/scim/v2/accounts/:accountId/Users/:userId', {


### PR DESCRIPTION
Adds a **Last sync activity** indicator to the Directory Sync surfaces — the SCIM card's Provisioning health panel and the setup wizard's verify panel.

Kortix is the SCIM *server*, so the honest signal we own is when the IdP last made an authenticated SCIM call — the backend already stamps `last_used_at` on every validated request (including no-change reconciliation reads); this surfaces it, computed across **active** tokens only, polling live.

Since the *next* sync time isn't knowable from the SP side, the indicator pairs the timestamp with each provider's real cadence (new `syncCadenceHint` per SCIM guide): Entra's ~40-min scheduled cycle, event-driven pushes for Okta/OneLogin/JumpCloud, PingOne's full-then-incremental. This also replaces the wizard footer that hardcoded Entra copy for every provider. Freshness tint: green <5m / <1h, neutral when quiet (normal for event-driven IdPs), amber only when a token exists but the IdP has never connected.

**Also: `PUT /scim/v2/accounts/:accountId/Groups/:groupId`** — Okta pushes group renames as full-resource PUT; only PATCH existed, so those calls 404'd (the exact gap previously closed for Users PUT). Omitted fields are left alone; a present `members` array (even empty) is authoritative. Route manifest regenerated (+1 route), SCIM-3 flow covers PUT rename + unknown→404.

Tests: pure helpers (`scim-sync.test.ts`, `parseGroupPut`) + structural pins; web 79 pass, api 25 pass, coverage gate green, tsc/lint clean.
