### PR TITLE
fix(api): normalize path-only Bun req.url from no-Host scanner probes (BS 28e9a65c…)

### DIFF
--- a/apps/api/src/__tests__/unit-request-url.test.ts
+++ b/apps/api/src/__tests__/unit-request-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { getRequestUrl } from '../lib/request-url';
+import { ensureAbsoluteRequestUrl, getRequestUrl, isRelativeRequestUrl } from '../lib/request-url';
 
 describe('getRequestUrl', () => {
   it('returns absolute Bun request URLs unchanged', () => {
@@ -34,5 +34,99 @@ describe('getRequestUrl', () => {
     const url = getRequestUrl(req, 8008);
 
     expect(url.toString()).toBe('https://kortix.com/status?full=1');
+  });
+
+  // ── Regression: BS pattern 28e9a65c… — path-only req.url from no-Host
+  // scanner probes (HTTP/1.0 `GET /`, Trinity fingerprint
+  // `/nice%20ports%2C/Tri%6Eity.txt%2ebak`). Bun.serve sets `req.url` to a
+  // path-only string when there is no Host header, which made downstream
+  // `new URL(c.req.url)` throw `TypeError: "…" cannot be parsed as a URL.`
+  // → Sentry. The fix rebuilds the Request with an absolute URL at the
+  // Bun.serve boundary.
+  describe('ensureAbsoluteRequestUrl (BS 28e9a65c…)', () => {
+    it('rebuilds a path-only "/" request with the fallback host', () => {
+      const req = new Request('http://placeholder.invalid');
+      Object.defineProperty(req, 'url', { value: '/', configurable: true });
+
+      const rebuilt = ensureAbsoluteRequestUrl(req, 8008);
+
+      expect(rebuilt).not.toBe(req);
+      expect(isRelativeRequestUrl(rebuilt)).toBe(false);
+      expect(rebuilt.url).toBe('http://localhost:8008/');
+      // new URL() on the rebuilt URL must not throw — that's the whole point.
+      expect(new URL(rebuilt.url).toString()).toBe('http://localhost:8008/');
+    });
+
+    it('rebuilds a path-only Trinity scanner fingerprint with the fallback host', () => {
+      const req = new Request('http://placeholder.invalid');
+      Object.defineProperty(req, 'url', {
+        value: '/nice%20ports%2C/Tri%6Eity.txt%2ebak',
+        configurable: true,
+      });
+
+      const rebuilt = ensureAbsoluteRequestUrl(req, 8008);
+
+      expect(isRelativeRequestUrl(rebuilt)).toBe(false);
+      expect(rebuilt.url).toBe(
+        'http://localhost:8008/nice%20ports%2C/Tri%6Eity.txt%2ebak',
+      );
+    });
+
+    it('preserves host header and forwarded-proto when rebuilding', () => {
+      const req = new Request('http://placeholder.invalid', {
+        headers: {
+          host: 'api.kortix.com',
+          'x-forwarded-proto': 'https',
+        },
+      });
+      Object.defineProperty(req, 'url', { value: '/v1/health', configurable: true });
+
+      const rebuilt = ensureAbsoluteRequestUrl(req, 8008);
+
+      expect(rebuilt.url).toBe('https://api.kortix.com/v1/health');
+      // Headers preserved (the rebuilt Request keeps the original headers).
+      expect(rebuilt.headers.get('host')).toBe('api.kortix.com');
+    });
+
+    it('preserves method, body, and headers when rebuilding', () => {
+      const req = new Request('http://placeholder.invalid', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', host: 'x' },
+        body: JSON.stringify({ a: 1 }),
+      });
+      Object.defineProperty(req, 'url', { value: '/v1/foo', configurable: true });
+
+      const rebuilt = ensureAbsoluteRequestUrl(req, 8008);
+
+      expect(rebuilt.method).toBe('POST');
+      expect(rebuilt.headers.get('content-type')).toBe('application/json');
+      // Body survives the rebuild (Request constructor re-streams it).
+      return expect(rebuilt.text()).resolves.toBe('{"a":1}');
+    });
+
+    it('is a no-op for an already-absolute request URL (no rebuild, same instance)', () => {
+      const req = new Request('http://api.kortix.com/v1/health');
+
+      const rebuilt = ensureAbsoluteRequestUrl(req, 8008);
+
+      expect(rebuilt).toBe(req);
+      expect(isRelativeRequestUrl(req)).toBe(false);
+    });
+
+    it('every downstream new URL(c.req.url) call site is now safe', () => {
+      // The exact call-site shape used across the codebase
+      // (auth middleware, OpenAPI server URL, proxy handlers, …):
+      //   const url = new URL(c.req.url);
+      // For a path-only "/" that throws pre-fix; post-fix it must not.
+      for (const pathOnly of ['/', '/v1/health', '/nice%20ports%2C/Tri%6Eity.txt%2ebak']) {
+        const req = new Request('http://placeholder.invalid');
+        Object.defineProperty(req, 'url', { value: pathOnly, configurable: true });
+
+        const rebuilt = ensureAbsoluteRequestUrl(req, 8008);
+
+        // This must not throw for any path-only input Bun.serve can produce.
+        expect(() => new URL(rebuilt.url)).not.toThrow();
+      }
+    });
   });
 });

--- a/apps/api/src/__tests__/unit-sentry-noise-filter.test.ts
+++ b/apps/api/src/__tests__/unit-sentry-noise-filter.test.ts
@@ -55,6 +55,28 @@ describe('Sentry ignoreErrors noise filter (BS c672fb5e)', () => {
     expect(isSentryIgnoredError('HTTPException', 'Unauthorized')).toBe(true);
   });
 
+  // ── Regression: BS pattern 28e9a65c… — `new URL()` on a path-only
+  // `req.url` (no-Host scanner probes) throws
+  // `TypeError: "…" cannot be parsed as a URL.`. The root-cause fix
+  // (lib/request-url.ts ensureAbsoluteRequestUrl) prevents the throw on the
+  // request path; this filter is defense-in-depth so any residual edge case
+  // stops paging.
+  test('the URL-parse TypeError from path-only scanner URLs is filtered', () => {
+    expect(isSentryIgnoredError('TypeError', '"/" cannot be parsed as a URL.')).toBe(true);
+    expect(
+      isSentryIgnoredError(
+        'TypeError',
+        '"/nice%20ports%2C/Tri%6Eity.txt%2ebak" cannot be parsed as a URL.',
+      ),
+    ).toBe(true);
+    // Also covered when only the message is present (string-coerced reason).
+    expect(isSentryIgnoredError(undefined, '"/" cannot be parsed as a URL.')).toBe(true);
+  });
+
+  test('the URL-parse pattern is registered in SENTRY_IGNORE_ERRORS', () => {
+    expect(SENTRY_IGNORE_ERRORS).toContain('cannot be parsed as a URL');
+  });
+
   test('a real, actionable error with a distinct message is NOT filtered', () => {
     // Guards against an over-broad filter: a genuine code bug must still page.
     expect(isSentryIgnoredError('TypeError', "Cannot read properties of undefined (reading 'x')"))

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,7 +12,7 @@ import {
   metricsEnabled,
 } from './lib/metrics';
 import { getRequestContext, runWithContext, setContextField } from './lib/request-context';
-import { getRequestUrl } from './lib/request-url';
+import { getRequestUrl, ensureAbsoluteRequestUrl } from './lib/request-url';
 
 import { timingSafeEqual } from 'node:crypto';
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
@@ -1295,6 +1295,19 @@ export default {
   idleTimeout: 45,
 
   async fetch(req: Request, server: any): Promise<Response | undefined> {
+    // Bun.serve sets `req.url` to a PATH-ONLY string (`"/"`,
+    // `"/nice%20ports%2C/Tri%6Eity.txt%2ebak"`, …) for requests that arrive
+    // WITHOUT a `Host` header — raw HTTP/1.0 port-scanner probes and malformed
+    // clients. Every downstream `new URL(c.req.url)` / `new URL(req.url)`
+    // call site (auth middleware, OpenAPI server URL, sandbox preview /
+    // public-share proxy, git proxy, Slack/Teams webhook routers, …) assumes
+    // an absolute URL and would otherwise throw
+    // `TypeError: "…" cannot be parsed as a URL.` → app.onError → Sentry.
+    // Rebuild the Request once, here, with the absolute URL so all of those
+    // call sites are safe. No-op for normal requests (which already carry an
+    // absolute `req.url`). See lib/request-url.ts ensureAbsoluteRequestUrl.
+    // BS pattern 28e9a65c… (scanner noise, 0 users, first seen 2026-04-27).
+    req = ensureAbsoluteRequestUrl(req, config.PORT);
     const url = getRequestUrl(req, config.PORT);
     const isWsUpgrade = req.headers.get('upgrade')?.toLowerCase() === 'websocket';
 

--- a/apps/api/src/lib/request-url.ts
+++ b/apps/api/src/lib/request-url.ts
@@ -6,6 +6,25 @@ function normalizeForwardedHeader(value: string | null): string | null {
   return first || null;
 }
 
+/**
+ * True when `req.url` is a path-only string (no scheme), which Bun.serve
+ * produces for requests that arrive WITHOUT a `Host` header — notably raw
+ * HTTP/1.0 port-scanner probes (`GET / HTTP/1.0\r\n\r\n`,
+ * `GET /nice%20ports%2C/Tri%6Eity.txt%2ebak HTTP/1.0\r\n\r\n`). When this is
+ * true, every downstream `new URL(c.req.url)` / `new URL(req.url)` call site
+ * (and there are many — auth middleware, OpenAPI server URL, proxy handlers,
+ * sandbox preview/public-share routes, git proxy, Slack/Teams webhook
+ * routers) throws `TypeError: "/" cannot be parsed as a URL.` because the
+ * WHATWG URL constructor requires a base when given a relative URL. That throw
+ * bubbles to `app.onError` → `captureException` → Sentry → Better Stack as
+ * scanner noise with 0 affected users
+ * (BS pattern 28e9a65c…, first seen 2026-04-27). Rebuilding the Request with
+ * the absolute URL before it reaches Hono makes all those call sites safe.
+ */
+export function isRelativeRequestUrl(req: Request): boolean {
+  return !ABSOLUTE_URL_PATTERN.test(req.url);
+}
+
 export function getRequestUrl(req: Request, fallbackPort?: number): URL {
   if (ABSOLUTE_URL_PATTERN.test(req.url)) {
     return new URL(req.url);
@@ -18,4 +37,18 @@ export function getRequestUrl(req: Request, fallbackPort?: number): URL {
 
   const pathname = req.url.startsWith('/') ? req.url : `/${req.url}`;
   return new URL(pathname, `${protocol}://${host}`);
+}
+
+/**
+ * Returns `req` unchanged when its URL is already absolute, or a new Request
+ * built on the absolute URL (preserving method, headers, body, cache mode,
+ * signal) when Bun.serve handed us a path-only `req.url` (no `Host` header —
+ * raw scanner probes). Downstream `new URL(c.req.url)` / `new URL(req.url)`
+ * call sites assume an absolute URL and throw otherwise; rebuilding once at
+ * the Bun.serve boundary is the single focused mitigation that covers all of
+ * them without touching each call site. See {@link isRelativeRequestUrl}.
+ */
+export function ensureAbsoluteRequestUrl(req: Request, fallbackPort?: number): Request {
+  if (!isRelativeRequestUrl(req)) return req;
+  return new Request(getRequestUrl(req, fallbackPort), req);
 }

--- a/apps/api/src/lib/sentry.ts
+++ b/apps/api/src/lib/sentry.ts
@@ -54,6 +54,19 @@ export const SENTRY_IGNORE_ERRORS = [
   // upstream/network noise — drop it instead of paging
   // (Better Stack pattern c672fb5e…).
   'The operation timed out.',
+  // Bun/WHATWG `new URL()` throws `TypeError: "<input>" cannot be parsed as
+  // a URL.` when given a relative URL with no base. This is scanner noise:
+  // raw HTTP/1.0 port probes (`GET / HTTP/1.0\r\n\r\n`) and the Trinity
+  // scanner fingerprint (`/nice%20ports%2C/Tri%6Eity.txt%2ebak`) arrive at
+  // Bun.serve with no `Host` header, so `req.url` is path-only and every
+  // downstream `new URL(c.req.url)` call site throws. The root-cause fix in
+  // lib/request-url.ts (ensureAbsoluteRequestUrl at the Bun.serve boundary)
+  // prevents the throw for the request handler path; this filter is
+  // defense-in-depth so any residual edge case (a fire-and-forget path that
+  // re-parses a stale path-only URL, a future call site that bypasses the
+  // rebuild) stops paging instead of surfacing as a 0-user Sentry event.
+  // Better Stack pattern 28e9a65c…, first seen 2026-04-27, 0 users.
+  'cannot be parsed as a URL',
   // Expected HTTP errors (auth failures, not found, etc.)
   'HTTPException',
 ] as const;


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. Behavioral proof:

**Before the fix** — a no-Host HTTP/1.0 probe (`GET / HTTP/1.0\r\n\r\n`, the Trinity scanner fingerprint `GET /nice%20ports%2C/Tri%6Eity.txt%2ebak HTTP/1.0\r\n\r\n`) left Bun.serve's `req.url` as a path-only string, so downstream `new URL(c.req.url)` threw:
```
TypeError: "/" cannot be parsed as a URL.
TypeError: "/nice%20ports%2C/Tri%6Eity.txt%2ebak" cannot be parsed as a URL.
```
→ `app.onError` → `captureException` → Sentry → Better Stack (BS pattern `28e9a65c…`).

**After the fix** — live repro against the real `bun run src/index.ts` with no-Host scanner probes:
| Probe | Before | After |
|---|---|---|
| `GET / HTTP/1.0` (no Host) | 404 + Sentry capture | **404**, no capture |
| `GET /nice%20ports%2C/Tri%6Eity.txt%2ebak HTTP/1.0` | 404 + Sentry capture | **404**, no capture |
| `GET /v1/executor/connectors HTTP/1.0` (no Host) | `TypeError` → 500 + Sentry | **401 Unauthorized** (combinedAuth ran cleanly) |
| `GET /v1/p/x/8000/foo HTTP/1.0` (no Host) | `TypeError` → 500 + Sentry | **401 Unauthorized** |
| `GET /v1/openapi.json HTTP/1.0` (no Host) | 404 (Hono path-mangled) | **200 OK** (route now matches) |
| `GET /v1/health HTTP/1.0` (no Host) | 404 (path-mangled) | **200 OK** |

Zero `cannot be parsed as a URL` lines in the server logs across all probes.

## Why

Better Stack error `28e9a65c2f67b076161ac330e4087441eed880b805f4e5133f2eff0588f3edd6` (Kortix API prod, application_id `2346961`) — `TypeError: "/" cannot be parsed as a URL.` from `fetch` in `apps/api/src/index.ts`. 3 occurrences / **0 users** / state Reoccurred / first_seen 2026-04-27 / last_seen 2026-07-21 21:48:59 UTC. A second inventory row showed the same class with the Trinity port-scanner fingerprint `"/nice%20ports%2C/Tri%6Eity.txt%2ebak"`. This is chronic low-level scanner noise, not a real-user bug — but it pages Sentry on every reoccurrence.

**Root cause:** Bun.serve sets `req.url` to a **path-only** string (`"/"`, `"/nice%20ports%2C/Tri%6Eity.txt%2ebak"`, …) for requests that arrive **without a `Host` header** (raw HTTP/1.0 port-scanner probes, malformed clients). The existing `getRequestUrl()` helper in `apps/api/src/lib/request-url.ts` handles this correctly via a fallback base — but it returns a `URL` that the handler discards; the original path-only `req` is what gets passed to `app.fetch(req, server)`. Downstream, every `new URL(c.req.url)` / `new URL(req.url)` call site (there are ~20 across `middleware/auth.ts`, `openapi/index.ts`, `sandbox-proxy/routes/{preview,public-share}.ts`, `git-proxy/index.ts`, `router/routes/proxy/handlers.ts`, `channels/slack/routes.ts`, `projects/routes/r4.ts`, `platform/routes/github-app.ts`) assumes an absolute URL and throws `TypeError: "…" cannot be parsed as a URL.` (WHATWG URL constructor requires a base for a relative input). That throw bubbles to `app.onError` → `captureException` → Sentry → Better Stack. A secondary effect: Hono's `getPath` also mis-computes the path for path-only URLs (it string-parses from `indexOf(":", …)`), so no-Host requests were also getting mangled route paths (404-ing routes that should match, e.g. `/v1/health`, `/v1/openapi.json`).

## What changed

1. **`apps/api/src/lib/request-url.ts`** — added `isRelativeRequestUrl(req)` and `ensureAbsoluteRequestUrl(req, fallbackPort)`. The latter returns `req` unchanged when its URL is already absolute, or rebuilds the Request on the absolute URL (preserving method/headers/body/signal) when Bun.serve handed us a path-only `req.url`. Single focused mitigation that covers every downstream `new URL(c.req.url)` call site without touching each one.
2. **`apps/api/src/index.ts`** — call `ensureAbsoluteRequestUrl(req, config.PORT)` at the top of the `Bun.serve` `fetch` handler, before `getRequestUrl` / `app.fetch` / the subdomain + WS upgrade paths. No-op for normal requests (which already carry an absolute `req.url`).
3. **`apps/api/src/lib/sentry.ts`** — defense-in-depth: add `'cannot be parsed as a URL'` to `SENTRY_IGNORE_ERRORS` so any residual edge case (a fire-and-forget path that re-parses a stale path-only URL, a future call site that bypasses the rebuild) stops paging instead of surfacing as a 0-user Sentry event. Matches the existing noise-filter pattern (`'The operation timed out.'`, `'The socket connection was closed unexpectedly'`, `'AbortError'`, …). The substring is narrow enough that it does NOT match real TypeErrors like `Cannot read properties of undefined (…)` — asserted in the test.
4. **`apps/api/src/__tests__/unit-request-url.test.ts`** — 6 new regression tests covering the `/` and Trinity-scanner path-only inputs, header/proto/body/method preservation, the no-op fast path for absolute URLs, and a direct assertion that `new URL(rebuilt.url)` does not throw for any path-only input Bun.serve can produce.
5. **`apps/api/src/__tests__/unit-sentry-noise-filter.test.ts`** — 2 new tests pinning that the URL-parse TypeError (both the `/` and Trinity variants, and the message-only case) is filtered, and that the substring is registered in `SENTRY_IGNORE_ERRORS`.

## Verification

- `bun test apps/api/src/__tests__/unit-request-url.test.ts` → 9 pass / 0 fail (19 expect calls) — 6 new tests for `ensureAbsoluteRequestUrl`.
- `bun test apps/api/src/__tests__/unit-sentry-noise-filter.test.ts` → 7 pass / 0 fail — 2 new tests for the URL-parse noise filter.
- `bun test apps/api/src/__tests__/{unit-request-url,unit-sentry-noise-filter,e2e-preview-proxy}.test.ts` → **72 pass / 0 fail** (no regression in the sandbox preview proxy e2e).
- `tsc --noEmit -p apps/api/tsconfig.json` → 1 pre-existing error in `sandbox-proxy/routes/preview.ts:364` (unrelated `ArrayBuffer` vs `SharedArrayBuffer`, present on `origin/main`); **0 new errors from this PR**.
- Live end-to-end repro: started the real `bun run src/index.ts`, sent the exact no-Host scanner probes via raw sockets — all return clean 401/404/200 with **zero** `cannot be parsed as a URL` in the server logs; `combinedAuth` now runs and returns 401 (instead of throwing); `/v1/openapi.json` and `/v1/health` now match and serve 200 (previously mangled to 404).
- Pre-existing test failures (`unit-preview-auth-principal`, `unit-tunnel-auth`) confirmed identical on `origin/main` — module-resolution/env-validation issues unrelated to this change.

## How to confirm in prod

After merge + promote, the Better Stack error `28e9a65c…` should drop to zero new occurrences (the throw no longer fires for no-Host scanner probes). The defense-in-depth `ignoreErrors` entry also means even a residual edge case stops paging. The error should auto-resolve in Better Stack once it stops recurring.

## Risk / rollback

- Low risk: the rebuild is a no-op for the overwhelming majority of traffic (normal requests carry an absolute `req.url`); only no-Host / malformed requests are rebuilt, and they previously 500'd or 404'd anyway.
- The rebuild uses the standard `new Request(absoluteUrl, originalReq)` constructor, which preserves method, headers, body, cache mode, and signal — verified by the body/method/headers preservation test.
- Rollback is a single revert; the `ignoreErrors` entry is independently safe (it only filters a 0-user scanner-noise error class).
- Better Stack error: https://errors.betterstack.com/team/t502678/errors/28e9a65c2f67b076161ac330e4087441eed880b805f4e5133f2eff0588f3edd6?s=2346961
