### PR TITLE
fix(web): marketplace item pages 500 (DYNAMIC_SERVER_USAGE) — force-dynamic

### DIFF
--- a/apps/web/src/app/(public)/(marketing)/marketplace/[company]/[...item]/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/marketplace/[company]/[...item]/page.tsx
@@ -8,25 +8,23 @@ import {
   listPublicMarketplaceItems,
   listPublicMarketplaces,
 } from '@/lib/marketplace-public';
-import { itemIdToPathParts, pathPartsToItemId } from '@/lib/marketplace-slug';
+import { pathPartsToItemId } from '@/lib/marketplace-slug';
 
-export const revalidate = 3600;
+// The root layout (app/layout.tsx) forces the whole app into per-request dynamic
+// rendering via `connection()`/`headers()` (so self-host Docker images read env
+// at request time, not build time). ISR config here (`revalidate` +
+// `generateStaticParams`) is therefore dead — and worse, it routed uncached
+// item URLs through Next's on-demand static-generation path, which collides with
+// the layout's dynamic APIs and throws an UNCAUGHT `DYNAMIC_SERVER_USAGE` → a 500
+// for EVERY /marketplace/<company>/<item> page (generateStaticParams also returns
+// [] whenever the API isn't reachable at build time, e.g. any Docker image build,
+// so nothing was pre-rendered anyway). Force dynamic to match reality: SSR each
+// request, no static-generation pass to conflict with.
+export const dynamic = 'force-dynamic';
 
 interface PageParams {
   company: string;
   item: string[];
-}
-
-export async function generateStaticParams() {
-  try {
-    const { items } = await listPublicMarketplaceItems();
-    return items.map((entry) => {
-      const { company, item } = itemIdToPathParts(entry.id);
-      return { company, item };
-    });
-  } catch {
-    return [];
-  }
 }
 
 export async function generateMetadata({


### PR DESCRIPTION
## Bug
**Every** `/marketplace/<company>/<item>` page returns **500** (reproduced on Essentia; a non-existent item 500s too, so it's not data). Next.js server-render crash, digest `DYNAMIC_SERVER_USAGE`. Not self-host-specific — reproduces in prod once any item URL is hit for params not in the (near-empty) build-time static set.

## Root cause
This route declared ISR — `export const revalidate = 3600` + `generateStaticParams` (#4001) — but the **root layout** (`app/layout.tsx:154,162`) forces the whole app dynamic via `connection()`/`headers()` (so self-host Docker images read env at request time). Any item URL not pre-rendered (all of them: `generateStaticParams` fetches the marketplace API at *build* time, when it's unreachable, and silently returns `[]`) gets routed through Next's on-demand static-generation path → collides with the layout's dynamic APIs → **uncaught** `DYNAMIC_SERVER_USAGE` → 500.

Proven by siblings: `/marketplace` (has `revalidate`, no `generateStaticParams`) → 200; `/marketplace/[company]` (neither) → 307. Only the one route mixing `generateStaticParams` with the forced-dynamic layout breaks.

## Fix
Drop the dead ISR config, add `export const dynamic = 'force-dynamic'` — SSR each request, no static-generation pass to conflict with (matches what the layout already forces app-wide). Removes the now-unused `itemIdToPathParts` import. tsc clean.

## Verify after deploy
`curl -o /dev/null -w '%{http_code}' https://<host>/marketplace/kortix-projects/starter` → **200**.