### PR TITLE
fix(web): suppress Sentry 10.x 'No error message' placeholder chunk noise (BS 141dcca3/19ee7c2f)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -1294,26 +1294,51 @@ test('does NOT suppress a real error that has a message', () => {
   )
 })
 
-test('does NOT suppress an empty-message error whose frame resolves to a source line', () => {
+test('does NOT suppress an empty-message error whose frame resolves to a first-party source path', () => {
   // `throw new Error()` / `Promise.reject(new Error())` in first-party code:
-  // sourcemaps resolve the frame to a real file:line → actionable, keep it.
+  // Sentry's sourcemap resolution rewrites the frame filename to a real
+  // `apps/web/src/…` source path → actionable, keep it. A named minified
+  // function in a RAW chunk path (e.g. `handleClick` in `chunks/21544-…js`)
+  // is NOT a resolved source path — the minifier may preserve names, and the
+  // lineno is the chunk's single-line bundle line, not a source line — so it
+  // does not by itself make an empty-message event actionable. The load-
+  // bearing signal is the sourcemap-resolved first-party source path.
   assert.equal(
     isEmptyMessageUnresolvedBrowserChunkNoise({
       message: '',
-      frames: [{ filename: CHUNK_21544, function: 'handleClick', lineno: 42 }],
+      frames: [{ filename: 'app:///apps/web/src/features/auth/use-auth.ts', function: 'handleClick', lineno: 42 }],
     }),
     false,
   )
-  // Mixed: one unresolved chunk frame + one resolved frame → keep.
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: '',
+      frames: [{ filename: 'apps/web/src/lib/foo.ts', function: '?', lineno: 0 }],
+    }),
+    false,
+  )
+  // Mixed: one unresolved chunk frame + one sourcemap-resolved first-party
+  // frame → keep (our own code is the throw site → actionable).
   assert.equal(
     isEmptyMessageUnresolvedBrowserChunkNoise({
       message: '',
       frames: [
         { filename: CHUNK_21544, function: '?', lineno: 0 },
-        { filename: 'app:///_next/static/chunks/76904-c52ab52c4900447c.js', function: 'render', lineno: 17 },
+        { filename: 'app:///apps/web/src/components/markdown/unified-markdown.tsx', function: 'render', lineno: 17 },
       ],
     }),
     false,
+  )
+  // A named minified function in a RAW chunk path (no `apps/web/src/…`
+  // resolution) is NOT actionable on its own — the minifier may preserve
+  // names and the lineno is the bundle line, so an empty-message event with
+  // only such frames is still the unactionable noise class.
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: '',
+      frames: [{ filename: CHUNK_21544, function: 'handleClick', lineno: 42 }],
+    }),
+    true,
   )
 })
 
