### PR TITLE
fix(api): reject replayed/consumed execution ids in the approval wait gate

### DIFF
--- a/apps/api/src/__tests__/integration-approvals.test.ts
+++ b/apps/api/src/__tests__/integration-approvals.test.ts
@@ -81,6 +81,44 @@ async function seedPending(): Promise<string> {
   execIds.push(row.id);
   return row.id;
 }
+
+/**
+ * Seed a resolved execution row DIRECTLY (bypassing the resolve endpoint) so the
+ * approval-wait guard can be exercised against each resolved shape a replayed
+ * execution id can point at.
+ *  - 'genuine'  — a real, still-unconsumed human approve (what POST /approvals
+ *                 writes on `approve`, before any waiter stamps consumed_at).
+ *  - 'consumed' — that same approve after a live waiter/carry-over already
+ *                 claimed it (consumed_at set): the shape a REPLAY sees.
+ *  - 'ok'/'error' — a plain terminal run row: resolved at insert, no approvedBy
+ *                 and no `decision: approve` marker.
+ */
+async function seedResolved(kind: 'genuine' | 'consumed' | 'ok' | 'error'): Promise<string> {
+  const approved = kind === 'genuine' || kind === 'consumed';
+  const resultSummary =
+    kind === 'genuine'
+      ? { decision: 'approve', decided_by: ctx!.userId }
+      : kind === 'consumed'
+        ? { decision: 'approve', decided_by: ctx!.userId, consumed_at: new Date().toISOString() }
+        : { ok: kind === 'ok' };
+  const [row] = await db
+    .insert(executorExecutions)
+    .values({
+      accountId: ctx!.accountId,
+      projectId: ctx!.projectId,
+      actionPath: 'github.repos.delete',
+      actingUserId: ctx!.userId,
+      sessionId: SESSION,
+      status: kind === 'genuine' || kind === 'consumed' ? 'ok' : kind,
+      risk: null,
+      approvedBy: approved ? ctx!.userId : null,
+      resolvedAt: new Date(),
+      resultSummary,
+    })
+    .returning({ id: executorExecutions.executionId });
+  execIds.push(row.id);
+  return row.id;
+}
 const authGet = (path: string) => app.request(path, { headers: { Authorization: `Bearer ${secret}` } });
 const authPost = (path: string, body: unknown) =>
   app.request(path, {
@@ -225,5 +263,35 @@ describe('waitForApprovalDecision (gateway pause/resume)', () => {
     const execId = await seedPending();
     const outcome = await waitForApprovalDecision(execId, 1200);
     expect(outcome).toBe('timeout');
+  });
+
+  // Security (require_approval bypass): the gate must resolve to 'approved' ONLY
+  // for a genuine, still-unconsumed human approve. Replaying a resolved execution
+  // id that is anything else — an already-consumed approval, or a plain run row —
+  // must NOT auto-authorize the sensitive call. Before the fix, any resolved
+  // non-denied row returned 'approved'.
+  test('a genuine, unconsumed approve still resolves to "approved"', async () => {
+    if (!ctx) return;
+    const execId = await seedResolved('genuine');
+    expect(await waitForApprovalDecision(execId, 1200)).toBe('approved');
+  });
+
+  test('replaying an already-consumed approve does NOT resolve to "approved"', async () => {
+    if (!ctx) return;
+    const execId = await seedResolved('consumed');
+    // The bypass would short-circuit to 'approved'; the guard keeps polling → timeout.
+    expect(await waitForApprovalDecision(execId, 1200)).toBe('timeout');
+  });
+
+  test('a plain ok run row does NOT resolve to "approved" (no approvedBy / decision)', async () => {
+    if (!ctx) return;
+    const execId = await seedResolved('ok');
+    expect(await waitForApprovalDecision(execId, 1200)).toBe('timeout');
+  });
+
+  test('a plain error run row does NOT resolve to "approved"', async () => {
+    if (!ctx) return;
+    const execId = await seedResolved('error');
+    expect(await waitForApprovalDecision(execId, 1200)).toBe('timeout');
   });
 });

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -124,14 +124,38 @@ export async function waitForApprovalDecision(
   }
   while (Date.now() < deadline) {
     const [row] = await db
-      .select({ status: executorExecutions.status, resolvedAt: executorExecutions.resolvedAt })
+      .select({
+        status: executorExecutions.status,
+        resolvedAt: executorExecutions.resolvedAt,
+        approvedBy: executorExecutions.approvedBy,
+        resultSummary: executorExecutions.resultSummary,
+      })
       .from(executorExecutions)
       .where(and(...conds))
       .limit(1);
     // No row under the expected binding → the supplied id belongs to a different
     // session/connector/action (or doesn't exist). Never wait on it.
     if (!row) return 'mismatch';
-    if (row.resolvedAt) return row.status === 'denied' ? 'denied' : 'approved';
+    if (row.resolvedAt) {
+      if (row.status === 'denied') return 'denied';
+      // Only a GENUINE, still-UNCONSUMED human approve authorizes the call —
+      // mirror consumeApprovedExecution's guard exactly. A resolved row that is
+      // NOT that (a plain ok/error run row, which never has approvedBy, or an
+      // already-consumed approval being REPLAYED, which has consumed_at stamped)
+      // must never resolve to 'approved' — treating any resolved non-denied row
+      // as approved is the require_approval bypass (replay a resolved execution
+      // id to auto-authorize a sensitive call). The legit FIRST waiter still
+      // passes: the gateway stamps consumed_at only AFTER this returns 'approved'
+      // (gateway.ts markApprovalConsumed), so consumed_at is still null in-band;
+      // only LATER replays see it set and are rejected here.
+      const rs: Record<string, unknown> = row.resultSummary ?? {};
+      if (row.approvedBy != null && rs.decision === 'approve' && rs.consumed_at == null) {
+        return 'approved';
+      }
+      // Resolved but not a genuine, unconsumed approve. Don't authorize: the
+      // bound row can't flip to genuine, so keep polling until it hits 'timeout'
+      // (the gateway then leaves the call paused, exactly as if never approved).
+    }
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
   return 'timeout';


### PR DESCRIPTION
## The bug (security)

The `require_approval` executor gate is bypassable by replaying a resolved execution id. In `apps/api/src/executor/db-deps.ts`, `waitForApprovalDecision` selected only `{ status, resolvedAt }` and returned `'approved'` for **any** bound row that had `resolvedAt` set and `status !== 'denied'`. It never checked `approvedBy` or `resultSummary`.

As a result, a plain `ok`/`error` run row, or an **already-consumed** approval, wrongly resolved to `'approved'` — so a client that supplied such an `approvalExecutionId` could auto-authorize a sensitive, approval-gated call without a genuine human approval.

Its sibling `consumeApprovedExecution` already guards correctly (`isNotNull(approvedBy)`, `resultSummary->>'decision' = 'approve'`, `consumed_at IS NULL`); `waitForApprovalDecision` did not mirror it.

## The fix

`waitForApprovalDecision` now also selects `approvedBy` and `resultSummary`, and gates the `'approved'` return on a genuine, unconsumed human approve — mirroring `consumeApprovedExecution`:

- `approvedBy != null`
- `resultSummary->>'decision' === 'approve'`
- `resultSummary->>'consumed_at' IS NULL`

The `denied` branch is unchanged. A resolved row that is **not** a genuine, unconsumed approve no longer short-circuits to `'approved'` — the waiter keeps polling and reaches `'timeout'` (the gateway then leaves the call paused, exactly as if it was never approved).

The legitimate **first** approval still resolves to `'approved'`: the gateway stamps `consumed_at` only *after* the waiter returns `'approved'` (`markApprovalConsumed`), so `consumed_at` is still null in-band for the live waiter; only later replays observe it set and are rejected.

## Tests

Extends `apps/api/src/__tests__/integration-approvals.test.ts` with a `seedResolved` helper and four cases against `waitForApprovalDecision`:

- a genuine, unconsumed approve still resolves to `'approved'`,
- replaying an already-consumed approve does **not** (→ `timeout`),
- a plain `ok` run row does **not** (→ `timeout`),
- a plain `error` run row does **not** (→ `timeout`).

The three negative cases fail against the pre-fix code (each returned `'approved'`) and pass with the fix.

## Verification

- `npx tsc --noEmit` (apps/api): 0 errors (unchanged from baseline).
- `bun test integration-approvals`: 13 pass, 0 fail.