### PR TITLE
feat(iam-web): status-first Identity tab (progressive disclosure)

### DIFF
--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -35,6 +35,7 @@ import { MfaRequiredCard } from '@/components/iam/mfa-required-card';
 import { PatPolicyCard } from '@/components/iam/pat-policy-card';
 import { PermissionsHelpPopover } from '@/components/iam/permissions-help-popover';
 import { RolesTab } from '@/components/iam/roles-tab';
+import { IdentityIntro } from '@/components/iam/identity-intro';
 import { ScimCard } from '@/components/iam/scim-card';
 import { ServiceAccountsCard } from '@/components/iam/service-accounts-card';
 import { SessionControlsCard } from '@/components/iam/session-controls-card';
@@ -618,18 +619,9 @@ export default function AccountSettingsPage() {
                   <Skeleton className="h-40 w-full rounded-md" />
                 ) : enterpriseIdentityEnabled ? (
                   <>
-                    <div className="border-border/60 bg-muted/20 space-y-1.5 rounded-md border px-4 py-3">
-                      <p className="text-foreground text-xs font-medium">Why connect both?</p>
-                      <p className="text-muted-foreground text-xs leading-relaxed">
-                        <span className="text-foreground font-medium">SAML SSO</span> is how people
-                        sign in — with your identity provider's own credentials and MFA, never a
-                        Kortix password.{' '}
-                        <span className="text-foreground font-medium">SCIM directory sync</span> is
-                        who exists — it keeps your Kortix roster matched to your IdP and
-                        automatically removes access the moment someone leaves. Most enterprises
-                        want both; set up SSO first, then Directory Sync.
-                      </p>
-                    </div>
+                    {/* Onboarding copy only — self-hides once either surface
+                        is configured (see IdentityIntro). */}
+                    <IdentityIntro accountId={account.account_id} />
                     <SsoCard accountId={account.account_id} canManage={canWriteAccount} />
                     <ScimCard accountId={account.account_id} canManage={canWriteAccount} />
                   </>

--- a/apps/web/src/components/iam/identity-intro.tsx
+++ b/apps/web/src/components/iam/identity-intro.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getSsoProvider, listScimTokens } from '@/lib/iam-client';
+
+/**
+ * "Why connect both?" onboarding explainer for the Identity tab. Educational
+ * copy is for FIRST contact — once either SSO or Directory Sync is set up the
+ * admin knows what these are, and the block is just noise above the fold, so
+ * it renders only while BOTH are unconfigured. Uses the same query keys as
+ * SsoCard/ScimCard (React Query dedupes → no extra round-trips).
+ */
+export function IdentityIntro({ accountId }: { accountId: string }) {
+  const providerQuery = useQuery({
+    queryKey: ['iam-sso-provider', accountId],
+    queryFn: () => getSsoProvider(accountId),
+    staleTime: 30_000,
+  });
+  const tokensQuery = useQuery({
+    queryKey: ['scim-tokens', accountId],
+    queryFn: () => listScimTokens(accountId),
+    staleTime: 30_000,
+  });
+
+  // While loading, render nothing — a flash-in/flash-out explainer is worse
+  // than none. Configured accounts (either surface) skip it entirely.
+  if (providerQuery.isLoading || tokensQuery.isLoading) return null;
+  if (providerQuery.data || (tokensQuery.data ?? []).length > 0) return null;
+
+  return (
+    <div className="border-border/60 bg-muted/20 space-y-1.5 rounded-md border px-4 py-3">
+      <p className="text-foreground text-xs font-medium">Why connect both?</p>
+      <p className="text-muted-foreground text-xs leading-relaxed">
+        <span className="text-foreground font-medium">SAML SSO</span> is how people sign in — with
+        your identity provider's own credentials and MFA, never a Kortix password.{' '}
+        <span className="text-foreground font-medium">SCIM directory sync</span> is who exists — it
+        keeps your Kortix roster matched to your IdP and automatically removes access the moment
+        someone leaves. Most enterprises want both; set up SSO first, then Directory Sync.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -251,8 +251,8 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
               ))}
           </p>
           <p className="text-muted-foreground text-xs">
-            Connect Okta, Azure AD, or any SCIM 2.0 provider to sync users and groups into this
-            account.
+            Sync users and groups from Microsoft Entra, Okta, OneLogin, JumpCloud, PingOne, or any
+            SCIM 2.0 provider.
           </p>
         </div>
         {canManage && (
@@ -289,10 +289,12 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
           )}
         </div>
 
