### PR TITLE
fix(web): filter Sentry non-Error undefined promise rejection noise (BS 5cfc90e5)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -15,6 +15,7 @@ import {
   isInjectedAppSource,
   isInpageWalletStreamNoise,
   isKnownBrowserNoiseMessage,
+  isNonErrorUndefinedRejectionNoise,
   isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
   isPaperShaderNullContextNoise,
@@ -3654,4 +3655,208 @@ test('does NOT suppress a runtime rejection whose reason is a real Error with an
     }),
     false,
   )
+})
+
+// ---------------------------------------------------------------------------
+// Sentry 10.x bare-`undefined` non-Error promise rejection noise
+// (Better Stack pattern
+// 5cfc90e5077a4f3d956f46b51beb633256b9a74532717d4b5797ca5cbc62f2f1,
+// Kortix Frontend prod, application_id 2346967, `UnhandledRejection`). A
+// promise rejected with the primitive `undefined` (NOT an Error instance),
+// captured by Sentry's GlobalHandlers `onunhandledrejection` integration as
+// the synthetic "Non-Error promise rejection captured with value: undefined"
+// message with NO stacktrace frames at all (there is no stack to de-minify —
+// the rejection carries none). The breadcrumbs around the production event
+// are all third-party fetches on the marketing site (`/api/github-stars`,
+// `/_vercel/insights/view`, `cdn-cookieyes.com`, `/api/maintenance`) plus the
+// recurring `Unsupported color format var(--kortix-orange)` console.error — a
+// third-party/cookie-library runtime, not first-party app code. 1 occurrence,
+// 0 identified users (anonymous), mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT global
+// unhandledrejection — never reached a React error boundary), release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6`, first 2026-04-23 / last
+// 2026-07-22, Safari 26.5.2 on iOS 18.7 (iPhone, Mobile), request URL
+// `https://kortix.com/` (the marketing/landing page). Stack trace: NONE —
+// `call_site_file`/`call_site_function` are null, `call_stack_hash` is null,
+// no frames at all.
+//
+// DISTINCT from the EIP-1193 wallet-extension plain-object rejection class
+// (`isExtensionRejectedObjectNoise` / Better Stack `0f78b2f8…`, PR #4720):
+// that one rejects with a serialized OBJECT (`{ code, message, stack }`) and
+// Sentry emits "Object captured as promise rejection with keys: …" (carrying
+// the extension stack in `extra.__serialized__.stack`). THIS class rejects
+// with the primitive `undefined` and Sentry emits
+// "Non-Error promise rejection captured with value: undefined" with no
+// serialized payload and no frames. The two message prefixes are disjoint, so
+// the matchers do not shadow each other.
+//
+// The "Non-Error promise rejection captured with value: undefined" message is
+// Sentry's generic signature for ANY `Promise.reject(undefined)` — a real
+// first-party `Promise.reject(undefined)` would produce the SAME signature —
+// so the matcher requires the canonical message AND NEGATIVE guards: if the
+// event has ANY resolved stack frame OR a resolved first-party
+// `apps/web/src/…` frame, keep reporting (a real first-party
+// `Promise.reject(undefined)` we can attribute should still surface). The
+// production noise pattern has NO frames at all; only the frameless capture
+// is dropped.
+// ---------------------------------------------------------------------------
+
+// The exact synthetic message from the production event.
+const NON_ERROR_UNDEFINED_REJECTION =
+  'Non-Error promise rejection captured with value: undefined'
+
+test('classifies the bare-undefined non-Error promise rejection noise', () => {
+  // Exact production shape: the canonical message, NO frames (the rejection
+  // carried no stack).
+  assert.equal(
+    isNonErrorUndefinedRejectionNoise({
+      message: NON_ERROR_UNDEFINED_REJECTION,
+      frames: [],
+    }),
+    true,
+  )
+})
+
+test('suppresses the assigned bare-undefined rejection Sentry event via the beforeSend gate', () => {
+  // Exact shape of the production event: type `UnhandledRejection`, mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (uncaught global
+  // unhandledrejection — never reached a React error boundary), NO
+  // stacktrace frames, request URL `https://kortix.com/` (marketing site).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: NON_ERROR_UNDEFINED_REJECTION,
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the bare-undefined rejection when frames are absent entirely (no stacktrace key)', () => {
+  // The production event has no frames at all — Sentry omits the stacktrace
+  // key entirely when there is nothing to serialize. The gate must still drop
+  // it (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [{ value: NON_ERROR_UNDEFINED_REJECTION }],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a non-undefined non-Error rejection (e.g. an object or string value)', () => {
+  // A rejection with a non-undefined value produces a DIFFERENT synthetic
+  // message ("…with value: [object Object]" / "…with value: some string") —
+  // that is the EIP-1193 plain-object class handled separately by
+  // `isExtensionRejectedObjectNoise` (PR #4720). THIS matcher must not shadow
+  // it: the canonical-`undefined` anchor is exact, so any other value keeps
+  // reporting.
+  for (const message of [
+    'Non-Error promise rejection captured with value: [object Object]',
+    'Non-Error promise rejection captured with value: some string',
+    'Non-Error promise rejection captured with value: null',
+    'Non-Error promise rejection captured with value: 0',
+    'Object captured as promise rejection with keys: code, message, stack',
+  ]) {
+    assert.equal(
+      isNonErrorUndefinedRejectionNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: message, stacktrace: { frames: [] } }],
+        },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress the bare-undefined rejection when a first-party frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code rejected a promise
+  // with `undefined` → actionable; the negative guard MUST preserve it so the
+  // call site can be found + fixed. This is the whole reason the matcher is
+  // frame-aware (the message is also a real first-party
+  // `Promise.reject(undefined)` signature).
+  for (const frames of [
+    [{ filename: 'apps/web/src/features/workspace/customize/index.ts', function: 'loadConfig' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/lib/api/client.ts', function: 'fetchProject' },
+    ],
+  ]) {
+    assert.equal(
+      isNonErrorUndefinedRejectionNoise({
+        message: NON_ERROR_UNDEFINED_REJECTION,
+        frames,
+      }),
+      false,
+      `expected first-party bare-undefined rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: NON_ERROR_UNDEFINED_REJECTION, stacktrace: { frames } }],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party bare-undefined rejection from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress the bare-undefined rejection when any resolvable (non-first-party) frame is present', () => {
+  // Any resolvable source location (real chunk / URL / named file) means the
+  // rejection is attributable — a real first-party or third-party
+  // `Promise.reject(undefined)` with a stack we can trace. Keep reporting;
+  // only the frameless capture (the production noise pattern) is dropped.
+  for (const frames of [
+    [{ filename: 'app:///_next/static/chunks/123-abc.js', function: 'x' }],
+    [{ filename: 'https://cdn.cookieyes.com/cookieyes.js', function: 'init' }],
+    [{ filename: 'app:///inpage.js', function: 'emit' }],
+  ]) {
+    assert.equal(
+      isNonErrorUndefinedRejectionNoise({
+        message: NON_ERROR_UNDEFINED_REJECTION,
+        frames,
+      }),
+      false,
+      `expected attributable bare-undefined rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a message that only mentions the non-Error rejection wording', () => {
+  // The matcher anchors on the EXACT canonical message; a different wording
+  // that merely mentions the prefix must not be matched.
+  for (const message of [
+    'Non-Error promise rejection captured with value: undefined (extra context)',
+    'Non-Error promise rejection',
+    'promise rejection captured with value: undefined',
+    'UnhandledRejection: undefined',
+  ]) {
+    assert.equal(
+      isNonErrorUndefinedRejectionNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+  }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -1548,6 +1548,102 @@ export function isFirefoxReactSchedulerReentryNoise(input: {
   return frames.some((frame) => isBrowserBundleSource(frame?.filename));
 }
 
+// Sentry 10.x's GlobalHandlers `onunhandledrejection` integration synthesizes a
+// placeholder message when a promise rejects with a value that is NOT an Error
+// instance (no `.message`/`.stack` to extract). For the primitive `undefined`,
+// it emits the canonical
+//   "Non-Error promise rejection captured with value: undefined"
+// with NO stacktrace frames at all (there is nothing to de-minify — the
+// rejection carries no stack). This is Sentry's generic signature for a
+// fire-and-forget `.then()` (or async-init race) somewhere in the page that
+// rejected with a bare `undefined`, OR a third-party script (analytics / cookie
+// banner / tag manager) whose own promise rejected with `undefined`. The
+// breadcrumbs around the production event are all third-party fetches on the
+// marketing site (`/api/github-stars`, `/_vercel/insights/view`,
+// `cdn-cookieyes.com`, `/api/maintenance`) plus the recurring
+// `Unsupported color format var(--kortix-orange)` console.error — i.e. a
+// third-party/cookie-library runtime, not first-party app code.
+//
+// Better Stack pattern
+// 5cfc90e5077a4f3d956f46b51beb633256b9a74532717d4b5797ca5cbc62f2f1
+// (Kortix Frontend prod, application_id 2346967): `UnhandledRejection`, 1
+// occurrence, 0 identified users (anonymous), mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT global
+// unhandledrejection — never reached any React error boundary), release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6`, first 2026-04-23 / last
+// 2026-07-22, Safari 26.5.2 on iOS 18.7 (iPhone, Mobile), request URL
+// `https://kortix.com/` (the marketing/landing page). Stack trace: NONE —
+// `call_site_file`/`call_site_function` are null, `call_stack_hash` is null,
+// no frames at all. A bare `onunhandledrejection` capture of `undefined`.
+//
+// DISTINCT from the EIP-1193 wallet-extension plain-object rejection class
+// (`isExtensionRejectedObjectNoise` / Better Stack `0f78b2f8…`, PR #4720):
+// that one rejects with a serialized OBJECT (`{ code, message, stack }`) and
+// Sentry emits "Object captured as promise rejection with keys: …" (which
+// carries the extension stack in `extra.__serialized__.stack`). THIS class
+// rejects with the primitive `undefined` and Sentry emits
+// "Non-Error promise rejection captured with value: undefined" with no
+// serialized payload and no frames. The two message prefixes are disjoint, so
+// the matchers do not shadow each other.
+//
+// The "Non-Error promise rejection captured with value: undefined" message is
+// Sentry's generic signature for ANY `Promise.reject(undefined)` — a real
+// first-party `Promise.reject(undefined)` (e.g. a code path that resolves a
+// promise with `undefined` on an error branch instead of throwing) would
+// produce the SAME signature — so matching on the message alone is too broad.
+// Require BOTH the canonical message AND a NEGATIVE guard: if the event has
+// ANY resolved stack frame OR a resolved first-party `apps/web/src/…` frame,
+// keep reporting (a real first-party `Promise.reject(undefined)` we can
+// attribute should still surface). The production noise pattern has NO frames
+// at all; only the frameless capture is dropped. Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare-string match there would swallow a real first-party
+// `Promise.reject(undefined)` the negative guard exists to preserve; the
+// frame-aware `beforeSend` hook (which calls this helper) is the only safe
+// gate.
+const NON_ERROR_UNDEFINED_REJECTION_PATTERN =
+  /^Non-Error promise rejection captured with value: undefined$/;
+
+/**
+ * Whether a Sentry event is the bare-`undefined` non-Error promise rejection
+ * noise class: Sentry 10.x's GlobalHandlers `onunhandledrejection`
+ * integration captured a promise that rejected with the primitive `undefined`
+ * (not an Error), and synthesized the canonical
+ * "Non-Error promise rejection captured with value: undefined" message with NO
+ * stacktrace frames. This is a fire-and-forget `.then()` or a third-party
+ * script (analytics / cookie banner) on the marketing site whose promise
+ * rejected with bare `undefined` — never first-party app code. Requires the
+ * canonical message AND a NEGATIVE guard: if any frame resolves to a
+ * de-minified first-party `apps/web/src/…` source path OR any resolvable
+ * frame location at all, the event keeps reporting (a real first-party
+ * `Promise.reject(undefined)` we can attribute should still surface). The
+ * production noise pattern has NO frames; only the frameless capture is
+ * dropped. See `NON_ERROR_UNDEFINED_REJECTION_PATTERN` for the full rationale.
+ */
+export function isNonErrorUndefinedRejectionNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const message = normalizeString(input.message);
+  if (!NON_ERROR_UNDEFINED_REJECTION_PATTERN.test(message)) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  // Negative guard #1: a resolved first-party `apps/web/src/…` frame means our
+  // own code rejected a promise with `undefined` → actionable; keep reporting
+  // so the call site can be found + fixed.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  // Negative guard #2: any resolvable source location (real chunk/URL/named
+  // file) → an attributable error with a real stack; keep reporting. Only the
+  // frameless capture (the production noise pattern) remains → drop it.
+  if (frames.some((frame) => isResolvableFrameSource(frame?.filename))) {
+    return false;
+  }
+  return true;
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -2001,6 +2097,24 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // no first-party frame are dropped. See
   // `isFirefoxReactSchedulerReentryNoise`.
   if (isFirefoxReactSchedulerReentryNoise({ message, frames })) {
+    return true;
+  }
+
+  // Sentry 10.x bare-`undefined` non-Error promise rejection noise — a promise
+  // rejected with the primitive `undefined` (not an Error), captured by
+  // Sentry's GlobalHandlers `onunhandledrejection` integration as the
+  // synthetic "Non-Error promise rejection captured with value: undefined"
+  // message with NO stacktrace frames. A fire-and-forget `.then()` or a
+  // third-party script (analytics / cookie banner / tag manager) on the
+  // marketing site whose promise rejected with bare `undefined`; never
+  // first-party app code. Requires the canonical message AND NEGATIVE guards:
+  // any resolved first-party `apps/web/src/…` frame OR any resolvable frame
+  // location → keep reporting (a real first-party `Promise.reject(undefined)`
+  // we can attribute should still surface). The production noise pattern has
+  // NO frames at all; only the frameless capture is dropped. See
+  // `isNonErrorUndefinedRejectionNoise`. NOT in `ignoreErrors` (no frame
+  // context there).
+  if (isNonErrorUndefinedRejectionNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This PR adds a Sentry telemetry noise filter; the proof is the regression test suite below (153 pass, including 7 new tests pinning the exact production event through both the classifier and the Sentry `beforeSend` gate) plus the all-green CI + live preview.

## Why

Better Stack reports a recurring (first 2026-04-23 / last 2026-07-22) low-volume `UnhandledRejection` from the production marketing site (`https://kortix.com/`):

- Better Stack app: **Kortix Frontend (prod)**, application_id `2346967`.
- Pattern: `5cfc90e5077a4f3d956f46b51beb633256b9a74532717d4b5797ca5cbc62f2f1`
- URL: https://errors.betterstack.com/team/t502678/errors/5cfc90e5077a4f3d956f46b51beb633256b9a74532717d4b5797ca5cbc62f2f1?s=2346967
- Type: `UnhandledRejection`, message: `Non-Error promise rejection captured with value: undefined`.
- Mechanism: `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT global unhandledrejection — never reached any React error boundary).
- Browser: Safari 26.5.2 on iOS 18.7 (iPhone), Mobile. Release `470fe6f3c88460212c3b187f6f86fb4ad456c4d6`.
- **Stack trace: NONE** — `call_site_file`/`call_site_function` are null, `call_stack_hash` is null, no frames at all. A bare `onunhandledrejection` capture of `undefined`.
- Breadcrumbs (all on `/`): console `[runtime-env]`, navigation `/` → `/`, repeated `console.error Unsupported color format var(--kortix-orange)` (3x), fetch `/api/github-stars` 200, fetch `/_vercel/insights/view` 200, several `cdn-cookieyes.com` fetches 200, fetch `/api/maintenance` 200.

This is Sentry 10.x capturing a promise that rejected with a bare `undefined` (not an Error object). There is no stack, no call site, no user. It is an uncaught global `onunhandledrejection` from a third-party script (CookieYes cookie banner / analytics / tag manager) or a fire-and-forget `.then()` on the landing page that rejected with `undefined`. The `Unsupported color format var(--kortix-orange)` breadcrumbs confirm a third-party/cookie-library runtime is resolving/rejecting promises with `undefined`. This is **browser/third-party noise, not a first-party product bug.**

## What changed

Extended the centralized browser noise filter in `apps/web/src/lib/browser-error-noise.ts` (where all prior noise classes live — #4538/#4540/#4544/#4674/#4710/#4711/#4720/#5172/#5173/#5174/#5181/#5182/#5183/#5185) with a new classifier `isNonErrorUndefinedRejectionNoise` (`apps/web/src/lib/browser-error-noise.ts:1623`), wired into the Sentry `beforeSend` path via `shouldIgnoreSentryBrowserNoise`.

**Match criteria (conservative, preserves real bugs):**
- The message matches Sentry 10.x's canonical wording for a non-Error `undefined` rejection exactly: `Non-Error promise rejection captured with value: undefined` (anchored regex — NOT other values like an object/string, which PR #4720 handles separately).
- Negative guard #1: if the event has a resolved first-party `apps/web/src/…` frame → keep reporting (a real first-party `Promise.reject(undefined)` we can attribute should still surface).
- Negative guard #2: if the event has ANY resolvable stack frame (real chunk/URL/named file) → keep reporting (an attributable error with a real stack). The production noise pattern has NO frames at all; only the frameless capture is dropped.

**Guard approach:** `beforeSend` gate only. Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there would swallow a real first-party `Promise.reject(undefined)` the negative guard exists to preserve. This mirrors the approach used by #4720/#5181/#5185 for no-frame/no-payload noise.

**Distinct from PR #4720** (EIP-1193 wallet-extension plain-object rejection): that class rejects with a serialized OBJECT (`{ code, message, stack }`) and Sentry emits `Object captured as promise rejection with keys: …` (carrying the extension stack in `extra.__serialized__.stack`). This class rejects with the primitive `undefined` and Sentry emits `Non-Error promise rejection captured with value: undefined` with no serialized payload and no frames. The two message prefixes are disjoint, so the matchers do not shadow each other — verified by a negative test.

## Verification

**Tests** (`cd apps/web && bun test src/lib/browser-error-noise.test.mts`):
- **153 pass, 0 fail** (146 pre-existing + 7 new regression tests).
- Positive: the exact prod event (canonical message, no frames) is ignored through both `isNonErrorUndefinedRejectionNoise` and the `shouldIgnoreSentryBrowserNoise` gate (with and without the `stacktrace` key).
- Negative: a rejection with a non-`undefined` value (object/string/null/0, and the #4720 `Object captured…` signature) is NOT ignored by this matcher (doesn't shadow #4720).
- Negative: a rejection with a resolved `apps/web/src/…` frame is NOT ignored (through both classifier and Sentry gate).
- Negative: a rejection with any resolvable (non-first-party) frame is NOT ignored.
- Negative: a message that only mentions the wording (not the exact canonical message) is NOT ignored.

**Typecheck:** `npx tsc --noEmit` on `apps/web` reports zero errors in the touched files (the 2 pre-existing `@/.source` module-resolution errors are unrelated generated-file issues present on `main`).

**Confirmation of resolution:** after this merges + promotes, the Better Stack group `5cfc90e5…` should drop to zero new occurrences (the frameless bare-`undefined` capture is dropped at the Sentry `beforeSend` gate before it reaches Better Stack). Resolve the group once `last_seen` stops advancing post-Promote.

## Risk / rollback

Pure additive telemetry filter — drops one class of frameless Sentry noise; no product behavior, no UI, no API change. A real first-party `Promise.reject(undefined)` is preserved by the negative guards (any resolved frame → keep reporting). Rollback is a single revert of this commit. Deduped against all prior noise PRs (none cover the bare-`undefined` global rejection with no stack).
