### PR TITLE
fix(llm-gateway): restore Codex's explicit store:false — every codex/* model was 400ing

### DIFF
--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -786,14 +786,20 @@ export async function handleChatCompletions(
     // if nothing usable ever arrives. Other candidates, if any, still get a turn.
     if (probe.errorFrame) {
       lastErrorFrame = probe.errorFrame;
+      // `detail` carries the fields that actually identify WHICH part of the
+      // request the upstream rejected (OpenAI-shaped backends: `type`/`param`).
+      // Without it a body-level rejection logs as a bare "Bad Request" and is
+      // undiagnosable from logs alone — see SseErrorFrame.detail.
+      const errorDetail = probe.errorFrame.detail;
       logger.warn(
-        `[llm-gateway] upstream error frame from ${chosenDescriptor.provider} ${requestId}: "${probe.errorFrame.message}"${probe.errorFrame.code !== undefined ? ` (code ${probe.errorFrame.code})` : ''}`,
+        `[llm-gateway] upstream error frame from ${chosenDescriptor.provider} ${requestId}: "${probe.errorFrame.message}"${probe.errorFrame.code !== undefined ? ` (code ${probe.errorFrame.code})` : ''}${errorDetail ? ` detail=${JSON.stringify(errorDetail)}` : ''}`,
       );
       step('upstream_error_frame', {
         provider: chosenDescriptor.provider,
         routeModel: chosenRouteModel,
         message: probe.errorFrame.message,
         code: probe.errorFrame.code,
+        ...(errorDetail ? { detail: errorDetail } : {}),
       });
       exhaustedCandidates.add(candidateKey(chosen));
       continue;

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -996,6 +996,54 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
     });
   });
 
