### PR TITLE
fix(sdk): make model visibility independent of the calling surface

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
@@ -10,6 +10,13 @@ import { useModelStore } from '@/hooks/opencode/use-model-store';
 import type { LlmProviderEntry } from '@/lib/llm-providers';
 import { useModelPricingLookup } from '@/lib/model-pricing';
 import { cn } from '@/lib/utils';
+// Full gateway catalog, independent of which providers are actually
+// connected — used ONLY to give `useModelStore` a canonical universe for
+// default/heuristic visibility resolution (see `catalogModels` below). Must
+// match what other surfaces (e.g. the session model picker) resolve
+// visibility against, or the same model silently defaults to a different
+// visibility depending on which tab/picker last computed it.
+import { flattenModels as flattenGatewayCatalog, useOpenCodeProviders } from '@kortix/sdk/react';
 import { ExternalLink } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useMemo } from 'react';
@@ -64,8 +71,21 @@ export function ModelsTab({
     return new Set(connectedProviders.filter((p) => p.id !== 'kortix').map((p) => p.id));
   }, [connectedProviders, llmGatewayEnabled]);
 
+  // Same route-scoped snapshot `useConnectedProviders` already reads (see
+  // use-connected-providers.ts) — reused here ONLY to give `useModelStore`
+  // the FULL gateway catalog as its default-resolution universe. `flatModels`
+  // above stays scoped to `connectedProviders` (what this tab actually
+  // renders); `catalogModels` must NOT be narrowed the same way, or a model
+  // present in the full catalog but outside this narrower list resolves a
+  // different (heuristic-default) visibility here than on other surfaces —
+  // the root cause of toggles reading differently between this tab and the
+  // session model picker.
+  const { data: ocProviders } = useOpenCodeProviders();
+  const catalogModels = useMemo(() => flattenGatewayCatalog(ocProviders), [ocProviders]);
+
   const modelStore = useModelStore(flatModels, {
     connectedProviderIds,
+    catalogModels,
   });
 
   const enabledCount = useMemo(

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -168,7 +168,9 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.75.2",
     "@types/react": "^19.1.17",
+    "@types/react-dom": "^19.2.3",
     "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "tsc-alias": "^1.8.17",
     "tsup": "^8.5.1",
     "typescript": "^5.4.0"

--- a/packages/sdk/src/react/use-model-store.test.ts
+++ b/packages/sdk/src/react/use-model-store.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import type { FlatModel } from './model-flatten';
-import { hasUsableModel } from './use-model-store';
+import { hasUsableModel, useModelStore, type ModelKey } from './use-model-store';
 
 // Regression coverage for connection-gating (`hasUsableModel`/`isVisible`)
 // preferring the explicit `provider` field the gateway now serves per model
@@ -53,5 +55,130 @@ describe('hasUsableModel — gateway connection gating prefers the explicit `pro
     const models = [gatewayModel({ modelID: 'claude-opus-4.8', provider: 'kortix' })];
     expect(hasUsableModel(models, { freeTier: true })).toBe(false);
     expect(hasUsableModel(models, { freeTier: false })).toBe(true);
+  });
+});
+
+// ============================================================================
+// `isVisible` must not depend on which `allModels` array a given surface
+// happens to pass — see the `catalogModels` option on `useModelStore`.
+// ============================================================================
+
+/**
+ * Renders `useModelStore(allModels, opts)` inside a throwaway component via
+ * `renderToStaticMarkup` (same no-DOM-needed pattern used by
+ * action-panel/mode-gate.test.tsx) and returns the hook's result. Every hook
+ * `useModelStore` calls (`useSyncExternalStore`, `useMemo`, `useCallback`)
+ * resolves fully synchronously during this render, so the captured value is
+ * safe to read and call after `renderToStaticMarkup` returns.
+ */
+function captureModelStore(
+  allModels: FlatModel[],
+  opts?: Parameters<typeof useModelStore>[1],
+): ReturnType<typeof useModelStore> {
+  let captured: ReturnType<typeof useModelStore> | undefined;
+  function Harness() {
+    captured = useModelStore(allModels, opts);
+    return null;
+  }
+  renderToStaticMarkup(createElement(Harness));
+  if (!captured) throw new Error('useModelStore did not produce a result');
+  return captured;
+}
+
+function codexModel(partial: Partial<FlatModel> & Pick<FlatModel, 'modelID'>): FlatModel {
+  return {
+    providerID: 'kortix',
+    providerName: 'Kortix',
+    modelName: partial.modelID,
+    provider: 'codex',
+    ...partial,
+  };
+}
+
+const monthsAgo = (n: number) => {
+  const d = new Date();
+  d.setMonth(d.getMonth() - n);
+  return d.toISOString();
+};
+
+describe('useModelStore — `isVisible` is independent of the calling surface (catalogModels)', () => {
+  // Mirrors the real-world shape that triggers the bug: a `codex/*` family
+  // where some models have a live models.dev `releaseDate` and some (e.g.
+  // gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna, which have no models.dev
+  // entry) do not.
+  //
+  // `gpt-5.6-max` (1 month ago) is the true newest-in-family; `gpt-5.6-nova`
+  // (5 months ago) is recent but NOT the newest. Both carry `family:
+  // 'gpt-5.6'` here, matching what the gateway actually serves (and what the
+  // full-catalog flattener passes through) — the "connected providers only"
+  // flattener some surfaces used (models-tab.tsx before the fix) drops the
+  // `family` field entirely, which is exactly what breaks the invariant
+  // below.
+  const FULL_CATALOG: FlatModel[] = [
+    codexModel({ modelID: 'codex/gpt-5.6-max', family: 'gpt-5.6', releaseDate: monthsAgo(1) }),
+    codexModel({ modelID: 'codex/gpt-5.6-nova', family: 'gpt-5.6', releaseDate: monthsAgo(5) }),
+    codexModel({ modelID: 'codex/gpt-5.6-sol', family: 'gpt-5.6' }),
+    codexModel({ modelID: 'codex/gpt-5.6-terra', family: 'gpt-5.6' }),
+    codexModel({ modelID: 'codex/gpt-5.6-luna', family: 'gpt-5.6' }),
+  ];
+
+  // Same 5 models, same releaseDates — but WITHOUT `family` set, reproducing
+  // the narrower/differently-shaped array a connected-providers-only surface
+  // (e.g. Settings > Models) builds by hand instead of reusing the shared
+  // flattener.
+  const CONNECTED_ONLY: FlatModel[] = FULL_CATALOG.map((m) => ({ ...m, family: undefined }));
+
+  const KEYS: ModelKey[] = FULL_CATALOG.map((m) => ({ providerID: m.providerID, modelID: m.modelID }));
+
+  const opts = { connectedProviderIds: new Set(['codex']) };
+
+  test('sanity: the two fixtures disagree on visibility without `catalogModels` (proves the fixture reproduces the bug)', () => {
+    const full = captureModelStore(FULL_CATALOG, opts);
+    const connectedOnly = captureModelStore(CONNECTED_ONLY, opts);
+
+    // Full, family-grouped catalog: only the true newest-in-family
+    // (gpt-5.6-max) is "latest"; gpt-5.6-nova has a valid-but-not-newest
+    // date so it's explicitly hidden, not merely defaulted.
+    expect(full.isVisible({ providerID: 'kortix', modelID: 'codex/gpt-5.6-max' })).toBe(true);
+    expect(full.isVisible({ providerID: 'kortix', modelID: 'codex/gpt-5.6-nova' })).toBe(false);
+
+    // Without `family`, every model is its own singleton family, so both
+    // dated models independently qualify as "latest" — gpt-5.6-nova comes
+    // back visible even though the full-catalog computation says it
+    // shouldn't be. This is the surface-dependence bug.
+    expect(connectedOnly.isVisible({ providerID: 'kortix', modelID: 'codex/gpt-5.6-max' })).toBe(true);
+    expect(connectedOnly.isVisible({ providerID: 'kortix', modelID: 'codex/gpt-5.6-nova' })).toBe(true);
+  });
+
+  test('fix: passing the same `catalogModels` makes both surfaces agree on every key', () => {
+    // Simulates model-selector.tsx: allModels IS the full catalog, so
+    // `catalogModels` defaults to it.
+    const fullCatalogSurface = captureModelStore(FULL_CATALOG, opts);
+
+    // Simulates models-tab.tsx post-fix: allModels stays the narrow,
+    // connected-only, family-less array (what's actually rendered), but
+    // `catalogModels` is explicitly the same full catalog every other
+    // surface uses to resolve defaults.
+    const connectedOnlySurface = captureModelStore(CONNECTED_ONLY, {
+      ...opts,
+      catalogModels: FULL_CATALOG,
+    });
+
+    for (const key of KEYS) {
+      expect(connectedOnlySurface.isVisible(key)).toBe(fullCatalogSurface.isVisible(key));
+    }
+
+    // Pin the actual values too, not just their equality, so a future change
+    // that makes both sides equally wrong still fails this test.
+    const expected: Record<string, boolean> = {
+      'codex/gpt-5.6-max': true,
+      'codex/gpt-5.6-nova': false,
+      'codex/gpt-5.6-sol': false,
+      'codex/gpt-5.6-terra': false,
+      'codex/gpt-5.6-luna': false,
+    };
+    for (const key of KEYS) {
+      expect(connectedOnlySurface.isVisible(key)).toBe(expected[key.modelID]);
+    }
   });
 });