-        {/* Setup-time reference, collapsed: the guided setup hands these over
-            inline; this is the re-copy escape hatch, not the main path. */}
+        {/* Setup-time reference: collapsed once things work — but OPEN while a
+            minted token is still waiting for its first IdP call, because that
+            is exactly when the admin is pasting these values into the IdP. It
+            tucks itself away automatically on the first successful sync. */}
         <div className="border-border border-t">
-          <Disclosure className="group">
+          <Disclosure className="group" open={tokens.length > 0 && freshness === 'never'}>
             <DisclosureTrigger>
               <div className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3">
                 <div className="min-w-0 flex-1">

--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -15,9 +15,21 @@ import { cn } from '@/lib/utils';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { listAccountMembers } from '@kortix/sdk/projects-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, Copy, KeyRound, Plus, RefreshCw, ShieldCheck, Trash2, Users } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  Copy,
+  KeyRound,
+  Plus,
+  RefreshCw,
+  ShieldCheck,
+  Trash2,
+  Users,
+} from 'lucide-react';
 import Link from 'next/link';
 import { type FormEvent, useState } from 'react';
+
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -210,11 +222,34 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
   );
   const scimBaseIsAbsolute = isAbsoluteHttpUrl(scimBaseUrl);
 
+  // Header status chip — the card leads with STATE, not reference data. Same
+  // freshness semantics as the health panel: amber only for the one genuinely
+  // wrong state (token minted but the IdP has never called).
+  const lastSyncAt = latestScimSyncAt(tokens);
+  const freshness = scimSyncFreshness(lastSyncAt);
+  const activeTokenCount = tokens.filter((t) => t.status === 'active').length;
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-4">
         <div className="space-y-0.5">
-          <p className="text-foreground text-sm font-medium">SCIM provisioning</p>
+          <p className="text-foreground flex items-center gap-2 text-sm font-medium">
+            Directory Sync
+            {tokens.length > 0 &&
+              (freshness === 'never' ? (
+                <Badge variant="warning" size="sm">
+                  waiting for IdP
+                </Badge>
+              ) : freshness === 'quiet' ? (
+                <Badge variant="outline" size="sm">
+                  connected
+                </Badge>
+              ) : (
+                <Badge variant="success" size="sm">
+                  active
+                </Badge>
+              ))}
+          </p>
           <p className="text-muted-foreground text-xs">
             Connect Okta, Azure AD, or any SCIM 2.0 provider to sync users and groups into this
             account.
@@ -237,140 +272,187 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
       )}
 
       <div className="bg-popover rounded-md border">
