### PR TITLE
fix(llm-gateway): COPY packages/llm-catalog into the gateway image (unblocks gateway deploys)

### DIFF
--- a/apps/llm-gateway/Dockerfile
+++ b/apps/llm-gateway/Dockerfile
@@ -5,8 +5,19 @@
 #   docker build -f apps/llm-gateway/Dockerfile -t kortix-gateway .
 #
 # Far simpler than apps/api — no sandbox-agent/CLI stages, no migrations. Just
-# the Bun+Hono server plus its two workspace packages (@kortix/llm-gateway →
-# @kortix/shared) and hono + langfuse.
+# the Bun+Hono server plus its workspace packages (@kortix/llm-gateway →
+# @kortix/shared + @kortix/llm-catalog) and hono + langfuse.
+#
+# LOAD-BEARING: every @kortix/* package that appears anywhere in the gateway's
+# transitive workspace dependency graph MUST be COPYed below. The synthetic
+# workspace root globs `packages/*`, but bun only sees the package dirs actually
+# copied into the image — a declared `workspace:*` dep whose directory is absent
+# fails install with "Workspace dependency not found", NOT a clear message. This
+# bit us once: the AI-SDK migration added @kortix/llm-catalog to
+# packages/llm-gateway's deps but not here, and because the gateway image only
+# rebuilds when something under it changes, the break stayed invisible until the
+# next gateway change and then blocked that deploy. If you add a @kortix/* dep to
+# the gateway or any package it pulls in, add its COPY to BOTH stages here.
 
 ARG BUN_VERSION=1.2
 
@@ -22,6 +33,7 @@ WORKDIR /app
 COPY apps/llm-gateway ./apps/llm-gateway
 COPY packages/llm-gateway ./packages/llm-gateway
 COPY packages/shared ./packages/shared
+COPY packages/llm-catalog ./packages/llm-catalog
 
 RUN printf '{"name":"kortix-gateway-build","private":true,"workspaces":["apps/llm-gateway","packages/*"]}\n' > package.json \
     && bun install --no-save
@@ -45,6 +57,7 @@ ENV KORTIX_COMMIT=${KORTIX_COMMIT}
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/package.json ./package.json
 COPY --from=deps /app/packages/shared ./packages/shared
+COPY --from=deps /app/packages/llm-catalog ./packages/llm-catalog
 COPY --from=deps /app/packages/llm-gateway ./packages/llm-gateway
 COPY --from=deps /app/apps/llm-gateway ./apps/llm-gateway
 


### PR DESCRIPTION
## Impact
**Every gateway deploy is currently broken**, including the Codex `store:false` fix (#5111). The Deploy Dev run for the last main merge failed on `Build gateway image (multi-arch)`, so `kortix/kortix-gateway:dev` still points at the pre-fix image.

## Symptom
```
error: Workspace dependency "@kortix/llm-catalog" not found
error: @kortix/llm-catalog@workspace:* failed to resolve
```
in the deps stage's `bun install --no-save`.

## Root cause
The AI-SDK migration added `@kortix/llm-catalog` to `packages/llm-gateway`'s dependencies (6 source files import it), but `apps/llm-gateway/Dockerfile` only ever copied `packages/llm-gateway` + `packages/shared`. The synthetic build workspace globs `packages/*`, so a declared `workspace:*` dep whose directory isn't physically in the image fails to resolve.

**Why it stayed hidden:** the gateway image only rebuilds when something under it changes. The dep was added in an earlier PR that didn't otherwise touch the gateway build inputs, so no rebuild happened. #5111 is the first gateway change since — the first rebuild since — so it's the one that surfaced the break. Classic committed-but-never-exercised.

## Fix
COPY `packages/llm-catalog` in **both** the deps and runner stages (it's a clean leaf — no further `@kortix` deps, runs from committed `src` incl. `catalog.generated.json`). Adds a load-bearing comment so the next `@kortix` dep added to the gateway doesn't repeat this.

## Verified locally (not just "looks right")
- `docker build -f apps/llm-gateway/Dockerfile .` now **completes** — `bun install` resolves 33 packages, the exact step CI failed on
- The built image **boots far enough to load the full module graph** including `@kortix/llm-catalog`, stopping only on expected runtime env vars (`KORTIX_API_URL`, `GATEWAY_INTERNAL_TOKEN`) that the deploy chart supplies — proving the import resolves at runtime, not just at install