### PR TITLE
fix(snapshots): reliable Platinum template build — poll by id + hardened S3 uploader

### DIFF
--- a/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
+++ b/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
@@ -48,6 +48,9 @@ mock.module('../shared/platinum', () => ({
         ? [{ id: 'tpl-1', name: registeredTemplateName, state: 'ready' }]
         : [];
     }
+    if (path === '/v1/templates/tpl-1') {
+      return { id: 'tpl-1', name: registeredTemplateName, state: 'ready' };
+    }
     throw new Error(`unexpected Platinum path: ${path}`);
   },
 }));

--- a/apps/api/src/snapshots/providers/platinum.build-reliability.test.ts
+++ b/apps/api/src/snapshots/providers/platinum.build-reliability.test.ts
@@ -1,0 +1,416 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const fixtureRoot = mkdtempSync(join(tmpdir(), 'kortix-platinum-reliability-test-'));
+const tarPath = join(fixtureRoot, 'context.tar.gz');
+writeFileSync(tarPath, 'fake-build-context-bytes');
+
+type Tpl = { id: string; name?: string; state?: string };
+
+let listResponse: Tpl[] = [];
+let byIdResponses: Record<string, Tpl> = {};
+let listCalls = 0;
+let byIdCalls: Record<string, number> = {};
+let byIdErrorOverride: Record<string, string> = {};
+
+mock.module('../../shared/platinum', () => ({
+  isPlatinumConfigured: () => true,
+  platinumJson: async (path: string) => {
+    if (path === '/v1/templates') {
+      listCalls++;
+      return listResponse;
+    }
+    const idMatch = path.match(/^\/v1\/templates\/([^/]+)$/);
+    if (idMatch) {
+      const id = idMatch[1];
+      byIdCalls[id] = (byIdCalls[id] ?? 0) + 1;
+      if (byIdErrorOverride[id]) throw new Error(byIdErrorOverride[id]);
+      const tpl = byIdResponses[id];
+      if (!tpl) throw new Error(`platinum GET ${path} -> 404 {"error":"template not found"}`);
+      return tpl;
+    }
+    throw new Error(`unexpected Platinum path: ${path}`);
+  },
+}));
+
+const { waitForActive, uploadWithRetry } = await import('./platinum');
+
+beforeEach(() => {
+  listResponse = [];
+  byIdResponses = {};
+  listCalls = 0;
+  byIdCalls = {};
+  byIdErrorOverride = {};
+});
+
+afterAll(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe('waitForActive', () => {
+  test('resolves via GET /:id even when the (truncated) name-list would not contain the template', async () => {
+    const id = 'tpl-primary';
+    listResponse = [];
+    byIdResponses = { [id]: { id, name: 'kortix-hidden', state: 'ready' } };
+
+    await expect(waitForActive('kortix-hidden', undefined, id)).resolves.toBeUndefined();
+
+    expect(byIdCalls[id]).toBeGreaterThanOrEqual(1);
+    expect(listCalls).toBe(0);
+  });
+
+  test('falls back to the name-list lookup when no id is available', async () => {
+    listResponse = [{ id: 'tpl-legacy', name: 'kortix-legacy', state: 'ready' }];
+    byIdResponses = {};
+
+    await expect(waitForActive('kortix-legacy', undefined, undefined)).resolves.toBeUndefined();
+
+    expect(listCalls).toBeGreaterThanOrEqual(1);
+    expect(byIdCalls).toEqual({});
+  });
+
+  test('treats a transient 404 on GET /:id as "not ready yet", not a hard failure', async () => {
+    const id = 'tpl-lagging';
+    byIdResponses = {};
+    listResponse = [];
+
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((fn: () => void) => {
+      byIdResponses = { [id]: { id, name: 'kortix-lagging', state: 'ready' } };
+      fn();
+    }) as unknown as typeof setTimeout;
+
+    try {
+      await expect(waitForActive('kortix-lagging', undefined, id)).resolves.toBeUndefined();
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+
+    expect(byIdCalls[id]).toBeGreaterThanOrEqual(2);
+  });
+
+  test('terminates immediately on state "failed" via GET /:id — not just "ready"', async () => {
+    const id = 'tpl-failed';
+    byIdResponses = { [id]: { id, name: 'kortix-failed', state: 'failed' } };
+
+    await expect(waitForActive('kortix-failed', undefined, id)).rejects.toThrow(
+      /Platinum template kortix-failed build failed/,
+    );
+    expect(byIdCalls[id]).toBe(1);
+  });
+
+  test('terminates on state "failed" via the name-list fallback path too (no id)', async () => {
+    listResponse = [{ id: 'tpl-failed-list', name: 'kortix-failed-list', state: 'failed' }];
+
+    await expect(waitForActive('kortix-failed-list', undefined, undefined)).rejects.toThrow(
+      /Platinum template kortix-failed-list build failed/,
+    );
+    expect(listCalls).toBe(1);
+  });
+
+  test('honors the deadline and does NOT spin forever on a persistent non-404 error (e.g. a 500)', async () => {
+    const id = 'tpl-stuck-500';
+    byIdErrorOverride = {
+      [id]: 'platinum GET /v1/templates/tpl-stuck-500 -> 500 {"error":"internal"}',
+    };
+
+    const originalDateNow = Date.now;
+    const originalSetTimeout = globalThis.setTimeout;
+    let simulatedNow = originalDateNow();
+    Date.now = (() => simulatedNow) as typeof Date.now;
+    globalThis.setTimeout = ((fn: () => void) => {
+      simulatedNow += 5 * 60 * 1000;
+      fn();
+    }) as unknown as typeof setTimeout;
+
+    try {
+      await expect(waitForActive('kortix-stuck', undefined, id)).rejects.toThrow(
+        /did not become ready \(last state: missing\)/,
+      );
+    } finally {
+      Date.now = originalDateNow;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+
+    expect(byIdCalls[id]).toBeGreaterThan(0);
+    expect(byIdCalls[id]).toBeLessThan(10);
+  });
+});
+
+describe('uploadWithRetry', () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  });
+
+  test('re-presigns and succeeds on the 2nd attempt after a first 408', async () => {
+    globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+    let putCalls = 0;
+    globalThis.fetch = Object.assign(
+      async () => {
+        putCalls++;
+        return putCalls === 1
+          ? new Response('idle timeout', { status: 408 })
+          : new Response('', { status: 200 });
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch;
+
+    const presignedKeys: string[] = [];
+    const presignFn = mock(async () => {
+      const key = `ctx-key-${presignedKeys.length + 1}`;
+      presignedKeys.push(key);
+      return { upload_url: `https://upload.test/${key}`, context_s3_key: key };
+    });
+
+    const winningKey = await uploadWithRetry(presignFn, tarPath);
+
+    expect(winningKey).toBe('ctx-key-2');
+    expect(presignFn).toHaveBeenCalledTimes(2);
+    expect(putCalls).toBe(2);
+  });
+
+  test('throws a clear error after 3 failed attempts', async () => {
+    globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+    let putCalls = 0;
+    globalThis.fetch = Object.assign(
+      async () => {
+        putCalls++;
+        return new Response('idle timeout', { status: 408 });
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch;
+
+    const presignedKeys: string[] = [];
+    const presignFn = mock(async () => {
+      const key = `ctx-key-${presignedKeys.length + 1}`;
+      presignedKeys.push(key);
+      return { upload_url: `https://upload.test/${key}`, context_s3_key: key };
+    });
+
+    await expect(uploadWithRetry(presignFn, tarPath)).rejects.toThrow(/3\/3 attempt/);
+    expect(presignFn).toHaveBeenCalledTimes(3);
+    expect(putCalls).toBe(3);
+  });
+
+  test('a 413 (non-retryable) throws immediately WITHOUT a re-presign', async () => {
+    globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+    let putCalls = 0;
+    globalThis.fetch = Object.assign(
+      async () => {
+        putCalls++;
+        return new Response('payload too large', { status: 413 });
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch;
+
+    const presignFn = mock(async () => ({ upload_url: 'https://upload.test/ctx-key-1', context_s3_key: 'ctx-key-1' }));
+
+    await expect(uploadWithRetry(presignFn, tarPath)).rejects.toThrow(/failed after 1\/3 attempt/);
+    expect(presignFn).toHaveBeenCalledTimes(1);
+    expect(putCalls).toBe(1);
+  });
+
+  test('a 500 fails once then succeeds on the 2nd attempt (fresh presign)', async () => {
+    globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+    let putCalls = 0;
+    globalThis.fetch = Object.assign(
+      async () => {
+        putCalls++;
+        return putCalls === 1
+          ? new Response('internal error', { status: 500 })
+          : new Response('', { status: 200 });
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch;
+
+    const presignedKeys: string[] = [];
+    const presignFn = mock(async () => {
+      const key = `ctx-key-${presignedKeys.length + 1}`;
+      presignedKeys.push(key);
+      return { upload_url: `https://upload.test/${key}`, context_s3_key: key };
+    });
+
+    const winningKey = await uploadWithRetry(presignFn, tarPath);
+    expect(winningKey).toBe('ctx-key-2');
+    expect(presignFn).toHaveBeenCalledTimes(2);
+    expect(putCalls).toBe(2);
+  });
+
+  test('a TimeoutError (our own AbortSignal firing) fails once then succeeds on retry', async () => {
+    globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+    let putCalls = 0;
+    globalThis.fetch = Object.assign(
+      async () => {
+        putCalls++;
+        if (putCalls === 1) {
+          throw Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' });
+        }
+        return new Response('', { status: 200 });
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch;
+
+    const presignedKeys: string[] = [];
+    const presignFn = mock(async () => {
+      const key = `ctx-key-${presignedKeys.length + 1}`;
+      presignedKeys.push(key);
+      return { upload_url: `https://upload.test/${key}`, context_s3_key: key };
+    });
+
+    const winningKey = await uploadWithRetry(presignFn, tarPath);
+    expect(winningKey).toBe('ctx-key-2');
+    expect(presignFn).toHaveBeenCalledTimes(2);
+    expect(putCalls).toBe(2);
+  });
+
+  test('all 3 attempts failing with heterogeneous retryable errors (500, TimeoutError, 500) still throws with the correct attempt count', async () => {
+    globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+    let putCalls = 0;
+    globalThis.fetch = Object.assign(
+      async () => {
+        putCalls++;
+        if (putCalls === 2) throw Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+        return new Response('internal error', { status: 500 });
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch;
+
+    const presignFn = mock(async () => ({ upload_url: 'https://upload.test/x', context_s3_key: 'k' }));
+
+    await expect(uploadWithRetry(presignFn, tarPath)).rejects.toThrow(/failed after 3\/3 attempt/);
+    expect(presignFn).toHaveBeenCalledTimes(3);
+    expect(putCalls).toBe(3);
+  });
+
+  describe('status-extraction regex robustness', () => {
+    test('a non-retryable status is NOT "rescued" by a stray 3-digit number embedded in the response body', async () => {
+      globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+      let putCalls = 0;
+      globalThis.fetch = Object.assign(
+        async () => {
+          putCalls++;
+          return new Response('payload too large (upstream node-500 rejected it)', { status: 413 });
+        },
+        { preconnect: originalFetch.preconnect },
+      ) as typeof fetch;
+
+      const presignFn = mock(async () => ({ upload_url: 'https://upload.test/x', context_s3_key: 'k' }));
+
+      await expect(uploadWithRetry(presignFn, tarPath)).rejects.toThrow(/failed after 1\/3 attempt/);
+      expect(presignFn).toHaveBeenCalledTimes(1);
+      expect(putCalls).toBe(1);
+    });
+
+    test('a retryable 5xx is recognized even when the body text contains an unrelated non-5xx 3-digit number', async () => {
+      globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+      let putCalls = 0;
+      globalThis.fetch = Object.assign(
+        async () => {
+          putCalls++;
+          return putCalls === 1
+            ? new Response('upstream said 404 to a different downstream request', { status: 500 })
+            : new Response('', { status: 200 });
+        },
+        { preconnect: originalFetch.preconnect },
+      ) as typeof fetch;
+
+      const presignFn = mock(async () => ({ upload_url: 'https://upload.test/x', context_s3_key: 'k' }));
+
+      await expect(uploadWithRetry(presignFn, tarPath)).resolves.toBe('k');
+      expect(putCalls).toBe(2);
+      expect(presignFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('presign-call failures (regression: presignFn used to bypass the retry loop entirely)', () => {
+    test('a transient (retryable) presign failure is retried, not thrown immediately', async () => {
+      globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+      globalThis.fetch = Object.assign(
+        async () => new Response('', { status: 200 }),
+        { preconnect: originalFetch.preconnect },
+      ) as typeof fetch;
+
+      let presignCalls = 0;
+      const presignFn = mock(async () => {
+        presignCalls++;
+        if (presignCalls === 1) {
+          throw new Error('platinum POST /v1/templates/from-build/presign -> 500 {"error":"internal"}');
+        }
+        return { upload_url: 'https://upload.test/ctx-key-2', context_s3_key: 'ctx-key-2' };
+      });
+
+      const winningKey = await uploadWithRetry(presignFn, tarPath);
+      expect(winningKey).toBe('ctx-key-2');
+      expect(presignFn).toHaveBeenCalledTimes(2);
+    });
+
+    test('a non-retryable presign failure (e.g. 401) still throws immediately after exactly 1 attempt', async () => {
+      globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+      globalThis.fetch = Object.assign(
+        async () => new Response('', { status: 200 }),
+        { preconnect: originalFetch.preconnect },
+      ) as typeof fetch;
+
+      const presignFn = mock(async () => {
+        throw new Error('platinum POST /v1/templates/from-build/presign -> 401 {"error":"unauthorized"}');
+      });
+
+      await expect(uploadWithRetry(presignFn, tarPath)).rejects.toThrow(/failed after 1\/3 attempt/);
+      expect(presignFn).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('uploadWithRetry signal hygiene (no double-abort / reused-signal across retries)', () => {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+  });
+
+  test('each attempt gets its own fresh AbortSignal — a 2nd attempt actually runs after the 1st one fails/aborts, unaffected by it', async () => {
+    globalThis.setTimeout = ((fn: () => void) => fn()) as unknown as typeof setTimeout;
+
+    const seenSignals: (AbortSignal | undefined)[] = [];
+    let putCalls = 0;
+    globalThis.fetch = Object.assign(
+      async (_url: unknown, init?: RequestInit) => {
+        putCalls++;
+        seenSignals.push(init?.signal ?? undefined);
+        if (putCalls === 1) {
+          throw Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' });
+        }
+        return new Response('', { status: 200 });
+      },
+      { preconnect: originalFetch.preconnect },
+    ) as typeof fetch;
+
+    const presignFn = mock(async () => ({ upload_url: 'https://upload.test/x', context_s3_key: 'k' }));
+
+    const winningKey = await uploadWithRetry(presignFn, tarPath);
+    expect(winningKey).toBe('k');
+    expect(putCalls).toBe(2);
+    expect(seenSignals).toHaveLength(2);
+    expect(seenSignals[0]).toBeDefined();
+    expect(seenSignals[1]).toBeDefined();
+    expect(seenSignals[0]).not.toBe(seenSignals[1]);
+    expect(seenSignals[1]!.aborted).toBe(false);
+  });
+});

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -36,6 +36,9 @@ const ACTIVATE_DEADLINE_MS = 12 * 60 * 1000; // build + activate ceiling
 const POLL_MS = 3_000;
 const MB_PER_GB = 1024;
 const BUILD_ATTEMPTS = 3;
+const UPLOAD_ATTEMPTS = 3;
+const UPLOAD_MIN_TIMEOUT_MS = 10 * 60_000;
+const UPLOAD_TIMEOUT_MS_PER_GIB = 60_000;
 // Platinum's POST /v1/templates/from-build hard-caps size_mb at this value (see
 // platinum apps/api/src/api/templates.ts ORG_MAX_SIZE_MB + the from-build zod).
 // The build ext4 is a FLOOR Platinum grows-to-fit, so clamping the build ceiling
@@ -97,6 +100,105 @@ const observeTemplates = shortLivedObservation(
   process.env.NODE_ENV === 'test' ? 0 : 2_000,
 );
 
+/**
+ * Direct GET /v1/templates/:id lookup — the PRIMARY signal `waitForActive`
+ * polls once `from-build`/`from-patch` has handed back an id. Unlike the
+ * name-list (`GET /v1/templates`, limit=50 created_at DESC — see the module
+ * header), this reads the exact row Platinum just created, so it can never
+ * miss it behind pagination. A 404 here is expected for a brief window right
+ * after registration (the row can lag its own id becoming visible) — treat it
+ * as "not ready yet", same as any other not-yet-ready state, and let the
+ * caller's deadline (not this single lookup) decide when to give up.
+ */
+async function findTemplateById(id: string): Promise<PlatinumTemplate | null> {
+  try {
+    return await platinumJson<PlatinumTemplate>(`/v1/templates/${id}`);
+  } catch (err) {
+    if (/ -> 404(?:\s|$)/.test(err instanceof Error ? err.message : String(err))) return null;
+    throw err;
+  }
+}
+
+/**
+ * Long-poll a just-registered template to `ready`. PRIMARY signal is
+ * `GET /v1/templates/:id` when `from-build`/`from-patch` returned an id — the
+ * name-list lookup is a FALLBACK for the (defensive) case no id is available.
+ * Polling the list here would risk exactly the false-negative this function
+ * exists to avoid: Platinum's idempotent-adopt path can hand back an OLD row,
+ * and the list truncates at 50 (see module header), so a template that exists
+ * and is `ready` can still be absent from the page this call sees. Standalone
+ * (not a class method) so it's directly unit-testable without driving the
+ * whole build pipeline.
+ */
+export async function waitForActive(name: string, tap?: BuildLogTap, id?: string): Promise<void> {
+  const deadline = Date.now() + ACTIVATE_DEADLINE_MS;
+  let last = 'unknown';
+  while (Date.now() < deadline) {
+    const tpl = id ? await findTemplateById(id).catch(() => null) : await findTemplateByName(name).catch(() => null);
+    const state = (tpl?.state ?? 'missing').toLowerCase();
+    if (state !== last) { last = state; tap?.onLine?.(`template ${name}: ${state}`); }
+    if (state === 'ready') return;
+    if (state === 'failed') throw new Error(`Platinum template ${name} build failed`);
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+  throw new Error(`Platinum template ${name} did not become ready (last state: ${last})`);
+}
+
+/** 408 (S3 idle-timeout), our own AbortSignal timeout, and 5xx are transient
+ *  — worth a fresh presign + retry. Anything else (400/401/403/404/...) is a
+ *  real error and must NOT be retried. */
+function isRetryableUploadError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === 'AbortError' || err.name === 'TimeoutError') return true;
+  const status = Number(err.message.match(/-> (\d{3})\b/)?.[1]);
+  return status === 408 || status >= 500;
+}
+
+/**
+ * Presigned-PUT build-context uploader, hardened against Scaleway S3's idle
+ * timeout on large (100s-of-MB) contexts: a mid-transfer stall used to trip a
+ * bare 408 with no retry, forcing a full re-upload (or failing the build
+ * outright) further up in `isRetryablePlatinumBuildError`'s BUILD_ATTEMPTS
+ * loop. Two things fix that here instead: (1) a per-attempt timeout scaled to
+ * file size, so a genuinely-large upload isn't cut off before it could ever
+ * finish; (2) on a transient failure (408 / timeout / 5xx), RE-PRESIGN for a
+ * fresh `upload_url` + `context_s3_key` rather than retrying the same
+ * (possibly already-consumed) presigned URL. The returned `context_s3_key` is
+ * whichever attempt actually succeeded — callers MUST register that key, not
+ * the one from their original presign call, or they'll upload to key A and
+ * tell `from-build`/`from-patch` to look for key B.
+ *
+ * `presignFn()` itself is called INSIDE the try/catch (not before it): a
+ * transient failure of the presign call (e.g. a 500/timeout from Platinum's
+ * own `/v1/templates/from-build/presign`) is a real-world possibility, same
+ * transport as the PUT, and must go through the same isRetryableUploadError
+ * decision + retry loop — not bypass it and fail the whole upload on attempt 1.
+ */
+export async function uploadWithRetry(
+  presignFn: () => Promise<{ upload_url: string; context_s3_key: string }>,
+  tarPath: string,
+): Promise<string> {
+  const sizeBytes = Bun.file(tarPath).size;
+  const timeoutMs = Math.max(UPLOAD_MIN_TIMEOUT_MS, Math.ceil((sizeBytes / 1024 ** 3) * UPLOAD_TIMEOUT_MS_PER_GIB));
+  for (let attempt = 1; attempt <= UPLOAD_ATTEMPTS; attempt++) {
+    try {
+      const { upload_url, context_s3_key } = await presignFn();
+      const put = await fetch(upload_url, { method: 'PUT', body: Bun.file(tarPath), signal: AbortSignal.timeout(timeoutMs) });
+      if (put.ok) return context_s3_key;
+      throw new Error(`build-context S3 upload -> ${put.status} ${(await put.text().catch(() => '')).slice(0, 200)}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!isRetryableUploadError(err) || attempt === UPLOAD_ATTEMPTS) {
+        throw new Error(`build-context upload failed after ${attempt}/${UPLOAD_ATTEMPTS} attempt(s): ${msg}`);
+      }
+      console.warn(`[snapshots] platinum build-context upload attempt ${attempt}/${UPLOAD_ATTEMPTS} failed — re-presigning + retrying: ${msg.slice(0, 160)}`);
+      await new Promise((r) => setTimeout(r, 2_000 * attempt));
+    }
+  }
+  // Unreachable: the loop above always returns or throws by UPLOAD_ATTEMPTS.
+  throw new Error('build-context upload failed');
+}
+
 class PlatinumAdapter implements SandboxProviderAdapter {
   readonly id = 'platinum' as const;
 
@@ -146,21 +248,24 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       // presigned PUT (phase 1 + 2), then register the build (phase 3). The
       // build itself still happens server-side on Platinum (podman build).
       console.info(`[snapshots] ${input.snapshotName}: presign + upload build context to Platinum (slug="${input.slug}")`);
-      const { upload_url, context_s3_key } = await platinumJson<{ upload_url: string; context_s3_key: string }>(
-        '/v1/templates/from-build/presign', { method: 'POST', body: JSON.stringify({}) },
-      );
       // STREAM the upload — Bun.file() sends the tarball in chunks, so a
       // 100s-of-MB context uploads in constant memory. The previous
       // new Uint8Array(await readFile()) buffered the ENTIRE tarball (twice) in
       // RAM and OOMKilled the 512Mi api pod (exit 137), 502-ing every session
       // whose request hit the crashing replica. Daytona never buffers — its SDK
       // streams the context — so this brings the Platinum path to parity.
-      const put = await fetch(upload_url, { method: 'PUT', body: Bun.file(tarPath) });
-      if (!put.ok) throw new Error(`build-context S3 upload -> ${put.status} ${(await put.text().catch(() => '')).slice(0, 200)}`);
+      // uploadWithRetry re-presigns + retries on a transient S3 408/timeout/5xx
+      // (see its doc comment) — context_s3_key below is whichever attempt won.
+      const context_s3_key = await uploadWithRetry(
+        () => platinumJson<{ upload_url: string; context_s3_key: string }>(
+          '/v1/templates/from-build/presign', { method: 'POST', body: JSON.stringify({}) },
+        ),
+        tarPath,
+      );
 
       const diskGb = Math.min(input.spec.diskGb ?? DEFAULT_DISK_GB, SANDBOX_SPEC_LIMITS.disk.max);
 
-      await platinumJson<PlatinumTemplate>('/v1/templates/from-build', {
+      const registered = await platinumJson<PlatinumTemplate>('/v1/templates/from-build', {
         method: 'POST',
         body: JSON.stringify({
           name: input.snapshotName,
@@ -178,7 +283,8 @@ class PlatinumAdapter implements SandboxProviderAdapter {
           entrypoint: (input.entrypoint ?? [KORTIX_ENTRYPOINT]).join(' '),
         }),
       });
-      await this.waitForActive(input.snapshotName, tap);
+      // Poll the id `from-build` handed back (primary signal) — see waitForActive.
+      await waitForActive(input.snapshotName, tap, registered?.id);
     } finally {
       await rm(ctx.contextDir, { recursive: true, force: true }).catch(() => {});
       await rm(tarPath, { force: true }).catch(() => {});
@@ -197,17 +303,19 @@ class PlatinumAdapter implements SandboxProviderAdapter {
     observeTemplates.invalidate();
     const { gzPath, cleanup } = await stageAgentBinaryGz();
     try {
-      const { upload_url, context_s3_key } = await platinumJson<{ upload_url: string; context_s3_key: string }>(
-        '/v1/templates/from-build/presign', { method: 'POST', body: JSON.stringify({}) },
+      // uploadWithRetry — streamed + retried on transient S3 failure; see buildOnce.
+      const context_s3_key = await uploadWithRetry(
+        () => platinumJson<{ upload_url: string; context_s3_key: string }>(
+          '/v1/templates/from-build/presign', { method: 'POST', body: JSON.stringify({}) },
+        ),
+        gzPath,
       );
-      const put = await fetch(upload_url, { method: 'PUT', body: Bun.file(gzPath) }); // streamed — see buildOnce
-      if (!put.ok) throw new Error(`agent-swap upload -> ${put.status} ${(await put.text().catch(() => '')).slice(0, 200)}`);
       // Platinum's GENERAL file-patch primitive: patch our one changed file (the
       // kortix-agent binary) into the predecessor's rootfs — no rebuild. The guest
       // path is OURS to specify (Platinum is file-agnostic); /usr/local/bin/kortix-agent
       // is where our runtime layer (dockerfile-layer.ts) installs it. mode 0100755 =
       // executable (debugfs `write` lands 0644 otherwise).
-      await platinumJson<PlatinumTemplate>('/v1/templates/from-patch', {
+      const patched = await platinumJson<PlatinumTemplate>('/v1/templates/from-patch', {
         method: 'POST',
         body: JSON.stringify({
           name: newSnapshotName,
@@ -215,7 +323,7 @@ class PlatinumAdapter implements SandboxProviderAdapter {
           files: [{ s3_key: context_s3_key, guest_path: '/usr/local/bin/kortix-agent', mode: 0o100755 }],
         }),
       });
-      await this.waitForActive(newSnapshotName);
+      await waitForActive(newSnapshotName, undefined, patched?.id);
     } finally {
       observeTemplates.invalidate();
       await cleanup();
@@ -256,20 +364,6 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       .map((template) => template.name)
       .filter((name): name is string => !!name)
       .map((name) => ({ name }));
-  }
-
-  private async waitForActive(name: string, tap?: BuildLogTap): Promise<void> {
-    const deadline = Date.now() + ACTIVATE_DEADLINE_MS;
-    let last = 'unknown';
-    while (Date.now() < deadline) {
-      const tpl = await findTemplateByName(name).catch(() => null);
-      const state = (tpl?.state ?? 'missing').toLowerCase();
-      if (state !== last) { last = state; tap?.onLine?.(`template ${name}: ${state}`); }
-      if (state === 'ready') return;
-      if (state === 'failed') throw new Error(`Platinum template ${name} build failed`);
-      await new Promise((r) => setTimeout(r, POLL_MS));
-    }
-    throw new Error(`Platinum template ${name} did not become ready (last state: ${last})`);
   }
 }
 


### PR DESCRIPTION
## Problem

Platinum template builds could report a false-negative "not ready" — the name-list poll misses templates behind pagination or Platinum's idempotent-adopt path — and a mid-transfer S3 stall on the build-context upload failed the whole build with no retry.

## Fix

- Poll by id: `waitForActive` now polls `GET /v1/templates/:id` using the id returned by `from-build`/`from-patch`, falling back to the name-list poll only when no id is available. This fixes the false "missing" hangs.
- Hardened uploader: `uploadWithRetry` scales the upload timeout to context size and re-presigns + retries on 408/5xx. Testing surfaced and fixed a bug where the presign call sat outside the retry loop, so a transient presign failure would fail the build on attempt 1 instead of retrying.

## Tests

20 tests (17 new + 3 mock updates), all green. `tsc --noEmit` clean. The by-id poll was verified end-to-end against hosted Platinum: a real template was built to `ready`, by-id `GET /v1/templates/:id` was confirmed firing throughout, and the test template was deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
