### PR TITLE
fix(llm-gateway): Codex rejects max_output_tokens — drop it for openai-codex

### DIFF
--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -1044,6 +1044,34 @@ describe('Piece A — OpenAI Responses API absorbed into the ai-sdk engine', () 
     });
   });
 
+  // REGRESSION (prod, 2026-07-20): every REAL Codex turn 400'd with
+  // `{"detail":"Unsupported parameter: max_output_tokens"}` (captured via the
+  // error-detail path). @ai-sdk/openai serializes maxOutputTokens →
+  // max_output_tokens, which the ChatGPT backend rejects. Simple probes with no
+  // cap passed, masking it. Drop the cap for Codex; keep it for plain OpenAI.
+  describe('buildAiSdkArgs — Codex must NOT send max_output_tokens', () => {
+    it('drops an explicit max_tokens for openai-codex', () => {
+      const args = buildAiSdkArgs({ messages: [], max_tokens: 1024 }, 'openai', {
+        providerName: 'openai-codex',
+      });
+      expect(args.maxOutputTokens).toBeUndefined();
+    });
+
+    it('drops max_completion_tokens for openai-codex too', () => {
+      const args = buildAiSdkArgs({ messages: [], max_completion_tokens: 2048 }, 'openai', {
+        providerName: 'openai-codex',
+      });
+      expect(args.maxOutputTokens).toBeUndefined();
+    });
+
+    it('STILL forwards max_tokens for plain OpenAI (the platform API accepts it)', () => {
+      const args = buildAiSdkArgs({ messages: [], max_tokens: 1024 }, 'openai', {
+        providerName: 'openai',
+      });
+      expect(args.maxOutputTokens).toBe(1024);
+    });
+  });
+
   // Codex's backend is stream-only (`stream:false` 400s — see
   // openai-responses/request.ts's chatToResponses comment). The AI SDK's
   // non-streaming `doGenerate` always sends `stream:false`, so

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -931,7 +931,21 @@ export function buildAiSdkArgs(
     providerOptions[adapter.optionsKey(opts.providerName)] = Object.fromEntries(definedFields);
   }
 
-  const maxTokens = req.explicitMaxTokens ?? adapter.defaultMaxTokens(req);
+  // Codex's ChatGPT backend (`https://chatgpt.com/backend-api/codex/responses`)
+  // REJECTS `max_output_tokens` outright — it 400s the whole request with
+  // `{"detail":"Unsupported parameter: max_output_tokens"}` (captured live via
+  // the error-detail path). @ai-sdk/openai's `.responses()` serializes
+  // `maxOutputTokens` → wire `max_output_tokens`, so any turn that carries a
+  // token cap dies. Requests with NO cap (a bare "hi") slip through, which is
+  // why simple probes passed while every real opencode turn — which always
+  // sends one — 400'd. The backend manages its own output budget, so dropping
+  // the cap for Codex is the correct behaviour, not a workaround. Codex-only:
+  // the real OpenAI platform API DOES accept max_output_tokens, so plain
+  // `openai` must keep sending it.
+  const maxTokens =
+    opts.providerName === 'openai-codex'
+      ? undefined
+      : (req.explicitMaxTokens ?? adapter.defaultMaxTokens(req));
 
   const stop = body.stop;
   const stopSequences =


### PR DESCRIPTION
## The actual root cause
`store:false` (#5111) was necessary but **not sufficient**. Real Codex turns kept 400ing. The error-detail path (#5117) finally captured the raw ChatGPT rejection:

```
detail={"responseBody":"{\"detail\":\"Unsupported parameter: max_output_tokens\"}"}
```

`@ai-sdk/openai`'s `.responses()` serializes `maxOutputTokens` → wire `max_output_tokens`, which `chatgpt.com/backend-api/codex` rejects with a 400 for the whole request.

## Why it looked model-specific (it isn't)
A turn with **no** token cap ("hi") passes; a turn **with** one 400s. Simple probes sent no cap → passed. Real opencode turns always send a cap → 400. Reproduced identically on **both** `gpt-5.6-sol` and `gpt-5.6-luna`: both succeed without `max_tokens`, both fail with it. The sol-works/luna-fails appearance was incidental (retry/cache).

## Fix
Drop `maxOutputTokens` when `providerName === 'openai-codex'`. The ChatGPT backend manages its own output budget. **Codex-only** — the real OpenAI platform API accepts `max_output_tokens`, so plain `openai` keeps sending it (test pins this).

## Verified
- 335 pass / 0 fail, tsc clean
- Reproduced the exact failure live (with max_tokens → 400) and the pass (without → streams) on Essentia before writing the fix
- Post-merge: will deploy + re-run a real Codex turn WITH max_tokens end-to-end before calling it done