### PR TITLE
fix(web): filter Firefox Paper Shaders null-context getSupportedExtensions noise

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -1353,25 +1353,43 @@ test('does NOT suppress a frameless empty-message event (origin unverifiable)', 
 
 // Reproduces the Paper Shaders (`@paper-design/shaders-react`) null-WebGL2-
 // context crash class — the `getSupportedExtensions` null-context path that
-// ESCAPES `<ShaderSafe>` (Better Stack pattern `34127fa4…`, call site `new b2`
-// in chunk `app:///_next/static/chunks/c76173f0.5ba9c330afa9d53d.js`, prod, 2
-// occurrences, last 2026-07-12 15:23:38 UTC) plus its known sibling
-// `getAttribLocation`. Paper Shaders' shader-mount `useEffect`/rAF callback
-// calls a WebGL2 context method on a context that became `null` after a
-// context-loss / GPU-blacklist event; the throw is in an async callback so the
-// React error boundary can't catch it → global error → Sentry → Better Stack.
-// The matcher is the leak-path backstop; the `supportsWebGL2()` probe in
-// `shader-safe.tsx` is the primary guard.
+// ESCAPES `<ShaderSafe>` (Better Stack pattern `34127fa4…` + Firefox-wording
+// recurrence `dfcb336b…`, call site `new b2` in chunk
+// `app:///_next/static/chunks/c76173f0.5ba9c330afa9d53d.js`, prod) plus its
+// known sibling `getAttribLocation`. Paper Shaders' shader-mount
+// `useEffect`/rAF callback calls a WebGL2 context method on a context that
+// became `null` after a context-loss / GPU-blacklist event; the throw is in an
+// async callback so the React error boundary can't catch it → global error →
+// Sentry → Better Stack. The matcher is the leak-path backstop; the
+// `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard. Covers
+// all three JS engine wordings for the same bug: V8
+// (`Cannot read properties of null (reading '<m>')`), old JSC
+// (`Cannot read property '<m>' of null`), and SpiderMonkey/Firefox
+// (`can't access property "<m>"<…>` — the recurrence that shipped through
+// PR #4544's V8/JSC-only filter).
 const PAPER_SHADER_NULL_CONTEXT_MESSAGES = [
+  // V8 (Chrome/Edge).
   "Cannot read properties of null (reading 'getSupportedExtensions')",
   "TypeError: Cannot read properties of null (reading 'getSupportedExtensions')",
   "Unhandled promise rejection: TypeError: Cannot read properties of null (reading 'getSupportedExtensions')",
   "Cannot read properties of null (reading 'getAttribLocation')",
   "TypeError: Cannot read properties of null (reading 'getAttribLocation')",
   "Unhandled promise rejection: Cannot read properties of null (reading 'getAttribLocation')",
-  // Old JSC form.
+  // Old JSC (old Safari/iOS).
   "Cannot read property 'getSupportedExtensions' of null",
   "Cannot read property 'getAttribLocation' of null",
+  // SpiderMonkey (Firefox) — the exact recurrence wording from Better Stack
+  // pattern `dfcb336b…`: `can't access property "getSupportedExtensions",
+  // this.gl is null`. The `, this.gl is null` suffix is library-specific, so
+  // the matcher anchors on the stable method-name prefix only.
+  'can\'t access property "getSupportedExtensions", this.gl is null',
+  'TypeError: can\'t access property "getSupportedExtensions", this.gl is null',
+  'Unhandled promise rejection: TypeError: can\'t access property "getSupportedExtensions", this.gl is null',
+  'can\'t access property "getAttribLocation", this.gl is null',
+  'TypeError: can\'t access property "getAttribLocation", this.gl is null',
+  // SpiderMonkey alternate phrasing seen on some Firefox versions
+  // (` of <var>. <var> is null` form) — the prefix anchor still matches.
+  'can\'t access property "getSupportedExtensions" of this.gl. this.gl is null',
 ]
 
 test('classifies every Paper Shaders null-context WebGL message as noise', () => {
@@ -1432,6 +1450,9 @@ test('does NOT suppress a real app TypeError with a different null-property name
   // `Cannot read properties of null (reading '<name>')` SHAPE but with an
   // app-property name, not a WebGL2 API method — it must keep reporting so a
   // real null-deref regression is never hidden by the Paper Shaders guard.
+  // Covers all three engine wordings (V8, old JSC, SpiderMonkey/Firefox) so
+  // the Firefox `can't access property "<m>"` pattern can't swallow a real
+  // first-party SpiderMonkey null-deref with a non-WebGL property name.
   const realAppNullDerefMessages = [
     "Cannot read properties of null (reading 'map')",
     "Cannot read properties of null (reading 'length')",
@@ -1440,6 +1461,12 @@ test('does NOT suppress a real app TypeError with a different null-property name
     // A non-null access on getSupportedExtensions (e.g. typo'd as a property
     // of a non-null object) is a different message and must keep reporting.
     "Cannot read properties of undefined (reading 'getSupportedExtensions')",
+    // Real first-party SpiderMonkey/Firefox null-deref with an app property
+    // name — same SHAPE as the Paper Shaders Firefox message but NOT a WebGL2
+    // API method, so it must keep reporting.
+    'can\'t access property "map", this.foo is null',
+    'TypeError: can\'t access property "id", this.bar is null',
+    'can\'t access property "length" of this.baz. this.baz is null',
   ]
   for (const message of realAppNullDerefMessages) {
     assert.equal(

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -178,33 +178,53 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
 // On GPUs/browsers without working WebGL2 (context loss, blacklisted driver,
 // stripped WebView, headless renderer), Paper Shaders' shader-mount
 // `useEffect`/rAF callback reaches a WebGL2 context that has become `null` and
-// calls a WebGL API method on it → `TypeError: Cannot read properties of null
-// (reading '<method>')`. The throw happens INSIDE an async callback, so it
-// ESCAPES the `<ShaderSafe>` React error boundary (which only catches
-// render-phase throws via `getDerivedStateFromError`) → global error → Sentry
-// → Better Stack. The two observed null-context method names are:
-//   - `getSupportedExtensions`  (Better Stack pattern `34127fa4…`, call site
-//                                `new b2` in chunk `c76173f0.…`, prod, 2 occ.)
+// calls a WebGL API method on it → `TypeError`. The throw happens INSIDE an
+// async callback, so it ESCAPES the `<ShaderSafe>` React error boundary (which
+// only catches render-phase throws via `getDerivedStateFromError`) → global
+// error → Sentry → Better Stack. The two observed null-context method names are:
+//   - `getSupportedExtensions`  (Better Stack pattern `34127fa4…` / recurrence
+//                                `dfcb336b…`, call site `new b2` in chunk
+//                                `c76173f0.…`, prod)
 //   - `getAttribLocation`       (the known sibling already documented in
 //                                `shader-safe.tsx`'s probe rationale).
 // These are WebGL2 context method names — they are NEVER called from
 // first-party app code (only from Paper Shaders' library internals), so the
 // message wording alone is specific enough to safely classify as noise without
 // a chunk-frame anchor (unlike the generic old-browser SyntaxError class). The
-// matching is exact-substring on the canonical `Cannot read properties of null
-// (reading '<method>')` (V8) and `Cannot read property '<method>' of null`
-// (old JSC) forms, with `TypeError: ` / `Error: ` /
-// `Unhandled promise rejection: ` wrappers stripped so all capture paths
-// (window.onerror, onunhandledrejection, Sentry exception) classify
-// consistently. `shouldIgnore*` here is the leak-path backstop for the throws
-// that still escape `<ShaderSafe>` after a context-loss event; the
-// `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard that
-// degrades to the fallback BEFORE the throw.
+// matching covers all three JS engine wordings for the same null-context bug:
+//   - V8 (Chrome/Edge):          `Cannot read properties of null (reading '<m>')`
+//   - old JSC (old Safari/iOS):  `Cannot read property '<m>' of null`
+//   - SpiderMonkey (Firefox):    `can't access property "<m>"<…>` (the variable
+//                                name after the method is library-specific, so
+//                                the pattern anchors on the stable method-name
+//                                prefix only — see the recurrence
+//                                `dfcb336b…` which shipped through PR #4544's
+//                                V8/JSC-only filter as
+//                                `can't access property "getSupportedExtensions",
+//                                this.gl is null`).
+// `TypeError: ` / `Error: ` / `Unhandled promise rejection: ` wrappers are
+// stripped before matching so all capture paths (window.onerror,
+// onunhandledrejection, Sentry exception) classify consistently.
+// `shouldIgnore*` here is the leak-path backstop for the throws that still
+// escape `<ShaderSafe>` after a context-loss event; the `supportsWebGL2()`
+// probe in `shader-safe.tsx` is the primary guard that degrades to the fallback
+// BEFORE the throw. The probe is engine-agnostic (it just calls
+// `ctx.getSupportedExtensions()`, which throws or returns null on any engine),
+// so it already prevents the throw at mount for Firefox — the filter backstop
+// catches the residual async-context-loss throws that bypass the one-shot probe.
 const PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS = [
+  // V8 (Chrome/Edge).
   "Cannot read properties of null (reading 'getSupportedExtensions')",
   "Cannot read properties of null (reading 'getAttribLocation')",
+  // Old JSC (old Safari/iOS).
   "Cannot read property 'getSupportedExtensions' of null",
   "Cannot read property 'getAttribLocation' of null",
+  // SpiderMonkey (Firefox) — anchors on the stable method-name prefix; the
+  // `, this.gl is null` variable suffix is library-specific and dropped so the
+  // pattern matches regardless of which Paper Shaders internal variable holds
+  // the null context.
+  'can\'t access property "getSupportedExtensions"',
+  'can\'t access property "getAttribLocation"',
 ] as const;
 
 // Old-browser / stripped-down-WebView minified-chunk parse failures. When a
@@ -843,9 +863,12 @@ export function isOldWebkitRegexNoiseMessage(message: unknown): boolean {
  * React error boundary, and reach Sentry/Better Stack as global errors. The
  * method names are WebGL2 API — never called from first-party app code — so the
  * message wording alone is specific enough; no chunk-frame anchor is needed.
- * Never page Better Stack for this class. See
- * `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full rationale and the
- * `supportsWebGL2()` probe in `shader-safe.tsx` for the primary guard.
+ * Matches all three JS engine wordings: V8
+ * (`Cannot read properties of null (reading '<m>')`), old JSC
+ * (`Cannot read property '<m>' of null`), and SpiderMonkey/Firefox
+ * (`can't access property "<m>"<…>`). Never page Better Stack for this class.
+ * See `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full rationale and
+ * the `supportsWebGL2()` probe in `shader-safe.tsx` for the primary guard.
  */
 export function isPaperShaderNullContextNoise(message: unknown): boolean {
   const stripped = stripErrorWrappers(normalizeString(message));


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies.

Proof: the exact production Firefox message that was paging Better Stack is now classified as noise and suppressed through all three gates (runtime `window.onerror`, Sentry `beforeSend` with a chunk frame, Sentry `beforeSend` frameless):

```
exact prod message: can't access property "getSupportedExtensions", this.gl is null
isPaperShaderNullContextNoise:        true
shouldIgnoreBrowserRuntimeNoise:      true
shouldIgnoreSentryBrowserNoise (chunk frame): true
shouldIgnoreSentryBrowserNoise (frameless):   true
```

`bun test apps/web/src/lib/browser-error-noise.test.mts` → **110 pass / 0 fail** (was 106; the existing Paper Shaders tests now also cover the Firefox wording variants and the expanded negative guard).

## Why

PR #4544 guarded the Paper Shaders (`@paper-design/shaders-react`) null-WebGL-context crash class, but its message-wording backstop only listed the V8 (Chrome/Edge) and old-JSC (old Safari/iOS) wordings. The same null-context bug on SpiderMonkey (Firefox) throws a different message — `can't access property "getSupportedExtensions", this.gl is null` — which is NOT matched by the V8/JSC patterns, so the Firefox recurrence slipped through to Better Stack (pattern `dfcb336b…`, Kortix Frontend prod, 2 occurrences, last 2026-07-21 02:41:44 UTC).

## What changed

`apps/web/src/lib/browser-error-noise.ts` — extend `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` with the SpiderMonkey/Firefox wording for both known null-context method names (`getSupportedExtensions` + `getAttribLocation`), anchoring on the stable method-name prefix only (the `, this.gl is null` variable suffix is library-specific). These are WebGL2 context API methods never called from first-party app code, so the message wording alone stays specific enough to safely classify as noise WITHOUT a chunk-frame anchor — a real first-party Firefox null-deref uses a different property name (e.g. `can't access property "map", this.foo is null`) and keeps reporting. Docstrings updated to document all three engine wordings.

No change to the `supportsWebGL2()` probe in `shader-safe.tsx` — it is already engine-agnostic (it just calls `ctx.getSupportedExtensions()`, which throws or returns null on any JS engine), so it already prevents the throw at mount on Firefox. This recurrence is the async-context-loss residual path that the wording backstop is meant to catch; the filter simply missed the Firefox variant.

## Verification

- `bun test apps/web/src/lib/browser-error-noise.test.mts` → **110 pass / 0 fail**
- Standalone reproducer against the live module: the exact prod Firefox message `can't access property "getSupportedExtensions", this.gl is null` is now `true` through `isPaperShaderNullContextNoise`, `shouldIgnoreBrowserRuntimeNoise`, and `shouldIgnoreSentryBrowserNoise` (with and without a chunk frame).
- `bun build apps/web/src/lib/browser-error-noise.ts` → bundles clean (no type/syntax errors).
- `biome check` on the two changed files: no new findings introduced (the 3 pre-existing findings are present on `origin/main` unchanged by this PR — verified by stashing the diff and re-running biome on the unmodified files).

### Regression tests added (in the existing Paper Shaders noise block)

Positive (must suppress) — covers all three engine wordings:
- V8: `Cannot read properties of null (reading 'getSupportedExtensions'|'getAttribLocation')` (+ `TypeError: `/`Unhandled promise rejection: ` wrappers)
- old JSC: `Cannot read property 'getSupportedExtensions'|'getAttribLocation' of null`
- SpiderMonkey/Firefox: `can't access property "getSupportedExtensions", this.gl is null` (+ `TypeError: `/`Unhandled promise rejection: ` wrappers), `getAttribLocation` variant, and the alternate `of <var>. <var> is null` phrasing
- Each variant asserted through all three gates (classify, runtime `window.onerror`, Sentry `beforeSend` with + without a chunk frame)

Negative guards (must keep reporting):
- V8 real-app null-derefs with non-WebGL property names (`map`, `length`, `id`)
- old-JSC real-app null-deref (`foo`)
- `undefined` (not `null`) accessor on a WebGL method name — different message, keeps reporting
- **SpiderMonkey/Firefox real-app null-derefs** with non-WebGL property names (`can't access property "map"`, `"id"`, `"length"`) — proves the Firefox pattern can't swallow a genuine first-party SpiderMonkey regression

## Risk / rollback

Conservative, additive-only change to a noise-filter pattern list. No behavior change for any message that was previously reported; only the Firefox-wording Paper Shaders null-context class is newly suppressed. Rollback = revert the two-file diff.

## Better Stack incident

- Error URL: https://errors.betterstack.com/team/t502678/errors/dfcb336bc5215f3955a00c33b2c136df33cecbc8f238cba006cf685410b07c2d?s=2346967
- Pattern hash: `dfcb336bc5215f3955a00c33b2c136df33cecbc8f238cba006cf685410b07c2d`
- Type/message: `TypeError: can't access property "getSupportedExtensions", this.gl is null`
- Application: Kortix Frontend (prod), application_id 2346967
- Call site: `app:///_next/static/chunks/c76173f0.5ba9c330afa9d53d.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno`, function `b2`
- Inventory: 2 occurrences / 0 users / last_seen 2026-07-21 02:41:44 UTC / unresolved

## Confirmation

After merge + promote, the `dfcb336b…` Better Stack error should drop to zero new occurrences: the Firefox-wording backstop now suppresses the residual async-context-loss throws that escape `<ShaderSafe>` on Firefox, and Better Stack auto-resolves the error once it's no longer seen.
