### PR TITLE
feat(iam): protect IdP-synced groups from local drift

### DIFF
--- a/apps/api/src/__tests__/unit-idp-managed-groups.test.ts
+++ b/apps/api/src/__tests__/unit-idp-managed-groups.test.ts
@@ -1,0 +1,163 @@
+/**
+ * SCIM-sourced groups are OWNED BY THE IDP — sign-in group claims and
+ * provisioning match by NAME, so a local rename orphans the group's grants
+ * (the next sign-in auto-provisions a duplicate under the old name), and
+ * local membership edits are silently clobbered by the IdP's next push.
+ * The groups routes must 409 (code `group_idp_managed`) on those writes,
+ * while description edits and same-name saves stay allowed, and manual
+ * groups keep full local control.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+
+mock.module('../iam', () => ({
+  ACCOUNT_ACTIONS: {
+    GROUP_READ: 'group.read',
+    GROUP_CREATE: 'group.create',
+    GROUP_UPDATE: 'group.update',
+    GROUP_DELETE: 'group.delete',
+    GROUP_MEMBERS_MANAGE: 'group.members.manage',
+  },
+  assertAuthorized: async () => {},
+}));
+
+mock.module('../shared/audit', () => ({
+  recordAuditEvent: async () => {},
+}));
+
+// Entitled account — these tests are about the IdP-managed guard, and a 402
+// would fire before it.
+mock.module('../billing/services/entitlements', () => ({
+  accountHasEntitlement: async () => true,
+}));
+
+mock.module('../iam/cache-invalidation', () => ({
+  invalidateIamCacheForGroup: async () => {},
+  invalidateIamCacheForUser: () => {},
+  invalidateIamCacheForUsers: () => {},
+}));
+
+const base = {
+  accountId: 'acct-1',
+  description: null as string | null,
+  externalId: null as string | null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+const scimGroup = { ...base, groupId: 'grp-scim', name: 'Engineers', source: 'scim' };
+const manualGroup = { ...base, groupId: 'grp-manual', name: 'Ops', source: 'manual' };
+
+mock.module('../repositories/iam', () => ({
+  getGroup: async (_accountId: string, groupId: string) =>
+    groupId === 'grp-scim' ? scimGroup : groupId === 'grp-manual' ? manualGroup : null,
+  updateGroup: async (
+    _accountId: string,
+    groupId: string,
+    patch: { name?: string; description?: string | null },
+  ) => ({
+    ...(groupId === 'grp-scim' ? scimGroup : manualGroup),
+    ...patch,
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+  }),
+  addGroupMembers: async () => ({ added: 1 }),
+  removeGroupMember: async () => true,
+  createGroup: async () => manualGroup,
+  deleteGroup: async () => true,
+  listGroups: async () => [],
+  listGroupMembers: async () => [],
+}));
+
+const { iamRouter } = await import('../accounts/iam/app');
+await import('../accounts/iam/groups');
+
+function buildApp() {
+  const app = new Hono();
+  app.use('*', async (c: any, next: any) => {
+    c.set('userId', 'admin-1');
+    await next();
+  });
+  app.route('/', iamRouter);
+  return app;
+}
+
+const ACCOUNT = 'acct-1';
+const jsonHeaders = { 'Content-Type': 'application/json' };
+
+describe('SCIM group — rename is IdP-owned', () => {
+  test('PATCH with a new name → 409 group_idp_managed', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-scim`, {
+      method: 'PATCH',
+      headers: jsonHeaders,
+      body: JSON.stringify({ name: 'Engineers-renamed' }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe('group_idp_managed');
+  });
+
+  test('PATCH description-only → 200 (locally editable)', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-scim`, {
+      method: 'PATCH',
+      headers: jsonHeaders,
+      body: JSON.stringify({ description: 'Platform engineers' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('PATCH with the SAME name → 200 (no-op rename is not a rename)', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-scim`, {
+      method: 'PATCH',
+      headers: jsonHeaders,
+      body: JSON.stringify({ name: 'Engineers', description: 'unchanged name' }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('SCIM group — membership is IdP-owned', () => {
+  test('POST members → 409 group_idp_managed', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-scim/members`, {
+      method: 'POST',
+      headers: jsonHeaders,
+      body: JSON.stringify({ userIds: ['u-1'] }),
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe('group_idp_managed');
+  });
+
+  test('DELETE member → 409 (a local remove is silently undone by the next push)', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-scim/members/u-1`, {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe('group_idp_managed');
+  });
+});
+
+describe('manual group — full local control retained', () => {
+  test('PATCH rename → 200', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-manual`, {
+      method: 'PATCH',
+      headers: jsonHeaders,
+      body: JSON.stringify({ name: 'Ops-renamed' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('POST members → 200', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-manual/members`, {
+      method: 'POST',
+      headers: jsonHeaders,
+      body: JSON.stringify({ userIds: ['u-1'] }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).added).toBe(1);
+  });
+
+  test('DELETE member → 200', async () => {
+    const res = await buildApp().request(`/${ACCOUNT}/iam/groups/grp-manual/members/u-1`, {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/accounts/iam/groups.ts
+++ b/apps/api/src/accounts/iam/groups.ts
@@ -5,10 +5,7 @@ import { json, errors, auth } from '../../openapi';
 import { and, asc, eq } from 'drizzle-orm';
 import { projectGroupGrants, projects } from '@kortix/db';
 import { db } from '../../shared/db';
-import {
-  ACCOUNT_ACTIONS,
-  assertAuthorized,
-} from '../../iam';
+import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
 import {
   invalidateIamCacheForGroup,
   invalidateIamCacheForUser,
@@ -39,6 +36,29 @@ import { auditIam, isUniqueViolation, readBody, requireEntitlement } from './hel
 // (create group, rename, add members); reads and deletions stay open so a
 // downgraded account can still see and clean up leftover groups — revoking
 // access is never paywalled. See TierEntitlements in ../../types.
+//
+// SCIM-sourced groups (source === 'scim') are OWNED BY THE IdP: renames and
+// membership edits here would corrupt sync — sign-in group claims and
+// provisioning match by NAME, so a local rename orphans the group's grants
+// (the next sign-in auto-provisions a duplicate under the old name), and
+// local membership edits are silently clobbered by the IdP's next push
+// (worse than a refusal: a "removed" member quietly comes back). Those
+// writes 409 with code `group_idp_managed`; description edits and deletion
+// (cleanup — the IdP recreates it if still pushed) stay allowed.
+
+/** 409 for writes that would corrupt IdP-managed group state. */
+function idpManagedGroupError(c: any, what: 'rename' | 'membership') {
+  return c.json(
+    {
+      error:
+        what === 'rename'
+          ? 'This group is synced from your identity provider — rename it there. Sign-in group claims match by name, so a local rename would orphan its access.'
+          : 'Membership of this group is synced from your identity provider — change it there. Local edits are overwritten by the next sync.',
+      code: 'group_idp_managed',
+    },
+    409,
+  );
+}
 
 // ─── Groups ────────────────────────────────────────────────────────────────
 
