### PR TITLE
fix(api): gate Teams + Slack channel writes on project.connector.write

### DIFF
--- a/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-read-leaf-gates-http.test.ts
@@ -210,6 +210,15 @@ const SEND_PRIMITIVE_CASES: Case[] = [
     leaf: PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
     path: () => `/v1/projects/${PROJECT}/channels/meet/speak`,
   },
+  {
+    // Teams consent-card upload drives the project bot to SEND into the
+    // customer's Teams channel — the same send primitive as Slack upload; the
+    // capability assert runs before teamsChannelEnabled(), so the 403 fires
+    // regardless of whether Teams is enabled in this harness.
+    name: 'teams file upload consent card',
+    leaf: PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+    path: () => `/v1/projects/${PROJECT}/channels/teams/file/upload`,
+  },
 ];
 
 describe('HTTP enforcement — send-primitive gates (Slack upload / meet speak)', () => {

--- a/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
+++ b/apps/api/src/__tests__/integration-project-write-leaf-gates-http.test.ts
@@ -165,6 +165,24 @@ const CASES: WCase[] = [
     tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
   },
   {
+    // Teams disconnect — twin of email installation DELETE; no feature-flag
+    // pre-gate, so the connector-write assert is directly exercised. (Teams
+    // CONNECT uses the identical assert but sits behind teamsChannelEnabled(),
+    // untestable here without the flag; DELETE covers the same code pattern.)
+    name: 'teams installation DELETE (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'DELETE',
+    path: () => `/v1/projects/${PROJECT}/channels/teams/installation`,
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
+    // Binding a Slack thread wires inbound channel→session routing — a
+    // connector-write action; empty body reaches the gate before validation.
+    name: 'slack bind-thread (connector.write)',
+    leaf: A.PROJECT_CONNECTOR_WRITE, method: 'POST',
+    path: () => `/v1/projects/${PROJECT}/channels/slack/bind-thread`, body: {},
+    tier: 'editor', denyGrant: [A.PROJECT_TRIGGER_FIRE], allowGrant: [A.PROJECT_CONNECTOR_WRITE],
+  },
+  {
     name: 'channel binding PATCH (connector.write)',
     leaf: A.PROJECT_CONNECTOR_WRITE, method: 'PATCH',
     path: () => `/v1/projects/${PROJECT}/channels/bindings/${sid()}`, body: {},

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -1019,6 +1019,16 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'manage');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // Connecting a Teams bot is a connector-write capability — a custom role can
+    // withhold it and a scoped agent must hold it (central fold), mirroring the
+    // Slack (r4 slack/connect) and email connect twins.
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+    );
 
     let body: { tenant_id?: string; team_name?: string; app_id?: string; app_password?: string };
     try {
@@ -1075,6 +1085,15 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'manage');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // Disconnecting the Teams bot is connector-write — twin of the Slack/email
+    // disconnect gates; a custom role can withhold it, a scoped agent must hold it.
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+    );
     await deleteTeamsInstall(projectId);
     void reconcileChannelConnectors(projectId);
     return c.json({ status: 'disconnected' });
@@ -1134,6 +1153,17 @@ projectsApp.openapi(
     const projectId = c.req.param('projectId');
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
+    // Posting a consent card drives the project bot to SEND into the customer's
+    // Teams channel — a send primitive gated on connector-write like the Slack
+    // (r4 slack/file/upload) and meet/speak twins. Authz before the feature-flag
+    // check so an unauthorized caller never gets a capability-independent answer.
+    await assertProjectCapability(
+      c,
+      loaded.userId,
+      loaded.row.accountId,
+      projectId,
+      PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+    );
     if (!teamsChannelEnabled()) return c.json({ error: 'Not found' }, 404);
     const body = await readBody(c);
     const result = await initiateTeamsUpload(projectId, {
@@ -1914,6 +1944,18 @@ projectsApp.openapi(
     } else {
       const loaded = await loadProjectForUser(c, projectId, 'read');
       if (!loaded) return c.json({ error: 'Not found' }, 404);
+      // Binding a Slack thread creates channel→session routing (inbound Slack
+      // messages drive this session) — a connector-write action, matching the
+      // Slack connect/disconnect/file-upload twins. Threads the acting token so
+      // a custom role that withholds connector.write, or a scoped agent lacking
+      // it, is denied. The sandbox-token branch above is already project-scoped.
+      await assertProjectCapability(
+        c,
+        loaded.userId,
+        loaded.row.accountId,
+        projectId,
+        PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+      );
     }
 
     let body: {


### PR DESCRIPTION
**Security / privilege escalation.** Four channel handlers were gated only on project-read (or coarse `manage`), while their Slack/email/meet twins require `project.connector.write`. A floor `member`, a custom role with connector.write revoked, or a scoped agent lacking it could drive the project bot:

- **POST `channels/teams/file/upload`** — a SEND primitive: posts a file-consent card into the customer's connected Teams channel using the project bot credentials. The Slack (`slack/file/upload`) and meet (`meet/speak`) twins already assert connector.write; Teams was missed by both the earlier fix and its test matrix.
- **POST `channels/teams/connect`** + **DELETE `channels/teams/installation`** — connect/disconnect the Teams bot (Slack/email twins gate this).
- **POST `channels/slack/bind-thread`** (user branch) — wires inbound channel→session routing; the sandbox-token branch was already project-scoped.

Adds the same `assertProjectCapability(PROJECT_CONNECTOR_WRITE)` the twins use — threads the acting token so the agent-grant fold fires. Teams file-upload asserts **before** the `teamsChannelEnabled()` flag (authz before feature disclosure).

Extends the existing HTTP leaf-gate enforcement suites with the Teams/Slack cases: **read-leaf 91 pass, write-leaf 83 pass** (174 total). tsc clean; no new imports (all already used by the adjacent Slack routes).