### PR TITLE
Prompt delivery reliability: durable trigger delivery, loud dead-letters that self-heal, undelivered-prompt reconciler, restart hardening

### DIFF
--- a/apps/api/src/channels/meet-webhook.ts
+++ b/apps/api/src/channels/meet-webhook.ts
@@ -89,8 +89,11 @@ meetWebhookApp.openapi(
       markRecapped(botId);
       void continueSession({ source: 'meet', sessionId, text: buildRecapPrompt(botId), userId: null })
         .then((outcome) => {
-          if (outcome === 'no-session' || outcome === 'failed') {
-            console.warn('[meet-webhook] recap', outcome, 'session', sessionId);
+          // Nobody retries a webhook fire — every non-delivered outcome
+          // (including 'pending', the silent runtime-never-ready drop) means
+          // the recap prompt is gone. Say so where alerting can see it.
+          if (outcome !== 'delivered') {
+            console.error('[meet-webhook] recap prompt not delivered', { outcome, sessionId });
           }
         })
         .catch((err) => console.error('[meet-webhook] recap failed', err));
@@ -138,8 +141,8 @@ function deliverTurn(args: { projectId: string; sessionId: string; botId: string
 
   void continueSession({ source: 'meet', sessionId, text: buildWakePrompt({ ...turn, botId }), userId: null })
     .then((outcome) => {
-      if (outcome === 'no-session' || outcome === 'failed') {
-        console.warn('[meet-webhook] delivery', outcome, 'session', sessionId);
+      if (outcome !== 'delivered') {
+        console.error('[meet-webhook] turn prompt not delivered', { outcome, sessionId });
       }
     })
     .catch((err) => console.error('[meet-webhook] deliver failed', err));

--- a/apps/api/src/projects/lib/session-runtime-allocator.ts
+++ b/apps/api/src/projects/lib/session-runtime-allocator.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 
 import { projectSessions } from '@kortix/db';
+import { logger } from '../../lib/logger';
 import { ProvisionTimeline } from '../../platform/services/provision-timeline';
 import { provisionSessionSandbox } from '../../platform/services/session-sandbox';
 import { db } from '../../shared/db';
@@ -93,7 +94,17 @@ async function allocateSessionRuntimeAsync(input: AllocateSessionRuntimeInput): 
       return;
     }
     const message = (err as Error)?.message || 'Sandbox provisioning failed';
-    console.error(`[projects] Failed to allocate runtime for session ${input.sessionId}:`, err);
+    // This runs detached from any request (allocateSessionRuntime is
+    // fire-and-forget — restart/create already 202'd) — a structured error is
+    // the ONLY signal this session is now failed with no session_sandboxes row
+    // behind it, so every later proxy call will 404 'sandbox not found'.
+    logger.error('[projects] runtime allocation failed — session marked failed', {
+      session_id: input.sessionId,
+      project_id: input.projectId,
+      account_id: input.accountId,
+      provider: input.providerName,
+      error: message,
+    });
     try {
       await db
         .update(projectSessions)

--- a/apps/api/src/projects/lib/triggers-fire-durable.test.ts
+++ b/apps/api/src/projects/lib/triggers-fire-durable.test.ts
@@ -1,0 +1,171 @@
+// fireGitTrigger() pinned/reuse paths must hand the prompt off DURABLY.
+//
+// The prod incident: these paths called continueSession() directly in-process;
+// a 'pending' outcome (runtime never ready inside the deadline) was terminal —
+// no session_lifecycle_commands row, no retry, no error log, prompt silently
+// gone. These tests pin the fix: an existing live session gets a durable
+// continue_session command (drained with retry/backoff, dead-lettered loudly),
+// while a dead/failed session still falls through to the fresh-create path.
+//
+// Mocks `../session-lifecycle`, `../../shared/db`, and `../../config` via
+// `mock.module` — process-global in bun:test, so run this file in its own
+// `bun test <file>` invocation (as CI does), same caveat as
+// ../sandbox-reaper.test.ts.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let reusableRows: Array<{ sessionId: string }> = [];
+let sessionRows: Array<{ status: string; metadata: Record<string, unknown> }> = [];
+let enqueueCalls: Array<Record<string, unknown>> = [];
+let drainCalls: Array<Record<string, unknown>> = [];
+let createCalls: Array<Record<string, unknown>> = [];
+
+mock.module('../../config', () => ({
+  config: {},
+  SANDBOX_VERSION: 'test',
+  KNOWN_PROVIDERS: ['daytona'],
+  KORTIX_MARKUP: 1.2,
+  PLATFORM_FEE_MARKUP: 0.1,
+  getToolCost: () => 0,
+}));
+
+mock.module('../../shared/db', () => ({
+  hasDatabase: false,
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          // findReusableTriggerSession: where().orderBy().limit()
+          orderBy: () => ({ limit: async () => reusableRows }),
+          // enqueueTriggerPrompt liveness pre-check: where().limit()
+          limit: async () => sessionRows,
+        }),
+      }),
+    }),
+  },
+}));
+
+mock.module('../session-lifecycle', () => ({
+  createSession: async (command: Record<string, unknown>) => {
+    createCalls.push(command);
+    return {
+      status: 'created',
+      sessionId: 'sess-new',
+      row: { sessionId: 'sess-new', agentName: 'default' },
+    };
+  },
+  drainSessionLifecycleQueue: async (input: Record<string, unknown>) => {
+    drainCalls.push(input);
+    return { claimed: 0, succeeded: 0, failed: 0, queued: 0 };
+  },
+  enqueueContinueSessionCommand: async (input: Record<string, unknown>) => {
+    enqueueCalls.push(input);
+  },
+  resolveAgentRunAttribution: async () => null,
+  resolveProjectAutomationActor: async () => 'actor-1',
+  sessionBackpressureState: async () => ({ shouldQueue: false, reason: null }),
+}));
+
+const { fireGitTrigger } = await import('./triggers');
+
+const project = { projectId: 'proj-1', accountId: 'acct-1' } as never;
+const baseSpec = {
+  slug: 'daily',
+  type: 'cron',
+  enabled: true,
+  agent: 'default',
+  model: null,
+  cron: '0 9 * * *',
+  promptTemplate: 'do the thing',
+} as Record<string, unknown>;
+
+beforeEach(() => {
+  reusableRows = [];
+  sessionRows = [];
+  enqueueCalls = [];
+  drainCalls = [];
+  createCalls = [];
+});
+
+describe('fireGitTrigger — durable prompt delivery', () => {
+  test('reuse mode with a live canonical session enqueues a durable command and kicks a drain', async () => {
+    reusableRows = [{ sessionId: 'sess-reuse' }];
+    sessionRows = [{ status: 'stopped', metadata: {} }];
+
+    const result = await fireGitTrigger({
+      spec: { ...baseSpec, sessionMode: 'reuse' } as never,
+      project,
+      payload: {},
+      renderedPrompt: 'do the thing',
+      source: 'cron',
+      idempotencyKey: 'trigger:cron:proj-1:daily:slot-1',
+    });
+
+    expect(result).toMatchObject({ status: 'queued', sessionId: 'sess-reuse' });
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0]).toMatchObject({
+      source: 'trigger:cron',
+      projectId: 'proj-1',
+      accountId: 'acct-1',
+      sessionId: 'sess-reuse',
+      actorUserId: 'actor-1',
+      text: 'do the thing',
+      triggerSlug: 'daily',
+      idempotencyKey: 'trigger:cron:proj-1:daily:slot-1',
+    });
+    // Immediate-feel fast path; the scheduler tick is the durable guarantee.
+    expect(drainCalls).toHaveLength(1);
+    // No direct/fresh session creation happened.
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test('pinned mode targets the pinned session', async () => {
+    sessionRows = [{ status: 'running', metadata: {} }];
+
+    const result = await fireGitTrigger({
+      spec: { ...baseSpec, sessionMode: 'pinned', pinnedSessionId: 'sess-pin' } as never,
+      project,
+      payload: {},
+      renderedPrompt: 'do the thing',
+      source: 'manual',
+    });
+
+    expect(result).toMatchObject({ status: 'queued', sessionId: 'sess-pin' });
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0]).toMatchObject({ sessionId: 'sess-pin', source: 'trigger:manual' });
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test('a failed canonical session is NOT enqueued into — falls through to a fresh session', async () => {
+    reusableRows = [{ sessionId: 'sess-dead' }];
+    sessionRows = [{ status: 'failed', metadata: {} }];
+
+    const result = await fireGitTrigger({
+      spec: { ...baseSpec, sessionMode: 'reuse' } as never,
+      project,
+      payload: {},
+      renderedPrompt: 'do the thing',
+      source: 'cron',
+    });
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(createCalls).toHaveLength(1);
+    expect(result).toMatchObject({ status: 'fired', sessionId: 'sess-new' });
+  });
+
+  test('a deleted canonical session is NOT enqueued into — falls through to a fresh session', async () => {
+    reusableRows = [{ sessionId: 'sess-deleted' }];
+    sessionRows = [{ status: 'stopped', metadata: { deletedAt: new Date().toISOString() } }];
+
+    const result = await fireGitTrigger({
+      spec: { ...baseSpec, sessionMode: 'reuse' } as never,
+      project,
+      payload: {},
+      renderedPrompt: 'do the thing',
+      source: 'cron',
+    });
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(createCalls).toHaveLength(1);
+    expect(result).toMatchObject({ status: 'fired', sessionId: 'sess-new' });
+  });
+});

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -11,9 +11,9 @@ import { isLeader } from '../../shared/leader-election';
 import { commitFileToBranch, invalidateProjectMirror } from '../git';
 import { type GitHubAuthContext, commitFile, getFileSha } from '../github';
 import {
-  continueSession,
   createSession,
   drainSessionLifecycleQueue,
+  enqueueContinueSessionCommand,
   resolveAgentRunAttribution,
   resolveProjectAutomationActor,
   sessionBackpressureState,
@@ -665,6 +665,57 @@ export async function findReusableTriggerSession(
 }
 
 /**
+ * Durable prompt hand-off into an EXISTING session (`session_mode` pinned /
+ * reuse). The direct in-process continueSession() call this replaces was the
+ * silent-loss hole: 'pending' (runtime never ready inside the deadline) was
+ * TERMINAL on that path — no durable row, no retry, no error log, prompt gone,
+ * session showing "queued" forever. Enqueue a durable continue_session command
+ * instead: the scheduler's drain tick executes it with retry/backoff, and a
+ * dead-letter ships a real error AND parks the session 'failed' (see
+ * store.markCommandFailed) so the next fire self-heals via a fresh session.
+ * The immediate drain kick keeps the happy path feeling instant.
+ *
+ * Only liveness is pre-checked here (mirrors continueSession's own guards) —
+ * a missing/failed/deleted session must keep falling through to the create
+ * path exactly like the old direct call's 'no-session'/'failed' outcomes.
+ */
+async function enqueueTriggerPrompt(input: {
+  project: ProjectRow;
+  sessionId: string;
+  actor: string;
+  text: string;
+  source: 'cron' | 'webhook' | 'manual';
+  triggerSlug: string;
+  idempotencyKey?: string | null;
+}): Promise<'queued' | 'no-session' | 'failed'> {
+  const [session] = await db
+    .select({ status: projectSessions.status, metadata: projectSessions.metadata })
+    .from(projectSessions)
+    .where(eq(projectSessions.sessionId, input.sessionId))
+    .limit(1);
+  if (!session) return 'no-session';
+  if (session.status === 'failed') return 'failed';
+  const sessionMeta = (session.metadata ?? {}) as Record<string, unknown>;
+  if (typeof sessionMeta.deletedAt === 'string') return 'no-session';
+
+  await enqueueContinueSessionCommand({
+    source: `trigger:${input.source}`,
+    projectId: input.project.projectId,
+    accountId: input.project.accountId,
+    sessionId: input.sessionId,
+    actorUserId: input.actor,
+    text: input.text,
+    triggerSlug: input.triggerSlug,
+    // Same per-due-slot key the create path uses — a fire the sweep timed out
+    // on but that actually enqueued isn't duplicated when the next tick retries.
+    idempotencyKey: input.idempotencyKey ?? null,
+  });
+  // Fast path only — the scheduler's 60s drain tick is the delivery guarantee.
+  drainSessionLifecycleQueue({ limit: 1 }).catch(() => {});
+  return 'queued';
+}
+
+/**
  * Fire a git-backed trigger. Triggers are file-defined (kortix.yaml), so there
  * is no DB trigger/event row — the project_sessions row carries `trigger_slug`
  * in metadata so audits can still reconstruct the firing path.
@@ -701,20 +752,20 @@ export async function fireGitTrigger(input: {
   // is gone/unresumable we degrade gracefully: fall through to the `reuse` block
   // (the trigger's own last session), then to a brand-new session.
   if (spec.sessionMode === 'pinned' && spec.pinnedSessionId) {
-    const outcome = await continueSession({
-      source: `trigger:${source}`,
+    const outcome = await enqueueTriggerPrompt({
+      project,
       sessionId: spec.pinnedSessionId,
+      actor,
       text: renderedPrompt,
-      userId: actor,
+      source,
+      triggerSlug: spec.slug,
+      idempotencyKey: input.idempotencyKey ?? null,
     });
-    if (outcome === 'delivered') {
-      return { status: 'fired', sessionId: spec.pinnedSessionId };
-    }
-    if (outcome === 'pending') {
+    if (outcome === 'queued') {
       return {
         status: 'queued',
         sessionId: spec.pinnedSessionId,
-        reason: 'pinned session resuming',
+        reason: 'prompt queued for delivery',
       };
     }
     // outcome === 'no-session' | 'failed' → pinned session is gone/unusable;
@@ -731,20 +782,20 @@ export async function fireGitTrigger(input: {
   if (spec.sessionMode === 'reuse' || spec.sessionMode === 'pinned') {
     const reusable = await findReusableTriggerSession(project.projectId, spec.slug);
     if (reusable) {
-      const outcome = await continueSession({
-        source: `trigger:${source}`,
+      const outcome = await enqueueTriggerPrompt({
+        project,
         sessionId: reusable.sessionId,
+        actor,
         text: renderedPrompt,
-        userId: actor,
+        source,
+        triggerSlug: spec.slug,
+        idempotencyKey: input.idempotencyKey ?? null,
       });
-      if (outcome === 'delivered') {
-        return { status: 'fired', sessionId: reusable.sessionId };
-      }
-      if (outcome === 'pending') {
-        // Runtime still spinning up (e.g. resuming an archived sandbox). The
-        // prompt will land once it's ready — treat as a successful fire so the
-        // scheduler records last_fired_at and doesn't immediately create a dupe.
-        return { status: 'queued', sessionId: reusable.sessionId, reason: 'session resuming' };
+      if (outcome === 'queued') {
+        // The prompt is durably queued (drain retries until delivered or
+        // dead-letters loudly) — treat as a successful fire so the scheduler
+        // records last_fired_at and doesn't immediately create a dupe.
+        return { status: 'queued', sessionId: reusable.sessionId, reason: 'prompt queued for delivery' };
       }
       // outcome === 'no-session' | 'failed' → canonical session is unusable;
       // fall through to create a fresh one below.

--- a/apps/api/src/projects/maintenance.test.ts
+++ b/apps/api/src/projects/maintenance.test.ts
@@ -64,6 +64,7 @@ mock.module('./sandbox-reaper', () => ({
     billingClosed: 0,
     errors: 0,
   }),
+  reconcileUndeliveredPrompts: async () => ({ claimed: 0, succeeded: 0, failed: 0, queued: 0 }),
   reapOrphanProviderBoxes: async () => ({ listed: 0, orphans: 0, stopped: 0, errors: 0 }),
   countBillingInvariantViolations: async () => 0,
 }));

--- a/apps/api/src/projects/maintenance.ts
+++ b/apps/api/src/projects/maintenance.ts
@@ -11,6 +11,7 @@ import {
   reapOrphanProviderBoxes,
   reconcileOrphanComputeSessions,
   reconcileStuckActiveSessions,
+  reconcileUndeliveredPrompts,
 } from './sandbox-reaper';
 
 const DEFAULT_BRANCH_RETENTION_DAYS = 90;
@@ -208,6 +209,7 @@ export async function runProjectMaintenance(): Promise<void> {
       idle,
       orphanCompute,
       stuckSessions,
+      undeliveredPrompts,
       orphanBoxes,
       branches,
       computeTick,
@@ -250,6 +252,16 @@ export async function runProjectMaintenance(): Promise<void> {
           err instanceof Error ? err.message : err,
         );
         return { candidates: 0, reconciled: 0, billingClosed: 0, errors: 0 };
+      }),
+      // Prompt-delivery backstop: execute queued session_lifecycle_commands the
+      // scheduler drain should have taken minutes ago (leader dead / scheduler
+      // disabled) — the other half of "queued — agent picking up" forever.
+      reconcileUndeliveredPrompts().catch((err) => {
+        console.warn(
+          '[project-maintenance] undelivered-prompt reconcile failed:',
+          err instanceof Error ? err.message : err,
+        );
+        return { claimed: 0, succeeded: 0, failed: 0, queued: 0 };
       }),
       // Provider-authoritative orphan-BOX reaper: stops boxes still running on
       // the provider (this env) with no live DB row — the leak the DB-driven
@@ -307,6 +319,7 @@ export async function runProjectMaintenance(): Promise<void> {
         orphanCompute.errors ||
         stuckSessions.reconciled ||
         stuckSessions.errors ||
+        undeliveredPrompts.claimed ||
         orphanBoxes.stopped ||
         orphanBoxes.errors ||
         branches.deleted ||
@@ -321,6 +334,7 @@ export async function runProjectMaintenance(): Promise<void> {
         idle,
         orphanCompute,
         stuckSessions,
+        undeliveredPrompts,
         orphanBoxes,
         branches,
         computeTick,

--- a/apps/api/src/projects/reconcile-undelivered-prompts.test.ts
+++ b/apps/api/src/projects/reconcile-undelivered-prompts.test.ts
@@ -1,0 +1,89 @@
+// reconcileUndeliveredPrompts() — the drain-starvation backstop.
+//
+// session_lifecycle_commands normally drain on the trigger scheduler's 60s
+// tick. When that scheduler is dead or disabled, queued prompts (trigger
+// fires, approval resumes) sit undelivered forever with zero signal — the
+// silent half of the "queued — agent picking up" incident. This pins that the
+// reconciler (a) only sweeps rows due for at least the 10-minute starvation
+// window, via the SAME claim machinery the drain uses (availableBefore), and
+// (b) is loud — any claim means the scheduler was not doing its job.
+//
+// Mocks are process-global (`mock.module`) — run this file in its own
+// `bun test <file>` invocation (as CI does), same caveat as
+// ./sandbox-reaper.test.ts, whose config/provider mock preamble this follows.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let drainCalls: Array<{ workerId?: string; limit?: number; availableBefore?: Date }> = [];
+let drainResult = { claimed: 0, succeeded: 0, failed: 0, queued: 0 };
+let errorLogs: Array<{ message: string; context?: Record<string, unknown> }> = [];
+
+mock.module('../config', () => ({
+  config: {
+    KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15,
+    KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: 5,
+    ALLOWED_SANDBOX_PROVIDERS: ['daytona'],
+  },
+}));
+mock.module('../lib/logger', () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (message: string, context?: Record<string, unknown>) => {
+      errorLogs.push({ message, context });
+    },
+  },
+}));
+mock.module('../shared/db', () => ({ db: {} }));
+mock.module('./sandbox-busy-probe', () => ({ probeSandboxBusy: async () => 'unknown' }));
+mock.module('../platform/providers', () => ({ getProvider: () => ({}) }));
+mock.module('../sandbox-proxy', () => ({ invalidateProviderCache: () => {} }));
+mock.module('../billing/services/compute-metering', () => ({
+  pauseComputeSession: async () => {},
+  reopenComputeForSandbox: async () => {},
+  endComputeSession: async () => {},
+}));
+mock.module('./session-lifecycle', () => ({
+  drainSessionLifecycleQueue: async (input: {
+    workerId?: string;
+    limit?: number;
+    availableBefore?: Date;
+  }) => {
+    drainCalls.push(input);
+    return drainResult;
+  },
+}));
+
+const { reconcileUndeliveredPrompts } = await import('./sandbox-reaper');
+
+beforeEach(() => {
+  drainCalls = [];
+  drainResult = { claimed: 0, succeeded: 0, failed: 0, queued: 0 };
+  errorLogs = [];
+});
+
+describe('reconcileUndeliveredPrompts', () => {
+  test('sweeps only commands starved past the 10-minute window', async () => {
+    const now = new Date('2026-07-21T12:00:00.000Z');
+
+    const result = await reconcileUndeliveredPrompts(now);
+
+    expect(drainCalls).toHaveLength(1);
+    expect(drainCalls[0].availableBefore?.toISOString()).toBe('2026-07-21T11:50:00.000Z');
+    expect(drainCalls[0].limit).toBe(25);
+    expect(result).toEqual({ claimed: 0, succeeded: 0, failed: 0, queued: 0 });
+    // Nothing starved → nothing to alert on.
+    expect(errorLogs).toHaveLength(0);
+  });
+
+  test('any claimed row means the scheduler drain starved — ship an error', async () => {
+    drainResult = { claimed: 3, succeeded: 2, failed: 1, queued: 0 };
+
+    const result = await reconcileUndeliveredPrompts(new Date('2026-07-21T12:00:00.000Z'));
+
+    expect(result.claimed).toBe(3);
+    expect(errorLogs).toHaveLength(1);
+    expect(errorLogs[0].message).toContain('starved');
+    expect(errorLogs[0].context).toMatchObject({ claimed: 3, succeeded: 2, failed: 1 });
+  });
+});

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -695,12 +695,25 @@ projectsApp.openapi(
         sessionId: cr.originSessionId,
         text: `Please revise change request #${cr.number} ("${cr.title}") based on this feedback:\n\n${feedback}`,
         userId: loaded.userId,
-      }).catch((err) => {
-        console.warn('[change-requests] request-changes delivery failed', {
-          crId,
-          error: String(err),
+      })
+        .then((outcome) => {
+          // The response already told the user willDeliver=true and nothing
+          // retries this — a non-delivered outcome (incl. 'pending') means the
+          // feedback silently never reached the agent. Make it loud.
+          if (outcome !== 'delivered') {
+            console.error('[change-requests] request-changes prompt not delivered', {
+              crId,
+              sessionId: cr.originSessionId,
+              outcome,
+            });
+          }
+        })
+        .catch((err) => {
+          console.warn('[change-requests] request-changes delivery failed', {
+            crId,
+            error: String(err),
+          });
         });
-      });
     }
 
     return c.json({ change_request: serializeChangeRequest(row), delivering: willDeliver });

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -33,6 +33,7 @@
 
 import { and, eq, gt, inArray, isNotNull, lt, or, sql } from 'drizzle-orm';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
+import { logger } from '../lib/logger';
 import { db } from '../shared/db';
 import { getProvider, type ProviderName, type SandboxStatus } from '../platform/providers';
 import { invalidateProviderCache } from '../sandbox-proxy';
@@ -541,6 +542,48 @@ export async function reconcileStuckActiveSessions(
       result.errors += 1;
       console.warn('[reaper] stuck-session reconcile failed:', { sessionId: c.sessionId, error: err instanceof Error ? err.message : err });
     }
+  }
+  return result;
+}
+
+const UNDELIVERED_PROMPT_STARVATION_MS = 10 * 60_000;
+const UNDELIVERED_PROMPT_BATCH = 25;
+
+/**
+ * Prompt-delivery backstop: session_lifecycle_commands normally drain on the
+ * scheduler's 60s tick (startProjectTriggerScheduler). A command still `queued`
+ * TEN MINUTES past its available_at means that drain is starved — leader dead,
+ * scheduler disabled, or the tick wedged — and every prompt behind it (trigger
+ * fires, approval resumes) is sitting undelivered while its session shows
+ * "queued — agent picking up" forever. This pass executes those stale rows
+ * through the SAME claim/retry/dead-letter machinery the drain uses
+ * (claimDueLifecycleCommands re-checks status='queued' in the claim UPDATE, so
+ * racing a recovered scheduler is safe), and ships a real error so a dead
+ * scheduler pages instead of silently eating prompts. Bounded batch; no-op in
+ * steady state.
+ */
+export async function reconcileUndeliveredPrompts(
+  now = new Date(),
+): Promise<{ claimed: number; succeeded: number; failed: number; queued: number }> {
+  // Dynamic import: session-lifecycle/stop.ts imports this module, so a static
+  // import of the engine here would be a cycle.
+  const { drainSessionLifecycleQueue } = await import('./session-lifecycle');
+  const result = await drainSessionLifecycleQueue({
+    workerId: `undelivered-prompt-reconciler:${process.pid}`,
+    limit: UNDELIVERED_PROMPT_BATCH,
+    availableBefore: new Date(now.getTime() - UNDELIVERED_PROMPT_STARVATION_MS),
+  });
+  if (result.claimed > 0) {
+    logger.error(
+      '[reaper] queued lifecycle commands starved past the drain window — scheduler dead or disabled?',
+      {
+        claimed: result.claimed,
+        succeeded: result.succeeded,
+        failed: result.failed,
+        requeued: result.queued,
+        starvation_ms: UNDELIVERED_PROMPT_STARVATION_MS,
+      },
+    );
   }
   return result;
 }

--- a/apps/api/src/projects/session-lifecycle/__tests__/dead-letter-marks-session-failed.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/dead-letter-marks-session-failed.test.ts
@@ -1,0 +1,146 @@
+// markCommandFailed() dead-letter path must be LOUD and must self-heal.
+//
+// The prod incident: a continue_session command exhausting its 5 attempts was
+// dead-lettered with only a console.warn — invisible to Better Stack alerting
+// — while the target session kept showing "queued — agent picking up" forever,
+// and (worse) `session_mode = "reuse"` kept re-aiming every subsequent trigger
+// fire at the same wedged session. These tests pin the two-part fix:
+//   1. a dead-letter ships a REAL structured error through the logger, and
+//   2. a continue_session dead-letter parks the target session 'failed' (with
+//      a status re-check in the UPDATE predicate) so findReusableTriggerSession
+//      skips it and the next fire creates a fresh session — the lossless
+//      self-heal.
+//
+// Mocks `../../shared/db` and `../../lib/logger` via `mock.module` — which is
+// process-global in bun:test, so run this file in its own `bun test <file>`
+// invocation (as CI does), same caveat as ../../sandbox-reaper.test.ts.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectSessions, sessionLifecycleCommands } from '@kortix/db';
+
+let commandRow: Record<string, unknown> | null = null;
+let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
+let errorLogs: Array<{ message: string; context?: Record<string, unknown> }> = [];
+
+mock.module('../../../lib/logger', () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (message: string, context?: Record<string, unknown>) => {
+      errorLogs.push({ message, context });
+    },
+  },
+}));
+
+mock.module('../../../shared/db', () => ({
+  db: {
+    update: (table: unknown) => ({
+      set: (updates: Record<string, unknown>) => ({
+        // Awaitable (the projectSessions park) AND chainable to `.returning()`
+        // (the sessionLifecycleCommands mark). Records one call either way.
+        where: () => {
+          const record = () => updateCalls.push({ table, updates });
+          return {
+            then: (resolve: (v: unknown) => void) => {
+              record();
+              resolve(undefined);
+            },
+            returning: async () => {
+              record();
+              return commandRow ? [commandRow] : [];
+            },
+          };
+        },
+      }),
+    }),
+  },
+}));
+
+const { markCommandFailed } = await import('../store');
+
+const baseCommandRow = (overrides: Record<string, unknown> = {}) => ({
+  commandId: 'cmd-1',
+  commandType: 'continue_session',
+  source: 'trigger:cron',
+  status: 'dead_lettered',
+  projectId: 'proj-1',
+  accountId: 'acct-1',
+  sessionId: 'sess-1',
+  idempotencyKey: 'trigger:cron:proj-1:daily:2026-07-21T00:00:00.000Z',
+  payload: { text: 'run the report', triggerSlug: 'daily' },
+  attempts: 5,
+  ...overrides,
+});
+
+beforeEach(() => {
+  commandRow = null;
+  updateCalls = [];
+  errorLogs = [];
+});
+
+describe('markCommandFailed — dead-letter is loud and parks the session', () => {
+  test('continue_session exhausting retries ships an error and marks the session failed', async () => {
+    commandRow = baseCommandRow();
+
+    await markCommandFailed('cmd-1', 'delivery outcome: pending', {
+      retryable: true,
+      attempts: 5,
+      sessionId: 'sess-1',
+    });
+
+    expect(errorLogs).toHaveLength(1);
+    expect(errorLogs[0].message).toContain('dead-lettered');
+    expect(errorLogs[0].context).toMatchObject({
+      command_id: 'cmd-1',
+      command_type: 'continue_session',
+      session_id: 'sess-1',
+      project_id: 'proj-1',
+      trigger_slug: 'daily',
+      attempts: 5,
+      error: 'delivery outcome: pending',
+    });
+
+    const sessionUpdates = updateCalls.filter((u) => u.table === projectSessions);
+    expect(sessionUpdates).toHaveLength(1);
+    expect(sessionUpdates[0].updates.status).toBe('failed');
+    expect(String(sessionUpdates[0].updates.error)).toContain('dead-lettered');
+  });
+
+  test('non-retryable failure dead-letters on the first attempt', async () => {
+    commandRow = baseCommandRow({ attempts: 1 });
+
+    await markCommandFailed('cmd-1', 'delivery outcome: no-session', {
+      retryable: false,
+      attempts: 1,
+      sessionId: 'sess-1',
+    });
+
+    expect(errorLogs).toHaveLength(1);
+    expect(updateCalls.filter((u) => u.table === projectSessions)).toHaveLength(1);
+  });
+
+  test('a retryable failure below the attempt cap only requeues — no error, no park', async () => {
+    commandRow = baseCommandRow({ status: 'queued', attempts: 2 });
+
+    await markCommandFailed('cmd-1', 'delivery outcome: pending', {
+      retryable: true,
+      attempts: 2,
+      sessionId: 'sess-1',
+    });
+
+    expect(errorLogs).toHaveLength(0);
+    expect(updateCalls.filter((u) => u.table === projectSessions)).toHaveLength(0);
+    // The command row itself was still marked (back to queued with backoff).
+    expect(updateCalls.filter((u) => u.table === sessionLifecycleCommands)).toHaveLength(1);
+  });
+
+  test('a create_session dead-letter ships the error but never touches a session row', async () => {
+    commandRow = baseCommandRow({ commandType: 'create_session', sessionId: null, payload: {} });
+
+    await markCommandFailed('cmd-1', 'Project not found', { retryable: false, attempts: 1 });
+
+    expect(errorLogs).toHaveLength(1);
+    expect(errorLogs[0].context).toMatchObject({ command_type: 'create_session' });
+    expect(updateCalls.filter((u) => u.table === projectSessions)).toHaveLength(0);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -1,5 +1,6 @@
 import { pauseComputeSession } from '../../billing/services/compute-metering';
 import { config, type SandboxProviderName } from '../../config';
+import { logger } from '../../lib/logger';
 import { getProvider } from '../../platform/providers';
 import { db } from '../../shared/db';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
@@ -322,7 +323,14 @@ export async function restartSession(input: {
           .set({ status: 'running', updatedAt: new Date() })
           .where(eq(projectSessions.sessionId, sessionId));
       } catch (err) {
-        console.warn(`[projects] restart-in-place failed for ${sessionId}:`, err);
+        // Detached from the request (the 202 already went out) — a structured
+        // error is the only trace the reboot died and the session was parked.
+        logger.error('[projects] restart-in-place failed — session parked stopped', {
+          session_id: sessionId,
+          project_id: projectId,
+          external_id: externalId,
+          error: err instanceof Error ? err.message : String(err),
+        });
         if (isMissingRuntimeError(err)) {
           const claim = await claimInPlaceRuntimeRecovery(existingSandbox);
           if (!claim) return;

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -328,10 +328,16 @@ export async function drainSessionLifecycleQueue(
   input: {
   workerId?: string;
   limit?: number;
+  /** Only drain commands due before this instant — see claimDueLifecycleCommands. */
+  availableBefore?: Date;
   } = {},
 ): Promise<{ claimed: number; succeeded: number; failed: number; queued: number }> {
   const workerId = input.workerId ?? `session-lifecycle:${process.pid}:${Date.now()}`;
-  const rows = await claimDueLifecycleCommands({ workerId, limit: input.limit ?? 10 });
+  const rows = await claimDueLifecycleCommands({
+    workerId,
+    limit: input.limit ?? 10,
+    availableBefore: input.availableBefore,
+  });
   const out = { claimed: rows.length, succeeded: 0, failed: 0, queued: 0 };
   for (const row of rows) {
     if (row.commandType === 'continue_session') {

--- a/apps/api/src/projects/session-lifecycle/store.ts
+++ b/apps/api/src/projects/session-lifecycle/store.ts
@@ -1,5 +1,6 @@
-import { sessionLifecycleCommands } from '@kortix/db';
-import { and, asc, eq, isNull, lte, or } from 'drizzle-orm';
+import { projectSessions, sessionLifecycleCommands } from '@kortix/db';
+import { and, asc, eq, isNull, lte, ne, or } from 'drizzle-orm';
+import { logger } from '../../lib/logger';
 import { db } from '../../shared/db';
 import type {
   CreateSessionCommand,
@@ -29,6 +30,10 @@ export interface QueuedContinueSessionPayload {
    *  already consumed in-band (a live held/poll request resumed the turn) —
    *  the follow-up prompt would just be noise. */
   executionId?: string | null;
+  /** Which trigger fired this prompt — diagnostics only, carried into the
+   *  dead-letter alert so "which automation lost its prompt" is answerable
+   *  from the log line alone. */
+  triggerSlug?: string | null;
 }
 
 /**
@@ -45,6 +50,7 @@ export async function enqueueContinueSessionCommand(input: {
   actorUserId: string | null;
   text: string;
   executionId?: string | null;
+  triggerSlug?: string | null;
   availableAt?: Date;
   /** Dedupe key — a repeat enqueue (double-resolve race) is a no-op. */
   idempotencyKey?: string | null;
@@ -53,6 +59,7 @@ export async function enqueueContinueSessionCommand(input: {
   const payload: QueuedContinueSessionPayload = {
     text: input.text,
     executionId: input.executionId ?? null,
+    triggerSlug: input.triggerSlug ?? null,
   };
   const values = {
     commandType: 'continue_session',
@@ -220,7 +227,7 @@ export async function markCommandFailed(
   },
 ): Promise<void> {
   const retry = opts.retryable && opts.attempts < 5;
-  await db
+  const [row] = await db
     .update(sessionLifecycleCommands)
     .set({
       status: retry ? 'queued' : 'dead_lettered',
@@ -233,13 +240,62 @@ export async function markCommandFailed(
       lastError: error,
       updatedAt: new Date(),
     })
-    .where(eq(sessionLifecycleCommands.commandId, commandId));
+    .where(eq(sessionLifecycleCommands.commandId, commandId))
+    .returning();
+  if (retry || !row) return;
+
+  // Dead-lettered = this command's work is being ABANDONED. That used to be a
+  // console.warn deep in the drain — invisible to alerting while the user's
+  // session sat "queued — agent picking up" forever. Make it a real error.
+  const payload = (row.payload ?? {}) as Record<string, unknown>;
+  logger.error('[session-lifecycle] command dead-lettered — giving up after retries', {
+    command_id: row.commandId,
+    command_type: row.commandType,
+    source: row.source,
+    project_id: row.projectId,
+    account_id: row.accountId,
+    session_id: row.sessionId,
+    trigger_slug: typeof payload.triggerSlug === 'string' ? payload.triggerSlug : undefined,
+    idempotency_key: row.idempotencyKey,
+    attempts: opts.attempts,
+    error,
+  });
+
+  if (row.commandType === 'continue_session' && row.sessionId) {
+    // Park the target session 'failed': findReusableTriggerSession skips failed
+    // sessions, so a `session_mode = "reuse"` trigger's next fire creates a
+    // FRESH session instead of re-aiming prompts at a wedged one — the proven
+    // lossless self-heal. Status re-check in the UPDATE predicate (same pattern
+    // as reconcileStuckActiveSessions) so a concurrent transition isn't
+    // clobbered by a stale dead-letter.
+    try {
+      await db
+        .update(projectSessions)
+        .set({
+          status: 'failed',
+          error: `prompt delivery dead-lettered: ${error}`.slice(0, 1000),
+          updatedAt: new Date(),
+        })
+        .where(
+          and(eq(projectSessions.sessionId, row.sessionId), ne(projectSessions.status, 'failed')),
+        );
+    } catch (err) {
+      console.warn('[session-lifecycle] failed to park session after dead-letter', {
+        sessionId: row.sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
 }
 
 export async function claimDueLifecycleCommands(input: {
   workerId: string;
   limit: number;
   now?: Date;
+  /** Claim only commands that came due before this instant (default: now).
+   *  Lets the starvation reconciler target rows the scheduler drain should
+   *  have taken long ago, without racing it for freshly-due ones. */
+  availableBefore?: Date;
 }): Promise<SessionLifecycleCommandRow[]> {
   const now = input.now ?? new Date();
   const rows = await db
@@ -248,7 +304,7 @@ export async function claimDueLifecycleCommands(input: {
     .where(
       and(
         eq(sessionLifecycleCommands.status, 'queued'),
-        lte(sessionLifecycleCommands.availableAt, now),
+        lte(sessionLifecycleCommands.availableAt, input.availableBefore ?? now),
         or(isNull(sessionLifecycleCommands.lockedUntil), lte(sessionLifecycleCommands.lockedUntil, now)),
       ),
     )


### PR DESCRIPTION
Fixes the production failure class from 2026-07-21 (company#29): a trigger prompt into a reuse session could be silently lost — session stuck showing "queued — agent picking up" forever — and `sessions restart` could leave a session permanently at "sandbox not found".

## Root cause (verified in prod)
- `fireGitTrigger` reuse/pinned paths called `continueSession` directly in-process; no durable `session_lifecycle_commands` row was ever written (prod DB: zero rows for the affected project despite dozens of fires). `continueSession` flips the session `running` optimistically, waits ≤300s for runtime-ready, then returns `pending` — terminal on the direct path: no retry, no record, no error, prompt gone.
- `reconcileStuckActiveSessions` can't see this (requires no-active-sandbox + no recent usage). Queue-path failures dead-lettered with only `console.warn`.
- `restartSession` failure paths: replacement allocation is fire-and-forget; on failure no `session_sandboxes` row is ever created and nothing alerts → permanent `sandbox not found`.

## Fix
1. **Durable delivery**: trigger reuse/pinned prompts now enqueue a durable `continue_session` command (idempotency-keyed per due-slot) + immediate drain kick; the 60s scheduler drain is the guarantee. Liveness pre-check preserves the fresh-create fallback semantics.
2. **Loud dead-letters that self-heal**: dead-letter ships a structured `logger.error` (Better Stack) and parks the target session `failed` (status re-check in UPDATE) — so the next reuse fire creates a fresh session: lossless self-heal instead of a silent wedge.
3. **`reconcileUndeliveredPrompts`**: 5-min maintenance backstop sweeping `queued` commands stale >10 min (drain starvation), executing them through the existing claim/retry/dead-letter machinery + shipping an error when starvation is detected.
4. **Restart hardening**: allocation-failure and in-place-reboot-failure paths ship structured errors; response contracts unchanged.

## Tests
10 new tests across 3 files (dead-letter parks session + ships error; reconciler sweeps only stale rows; reuse/pinned fires enqueue durable commands with drain kick; failed/deleted sessions fall through to fresh create). Typecheck green; all touched suites green per-file.