@@ -56,24 +76,24 @@ iamRouter.openapi(
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
 
-  const rows = await listGroups(accountId);
-  return c.json({
-    groups: rows.map((g) => ({
-      group_id: g.groupId,
-      name: g.name,
-      description: g.description,
-      source: g.source,
-      member_count: g.memberCount,
-      // Number of project_group_grants for this group.
-      project_count: g.projectCount,
-      created_at: g.createdAt.toISOString(),
-      updated_at: g.updatedAt.toISOString(),
-    })),
-  });
+    const rows = await listGroups(accountId);
+    return c.json({
+      groups: rows.map((g) => ({
+        group_id: g.groupId,
+        name: g.name,
+        description: g.description,
+        source: g.source,
+        member_count: g.memberCount,
+        // Number of project_group_grants for this group.
+        project_count: g.projectCount,
+        created_at: g.createdAt.toISOString(),
+        updated_at: g.updatedAt.toISOString(),
+      })),
+    });
   },
 );
 
@@ -84,54 +104,62 @@ iamRouter.openapi(
     tags: ['iam'],
     summary: 'Create an account group',
     ...auth,
-    request: { params: AccountIdParam, body: { content: { 'application/json': { schema: z.object({ name: z.string(), description: z.string().nullable().optional() }) } } } },
+    request: {
+      params: AccountIdParam,
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({ name: z.string(), description: z.string().nullable().optional() }),
+          },
+        },
+      },
+    },
     responses: {
       201: json(GroupSchema, 'The created group'),
       ...errors(400, 401, 403, 409),
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_CREATE);
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_CREATE);
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
-  const body = await readBody(c);
-  const name = typeof body.name === 'string' ? body.name.trim() : '';
-  if (!name) return c.json({ error: 'name is required' }, 400);
-  if (name.length > 128) return c.json({ error: 'name too long' }, 400);
+    const body = await readBody(c);
+    const name = typeof body.name === 'string' ? body.name.trim() : '';
+    if (!name) return c.json({ error: 'name is required' }, 400);
+    if (name.length > 128) return c.json({ error: 'name too long' }, 400);
 
-  const description =
-    typeof body.description === 'string' ? body.description : null;
+    const description = typeof body.description === 'string' ? body.description : null;
 
