### PR TITLE
feat(iam-web): per-provider 'start automatic sync' cheat sheet

### DIFF
--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -131,26 +131,31 @@ function ProvisioningHealthPanel({
           </span>
         </p>
       )}
-      <p className="flex items-center gap-1.5 text-xs">
-        <span
-          className={cn(
-            'size-1.5 shrink-0 rounded-full',
-            freshness === 'live' && 'bg-kortix-green',
-            freshness === 'recent' && 'bg-kortix-green/60',
-            freshness === 'quiet' && 'bg-muted-foreground/40',
-            freshness === 'never' && 'bg-amber-500',
-          )}
-        />
-        <span className="text-muted-foreground">Last sync activity</span>
-        <span className="text-foreground font-medium">
-          {lastSyncAt ? formatRelative(lastSyncAt) : 'none yet'}
-        </span>
-        <span className="text-muted-foreground">
+      {/* Two lines on purpose: label + value stay on one unbreakable line,
+          the schedule explainer wraps underneath — the old single-flex row
+          wrapped mid-label ("Last sync / activity") on narrow cards. */}
+      <div className="space-y-0.5 text-xs">
+        <p className="flex items-center gap-1.5">
+          <span
+            className={cn(
+              'size-1.5 shrink-0 rounded-full',
+              freshness === 'live' && 'bg-kortix-green',
+              freshness === 'recent' && 'bg-kortix-green/60',
+              freshness === 'quiet' && 'bg-muted-foreground/40',
+              freshness === 'never' && 'bg-amber-500',
+            )}
+          />
+          <span className="text-muted-foreground whitespace-nowrap">Last sync activity</span>
+          <span className="text-foreground whitespace-nowrap font-medium">
+            {lastSyncAt ? formatRelative(lastSyncAt) : 'none yet'}
+          </span>
+        </p>
+        <p className="text-muted-foreground pl-3">
           {freshness === 'never'
-            ? '— your IdP hasn’t connected; check provisioning is running there'
-            : '— your IdP pushes on its own schedule (Entra ~every 40 min; most others as changes happen)'}
-        </span>
-      </p>
+            ? 'Your IdP hasn’t connected — check provisioning is running there.'
+            : 'Your IdP pushes on its own schedule — Entra ~every 40 min; most others as changes happen.'}
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/iam/scim-card.tsx
+++ b/apps/web/src/components/iam/scim-card.tsx
@@ -58,6 +58,7 @@ import {
   listScimTokens,
   revokeScimToken,
 } from '@/lib/iam-client';
