### PR TITLE
test(api): cover tunnel-revoke, system-secret-delete guard, oauth-delete

### DIFF
--- a/apps/api/src/__tests__/unit-project-oauth-delete.test.ts
+++ b/apps/api/src/__tests__/unit-project-oauth-delete.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { projectSecrets } from '@kortix/db';
+
+const PROJECT_ID = '33333333-3333-4333-8333-333333333333';
+const ACCOUNT_ID = '44444444-4444-4444-8444-444444444444';
+const AUTHORIZED_USER_ID = '11111111-1111-4111-8111-111111111111';
+const UNAUTHORIZED_USER_ID = '22222222-2222-4222-8222-222222222222';
+
+const PROJECT_ACTIONS = {
+  PROJECT_CONNECTOR_READ: 'project.connector.read',
+  PROJECT_CONNECTOR_WRITE: 'project.connector.write',
+  PROJECT_CUSTOMIZE_WRITE: 'project.customize.write',
+  PROJECT_SECRET_READ: 'project.secret.read',
+  PROJECT_SECRET_WRITE: 'project.secret.write',
+};
+mock.module('../iam', () => ({ PROJECT_ACTIONS }));
+
+const deleteCalls: Array<{ table: unknown; where: unknown }> = [];
+const propagateCalls: Array<{ projectId: string; opts: unknown }> = [];
+const capabilityChecks: Array<{ userId: string; accountId: string; projectId: string; action: string }> = [];
+
+mock.module('../shared/db', () => ({
+  hasDatabase: true,
+  db: {
+    delete: (table: unknown) => ({
+      where: (cond: unknown) => {
+        deleteCalls.push({ table, where: cond });
+        return Promise.resolve();
+      },
+    }),
+  },
+}));
+
+mock.module('../projects/lib/access', () => ({
+  loadProjectForUser: async (c: any) => ({
+    row: { accountId: ACCOUNT_ID, projectId: PROJECT_ID },
+    userId: c.get('userId'),
+    accountRole: 'owner',
+    projectRole: 'owner',
+    effectiveRole: 'owner',
+    adminBypass: false,
+  }),
+  assertProjectCapability: async (_c: any, userId: string, accountId: string, projectId: string, action: string) => {
+    capabilityChecks.push({ userId, accountId, projectId, action });
+    if (userId !== AUTHORIZED_USER_ID) {
+      throw new HTTPException(403, { message: 'You do not have access to this project' });
+    }
+  },
+}));
+
+mock.module('../projects/lib/sandbox-env-sync', () => ({
+  propagateProjectSecretsToActiveSandboxes: async (projectId: string, opts: unknown) => {
+    propagateCalls.push({ projectId, opts });
+  },
+}));
+
+const { projectsApp } = await import('../projects/lib/app');
+await import('../projects/routes/r3');
+
+function buildApp(userId: string) {
+  const app = new Hono();
+  app.use('*', async (c: any, next: any) => {
+    c.set('userId', userId);
+    await next();
+  });
+  app.route('/v1/projects', projectsApp);
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) return c.json({ error: err.message }, err.status);
+    return c.json({ error: String(err) }, 500);
+  });
+  return app;
+}
+
+describe('DELETE /v1/projects/:projectId/oauth/:provider', () => {
+  beforeEach(() => {
+    deleteCalls.length = 0;
+    propagateCalls.length = 0;
+    capabilityChecks.length = 0;
+  });
+
+  test('authorized principal deletes the backing secret and propagates to sandboxes', async () => {
+    const res = await buildApp(AUTHORIZED_USER_ID).request(`/v1/projects/${PROJECT_ID}/oauth/openai`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    expect(capabilityChecks).toHaveLength(1);
+    expect(capabilityChecks[0]).toMatchObject({
+      userId: AUTHORIZED_USER_ID,
+      accountId: ACCOUNT_ID,
+      projectId: PROJECT_ID,
+      action: PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+    });
+
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0].table).toBe(projectSecrets);
+
+    expect(propagateCalls).toHaveLength(1);
+    expect(propagateCalls[0].projectId).toBe(PROJECT_ID);
+  });
+
+  test('unauthorized principal is denied and no delete is issued', async () => {
+    const res = await buildApp(UNAUTHORIZED_USER_ID).request(`/v1/projects/${PROJECT_ID}/oauth/openai`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(403);
+    expect(capabilityChecks).toHaveLength(1);
+    expect(deleteCalls).toHaveLength(0);
+    expect(propagateCalls).toHaveLength(0);
+  });
+
+  test('unknown provider → 404 before any capability side effect', async () => {
+    const res = await buildApp(AUTHORIZED_USER_ID).request(`/v1/projects/${PROJECT_ID}/oauth/not-a-real-provider`, {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(404);
+    expect(deleteCalls).toHaveLength(0);
+  });
+});

--- a/tests/src/flows/secrets.flow.ts
+++ b/tests/src/flows/secrets.flow.ts
@@ -55,6 +55,13 @@ flow(
         .del("/v1/projects/:projectId/secrets/:name", { params: { projectId: p.id, name: "TO_DELETE" } });
       r.status(200);
     });
+
+    await ctx.step("system KORTIX_* secret cannot be deleted → 403", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .del("/v1/projects/:projectId/secrets/:name", { params: { projectId: p.id, name: "KORTIX_TOKEN" } });
+      r.status(403);
+    });
   },
 );
 