-  try {
-    const group = await createGroup({ accountId, name, description, createdBy: userId });
+    try {
+      const group = await createGroup({ accountId, name, description, createdBy: userId });
 
-    await auditIam(c, {
-      accountId,
-      action: 'iam.group.create',
-      resourceType: 'account_group',
-      resourceId: group.groupId,
-      after: { name: group.name, description: group.description, source: group.source },
-    });
+      await auditIam(c, {
+        accountId,
+        action: 'iam.group.create',
+        resourceType: 'account_group',
+        resourceId: group.groupId,
+        after: { name: group.name, description: group.description, source: group.source },
+      });
 
-    return c.json(
-      {
-        group_id: group.groupId,
-        name: group.name,
-        description: group.description,
-        source: group.source,
-        created_at: group.createdAt.toISOString(),
-      },
-      201,
-    );
-  } catch (err: unknown) {
-    if (isUniqueViolation(err)) {
-      return c.json({ error: 'A group with this name already exists' }, 409);
+      return c.json(
+        {
+          group_id: group.groupId,
+          name: group.name,
+          description: group.description,
+          source: group.source,
+          created_at: group.createdAt.toISOString(),
+        },
+        201,
+      );
+    } catch (err: unknown) {
+      if (isUniqueViolation(err)) {
+        return c.json({ error: 'A group with this name already exists' }, 409);
+      }
+      throw err;
     }
-    throw err;
-  }
   },
 );
 
@@ -149,23 +177,23 @@ iamRouter.openapi(
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  const groupId = c.req.param('groupId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
 
-  const group = await getGroup(accountId, groupId);
-  if (!group) return c.json({ error: 'group not found' }, 404);
+    const group = await getGroup(accountId, groupId);
+    if (!group) return c.json({ error: 'group not found' }, 404);
 
-  return c.json({
-    group_id: group.groupId,
-    name: group.name,
-    description: group.description,
-    source: group.source,
-    external_id: group.externalId,
-    created_at: group.createdAt.toISOString(),
-    updated_at: group.updatedAt.toISOString(),
-  });
+    return c.json({
+      group_id: group.groupId,
+      name: group.name,
+      description: group.description,
+      source: group.source,
+      external_id: group.externalId,
+      created_at: group.createdAt.toISOString(),
+      updated_at: group.updatedAt.toISOString(),
+    });
   },
 );
 
@@ -176,56 +204,72 @@ iamRouter.openapi(
     tags: ['iam'],
     summary: 'Update a group',
     ...auth,
-    request: { params: GroupParams, body: { content: { 'application/json': { schema: z.object({ name: z.string(), description: z.string().nullable() }).partial() } } } },
+    request: {
+      params: GroupParams,
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({ name: z.string(), description: z.string().nullable() }).partial(),
+          },
+        },
+      },
+    },
     responses: {
       200: json(GroupSchema, 'The updated group'),
-      ...errors(400, 401, 403, 404),
+      ...errors(400, 401, 403, 404, 409),
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  const groupId = c.req.param('groupId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_UPDATE, {
-    type: 'group',
-    id: groupId,
-  });
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_UPDATE, {
+      type: 'group',
+      id: groupId,
+    });
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
-  const body = await readBody(c);
-  const patch: { name?: string; description?: string | null } = {};
-  if (typeof body.name === 'string') {
-    const name = body.name.trim();
-    if (!name || name.length > 128) return c.json({ error: 'invalid name' }, 400);
-    patch.name = name;
-  }
-  if (body.description !== undefined) {
-    patch.description = typeof body.description === 'string' ? body.description : null;
-  }
+    const body = await readBody(c);
+    const patch: { name?: string; description?: string | null } = {};
+    if (typeof body.name === 'string') {
+      const name = body.name.trim();
+      if (!name || name.length > 128) return c.json({ error: 'invalid name' }, 400);
+      patch.name = name;
+    }
+    if (body.description !== undefined) {
+      patch.description = typeof body.description === 'string' ? body.description : null;
+    }
 
-  const beforeGroup = await getGroup(accountId, groupId);
+    const beforeGroup = await getGroup(accountId, groupId);
+    if (!beforeGroup) return c.json({ error: 'group not found' }, 404);
+    // IdP-owned name: a local rename breaks claim-name matching (see header).
+    if (
+      beforeGroup.source === 'scim' &&
+      patch.name !== undefined &&
+      patch.name !== beforeGroup.name
+    ) {
+      return idpManagedGroupError(c, 'rename');
+    }
 
-  const updated = await updateGroup(accountId, groupId, patch);
-  if (!updated) return c.json({ error: 'group not found' }, 404);
+    const updated = await updateGroup(accountId, groupId, patch);
+    if (!updated) return c.json({ error: 'group not found' }, 404);
 
-  await auditIam(c, {
-    accountId,
-    action: 'iam.group.update',
-    resourceType: 'account_group',
-    resourceId: groupId,
-    before: beforeGroup
-      ? { name: beforeGroup.name, description: beforeGroup.description }
-      : null,
-    after: { name: updated.name, description: updated.description },
-  });
+    await auditIam(c, {
+      accountId,
+      action: 'iam.group.update',
+      resourceType: 'account_group',
+      resourceId: groupId,
+      before: beforeGroup ? { name: beforeGroup.name, description: beforeGroup.description } : null,
+      after: { name: updated.name, description: updated.description },
+    });
 
