### PR TITLE
docs: Kortix-as-a-Backend v1 — session-start overrides, origin gate, service-account auth

### DIFF
--- a/docs/KORTIX_AS_BACKEND_V1_PLAN.md
+++ b/docs/KORTIX_AS_BACKEND_V1_PLAN.md
@@ -27,17 +27,17 @@ Connectors are already **user-owned profiles decoupled from the agent** (`execut
 
 **Kortix authenticates the wrapper; the wrapper vouches for its end-user.** (Stripe-Connect / Twilio-subaccount model.)
 
-- **Caller = a Service Account token (`kortix_sa_`)** — a *machine* identity, held server-side, never exposed. IAM-scoped (deny-by-default governance) to exactly `session.start` + connector-profile management. Survives offboarding; auditable; independently revocable. **Not** a user PAT (ties to a person, over-privileged, and end-users aren't members) and **not** a raw API key (coarse, no policy). Service accounts already ship.
+- **Caller = any programmatic customer credential** *(REV 3 — shipped in PR #5147; supersedes the SA-only stance below)*: the **account API key / PAT** (`kortix_pat_` — the credential the Tokens UI mints as "Create API key"), a **Service Account** (`kortix_sa_`), or a dedicated account API key (`kortix_`, `apiKeyType='user'`, dormant until issuance ships). All resolve `origin: backend`. **Why the reversal from SA-only:** a fresh service account has *no* IAM policy binding — `createServiceAccount` attaches none, the engine skips membership for SAs, and granting `project.session.start` requires a custom role + per-project token-principal policy, both behind the enterprise-only `rbac` entitlement. SA-only would be dark for every non-enterprise account. The PAT inherits its creator's project membership → works on every tier with zero IAM setup. SA remains the *recommended* credential for enterprise/CI (deny-by-default governance, survives offboarding, independently revocable). Hard exclusions, enforced with regression tests: the **internal sandbox key** (`kortix_sb_`, the `KORTIX_TOKEN` inside every sandbox) and **any agent-scoped token** are never backend — an in-session agent cannot vouch for a phantom end-user.
 - **End-user identity = a parameter, not an auth principal** — the wrapper passes `origin_ref` (its own user id) + that user's `profile_id`s. Kortix records `origin: backend`, resolves *that user's* profiles, attributes usage to `origin_ref`. **End-users never authenticate to Kortix.** Scales to 100k with no per-user login and no subject-identity system.
 
-**Developer UX (the whole integration):**
+**Developer UX (the whole integration — zero-setup path, any tier):**
 ```
-1. Tokens → New service account → paste kortix_sa_… into backend env        (once)
-2. Attach policy: session.start + connector-profiles                        (least privilege)
-3. Per end-user: store their credential once → get profile_id               (server-to-server)
-4. POST /sessions  (Bearer kortix_sa_…)
+1. Settings → Tokens → Create API key → paste kortix_pat_… into backend env  (once)
+2. Per end-user: store their credential once → get profile_id                (server-to-server)
+3. POST /sessions  (Bearer kortix_pat_…)
    { agent_name, origin_ref:"user-123", connector_bindings:{ gmail:{profile_id} } }
 ```
+**Enterprise/CI path (least privilege):** New service account → attach policy (`session.start` + connector-profiles) → same call with `Bearer kortix_sa_…`.
 Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 **Direct streaming (optional):** to let an end-user's browser stream a session directly, the backend mints a **short-lived, session-scoped token** for that one session and hands *that* to the browser — never the `kortix_sa_` key. Governed by the existing PAT max-lifetime / idle-revoke policy.
@@ -62,7 +62,7 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 **4.5 Profile revoked mid-session.** End-user disconnects their Gmail while a session is live. *Handling:* the broker fails **closed** — a bound-but-revoked profile returns null, never falls back to the shared default (verified). The wrapper must surface "reconnect".
 
-**4.6 Origin spoofing.** A user PAT must not be able to claim `origin: backend` or pass connector overrides. *Handling:* origin is **derived from the caller's token kind**, not accepted from the body; `canOverride` rejects out-of-envelope fields. `origin_ref` is trusted only from a service-account caller.
+**4.6 Origin spoofing.** *(updated for REV 3)* No caller may claim `origin: backend` via the body — origin is **derived from the caller's token kind** (`authType` + `apiKeyType` + agent-scope), never accepted from the request. The spoofing surface that matters: the **in-sandbox `KORTIX_TOKEN`** (`apiKey`+`sandbox`) and **agent-scoped tokens** must never resolve backend — enforced with a *positive* `apiKeyType==='user'` check (a missing/unknown type can never be promoted) and an explicit agent-scope exclusion, both regression-tested. `origin_ref` is trusted only from a backend-origin caller; anyone else supplying it gets `403 origin_override_forbidden`. The queued-create path replays the same derivation signals captured at enqueue time, so backpressure can't degrade or upgrade an origin.
 
 **4.7 Model not servable / wrong form.** *Handling:* normalize via `toOpencodeModelRef` and **fail-fast** at create with `isModelServableForAccount` (reuses the request-time resolver) — never silently fall to default.
 
@@ -76,10 +76,10 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 ## 5. Build order
 
-1. `origin` field + resolver + `canOverride` policy gate — the spine.
+1. ✅ **SHIPPED (PR #5147)** — `origin` field + resolver + `canOverride` policy gate, incl. REV 3 backend credentials (PAT/SA/user-apiKey), sandbox+agent-scope exclusions, queued-create signal carry, and the Tokens-UI "Using the API" story.
 2. Document + expose the shipping path (connectors/model/agent/context) as the "backend" contract, with §4 gotchas. **This alone makes base-agent wrapping real today.**
 3. Server-to-server connector-profile mint + all-or-nothing softening (4.1).
-4. Secret-bundle by reference — hot-push merge + scope split (4.2).
+4. Secret-bundle by reference — hot-push merge + scope split (4.2). *(in design — per-session allowlist by identifier, pure narrowing, enforced at boot + hot-push)*
 5. Skills subset (v2, optional).
 
 Each new contract field needs a schema add + a ke2e route-coverage test (the `.strict()` contract + coverage gate); transport is free (body flows verbatim to the core).

--- a/docs/KORTIX_AS_BACKEND_V1_PLAN.md
+++ b/docs/KORTIX_AS_BACKEND_V1_PLAN.md
@@ -79,7 +79,7 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 1. ✅ **SHIPPED (PR #5147)** — `origin` field + resolver + `canOverride` policy gate, incl. REV 3 backend credentials (PAT/SA/user-apiKey), sandbox+agent-scope exclusions, queued-create signal carry, and the Tokens-UI "Using the API" story.
 2. Document + expose the shipping path (connectors/model/agent/context) as the "backend" contract, with §4 gotchas. **This alone makes base-agent wrapping real today.**
 3. Server-to-server connector-profile mint + all-or-nothing softening (4.1).
-4. Secret-bundle by reference — hot-push merge + scope split (4.2). *(in design — per-session allowlist by identifier, pure narrowing, enforced at boot + hot-push)*
+4. ✅ **SHIPPED (PR #5154, stacked on #5147)** — Secret-bundle by reference: a backend-only per-session `secrets` allowlist by identifier. Pure NARROWING — injected env = (agent grant) ∩ (allowlist), enforced at BOTH sandbox boot and hot-push (the clobber fix); `[]` = zero secrets; null = byte-identical to today. Immutable first-class column, 403/400/404/409 validation. (Deferred: create-time ambiguity 409, silent-drop warning, web UX.)
 5. Skills subset (v2, optional).
 
 Each new contract field needs a schema add + a ke2e route-coverage test (the `.strict()` contract + coverage gate); transport is free (body flows verbatim to the core).

--- a/docs/KORTIX_AS_BACKEND_V1_PLAN.md
+++ b/docs/KORTIX_AS_BACKEND_V1_PLAN.md
@@ -1,0 +1,252 @@
+# Kortix as a Backend (KaaB) v1 — Subjects, Releases, State Overlay & the Credential Broker
+
+Status: Draft RFC for review · 2026-07-21
+
+## 0. TL;DR
+
+**The ask:** Let a third party wrap Kortix as a pure backend — e.g. a consumer AI app with 100k end-users all driving **one shared agent in one repo**, where every end-user brings **their own** connections (their Gmail, their Notion), their own files/memory, and their own metered costs — without those users being Kortix members, and **without trusting them with anything inside the sandbox**.
+
+**The reality (verified):** the current architecture assumes the opposite on three axes:
+
+1. **Trusted principal** — `runtime` secrets are pushed into the sandbox as env at boot and on hot-push ([sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts)). Any principal who can make the agent run code (or just prompt it) can exfiltrate them. Acceptable for members; disqualifying for third-party end-users.
+2. **Repo as the universe** — code *and* state (workspace files, memory, brain) live in one working tree, cloned per session. There is nowhere for per-end-user state to live, and clone-per-session is the wrong boot path for an API product.
+3. **Agent-bound credentials** — one connector profile per agent. Per-user connector credentials *existed and were removed on 2026-07-05* ("every connector resolves the one shared credential regardless of owner" — [kortix.ts:733–735](../packages/db/src/schema/kortix.ts)). The need was real; the layer was wrong.
+
+**The unlock (verified — this is activate + extend, not greenfield):**
+
+- **The credential broker already exists.** `project_secret_scope = 'connector'` secrets are "resolved **SERVER-SIDE by the gateway** and **NEVER injected into the sandbox**" ([kortix.ts:427](../packages/db/src/schema/kortix.ts)). The pattern KaaB needs is live today for executor connectors — it just resolves one shared credential instead of a per-principal one.
+- **Principal-shaped connector grants already exist** — `executor_connectors` / `executor_connector_grants` carry member|group allow-lists ([kortix.ts:411](../packages/db/src/schema/kortix.ts)). Extending the principal set is a schema evolution, not a new concept.
+- **Public pre-authorized credential capture already exists** — `/v1/setup-links/{secret,connector}/:token` ([index.ts:798](../apps/api/src/index.ts)) is exactly the primitive a hosted "connect your Gmail" flow for end-users needs.
+- **Per-session metering already exists** — `usage_events` with per-session attribution ([kortix.ts:1553, 1822](../packages/db/src/schema/kortix.ts)); adding a subject dimension is one nullable column.
+- **Token infra already exists** — hash-stored bearer tokens with status/revocation (PATs, SCIM tokens, sandbox session tokens; pattern in [repositories/scim.ts](../apps/api/src/repositories/scim.ts)). A subject session token is one more audience.
+- **Release infra already exists** — snapshots + warm pool ([snapshots/templates.ts](../apps/api/src/snapshots/templates.ts)) already bake and boot prepared images.
+
+**Strategy:** introduce **`subject`** — an external end-user principal with no IAM seat — and make today's internal mode the *permissive special case* of one general model. **Not a toggle**: a toggle forks the product into two modes that rot independently; instead, every session runs as a principal inside a policy envelope, and a member is simply a principal whose envelope is permissive. Four decouplings carry the whole design (§2). Each phase ships independently; **Phase 1 alone makes "wrap a base chat agent" sellable**.
+
+---
+
+## 1. Problem statement
+
+The wrapper scenario: a company builds a consumer product on top of Kortix. They deploy **one agent** (one repo: prompts, skills, executors). Their backend authenticates **their** users and calls Kortix server-to-server. Requirements:
+
+| Requirement | Today | Why it fails |
+| --- | --- | --- |
+| 100k users share 1 agent, each with their own Gmail/Notion | One connector credential per connector, agent/project-wide | Users would share one Gmail — absurd — or need 100k agent copies |
+| End-users must never see operator or other-user credentials | `runtime` secrets land in sandbox env | Prompt injection or a plain "print your env" exfiltrates them |
+| Per-user files/memory that persist across sessions | State lives in the repo working tree | Per-user writes would pollute the shared repo or vanish |
+| Per-user cost attribution + caps | Account-level billing; per-session usage rows | No end-user identity to attribute to |
+| Fast, cheap session boot at API scale | Git clone per session | Clone of a shared, unchanging program 100k× is waste |
+| End-users are not Kortix members | Principals are account members (IAM seats) | Seats, invites, and login flows make no sense for `user-123` |
+
+The wrapper can build its own proxy that mints tokens and attributes costs — but it **cannot** work around agent-bound connector profiles, repo-bound state, or secrets-in-sandbox. Those are ours to fix.
+
+**Why not a mode toggle:** a "backend mode" flag creates two products in one codebase — every feature decision forks, and the untrusted path becomes the untested path. The safer architecture makes untrusted the *general* case and trusted the *policy exception*, so one code path is exercised by both.
+
+## 2. Design thesis — four decouplings
+
+**D1. Identity: `principal = member | group | subject`.**
+A **subject** is an external end-user identity owned by the wrapper: a row keyed by the wrapper's `external_id`, no `auth.users` row, no seat, no sign-in. The wrapper's backend mints **scoped subject session tokens** server-to-server. A member is a principal with a permissive envelope; a subject is a principal with a restrictive one. One engine.
+
+**D2. Code vs. state: the repo is the program; state lives in a per-principal overlay.**
+A **release** = `repo@commit` baked into a snapshot (existing template infra). Subject sessions boot a release: `/repo` is read-only, there is no clone and no git credential in the sandbox. Beside it, `/workspace` is the session's **state overlay**: for a *member* session the overlay **is** the repo working tree (today's behavior, byte-identical); for a *subject* session it is that subject's persistent storage prefix (files, memory, artifacts — quota'd, lazily created). One session pipeline; the mount policy differs.
+This is the direct answer to *"how, if everything is stored in a repo?"* — for subjects, it isn't. The repo is the app, not the database.
+
+**D3. Credentials: requirement ≠ profile ≠ execution.**
+- The **requirement** ("this agent uses gmail") stays in the manifest. It is code; it belongs to the repo.
+- The **profile** (whose Gmail) becomes a `connections` row keyed by **principal** — the 2026-07-05 removal re-landed at the correct layer.
+- The **execution** happens at the **broker**: the sandbox emits "invoke `gmail.search` as my principal" carrying only its session token; the gateway resolves the caller's connection, attaches the credential server-side, executes, and returns the result. The `'connector'` secret scope already works exactly this way — we generalize *which credential* it resolves, per principal. Secrets never enter a subject sandbox **by construction**, not by review.
+
+**D4. Policy & metering: every session runs in a policy envelope.**
+Envelope = capability set + resource mounts + caps. Subject default: create/continue own sessions, message, invoke granted connector types, read/write own overlay — **no** repo write, no config/trigger mutation, no secret read, no env delivery, no git push. Member default: today's behavior. Usage events carry the principal; caps enforce at the gateway pre-flight where account caps already live.
+
+## 3. Verified seams (file:line) and their v1 role
+
+| Seam | Today | v1 role |
+| --- | --- | --- |
+| [sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts) | Builds + pushes secret env, agent-scope-gated, boot + hot-push | The single choke point where subject sessions resolve to an **empty** secret env |
+| [kortix.ts:427](../packages/db/src/schema/kortix.ts) `project_secret_scope='connector'` | Gateway-resolved, never injected | The broker precedent; generalized to per-principal resolution |
+| [kortix.ts:411](../packages/db/src/schema/kortix.ts) `executor_connectors(_grants)` | member\|group connector sharing | Principal model precedent; informs `connections` shape |
+| [kortix.ts:733](../packages/db/src/schema/kortix.ts) (comment) | `per_user` connector creds removed 2026-07-05 | Evidence the need existed; re-landed as `connections` keyed by principal |
+| [index.ts:798](../apps/api/src/index.ts) `/v1/setup-links` | Public, pre-authorized secret/connector capture | Basis for hosted subject **connect links** (OAuth per end-user) |
+| [repositories/scim.ts](../apps/api/src/repositories/scim.ts) | Hash-stored bearer tokens, status, revocation, `last_used_at` | Pattern for **subject session tokens** |
+| [kortix.ts:1822](../packages/db/src/schema/kortix.ts) `usage_events` (+ per-session attribution at 1553) | Account/session metering | + nullable `subject_id` dimension; per-subject usage API + caps |
+| [snapshots/templates.ts](../apps/api/src/snapshots/templates.ts) | Bake + boot prepared images, warm pool | **Releases**: bake `repo@commit`; subject sessions boot releases only |
+| [engine-v2.ts](../apps/api/src/iam/engine-v2.ts) | Allow-only decision engine for members | Gains a `subject` actor kind resolving to the restrictive envelope |
+
+## 4. Architecture
+
+### 4.1 Subjects
+
+```sql
+CREATE TABLE kortix.subjects (
+  subject_id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id   uuid NOT NULL REFERENCES kortix.accounts(account_id) ON DELETE CASCADE,
+  project_id   uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
+  external_id  text NOT NULL,                 -- the wrapper's user id, opaque to us
+  display_name text,
+  status       text NOT NULL DEFAULT 'active',-- active | disabled
+  caps         jsonb,                          -- per-subject overrides: {credits_month, tokens_day, ...}
+  metadata     jsonb,                          -- wrapper-owned bag, returned verbatim
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (project_id, external_id)
+);
+```
+
+Deliberately **not** members: no seat, no invite, no login, no IAM group membership. Disabling a subject revokes its tokens and blocks new sessions (same posture as SCIM deactivation: revoke fast, keep rows for attribution).
+
+### 4.2 Subject session tokens
+
+- Mint (server-to-server, PAT-authenticated): `POST /v1/projects/:projectId/subjects/:externalId/tokens` — upserts the subject, returns a short-TTL bearer (hash-stored, SCIM-token pattern) bound to `{subject_id, project_id, agent, capabilities, exp}`.
+- The sandbox receives **only this token** (in the existing session-token slot). It authenticates the session stream, overlay file APIs, and broker calls — and authorizes nothing else.
+- Revocation: `DELETE .../subjects/:externalId/tokens` (all) — same "revoke is never gated" rule as SCIM tokens.
+
+### 4.3 Policy envelope
+
+Session class derives from the actor: `member` → today's decisions; `subject` → fixed restrictive envelope (v1: not customizable per role — keep the matrix small until real demand):
+
+| Capability | Subject |
+| --- | --- |
+| session create/continue (own), message, stream | ✅ |
+| connector invoke — granted types, own profile | ✅ (broker) |
+| overlay files read/write (own prefix, quota'd) | ✅ |
+| repo write / git push / config / triggers / secrets | ❌ |
+| env secret delivery (`runtime` scope) | ❌ — env resolves empty in [sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts) |
+| see other subjects' sessions/files/connections | ❌ |
+
+Enforced in three places, all existing choke points: route layer (engine actor kind), sandbox boot/hot-push (env + mount policy), gateway (per-call capability + cap check).
+
+### 4.4 Releases
+
+```sql
+CREATE TABLE kortix.releases (
+  release_id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id   uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
+  commit_sha   text NOT NULL,
+  manifest_hash text NOT NULL,
+  snapshot_ref text,                            -- baked image (templates infra)
+  status       text NOT NULL DEFAULT 'building',-- building | ready | retired
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (project_id, commit_sha)
+);
+```
+
+`POST /v1/projects/:id/releases` bakes `repo@commit` via the existing template pipeline. **Subject sessions boot releases only**: `/repo` read-only, no clone, no git credential present. Member sessions are untouched in v1 (they keep the working tree — that *is* their overlay). Publishing is the operator's deliberate act — the wrapper's users never see un-released commits.
+
+### 4.5 State overlay
+
+- Mounts: `/repo` (RO release) + `/workspace` (the principal's overlay).
+- **Member session:** overlay = repo working tree. Today's behavior, byte-identical, no migration.
+- **Subject session:** overlay = per-subject object-store prefix (`kaab/{project}/{subject}/…`), materialized into the sandbox at boot and synced back by the daemon on write/close (v1: daemon-driven sync, not FUSE — simpler, good enough for files/memory; revisit if latency demands).
+- Memory/brain writes resolve through the overlay path for subjects — same agent code, different mount.
+- Quotas: per-subject bytes + object count enforced at sync; overruns fail the write with a typed error the agent can surface.
+
+### 4.6 Connections & the broker
+
+```sql
+CREATE TYPE kortix.connection_principal AS ENUM ('project', 'member', 'subject');
+
+CREATE TABLE kortix.connections (
+  connection_id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id      uuid NOT NULL,
+  project_id      uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
+  connector_type  text NOT NULL,               -- 'gmail' | 'notion' | ...
+  principal_type  kortix.connection_principal NOT NULL,
+  principal_id    uuid,                         -- NULL for 'project'
+  credentials_ref uuid NOT NULL,                -- encrypted credential row (KMS), 'connector' scope
+  oauth_app_id    uuid,                         -- NULL = Kortix-owned OAuth app; else BYO (below)
+  status          text NOT NULL DEFAULT 'active',
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (project_id, connector_type, principal_type, principal_id)
+);
+
+CREATE TABLE kortix.oauth_apps (                -- wrapper-branded consent screens
+  oauth_app_id  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id    uuid NOT NULL,
+  connector_type text NOT NULL,
+  client_id     text NOT NULL,
+  client_secret_ref uuid NOT NULL,              -- encrypted
+  redirect_base text,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- **Resolution at call time (gateway):** subject profile → per-connector fallback policy (`none` — the safe default — or `project` shared credential for operator-owned connectors like an internal knowledge base). Member sessions resolve exactly as today until/unless migrated.
+- **Broker flow:** sandbox emits `connector.invoke {type, method, args}` with its session token → gateway checks capability + resolves the caller's connection → decrypts server-side → executes (or attaches the token for pass-through executors) → returns the result. The `'connector'` scope already guarantees "never injected"; this only changes *which* credential resolves.
+- **Hosted connect flow:** `POST /v1/projects/:id/subjects/:externalId/connect-links {connector_type}` → pre-authorized URL (setup-links pattern) → OAuth consent (Kortix-owned app, or the wrapper's own `oauth_apps` row so *their* branding appears) → callback stores `credentials_ref` on the subject's connection. The wrapper embeds or redirects; it never touches the tokens.
+
+### 4.7 Metering & caps
+
+- `usage_events.subject_id uuid NULL` — new dimension, populated for subject sessions (backfill-free).
+- `GET /v1/projects/:id/subjects/:externalId/usage?from&to` — the wrapper's cost-attribution feed.
+- Caps: `subjects.caps` checked at the gateway pre-flight alongside account caps; exceeding returns a typed 402-class error the wrapper can map to its own paywall.
+
+## 5. API surface (v1)
+
+Server-to-server (operator PAT):
+
+```
+PUT    /v1/projects/:id/subjects/:externalId            upsert (display_name, caps, metadata)
+GET    /v1/projects/:id/subjects[?cursor]               list
+DELETE /v1/projects/:id/subjects/:externalId            disable + revoke tokens
+POST   /v1/projects/:id/subjects/:externalId/tokens     mint scoped session token
+DELETE /v1/projects/:id/subjects/:externalId/tokens     revoke all
+POST   /v1/projects/:id/subjects/:externalId/connect-links   {connector_type} → url
+GET    /v1/projects/:id/subjects/:externalId/connections     list (types + status, never credentials)
+DELETE /v1/projects/:id/subjects/:externalId/connections/:type
+GET    /v1/projects/:id/subjects/:externalId/usage
+POST   /v1/projects/:id/releases                        bake repo@commit
+GET    /v1/projects/:id/releases                        list
+```
+
+Subject-token surface (called by the wrapper's client or server, scoped by the token itself): create/continue session, send message, stream, overlay file read/write. Nothing else resolves.
+
+## 6. Threat-model deltas
+
+| Threat | Answer |
+| --- | --- |
+| Prompt-injected credential exfil | Nothing to exfiltrate: env empty, broker executes server-side, only results cross the boundary |
+| Stolen subject token | Short TTL, capability-scoped, per-subject revoke-all; token is useless outside its project/agent/subject |
+| Cross-subject access | Overlay prefix + connection resolution + session visibility all key on the token's `subject_id` |
+| Repo tampering | RO release mount, no git credential in subject sandboxes |
+| Cost abuse | Per-subject caps at the gateway pre-flight; wrapper sees usage per subject and can cut off upstream |
+| Sandbox egress | Phase 4: restricted egress policy for subject sessions (broker + LLM gateway + overlay endpoints only) |
+
+## 7. Phases — independently shippable
+
+**Phase 0 — this RFC + three decisions (§8).**
+
+**Phase 1 — Subjects, sessions, metering ("wrap a base agent").**
+- Migration (hand-written, repo convention): `subjects`, `usage_events.subject_id`.
+- `repositories/subjects.ts` + token mint/validate (SCIM-token pattern).
+- Session create accepts a subject actor; engine actor kind `subject` → restrictive envelope; env resolves empty in [sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts); repo mounted read-only for subject sessions (clone path retained but RO — releases land in Phase 4).
+- Usage attribution + usage endpoint + caps pre-flight.
+- **Acceptance:** a wrapper mints a token for `user-123`, opens a session on the shared agent, chats; a test asserts the sandbox env contains zero project secrets; usage rows carry `subject_id`; subject B cannot address subject A's session; disabling a subject kills its tokens.
+
+**Phase 2 — Connections + broker (the hard core).**
+- `connections` + `oauth_apps` migrations; repository + operator/subject APIs.
+- Gateway connector resolution goes principal-first (today's shared-credential resolution — [kortix.ts:735](../packages/db/src/schema/kortix.ts) — becomes the `project` fallback).
+- `connector.invoke` gateway route + sandbox tool shim; connect-links on the setup-links pattern; BYO OAuth apps.
+- **Acceptance:** two subjects, one agent — each call uses the caller's own Gmail; a test greps sandbox env + fs for credential material and finds none; revoking a connection 403s the next invoke.
+
+**Phase 3 — State overlay.**
+- Object-store prefix per subject; daemon materialize/sync; overlay resolver (member → worktree unchanged, byte-identical); quotas; subject file APIs.
+- **Acceptance:** subject files/memory persist across sessions and survive sandbox recycling; the repo shows zero subject writes; member-session behavior unchanged under the existing test suite.
+
+**Phase 4 — Releases + hardening.**
+- `releases` + publish API baking via [snapshots/templates.ts](../apps/api/src/snapshots/templates.ts); subject boot = release only (no clone); egress policy for subject sandboxes; optional: begin migrating member sessions' `runtime` secrets onto the broker for a single credential story.
+- **Acceptance:** subject session boots with no git operation at all; un-released commits are invisible to subjects; egress from a subject sandbox is limited to gateway/overlay endpoints.
+
+## 8. Decisions needed
+
+1. **Per-subject custom code (skills/executors)** — recommendation: **out of v1**. Per-subject *state, connections, caps* yes; per-subject *code* means executing untrusted end-user code and is a different product surface. Revisit post-Phase-4 as an overlay-mounted skills dir behind the egress policy.
+2. **Member sessions on the broker eventually?** — recommendation: **yes, as a Phase-4+ migration**, so there is one credential story and "env secrets" become legacy. Not a prerequisite for any phase.
+3. **Overlay backend** — recommendation: **object-store prefix + daemon sync** for v1 (cheap at 100k subjects, no volume orchestration); per-subject volumes only if fs-semantics demand it later.
+
+## 9. Non-goals (v1)
+
+- Per-subject custom skills/executors/agents (decision 1).
+- Any Kortix-hosted UI for end-users — subjects are API-only; the wrapper owns all UX except the OAuth consent hop.
+- Wrapper-facing billing UI — usage is API-only; the wrapper bills its own users.
+- Subject-visible dashboards, subject IAM roles, subject-to-subject sharing.

--- a/docs/KORTIX_AS_BACKEND_V1_PLAN.md
+++ b/docs/KORTIX_AS_BACKEND_V1_PLAN.md
@@ -1,252 +1,95 @@
-# Kortix as a Backend (KaaB) v1 — Subjects, Releases, State Overlay & the Credential Broker
+# Kortix as a Backend (KaaB) — v1 Plan
 
-Status: Draft RFC for review · 2026-07-21
+Status: Draft for review · rev 2 (verified against current `main`)
 
 ## 0. TL;DR
 
-**The ask:** Let a third party wrap Kortix as a pure backend — e.g. a consumer AI app with 100k end-users all driving **one shared agent in one repo**, where every end-user brings **their own** connections (their Gmail, their Notion), their own files/memory, and their own metered costs — without those users being Kortix members, and **without trusting them with anything inside the sandbox**.
+**The ask:** let a third party wrap Kortix as a backend — many end-users on **one shared agent + repo**, each bringing **their own** connectors, model, and context, passed **at session start**, overriding the agent's defaults.
 
-**The reality (verified):** the current architecture assumes the opposite on three axes:
+**The finding (verified in-repo):** ~80% of this **already ships**. The session-create contract already accepts per-session overrides, by reference, broker-safe. This is **activation + two small gaps**, not a rewrite.
 
-1. **Trusted principal** — `runtime` secrets are pushed into the sandbox as env at boot and on hot-push ([sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts)). Any principal who can make the agent run code (or just prompt it) can exfiltrate them. Acceptable for members; disqualifying for third-party end-users.
-2. **Repo as the universe** — code *and* state (workspace files, memory, brain) live in one working tree, cloned per session. There is nowhere for per-end-user state to live, and clone-per-session is the wrong boot path for an API product.
-3. **Agent-bound credentials** — one connector profile per agent. Per-user connector credentials *existed and were removed on 2026-07-05* ("every connector resolves the one shared credential regardless of owner" — [kortix.ts:733–735](../packages/db/src/schema/kortix.ts)). The need was real; the layer was wrong.
+**The shape:** a session is `{ config-with-optional-overrides, provenance }`. **Origin** decides who may override what and how the session behaves; **overrides** carry references; the broker resolves them server-side. Internal Kortix = `origin: user`, no overrides → **byte-identical to today**. Not a mode toggle — one pipeline, policy branches on the origin enum.
 
-**The unlock (verified — this is activate + extend, not greenfield):**
+## 1. Already works today (use it now)
 
-- **The credential broker already exists.** `project_secret_scope = 'connector'` secrets are "resolved **SERVER-SIDE by the gateway** and **NEVER injected into the sandbox**" ([kortix.ts:427](../packages/db/src/schema/kortix.ts)). The pattern KaaB needs is live today for executor connectors — it just resolves one shared credential instead of a per-principal one.
-- **Principal-shaped connector grants already exist** — `executor_connectors` / `executor_connector_grants` carry member|group allow-lists ([kortix.ts:411](../packages/db/src/schema/kortix.ts)). Extending the principal set is a schema evolution, not a new concept.
-- **Public pre-authorized credential capture already exists** — `/v1/setup-links/{secret,connector}/:token` ([index.ts:798](../apps/api/src/index.ts)) is exactly the primitive a hosted "connect your Gmail" flow for end-users needs.
-- **Per-session metering already exists** — `usage_events` with per-session attribution ([kortix.ts:1553, 1822](../packages/db/src/schema/kortix.ts)); adding a subject dimension is one nullable column.
-- **Token infra already exists** — hash-stored bearer tokens with status/revocation (PATs, SCIM tokens, sandbox session tokens; pattern in [repositories/scim.ts](../apps/api/src/repositories/scim.ts)). A subject session token is one more audience.
-- **Release infra already exists** — snapshots + warm pool ([snapshots/templates.ts](../apps/api/src/snapshots/templates.ts)) already bake and boot prepared images.
+Session create — `POST /v1/projects/:id/sessions` ([contract `index.ts:298`, `.strict()`](../packages/api-contract/src/index.ts); core [`lib/sessions.ts:434`](../apps/api/src/projects/lib/sessions.ts)) — already accepts and overrides-over-defaults:
 
-**Strategy:** introduce **`subject`** — an external end-user principal with no IAM seat — and make today's internal mode the *permissive special case* of one general model. **Not a toggle**: a toggle forks the product into two modes that rot independently; instead, every session runs as a principal inside a policy envelope, and a member is simply a principal whose envelope is permissive. Four decouplings carry the whole design (§2). Each phase ships independently; **Phase 1 alone makes "wrap a base chat agent" sellable**.
+| Dimension | Field today | Safe because | Gotcha |
+| --- | --- | --- | --- |
+| **Connectors** | `connector_bindings: {alias: {profile_id}}` | broker resolves per gateway call (`resolveSessionConnectorProfile(sessionId, alias)`); session binding beats default; **credential never enters the request or sandbox** | **all-or-nothing**: bind any → every *unbound* alias goes null (§4.1) |
+| **Model** | `opencode_model` | inline id, not a secret; catalog-validated | must be opencode ref form `kortix/<id>` — a bare wire id **silently drops** to default |
+| **Agent** | `agent_name` | per-resource `agent.read` gate | soft-bound — the runtime prompt's `agent` can still switch it (still grant-gated) |
+| **End-user context** | `runtime_context` (scalar map) | credential-like keys regex-rejected → `KORTIX_SESSION_CONTEXT` env | non-secret only; 64 keys / 16KB cap |
 
----
+Connectors are already **user-owned profiles decoupled from the agent** (`executor_connection_profiles` + encrypted `executor_credentials`, migration `20260712190000000`). **That is exactly "each user brings their own, pass the reference."**
 
-## 1. Problem statement
+## 2. Auth — how the wrapper connects
 
-The wrapper scenario: a company builds a consumer product on top of Kortix. They deploy **one agent** (one repo: prompts, skills, executors). Their backend authenticates **their** users and calls Kortix server-to-server. Requirements:
+**Kortix authenticates the wrapper; the wrapper vouches for its end-user.** (Stripe-Connect / Twilio-subaccount model.)
 
-| Requirement | Today | Why it fails |
-| --- | --- | --- |
-| 100k users share 1 agent, each with their own Gmail/Notion | One connector credential per connector, agent/project-wide | Users would share one Gmail — absurd — or need 100k agent copies |
-| End-users must never see operator or other-user credentials | `runtime` secrets land in sandbox env | Prompt injection or a plain "print your env" exfiltrates them |
-| Per-user files/memory that persist across sessions | State lives in the repo working tree | Per-user writes would pollute the shared repo or vanish |
-| Per-user cost attribution + caps | Account-level billing; per-session usage rows | No end-user identity to attribute to |
-| Fast, cheap session boot at API scale | Git clone per session | Clone of a shared, unchanging program 100k× is waste |
-| End-users are not Kortix members | Principals are account members (IAM seats) | Seats, invites, and login flows make no sense for `user-123` |
+- **Caller = a Service Account token (`kortix_sa_`)** — a *machine* identity, held server-side, never exposed. IAM-scoped (deny-by-default governance) to exactly `session.start` + connector-profile management. Survives offboarding; auditable; independently revocable. **Not** a user PAT (ties to a person, over-privileged, and end-users aren't members) and **not** a raw API key (coarse, no policy). Service accounts already ship.
+- **End-user identity = a parameter, not an auth principal** — the wrapper passes `origin_ref` (its own user id) + that user's `profile_id`s. Kortix records `origin: backend`, resolves *that user's* profiles, attributes usage to `origin_ref`. **End-users never authenticate to Kortix.** Scales to 100k with no per-user login and no subject-identity system.
 
-The wrapper can build its own proxy that mints tokens and attributes costs — but it **cannot** work around agent-bound connector profiles, repo-bound state, or secrets-in-sandbox. Those are ours to fix.
-
-**Why not a mode toggle:** a "backend mode" flag creates two products in one codebase — every feature decision forks, and the untrusted path becomes the untested path. The safer architecture makes untrusted the *general* case and trusted the *policy exception*, so one code path is exercised by both.
-
-## 2. Design thesis — four decouplings
-
-**D1. Identity: `principal = member | group | subject`.**
-A **subject** is an external end-user identity owned by the wrapper: a row keyed by the wrapper's `external_id`, no `auth.users` row, no seat, no sign-in. The wrapper's backend mints **scoped subject session tokens** server-to-server. A member is a principal with a permissive envelope; a subject is a principal with a restrictive one. One engine.
-
-**D2. Code vs. state: the repo is the program; state lives in a per-principal overlay.**
-A **release** = `repo@commit` baked into a snapshot (existing template infra). Subject sessions boot a release: `/repo` is read-only, there is no clone and no git credential in the sandbox. Beside it, `/workspace` is the session's **state overlay**: for a *member* session the overlay **is** the repo working tree (today's behavior, byte-identical); for a *subject* session it is that subject's persistent storage prefix (files, memory, artifacts — quota'd, lazily created). One session pipeline; the mount policy differs.
-This is the direct answer to *"how, if everything is stored in a repo?"* — for subjects, it isn't. The repo is the app, not the database.
-
-**D3. Credentials: requirement ≠ profile ≠ execution.**
-- The **requirement** ("this agent uses gmail") stays in the manifest. It is code; it belongs to the repo.
-- The **profile** (whose Gmail) becomes a `connections` row keyed by **principal** — the 2026-07-05 removal re-landed at the correct layer.
-- The **execution** happens at the **broker**: the sandbox emits "invoke `gmail.search` as my principal" carrying only its session token; the gateway resolves the caller's connection, attaches the credential server-side, executes, and returns the result. The `'connector'` secret scope already works exactly this way — we generalize *which credential* it resolves, per principal. Secrets never enter a subject sandbox **by construction**, not by review.
-
-**D4. Policy & metering: every session runs in a policy envelope.**
-Envelope = capability set + resource mounts + caps. Subject default: create/continue own sessions, message, invoke granted connector types, read/write own overlay — **no** repo write, no config/trigger mutation, no secret read, no env delivery, no git push. Member default: today's behavior. Usage events carry the principal; caps enforce at the gateway pre-flight where account caps already live.
-
-## 3. Verified seams (file:line) and their v1 role
-
-| Seam | Today | v1 role |
-| --- | --- | --- |
-| [sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts) | Builds + pushes secret env, agent-scope-gated, boot + hot-push | The single choke point where subject sessions resolve to an **empty** secret env |
-| [kortix.ts:427](../packages/db/src/schema/kortix.ts) `project_secret_scope='connector'` | Gateway-resolved, never injected | The broker precedent; generalized to per-principal resolution |
-| [kortix.ts:411](../packages/db/src/schema/kortix.ts) `executor_connectors(_grants)` | member\|group connector sharing | Principal model precedent; informs `connections` shape |
-| [kortix.ts:733](../packages/db/src/schema/kortix.ts) (comment) | `per_user` connector creds removed 2026-07-05 | Evidence the need existed; re-landed as `connections` keyed by principal |
-| [index.ts:798](../apps/api/src/index.ts) `/v1/setup-links` | Public, pre-authorized secret/connector capture | Basis for hosted subject **connect links** (OAuth per end-user) |
-| [repositories/scim.ts](../apps/api/src/repositories/scim.ts) | Hash-stored bearer tokens, status, revocation, `last_used_at` | Pattern for **subject session tokens** |
-| [kortix.ts:1822](../packages/db/src/schema/kortix.ts) `usage_events` (+ per-session attribution at 1553) | Account/session metering | + nullable `subject_id` dimension; per-subject usage API + caps |
-| [snapshots/templates.ts](../apps/api/src/snapshots/templates.ts) | Bake + boot prepared images, warm pool | **Releases**: bake `repo@commit`; subject sessions boot releases only |
-| [engine-v2.ts](../apps/api/src/iam/engine-v2.ts) | Allow-only decision engine for members | Gains a `subject` actor kind resolving to the restrictive envelope |
-
-## 4. Architecture
-
-### 4.1 Subjects
-
-```sql
-CREATE TABLE kortix.subjects (
-  subject_id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  account_id   uuid NOT NULL REFERENCES kortix.accounts(account_id) ON DELETE CASCADE,
-  project_id   uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
-  external_id  text NOT NULL,                 -- the wrapper's user id, opaque to us
-  display_name text,
-  status       text NOT NULL DEFAULT 'active',-- active | disabled
-  caps         jsonb,                          -- per-subject overrides: {credits_month, tokens_day, ...}
-  metadata     jsonb,                          -- wrapper-owned bag, returned verbatim
-  created_at   timestamptz NOT NULL DEFAULT now(),
-  updated_at   timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (project_id, external_id)
-);
+**Developer UX (the whole integration):**
 ```
-
-Deliberately **not** members: no seat, no invite, no login, no IAM group membership. Disabling a subject revokes its tokens and blocks new sessions (same posture as SCIM deactivation: revoke fast, keep rows for attribution).
-
-### 4.2 Subject session tokens
-
-- Mint (server-to-server, PAT-authenticated): `POST /v1/projects/:projectId/subjects/:externalId/tokens` — upserts the subject, returns a short-TTL bearer (hash-stored, SCIM-token pattern) bound to `{subject_id, project_id, agent, capabilities, exp}`.
-- The sandbox receives **only this token** (in the existing session-token slot). It authenticates the session stream, overlay file APIs, and broker calls — and authorizes nothing else.
-- Revocation: `DELETE .../subjects/:externalId/tokens` (all) — same "revoke is never gated" rule as SCIM tokens.
-
-### 4.3 Policy envelope
-
-Session class derives from the actor: `member` → today's decisions; `subject` → fixed restrictive envelope (v1: not customizable per role — keep the matrix small until real demand):
-
-| Capability | Subject |
-| --- | --- |
-| session create/continue (own), message, stream | ✅ |
-| connector invoke — granted types, own profile | ✅ (broker) |
-| overlay files read/write (own prefix, quota'd) | ✅ |
-| repo write / git push / config / triggers / secrets | ❌ |
-| env secret delivery (`runtime` scope) | ❌ — env resolves empty in [sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts) |
-| see other subjects' sessions/files/connections | ❌ |
-
-Enforced in three places, all existing choke points: route layer (engine actor kind), sandbox boot/hot-push (env + mount policy), gateway (per-call capability + cap check).
-
-### 4.4 Releases
-
-```sql
-CREATE TABLE kortix.releases (
-  release_id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  project_id   uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
-  commit_sha   text NOT NULL,
-  manifest_hash text NOT NULL,
-  snapshot_ref text,                            -- baked image (templates infra)
-  status       text NOT NULL DEFAULT 'building',-- building | ready | retired
-  created_at   timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (project_id, commit_sha)
-);
+1. Tokens → New service account → paste kortix_sa_… into backend env        (once)
+2. Attach policy: session.start + connector-profiles                        (least privilege)
+3. Per end-user: store their credential once → get profile_id               (server-to-server)
+4. POST /sessions  (Bearer kortix_sa_…)
+   { agent_name, origin_ref:"user-123", connector_bindings:{ gmail:{profile_id} } }
 ```
+Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
-`POST /v1/projects/:id/releases` bakes `repo@commit` via the existing template pipeline. **Subject sessions boot releases only**: `/repo` read-only, no clone, no git credential present. Member sessions are untouched in v1 (they keep the working tree — that *is* their overlay). Publishing is the operator's deliberate act — the wrapper's users never see un-released commits.
+**Direct streaming (optional):** to let an end-user's browser stream a session directly, the backend mints a **short-lived, session-scoped token** for that one session and hands *that* to the browser — never the `kortix_sa_` key. Governed by the existing PAT max-lifetime / idle-revoke policy.
 
-### 4.5 State overlay
+## 3. The 3 gaps to build
 
-- Mounts: `/repo` (RO release) + `/workspace` (the principal's overlay).
-- **Member session:** overlay = repo working tree. Today's behavior, byte-identical, no migration.
-- **Subject session:** overlay = per-subject object-store prefix (`kaab/{project}/{subject}/…`), materialized into the sandbox at boot and synced back by the daemon on write/close (v1: daemon-driven sync, not FUSE — simpler, good enough for files/memory; revisit if latency demands).
-- Memory/brain writes resolve through the overlay path for subjects — same agent code, different mount.
-- Quotas: per-subject bytes + object count enforced at sync; overruns fail the write with a typed error the agent can surface.
+1. **`origin` as a first-class field + policy gate** (the spine). Today it's informal (`metadata.source='trigger:cron'`). Promote to `origin: user|trigger|schedule|backend` + `origin_ref`, resolved once at create in `sessions.ts`. It gates **which override fields a caller may set** (only `backend` may set connector/secret refs; `user` only model) and **behavior** (approval relay, attribution). Small: column + resolve-at-create + a `canOverride(origin, field)` check.
+2. **Secrets by reference** (the one net-new config dim). Merge a referenced secret bundle in **`resolveOwnerRawEnv`** (the hot-push path), not just boot (§4.2). Scope split: `connector`-scope = broker, never in sandbox = always safe; `runtime`-scope enters the sandbox = only safe while the wrapper **proxies chat** (end-users have no raw sandbox access).
+3. **Skills subset** (v2-manifest only, mostly deferred). Intersect a requested subset with each agent's compiled `permission.skill` grant in `buildSessionSandboxEnvVars`. *Selecting* repo skills = clean; *injecting new* skills = untrusted code = out of scope.
 
-### 4.6 Connections & the broker
+**Enablers:** a **server-to-server connector-profile mint** for the wrapper; softening the **all-or-nothing binding** (a "bind these, inherit rest" mode).
 
-```sql
-CREATE TYPE kortix.connection_principal AS ENUM ('project', 'member', 'subject');
+## 4. Edge cases (the parts that bite)
 
-CREATE TABLE kortix.connections (
-  connection_id   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  account_id      uuid NOT NULL,
-  project_id      uuid NOT NULL REFERENCES kortix.projects(project_id) ON DELETE CASCADE,
-  connector_type  text NOT NULL,               -- 'gmail' | 'notion' | ...
-  principal_type  kortix.connection_principal NOT NULL,
-  principal_id    uuid,                         -- NULL for 'project'
-  credentials_ref uuid NOT NULL,                -- encrypted credential row (KMS), 'connector' scope
-  oauth_app_id    uuid,                         -- NULL = Kortix-owned OAuth app; else BYO (below)
-  status          text NOT NULL DEFAULT 'active',
-  created_at      timestamptz NOT NULL DEFAULT now(),
-  updated_at      timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (project_id, connector_type, principal_type, principal_id)
-);
+**4.1 Connector all-or-nothing (verified).** Bind one connector and every unbound alias resolves null → that connector goes dark for the session. *Handling:* v1 — the mint API returns the agent's full connector set so the wrapper binds all; v1.1 — add an `inherit_unbound: true` mode. **Decide which.**
 
-CREATE TABLE kortix.oauth_apps (                -- wrapper-branded consent screens
-  oauth_app_id  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  account_id    uuid NOT NULL,
-  connector_type text NOT NULL,
-  client_id     text NOT NULL,
-  client_secret_ref uuid NOT NULL,              -- encrypted
-  redirect_base text,
-  created_at    timestamptz NOT NULL DEFAULT now()
-);
-```
+**4.2 Secret hot-push clobber (verified, the killer).** Every prompt re-pushes the project snapshot; a boot-only secret override reverts on turn 1. *Handling:* the merge MUST live in `resolveOwnerRawEnv`, not only boot. Non-negotiable.
 
-- **Resolution at call time (gateway):** subject profile → per-connector fallback policy (`none` — the safe default — or `project` shared credential for operator-owned connectors like an internal knowledge base). Member sessions resolve exactly as today until/unless migrated.
-- **Broker flow:** sandbox emits `connector.invoke {type, method, args}` with its session token → gateway checks capability + resolves the caller's connection → decrypts server-side → executes (or attaches the token for pass-through executors) → returns the result. The `'connector'` scope already guarantees "never injected"; this only changes *which* credential resolves.
-- **Hosted connect flow:** `POST /v1/projects/:id/subjects/:externalId/connect-links {connector_type}` → pre-authorized URL (setup-links pattern) → OAuth consent (Kortix-owned app, or the wrapper's own `oauth_apps` row so *their* branding appears) → callback stores `credentials_ref` on the subject's connection. The wrapper embeds or redirects; it never touches the tokens.
+**4.3 Session-sharing / resume identity leak.** A `backend` session resumed or viewed by a teammate (or the wrapper's own admin) must NOT resolve the *viewer's* profiles. *Handling:* **lock the resolved profile set to the session at start** (bindings are already session-rows) — never re-resolve by the current actor. `backend` sessions default `visibility: private`.
 
-### 4.7 Metering & caps
+**4.4 Profile authorization (cross-tenant).** A service account referencing a `profile_id` it doesn't own must 403 (already: `validateSessionConnectorBindings`, same account+project+active). *Suggest:* also reject a profile for a connector the **agent isn't granted** (already: `agentMayUseConnector` fold) — keep both.
 
-- `usage_events.subject_id uuid NULL` — new dimension, populated for subject sessions (backfill-free).
-- `GET /v1/projects/:id/subjects/:externalId/usage?from&to` — the wrapper's cost-attribution feed.
-- Caps: `subjects.caps` checked at the gateway pre-flight alongside account caps; exceeding returns a typed 402-class error the wrapper can map to its own paywall.
+**4.5 Profile revoked mid-session.** End-user disconnects their Gmail while a session is live. *Handling:* the broker fails **closed** — a bound-but-revoked profile returns null, never falls back to the shared default (verified). The wrapper must surface "reconnect".
 
-## 5. API surface (v1)
+**4.6 Origin spoofing.** A user PAT must not be able to claim `origin: backend` or pass connector overrides. *Handling:* origin is **derived from the caller's token kind**, not accepted from the body; `canOverride` rejects out-of-envelope fields. `origin_ref` is trusted only from a service-account caller.
 
-Server-to-server (operator PAT):
+**4.7 Model not servable / wrong form.** *Handling:* normalize via `toOpencodeModelRef` and **fail-fast** at create with `isModelServableForAccount` (reuses the request-time resolver) — never silently fall to default.
 
-```
-PUT    /v1/projects/:id/subjects/:externalId            upsert (display_name, caps, metadata)
-GET    /v1/projects/:id/subjects[?cursor]               list
-DELETE /v1/projects/:id/subjects/:externalId            disable + revoke tokens
-POST   /v1/projects/:id/subjects/:externalId/tokens     mint scoped session token
-DELETE /v1/projects/:id/subjects/:externalId/tokens     revoke all
-POST   /v1/projects/:id/subjects/:externalId/connect-links   {connector_type} → url
-GET    /v1/projects/:id/subjects/:externalId/connections     list (types + status, never credentials)
-DELETE /v1/projects/:id/subjects/:externalId/connections/:type
-GET    /v1/projects/:id/subjects/:externalId/usage
-POST   /v1/projects/:id/releases                        bake repo@commit
-GET    /v1/projects/:id/releases                        list
-```
+**4.8 Idempotent retries.** Session create already takes an idempotency key; a retried start must not double-create or double-charge. *Handling:* require the wrapper to send it; document it.
 
-Subject-token surface (called by the wrapper's client or server, scoped by the token itself): create/continue session, send message, stream, overlay file read/write. Nothing else resolves.
+**4.9 Warm-pool / snapshot reuse.** A recycled warm sandbox must not carry a prior session's overridden env/secrets. *Verify:* env is (re)pushed per session at boot + hot-push — confirm no residual from the pool image before GA.
 
-## 6. Threat-model deltas
+**4.10 Per-end-user cost & concurrency.** Caps are account-level (`enforceAccountCap`); one end-user could exhaust the account cap and block others. *v1:* usage is attributed per `origin_ref`; the wrapper reads it and cuts off upstream. *Later:* native per-`origin_ref` cap + concurrency in the gateway pre-flight (the one thing the earlier subject-metering idea is still good for).
 
-| Threat | Answer |
-| --- | --- |
-| Prompt-injected credential exfil | Nothing to exfiltrate: env empty, broker executes server-side, only results cross the boundary |
-| Stolen subject token | Short TTL, capability-scoped, per-subject revoke-all; token is useless outside its project/agent/subject |
-| Cross-subject access | Overlay prefix + connection resolution + session visibility all key on the token's `subject_id` |
-| Repo tampering | RO release mount, no git credential in subject sandboxes |
-| Cost abuse | Per-subject caps at the gateway pre-flight; wrapper sees usage per subject and can cut off upstream |
-| Sandbox egress | Phase 4: restricted egress policy for subject sessions (broker + LLM gateway + overlay endpoints only) |
+**4.11 Trigger/webhook on behalf of an end-user.** A webhook that should run as end-user X needs `origin: trigger` **plus** X's `origin_ref` + profile binding. *Suggest:* let a trigger carry an `origin_ref` + connector bindings so origin and overrides compose — the wrapper's most powerful pattern (event → the right user's session).
 
-## 7. Phases — independently shippable
+## 5. Build order
 
-**Phase 0 — this RFC + three decisions (§8).**
+1. `origin` field + resolver + `canOverride` policy gate — the spine.
+2. Document + expose the shipping path (connectors/model/agent/context) as the "backend" contract, with §4 gotchas. **This alone makes base-agent wrapping real today.**
+3. Server-to-server connector-profile mint + all-or-nothing softening (4.1).
+4. Secret-bundle by reference — hot-push merge + scope split (4.2).
+5. Skills subset (v2, optional).
 
-**Phase 1 — Subjects, sessions, metering ("wrap a base agent").**
-- Migration (hand-written, repo convention): `subjects`, `usage_events.subject_id`.
-- `repositories/subjects.ts` + token mint/validate (SCIM-token pattern).
-- Session create accepts a subject actor; engine actor kind `subject` → restrictive envelope; env resolves empty in [sandbox-env-sync.ts](../apps/api/src/projects/lib/sandbox-env-sync.ts); repo mounted read-only for subject sessions (clone path retained but RO — releases land in Phase 4).
-- Usage attribution + usage endpoint + caps pre-flight.
-- **Acceptance:** a wrapper mints a token for `user-123`, opens a session on the shared agent, chats; a test asserts the sandbox env contains zero project secrets; usage rows carry `subject_id`; subject B cannot address subject A's session; disabling a subject kills its tokens.
+Each new contract field needs a schema add + a ke2e route-coverage test (the `.strict()` contract + coverage gate); transport is free (body flows verbatim to the core).
 
-**Phase 2 — Connections + broker (the hard core).**
-- `connections` + `oauth_apps` migrations; repository + operator/subject APIs.
-- Gateway connector resolution goes principal-first (today's shared-credential resolution — [kortix.ts:735](../packages/db/src/schema/kortix.ts) — becomes the `project` fallback).
-- `connector.invoke` gateway route + sandbox tool shim; connect-links on the setup-links pattern; BYO OAuth apps.
-- **Acceptance:** two subjects, one agent — each call uses the caller's own Gmail; a test greps sandbox env + fs for credential material and finds none; revoking a connection 403s the next invoke.
+## 6. Open decisions
 
-**Phase 3 — State overlay.**
-- Object-store prefix per subject; daemon materialize/sync; overlay resolver (member → worktree unchanged, byte-identical); quotas; subject file APIs.
-- **Acceptance:** subject files/memory persist across sessions and survive sandbox recycling; the repo shows zero subject writes; member-session behavior unchanged under the existing test suite.
+1. **All-or-nothing vs inherit-unbound** connector binding (4.1) — pick the default.
+2. **Runtime-secret overrides**: allow at all in v1, or connector-scope only until untrusted-sandbox hardening exists?
+3. **Native per-`origin_ref` caps/concurrency** (4.10) — v1 (wrapper-enforced) or build now?
 
-**Phase 4 — Releases + hardening.**
-- `releases` + publish API baking via [snapshots/templates.ts](../apps/api/src/snapshots/templates.ts); subject boot = release only (no clone); egress policy for subject sandboxes; optional: begin migrating member sessions' `runtime` secrets onto the broker for a single credential story.
-- **Acceptance:** subject session boots with no git operation at all; un-released commits are invisible to subjects; egress from a subject sandbox is limited to gateway/overlay endpoints.
+## 7. Explicitly out of scope (v1)
 
-## 8. Decisions needed
-
-1. **Per-subject custom code (skills/executors)** — recommendation: **out of v1**. Per-subject *state, connections, caps* yes; per-subject *code* means executing untrusted end-user code and is a different product surface. Revisit post-Phase-4 as an overlay-mounted skills dir behind the egress policy.
-2. **Member sessions on the broker eventually?** — recommendation: **yes, as a Phase-4+ migration**, so there is one credential story and "env secrets" become legacy. Not a prerequisite for any phase.
-3. **Overlay backend** — recommendation: **object-store prefix + daemon sync** for v1 (cheap at 100k subjects, no volume orchestration); per-subject volumes only if fs-semantics demand it later.
-
-## 9. Non-goals (v1)
-
-- Per-subject custom skills/executors/agents (decision 1).
-- Any Kortix-hosted UI for end-users — subjects are API-only; the wrapper owns all UX except the OAuth consent hop.
-- Wrapper-facing billing UI — usage is API-only; the wrapper bills its own users.
-- Subject-visible dashboards, subject IAM roles, subject-to-subject sharing.
+Per-end-user **custom code** (new skills/executors — untrusted code); per-end-user **file/memory state** + the release/overlay machinery (a proxying wrapper doesn't need it); a Kortix-hosted end-user UI. These return only if a wrapper needs untrusted **direct** sandbox access — a later phase, not now.


### PR DESCRIPTION
Design plan for wrapping Kortix as a backend — many end-users on one shared agent/repo, each bringing their own connectors/model/context passed at session start.

**Rev 2 — verified against current `main`.** Recon found ~80% already ships, so this is **activation + two small gaps**, not the subjects/releases/overlay rewrite the first draft proposed.

- **Already works:** the session-create contract accepts `connector_bindings: {alias:{profile_id}}` (by-reference, broker-resolved, credential never enters request or sandbox), `opencode_model`, `agent_name`, and non-secret `runtime_context` — overriding the agent's defaults today.
- **Auth:** the wrapper uses a **service account** (`kortix_sa_`, a machine identity with a least-privilege policy); it passes its end-user as a parameter (`origin_ref` + that user's profile IDs). Kortix authenticates the wrapper; the wrapper vouches for its end-user. No per-user Kortix login; scales to 100k. Optional short-lived session-scoped token for direct browser streaming.
- **The 3 gaps:** (1) `origin` as a first-class field + policy gate (who may override what + behavior); (2) secrets by reference (hot-push merge + connector-vs-runtime scope safety); (3) skills-subset (v2, optional).
- **11 edge cases** with handling: connector all-or-nothing binding, secret hot-push clobber, session-share/resume identity leak, cross-tenant profile authz, profile-revoked-mid-session (fails closed), origin spoofing, model form/servability, idempotent retries, warm-pool reuse, per-end-user caps/concurrency, trigger-on-behalf-of-user.
- Build order + 3 open decisions + explicit out-of-scope.

Internal Kortix = `origin: user`, no overrides → byte-identical to today. Not a mode toggle — one pipeline, policy branches on the origin enum.