-        <div className="space-y-4 px-4 py-5">
-          {tokens.length > 0 && (
-            <ProvisioningHealthPanel accountId={accountId} lastSyncAt={latestScimSyncAt(tokens)} />
+        {/* State first: the live health line is the card's headline content —
+            reference values live in the collapsed sections below. */}
+        <div className="px-4 py-4">
+          {tokensQuery.isLoading ? (
+            <Skeleton className="h-12 w-full rounded-md" />
+          ) : tokens.length > 0 ? (
+            <ProvisioningHealthPanel accountId={accountId} lastSyncAt={lastSyncAt} />
+          ) : (
+            <EmptyState
+              icon={KeyRound}
+              size="sm"
+              title="Not connected yet"
+              description="Run the guided setup — it mints the bearer token and walks your IdP's provisioning config step by step."
+            />
           )}
-          {/* Endpoint URL */}
-          <div className="space-y-1.5">
-            <Label className="text-xs">SCIM base URL</Label>
-            <div className="flex items-center gap-2">
-              <code className="bg-muted/30 min-w-0 flex-1 truncate rounded-md border px-3 py-2 font-mono text-xs">
-                {scimBaseUrl}
-              </code>
-              <Button
-                variant="outline"
-                size="icon"
-                aria-label="Copy SCIM base URL"
-                onClick={() => copyValue(scimBaseUrl, 'SCIM URL copied')}
-              >
-                <Copy className="size-3.5 shrink-0" />
-              </Button>
-            </div>
-            <p className="text-muted-foreground text-xs">
-              {scimBaseIsAbsolute ? (
-                <>
-                  Your IdP appends <code>/Users</code> and <code>/Groups</code>.
-                </>
-              ) : (
-                <>
-                  Prepend your API origin (e.g. <code>https://api.kortix.com</code>). The IdP
-                  appends <code>/Users</code> and <code>/Groups</code>.
-                </>
-              )}
-            </p>
-          </div>
+        </div>
 
-          {/* IdP setup hint — what to fill in on the Okta / Azure side, so admins
-              don't have to guess the identifier + auth from docs. */}
-          <div className="bg-muted/20 text-muted-foreground space-y-1.5 rounded-md border px-3 py-2.5 text-xs">
-            <p className="text-foreground text-xs font-medium">Configure your IdP with</p>
-            <div className="flex gap-2">
-              <span className="w-24 shrink-0">Identifier</span>
-              <span className="text-foreground">
-                <code className="bg-muted/60 rounded px-1 py-0.5 font-mono">userName</code> — the
-                user's email
-              </span>
-            </div>
-            <div className="flex gap-2">
-              <span className="w-24 shrink-0">Auth</span>
-              <span className="text-foreground">Bearer token — Okta HTTP Header mode</span>
-            </div>
-            <div className="flex gap-2">
-              <span className="w-24 shrink-0">Actions</span>
-              <span className="text-foreground">
-                Push users &amp; groups; deactivation deprovisions
-              </span>
-            </div>
-          </div>
+        {/* Setup-time reference, collapsed: the guided setup hands these over
+            inline; this is the re-copy escape hatch, not the main path. */}
+        <div className="border-border border-t">
+          <Disclosure className="group">
+            <DisclosureTrigger>
+              <div className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="text-foreground text-sm font-medium">Setup values</p>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    The SCIM base URL and what to enter on the IdP side.
+                  </p>
+                </div>
+                <ChevronDown className="text-muted-foreground size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+              </div>
+            </DisclosureTrigger>
+            <DisclosureContent contentClassName="border-border border-t">
+              <div className="space-y-4 px-4 py-4">
+                {/* Endpoint URL */}
+                <div className="space-y-1.5">
+                  <Label className="text-xs">SCIM base URL</Label>
+                  <div className="flex items-center gap-2">
+                    <code className="bg-muted/30 min-w-0 flex-1 truncate rounded-md border px-3 py-2 font-mono text-xs">
+                      {scimBaseUrl}
+                    </code>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      aria-label="Copy SCIM base URL"
+                      onClick={() => copyValue(scimBaseUrl, 'SCIM URL copied')}
+                    >
+                      <Copy className="size-3.5 shrink-0" />
+                    </Button>
+                  </div>
+                  <p className="text-muted-foreground text-xs">
+                    {scimBaseIsAbsolute ? (
+                      <>
+                        Your IdP appends <code>/Users</code> and <code>/Groups</code>.
+                      </>
+                    ) : (
+                      <>
+                        Prepend your API origin (e.g. <code>https://api.kortix.com</code>). The IdP
+                        appends <code>/Users</code> and <code>/Groups</code>.
+                      </>
+                    )}
+                  </p>
+                </div>
+
+                {/* IdP setup hint — what to fill in on the Okta / Azure side, so admins
+                    don't have to guess the identifier + auth from docs. */}
+                <div className="bg-muted/20 text-muted-foreground space-y-1.5 rounded-md border px-3 py-2.5 text-xs">
+                  <p className="text-foreground text-xs font-medium">Configure your IdP with</p>
+                  <div className="flex gap-2">
+                    <span className="w-24 shrink-0">Identifier</span>
+                    <span className="text-foreground">
+                      <code className="bg-muted/60 rounded px-1 py-0.5 font-mono">userName</code> —
+                      the user's email
+                    </span>
+                  </div>
+                  <div className="flex gap-2">
+                    <span className="w-24 shrink-0">Auth</span>
+                    <span className="text-foreground">Bearer token — Okta HTTP Header mode</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <span className="w-24 shrink-0">Actions</span>
+                    <span className="text-foreground">
+                      Push users &amp; groups; deactivation deprovisions
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </DisclosureContent>
+          </Disclosure>
         </div>
 
         <div className="border-border border-t">
-          <div className="flex items-center justify-between gap-3 px-4 py-3">
-            <div>
-              <p className="text-foreground text-sm font-medium">Bearer tokens</p>
-              <p className="text-muted-foreground text-xs">
-                Each token authenticates a single IdP integration. Rotate by minting a new one and
-                revoking the old.
-              </p>
-            </div>
-            {canManage && (
-              <Button
-                onClick={() => setCreateOpen(true)}
-                size="sm"
-                variant="secondary"
-                className="shrink-0 gap-1.5"
-              >
-                <Plus className="size-4 shrink-0" />
-                New SCIM token
-              </Button>
-            )}
-          </div>
-
-          <div className="border-border border-t">
-            {tokensQuery.isLoading && (
-              <div className="space-y-2 px-4 py-4">
-                <Skeleton className="h-12 rounded-md" />
-                <Skeleton className="h-12 rounded-md" />
-              </div>
-            )}
-
-            {!tokensQuery.isLoading && tokens.length === 0 && (
-              <div className="px-4 py-4">
-                <EmptyState
-                  icon={KeyRound}
-                  size="sm"
-                  title="No SCIM tokens yet"
-                  description="Create one to connect your IdP."
-                />
-              </div>
-            )}
-
-            {!tokensQuery.isLoading && tokens.length > 0 && (
-              <div className="divide-border divide-y">
-                {tokens.map((t) => (
-                  <div key={t.token_id} className="flex items-center gap-3 px-4 py-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate text-sm font-medium">{t.name}</span>
-                        <Badge variant={t.status === 'active' ? 'success' : 'muted'} size="sm">
-                          {t.status}
-                        </Badge>
-                      </div>
-                      <div className="text-muted-foreground mt-0.5 flex items-center gap-3 text-xs">
-                        <code className="font-mono">{t.public_prefix}</code>
-                        <span>·</span>
-                        <span>Last used {formatRelative(t.last_used_at)}</span>
-                        <span>·</span>
-                        <span>Created {formatRelative(t.created_at)}</span>
-                      </div>
-                    </div>
-                    {canManage && t.status === 'active' && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        aria-label={`Revoke ${t.name}`}
-                        onClick={() => setRevokeTarget(t)}
-                        className="text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 className="size-3.5 shrink-0" />
-                      </Button>
+          <Disclosure className="group">
+            <DisclosureTrigger>
+              <div className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="text-foreground flex items-center gap-2 text-sm font-medium">
+                    Bearer tokens
+                    {activeTokenCount > 0 && (
+                      <Badge variant="muted" size="sm">
+                        {activeTokenCount} active
+                      </Badge>
                     )}
-                  </div>
-                ))}
+                  </p>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    Each token authenticates a single IdP integration — rotate by minting a new one
+                    and revoking the old.
+                  </p>
+                </div>
+                <ChevronDown className="text-muted-foreground size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
               </div>
-            )}
-          </div>
+            </DisclosureTrigger>
+            <DisclosureContent contentClassName="border-border border-t">
+              {canManage && (
+                <div className="flex justify-end px-4 pt-3">
+                  <Button
+                    onClick={() => setCreateOpen(true)}
+                    size="sm"
+                    variant="secondary"
+                    className="shrink-0 gap-1.5"
+                  >
+                    <Plus className="size-4 shrink-0" />
+                    New SCIM token
+                  </Button>
+                </div>
+              )}
+
+              {tokensQuery.isLoading && (
+                <div className="space-y-2 px-4 py-4">
+                  <Skeleton className="h-12 rounded-md" />
+                  <Skeleton className="h-12 rounded-md" />
+                </div>
+              )}
+
+              {!tokensQuery.isLoading && tokens.length === 0 && (
+                <div className="px-4 py-4">
+                  <EmptyState
+                    icon={KeyRound}
+                    size="sm"
+                    title="No SCIM tokens yet"
+                    description="Create one to connect your IdP."
+                  />
+                </div>
+              )}
+
+              {!tokensQuery.isLoading && tokens.length > 0 && (
+                <div className="divide-border divide-y">
+                  {tokens.map((t) => (
+                    <div key={t.token_id} className="flex items-center gap-3 px-4 py-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate text-sm font-medium">{t.name}</span>
+                          <Badge variant={t.status === 'active' ? 'success' : 'muted'} size="sm">
+                            {t.status}
+                          </Badge>
+                        </div>
+                        <div className="text-muted-foreground mt-0.5 flex items-center gap-3 text-xs">
+                          <code className="font-mono">{t.public_prefix}</code>
+                          <span>·</span>
+                          <span>Last used {formatRelative(t.last_used_at)}</span>
+                          <span>·</span>
+                          <span>Created {formatRelative(t.created_at)}</span>
+                        </div>
+                      </div>
+                      {canManage && t.status === 'active' && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Revoke ${t.name}`}
+                          onClick={() => setRevokeTarget(t)}
+                          className="text-muted-foreground hover:text-destructive"
+                        >
+                          <Trash2 className="size-3.5 shrink-0" />
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </DisclosureContent>
+          </Disclosure>
         </div>
       </div>
 

--- a/apps/web/src/components/iam/sso-card.test.ts
+++ b/apps/web/src/components/iam/sso-card.test.ts
@@ -60,15 +60,17 @@ describe('SSO card — service provider details block', () => {
     expect(source).toContain('copyToClipboard');
   });
 
-  test('renders the block before a provider is configured, and inside the configure/edit dialog', () => {
-    expect(source).toMatch(/\{!provider && spUrls && \([\s\S]*?<SpDetails/);
+  test('renders the values in a collapsed disclosure (both states) and inside the edit dialog', () => {
+    // The card no longer leads with the URL block — the values live in the
+    // "Service provider values" disclosure, available connected or not.
+    expect(source).toMatch(/\{spUrls && \([\s\S]*?Service provider values[\s\S]*?<SpDetails/);
     expect(source).toMatch(/\{spUrls && (?:\(\s*)?<SpDetails/);
   });
 
   test('hides the block rather than render a broken URL when the origin is unavailable', () => {
     // Null-origin handling is unit-tested in lib/saml-sp.test.ts; the card
     // just guards the render on the derived value.
-    expect(source).toMatch(/\{!provider && spUrls && \([\s\S]*?<SpDetails/);
+    expect(source).toMatch(/\{spUrls && \([\s\S]*?<SpDetails/);
   });
 });
 

--- a/apps/web/src/components/iam/sso-card.tsx
+++ b/apps/web/src/components/iam/sso-card.tsx
@@ -10,13 +10,14 @@ import { getEnv } from '@/lib/env-config';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowRight, Check, Copy, Plus, Trash2, X } from 'lucide-react';
+import { ArrowRight, Check, ChevronDown, Copy, Plus, Trash2, X } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
@@ -69,14 +70,28 @@ async function copyValue(value: string, successMsg = 'Copied to clipboard') {
  * dialog. Deliberately does not mention the delegated identity provider by
  * name — see sso-card.test.ts.
  */
-function SpDetails({ urls, className }: { urls: SamlSpUrls; className?: string }) {
+function SpDetails({
+  urls,
+  className,
+  // The card's collapsed "Service provider values" section already titles this
+  // block — heading off there; the edit dialog still wants it.
+  heading = true,
+}: {
+  urls: SamlSpUrls;
+  className?: string;
+  heading?: boolean;
+}) {
   return (
     <div className={className}>
-      <h3 className="text-foreground text-sm font-medium">Service provider details</h3>
-      <p className="text-muted-foreground mt-0.5 text-xs">
-        Paste these into your identity provider's SAML configuration.
-      </p>
-      <div className="mt-3 space-y-3">
+      {heading && (
+        <>
+          <h3 className="text-foreground text-sm font-medium">Service provider details</h3>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            Paste these into your identity provider's SAML configuration.
+          </p>
+        </>
+      )}
+      <div className={heading ? 'mt-3 space-y-3' : 'space-y-3'}>
         <div className="space-y-1.5">
           <Label className="text-xs">Identifier (Entity ID)</Label>
           <div className="flex items-center gap-2">
@@ -227,9 +242,21 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
       </div>
 
       <div className="bg-popover rounded-md border">
-        {!provider && spUrls && (
+        {/* Not connected → a calm call-to-action, not a wall of URLs. The
+            guided wizard hands over the SP values at the step that needs
+            them; the collapsed section below is the re-copy escape hatch. */}
+        {!provider && providerQuery.isLoading && (
           <div className="px-4 py-5">
-            <SpDetails urls={spUrls} />
+            <Skeleton className="h-12 w-full rounded-md" />
+          </div>
+        )}
+        {!provider && !providerQuery.isLoading && (
+          <div className="px-4 py-5">
+            <p className="text-foreground text-sm font-medium">Not connected yet</p>
+            <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
+              Route your domain's sign-ins through your identity provider — Configure walks Entra,
+              Okta, Google and more step by step, including everything your IdP asks for.
+            </p>
           </div>
         )}
 
@@ -294,12 +321,9 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
           <div className="border-border border-t px-4 py-4">
             <div className="flex items-center justify-between gap-4">
               <div className="min-w-0 space-y-0.5">
-                <p className="text-foreground text-sm font-medium">
-                  Enforce SSO for this domain
-                </p>
+                <p className="text-foreground text-sm font-medium">Enforce SSO for this domain</p>
                 <p className="text-muted-foreground text-xs">
-                  Members must sign in with your identity provider — the password option
-                  disappears.
+                  Members must sign in with your identity provider — the password option disappears.
                 </p>
               </div>
               {canManage && (
@@ -376,6 +400,31 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
                 </div>
               )}
             </div>
+          </div>
+        )}
+
+        {/* Reference values, collapsed in BOTH states — needed only while
+            configuring the IdP side, so they stay out of the way otherwise. */}
+        {spUrls && (
+          <div className="border-border border-t">
+            <Disclosure className="group">
+              <DisclosureTrigger>
+                <div className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-foreground text-sm font-medium">Service provider values</p>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      The Entity ID and ACS URL your IdP's SAML config asks for.
+                    </p>
+                  </div>
+                  <ChevronDown className="text-muted-foreground size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+                </div>
+              </DisclosureTrigger>
+              <DisclosureContent contentClassName="border-border border-t">
+                <div className="px-4 py-4">
+                  <SpDetails urls={spUrls} heading={false} />
+                </div>
+              </DisclosureContent>
+            </Disclosure>
           </div>
         )}
 
@@ -474,7 +523,9 @@ function EditProviderDialog({
   const [autoCreate, setAutoCreate] = useState(existing?.auto_create_members ?? true);
   // New connections default auto-provision ON (groups appear without
   // hand-mapping); an existing provider keeps whatever the admin chose.
-  const [autoProvision, setAutoProvision] = useState(existing ? existing.auto_provision_groups : true);
+  const [autoProvision, setAutoProvision] = useState(
+    existing ? existing.auto_provision_groups : true,
+  );
   // New providers register by importing the IdP metadata (XML or URL) — the
   // backend handles the identity-provider registration; no internals surface in
   // the UI. Edits reuse the stored provider id under the hood.
@@ -550,7 +601,9 @@ function EditProviderDialog({
         </ModalHeader>
 
         <ModalBody className="max-h-[60vh] space-y-4 overflow-y-auto">
-          {spUrls && <SpDetails urls={spUrls} className="bg-muted/20 rounded-md border px-3 py-3" />}
+          {spUrls && (
+            <SpDetails urls={spUrls} className="bg-muted/20 rounded-md border px-3 py-3" />
+          )}
 
           <div className="space-y-1.5">
             <Label>Display name</Label>
@@ -625,14 +678,14 @@ function EditProviderDialog({
               variant="popover"
             />
             <p className="text-muted-foreground text-xs">
-              Every sign-in from this domain is routed to this identity provider instead of
-              password login — only add a domain your IdP actually controls. Users on other
-              domains are unaffected.
+              Every sign-in from this domain is routed to this identity provider instead of password
+              login — only add a domain your IdP actually controls. Users on other domains are
+              unaffected.
             </p>
             {adminEmailDomain && domain.trim().toLowerCase() === adminEmailDomain && (
               <p className="text-kortix-yellow text-xs">
-                This is your own email domain — saving this will route YOUR next sign-in to the
-                IdP too. Make sure your account exists there before you continue.
+                This is your own email domain — saving this will route YOUR next sign-in to the IdP
+                too. Make sure your account exists there before you continue.
               </p>
             )}
           </div>
@@ -654,11 +707,10 @@ function EditProviderDialog({
             <p className="text-muted-foreground text-xs leading-relaxed">
               <span className="text-kortix-yellow">Entra tip:</span> set your SAML{' '}
               <span className="font-mono">emailaddress</span> claim source to{' '}
-              <span className="font-mono">userPrincipalName</span> — onmicrosoft.com users have
-              no <span className="font-mono">mail</span>, and an empty email breaks sign-in. Entra
-              also emits group <span className="font-mono">Object IDs</span> by default: map
-              those, or emit names via “Groups assigned to the application” (needs Entra ID
-              P1/P2).
+              <span className="font-mono">userPrincipalName</span> — onmicrosoft.com users have no{' '}
+              <span className="font-mono">mail</span>, and an empty email breaks sign-in. Entra also
+              emits group <span className="font-mono">Object IDs</span> by default: map those, or
+              emit names via “Groups assigned to the application” (needs Entra ID P1/P2).
             </p>
           </div>
 
@@ -673,8 +725,8 @@ function EditProviderDialog({
             <span>
               <span className="font-medium">Auto-create members</span>
               <span className="text-muted-foreground block text-xs">
-                When off, only users an admin has already invited can sign in via SAML. Group
-                sync still runs for those members.
+                When off, only users an admin has already invited can sign in via SAML. Group sync
+                still runs for those members.
               </span>
             </span>
           </label>
@@ -690,8 +742,8 @@ function EditProviderDialog({
             <span>
               <span className="font-medium">Auto-provision groups</span>
               <span className="text-muted-foreground block text-xs">
-                Create an IAM group for every group the IdP sends and add users to it — no
-                per-group mapping. You just attach project roles to the auto-created groups.
+                Create an IAM group for every group the IdP sends and add users to it — no per-group
+                mapping. You just attach project roles to the auto-created groups.
               </span>
             </span>
           </label>
@@ -776,8 +828,8 @@ function AddMappingDialog({
         <ModalHeader>
           <ModalTitle>Add group mapping</ModalTitle>
           <ModalDescription>
-            Users with this claim value in their SAML token will be added to the chosen IAM group
-            on sign-in.
+            Users with this claim value in their SAML token will be added to the chosen IAM group on
+            sign-in.
           </ModalDescription>
         </ModalHeader>
 

--- a/apps/web/src/components/iam/sso-card.tsx
+++ b/apps/web/src/components/iam/sso-card.tsx
@@ -262,58 +262,56 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
 
         {provider && (
           <div className="px-4 py-5">
-            {providerQuery.isLoading ? (
-              <Skeleton className="h-16 w-full rounded-md" />
-            ) : (
-              <dl className="divide-border divide-y text-sm">
-                <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                  <dt className="text-muted-foreground shrink-0">Provider</dt>
-                  <dd className="text-foreground min-w-0 truncate text-right font-medium">
-                    {provider.name}
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                  <dt className="text-muted-foreground shrink-0">Primary domain</dt>
-                  <dd className="text-foreground min-w-0 truncate text-right font-mono text-xs">
-                    {provider.primary_domain}
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                  <dt className="text-muted-foreground shrink-0">Group claim</dt>
-                  <dd className="min-w-0 truncate text-right">
-                    <code className="bg-muted/60 text-foreground rounded px-1.5 py-0.5 font-mono text-xs">
-                      {provider.group_claim_name}
-                    </code>
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                  <dt className="text-muted-foreground shrink-0">Auto-create members</dt>
-                  <dd className="text-right">
-                    {provider.auto_create_members ? (
-                      <span className="text-kortix-green inline-flex items-center gap-1 font-medium">
-                        <Check className="size-3.5 shrink-0" />
-                        Yes
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground">No</span>
-                    )}
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                  <dt className="text-muted-foreground shrink-0">Auto-provision groups</dt>
-                  <dd className="text-right">
-                    {provider.auto_provision_groups ? (
-                      <span className="text-kortix-green inline-flex items-center gap-1 font-medium">
-                        <Check className="size-3.5 shrink-0" />
-                        Yes
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground">No</span>
-                    )}
-                  </dd>
-                </div>
-              </dl>
-            )}
+            {/* No loading ternary here — `provider` truthy means the query
+                already resolved; the pre-connect skeleton lives above. */}
+            <dl className="divide-border divide-y text-sm">
+              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
+                <dt className="text-muted-foreground shrink-0">Provider</dt>
+                <dd className="text-foreground min-w-0 truncate text-right font-medium">
+                  {provider.name}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
+                <dt className="text-muted-foreground shrink-0">Primary domain</dt>
+                <dd className="text-foreground min-w-0 truncate text-right font-mono text-xs">
+                  {provider.primary_domain}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
+                <dt className="text-muted-foreground shrink-0">Group claim</dt>
+                <dd className="min-w-0 truncate text-right">
+                  <code className="bg-muted/60 text-foreground rounded px-1.5 py-0.5 font-mono text-xs">
+                    {provider.group_claim_name}
+                  </code>
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
+                <dt className="text-muted-foreground shrink-0">Auto-create members</dt>
+                <dd className="text-right">
+                  {provider.auto_create_members ? (
+                    <span className="text-kortix-green inline-flex items-center gap-1 font-medium">
+                      <Check className="size-3.5 shrink-0" />
+                      Yes
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">No</span>
+                  )}
+                </dd>
+              </div>
+              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
+                <dt className="text-muted-foreground shrink-0">Auto-provision groups</dt>
+                <dd className="text-right">
+                  {provider.auto_provision_groups ? (
+                    <span className="text-kortix-green inline-flex items-center gap-1 font-medium">
+                      <Check className="size-3.5 shrink-0" />
+                      Yes
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">No</span>
+                  )}
+                </dd>
+              </div>
+            </dl>
           </div>
         )}
 

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -203,7 +203,10 @@ describe('auto-provision groups default', () => {
   });
 
   test('the SSO card dialog defaults ON for new providers, stored value for existing', () => {
-    expect(cardSource).toContain('useState(existing ? existing.auto_provision_groups : true)');
+    // Whitespace-tolerant: the formatter may wrap the useState initializer.
+    expect(cardSource.replace(/\s+/g, ' ')).toContain(
+      'useState( existing ? existing.auto_provision_groups : true',
+    );
   });
 });
 
@@ -323,6 +326,41 @@ describe('SCIM last-sync indicator', () => {
     expect(scimCardSource).toMatch(
       /queryFn: \(\) => listScimTokens\(accountId\)[\s\S]{0,200}refetchInterval/,
     );
+  });
+});
+
+// Identity page progressive disclosure — the cards lead with STATE (chip +
+// health line + one action); setup-time reference values (SP URLs, SCIM base
+// URL, IdP table, token list) collapse behind disclosures. Pins the redesign
+// of the "messy, everything at once" Identity tab.
+describe('identity page progressive disclosure', () => {
+  const pageSource = readFileSync(join(dir, '../../app/(app)/accounts/[id]/page.tsx'), 'utf8');
+  const introSource = readFileSync(
+    join(dir, '../../components/iam/identity-intro.tsx'),
+    'utf8',
+  ).replace(/\s+/g, ' ');
+
+  test('the "Why connect both?" explainer self-hides once either surface is configured', () => {
+    expect(pageSource).toContain('<IdentityIntro');
+    expect(pageSource).not.toContain('Why connect both?');
+    expect(introSource).toContain('Why connect both?');
+    // Renders only while BOTH SSO and SCIM are unconfigured.
+    expect(introSource).toContain('(tokensQuery.data ?? []).length > 0) return null');
+  });
+
+  test('the SSO card collapses SP values behind a disclosure in both states', () => {
+    expect(cardSource).toContain('Service provider values');
+    expect(cardSource).toContain('DisclosureTrigger');
+    // Not-connected leads with a call-to-action, not a wall of URLs.
+    expect(cardSource).toContain('Not connected yet');
+  });
+
+  test('the SCIM card leads with a status chip and collapses setup values + tokens', () => {
+    expect(scimCardSource).toContain('Setup values');
+    expect(scimCardSource).toContain('DisclosureTrigger');
+    // Amber only for the one genuinely wrong state: minted but never called.
+    expect(scimCardSource).toContain('waiting for IdP');
+    expect(scimCardSource).toContain("freshness === 'never'");
   });
 });
 

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -361,6 +361,11 @@ describe('identity page progressive disclosure', () => {
     // Amber only for the one genuinely wrong state: minted but never called.
     expect(scimCardSource).toContain('waiting for IdP');
     expect(scimCardSource).toContain("freshness === 'never'");
+    // Setup values auto-open while a minted token awaits its first IdP call —
+    // that is exactly when the admin is pasting them — and tuck away after.
+    expect(scimCardSource.replace(/\s+/g, ' ')).toContain(
+      "open={tokens.length > 0 && freshness === 'never'}",
+    );
   });
 });
 


### PR DESCRIPTION
Redesigns the Identity tab from "everything expanded at once" to status-first cards. Setup-time reference data (SP URLs, SCIM base URL, IdP table, token list) collapses behind disclosures; each card leads with state.

- **SSO card** — connected chip + summary, or a calm call-to-action; Entity ID / ACS collapse into a "Service provider values" row (available in both states)
- **Directory Sync card** — header status chip (`active` / `connected` / amber `waiting for IdP`) + the live health line; "Setup values" and "Bearer tokens (N active)" collapse. Setup values **auto-open while a minted token awaits its first IdP call** (exactly when the admin is pasting them) and tuck away on the first successful sync
- **"Why connect both?"** explainer self-hides once either surface is configured (new `IdentityIntro`, deduped queries)
- Subtitle names the real provider set (Entra, Okta, OneLogin, JumpCloud, PingOne); dead loading branch removed

No functionality removed — mint/revoke/copy/enforce/mappings all intact, one click away. 96 tests pass (new pins for the disclosure structure + smart-open), tsc/lint clean.

Note: contains `acc4c4c65`, which was pushed to the #5094 branch moments after that PR merged — carried here onto a fresh branch off main.