-  return c.json({
-    group_id: updated.groupId,
-    name: updated.name,
-    description: updated.description,
-    updated_at: updated.updatedAt.toISOString(),
-  });
+    return c.json({
+      group_id: updated.groupId,
+      name: updated.name,
+      description: updated.description,
+      updated_at: updated.updatedAt.toISOString(),
+    });
   },
 );
 
@@ -243,37 +287,41 @@ iamRouter.openapi(
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  const groupId = c.req.param('groupId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_DELETE, {
-    type: 'group',
-    id: groupId,
-  });
-  // No entitlement gate: deletion is cleanup, always allowed (see file header).
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_DELETE, {
+      type: 'group',
+      id: groupId,
+    });
+    // No entitlement gate: deletion is cleanup, always allowed (see file header).
 
-  const beforeGroup = await getGroup(accountId, groupId);
+    const beforeGroup = await getGroup(accountId, groupId);
 
-  // Bust every member's cached decision BEFORE the delete: the cascade removes
-  // accountGroupMembers, so invalidateIamCacheForGroup (which reads that table)
-  // would find no one to bust if called afterwards. Otherwise the group's
-  // grants would keep applying for up to the cache TTL after deletion.
-  await invalidateIamCacheForGroup(groupId);
+    // Bust every member's cached decision BEFORE the delete: the cascade removes
+    // accountGroupMembers, so invalidateIamCacheForGroup (which reads that table)
+    // would find no one to bust if called afterwards. Otherwise the group's
+    // grants would keep applying for up to the cache TTL after deletion.
+    await invalidateIamCacheForGroup(groupId);
 
-  const ok = await deleteGroup(accountId, groupId);
-  if (!ok) return c.json({ error: 'group not found' }, 404);
+    const ok = await deleteGroup(accountId, groupId);
+    if (!ok) return c.json({ error: 'group not found' }, 404);
 
-  await auditIam(c, {
-    accountId,
-    action: 'iam.group.delete',
-    resourceType: 'account_group',
-    resourceId: groupId,
-    before: beforeGroup
-      ? { name: beforeGroup.name, description: beforeGroup.description, source: beforeGroup.source }
-      : null,
-  });
+    await auditIam(c, {
+      accountId,
+      action: 'iam.group.delete',
+      resourceType: 'account_group',
+      resourceId: groupId,
+      before: beforeGroup
+        ? {
+            name: beforeGroup.name,
+            description: beforeGroup.description,
+            source: beforeGroup.source,
+          }
+        : null,
+    });
 
-  return c.json({ deleted: true });
+    return c.json({ deleted: true });
   },
 );
 
@@ -293,19 +341,19 @@ iamRouter.openapi(
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  const groupId = c.req.param('groupId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
 
-  const members = await listGroupMembers(accountId, groupId);
-  return c.json({
-    members: members.map((m) => ({
-      user_id: m.userId,
-      added_at: m.addedAt.toISOString(),
-      added_by: m.addedBy,
-    })),
-  });
+    const members = await listGroupMembers(accountId, groupId);
+    return c.json({
+      members: members.map((m) => ({
+        user_id: m.userId,
+        added_at: m.addedAt.toISOString(),
+        added_by: m.addedBy,
+      })),
+    });
   },
 );
 
