### PR TITLE
fix(web): filter Firefox React #327 scheduler re-entrancy noise (BS 0f03b24eb6)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -9,6 +9,7 @@ import {
   isExpectedBillingGateMessage,
   isExtensionRejectedObjectNoise,
   isExtensionSource,
+  isFirefoxReactSchedulerReentryNoise,
   isInjectedAppSource,
   isInpageWalletStreamNoise,
   isKnownBrowserNoiseMessage,
@@ -2707,6 +2708,208 @@ test('does NOT suppress a non-React message that happens to mention #185', () =>
       `expected "${message}" to keep reporting`,
     )
   }
+})
+
+// ---------------------------------------------------------------------------
+// Firefox-specific React scheduler re-entrancy noise (React #327
+// "Should not already be working.", Better Stack pattern
+// 0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7,
+// Kortix Frontend prod, application_id 2346967). The React production
+// reconciler's `performSyncWorkOnRoot` throws `Error(i(327))` when
+// `executionContext & (RenderContext | CommitContext)` is set — i.e. the
+// scheduler re-entered while React was already rendering/committing. A
+// well-known Firefox-specific scheduler quirk (react-router#10314 / react#17355
+// / react#29908) that does NOT reproduce on Chromium/WebKit. 1 occurrence ever
+// (90-day window), 0 identified users (anonymous), single release
+// `22e12080d2b37642aa92a839da6b37f30fc21b9d`, 2026-07-20 11:53:33 UTC, route
+// `/projects/:id/sessions/:sessionId`, Firefox 152.0 on Generic Linux, mechanism
+// `auto.browser.global_handlers.onerror` (UNCAUGHT global error). Stack: 2
+// frames, BOTH raw React-internal minified production chunks (the React DOM
+// reconciler chunk `5ccd075d-…` function `iX` plus the scheduler chunk `66499-…`
+// function `x`) — NO first-party `apps/web/src/…` source frame. React #327 is
+// ALSO the exact message a real first-party `flushSync`-inside-render or
+// sync-setState-during-commit regression would produce, so the matcher requires
+// BOTH the canonical `#327;` message AND a NEGATIVE guard: any resolved
+// first-party `apps/web/src/…` frame means our own code is the re-entrant
+// culprit → keep reporting so the call site can be found + fixed.
+// ---------------------------------------------------------------------------
+
+// The exact React #327 message from the production event.
+const REACT_327 =
+  'Minified React error #327; visit https://react.dev/errors/327 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
+
+// The exact 2-frame production stack (oldest-first → throwing frame last): the
+// scheduler continuation `x` in chunk 66499 + the React DOM reconciler `iX`
+// (the `ensureRootIsScheduled`/`performConcurrentWorkOnRoot` continuation →
+// `iu`/`performSyncWorkOnRoot` which throws `Error(i(327))`). Both frames are
+// raw `_next/static/chunks/…` bundles — none resolve to first-party source.
+const FIREFOX_REACT_327_FRAMES = [
+  { filename: 'app:///_next/static/chunks/66499-30a0e6805d268c02.js?dpl=dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2', function: 'x', in_app: true, lineno: 3, colno: 29932 },
+  { filename: 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js?dpl=dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2', function: 'iX', in_app: true, lineno: 1, colno: 132934 },
+]
+
+test('classifies the Firefox React scheduler re-entrancy (#327) noise', () => {
+  assert.equal(
+    isFirefoxReactSchedulerReentryNoise({
+      message: REACT_327,
+      frames: FIREFOX_REACT_327_FRAMES,
+    }),
+    true,
+  )
+})
+
+test('suppresses the assigned Firefox React #327 Sentry event via the beforeSend gate', () => {
+  // Exact shape of the production event: mechanism
+  // `auto.browser.global_handlers.onerror` (uncaught global error), 2 React-
+  // internal minified-chunk frames, NO first-party source frame, route
+  // `/projects/:id/sessions/:sessionId`.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/3cdc1df5-01e6-492d-b2ab-d81bb8c42fa2/sessions/c102f5de-1b6b-4baf-8cd6-cdd11855330f',
+      },
+      exception: {
+        values: [
+          {
+            value: REACT_327,
+            stacktrace: { frames: FIREFOX_REACT_327_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Firefox React #327 event even with only the React reconciler chunk frame', () => {
+  // A minimal capture carrying just the React DOM reconciler `iX` frame (the
+  // throwing frame Better Stack surfaces as the call site) still qualifies —
+  // it is the React-internal minified-chunk anchor that matters.
+  assert.equal(
+    isFirefoxReactSchedulerReentryNoise({
+      message: REACT_327,
+      frames: [FIREFOX_REACT_327_FRAMES[1]],
+    }),
+    true,
+  )
+})
+
+test('suppresses the Firefox React #327 event with a chunk filename that has no dpl query', () => {
+  // Different Vercel deployment / cached chunk: the frame is still a React
+  // minified production chunk (`_next/static/chunks/…`) with no first-party
+  // source path, so it still classifies. The `dpl=dpl_…` query is not load-
+  // bearing for the matcher — `isBrowserBundleSource` matches the path prefix.
+  assert.equal(
+    isFirefoxReactSchedulerReentryNoise({
+      message: REACT_327,
+      frames: [
+        { filename: 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js', function: 'iX' },
+      ],
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the Firefox React #327 when a first-party frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code IS the re-entrant
+  // culprit (e.g. a real `flushSync` inside a render phase, or a sync
+  // `setState` during commit) → actionable; the negative guard MUST preserve
+  // it so the call site can be found + fixed. This is the whole reason the
+  // matcher is frame-aware (React #327 is also a real first-party re-entrancy
+  // message — see `pdf-viewer.tsx:2101` for the only first-party `flushSync`
+  // call site, which would surface this way if it ever regresses).
+  for (const frames of [
+    [{ filename: 'apps/web/src/features/file-renderers/pdf/pdf-viewer.tsx', function: 'rotatePage' }],
+    [
+      { filename: 'app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js', function: 'iX' },
+      { filename: 'app:///apps/web/src/features/session/session-chat.tsx', function: 'SessionChat' },
+    ],
+  ]) {
+    assert.equal(
+      isFirefoxReactSchedulerReentryNoise({ message: REACT_327, frames }),
+      false,
+      `expected first-party React #327 from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: REACT_327, stacktrace: { frames } }],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party React #327 from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress a React #327 with NO browser-bundle frame (a real app or different-third-party throw)', () => {
+  // A real first-party `throw new Error('Should not already be working.')` in
+  // app code (NOT via React's minified-error-#327 path) — or a #327 from a
+  // third-party lib whose frames don't resolve to our bundle — carries NO
+  // React-internal chunk frame, so the React-internal anchor is missing. Keep
+  // reporting rather than blanket-dropping events of unknown origin.
+  for (const frames of [
+    [{ filename: 'apps/web/src/features/co-worker/foo.tsx', function: 'bar' }],
+    [{ filename: 'https://cdn.example.com/some-lib.js', function: 'f' }],
+    [],
+  ]) {
+    assert.equal(
+      isFirefoxReactSchedulerReentryNoise({ message: REACT_327, frames }),
+      false,
+      `expected React #327 from ${JSON.stringify(frames)} (no React-internal chunk frame) to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a different React error (#185) even with the same React chunk frames', () => {
+  // The matcher anchors on the EXACT #327 (re-entrancy guard) code; a
+  // different React minified error from the same React chunk is a different,
+  // actionable class and must keep reporting. (The sibling @embedpdf #185
+  // classifier handles its own #185 noise class.)
+  assert.equal(
+    isFirefoxReactSchedulerReentryNoise({
+      message:
+        'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.',
+      frames: FIREFOX_REACT_327_FRAMES,
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a non-React message that happens to mention #327', () => {
+  // The matcher anchors on `Minified React error #327;` — a different message
+  // wording must not be matched.
+  for (const message of [
+    'Should not already be working.',
+    'Error #327 in custom handler',
+    'react.dev/errors/327',
+    'Unhandled promise rejection: Should not already be working.',
+  ]) {
+    assert.equal(
+      isFirefoxReactSchedulerReentryNoise({
+        message,
+        frames: FIREFOX_REACT_327_FRAMES,
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a bare `Should not already be working.` thrown from first-party app code', () => {
+  // A real first-party `throw new Error('Should not already be working.')` is
+  // NOT a React-minified-error-#327 capture (no `Minified React error #327;`
+  // prefix), so it never matches the React-internal noise class and keeps
+  // reporting — even if its frame happens to be a chunk frame. The matcher is
+  // anchored on React's canonical minified-error wording, not the bare
+  // message text, so app-code throws of the same string never get swallowed.
+  assert.equal(
+    isFirefoxReactSchedulerReentryNoise({
+      message: 'Should not already be working.',
+      frames: FIREFOX_REACT_327_FRAMES,
+    }),
+    false,
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -1211,6 +1211,113 @@ export function isEmbedPdfTilingReactUpdateDepthNoise(input: {
   return frames.some(frameMatchesEmbedPdfTilingCallback);
 }
 
+// React #327 = `Should not already be working.` — the React production
+// reconciler's re-entrancy guard. It throws from
+// `packages/react-reconciler/src/ReactFiberWorkLoop.js`'s `performSyncWorkOnRoot`
+// (and the `flushSyncUpdateQueue` path at the end of `flushPendingEffects`):
+//
+//   function performSyncWorkOnRoot(root, lanes) {
+//     if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
+//       throw new Error('Should not already be working.');   // ← #327
+//     }
+//     …
+//   }
+//
+// i.e. React's scheduler entered `performSyncWorkOnRoot` while it was ALREADY
+// rendering or committing. The documented Firefox-specific trigger is React
+// Router's `unstable_usePrompt` calling `setTimeout(blocker.proceed, 0)` after
+// `window.confirm()` (react-router#10314 — the React team itself called this a
+// "browser-specific issue, possibly related to policy things built-in to
+// Firefox"). The same #327 has been reported across the React ecosystem from
+// Firefox's MessageChannel-based scheduler re-entering during the commit phase
+// (react#17355, react#29908, react-router#10314, react-router#10547) — it does
+// NOT reproduce on Chromium/WebKit, only on Firefox.
+//
+// Better Stack pattern
+// 0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7
+// (Kortix Frontend prod, application_id 2346967): 1 occurrence ever (90-day
+// window), 0 identified users (anonymous), single release
+// `22e12080d2b37642aa92a839da6b37f30fc21b9d`, 2026-07-20 11:53:33 UTC, route
+// `/projects/:id/sessions/:sessionId` (co-worker session page actively polling
+// `prompt_async` + UI clicks to remove queued messages — a state-heavy surface
+// that maximises scheduler churn), Firefox 152.0 on Generic Linux, mechanism
+// `auto.browser.global_handlers.onerror` (UNCAUGHT global error — never reached
+// a React error boundary). Stack: 2 frames, BOTH raw React-internal minified
+// production chunks:
+//   - chunk 66499-30a0e6805d268c02.js  function `x`   (scheduler continuation)
+//   - chunk 5ccd075d-fe5b6a678bf52bfe.js function `iX` (React DOM reconciler
+//     `ensureRootIsScheduled`/`performConcurrentWorkOnRoot` continuation →
+//     `iu` (`performSyncWorkOnRoot`) which throws `Error(i(327))` when
+//     `executionContext & 6` is set)
+// NO first-party `apps/web/src/…` source frame — the throw is inside React's
+// own production reconciler, never in our code. There is exactly ONE `flushSync`
+// call site in the entire frontend (`pdf-viewer.tsx:2101`) and it is on a
+// different route, so a first-party sync-render regression is ruled out.
+//
+// The `Minified React error #327;` message is React's canonical production
+// wording for the re-entrancy guard — a real first-party `throw new Error(
+// 'Should not already be working.')` in app code would surface as that exact
+// string, so the matcher anchors on React's minified-error format (`#327;`)
+// rather than the bare message text, AND a NEGATIVE guard: if any frame
+// resolves to a de-minified first-party `apps/web/src/…` source path, the event
+// keeps reporting (our own code IS the re-entrant culprit → actionable). A
+// real first-party #327 surfaces with a resolved `apps/web/src/…` frame and is
+// preserved; only React-internal minified-chunk captures with no first-party
+// frame are dropped. Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare `#327` match there would swallow a real first-party
+// re-entrancy regression; the frame-aware `beforeSend` hook (which calls this
+// helper) is the only safe gate.
+const REACT_SCHEDULER_REENTRY_NOISE_PATTERN = /^Minified React error #327;/;
+
+/**
+ * Whether a Sentry / window.onerror event is the Firefox-specific React
+ * scheduler re-entrancy noise class: a `Minified React error #327;` (the
+ * canonical React production wording for `Should not already be working.`)
+ * thrown from React's own production reconciler chunk (function `iX` in the
+ * React DOM bundle's `ensureRootIsScheduled`/`performConcurrentWorkOnRoot`
+ * continuation → `iu` (`performSyncWorkOnRoot`), which throws when
+ * `executionContext & (RenderContext | CommitContext)` is set). The throw is
+ * inside React's own minified production chunk, never first-party; it is a
+ * well-known Firefox-specific scheduler quirk that does not reproduce on
+ * Chromium/WebKit (see `REACT_SCHEDULER_REENTRY_NOISE_PATTERN` for refs).
+ * Requires the `#327;` message AND a NEGATIVE guard: if any frame resolves to
+ * a de-minified first-party `apps/web/src/…` source, the event keeps reporting
+ * (our own code is the re-entrant culprit → actionable). Returns false when
+ * there are no frames (can't confirm the throw is React-internal — keep
+ * reporting rather than swallow a possible app re-entrancy regression). See
+ * `REACT_SCHEDULER_REENTRY_NOISE_PATTERN` for the full rationale.
+ */
+export function isFirefoxReactSchedulerReentryNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown; function?: unknown } | undefined>;
+}): boolean {
+  const message = stripErrorWrappers(normalizeString(input.message));
+  if (!REACT_SCHEDULER_REENTRY_NOISE_PATTERN.test(message)) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  // No frames at all → can't confirm the throw is React-internal; keep
+  // reporting rather than blanket-dropping frameless events of unknown origin.
+  if (frames.length === 0) {
+    return false;
+  }
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our own
+  // code is the re-entrant culprit (e.g. a real `flushSync` inside a render
+  // phase, or a sync `setState` during commit) → actionable; keep reporting so
+  // the call site can be found + fixed.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  // Anchor: the throw must be inside React's own minified production bundle
+  // (`_next/static/chunks/…`). A real first-party `throw new Error('Should not
+  // already be working.')` de-minifies to `apps/web/src/…` and is preserved by
+  // the negative guard above; a #327 from a non-React third-party lib (which
+  // would surface with a different chunk frame) is preserved too. Only the
+  // React-internal #327 with no first-party frame is dropped.
+  return frames.some((frame) => isBrowserBundleSource(frame?.filename));
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -1573,6 +1680,21 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // real first-party setState loop keeps reporting. See
   // `isEmbedPdfTilingReactUpdateDepthNoise`.
   if (isEmbedPdfTilingReactUpdateDepthNoise({ message, frames })) {
+    return true;
+  }
+
+  // Firefox-specific React scheduler re-entrancy noise — `Minified React error
+  // #327;` (`Should not already be working.`), thrown from React's own
+  // production reconciler chunk when the scheduler re-enters during the commit
+  // phase. A well-known Firefox-specific quirk (react-router#10314 / react#17355
+  // / react#29908) that does NOT reproduce on Chromium/WebKit. Requires the
+  // canonical `#327;` message AND a NEGATIVE guard: a resolved first-party
+  // `apps/web/src/…` frame means our own code is the re-entrant culprit (a real
+  // `flushSync` inside render or sync `setState` during commit) → actionable, so
+  // the event keeps reporting. Only React-internal minified-chunk captures with
+  // no first-party frame are dropped. See
+  // `isFirefoxReactSchedulerReentryNoise`.
+  if (isFirefoxReactSchedulerReentryNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies.

**Proof the noise is classified:** 9 new unit tests pin the exact production event through both the classifier and the Sentry `beforeSend` gate, plus 6 negative cases preserving real React-internal & first-party re-entrancy regressions:

```
$ bun test src/lib/browser-error-noise.test.mts
bun test v1.3.14
  126 pass
  0 fail
Ran 126 tests across 1 file. [88.00ms]
```

(was 117 → +9 new React #327 tests, all green.)

## Why

Better Stack error `0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7` (Kortix Frontend prod, application_id 2346967) fired once on Firefox 152 only, with **no first-party source frame** — it's React's own internal scheduler re-entrancy assertion (`Should not already be working.`), a well-known Firefox-specific browser quirk that does not reproduce on Chromium/WebKit. Treating it as a product bug would be a dead end; the right fix is to stop paging Better Stack for it while preserving real first-party re-entrancy regressions.

## What changed

Added `isFirefoxReactSchedulerReentryNoise` to `apps/web/src/lib/browser-error-noise.ts` (wired into the Sentry `beforeSend` gate via `shouldIgnoreSentryBrowserNoise`). The matcher is conservative and frame-aware:

- **Requires** the canonical React production wording `Minified React error #327;` (the minified-error format, NOT the bare `Should not already be working.` string — a real app throw of the same string is never matched).
- **Requires** at least one React-internal minified-chunk frame (`_next/static/chunks/…`) — anchors the throw to React's own production reconciler bundle.
- **Negative guard:** if ANY frame resolves to a de-minified first-party `apps/web/src/…` source path, the event KEEPS reporting (our own code is the re-entrant culprit → actionable). This is the load-bearing guard: a real `flushSync`-inside-render or sync-`setState`-during-commit regression in our code de-minifies to `apps/web/src/…` and is preserved.
- **Returns false** when there are no frames at all (can't confirm React-internal origin — keep reporting rather than blanket-drop).

Deliberately **NOT** added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare `#327` match there would swallow a real first-party re-entrancy regression. The frame-aware `beforeSend` hook is the only safe gate (same design as the existing `@embedpdf` React #185 noise class — `isEmbedPdfTilingReactUpdateDepthNoise`).

## Evidence (Better Stack + React source)

**One-line root cause:** React #327 (`Should not already be working.`) fires from `packages/react-reconciler/src/ReactFiberWorkLoop.js`'s `performSyncWorkOnRoot` when `executionContext & (RenderContext | CommitContext)` is set — i.e. the React scheduler re-entered while already rendering/committing. A well-known Firefox-specific scheduler quirk that does NOT reproduce on Chromium/WebKit.

**Production event (raw evidence from Better Stack Telemetry + ClickHouse):**
- Pattern: `0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7`
- Type/message: `Error: Minified React error #327; visit https://react.dev/errors/327 for the full message …`
- Decoded: `327 -> Should not already be working.` (per `scripts/error-codes/codes.json` in `facebook/react`)
- Call site function: `iX` (minified)
- Call site file: `app:///_next/static/chunks/5ccd075d-fe5b6a678bf52bfe.js?dpl=dpl_BEo2Xvs3YxqRXbFpXiss8RKeu4b2`
- Occurrences (90-day window): **1 occurrence ever**, **0 identified users** (anonymous), single release `22e12080d2b37642aa92a839da6b37f30fc21b9d`
- First/last seen: 2026-07-20 11:53:33 UTC (same — one-shot)
- Environment: prod
- Mechanism: `auto.browser.global_handlers.onerror` (UNCAUGHT global error — never reached a React error boundary)
- Browser: Firefox 152.0 on Generic Linux
- Route: `/projects/:id/sessions/:sessionId`
- URL: `https://kortix.com/projects/3cdc1df5-01e6-492d-b2ab-d81bb8c42fa2/sessions/c102f5de-1b6b-4baf-8cd6-cdd11855330f`
- SDK: sentry.javascript.nextjs 10.63.0
- Stack: **2 frames, BOTH raw React-internal minified production chunks**:
  - `chunk 66499-30a0e6805d268c02.js` function `x` (scheduler continuation)
  - `chunk 5ccd075d-fe5b6a678bf52bfe.js` function `iX` (React DOM reconciler `ensureRootIsScheduled`/`performConcurrentWorkOnRoot` continuation → `iu`/`performSyncWorkOnRoot` which throws `Error(i(327))` when `executionContext & 6` is set)
  - **NO first-party `apps/web/src/…` source frame** — the throw is inside React's own production reconciler, never in our code.
- Breadcrumbs (last 10): user was actively clicking UI controls on a co-worker project session page (Remove queued message buttons, session controls) while `prompt_async` was polling — a state-heavy surface that maximises scheduler churn. No PDF viewer activity.

**React source confirmation:** Pulled `packages/react-reconciler/src/ReactFiberWorkLoop.js` from `react/react@main`. The string `Should not already be working.` appears at exactly two lines — `performWorkOnRoot` (line 1129) and the end of `flushPendingEffects` (line 3528). Both are re-entrancy guards:
```js
function performSyncWorkOnRoot(root, lanes) {
  if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
    throw new Error('Should not already be working.');   // ← #327
  }
  …
}
```
The production chunk `5ccd075d-…` confirmed (via fetch) to contain `function iu(e,n,t){if(0!=(6&uM))throw Error(i(327)); …}` (the minified `performSyncWorkOnRoot`) — i.e. React's scheduler entered `performSyncWorkOnRoot` while `executionContext & 6` (`RenderContext | CommitContext`) was set.

**Firefox-specific confirmation:** This is a documented Firefox-only React scheduler quirk — see:
- react-router#10314 — `unstable_usePrompt` triggers `Minified React error #327` on Firefox only; the React team itself called it "a browser-specific issue, possibly related to policy things built-in to Firefox".
- react#17355 — "Should not already be working" in Firefox after a breakpoint/alert; Sentry littered with these errors from Firefox only.
- react#29908 — "Should not already be working" provides no information; tied to Firefox.
- react-router#10547 — sibling Firefox-only #327 issue.

**First-party `flushSync` regression ruled out:** There is exactly ONE `flushSync` call site in the entire frontend (`apps/web/src/features/file-renderers/pdf/pdf-viewer.tsx:2101`), and it is on a different route (PDF viewer, not the session page the user was on). The user was on `/projects/:id/sessions/:sessionId`, not the PDF viewer.

**Not a release-regression spike:** 1 occurrence ever across a 90-day window, on a single release, on a single browser (Firefox 152), with 0 identified users. A real deterministic app regression would spike on one release across multiple browsers with identified users.

## Verification

- `bun test src/lib/browser-error-noise.test.mts` → **126 pass / 0 fail** (was 117; +9 new React #327 tests).
- `bun build src/lib/browser-error-noise.ts` → bundles cleanly (19.42 KB), no TypeScript or syntax errors.
- 9 new tests pin the production event through both the classifier (`isFirefoxReactSchedulerReentryNoise`) and the Sentry `beforeSend` gate (`shouldIgnoreSentryBrowserNoise`), plus 6 negative cases:
  - the assigned production event classifies as noise ✅
  - the assigned Sentry event is suppressed via `beforeSend` ✅
  - the event still classifies with only the React reconciler chunk frame ✅
  - the event classifies regardless of the `?dpl=…` deploy-hash query ✅
  - **NEGATIVE:** a #327 with a first-party `apps/web/src/…` frame KEEPS reporting (real first-party re-entrancy regression preserved) ✅
  - **NEGATIVE:** a #327 with NO browser-bundle frame KEEPS reporting (a real app throw or different-third-party throw) ✅
  - **NEGATIVE:** a different React minified error (#185) from the same React chunk KEEPS reporting ✅
  - **NEGATIVE:** a non-React message that mentions `#327` KEEPS reporting ✅
  - **NEGATIVE:** a bare `Should not already be working.` from first-party app code KEEPS reporting ✅

## Risk / rollback

- **Low risk.** The matcher only drops events that are ALL of: (a) the exact React minified #327 wording, (b) no resolved first-party `apps/web/src/…` frame, (c) at least one `_next/static/chunks/…` frame. The load-bearing negative guard (first-party frame → keep reporting) means a real first-party re-entrancy regression still surfaces.
- **Rollback:** revert the single commit (only `apps/web/src/lib/browser-error-noise.ts` + test).
- After this PR merges + Promotes, the Better Stack group `0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7` should be resolved once `last_seen` stops advancing (the single occurrence is already >24h old; this PR prevents recurrence on the next Firefox visitor hitting the same scheduler quirk).

## Preview verification plan

Non-visual telemetry-side change — the preview frontend will continue to render the co-worker session page identically. To smoke-verify on the preview:
1. Open the preview frontend URL → `/projects/<any-project-id>/sessions/<any-session-id>` (the route where the production event fired).
2. Confirm the page renders, the session chat loads, and `prompt_async` polling works.
3. Confirm no new Sentry/Better Stack errors fire from the route on Chromium (the matcher only affects the Sentry `beforeSend` gate; it does not change render behavior).

Better Stack error id: `0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7`
Better Stack error URL: https://errors.betterstack.com/team/t502678/errors/0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7?s=2346967
