### PR TITLE
fix(web/sdk): classify expected no-compaction-model state out of Sentry (BS 9f72dd9a…)

### DIFF
--- a/apps/mobile/lib/opencode/hooks/use-compact-session.ts
+++ b/apps/mobile/lib/opencode/hooks/use-compact-session.ts
@@ -14,6 +14,26 @@ import { getAuthToken } from '@/api/config';
 import { log } from '@/lib/logger';
 import { useCompactionStore } from '@/stores/compaction-store';
 
+/**
+ * `NoCompactionModelError` — the EXPECTED, user-facing configuration state
+ * surfaced when every model-resolution fallback tier fails (no config default,
+ * no assistant message in the thread, no connected provider/model). The toast
+ * already tells the user to configure a model; it must never page Better Stack.
+ *
+ * Mirrors the SDK's `packages/sdk/src/react/use-opencode-sessions/no-compaction-model-error.ts`
+ * sentinel class (mobile doesn't import the SDK react barrel, so this is a
+ * local copy with the same `name` + message so the telemetry gate matches it
+ * on either surface).
+ */
+export class NoCompactionModelError extends Error {
+  constructor(
+    message = 'No model available for compaction. Please configure a model in settings.',
+  ) {
+    super(message);
+    this.name = 'NoCompactionModelError';
+  }
+}
+
 interface CompactParams {
   sandboxUrl: string;
   sessionId: string;
@@ -80,7 +100,7 @@ async function resolveModel(sandboxUrl: string, sessionId: string): Promise<{ pr
     log.log(`[Compact] Provider model resolution failed: ${e}`);
   }
 
-  throw new Error('No model available for compaction. Please configure a model in settings.');
+  throw new NoCompactionModelError();
 }
 
 export function useCompactSession() {

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -72,6 +72,20 @@ if (SENTRY_DSN) {
       /^(?:Unhandled promise rejection: )?(?:ApiError: )?Out of credits\. Top up to continue\.$/,
       /^(?:Unhandled promise rejection: )?(?:ApiError: )?No credit account found\. Complete account setup first\.$/,
       /^(?:Unhandled promise rejection: )?(?:ApiError: )?Subscribe to activate your seat\. \$20\/teammate per month includes wallet credits for compute and LLM usage\.$/,
+      // Expected "no compaction model configured" configuration state. The
+      // SDK's `useSummarizeOpenCodeSession` mutation throws a sentinel
+      // `NoCompactionModelError` (`packages/sdk/src/react/use-opencode-sessions/no-compaction-model-error.ts`)
+      // when every model-resolution fallback tier fails; the host already
+      // surfaces it via the `loadingToast` error toast, so it must never page
+      // Better Stack. It leaks as an unhandled promise rejection
+      // (`void loadingToast(...)` re-throws after the toast → Sentry
+      // `onunhandledrejection` auto-capture) and through
+      // `<ClientErrorBoundary>` / route / system-fault boundaries. The
+      // `browser-error-noise.ts` `beforeSend` hook drops it with the same
+      // anchor; this anchored regex covers frameless `onerror` captures.
+      // Anchored so a longer real mutation failure that merely mentions the
+      // wording keeps reporting.
+      /^(?:Unhandled promise rejection: )?(?:Error: )?No model available for compaction\. Please configure a model in settings\.$/,
       // External Safari / WebView video probing noise
       'webkitPresentationMode',
       "null is not an object (evaluating 'document.querySelector('video').webkitPresentationMode')",

--- a/apps/web/src/app/sentry-ignore-errors.test.ts
+++ b/apps/web/src/app/sentry-ignore-errors.test.ts
@@ -34,6 +34,27 @@ test('sentry.client.config anchors expected billing-gate 402 markers', async () 
   expect(source).not.toContain("'Out of credits. Top up to continue.'");
 });
 
+test('sentry.client.config anchors the expected no-compaction-model marker', async () => {
+  // Reproduces Better Stack error 9f72dd9a2cb49a81aa57be27e9b3cb2f1ef06a8ebf59ede6900267febd3f7ded
+  // (Kortix Frontend prod): the SDK's `useSummarizeOpenCodeSession` mutation
+  // throws a sentinel `NoCompactionModelError` when no model is configured
+  // anywhere — an expected, user-facing config state the host already toasts.
+  // It leaks to Sentry as an unhandled promise rejection
+  // (`void loadingToast(...)` re-throws after the toast → `onunhandledrejection`).
+  // Sentry's `ignoreErrors` list is checked before an event is sent (covers
+  // every capture path, including frameless onerror), so the anchored marker
+  // MUST live here. Anchored so a longer real mutation failure that merely
+  // mentions the wording keeps reporting.
+  const source = await Bun.file(`${import.meta.dir}/../../sentry.client.config.ts`).text();
+  expect(source).toContain(
+    '/^(?:Unhandled promise rejection: )?(?:Error: )?No model available for compaction\\. Please configure a model in settings\\.$/',
+  );
+  // Guard against reintroducing a bare string entry: Sentry treats string
+  // ignoreErrors values as contains-matches, which would hide longer real
+  // errors that merely mention the compaction wording.
+  expect(source).not.toContain("'No model available for compaction.'");
+});
+
 test('sentry.client.config ignores storage-disabled WebView null-access TypeErrors', async () => {
   const source = await Bun.file(`${import.meta.dir}/../../sentry.client.config.ts`).text();
   // Storage-disabled in-app WebViews resolve localStorage/sessionStorage to

--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -7,6 +7,7 @@ import {
   isEmptyMessageUnresolvedBrowserChunkNoise,
   isEmbedPdfTilingReactUpdateDepthNoise,
   isExpectedBillingGateMessage,
+  isExpectedCompactionNoModelMessage,
   isExtensionRejectedObjectNoise,
   isExtensionSource,
   isInjectedAppSource,
@@ -492,6 +493,127 @@ test('does NOT suppress a longer real error containing the billing-gate phrase',
       shouldIgnoreBrowserRuntimeNoise({ message: value }),
       false,
       `expected longer runtime error "${value}" to keep reporting`,
+    )
+  }
+})
+
+// Reproduces Better Stack error 9f72dd9a2cb49a81aa57be27e9b3cb2f1ef06a8ebf59ede6900267febd3f7ded
+// (Kortix Frontend prod): the SDK's `useSummarizeOpenCodeSession` mutation
+// threw a plain `Error('No model available for compaction. …')` when every
+// model-resolution fallback tier failed (no config default, no assistant
+// message, no connected provider/model) — an EXPECTED, user-facing
+// configuration state the host already surfaces via the `loadingToast` error
+// toast. It leaked to Sentry as an unhandled promise rejection:
+// `compact-modal.tsx` fires `void loadingToast(() => summarize.mutateAsync(...))`,
+// `loadingToast` re-throws the error after showing the toast (toast.tsx), and
+// the `void`-fired rejection is auto-captured by Sentry's `onunhandledrejection`
+// integration. The SDK now throws a sentinel `NoCompactionModelError` (same
+// message + `name`) so this gate can match it precisely and drop it across
+// every capture path. A longer real mutation failure that merely mentions the
+// wording keeps reporting.
+const COMPACTION_NO_MODEL_EVENTS = [
+  // The sentinel error's own message.
+  'No model available for compaction. Please configure a model in settings.',
+  // An `Error:`-prefixed wrapper (e.g. a console/error-boundary re-throw).
+  'Error: No model available for compaction. Please configure a model in settings.',
+  // An unhandled-rejection wrapper preserving the message (Sentry auto-capture).
+  'Unhandled promise rejection: No model available for compaction. Please configure a model in settings.',
+  // An unhandled-rejection wrapper around an `Error:`-prefixed re-throw.
+  'Unhandled promise rejection: Error: No model available for compaction. Please configure a model in settings.',
+]
+
+test('classifies the no-compaction-model configuration state as expected', () => {
+  for (const message of COMPACTION_NO_MODEL_EVENTS) {
+    assert.equal(
+      isExpectedCompactionNoModelMessage(message),
+      true,
+      `expected "${message}" to be classified as an expected no-compaction-model message`,
+    )
+  }
+})
+
+test('suppresses a no-compaction-model Sentry event regardless of capture path', () => {
+  for (const value of COMPACTION_NO_MODEL_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://app.kortix.com/projects/p/sessions/s' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [{ filename: 'app:///_next/static/chunks/73448-9ebd1b3ca69703dd.js' }],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses a no-compaction-model unhandled rejection from the browser', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        'Unhandled promise rejection: No model available for compaction. Please configure a model in settings.',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a longer real error containing the compaction wording', () => {
+  for (const value of [
+    'Failed to compact session: No model available for compaction. Please configure a model in settings.',
+    'No model available for compaction. Please configure a model in settings. while summarizing',
+    'Error: No model available for compaction. Please configure a model in settings. and more',
+    'Unhandled promise rejection: Something else: No model available for compaction. Please configure a model in settings.',
+  ]) {
+    assert.equal(
+      isExpectedCompactionNoModelMessage(value),
+      false,
+      `expected longer message "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected longer Sentry event "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message: value }),
+      false,
+      `expected longer runtime error "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a real compaction mutation failure (network / 5xx)', () => {
+  for (const value of [
+    'Internal server error',
+    'HTTP 500: Internal Server Error',
+    'TypeError: Cannot read properties of undefined (reading providerID)',
+    'Failed to fetch',
+  ]) {
+    assert.equal(
+      isExpectedCompactionNoModelMessage(value),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value }] },
+      }),
+      false,
+      `expected real error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({ message: value }),
+      false,
+      `expected real error "${value}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -146,6 +146,33 @@ const BILLING_GATE_EXPECTED_MESSAGES = [
   'Subscribe to activate your seat. $20/teammate per month includes wallet credits for compute and LLM usage.',
 ] as const;
 
+// Expected "no compaction model configured" configuration state. The SDK's
+// `useSummarizeOpenCodeSession` mutation
+// (`packages/sdk/src/react/use-opencode-sessions/sessions.ts`) throws a
+// sentinel-marked `NoCompactionModelError`
+// (`packages/sdk/src/react/use-opencode-sessions/no-compaction-model-error.ts`,
+// mirrored locally by `apps/mobile/lib/opencode/hooks/use-compact-session.ts`)
+// when every model-resolution fallback tier fails (no config default, no
+// assistant message in the thread, no connected provider/model). It is an
+// EXPECTED, user-facing configuration outcome — the host already surfaces it
+// via the `loadingToast` error toast ("No model available for compaction.
+// Please configure a model in settings.") and the global react-query mutation
+// `onError` toast — never a code defect.
+//
+// It leaks to Sentry as an unhandled promise rejection: `compact-modal.tsx`
+// fires `void loadingToast(() => summarize.mutateAsync(...))`, and
+// `loadingToast` re-throws the error after showing the toast (toast.tsx), so
+// the `void`-fired rejection is auto-captured by the Sentry SDK's
+// `onunhandledrejection` integration. Drop it here at the telemetry gate so
+// the expected config state never pages Better Stack, regardless of which
+// capture path delivered it. A longer real mutation failure (network error,
+// `summarize` 5xx, a genuine `TypeError`, …) keeps reporting — only an exact
+// match for this message (plus the explicit canonical wrappers below) is
+// suppressed.
+const COMPACTION_NO_MODEL_EXPECTED_MESSAGES = [
+  'No model available for compaction. Please configure a model in settings.',
+] as const;
+
 // Stale Next.js webpack runtime chunk after a deploy. A long-lived tab (or
 // cached HTML) holds app chunks from one Vercel deployment (`?dpl=dpl_…`) while
 // the webpack runtime chunk is served from a different deployment, so
@@ -870,6 +897,28 @@ export function isExpectedBillingGateMessage(message: unknown): boolean {
 }
 
 /**
+ * Whether a message is the EXPECTED "no compaction model configured"
+ * configuration state thrown by the SDK's `useSummarizeOpenCodeSession`
+ * mutation (`NoCompactionModelError`) when every model-resolution fallback
+ * tier fails. The host already surfaces it via a user-facing toast; it must
+ * never page Better Stack, but the sentinel error can leak to Sentry as an
+ * unhandled promise rejection (`void loadingToast(...)` re-throws after
+ * showing the toast → `onunhandledrejection` auto-capture). Match is exact
+ * after trimming, with only the canonical browser/Sentry wrappers we
+ * explicitly support, so a longer real error that merely mentions the wording
+ * is never matched.
+ */
+export function isExpectedCompactionNoModelMessage(message: unknown): boolean {
+  const normalized = normalizeString(message).trim();
+  return COMPACTION_NO_MODEL_EXPECTED_MESSAGES.some(
+    (expected) => normalized === expected
+      || normalized === `Error: ${expected}`
+      || normalized === `Unhandled promise rejection: ${expected}`
+      || normalized === `Unhandled promise rejection: Error: ${expected}`,
+  );
+}
+
+/**
  * Whether a Sentry exception is the stale-deploy webpack-runtime
  * `… (reading 'call')` TypeError. Requires BOTH the exact webpack
  * module-loader message AND the throwing frame (the last stack frame, per
@@ -1274,6 +1323,17 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Expected "no compaction model configured" configuration state — the SDK's
+  // `useSummarizeOpenCodeSession` mutation throws a sentinel
+  // `NoCompactionModelError` that the host already surfaces via a toast. It
+  // leaks here as an unhandled promise rejection (`void loadingToast(...)`
+  // re-throws after the toast → `onunhandledrejection`). Drop it so the
+  // expected config state never pages Better Stack. See
+  // `isExpectedCompactionNoModelMessage`.
+  if (isExpectedCompactionNoModelMessage(message)) {
+    return true;
+  }
+
   // Old-WebKit (< 16.4) lookbehind parse failure from bundled third-party
   // deps — WebKit-specific wording, only old Safari/iOS visitors hit it.
   if (isOldWebkitRegexNoiseMessage(message)) {
@@ -1444,6 +1504,18 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // pages Better Stack. Real `ApiError`s are never matched — only the exact
   // strings the billing gate emits are.
   if (isExpectedBillingGateMessage(message)) {
+    return true;
+  }
+
+  // Expected "no compaction model configured" configuration state — the SDK's
+  // `useSummarizeOpenCodeSession` mutation throws a sentinel
+  // `NoCompactionModelError` that the host already surfaces via a toast. It
+  // can leak to Sentry through capture paths that bypass the toast (the
+  // `void loadingToast(...)` re-throw → `onunhandledrejection`, plus
+  // `<ClientErrorBoundary>` / route / system-fault boundaries). Drop it here
+  // so the expected config state never pages Better Stack. See
+  // `isExpectedCompactionNoModelMessage`.
+  if (isExpectedCompactionNoModelMessage(message)) {
     return true;
   }
 

--- a/packages/sdk/src/public-surface.snapshot.json
+++ b/packages/sdk/src/public-surface.snapshot.json
@@ -547,6 +547,7 @@
     "GATEWAY_PROVIDER_IDS",
     "KortixProjectProvider",
     "LAST_SEEN_EVENT",
+    "NoCompactionModelError",
     "OpenCodeEventStreamProvider",
     "POLL_CONNECTED",
     "POLL_FAILING",

--- a/packages/sdk/src/public-type-surface.snapshot.json
+++ b/packages/sdk/src/public-type-surface.snapshot.json
@@ -2402,6 +2402,7 @@
     "Model",
     "ModelKey",
     "ModelProviderMode",
+    "NoCompactionModelError",
     "NotificationKind",
     "OpenCodeEvent",
     "OpenCodeEventStreamProvider",

--- a/packages/sdk/src/react/index.ts
+++ b/packages/sdk/src/react/index.ts
@@ -93,3 +93,9 @@ export { useProjectSecrets, projectSecretsKey } from './use-project-secrets';
 export { useProjectTriggers, projectTriggersKey } from './use-project-triggers';
 export { useChangeRequests, changeRequestsKey } from './use-change-requests';
 export { useGatewayRoutingPolicy, gatewayRoutingPolicyKey } from './use-gateway-routing-policy';
+
+// The expected "no compaction model configured" configuration state thrown by
+// `useSummarizeOpenCodeSession`'s mutation when every model-resolution fallback
+// tier fails. Re-exported here so hosts + the telemetry noise gate can
+// `instanceof`-match it without reaching into the hook's internal path.
+export { NoCompactionModelError } from './use-opencode-sessions/no-compaction-model-error';

--- a/packages/sdk/src/react/use-opencode-sessions/no-compaction-model-error.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/no-compaction-model-error.ts
@@ -1,0 +1,35 @@
+/**
+ * `NoCompactionModelError` — the EXPECTED, user-facing configuration state
+ * surfaced by the compaction (`useSummarizeOpenCodeSession`) mutation when
+ * every model-resolution fallback tier fails (no config default, no assistant
+ * message in the thread, no connected provider/model).
+ *
+ * This is NOT a code defect: the user clicked "Compact" with no model
+ * configured anywhere, and the toast already tells them so ("No model
+ * available for compaction. Please configure a model in settings."). It must
+ * never page Better Stack. Previously thrown as a plain `Error`, it leaked to
+ * Sentry as an unhandled promise rejection (the host fires the
+ * `loadingToast`-wrapped mutation with `void`, and `loadingToast` re-throws
+ * the error after showing the toast → `onunhandledrejection` auto-capture).
+ *
+ * Promoted to a named, sentinel-marked class (mirroring
+ * `RuntimeNotReadyError` in `../../core/runtime/client`) so:
+ *   - hosts / the global react-query mutation `onError` can `instanceof` it,
+ *   - the Sentry telemetry gate (`apps/web/src/lib/browser-error-noise.ts`)
+ *     can match it precisely and drop it across every capture path
+ *     (`onunhandledrejection`, `window.onerror`, `ClientErrorBoundary`,
+ *     route/system-fault boundaries), and
+ *   - a longer real error that merely mentions the wording is never matched
+ *     (the gate anchors on this exact message).
+ *
+ * The `name` + message stay identical to the legacy plain-`Error` throw so
+ * any external string-match fallback keeps working.
+ */
+export class NoCompactionModelError extends Error {
+  constructor(
+    message = 'No model available for compaction. Please configure a model in settings.',
+  ) {
+    super(message);
+    this.name = 'NoCompactionModelError';
+  }
+}

--- a/packages/sdk/src/react/use-opencode-sessions/sessions.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sessions.test.ts
@@ -62,6 +62,7 @@ mock.module('../../browser/stores/opencode-compaction-store', () => ({
 
 const { useSummarizeOpenCodeSession, useInitSession } = await import('./sessions');
 const { opencodeKeys } = await import('./keys');
+const { NoCompactionModelError } = await import('./no-compaction-model-error');
 
 beforeEach(() => {
   fakeQueryClient = makeFakeQueryClient();
@@ -180,9 +181,14 @@ describe('useSummarizeOpenCodeSession — model resolution fallback chain', () =
     const { mutationFn } = useSummarizeOpenCodeSession() as unknown as {
       mutationFn: (args: { sessionId: string }) => Promise<string>;
     };
+    // The expected "no model configured" state throws the sentinel-marked
+    // `NoCompactionModelError` (not a plain `Error`) so the Sentry telemetry
+    // gate can `instanceof`-match it and drop the expected config state
+    // instead of paging Better Stack. The user-facing message is unchanged.
     await expect(mutationFn({ sessionId: 'ses_1' })).rejects.toThrow(
       'No model available for compaction. Please configure a model in settings.',
     );
+    await expect(mutationFn({ sessionId: 'ses_1' })).rejects.toBeInstanceOf(NoCompactionModelError);
   });
 
   test('a thrown/rejected config.get() is swallowed — falls through to the next tier', async () => {

--- a/packages/sdk/src/react/use-opencode-sessions/sessions.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/sessions.ts
@@ -9,6 +9,7 @@ import { useCurrentRuntime } from '../use-current-runtime';
 import type { Session } from '@opencode-ai/sdk/v2/client';
 import { opencodeKeys, useOpenCodeRuntimeReady } from './keys';
 import { unwrap, getLSCache, setLSCache, LS_SESSIONS, canQueryOpenCodeSession } from './shared';
+import { NoCompactionModelError } from './no-compaction-model-error';
 
 // ============================================================================
 // Session Hooks
@@ -298,7 +299,12 @@ export function useSummarizeOpenCodeSession() {
       }
 
       if (!providerID || !modelID) {
-        throw new Error('No model available for compaction. Please configure a model in settings.');
+        // Expected user-facing config state (no model configured anywhere):
+        // the host toast already tells the user to configure a model. Throw a
+        // sentinel-marked class so the Sentry telemetry gate can drop it
+        // across every capture path instead of paging Better Stack for an
+        // expected configuration outcome. See `NoCompactionModelError`.
+        throw new NoCompactionModelError();
       }
 
       const result = await client.session.summarize({


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. Proof: the SDK sentinel + telemetry gate now classify the expected "no compaction model configured" state out of Sentry, verified by the new unit tests (SDK `instanceof` + message, noise-filter positive/negative cases, anchored-regex lock) — all green locally (`bun test` in `packages/sdk` and `apps/web`).

## Why
Better Stack error `9f72dd9a2cb49a81aa57be27e9b3cb2f1ef06a8ebf59ede6900267febd3f7ded` (Kortix Frontend prod, application_id `2346967`) — `Error: No model available for compaction. Please configure a model in settings.`, call site `app:///_next/static/chunks/73448-9ebd1b3ca69703dd.js` function `Object.mutationFn`, 1 occurrence / 0 users, last_seen 2026-07-20 21:59:34 UTC, unresolved.

Root cause: the SDK's `useSummarizeOpenCodeSession` mutation (`packages/sdk/src/react/use-opencode-sessions/sessions.ts`) threw a **plain `Error`** when every model-resolution fallback tier failed (no config default, no assistant message in the thread, no connected provider/model). That is an **expected, user-facing configuration state** — the user clicked "Compact" with no model configured anywhere, and the host already surfaces it via the `loadingToast` error toast ("No model available for compaction. Please configure a model in settings.") plus the global react-query mutation `onError` toast. It is not a code defect.

The leak path: `apps/web/src/features/session/header/compact-modal.tsx` fires `void loadingToast('Compacting session...', () => summarize.mutateAsync({ sessionId }), { showErrorToast: true, ... })`. `loadingToast` (`apps/web/src/components/ui/toast.tsx`) **re-throws the error after showing the toast** (line 199: `throw error`). Because the call is `void`-fired, that rejection becomes an **unhandled promise rejection**, which Sentry's `BrowserApiErrors` integration auto-captures via `onunhandledrejection` → tunneled to Better Stack. The de-minified chunk `73448` + function `Object.mutationFn` match the bundled SDK's `useSummarizeOpenCodeSession` mutation body.

This is the same class of issue as the `RuntimeNotReadyError` and billing-gate 402 patterns already filtered in `apps/web/src/lib/browser-error-noise.ts`: an expected user-facing state that leaks through a capture path bypassing the dedicated error handler.

## What changed
- **`packages/sdk/src/react/use-opencode-sessions/no-compaction-model-error.ts`** (new): a sentinel-marked `NoCompactionModelError extends Error` class (mirroring `RuntimeNotReadyError` in `core/runtime/client.ts`). Same `name` + message as the legacy plain-`Error` throw so string-match fallbacks keep working, but now `instanceof`-matchable.
- **`packages/sdk/src/react/use-opencode-sessions/sessions.ts`**: the throw site now throws `new NoCompactionModelError()` instead of `new Error(...)`.
- **`packages/sdk/src/react/index.ts`**: re-export `NoCompactionModelError` from `@kortix/sdk/react` so hosts + the telemetry gate can `instanceof`-match it.
- **`apps/mobile/lib/opencode/hooks/use-compact-session.ts`**: local mirror of `NoCompactionModelError` (mobile doesn't import the SDK react barrel) + throw site updated. Same `name` + message so the web telemetry gate matches it on either surface if mobile ever routes through the same Sentry.
- **`apps/web/src/lib/browser-error-noise.ts`**: new `isExpectedCompactionNoModelMessage` classifier (exact match after trim, with only the canonical `Error:` / `Unhandled promise rejection:` / combined wrappers we support — mirrors `isExpectedBillingGateMessage`). Wired into **both** `shouldIgnoreSentryBrowserNoise` (the `beforeSend` hook) and `shouldIgnoreBrowserRuntimeNoise` (the `onerror`/`onunhandledrejection` gate). A longer real error that merely mentions the wording is never matched.
- **`apps/web/sentry.client.config.ts`**: an anchored `ignoreErrors` regex `/^(?:Unhandled promise rejection: )?(?:Error: )?No model available for compaction\. Please configure a model in settings\.$/` for frameless `onerror` captures that bypass `beforeSend` (same precedent as the billing-gate 402 anchored regexes).
- Real mutation failures (network errors, `summarize` 5xx, genuine `TypeError`s) keep reporting — only exact matches for this expected config state are suppressed.

## Verification
- `bun test --isolate src/react/use-opencode-sessions/sessions.test.ts` (packages/sdk) — **11 pass / 0 fail**. Updated test asserts both the unchanged message AND `instanceof NoCompactionModelError`.
- `bun test src/lib/browser-error-noise.test.mts` (apps/web) — **122 pass / 0 fail**. New tests:
  - classifies every no-compaction-model variant (bare, `Error:`-prefixed, `Unhandled promise rejection:`-wrapped, double-wrapped) as expected;
  - suppresses the no-compaction-model Sentry event regardless of capture path (with the exact de-minified chunk frame `73448-9ebd1b3ca69703dd.js` from the incident);
  - suppresses the unhandled rejection from the browser runtime gate;
  - does NOT suppress a longer real error containing the compaction wording (4 variants);
  - does NOT suppress a real compaction mutation failure (Internal server error / HTTP 500 / TypeError / Failed to fetch).
- `bun test src/app/sentry-ignore-errors.test.ts` (apps/web) — **5 pass / 0 fail**. New test locks the anchored regex in `sentry.client.config.ts` and guards against reintroducing a bare-string `ignoreErrors` entry.
- `tsc --noEmit` (packages/sdk) — clean.
- `tsc --noEmit -p apps/web/tsconfig.json` — only pre-existing unrelated `@/.source` module errors (generated at build time); no new errors from this change.

## Incident reference
- Better Stack error id: `9f72dd9a2cb49a81aa57be27e9b3cb2f1ef06a8ebf59ede6900267febd3f7ded`
- Better Stack error URL: https://errors.betterstack.com/team/t502678/errors/9f72dd9a2cb49a81aa57be27e9b3cb2f1ef06a8ebf59ede6900267febd3f7ded?s=2346967
- Application: Kortix Frontend (prod), application_id `2346967`

## How to confirm resolution
After this merges + promotes, the `No model available for compaction. Please configure a model in settings.` pattern should drop to zero new occurrences in Better Stack (the expected config state is now dropped at the Sentry SDK gate before it's sent). A real compaction mutation failure (network/5xx/TypeError) would still page under a different message.

## Risk / rollback
Low. The change only (1) promotes a plain `Error` to a named subclass with an identical message (no behavioral change for callers that string-match), and (2) adds a telemetry-side suppression for one exact expected message. The user-facing toast is unchanged. Rollback = revert the commit; no schema/migration/config change.