--- a/tests/src/flows/tunnel.flow.ts
+++ b/tests/src/flows/tunnel.flow.ts
@@ -104,6 +104,7 @@ flow(
   },
   async (ctx) => {
     let tunnelId = "";
+    let permissionId = "";
 
     await ctx.step("create a tunnel to attach permissions to", async () => {
       const r = await ctx.client
@@ -125,6 +126,7 @@ flow(
         .as(ctx.P.OWNER)
         .post("/v1/tunnel/permissions/:tunnelId", { capability: "shell" }, { params: { tunnelId } });
       r.status(201).body().exists("$.permissionId");
+      permissionId = r.json<any>().permissionId;
       ctx.track("tunnelPermission", r.json<any>().permissionId, { tunnelId });
     });
 
@@ -161,6 +163,13 @@ flow(
         .as(ctx.P.ANON)
         .post("/v1/tunnel/permissions/:tunnelId", { capability: "shell" }, { params: { tunnelId } });
       r.status(401);
+    });
+
+    await ctx.step("revoke the granted permission → 200", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .del("/v1/tunnel/permissions/:tunnelId/:permissionId", { params: { tunnelId, permissionId } });
+      r.status(200).body().has("$.success", true);
     });
   },
 );


### PR DESCRIPTION
## Summary

Adds coverage for three verified-untested critical mutations. Tests only — no production code changes.

- **`tests/src/flows/tunnel.flow.ts` (TUN-2)**: the DELETE tunnel-permission route only had 404-boundary coverage (revoking a non-existent permission). Now also exercises the 200 success path — grants a permission, captures its `permissionId`, and revokes it, asserting `{ success: true }`.
- **`tests/src/flows/secrets.flow.ts` (SEC-3)**: adds a case asserting that a `KORTIX_*`-prefixed secret name cannot be deleted (403, "managed by Kortix"). Uses `KORTIX_TOKEN`, which the route's `isSystemProjectSecretName` guard (prefix check, no DB read) rejects deterministically.
- **`apps/api/src/__tests__/unit-project-oauth-delete.test.ts`** (new): route-level unit test for `DELETE /v1/projects/:projectId/oauth/:provider`, which previously only had 404 (unknown provider) coverage. Mocks the db, project-access gate, and sandbox-propagation side effect to assert (a) an authorized principal's delete issues the `projectSecrets` delete and propagates to active sandboxes, (b) an unauthorized principal is denied with 403, and (c) an unknown provider still 404s before any side effect.

## Verification

- `apps/api`: `npx tsc --noEmit` — clean, zero errors.
- New unit test: `KORTIX_URL=https://localhost npx dotenvx run -- bun test unit-project-oauth-delete` — 3 pass, 0 fail (re-run repeatedly to confirm determinism).
- `tests/` package: `npx tsc --noEmit` — clean, zero errors (after `bun install` in `tests/`, which has its own lockfile outside the pnpm workspace).
- `tests/`: `bun bin/ke2e.ts coverage` — gate passes (98.2% covered, 0 uncovered).
- `tests/`: `bun bin/ke2e.ts list` — both edited flows load without error.
- Route shapes were verified directly against the handlers (not assumed) before writing assertions: `apps/api/src/tunnel/routes/permissions.ts` (DELETE returns `{ success: true, permission }`, mounted at `/v1/tunnel/permissions/:tunnelId/:permissionId`), and `apps/api/src/projects/routes/r3.ts` (secret-delete system guard at the `isSystemProjectSecretName` check, 403; oauth-delete handler and its `OAUTH_PROVIDERS` map).

Not run: the live e2e flow execution (`ke2e run`) against a deployed API — that needs `KE2E_API_URL`/owner credentials not available in this context, and would mutate real infra resources. Flow correctness was instead verified via typecheck + the coverage gate + direct route-handler inspection.