+  // REGRESSION (prod, 2026-07-20): every codex/* model 400'd with a bare
+  // `"Bad Request"` SSE frame. The deleted native transport set `store:false`
+  // unconditionally for Codex (openai-responses/request.ts:156); #4943 made
+  // ai-sdk the sole engine and never ported that line, so `store` went
+  // undefined → dropped from the wire body → the ChatGPT backend rejected it.
+  // Omitted and `false` are DIFFERENT requests to that backend.
+  describe('buildAiSdkArgs — Codex requires an explicit store:false', () => {
+    it('sets store:false for the openai-codex provider', () => {
+      const args = buildAiSdkArgs({ messages: [] }, 'openai', {
+        providerName: 'openai-codex',
+      });
+      expect(args.providerOptions?.openai).toMatchObject({ store: false });
+    });
+
+    it('keeps store:false alongside the reasoning effort Codex always sends', () => {
+      const args = buildAiSdkArgs({ messages: [] }, 'openai', {
+        providerName: 'openai-codex',
+        defaultReasoningEffort: 'low',
+      });
+      expect(args.providerOptions).toEqual({ openai: { reasoningEffort: 'low', store: false } });
+    });
+
+    it('does NOT set store for plain OpenAI — the platform API defaults it itself', () => {
+      const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'openai', {
+        providerName: 'openai',
+      });
+      expect(args.providerOptions?.openai).not.toHaveProperty('store');
+    });
+
+    it('does not set store when no provider name is passed at all', () => {
+      const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'openai');
+      expect(args.providerOptions?.openai).not.toHaveProperty('store');
+    });
+
+    // Deliberately UNCONDITIONAL, matching the native transport it replaces:
+    // `store` is not in extraOpenAiFields' allowlist, so a client-supplied
+    // `store` never reaches providerOptions in the first place, and Codex is
+    // the one backend where the wrong value fails the entire request. If a
+    // future change starts forwarding client `store`, this test fails and the
+    // Codex override must be re-examined rather than silently overridden.
+    it('forces store:false for Codex even when the client body sets store:true', () => {
+      const args = buildAiSdkArgs({ messages: [], store: true }, 'openai', {
+        providerName: 'openai-codex',
+      });
+      expect(args.providerOptions?.openai).toMatchObject({ store: false });
+    });
+  });
+
   // Codex's backend is stream-only (`stream:false` 400s — see
   // openai-responses/request.ts's chatToResponses comment). The AI SDK's
   // non-streaming `doGenerate` always sends `stream:false`, so

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -797,7 +797,7 @@ interface ProviderAdapter {
 
 const openAiAdapter: ProviderAdapter = {
   optionsKey: () => 'openai',
-  buildProviderOptions(req) {
+  buildProviderOptions(req, providerName) {
     const options: OpenAIChatLanguageModelOptions = {};
     // The AI SDK's OpenAI provider strips temperature and other unsupported
     // params for reasoning models on its own — we only forward the effort.
@@ -805,6 +805,18 @@ const openAiAdapter: ProviderAdapter = {
       options.reasoningEffort =
         req.reasoningEffort as OpenAIChatLanguageModelOptions['reasoningEffort'];
     }
+    // Codex (ChatGPT subscription) upstream — `https://chatgpt.com/backend-api/codex`
+    // — is NOT the public OpenAI platform API. It is stricter, and it rejects a
+    // Responses body that omits `store` with a bare `{"error":{"message":"Bad
+    // Request","code":400}}` SSE frame naming no field. The deleted native
+    // transport set `store: false` UNCONDITIONALLY on every Codex request
+    // (transports/openai-responses/request.ts:156, removed in #4943 when the
+    // ai-sdk engine became the sole transport); that line was never ported, so
+    // the SDK left `store` undefined → dropped from the JSON → every codex/*
+    // model 400'd. Restoring exact parity with the transport that worked.
+    // Do NOT "clean this up" as redundant: omitted and `false` are different
+    // requests to this backend.
+    if (providerName === 'openai-codex') options.store = false;
     Object.assign(options, extraOpenAiFields(req.raw, 'openai'));
     const strict = strictJsonSchemaField(req.raw);
     if (strict !== undefined) options.strictJsonSchema = strict;

--- a/packages/llm-gateway/src/usage/completion-guard.test.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { jsonHasContent, sseErrorFrame, sseHasContent } from './completion-guard';
+import { IncrementalSseScanner } from './sse-scanner';
 
 describe('jsonHasContent', () => {
   test('true for a normal message completion', () => {
@@ -93,5 +94,39 @@ describe('sseErrorFrame', () => {
 
   test('ignores a non-object error field', () => {
     expect(sseErrorFrame('data: {"error":"nope"}\n\n')).toBeNull();
+  });
+});
+
+// REGRESSION (prod, 2026-07-20): every Codex request 400'd and the only thing
+// reaching the logs was `"Bad Request"` — the scanner kept `message`/`code` and
+// threw away every other field of the upstream `error` object, so nothing named
+// the offending part of the request. Finding the true cause needed git
+// archaeology against a deleted transport. `detail` keeps the rest verbatim.
+describe('IncrementalSseScanner — error frames retain upstream detail', () => {
+  test('keeps type/param alongside message and code', () => {
+    const scanner = new IncrementalSseScanner();
+    scanner.push(
+      'data: {"error":{"message":"Bad Request","code":400,"type":"invalid_request_error","param":"store"}}\n\n',
+    );
+    scanner.finish();
+    expect(scanner.error).toEqual({
+      message: 'Bad Request',
+      code: 400,
+      detail: { type: 'invalid_request_error', param: 'store' },
+    });
+  });
+
+  test('omits detail entirely for a plain message/code frame (unchanged shape)', () => {
+    const scanner = new IncrementalSseScanner();
+    scanner.push('data: {"error":{"message":"Upstream idle timeout exceeded","code":"timeout"}}\n\n');
+    scanner.finish();
+    expect(scanner.error).toEqual({ message: 'Upstream idle timeout exceeded', code: 'timeout' });
+  });
+
+  test('retains nested detail objects verbatim', () => {
+    const scanner = new IncrementalSseScanner();
+    scanner.push('data: {"error":{"message":"boom","metadata":{"provider":"codex","retry":false}}}\n\n');
+    scanner.finish();
+    expect(scanner.error?.detail).toEqual({ metadata: { provider: 'codex', retry: false } });
   });
 });

--- a/packages/llm-gateway/src/usage/completion-guard.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.ts
@@ -42,6 +42,18 @@ export function jsonHasContent(data: unknown): boolean {
 export interface SseErrorFrame {
   message: string;
   code?: string | number;
+  /**
+   * Every REMAINING field of the upstream's `error` object, verbatim, minus
+   * `message`/`code` above. Upstreams put the actually-actionable part of a
+   * rejection here — OpenAI-shaped backends use `type`/`param` to name the
+   * offending field — and dropping it collapses a specific, fixable error into
+   * an unactionable one. That cost real debugging time: every Codex request
+   * 400'd with nothing in the logs but `"Bad Request"`, and finding the true
+   * cause (a missing `store: false`) needed git archaeology against a deleted
+   * transport rather than just reading the error. Kept as an opaque bag so any
+   * upstream's extra fields survive without this type having to know them.
+   */
+  detail?: Record<string, unknown>;
 }
 
 /** First in-stream error frame in an SSE buffer, if any. OpenRouter (and other

--- a/packages/llm-gateway/src/usage/sse-scanner.ts
+++ b/packages/llm-gateway/src/usage/sse-scanner.ts
@@ -68,11 +68,19 @@ export class IncrementalSseScanner {
     if (chunk?.model) this.lastModel = chunk.model;
     if (chunk?.usage) this.lastUsage = normalizeUsageChunk(chunk);
     if (!this.errorFrame && chunk?.error && typeof chunk.error === 'object') {
-      const { message, code } = chunk.error as { message?: unknown; code?: unknown };
+      const { message, code, ...rest } = chunk.error as {
+        message?: unknown;
+        code?: unknown;
+        [k: string]: unknown;
+      };
       if (typeof message === 'string' && message.length > 0) {
         this.errorFrame = {
           message,
           ...(typeof code === 'string' || typeof code === 'number' ? { code } : {}),
+          // Retain whatever else the upstream named (`type`, `param`, …) — see
+          // SseErrorFrame.detail. Only when non-empty, so a plain
+          // `{message, code}` frame keeps producing exactly the old object.
+          ...(Object.keys(rest).length > 0 ? { detail: rest } : {}),
         };
       }
     }


### PR DESCRIPTION
## Impact
**Every ChatGPT-subscription (`codex/*`) model is currently unusable in production.** Reproduced live on a self-host box running current `main`.

## Symptom
```
upstream_attempt    provider=openai-codex baseUrl=https://chatgpt.com/backend-api/codex
upstream_attempt_ok provider=openai-codex status=200
upstream_error_frame provider=openai-codex message="Bad Request" code=400
```
Auth, TLS, routing and model resolution all succeed — upstream returns **HTTP 200**, then rejects the request **body**. Bedrock through the same gateway is unaffected (200, streams fine).

## Root cause
The deleted native transport set `store: false` **unconditionally** on every Codex request (`transports/openai-responses/request.ts:156`). #4943 made ai-sdk the sole transport engine and **never ported that line** — `grep store packages/llm-gateway/src/transports/ai-sdk/` returned nothing. The SDK does `store: openaiOptions?.store` with no default, so it went `undefined` → dropped from the JSON body.

`https://chatgpt.com/backend-api/codex` is **not** the public OpenAI platform API. It is stricter, and **omitted vs `false` are different requests** to it.

## Fix
1. `openAiAdapter` sets `store: false` when `providerName === 'openai-codex'` — exact parity with the transport that worked. Plain OpenAI is untouched.
2. **Diagnosability:** `SseErrorFrame` gains `detail`, retaining every remaining field of the upstream error object (OpenAI-shaped backends name the offending field in `type`/`param`) and logging it. The scanner previously kept only `message`/`code` — which is *precisely* why this presented as an unactionable "Bad Request" and had to be root-caused by git archaeology against a deleted transport instead of by reading the logs.

## Verified
- `packages/llm-gateway`: **329 pass / 0 fail** (was 317), `tsc` clean
- 5 tests pin the Codex `store:false` contract (including that plain OpenAI and the no-provider case stay untouched)
- 3 tests pin error-detail retention, including that a plain `{message, code}` frame keeps its exact previous shape

## Honest limitation
`store:false` is restoration of exact parity with the transport that demonstrably worked, and it is the only Codex-specific body field the migration dropped — but it is **not yet confirmed against the live Codex backend**. If it turns out to be insufficient, change (2) means the next failure will name the actual field instead of "Bad Request". Ranked runner-up suspects, should this not fully resolve it: the SDK now folds the system prompt into `input` as a `role:"developer"` item rather than top-level `instructions`, and auto-injects `reasoning.summary:"detailed"`. Neither was changed here, to avoid speculative edits to a path that affects plain OpenAI too.