--- a/packages/sdk/src/react/use-model-store.ts
+++ b/packages/sdk/src/react/use-model-store.ts
@@ -332,15 +332,32 @@ export function useModelStore(
     connectedProviderIds?: Set<string>;
     // Free tier (no active paid sub): hides every Kortix managed model.
     freeTier?: boolean;
+    /**
+     * Canonical universe used to resolve default/heuristic visibility (the
+     * "latest per family" set and each model's `releaseDate` lookup).
+     * Defaults to `allModels`.
+     *
+     * `isVisible` must NOT be a function of which (possibly narrowed) array
+     * a given call site happens to pass as `allModels` — different surfaces
+     * (session picker vs. Settings > Models vs. command palette) otherwise
+     * compute a different `latestSet`/`modelByKey` for the SAME model key,
+     * so the same model can silently resolve to a different default
+     * visibility (and therefore a different persisted 'show' write) on one
+     * surface vs. another. Pass the full gateway catalog here from every
+     * call site so default resolution is identical everywhere; `allModels`
+     * keeps its existing meaning (what's actually rendered/iterated).
+     */
+    catalogModels?: FlatModel[];
   },
 ) {
   const store = useSyncExternalStore(subscribe, getStore, getStore);
   const connectedProviderIds = opts?.connectedProviderIds;
   const freeTier = opts?.freeTier ?? false;
+  const catalogModels = opts?.catalogModels ?? allModels;
 
   // Compute latest set
-  const latestSet = useMemo(() => computeLatestSet(allModels), [allModels]);
-  const modelByKey = useMemo(() => createModelLookup(allModels), [allModels]);
+  const latestSet = useMemo(() => computeLatestSet(catalogModels), [catalogModels]);
+  const modelByKey = useMemo(() => createModelLookup(catalogModels), [catalogModels]);
 
   // Visibility map from user preferences
   const visibilityMap = useMemo(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1439,9 +1439,15 @@ importers:
       '@types/react':
         specifier: ^19.1.17
         version: 19.1.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.1.17)
       react:
         specifier: ^19.1.0
         version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
       tsc-alias:
         specifier: ^1.8.17
         version: 1.9.0


### PR DESCRIPTION
## Bug
Settings > Models showed all 5 connected ChatGPT models with toggles **ON**; the session picker showed only **3** of them (`codex/gpt-5.6-sol` and `-terra` missing).

## Root cause
Not a key mismatch — both surfaces key visibility identically (`kortix:codex/gpt-5.6-sol`). The defect is that **`isVisible` was not a pure function of (model key, stored prefs).**

`useModelStore(allModels)` computes `latestSet`/`modelByKey` — the two heuristic-default inputs `isVisible` falls back to — from whatever array the **caller** passes. The four call sites pass different universes:

| call site | universe passed |
|---|---|
| `models-tab.tsx:67` | only **connected** providers' models |
| `model-selector.tsx:240` | **full** gateway catalog |
| `command-palette.tsx:442` | full catalog |
| `use-opencode-local.ts:283` | full catalog |

Same key + same prefs → **different answer per surface**. Models with no models.dev entry (`gpt-5.6-sol`/`-terra`/`-luna` have no `releaseDate`) are precisely the ones the heuristic decides, so they flipped between surfaces.

This also explains the confusing UX: those toggles appeared ON **via the heuristic, with no stored `'show'` override** — so the explicit `state === 'show'` branch never rescued them, and toggling an already-ON-looking switch didn't do what you'd expect.

## Fix
Add `opts.catalogModels` — the canonical universe for default resolution — defaulting to `allModels` (no behavior change anywhere it isn't passed). `models-tab` now passes the full flattened catalog (reusing the sdk's existing `flattenModels`, no new flattener) while still rendering only connected providers' rows. The other three call sites already pass the full catalog and were left untouched.

## Verified
- `packages/sdk`: **1141 pass / 2 skip / 0 fail**; `tsc` clean; type-surface snapshot unchanged (new field is on an inline options type, not a named export)
- New regression test renders the **real** hook and asserts every key resolves identically across the narrow and full arrays. **Confirmed it fails without the fix** (stash → 1 failure on the no-`releaseDate` model → unstash → 7/7 pass)
- `apps/web`: **515 pass / 29 fail**, byte-identical to the pre-existing baseline (29 stale-generated-export failures, unrelated) — **zero new failures**

## Note
`packages/sdk` had no `react-dom` devDependency (needed to render the hook under test); added it plus `@types/react-dom` at the versions apps/web already uses — lockfile change is purely additive.

## Not included
Project-**wide** (shared) visibility is still not implemented; this is still per-user localStorage. The blocker remains `use-opencode-local.ts:541`, which calls `setVisibility(model, true)` as a side effect of *selecting* a model — under shared storage that would mutate state for every member and 403 for read-only members. Needs a write-capability gate.