### PR TITLE
fix(web): classify userscript-manager JSON.parse noise out of Sentry (BS 2249441898…)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -21,6 +21,7 @@ import {
   isStorageSecurityErrorNoise,
   isTronLinkProxyNoise,
   isUnresolvableStackOverflowNoise,
+  isUserscriptManagerNoise,
   shouldIgnoreBrowserRuntimeNoise,
   shouldIgnoreSentryBrowserNoise,
 } from './browser-error-noise.ts'
@@ -1969,6 +1970,187 @@ test('does NOT suppress a real first-party Proxy `set` failure on a DIFFERENT pr
       `expected non-TronLink Proxy message "${value}" to keep reporting`,
     )
   }
+})
+
+// Reproduces Better Stack error
+// 2249441898cd4d7bb679841d57b829b8863c9a4dc1675a88075d794cfd3cd600
+// (Kortix Frontend prod, application_id 2346967): 1 occurrence, 0 identified
+// users, 2026-07-21 05:08 UTC. A Tampermonkey/Violentmonkey userscript
+// (`YoutubeDL.user.js`) `@match`ing `*://*/*` ran on the marketing homepage
+// (`https://kortix.com/`, Chrome 150 / Windows 10). The user script's own
+// logic called `JSON.parse()` on an `undefined` value, throwing
+// `SyntaxError: "undefined" is not valid JSON` as an unhandled promise
+// rejection, captured by Sentry's `GlobalHandlers` `onunhandledrejection`.
+// The throw's frame is the userscript-manager's synthetic
+// `app:///userscript.html?name=YoutubeDL.user.js&id=303c1708-…` wrapper page
+// (fn `?`, line 1614) plus a `<anonymous>` `JSON.parse` frame — never
+// first-party app code. The `app:///userscript.html` prefix is specific to
+// userscript-manager wrappers and never appears on a first-party
+// `app:///_next/…` bundle frame or a de-minified `apps/web/src/…` source
+// path, so anchoring on it is conservative: a real first-party
+// `JSON.parse(undefined)` regression throws inside an app chunk (or a
+// de-minified `apps/web/src/…` frame) and is never matched.
+const USERSCRIPT_MANAGER_FRAME =
+  'app:///userscript.html?name=YoutubeDL.user.js&id=303c1708-e3a7-42b9-bdd1-9c21ea14f6b4'
+
+const USERSCRIPT_MANAGER_FRAMES: Array<{ filename: unknown; function: unknown }> = [
+  { filename: USERSCRIPT_MANAGER_FRAME, function: '?' },
+  { filename: '<anonymous>', function: 'JSON.parse' },
+]
+
+test('classifies the userscript-manager JSON.parse SyntaxError as noise', () => {
+  assert.equal(
+    isUserscriptManagerNoise({
+      message: '"undefined" is not valid JSON',
+      frames: USERSCRIPT_MANAGER_FRAMES,
+    }),
+    true,
+  )
+})
+
+test('classifies a userscript-manager event from the filename alone (window.onerror)', () => {
+  assert.equal(
+    isUserscriptManagerNoise({
+      message: '"undefined" is not valid JSON',
+      filename: USERSCRIPT_MANAGER_FRAME,
+    }),
+    true,
+  )
+})
+
+test('classifies userscript-manager frames with different script names/ids as noise', () => {
+  // The `app:///userscript.html` prefix is the stable anchor; the script name
+  // and id vary per installed user script, so a different script must still
+  // classify.
+  for (const filename of [
+    'app:///userscript.html?name=AdBlockerPro.user.js&id=abc123',
+    'app:///userscript.html?name=dark-mode.user.js&id=00000000-0000-0000-0000-000000000000',
+    'app:///userscript.html',
+  ]) {
+    assert.equal(
+      isUserscriptManagerNoise({ message: 'anything', filename }),
+      true,
+      `expected ${filename} to be userscript-manager noise`,
+    )
+  }
+})
+
+test('suppresses the userscript-manager JSON.parse Sentry event', () => {
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            type: 'SyntaxError',
+            value: '"undefined" is not valid JSON',
+            stacktrace: { frames: USERSCRIPT_MANAGER_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the userscript-manager JSON.parse unhandled rejection from the browser (window.onerror)', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: 'Unhandled promise rejection: "undefined" is not valid JSON',
+      filename: USERSCRIPT_MANAGER_FRAME,
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a real first-party JSON.parse SyntaxError from app code', () => {
+  // A genuine first-party `JSON.parse(undefined)` regression throws the SAME
+  // `SyntaxError: "undefined" is not valid JSON` wording but inside an
+  // `app:///_next/…` chunk or a de-minified `apps/web/src/…` frame — never from
+  // the userscript-manager wrapper. It must keep reporting so the call site can
+  // be found + fixed.
+  const realAppFrames: Array<{ filename: unknown; function: unknown }> = [
+    { filename: 'app:///_next/static/chunks/parse-helpers.js', function: 'parseBody' },
+    { filename: 'app:///apps/web/src/lib/api-client.ts', function: 'safeParse' },
+    { filename: 'https://app.kortix.com/_next/static/chunks/json.js', function: 'revive' },
+  ]
+  for (const frames of [realAppFrames, [{ filename: 'apps/web/src/lib/store.ts' }]]) {
+    assert.equal(
+      isUserscriptManagerNoise({
+        message: '"undefined" is not valid JSON',
+        frames,
+      }),
+      false,
+      `expected JSON.parse SyntaxError from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://app.kortix.com/projects' },
+        exception: {
+          values: [
+            {
+              type: 'SyntaxError',
+              value: '"undefined" is not valid JSON',
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting JSON.parse SyntaxError from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party/chunk filename keeps reporting too.
+  for (const filename of [
+    'app:///_next/static/chunks/json.js',
+    'app:///apps/web/src/lib/api-client.ts',
+    'https://app.kortix.com/_next/static/chunks/json.js',
+  ]) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message: '"undefined" is not valid JSON',
+        filename,
+      }),
+      false,
+      `expected runtime gate to keep reporting JSON.parse SyntaxError from ${filename}`,
+    )
+  }
+})
+
+test('does NOT suppress a userscript-shaped event that is NOT from a userscript-manager frame', () => {
+  // No userscript-manager frame anchor → can't confirm the throw originated in
+  // a user script; keep reporting rather than swallow a possible app bug.
+  assert.equal(
+    isUserscriptManagerNoise({ message: '"undefined" is not valid JSON' }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [{ value: '"undefined" is not valid JSON' }],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT match the userscript-manager prefix against a first-party _next bundle frame', () => {
+  // `app:///_next/static/…` has a single slash after `app:`; the userscript
+  // wrapper is `app:///userscript.html` (empty host). They must never collide.
+  assert.equal(
+    isUserscriptManagerNoise({
+      message: 'x',
+      filename: 'app:///_next/static/chunks/userscript.html.js',
+    }),
+    false,
+  )
+  assert.equal(
+    isUserscriptManagerNoise({
+      message: 'x',
+      frames: [{ filename: 'app:///_next/static/chunks/userscript-helper.js' }],
+    }),
+    false,
+  )
 })
 
 // Reproduces Better Stack error e6a45fe4999b5a60f5cd64fd4153b18c2beebfc4409a3d54da456a4bbc24e5d2

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -354,6 +354,52 @@ const INJECTED_APP_SOURCE_PATTERNS = [
   /^app:\/\/\/embed\/embed\.js$/,
 ] as const;
 
+// Browser userscript-manager (Tampermonkey / Violentmonkey / Greasemonkey /
+// FireMonkey) injected-script noise. A userscript-manager extension wraps each
+// injected user script in a synthetic `app:///userscript.html?name=<Script>.user.js&id=<uuid>`
+// page so it can run in an isolated sandbox with privileged APIs
+// (`GM_*` / `GM_` / `unsafeWindow`). The user script executes on every page
+// whose URL matches its `@match` / `@include` rules (a `YoutubeDL.user.js`
+// download-helper script `@match`s `*://*/*` and runs on `https://kortix.com/`).
+// When the script's own logic is buggy — e.g. it calls `JSON.parse()` on a
+// value that resolved to `undefined` (an attribute / text node it expected to
+// find was absent on our page) — it throws `SyntaxError: "undefined" is not
+// valid JSON` as an UNHANDLED promise rejection inside the userscript wrapper.
+// Sentry's `GlobalHandlers` `onunhandledrejection` integration captures it,
+// and because the throw's frame is the synthetic `app:///userscript.html?…`
+// source (NOT an `app:///_next/…` bundle frame and NOT a de-minified
+// `apps/web/src/…` frame), it leaks to Better Stack. Better Stack pattern
+// 2249441898cd4d7bb679841d57b829b8863c9a4dc1675a88075d794cfd3cd600
+// (Kortix Frontend prod, application_id 2346967): 1 occurrence, 0 identified
+// users, 2026-07-21 05:08 UTC, `SyntaxError: "undefined" is not valid JSON`,
+// call site `JSON.parse` at `<anonymous>`, frames
+// `app:///userscript.html?name=YoutubeDL.user.js&id=303c1708-…` (fn `?`, line 1614)
+// + `<anonymous>` (`JSON.parse`), mechanism `auto.browser.global_handlers.
+// onunhandledrejection`, request URL `https://kortix.com/`, Chrome 150 / Win 10.
+// The throw is in the THIRD-PARTY user script's own logic, never in first-party
+// app code: `app:///userscript.html` is the userscript-manager's synthetic
+// wrapper page (it has the same `app:///` empty-host origin shape as the other
+// injected/extension sources above), and `JSON.parse` is a built-in. Our app
+// never runs from a `userscript.html` frame.
+//
+// The `app:///userscript.html` prefix is specific to userscript-manager
+// wrappers and never appears on a first-party `app:///_next/…` bundle frame or
+// a de-minified `apps/web/src/…` source path (those carry `_next/static/` or
+// the `apps/web/src/` path), so anchoring on it is conservative. A real
+// first-party `JSON.parse(undefined)` regression throws inside an
+// `app:///_next/…` chunk (or a de-minified `apps/web/src/…` frame) and is never
+// matched. This mirrors `isInjectedAppSource` / `isExtensionSource`: a
+// definitive third-party-injected-source anchor that drops the event.
+// Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list —
+// that gate has no frame context, so a bare-string match there would swallow a
+// real first-party `JSON.parse` SyntaxError; the frame-aware `beforeSend` hook
+// (which calls `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const USERSCRIPT_MANAGER_FRAME_PATTERN = /^app:\/\/\/userscript\.html\b/;
+
+function isUserscriptManagerInjectedSource(filename: unknown): boolean {
+  return USERSCRIPT_MANAGER_FRAME_PATTERN.test(normalizeString(filename));
+}
+
 // TronLink (Tron blockchain wallet) browser-extension injected-script noise.
 // The TronLink extension injects a content script
 // (`app:///injected/injected.js`, function `BI`) that wraps a page object
@@ -758,6 +804,37 @@ export function isExtensionSource(filename: unknown): boolean {
 export function isInjectedAppSource(filename: unknown): boolean {
   const normalized = normalizeString(filename);
   return INJECTED_APP_SOURCE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+/**
+ * Whether a Sentry / window.onerror event originates from a browser
+ * userscript-manager (Tampermonkey / Violentmonkey / Greasemonkey / FireMonkey)
+ * injected user script — a frame whose filename is the userscript-manager's
+ * synthetic `app:///userscript.html?name=<Script>.user.js&id=<uuid>` wrapper
+ * page. The user script runs on every `@match`ed page (e.g. a download-helper
+ * script `@match`ing a wildcard `https-or-http any-host any-path` rule and
+ * running on `https://kortix.com/`); its OWN
+ * logic bugs (e.g. `JSON.parse(undefined)` → `SyntaxError: "undefined" is not
+ * valid JSON`) surface as unhandled rejections captured by Sentry and leak to
+ * Better Stack because the frame is the synthetic wrapper, never first-party
+ * code. The `app:///userscript.html` prefix is specific to userscript-manager
+ * wrappers and never appears on a first-party `app:///_next/…` bundle frame or
+ * a de-minified `apps/web/src/…` source path, so anchoring on it is
+ * conservative: a real first-party `JSON.parse` SyntaxError throws inside an
+ * app chunk (or a de-minified `apps/web/src/…` frame) and is never matched.
+ * See `USERSCRIPT_MANAGER_FRAME_PATTERN` for the full rationale and the
+ * production pattern `2249441898…`.
+ */
+export function isUserscriptManagerNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown }>;
+}): boolean {
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  return sources.some(isUserscriptManagerInjectedSource);
 }
 
 /**
@@ -1317,6 +1394,16 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Browser userscript-manager (Tampermonkey / Violentmonkey / Greasemonkey /
+  // FireMonkey) injected user-script noise — the script's own logic bug (e.g.
+  // `JSON.parse(undefined)` → `SyntaxError: "undefined" is not valid JSON`)
+  // thrown from the synthetic `app:///userscript.html?…` wrapper page and
+  // captured as an unhandled rejection. Third-party user-script defect, never
+  // first-party app code; drop it. See `isUserscriptManagerNoise`.
+  if (isUserscriptManagerNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
   // TronLink browser-extension injected-Proxy `set`-trap noise — the
   // extension's `injected.js` wraps a page object in a Proxy and a `set` on
   // `tronlinkParams` is declined. Requires BOTH the TronLink property name AND
@@ -1516,6 +1603,20 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   }
 
   if (frames.some((frame) => isInjectedAppSource(frame.filename))) {
+    return true;
+  }
+
+  // Browser userscript-manager (Tampermonkey / Violentmonkey / Greasemonkey /
+  // FireMonkey) injected user-script noise — the script's own logic bug (e.g.
+  // `JSON.parse(undefined)` → `SyntaxError: "undefined" is not valid JSON`)
+  // thrown from the synthetic `app:///userscript.html?…` wrapper page and
+  // captured as an unhandled rejection. Third-party user-script defect, never
+  // first-party app code; drop it so a buggy user script someone installed on
+  // their browser never pages Better Stack. A real first-party `JSON.parse`
+  // SyntaxError throws inside an `app:///_next/…` chunk (or a de-minified
+  // `apps/web/src/…` frame) and is never matched. See
+  // `isUserscriptManagerNoise` and the production pattern `2249441898…`.
+  if (isUserscriptManagerNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo
Non-visual change — telemetry-noise classification fix. Proof below in **Verification**; no screen recording applies.

## Why
Better Stack error
[`2249441898cd4d7bb679841d57b829b8863c9a4dc1675a88075d794cfd3cd600`](https://errors.betterstack.com/team/t502678/errors/2249441898cd4d7bb679841d57b829b8863c9a4dc1675a88075d794cfd3cd600?s=2346967)
(Kortix Frontend prod, application_id 2346967): `SyntaxError: "undefined" is not valid JSON`, call
site `JSON.parse` at `<anonymous>`, 1 occurrence / 0 users / last_seen 2026-07-21 05:08 UTC /
unresolved. A third-party userscript injected by a browser extension is throwing on our marketing
homepage and paging Better Stack; it is not an app defect.

## Evidence (Better Stack → ClickHouse raw occurrence)
- `environment=prod`, `release=470fe6f3c88460212c3b187f6f86fb4ad456c4d6`, request URL
  `https://kortix.com/`, Chrome 150 / Windows 10.
- Mechanism: `auto.browser.global_handlers.onunhandledrejection`.
- Stack frames (de-minified):
  1. `app:///userscript.html?name=YoutubeDL.user.js&id=303c1708-e3a7-42b9-bdd1-9c21ea14f6b4` (fn `?`, line 1614)
  2. `<anonymous>` (fn `JSON.parse`)
- Exception: `SyntaxError` / `"undefined" is not valid JSON`.

## Root cause
A **Tampermonkey / Violentmonkey / Greasemonkey userscript-manager** extension injects a user
script (`YoutubeDL.user.js`, `@match`ing `*://*/*`) that runs on `https://kortix.com/`. The user
script's own logic calls `JSON.parse()` on a value that resolved to `undefined` (an attribute /
text node it expected to find was absent on our page), throwing
`SyntaxError: "undefined" is not valid JSON` as an unhandled promise rejection inside the
userscript-manager's synthetic `app:///userscript.html?…` wrapper page. Sentry's `GlobalHandlers`
`onunhandledrejection` integration captures it and the event leaks to Better Stack because the
throw's frame is the synthetic userscript wrapper — never first-party `apps/web/src/…` code, never
an `app:///_next/…` bundle frame — so the existing `shouldIgnoreSentryBrowserNoise` noise filter
fell through (no matching noise class) and reported the event.

This is **browser/extension noise**, not an app bug. The userscript wrapper is a definitive
third-party-injected source, identical in shape to the `isInjectedAppSource` /
`isExtensionSource` guards already in the file.

## What changed
`apps/web/src/lib/browser-error-noise.ts`
- New `USERSCRIPT_MANAGER_FRAME_PATTERN = /^app:\/\/\/userscript\.html\b/` + private
  `isUserscriptManagerInjectedSource`.
- New exported `isUserscriptManagerNoise({ message?, filename?, frames? })` — drops an event when
  any frame's filename (or the window.onerror `filename`) is the userscript-manager synthetic
  wrapper page `app:///userscript.html…`.
- Wired into BOTH capture paths:
  - the frame-aware Sentry `beforeSend` gate (`shouldIgnoreSentryBrowserNoise`), and
  - the filename-aware window.onerror / `onunhandledrejection` runtime gate
    (`shouldIgnoreBrowserRuntimeNoise`).
- `sentry.edge.config.ts` / `sentry.server.config.ts` both go through `shouldIgnoreSentryNoiseEvent`
  → `shouldIgnoreSentryBrowserNoise`, so the fix covers all Sentry capture paths.

The match is anchored on the `app:///userscript.html` prefix, which is specific to
userscript-manager wrappers and never appears on a first-party `app:///_next/…` bundle frame or a
de-minified `apps/web/src/…` source path (those carry `_next/static/` or `apps/web/src/`). A real
first-party `JSON.parse(undefined)` regression throws inside an app chunk (or a de-minified
`apps/web/src/…` frame) and is **never matched** — reporting for real malformed-JSON bugs is
preserved. Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has
no frame context, so a bare-string match there would swallow a real first-party `JSON.parse`
SyntaxError; the frame-aware `beforeSend` hook is the only safe gate (same posture as the TronLink
/ inpage-wallet / Android-WebView / storage-`SecurityError` noise classes already in the file).

## Verification
- **Unit tests** (`bun test src/lib/browser-error-noise.test.mts`): 125 pass / 0 fail
  (was 117; +8 new tests covering the production occurrence + negatives).
  - Reproduces the exact prod occurrence: `isUserscriptManagerNoise` + both gates classify the
    `SyntaxError: "undefined" is not valid JSON` event from the
    `app:///userscript.html?name=YoutubeDL.user.js&id=303c1708-…` frame as noise → suppressed.
  - Negative cases (kept reporting):
    - a real first-party `JSON.parse(undefined)` `SyntaxError` from `app:///_next/…` chunk frames,
      from de-minified `app:///apps/web/src/…` frames, and from `https://app.kortix.com/_next/…`
      URL frames — all preserved through both the matcher and both gates;
    - a userscript-shaped event with NO userscript-manager frame (frameless) — kept reporting;
    - the `app:///_next/static/chunks/userscript.html.js` near-collision — not matched (single-slash
      `app:///_next/` vs empty-host `app:///userscript.html` are distinct, never collide).
  - Parametric: different script names / ids and the bare `app:///userscript.html` all classify.
- Companion module smoke: `bun test src/lib/browser-error-noise.test.mts src/components/common/runtime-not-ready-noise.test.ts` → 127 pass / 0 fail.
- `bun` type-stripped and executed both `.ts` and `.mts` files cleanly (no full install was needed
  for these standalone `node:test` files).

## Risk / rollback
Purely additive telemetry-filtering (drops a third-party noise class from Sentry/Better Stack).
No user-facing or API behaviour change; no runtime path that could throw is altered. A real
first-party `JSON.parse` SyntaxError keeps reporting (anchored on the synthetic
`app:///userscript.html` source, never first-party). Rollback = revert the two-file diff.

## How to confirm resolution
After merge + promote, the Better Stack error
[`2249441898…`](https://errors.betterstack.com/team/t502678/errors/2249441898cd4d7bb679841d57b829b8863c9a4dc1675a88075d794cfd3cd600?s=2346967)
should drop to zero new occurrences (the userscript-manager class is dropped at the Sentry
`beforeSend` gate before it reaches Better Stack) and auto-resolve once it stops recurring.

Incident ref: Better Stack error id
`2249441898cd4d7bb679841d57b829b8863c9a4dc1675a88075d794cfd3cd600`, application_id 2346967
(Kortix Frontend prod).
