### PR TITLE
fix(llm-gateway): surface raw upstream error body (Codex 400 diagnosability)

### DIFF
--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -272,7 +272,30 @@ export function openAiSseFromFullStream(
                   : looksLikeTerminalAuthFailure(message)
                     ? 401
                     : undefined;
-              emit(sse({ error: { message, ...(code != null ? { code } : {}) } }));
+              // `@ai-sdk/*` wraps an HTTP failure in an APICallError whose
+              // `.message` is generic ("Bad Request") — the actionable part (WHICH
+              // field the upstream rejected) lives in `.responseBody` (raw string)
+              // / `.data` (parsed) / `.url`. Dropping those is exactly why Codex
+              // 400s read as an opaque "Bad Request" and had to be root-caused by
+              // git archaeology. Thread them into the emitted frame's error object
+              // so `sseErrorFrame`'s `detail` carries them to the logs. Bounded so
+              // a huge upstream body can't blow up a log line.
+              const detail: Record<string, unknown> = {};
+              const responseBody = errObj?.responseBody;
+              if (typeof responseBody === 'string' && responseBody.length > 0) {
+                detail.responseBody = responseBody.slice(0, 2000);
+              }
+              if (errObj?.data !== undefined) detail.data = errObj.data;
+              if (typeof errObj?.url === 'string') detail.url = errObj.url;
+              emit(
+                sse({
+                  error: {
+                    message,
+                    ...(code != null ? { code } : {}),
+                    ...(Object.keys(detail).length > 0 ? detail : {}),
+                  },
+                }),
+              );
               break;
             }
             default:

--- a/packages/llm-gateway/src/usage/completion-guard.test.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.test.ts
@@ -95,6 +95,37 @@ describe('sseErrorFrame', () => {
   test('ignores a non-object error field', () => {
     expect(sseErrorFrame('data: {"error":"nope"}\n\n')).toBeNull();
   });
+
+  // The Codex 400 path: the ai-sdk transport (sse.ts) threads the APICallError's
+  // responseBody/data/url into the frame's error object; sseErrorFrame must keep
+  // them as `detail` so handler.ts can log WHICH field the upstream rejected,
+  // instead of the opaque "Bad Request" that cost a full root-cause session.
+  test('retains responseBody/data/url as detail (Codex diagnosability path)', () => {
+    const frame = sseErrorFrame(
+      'data: {"error":{"message":"Bad Request","code":400,"responseBody":"{\\"error\\":{\\"param\\":\\"reasoning.summary\\"}}","url":"https://chatgpt.com/backend-api/codex/responses"}}\n\n',
+    );
+    expect(frame?.message).toBe('Bad Request');
+    expect(frame?.code).toBe(400);
+    expect(frame?.detail).toEqual({
+      responseBody: '{"error":{"param":"reasoning.summary"}}',
+      url: 'https://chatgpt.com/backend-api/codex/responses',
+    });
+  });
+
+  test('keeps type/param as detail while type still backfills a missing code', () => {
+    const frame = sseErrorFrame(
+      'data: {"error":{"message":"boom","type":"invalid_request_error","param":"store"}}\n\n',
+    );
+    expect(frame?.code).toBe('invalid_request_error'); // type backfills absent code
+    expect(frame?.detail).toEqual({ type: 'invalid_request_error', param: 'store' });
+  });
+
+  test('a plain message/code frame still produces no detail (unchanged shape)', () => {
+    expect(sseErrorFrame('data: {"error":{"message":"nope","code":429}}\n\n')).toEqual({
+      message: 'nope',
+      code: 429,
+    });
+  });
 });
 
 // REGRESSION (prod, 2026-07-20): every Codex request 400'd and the only thing

--- a/packages/llm-gateway/src/usage/completion-guard.ts
+++ b/packages/llm-gateway/src/usage/completion-guard.ts
@@ -81,7 +81,12 @@ export function sseErrorFrame(buffer: string): SseErrorFrame | null {
       const chunk = JSON.parse(payload) as { error?: unknown };
       const error = chunk.error;
       if (!error || typeof error !== 'object') continue;
-      const { message, code, type } = error as { message?: unknown; code?: unknown; type?: unknown };
+      const { message, code, ...rest } = error as {
+        message?: unknown;
+        code?: unknown;
+        [k: string]: unknown;
+      };
+      const type = rest.type;
       if (typeof message === 'string' && message.length > 0) {
         const resolvedCode =
           typeof code === 'string' || typeof code === 'number'
@@ -89,9 +94,15 @@ export function sseErrorFrame(buffer: string): SseErrorFrame | null {
             : typeof type === 'string' && type.length > 0
               ? type
               : undefined;
+        // Keep every remaining field (type/param, and the responseBody/data/url
+        // the ai-sdk transport threads in for @ai-sdk APICallErrors — see
+        // sse.ts) so a rejection's actionable detail survives to the logs
+        // instead of collapsing to a bare message. Only when non-empty, so a
+        // plain {message, code} frame keeps producing exactly the old object.
         return {
           message,
           ...(resolvedCode !== undefined ? { code: resolvedCode } : {}),
+          ...(Object.keys(rest).length > 0 ? { detail: rest } : {}),
         };
       }
     } catch {


### PR DESCRIPTION
`store:false` (#5111) did **not** resolve the Codex 400s — they persist, and logs still show only "Bad Request" because the real rejection detail was dropped at three points, none reached by #5111's `SseErrorFrame.detail`:

1. **`transports/ai-sdk/sse.ts`** synthesized the error frame as `{message, code}`. For an `@ai-sdk` APICallError the message is generic ("Bad Request"); the actionable part is `.responseBody`/`.data`/`.url`. Now threaded in (responseBody bounded to 2KB).
2. **`usage/completion-guard.ts` `sseErrorFrame`** — the parser `handler.ts` actually logs from — kept only message/code. Now retains remaining fields as `detail`. (#5111 only touched `IncrementalSseScanner`, the usage-side parser, which does NOT feed the operator log — my miss.)
3. `handler.ts` already logs `detail=` (from #5111).

**Purely diagnostic** — adds fields to the error frame + logs, zero change to the request path or any non-erroring turn. This deploy *reveals* the real Codex rejection so the body-shape fix can be exact instead of guessed at on a code path shared with plain OpenAI.

332 pass / 0 fail, tsc clean.