### PR TITLE
fix(api): hide internal admin/ops routes from the public OpenAPI spec

### DIFF
--- a/apps/api/src/__tests__/unit-openapi-spec-filter.test.ts
+++ b/apps/api/src/__tests__/unit-openapi-spec-filter.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The public OpenAPI spec (/v1/openapi.json) must NOT advertise internal
+ * routers. admin/ops are runtime-gated but their typed route DEFINITIONS still
+ * merge into the shared registry via app.route() — so without filtering, the
+ * spec published admin credit-debit / tier-change / ops shapes to anyone.
+ * These tests pin both the pure filter and the end-to-end served document.
+ */
+import { createRoute, z } from '@hono/zod-openapi';
+import { describe, expect, test } from 'bun:test';
+import {
+  INTERNAL_SPEC_PREFIXES,
+  filterSpecPaths,
+  makeOpenApiApp,
+  mountOpenApiDocs,
+} from '../openapi';
+
+describe('filterSpecPaths', () => {
+  test('drops internal prefixes and everything beneath them', () => {
+    const doc = {
+      openapi: '3.1.0',
+      paths: {
+        '/v1/admin': {},
+        '/v1/admin/api/accounts/{id}/credits/debit': {},
+        '/v1/ops/overview': {},
+        '/v1/projects/{id}': {},
+        '/scim/v2/accounts/{accountId}/Users': {},
+      },
+    };
+    const out = filterSpecPaths(doc);
+    expect(Object.keys(out.paths).sort()).toEqual([
+      '/scim/v2/accounts/{accountId}/Users', // SCIM stays public (RFC-7644)
+      '/v1/projects/{id}',
+    ]);
+  });
+
+  test('respects the prefix boundary — a sibling like /v1/administrators is kept', () => {
+    const out = filterSpecPaths({ paths: { '/v1/administrators': {}, '/v1/admin/x': {} } });
+    expect(Object.keys(out.paths)).toEqual(['/v1/administrators']);
+  });
+
+  test('is a no-op when there are no paths, and never mutates the input', () => {
+    // Typed with the optional `paths` so it satisfies the helper's constraint
+    // (a real OpenAPI doc has many more fields); asserts the no-paths early return.
+    const noPaths: { openapi: string; paths?: Record<string, unknown> } = { openapi: '3.1.0' };
+    expect(filterSpecPaths(noPaths)).toEqual({ openapi: '3.1.0' });
+    const input = { paths: { '/v1/admin': {}, '/v1/projects': {} } };
+    filterSpecPaths(input);
+    expect(Object.keys(input.paths)).toContain('/v1/admin'); // input untouched
+  });
+
+  test('the internal prefix list covers admin + ops (and NOT scim)', () => {
+    expect([...INTERNAL_SPEC_PREFIXES]).toEqual(['/v1/admin', '/v1/ops']);
+  });
+});
+
+describe('mountOpenApiDocs — served spec excludes internal routers', () => {
+  test('/v1/openapi.json omits an /v1/admin route but keeps a public route', async () => {
+    const app = makeOpenApiApp();
+
+    const publicRoute = createRoute({
+      method: 'get',
+      path: '/v1/projects/{id}',
+      responses: { 200: { description: 'ok' } },
+    });
+    app.openapi(publicRoute, (c: any) => c.json({}));
+
+    const admin = makeOpenApiApp();
+    const adminRoute = createRoute({
+      method: 'post',
+      path: '/api/accounts/{id}/credits/debit',
+      responses: { 200: { description: 'ok' } },
+    });
+    admin.openapi(adminRoute, (c: any) => c.json({}));
+    app.route('/v1/admin', admin);
+
+    mountOpenApiDocs(app, 'test');
+
+    const res = await app.request('/v1/openapi.json');
+    expect(res.status).toBe(200);
+    const spec = (await res.json()) as { paths: Record<string, unknown> };
+    const paths = Object.keys(spec.paths);
+    expect(paths).toContain('/v1/projects/{id}');
+    expect(paths.some((p) => p.startsWith('/v1/admin'))).toBe(false);
+  });
+});

--- a/apps/api/src/__tests__/unit-openapi-spec-filter.test.ts
+++ b/apps/api/src/__tests__/unit-openapi-spec-filter.test.ts
@@ -5,7 +5,7 @@
  * spec published admin credit-debit / tier-change / ops shapes to anyone.
  * These tests pin both the pure filter and the end-to-end served document.
  */
