### PR TITLE
fix(runtime): keep initialized sessions stream-ready

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -344,6 +344,77 @@ describe('daemon proxy auth gate', () => {
     expect(body.auth).toBe('unconfigured')
   })
 
+  it('keeps runtime ready after the initialized repository changes branches', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-health-branch-'))
+    const target = join(root, 'workspace')
+    const previousBranch = process.env.KORTIX_BRANCH_NAME
+    try {
+      mkdirSync(target)
+      git(['init'], target)
+      git(['checkout', '-b', 'main'], target)
+      writeFileSync(join(target, 'README.md'), 'ready\n')
+      git(['add', 'README.md'], target)
+      git(['-c', 'user.email=test@kortix.dev', '-c', 'user.name=Kortix Test', 'commit', '-m', 'ready'], target)
+      git(['checkout', '-b', 'session-branch'], target)
+      process.env.KORTIX_BRANCH_NAME = 'session-branch'
+
+      const app = buildOpencodeApp(
+        baseConfig({ autoClone: true, projectTarget: target, branchName: 'session-branch' }),
+        fakeOpencode('ok'),
+        Date.now(),
+      )
+
+      const initialized = (await (await app.request('/kortix/health')).json()) as {
+        runtimeReady: boolean
+        repo_ready: boolean
+        branch: string
+      }
+      expect(initialized).toMatchObject({
+        runtimeReady: true,
+        repo_ready: true,
+        branch: 'session-branch',
+      })
+
+      git(['checkout', 'main'], target)
+
+      const changed = (await (await app.request('/kortix/health')).json()) as {
+        runtimeReady: boolean
+        repo_ready: boolean
+        branch: string
+      }
+      expect(changed).toMatchObject({
+        runtimeReady: true,
+        repo_ready: true,
+        branch: 'main',
+      })
+
+      process.env.KORTIX_BRANCH_NAME = 'another-session-branch'
+      const differentSession = (await (await app.request('/kortix/health')).json()) as {
+        runtimeReady: boolean
+        repo_ready: boolean
+      }
+      expect(differentSession).toMatchObject({
+        runtimeReady: false,
+        repo_ready: false,
+      })
+
+      process.env.KORTIX_BRANCH_NAME = 'session-branch'
+      rmSync(join(target, '.git'), { recursive: true, force: true })
+      const missingRepo = (await (await app.request('/kortix/health')).json()) as {
+        runtimeReady: boolean
+        repo_ready: boolean
+      }
+      expect(missingRepo).toMatchObject({
+        runtimeReady: false,
+        repo_ready: false,
+      })
+    } finally {
+      if (previousBranch === undefined) delete process.env.KORTIX_BRANCH_NAME
+      else process.env.KORTIX_BRANCH_NAME = previousBranch
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('reports runtime not ready and blocks OpenCode proxy when repo materialization failed', async () => {
     const root = mkdtempSync(join(tmpdir(), 'kortix-repo-failed-'))
     try {

--- a/apps/kortix-sandbox-agent-server/src/routes/health.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/health.ts
@@ -81,6 +81,7 @@ export function createHealthRouter(
   staticWebPort: number | null = null,
 ): Hono {
   const router = new Hono()
+  let initializedRepoBranch: string | null = null
 
   router.get('/', async (c) => {
     const repoInfo = await readRepoInfo(cfg.projectTarget).catch(() => null)
@@ -94,8 +95,17 @@ export function createHealthRouter(
     // on the default branch (observed live: `main` at ready, session branch
     // +3s). Seed builders have no session branch → gate inert for capture.
     const wantBranch = repoRequired ? wantedSessionBranch() : ''
+    if (repoInfo !== null && wantBranch && repoInfo.branch === wantBranch) {
+      initializedRepoBranch = wantBranch
+    }
+    // Branch equality is a boot gate, not a permanent liveness condition.
+    // After initialization, an agent can inspect or update another branch.
+    // Keep runtimeReady true while the repository still exists. A different
+    // session branch must pass the equality gate independently.
     const repoReady =
-      !repoRequired || (repoInfo !== null && (!wantBranch || repoInfo.branch === wantBranch))
+      !repoRequired ||
+      (repoInfo !== null &&
+        (!wantBranch || repoInfo.branch === wantBranch || initializedRepoBranch === wantBranch))
     const initialSessionReady =
       !bootState.initialOpenCodeSessionRequired || !!bootState.initialOpenCodeSessionId
     const initialSessionError = bootState.initialOpenCodeSessionError ?? null


### PR DESCRIPTION
## Incident

A running session stops streaming after the agent changes the repository branch.
The assistant response becomes visible only after a hard refresh.

The sandbox remains reachable.
`/kortix/health` reports `opencode: "ok"` and `runtimeReady: false`.
The SDK then closes SSE and disables fallback polling.

## Root cause

`apps/kortix-sandbox-agent-server/src/routes/health.ts` applies session-branch equality as a permanent liveness gate.
The gate changes `runtimeReady` to `false` after `git checkout main`.

## Fix

- Keep session-branch equality as an initialization gate.
- Record the required branch after the first successful match.
- Keep `runtimeReady: true` after later branch changes.
- Require each new session branch to pass the initialization gate.
- Keep a missing `.git` directory unhealthy.

## Verification

- Regression test before fix: branch switch changed `runtimeReady` from `true` to `false`.
- Focused regression after fix: `1 pass`, `0 fail`, `4 expect()` calls.
- `bun test src`: `215 pass`, `0 fail`, `537 expect()` calls.
- `bun tsc --noEmit`: exit `0`.
- `pnpm --filter @kortix/sandbox-agent-server build`: exit `0`.
- `git diff --check origin/main...HEAD`: exit `0`.

## Source

The worktree branch starts from `origin/main` at `bd05a65901da1a42dc956034185cc78042b01ce4`.
