### PR TITLE
fix(web): filter Android WebView native-bridge postEvent noise (Java object is gone)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  isAndroidWebViewNativeBridgePostEventNoise,
   isAndroidWebViewNativeBridgePostMessageNoise,
   isClientRequestTimeoutMessage,
   isEmptyMessageUnresolvedBrowserChunkNoise,
@@ -2156,6 +2157,222 @@ test('does NOT suppress a same-worded message from a different bridge / non-Andr
       }),
       false,
     )
+})
+
+// ---------------------------------------------------------------------------
+// Android System WebView native-bridge `postEvent` noise — the FRAMELESS
+// sibling of the `postMessage` class above.
+// (Better Stack pattern
+//  a6795db236a92a4f9738698e93a8d7ae4e60dae607cacedccb7ed8bbd225b2d4,
+//  Kortix Frontend prod, application_id 2346967): the Android Chromium
+// WebView's injected `JavaBridge` calls `postEvent` on a Java bridge whose
+// backing `JavaObject` has been GC'd (page navigation / WebView teardown /
+// in-app browser dismiss) → `Error invoking postEvent: Java object is gone`.
+// Unlike the `postMessage` sibling (PR #4610, which carried the synthetic
+// `app://navigation_performance_logger_android` frame), this `postEvent`
+// variant surfaced as a FRAMELESS capture: call_site_file `<anonymous>`,
+// call_site_function `?`, no resolvable stack. So the matcher is anchored on
+// BOTH the exact message AND a frameless/injected-WebView origin (no
+// resolvable source location, OR the Android nav-perf-logger bridge frame),
+// with negative guards preserving any first-party `apps/web/src/…` frame or
+// any resolvable real source location so a genuine first-party
+// `postEvent`/`dispatchEvent` failure keeps reporting.
+// 1 occurrence / 0 identified users, last_seen 2026-07-20 19:05:34 UTC.
+// ---------------------------------------------------------------------------
+
+const ANDROID_WEBVIEW_BRIDGE_POSTEVENT_EVENTS = [
+  // The exact raw exception value from the production event.
+  'Error invoking postEvent: Java object is gone',
+  // An unhandled-rejection wrapper preserving the message.
+  'Unhandled promise rejection: Error invoking postEvent: Java object is gone',
+]
+
+// The frameless capture shape from the production event — no resolvable
+// source location, `<anonymous>` / `?` call site.
+const FRAMELESS_ANDROID_BRIDGE_FRAMES = [
+  { function: '?', filename: 'undefined', lineno: 1 },
+]
+
+test('classifies the Android WebView native-bridge postEvent noise (frameless capture)', () => {
+  for (const message of ANDROID_WEBVIEW_BRIDGE_POSTEVENT_EVENTS) {
+    // Frameless Sentry event — no frames, no filename.
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({ message }),
+      true,
+      `expected frameless "${message}" to be classified as noise`,
+    )
+    // Frameless Sentry event — only the synthetic `<anonymous>`/`undefined`
+    // placeholder frame (the exact production capture shape).
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message,
+        frames: FRAMELESS_ANDROID_BRIDGE_FRAMES,
+      }),
+      true,
+      `expected frameless Sentry event for "${message}" to be classified as noise`,
+    )
+    // Runtime gate — frameless global-onerror with the synthetic `undefined`
+    // filename.
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message,
+        filename: 'undefined',
+      }),
+      true,
+      `expected runtime gate frameless "${message}" to be classified as noise`,
+    )
+  }
+})
+
+test('classifies the Android WebView native-bridge postEvent noise (framed sibling — bridge frame)', () => {
+  // Forward-compat: if a future occurrence carries the synthetic Android
+  // nav-performance-logger bridge frame (the #4610 shape), it is also noise.
+  for (const message of ANDROID_WEBVIEW_BRIDGE_POSTEVENT_EVENTS) {
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message,
+        frames: [{ filename: ANDROID_NAV_PERF_LOGGER_FRAME }],
+      }),
+      true,
+      `expected framed "${message}" from the Android bridge to be noise`,
+    )
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message,
+        filename: ANDROID_NAV_PERF_LOGGER_FRAME,
+      }),
+      true,
+      `expected runtime gate to treat "${message}" from the bridge as noise`,
+    )
+  }
+})
+
+test('suppresses the frameless Android WebView postEvent noise via the Sentry beforeSend gate', () => {
+  // Frameless Sentry event — no stack frames at all (the exact production
+  // capture shape).
+  for (const value of ANDROID_WEBVIEW_BRIDGE_POSTEVENT_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/' },
+        exception: {
+          values: [{ value, stacktrace: { frames: [] } }],
+        },
+      }),
+      true,
+      `expected frameless Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses the frameless Android WebView postEvent noise via the runtime (window.onerror) gate', () => {
+  for (const message of ANDROID_WEBVIEW_BRIDGE_POSTEVENT_EVENTS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message, filename: 'undefined' }),
+      true,
+      `expected runtime gate to suppress frameless "${message}"`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message, filename: '' }),
+      true,
+      `expected runtime gate to suppress "${message}" with empty filename`,
+    )
+  }
+})
+
+test('does NOT suppress a real first-party postEvent/dispatchEvent failure from an app chunk', () => {
+  // A genuine `window.postMessage`/`dispatchEvent` failure in our own code
+  // could share the message wording but throws from an `app:///_next/…` chunk
+  // (or a de-minified `apps/web/src/…` frame) — a resolvable source location
+  // — so it must keep reporting so a real regression is never hidden.
+  const realAppFrames: Array<{ filename: unknown }> = [
+    { filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js' },
+    { filename: 'apps/web/src/features/messaging/event-bridge.ts' },
+  ]
+  for (const frames of [
+    realAppFrames,
+    [{ filename: 'app:///apps/web/src/features/messaging/event-bridge.ts' }],
+  ]) {
+    assert.equal(
+      isAndroidWebViewNativeBridgePostEventNoise({
+        message: 'Error invoking postEvent: Java object is gone',
+        frames,
+      }),
+      false,
+      `expected real first-party postEvent error from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: 'Error invoking postEvent: Java object is gone',
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting real first-party postEvent error from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      filename: 'apps/web/src/features/messaging/event-bridge.ts',
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      filename: 'app:///_next/static/chunks/66499-704f783b0e8ea993.js',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress the postMessage sibling message under the postEvent matcher (and vice versa)', () => {
+  // The two matchers are message-specific: a `postMessage` event must not be
+  // swallowed by the `postEvent` guard, and a `postEvent` event must not be
+  // swallowed by the `postMessage` guard (which would also keep reporting
+  // because it has no bridge frame).
+  assert.equal(
+    isAndroidWebViewNativeBridgePostEventNoise({
+      message: 'Error invoking postMessage: Java object is gone',
+      frames: [{ filename: ANDROID_NAV_PERF_LOGGER_FRAME }],
+    }),
+    false,
+    'postEvent matcher must not swallow the postMessage message',
+  )
+  assert.equal(
+    isAndroidWebViewNativeBridgePostMessageNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      frames: [{ filename: ANDROID_NAV_PERF_LOGGER_FRAME }],
+    }),
+    false,
+    'postMessage matcher must not swallow the postEvent message',
+  )
+})
+
+test('does NOT suppress a same-worded message from a different bridge / non-Android source with a resolvable frame', () => {
+  // A resolvable non-bridge frame (e.g. an iOS sibling filename) keeps
+  // reporting — the matcher only suppresses frameless or
+  // Android-nav-perf-logger-bridge-originated captures.
+  assert.equal(
+    isAndroidWebViewNativeBridgePostEventNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      frames: [{ filename: 'app://navigation_performance_logger_ios' }],
+    }),
+    false,
+  )
+  assert.equal(
+    isAndroidWebViewNativeBridgePostEventNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      filename: 'app://navigation_performance_logger_androidx',
+    }),
+    false,
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -309,6 +309,52 @@ function isAndroidNavPerfLoggerFrame(filename: unknown): boolean {
   return normalizeString(filename) === ANDROID_NAV_PERF_LOGGER_FRAME_SOURCE;
 }
 
+// Android System WebView native-bridge instrumentation noise — the `postEvent`
+// sibling of the `postMessage` class above. Android's Chromium WebView ships a
+// `JavaBridge` (the V8↔Java bridge injected into every page) whose
+// `postEvent`/`postMessage` thread-hop hands a serialized event to the Java
+// side via a WEAK reference to the backing `JavaObject`. When that object is
+// garbage-collected — page navigation, WebView teardown, or the host in-app
+// browser (Threads/Barcelona, Facebook, Instagram, …) dismissing the tab — the
+// next `postEvent` throws `Error invoking postEvent: Java object is gone`.
+// This is the WebView's OWN bridge plumbing, never first-party code: there is
+// no app chunk frame, no de-minified `apps/web/src/…` frame, and (unlike the
+// `postMessage` sibling) frequently NO resolvable frame at all — the throw
+// escapes from the GC'd bridge hop with a frameless `<anonymous>` / `?`
+// call site (Sentry mechanism
+// `auto.browser.global_handlers.onerror`/`onunhandledrejection`).
+//
+// Better Stack pattern
+// a6795db236a92a4f9738698e93a8d7ae4e60dae607cacedccb7ed8bbd225b2d4
+// (Kortix Frontend prod, application_id 2346967): 1 occurrence / 0 identified
+// users, last_seen 2026-07-20 19:05:34 UTC, call_site_file `<anonymous>`,
+// call_site_function `?` — the frameless capture shape. The `postMessage`
+// sibling `e6a45fe4…` (PR #4610) carried the synthetic
+// `app://navigation_performance_logger_android` frame; this `postEvent` variant
+// surfaced frameless, so the bridge-frame-only anchor from #4610 does not
+// match it. `Java object is gone` is the canonical Android System WebView
+// Java-bridge-GC'd message; it is not raised by app code or by desktop
+// Chrome.
+//
+// The message wording (`Error invoking <method>: Java object is gone`) is
+// shared with the `postMessage` sibling and could conceivably be reused by a
+// hostile/injected script, so this matcher — like the iOS-WebKit
+// stack-overflow frameless-capture class — is anchored on BOTH the exact
+// `postEvent` message AND a frameless/injected-WebView origin: it suppresses
+// only when there is NO resolvable source location (no app chunk, no URL, no
+// de-minified `apps/web/src/…` frame) OR the frame is the synthetic Android
+// nav-performance-logger bridge source. A genuine first-party `postEvent` /
+// `dispatchEvent` failure throws from an `app:///_next/…` chunk or a
+// de-minified `apps/web/src/…` frame and is preserved by the negative guard.
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list
+// — that gate has no frame context, so a bare-string match there could
+// swallow a real first-party event-dispatch failure; the frame-aware
+// `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`) is the only
+// safe gate.
+const ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTEVENT_NOISE_MESSAGES = [
+  'Error invoking postEvent: Java object is gone',
+] as const;
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -1034,6 +1080,64 @@ export function isAndroidWebViewNativeBridgePostMessageNoise(input: {
   return sources.some((filename) => isAndroidNavPerfLoggerFrame(filename));
 }
 
+/**
+ * Whether an event is the Android System WebView native-bridge
+ * `Error invoking postEvent: Java object is gone` noise class: the WebView's
+ * injected `JavaBridge` calls `postEvent` on a native Java bridge whose
+ * backing `JavaObject` has been garbage-collected (page navigation / WebView
+ * teardown / in-app browser dismiss). This is the WebView's OWN bridge
+ * plumbing, not first-party code. Unlike the `postMessage` sibling (PR #4610),
+ * the `postEvent` variant is observed as a FRAMELESS capture
+ * (`<anonymous>` / `?` call site, no resolvable stack), so it cannot be
+ * anchored on the synthetic `app://navigation_performance_logger_android`
+ * frame. Instead — like the iOS-WebKit stack-overflow frameless class — it
+ * requires BOTH the exact message AND a frameless/injected-WebView origin:
+ * suppress only when there is NO resolvable source location OR the frame is
+ * the Android nav-performance-logger bridge source. A genuine first-party
+ * `postEvent` / `dispatchEvent` failure throws from an app chunk or a
+ * de-minified `apps/web/src/…` frame and is preserved by the negative guard.
+ * Never page Better Stack for this class. See
+ * `ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTEVENT_NOISE_MESSAGES` for the full
+ * rationale.
+ */
+export function isAndroidWebViewNativeBridgePostEventNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const message = stripErrorWrappers(normalizeString(input.message));
+  if (
+    !ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTEVENT_NOISE_MESSAGES.some(
+      (noise) => message === noise,
+    )
+  ) {
+    return false;
+  }
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Positive anchor: the synthetic Android nav-performance-logger bridge
+  // source (the framed sibling shape, forward-compat with #4610's evidence).
+  if (sources.some((filename) => isAndroidNavPerfLoggerFrame(filename))) {
+    return true;
+  }
+  // Negative guard #1: a resolved first-party `apps/web/src/…` frame → our
+  // own event-dispatch code is failing; keep reporting so the call site can
+  // be found + fixed.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  // Negative guard #2: any resolvable source location (real app chunk, URL,
+  // or named file) → an actionable event-dispatch error with a real stack;
+  // keep reporting. Only the frameless synthetic-`undefined`/`<anonymous>`
+  // global-onerror/onunhandledrejection capture remains → Android WebView
+  // native-bridge GC noise.
+  if (sources.some(isResolvableFrameSource)) {
+    return false;
+  }
+  return true;
+}
 // iOS WebKit (Safari, Chrome-on-iOS, Google Search App — all WKWebView/JSC)
 // stack-overflow noise. When iOS WebKit exhausts its (lower-than-desktop) call
 // stack, it surfaces `RangeError: Maximum call stack size exceeded.` through
@@ -1313,6 +1417,22 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Android System WebView native-bridge instrumentation noise — the
+  // `postEvent` sibling of the `postMessage` class above. The WebView's
+  // `JavaBridge` calls `postEvent` on a GC'd Java bridge object; the throw
+  // escapes framelessly (`<anonymous>` / `?`). Requires the exact message AND
+  // a frameless/injected-WebView origin so a real first-party
+  // `postEvent`/`dispatchEvent` failure keeps reporting. See
+  // `isAndroidWebViewNativeBridgePostEventNoise`.
+  if (
+    isAndroidWebViewNativeBridgePostEventNoise({
+      message,
+      filename: input.filename,
+    })
+  ) {
+    return true;
+  }
+
   if (isInjectedAppSource(input.filename)) {
     return true;
   }
@@ -1486,6 +1606,19 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // so a genuine first-party `window.postMessage` failure keeps reporting. Not
   // in `ignoreErrors` (no frame context there).
   if (isAndroidWebViewNativeBridgePostMessageNoise({ message, frames })) {
+    return true;
+  }
+
+  // Android System WebView native-bridge instrumentation noise — the
+  // `postEvent` sibling of the `postMessage` class above, captured by Sentry's
+  // global onerror/onunhandledrejection handlers. Unlike the `postMessage`
+  // sibling, the `postEvent` variant is observed as a FRAMELESS capture
+  // (`<anonymous>` / `?`), so it is anchored on the exact message AND a
+  // frameless/injected-WebView origin (no resolvable source location, OR the
+  // Android nav-performance-logger bridge frame). A genuine first-party
+  // `postEvent`/`dispatchEvent` failure keeps reporting. Not in `ignoreErrors`
+  // (no frame context there).
+  if (isAndroidWebViewNativeBridgePostEventNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. Proof: `bun test src/lib/browser-error-noise.test.mts` → **124 pass / 0 fail** (was 116; +8 new tests), and `tsc` on `browser-error-noise.ts` under the project's strictness is clean.

## Why

Better Stack is paging on a new Android WebView native-bridge noise variant that slipped past the `postMessage`-only suppression shipped in #4610. The `postEvent` sibling surfaces **framelessly** (`<anonymous>` / `?` call site, no resolvable stack), so #4610's bridge-frame-only anchor doesn't match it and it leaks through to Better Stack as an unactionable global error. This PR adds a conservative, frame-anchored suppression for the verified `postEvent` class while preserving every genuine first-party `postEvent`/`dispatchEvent` failure.

## What changed

- **`apps/web/src/lib/browser-error-noise.ts`**
  - New noise class `isAndroidWebViewNativeBridgePostEventNoise` (the `postEvent` sibling of #4610's `postMessage` matcher), wired into **both** capture-path gates: `shouldIgnoreSentryBrowserNoise` (Sentry `beforeSend` hook, primary) and `shouldIgnoreBrowserRuntimeNoise` (the `window.onerror`/`onunhandledrejection` gate, defense-in-depth).
  - **Conservative, frame-anchored match** (mirrors the iOS-WebKit stack-overflow frameless-capture precedent, since this variant is frameless unlike #4610):
    1. requires the **exact** message `Error invoking postEvent: Java object is gone` (after stripping canonical `Unhandled promise rejection: ` / `…Error: ` wrappers);
    2. suppresses if a frame's filename is exactly `app://navigation_performance_logger_android` (forward-compat with a framed sibling), **OR** the capture is frameless — no resolvable source location (every frame's filename is empty or the literal `"undefined"` placeholder, and the `window.onerror` filename is empty/`undefined`);
    3. **negative guard #1**: any resolved first-party `apps/web/src/…` frame → our own event-dispatch code is failing → keep reporting;
    4. **negative guard #2**: any resolvable source location (real app chunk `app:///_next/…`, URL, or named file) → an actionable error with a real stack → keep reporting.
  - **Deliberately NOT** added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party event-dispatch failure. The frame-aware `beforeSend` hook is the only safe gate.

- **`apps/web/src/lib/browser-error-noise.test.mts`** — +8 tests (116 → 124):
  - ✅ classifies the frameless `postEvent` noise (no frames / synthetic `undefined` frame / `undefined` filename)
  - ✅ classifies the framed sibling (Android nav-perf-logger bridge frame) — forward-compat
  - ✅ suppresses via the Sentry `beforeSend` gate (frameless event, exact production shape)
  - ✅ suppresses via the runtime `window.onerror` gate (`undefined` and empty filename)
  - ❌ does NOT suppress a real first-party `postEvent`/`dispatchEvent` failure that throws from an app chunk / de-minified `apps/web/src/…` frame
  - ❌ does NOT suppress the `postMessage` sibling under the `postEvent` matcher (and vice versa) — message-specific
  - ❌ does NOT suppress a same-worded message from a different bridge / non-Android source that carries a resolvable frame

## Evidence (from Better Stack inventory + the verified `postMessage` sibling)

- **Error page:** https://errors.betterstack.com/team/t502678/errors/a6795db236a92a4f9738698e93a8d7ae4e60dae607cacedccb7ed8bbd225b2d4?s=2346967
- **Inventory row (Kortix Frontend prod, application_id 2346967, post first batch 2026-07-21 21:33 UTC):** pattern `a6795db2…`, message `Error invoking postEvent: Java object is gone`, type `Error`, **1 occurrence / 0 identified users**, `last_seen 2026-07-20 19:05:34 UTC`, unresolved, call_site_file `<anonymous>`, call_site_function `?`.
- **Sibling precedent (PR #4610):** the `postMessage` variant `e6a45fe4…` was verified end-to-end from the raw S3 occurrence payload as Android System WebView native-bridge instrumentation noise: Android 14 / Chrome 149 / Threads (Barcelona) in-app WebView visiting the marketing homepage; the synthetic `app://navigation_performance_logger_android` frame + `sendDataToNative`/`sendJsBlockingTimeMessage` functions + `FBNav*` navigation-timing breadcrumbs confirmed the throw originates from the WebView's **own** injected navigation-performance logger, not first-party code. `Java object is gone` is the canonical Android System WebView Java-bridge-GC'd message emitted when the bridge's weak `JavaObject` ref is cleared during navigation/teardown/in-app-browser-dismiss.
- **This `postEvent` variant** shares the `Java object is gone` canonical Android-WebView-bridge message; `postEvent` is the `JavaBridge` thread-hop method (sibling of `postMessage`). The only structural difference from #4610 is the **frameless** capture shape (`<anonymous>`/`?`, no resolvable stack) — the throw escaped the GC'd bridge hop before a stack could be produced. Same Android WebView native-bridge origin, same unactionable noise class; the conservative matcher reflects that shape.

## Verification (local)

- `node --experimental-strip-types --test src/lib/browser-error-noise.test.mts` → **124 pass / 0 fail** (node 22)
- `bun test src/lib/browser-error-noise.test.mts` → **124 pass / 0 fail** (CI parity — `package-tests` runs `bun test`)
- `bun test src/app/sentry-ignore-errors.test.ts` → **4 pass / 0 fail** (untouched, regression-safe)
- `tsc` on `browser-error-noise.ts` under the project's `tsconfig.base.json` strictness (`strict`, `skipLibCheck`, `moduleResolution: bundler`) → **clean** (the `.mts` test is not in the project `include` and is runtime-tested, not typechecked; matches existing pattern)

## Risk / rollback

Low. The matcher is double-anchored (exact message + frameless/injected-WebView origin) with two negative guards preserving any first-party or resolvable-frame event; a real `postEvent`/`dispatchEvent` regression surfaces as a *different* pattern (message from an app/source frame) and is unaffected. Revert is a single commit removing the new noise class + its two wire-ins + the 8 tests.

## Confirmation of resolution

After merge + promote, this exact Better Stack pattern (`a6795db2…`) should drop to **zero new occurrences**: any subsequent Android in-app WebView visit that triggers the GC'd-bridge `postEvent` throw will be dropped at the Sentry `beforeSend` gate before reaching Better Stack. A real first-party `postEvent` regression surfaces as a *different* pattern (message from an app/source frame) and is unaffected.

## Incident reference

- Error id: `a6795db236a92a4f9738698e93a8d7ae4e60dae607cacedccb7ed8bbd225b2d4`
- Error URL: https://errors.betterstack.com/team/t502678/errors/a6795db236a92a4f9738698e93a8d7ae4e60dae607cacedccb7ed8bbd225b2d4?s=2346967
- Application: Kortix Frontend (prod), application_id `2346967`
- Sibling precedent: PR #4610 (pattern `e6a45fe4…`, `Error invoking postMessage: Java object is gone`)
