### PR TITLE
fix(runtime): route explicit models through Kortix gateway

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
@@ -133,13 +133,13 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
     expect(config.model).toMatch(/^kortix\//)
   })
 
-  test('preserves user-set default model from pre-existing config', async () => {
+  test('routes a user-set default model through the Kortix provider', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const existing = JSON.stringify({ model: 'anthropic/claude-sonnet-4.6' })
     const config = JSON.parse(
       (await buildOpencodeConfigContent({ ...GATEWAY_ENV, OPENCODE_CONFIG_CONTENT: existing }))!,
     )
-    expect(config.model).toBe('anthropic/claude-sonnet-4.6')
+    expect(config.model).toBe('kortix/anthropic/claude-sonnet-4.6')
   })
 
   test('does not include executor MCP alongside the provider unless explicitly enabled', async () => {
@@ -274,14 +274,31 @@ describe('buildOpencodeConfigContent — server-compiled v2 agent config (KORTIX
     expect(await buildOpencodeConfigContent({})).toBeUndefined()
   })
 
-  test('the gateway overlay fills small_model but leaves the compiled top-level model untouched', async () => {
+  test('the gateway overlay normalizes compiled top-level and agent models', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const config = JSON.parse(
       (await buildOpencodeConfigContent({ ...GATEWAY_ENV, KORTIX_COMPILED_AGENT_CONFIG: COMPILED }))!,
     )
-    expect(config.model).toBe('anthropic/claude-sonnet-5')
+    expect(config.model).toBe('kortix/anthropic/claude-sonnet-5')
     expect(config.small_model).toMatch(/^kortix\//)
-    expect(config.agent.support).toBeDefined()
+    expect(config.agent.support.model).toBe('kortix/anthropic/claude-sonnet-5')
+  })
+
+  test('the gateway overlay keeps the complete Codex wire model as the Kortix model id', async () => {
+    stubGatewayModels(GATEWAY_CATALOG)
+    const compiled = JSON.stringify({
+      model: 'codex/gpt-5.6-sol',
+      agent: { mike: { mode: 'primary', model: 'codex/gpt-5.6-sol' } },
+    })
+    const raw = await buildOpencodeConfigContent({
+      ...GATEWAY_ENV,
+      KORTIX_COMPILED_AGENT_CONFIG: compiled,
+    })
+    expect(raw).toBeDefined()
+    if (!raw) throw new Error('expected gateway config')
+    const config = JSON.parse(raw)
+    expect(config.model).toBe('kortix/codex/gpt-5.6-sol')
+    expect(config.agent.mike.model).toBe('kortix/codex/gpt-5.6-sol')
   })
 
   test('a Slack session still gets its question:deny overlay on top of the compiled agent map', async () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/resolve-opencode-model.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/resolve-opencode-model.test.ts
@@ -3,10 +3,19 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import { resolveOpencodeModel } from '../main'
 
 const ORIGINAL_MODEL = process.env.KORTIX_OPENCODE_MODEL
+const ORIGINAL_LLM_BASE_URL = process.env.KORTIX_LLM_BASE_URL
+const ORIGINAL_LLM_API_KEY = process.env.KORTIX_LLM_API_KEY
+const ORIGINAL_LLM_PROXY_URL = process.env.KORTIX_LLM_PROXY_URL
 
 afterEach(() => {
   if (ORIGINAL_MODEL === undefined) delete process.env.KORTIX_OPENCODE_MODEL
   else process.env.KORTIX_OPENCODE_MODEL = ORIGINAL_MODEL
+  if (ORIGINAL_LLM_BASE_URL === undefined) delete process.env.KORTIX_LLM_BASE_URL
+  else process.env.KORTIX_LLM_BASE_URL = ORIGINAL_LLM_BASE_URL
+  if (ORIGINAL_LLM_API_KEY === undefined) delete process.env.KORTIX_LLM_API_KEY
+  else process.env.KORTIX_LLM_API_KEY = ORIGINAL_LLM_API_KEY
+  if (ORIGINAL_LLM_PROXY_URL === undefined) delete process.env.KORTIX_LLM_PROXY_URL
+  else process.env.KORTIX_LLM_PROXY_URL = ORIGINAL_LLM_PROXY_URL
 })
 
 describe('resolveOpencodeModel', () => {
@@ -34,6 +43,48 @@ describe('resolveOpencodeModel', () => {
     expect(resolveOpencodeModel()).toEqual({
       providerID: 'anthropic',
       modelID: 'claude-sonnet-4-6',
+    })
+  })
+
+  test('routes a Codex wire model through the Kortix provider in gateway mode', () => {
+    process.env.KORTIX_LLM_BASE_URL = 'https://api.kortix.test/v1/llm'
+    process.env.KORTIX_LLM_API_KEY = 'test-key'
+    process.env.KORTIX_OPENCODE_MODEL = 'codex/gpt-5.6-sol'
+
+    expect(resolveOpencodeModel()).toEqual({
+      providerID: 'kortix',
+      modelID: 'codex/gpt-5.6-sol',
+    })
+  })
+
+  test('routes a BYOK wire model through the Kortix provider in gateway mode', () => {
+    process.env.KORTIX_LLM_BASE_URL = 'https://api.kortix.test/v1/llm'
+    process.env.KORTIX_LLM_API_KEY = 'test-key'
+    process.env.KORTIX_OPENCODE_MODEL = 'anthropic/claude-sonnet-4-6'
+
+    expect(resolveOpencodeModel()).toEqual({
+      providerID: 'kortix',
+      modelID: 'anthropic/claude-sonnet-4-6',
+    })
+  })
+
+  test('routes a bare managed model through the Kortix provider in gateway mode', () => {
+    process.env.KORTIX_LLM_PROXY_URL = 'http://127.0.0.1:4319'
+    process.env.KORTIX_OPENCODE_MODEL = 'glm-5.2'
+
+    expect(resolveOpencodeModel()).toEqual({
+      providerID: 'kortix',
+      modelID: 'glm-5.2',
+    })
+  })
+
+  test('accepts an explicit Kortix OpenCode model reference in gateway mode', () => {
+    process.env.KORTIX_LLM_PROXY_URL = 'http://127.0.0.1:4319'
+    process.env.KORTIX_OPENCODE_MODEL = 'kortix/codex/gpt-5.6-sol'
+
+    expect(resolveOpencodeModel()).toEqual({
+      providerID: 'kortix',
+      modelID: 'codex/gpt-5.6-sol',
     })
   })
 

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -15,6 +15,7 @@ import {
 import { logger } from './logger'
 import {
   createOpencodeSupervisor,
+  hasKortixLlmGateway,
   OPENCODE_HOME,
   refreshGatewayCatalogFile,
   waitForOpencodeReady,
@@ -1391,12 +1392,23 @@ async function isRootOpencodeSession(
   }
 }
 
-/** Per-session model override from KORTIX_OPENCODE_MODEL. Most models use
- *  provider/model form and are returned in OpenCode's `{ providerID, modelID }`
- *  shape. Bare legacy Zen ids are normalized onto the OpenCode provider so old
- *  queued boot prompts keep using the schema accepted by `prompt_async`. */
+/** Per-session model override from KORTIX_OPENCODE_MODEL.
+ *
+ * Gateway mode exposes one OpenCode provider (`kortix`). Its model ids are the
+ * complete gateway wire refs, including nested refs such as
+ * `codex/gpt-5.6-sol` and `anthropic/claude-sonnet-4-6`. Gateway overrides must
+ * therefore keep the complete wire ref as `modelID` instead of treating its
+ * first segment as an OpenCode provider.
+ *
+ * Gateway-disabled sessions keep the native `provider/model` split. Bare
+ * legacy Zen ids remain normalized onto the native OpenCode provider. */
 export function resolveOpencodeModel(): { providerID: string; modelID: string } | undefined {
   const raw = (process.env.KORTIX_OPENCODE_MODEL ?? '').trim()
+  if (!raw) return undefined
+  if (hasKortixLlmGateway(process.env)) {
+    const modelID = raw.startsWith('kortix/') ? raw.slice('kortix/'.length) : raw
+    return modelID ? { providerID: 'kortix', modelID } : undefined
+  }
   if (LEGACY_OPENCODE_ZEN_FREE_MODELS.has(raw)) return { providerID: 'opencode', modelID: raw }
   const slash = raw.indexOf('/')
   if (slash <= 0 || slash === raw.length - 1) return undefined

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -31,6 +31,39 @@ const OPENCODE_AUTH_PATH = `${OPENCODE_DATA_HOME}/opencode/auth.json`
 const CODEX_AUTH_JSON_SECRET = 'CODEX_AUTH_JSON'
 const OPENCODE_AUTH_JSON_SECRET = 'OPENCODE_AUTH_JSON'
 
+/** True when OpenCode uses the single synthetic `kortix` LLM provider. */
+export function hasKortixLlmGateway(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    env.KORTIX_LLM_PROXY_URL ||
+    (env.KORTIX_LLM_BASE_URL && env.KORTIX_LLM_API_KEY),
+  )
+}
+
+/** Convert a gateway wire model into OpenCode's `provider/model` string. */
+export function toKortixOpencodeModelRef(ref: string): string {
+  const trimmed = ref.trim()
+  return trimmed.startsWith('kortix/') ? trimmed : `kortix/${trimmed}`
+}
+
+/** Route every configured model through the only provider enabled in gateway mode. */
+function normalizeGatewayModelRefs(config: Record<string, unknown>): void {
+  for (const key of ['model', 'small_model'] as const) {
+    if (typeof config[key] === 'string' && config[key].trim()) {
+      config[key] = toKortixOpencodeModelRef(config[key])
+    }
+  }
+
+  const agents = config.agent
+  if (!agents || typeof agents !== 'object' || Array.isArray(agents)) return
+  for (const value of Object.values(agents)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+    const agent = value as Record<string, unknown>
+    if (typeof agent.model === 'string' && agent.model.trim()) {
+      agent.model = toKortixOpencodeModelRef(agent.model)
+    }
+  }
+}
+
 // Assemble the inline opencode config (OPENCODE_CONFIG_CONTENT) the daemon hands
 // opencode at spawn. It MERGES over the repo's own opencode config and has four
 // independent contributors, any of which may apply:
@@ -72,7 +105,7 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
 
   // Direct mode needs both token+url; proxy mode needs only the proxy URL.
   const hasExecutorMcp = executorMcpEnabled && (executorProxyMode || (!!executorToken && !!apiUrl))
-  const hasLlmGateway = proxyMode || (!!llmBaseUrl && !!llmApiKey)
+  const hasLlmGateway = hasKortixLlmGateway(env)
   // A Slack-provisioned session carries SLACK_CHANNEL_ID / SLACK_THREAD_TS (the
   // session identity the API hands us at boot; also what the in-sandbox `slack`
   // CLI uses to post back to the thread). Contributor #3 keys off it.
@@ -167,6 +200,7 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
         fetchApiKey: llmApiKey,
       }),
     }
+    normalizeGatewayModelRefs(out)
     if (!('model' in out) || typeof out.model !== 'string') {
       out.model = DEFAULT_KORTIX_MODEL
     }


### PR DESCRIPTION
## Problem

Gateway-enabled sandboxes expose one OpenCode provider: `kortix`. Trigger-level `codex/gpt-5.6-sol` overrides were split into provider `codex` and model `gpt-5.6-sol`. OpenCode rejected the prompt with `Model not found: codex/gpt-5.6-sol`.

## Change

- Route every explicit model override through provider `kortix` when the LLM gateway is active.
- Preserve the complete gateway wire model as the OpenCode `modelID`.
- Normalize top-level and per-agent configured models to `kortix/<wire-model>`.
- Preserve native provider splitting when the gateway is disabled.

## Verification

- `pnpm --filter @kortix/sandbox-agent-server test`
  - 214 tests passed.
  - 532 assertions passed.
- `pnpm --filter @kortix/sandbox-agent-server typecheck`
  - Exit 0.
- `pnpm --filter @kortix/sandbox-agent-server build`
  - Built `dist/kortix-agent` for `bun-linux-x64`.
- Live dev incident evidence:
  - Session `89271a51-6621-4f41-824a-dceafe474d76` stored `opencode_model: codex/gpt-5.6-sol`.
  - Its webhook messages used `{providerID: codex, modelID: gpt-5.6-sol}`.
  - The same session succeeded through `{providerID: kortix, modelID: codex/gpt-5.6-sol}`.