@@ -1347,6 +1372,204 @@ test('does NOT suppress a frameless empty-message event (origin unverifiable)', 
   )
   assert.equal(
     isEmptyMessageUnresolvedBrowserChunkNoise({ message: '' }),
+    false,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Post-0.10.13 recurrence (Sentry SDK 10.x `"No error message"` placeholder),
+// chunk 21544 again. Better Stack patterns:
+//   141dcca3d176082360456b74d56119f59acdf806ae0f3ab1e7e7bd8218bca8d2
+//     (8 occ / 0 users / last 2026-07-20 21:21:55 UTC, dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2)
+//   19ee7c2fe89a3f3302fb8209574d906a7b7c8f04d55746e9b443e9bf078c64ca
+//     (6 occ / 0 users / last 2026-07-21 17:03:18 UTC, dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno)
+// Siblings in the same now-3d window:
+//   8e9a9022fabcc836b3e8f561a722430ff452536daae6b893d2ce3eab406849a9
+//     (1 occ / 0 users / last 2026-07-21 01:58:52 UTC)
+//   c9457126bec6355b76b4fef6c62f4e212f1271b3f3df6cb80c97a60b8e473305
+//     (1 occ / 0 users / last 2026-07-20 06:23:46 UTC)
+// All are `auto.browser.global_handlers.onerror` captures whose thrown value
+// had no `.message`, so Sentry SDK 10.x (`@sentry/nextjs@10.63.0`) writes the
+// literal placeholder string `"No error message"` into
+// `exception.values[0].value` (the pre-10.x SDK left it empty/undefined,
+// which is the shape #4540's original matcher handled). The frames are mostly
+// NAMED minified functions (`iX`/`iu`/`ib`/`ik`/`oq`/`o_`/`l9`/`l`/
+// `MessagePort.x`) with real linenos — NOT the all-`?`-and-`lineno:0` shape
+// #4540 required — but NONE resolve to a first-party `apps/web/src/…` source
+// path (sourcemap resolution produced no first-party source location), so
+// there is still no actionable call site. The last frame (chunk 21544, `?`
+// function, lineno 1) is the call-site frame Better Stack surfaces.
+// ---------------------------------------------------------------------------
+
+// Exact frames of the 2026-07-20 21:21:55 UTC occurrence of pattern
+// `141dcca3…` (release `22e12080d2b37642aa92a839da6b37f30fc21b9d`,
+// dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2, request `/auth?redirect=…`, Chrome 150).
+const CHUNK_66499_BEo2 = 'app:///_next/static/chunks/66499-30a0e6805d268c02.js?dpl=dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2'
+const CHUNK_5CCD075D_BEo2 = 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js?dpl=dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2'
+const CHUNK_GLOBAL_ERROR_BEo2 = 'app:///_next/static/chunks/app/global-error-ae7fee8d93446b5c.js?dpl=dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2'
+const CHUNK_21544_BEo2 = 'app:///_next/static/chunks/21544-ac9e889808bbe0af.js?dpl=dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2'
+
+const PATTERN_141DCCA3_FRAMES = [
+  { filename: CHUNK_66499_BEo2, function: 'MessagePort.x', lineno: 3 },
+  { filename: CHUNK_5CCD075D_BEo2, function: 'iX', lineno: 1 },
+  { filename: CHUNK_5CCD075D_BEo2, function: 'iu', lineno: 1 },
+  { filename: CHUNK_5CCD075D_BEo2, function: 'ib', lineno: 1 },
+  { filename: CHUNK_5CCD075D_BEo2, function: '?', lineno: 1 },
+  { filename: CHUNK_5CCD075D_BEo2, function: 'ik', lineno: 1 },
+  { filename: CHUNK_5CCD075D_BEo2, function: 'oq', lineno: 1 },
+  { filename: CHUNK_5CCD075D_BEo2, function: 'o_', lineno: 1 },
+  { filename: CHUNK_5CCD075D_BEo2, function: 'l9', lineno: 1 },
+  { filename: CHUNK_GLOBAL_ERROR_BEo2, function: 'l', lineno: 1 },
+  { filename: CHUNK_21544_BEo2, function: '?', lineno: 1 },
+]
+
+test('suppresses the post-0.10.13 Sentry 10.x "No error message" placeholder event (pattern 141dcca3…)', () => {
+  // The placeholder `"No error message"` is Sentry SDK 10.x's "no message"
+  // marker (a window.onerror capture whose thrown value had no `.message`),
+  // NOT a real app error message — so it must be treated as empty by the
+  // noise matcher. The frames are mostly NAMED minified functions with real
+  // linenos but NONE resolve to a first-party `apps/web/src/…` source path,
+  // so there is no actionable call site. The event is the same unactionable
+  // noise class #4540 suppressed for the pre-10.x empty-value shape.
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: 'No error message',
+      frames: PATTERN_141DCCA3_FRAMES,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/auth?redirect=%2Fprojects%2F038ce7cd-c239-47eb-9ad3-83f2e5345aa6%2Fthread%2F75e8053d-85f9-4f18-a6e5-2ac4f0600e44' },
+      exception: {
+        values: [
+          {
+            value: 'No error message',
+            stacktrace: { frames: PATTERN_141DCCA3_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the sibling post-0.10.13 pattern 19ee7c2f… (different dpl, same shape)', () => {
+  // Same shape as 141dcca3… but a different Vercel deployment id
+  // (dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno) and release
+  // (470fe6f3c88460212c3b187f6f86fb4ad456c4d6). Confirms the matcher is not
+  // anchored on one specific dpl/release hash.
+  const dpl = 'dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno'
+  const frames = PATTERN_141DCCA3_FRAMES.map((f) => ({
+    ...f,
+    filename: f.filename.replace(/dpl=dpl_[A-Za-z0-9]+/, `dpl=${dpl}`),
+  }))
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: 'No error message',
+      frames,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/auth?redirect=%2Fprojects%2F59aa5850-de1d-4e56-81fb-34d532146f01%2Fthread%2F2149cad0-e79e-4d38-84ac-273364cfb434' },
+      exception: {
+        values: [
+          {
+            value: 'No error message',
+            stacktrace: { frames },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a "No error message" event whose frame resolves to a first-party source path', () => {
+  // A real `throw new Error()` / `Promise.reject(new Error())` in first-party
+  // code de-minifies (via uploaded sourcemaps) to an `apps/web/src/…` frame —
+  // even when the Sentry 10.x placeholder `"No error message"` is the value.
+  // The first-party source resolution is the load-bearing actionable signal.
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: 'No error message',
+      frames: [
+        ...PATTERN_141DCCA3_FRAMES.slice(0, 5),
+        { filename: 'app:///apps/web/src/components/markdown/unified-markdown.tsx', function: 'highlightAsync', lineno: 142 },
+      ],
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: 'No error message',
+            stacktrace: {
+              frames: [
+                { filename: 'apps/web/src/lib/foo.ts' },
+              ],
+            },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a "No error message" event with a non-browser-bundle frame', () => {
+  // A wallet-extension `app:///inpage.js` frame at the top of the stack (the
+  // EVM-wallet onGlobalMessage → runIfPresent → run → our chunk chain, e.g.
+  // sibling pattern d371a1e2…) is a DIFFERENT noise class with a real
+  // extension-origin anchor. Leave it reporting so a future triage can
+  // address it specifically; the assigned class (141dcca3…/19ee7c2f…) is
+  // pure browser-bundle frames.
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: 'No error message',
+      frames: [
+        { filename: 'app:///inpage.js', function: 'onGlobalMessage', lineno: 59 },
+        { filename: 'app:///inpage.js', function: 'runIfPresent', lineno: 59 },
+        { filename: 'app:///inpage.js', function: 'run', lineno: 59 },
+        ...PATTERN_141DCCA3_FRAMES,
+      ],
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress an event with a real, non-placeholder message even from chunk 21544', () => {
+  // The placeholder is the EXACT literal `"No error message"`; any other
+  // non-empty message is a real app error and keeps reporting, even if its
+  // frames are the same chunk-21544 shape.
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: 'No error message: chunk 21544 failed to load',
+      frames: PATTERN_141DCCA3_FRAMES,
+    }),
+    false,
+  )
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({
+      message: 'No error',
+      frames: PATTERN_141DCCA3_FRAMES,
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a frameless "No error message" event (origin unverifiable)', () => {
+  // No frames at all → can't confirm it's our browser chunk; keep reporting.
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({ message: 'No error message', frames: [] }),
+    false,
+  )
+  assert.equal(
+    isEmptyMessageUnresolvedBrowserChunkNoise({ message: 'No error message' }),
     false,
   )
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -613,33 +613,79 @@ export function isStorageSecurityErrorNoise(input: {
 //
 // A real first-party regression — `throw new Error()` /
 // `Promise.reject(new Error())` in our own code — keeps reporting: its frames
-// resolve (via uploaded sourcemaps) to a real source file:line, so the
-// "any resolved frame" negative guard preserves the event. Only events with
-// NEITHER a message NOR a single resolvable frame are dropped.
-function isFrameUnresolved(frame: {
-  filename?: unknown;
-  function?: unknown;
-  lineno?: unknown;
-}): boolean {
-  const fn = normalizeString(frame.function).trim();
-  const lineno = typeof frame.lineno === 'number' ? frame.lineno : 0;
-  return (fn === '' || fn === '?') && lineno <= 0;
+// resolve (via uploaded sourcemaps) to a real `apps/web/src/…` source file
+// (Sentry uploads sourcemaps and rewrites the frame filename), so the
+// "any resolved first-party source frame" negative guard preserves the event.
+// Only events with NEITHER a real message NOR a single resolvable first-party
+// source frame are dropped.
+//
+// --- 2026-07-21 extension (post-0.10.13 recurrence, chunk 21544 again) ---
+// Sentry SDK 10.x (`@sentry/nextjs@10.63.0`) changed how it serializes an
+// onerror capture whose thrown value has NO `.message`: instead of leaving
+// `exception.values[0].value` empty/undefined, it now sets the literal
+// placeholder string `"No error message"` there (which is also what Better
+// Stack displays). The new production patterns
+//   `141dcca3d176082360456b74d56119f59acdf806ae0f3ab1e7e7bd8218bca8d2`
+//   (8 occ / 0 users / last 2026-07-20 21:21:55 UTC, dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2)
+//   `19ee7c2fe89a3f3302fb8209574d906a7b7c8f04d55746e9b443e9bf078c64ca`
+//   (6 occ / 0 users / last 2026-07-21 17:03:18 UTC, dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno)
+// are the SAME noise class as #4540 (window.onerror, value-less throw, call
+// site the chunk-21544 frame) but the original matcher missed them for TWO
+// reasons:
+//   1. The placeholder `"No error message"` is a NON-EMPTY string, so the
+//      `message.trim() !== ''` negative guard #1 bailed immediately.
+//   2. The SDK 10.x frames are mostly NAMED minified functions (`iX`, `iu`,
+//      `ib`, `ik`, `oq`, `o_`, `l9`, `l`, `MessagePort.x`) with real linenos,
+//      so the "every frame unresolved" negative guard #3 also bailed. The
+//      LAST frame (chunk 21544, `?` function, lineno 1) is still unresolved —
+//      that's the call-site frame Better Stack surfaces — but the older
+//      "all frames must be unresolved" rule no longer holds.
+// The fix treats the literal `"No error message"` placeholder as equivalent
+// to an empty message (it is Sentry's own "no message" marker, never a real
+// app error message), and relaxes the frame guard from "every frame
+// unresolved" to "no frame resolves to a first-party `apps/web/src/…` source
+// path". The first-party-source negative guard is the load-bearing one: a
+// real `throw new Error(...)` / `Promise.reject(new Error(...))` in our own
+// code de-minifies to `apps/web/src/…` and is preserved; only events whose
+// frames are ALL raw minified chunk paths (sourcemap resolution produced no
+// first-party source path) keep being dropped. A non-browser-bundle frame
+// (extension / injected / cross-origin) still keeps the event reporting.
+//
+// The literal placeholder Sentry SDK 10.x writes into
+// `exception.values[0].value` when a `window.onerror` capture has no
+// `error.message` (the thrown value was a non-Error, or an Error with an
+// empty message). It is the SDK's own "no message" marker — never a real
+// app error message — so it is equivalent to an empty message for the noise
+// matcher. Better Stack displays this exact string as the error's "Message".
+const SENTRY_NO_ERROR_MESSAGE_PLACEHOLDER = 'No error message';
+
+function isMessageEmptyOrPlaceholder(message: unknown): boolean {
+  const normalized = normalizeString(message).trim();
+  return (
+    normalized === ''
+    || normalized === SENTRY_NO_ERROR_MESSAGE_PLACEHOLDER
+  );
 }
 
 /**
  * Whether a Sentry event is the unactionable "No error message" + unresolved
  * minified-chunk-frame class from our browser bundle — empty exception value
- * AND every frame an unresolved (`?` function, no line) `_next/static/chunks`
- * frame. Real errors (non-empty message, or any resolvable frame, or any
- * non-browser-bundle frame) are never matched. See
+ * (or the Sentry 10.x `"No error message"` placeholder string) AND every
+ * frame a raw `_next/static/chunks` minified-chunk frame with NO resolved
+ * first-party `apps/web/src/…` source path. Real errors (a real non-placeholder
+ * message, or any frame that sourcemap-resolved to a first-party source path,
+ * or any non-browser-bundle frame) are never matched. See
  * `isEmptyMessageUnresolvedBrowserChunkNoise` for the full rationale.
  */
 export function isEmptyMessageUnresolvedBrowserChunkNoise(input: {
   message?: unknown;
   frames?: Array<{ filename?: unknown; function?: unknown; lineno?: unknown }>;
 }): boolean {
-  // Negative guard #1: a real, actionable message always reports.
-  if (normalizeString(input.message).trim() !== '') {
+  // Negative guard #1: a real, actionable message always reports. The Sentry
+  // 10.x `"No error message"` placeholder is the SDK's own "no message"
+  // marker (a window.onerror capture whose thrown value had no `.message`),
+  // NOT a real app error message, so it is treated as empty here.
+  if (!isMessageEmptyOrPlaceholder(input.message)) {
     return false;
   }
   const frames = input.frames ?? [];
@@ -653,9 +699,16 @@ export function isEmptyMessageUnresolvedBrowserChunkNoise(input: {
   if (!frames.every((frame) => isBrowserBundleSource(frame.filename))) {
     return false;
   }
-  // Negative guard #3: any resolvable frame (real source line via sourcemap,
-  // or a named function) → an actionable error; keep it.
-  if (frames.some((frame) => !isFrameUnresolved(frame))) {
+  // Negative guard #3: any frame that sourcemap-resolved to a real first-party
+  // `apps/web/src/…` source path → an actionable error with a fixable call
+  // site; keep it. A real `throw new Error(...)` / `Promise.reject(new Error())`
+  // in our own code de-minifies to `apps/web/src/…`, so it is preserved.
+  // (Sentry SDK 10.x frames may be named minified functions like `iX`/`oq`
+  // with real linenos but STILL not resolve to a first-party source path —
+  // those are raw chunk frames with no actionable source location, so they
+  // do not trip this guard. The load-bearing signal is the resolved
+  // first-party source path, not the function-name/lineno resolution.)
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies.

Proof the filter works: running the affected test suite locally.

```
$ cd apps/web && node --experimental-strip-types --test src/lib/browser-error-noise.test.mts
# tests 116
# pass 116
# fail 0
```

The two assigned production patterns (with their exact ClickHouse frame chains) are now classified as noise:

```
isEmptyMessageUnresolvedBrowserChunkNoise({
  message: 'No error message',
  frames: <exact 11-frame chain from pattern 141dcca3…>,
}) === true   ✅   (was false before this PR)

shouldIgnoreSentryBrowserNoise({ exception: { values: [{ value: 'No error message', stacktrace: { frames: <…> } }] } }) === true   ✅
```

Negative guards keep real errors reporting:
```
isEmptyMessageUnresolvedBrowserChunkNoise({ message: 'No error message',
  frames: [...chunkFrames, { filename: 'app:///apps/web/src/components/markdown/unified-markdown.tsx', ... }] }) === false   ✅ (first-party source → actionable)
isEmptyMessageUnresolvedBrowserChunkNoise({ message: 'No error message',
  frames: [{ filename: 'app:///inpage.js', ... }, ...chunkFrames] }) === false   ✅ (wallet-extension frame → different class, keep)
isEmptyMessageUnresolvedBrowserChunkNoise({ message: 'No error message', frames: [] }) === false   ✅ (frameless → keep)
isEmptyMessageUnresolvedBrowserChunkNoise({ message: 'Something went wrong', frames: <chunkFrames> }) === false   ✅ (real message → keep)
```

## Why

Post-0.10.13 production recurrence of the "No error message" + chunk-21544 noise class that PR #4540 suppressed. Sentry SDK 10.x (`@sentry/nextjs@10.63.0`, shipped in 0.10.13) changed how it serializes a `window.onerror` capture whose thrown value has no `.message`: instead of leaving `exception.values[0].value` empty/undefined (the shape #4540's matcher handled), it now writes the literal placeholder string `"No error message"` there. The two assigned Better Stack patterns — `141dcca3…` (8 occ / 0 users / last 2026-07-20 21:21:55 UTC) and `19ee7c2f…` (6 occ / 0 users / last 2026-07-21 17:03:18 UTC) — are the SAME unactionable noise class #4540 already recognized (value-less throw, call site the chunk-21544 frame, 0 identified users, window.onerror mechanism), but #4540's matcher missed them for two reasons:

1. The placeholder `"No error message"` is a NON-EMPTY string, so the `message.trim() !== ''` negative guard #1 bailed immediately.
2. The SDK 10.x frames are mostly NAMED minified functions (`iX`, `iu`, `ib`, `ik`, `oq`, `o_`, `l9`, `l`, `MessagePort.x`) with real linenos, so the "every frame unresolved" negative guard #3 also bailed. Only the LAST frame (chunk 21544, `?` function, lineno 1 — the call-site frame Better Stack surfaces) is unresolved.

**Better Stack error ids / URLs:**
- `141dcca3d176082360456b74d56119f59acdf806ae0f3ab1e7e7bd8218bca8d2` — https://errors.betterstack.com/team/t502678/errors/141dcca3d176082360456b74d56119f59acdf806ae0f3ab1e7e7bd8218bca8d2?s=2346967
- `19ee7c2fe89a3f3302fb8209574d906a7b7c8f04d55746e9b443e9bf078c64ca` — https://errors.betterstack.com/team/t502678/errors/19ee7c2fe89a3f3302fb8209574d906a7b7c8f04d55746e9b443e9bf078c64ca?s=2346967

## What changed

`apps/web/src/lib/browser-error-noise.ts` — extends `isEmptyMessageUnresolvedBrowserChunkNoise`:

- Treat the literal `"No error message"` placeholder as equivalent to an empty message (it is Sentry SDK 10.x's own "no message" marker for a `window.onerror` capture whose thrown value had no `.message`, never a real app error message). New `SENTRY_NO_ERROR_MESSAGE_PLACEHOLDER` constant + `isMessageEmptyOrPlaceholder` helper.
- Relax the frame guard from "every frame unresolved (`?` function / `lineno <= 0`)" to "no frame resolves to a first-party `apps/web/src/…` source path". The first-party-source negative guard is the load-bearing actionable signal: a real `throw new Error(...)` / `Promise.reject(new Error(...))` in our own code de-minifies (via uploaded sourcemaps) to `apps/web/src/…` and is preserved; only events whose frames are ALL raw minified chunk paths (sourcemap resolution produced no first-party source path) keep being dropped. A named minified function in a raw chunk path (e.g. `handleClick` in `chunks/21544-…js`) is NOT a resolved source path — the minifier may preserve names and the lineno is the bundle line, not a source line — so it does not by itself make an empty-message event actionable.
- Negative guard #2 (any non-browser-bundle frame → keep) is unchanged, so extension / injected / cross-origin frames still keep the event reporting.
- Removed the now-unused `isFrameUnresolved` helper (the relaxed guard no longer needs it).

`apps/web/src/lib/browser-error-noise.test.mts` — regression tests:

- Updated the existing "resolves to a source line" test to reflect the corrected semantics (sourcemap-resolved `apps/web/src/…` is the actionable signal, not a named minified function in a raw chunk). Added a case confirming a named-minified-function raw-chunk empty-message event IS suppressed (the relaxed guard).
- Added 5 new tests for the post-0.10.13 Sentry 10.x placeholder class:
  - `suppresses the post-0.10.13 Sentry 10.x "No error message" placeholder event (pattern 141dcca3…)` — exact 11-frame production chain.
  - `suppresses the sibling post-0.10.13 pattern 19ee7c2f… (different dpl, same shape)` — confirms the matcher is not anchored on one dpl/release.
  - `does NOT suppress a "No error message" event whose frame resolves to a first-party source path` — negative guard for real first-party throws.
  - `does NOT suppress a "No error message" event with a non-browser-bundle frame` — the `app:///inpage.js` wallet-extension sibling (`d371a1e2…`) is deliberately left reporting (different noise class with a real extension-origin anchor).
  - `does NOT suppress an event with a real, non-placeholder message even from chunk 21544` — the placeholder is the EXACT literal; any other non-empty message keeps reporting.
  - `does NOT suppress a frameless "No error message" event (origin unverifiable)` — no frames → keep reporting.

## Verification

- **Unit tests**: `cd apps/web && node --experimental-strip-types --test src/lib/browser-error-noise.test.mts` → **116/116 pass** (was 110; +6 new tests). 0 fail, 0 cancelled.
- **Typecheck**: `tsc --noEmit --strict --skipLibCheck src/lib/browser-error-noise.ts` → clean (exit 0). The test file has the same 12 pre-existing structural-type looseness warnings it had before this PR (extra `function`/`lineno` props on the loosely-typed `shouldIgnoreSentryBrowserNoise` event input); no new type errors introduced.
- **Evidence**: pulled the raw Sentry payloads from Better Stack ClickHouse (`s3Cluster(primary, t502678_kortix_frontend_s3)`) for both assigned patterns + the 3 sibling "No error message" patterns in the now-3d window. All 5 confirmed as `auto.browser.global_handlers.onerror`, value `"No error message"`, frames in our `_next/static/chunks/` browser bundle with no `apps/web/src/…` resolution. Pattern `d371a1e2…` (with `app:///inpage.js` frames) is correctly left reporting by the unchanged negative guard #2.

## Coverage

| Better Stack pattern | Occ | Users | Last seen | Covered by this PR? |
| --- | --- | --- | --- | --- |
| `141dcca3d176082360456b74d56119f59acdf806ae0f3ab1e7e7bd8218bca8d2` | 8 | 0 | 2026-07-20 21:21:55 UTC | ✅ (assigned) |
| `19ee7c2fe89a3f3302fb8209574d906a7b7c8f04d55746e9b443e9bf078c64ca` | 6 | 0 | 2026-07-21 17:03:18 UTC | ✅ (assigned) |
| `8e9a9022fabcc836b3e8f561a722430ff452536daae6b893d2ce3eab406849a9` | 1 | 0 | 2026-07-21 01:58:52 UTC | ✅ (same class, pure browser-bundle frames) |
| `c9457126bec6355b76b4fef6c62f4e212f1271b3f3df6cb80c97a60b8e473305` | 1 | 0 | 2026-07-20 06:23:46 UTC | ✅ (same class, pure browser-bundle frames) |
| `d371a1e22aa7195b0e66bebbfda7cb2595f9724882d39abc26d3772636fa0608` | 2 | 0 | 2026-07-19 18:37:13 UTC | ❌ (deliberately — `app:///inpage.js` wallet-extension origin; different noise class for a future triage) |

## Risk / rollback

Low. The change only drops Sentry events that (a) carry no real message (empty OR the exact `"No error message"` placeholder), (b) have ALL frames inside our own `_next/static/chunks/` browser bundle, and (c) have NO sourcemap-resolved first-party `apps/web/src/…` frame. A real first-party regression — `throw new Error(...)` / `Promise.reject(new Error(...))` — de-minifies to `apps/web/src/…` and is preserved by the negative guard. A non-browser-bundle frame (extension / injected / cross-origin) also keeps the event reporting. Revert is a single-commit `git revert`.

## Confirm

After this PR merges + promotes past `0.10.13`, the five Better Stack groups above (except `d371a1e2…`) should drop to zero new occurrences and auto-resolve. `d371a1e2…` is expected to keep reporting until a follow-up triage addresses the wallet-extension-origin class specifically.