-import { createRoute, z } from '@hono/zod-openapi';
+import { createRoute } from '@hono/zod-openapi';
 import { describe, expect, test } from 'bun:test';
 import {
   INTERNAL_SPEC_PREFIXES,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -34,23 +34,32 @@ const optStrDefault = (def: string) => z.string().optional().default(def);
 
 /** Optional URL string with a custom default. Not required, just validated if present. */
 const optUrl = (def: string) =>
-  z.string().optional().default(def).refine(
-    (v) => v === '' || /^https?:\/\//.test(v),
-    { message: 'Must be a valid HTTP(S) URL' },
-  );
+  z
+    .string()
+    .optional()
+    .default(def)
+    .refine((v) => v === '' || /^https?:\/\//.test(v), { message: 'Must be a valid HTTP(S) URL' });
 
 /** Optional int with a default. */
 const optInt = (def: number) =>
-  z.string().optional().default(String(def)).transform((v) => {
-    const n = parseInt(v, 10);
-    return Number.isNaN(n) ? def : n;
-  });
+  z
+    .string()
+    .optional()
+    .default(String(def))
+    .transform((v) => {
+      const n = parseInt(v, 10);
+      return Number.isNaN(n) ? def : n;
+    });
 
 /** Optional boolean. optBoolFalse accepts the common truthy spellings
  * (case-insensitive) so a "1" / "yes" / "on" from a k8s env or secret bundle
  * isn't silently dropped. optBoolTrue keeps its original 'anything but false'
  * rule. */
-const optBoolTrue = z.string().optional().default('true').transform((v) => v !== 'false');
+const optBoolTrue = z
+  .string()
+  .optional()
+  .default('true')
+  .transform((v) => v !== 'false');
 const optBoolFalse = z
   .string()
   .optional()
@@ -92,18 +101,17 @@ const optFallbackPolicies = z
 //   - OPTIONAL:    graceful degradation or sane default if missing
 
 const envSchema = z.object({
-
   // ── Core (required) ──────────────────────────────────────────────────────
-  PORT:                        optInt(8008),
+  PORT: optInt(8008),
 
   // ── Database (REQUIRED) ──────────────────────────────────────────────────
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required — cannot start without a database'),
 
   // ── Supabase (REQUIRED) ──────────────────────────────────────────────────
-  SUPABASE_URL: z.string().min(1, 'SUPABASE_URL is required').refine(
-    (v) => /^https?:\/\//.test(v),
-    { message: 'SUPABASE_URL must be a valid HTTP(S) URL' },
-  ),
+  SUPABASE_URL: z
+    .string()
+    .min(1, 'SUPABASE_URL is required')
+    .refine((v) => /^https?:\/\//.test(v), { message: 'SUPABASE_URL must be a valid HTTP(S) URL' }),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1, 'SUPABASE_SERVICE_ROLE_KEY is required'),
 
   // ── API Key Hashing (REQUIRED) ───────────────────────────────────────────
@@ -112,15 +120,21 @@ const envSchema = z.object({
   // ── Internal Deployment Controls (optional, safe defaults for self-hosted) ─
   // `preview` = ephemeral per-PR API on EKS (shares the dev data plane, never
   // migrates it, workers off, allows preview frontends in CORS). See ensure-schema.ts + the CORS block in index.ts.
-  INTERNAL_KORTIX_ENV:              z.enum(['dev', 'staging', 'prod', 'preview']).optional().default('dev'),
+  INTERNAL_KORTIX_ENV: z.enum(['dev', 'staging', 'prod', 'preview']).optional().default('dev'),
   // Master switch: turns on real billing (Stripe + credit ledger), makes
   // KORTIX_URL fatal-required, mounts the proxy-auth gate, hides /v1/setup.
   // Set to true on managed/cloud deployments; leave false for self-host + dev.
-  KORTIX_BILLING_INTERNAL_ENABLED:  optBoolFalse,
+  KORTIX_BILLING_INTERNAL_ENABLED: optBoolFalse,
   // EXPERIMENTAL: the "Use this template" install feature — the /v1/templates
   // routes plus the use-case-page button + install wizard. Single kill-switch;
   // off by default so it stays hidden in prod while templates are authored.
-  KORTIX_TEMPLATES_ENABLED:         optBoolTrue,
+  KORTIX_TEMPLATES_ENABLED: optBoolTrue,
+  // Serve the public OpenAPI spec (/v1/openapi.json) + Scalar docs UI (/v1/docs).
+  // On by default — the base API surface is meant to be discoverable. Internal
+  // routers (/v1/admin, /v1/ops) are ALWAYS stripped from the spec regardless
+  // (see openapi/index.ts filterSpecPaths); this flag lets a hardened self-host
+  // deployment turn the whole docs/spec surface OFF so no route shapes publish.
+  OPENAPI_PUBLIC_DOCS: optBoolTrue,
   // Self-host enterprise license: when the operator has purchased/holds a
   // Kortix Enterprise license, this bypasses the sales-assigned `enterprise`
   // tier check and unlocks every enterprise entitlement (SSO, SCIM, RBAC,
@@ -129,7 +143,7 @@ const envSchema = z.object({
   // billing/services/entitlements.ts. Off by default; billing is irrelevant
   // for a self-host license check, unlike the `demoEnterprise` per-account
   // preview toggle this mirrors.
-  ENTERPRISE_LICENSE_AVAILABLE:     optBoolFalse,
+  ENTERPRISE_LICENSE_AVAILABLE: optBoolFalse,
   // Self-host account-creation restriction: when true, POST /v1/accounts
   // (creating an ADDITIONAL/org account) is blocked with 403 for everyone
   // except a platform admin (KORTIX_PLATFORM_ADMIN_EMAILS — see
@@ -148,20 +162,20 @@ const envSchema = z.object({
   KORTIX_RESTRICT_ACCOUNT_CREATION: optBoolFalse,
 
   // ── Search Providers (optional — features degrade gracefully) ────────────
-  TAVILY_API_URL:              optUrl('https://api.tavily.com'),
-  TAVILY_API_KEY:              optStr,
-  SERPER_API_URL:              optUrl('https://google.serper.dev'),
-  SERPER_API_KEY:              optStr,
-  APIFY_API_URL:               optUrl('https://api.apify.com'),
-  APIFY_TOKEN:                 optStr,
+  TAVILY_API_URL: optUrl('https://api.tavily.com'),
+  TAVILY_API_KEY: optStr,
+  SERPER_API_URL: optUrl('https://google.serper.dev'),
+  SERPER_API_KEY: optStr,
+  APIFY_API_URL: optUrl('https://api.apify.com'),
+  APIFY_TOKEN: optStr,
 
   // ── Proxy Providers (optional) ───────────────────────────────────────────
-  FIRECRAWL_API_URL:           optUrl('https://api.firecrawl.dev'),
-  FIRECRAWL_API_KEY:           optStr,
-  REPLICATE_API_URL:           optUrl('https://api.replicate.com'),
-  REPLICATE_API_TOKEN:         optStr,
-  CONTEXT7_API_URL:            optUrl('https://context7.com'),
-  CONTEXT7_API_KEY:            optStr,
+  FIRECRAWL_API_URL: optUrl('https://api.firecrawl.dev'),
+  FIRECRAWL_API_KEY: optStr,
+  REPLICATE_API_URL: optUrl('https://api.replicate.com'),
+  REPLICATE_API_TOKEN: optStr,
+  CONTEXT7_API_URL: optUrl('https://context7.com'),
+  CONTEXT7_API_KEY: optStr,
 
   // ── Managed git (provider-agnostic via the git proxy) ────────────────────
   // MANAGED_GIT_PROVIDER selects the backend NEW managed repos provision on
@@ -170,38 +184,38 @@ const envSchema = z.object({
   // installed there (MANAGED_GIT_GITHUB_INSTALL_ID). Reuses KORTIX_GITHUB_APP_*
   // for the App JWT. Each backend's isConfigured() checks its own vars, so
   // leaving these blank keeps the managed-git path inert.
-  MANAGED_GIT_PROVIDER:            optStr,
-  MANAGED_GIT_GITHUB_OWNER:        optStr,
-  MANAGED_GIT_GITHUB_INSTALL_ID:   optStr,
+  MANAGED_GIT_PROVIDER: optStr,
+  MANAGED_GIT_GITHUB_OWNER: optStr,
+  MANAGED_GIT_GITHUB_INSTALL_ID: optStr,
   // Optional straight org PAT for the managed org (the "one server-side key"
   // model). When set it takes precedence
   // over the GitHub App for managed-org admin ops (create/delete repo, invite
   // collaborator). Leave blank to use the App installation instead.
-  MANAGED_GIT_GITHUB_TOKEN:        optStr,
+  MANAGED_GIT_GITHUB_TOKEN: optStr,
   // Second managed backend: code.storage (Pierre), a headless git-hosting API
   // (https://code.storage/docs). Select it with MANAGED_GIT_PROVIDER=code-storage
   // — inert (isConfigured() false) until org + private key are both set.
   // CODE_STORAGE_ORG: your code.storage organization identifier — doubles as
   // the JWT `iss` claim and (unless overridden) the git-remote/API host prefix.
-  CODE_STORAGE_ORG:                optStr,
+  CODE_STORAGE_ORG: optStr,
   // PKCS8 PEM private key (EC or RSA — algorithm auto-detected) code.storage
   // issued you; signs every management-API and git-push/pull JWT server-side
   // (projects/git-backends/code-storage.ts's `mintCodeStorageJwt`). Never
   // logged, returned to a caller, or embedded verbatim — only its signatures
   // leave this process. \n-escaped or quote-wrapped values are normalized.
-  CODE_STORAGE_PRIVATE_KEY:        optStr,
+  CODE_STORAGE_PRIVATE_KEY: optStr,
   // Management API base URL. Defaults to `https://api.<CODE_STORAGE_ORG>.code.storage`
   // when blank; set only for a non-standard cluster mapping.
-  CODE_STORAGE_API_BASE:           optStr,
+  CODE_STORAGE_API_BASE: optStr,
   // Git remote host for clone/push URLs. Defaults to `<CODE_STORAGE_ORG>.code.storage`
   // when blank.
-  CODE_STORAGE_GIT_HOST:           optStr,
+  CODE_STORAGE_GIT_HOST: optStr,
   // When true, runtime clients (sandbox + `kortix` CLI) use the Kortix git
   // proxy as their git origin (auth = KORTIX_TOKEN) instead of the real host —
   // so a real GitHub credential never reaches a sandbox. Requires a
   // daemon snapshot that returns KORTIX_TOKEN for the proxy host (back-compat:
   // OFF leaves the direct clone-credential token flow untouched).
-  KORTIX_GIT_PROXY:                optBoolFalse,
+  KORTIX_GIT_PROXY: optBoolFalse,
   // ── Pause / resume tuning ─────────────────────────────────────────────────
   // The sandbox idle→stop / stop→archive / →delete intervals live below as
   // KORTIX_SANDBOX_AUTOSTOP_MINUTES / AUTOARCHIVE_MINUTES / AUTODELETE_MINUTES
@@ -214,7 +228,7 @@ const envSchema = z.object({
   // resumeStoppedSandbox (idempotent with the on-open resume). GATED OFF by
   // default (speculative compute — starts a box the user might not open). Enable
   // after validating; tune how many recent sessions to pre-resume per project.
-  KORTIX_PRERESUME_ENABLED:         optBoolFalse,
+  KORTIX_PRERESUME_ENABLED: optBoolFalse,
   KORTIX_PRERESUME_MAX_PER_PROJECT: optInt(1),
 
   // Lock a session to the agent it booted with: the preview proxy 409s a prompt
@@ -244,20 +258,20 @@ const envSchema = z.object({
   LEGACY_MIGRATION_BACKUP_BUCKET: optStrDefault('legacy-migrations'),
 
   // ── Channels — Slack adapter (optional) ──────────────────────────────────
-  SLACK_BOT_TOKEN:             optStr,
-  SLACK_SIGNING_SECRET:        optStr,
-  SLACK_TEAM_ID:               optStr,
-  SLACK_CLIENT_ID:             optStr,
-  SLACK_CLIENT_SECRET:         optStr,
-  SLACK_REDIRECT_URI:          optStr,
+  SLACK_BOT_TOKEN: optStr,
+  SLACK_SIGNING_SECRET: optStr,
+  SLACK_TEAM_ID: optStr,
+  SLACK_CLIENT_ID: optStr,
+  SLACK_CLIENT_SECRET: optStr,
+  SLACK_REDIRECT_URI: optStr,
   // Derived from the SINGLE scope source of truth (SLACK_BOT_SCOPES in
   // channels/slack-manifest.ts) so OAuth always grants exactly what the manifest
   // declares — no hand-synced drift. 100% bot-token scopes; the integration
   // never requests a user token (no user_scope= param).
-  SLACK_OAUTH_SCOPES:          optStrDefault(SLACK_BOT_SCOPES.join(',')),
+  SLACK_OAUTH_SCOPES: optStrDefault(SLACK_BOT_SCOPES.join(',')),
   // Optional banner image rendered at the top of the App Home tab. Must be a
   // public HTTPS URL Slack can fetch (no auth). Recommended 1600×400 PNG.
-  SLACK_HOME_HERO_URL:         optStr,
+  SLACK_HOME_HERO_URL: optStr,
   // Per-Slack-user identity. Default-on: each sender must link their own Kortix
   // account via `/kortix login` and the agent runs AS them; unlinked senders
   // are blocked. Set explicitly to "false" only for legacy fallback where
@@ -265,9 +279,9 @@ const envSchema = z.object({
   SLACK_REQUIRE_USER_IDENTITY: optBoolTrue,
 
   // ── Channels — AgentMail email adapter (optional) ────────────────────────
-  AGENTMAIL_API_URL:           optUrl('https://api.agentmail.to/v0'),
-  AGENTMAIL_API_KEY:           optStr,
-  AGENTMAIL_WEBHOOK_SECRET:    optStr,
+  AGENTMAIL_API_URL: optUrl('https://api.agentmail.to/v0'),
+  AGENTMAIL_API_KEY: optStr,
+  AGENTMAIL_WEBHOOK_SECRET: optStr,
 
   // ── Channels — Recall.ai meeting bot (optional) ──────────────────────────
   // MEET_ENABLED is the operator master switch (the global gate): when false the
@@ -275,39 +289,41 @@ const envSchema = z.object({
   // any per-project choice. RECALL_BASE_URL is the regional gateway (us-west-2 =
   // pay-as-you-go default; us-east-1 / eu-central-1 / ap-northeast-1 also exist).
   // The key is sent server-side as `Authorization: Token <key>`; never in a sandbox.
-  MEET_ENABLED:                optBoolFalse,
-  RECALL_BASE_URL:             optUrl('https://us-west-2.recall.ai/api/v1'),
-  RECALL_API_KEY:              optStr,
+  MEET_ENABLED: optBoolFalse,
+  RECALL_BASE_URL: optUrl('https://us-west-2.recall.ai/api/v1'),
+  RECALL_API_KEY: optStr,
   // ElevenLabs TTS — gives the meeting bot a voice (the agent speaks in-call).
-  ELEVENLABS_BASE_URL:         optUrl('https://api.elevenlabs.io'),
-  ELEVENLABS_API_KEY:          optStr,
+  ELEVENLABS_BASE_URL: optUrl('https://api.elevenlabs.io'),
+  ELEVENLABS_API_KEY: optStr,
 
   // ── Channels — Microsoft Teams adapter (optional) ────────────────────────
   // One Kortix-owned multi-tenant Azure AD bot app. The same app id/password
   // serve every tenant; the per-conversation tenant id arrives on each inbound
   // activity. Outbound auth is a short-lived AAD token minted per scope at call
   // time (channels/teams-auth.ts) — there is no static bot token to store.
-  MICROSOFT_APP_ID:            optStr,
-  MICROSOFT_APP_PASSWORD:      optStr,
+  MICROSOFT_APP_ID: optStr,
+  MICROSOFT_APP_PASSWORD: optStr,
   // The bot's home tenant. Multi-tenant bots authenticate against the shared
   // `botframework.com` tenant; single-tenant deployments set their own.
-  MICROSOFT_APP_TENANT:        optStrDefault('botframework.com'),
+  MICROSOFT_APP_TENANT: optStrDefault('botframework.com'),
   // OpenID metadata used to validate the signed JWT on every inbound activity
   // (the Teams analog of Slack signature verification).
-  MICROSOFT_BOT_OPENID_METADATA: optUrl('https://login.botframework.com/v1/.well-known/openidconfiguration'),
+  MICROSOFT_BOT_OPENID_METADATA: optUrl(
+    'https://login.botframework.com/v1/.well-known/openidconfiguration',
+  ),
   TEAMS_REQUIRE_USER_IDENTITY: optBoolTrue,
   TEAMS_CHANNEL_ENABLED: optBoolFalse,
   TEAMS_APP_NAME: optStrDefault('Kortix'),
 
   // ── LLM Providers (optional — only needed in cloud mode) ─────────────────
-  OPENROUTER_API_URL:          optUrl('https://openrouter.ai/api/v1'),
+  OPENROUTER_API_URL: optUrl('https://openrouter.ai/api/v1'),
   // Single OpenRouter key for BOTH the router (/v1/router) and the managed LLM
   // gateway (/v1/llm). The gateway used to read a separate KORTIX_OPENROUTER_API_KEY
   // — consolidated onto this one var.
-  OPENROUTER_API_KEY:          optStr,
+  OPENROUTER_API_KEY: optStr,
   // Managed LLM gateway (/v1/llm) — the `kortix` OpenCode provider routes every
   // sandbox model call here. Off by default; needs OPENROUTER_API_KEY when on.
-  LLM_GATEWAY_ENABLED:         optBoolFalse,
+  LLM_GATEWAY_ENABLED: optBoolFalse,
   // CLOUD-ONLY. Whether KORTIX's own managed model lineup (Claude/GLM/Qwen/
   // DeepSeek/…, routed through Kortix's SHARED Bedrock/OpenRouter credentials
   // and billed as platform credits — "Managed · Included with your plan" in
@@ -332,12 +348,12 @@ const envSchema = z.object({
   LLM_GATEWAY_DEFAULT_ENABLED: optBoolTrue,
   // Empty = the in-API gateway at `${KORTIX_URL}/v1/llm`. Set to a standalone
   // gateway's public base (…/v1/llm) to route every sandbox model call there.
-  LLM_GATEWAY_BASE_URL:        optStr,
+  LLM_GATEWAY_BASE_URL: optStr,
   // Runtime routing is control-plane configuration, not a model-catalog
   // constant baked into the gateway binary. Operators can replace the default
   // and define any number of exact-match fallback policies without code changes.
-  LLM_GATEWAY_DEFAULT_MODEL:   optStrDefault('codex/gpt-5.6-sol'),
-  LLM_GATEWAY_VISION_MODEL:    optStrDefault('claude-sonnet-4.6'),
+  LLM_GATEWAY_DEFAULT_MODEL: optStrDefault('codex/gpt-5.6-sol'),
+  LLM_GATEWAY_VISION_MODEL: optStrDefault('claude-sonnet-4.6'),
   LLM_GATEWAY_FALLBACK_POLICIES: optFallbackPolicies,
   // Optional JSON array replacing the platform managed-model overlay (transport,
   // upstream id, pricing ref, capabilities). Empty uses the bundled last-known
@@ -345,39 +361,39 @@ const envSchema = z.object({
   LLM_GATEWAY_MANAGED_MODELS: optStr,
   // Runtime source for provider/model metadata. The API keeps the last known
   // snapshot if this source is temporarily unavailable.
-  LLM_GATEWAY_CATALOG_URL:     optUrl('https://models.dev/api.json'),
+  LLM_GATEWAY_CATALOG_URL: optUrl('https://models.dev/api.json'),
   // BYOK resilience: when a user's own provider key hits a rate-limit / quota /
   // billing error (429/402/403), fall over to THIS managed model (billed as
   // Kortix credits) so the turn survives instead of erroring. Empty disables.
   LLM_GATEWAY_BYOK_FALLBACK_MODEL: optStrDefault('claude-sonnet-4.6'),
   // Dev: reverse-proxy /v1/llm-gateway/* to a standalone gateway on this port,
   // so sandboxes reach it through the API's own tunnel (no separate tunnel).
-  LLM_GATEWAY_PROXY_PORT:      optInt(0),
+  LLM_GATEWAY_PROXY_PORT: optInt(0),
   // Where the /v1/llm-gateway/* reverse-proxy forwards. Defaults to
   // 127.0.0.1:LLM_GATEWAY_PROXY_PORT (local, gateway same host). In K8s set to
   // the in-cluster gateway service, e.g. http://kortix-gateway:8090, so the
   // gateway stays internal and sandboxes reach it via the API's public origin.
-  LLM_GATEWAY_PROXY_TARGET:    optStr,
+  LLM_GATEWAY_PROXY_TARGET: optStr,
   // AWS Bedrock — the managed ("Kortix") models route here via a Bedrock API key
   // (bearer). Region selects the bedrock-runtime endpoint; the key is an IAM
   // service-specific credential for bedrock.amazonaws.com.
-  AWS_BEDROCK_REGION:          optStr,
-  AWS_BEDROCK_API_KEY:         optStr,
-  ANTHROPIC_API_URL:           optUrl('https://api.anthropic.com/v1'),
-  ANTHROPIC_API_KEY:           optStr,
-  OPENAI_API_URL:              optUrl('https://api.openai.com/v1'),
-  OPENAI_API_KEY:              optStr,
+  AWS_BEDROCK_REGION: optStr,
+  AWS_BEDROCK_API_KEY: optStr,
+  ANTHROPIC_API_URL: optUrl('https://api.anthropic.com/v1'),
+  ANTHROPIC_API_KEY: optStr,
+  OPENAI_API_URL: optUrl('https://api.openai.com/v1'),
+  OPENAI_API_KEY: optStr,
   // xAI / Gemini / Groq route through OpenRouter (see router/config/proxy-services.ts),
   // so only their base URLs are read — no per-provider API keys.
-  XAI_API_URL:                 optUrl('https://api.x.ai/v1'),
-  GEMINI_API_URL:              optUrl('https://generativelanguage.googleapis.com/v1beta'),
-  GROQ_API_URL:                optUrl('https://api.groq.com/openai/v1'),
+  XAI_API_URL: optUrl('https://api.x.ai/v1'),
+  GEMINI_API_URL: optUrl('https://generativelanguage.googleapis.com/v1beta'),
+  GROQ_API_URL: optUrl('https://api.groq.com/openai/v1'),
   // ── Billing — Stripe (optional, only for cloud billing) ──────────────────
-  STRIPE_SECRET_KEY:           optStr,
-  STRIPE_WEBHOOK_SECRET:       optStr,
+  STRIPE_SECRET_KEY: optStr,
+  STRIPE_WEBHOOK_SECRET: optStr,
 
   // ── Billing — RevenueCat (optional) ──────────────────────────────────────
-  REVENUECAT_WEBHOOK_SECRET:   optStr,
+  REVENUECAT_WEBHOOK_SECRET: optStr,
 
   // ── Daytona — Sandbox provisioning (conditional: required if daytona provider enabled) ──
   // Note: there is intentionally no DAYTONA_SNAPSHOT here. Every sandbox
@@ -385,13 +401,13 @@ const envSchema = z.object({
   // (apps/api/src/snapshots/builder.ts). A shared/global fallback image
   // would silently bypass per-project Dockerfiles and is explicitly
   // disallowed.
-  DAYTONA_API_KEY:             optStr,
-  DAYTONA_SERVER_URL:          optStr,
-  DAYTONA_TARGET:              optStr,
+  DAYTONA_API_KEY: optStr,
+  DAYTONA_SERVER_URL: optStr,
+  DAYTONA_TARGET: optStr,
   // Org-level Daytona webhook signing secret (Svix `whsec_…`). When set, the
   // /v1/billing/webhooks/daytona endpoint closes compute billing the instant a
   // box stops; the reaper sweep is the backstop, so this is optional.
-  DAYTONA_WEBHOOK_SECRET:      optStr,
+  DAYTONA_WEBHOOK_SECRET: optStr,
 
   // When a template's content hash changes and a fresh snapshot is built, drop
   // the now-superseded predecessor immediately (reap-on-repoint) instead of
@@ -409,18 +425,18 @@ const envSchema = z.object({
   // (https://api.platinum.dev). PLATINUM_TEMPLATE is a ready Platinum template
   // id to boot sessions from (e.g. kortix-computer) — used as the fallback when
   // a session hasn't built its own per-project Platinum template.
-  PLATINUM_API_KEY:            optStr,
-  PLATINUM_API_URL:            optStr,
-  PLATINUM_TEMPLATE:           optStr,
+  PLATINUM_API_KEY: optStr,
+  PLATINUM_API_URL: optStr,
+  PLATINUM_TEMPLATE: optStr,
   // Per-webhook HMAC-SHA-256 secret from Platinum's `POST /v1/webhooks` (shown
   // once at registration). Optional — same backstop story as Daytona's.
-  PLATINUM_WEBHOOK_SECRET:     optStr,
+  PLATINUM_WEBHOOK_SECRET: optStr,
 
   // ── E2B Cloud — sandbox provisioning (conditional: required if enabled) ──
   // E2B_TEMPLATE is an optional ready fallback template. Project-specific
   // templates built by the shared snapshot system take precedence.
-  E2B_API_KEY:                 optStr,
-  E2B_TEMPLATE:                optStr,
+  E2B_API_KEY: optStr,
+  E2B_TEMPLATE: optStr,
 
   // ── Local Docker — EXPERIMENTAL sandbox provider (same-machine only) ────
   // Runs sandboxes as Docker containers on the SAME host as kortix-api, via
@@ -437,13 +453,13 @@ const envSchema = z.object({
   //   LOCAL_DOCKER_SOCKET_PATH — override for the Docker Engine unix socket.
   //     Empty = dockerode's own default (respects DOCKER_HOST, else
   //     /var/run/docker.sock).
-  LOCAL_DOCKER_NETWORK:        optStrDefault('kortix-local-docker'),
-  LOCAL_DOCKER_SOCKET_PATH:    optStr,
+  LOCAL_DOCKER_NETWORK: optStrDefault('kortix-local-docker'),
+  LOCAL_DOCKER_SOCKET_PATH: optStr,
 
   // ── Sandbox Platform ──────────────────────────────────────────────────────
   // Public API base URL, without a route suffix. Auto-derived from PORT in local mode.
-  KORTIX_URL:                  optStr,
-  ALLOWED_SANDBOX_PROVIDERS:   optStrDefault('daytona'),
+  KORTIX_URL: optStr,
+  ALLOWED_SANDBOX_PROVIDERS: optStrDefault('daytona'),
 
   // ── Sandbox lifecycle (Daytona auto-stop / auto-archive / auto-delete) ────
   // Set as SDK create() params so a box self-manages even if the API/tunnel
@@ -472,86 +488,86 @@ const envSchema = z.object({
   //   autodelete → NEVER (-1). A sandbox is only ever removed when a user
   //                explicitly deletes the session — auto-stop + cold archive
   //                make an idle box nearly free, so we never destroy disk.
-  KORTIX_SANDBOX_AUTOSTOP_MINUTES:    optInt(15),
+  KORTIX_SANDBOX_AUTOSTOP_MINUTES: optInt(15),
   KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: optInt(5),
-  KORTIX_SANDBOX_AUTOARCHIVE_MINUTES: optInt(720),    // 12 hours
-  KORTIX_SANDBOX_AUTODELETE_MINUTES:  optInt(-1),     // never auto-delete
+  KORTIX_SANDBOX_AUTOARCHIVE_MINUTES: optInt(720), // 12 hours
+  KORTIX_SANDBOX_AUTODELETE_MINUTES: optInt(-1), // never auto-delete
 
   // ── Internal Service Key (auto-generated if missing — never fails) ───────
-  INTERNAL_SERVICE_KEY:        optStr,
+  INTERNAL_SERVICE_KEY: optStr,
 
   // ── Frontend (optional) ──────────────────────────────────────────────────
-  FRONTEND_URL:                optUrl('http://localhost:3000'),
+  FRONTEND_URL: optUrl('http://localhost:3000'),
 
   // ── Pipedream Connect (optional — powers the Executor's 1-click connectors) ─
-  PIPEDREAM_CLIENT_ID:         optStr,
-  PIPEDREAM_CLIENT_SECRET:     optStr,
-  PIPEDREAM_PROJECT_ID:        optStr,
-  PIPEDREAM_ENVIRONMENT:       optStrDefault('production'),
-  PIPEDREAM_WEBHOOK_SECRET:    optStr,
+  PIPEDREAM_CLIENT_ID: optStr,
+  PIPEDREAM_CLIENT_SECRET: optStr,
+  PIPEDREAM_PROJECT_ID: optStr,
+  PIPEDREAM_ENVIRONMENT: optStrDefault('production'),
+  PIPEDREAM_WEBHOOK_SECRET: optStr,
   // Optional: required only when importing a public Postman workspace URL.
   // Exported collection JSON and Postman-managed Git repositories need no key.
-  POSTMAN_API_KEY:              optStr,
+  POSTMAN_API_KEY: optStr,
 
   // ── Tunnel (optional, all have sane defaults) ────────────────────────────
-  TUNNEL_SIGNING_SECRET:             optStr,
-  TUNNEL_ENABLED:                    optBoolTrue,
-  TUNNEL_HEARTBEAT_INTERVAL_MS:      optInt(30_000),
-  TUNNEL_HEARTBEAT_MAX_MISSED:       optInt(3),
-  TUNNEL_RPC_TIMEOUT_MS:             optInt(30_000),
-  TUNNEL_RATE_LIMIT_RPC:             optInt(100),
-  TUNNEL_RATE_LIMIT_PERM_REQUEST:    optInt(20),
-  TUNNEL_RATE_LIMIT_WS_CONNECT:      optInt(5),
-  TUNNEL_RATE_LIMIT_PERM_GRANT:      optInt(30),
-  TUNNEL_MAX_WS_MESSAGE_SIZE:        optInt(5 * 1024 * 1024),
+  TUNNEL_SIGNING_SECRET: optStr,
+  TUNNEL_ENABLED: optBoolTrue,
+  TUNNEL_HEARTBEAT_INTERVAL_MS: optInt(30_000),
+  TUNNEL_HEARTBEAT_MAX_MISSED: optInt(3),
+  TUNNEL_RPC_TIMEOUT_MS: optInt(30_000),
+  TUNNEL_RATE_LIMIT_RPC: optInt(100),
+  TUNNEL_RATE_LIMIT_PERM_REQUEST: optInt(20),
+  TUNNEL_RATE_LIMIT_WS_CONNECT: optInt(5),
+  TUNNEL_RATE_LIMIT_PERM_GRANT: optInt(30),
+  TUNNEL_MAX_WS_MESSAGE_SIZE: optInt(5 * 1024 * 1024),
 
   // ── Abuse controls (optional, all have sane defaults) ────────────────────
-  KORTIX_INVITE_ACCEPT_REQS_PER_MIN:      optInt(20),
+  KORTIX_INVITE_ACCEPT_REQS_PER_MIN: optInt(20),
   KORTIX_PUBLIC_SESSION_SHARE_REQS_PER_MIN: optInt(60),
-  KORTIX_DEMO_REQUEST_REQS_PER_MIN:       optInt(10),
-  KORTIX_LLM_ROUTER_REQS_PER_MIN_FREE:    optInt(60),
-  KORTIX_LLM_ROUTER_REQS_PER_MIN_PAID:    optInt(600),
-  KORTIX_PROXY_REQS_PER_MIN:              optInt(600),
+  KORTIX_DEMO_REQUEST_REQS_PER_MIN: optInt(10),
+  KORTIX_LLM_ROUTER_REQS_PER_MIN_FREE: optInt(60),
+  KORTIX_LLM_ROUTER_REQS_PER_MIN_PAID: optInt(600),
+  KORTIX_PROXY_REQS_PER_MIN: optInt(600),
   KORTIX_TRIGGER_MAX_PROVISIONING_SESSIONS_PER_PROJECT: optInt(3),
-  KORTIX_TRIGGER_SCHEDULER_ENABLED:        optBoolTrue,
-  KORTIX_TRIGGER_SCHEDULER_INTERVAL_MS:    optInt(60_000),
+  KORTIX_TRIGGER_SCHEDULER_ENABLED: optBoolTrue,
+  KORTIX_TRIGGER_SCHEDULER_INTERVAL_MS: optInt(60_000),
 
   // ── Version / GitHub (optional) ───────────────────────────────────────────
-  SANDBOX_VERSION:             optStr,  // dev override: skip npm registry lookup for latest version
-  GITHUB_TOKEN:                optStr,  // optional: authenticated GitHub API calls for changelog
+  SANDBOX_VERSION: optStr, // dev override: skip npm registry lookup for latest version
+  GITHUB_TOKEN: optStr, // optional: authenticated GitHub API calls for changelog
 
   // ── Mailtrap (optional — provisioning email notifications) ────────────────
-  MAILTRAP_API_TOKEN:          optStr,
-  MAILTRAP_FROM_EMAIL:         optStrDefault('noreply@kortix.com'),
-  MAILTRAP_FROM_NAME:          optStrDefault('Kortix'),
+  MAILTRAP_API_TOKEN: optStr,
+  MAILTRAP_FROM_EMAIL: optStrDefault('noreply@kortix.com'),
+  MAILTRAP_FROM_NAME: optStrDefault('Kortix'),
   // Where public demo-request / "book a demo" lead notifications are sent.
   // Comma-separated list; every address gets every submission.
-  DEMO_LEAD_NOTIFY_EMAIL:      optStrDefault('marko@kortix.ai,hey@kortix.ai'),
+  DEMO_LEAD_NOTIFY_EMAIL: optStrDefault('marko@kortix.ai,hey@kortix.ai'),
   // Sender for those notifications. kortix.ai (not the global MAILTRAP_FROM_
   // EMAIL on kortix.com) so the send is DKIM-aligned with the kortix.ai
   // recipient inboxes — the kortix.com sender was landing in spam.
-  DEMO_LEAD_FROM_EMAIL:        optStrDefault('hi@kortix.ai'),
+  DEMO_LEAD_FROM_EMAIL: optStrDefault('hi@kortix.ai'),
 
   // ── Mailtrap contact sync (signup → automation lists) ─────────────────────
   // The email automations themselves live in Mailtrap's Automations UI; the
   // API only registers each new signup as a contact. Sync is active iff
   // MAILTRAP_API_TOKEN + MAILTRAP_ACCOUNT_ID are both set.
-  MAILTRAP_ACCOUNT_ID:               optStr,
+  MAILTRAP_ACCOUNT_ID: optStr,
   // Contact list every signup joins (automation trigger: "added to list").
-  MAILTRAP_SIGNUPS_LIST_ID:          optStr,
+  MAILTRAP_SIGNUPS_LIST_ID: optStr,
   // Additional list for work-email signups (founder "book a call" flow).
   MAILTRAP_BUSINESS_SIGNUPS_LIST_ID: optStr,
 
   // ── Better Stack Observability (optional — graceful degradation) ────────
-  BETTERSTACK_API_LOG_TOKEN:   optStr,  // Logtail source token for structured logs
-  BETTERSTACK_API_LOG_HOST:    optStr,  // Logtail ingesting host (e.g. s1234.us-east-9.betterstackdata.com)
-  BETTERSTACK_API_SENTRY_DSN:  optStr,  // Sentry DSN for error tracking (Better Stack compatible)
+  BETTERSTACK_API_LOG_TOKEN: optStr, // Logtail source token for structured logs
+  BETTERSTACK_API_LOG_HOST: optStr, // Logtail ingesting host (e.g. s1234.us-east-9.betterstackdata.com)
+  BETTERSTACK_API_SENTRY_DSN: optStr, // Sentry DSN for error tracking (Better Stack compatible)
 
   // ── Stray env vars used directly in other files (centralized here) ───────
-  CORS_ALLOWED_ORIGINS:        optStr,
-  KORTIX_MASTER_URL:           optStr,
-  OPENCODE_URL:                optStr,
-  KORTIX_DATA_DIR:             optStr,
+  CORS_ALLOWED_ORIGINS: optStr,
+  KORTIX_MASTER_URL: optStr,
+  OPENCODE_URL: optStr,
+  KORTIX_DATA_DIR: optStr,
 });
 
 // ─── Validation + Conditional Checks ────────────────────────────────────────
@@ -561,19 +577,29 @@ type EnvIssue = { var: string; message: string; level: 'error' | 'warn' };
 // Recognised provider names. Source-of-truth for what can legally appear in
 // ALLOWED_SANDBOX_PROVIDERS — adding a new provider is a one-place change
 // here plus a case in `getProvider()` in platform/providers/index.ts.
-export const KNOWN_PROVIDERS: readonly SandboxProviderName[] = ['daytona', 'platinum', 'e2b', 'local-docker'] as const;
+export const KNOWN_PROVIDERS: readonly SandboxProviderName[] = [
+  'daytona',
+  'platinum',
+  'e2b',
+  'local-docker',
+] as const;
 
 /** Parse comma-separated provider list (e.g. "daytona,platinum"). */
 function parseAllowedProviders(raw: string): SandboxProviderName[] {
   if (!raw) return ['daytona'];
-  const names = raw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+  const names = raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
   const valid: SandboxProviderName[] = [];
   for (const n of names) {
     if ((KNOWN_PROVIDERS as readonly string[]).includes(n)) {
       const known = n as SandboxProviderName;
       if (!valid.includes(known)) valid.push(known);
     } else {
-      console.warn(`[config] Unknown sandbox provider "${n}" in ALLOWED_SANDBOX_PROVIDERS - ignored`);
+      console.warn(
+        `[config] Unknown sandbox provider "${n}" in ALLOWED_SANDBOX_PROVIDERS - ignored`,
+      );
     }
   }
   return valid.length > 0 ? valid : ['daytona'];
@@ -602,33 +628,83 @@ function validateEnv(): z.infer<typeof envSchema> {
   // start so they can reach that dashboard at all. Sandbox creation fails with
   // a clear error until the key lands.
   const providers = parseAllowedProviders((raw as any).ALLOWED_SANDBOX_PROVIDERS || '');
-  const billingOn = (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === 'true' || (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === true;
+  const billingOn =
+    (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === 'true' ||
+    (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === true;
   const providerKeyLevel: 'error' | 'warn' = billingOn ? 'error' : 'warn';
-  const providerKeySuffix = billingOn ? '' : ' — agent sessions will fail until it is set (kortix self-host env set ...)';
+  const providerKeySuffix = billingOn
+    ? ''
+    : ' — agent sessions will fail until it is set (kortix self-host env set ...)';
   if (providers.includes('daytona')) {
-    if (!raw.DAYTONA_API_KEY)    issues.push({ var: 'DAYTONA_API_KEY',    message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"${providerKeySuffix}`, level: providerKeyLevel });
-    if (!raw.DAYTONA_SERVER_URL) issues.push({ var: 'DAYTONA_SERVER_URL', message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"${providerKeySuffix}`, level: providerKeyLevel });
-    if (!raw.DAYTONA_TARGET)     issues.push({ var: 'DAYTONA_TARGET',     message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"${providerKeySuffix}`, level: providerKeyLevel });
+    if (!raw.DAYTONA_API_KEY)
+      issues.push({
+        var: 'DAYTONA_API_KEY',
+        message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"${providerKeySuffix}`,
+        level: providerKeyLevel,
+      });
+    if (!raw.DAYTONA_SERVER_URL)
+      issues.push({
+        var: 'DAYTONA_SERVER_URL',
+        message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"${providerKeySuffix}`,
+        level: providerKeyLevel,
+      });
+    if (!raw.DAYTONA_TARGET)
+      issues.push({
+        var: 'DAYTONA_TARGET',
+        message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "daytona"${providerKeySuffix}`,
+        level: providerKeyLevel,
+      });
   }
   if (providers.includes('platinum')) {
-    if (!raw.PLATINUM_API_KEY) issues.push({ var: 'PLATINUM_API_KEY', message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "platinum"${providerKeySuffix}`, level: providerKeyLevel });
-    if (!raw.PLATINUM_API_URL) issues.push({ var: 'PLATINUM_API_URL', message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "platinum"${providerKeySuffix}`, level: providerKeyLevel });
+    if (!raw.PLATINUM_API_KEY)
+      issues.push({
+        var: 'PLATINUM_API_KEY',
+        message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "platinum"${providerKeySuffix}`,
+        level: providerKeyLevel,
+      });
+    if (!raw.PLATINUM_API_URL)
+      issues.push({
+        var: 'PLATINUM_API_URL',
+        message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "platinum"${providerKeySuffix}`,
+        level: providerKeyLevel,
+      });
   }
   if (providers.includes('e2b') && !raw.E2B_API_KEY) {
-    issues.push({ var: 'E2B_API_KEY', message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "e2b"${providerKeySuffix}`, level: providerKeyLevel });
+    issues.push({
+      var: 'E2B_API_KEY',
+      message: `Required when ALLOWED_SANDBOX_PROVIDERS includes "e2b"${providerKeySuffix}`,
+      level: providerKeyLevel,
+    });
   }
 
   // ── Conditional: Billing enabled → need Stripe keys ────────────────────
-  const billingWillBeEnabled = (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === 'true' || (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === true;
+  const billingWillBeEnabled =
+    (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === 'true' ||
+    (raw as any).KORTIX_BILLING_INTERNAL_ENABLED === true;
   if (billingWillBeEnabled) {
-    if (!raw.STRIPE_SECRET_KEY)    issues.push({ var: 'STRIPE_SECRET_KEY',    message: 'Required when KORTIX_BILLING_INTERNAL_ENABLED=true', level: 'error' });
-    if (!raw.STRIPE_WEBHOOK_SECRET) issues.push({ var: 'STRIPE_WEBHOOK_SECRET', message: 'Required when KORTIX_BILLING_INTERNAL_ENABLED=true', level: 'error' });
+    if (!raw.STRIPE_SECRET_KEY)
+      issues.push({
+        var: 'STRIPE_SECRET_KEY',
+        message: 'Required when KORTIX_BILLING_INTERNAL_ENABLED=true',
+        level: 'error',
+      });
+    if (!raw.STRIPE_WEBHOOK_SECRET)
+      issues.push({
+        var: 'STRIPE_WEBHOOK_SECRET',
+        message: 'Required when KORTIX_BILLING_INTERNAL_ENABLED=true',
+        level: 'error',
+      });
   }
 
   // ── Conditional: Tunnel enabled → need signing secret ──────────────────
-  const tunnelEnabled = (raw as any).TUNNEL_ENABLED !== 'false' && (raw as any).TUNNEL_ENABLED !== false;
+  const tunnelEnabled =
+    (raw as any).TUNNEL_ENABLED !== 'false' && (raw as any).TUNNEL_ENABLED !== false;
   if (tunnelEnabled && !raw.TUNNEL_SIGNING_SECRET) {
-    issues.push({ var: 'TUNNEL_SIGNING_SECRET', message: 'Required when tunnel is enabled — used for HMAC signing key derivation', level: 'error' });
+    issues.push({
+      var: 'TUNNEL_SIGNING_SECRET',
+      message: 'Required when tunnel is enabled — used for HMAC signing key derivation',
+      level: 'error',
+    });
   }
 
   // ── Conditional: KORTIX_URL — required for sandbox routing ──────────────
@@ -637,7 +713,12 @@ function validateEnv(): z.infer<typeof envSchema> {
   if (!raw.KORTIX_URL) {
     const port = (raw as any).PORT || '8008';
     if (billingWillBeEnabled) {
-      issues.push({ var: 'KORTIX_URL', message: 'Required when KORTIX_BILLING_INTERNAL_ENABLED=true — sandbox routing and health checks will break', level: 'error' });
+      issues.push({
+        var: 'KORTIX_URL',
+        message:
+          'Required when KORTIX_BILLING_INTERNAL_ENABLED=true — sandbox routing and health checks will break',
+        level: 'error',
+      });
     } else {
       // Auto-derive so dev/self-host "just works". KORTIX_URL is the public
       // API origin/base; individual callers append /v1, /v1/router, etc.
@@ -645,20 +726,38 @@ function validateEnv(): z.infer<typeof envSchema> {
       process.env.KORTIX_URL = derived;
       if (result.success) (result.data as any).KORTIX_URL = derived;
       console.warn(`[config] KORTIX_URL not set — auto-derived: ${derived}`);
-      issues.push({ var: 'KORTIX_URL', message: `Not set — auto-derived to ${derived} (add to .env to silence this)`, level: 'warn' });
+      issues.push({
+        var: 'KORTIX_URL',
+        message: `Not set — auto-derived to ${derived} (add to .env to silence this)`,
+        level: 'warn',
+      });
     }
   }
 
   // ── Warnings (non-fatal but worth knowing) ─────────────────────────────
   if (!raw.OPENROUTER_API_KEY) {
-    issues.push({ var: 'OPENROUTER_API_KEY', message: 'Not set — primary LLM route will fail with silent 401 errors', level: 'warn' });
+    issues.push({
+      var: 'OPENROUTER_API_KEY',
+      message: 'Not set — primary LLM route will fail with silent 401 errors',
+      level: 'warn',
+    });
     if (raw.LLM_GATEWAY_ENABLED === 'true') {
-      issues.push({ var: 'LLM_GATEWAY_ENABLED', message: 'Gateway is on but OPENROUTER_API_KEY is unset — /v1/llm will 500 "openrouterApiKey missing"', level: 'warn' });
+      issues.push({
+        var: 'LLM_GATEWAY_ENABLED',
+        message:
+          'Gateway is on but OPENROUTER_API_KEY is unset — /v1/llm will 500 "openrouterApiKey missing"',
+        level: 'warn',
+      });
     }
   }
 
   if (raw.MEET_ENABLED === 'true' && !raw.RECALL_API_KEY) {
-    issues.push({ var: 'RECALL_API_KEY', message: 'MEET_ENABLED is on but RECALL_API_KEY is unset — the meeting bot cannot join or transcribe', level: 'warn' });
+    issues.push({
+      var: 'RECALL_API_KEY',
+      message:
+        'MEET_ENABLED is on but RECALL_API_KEY is unset — the meeting bot cannot join or transcribe',
+      level: 'warn',
+    });
   }
 
   // ── Print results ─────────────────────────────────────────────────────
@@ -680,7 +779,9 @@ function validateEnv(): z.infer<typeof envSchema> {
   if (errors.length > 0) {
     console.error('');
     console.error('\x1b[31m' + '='.repeat(70) + '\x1b[0m');
-    console.error('\x1b[31m  kortix-api: Environment validation FAILED — server cannot start\x1b[0m');
+    console.error(
+      '\x1b[31m  kortix-api: Environment validation FAILED — server cannot start\x1b[0m',
+    );
     console.error('\x1b[31m' + '='.repeat(70) + '\x1b[0m');
     for (const e of errors) {
       console.error(`\x1b[31m  ${e.var.padEnd(40)} ${e.message}\x1b[0m`);
@@ -698,7 +799,9 @@ function validateEnv(): z.infer<typeof envSchema> {
     process.exit(1);
   }
 
-  console.log(`[config] Environment validated (${Object.keys(envSchema.shape).length} vars, ${warnings.length} warnings)`);
+  console.log(
+    `[config] Environment validated (${Object.keys(envSchema.shape).length} vars, ${warnings.length} warnings)`,
+  );
   return result.data;
 }
 
@@ -720,6 +823,7 @@ export const config = {
   // Single master switch — see schema docstring above.
   KORTIX_BILLING_INTERNAL_ENABLED: env.KORTIX_BILLING_INTERNAL_ENABLED,
   KORTIX_TEMPLATES_ENABLED: env.KORTIX_TEMPLATES_ENABLED,
+  OPENAPI_PUBLIC_DOCS: env.OPENAPI_PUBLIC_DOCS,
   ENTERPRISE_LICENSE_AVAILABLE: env.ENTERPRISE_LICENSE_AVAILABLE,
   KORTIX_RESTRICT_ACCOUNT_CREATION: env.KORTIX_RESTRICT_ACCOUNT_CREATION,
 
@@ -894,8 +998,8 @@ export const config = {
         const { appendFileSync, readFileSync } = require('fs');
         const { resolve } = require('path');
         const candidates = [
-          resolve(__dirname, '../../.env'),       // from src/config.ts -> ../../.env
-          resolve(process.cwd(), '.env'),          // cwd/.env
+          resolve(__dirname, '../../.env'), // from src/config.ts -> ../../.env
+          resolve(process.cwd(), '.env'), // cwd/.env
         ];
         for (const envPath of candidates) {
           // No existsSync-then-write: check-then-act on a path is a TOCTOU race.
@@ -908,7 +1012,10 @@ export const config = {
             continue;
           }
           if (!content.includes('INTERNAL_SERVICE_KEY=')) {
-            appendFileSync(envPath, `\n# Auto-generated service key for sandbox auth (do not remove)\nINTERNAL_SERVICE_KEY=${generated}\n`);
+            appendFileSync(
+              envPath,
+              `\n# Auto-generated service key for sandbox auth (do not remove)\nINTERNAL_SERVICE_KEY=${generated}\n`,
+            );
             console.log(`[config] Persisted INTERNAL_SERVICE_KEY to ${envPath}`);
           }
           break;
@@ -943,7 +1050,8 @@ export const config = {
   KORTIX_LLM_ROUTER_REQS_PER_MIN_FREE: env.KORTIX_LLM_ROUTER_REQS_PER_MIN_FREE,
   KORTIX_LLM_ROUTER_REQS_PER_MIN_PAID: env.KORTIX_LLM_ROUTER_REQS_PER_MIN_PAID,
   KORTIX_PROXY_REQS_PER_MIN: env.KORTIX_PROXY_REQS_PER_MIN,
-  KORTIX_TRIGGER_MAX_PROVISIONING_SESSIONS_PER_PROJECT: env.KORTIX_TRIGGER_MAX_PROVISIONING_SESSIONS_PER_PROJECT,
+  KORTIX_TRIGGER_MAX_PROVISIONING_SESSIONS_PER_PROJECT:
+    env.KORTIX_TRIGGER_MAX_PROVISIONING_SESSIONS_PER_PROJECT,
   KORTIX_TRIGGER_SCHEDULER_ENABLED: env.KORTIX_TRIGGER_SCHEDULER_ENABLED,
   KORTIX_TRIGGER_SCHEDULER_INTERVAL_MS: env.KORTIX_TRIGGER_SCHEDULER_INTERVAL_MS,
 
@@ -975,14 +1083,18 @@ export const config = {
   isProviderEnabled(name: SandboxProviderName): boolean {
     if (!this.ALLOWED_SANDBOX_PROVIDERS.includes(name)) return false;
     switch (name) {
-      case 'daytona': return !!this.DAYTONA_API_KEY;
-      case 'platinum': return !!this.PLATINUM_API_KEY;
-      case 'e2b': return !!this.E2B_API_KEY;
+      case 'daytona':
+        return !!this.DAYTONA_API_KEY;
+      case 'platinum':
+        return !!this.PLATINUM_API_KEY;
+      case 'e2b':
+        return !!this.E2B_API_KEY;
       // No API key: "enabled" means selected. Docker socket reachability is
       // checked lazily at first real use (create/start/stop/status) — see
       // platform/providers/local-docker.ts — never here, so an operator can
       // still start the API/dashboard before Docker is wired up.
-      case 'local-docker': return true;
+      case 'local-docker':
+        return true;
       default: {
         const exhaustive: never = name;
         return exhaustive;
@@ -1015,7 +1127,6 @@ export const config = {
   isE2BEnabled(): boolean {
     return this.ALLOWED_SANDBOX_PROVIDERS.includes('e2b') && !!this.E2B_API_KEY;
   },
-
 };
 
 // ─── Billing Markup Constants ────────────────────────────────────────────────

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,7 +26,7 @@ import { HTTPException } from 'hono/http-exception';
 import { config } from './config';
 import { BillingError } from './errors';
 
-// ─── Sub-Service Imports ──────────────────────────────────────────────────── 
+// ─── Sub-Service Imports ────────────────────────────────────────────────────
 
 import { router } from './router';
 import { billingApp, accountDeletionApp } from './billing';
@@ -49,11 +49,20 @@ import { eq } from 'drizzle-orm';
 import { ensureSchema } from './ensure-schema';
 import { initModelPricing, stopModelPricing } from './router/config/model-pricing';
 import { runtimeModelCatalog } from './llm-gateway/models/runtime-catalog';
-import { tunnelApp, wsHandlers as tunnelWsHandlers, startTunnelService, stopTunnelService } from './tunnel';
+import {
+  tunnelApp,
+  wsHandlers as tunnelWsHandlers,
+  startTunnelService,
+  stopTunnelService,
+} from './tunnel';
 import { accessControlApp } from './access-control';
 import { startAccessControlCache, stopAccessControlCache } from './shared/access-control-cache';
 import { startTmpReaper, stopTmpReaper } from './snapshots/tmp-reaper';
-import { startLeaderElection, stopLeaderElection, runsSingletonWorkers } from './shared/leader-election';
+import {
+  startLeaderElection,
+  stopLeaderElection,
+  runsSingletonWorkers,
+} from './shared/leader-election';
 import { marketplaceApp } from './marketplace';
 import { oauthApp } from './oauth';
 import {
@@ -65,7 +74,10 @@ import {
 import { startProjectMaintenance, stopProjectMaintenance } from './projects/maintenance';
 import { kickStartupPreBuild } from './snapshots/builder';
 import { registerSunaMigrationRoutes } from './projects/suna-migration/suna-migration-routes';
-import { startSunaMigrationWorker, stopSunaMigrationWorker } from './projects/suna-migration/suna-migration-worker';
+import {
+  startSunaMigrationWorker,
+  stopSunaMigrationWorker,
+} from './projects/suna-migration/suna-migration-worker';
 import { accountsRouter } from './accounts';
 import { authRouter } from './auth';
 import { scimRouter } from './scim';
@@ -104,10 +116,15 @@ process.on('unhandledRejection', (reason: unknown) => {
 process.on('uncaughtException', (err: Error) => {
   try {
     if (isLoggingTransportError(`${err?.message ?? ''}\n${err?.stack ?? ''}`)) {
-      appLogger.localError('Dropped logging-transport exception', { error: err?.message ?? String(err) });
+      appLogger.localError('Dropped logging-transport exception', {
+        error: err?.message ?? String(err),
+      });
       return;
     }
-    appLogger.error('Uncaught exception', { error: err?.message ?? String(err), stack: err?.stack });
+    appLogger.error('Uncaught exception', {
+      error: err?.message ?? String(err),
+      stack: err?.stack,
+    });
     captureException(err, { handler: 'uncaughtException' });
   } catch {
     // never let the crash guard itself crash the process
@@ -148,7 +165,7 @@ app.use('*', async (c, next) => {
   }
 });
 
-// === Global Middleware === 
+// === Global Middleware ===
 
 // CORS origins: production domains + localhost for local dev + any extras from env.
 const cloudOrigins = [
@@ -170,12 +187,14 @@ const localOrigins = [
   'http://127.0.0.1:3010',
 ];
 const extraOrigins = process.env.CORS_ALLOWED_ORIGINS
-  ? process.env.CORS_ALLOWED_ORIGINS.split(',').map((s) => s.trim()).filter(Boolean)
+  ? process.env.CORS_ALLOWED_ORIGINS.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
   : [];
 const corsOrigins = [
   ...new Set([
     ...cloudOrigins,
-    ...localOrigins,  // Always include — needed for local dev and self-hosted
+    ...localOrigins, // Always include — needed for local dev and self-hosted
     ...extraOrigins,
   ]),
 ];
@@ -198,9 +217,20 @@ app.use(
       return null; // not allowed → no Access-Control-Allow-Origin
     },
     allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowHeaders: ['Content-Type', 'Authorization', 'X-Kortix-Token', 'X-Api-Key', 'Accept', 'X-Kortix-Signature', 'X-Hub-Signature-256', 'traceparent', 'tracestate', 'X-Request-Id'],
+    allowHeaders: [
+      'Content-Type',
+      'Authorization',
+      'X-Kortix-Token',
+      'X-Api-Key',
+      'Accept',
+      'X-Kortix-Signature',
+      'X-Hub-Signature-256',
+      'traceparent',
+      'tracestate',
+      'X-Request-Id',
+    ],
     credentials: true,
-  })
+  }),
 );
 
 // ─── Request context (AsyncLocalStorage) ────────────────────────────────────
@@ -208,27 +238,31 @@ app.use(
 // (auth, route handlers, console.error calls) automatically gets context fields
 // (requestId, userId, accountId, sandboxId) attached to every log.
 app.use('*', async (c, next) => {
-  await runWithContext(c.req.method, c.req.path, async () => {
-    // Auto-extract common resource IDs from URL patterns for logs/traces.
-    const path = c.req.path;
-    const projectSessionMatch = path.match(/\/projects\/([^/]+)\/sessions\/([^/]+)/);
-    if (projectSessionMatch) {
-      setContextField('projectId', projectSessionMatch[1]);
-      setContextField('sessionId', projectSessionMatch[2]);
-    } else {
-      const projectMatch = path.match(/\/projects\/([^/]+)/);
-      if (projectMatch) setContextField('projectId', projectMatch[1]);
-    }
-    const sbMatch = path.match(/\/sandbox(?:es)?\/([^/]+)/) ||
-                    path.match(/\/p\/([^/]+)/);
-    if (sbMatch) setContextField('sandboxId', sbMatch[1]);
-    await next();
-    const ctx = getRequestContext();
-    if (ctx) {
-      c.header('X-Request-Id', ctx.requestId);
-      c.header('traceparent', ctx.traceparent);
-    }
-  }, c.req.header('traceparent'));
+  await runWithContext(
+    c.req.method,
+    c.req.path,
+    async () => {
+      // Auto-extract common resource IDs from URL patterns for logs/traces.
+      const path = c.req.path;
+      const projectSessionMatch = path.match(/\/projects\/([^/]+)\/sessions\/([^/]+)/);
+      if (projectSessionMatch) {
+        setContextField('projectId', projectSessionMatch[1]);
+        setContextField('sessionId', projectSessionMatch[2]);
+      } else {
+        const projectMatch = path.match(/\/projects\/([^/]+)/);
+        if (projectMatch) setContextField('projectId', projectMatch[1]);
+      }
+      const sbMatch = path.match(/\/sandbox(?:es)?\/([^/]+)/) || path.match(/\/p\/([^/]+)/);
+      if (sbMatch) setContextField('sandboxId', sbMatch[1]);
+      await next();
+      const ctx = getRequestContext();
+      if (ctx) {
+        c.header('X-Request-Id', ctx.requestId);
+        c.header('traceparent', ctx.traceparent);
+      }
+    },
+    c.req.header('traceparent'),
+  );
 });
 
 // Request logger — uses Hono's built-in logger for stdout (Docker captures these)
@@ -250,37 +284,40 @@ app.use('*', async (c, next) => {
   if (accountId) setContextField('accountId', accountId);
 
   // Add breadcrumb to Sentry for request context on future errors
-  addBreadcrumb(`${c.req.method} ${c.req.path} ${status}`, {
-    method,
-    path,
-    status,
-    duration,
-    userAgent: c.req.header('user-agent')?.slice(0, 100),
-  }, 'http');
+  addBreadcrumb(
+    `${c.req.method} ${c.req.path} ${status}`,
+    {
+      method,
+      path,
+      status,
+      duration,
+      userAgent: c.req.header('user-agent')?.slice(0, 100),
+    },
+    'http',
+  );
 
   // Expected sandbox proxy noise we intentionally suppress:
   // - long-poll/SSE event stream timing out after ~30s (504)
   // - sandbox startup probes returning 502/503 before services are ready
   const isSandboxProxyPath = path.includes('/v1/p/');
-  const isProxyLongPoll = isSandboxProxyPath && (
-    path.includes('/global/event') ||
-    path.includes('/session/status') ||
-    /\/session\/[^/]+\/message(?:$|\?)/.test(path)
-  );
-  const isProxyStartupProbe = isSandboxProxyPath && (
-    path.includes('/global/health') ||
-    path.includes('/kortix/health') ||
-    /\/sessions(?:\/|$)/.test(path)
-  );
-  const isExpectedProxyNoise = method === 'GET' && (
-    (isProxyLongPoll && (
-      (status === 200 && duration > 5000) ||
-      status === 504 ||
-      status === 502 ||
-      status === 503
-    )) ||
-    (isProxyStartupProbe && (status === 502 || status === 503 || status === 504))
-  );
+  const isProxyLongPoll =
+    isSandboxProxyPath &&
+    (path.includes('/global/event') ||
+      path.includes('/session/status') ||
+      /\/session\/[^/]+\/message(?:$|\?)/.test(path));
+  const isProxyStartupProbe =
+    isSandboxProxyPath &&
+    (path.includes('/global/health') ||
+      path.includes('/kortix/health') ||
+      /\/sessions(?:\/|$)/.test(path));
+  const isExpectedProxyNoise =
+    method === 'GET' &&
+    ((isProxyLongPoll &&
+      ((status === 200 && duration > 5000) ||
+        status === 504 ||
+        status === 502 ||
+        status === 503)) ||
+      (isProxyStartupProbe && (status === 502 || status === 503 || status === 504)));
 
   // Health/liveness probes fire every few seconds from the ALB + kubelet across
   // every pod — by far the highest-volume request. A healthy probe carries no
@@ -343,7 +380,9 @@ const API_INSTANCE = process.env.HOSTNAME || 'unknown';
 
 // OpenAPI spec (/v1/openapi.json) + Scalar API reference (/v1/docs). Typed routes
 // register into the spec as each sub-router is migrated to @hono/zod-openapi.
-mountOpenApiDocs(app, API_VERSION);
+// Internal routers are always stripped from the spec; this flag can suppress
+// the whole docs surface for hardened self-host deployments.
+if (config.OPENAPI_PUBLIC_DOCS) mountOpenApiDocs(app, API_VERSION);
 
 const HealthSchema = z
   .object({
@@ -520,14 +559,15 @@ app.openapi(
     responses: { 200: json(MaintenanceSchema, 'Maintenance config') },
   }),
   async (c: any) => {
-  if (!hasDatabase) return c.json(DEFAULT_MAINTENANCE);
-  const [row] = await db
-    .select({ value: platformSettings.value })
-    .from(platformSettings)
-    .where(eq(platformSettings.key, MAINTENANCE_KEY))
-    .limit(1);
-  return c.json(row?.value ?? DEFAULT_MAINTENANCE);
-});
+    if (!hasDatabase) return c.json(DEFAULT_MAINTENANCE);
+    const [row] = await db
+      .select({ value: platformSettings.value })
+      .from(platformSettings)
+      .where(eq(platformSettings.key, MAINTENANCE_KEY))
+      .limit(1);
+    return c.json(row?.value ?? DEFAULT_MAINTENANCE);
+  },
+);
 
 app.openapi(
   createRoute({
@@ -548,11 +588,18 @@ app.openapi(
     }
     if (!hasDatabase) return c.json({ error: 'Database not configured' }, 503);
     const body = await c.req.json().catch(() => ({}));
-    const maintenanceConfig = { ...DEFAULT_MAINTENANCE, ...body, updatedAt: new Date().toISOString() };
+    const maintenanceConfig = {
+      ...DEFAULT_MAINTENANCE,
+      ...body,
+      updatedAt: new Date().toISOString(),
+    };
     await db
       .insert(platformSettings)
       .values({ key: MAINTENANCE_KEY, value: maintenanceConfig, updatedAt: new Date() })
-      .onConflictDoUpdate({ target: platformSettings.key, set: { value: maintenanceConfig, updatedAt: new Date() } });
+      .onConflictDoUpdate({
+        target: platformSettings.key,
+        set: { value: maintenanceConfig, updatedAt: new Date() },
+      });
     return c.json(maintenanceConfig);
   },
 );
@@ -647,7 +694,6 @@ app.route('/v1/account-invites', accountInvitesRouter);
 
 app.route('/v1/ops', opsApp);
 
-
 app.openapi(
   createRoute({
     method: 'get',
@@ -657,23 +703,26 @@ app.openapi(
     ...auth,
     middleware: [supabaseAuth] as const,
     responses: {
-      200: json(z.object({ isAdmin: z.boolean(), role: z.string().nullable() }).openapi('UserRoles'), 'Platform role'),
+      200: json(
+        z.object({ isAdmin: z.boolean(), role: z.string().nullable() }).openapi('UserRoles'),
+        'Platform role',
+      ),
       ...errors(401),
     },
   }),
   async (c: any) => {
-  const accountId = c.get('userId') as string;
-  const role = await getPlatformRole(accountId);
-  const isAdmin = role === 'admin' || role === 'super_admin';
+    const accountId = c.get('userId') as string;
+    const role = await getPlatformRole(accountId);
+    const isAdmin = role === 'admin' || role === 'super_admin';
 
-  return c.json({ isAdmin, role });
+    return c.json({ isAdmin, role });
   },
 );
 
 // ─── Mount Sub-Services ─────────────────────────────────────────────────────
 // All services follow the pattern: /v1/{serviceName}/...
 
-app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/router/models, /v1/router/web-search, /v1/router/tavily/*, etc.
+app.route('/v1/router', router); // /v1/router/chat/completions, /v1/router/models, /v1/router/web-search, /v1/router/tavily/*, etc.
 
 {
   // LLM gateway surfaces: in-API /v1/llm (full pipeline), /internal/gateway
@@ -686,9 +735,9 @@ app.route('/v1/router', router);        // /v1/router/chat/completions, /v1/rout
 import { generationApp } from './router/routes/generation';
 import { usageApp } from './router/routes/usage';
 app.route('/v1/generation', generationApp); // GET /v1/generation?id=<requestId> — single gateway-call forensics
-app.route('/v1/usage', usageApp);       // GET /v1/usage[?start&end&group_by] — account usage rollup
+app.route('/v1/usage', usageApp); // GET /v1/usage[?start&end&group_by] — account usage rollup
 
-app.route('/v1/billing', billingApp);   // /v1/billing/account-state, /v1/billing/webhooks/*
+app.route('/v1/billing', billingApp); // /v1/billing/account-state, /v1/billing/webhooks/*
 app.route('/v1/account', accountDeletionApp); // account deletion status/request/cancel/immediate
 app.route('/v1/platform', platformApp); // /v1/platform, /v1/platform/sandbox/version
 registerSunaMigrationRoutes(projectsApp); // /v1/projects/suna-migration/* (OG Suna → opencode, user-triggered)
@@ -715,7 +764,17 @@ app.route('/v1/marketplace', marketplaceApp); // /v1/marketplace — browse the 
 
 app.route('/v1/webhooks', projectWebhooksApp); // /v1/webhooks/:triggerId — signed project trigger fires
 
-const { slackWebhookApp, teamsWebhookApp, teamsIdentityApp, teamsOauthApp, telegramWebhookApp, slackOauthApp, slackIdentityApp, emailWebhookApp, meetWebhookApp } = await import('./channels');
+const {
+  slackWebhookApp,
+  teamsWebhookApp,
+  teamsIdentityApp,
+  teamsOauthApp,
+  telegramWebhookApp,
+  slackOauthApp,
+  slackIdentityApp,
+  emailWebhookApp,
+  meetWebhookApp,
+} = await import('./channels');
 app.route('/v1/webhooks/slack/oauth', slackOauthApp); // /v1/webhooks/slack/oauth/callback — OAuth dance
 app.route('/v1/webhooks/slack', slackWebhookApp); // /v1/webhooks/slack/:projectId — raw Slack events (BYO mode)
 app.route('/v1/webhooks/teams/oauth', teamsOauthApp); // /v1/webhooks/teams/oauth/callback — admin-consent + catalog publish
@@ -750,7 +809,7 @@ app.route('/v1/public/session-shares', publicSessionSharesApp); // /v1/public/se
 // Setup — local/self-hosted only. Hidden when billing is enabled so the admin
 // surface isn't exposed on managed/cloud deployments.
 if (!config.KORTIX_BILLING_INTERNAL_ENABLED) {
-  app.route('/v1/setup', setupApp);        // /v1/setup/install-status (public), rest (auth inside router)
+  app.route('/v1/setup', setupApp); // /v1/setup/install-status (public), rest (auth inside router)
 }
 // /v1/admin/* — admin console (accounts/users/ledger/credits). supabaseAuth +
 // requireAdmin enforced inside the router. Backs apps/web/src/app/admin/.
@@ -807,7 +866,9 @@ app.onError((err, c) => {
   // shared/platinum.ts PlatinumSandboxNotRunningError.
   if (isPlatinumSandboxNotRunningError(err)) {
     appLogger.warn(`${method} ${path} -> 503 [PlatinumSandboxNotRunningError] ${err.message}`, {
-      method, path, errorType: 'PlatinumSandboxNotRunningError',
+      method,
+      path,
+      errorType: 'PlatinumSandboxNotRunningError',
     });
     c.header('Retry-After', '10');
     return c.json({ error: true, message: 'sandbox is not running', status: 503 }, 503);
@@ -827,16 +888,26 @@ app.onError((err, c) => {
   // projects/git/mirror.ts.
   if (isGitOperationError(err) && err.kind === 'timeout') {
     appLogger.warn(`${method} ${path} -> 503 [GitOperationError:timeout] ${err.message}`, {
-      method, path, errorType: 'GitOperationError', gitKind: 'timeout',
-      gitArgs: err.gitArgs, signal: err.signal,
+      method,
+      path,
+      errorType: 'GitOperationError',
+      gitKind: 'timeout',
+      gitArgs: err.gitArgs,
+      signal: err.signal,
     });
     c.header('Retry-After', '10');
-    return c.json({ error: true, message: 'git mirror is temporarily unavailable', status: 503 }, 503);
+    return c.json(
+      { error: true, message: 'git mirror is temporarily unavailable', status: 503 },
+      503,
+    );
   }
 
   if (err instanceof BillingError) {
     appLogger.error(`${method} ${path} -> ${err.statusCode} [BillingError]`, {
-      statusCode: err.statusCode, message: err.message, path, method,
+      statusCode: err.statusCode,
+      message: err.message,
+      path,
+      method,
     });
     return c.json({ error: err.message }, err.statusCode as any);
   }
@@ -853,7 +924,10 @@ app.onError((err, c) => {
       captureException(err, { method, path, status: err.status });
     }
     appLogger.error(`${method} ${path} -> ${err.status} [HTTPException]`, {
-      status: err.status, message: err.message, path, method,
+      status: err.status,
+      message: err.message,
+      path,
+      method,
     });
 
     const response: Record<string, unknown> = {
@@ -871,23 +945,40 @@ app.onError((err, c) => {
   }
 
   // Database / postgres.js errors — extract the useful info, not the full SQL dump
-  const isDbError = errName === 'PostgresError' || (err as any).severity || (err as any).code?.match?.(/^[0-9]{5}$/);
+  const isDbError =
+    errName === 'PostgresError' ||
+    (err as any).severity ||
+    (err as any).code?.match?.(/^[0-9]{5}$/);
   if (isDbError) {
     const pgErr = err as any;
     captureException(err, {
-      method, path, errorType: 'database',
-      pgCode: pgErr.code, table: pgErr.table, schema: pgErr.schema_name || pgErr.schema,
+      method,
+      path,
+      errorType: 'database',
+      pgCode: pgErr.code,
+      table: pgErr.table,
+      schema: pgErr.schema_name || pgErr.schema,
     });
-    appLogger.error(`${method} ${path} -> 500 [DB ${pgErr.severity || 'ERROR'} ${pgErr.code || '?'}]`, {
-      method, path, errorType: 'database',
-      pgCode: pgErr.code, table: pgErr.table, hint: pgErr.hint, detail: pgErr.detail,
-      message: err.message.split('\n')[0],
-    });
+    appLogger.error(
+      `${method} ${path} -> 500 [DB ${pgErr.severity || 'ERROR'} ${pgErr.code || '?'}]`,
+      {
+        method,
+        path,
+        errorType: 'database',
+        pgCode: pgErr.code,
+        table: pgErr.table,
+        hint: pgErr.hint,
+        detail: pgErr.detail,
+        message: err.message.split('\n')[0],
+      },
+    );
   } else {
     // Generic unhandled error — capture to Sentry + structured log
     captureException(err, { method, path, errorType: errName });
     appLogger.error(`${method} ${path} -> 500 [${errName}] ${err.message}`, {
-      method, path, errorType: errName,
+      method,
+      path,
+      errorType: errName,
       stack: err.stack?.split('\n').slice(0, 5).join('\n'),
     });
   }
@@ -898,7 +989,7 @@ app.onError((err, c) => {
       message: 'Internal server error',
       status: 500,
     },
-    500
+    500,
   );
 });
 
@@ -911,7 +1002,7 @@ app.notFound((c) => {
       message: 'Not found',
       status: 404,
     },
-    404
+    404,
   );
 });
 
@@ -947,9 +1038,11 @@ console.log(`
 initModelPricing().catch((err) =>
   console.error('[startup] Model pricing init failed (will retry in 24h):', err),
 );
-runtimeModelCatalog.start().catch((err) =>
-  console.error('[startup] Gateway model catalog init failed (keeping bundled snapshot):', err),
-);
+runtimeModelCatalog
+  .start()
+  .catch((err) =>
+    console.error('[startup] Gateway model catalog init failed (keeping bundled snapshot):', err),
+  );
 
 // Schema readiness gate — blocks DB-dependent requests until push completes.
 let schemaReady = false;
@@ -1028,7 +1121,9 @@ async function bootServices() {
   // holding it while running nothing and starving the scheduler fleet-wide.
   const eligible = runsSingletonWorkers();
   if (!eligible) {
-    appLogger.info('[workers] API-only pod — singleton workers disabled; not joining leader election');
+    appLogger.info(
+      '[workers] API-only pod — singleton workers disabled; not joining leader election',
+    );
   }
   startLeaderElection(
     {
@@ -1085,7 +1180,11 @@ if (import.meta.main) {
 // Handled at the Bun.serve level so the proxied app sees itself at root `/`
 // (Hono can't match on the Host header). See `sandbox-proxy/subdomain.ts`.
 import { handleSubdomainRequest, parsePreviewSubdomain } from './sandbox-proxy/subdomain';
-import { matchPreviewWsPath, preparePreviewWsUpgrade, previewWsHandlers } from './sandbox-proxy/ws-proxy';
+import {
+  matchPreviewWsPath,
+  preparePreviewWsUpgrade,
+  previewWsHandlers,
+} from './sandbox-proxy/ws-proxy';
 
 export default {
   port: config.PORT,
@@ -1160,13 +1259,16 @@ export default {
       const { tunnelRateLimiter } = await import('./tunnel/core/rate-limiter');
       const wsRateCheck = tunnelRateLimiter.check('wsConnect', tunnelId);
       if (!wsRateCheck.allowed) {
-        return new Response(JSON.stringify({
-          error: 'Too many connection attempts',
-          retryAfterMs: wsRateCheck.retryAfterMs,
-        }), {
-          status: 429,
-          headers: { 'Content-Type': 'application/json' },
-        });
+        return new Response(
+          JSON.stringify({
+            error: 'Too many connection attempts',
+            retryAfterMs: wsRateCheck.retryAfterMs,
+          }),
+          {
+            status: 429,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
       }
 
       const success = server.upgrade(req, {
@@ -1213,7 +1315,11 @@ export default {
     // heartbeat mechanism (30s ping/pong) for liveness detection.
     idleTimeout: 0,
 
-    open(ws: { data: any; send: (data: any) => void; close: (code?: number, reason?: string) => void }) {
+    open(ws: {
+      data: any;
+      send: (data: any) => void;
+      close: (code?: number, reason?: string) => void;
+    }) {
       if (ws.data?.type === 'tunnel-agent') {
         tunnelWsHandlers.onOpen(ws.data.tunnelId, ws as any);
         return;
@@ -1223,10 +1329,15 @@ export default {
         return;
       }
       // No other WS upgrades are accepted.
-      try { ws.close(1011, 'unsupported websocket upgrade'); } catch {}
+      try {
+        ws.close(1011, 'unsupported websocket upgrade');
+      } catch {}
     },
 
-    message(ws: { data: any; close: (code?: number, reason?: string) => void }, message: string | Buffer) {
+    message(
+      ws: { data: any; close: (code?: number, reason?: string) => void },
+      message: string | Buffer,
+    ) {
       if (ws.data?.type === 'tunnel-agent') {
         tunnelWsHandlers.onMessage(ws.data.tunnelId, message);
         return;

--- a/apps/api/src/openapi/index.ts
+++ b/apps/api/src/openapi/index.ts
@@ -6,33 +6,33 @@
  * error contract. Routes are defined with `createRoute()` + zod; the spec is
  * served at /v1/openapi.json and rendered by Scalar at /v1/docs.
  */
-import { OpenAPIHono, z, type RouteConfig } from "@hono/zod-openapi";
-import { ErrorEnvelopeSchema } from "@kortix/api-contract";
-import type { Env } from "hono";
-import { Scalar } from "@scalar/hono-api-reference";
+import { OpenAPIHono, z, type RouteConfig } from '@hono/zod-openapi';
+import { ErrorEnvelopeSchema } from '@kortix/api-contract';
+import type { Env } from 'hono';
+import { Scalar } from '@scalar/hono-api-reference';
 
 /** Permissive error envelope — matches the platform's `{error,message,status}` 404 shape. */
-export const ErrorSchema = ErrorEnvelopeSchema.openapi("Error");
+export const ErrorSchema = ErrorEnvelopeSchema.openapi('Error');
 
 const STATUS_TEXT: Record<number, string> = {
-  400: "Bad request",
-  401: "Unauthorized",
-  402: "Payment required",
-  403: "Forbidden",
-  404: "Not found",
-  409: "Conflict",
-  410: "Gone",
-  429: "Rate limited",
-  500: "Server error",
-  501: "Not implemented",
-  502: "Bad gateway",
-  503: "Service unavailable",
+  400: 'Bad request',
+  401: 'Unauthorized',
+  402: 'Payment required',
+  403: 'Forbidden',
+  404: 'Not found',
+  409: 'Conflict',
+  410: 'Gone',
+  429: 'Rate limited',
+  500: 'Server error',
+  501: 'Not implemented',
+  502: 'Bad gateway',
+  503: 'Service unavailable',
 };
 
 /** A JSON response entry for a createRoute `responses` map. */
 export const json = <T extends z.ZodTypeAny>(schema: T, description: string) => ({
   description,
-  content: { "application/json": { schema } },
+  content: { 'application/json': { schema } },
 });
 
 /**
@@ -42,12 +42,14 @@ export const json = <T extends z.ZodTypeAny>(schema: T, description: string) => 
  * widened `Record<number,…>` would break `c.json(body, 401)` handler typing.
  */
 export const errors = <C extends number>(...codes: C[]): { [K in C]: ReturnType<typeof json> } =>
-  Object.fromEntries(codes.map((c) => [c, json(ErrorSchema, STATUS_TEXT[c] ?? "Error")])) as unknown as {
+  Object.fromEntries(
+    codes.map((c) => [c, json(ErrorSchema, STATUS_TEXT[c] ?? 'Error')]),
+  ) as unknown as {
     [K in C]: ReturnType<typeof json>;
   };
 
 /** Mark an operation as requiring a bearer token. */
-export const auth: Pick<RouteConfig, "security"> = { security: [{ bearerAuth: [] }] };
+export const auth: Pick<RouteConfig, 'security'> = { security: [{ bearerAuth: [] }] };
 
 /**
  * Single validation-error contract for every typed route. Zod failures (bad body,
@@ -56,7 +58,7 @@ export const auth: Pick<RouteConfig, "security"> = { security: [{ bearerAuth: []
 function defaultHook(result: { success: boolean; error?: { issues: unknown } }, c: any) {
   if (!result.success) {
     return c.json(
-      { error: true, message: "Validation failed", status: 400, issues: result.error?.issues },
+      { error: true, message: 'Validation failed', status: 400, issues: result.error?.issues },
       400,
     );
   }
@@ -67,28 +69,64 @@ export function makeOpenApiApp<E extends Env = Env>() {
   return new OpenAPIHono<E>({ defaultHook });
 }
 
+/**
+ * Route prefixes whose schemas are INTERNAL and must not appear in the public
+ * spec. These routers are runtime-gated (admin: supabaseAuth + requireAdmin;
+ * ops: platform-admin) but `app.route()` still merges their typed definitions
+ * into the shared registry, so `getOpenAPI31Document` would otherwise publish
+ * admin credit-debit / tier-change / ops shapes to anyone hitting
+ * /v1/openapi.json. SCIM (`/scim/v2`) is deliberately NOT here — it's an
+ * RFC-7644 standard surface IdP admins legitimately introspect.
+ */
+export const INTERNAL_SPEC_PREFIXES = ['/v1/admin', '/v1/ops'] as const;
+
+/**
+ * Drop any path whose key equals an internal prefix or sits under it
+ * (`prefix + '/'`). Pure + exported for unit tests. The `+ '/'` boundary keeps
+ * a sibling like `/v1/administrators` from being swept by the `/v1/admin`
+ * prefix. Returns a shallow-cloned doc; the input is not mutated.
+ */
+export function filterSpecPaths<T extends { paths?: Record<string, unknown> }>(
+  doc: T,
+  prefixes: readonly string[] = INTERNAL_SPEC_PREFIXES,
+): T {
+  if (!doc.paths) return doc;
+  const kept: Record<string, unknown> = {};
+  for (const [path, item] of Object.entries(doc.paths)) {
+    const internal = prefixes.some((p) => path === p || path.startsWith(`${p}/`));
+    if (!internal) kept[path] = item;
+  }
+  return { ...doc, paths: kept };
+}
+
 /** Register security + serve the spec (/v1/openapi.json) and Scalar UI (/v1/docs). */
 export function mountOpenApiDocs(app: OpenAPIHono<any, any, any>, version: string): void {
-  app.openAPIRegistry.registerComponent("securitySchemes", "bearerAuth", {
-    type: "http",
-    scheme: "bearer",
+  app.openAPIRegistry.registerComponent('securitySchemes', 'bearerAuth', {
+    type: 'http',
+    scheme: 'bearer',
     description:
-      "Supabase user JWT, or a Kortix token: PAT (`kortix_pat_…`), API key (`kortix_…`), service account (`kortix_sa_…`), or (LLM Gateway inference routes only) a project gateway key (`kortix_gw_…`).",
+      'Supabase user JWT, or a Kortix token: PAT (`kortix_pat_…`), API key (`kortix_…`), service account (`kortix_sa_…`), or (LLM Gateway inference routes only) a project gateway key (`kortix_gw_…`).',
   });
 
-  app.doc31("/v1/openapi.json", (c) => ({
-    openapi: "3.1.0",
-    info: {
-      title: "Kortix API",
-      version,
-      description:
-        "The Kortix platform REST API — typed schemas via @hono/zod-openapi. " +
-        "For application code, prefer the TypeScript SDK (`@kortix/sdk`), which wraps " +
-        "this API and the OpenCode runtime behind one session-scoped client — " +
-        "docs at https://kortix.com/docs/sdk.",
-    },
-    servers: [{ url: new URL(c.req.url).origin }],
-  }));
+  // Serve the same document `doc31` would (getOpenAPI31Document is exactly what
+  // doc31 delegates to) but with the internal-router paths stripped, so the
+  // public spec never advertises admin/ops endpoints.
+  app.get('/v1/openapi.json', (c) => {
+    const document = app.getOpenAPI31Document({
+      openapi: '3.1.0',
+      info: {
+        title: 'Kortix API',
+        version,
+        description:
+          'The Kortix platform REST API — typed schemas via @hono/zod-openapi. ' +
+          'For application code, prefer the TypeScript SDK (`@kortix/sdk`), which wraps ' +
+          'this API and the OpenCode runtime behind one session-scoped client — ' +
+          'docs at https://kortix.com/docs/sdk.',
+      },
+      servers: [{ url: new URL(c.req.url).origin }],
+    });
+    return c.json(filterSpecPaths(document));
+  });
 
-  app.get("/v1/docs", Scalar({ url: "/v1/openapi.json", pageTitle: "Kortix API" }));
+  app.get('/v1/docs', Scalar({ url: '/v1/openapi.json', pageTitle: 'Kortix API' }));
 }


### PR DESCRIPTION
**Security / information-disclosure.** The public OpenAPI spec at `/v1/openapi.json` served the full merged route registry, unauthenticated, in every environment — including `/v1/admin` (credit-debit, tier-change, sandbox-migration) and `/v1/ops` route schemas. Those routers are runtime-gated (admin: `supabaseAuth + requireAdmin`), but `app.route()` still merges their typed *definitions* into the shared registry, so `getOpenAPI31Document` published their shapes to anyone. Verified at runtime: `GET /v1/openapi.json` → 200 exposing 12 `/v1/admin/*` paths incl. `/v1/admin/api/accounts/{id}/credits/debit`.

- **Strip internal paths from the public spec** — new pure `filterSpecPaths` drops `/v1/admin` + `/v1/ops` (prefix-boundary safe, so `/v1/administrators` survives). Serves `getOpenAPI31Document` — exactly what `doc31` delegates to — so output is byte-identical minus the internal paths. **SCIM stays public** (RFC-7644, IdP-facing).
- **`OPENAPI_PUBLIC_DOCS` flag (default on)** — lets a hardened self-host deployment turn the whole docs/spec surface off; base behavior unchanged.

Public API surface (base spec + Scalar UI) is unchanged; only internal route shapes are removed, so the DOCS-1 smoke flow stays green.

Tests: pure `filterSpecPaths` cases (prefix boundary, no-op, SCIM-kept) + a mounted-app test asserting a real `/v1/admin` route is absent from the served `/v1/openapi.json`. tsc clean, 5 pass.