### PR TITLE
fix(iam-web): confirm role changes + use one role-descriptor source

### DIFF
--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -34,6 +34,7 @@ import { GroupsTab } from '@/components/iam/groups-tab';
 import { MfaRequiredCard } from '@/components/iam/mfa-required-card';
 import { PatPolicyCard } from '@/components/iam/pat-policy-card';
 import { PermissionsHelpPopover } from '@/components/iam/permissions-help-popover';
+import { ACCOUNT_ROLE_DESCRIPTORS } from '@/components/iam/project-role-descriptors';
 import { RolesTab } from '@/components/iam/roles-tab';
 import { IdentityIntro } from '@/components/iam/identity-intro';
 import { ScimCard } from '@/components/iam/scim-card';
@@ -1068,6 +1069,12 @@ function MembersCard({
     });
   const [removeTarget, setRemoveTarget] = useState<AccountMember | null>(null);
   const [leaveConfirmOpen, setLeaveConfirmOpen] = useState(false);
+  // Staged like removeTarget/leaveConfirmOpen above — role changes (including
+  // the hard-to-undo promote-to-Owner) go through a confirmation instead of
+  // firing on click. See roleMutation below for the actual mutate call.
+  const [pendingRole, setPendingRole] = useState<{ userId: string; role: AccountRole } | null>(
+    null,
+  );
   // Free-text search over email + user_id. Lives in component state so
   // it doesn't survive tab switches — admins almost never want to jump
   // back to the same search after navigating away.
@@ -1271,6 +1278,15 @@ function MembersCard({
       setBulkBusy(false);
     }
   }
+
+  // Looked up from the full roster (not the filtered `sorted` list) so the
+  // pending-role dialog's copy stays correct even if the search box changes
+  // while it's open.
+  const pendingRoleMember = pendingRole
+    ? members.find((m) => m.user_id === pendingRole.userId)
+    : undefined;
+  const pendingRoleLabel = pendingRole ? ROLE_LABEL[pendingRole.role] : '';
+  const pendingRoleBlurb = pendingRole ? ACCOUNT_ROLE_DESCRIPTORS[pendingRole.role].blurb : '';
 
   return (
     <div className="space-y-4">
@@ -1545,10 +1561,7 @@ function MembersCard({
                                         key={role}
                                         disabled={role === member.account_role}
                                         onSelect={() =>
-                                          roleMutation.mutate({
-                                            userId: member.user_id,
-                                            role,
-                                          })
+                                          setPendingRole({ userId: member.user_id, role })
                                         }
                                         className="gap-2"
                                       >
@@ -1630,6 +1643,30 @@ function MembersCard({
         onOpenChange={setInviteOpen}
         accountId={account.account_id}
         onInvited={invalidateMembers}
+      />
+
+      <ConfirmDialog
+        open={!!pendingRole}
+        onOpenChange={(o) => {
+          if (!o) setPendingRole(null);
+        }}
+        title="Change role"
+        description={
+          <span>
+            Change{' '}
+            <span className="text-foreground font-medium">
+              {pendingRoleMember ? memberLabel(pendingRoleMember) : ''}
+            </span>{' '}
+            to <span className="text-foreground font-medium">{pendingRoleLabel}</span>.{' '}
+            {pendingRoleBlurb}
+          </span>
+        }
+        confirmLabel="Change role"
+        onConfirm={() => {
+          if (pendingRole) roleMutation.mutate(pendingRole);
+          setPendingRole(null);
+        }}
+        isPending={roleMutation.isPending}
       />
 
       <ConfirmDialog
@@ -2000,8 +2037,13 @@ function InviteMemberModal({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="member">Member — can use assigned projects</SelectItem>
-                  <SelectItem value="admin">Admin — can invite members</SelectItem>
+                  <SelectItem value="member">
+                    {ACCOUNT_ROLE_DESCRIPTORS.member.label} —{' '}
+                    {ACCOUNT_ROLE_DESCRIPTORS.member.blurb}
+                  </SelectItem>
+                  <SelectItem value="admin">
+                    {ACCOUNT_ROLE_DESCRIPTORS.admin.label} — {ACCOUNT_ROLE_DESCRIPTORS.admin.blurb}
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -2335,9 +2377,15 @@ function BulkSetRoleDialog({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="owner">Owner — full control</SelectItem>
-                <SelectItem value="admin">Admin — everything except ownership</SelectItem>
-                <SelectItem value="member">Member — no implicit access</SelectItem>
+                <SelectItem value="owner">
+                  {ACCOUNT_ROLE_DESCRIPTORS.owner.label} — {ACCOUNT_ROLE_DESCRIPTORS.owner.blurb}
+                </SelectItem>
+                <SelectItem value="admin">
+                  {ACCOUNT_ROLE_DESCRIPTORS.admin.label} — {ACCOUNT_ROLE_DESCRIPTORS.admin.blurb}
+                </SelectItem>
+                <SelectItem value="member">
+                  {ACCOUNT_ROLE_DESCRIPTORS.member.label} — {ACCOUNT_ROLE_DESCRIPTORS.member.blurb}
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/apps/web/src/components/iam/member-role-safety.test.ts
+++ b/apps/web/src/components/iam/member-role-safety.test.ts
@@ -1,0 +1,32 @@
+// Two safety/consistency pins on the account members page:
+//  1. Changing a member's role — including promotion to Owner (full account
+//     control + billing + deletion) — must go through a confirmation dialog,
+//     matching remove/leave; it previously fired instantly on menu select.
+//  2. Role labels/blurbs come from ONE source (ACCOUNT_ROLE_DESCRIPTORS), so the
+//     Invite, bulk-change, and permissions-popover copy can't drift apart.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(
+  join(import.meta.dir, '../../app/(app)/accounts/[id]/page.tsx'),
+  'utf8',
+);
+const flat = source.replace(/\s+/g, ' ');
+
+describe('member role change is confirmed', () => {
+  test('selecting a role stages a confirmation instead of mutating directly', () => {
+    // The mutation must fire from the confirm dialog, not the menu onSelect.
+    expect(source).toContain('setPendingRole(');
+    expect(flat).toMatch(/if \(pendingRole\) roleMutation\.mutate\(pendingRole\)/);
+  });
+});
+
+describe('role copy has a single source of truth', () => {
+  test('the page renders role labels/blurbs from ACCOUNT_ROLE_DESCRIPTORS', () => {
+    expect(source).toContain(
+      "import { ACCOUNT_ROLE_DESCRIPTORS } from '@/components/iam/project-role-descriptors'",
+    );
+    expect(source).toContain('ACCOUNT_ROLE_DESCRIPTORS');
+  });
+});


### PR DESCRIPTION
## Summary
- Promoting/demoting a member's account role from the members-list kebab now goes through a confirmation dialog instead of calling the API the instant an option is clicked. Previously "Remove from team" and "Leave team" were both confirmed, but role changes — including handing over full account control (billing, deletion) via Owner — fired with only a post-hoc toast.
- The role labels/blurbs shown in the Invite dialog and the bulk role-change dialog now pull from the same `ACCOUNT_ROLE_DESCRIPTORS` source of truth already used by the permissions help popover, instead of separately hardcoded copy that had drifted out of sync between the two Selects.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — only the 2 pre-existing `@/.source` errors, no new ones
- [x] `npx next lint` — no errors; only pre-existing warnings in unrelated files
- [x] `npx @biomejs/biome format --write` on the changed file
- [x] `bun test` on the co-located suites that source-check this page (`enterprise-upsell.test.ts`, `sso-setup.test.ts`) plus the rest of `src/components/iam` and `src/features/accounts` — all green