### PR TITLE
fix(iam-web): surface the member-detail actions (View as / permissions)

### DIFF
--- a/apps/web/src/app/(app)/accounts/[id]/members/[userId]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/members/[userId]/page.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, ChevronLeft, Eye, FolderOpen, Users, X } from 'lucide-react';
+import {
+  Check,
+  ChevronLeft,
+  Eye,
+  FolderOpen,
+  MoreHorizontal,
+  Shield,
+  ShieldOff,
+  Users,
+  X,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
@@ -10,6 +20,13 @@ import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { InfoBanner } from '@/components/ui/info-banner';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { Label } from '@/components/ui/label';
@@ -104,9 +121,10 @@ export default function MemberDetailPage() {
     () => (membersQuery.data ?? []).find((m) => m.user_id === memberUserId),
     [membersQuery.data, memberUserId],
   );
-  // canPromoteSuperAdmin gates the bypass toggle below.
+  // canPromoteSuperAdmin gates the Grant/Revoke super-admin menu items below —
+  // it's the caller's own member.super_admin.grant permission, the same
+  // action the PATCH .../super-admin route asserts server-side.
   const canPromoteSuperAdmin = usePermission(accountId, 'member.super_admin.grant').allowed;
-  void canPromoteSuperAdmin;
 
   if (authLoading || !user) {
     return <ConnectingScreen forceConnecting overrideStage="auth" hideWorkspacePicker />;
@@ -114,9 +132,9 @@ export default function MemberDetailPage() {
 
   const account = accountQuery.data;
 
-  // Note: we don't currently surface is_super_admin in listAccountMembers, so
-  // we can't show a pre-existing on/off state. Wire the column once the
-  // members endpoint includes it.
+  // listAccountMembers's AccountMember.is_super_admin is what decides Grant
+  // vs Revoke below — it's a required field on the wire (AccountMemberSchema),
+  // so `member` always carries the real current state, no extra fetch needed.
 
   const memberLabel = member?.email ?? memberUserId ?? 'Member';
 
@@ -131,25 +149,70 @@ export default function MemberDetailPage() {
           {account?.name ?? 'Account'}
         </Link>
 
-        <div className="flex min-w-0 items-center gap-3.5">
-          {membersQuery.isLoading ? (
-            <Skeleton className="size-10 rounded-full" />
-          ) : (
-            <UserAvatar email={memberLabel} name={member?.email ?? undefined} size="lg" />
-          )}
-          <div className="min-w-0 space-y-0.5">
+        <div className="flex min-w-0 items-center justify-between gap-3.5">
+          <div className="flex min-w-0 items-center gap-3.5">
             {membersQuery.isLoading ? (
-              <Skeleton className="h-6 w-52" />
+              <Skeleton className="size-10 rounded-full" />
             ) : (
-              <h2 className="text-foreground truncate text-xl font-medium">{memberLabel}</h2>
+              <UserAvatar email={memberLabel} name={member?.email ?? undefined} size="lg" />
             )}
-            {member ? (
-              <InlineMeta className="text-sm">
-                <span>{ROLE_LABEL[member.account_role] ?? member.account_role}</span>
-                <span>Joined {formatDate(member.joined_at)}</span>
-              </InlineMeta>
-            ) : null}
+            <div className="min-w-0 space-y-0.5">
+              {membersQuery.isLoading ? (
+                <Skeleton className="h-6 w-52" />
+              ) : (
+                <h2 className="text-foreground truncate text-xl font-medium">{memberLabel}</h2>
+              )}
+              {member ? (
+                <InlineMeta className="text-sm">
+                  <span>{ROLE_LABEL[member.account_role] ?? member.account_role}</span>
+                  <span>Joined {formatDate(member.joined_at)}</span>
+                </InlineMeta>
+              ) : null}
+            </div>
           </div>
+
+          {account && member ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-muted-foreground hover:text-foreground size-7 shrink-0"
+                  aria-label={`Actions for ${memberLabel}`}
+                >
+                  <MoreHorizontal className="size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuItem onSelect={() => setViewAsOpen(true)} className="gap-2">
+                  <Eye className="size-3.5" />
+                  View as this member
+                </DropdownMenuItem>
+                {canPromoteSuperAdmin ? (
+                  <>
+                    <DropdownMenuSeparator />
+                    {member.is_super_admin ? (
+                      <DropdownMenuItem
+                        onSelect={() => setRevokeConfirmOpen(true)}
+                        className="gap-2"
+                      >
+                        <ShieldOff className="size-3.5" />
+                        Revoke super-admin
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem
+                        onSelect={() => setGrantConfirmOpen(true)}
+                        className="gap-2"
+                      >
+                        <Shield className="size-3.5" />
+                        Grant super-admin
+                      </DropdownMenuItem>
+                    )}
+                  </>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
         </div>
       </div>
 
@@ -196,8 +259,8 @@ export default function MemberDetailPage() {
         title="Grant super-admin"
         description={
           <span>
-            Super-admin bypasses every permission check. <strong>{memberLabel}</strong> will be
-            able to do anything in this account.
+            Super-admin bypasses every permission check. <strong>{memberLabel}</strong> will be able
+            to do anything in this account.
           </span>
         }
         confirmLabel="Grant super-admin"
@@ -382,9 +445,7 @@ function MemberGroupsCard({
   return (
     <section className="space-y-4">
       <div className="space-y-1">
-        <Label>
-          Groups{memberGroups.length > 0 ? ` · ${memberGroups.length}` : ''}
-        </Label>
+        <Label>Groups{memberGroups.length > 0 ? ` · ${memberGroups.length}` : ''}</Label>
         <p className="text-muted-foreground text-xs">
           Any policy attached to one of these groups also applies to this member.
         </p>

--- a/apps/web/src/components/iam/member-detail-actions.test.ts
+++ b/apps/web/src/components/iam/member-detail-actions.test.ts
@@ -1,0 +1,35 @@
+// The member-detail page (reached via the members-list "View & edit
+// permissions" kebab) must SURFACE its built actions — the "View as" simulator
+// and the super-admin grant/revoke dialogs. They regressed once to fully
+// unreachable (dialogs + mutation present, but nothing opened them and the
+// permission probe was a `void` no-op), leaving a page literally labelled
+// "…& edit permissions" that was read-only. These pins keep the triggers wired.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(
+  join(import.meta.dir, '../../app/(app)/accounts/[id]/members/[userId]/page.tsx'),
+  'utf8',
+);
+const flat = source.replace(/\s+/g, ' ');
+
+describe('member-detail actions are reachable', () => {
+  test('an actions dropdown menu is rendered with an accessible label', () => {
+    expect(source).toContain('DropdownMenuTrigger');
+    expect(source).toContain('Actions for ${memberLabel}');
+  });
+
+  test('"View as this member" opens the simulator dialog', () => {
+    expect(flat).toContain('setViewAsOpen(true)');
+  });
+
+  test('super-admin grant/revoke is gated on the permission probe (no dead no-op)', () => {
+    // The probe must be USED to gate the menu, not discarded.
+    expect(source).not.toContain('void canPromoteSuperAdmin');
+    expect(source).toContain('canPromoteSuperAdmin');
+    // Grant vs Revoke is chosen from the member's current state.
+    expect(source).toContain('is_super_admin');
+    expect(flat).toMatch(/setGrantConfirmOpen\(true\)|setRevokeConfirmOpen\(true\)/);
+  });
+});


### PR DESCRIPTION
## Summary

The member-detail page (`/accounts/{id}/members/{userId}`) is reached from the members-list kebab menu via **"View & edit permissions"**, but it renders read-only Groups/Projects/Capabilities cards with no way to actually invoke any action. The page already builds a "View as this member" permission simulator and grant/revoke super-admin confirm dialogs, wired to a mutation — but none of them have a trigger, so the entry point promises "edit permissions" and delivers a dead end.

## Fix

Added a right-aligned actions menu (`MoreHorizontal` kebab, same `DropdownMenu` pattern used for the per-row kebab on the account's members list) to the member-detail header:

- **View as this member** — always available once the member is loaded; opens the existing read-only permission simulator.
- **Grant / Revoke super-admin** — gated on the caller's own `member.super_admin.grant` permission (already computed on this page, previously discarded via a `void` no-op). The label is derived from `member.is_super_admin`, which `listAccountMembers` already returns as a required field on the wire — no new fetch needed.

No dialogs, mutations, or business logic were changed; this only wires up existing, already-built UI to a trigger.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — no new errors in touched files
- [x] `npx next lint` — no new errors (`react-hooks/rules-of-hooks` etc. clean) in touched files
- [x] `npx @biomejs/biome format --write` on the touched file
- [x] Manual read-through of the resulting menu logic (View as always shown; Grant/Revoke mutually exclusive based on current state; both gated on permission)