@@ -316,51 +364,65 @@ iamRouter.openapi(
     tags: ['iam'],
     summary: 'Add members to a group',
     ...auth,
-    request: { params: GroupParams, body: { content: { 'application/json': { schema: z.object({ userIds: z.array(z.string()).optional(), userId: z.string().optional() }) } } } },
+    request: {
+      params: GroupParams,
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              userIds: z.array(z.string()).optional(),
+              userId: z.string().optional(),
+            }),
+          },
+        },
+      },
+    },
     responses: {
       200: json(z.object({ added: z.number() }), 'Number of members added'),
-      ...errors(400, 401, 403, 404),
+      ...errors(400, 401, 403, 404, 409),
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  const groupId = c.req.param('groupId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_MEMBERS_MANAGE, {
-    type: 'group',
-    id: groupId,
-  });
-  const denied = await requireEntitlement(c, accountId, 'rbac');
-  if (denied) return denied;
-
-  const group = await getGroup(accountId, groupId);
-  if (!group) return c.json({ error: 'group not found' }, 404);
-
-  const body = await readBody(c);
-  const userIds: string[] = Array.isArray(body.userIds)
-    ? body.userIds.filter((v): v is string => typeof v === 'string')
-    : typeof body.userId === 'string'
-      ? [body.userId]
-      : [];
-  if (userIds.length === 0) return c.json({ error: 'userIds required' }, 400);
-
-  const result = await addGroupMembers({ accountId, groupId, userIds, addedBy: userId });
-
-  // New members inherit the group's project grants immediately — bust their
-  // cached decisions so the added access isn't delayed by the cache TTL.
-  if (result.added > 0) invalidateIamCacheForUsers(userIds);
-
-  if (result.added > 0) {
-    await auditIam(c, {
-      accountId,
-      action: 'iam.group.members.add',
-      resourceType: 'account_group',
-      resourceId: groupId,
-      after: { added_user_ids: userIds, added_count: result.added },
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_MEMBERS_MANAGE, {
+      type: 'group',
+      id: groupId,
     });
-  }
+    const denied = await requireEntitlement(c, accountId, 'rbac');
+    if (denied) return denied;
 
-  return c.json({ added: result.added });
+    const group = await getGroup(accountId, groupId);
+    if (!group) return c.json({ error: 'group not found' }, 404);
+    // IdP-owned membership: local adds get clobbered by the next push.
+    if (group.source === 'scim') return idpManagedGroupError(c, 'membership');
+
+    const body = await readBody(c);
+    const userIds: string[] = Array.isArray(body.userIds)
+      ? body.userIds.filter((v): v is string => typeof v === 'string')
+      : typeof body.userId === 'string'
+        ? [body.userId]
+        : [];
+    if (userIds.length === 0) return c.json({ error: 'userIds required' }, 400);
+
+    const result = await addGroupMembers({ accountId, groupId, userIds, addedBy: userId });
+
+    // New members inherit the group's project grants immediately — bust their
+    // cached decisions so the added access isn't delayed by the cache TTL.
+    if (result.added > 0) invalidateIamCacheForUsers(userIds);
+
+    if (result.added > 0) {
+      await auditIam(c, {
+        accountId,
+        action: 'iam.group.members.add',
+        resourceType: 'account_group',
+        resourceId: groupId,
+        after: { added_user_ids: userIds, added_count: result.added },
+      });
+    }
+
+    return c.json({ added: result.added });
   },
 );
 
@@ -371,42 +433,47 @@ iamRouter.openapi(
     tags: ['iam'],
     summary: 'Remove a member from a group',
     ...auth,
-    request: { params: z.object({ accountId: z.string(), groupId: z.string(), userId: z.string() }) },
+    request: {
+      params: z.object({ accountId: z.string(), groupId: z.string(), userId: z.string() }),
+    },
     responses: {
       200: json(z.object({ removed: z.boolean() }), 'Removal result'),
-      ...errors(401, 403, 404),
+      ...errors(401, 403, 404, 409),
     },
   }),
   async (c: any) => {
-  const callerId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  const groupId = c.req.param('groupId');
-  const targetUserId = c.req.param('userId');
-  await assertAuthorized(callerId, accountId, ACCOUNT_ACTIONS.GROUP_MEMBERS_MANAGE, {
-    type: 'group',
-    id: groupId,
-  });
-  // No entitlement gate: removing a member is cleanup, always allowed.
+    const callerId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+    const targetUserId = c.req.param('userId');
+    await assertAuthorized(callerId, accountId, ACCOUNT_ACTIONS.GROUP_MEMBERS_MANAGE, {
+      type: 'group',
+      id: groupId,
+    });
+    // No entitlement gate: removing a member is cleanup, always allowed.
 
-  const group = await getGroup(accountId, groupId);
-  if (!group) return c.json({ error: 'group not found' }, 404);
+    const group = await getGroup(accountId, groupId);
+    if (!group) return c.json({ error: 'group not found' }, 404);
+    // IdP-owned membership: a local remove is silently undone by the next push —
+    // a false sense of revocation. Deprovision the person in the IdP instead.
+    if (group.source === 'scim') return idpManagedGroupError(c, 'membership');
 
-  const ok = await removeGroupMember(groupId, targetUserId);
-  if (!ok) return c.json({ error: 'not a member of this group' }, 404);
+    const ok = await removeGroupMember(groupId, targetUserId);
+    if (!ok) return c.json({ error: 'not a member of this group' }, 404);
 
-  // Revocation must take effect now, not after the cache TTL: drop the removed
-  // user's cached decision so the group's grants stop applying immediately.
-  invalidateIamCacheForUser(targetUserId);
+    // Revocation must take effect now, not after the cache TTL: drop the removed
+    // user's cached decision so the group's grants stop applying immediately.
+    invalidateIamCacheForUser(targetUserId);
 
-  await auditIam(c, {
-    accountId,
-    action: 'iam.group.members.remove',
-    resourceType: 'account_group',
-    resourceId: groupId,
-    before: { removed_user_id: targetUserId },
-  });
+    await auditIam(c, {
+      accountId,
+      action: 'iam.group.members.remove',
+      resourceType: 'account_group',
+      resourceId: groupId,
+      before: { removed_user_id: targetUserId },
+    });
 
-  return c.json({ removed: true });
+    return c.json({ removed: true });
   },
 );
 
