### PR TITLE
fix(snapshots): stop the sandbox-template rebuild storm + Daytona 429 feedback loop

### DIFF
--- a/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
@@ -146,7 +146,32 @@ describe('Daytona snapshot state', () => {
       });
     };
 
-    expect(await daytonaProvider.getSnapshotState('kortix-new-template')).toBe('unknown');
+    expect(await daytonaProvider.getSnapshotState('kortix-transient-probe')).toBe('unknown');
+  });
+
+  test('briefly caches a negative probe result per name (burst collapse)', async () => {
+    let calls = 0;
+    getSnapshotImpl = async () => {
+      calls += 1;
+      throw Object.assign(new Error('Snapshot with name kortix-neg-cache not found'), {
+        statusCode: 404,
+      });
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-neg-cache')).toBe('missing');
+    expect(await daytonaProvider.getSnapshotState('kortix-neg-cache')).toBe('missing');
+    expect(calls).toBe(1);
+  });
+
+  test('never caches unknown — recovery after an outage is observed immediately', async () => {
+    getSnapshotImpl = async () => {
+      throw Object.assign(new Error('upstream unavailable'), { statusCode: 503 });
+    };
+
+    expect(await daytonaProvider.getSnapshotState('kortix-outage-recovery')).toBe('unknown');
+
+    getSnapshotImpl = async () => ({ state: 'active' });
+    expect(await daytonaProvider.getSnapshotState('kortix-outage-recovery')).toBe('active');
   });
 
   test('keeps a timed-out Daytona probe unknown', async () => {

--- a/apps/api/src/__tests__/unit-quota-gc-select.test.ts
+++ b/apps/api/src/__tests__/unit-quota-gc-select.test.ts
@@ -154,6 +154,26 @@ describe('selectSnapshotsToReap — safety invariants', () => {
     expect(reaped).not.toContain('kortix-ppwarm-ffffffff-solo');
   });
 
+  // Two concurrently-live code versions produce two live warm names for the SAME
+  // project (different base identities). The freshly-built "superseded" one is
+  // very likely the other runtime's CURRENT tip — deleting it triggers an
+  // immediate full re-bake (churn), and symmetric reaps loop forever.
+  it('spares a freshly-built "superseded" ppwarm tip (mixed-version protection)', () => {
+    const minutes = (n: number) => new Date(NOW - n * 60_000).toISOString();
+    const all = padToOrgSize(
+      [
+        snap('kortix-ppwarm-0945686d-current', { lastUsedAt: minutes(1) }),
+        snap('kortix-ppwarm-0945686d-otherver', { lastUsedAt: minutes(10), createdAt: minutes(10) }),
+        snap('kortix-ppwarm-0945686d-trulyold', { lastUsedAt: ago(2) }),
+      ],
+      UNDER_TARGET,
+    );
+    const reaped = names(run(all));
+    expect(reaped).not.toContain('kortix-ppwarm-0945686d-current');
+    expect(reaped).not.toContain('kortix-ppwarm-0945686d-otherver');
+    expect(reaped).toContain('kortix-ppwarm-0945686d-trulyold');
+  });
+
   // One Daytona org, many databases: a ppwarm tip we can't attribute may belong to
   // another environment. Idle time is the ONLY cross-env-safe liveness signal.
   it('reaps a long-idle ppwarm tip but spares a recently used one', () => {

--- a/apps/api/src/__tests__/unit-warm-bake-cooldown.test.ts
+++ b/apps/api/src/__tests__/unit-warm-bake-cooldown.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('ALLOWED_SANDBOX_PROVIDERS', 'daytona');
+setTestEnv('DAYTONA_API_KEY', 'test-daytona-key');
+setTestEnv('DAYTONA_SERVER_URL', 'https://daytona.example.test');
+setTestEnv('DAYTONA_TARGET', 'test-target');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+setTestEnv('RECALL_BASE_URL', 'https://us-west-2.recall.ai/api/v1');
+
+const { warmBakeCooldownGate } = await import('../snapshots/builder');
+
+const PROJECT = '2d34b9f0-0000-0000-0000-000000000000';
+const COOLDOWN = 10 * 60 * 1000;
+
+describe('warmBakeCooldownGate — per-(project, provider) bake pacing', () => {
+  test('first kick passes and starts the cooldown', () => {
+    const registry = new Map<string, number>();
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: 0, cooldownMs: COOLDOWN, registry })).toBe(true);
+    expect(registry.get(`${PROJECT}:daytona`)).toBe(0);
+  });
+
+  test('kicks inside the cooldown are rejected — a push every few minutes bakes once per window', () => {
+    const registry = new Map<string, number>();
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: 0, cooldownMs: COOLDOWN, registry })).toBe(true);
+    for (const minute of [1, 4, 7, 9]) {
+      expect(
+        warmBakeCooldownGate(PROJECT, 'daytona', { now: minute * 60_000, cooldownMs: COOLDOWN, registry }),
+      ).toBe(false);
+    }
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: COOLDOWN, cooldownMs: COOLDOWN, registry })).toBe(true);
+  });
+
+  test('a rejected kick does not extend the cooldown window', () => {
+    const registry = new Map<string, number>();
+    warmBakeCooldownGate(PROJECT, 'daytona', { now: 0, cooldownMs: COOLDOWN, registry });
+    warmBakeCooldownGate(PROJECT, 'daytona', { now: COOLDOWN - 1, cooldownMs: COOLDOWN, registry });
+    expect(registry.get(`${PROJECT}:daytona`)).toBe(0);
+  });
+
+  test('providers cool down independently — parity fan-out is paced per provider, not globally', () => {
+    const registry = new Map<string, number>();
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: 0, cooldownMs: COOLDOWN, registry })).toBe(true);
+    expect(warmBakeCooldownGate(PROJECT, 'platinum', { now: 0, cooldownMs: COOLDOWN, registry })).toBe(true);
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: 1, cooldownMs: COOLDOWN, registry })).toBe(false);
+    expect(warmBakeCooldownGate(PROJECT, 'platinum', { now: 1, cooldownMs: COOLDOWN, registry })).toBe(false);
+  });
+
+  test('projects cool down independently', () => {
+    const registry = new Map<string, number>();
+    const other = 'adfd91b6-0000-0000-0000-000000000000';
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: 0, cooldownMs: COOLDOWN, registry })).toBe(true);
+    expect(warmBakeCooldownGate(other, 'daytona', { now: 1, cooldownMs: COOLDOWN, registry })).toBe(true);
+  });
+
+  test('a zero cooldown disables pacing (escape hatch for tests/ops)', () => {
+    const registry = new Map<string, number>();
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: 0, cooldownMs: 0, registry })).toBe(true);
+    expect(warmBakeCooldownGate(PROJECT, 'daytona', { now: 0, cooldownMs: 0, registry })).toBe(true);
+  });
+});

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -13,14 +13,14 @@
  * table for UI display + "Fix with agent."
  */
 
