### PR TITLE
Promote exact latest main to staging (v0.10.14 dev pin sync)

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-9db97511"
+  tag: "dev-ea017504"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
Promotes the exact latest `main` tip to `staging`.

Source SHA: `577c02cedf23da6d4470d7e094c1d123dcfab1bf`

### Included since staging source `c23531878a`

- Synchronize the generated dev API GitOps pin for source `ea017504`.

This commit changes only `infra/k8s/envs/dev/values.yaml`. It contains no product-code change.