+import { SCIM_PROVIDER_GUIDES } from '@/features/sso-setup/guides';
 import { latestScimSyncAt, scimSyncFreshness } from '@/lib/scim-sync';
 
 interface ScimCardProps {
@@ -300,7 +301,8 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
                 <div className="min-w-0 flex-1">
                   <p className="text-foreground text-sm font-medium">Setup values</p>
                   <p className="text-muted-foreground mt-0.5 text-xs">
-                    The SCIM base URL and what to enter on the IdP side.
+                    The SCIM base URL, what to enter on the IdP side, and how each provider starts
+                    automatic sync.
                   </p>
                 </div>
                 <ChevronDown className="text-muted-foreground size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
@@ -359,6 +361,32 @@ export function ScimCard({ accountId, canManage }: ScimCardProps) {
                       Push users &amp; groups; deactivation deprovisions
                     </span>
                   </div>
+                </div>
+
+                {/* Per-provider "flip this switch" cheat sheet — the guides
+                    registry is the single source of truth (startSyncHint),
+                    each row deep-links into that provider's guided setup. An
+                    admin stuck at "waiting for IdP" sees exactly what to turn
+                    on without re-entering the wizard. */}
+                <div className="bg-muted/20 text-muted-foreground space-y-2 rounded-md border px-3 py-2.5 text-xs">
+                  <p className="text-foreground text-xs font-medium">
+                    Start automatic sync in your IdP
+                  </p>
+                  {SCIM_PROVIDER_GUIDES.filter((g) => g.config.startSyncHint).map((g) => (
+                    <div key={g.id} className="flex gap-2">
+                      <span className="w-24 shrink-0">{g.name.split(' (')[0]}</span>
+                      <span className="text-foreground min-w-0 flex-1">
+                        {g.config.startSyncHint}{' '}
+                        <Link
+                          href={`/accounts/${accountId}/scim-setup?provider=${g.id}`}
+                          className="text-muted-foreground hover:text-foreground underline underline-offset-2"
+                        >
+                          Guide
+                        </Link>
+                      </span>
+                    </div>
+                  ))}
+                  <p>Once enabled, users and groups sync on their own — no manual pushing.</p>
                 </div>
               </div>
             </DisclosureContent>

--- a/apps/web/src/components/iam/sso-card.tsx
+++ b/apps/web/src/components/iam/sso-card.tsx
@@ -264,51 +264,53 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
           <div className="px-4 py-5">
             {/* No loading ternary here — `provider` truthy means the query
                 already resolved; the pre-connect skeleton lives above. */}
-            <dl className="divide-border divide-y text-sm">
-              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                <dt className="text-muted-foreground shrink-0">Provider</dt>
-                <dd className="text-foreground min-w-0 truncate text-right font-medium">
-                  {provider.name}
-                </dd>
+            {/* Compact facts grid (Vercel-style) — two columns instead of five
+                stacked full-width rows, so the connected summary reads at a
+                glance instead of eating half the card. */}
+            <dl className="grid gap-x-8 gap-y-4 text-sm sm:grid-cols-2">
+              <div className="min-w-0">
+                <dt className="text-muted-foreground text-xs">Provider</dt>
+                <dd className="text-foreground mt-0.5 truncate font-medium">{provider.name}</dd>
               </div>
-              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                <dt className="text-muted-foreground shrink-0">Primary domain</dt>
-                <dd className="text-foreground min-w-0 truncate text-right font-mono text-xs">
+              <div className="min-w-0">
+                <dt className="text-muted-foreground text-xs">Primary domain</dt>
+                <dd className="text-foreground mt-1 truncate font-mono text-xs">
                   {provider.primary_domain}
                 </dd>
               </div>
-              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                <dt className="text-muted-foreground shrink-0">Group claim</dt>
-                <dd className="min-w-0 truncate text-right">
+              <div className="min-w-0">
+                <dt className="text-muted-foreground text-xs">Group claim</dt>
+                <dd className="mt-1">
                   <code className="bg-muted/60 text-foreground rounded px-1.5 py-0.5 font-mono text-xs">
                     {provider.group_claim_name}
                   </code>
                 </dd>
               </div>
-              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                <dt className="text-muted-foreground shrink-0">Auto-create members</dt>
-                <dd className="text-right">
-                  {provider.auto_create_members ? (
-                    <span className="text-kortix-green inline-flex items-center gap-1 font-medium">
+              <div className="min-w-0">
+                <dt className="text-muted-foreground text-xs">Provisioning</dt>
+                <dd className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+                  <span
+                    className={
+                      provider.auto_create_members
+                        ? 'text-kortix-green inline-flex items-center gap-1 font-medium'
+                        : 'text-muted-foreground inline-flex items-center gap-1'
+                    }
+                  >
+                    {provider.auto_create_members ? <Check className="size-3.5 shrink-0" /> : null}
+                    Auto-create members{provider.auto_create_members ? '' : ': off'}
+                  </span>
+                  <span
+                    className={
+                      provider.auto_provision_groups
+                        ? 'text-kortix-green inline-flex items-center gap-1 font-medium'
+                        : 'text-muted-foreground inline-flex items-center gap-1'
+                    }
+                  >
+                    {provider.auto_provision_groups ? (
                       <Check className="size-3.5 shrink-0" />
-                      Yes
-                    </span>
-                  ) : (
-                    <span className="text-muted-foreground">No</span>
-                  )}
-                </dd>
-              </div>
-              <div className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0">
-                <dt className="text-muted-foreground shrink-0">Auto-provision groups</dt>
-                <dd className="text-right">
-                  {provider.auto_provision_groups ? (
-                    <span className="text-kortix-green inline-flex items-center gap-1 font-medium">
-                      <Check className="size-3.5 shrink-0" />
-                      Yes
-                    </span>
-                  ) : (
-                    <span className="text-muted-foreground">No</span>
-                  )}
+                    ) : null}
+                    Auto-provision groups{provider.auto_provision_groups ? '' : ': off'}
+                  </span>
                 </dd>
               </div>
             </dl>
@@ -321,7 +323,8 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
               <div className="min-w-0 space-y-0.5">
                 <p className="text-foreground text-sm font-medium">Enforce SSO for this domain</p>
                 <p className="text-muted-foreground text-xs">
-                  Members must sign in with your identity provider — the password option disappears.
+                  Members must sign in with your identity provider — the password option disappears
+                  the moment this is on, and only your identity provider works after that.
                 </p>
               </div>
               {canManage && (
@@ -333,71 +336,88 @@ export function SsoCard({ accountId, canManage }: SsoCardProps) {
                 />
               )}
             </div>
-            <p className="text-muted-foreground mt-2 text-xs">
-              Anyone on this domain who currently signs in with a password loses that option the
-              moment you turn this on — only your identity provider works after that.
-            </p>
           </div>
         )}
 
         {provider && (
           <div className="border-border border-t">
-            <div className="flex items-center justify-between gap-3 px-4 py-3">
-              <p className="text-foreground text-sm font-medium">Group mappings</p>
-              {canManage && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="gap-1.5"
-                  onClick={() => setMapOpen(true)}
-                >
-                  <Plus className="size-3.5 shrink-0" />
-                  Add mapping
-                </Button>
-              )}
-            </div>
-            <div className="border-border border-t">
-              {mappingsQuery.isLoading ? (
-                <div className="px-4 py-3">
-                  <Skeleton className="h-8 w-full rounded-md" />
-                </div>
-              ) : mappings.length === 0 ? (
-                <p className="text-muted-foreground px-4 py-4 text-xs">
-                  No mappings yet. Map IdP group/role values (from the{' '}
-                  <span className="font-mono">{provider.group_claim_name}</span> claim) to IAM
-                  groups so users land in the right group on sign-in.
-                </p>
-              ) : (
-                <div className="divide-border divide-y">
-                  {mappings.map((m) => (
-                    <div key={m.mapping_id} className="flex items-center gap-2.5 px-4 py-3">
-                      <code
-                        title={m.claim_value}
-                        className="text-foreground max-w-[42%] truncate font-mono text-xs"
-                      >
-                        {m.claim_value}
-                      </code>
-                      <ArrowRight className="text-muted-foreground/50 size-3.5 shrink-0" />
-                      <Badge variant="outline" size="sm" className="min-w-0 max-w-[42%] truncate">
-                        {m.group_name}
-                      </Badge>
-                      <span className="flex-1" />
-                      {canManage && (
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          className="text-muted-foreground hover:text-destructive shrink-0"
-                          onClick={() => setMapDeleteTarget(m)}
-                          aria-label="Remove mapping"
-                        >
-                          <X className="size-3.5 shrink-0" />
-                        </Button>
+            <Disclosure className="group">
+              <DisclosureTrigger>
+                <div className="flex w-full cursor-pointer items-center justify-between gap-3 px-4 py-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-foreground flex items-center gap-2 text-sm font-medium">
+                      Group mappings
+                      {mappings.length > 0 && (
+                        <Badge variant="muted" size="sm">
+                          {mappings.length}
+                        </Badge>
                       )}
-                    </div>
-                  ))}
+                    </p>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Route IdP group values (from the{' '}
+                      <span className="font-mono">{provider.group_claim_name}</span> claim) to
+                      specific IAM groups.
+                    </p>
+                  </div>
+                  <ChevronDown className="text-muted-foreground size-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
                 </div>
-              )}
-            </div>
+              </DisclosureTrigger>
+              <DisclosureContent contentClassName="border-border border-t">
+                {canManage && (
+                  <div className="flex justify-end px-4 pt-3">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="gap-1.5"
+                      onClick={() => setMapOpen(true)}
+                    >
+                      <Plus className="size-3.5 shrink-0" />
+                      Add mapping
+                    </Button>
+                  </div>
+                )}
+                {mappingsQuery.isLoading ? (
+                  <div className="px-4 py-3">
+                    <Skeleton className="h-8 w-full rounded-md" />
+                  </div>
+                ) : mappings.length === 0 ? (
+                  <p className="text-muted-foreground px-4 py-4 text-xs">
+                    No mappings yet — with auto-provision on, your IdP&apos;s groups appear by
+                    themselves; add a mapping only to route a claim value into a specific existing
+                    group.
+                  </p>
+                ) : (
+                  <div className="divide-border divide-y">
+                    {mappings.map((m) => (
+                      <div key={m.mapping_id} className="flex items-center gap-2.5 px-4 py-3">
+                        <code
+                          title={m.claim_value}
+                          className="text-foreground max-w-[42%] truncate font-mono text-xs"
+                        >
+                          {m.claim_value}
+                        </code>
+                        <ArrowRight className="text-muted-foreground/50 size-3.5 shrink-0" />
+                        <Badge variant="outline" size="sm" className="min-w-0 max-w-[42%] truncate">
+                          {m.group_name}
+                        </Badge>
+                        <span className="flex-1" />
+                        {canManage && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="text-muted-foreground hover:text-destructive shrink-0"
+                            onClick={() => setMapDeleteTarget(m)}
+                            aria-label="Remove mapping"
+                          >
+                            <X className="size-3.5 shrink-0" />
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </DisclosureContent>
+            </Disclosure>
           </div>
         )}
 

--- a/apps/web/src/features/sso-setup/guides.ts
+++ b/apps/web/src/features/sso-setup/guides.ts
@@ -136,6 +136,12 @@ export interface ProviderConfig {
    *  when the next call comes; this states the provider's real cadence
    *  (Entra: ~40-min scheduled cycle; most others: event-driven pushes). */
   syncCadenceHint?: string;
+  /** SCIM guides: the one-liner for turning AUTOMATIC provisioning on in this
+   *  IdP's console — the switch/steps after which no manual pushing is needed.
+   *  Rendered on the Identity card's Setup values next to a deep link into
+   *  this guide, so an admin stuck at "waiting for IdP" sees exactly what to
+   *  flip without re-entering the wizard. */
+  startSyncHint?: string;
 }
 
 export interface ProviderGuide {
@@ -1959,6 +1965,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
         'Groups pushed via SCIM are created in Kortix under their Entra display names.',
       syncCadenceHint:
         'Entra runs its scheduled provisioning cycle roughly every 40 minutes — changes apply on the next cycle, or instantly with "Provision on demand".',
+      startSyncHint:
+        'Provisioning → "Start provisioning" (Provisioning Status: On). The scheduled cycle then runs every ~40 minutes on its own; "Provision on demand" pushes one user instantly.',
     },
     steps: [
       {
@@ -2111,6 +2119,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
       groupValueHint: 'Groups pushed via Push Groups are created in Kortix under their Okta names.',
       syncCadenceHint:
         'Okta pushes changes as they happen (assignments, profile updates, group pushes) — a quiet period just means nothing changed.',
+      startSyncHint:
+        'Provisioning → "To App" → Edit → enable Create / Update / Deactivate Users → Save. Assignments and pushed groups then sync automatically as they change.',
     },
     steps: [
       {
@@ -2230,6 +2240,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
         'Groups pushed from OneLogin Rules are created in Kortix under their OneLogin names.',
       syncCadenceHint:
         'OneLogin pushes changes as they happen once provisioning is enabled — a quiet period just means nothing changed (or actions are held in the approval queue).',
+      startSyncHint:
+        'Provisioning tab → tick "Enable provisioning" and UNCHECK "Require admin approval" for Create/Update/Delete — otherwise every change waits in the pending queue.',
     },
     steps: [
       {
@@ -2339,6 +2351,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
         'The JumpCloud user groups you bind to the app are created in Kortix under their JumpCloud names.',
       syncCadenceHint:
         'JumpCloud pushes changes as they happen (group binds, membership changes) — a quiet period just means nothing changed.',
+      startSyncHint:
+        'Identity Management → "Test Connection" → "Activate", then bind user groups on the "User Groups" tab — bound groups and their members push automatically.',
     },
     steps: [
       {
@@ -2428,6 +2442,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
         'The internal PingOne groups you select on the provisioning rule are created in Kortix under their PingOne names.',
       syncCadenceHint:
         'PingOne runs an initial full sync when the rule goes Active, then pushes incremental changes as your directory changes.',
+      startSyncHint:
+        'Enable the CONNECTION toggle (top of its details panel, turns blue) AND set the provisioning rule to Active — both are required; a saved-but-disabled connection provisions nothing.',
     },
     steps: [
       {
@@ -2525,6 +2541,8 @@ export const SCIM_PROVIDER_GUIDES: ProviderGuide[] = [
       groupValueHint: 'Pushed groups are created in Kortix under their displayName.',
       syncCadenceHint:
         'Cadence depends on your IdP — most push changes as they happen; some run scheduled cycles. Check its provisioning log if nothing arrives.',
+      startSyncHint:
+        'Enable provisioning/sync in your IdP’s SCIM client and scope the users/groups to push — it then runs on the IdP’s own schedule.',
     },
     steps: [
       scimConnectStep({

--- a/apps/web/src/features/sso-setup/setup-wizard.tsx
+++ b/apps/web/src/features/sso-setup/setup-wizard.tsx
@@ -1202,26 +1202,30 @@ function ProvisionedStatusPanel({
           <RefreshCw className={cn('size-3.5', isLoading && 'animate-spin')} />
         </Button>
       </div>
-      <p className="flex items-center gap-1.5 text-xs">
-        <span
-          className={cn(
-            'size-1.5 shrink-0 rounded-full',
-            freshness === 'live' && 'bg-kortix-green',
-            freshness === 'recent' && 'bg-kortix-green/60',
-            freshness === 'quiet' && 'bg-muted-foreground/40',
-            freshness === 'never' && 'bg-amber-500',
-          )}
-        />
-        <span className="text-muted-foreground">Last sync activity</span>
-        <span className="text-foreground font-medium">
-          {lastSyncAt ? relativeTime(lastSyncAt) : 'none yet'}
-        </span>
-        {freshness === 'never' && !tokensQuery.isLoading && (
-          <span className="text-muted-foreground">
-            — your IdP hasn’t connected; check provisioning is running there
+      {/* Two lines on purpose — mirrors the SCIM card's panel so the label +
+          value never wrap mid-phrase on narrow layouts. */}
+      <div className="space-y-0.5 text-xs">
+        <p className="flex items-center gap-1.5">
+          <span
+            className={cn(
+              'size-1.5 shrink-0 rounded-full',
+              freshness === 'live' && 'bg-kortix-green',
+              freshness === 'recent' && 'bg-kortix-green/60',
+              freshness === 'quiet' && 'bg-muted-foreground/40',
+              freshness === 'never' && 'bg-amber-500',
+            )}
+          />
+          <span className="text-muted-foreground whitespace-nowrap">Last sync activity</span>
+          <span className="text-foreground whitespace-nowrap font-medium">
+            {lastSyncAt ? relativeTime(lastSyncAt) : 'none yet'}
           </span>
+        </p>
+        {freshness === 'never' && !tokensQuery.isLoading && (
+          <p className="text-muted-foreground pl-3">
+            Your IdP hasn’t connected — check provisioning is running there.
+          </p>
         )}
-      </p>
+      </div>
       {isLoading ? (
         <Skeleton className="h-12 w-full rounded-md" />
       ) : (

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -369,6 +369,29 @@ describe('identity page progressive disclosure', () => {
   });
 });
 
+// "How do I start auto-sync?" — every SCIM guide carries the one-liner for
+// turning automatic provisioning ON, and the Identity card renders the full
+// cheat sheet with a deep link into each provider's guided setup.
+describe('SCIM start-sync guides', () => {
+  test('every SCIM guide states how to turn automatic provisioning on', () => {
+    for (const g of SCIM_PROVIDER_GUIDES) {
+      expect(g.config.startSyncHint, `${g.id} missing startSyncHint`).toBeTruthy();
+    }
+    expect(getScimGuide('entra')!.config.startSyncHint).toContain('Start provisioning');
+    // PingOne's double switch — the fact-checked blocker (connection AND rule).
+    expect(getScimGuide('pingone')!.config.startSyncHint).toContain('CONNECTION toggle');
+    expect(getScimGuide('pingone')!.config.startSyncHint).toContain('Active');
+    // OneLogin's silent pending-queue trap.
+    expect(getScimGuide('onelogin')!.config.startSyncHint).toContain('Require admin approval');
+  });
+
+  test('the SCIM card renders the cheat sheet with deep links into each guide', () => {
+    expect(scimCardSource).toContain('Start automatic sync in your IdP');
+    expect(scimCardSource).toContain('startSyncHint');
+    expect(scimCardSource).toContain('scim-setup?provider=');
+  });
+});
+
 describe('SCIM scope trade-off copy (live confusion: "why only assigned?")', () => {
   test('the Entra configure step explains "sync only assigned" vs "sync all" in plain terms', () => {
     const text = JSON.stringify(getScimGuide('entra')!.steps);

--- a/apps/web/src/features/sso-setup/sso-setup.test.ts
+++ b/apps/web/src/features/sso-setup/sso-setup.test.ts
@@ -353,6 +353,8 @@ describe('identity page progressive disclosure', () => {
     expect(cardSource).toContain('DisclosureTrigger');
     // Not-connected leads with a call-to-action, not a wall of URLs.
     expect(cardSource).toContain('Not connected yet');
+    // Group mappings collapse too, with a count chip in the trigger.
+    expect(cardSource).toContain('{mappings.length}');
   });
 
   test('the SCIM card leads with a status chip and collapses setup values + tokens', () => {


### PR DESCRIPTION
Answers the recurring question on the Identity card: *how do I make sync run automatically for MY provider?*

Each SCIM guide now carries a `startSyncHint` — the exact console switch that turns automatic provisioning on, sourced from the fact-checked guides:

- **Entra** — Provisioning → "Start provisioning" (then the ~40-min cycle runs itself)
- **Okta** — To App → enable Create/Update/Deactivate → Save (pushes as changes happen)
- **OneLogin** — enable provisioning **and uncheck admin approval** (the silent pending-queue trap)
- **JumpCloud** — Test Connection → Activate, then bind user groups
- **PingOne** — the connection toggle **AND** the rule Active (both required — the fact-checked blocker)
- **Custom** — generic fallback

The card's Setup values section renders the full cheat sheet with a **deep link into each provider's guided setup** (`/scim-setup?provider=…`), right where the smart-open disclosure already lands an admin stuck at "waiting for IdP".

Single source of truth: the guides registry — no copy duplicated in the card. Tests pin every guide has the hint + the card renders the sheet; 87 pass, tsc/lint clean.