@@ -433,46 +500,43 @@ iamRouter.openapi(
     },
   }),
   async (c: any) => {
-  const userId = c.get('userId') as string;
-  const accountId = c.req.param('accountId');
-  const groupId = c.req.param('groupId');
-  await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
+    const userId = c.get('userId') as string;
+    const accountId = c.req.param('accountId');
+    const groupId = c.req.param('groupId');
+    await assertAuthorized(userId, accountId, ACCOUNT_ACTIONS.GROUP_READ);
 
-  const group = await getGroup(accountId, groupId);
-  if (!group) return c.json({ error: 'group not found' }, 404);
+    const group = await getGroup(accountId, groupId);
+    if (!group) return c.json({ error: 'group not found' }, 404);
 
-  const rows = await db
-    .select({
-      projectId: projectGroupGrants.projectId,
-      projectName: projects.name,
-      role: projectGroupGrants.role,
-      grantedBy: projectGroupGrants.grantedBy,
-      createdAt: projectGroupGrants.createdAt,
-      expiresAt: projectGroupGrants.expiresAt,
-    })
-    .from(projectGroupGrants)
-    .innerJoin(projects, eq(projects.projectId, projectGroupGrants.projectId))
-    .where(
-      and(
-        eq(projectGroupGrants.groupId, groupId),
-        eq(projectGroupGrants.accountId, accountId),
-      ),
-    )
-    // Deterministic order so the row position doesn't visibly shift after
-    // a role change. Without ORDER BY, Postgres can return rows in heap
-    // order, which moves UPDATEd rows around. See twin query in
-    // apps/api/src/projects/index.ts.
-    .orderBy(asc(projectGroupGrants.createdAt), asc(projectGroupGrants.projectId));
+    const rows = await db
+      .select({
+        projectId: projectGroupGrants.projectId,
+        projectName: projects.name,
+        role: projectGroupGrants.role,
+        grantedBy: projectGroupGrants.grantedBy,
+        createdAt: projectGroupGrants.createdAt,
+        expiresAt: projectGroupGrants.expiresAt,
+      })
+      .from(projectGroupGrants)
+      .innerJoin(projects, eq(projects.projectId, projectGroupGrants.projectId))
+      .where(
+        and(eq(projectGroupGrants.groupId, groupId), eq(projectGroupGrants.accountId, accountId)),
+      )
+      // Deterministic order so the row position doesn't visibly shift after
+      // a role change. Without ORDER BY, Postgres can return rows in heap
+      // order, which moves UPDATEd rows around. See twin query in
+      // apps/api/src/projects/index.ts.
+      .orderBy(asc(projectGroupGrants.createdAt), asc(projectGroupGrants.projectId));
 
-  return c.json({
-    grants: rows.map((r) => ({
-      project_id: r.projectId,
-      project_name: r.projectName,
-      role: r.role,
-      granted_by: r.grantedBy,
-      created_at: r.createdAt.toISOString(),
-      expires_at: r.expiresAt?.toISOString() ?? null,
-    })),
-  });
+    return c.json({
+      grants: rows.map((r) => ({
+        project_id: r.projectId,
+        project_name: r.projectName,
+        role: r.role,
+        granted_by: r.grantedBy,
+        created_at: r.createdAt.toISOString(),
+        expires_at: r.expiresAt?.toISOString() ?? null,
+      })),
+    });
   },
 );

