### PR TITLE
Default new projects to managed repositories

### DIFF
--- a/apps/web/src/features/projects/modal/project-create-git-default.test.ts
+++ b/apps/web/src/features/projects/modal/project-create-git-default.test.ts
@@ -5,18 +5,17 @@ import { join } from 'node:path';
 const source = readFileSync(join(import.meta.dir, 'project-create-modal.tsx'), 'utf8');
 
 describe('new project git provider default', () => {
-  test('starts with a user GitHub repository and keeps managed git explicit', () => {
+  test('starts with a managed repository and keeps user GitHub explicit', () => {
     expect(source).toContain("'github-create' | 'github-import' | 'managed' | 'template'");
-    expect(source).toMatch(/useState<[\s\S]*?>\(\s*'github-create'/);
+    expect(source).toMatch(/useState<[\s\S]*?>\(\s*'managed'/);
     expect(source).toContain('createProjectRepo');
     expect(source).toContain('Create in your GitHub');
-    expect(source).toContain('Managed by Kortix');
+    expect(source).not.toContain('Code Storage');
+    expect(source).not.toMatch(/<GitFork className="size-4" \/> Managed by Kortix/);
   });
 
-  test('keeps a selected marketplace template on the GitHub create path', () => {
-    const start = source.indexOf('githubCreateMutation.mutate({');
-    const end = source.indexOf('});', start);
-    expect(source.slice(start, end)).toContain('source_item_id: effectiveSourceItemId');
+  test('keeps a selected marketplace template on the managed path', () => {
+    expect(source).toMatch(/function pickTemplate[\s\S]*?setMode\('managed'\)/);
   });
 
   test('uses current project-modal list and radius primitives', () => {

--- a/apps/web/src/features/projects/modal/project-create-modal.tsx
+++ b/apps/web/src/features/projects/modal/project-create-modal.tsx
@@ -153,7 +153,7 @@ export const ProjectCreateModal = ({
   const queryClient = useQueryClient();
 
   const [mode, setMode] = useState<'github-create' | 'github-import' | 'managed' | 'template'>(
-    'github-create',
+    'managed',
   );
   const [isConnectingGitHub, setIsConnectingGitHub] = useState(false);
   const [sourceNameApplied, setSourceNameApplied] = useState(false);
@@ -213,7 +213,7 @@ export const ProjectCreateModal = ({
   const selectedRepo = githubForm.watch('repo');
 
   function resetAndClose() {
-    setMode('github-create');
+    setMode('managed');
     setSourceNameApplied(false);
     setPickedAccountId(null);
     setPickedTemplateId(null);
@@ -243,7 +243,7 @@ export const ProjectCreateModal = ({
   function pickTemplate(itemId: string) {
     setSourceNameApplied(false);
     setPickedTemplateId(itemId);
-    setMode('github-create');
+    setMode('managed');
   }
 
   function clearPickedTemplate() {
@@ -569,7 +569,7 @@ export const ProjectCreateModal = ({
             templates={templates}
             loading={templatesQuery.isLoading}
             onPick={pickTemplate}
-            onCancel={switchToGitHubCreateMode}
+            onCancel={switchToManagedMode}
           />
         ) : mode === 'managed' || mode === 'github-create' ? (
           <Form {...managedForm}>
@@ -678,9 +678,11 @@ export const ProjectCreateModal = ({
                     <div className="border-border flex items-start gap-3 rounded-md border px-3.5 py-3">
                       <GitFork className="text-muted-foreground mt-0.5 size-4" />
                       <div>
-                        <div className="text-foreground text-sm font-medium">Managed by Kortix</div>
+                        <div className="text-foreground text-sm font-medium">
+                          Managed repository
+                        </div>
                         <p className="text-muted-foreground mt-0.5 text-xs">
-                          Kortix hosts the repository in Code Storage and manages its credentials.
+                          Kortix creates a private repository and manages its credentials.
                         </p>
                       </div>
                     </div>
@@ -772,7 +774,7 @@ export const ProjectCreateModal = ({
                           disabled={submitting}
                           onClick={switchToManagedMode}
                         >
-                          <GitFork className="size-4" /> Managed by Kortix
+                          <GitFork className="size-4" /> Use managed repository
                         </Button>
                       ) : (
                         <Button
@@ -1038,7 +1040,7 @@ export const ProjectCreateModal = ({
                   type="button"
                   variant="outline-ghost"
                   className="w-full sm:w-auto"
-                  onClick={switchToGitHubCreateMode}
+                  onClick={switchToManagedMode}
                 >
                   {tI18nHardcoded.raw(
                     'autoFeaturesProjectsModalProjectCreateModalJsxTextGoBack8b169f5b',


### PR DESCRIPTION
## Summary\n- open New Project on the managed repository path\n- keep Create in your GitHub and GitHub import as explicit alternatives\n- remove Code Storage-specific wording from the managed flow\n- keep template clones on the managed default path\n\n## Verification\n- bun test apps/web/src/features/projects/modal/project-create-git-default.test.ts\n- pnpm --dir apps/web exec eslint src/features/projects/modal/project-create-modal.tsx src/features/projects/modal/project-create-git-default.test.ts\n- pnpm --dir apps/web exec tsc --noEmit --pretty false\n- authenticated local GET /v1/projects/managed-git/status returned HTTP 200\n\n## Dev configuration\n- kortix-dev-env MANAGED_GIT_PROVIDER changed from code-storage to github in AWS Secrets Manager