-import { and, desc, eq, lt } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, lt, or } from 'drizzle-orm';
 import { projectSnapshotBuilds } from '@kortix/db';
 import { db } from '../shared/db';
 import { resolveCommitSha, type GitBackedProject } from '../projects/git';
 import { getSandboxProvider, type ProviderState, type SandboxProviderAdapter } from './providers';
 import { config, type SandboxProviderName } from '../config';
 import { warmPrebakeProviders } from '../projects/lib/provider-precedence';
-import { perProjectWarmImageName, ppwarmReapTargets, warmBuildSlug } from './ppwarm-names';
+import { PPWARM_REAP_PROTECT_MS, perProjectWarmImageName, ppwarmReapTargets, warmBuildSlug } from './ppwarm-names';
 import {
   computeTemplateIdentity,
   listTemplatesForProject,
@@ -423,10 +423,27 @@ async function runInlineBuild(
     // snapshot. Delete it so old runtime fingerprints don't accumulate — this
     // was leaking a full ~8 GB rootfs template per agent-source change (7 stale
     // copies = 56 GB observed before this fix).
+    //
+    // EXCEPT when the predecessor itself was built (or is building) recently:
+    // that means another live code version — an overlapping rolling deploy, or
+    // dev's ECS/EKS split — computed a DIFFERENT identity and is actively
+    // serving it. Deleting it makes that version's sessions miss, rebuild, and
+    // (symmetrically) delete OURS — an infinite mutual-destruction loop of full
+    // image builds (observed live 2026-07-22: the shared default rebuilt 4× in
+    // 6 minutes). A genuinely superseded identity stops being rebuilt, ages out
+    // of the window, and is pruned by the next drift build or the quota GC.
     if (prevSnapshot && prevSnapshot !== identity.snapshotName) {
-      await provider
-        .deleteSnapshot(prevSnapshot)
-        .catch((e) => console.warn(`[snapshots] prune predecessor ${prevSnapshot} failed: ${e?.message ?? e}`));
+      const recent = await recentlyBuiltSnapshotNames([prevSnapshot], PREDECESSOR_PRUNE_PROTECT_MS);
+      if (recent.has(prevSnapshot)) {
+        console.log(
+          `[snapshots] keeping predecessor ${prevSnapshot}: it was built recently, so another ` +
+          `live replica/code version likely still serves it; it is pruned once it stops being rebuilt`,
+        );
+      } else {
+        await provider
+          .deleteSnapshot(prevSnapshot)
+          .catch((e) => console.warn(`[snapshots] prune predecessor ${prevSnapshot} failed: ${e?.message ?? e}`));
+      }
     }
     return {
       snapshotName: identity.snapshotName,
@@ -785,6 +802,52 @@ async function closeBuildLogFailed(buildId: string, message: string): Promise<vo
 }
 
 /**
+ * How long a freshly-built PREDECESSOR identity is protected from the
+ * supersession prune in {@link runInlineBuild}. Long: a stale-but-live code
+ * version (dev's split-brain ran for days) keeps re-building its identity, so
+ * every prune within the window would re-arm the mutual-destruction loop, and a
+ * kept default costs only provider storage (Daytona's quota GC ranks defaults
+ * by freshness; Platinum templates are CAS-chunked).
+ */
+const PREDECESSOR_PRUNE_PROTECT_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Of `snapshotNames`, the ones with a successful build finished — or a build
+ * started — within `withinMs`, per this environment's build log. Used as the
+ * "another live runtime still serves this" signal before pruning superseded
+ * snapshots. Fail-open (empty set) on a DB error: the callers' deletes then
+ * behave exactly as before this guard existed.
+ */
+async function recentlyBuiltSnapshotNames(
+  snapshotNames: string[],
+  withinMs: number,
+): Promise<Set<string>> {
+  if (snapshotNames.length === 0) return new Set();
+  try {
+    const cutoff = new Date(Date.now() - withinMs);
+    const rows = await db
+      .select({ snapshotName: projectSnapshotBuilds.snapshotName })
+      .from(projectSnapshotBuilds)
+      .where(
+        and(
+          inArray(projectSnapshotBuilds.snapshotName, snapshotNames),
+          or(
+            and(eq(projectSnapshotBuilds.status, 'ready'), gt(projectSnapshotBuilds.finishedAt, cutoff)),
+            and(eq(projectSnapshotBuilds.status, 'building'), gt(projectSnapshotBuilds.startedAt, cutoff)),
+          ),
+        ),
+      );
+    return new Set(rows.map((row) => row.snapshotName));
+  } catch (err) {
+    console.warn(
+      '[snapshots] recent-build lookup failed (skipping prune protection):',
+      err instanceof Error ? err.message : err,
+    );
+    return new Set();
+  }
+}
+
+/**
  * In-flight background rebuilds, keyed by provider + target snapshot name. A
  * burst of sessions booting off the same drifted identity must kick exactly
  * one build on EACH provider; same-name builds on different providers are
@@ -825,10 +888,92 @@ function kickBackgroundRebuild(
 }
 
 /**
+ * Minimum spacing between warm-bake STARTS per (project, provider). The warm
+ * image is a pure boot-latency cache, yet every default-branch push (and every
+ * session-start warm miss) used to kick a full multi-minute image bake, per
+ * enabled provider, with no pacing. A busy project pushing every few minutes
+ * baked continuously — observed live 2026-07-22: one prod project baked a new
+ * warm image every 3-8 minutes, ×2 providers, 227 builds/24h, which also
+ * rate-limited the whole Daytona org (429 ThrottlerException). Skipping a kick
+ * only delays warmth: the next kick after the window bakes the CURRENT tip.
+ */
+const WARM_BAKE_COOLDOWN_MS = (() => {
+  const raw = Number.parseInt(process.env.KORTIX_WARM_BAKE_COOLDOWN_MS || '', 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 10 * 60 * 1000;
+})();
+const warmBakeLastKickAt = new Map<string, number>();
+
+/**
+ * True — and the kick is recorded — when a warm bake for (project, provider)
+ * is allowed to start now; false while a prior kick is inside the cooldown.
+ * Pure given injected `now`/`registry` (exported for tests).
+ */
+export function warmBakeCooldownGate(
+  projectId: string,
+  provider: string,
+  opts: { now?: number; cooldownMs?: number; registry?: Map<string, number> } = {},
+): boolean {
+  const now = opts.now ?? Date.now();
+  const cooldownMs = opts.cooldownMs ?? WARM_BAKE_COOLDOWN_MS;
+  const registry = opts.registry ?? warmBakeLastKickAt;
+  const key = `${projectId}:${provider}`;
+  const last = registry.get(key);
+  if (last !== undefined && now - last < cooldownMs) return false;
+  registry.set(key, now);
+  return true;
+}
+
+/**
+ * Warm bakes currently running, keyed by (project, provider) — a hot project
+ * whose tip moves mid-bake must NOT start a second concurrent bake for the new
+ * tip (the name-keyed inflight set can't see that: new tip = new name).
+ */
+const inflightWarmBakesByProject = new Set<string>();
+
+/**
+ * Cluster-wide cooldown: the in-memory gate above is per-replica (the api runs
+ * several pods under an HPA), so a burst spread across N replicas could still
+ * start N bakes per window. The build log is shared, so a warm-bake row STARTED
+ * by ANY replica within the window is visible here. Best-effort: rows exist
+ * only for account-attributed bakes, and any DB error fails open to the local
+ * gate — this narrows the cross-replica window, it does not have to be perfect
+ * (same-name races are still collapsed by provider-truth 'building' checks).
+ */
+async function warmBakeRecentlyStartedCluster(
+  projectId: string,
+  provider: string,
+  withinMs: number,
+): Promise<boolean> {
+  try {
+    const cutoff = new Date(Date.now() - withinMs);
+    const rows = await db
+      .select({ metadata: projectSnapshotBuilds.metadata })
+      .from(projectSnapshotBuilds)
+      .where(
+        and(
+          eq(projectSnapshotBuilds.projectId, projectId),
+          gt(projectSnapshotBuilds.startedAt, cutoff),
+        ),
+      )
+      .orderBy(desc(projectSnapshotBuilds.startedAt))
+      .limit(25);
+    const warmSlug = warmBuildSlug(DEFAULT_SANDBOX_SLUG);
+    return rows.some((row) => {
+      const meta = (row.metadata ?? {}) as Record<string, unknown>;
+      return meta.slug === warmSlug && meta.provider === provider;
+    });
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Fire-and-forget per-project warm bake, off the session hot path. Deduped by the
  * target warm snapshot name (via the same inflight set) so a burst of sessions on
- * the same (project, tip) kicks exactly one bake. Best-effort: a failure just means
- * the next session retries; sessions keep booting cold until the bake lands.
+ * the same (project, tip) kicks exactly one bake, single-flighted per
+ * (project, provider), and paced by {@link warmBakeCooldownGate}. Best-effort: a
+ * skipped or failed kick just means the next session/push retries; sessions keep
+ * booting cold until a bake lands.
  */
 function kickBackgroundWarmBuild(
   project: GitBackedProject,
@@ -836,19 +981,35 @@ function kickBackgroundWarmBuild(
 ): void {
   const key = backgroundBuildKey(opts.provider, opts.snapshotName);
   if (inflightBackgroundBuilds.has(key)) return;
+  const projectKey = `${project.projectId}:${opts.provider}`;
+  if (inflightWarmBakesByProject.has(projectKey)) return;
+  if (!warmBakeCooldownGate(project.projectId, opts.provider)) return;
   inflightBackgroundBuilds.add(key);
-  void ensurePerProjectWarmImage(project, {
-    accountId: opts.accountId,
-    provider: opts.provider,
-    source: 'background',
-  })
+  inflightWarmBakesByProject.add(projectKey);
+  void (async () => {
+    if (await warmBakeRecentlyStartedCluster(project.projectId, opts.provider, WARM_BAKE_COOLDOWN_MS)) {
+      console.log(
+        `[snapshots] warm bake for ${project.projectId.slice(0, 8)} (${opts.provider}) skipped: ` +
+        `another replica started one inside the cooldown window`,
+      );
+      return;
+    }
+    await ensurePerProjectWarmImage(project, {
+      accountId: opts.accountId,
+      provider: opts.provider,
+      source: 'background',
+    });
+  })()
     .catch((err) =>
       console.warn(
         `[snapshots] background warm bake of ${opts.snapshotName} failed for ${project.projectId}:`,
         err instanceof Error ? err.message : err,
       ),
     )
-    .finally(() => inflightBackgroundBuilds.delete(key));
+    .finally(() => {
+      inflightBackgroundBuilds.delete(key);
+      inflightWarmBakesByProject.delete(projectKey);
+    });
 }
 
 /**
@@ -1291,7 +1452,20 @@ async function reapOldPerProjectWarm(projectId: string, currentName: string, bui
   try {
     const provider = getSandboxProvider(buildProvider);
     const names = (await provider.listSnapshots()).map((snapshot) => snapshot.name);
-    for (const name of ppwarmReapTargets(projectId, currentName, names)) {
+    const targets = ppwarmReapTargets(projectId, currentName, names);
+    if (targets.length === 0) return;
+    // A "superseded" name built minutes ago is very likely another live code
+    // version's CURRENT warm image (different runtime fingerprint → different
+    // base identity → different warm name for the SAME project+tip). Deleting
+    // it makes that runtime re-bake — and its reap symmetrically deletes OURS:
+    // an infinite loop of full image builds. Freshly-built names are skipped;
+    // once a name stops being rebuilt it ages out and is reaped normally.
+    const recent = await recentlyBuiltSnapshotNames(targets, PPWARM_REAP_PROTECT_MS);
+    for (const name of targets) {
+      if (recent.has(name)) {
+        console.log(`[snapshots] per-project warm: keeping ${name} (built recently — likely a live runtime's current tip)`);
+        continue;
+      }
       await provider.deleteSnapshot(name);
       console.log(`[snapshots] per-project warm: reaped superseded ${name}`);
     }

--- a/apps/api/src/snapshots/observation-cache.test.ts
+++ b/apps/api/src/snapshots/observation-cache.test.ts
@@ -29,6 +29,38 @@ describe('provider catalog observation cache', () => {
     expect(calls).toBe(2);
   });
 
+  test('per-value TTL: negative results cache briefly, positive ones longer', async () => {
+    let calls = 0;
+    const observe = shortLivedObservation(
+      async () => {
+        calls += 1;
+        return calls === 1 ? 'missing' : 'active';
+      },
+      (value) => (value === 'active' ? 60_000 : 1),
+    );
+
+    expect(await observe()).toBe('missing');
+    await new Promise((r) => setTimeout(r, 5));
+    expect(await observe()).toBe('active');
+    expect(await observe()).toBe('active');
+    expect(calls).toBe(2);
+  });
+
+  test('a zero TTL for a value means it is never cached', async () => {
+    let calls = 0;
+    const observe = shortLivedObservation(
+      async () => {
+        calls += 1;
+        return 'unknown';
+      },
+      (value) => (value === 'unknown' ? 0 : 60_000),
+    );
+
+    expect(await observe()).toBe('unknown');
+    expect(await observe()).toBe('unknown');
+    expect(calls).toBe(2);
+  });
+
   test('invalidation prevents an older in-flight read from restoring stale data', async () => {
     let calls = 0;
     let resolveStale!: (value: string[]) => void;

--- a/apps/api/src/snapshots/observation-cache.ts
+++ b/apps/api/src/snapshots/observation-cache.ts
@@ -4,10 +4,14 @@ export interface InvalidatableObservation<T> {
   invalidate(): void;
 }
 
-/** Collapse concurrent provider catalog reads and briefly reuse a confirmed result. */
+/**
+ * Collapse concurrent provider catalog reads and briefly reuse a confirmed
+ * result. `ttlMs` may be a function of the observed value so callers can hold
+ * a confirmed-positive result longer than a transient/negative one.
+ */
 export function shortLivedObservation<T>(
   observe: () => Promise<T>,
-  ttlMs = 2_000,
+  ttlMs: number | ((value: T) => number) = 2_000,
   shouldCache: (value: T) => boolean = () => true,
 ): InvalidatableObservation<T> {
   let cached: { value: T; expiresAt: number } | null = null;
@@ -21,8 +25,9 @@ export function shortLivedObservation<T>(
     const observationGeneration = generation;
     const promise = observe()
       .then((value) => {
-        if (generation === observationGeneration && shouldCache(value)) {
-          cached = { value, expiresAt: Date.now() + ttlMs };
+        const ttl = typeof ttlMs === 'function' ? ttlMs(value) : ttlMs;
+        if (generation === observationGeneration && ttl > 0 && shouldCache(value)) {
+          cached = { value, expiresAt: Date.now() + ttl };
         }
         return value;
       })

--- a/apps/api/src/snapshots/ppwarm-names.ts
+++ b/apps/api/src/snapshots/ppwarm-names.ts
@@ -10,6 +10,19 @@ import { createHash } from 'node:crypto';
 export const PPWARM_PREFIX = 'kortix-ppwarm-';
 
 /**
+ * A ppwarm image (re)built within this window is protected from supersession
+ * reaping — by the on-bake reaper AND the quota GC's superseded-tip rule. Two
+ * concurrently-live code versions (a rolling deploy; dev's ECS+EKS split-brain)
+ * compute DIFFERENT base identities, so each considers the other's current warm
+ * image "superseded" and deletes it on every bake — an infinite full-rebuild
+ * loop (observed live 2026-07-22). A freshly-built image is by definition some
+ * live runtime's current tip; leave it alone and reap it once it has actually
+ * gone stale. Kept short so a hot project's genuinely superseded tips still
+ * reclaim fast enough for the Daytona org snapshot quota.
+ */
+export const PPWARM_REAP_PROTECT_MS = 45 * 60 * 1000;
+
+/**
  * Suffix that distinguishes the warm bake's BUILD-LOG row from the template it
  * layers on top of. `project_snapshot_builds.metadata.slug` records
  * `<template>-warm` for a warm bake, but no such template exists in

--- a/apps/api/src/snapshots/providers/daytona-errors.test.ts
+++ b/apps/api/src/snapshots/providers/daytona-errors.test.ts
@@ -41,6 +41,9 @@ describe('Daytona snapshot not-found classifier', () => {
     ['503', Object.assign(new Error('upstream failed'), { statusCode: 503 })],
     ['generic not-found text', new Error('repository not found')],
     ['imprecise snapshot text', new Error('snapshot lookup not found')],
+    // A throttled lookup must NEVER read as "missing" — that would turn every
+    // rate-limited call into a spurious rebuild trigger.
+    ['rate limit (429)', Object.assign(new Error('ThrottlerException: Too Many Requests'), { statusCode: 429 })],
   ])('rejects %s as an unconfirmed not-found', (_label, err) => {
     expect(isDaytonaSnapshotNotFoundError(err)).toBe(false);
   });

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -11,6 +11,7 @@
 import { rm } from 'node:fs/promises';
 import { Image } from '@daytonaio/sdk';
 import { getDaytona, isDaytonaConfigured, listDaytonaSnapshots } from '../../shared/daytona';
+import { isDaytonaRateLimitError } from '../../shared/daytona-rate-limit';
 import { withTimeout } from '../../shared/with-timeout';
 import {
   DEFAULT_CPU,
@@ -39,12 +40,18 @@ const POST_FAILURE_SETTLE_POLL_MS = 4_000;
 const ACTIVATE_DEADLINE_MS = 120_000;
 
 /**
- * Positive-state cache for Daytona snapshots. Keyed by snapshot name; only
- * 'active' is cached. TTL is 60s — long enough to collapse a burst of session
- * boots into one round-trip, short enough that a manual delete in the
- * Daytona dashboard surfaces in under a minute.
+ * State cache for Daytona snapshots, keyed by snapshot name. 'active' is held
+ * for 60s — long enough to collapse a burst of session boots into one
+ * round-trip, short enough that a manual delete in the Daytona dashboard
+ * surfaces in under a minute. Non-active states ('missing' / 'building' /
+ * 'build_failed') are held briefly too: they are re-read by every session boot,
+ * build poll, and templates-UI refresh, and uncached negative lookups were a
+ * major contributor to org-wide 429s (ThrottlerException) once builds churned.
+ * 'unknown' (transport/rate-limit error) is never cached so recovery is
+ * observed immediately.
  */
 const SNAPSHOT_STATE_CACHE_TTL_MS = 60_000;
+const SNAPSHOT_STATE_NEGATIVE_TTL_MS = 5_000;
 /**
  * Per-call wall-clock budget for the (timeout-less) Daytona `snapshot.get`.
  * A healthy call is ~50-200ms; 8s is generous headroom for a slow-but-alive
@@ -78,8 +85,8 @@ function observeSnapshotState(snapshotName: string): InvalidatableObservation<Pr
         return 'unknown';
       }
     },
-    SNAPSHOT_STATE_CACHE_TTL_MS,
-    (state) => state === 'active',
+    (state) => (state === 'active' ? SNAPSHOT_STATE_CACHE_TTL_MS : SNAPSHOT_STATE_NEGATIVE_TTL_MS),
+    (state) => state !== 'unknown',
   );
   snapshotStateObservations.set(snapshotName, observation);
   return observation;
@@ -182,7 +189,10 @@ class DaytonaAdapter implements SandboxProviderAdapter {
         console.warn(
           `[snapshots] build attempt ${attempt}/${BUILD_ATTEMPTS} for ${input.snapshotName} failed — re-staging + retrying: ${msg.slice(0, 120)}`,
         );
-        await new Promise((r) => setTimeout(r, BUILD_RETRY_BASE_MS * attempt));
+        // Rate-limited attempts back off much longer — retrying a 429 in
+        // seconds just spends another request against an exhausted quota.
+        const retryBaseMs = isDaytonaRateLimitError(err) ? RATE_LIMIT_RETRY_BASE_MS : BUILD_RETRY_BASE_MS;
+        await new Promise((r) => setTimeout(r, retryBaseMs * attempt));
       } finally {
         await rm(ctx.contextDir, { recursive: true, force: true }).catch(() => {});
       }
@@ -193,14 +203,13 @@ class DaytonaAdapter implements SandboxProviderAdapter {
 
   async getSnapshotState(snapshotName: string): Promise<ProviderState> {
     if (!isDaytonaConfigured()) return 'missing';
-    // 60s positive-state cache. Daytona's snapshot.get is ~50-200ms per call
-    // over the public internet; on a burst of session boots this dominates
-    // the warm path. We cache only `active` (the common case) because that's
-    // the only state where speeding the boot up is safe: if the snapshot is
-    // mid-build / removing / missing, the caller's logic depends on the
-    // accurate state, and the auto-heal in session-sandbox.ts already covers
-    // the rare race where an `active` snapshot disappears between our check
-    // and the actual sandbox.create.
+    // Cached — 60s for `active`, a few seconds for negative states, never for
+    // `unknown`. Daytona's snapshot.get is ~50-200ms per call over the public
+    // internet; on a burst of session boots this dominates the warm path, and
+    // uncached negative lookups compounded into org-wide 429s. Mutating paths
+    // (build/delete) invalidate, and the auto-heal in session-sandbox.ts
+    // already covers the rare race where an `active` snapshot disappears
+    // between our check and the actual sandbox.create.
     return observeSnapshotState(snapshotName)();
   }
 
@@ -283,7 +292,9 @@ class DaytonaAdapter implements SandboxProviderAdapter {
         if (message.includes('build_failed') || message.includes('error')) throw err;
         lastState = message.slice(0, 120) || 'lookup failed';
       }
-      await new Promise((r) => setTimeout(r, 1_000));
+      // 2s, not 1s: post-create activation takes tens of seconds; halving the
+      // poll rate meaningfully cuts org-wide API traffic with no visible cost.
+      await new Promise((r) => setTimeout(r, 2_000));
     }
     throw new Error(
       `Snapshot ${name} did not become active after create (last state: ${lastState})`,
@@ -348,7 +359,17 @@ export function isDaytonaSnapshotNotFoundError(err: unknown): boolean {
   return has404Status || hasDaytonaNotFoundName || hasPreciseSnapshotNotFoundMessage;
 }
 
+/** Extra breathing room before retrying a rate-limited call. */
+const RATE_LIMIT_RETRY_BASE_MS = 15_000;
+
+// Rate limiting (`DaytonaRateLimitError` / "ThrottlerException: Too Many
+// Requests") MUST be retryable: a throttled build attempt is not a build
+// failure, and failing it re-queues the whole bake later — which generates
+// MORE API traffic and feeds the very storm that caused the 429 (observed
+// live in prod 2026-07-22). Classification lives in shared/daytona-rate-limit
+// (the same conservative classifier app.onError uses).
 function isTransientDaytonaError(err: unknown): boolean {
+  if (isDaytonaRateLimitError(err)) return true;
   const m = (err instanceof Error ? err.message : String(err)).toLowerCase();
   const statusCode = (err as { statusCode?: number } | null | undefined)?.statusCode;
   if (statusCode === 404) return true;

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -74,6 +74,9 @@ export function isRetryablePlatinumBuildError(err: unknown): boolean {
     m.includes('timeout') || m.includes('timed out') || m.includes('econnreset') ||
     m.includes('econnrefused') || m.includes('network') || m.includes('gateway') ||
     m.includes(' 502') || m.includes(' 503') || m.includes(' 504') ||
+    // Rate limiting is transient by definition — failing the build on a 429
+    // re-queues the whole bake later, generating more traffic, not less.
+    m.includes(' 429') || m.includes('too many requests') ||
     m.includes('last state: missing')
   );
 }

--- a/apps/api/src/snapshots/quota-gc-select.ts
+++ b/apps/api/src/snapshots/quota-gc-select.ts
@@ -79,6 +79,14 @@ export const QUOTA_GC_PPWARM_MAX_IDLE_MS = 14 * 24 * 60 * 60 * 1000;
  */
 export const QUOTA_GC_PPWARM_EVICT_PROTECT_MS = 6 * 60 * 60 * 1000;
 
+/**
+ * A "superseded" ppwarm tip created/used this recently is likely another live
+ * runtime's CURRENT tip (mixed code versions → mixed base identities). Mirrors
+ * PPWARM_REAP_PROTECT_MS in ppwarm-names.ts (kept as a local constant because
+ * this module deliberately imports nothing).
+ */
+export const QUOTA_GC_PPWARM_FRESH_PROTECT_MS = 45 * 60 * 1000;
+
 /** Max deletions per sweep pass — keeps each pass cheap and observable. */
 export const QUOTA_GC_MAX_PER_PASS = 15;
 
@@ -220,7 +228,16 @@ export function selectSnapshotsToReap(input: SelectInput): SelectResult {
   for (const [proj8, group] of byProj) {
     if (group.length < 2) continue;
     const [, ...superseded] = [...group].sort(byFreshestFirst);
-    for (const s of superseded) claim(s, `superseded ppwarm tip for project ${proj8}`);
+    for (const s of superseded) {
+      // A "superseded" tip that was created/used minutes ago is very likely
+      // another live runtime's CURRENT tip (two code versions → two base
+      // identities → two live warm names for the same project). Deleting it
+      // triggers an immediate full re-bake — churn, not reclamation. See
+      // PPWARM_REAP_PROTECT_MS (ppwarm-names.ts) for the incident writeup.
+      const t = lastTouch(s);
+      if (Number.isFinite(t) && now - t < QUOTA_GC_PPWARM_FRESH_PROTECT_MS) continue;
+      claim(s, `superseded ppwarm tip for project ${proj8}`);
+    }
   }
 
   // 3. ppwarm tips nobody has booted in a long time. We cannot see other envs' DBs,


### PR DESCRIPTION
## Incident (observed live 2026-07-22)

- **prod**: one project (`adfd91b6`, math-god) baked a NEW per-project warm image every 3-8 minutes, x2 providers — 227 builds/24h — which rate-limited the whole Daytona org (Better Stack: 100th `DaytonaRateLimitError: ThrottlerException`).
- **dev**: the shared default image rebuilt 4x in 6 minutes. The stale-ECS and fresh-EKS backends compute different content-addressed identities, and each build DELETED the other's snapshot (predecessor prune + ppwarm reap) — an infinite mutual-destruction loop of full image builds. This is the constant 'building' churn on the Sandbox templates page.

## Fixes

1. **Warm bakes are paced** — single-flight per (project, provider), a 10-min cooldown between bake starts (`KORTIX_WARM_BAKE_COOLDOWN_MS`), enforced both in-process and cluster-wide via the shared build log (the api runs 3-12 replicas). The warm image is a boot-latency cache; a skipped kick only delays warmth — the next kick bakes the current tip.
2. **Supersession pruning protects freshly-built snapshots** — a predecessor or 'superseded' ppwarm name with a ready/building build-log row inside the protect window is another live runtime's current image; keep it, reap once it stops being rebuilt. Same guard in quota-GC's superseded-tip rule.
3. **429s are retryable, never 'missing'** — Daytona rate limits (classified by the existing conservative `shared/daytona-rate-limit` classifier) and Platinum 429s retry with a long backoff instead of failing the build and re-queuing it later; a throttled state lookup can never read as 'missing' (which would turn every 429 into a rebuild trigger).
4. **Less Daytona API traffic** — snapshot-state lookups briefly cache negative states (5s; 'unknown' never cached), activate poll 1s -> 2s.

## Verification

- 82 targeted tests green (new: cooldown gate, negative-state cache semantics, quota-GC fresh-tip protection); `tsc` clean; full API unit suite failure set is identical to main's baseline (local-env noise only).
- Adversarially reviewed; the two findings (duplicate rate-limit classifier, per-replica-only pacing) are addressed in this diff.

## Follow-ups (not this PR)

- Ops: dev's ECS backend runs a stale api image while CI only rolls EKS — that split-brain is what makes the mutual-destruction loop chronic on dev. Align the dev ECS service with deploy-dev (known gap).
- Prod needs a release + ECS roll to pick this up.