### PR TITLE
Add canonical project sessions page

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { ProjectShell } from '@/features/workspace/project-layout/project-shell';
+import { ProjectSessionsView } from '@/features/workspace/project-sessions/project-sessions-view';
+
+export default function ProjectSessionsPage() {
+  const { id: projectId } = useParams<{ id: string }>();
+
+  return (
+    <ProjectShell projectId={projectId}>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <ProjectSessionsView projectId={projectId} />
+      </div>
+    </ProjectShell>
+  );
+}

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.test.ts
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.test.ts
@@ -1,0 +1,107 @@
+import type { ProjectSession } from '@kortix/sdk/projects-client';
+import { describe, expect, test } from 'bun:test';
+
+import {
+  filterProjectSessions,
+  matchesProjectSessionsFilter,
+  projectSessionsFilterCounts,
+} from './project-sessions-helpers';
+
+function makeSession(overrides: Partial<ProjectSession> = {}): ProjectSession {
+  return {
+    session_id: 'session-1',
+    account_id: 'account-1',
+    project_id: 'project-1',
+    branch_name: 'session-1',
+    base_ref: 'main',
+    sandbox_provider: 'daytona',
+    sandbox_id: 'session-1',
+    sandbox_url: null,
+    opencode_session_id: null,
+    name: 'Investigate checkout',
+    custom_name: null,
+    agent_name: 'kortix',
+    status: 'running',
+    error: null,
+    metadata: {},
+    opencode_sessions: [],
+    created_at: '2026-07-20T10:00:00.000Z',
+    updated_at: '2026-07-20T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('matchesProjectSessionsFilter', () => {
+  test('groups every provisioning state with running sessions as active', () => {
+    for (const status of ['queued', 'branching', 'provisioning', 'running'] as const) {
+      expect(matchesProjectSessionsFilter(makeSession({ status }), 'active')).toBe(true);
+    }
+    expect(matchesProjectSessionsFilter(makeSession({ status: 'completed' }), 'active')).toBe(
+      false,
+    );
+  });
+
+  test('detects automation and viewer-relative shared sessions', () => {
+    const automated = makeSession({ metadata: { trigger_source: 'cron' } });
+    const shared = makeSession({ is_owner: false });
+
+    expect(matchesProjectSessionsFilter(automated, 'automated')).toBe(true);
+    expect(matchesProjectSessionsFilter(shared, 'shared')).toBe(true);
+    expect(matchesProjectSessionsFilter(makeSession(), 'shared')).toBe(false);
+  });
+});
+
+describe('filterProjectSessions', () => {
+  test('searches visible session fields and sorts by latest activity', () => {
+    const older = makeSession({
+      session_id: 'older',
+      name: 'Slack triage',
+      metadata: { source: 'slack' },
+      updated_at: '2026-07-20T10:00:00.000Z',
+    });
+    const newer = makeSession({
+      session_id: 'newer',
+      name: 'Slack deploy',
+      metadata: { source: 'slack' },
+      updated_at: '2026-07-21T10:00:00.000Z',
+    });
+    const unrelated = makeSession({ session_id: 'third', name: 'Email report' });
+
+    expect(
+      filterProjectSessions([older, unrelated, newer], 'all', 'slack').map((s) => s.session_id),
+    ).toEqual(['newer', 'older']);
+  });
+
+  test('combines status filters with search', () => {
+    const failedDeploy = makeSession({ name: 'Deploy API', status: 'failed' });
+    const runningDeploy = makeSession({ name: 'Deploy web', status: 'running' });
+
+    expect(filterProjectSessions([failedDeploy, runningDeploy], 'failed', 'deploy')).toEqual([
+      failedDeploy,
+    ]);
+  });
+});
+
+describe('projectSessionsFilterCounts', () => {
+  test('reports counts for every filter', () => {
+    const counts = projectSessionsFilterCounts([
+      makeSession({ status: 'running' }),
+      makeSession({ session_id: 'two', status: 'failed', is_owner: false }),
+      makeSession({
+        session_id: 'three',
+        status: 'completed',
+        metadata: { trigger_source: 'cron' },
+      }),
+    ]);
+
+    expect(counts).toMatchObject({
+      all: 3,
+      active: 1,
+      completed: 1,
+      stopped: 0,
+      failed: 1,
+      automated: 1,
+      shared: 1,
+    });
+  });
+});

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.ts
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-helpers.ts
@@ -1,0 +1,90 @@
+import type { ProjectSession } from '@kortix/sdk/projects-client';
+
+import { sessionSource } from '@/components/projects/session-label';
+import { getSessionDisplayTitle } from '@/features/workspace/project-sidebar/project-session-list-helpers';
+
+export type ProjectSessionsFilter =
+  'all' | 'active' | 'completed' | 'stopped' | 'failed' | 'automated' | 'shared';
+
+export const PROJECT_SESSIONS_FILTERS: Array<{
+  value: ProjectSessionsFilter;
+  label: string;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'active', label: 'Active' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'stopped', label: 'Stopped' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'automated', label: 'Automated' },
+  { value: 'shared', label: 'Shared' },
+];
+
+const ACTIVE_STATUSES = new Set<ProjectSession['status']>([
+  'queued',
+  'branching',
+  'provisioning',
+  'running',
+]);
+
+export function matchesProjectSessionsFilter(
+  session: ProjectSession,
+  filter: ProjectSessionsFilter,
+): boolean {
+  if (filter === 'all') return true;
+  if (filter === 'active') return ACTIVE_STATUSES.has(session.status);
+  if (filter === 'automated') return sessionSource(session).kind !== 'chat';
+  if (filter === 'shared') return session.is_owner === false;
+  return session.status === filter;
+}
+
+export function sessionSearchText(session: ProjectSession): string {
+  const source = sessionSource(session);
+  return [
+    getSessionDisplayTitle(session),
+    session.session_id,
+    session.branch_name,
+    session.base_ref,
+    session.agent_name,
+    session.owner_email,
+    session.sandbox_provider,
+    session.status,
+    session.visibility,
+    source.label,
+    source.triggerSlug,
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join(' ')
+    .toLocaleLowerCase();
+}
+
+export function filterProjectSessions(
+  sessions: ProjectSession[],
+  filter: ProjectSessionsFilter,
+  query: string,
+): ProjectSession[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  return sessions
+    .filter((session) => matchesProjectSessionsFilter(session, filter))
+    .filter((session) => !normalizedQuery || sessionSearchText(session).includes(normalizedQuery))
+    .sort((a, b) => {
+      const parsedA = new Date(a.updated_at || a.created_at).getTime();
+      const parsedB = new Date(b.updated_at || b.created_at).getTime();
+      const aTime = Number.isFinite(parsedA) ? parsedA : 0;
+      const bTime = Number.isFinite(parsedB) ? parsedB : 0;
+      return bTime - aTime;
+    });
+}
+
+export function projectSessionsFilterCounts(
+  sessions: ProjectSession[],
+): Record<ProjectSessionsFilter, number> {
+  return PROJECT_SESSIONS_FILTERS.reduce(
+    (counts, option) => {
+      counts[option.value] = sessions.filter((session) =>
+        matchesProjectSessionsFilter(session, option.value),
+      ).length;
+      return counts;
+    },
+    {} as Record<ProjectSessionsFilter, number>,
+  );
+}

--- a/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
+++ b/apps/web/src/features/workspace/project-sessions/project-sessions-view.tsx
@@ -1,0 +1,538 @@
+'use client';
+
+import { sessionSource, type SessionSourceKind } from '@/components/projects/session-label';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { InfoBanner } from '@/components/ui/info-banner';
+import {
+  InputGroupSearch,
+  InputGroupSearchClear,
+  InputGroupSearchIcon,
+  InputGroupSearchInput,
+} from '@/components/ui/input-group';
+import Loading from '@/components/ui/loading';
+import { Skeleton } from '@/components/ui/skeleton';
+import { FilterBar, FilterBarItem } from '@/components/ui/tabs';
+import { errorToast, successToast } from '@/components/ui/toast';
+import { Icon } from '@/features/icon/icon';
+import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
+import CustomizeSectionWrapper from '@/features/workspace/customize/sections/component/section-wrapper';
+import { RenameSessionModal } from '@/features/workspace/project-sidebar/modal/rename-session-modal';
+import { SessionDeleteModal } from '@/features/workspace/project-sidebar/modal/session-delete-modal';
+import {
+  sessionVisibilityMeta,
+  ShareSessionModal,
+} from '@/features/workspace/project-sidebar/modal/share-session-modal';
+import {
+  getSessionDisplayTitle,
+  shouldPollProjectSessions,
+} from '@/features/workspace/project-sidebar/project-session-list-helpers';
+import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
+import { cn } from '@/lib/utils';
+import {
+  listProjectSessions,
+  restartProjectSession,
+  stopProjectSession,
+  type ProjectSession,
+  type ProjectSessionStatus,
+} from '@kortix/sdk/projects-client';
+import { Pencil, Share, TrashSolid } from '@mynaui/icons-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { format, formatDistanceToNowStrict } from 'date-fns';
+import {
+  AlertTriangle,
+  CalendarClock,
+  ChevronDown,
+  ExternalLink,
+  GitBranch,
+  Mail,
+  MessageSquare,
+  MoreHorizontal,
+  Plus,
+  RotateCcw,
+  Search,
+  Square,
+  Webhook,
+  type LucideIcon,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import type { IconType } from 'react-icons/lib';
+
+import {
+  filterProjectSessions,
+  PROJECT_SESSIONS_FILTERS,
+  projectSessionsFilterCounts,
+  type ProjectSessionsFilter,
+} from './project-sessions-helpers';
+
+const SOURCE_ICONS: Record<SessionSourceKind, LucideIcon | IconType> = {
+  chat: MessageSquare,
+  slack: Icon.Slack,
+  telegram: Icon.Telegram,
+  email: Mail,
+  schedule: CalendarClock,
+  webhook: Webhook,
+};
+
+const STATUS_META: Record<
+  ProjectSessionStatus,
+  { label: string; variant: 'success' | 'warning' | 'muted' | 'destructive' | 'kortix' }
+> = {
+  queued: { label: 'Queued', variant: 'warning' },
+  branching: { label: 'Branching', variant: 'warning' },
+  provisioning: { label: 'Provisioning', variant: 'warning' },
+  running: { label: 'Running', variant: 'success' },
+  completed: { label: 'Completed', variant: 'kortix' },
+  stopped: { label: 'Stopped', variant: 'muted' },
+  failed: { label: 'Failed', variant: 'destructive' },
+};
+
+function formatTimestamp(value: string): { relative: string; exact: string } {
+  try {
+    const date = new Date(value);
+    return {
+      relative: formatDistanceToNowStrict(date, { addSuffix: true }),
+      exact: format(date, 'MMM d, yyyy, h:mm a'),
+    };
+  } catch {
+    return { relative: 'Unknown', exact: value };
+  }
+}
+
+function SessionListSkeleton() {
+  return (
+    <div className="space-y-2" aria-hidden>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div key={index} className="bg-popover flex items-center gap-3 rounded-md border px-4 py-3">
+          <Skeleton className="size-9 shrink-0 rounded-sm" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <Skeleton className={cn('h-3.5 rounded-sm', index % 2 ? 'w-44' : 'w-64')} />
+            <Skeleton className="h-3 w-36 rounded-sm" />
+          </div>
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DetailItem({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="min-w-0 space-y-1">
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd
+        className={cn(
+          'text-foreground text-sm break-words',
+          mono && 'font-mono text-xs tabular-nums',
+        )}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function SessionRow({
+  projectId,
+  session,
+  onRename,
+  onShare,
+  onDelete,
+  onRestart,
+  onStop,
+  restarting,
+  stopping,
+}: {
+  projectId: string;
+  session: ProjectSession;
+  onRename: (sessionId: string, currentName: string) => void;
+  onShare: (session: ProjectSession) => void;
+  onDelete: (sessionId: string, label: string) => void;
+  onRestart: (sessionId: string, label: string) => void;
+  onStop: (sessionId: string, label: string) => void;
+  restarting: boolean;
+  stopping: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const title = getSessionDisplayTitle(session);
+  const source = sessionSource(session);
+  const SourceIcon = SOURCE_ICONS[source.kind];
+  const status = STATUS_META[session.status];
+  const visibility = sessionVisibilityMeta(session);
+  const ownerLabel = session.owner_email || (session.is_owner === false ? 'Project member' : 'You');
+  const created = formatTimestamp(session.created_at);
+  const updated = formatTimestamp(session.updated_at || session.created_at);
+  const conversationCount = (session.opencode_sessions ?? []).length;
+  const archivedConversationCount = (session.opencode_sessions ?? []).filter(
+    (item) => item.archived_at,
+  ).length;
+  const href = `/projects/${projectId}/sessions/${session.session_id}`;
+
+  return (
+    <Disclosure
+      open={open}
+      onOpenChange={setOpen}
+      variant="outline"
+      className="group/session bg-popover overflow-hidden"
+    >
+      <DisclosureTrigger variant="outline">
+        <button
+          type="button"
+          className="hover:bg-muted/40 flex min-h-16 w-full cursor-pointer items-center gap-3 rounded-md px-4 py-3 text-left transition-colors duration-150"
+          aria-label={`${open ? 'Hide' : 'Show'} details for ${title}`}
+        >
+          <span className="bg-kortix-base/20 flex size-9 shrink-0 items-center justify-center rounded-sm">
+            <SourceIcon className="text-foreground size-5" />
+          </span>
+
+          <span className="min-w-0 flex-1">
+            <span className="flex min-w-0 flex-wrap items-center gap-1.5">
+              <span className="text-foreground max-w-full truncate text-sm font-medium">
+                {title}
+              </span>
+              {session.is_owner === false ? (
+                <Badge variant="kortix" size="xs">
+                  Shared
+                </Badge>
+              ) : null}
+            </span>
+            <span className="text-muted-foreground mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-xs">
+              <span>
+                {source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label}
+              </span>
+              <span className="text-muted-foreground/40">&bull;</span>
+              <span className="truncate">{ownerLabel}</span>
+              <span className="text-muted-foreground/40">&bull;</span>
+              <span className="tabular-nums" title={updated.exact}>
+                {updated.relative}
+              </span>
+            </span>
+          </span>
+
+          <Badge variant={status.variant} size="sm" className="hidden sm:inline-flex">
+            {status.label}
+          </Badge>
+          <ChevronDown className="text-muted-foreground size-4 shrink-0 transition-transform duration-150 ease-out group-data-[state=open]/session:rotate-180" />
+        </button>
+      </DisclosureTrigger>
+
+      <DisclosureContent variant="outline" contentClassName="border-border border-t">
+        <div className="space-y-5 px-4 py-5">
+          <div className="flex flex-wrap items-center gap-2 sm:hidden">
+            <Badge variant={status.variant} size="sm">
+              {status.label}
+            </Badge>
+            <Badge variant="outline" size="sm">
+              {visibility.label}
+            </Badge>
+          </div>
+
+          <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
+            <DetailItem label="Created" value={created.exact} />
+            <DetailItem label="Last activity" value={updated.exact} />
+            <DetailItem label="Status" value={status.label} />
+            <DetailItem label="Owner" value={ownerLabel} />
+            <DetailItem label="Visibility" value={visibility.label} />
+            <DetailItem
+              label="Source"
+              value={source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label}
+            />
+            <DetailItem label="Agent" value={session.agent_name || 'Project default'} />
+            <DetailItem label="Runtime" value={session.sandbox_provider || 'Not provisioned'} />
+            <DetailItem
+              label="Conversations"
+              value={`${conversationCount} OpenCode session${conversationCount === 1 ? '' : 's'}${
+                archivedConversationCount > 0 ? ` · ${archivedConversationCount} archived` : ''
+              }`}
+            />
+            <DetailItem label="Base ref" value={session.base_ref || 'Default branch'} mono />
+            <DetailItem label="Branch" value={session.branch_name || 'Not created'} mono />
+            <DetailItem label="Session ID" value={session.session_id} mono />
+            <DetailItem
+              label="Root conversation ID"
+              value={session.opencode_session_id || 'Not synced'}
+              mono
+            />
+          </dl>
+
+          {session.error ? (
+            <InfoBanner tone="destructive" icon={AlertTriangle} title="Session error">
+              <span className="break-words">{session.error}</span>
+            </InfoBanner>
+          ) : null}
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+            <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs">
+              <GitBranch className="size-3.5 shrink-0" />
+              <span className="truncate font-mono">
+                {session.branch_name || session.session_id}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" asChild>
+                <Link href={href}>
+                  Open session
+                  <ExternalLink className="size-3.5 shrink-0" />
+                </Link>
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button type="button" variant="secondary" size="sm">
+                    <MoreHorizontal className="size-3.5 shrink-0" />
+                    Actions
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  <DropdownMenuItem onSelect={() => onRename(session.session_id, title)}>
+                    <Pencil />
+                    Rename
+                  </DropdownMenuItem>
+                  {session.can_manage_sharing !== false ? (
+                    <DropdownMenuItem onSelect={() => onShare(session)}>
+                      <Share />
+                      Share
+                    </DropdownMenuItem>
+                  ) : null}
+                  <DropdownMenuItem
+                    disabled={restarting}
+                    onSelect={() => onRestart(session.session_id, title)}
+                  >
+                    {restarting ? <Loading className="size-4 shrink-0" /> : <RotateCcw />}
+                    Restart
+                  </DropdownMenuItem>
+                  {session.status === 'running' && session.can_manage_sharing !== false ? (
+                    <DropdownMenuItem
+                      disabled={stopping}
+                      onSelect={() => onStop(session.session_id, title)}
+                    >
+                      {stopping ? <Loading className="size-4 shrink-0" /> : <Square />}
+                      Stop
+                    </DropdownMenuItem>
+                  ) : null}
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onSelect={() => onDelete(session.session_id, title)}
+                  >
+                    <TrashSolid />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+        </div>
+      </DisclosureContent>
+    </Disclosure>
+  );
+}
+
+export function ProjectSessionsView({ projectId }: { projectId: string }) {
+  const queryClient = useQueryClient();
+  const [filter, setFilter] = useState<ProjectSessionsFilter>('all');
+  const [search, setSearch] = useState('');
+  const [sessionToRename, setSessionToRename] = useState<{ id: string; name: string } | null>(null);
+  const [sessionToShare, setSessionToShare] = useState<ProjectSession | null>(null);
+  const [sessionToDelete, setSessionToDelete] = useState<{ id: string; label: string } | null>(
+    null,
+  );
+  const newSession = useNewProjectSession(projectId);
+
+  const sessionsQuery = useQuery({
+    queryKey: ['project-sessions', projectId],
+    queryFn: () => listProjectSessions(projectId),
+    staleTime: 10_000,
+    refetchInterval: (query) =>
+      shouldPollProjectSessions(query.state.data as ProjectSession[] | undefined) ? 5_000 : false,
+    refetchOnWindowFocus: false,
+  });
+
+  const sessions = useMemo(() => sessionsQuery.data ?? [], [sessionsQuery.data]);
+  const counts = useMemo(() => projectSessionsFilterCounts(sessions), [sessions]);
+  const visibleSessions = useMemo(
+    () => filterProjectSessions(sessions, filter, search),
+    [sessions, filter, search],
+  );
+
+  const restartMutation = useMutation({
+    mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
+      restartProjectSession(projectId, sessionId),
+    onSuccess: (_data, { label }) => {
+      successToast(`Restarting "${label}"…`);
+      queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+    },
+    onError: (error) =>
+      errorToast(error instanceof Error ? error.message : 'Failed to restart session'),
+  });
+
+  const stopMutation = useMutation({
+    mutationFn: ({ sessionId }: { sessionId: string; label: string }) =>
+      stopProjectSession(projectId, sessionId),
+    onSuccess: (_data, { label }) => {
+      successToast(`"${label}" stopped`);
+      queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] });
+    },
+    onError: (error) =>
+      errorToast(error instanceof Error ? error.message : 'Failed to stop session'),
+  });
+
+  const action = (
+    <Button
+      type="button"
+      size="sm"
+      variant="secondary"
+      className="gap-1.5"
+      onClick={() => newSession()}
+    >
+      <Plus className="size-4 shrink-0" />
+      New session
+    </Button>
+  );
+
+  return (
+    <CustomizeSectionWrapper
+      title="Sessions"
+      description="Every chat, shared thread, and automation run in this project."
+      action={action}
+      className="max-w-5xl"
+    >
+      <div className="space-y-4">
+        <InputGroupSearch>
+          <InputGroupSearchIcon>
+            <Search />
+          </InputGroupSearchIcon>
+          <InputGroupSearchInput
+            variant="popover"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search by title, owner, source, branch, agent, or ID"
+            aria-label="Search sessions"
+          />
+          {search ? <InputGroupSearchClear onClick={() => setSearch('')} /> : null}
+        </InputGroupSearch>
+
+        <div className="[scrollbar-width:none] overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden">
+          <FilterBar className="h-8 rounded-md">
+            {PROJECT_SESSIONS_FILTERS.map((option) => (
+              <FilterBarItem
+                key={option.value}
+                className="h-[calc(100%-4px)] rounded-[calc(var(--radius)-3px)] px-2.5 text-xs"
+                data-state={filter === option.value ? 'active' : 'inactive'}
+                aria-selected={filter === option.value}
+                onClick={() => setFilter(option.value)}
+              >
+                {option.label}
+                <span className="tabular-nums">{counts[option.value]}</span>
+              </FilterBarItem>
+            ))}
+          </FilterBar>
+        </div>
+
+        {sessionsQuery.isLoading ? (
+          <SessionListSkeleton />
+        ) : sessionsQuery.isError ? (
+          <ErrorState
+            size="sm"
+            title="Sessions could not be loaded"
+            description={
+              sessionsQuery.error instanceof Error ? sessionsQuery.error.message : undefined
+            }
+            action={
+              <Button variant="outline" size="sm" onClick={() => sessionsQuery.refetch()}>
+                Retry
+              </Button>
+            }
+          />
+        ) : sessions.length === 0 ? (
+          <EmptyState
+            size="sm"
+            icon={MessageSquare}
+            title="No sessions yet"
+            description="Start a session to give this project its first task."
+            action={
+              <Button variant="outline" size="sm" className="gap-1.5" onClick={() => newSession()}>
+                <Plus className="size-3.5 shrink-0" />
+                New session
+              </Button>
+            }
+          />
+        ) : visibleSessions.length === 0 ? (
+          <EmptyState
+            size="sm"
+            icon={Search}
+            title="No matching sessions"
+            description="Try another search or clear the current filter."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setFilter('all');
+                  setSearch('');
+                }}
+              >
+                Clear filters
+              </Button>
+            }
+          />
+        ) : (
+          <div className="space-y-2" aria-live="polite">
+            <p className="text-muted-foreground text-xs tabular-nums">
+              Showing {visibleSessions.length} of {sessions.length}{' '}
+              {sessions.length === 1 ? 'session' : 'sessions'}
+            </p>
+            {visibleSessions.map((session) => (
+              <SessionRow
+                key={session.session_id}
+                projectId={projectId}
+                session={session}
+                onRename={(id, name) => setSessionToRename({ id, name })}
+                onShare={setSessionToShare}
+                onDelete={(id, label) => setSessionToDelete({ id, label })}
+                onRestart={(sessionId, label) => restartMutation.mutate({ sessionId, label })}
+                onStop={(sessionId, label) => stopMutation.mutate({ sessionId, label })}
+                restarting={
+                  restartMutation.isPending &&
+                  restartMutation.variables?.sessionId === session.session_id
+                }
+                stopping={
+                  stopMutation.isPending && stopMutation.variables?.sessionId === session.session_id
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ShareSessionModal
+        projectId={projectId}
+        session={sessionToShare}
+        open={!!sessionToShare}
+        onOpenChange={(open) => !open && setSessionToShare(null)}
+        onSaved={() => queryClient.invalidateQueries({ queryKey: ['project-sessions', projectId] })}
+      />
+      <RenameSessionModal
+        projectId={projectId}
+        sessionId={sessionToRename?.id ?? null}
+        currentName={sessionToRename?.name}
+        open={!!sessionToRename}
+        onOpenChange={(open) => !open && setSessionToRename(null)}
+      />
+      <SessionDeleteModal
+        projectId={projectId}
+        sessionId={sessionToDelete?.id ?? null}
+        sessionLabel={sessionToDelete?.label}
+        open={!!sessionToDelete}
+        onOpenChange={(open) => !open && setSessionToDelete(null)}
+      />
+    </CustomizeSectionWrapper>
+  );
+}

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -221,12 +221,15 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
 
           <SidebarGroup className="min-h-0 flex-1 flex-col py-0" ref={sessionsGroupRef}>
             {/* Sessions are always expanded — no collapse toggle. The header
-                label only carries the active filter; the ⋯ button opens the
-                filter menu. */}
+                label opens the full sessions page and carries the active
+                filter; the ⋯ button opens the filter menu. */}
             <div className="flex min-h-0 flex-1 flex-col space-y-2">
               <SidebarGroupLabel className="text-muted-foreground/60 mt-1 flex h-6 items-center px-0 text-[11px] font-medium tracking-wider uppercase">
                 <div className="flex w-full flex-row items-center gap-0.5">
-                  <div className="flex min-w-0 flex-1 flex-row items-center gap-1.5 px-2">
+                  <Link
+                    href={`/projects/${projectId}/sessions`}
+                    className="hover:text-sidebar-foreground flex min-w-0 flex-1 flex-row items-center gap-1.5 self-stretch px-2 transition-colors duration-150"
+                  >
                     <span>Sessions</span>
                     {sessionFilter !== 'all' && (
                       <span className="text-muted-foreground/90 truncate tracking-normal normal-case">
@@ -236,7 +239,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
                         {activeFilterOption.label}
                       </span>
                     )}
-                  </div>
+                  </Link>
                   <DropdownMenu onOpenChange={holdPeek}>
                     <DropdownMenuContent align="start" className="w-44 p-1">
                       {SESSION_FILTER_OPTIONS.map((option) => {

--- a/apps/web/src/lib/menu-registry.test.ts
+++ b/apps/web/src/lib/menu-registry.test.ts
@@ -83,3 +83,12 @@ describe('toggle-panel-mode command palette item', () => {
     expect(matchesPaletteQuery(panelModeItem!, 'session')).toBe(true);
   });
 });
+
+describe('project sessions command palette item', () => {
+  test('falls back to the canonical project sessions page', () => {
+    const sessionsItem = paletteItems.find((item) => item.id === 'proj-sessions');
+
+    expect(sessionsItem).toBeDefined();
+    expect(sessionsItem!.href).toBe('/projects/{projectId}/sessions');
+  });
+});

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -362,9 +362,9 @@ export const menuRegistry: MenuItemDef[] = [
     showIn: ['commandPalette'],
     kind: 'navigate',
     // Opens the in-palette "Open Session" sub-picker (see SUBMENU_PAGE_BY_ID);
-    // the href is only a non-palette fallback and points at the project root
-    // (the session-list page was removed in favour of the composer landing).
-    href: '/projects/{projectId}',
+    // the href is the routed fallback for surfaces that consume this registry
+    // without the palette's nested picker.
+    href: '/projects/{projectId}/sessions',
     requiresProject: true,
     keywords: 'sessions runs threads project conversations open',
   },


### PR DESCRIPTION
## Summary\n- add /projects/:id/sessions as the full project session index\n- show searchable, filterable session rows with source, ownership, status, runtime, branch, conversation, and timestamp details\n- reuse existing SDK queries and session action modals, and link the sidebar/registry fallback to the page\n\n## Verification\n- pnpm --dir apps/web exec bun test src/features/workspace/project-sessions/project-sessions-helpers.test.ts src/features/workspace/project-sidebar/project-session-list-helpers.test.ts src/lib/menu-registry.test.ts\n- pnpm --dir apps/web exec eslint src/features/workspace/project-sessions/project-sessions-view.tsx src/features/workspace/project-sessions/project-sessions-helpers.ts src/features/workspace/project-sessions/project-sessions-helpers.test.ts 'src/app/(app)/projects/[id]/sessions/page.tsx' src/features/workspace/project-sidebar/project-sidebar.tsx src/lib/menu-registry.ts src/lib/menu-registry.test.ts\n- pnpm --dir apps/web exec tsc --noEmit --pretty false\n- authenticated local GET /v1/projects/:id/sessions -> 200 with 3 rows; authenticated page -> 200; unauthenticated page -> 307 to /auth