### PR TITLE
fix(api): atomic SCIM group-park append + branch-GC forward progress

### DIFF
--- a/apps/api/src/__tests__/e2e-project-maintenance.test.ts
+++ b/apps/api/src/__tests__/e2e-project-maintenance.test.ts
@@ -30,7 +30,12 @@ mock.module('../shared/db', () => ({
         }),
         innerJoin: () => ({
           where: () => ({
-            limit: async () => branchCandidates,
+            // The sweep now orders oldest-first (forward-progress guarantee) and
+            // excludes never-deletable rows in SQL; this mock ignores predicates
+            // and returns the fixtures, so orderBy is a passthrough here.
+            orderBy: () => ({
+              limit: async () => branchCandidates,
+            }),
           }),
         }),
       }),

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -1,5 +1,5 @@
 import { projectSessions, projects } from '@kortix/db';
-import { and, eq, inArray, lt, ne } from 'drizzle-orm';
+import { and, asc, eq, inArray, lt, ne, sql } from 'drizzle-orm';
 import { tickRunningComputeCharges } from '../billing/services/compute-metering';
 import { db } from '../shared/db';
 import { reconcileStaleBuilds } from '../snapshots/builder';
@@ -127,8 +127,25 @@ export async function sweepExpiredSessionBranches(now = new Date()): Promise<{
         inArray(projectSessions.status, [...TERMINAL_SESSION_STATUSES]),
         lt(projectSessions.updatedAt, cutoff),
         ne(projectSessions.branchName, projects.defaultBranch),
+        // Exclude the two NEVER-deletable classes at the query so they can't
+        // occupy batch slots forever and starve deletable rows: a skipped row
+        // never gets a db.update, so its updatedAt stays < cutoff and it
+        // re-matches every sweep. (1) already-GC'd. (2) open-PR — mirrors
+        // hasOpenPullRequestMarker. The in-loop guards below stay as
+        // defense-in-depth for a marker written AFTER selection.
+        sql`(${projectSessions.metadata}->'branch_gc'->>'deleted_at') IS NULL`,
+        sql`NOT (
+          COALESCE(${projectSessions.metadata}->>'open_pr', 'false') = 'true'
+          OR COALESCE(${projectSessions.metadata}->>'has_open_pr', 'false') = 'true'
+          OR lower(COALESCE(${projectSessions.metadata}->'pull_request'->>'state', '')) = 'open'
+          OR lower(COALESCE(${projectSessions.metadata}->'github_pull_request'->>'state', '')) = 'open'
+          OR lower(COALESCE(${projectSessions.metadata}->'pr'->>'state', '')) = 'open'
+        )`,
       ),
     )
+    // Oldest deletable rows first — deterministic drain so the planner's scan
+    // order can't crowd them out of the batch.
+    .orderBy(asc(projectSessions.updatedAt))
     .limit(GC_BATCH_SIZE);
 
   let deleted = 0;

--- a/apps/api/src/scim/groups.ts
+++ b/apps/api/src/scim/groups.ts
@@ -4,7 +4,7 @@
 
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountInvitations, accountMembers } from '@kortix/db';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { invalidateIamCacheForGroup, invalidateIamCacheForUsers } from '../iam/cache-invalidation';
 import { scimError } from '../middleware/scim-auth';
 import { errors, json } from '../openapi';
@@ -98,12 +98,24 @@ async function addGroupMembersOrDeferInvites(
       continue;
     }
     if (action !== 'park') continue;
-    const existing = inv.bootstrapGrants ?? [];
-    if (existing.some((g) => 'group_id' in g && g.group_id === groupId)) continue;
+    // Atomic append. The previous read-modify-write wrote the WHOLE array back
+    // from a stale snapshot, so two concurrent parks of DIFFERENT groups onto
+    // the same invite clobbered each other (last write wins). `||` concatenates
+    // against the row's CURRENT committed value at write time, so both land; the
+    // `@>` guard in the WHERE preserves the old same-group idempotency (a
+    // duplicate park is a no-op UPDATE instead of appending twice).
+    const grantJson = sql`jsonb_build_array(jsonb_build_object('group_id', ${groupId}::text))`;
     await db
       .update(accountInvitations)
-      .set({ bootstrapGrants: [...existing, { group_id: groupId }] })
-      .where(eq(accountInvitations.inviteId, inv.inviteId));
+      .set({
+        bootstrapGrants: sql`COALESCE(${accountInvitations.bootstrapGrants}, '[]'::jsonb) || ${grantJson}`,
+      })
+      .where(
+        and(
+          eq(accountInvitations.inviteId, inv.inviteId),
+          sql`NOT (COALESCE(${accountInvitations.bootstrapGrants}, '[]'::jsonb) @> ${grantJson})`,
+        ),
+      );
   }
 }
 


### PR DESCRIPTION
Two verified correctness bugs (found by a code-audit sweep), one PR — disjoint files.

**1. SCIM group-park drops a concurrent grant.** `addGroupMembersOrDeferInvites` (scim/groups.ts) did a read-modify-write of the whole `bootstrap_grants` array from a stale batch snapshot, so two concurrent parks of *different* groups onto the same pending invite clobbered each other (last write wins). Replaced with an atomic jsonb append — `COALESCE(bootstrap_grants,'[]') || jsonb_build_array(jsonb_build_object('group_id', …))` guarded by `@>` for same-group idempotency. Verified against Postgres: both different-group appends compose; a duplicate is a no-op.

**2. Branch-GC batch starvation.** `sweepExpiredSessionBranches` (projects/maintenance.ts) selected a `.limit(50)` batch with no ordering; rows it always skips (open-PR / already-GC'd) never get a `db.update`, so their `updatedAt` stays < cutoff and they re-match every sweep, permanently occupying slots and starving deletable rows. Now excludes both never-deletable classes in SQL and orders oldest-first (`asc(updatedAt)`) for a deterministic drain; the in-loop guards stay as defense-in-depth for markers written after selection.

tsc clean; unit-bootstrap-group + e2e-project-maintenance pass (18). Note: the atomic append is verified by a direct Postgres probe (the function is internal, and the maintenance mock ignores WHERE predicates); the runtime jsonb behavior is exercised by CI's integration suite.