### PR TITLE
fix(billing): show top-up, not the Free-plan pitch, when a Team wallet is out of credits

### DIFF
--- a/apps/api/src/billing/services/billing-gate.test.ts
+++ b/apps/api/src/billing/services/billing-gate.test.ts
@@ -28,7 +28,9 @@ mock.module('../repositories/credit-accounts', () => ({
   getCreditAccount: async () => account,
 }));
 
-const { assertBillingActive, checkBillingActive, BillingGateError } = await import('./billing-gate');
+const { assertBillingActive, checkBillingActive, BillingGateError } = await import(
+  './billing-gate'
+);
 
 function creditAccount(overrides: Record<string, unknown> = {}) {
   return {
@@ -57,12 +59,41 @@ describe('checkBillingActive — real reason per gate (ERROR-TAXONOMY finding #4
     if (!result.ok) expect(result.reason).toBe('no_account');
   });
 
-  test('per-seat account with no active subscription and insufficient balance → "subscription_required"', async () => {
+  test('per-seat account that NEVER subscribed (no subscription row) and insufficient balance → "subscription_required"', async () => {
     billingEnabled = true;
-    account = creditAccount({ billingModel: 'per_seat', balance: '0', stripeSubscriptionStatus: 'canceled' });
+    account = creditAccount({
+      billingModel: 'per_seat',
+      balance: '0',
+      stripeSubscriptionStatus: 'canceled',
+    });
     const result = await checkBillingActive('acct-1');
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.reason).toBe('subscription_required');
+    if (!result.ok) {
+      expect(result.reason).toBe('subscription_required');
+      expect(result.billingModel).toBe('per_seat');
+      expect(result.hasSubscription).toBe(false);
+    }
+  });
+
+  test('per-seat Team account WITH a lapsed subscription and a drained wallet → "insufficient_credits" (top up, not "subscribe from Free")', async () => {
+    billingEnabled = true;
+    // Has a real subscription row (id set) but it lapsed to unpaid, and the
+    // wallet is deep negative — this is the exact "$-9k Team account" case. It
+    // must NOT be pitched the Free plan; it's out of credits.
+    account = creditAccount({
+      billingModel: 'per_seat',
+      balance: '-9237.85',
+      stripeSubscriptionId: 'sub_lapsed',
+      stripeSubscriptionStatus: 'unpaid',
+    });
+    const result = await checkBillingActive('acct-1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('insufficient_credits');
+      expect(result.billingModel).toBe('per_seat');
+      expect(result.hasSubscription).toBe(true);
+      expect(result.balance).toBe(-9237.85);
+    }
   });
 
   test('legacy (non-per-seat) account with an exhausted balance → "insufficient_credits", NOT subscription_required', async () => {
@@ -104,9 +135,15 @@ describe('assertBillingActive / BillingGateError — the reason survives the thr
     } catch (err) {
       creditsErr = err;
     }
-    expect((creditsErr as InstanceType<typeof BillingGateError>).reason).toBe('insufficient_credits');
+    expect((creditsErr as InstanceType<typeof BillingGateError>).reason).toBe(
+      'insufficient_credits',
+    );
 
-    account = creditAccount({ billingModel: 'per_seat', balance: '0', stripeSubscriptionStatus: 'canceled' });
+    account = creditAccount({
+      billingModel: 'per_seat',
+      balance: '0',
+      stripeSubscriptionStatus: 'canceled',
+    });
     let subErr: unknown;
     try {
       await assertBillingActive('acct-1');
@@ -129,6 +166,26 @@ describe('assertBillingActive / BillingGateError — the reason survives the thr
       const gateError = err as InstanceType<typeof BillingGateError>;
       const body = await gateError.res!.clone().json();
       expect(body.code).toBe('insufficient_credits');
+    }
+  });
+
+  test('the 402 body carries billing_model + has_subscription so the client can route to top-up vs subscribe', async () => {
+    billingEnabled = true;
+    account = creditAccount({
+      billingModel: 'per_seat',
+      balance: '-9237.85',
+      stripeSubscriptionId: 'sub_lapsed',
+      stripeSubscriptionStatus: 'unpaid',
+    });
+    try {
+      await assertBillingActive('acct-1');
+      throw new Error('expected assertBillingActive to throw');
+    } catch (err) {
+      const gateError = err as InstanceType<typeof BillingGateError>;
+      const body = await gateError.res!.clone().json();
+      expect(body.code).toBe('insufficient_credits');
+      expect(body.billing_model).toBe('per_seat');
+      expect(body.has_subscription).toBe(true);
     }
   });
 });

--- a/apps/api/src/billing/services/billing-gate.ts
+++ b/apps/api/src/billing/services/billing-gate.ts
@@ -1,14 +1,11 @@
-import { HTTPException } from "hono/http-exception";
-import { config } from "../../config";
-import { getCreditAccount } from "../repositories/credit-accounts";
-import { deductCredits } from "./credits";
-import { ensureFreeTierAccountReady } from "./free-tier";
-import { isPerSeatAccount, MINIMUM_CREDIT_FOR_RUN } from "./tiers";
+import { HTTPException } from 'hono/http-exception';
+import { config } from '../../config';
+import { getCreditAccount } from '../repositories/credit-accounts';
+import { deductCredits } from './credits';
+import { ensureFreeTierAccountReady } from './free-tier';
+import { type BillingModel, MINIMUM_CREDIT_FOR_RUN, isPerSeatAccount } from './tiers';
 
-type BillingGateReason =
-  | "subscription_required"
-  | "insufficient_credits"
-  | "no_account";
+type BillingGateReason = 'subscription_required' | 'insufficient_credits' | 'no_account';
 
 export interface BillingGateOk {
   ok: true;
@@ -27,6 +24,13 @@ export interface BillingGateBlocked {
   reason: BillingGateReason;
   balance: number;
   message: string;
+  // The account's billing model + whether it has a subscription row at all.
+  // Carried on the 402 so the client can tell a genuinely-free/no-plan account
+  // ("subscribe" pitch) apart from a paying Team account whose wallet ran dry
+  // ("top up" pitch) — the same `subscription_required` reason otherwise
+  // mislabels a per-seat Team account as Free. See web global-upgrade-modal.
+  billingModel: BillingModel;
+  hasSubscription: boolean;
 }
 
 /**
@@ -40,7 +44,13 @@ export interface BillingGateBlocked {
  * read the real cause synchronously, no body parsing required.
  */
 export class BillingGateError extends HTTPException {
-  constructor(readonly reason: BillingGateReason, readonly balance: number, message: string, accountId: string) {
+  constructor(
+    readonly reason: BillingGateReason,
+    readonly balance: number,
+    message: string,
+    accountId: string,
+    extra?: { billingModel?: BillingModel; hasSubscription?: boolean },
+  ) {
     super(402, {
       message,
       res: new Response(
@@ -48,11 +58,14 @@ export class BillingGateError extends HTTPException {
           error: message,
           code: reason,
           balance,
+          // Distinguish "no plan → subscribe" from "Team wallet drained → top up".
+          billing_model: extra?.billingModel ?? 'legacy',
+          has_subscription: extra?.hasSubscription ?? false,
           // The blocked account — so the upgrade dialog scopes to it instead of
           // the caller's primary account (see web error-handler → openUpgradeDialog).
           account_id: accountId,
         }),
-        { status: 402, headers: { "content-type": "application/json" } },
+        { status: 402, headers: { 'content-type': 'application/json' } },
       ),
     });
   }
@@ -74,29 +87,50 @@ export async function checkBillingActive(
   if (!account) {
     return {
       ok: false,
-      reason: "no_account",
+      reason: 'no_account',
       balance: 0,
-      message: "No credit account found. Complete account setup first.",
+      message: 'No credit account found. Complete account setup first.',
+      billingModel: 'legacy',
+      hasSubscription: false,
     };
   }
 
   const balance = Number(account.balance ?? 0);
+  const billingModel: BillingModel = isPerSeatAccount(account.billingModel) ? 'per_seat' : 'legacy';
+  // Any subscription row at all — used to distinguish a paying-but-lapsed Team
+  // account (top up) from one that never subscribed (subscribe to activate).
+  const hasSubscription = !!account.stripeSubscriptionId;
   const hasActiveSub =
-    !!account.stripeSubscriptionId &&
-    account.stripeSubscriptionStatus !== "canceled" &&
-    account.stripeSubscriptionStatus !== "unpaid";
+    hasSubscription &&
+    account.stripeSubscriptionStatus !== 'canceled' &&
+    account.stripeSubscriptionStatus !== 'unpaid';
 
   if (isPerSeatAccount(account.billingModel)) {
     // An active subscription isn't wallet-gated at all — no hold to take.
     if (hasActiveSub) return { ok: true };
     if (balance >= MINIMUM_CREDIT_FOR_RUN) return { ok: true };
-    return {
-      ok: false,
-      reason: "subscription_required",
-      balance,
-      message:
-        "Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.",
-    };
+    // A Team account that HAS a (now-lapsed) subscription and a drained wallet
+    // isn't a "subscribe from Free" case — it's out of credits. Surface it as
+    // insufficient_credits so the client shows top-up, not the Free-plan pitch.
+    // Only a per-seat account that never subscribed gets the subscribe CTA.
+    return hasSubscription
+      ? {
+          ok: false,
+          reason: 'insufficient_credits',
+          balance,
+          message: 'Your team wallet is out of credits. Top up to keep your agents running.',
+          billingModel,
+          hasSubscription,
+        }
+      : {
+          ok: false,
+          reason: 'subscription_required',
+          balance,
+          message:
+            'Subscribe to activate your seat. $40/teammate per month includes wallet credits for compute and LLM usage.',
+          billingModel,
+          hasSubscription,
+        };
   }
 
   // Pure-wallet path: this used to be a read-only `balance >= floor` check,
@@ -125,14 +159,21 @@ export async function checkBillingActive(
   // an overdrawn account). See RELIABILITY-BACKLOG item 2 / PR description
   // for the full reservation system this is a pragmatic slice of.
   try {
-    await deductCredits(accountId, MINIMUM_CREDIT_FOR_RUN, "LLM gateway admission hold", "llm_debit");
+    await deductCredits(
+      accountId,
+      MINIMUM_CREDIT_FOR_RUN,
+      'LLM gateway admission hold',
+      'llm_debit',
+    );
     return { ok: true, holdUsd: MINIMUM_CREDIT_FOR_RUN };
   } catch {
     return {
       ok: false,
-      reason: "insufficient_credits",
+      reason: 'insufficient_credits',
       balance,
-      message: "Out of credits. Top up to continue.",
+      message: 'Out of credits. Top up to continue.',
+      billingModel,
+      hasSubscription,
     };
   }
 }
@@ -140,5 +181,8 @@ export async function checkBillingActive(
 export async function assertBillingActive(accountId: string): Promise<BillingGateOk> {
   const result = await checkBillingActive(accountId);
   if (result.ok) return result;
-  throw new BillingGateError(result.reason, result.balance, result.message, accountId);
+  throw new BillingGateError(result.reason, result.balance, result.message, accountId, {
+    billingModel: result.billingModel,
+    hasSubscription: result.hasSubscription,
+  });
 }

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -657,6 +657,11 @@ export async function createProjectSession(input: {
           message: billingCheck.message,
           code: billingCheck.reason,
           balance: billingCheck.balance,
+          // Lets the client tell a genuinely-free/no-plan account ("subscribe")
+          // from a paying Team account whose wallet ran dry ("top up") instead
+          // of pitching the Free plan to a Team account. See web error-handler.
+          billing_model: billingCheck.billingModel,
+          has_subscription: billingCheck.hasSubscription,
           // The account that actually needs the upgrade — the project's owning
           // (team) account, NOT the caller's primary account. The upgrade dialog
           // scopes itself to this so a non-billing member sees the *team's*

--- a/apps/web/src/features/accounts/settings/billing-tab.tsx
+++ b/apps/web/src/features/accounts/settings/billing-tab.tsx
@@ -5,10 +5,10 @@ import { InfoBanner } from '@/components/ui/info-banner';
 import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
-import { errorToast } from '@/components/ui/toast';
 import { AccountOverviewTab } from '@/features/billing/account-overview';
 import { AutoTopupCard } from '@/features/billing/auto-topup-card';
 import { ClaimPerSeatCard } from '@/features/billing/claim-per-seat-card';
+import { CreditTopupSection } from '@/features/billing/credit-topup-section';
 import { SeatManagementCard } from '@/features/billing/seat-management-card';
 import { useAuth } from '@/features/providers/auth-provider';
 import {
@@ -17,36 +17,20 @@ import {
   invalidateAccountState,
   useCreatePortalSession,
 } from '@/hooks/billing';
-import { AccountState, billingApi } from '@/lib/api/billing';
+import { type AccountState, billingApi } from '@/lib/api/billing';
 import { isBillingEnabled } from '@/lib/config';
-import { cn } from '@/lib/utils';
 import { useBillingAccountId } from '@/stores/billing-account-context';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { useUserSettingsModalStore } from '@/stores/user-settings-modal-store';
-import { formatCredits } from '@kortix/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
-import { useEffect, useRef, useState } from 'react';
-
-const CREDIT_PACKAGES: { credits: number; price: number }[] = [
-  { credits: 1000, price: 10 },
-  { credits: 2500, price: 25 },
-  { credits: 5000, price: 50 },
-  { credits: 10000, price: 100 },
-  { credits: 25000, price: 250 },
-  { credits: 50000, price: 500 },
-];
+import { useEffect, useRef } from 'react';
 
 export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActive: boolean }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const { session, isLoading: authLoading } = useAuth();
   const highlight = useUserSettingsModalStore((s) => s.highlight);
   const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
-  const [selectedPackage, setSelectedPackage] = useState<(typeof CREDIT_PACKAGES)[number] | null>(
-    null,
-  );
-  const [isPurchasing, setIsPurchasing] = useState(false);
-  const [purchaseError, setPurchaseError] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const billingAccountId = useBillingAccountId();
 
@@ -86,34 +70,6 @@ export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActiv
 
   const handleManageSubscription = () => {
     createPortalSessionMutation.mutate({ return_url: returnUrl });
-  };
-
-  const handlePurchaseCredits = async () => {
-    if (!selectedPackage) return;
-    setIsPurchasing(true);
-    setPurchaseError(null);
-    try {
-      const response = await billingApi.purchaseCredits(
-        {
-          amount: selectedPackage.price,
-          success_url: `${window.location.origin}/dashboard?credit_purchase=success`,
-          cancel_url: window.location.href,
-        },
-        billingAccountId,
-      );
-      if (response.checkout_url) {
-        window.location.href = response.checkout_url;
-      } else {
-        throw new Error('No checkout URL received');
-      }
-    } catch (err: unknown) {
-      const error = err as { details?: { detail?: string }; message?: string };
-      const msg = error?.details?.detail || error?.message || 'Failed to create checkout session';
-      setPurchaseError(msg);
-      errorToast(msg);
-    } finally {
-      setIsPurchasing(false);
-    }
   };
 
   const isLoading = isLoadingSubscription || authLoading;
@@ -231,43 +187,8 @@ export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActiv
                   )}
                 </p>
               </div>
-              <div className="bg-popover space-y-3 rounded-md border px-4 py-5">
-                <div className="grid grid-cols-3 gap-2">
-                  {CREDIT_PACKAGES.map((pkg) => {
-                    const isSelected = selectedPackage?.price === pkg.price;
-                    return (
-                      <Button
-                        key={pkg.price}
-                        type="button"
-                        onClick={() => setSelectedPackage(pkg)}
-                        disabled={isPurchasing}
-                        variant="outline"
-                        className={cn(
-                          'h-auto flex-col rounded-md p-3 text-center',
-                          isSelected && 'border-primary bg-primary/[0.06]',
-                        )}
-                      >
-                        <span className="text-lg font-semibold tabular-nums">${pkg.price}</span>
-                        <span className="text-muted-foreground text-xs">
-                          {formatCredits(pkg.credits)} credits
-                        </span>
-                      </Button>
-                    );
-                  })}
-                </div>
-                {purchaseError && <InfoBanner tone="destructive">{purchaseError}</InfoBanner>}
-                <Button
-                  onClick={handlePurchaseCredits}
-                  disabled={isPurchasing || !selectedPackage}
-                  className="w-full gap-1.5"
-                >
-                  {isPurchasing ? <Loading className="size-4 shrink-0" /> : null}
-                  {isPurchasing
-                    ? 'Processing'
-                    : selectedPackage
-                      ? `Buy $${selectedPackage.price} in credits`
-                      : 'Select a package'}
-                </Button>
+              <div className="bg-popover rounded-md border px-4 py-5">
+                <CreditTopupSection />
               </div>
             </section>
           )}

--- a/apps/web/src/features/billing/credit-topup-section.tsx
+++ b/apps/web/src/features/billing/credit-topup-section.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { InfoBanner } from '@/components/ui/info-banner';
+import { Input } from '@/components/ui/input';
+import Loading from '@/components/ui/loading';
+import { errorToast } from '@/components/ui/toast';
+import { billingApi } from '@/lib/api/billing';
+import { cn } from '@/lib/utils';
+import { useBillingAccountId } from '@/stores/billing-account-context';
+import { dollarsToCredits, formatCredits } from '@kortix/shared';
+import { useMemo, useState } from 'react';
+
+/** Preset one-time credit packages. $1 = 100 credits (CREDITS_PER_DOLLAR). The
+ *  backend (payments.ts) maps these exact dollar amounts to fixed Stripe prices
+ *  and falls back to a dynamic price_data line item for any other (custom)
+ *  amount, so custom top-ups work end-to-end with no preset. */
+const CREDIT_PACKAGES: { credits: number; price: number }[] = [
+  { credits: 1000, price: 10 },
+  { credits: 2500, price: 25 },
+  { credits: 5000, price: 50 },
+  { credits: 10000, price: 100 },
+  { credits: 25000, price: 250 },
+  { credits: 50000, price: 500 },
+];
+
+/** Minimum custom top-up. Stripe rejects sub-$0.50 charges; $5 keeps the
+ *  checkout worthwhile and matches the smallest amount worth a card round-trip. */
+const CUSTOM_MIN_USD = 5;
+const CUSTOM_MAX_USD = 10000;
+
+interface CreditTopupSectionProps {
+  /** Where Stripe returns on success. Defaults to /dashboard?credit_purchase=success. */
+  successUrl?: string;
+  /** Where Stripe returns on cancel. Defaults to the current URL. */
+  cancelUrl?: string;
+  className?: string;
+}
+
+/**
+ * One-time credit purchase: preset packages + a custom amount, then a single
+ * "Buy" action that opens Stripe checkout. Shared by the Billing tab and the
+ * out-of-credits blocking modal so both offer the same top-up (incl. custom
+ * amount) instead of duplicating the grid.
+ */
+export function CreditTopupSection({ successUrl, cancelUrl, className }: CreditTopupSectionProps) {
+  const billingAccountId = useBillingAccountId();
+  const [selectedPrice, setSelectedPrice] = useState<number | null>(null);
+  const [customValue, setCustomValue] = useState('');
+  const [isCustom, setIsCustom] = useState(false);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [purchaseError, setPurchaseError] = useState<string | null>(null);
+
+  // The dollar amount that would actually be charged. Custom wins when the
+  // custom input is focused/filled; otherwise the selected preset.
+  const amount = useMemo(() => {
+    if (isCustom) {
+      const parsed = Number.parseFloat(customValue);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return selectedPrice;
+  }, [isCustom, customValue, selectedPrice]);
+
+  const customTooLow = isCustom && amount !== null && amount < CUSTOM_MIN_USD;
+  const customTooHigh = isCustom && amount !== null && amount > CUSTOM_MAX_USD;
+  const canBuy =
+    amount !== null && amount >= CUSTOM_MIN_USD && amount <= CUSTOM_MAX_USD && !isPurchasing;
+
+  const handlePurchase = async () => {
+    if (amount === null || !canBuy) return;
+    setIsPurchasing(true);
+    setPurchaseError(null);
+    try {
+      const response = await billingApi.purchaseCredits(
+        {
+          // Whole-dollar amounts only — custom prices are per-dollar on the
+          // backend and the ledger displays cleanly. Round to be safe.
+          amount: Math.round(amount),
+          success_url: successUrl ?? `${window.location.origin}/dashboard?credit_purchase=success`,
+          cancel_url: cancelUrl ?? window.location.href,
+        },
+        billingAccountId,
+      );
+      if (response.checkout_url) {
+        window.location.href = response.checkout_url;
+      } else {
+        throw new Error('No checkout URL received');
+      }
+    } catch (err: unknown) {
+      const error = err as { details?: { detail?: string }; message?: string };
+      const msg = error?.details?.detail || error?.message || 'Failed to create checkout session';
+      setPurchaseError(msg);
+      errorToast(msg);
+    } finally {
+      setIsPurchasing(false);
+    }
+  };
+
+  const buyLabel = isPurchasing
+    ? 'Processing'
+    : amount !== null && canBuy
+      ? `Buy $${Math.round(amount)} in credits`
+      : 'Select an amount';
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <div className="grid grid-cols-3 gap-2">
+        {CREDIT_PACKAGES.map((pkg) => {
+          const isSelected = !isCustom && selectedPrice === pkg.price;
+          return (
+            <Button
+              key={pkg.price}
+              type="button"
+              onClick={() => {
+                setSelectedPrice(pkg.price);
+                setIsCustom(false);
+                setPurchaseError(null);
+              }}
+              disabled={isPurchasing}
+              variant="outline"
+              className={cn(
+                'h-auto flex-col rounded-md p-3 text-center',
+                isSelected && 'border-primary bg-primary/[0.06]',
+              )}
+            >
+              <span className="text-lg font-semibold tabular-nums">${pkg.price}</span>
+              <span className="text-muted-foreground text-xs">
+                {formatCredits(pkg.credits)} credits
+              </span>
+            </Button>
+          );
+        })}
+      </div>
+
+      {/* Custom amount — activates on focus/typing so it wins over a preset. */}
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-md border px-3 py-2 transition-colors',
+          isCustom && 'border-primary bg-primary/[0.06]',
+        )}
+      >
+        <span className="text-muted-foreground shrink-0 text-sm">Custom</span>
+        <div className="relative flex-1">
+          <span className="text-muted-foreground absolute left-2.5 top-1/2 -translate-y-1/2 text-sm">
+            $
+          </span>
+          <Input
+            type="number"
+            min={CUSTOM_MIN_USD}
+            max={CUSTOM_MAX_USD}
+            step={1}
+            inputMode="numeric"
+            value={customValue}
+            placeholder={String(CUSTOM_MIN_USD)}
+            disabled={isPurchasing}
+            onFocus={() => {
+              setIsCustom(true);
+              setPurchaseError(null);
+            }}
+            onChange={(e) => {
+              setCustomValue(e.target.value);
+              setIsCustom(true);
+              setPurchaseError(null);
+            }}
+            className="h-9 pl-6 pr-2 tabular-nums"
+          />
+        </div>
+        {isCustom && amount !== null && amount >= CUSTOM_MIN_USD && (
+          <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+            {formatCredits(dollarsToCredits(Math.round(amount)))} credits
+          </span>
+        )}
+      </div>
+
+      {customTooLow && (
+        <p className="text-muted-foreground text-xs">Minimum top-up is ${CUSTOM_MIN_USD}.</p>
+      )}
+      {customTooHigh && (
+        <p className="text-muted-foreground text-xs">
+          For more than ${CUSTOM_MAX_USD.toLocaleString()}, contact sales.
+        </p>
+      )}
+
+      {purchaseError && <InfoBanner tone="destructive">{purchaseError}</InfoBanner>}
+
+      <Button onClick={handlePurchase} disabled={!canBuy} className="w-full gap-1.5">
+        {isPurchasing ? <Loading className="size-4 shrink-0" /> : null}
+        {buyLabel}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/billing/global-upgrade-modal.tsx
+++ b/apps/web/src/features/billing/global-upgrade-modal.tsx
@@ -3,35 +3,76 @@
 import { Button } from '@/components/ui/button';
 import Hint from '@/components/ui/hint';
 import { Item, ItemContent, ItemDescription, ItemMedia, ItemTitle } from '@/components/ui/item';
+import { Label } from '@/components/ui/label';
 import Loading from '@/components/ui/loading';
 import {
   Modal,
   ModalBody,
   ModalContent,
   ModalDescription,
+  ModalFooter,
   ModalHeader,
   ModalTitle,
 } from '@/components/ui/modal';
-import { useRequestDemo } from '@/features/contact/request-demo-provider';
+import { AutoTopupCard } from '@/features/billing/auto-topup-card';
+import { CreditTopupSection } from '@/features/billing/credit-topup-section';
 import { PricingPlanCard } from '@/features/billing/pricing-plan-card';
 import { UPGRADE_MODAL_PLANS, type UpgradeModalPlanId } from '@/features/billing/pricing-plans';
-import { useAccountState, useCreatePerSeatCheckout } from '@/hooks/billing';
+import { useRequestDemo } from '@/features/contact/request-demo-provider';
+import { useAccountState, useCreatePerSeatCheckout, useCreatePortalSession } from '@/hooks/billing';
 import type { AccountState } from '@/lib/api/billing';
+import { cn } from '@/lib/utils';
 import { BillingAccountProvider } from '@/stores/billing-account-context';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
-import { ArrowRight, UserPlus } from 'lucide-react';
+import { formatCredits } from '@kortix/shared';
+import { ArrowRight, CreditCard, UserPlus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 export interface UpgradePlansModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   accountState?: AccountState;
+  /** From the 402: distinguishes "Team wallet drained → top up" (credit view)
+   *  from "no plan → subscribe" (plans view). Fall back to accountState. */
+  reason?: string;
+  billingModel?: string;
+  hasSubscription?: boolean;
+  balance?: number;
 }
 
-export function UpgradePlansModal({ open, onOpenChange, accountState }: UpgradePlansModalProps) {
+export function UpgradePlansModal({
+  open,
+  onOpenChange,
+  accountState,
+  reason,
+  billingModel,
+  hasSubscription,
+  balance,
+}: UpgradePlansModalProps) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const createPerSeat = useCreatePerSeatCheckout();
   const openDemo = useRequestDemo();
+
+  // Show the top-up view (not the Free-plan pitch) whenever we can tell the
+  // account is already a paying/Team account whose wallet ran dry. Prefer the
+  // 402 hints (billing_model / has_subscription / reason) since accountState can
+  // still be loading when the modal opens; fall back to it once available.
+  const isPerSeat = billingModel === 'per_seat' || accountState?.billing_model === 'per_seat';
+  const hasSub = hasSubscription ?? Boolean(accountState?.subscription?.subscription_id);
+  const canPurchaseCredits = accountState?.tier?.can_purchase_credits ?? isPerSeat;
+  const showTopUp =
+    (reason === 'insufficient_credits' || isPerSeat || hasSub) && canPurchaseCredits;
+
+  if (showTopUp) {
+    return (
+      <CreditTopUpModal
+        open={open}
+        onOpenChange={onOpenChange}
+        accountState={accountState}
+        balance={balance}
+      />
+    );
+  }
 
   const pricePerSeat = accountState?.seats?.price_per_seat_usd ?? 40;
   const seatCount = Math.max(1, accountState?.member_count ?? accountState?.seats?.count ?? 1);
@@ -101,9 +142,13 @@ export function UpgradePlansModal({ open, onOpenChange, accountState }: UpgradeP
     ),
   };
 
-  const planBadges: Partial<Record<UpgradeModalPlanId, string>> = {
-    free: 'Current plan',
-  };
+  // Badge the plan the account is ACTUALLY on, computed from account state —
+  // never hardcoded to Free (that mislabels every paying account as Free, the
+  // core bug here). The top-up view already handles per-seat/subscribed
+  // accounts, so this plans view is only reached for free/no-plan accounts.
+  const planBadges: Partial<Record<UpgradeModalPlanId, string>> = isPerSeat
+    ? { team: 'Current plan' }
+    : { free: 'Current plan' };
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
@@ -181,8 +226,96 @@ export function UpgradePlansModal({ open, onOpenChange, accountState }: UpgradeP
   );
 }
 
+interface CreditTopUpModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accountState?: AccountState;
+  balance?: number;
+}
+
+/**
+ * The out-of-credits view of the blocking modal: a clear "why you're blocked"
+ * header + wallet balance, one-time top-up (packages + custom amount), and
+ * auto-top-up config underneath so a drained Team account can both refill now
+ * and never hit zero again — instead of being wrongly pitched the Free plan.
+ */
+function CreditTopUpModal({ open, onOpenChange, accountState, balance }: CreditTopUpModalProps) {
+  const createPortal = useCreatePortalSession();
+  const walletUsd = balance ?? accountState?.credits?.total ?? 0;
+  const isNegative = walletUsd < 0;
+  const walletLabel = `${walletUsd < 0 ? '-' : ''}$${Math.abs(walletUsd).toFixed(2)}`;
+  const creditsLabel = formatCredits(Math.round(Math.abs(walletUsd) * 100));
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent className="gap-0 space-y-0 p-0 lg:max-w-lg">
+        <ModalHeader className="space-y-2 px-6 pt-6 pb-4">
+          <div className="flex items-center gap-2">
+            <span className="bg-kortix-orange/10 text-kortix-orange flex size-9 items-center justify-center rounded-full">
+              <CreditCard className="size-4" />
+            </span>
+            <ModalTitle className="text-xl font-medium tracking-tight">Out of credits</ModalTitle>
+          </div>
+          <ModalDescription className="text-sm">
+            Your agents are paused because the wallet is empty. Top up to keep compute and the
+            latest AI models running — your Team plan and seats are unaffected.
+          </ModalDescription>
+        </ModalHeader>
+
+        <ModalBody className="space-y-5 px-6 pb-2">
+          {/* Wallet balance — the concrete "why" behind the block. */}
+          <div className="bg-popover flex items-center justify-between rounded-md border px-4 py-3">
+            <span className="text-muted-foreground text-sm">Wallet balance</span>
+            <span
+              className={cn(
+                'text-lg font-medium tabular-nums',
+                isNegative ? 'text-kortix-red' : 'text-foreground',
+              )}
+            >
+              {walletLabel}
+              {isNegative && (
+                <span className="text-muted-foreground ml-1.5 text-xs">
+                  ({creditsLabel} credits owed)
+                </span>
+              )}
+            </span>
+          </div>
+
+          <div className="space-y-3">
+            <Label>Buy credits</Label>
+            <CreditTopupSection />
+          </div>
+
+          {/* Auto top-up underneath — configure it here so it never happens again. */}
+          <div className="space-y-3">
+            <Label>Auto top-up</Label>
+            <div className="bg-popover rounded-md border px-4 py-4">
+              <AutoTopupCard fetchSettings showSaveButton />
+            </div>
+          </div>
+        </ModalBody>
+
+        <ModalFooter className="px-6 pb-6 pt-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground gap-1.5"
+            disabled={createPortal.isPending}
+            onClick={() => createPortal.mutate({ return_url: window.location.href })}
+          >
+            {createPortal.isPending ? <Loading className="size-4 shrink-0" /> : null}
+            Manage billing
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
 export function GlobalUpgradeModal() {
-  const { isOpen, closeUpgradeDialog, accountId } = useUpgradeDialogStore();
+  const { isOpen, closeUpgradeDialog, accountId, reason, billingModel, hasSubscription, balance } =
+    useUpgradeDialogStore();
   const { data: accountState } = useAccountState({ accountId });
 
   return (
@@ -191,6 +324,10 @@ export function GlobalUpgradeModal() {
         open={isOpen}
         onOpenChange={(open) => !open && closeUpgradeDialog()}
         accountState={accountState}
+        reason={reason}
+        billingModel={billingModel}
+        hasSubscription={hasSubscription}
+        balance={balance}
       />
     </BillingAccountProvider>
   );

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-balance-warning.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-balance-warning.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { useAccountState } from '@/hooks/billing';
+import { isBillingEnabled } from '@/lib/config';
+import { cn } from '@/lib/utils';
+import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
+import { AlertTriangle, CreditCard } from 'lucide-react';
+import { useCallback } from 'react';
+
+/** Warn once the wallet drops below this (dollars). Negative/zero is always a
+ *  hard "out of credits"; between $0 and here is a softer "low balance" nudge. */
+const LOW_BALANCE_USD = 5;
+
+function useBalanceWarning(accountId?: string) {
+  const { data: accountState } = useAccountState({ accountId });
+  const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
+
+  const balance = accountState?.credits?.total ?? 0;
+  const isPerSeat = accountState?.billing_model === 'per_seat';
+  // Only accounts that can actually top up (Team / paid) get this warning —
+  // a free account can't buy credits, so it keeps the "Upgrade Plan" button.
+  const canTopUp = (accountState?.tier?.can_purchase_credits ?? false) || isPerSeat;
+
+  const handleClick = useCallback(
+    () =>
+      openUpgradeDialog({
+        reason: 'insufficient_credits',
+        accountId,
+        billingModel: accountState?.billing_model,
+        hasSubscription: Boolean(accountState?.subscription?.subscription_id),
+        balance,
+      }),
+    [openUpgradeDialog, accountId, accountState, balance],
+  );
+
+  if (!isBillingEnabled() || !accountState || !canTopUp) {
+    return { severity: null as 'empty' | 'low' | null, handleClick };
+  }
+
+  const severity: 'empty' | 'low' | null =
+    balance <= 0 ? 'empty' : balance < LOW_BALANCE_USD ? 'low' : null;
+
+  return { severity, handleClick };
+}
+
+export function SidebarBalanceWarning({ accountId }: { accountId?: string }) {
+  const { severity, handleClick } = useBalanceWarning(accountId);
+  if (!severity) return null;
+
+  const isEmpty = severity === 'empty';
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        type="button"
+        size="md"
+        onClick={handleClick}
+        className={cn(
+          'flex w-full items-center gap-2 border font-medium [&_svg]:size-3.5!',
+          isEmpty
+            ? 'text-destructive border-destructive/30 bg-destructive/[0.06] hover:bg-destructive/10 hover:text-destructive'
+            : 'text-kortix-orange border-kortix-orange/30 bg-kortix-orange/[0.06] hover:bg-kortix-orange/10 hover:text-kortix-orange',
+        )}
+      >
+        {isEmpty ? <AlertTriangle /> : <CreditCard />}
+        <span className="flex-1 text-left">{isEmpty ? 'Out of credits' : 'Low balance'}</span>
+        <span className="text-xs opacity-70">Top up</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-upgrade-button.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-upgrade-button.tsx
@@ -37,7 +37,12 @@ function useSidebarUpgrade(accountId?: string) {
   const tierKey = accountStateSelectors.tierKey(accountState).toLowerCase();
   const hasActiveSubscription = !!accountState.subscription?.subscription_id;
   const isFreeOrNoPlan = tierKey === 'free' || tierKey === 'none';
-  const show = isFreeOrNoPlan && !hasActiveSubscription;
+  // A per-seat (Team) account is never "on Free" even though its legacy tier_key
+  // can still read 'free' — it gets the balance/top-up warning instead of an
+  // "Upgrade Plan" pitch. Excluding it here is what keeps a paying Team account
+  // from being mislabeled as Free in the sidebar.
+  const isPerSeat = accountState.billing_model === 'per_seat';
+  const show = isFreeOrNoPlan && !hasActiveSubscription && !isPerSeat;
 
   return { show, handleClick };
 }

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -64,6 +64,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { HiDotsHorizontal } from 'react-icons/hi';
 import { IconType } from 'react-icons/lib';
+import { SidebarBalanceWarning } from './footer/project-balance-warning';
 import { SidebarUpgradeButton } from './footer/project-upgrade-button';
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
@@ -295,6 +296,7 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
               <ProjectFilesNavItem />
               <ProjectCustomizeNavItem />
               <ProjectChatGptConnectNavItem projectId={projectId} />
+              <SidebarBalanceWarning accountId={accountId} />
               <SidebarUpgradeButton accountId={accountId} />
             </SidebarMenu>
           </SidebarGroup>

--- a/apps/web/src/lib/error-handler.tsx
+++ b/apps/web/src/lib/error-handler.tsx
@@ -7,7 +7,6 @@ import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import * as Sentry from '@sentry/nextjs';
 import { BillingError, formatBillingErrorForUI, isBillingError } from '@kortix/sdk/react';
 
-const TOP_UP_LABEL = 'Top up';
 const MANAGE_PLAN_LABEL = 'Manage plan';
 
 export interface ApiError extends Error {
@@ -217,44 +216,27 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
   const v2AccountId: string | undefined =
     typeof v2Detail?.account_id === 'string' ? v2Detail.account_id : undefined;
 
-  // No active plan → pitch the one central Team plan subscribe modal.
+  // Billing block on a user action (session start, send, purchase). One modal
+  // handles both shapes and picks the right view off the 402's billing_model +
+  // has_subscription: a genuinely-free/no-plan account gets the subscribe pitch;
+  // a paying Team account whose wallet ran dry gets the top-up view (packages +
+  // custom amount + auto-top-up) — never the wrong "you're on Free" pitch.
   if (
     isBillingEnabled() &&
     v2Status === 402 &&
-    (v2Code === 'subscription_required' || v2Code === 'no_account')
+    (v2Code === 'subscription_required' ||
+      v2Code === 'no_account' ||
+      v2Code === 'insufficient_credits')
   ) {
     useUpgradeDialogStore.getState().openUpgradeDialog({
       reason: v2Code,
       message: v2Message ?? '',
       balance: v2Balance,
       accountId: v2AccountId,
+      billingModel: typeof v2Detail?.billing_model === 'string' ? v2Detail.billing_model : undefined,
+      hasSubscription:
+        typeof v2Detail?.has_subscription === 'boolean' ? v2Detail.has_subscription : undefined,
     });
-    return;
-  }
-
-  // Already on a plan but the wallet ran dry. Don't pitch a subscription —
-  // they're subscribed and can still CRUD sessions; only metered LLM/compute
-  // spend is affected. Nudge a top-up instead of blocking with the modal.
-  if (isBillingEnabled() && v2Status === 402 && v2Code === 'insufficient_credits') {
-    const title = 'Out of credits';
-    if (!shouldSuppressDuplicate(v2Status, title)) {
-      warningToast(title, {
-        description: 'Top up your wallet or turn on auto-refill to keep using compute and LLMs.',
-        duration: 6000,
-        button: (
-          <Button
-            size="sm"
-            onClick={() =>
-              useAccountSettingsModalStore
-                .getState()
-                .openAccountSettings({ tab: 'billing', highlight: 'credits' })
-            }
-          >
-            {TOP_UP_LABEL}
-          </Button>
-        ),
-      });
-    }
     return;
   }
 

--- a/apps/web/src/stores/upgrade-dialog-store.ts
+++ b/apps/web/src/stores/upgrade-dialog-store.ts
@@ -13,11 +13,18 @@ interface UpgradeDialogState {
    *  action to this, so a non-billing member sees the *team's* gated CTA, not
    *  their own personal account's. */
   accountId?: string;
+  /** From the 402 body — lets the modal show the top-up view (Team/paid wallet
+   *  drained) vs the Free-plan pitch (no plan) without guessing off tier_key,
+   *  which stays 'free' for per-seat accounts. */
+  billingModel?: string;
+  hasSubscription?: boolean;
   openUpgradeDialog: (opts: {
     reason?: UpgradeReason;
     message?: string;
     balance?: number;
     accountId?: string;
+    billingModel?: string;
+    hasSubscription?: boolean;
   }) => void;
   closeUpgradeDialog: () => void;
 }
@@ -28,6 +35,8 @@ export const useUpgradeDialogStore = create<UpgradeDialogState>((set) => ({
   message: '',
   balance: 0,
   accountId: undefined,
+  billingModel: undefined,
+  hasSubscription: undefined,
   openUpgradeDialog: (opts) =>
     set({
       isOpen: true,
@@ -35,6 +44,8 @@ export const useUpgradeDialogStore = create<UpgradeDialogState>((set) => ({
       message: opts.message ?? '',
       balance: opts.balance ?? 0,
       accountId: opts.accountId,
+      billingModel: opts.billingModel,
+      hasSubscription: opts.hasSubscription,
     }),
   closeUpgradeDialog: () => set({ isOpen: false }),
 }));


### PR DESCRIPTION
## Problem
A per-seat **Team** account with a drained/negative wallet (e.g. `-$9,237.85`) that can't start a session was shown the **"Subscribe to Kortix / Free = Current plan"** modal — because the billing gate returned a 402 `code: "subscription_required"`, the same code a brand-new Free account gets. Every downstream surface then treated the paying Team account as Free.

## Root cause
`billing-gate.ts` returned `subscription_required` for a per-seat account with a low balance and no *active* sub. Downstream: `global-upgrade-modal.tsx` hardcoded `planBadges = { free: 'Current plan' }`; the inline card routed that code to "Upgrade plan"; the sidebar keyed off the legacy `tier_key` (stays `'free'` for per-seat). The correct "top up" flow only fired on `insufficient_credits`, which per-seat accounts never received.

## Changes
**Backend**
- 402 body now carries `billing_model` + `has_subscription` so the client can tell "no plan → subscribe" from "Team wallet drained → top up".
- A per-seat account with a **lapsed** subscription + drained wallet now returns `insufficient_credits` (top up); only a never-subscribed per-seat account gets `subscription_required`. Unit tests added (incl. the enriched body + the exact negative-balance case).

**Frontend**
- Credit-aware blocking modal: Team/subscribed/out-of-credits → "Out of credits" view with wallet balance, one-time top-up (**presets + custom amount**), and **auto-top-up config underneath**, instead of the Free-plan pitch. "Current plan" badge computed from account state.
- New shared `CreditTopupSection` (presets + custom amount) reused by the Billing tab and the modal. Backend already prices arbitrary amounts via a dynamic Stripe line item — custom top-ups work end to end.
- `error-handler` routes `insufficient_credits` to the same modal so a session-start block explains itself.
- New `SidebarBalanceWarning` in the project sidebar footer for out-of-credits / low balance; the upgrade button no longer shows for per-seat accounts.

## Testing
- `tsc --noEmit` clean (api + web) on all touched files; Biome clean on new files.
- Added `billing-gate` unit tests for the per-seat lapsed-sub path and enriched 402 body.
- Not yet exercised against a live negative-balance account in the running app.

Key rule going forward: never trust `tier`/`tier_key` to identify a Team account — it stays `'free'` for per-seat. Use `billing_model === 'per_seat'`.