--- a/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/groups/[groupId]/page.tsx
@@ -136,7 +136,19 @@ export default function GroupDetailPage() {
             {groupQuery.isLoading ? (
               <Skeleton className="h-6 w-44" />
             ) : (
-              <h2 className="text-foreground truncate text-xl font-medium">{group?.name}</h2>
+              <div className="flex min-w-0 items-center gap-2">
+                <h2 className="text-foreground truncate text-xl font-medium">{group?.name}</h2>
+                {group?.source === 'scim' ? (
+                  <Badge
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0"
+                    title="This group is pushed by your identity provider via Directory Sync — its name and membership are managed there."
+                  >
+                    Synced from IdP
+                  </Badge>
+                ) : null}
+              </div>
             )}
             {group?.description ? (
               <p className="text-muted-foreground truncate text-sm">{group.description}</p>
@@ -177,6 +189,7 @@ export default function GroupDetailPage() {
               accountId={account.account_id}
               groupId={group.group_id}
               canManage={canManageMembers}
+              idpManaged={group.source === 'scim'}
             />
           </TabsContent>
 
@@ -196,6 +209,7 @@ export default function GroupDetailPage() {
               initialDescription={group.description ?? ''}
               canEdit={canEditGroup}
               canDelete={canDeleteGroup}
+              idpManaged={group.source === 'scim'}
               onDeleted={() => router.push(`/accounts/${account.account_id}?tab=groups`)}
             />
           </TabsContent>
@@ -211,11 +225,17 @@ function GroupMembersCard({
   accountId,
   groupId,
   canManage,
+  idpManaged,
 }: {
   accountId: string;
   groupId: string;
   canManage: boolean;
+  /** SCIM-sourced group: membership is owned by the IdP — the API 409s local
+   *  edits (they'd be clobbered by the next push), so hide the affordances. */
+  idpManaged: boolean;
 }) {
+  // Local membership edits only make sense for locally-owned groups.
+  const canMutate = canManage && !idpManaged;
   const queryClient = useQueryClient();
   const [addOpen, setAddOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<string | null>(null);
@@ -284,11 +304,18 @@ function GroupMembersCard({
             Members{members.length > 0 ? ` · ${members.length}` : ''}
           </p>
           <p className="text-muted-foreground text-xs">
-            Members of this group inherit every policy attached to it.
+            {idpManaged
+              ? 'Membership is synced from your identity provider — add or remove people there.'
+              : 'Members of this group inherit every policy attached to it.'}
           </p>
         </div>
-        {canManage ? (
-          <Button size="sm" variant="secondary" className="gap-1.5" onClick={() => setAddOpen(true)}>
+        {canMutate ? (
+          <Button
+            size="sm"
+            variant="secondary"
+            className="gap-1.5"
+            onClick={() => setAddOpen(true)}
+          >
             <Plus className="size-4" />
             Add members
           </Button>
@@ -309,7 +336,11 @@ function GroupMembersCard({
           size="sm"
           title="No members in this group"
           description={
-            canManage ? "Add account members to grant them this group's policies." : undefined
+            idpManaged
+              ? 'Members appear here as your identity provider pushes them.'
+              : canMutate
+                ? "Add account members to grant them this group's policies."
+                : undefined
           }
         />
       ) : null}
@@ -361,7 +392,7 @@ function GroupMembersCard({
                     </InlineMeta>
                   </span>
                 </div>
-                {canManage ? (
+                {canMutate ? (
                   <Button
                     variant="ghost"
                     size="icon"
@@ -546,6 +577,7 @@ function GroupSettingsCard({
   initialDescription,
   canEdit,
   canDelete,
+  idpManaged,
   onDeleted,
 }: {
   accountId: string;
@@ -554,6 +586,9 @@ function GroupSettingsCard({
   initialDescription: string;
   canEdit: boolean;
   canDelete: boolean;
+  /** SCIM-sourced group: the NAME is owned by the IdP (claims match by name;
+   *  the API 409s a local rename). Description stays locally editable. */
+  idpManaged: boolean;
   onDeleted: () => void;
 }) {
   const queryClient = useQueryClient();
@@ -600,9 +635,15 @@ function GroupSettingsCard({
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 maxLength={128}
-                disabled={!canEdit || updateMutation.isPending}
+                disabled={!canEdit || updateMutation.isPending || idpManaged}
                 className="max-w-md"
               />
+              {idpManaged ? (
+                <p className="text-muted-foreground text-xs">
+                  The name is managed by your identity provider — rename the group there. Sign-in
+                  group claims match by name, so a local rename would orphan its access.
+                </p>
+              ) : null}
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="group-description">Description</Label>
@@ -658,7 +699,11 @@ function GroupSettingsCard({
         open={deleteOpen}
         onOpenChange={setDeleteOpen}
         title="Delete group"
-        description={`Delete "${initialName}"? This cannot be undone.`}
+        description={
+          idpManaged
+            ? `Delete "${initialName}"? This cannot be undone — and if your identity provider still pushes this group, the next sync recreates it (without its project roles).`
+            : `Delete "${initialName}"? This cannot be undone.`
+        }
         confirmLabel="Delete group"
         isPending={deleteMutation.isPending}
         onConfirm={() => deleteMutation.mutate()}
@@ -741,8 +786,8 @@ function GroupProjectGrantsCard({
             Projects{grants.length > 0 ? ` · ${grants.length}` : ''}
           </p>
           <p className="text-muted-foreground text-xs">
-            Every group member inherits the chosen role on these projects. Account owners and
-            admins always have Manager.
+            Every group member inherits the chosen role on these projects. Account owners and admins
+            always have Manager.
           </p>
         </div>
         <Button

--- a/apps/web/src/components/iam/groups-tab.tsx
+++ b/apps/web/src/components/iam/groups-tab.tsx
@@ -104,12 +104,7 @@ export function GroupsTab({ accountId, canCreate, rbacEnabled }: GroupsTabProps)
   const gated = canCreate && !rbacEnabled;
   const createAction = canCreate ? (
     rbacEnabled ? (
-      <Button
-        onClick={() => setCreateOpen(true)}
-        size="sm"
-        variant="secondary"
-        className="gap-1.5"
-      >
+      <Button onClick={() => setCreateOpen(true)} size="sm" variant="secondary" className="gap-1.5">
         <Plus className="size-4" />
         Create a group
       </Button>
@@ -228,11 +223,18 @@ export function GroupsTab({ accountId, canCreate, rbacEnabled }: GroupsTabProps)
                 <EntityAvatar icon={Users} size="md" />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <span className="text-foreground truncate text-sm font-medium">
-                      {g.name}
-                    </span>
-                    <Badge variant="outline" size="sm" className="capitalize">
-                      {g.source}
+                    <span className="text-foreground truncate text-sm font-medium">{g.name}</span>
+                    <Badge
+                      variant="outline"
+                      size="sm"
+                      className={g.source === 'scim' ? undefined : 'capitalize'}
+                      title={
+                        g.source === 'scim'
+                          ? 'Pushed by your identity provider via Directory Sync — name and membership are managed there.'
+                          : undefined
+                      }
+                    >
+                      {g.source === 'scim' ? 'Synced from IdP' : g.source}
                     </Badge>
                   </div>
                   <span className="text-muted-foreground text-xs">

--- a/apps/web/src/components/iam/idp-managed-groups.test.ts
+++ b/apps/web/src/components/iam/idp-managed-groups.test.ts
@@ -1,0 +1,51 @@
+// SCIM-sourced groups are owned by the IdP: the API 409s renames and
+// membership edits (claims match by name; local edits get clobbered by the
+// next push), so the UI must not offer those affordances — and must say WHY
+// and WHERE to do it instead. Pins the group detail page + groups tab.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const pageSource = readFileSync(
+  join(import.meta.dir, '../../app/(app)/accounts/[id]/groups/[groupId]/page.tsx'),
+  'utf8',
+);
+const flatPageSource = pageSource.replace(/\s+/g, ' ');
+const tabSource = readFileSync(join(import.meta.dir, 'groups-tab.tsx'), 'utf8');
+
+describe('IdP-managed groups — detail page', () => {
+  test('the page derives idpManaged from the group source and threads it to both cards', () => {
+    expect(pageSource).toContain("idpManaged={group.source === 'scim'}");
+    expect(pageSource).toContain('const canMutate = canManage && !idpManaged');
+  });
+
+  test('membership affordances hide for IdP-managed groups, with copy pointing at the IdP', () => {
+    // Add-members button and per-row remove gate on canMutate, not canManage.
+    expect(flatPageSource).toContain('{canMutate ? ( <Button');
+    expect(flatPageSource).toContain(
+      'Membership is synced from your identity provider — add or remove people there.',
+    );
+  });
+
+  test('the name field locks with a why + where hint; description stays editable', () => {
+    expect(flatPageSource).toContain('updateMutation.isPending || idpManaged');
+    expect(flatPageSource).toContain('rename the group there');
+    // Only the NAME input carries the idpManaged lock — one occurrence.
+    const locks = pageSource.match(/isPending \|\| idpManaged/g) ?? [];
+    expect(locks.length).toBe(1);
+  });
+
+  test('deletion stays allowed but warns the next sync recreates the group', () => {
+    expect(flatPageSource).toContain('the next sync recreates it');
+  });
+
+  test('the header badges IdP-synced groups', () => {
+    expect(pageSource).toContain('Synced from IdP');
+  });
+});
+
+describe('IdP-managed groups — groups tab', () => {
+  test('scim-sourced rows read "Synced from IdP" instead of a raw enum value', () => {
+    expect(tabSource).toContain("g.source === 'scim' ? 'Synced from IdP' : g.source");
+  });
+});


### PR DESCRIPTION
Found while auditing the Directory Sync surface: SCIM-sourced groups could be renamed and have members added/removed **locally**, silently corrupting sync.

**Why it matters:** sign-in group claims and provisioning match by **name** — a local rename orphans the group's grants (the next sign-in auto-provisions a *duplicate* group under the old name, holding none of the roles), and local membership edits are clobbered by the IdP's next push (a "removed" member quietly comes back — a false sense of revocation).

- **API** — rename + member add/remove on `source='scim'` groups now **409** (`group_idp_managed`) with copy pointing at the IdP. Description edits, same-name saves, and deletion (cleanup — the IdP recreates it if still pushed) stay allowed.
- **UI** — "Synced from IdP" badge on the groups tab + detail header; membership/name affordances hide or lock with a why + where hint; delete confirm warns the next sync recreates the group.

Tests: 8 route tests (409s + manual-group controls, mock-harness style) + structural pins; api 29 pass, web 91 pass, tsc/lint clean.