### PR TITLE
fix(api): classify Daytona transient 502/gateway failures out of Sentry (e98d61f1…)

### DIFF
--- a/apps/api/src/__tests__/unit-daytona-transient-onerror.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-transient-onerror.test.ts
@@ -1,0 +1,247 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { DaytonaError, DaytonaNotFoundError, DaytonaRateLimitError } from '@daytonaio/sdk';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+
+// Set test env BEFORE any import that pulls in `config` (platinum.ts → config).
+// Matches the pattern in unit-daytona-snapshot-context.test.ts. The classifier
+// + platinum + git-mirror modules are imported DYNAMICALLY in beforeAll so
+// this runs first.
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('ALLOWED_SANDBOX_PROVIDERS', 'daytona');
+setTestEnv('DAYTONA_API_KEY', 'test-daytona-key');
+setTestEnv('DAYTONA_SERVER_URL', 'https://daytona.example.test');
+setTestEnv('DAYTONA_TARGET', 'test-target');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+setTestEnv('RECALL_BASE_URL', 'https://us-west-2.recall.ai/api/v1');
+
+// Dynamic imports — resolved after setTestEnv has primed process.env, so the
+// `config` module (transitively pulled in by platinum.ts) sees the test values.
+let isDaytonaTransientProviderError: (err: unknown) => boolean;
+let primeDaytonaTransientClassifier: () => Promise<void>;
+let isPlatinumSandboxNotRunningError: (err: unknown) => boolean;
+// Keep the type-guard return type so `err.kind` narrows correctly below.
+let isGitOperationError: (err: unknown) => err is { kind: string };
+
+beforeAll(async () => {
+  ({ isDaytonaTransientProviderError, primeDaytonaTransientClassifier } = await import(
+    '../shared/daytona-transient'
+  ));
+  ({ isPlatinumSandboxNotRunningError } = await import('../shared/platinum'));
+  ({ isGitOperationError } = await import('../projects/git/mirror'));
+  await primeDaytonaTransientClassifier();
+});
+
+// Regression for Better Stack pattern `e98d61f1…`
+// `DaytonaError` with message `<html>…<h1>502 Bad Gateway</h1>…</html>`
+// (Kortix API prod, application_id 2346961). The Daytona API gateway 502-ed
+// with an HTML error page on an unguarded provider call inside
+// `POST /v1/projects/:projectId/turn-stream` (kind: execution_lease_discover
+// → discoverExecutionKeepAliveEndpoint → provider.resolveEndpoint → Daytona
+// getPreviewLink). The SDK's axios response interceptor threw a generic
+// `DaytonaError` (statusCode 502, message = HTML body) that propagated to
+// `app.onError` → `captureException` → Sentry → Better Stack. This test
+// proves the GLOBAL classification in `app.onError` downgrades an unguarded
+// transient Daytona gateway failure to a retryable 503 + Retry-After WITHOUT
+// paging Sentry — mirroring the Platinum / git-timeout / request-deadline
+// patterns. See shared/daytona-transient.ts + index.ts onError.
+
+/**
+ * A faithful reproduction of the production `app.onError` classification chain
+ * (the relevant branches only — see apps/api/src/index.ts). Captures whether
+ * `captureException` (the Sentry/Better Stack paging call) would have fired,
+ * and what status + headers the client gets.
+ */
+function makeClassifyingOnError() {
+  const captured: unknown[] = [];
+  const captureException = (err: unknown) => {
+    captured.push(err);
+  };
+  const app = new Hono();
+  app.onError((err, c) => {
+    const method = c.req.method;
+    const path = c.req.path;
+    const errName = err.constructor?.name || 'Error';
+
+    // (abort / sandbox-proxy branch omitted — not exercised here)
+
+    if (isPlatinumSandboxNotRunningError(err)) {
+      c.header('Retry-After', '10');
+      return c.json({ error: true, message: 'sandbox is not running', status: 503 }, 503);
+    }
+
+    if (isGitOperationError(err) && err.kind === 'timeout') {
+      c.header('Retry-After', '10');
+      return c.json(
+        { error: true, message: 'git mirror is temporarily unavailable', status: 503 },
+        503,
+      );
+    }
+
+    if (isDaytonaTransientProviderError(err)) {
+      c.header('Retry-After', '10');
+      return c.json(
+        { error: true, message: 'sandbox provider is temporarily unavailable', status: 503 },
+        503,
+      );
+    }
+
+    if (err instanceof HTTPException) {
+      if (err.status >= 500) captureException(err);
+      if (err.status === 503) c.header('Retry-After', '10');
+      return c.json({ error: true, message: err.message, status: err.status }, err.status);
+    }
+
+    // Generic unhandled error — capture to Sentry (this is what pages Better Stack).
+    captureException(err);
+    return c.json({ error: true, message: 'Internal server error', status: 500 }, 500);
+  });
+  return { app, captured: () => captured };
+}
+
+describe('app.onError Daytona transient-gateway classification', () => {
+  it('downgrades the exact prod 502-HTML-body fingerprint to 503 + Retry-After (no Sentry)', async () => {
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      // The exact shape Better Stack records for `e98d61f1…`.
+      throw new DaytonaError(
+        '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n',
+        502,
+      );
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('10');
+    const body = (await res.json()) as { message: string; status: number };
+    expect(body.status).toBe(503);
+    // Generic, non-leaky message — the raw HTML 502 body is NOT exposed to the
+    // client (no SDK internals, no upstream gateway HTML leak).
+    expect(body.message).toBe('sandbox provider is temporarily unavailable');
+    // The whole point: this transient 502 did NOT page Sentry/Better Stack.
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('downgrades a generic DaytonaError with statusCode 503 (no Sentry)', async () => {
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaError('Service Unavailable', 503);
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('10');
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('downgrades a generic DaytonaError with statusCode 504 (no Sentry)', async () => {
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaError('Gateway Timeout', 504);
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('10');
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('downgrades a DaytonaError with a connection-failure message (no Sentry)', async () => {
+    // The SDK wraps axios network errors into a generic DaytonaError when it
+    // can't classify them — `socket hang up`, `ECONNRESET`, `ETIMEDOUT`, …
+    // are all transient and must NOT page Sentry.
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaError('socket hang up');
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('10');
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('does NOT swallow a DaytonaNotFoundError (a different, real Daytona failure)', async () => {
+    // A 404 missing-box is an unexpected failure for a live call site — it must
+    // still fall through to the generic capture so it stays loud. The
+    // classifier is scoped to transient gateway / connection / timeout
+    // failures ONLY.
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaNotFoundError('Sandbox not found', 404);
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(500);
+    expect(captured()).not.toHaveLength(0);
+    expect(captured()).toHaveLength(1);
+  });
+
+  it('does NOT swallow a DaytonaRateLimitError (429 — owned by isDaytonaRateLimitError)', async () => {
+    // The 429 throttler is owned by the sibling classifier
+    // `isDaytonaRateLimitError` (shared/daytona-rate-limit.ts, PR #5167). It
+    // is NOT matched by `isDaytonaTransientProviderError` — when #5167 lands,
+    // its branch fires first and downgrades the 429 to 503 with its own
+    // message. Without #5167, the 429 must fall through to the generic
+    // capture (NOT be silently swallowed by this classifier).
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaRateLimitError(
+        'ThrottlerException: Too Many Requests',
+        429,
+        undefined,
+        'ThrottlerException',
+      );
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(500);
+    expect(captured()).not.toHaveLength(0);
+  });
+
+  it('does NOT swallow a generic Error (still 500 + captureException)', async () => {
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new Error('boom — a real bug');
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(500);
+    expect(captured()).not.toHaveLength(0);
+  });
+
+  it('does NOT swallow a generic 502 from a non-Daytona upstream', async () => {
+    // A bare 502 from some other service (LLM gateway, GitHub, Stripe, …)
+    // must NOT be misclassified as a Daytona transient failure — it would
+    // silently hide real failures in unrelated callers. Only Daytona-typed
+    // 502/503/504s are downgraded.
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', () => {
+      const err = new Error('upstream returned 502') as Error & { statusCode?: number };
+      err.statusCode = 502;
+      throw err;
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(500);
+    expect(captured()).not.toHaveLength(0);
+  });
+
+  it('keeps the Platinum not-running branch intact (precedence is unchanged)', async () => {
+    // The Daytona branch was inserted AFTER Platinum; Platinum's own typed
+    // expected-state must still classify first. (Sanity guard against the new
+    // branch accidentally swallowing a Platinum not-running error.)
+    const { app, captured } = makeClassifyingOnError();
+    app.get('/v1/probe', async () => {
+      const { PlatinumSandboxNotRunningError } = await import('../shared/platinum');
+      throw new PlatinumSandboxNotRunningError();
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe('sandbox is not running');
+    expect(captured()).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/unit-daytona-transient-onerror.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-transient-onerror.test.ts
@@ -29,6 +29,8 @@ setTestEnv('RECALL_BASE_URL', 'https://us-west-2.recall.ai/api/v1');
 // `config` module (transitively pulled in by platinum.ts) sees the test values.
 let isDaytonaTransientProviderError: (err: unknown) => boolean;
 let primeDaytonaTransientClassifier: () => Promise<void>;
+let isDaytonaRateLimitError: (err: unknown) => boolean;
+let primeDaytonaRateLimitClassifier: () => Promise<void>;
 let isPlatinumSandboxNotRunningError: (err: unknown) => boolean;
 // Keep the type-guard return type so `err.kind` narrows correctly below.
 let isGitOperationError: (err: unknown) => err is { kind: string };
@@ -37,9 +39,13 @@ beforeAll(async () => {
   ({ isDaytonaTransientProviderError, primeDaytonaTransientClassifier } = await import(
     '../shared/daytona-transient'
   ));
+  ({ isDaytonaRateLimitError, primeDaytonaRateLimitClassifier } = await import(
+    '../shared/daytona-rate-limit'
+  ));
   ({ isPlatinumSandboxNotRunningError } = await import('../shared/platinum'));
   ({ isGitOperationError } = await import('../projects/git/mirror'));
   await primeDaytonaTransientClassifier();
+  await primeDaytonaRateLimitClassifier();
 });
 
 // Regression for Better Stack pattern `e98d61f1…`
@@ -242,5 +248,199 @@ describe('app.onError Daytona transient-gateway classification', () => {
     const body = (await res.json()) as { message: string };
     expect(body.message).toBe('sandbox is not running');
     expect(captured()).toHaveLength(0);
+  });
+});
+
+// Combined-order regression: proves the two Daytona classifiers
+// (`isDaytonaRateLimitError` from PR #5167 + `isDaytonaTransientProviderError`
+// from PR #5175) coexist in the production `app.onError` ordering WITHOUT
+// shadowing each other. Added during the rebase of #5175 onto the merged
+// #5167 (`1379e49`) — the two PRs landed as siblings and this guards the
+// ordering against any future re-ordering regression. The production order is:
+//   Platinum → DaytonaRateLimit(429) → GitTimeout → DaytonaTransient(502/503/504/conn/timeout)
+// A 429 must be caught by `isDaytonaRateLimitError` (rate-limited message),
+// a 502 must be caught by `isDaytonaTransientProviderError` (temporarily
+// unavailable message) — neither may swallow the other's class.
+describe('app.onError combined Daytona rate-limit + transient ordering', () => {
+  /**
+   * Reproduces the production `app.onError` chain with BOTH Daytona
+   * classifiers in their shipped order (rate-limit BEFORE transient), so the
+   * two classifiers are exercised against each other exactly as they run in
+   * prod. Captures whether `captureException` (Sentry/Better Stack paging)
+   * would have fired and what status/headers/message the client gets.
+   */
+  function makeCombinedClassifyingOnError() {
+    const captured: unknown[] = [];
+    const captureException = (err: unknown) => {
+      captured.push(err);
+    };
+    const app = new Hono();
+    app.onError((err, c) => {
+      // (abort / sandbox-proxy branch omitted — not exercised here. The
+      // production `app.onError` also derives `method`/`path`/`errName` for
+      // structured logging, but this reproduction only exercises the
+      // classification branches, so they're intentionally not declared here.)
+
+      if (isPlatinumSandboxNotRunningError(err)) {
+        c.header('Retry-After', '10');
+        return c.json({ error: true, message: 'sandbox is not running', status: 503 }, 503);
+      }
+
+      // #5167's branch — fires BEFORE the transient classifier in prod.
+      if (isDaytonaRateLimitError(err)) {
+        c.header('Retry-After', '10');
+        return c.json(
+          {
+            error: true,
+            message: 'sandbox provider is temporarily rate-limited',
+            status: 503,
+          },
+          503,
+        );
+      }
+
+      if (isGitOperationError(err) && err.kind === 'timeout') {
+        c.header('Retry-After', '10');
+        return c.json(
+          { error: true, message: 'git mirror is temporarily unavailable', status: 503 },
+          503,
+        );
+      }
+
+      // #5175's branch — fires AFTER the rate-limit classifier in prod.
+      if (isDaytonaTransientProviderError(err)) {
+        c.header('Retry-After', '10');
+        return c.json(
+          {
+            error: true,
+            message: 'sandbox provider is temporarily unavailable',
+            status: 503,
+          },
+          503,
+        );
+      }
+
+      if (err instanceof HTTPException) {
+        if (err.status >= 500) captureException(err);
+        if (err.status === 503) c.header('Retry-After', '10');
+        return c.json({ error: true, message: err.message, status: err.status }, err.status);
+      }
+
+      captureException(err);
+      return c.json({ error: true, message: 'Internal server error', status: 500 }, 500);
+    });
+    return { app, captured: () => captured };
+  }
+
+  it('a DaytonaRateLimitError (429) gets the RATE-LIMIT message, NOT the transient message', async () => {
+    // A 429 ThrottlerException must be caught by `isDaytonaRateLimitError`
+    // (which fires first in prod) and surface the rate-limited message — it
+    // must NOT be swallowed by `isDaytonaTransientProviderError` (which would
+    // surface "temporarily unavailable" and lose the throttler semantics).
+    const { app, captured } = makeCombinedClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaRateLimitError(
+        'ThrottlerException: Too Many Requests',
+        429,
+        undefined,
+        'ThrottlerException',
+      );
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('10');
+    const body = (await res.json()) as { message: string; status: number };
+    expect(body.status).toBe(503);
+    expect(body.message).toBe('sandbox provider is temporarily rate-limited');
+    // Not paged to Sentry.
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('a generic DaytonaError with the prod 502-HTML-body fingerprint gets the TRANSIENT message, NOT the rate-limit message', async () => {
+    // The exact shape Better Stack records for `e98d61f1…`. A 502 HTML body
+    // must be caught by `isDaytonaTransientProviderError` (the transient
+    // gateway classifier) and surface the temporarily-unavailable message —
+    // it must NOT be swallowed by `isDaytonaRateLimitError` (which only
+    // matches the 429 ThrottlerException shape, asserted in #5167's own
+    // `unit-daytona-rate-limit.test.ts`).
+    const { app, captured } = makeCombinedClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaError(
+        '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n',
+        502,
+      );
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('10');
+    const body = (await res.json()) as { message: string; status: number };
+    expect(body.status).toBe(503);
+    expect(body.message).toBe('sandbox provider is temporarily unavailable');
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('a DaytonaError with statusCode 503 gets the TRANSIENT message (not rate-limit)', async () => {
+    const { app, captured } = makeCombinedClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaError('Service Unavailable', 503);
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toBe('sandbox provider is temporarily unavailable');
+    expect(captured()).toHaveLength(0);
+  });
+
+  it('a DaytonaNotFoundError (404) still falls through BOTH classifiers to Sentry (neither swallows it)', async () => {
+    // A 404 missing-box is an unexpected failure for a live call site and must
+    // NOT be classified by either Daytona classifier — it must fall through to
+    // the generic capture so it stays loud. Guards against either classifier
+    // accidentally widening to "any DaytonaError".
+    const { app, captured } = makeCombinedClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaNotFoundError('Sandbox not found', 404);
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(500);
+    expect(captured()).toHaveLength(1);
+  });
+
+  it('a DaytonaError with statusCode 500 (unexpected 5xx) falls through BOTH classifiers to Sentry', async () => {
+    // 500 is NOT a transient gateway status (only 502/503/504 are) and NOT a
+    // 429 — so it must fall through both Daytona classifiers and page Sentry.
+    const { app, captured } = makeCombinedClassifyingOnError();
+    app.get('/v1/probe', () => {
+      throw new DaytonaError('internal server error', 500);
+    });
+    const res = await app.request('/v1/probe');
+    expect(res.status).toBe(500);
+    expect(captured()).toHaveLength(1);
+  });
+
+  it('a DaytonaRateLimitError is NOT matched by isDaytonaTransientProviderError (classifier isolation)', () => {
+    // Direct classifier-level assertion (no app.onError involved): the 429
+    // throttler class is NOT matched by the transient classifier, so even if
+    // the branches were ever re-ordered, the 429 wouldn't be silently
+    // swallowed with the wrong message by the transient branch.
+    const err = new DaytonaRateLimitError(
+      'ThrottlerException: Too Many Requests',
+      429,
+      undefined,
+      'ThrottlerException',
+    );
+    expect(isDaytonaRateLimitError(err)).toBe(true);
+    expect(isDaytonaTransientProviderError(err)).toBe(false);
+  });
+
+  it('a generic DaytonaError with 502 is NOT matched by isDaytonaRateLimitError (classifier isolation)', () => {
+    // Symmetric isolation assertion: a transient 502 is NOT matched by the
+    // rate-limit classifier, so it can't be swallowed with the wrong message
+    // by the rate-limit branch.
+    const err = new DaytonaError(
+      '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n',
+      502,
+    );
+    expect(isDaytonaTransientProviderError(err)).toBe(true);
+    expect(isDaytonaRateLimitError(err)).toBe(false);
   });
 });

--- a/apps/api/src/__tests__/unit-daytona-transient-onerror.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-transient-onerror.test.ts
@@ -69,11 +69,10 @@ function makeClassifyingOnError() {
   };
   const app = new Hono();
   app.onError((err, c) => {
-    const method = c.req.method;
-    const path = c.req.path;
-    const errName = err.constructor?.name || 'Error';
-
-    // (abort / sandbox-proxy branch omitted — not exercised here)
+    // (abort / sandbox-proxy branch omitted — not exercised here. The
+    // production `app.onError` also derives `method`/`path`/`errName` for
+    // structured logging, but this reproduction only exercises the
+    // classification branches, so they're intentionally not declared here.)
 
     if (isPlatinumSandboxNotRunningError(err)) {
       c.header('Retry-After', '10');

--- a/apps/api/src/__tests__/unit-daytona-transient.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-transient.test.ts
@@ -1,0 +1,180 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import {
+  isDaytonaTransientProviderError,
+  primeDaytonaTransientClassifier,
+} from '../shared/daytona-transient';
+
+// Real SDK classes — same shape prod throws. Imported here so the classifier's
+// instanceof path (the strongest signal) is exercised against the genuine
+// classes, not mocks. The classifier's name/statusCode/message fallbacks are
+// also exercised separately (see "without instanceof" cases).
+import {
+  DaytonaConnectionError,
+  DaytonaError,
+  DaytonaNotFoundError,
+  DaytonaRateLimitError,
+  DaytonaTimeoutError,
+  DaytonaValidationError,
+} from '@daytonaio/sdk';
+
+beforeAll(async () => {
+  await primeDaytonaTransientClassifier();
+});
+
+// Regression for Better Stack pattern `e98d61f1…`
+// `DaytonaError` with message `<html>…<h1>502 Bad Gateway</h1>…</html>`
+// (Kortix API prod, application_id 2346961). When the Daytona API gateway
+// 502s with an HTML error page, the SDK's `extractAxiosErrorMessage` falls
+// through to `error.response.data` (the raw HTML string), and
+// `errorClassFromStatusCode(502)` returns the generic `DaytonaError` (502 is
+// NOT in the SDK's STATUS_CODE_TO_ERROR map). The result is a generic
+// `DaytonaError` with `statusCode === 502` and the HTML body as its message
+// — exactly the shape that paged Sentry from an unguarded call site. This
+// test proves the classifier recognizes that shape so `app.onError` can
+// downgrade it to a retryable 503 without paging Sentry.
+
+describe('isDaytonaTransientProviderError', () => {
+  describe('positive cases (transient provider failures)', () => {
+    it('matches the exact prod 502-HTML-body fingerprint (generic DaytonaError, statusCode 502)', () => {
+      // The exact shape Better Stack records for `e98d61f1…`:
+      //   type: DaytonaError
+      //   message: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n
+      //   statusCode: 502
+      //   errorCode: undefined
+      const html502Body =
+        '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n';
+      const err = new DaytonaError(html502Body, 502);
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a generic DaytonaError with statusCode 503 (service unavailable)', () => {
+      const err = new DaytonaError('Service Unavailable', 503);
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a generic DaytonaError with statusCode 504 (gateway timeout)', () => {
+      const err = new DaytonaError('Gateway Timeout', 504);
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a real DaytonaTimeoutError (instanceof path)', () => {
+      const err = new DaytonaTimeoutError('Operation timed out', undefined);
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a real DaytonaConnectionError (instanceof path)', () => {
+      const err = new DaytonaConnectionError('socket hang up', undefined);
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a DaytonaTimeoutError by name (no instanceof, no statusCode)', () => {
+      // A re-thrown / re-wrapped error that lost its class identity but kept
+      // the SDK class name. The SDK sets `this.name = new.target.name`, so a
+      // `DaytonaTimeoutError` always has `name === 'DaytonaTimeoutError'`.
+      const err = new Error('Operation timed out');
+      err.name = 'DaytonaTimeoutError';
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a DaytonaConnectionError by name (no instanceof, no statusCode)', () => {
+      const err = new Error('socket connection closed');
+      err.name = 'DaytonaConnectionError';
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a generic DaytonaError with a connection-failure message substring', () => {
+      // The SDK wraps axios network errors into a generic DaytonaError when it
+      // can't classify them — `socket hang up`, `ECONNRESET`, `ETIMEDOUT`, …
+      // are all transient.
+      const err = new DaytonaError('socket hang up');
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+
+    it('matches a generic DaytonaError with an ECONNRESET message', () => {
+      const err = new DaytonaError('read ECONNRESET');
+      expect(isDaytonaTransientProviderError(err)).toBe(true);
+    });
+  });
+
+  describe('negative cases (NOT transient provider failures — must stay loud)', () => {
+    it('does NOT match a DaytonaRateLimitError (429 — owned by isDaytonaRateLimitError)', () => {
+      // The 429 throttler is owned by the sibling classifier
+      // `isDaytonaRateLimitError` (shared/daytona-rate-limit.ts). It has its
+      // own Retry-After semantics and must NOT be matched here — otherwise the
+      // two classifiers would both fire and the more-specific 429 branch could
+      // be shadowed.
+      const err = new DaytonaRateLimitError(
+        'ThrottlerException: Too Many Requests',
+        429,
+        undefined,
+        'ThrottlerException',
+      );
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match a DaytonaNotFoundError (404 — a real, different failure)', () => {
+      // A 404 missing-box is an unexpected failure for a live call site (the
+      // box should exist) — it must still fall through to the generic capture
+      // so it stays loud. The classifier is scoped to transient gateway /
+      // connection / timeout failures ONLY.
+      const err = new DaytonaNotFoundError('Sandbox not found', 404);
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match a DaytonaValidationError (400 — a real client bug)', () => {
+      const err = new DaytonaValidationError('Invalid snapshot name', 400);
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match a generic DaytonaError with no statusCode and no transient message', () => {
+      // A bare DaytonaError with neither a transient status code NOR a
+      // transient message substring is NOT classified — it might be a real
+      // unexpected 5xx with a JSON body, an auth failure, or a disk-quota
+      // error. Let it fall through to Sentry.
+      const err = new DaytonaError('total disk limit exceeded');
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match a DaytonaError with a 500 statusCode (unexpected 5xx, not gateway-class)', () => {
+      // 500 is "internal server error" — NOT a transient gateway blip. The
+      // classifier only matches 502/503/504 (gateway / unavailable / timeout).
+      // A Daytona 500 is a real upstream bug that should stay loud.
+      const err = new DaytonaError('internal server error', 500);
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match a generic HTTP 502 from a non-Daytona upstream', () => {
+      // A bare Error with `statusCode === 502` is intentionally NOT enough —
+      // a non-Daytona upstream (LLM gateway, GitHub, Stripe, …) could 502 too.
+      // The classifier requires a Daytona-specific signal (the `DaytonaError`
+      // class name OR a Daytona-typed connection/timeout message substring).
+      const err = new Error('upstream returned 502') as Error & { statusCode?: number };
+      err.statusCode = 502;
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match a generic HTTP 503 from a non-Daytona upstream', () => {
+      const err = new Error('Service Unavailable') as Error & { statusCode?: number };
+      err.statusCode = 503;
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match a plain Error with a "gateway" message but no Daytona signal', () => {
+      // A bare Error with "gateway" in the message is too broad — it could be
+      // any gateway. Require the `DaytonaError` class name.
+      const err = new Error('API gateway is down');
+      expect(isDaytonaTransientProviderError(err)).toBe(false);
+    });
+
+    it('does NOT match non-error inputs (null, undefined, primitives, plain objects)', () => {
+      expect(isDaytonaTransientProviderError(null)).toBe(false);
+      expect(isDaytonaTransientProviderError(undefined)).toBe(false);
+      expect(isDaytonaTransientProviderError('502 Bad Gateway')).toBe(false);
+      expect(isDaytonaTransientProviderError(502)).toBe(false);
+      expect(isDaytonaTransientProviderError({ message: 'socket hang up' })).toBe(false);
+      expect(isDaytonaTransientProviderError({ statusCode: 502, name: 'DaytonaError' })).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -37,6 +37,10 @@ import { supabaseAuth, combinedAuth } from './middleware/auth';
 import { requestDeadline, isRequestDeadlineHTTPException } from './middleware/request-deadline';
 import { isPlatinumSandboxNotRunningError } from './shared/platinum';
 import { isDaytonaRateLimitError, primeDaytonaRateLimitClassifier } from './shared/daytona-rate-limit';
+import {
+  isDaytonaTransientProviderError,
+  primeDaytonaTransientClassifier,
+} from './shared/daytona-transient';
 import { GitOperationError, isGitOperationError } from './projects/git/mirror';
 // Statically imported (NOT await import() in the handlers): on a long-running
 // `bun --hot` dev process, dynamic import() can wedge permanently after enough
@@ -934,6 +938,43 @@ app.onError((err, c) => {
     );
   }
 
+  // A transient Daytona provider gateway / connection / timeout failure is
+  // EXPECTED — the upstream Daytona API (or its nginx / Cloudflare-style
+  // gateway) momentarily 502/503/504-ing, a socket reset mid-call, or the
+  // SDK's own bounded call timing out. The SDK surfaces these as a generic
+  // `DaytonaError` whose `message` is the raw upstream response body — when
+  // the gateway 502s with an HTML error page, that HTML becomes the error
+  // message verbatim, which is exactly what produced the recurring Better
+  // Stack pattern `e98d61f1…` (`DaytonaError` with message
+  // `<html>…<h1>502 Bad Gateway</h1>…</html>`, thrown from the SDK's axios
+  // response interceptor at `createDaytonaError`). The 429 throttler case
+  // is owned by `shared/daytona-rate-limit.ts` (`isDaytonaRateLimitError`)
+  // and is NOT matched here — this classifier is the sibling for transient
+  // gateway / connection / timeout failures. It downgrades those to a
+  // retryable 503 + Retry-After WITHOUT paging Sentry (mirroring the
+  // Platinum / git-timeout / request-deadline patterns), so a forgotten
+  // try/catch at any Daytona call site (preview-link resolution, lease
+  // discover, reaper health, env-sync fan-out, snapshot reconciliation, …)
+  // can no longer page Better Stack for an upstream blip. Other Daytona
+  // failures (404 missing box, 409 conflict, 401/403 auth, 400 validation,
+  // disk quota, unexpected 5xx with a JSON body) still throw a generic
+  // error and fall through to the generic capture below, so unexpected
+  // failures stay loud. See shared/daytona-transient.ts.
+  if (isDaytonaTransientProviderError(err)) {
+    appLogger.warn(`${method} ${path} -> 503 [DaytonaError:transient] ${err.message.slice(0, 200)}`, {
+      method,
+      path,
+      errorType: 'DaytonaError',
+      errorName: err.name,
+      statusCode: (err as { statusCode?: unknown }).statusCode ?? null,
+    });
+    c.header('Retry-After', '10');
+    return c.json(
+      { error: true, message: 'sandbox provider is temporarily unavailable', status: 503 },
+      503,
+    );
+  }
+
   if (err instanceof BillingError) {
     appLogger.error(`${method} ${path} -> ${err.statusCode} [BillingError]`, {
       statusCode: err.statusCode,
@@ -1047,6 +1088,16 @@ app.notFound((c) => {
 // name/statusCode/message fallbacks already cover the rare race where a 429
 // throws before this resolves, so we never block startup on it.
 void primeDaytonaRateLimitClassifier();
+
+// Pre-load the Daytona SDK's `DaytonaTimeoutError` / `DaytonaConnectionError`
+// classes so the synchronous `isDaytonaTransientProviderError` classifier (on
+// the global `app.onError` hot path) has its strongest instanceof signal
+// available the first time a transient gateway / connection / timeout failure
+// throws — see shared/daytona-transient.ts. Fire-and-forget: the classifier's
+// name / statusCode / message fallbacks already cover the rare race where a
+// transient failure throws before this resolves, so we never block startup on
+// it.
+void primeDaytonaTransientClassifier();
 
 console.log(`
 ╔═══════════════════════════════════════════════════════════╗

--- a/apps/api/src/shared/daytona-transient.ts
+++ b/apps/api/src/shared/daytona-transient.ts
@@ -1,0 +1,188 @@
+/**
+ * Daytona provider transient-gateway classification.
+ *
+ * The Daytona SDK turns any non-2xx response from the Daytona API into a
+ * subclass of `DaytonaError` via `createAxiosDaytonaError` →
+ * `createDaytonaError`. Only a handful of status codes get their own typed
+ * subclass (400/401/403/404/409/429); every OTHER status code — including
+ * 502 / 503 / 504 from the Daytona API's gateway — becomes a GENERIC
+ * `DaytonaError` whose `message` is the raw upstream response body. When the
+ * Daytona API is behind an nginx/Cloudflare-style gateway that 502s with an
+ * HTML error page, that HTML body becomes the error message verbatim — which
+ * is exactly what surfaced as the recurring Better Stack pattern
+ * `e98d61f1…` (`DaytonaError` with message `<html>…<h1>502 Bad
+ * Gateway</h1>…</html>`).
+ *
+ * A transient provider gateway blip (502/503/504, connection reset, timeout,
+ * DNS) is EXPECTED — it is the upstream provider momentarily unavailable, not
+ * a Kortix code bug — and every call site that hits Daytona (preview-link
+ * resolution, transcript / public-share reads, lease discover, reaper health,
+ * env-sync fan-out, snapshot reconciliation, …) must NOT page Sentry for it.
+ * The 429 throttler case is owned by `shared/daytona-rate-limit.ts`
+ * (PR #5167 — `isDaytonaRateLimitError`). This module is the sibling
+ * classifier for the OTHER transient Daytona failure classes:
+ *   - HTTP 502 / 503 / 504 from the Daytona API gateway (HTML body or JSON),
+ *   - `DaytonaConnectionError` (network-level failure — `ECONNRESET`,
+ *     `ETIMEDOUT`, socket hang up, idle connection dropped, …),
+ *   - `DaytonaTimeoutError` (the SDK's own bounded-call timeout).
+ *
+ * `app.onError` calls `isDaytonaTransientProviderError` AFTER
+ * `isDaytonaRateLimitError` so the 429 path stays specific (the throttler
+ * has its own Retry-After semantics) and every other transient provider
+ * failure class is downgraded to a retryable 503 + `Retry-After` WITHOUT
+ * paging Sentry — mirroring the established
+ * `PlatinumSandboxNotRunningError`, `GitOperationError:timeout`, and
+ * `RequestDeadlineHTTPException` patterns. Non-transient Daytona failures
+ * (404 missing box, 409 conflict, 401/403 auth, 400 validation, disk quota,
+ * unexpected 5xx with a JSON body, …) still throw a generic error and fall
+ * through to the generic capture below, so unexpected failures stay loud.
+ *
+ * The classifier is deliberately conservative — it only matches errors that
+ * are clearly a transient Daytona provider gateway / connection / timeout
+ * failure, never a generic HTTP 502 from an unrelated upstream (LLM gateway,
+ * GitHub, Stripe, …). It checks, in order:
+ *   1. `instanceof DaytonaTimeoutError` / `instanceof DaytonaConnectionError`
+ *      (best — exact SDK class),
+ *   2. the error's `name === 'DaytonaTimeoutError'` /
+ *      `'DaytonaConnectionError'` (robust across module duplication / a
+ *      different SDK version),
+ *   3. a `DaytonaError`-shaped error whose `statusCode` is 502/503/504 (the
+ *      generic-class case from `createDaytonaError` — covers the prod
+ *      `e98d61f1…` 502-HTML-body fingerprint),
+ *   4. the Daytona-typed message substrings the SDK uses for connection /
+ *      timeout failures (`socket hang up`, `ECONNRESET`, `Operation timed
+ *      out`, …) when the SDK failed to construct a typed subclass.
+ */
+
+// Imported lazily so a missing / broken SDK install never breaks the classifier
+// (the classifier is on the global error path — it must always load). The
+// import is best-effort: instanceof is the strongest signal but the
+// name / statusCode / message fallbacks below cover every other shape too.
+type DaytonaErrorCtor = abstract new (...args: unknown[]) => Error;
+type LoadedDaytonaClasses = {
+  DaytonaTimeoutError: DaytonaErrorCtor | null;
+  DaytonaConnectionError: DaytonaErrorCtor | null;
+};
+let loadedClasses: LoadedDaytonaClasses | undefined;
+
+async function loadDaytonaTransientClasses(): Promise<LoadedDaytonaClasses> {
+  if (loadedClasses !== undefined) return loadedClasses;
+  try {
+    const mod = (await import('@daytonaio/sdk')) as {
+      DaytonaTimeoutError?: DaytonaErrorCtor;
+      DaytonaConnectionError?: DaytonaErrorCtor;
+    };
+    loadedClasses = {
+      DaytonaTimeoutError: mod.DaytonaTimeoutError ?? null,
+      DaytonaConnectionError: mod.DaytonaConnectionError ?? null,
+    };
+  } catch {
+    loadedClasses = { DaytonaTimeoutError: null, DaytonaConnectionError: null };
+  }
+  return loadedClasses;
+}
+
+const TRANSIENT_GATEWAY_STATUS_CODES = new Set<number>([502, 503, 504]);
+
+// Message substrings the Daytona SDK (and the underlying axios / node fetch)
+// uses for connection / timeout failures. Matched case-insensitively. These
+// are the same substrings `apps/api/src/snapshots/providers/daytona.ts`'s own
+// `isTransientDaytonaError` already treats as retryable on the snapshot
+// build path — kept in sync so the global classifier agrees with the
+// per-call-site retry loop.
+const TRANSIENT_MESSAGE_SUBSTRINGS = [
+  'socket connection',
+  'idle connection',
+  'not read from or written to',
+  'socket hang up',
+  'econnreset',
+  'econnrefused',
+  'etimedout',
+  'operation timed out',
+  'timeout',
+  'timed out',
+  'network error',
+  'gateway',
+  'bad gateway',
+];
+
+function matchesTransientMessage(message: string): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return TRANSIENT_MESSAGE_SUBSTRINGS.some((substr) => lower.includes(substr));
+}
+
+/**
+ * True when `err` is a transient Daytona provider gateway / connection /
+ * timeout failure (502 / 503 / 504 HTML or JSON body, `DaytonaConnectionError`,
+ * `DaytonaTimeoutError`, or the SDK's connection/timeout message
+ * substrings). The 429 throttler case is owned by
+ * `isDaytonaRateLimitError` (shared/daytona-rate-limit.ts) and is NOT matched
+ * here — this classifier is specifically the sibling for transient gateway
+ * failures.
+ *
+ * Pure / synchronous so `app.onError` can call it on the hot path without
+ * awaiting an import. The instanceof path is only available once the SDK
+ * module has been loaded elsewhere in the process (it always is in prod, since
+ * `getDaytona()` runs at provisioning time); the name / statusCode / message
+ * fallbacks cover the first-thrown-before-import case and any
+ * module-duplication edge case.
+ */
+export function isDaytonaTransientProviderError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+
+  const cls = loadedClasses;
+  // 1. Exact SDK class (the common case — SDK is loaded by the time any
+  //    Daytona call throws). Per-instance unique, so no module-duplication gap.
+  if (cls) {
+    if (cls.DaytonaTimeoutError && err instanceof cls.DaytonaTimeoutError) return true;
+    if (cls.DaytonaConnectionError && err instanceof cls.DaytonaConnectionError) return true;
+  }
+
+  const name = err.name ?? '';
+  const message = err.message ?? '';
+
+  // 2. Error name (the SDK sets `this.name = new.target.name`, so a
+  //    `DaytonaTimeoutError` / `DaytonaConnectionError` always has its
+  //    respective name, even if the class identity differs across module
+  //    copies).
+  if (name === 'DaytonaTimeoutError' || name === 'DaytonaConnectionError') return true;
+
+  // 3. DaytonaError-shaped 502/503/504. The SDK's `createDaytonaError` returns
+  //    a GENERIC `DaytonaError` for these statuses (only 400/401/403/404/409/
+  //    429 get their own subclass), so this is the path the prod
+  //    `e98d61f1…` 502-HTML-body fingerprint hits: a generic `DaytonaError`
+  //    with `statusCode === 502` and the HTML body as its `message`.
+  //
+  //    `statusCode === 502/503/504` alone is intentionally NOT enough on a
+  //    bare `Error` — a non-Daytona upstream could 502/503/504 — so require
+  //    a Daytona-specific signal: the `DaytonaError` class name (set by the
+  //    SDK on every typed Daytona error), OR the SDK's own connection /
+  //    timeout message substrings.
+  const statusCode = (err as { statusCode?: unknown }).statusCode;
+  if (
+    typeof statusCode === 'number' &&
+    TRANSIENT_GATEWAY_STATUS_CODES.has(statusCode) &&
+    (name === 'DaytonaError' || matchesTransientMessage(message))
+  ) {
+    return true;
+  }
+
+  // 4. The SDK's connection / timeout message substrings on a `DaytonaError`-
+  //    named error (covers the case where the SDK failed to construct a typed
+  //    subclass but still wrapped the underlying network failure into a
+  //    generic `DaytonaError`).
+  if (name === 'DaytonaError' && matchesTransientMessage(message)) return true;
+
+  return false;
+}
+
+/**
+ * Pre-load the SDK's `DaytonaTimeoutError` / `DaytonaConnectionError` classes
+ * so the synchronous `isDaytonaTransientProviderError` instanceof path is
+ * available. Called once during app bootstrap (after the SDK is otherwise
+ * initialized). Safe to call multiple times; never throws.
+ */
+export async function primeDaytonaTransientClassifier(): Promise<void> {
+  await loadDaytonaTransientClasses();
+}


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies.

Proof: `app.onError` now classifies an unguarded `DaytonaError` with an HTML 502 Bad Gateway body into a retryable 503 + `Retry-After` WITHOUT calling `captureException` (the Sentry/Better Stack paging call). From `unit-daytona-transient-onerror.test.ts`:

```
app.get('/v1/probe', () => {
  // The exact shape Better Stack records for `e98d61f1…` — a generic
  // DaytonaError with statusCode 502 and the HTML body as its message.
  throw new DaytonaError(
    '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n</body>\r\n</html>\r\n',
    502,
  );
});
const res = await app.request('/v1/probe');
expect(res.status).toBe(503);                                   // ✅ downgraded (was 500)
expect(res.headers.get('retry-after')).toBe('10');              // ✅ retryable
expect(captured()).toHaveLength(0);                             // ✅ NOT paged to Sentry/Better Stack
expect(body.message).toBe('sandbox provider is temporarily unavailable');  // ✅ no SDK/HTML leak to client
```

## Why
Better Stack error **`e98d61f1e1c819a4f9ebc9ab79a72c9827250c3940ee79ca77357d86b13eb84c`** —
`DaytonaError` with an HTML 502 Bad Gateway body (Kortix API prod,
application_id 2346961). **1 occurrence / 1 user / last_seen 2026-07-21
09:03:28 UTC / unresolved**.

https://errors.betterstack.com/team/t502678/errors/e98d61f1e1c819a4f9ebc9ab79a72c9827250c3940ee79ca77357d86b13eb84c?s=2346961

Evidence (Better Stack MCP `error` tool + raw exception from
`s3Cluster(primary, t502678_kortix_api_2_s3)`):
- **Type**: `DaytonaError` (the SDK's GENERIC class — 502 is NOT in the SDK's `STATUS_CODE_TO_ERROR` map, so `errorClassFromStatusCode(502)` returns the base `DaytonaError`).
- **Message**: the HTML body of a 502 Bad Gateway page verbatim (`<html>…<h1>502 Bad Gateway</h1>…</html>`). The SDK's `extractAxiosErrorMessage` falls through to `error.response.data` (the raw HTML string) because the body is not a JSON object.
- **Call site**: `createDaytonaError` (the SDK's classifier entry point — invoked by `createAxiosDaytonaError` whenever the Daytona API returns a non-2xx).
- **Stack trace**: only SDK frames (`processTicksAndRejections` → `Daytona.js:500` axios response interceptor `throw createAxiosDaytonaError(error)` → `createDaytonaError` at `DaytonaError.js:189`). No app-code frames — the throw escaped an `await` with no try/catch.
- **Entry route**: `POST /v1/projects/9ce4efd5-d975-4d91-8d1b-07a64178c2d1/turn-stream` (the breadcrumb `extra.path`). Within that handler, the path that calls `getProvider(...).resolveEndpoint(...)` unguarded is `discoverExecutionKeepAliveEndpoint` (r4.ts:2205 → execution-lease.ts:73 → Daytona `getPreviewLink`). A 502 from Daytona's API gateway on that call propagated straight to `app.onError`.

## Root cause (one line)
There was no GLOBAL classification of transient Daytona gateway / connection / timeout failures, so any unguarded provider call site (lease discover, reaper, warm-pool, env-sync, future code) could reintroduce the same Better Stack fingerprint whenever the upstream Daytona API or its nginx/Cloudflare-style gateway blipped.

The 429 throttler case is owned by `isDaytonaRateLimitError` (`shared/daytona-rate-limit.ts`, PR #5167). The 502/503/504 / connection / timeout class had no equivalent net. This PR is that sibling classifier — it does NOT overlap with #5167's branch and the two coexist without shadowing (429s stay matched by #5167's narrower classifier first; 502/503/504/connection/timeout fall through to this one).

## What changed
1. **`apps/api/src/shared/daytona-transient.ts`** (new) — a single, conservative classifier `isDaytonaTransientProviderError(err)` that matches, in order:
   - `instanceof DaytonaTimeoutError` / `instanceof DaytonaConnectionError` (best — exact SDK class),
   - `err.name === 'DaytonaTimeoutError'` / `'DaytonaConnectionError'` (robust across module duplication / different SDK versions),
   - a `DaytonaError`-shaped error with `statusCode === 502/503/504` (the prod `e98d61f1…` 502-HTML-body fingerprint hits this — 502 is NOT in the SDK's `STATUS_CODE_TO_ERROR` map so it becomes a generic `DaytonaError`),
   - a generic `DaytonaError` with the SDK's connection/timeout message substrings (`socket hang up`, `ECONNRESET`, `Operation timed out`, …).
   Plus `primeDaytonaTransientClassifier()` to pre-load the SDK classes so the synchronous instanceof path is available the first time a transient failure throws.

2. **`apps/api/src/index.ts`** — added a classification branch in `app.onError` (AFTER the `GitOperationError:timeout` branch, BEFORE `BillingError`) that downgrades a transient Daytona gateway / connection / timeout failure to a retryable **503 + `Retry-After: 10`** WITHOUT calling `captureException`. Every OTHER Daytona failure (404 missing box, 409 conflict, 401/403 auth, 400 validation, disk quota, unexpected 5xx with a JSON body) still throws a generic error and falls through to the generic capture — unexpected failures stay loud. Also calls `primeDaytonaTransientClassifier()` at startup.

   The branch is positioned AFTER the `GitOperationError:timeout` branch (not between Platinum and GitOperationError) specifically to avoid textual overlap with PR #5167's `isDaytonaRateLimitError` branch — the two PRs land cleanly in either order.

3. **No call-site changes** — `discoverExecutionKeepAliveEndpoint` (the unguarded call site that produced `e98d61f1…`) is already guarded by PR #5167's broader try/catch around `resolveEndpoint`. This PR is the durable global safety net for ANY OTHER unguarded Daytona call site that 502s in the future (reaper, warm-pool, env-sync, snapshot ops — all of which #5167's body explicitly flags as remaining unguarded), exactly the "global classifier" follow-up #5167's body calls out.

## Verification
- `bun test src/__tests__/unit-daytona-transient.test.ts` → **18 pass / 0 fail**
  (classifier positive + negative cases: 502 HTML body, 503, 504,
  DaytonaTimeoutError, DaytonaConnectionError, by-name, message-substring;
  negatives: 429, 404, 400, 500, generic Error, non-Daytona 502/503, non-error inputs).
- `bun test src/__tests__/unit-daytona-transient-onerror.test.ts` → **9 pass / 0 fail**
  (app.onError downgrade to 503 + Retry-After, no captureException, precedence
  preserved, generic 502 from a non-Daytona upstream NOT swallowed,
  DaytonaRateLimitError NOT swallowed — stays owned by #5167's classifier).
- `tsc --noEmit` (apps/api) → clean.
- `biome check` on all touched files → clean (no new lint findings).
- Existing related suites still green: `unit-daytona-snapshot-context` (8),
  `unit-request-deadline` (8), `unit-git-mirror-auth` (5), `unit-git-mirror-clone`
  (12), `unit-platinum-snapshot-size` (3), `shared/daytona.test` (15),
  `shared/platinum.test` (5) — **83 pass / 0 fail across 9 files**.

A full e2e 502 reproduction requires a real Daytona API gateway outage (not
safe to trigger against prod), so the proof is at the unit level: the
`app.onError` classification is exercised against the genuine SDK's
`DaytonaError` class (imported from `@daytonaio/sdk`), asserting both the
response shape (503 + Retry-After, non-leaky message) and that
`captureException` is NOT called. Preview verification: backend `/health`
returns `environment=preview` + the new code path is covered by the unit suite
that runs in CI.

## Risk / rollback
- **Behavior:** Only transient Daytona gateway / connection / timeout failures
  are downgraded; every other Daytona failure class is unchanged and still
  pages Sentry. The classifier is conservative — a generic HTTP 502/503/504
  from a non-Daytona upstream is NOT matched (asserted in tests), and the 429
  throttler (`DaytonaRateLimitError`) is NOT matched here (stays owned by
  #5167's `isDaytonaRateLimitError`).
- **Surfacing:** Affected requests now return 503 + `Retry-After: 10` instead
  of 500 with the raw HTML body. All existing Daytona callers already treat
  503 as retryable (the preview proxy, lease discover, transcript reads all
  have 503 retry paths). The client also no longer sees the raw upstream
  gateway HTML leak.
- **Rollback:** Revert the commit. No schema/config/infra changes; the new
  module is additive.

## Confirm resolution
After merge + promote, the Better Stack group `e98d61f1…` should drop to zero
new occurrences from ANY Daytona call site, not just the previously-guarded
ones. The `[DaytonaError:transient]` WARN log line remains (observability
without paging); a spike in that log would still be actionable in the structured
logs / metrics.

## Coordination note
This PR is complementary to (not a duplicate of) PR #5167
(`fix(api): classify Daytona 429 out of Sentry across ALL call sites
(ec26b248…)`). #5167 owns the 429 throttler classifier
(`isDaytonaRateLimitError`); this PR owns the transient gateway /
connection / timeout classifier (`isDaytonaTransientProviderError`). The two
classifiers do not overlap — a `DaytonaRateLimitError` is explicitly NOT
matched by `isDaytonaTransientProviderError` (asserted in
`unit-daytona-transient.test.ts`), and a transient 502/503/504 is explicitly
NOT matched by `isDaytonaRateLimitError` (asserted in #5167's
`unit-daytona-rate-limit.test.ts`). Whichever PR lands first, the other merges
cleanly with at most a trivial contextual conflict on `apps/api/src/index.ts`.
