### PR TITLE
Non-duplicating prompt delivery + accurate session status label

### DIFF
--- a/apps/api/src/sandbox-proxy/prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/prompt-dedupe.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { __resetPromptDedupe, claimPromptDelivery, promptDeliveryKey } from './prompt-dedupe';
+
+beforeEach(() => __resetPromptDedupe());
+
+describe('promptDeliveryKey', () => {
+  test('prefers a trimmed Idempotency-Key over the content hash', () => {
+    const key = promptDeliveryKey({
+      idempotencyKey: '  abc-123  ',
+      sandboxId: 'sb',
+      sessionId: 'se',
+      body: undefined,
+    });
+    expect(key).toBe('idem:abc-123');
+  });
+
+  test('falls back to a stable content hash when no key is supplied', () => {
+    const body = new TextEncoder().encode('{"parts":[{"type":"text","text":"hi"}]}').buffer;
+    const a = promptDeliveryKey({ idempotencyKey: null, sandboxId: 'sb', sessionId: 'se', body });
+    const b = promptDeliveryKey({ idempotencyKey: '', sandboxId: 'sb', sessionId: 'se', body });
+    expect(a).toBe(b);
+    expect(a.startsWith('hash:')).toBe(true);
+    // Different session ⇒ different key (no cross-session collisions).
+    const c = promptDeliveryKey({ idempotencyKey: null, sandboxId: 'sb', sessionId: 'other', body });
+    expect(c).not.toBe(a);
+  });
+});
+
+describe('claimPromptDelivery', () => {
+  test('first claim wins, an immediate repeat is deduped', () => {
+    expect(claimPromptDelivery('k1', 1_000)).toBe(true);
+    expect(claimPromptDelivery('k1', 1_000)).toBe(false);
+    expect(claimPromptDelivery('k2', 1_000)).toBe(true);
+  });
+
+  test('a key is claimable again once its TTL has elapsed', () => {
+    expect(claimPromptDelivery('k1', 0)).toBe(true);
+    expect(claimPromptDelivery('k1', 59_999)).toBe(false); // still within TTL
+    expect(claimPromptDelivery('k1', 60_001)).toBe(true); // TTL expired → reclaimable
+  });
+
+  test('the cache is bounded — it never grows past the max entry count', () => {
+    // Far more than MAX_ENTRIES (2_000) distinct keys, all non-expiring.
+    for (let i = 0; i < 5_000; i++) {
+      expect(claimPromptDelivery(`bulk-${i}`, 1_000)).toBe(true);
+    }
+    // The most-recent key is still remembered (deduped)…
+    expect(claimPromptDelivery('bulk-4999', 1_000)).toBe(false);
+    // …but the oldest were evicted, so they read as fresh again.
+    expect(claimPromptDelivery('bulk-0', 1_000)).toBe(true);
+  });
+});

--- a/apps/api/src/sandbox-proxy/prompt-dedupe.ts
+++ b/apps/api/src/sandbox-proxy/prompt-dedupe.ts
@@ -1,0 +1,69 @@
+import { createHash } from 'node:crypto';
+
+// Prompt delivery is the one MUTATING call on the sandbox proxy: POSTing the
+// same body twice to opencode enqueues the user's message twice (the 3x-queued
+// bug). opencode has no idempotency of its own, so the proxy must never re-send
+// a prompt body it may already have delivered. This tiny in-memory cache records
+// each prompt delivery by its Idempotency-Key (or a content-hash fallback) so a
+// duplicate inbound request — a client resend, or the other proxy edge — carrying
+// the same key SHORT-CIRCUITS instead of re-POSTing. It is intentionally best-
+// effort (a hot-path Map, no DB write per request) and strictly bounded by both a
+// TTL and a max entry count so it can never grow without bound.
+
+const DEDUPE_TTL_MS = 60_000;
+const MAX_ENTRIES = 2_000;
+
+const seen = new Map<string, number>(); // key -> expiresAt (ms epoch)
+
+// Map preserves insertion order, so the oldest entries live at the front: trim
+// expired ones from the front, then cap total size by dropping the oldest.
+function evict(now: number): void {
+  for (const [key, expiresAt] of seen) {
+    if (expiresAt > now) break;
+    seen.delete(key);
+  }
+  while (seen.size > MAX_ENTRIES) {
+    const oldest = seen.keys().next().value;
+    if (oldest === undefined) break;
+    seen.delete(oldest);
+  }
+}
+
+// Stable per-prompt key: the caller's Idempotency-Key when present (the CLI mints
+// one UUID per logical prompt), else a content hash so retries of the SAME body
+// still collide even from a client that sends no header.
+export function promptDeliveryKey(opts: {
+  idempotencyKey: string | null;
+  sandboxId: string;
+  sessionId: string;
+  body: ArrayBuffer | undefined;
+}): string {
+  const provided = opts.idempotencyKey?.trim();
+  if (provided) return `idem:${provided}`;
+  const hash = createHash('sha256')
+    .update(opts.sandboxId)
+    .update('\0')
+    .update(opts.sessionId)
+    .update('\0')
+    .update(opts.body ? new Uint8Array(opts.body) : new Uint8Array())
+    .digest('hex');
+  return `hash:${hash}`;
+}
+
+// Claim a prompt delivery. Returns true the first time a key is seen within the
+// TTL (the caller should deliver), false on a repeat (the caller should short-
+// circuit without re-POSTing). The claim is taken up-front — modelling the
+// delivery as "in-flight" — so a concurrent duplicate is deduped even before the
+// first attempt returns.
+export function claimPromptDelivery(key: string, now: number = Date.now()): boolean {
+  evict(now);
+  const expiresAt = seen.get(key);
+  if (expiresAt !== undefined && expiresAt > now) return false;
+  seen.set(key, now + DEDUPE_TTL_MS);
+  return true;
+}
+
+// Test-only: drop all cached claims so cases don't leak into one another.
+export function __resetPromptDedupe(): void {
+  seen.clear();
+}

--- a/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
@@ -1,0 +1,139 @@
+// forwardToSandbox must deliver a PROMPT body to the sandbox at most once. The
+// proxy buffers the POST body and retries on 502/503/timeout; for an idempotent
+// GET that's fine, but a prompt POST the sandbox may already have accepted must
+// never be re-sent — a re-POST enqueues the user's message again (the 3x-queued
+// bug). These tests pin: (a) a prompt POST that 502s is fetched exactly once,
+// (b) a GET still retries, (c) a duplicate inbound prompt under the same
+// Idempotency-Key short-circuits without re-hitting the upstream.
+//
+// The heavier ../backend + ownership + env-sync deps are mocked to inert stubs.
+// `bun:test`'s mock.module is process-global, so this lives in its own file (run
+// per-file) to avoid leaking stubs into sibling suites — same caveat other
+// sandbox-proxy tests document.
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mock } from 'bun:test';
+
+const ACTIVE_RECORD = {
+  status: 'active',
+  serviceKey: 'svc-key',
+  sessionId: 'sess-1',
+  projectId: 'proj-1',
+  accountId: 'acct-1',
+  externalId: 'ext-1',
+  agentName: 'default',
+  provider: 'daytona',
+};
+
+mock.module('../../config', () => ({ config: { KORTIX_ENFORCE_SESSION_AGENT_LOCK: false } }));
+mock.module('../../lib/request-context', () => ({ getTraceHeaders: () => ({}) }));
+mock.module('../../shared/kortix-user-context', () => ({
+  KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
+}));
+mock.module('../../shared/preview-ownership', () => ({
+  canAccessPreviewSandbox: async () => true,
+  canAccessSandboxSession: async () => true,
+}));
+mock.module('../../projects/lib/sandbox-env-sync', () => ({
+  syncSandboxEnvForPrompt: async () => {},
+}));
+mock.module('../../projects/opencode-title-capture', () => ({
+  scheduleTitleCaptureAfterPrompt: () => {},
+}));
+mock.module('../../projects/routes/shared', () => ({
+  resumeStoppedSandboxByExternalId: async () => true,
+}));
+mock.module('../backend', () => ({
+  loadSandbox: async () => ({ ...ACTIVE_RECORD }),
+  routeSandboxIngress: () => ({ effectivePort: 8000 }),
+  resolveSandboxIngress: async () => ({ url: 'http://sandbox.local', headers: {} }),
+  buildSandboxUpstreamHeaders: async () => ({}),
+  invalidatePreviewLink: () => {},
+  markSandboxUsed: () => {},
+  markSandboxErrored: async () => {},
+  wakeSandbox: async () => {},
+}));
+
+const { forwardToSandbox } = await import('./preview');
+const { __resetPromptDedupe } = await import('../prompt-dedupe');
+
+const ORIGINAL_FETCH = globalThis.fetch;
+let fetchCalls = 0;
+let responses: Response[] = [];
+
+function queueFetch(...rs: Response[]) {
+  responses = rs;
+  fetchCalls = 0;
+  (globalThis as { fetch: unknown }).fetch = async () => {
+    fetchCalls += 1;
+    const next = responses.shift();
+    if (!next) throw new Error('fetch called more times than queued');
+    return next;
+  };
+}
+
+function jsonHeaders(extra?: Record<string, string>): Headers {
+  return new Headers({ 'content-type': 'application/json', ...(extra ?? {}) });
+}
+
+const PROMPT_BODY = new TextEncoder().encode(
+  JSON.stringify({ parts: [{ type: 'text', text: 'hi' }] }),
+).buffer;
+
+beforeEach(() => __resetPromptDedupe());
+afterAll(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+
+describe('forwardToSandbox — prompt delivery is never double-sent', () => {
+  test('a prompt POST that 502s is delivered to the sandbox at most once', async () => {
+    queueFetch(new Response('bad gateway', { status: 502 }));
+    const res = await forwardToSandbox(
+      'sb-1', 8000, { kind: 'principal', userId: 'u1' },
+      'POST', '/session/sess-1/message', '', jsonHeaders(), PROMPT_BODY, 'http://app.local',
+    );
+    // Exactly ONE upstream attempt — the 502 is passed straight through, never retried.
+    expect(fetchCalls).toBe(1);
+    expect(res.status).toBe(502);
+  });
+
+  test('a prompt POST that succeeds is forwarded once (happy path unchanged)', async () => {
+    queueFetch(new Response('{"info":{},"parts":[]}', { status: 200 }));
+    const res = await forwardToSandbox(
+      'sb-1', 8000, { kind: 'principal', userId: 'u1' },
+      'POST', '/session/sess-1/message', '', jsonHeaders(), PROMPT_BODY, 'http://app.local',
+    );
+    expect(fetchCalls).toBe(1);
+    expect(res.status).toBe(200);
+  });
+
+  test('a duplicate inbound prompt under the same Idempotency-Key short-circuits', async () => {
+    queueFetch(new Response('{"info":{},"parts":[]}', { status: 200 }));
+    const args = [
+      'sb-1', 8000, { kind: 'principal', userId: 'u1' } as const,
+      'POST', '/session/sess-1/message', '', jsonHeaders({ 'idempotency-key': 'dup-1' }),
+      PROMPT_BODY, 'http://app.local',
+    ] as const;
+    const first = await forwardToSandbox(...args);
+    const second = await forwardToSandbox(...args);
+    // Only the first reached the upstream; the second was deduped.
+    expect(fetchCalls).toBe(1);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({ status: 'duplicate', deduplicated: true });
+  });
+});
+
+describe('forwardToSandbox — idempotent GET retry is unchanged', () => {
+  test('a GET that 502s then 200s is retried and returns the eventual success', async () => {
+    queueFetch(
+      new Response('bad gateway', { status: 502 }),
+      new Response('ok', { status: 200 }),
+    );
+    const res = await forwardToSandbox(
+      'sb-1', 8000, { kind: 'principal', userId: 'u1' },
+      'GET', '/session', '', new Headers(), undefined, 'http://app.local',
+    );
+    expect(fetchCalls).toBe(2);
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -23,6 +23,7 @@ import {
   isLongTurnCompletionRequest,
   proxyAttemptTimeoutMs,
 } from '../preview-retry-budget';
+import { claimPromptDelivery, promptDeliveryKey } from '../prompt-dedupe';
 
 // `userId` is set by combinedAuth (mounted in ../index.ts) before this route.
 const preview = new Hono<{ Variables: { userId: string; userEmail: string } }>();
@@ -298,6 +299,29 @@ function shouldSyncProjectEnvBeforeProxy(port: number, method: string, path: str
   return /^\/session\/[^/]+\/(?:prompt_async|message)(?:$|[/?#])/.test(path);
 }
 
+// A prompt-delivery POST is the ONE mutating, non-idempotent call on this proxy
+// (POST /session/:id/prompt_async|message on the daemon port). opencode has no
+// idempotency of its own, so re-POSTing the same body enqueues the user's
+// message a second time (the 3x-queued bug). This is exactly the set the
+// env-sync-before-prompt gate already recognises, so delegate to it.
+function isPromptDelivery(method: string, port: number, path: string): boolean {
+  return shouldSyncProjectEnvBeforeProxy(port, method, path);
+}
+
+// True only when a fetch failure PROVES nothing reached the box: the upstream
+// actively refused the connection (nothing was ever accepted). Any other thrown
+// error — timeout, abort, connection reset mid-flight — is ambiguous: the
+// sandbox may already have received and accepted the prompt, so a re-send would
+// duplicate it. Used to gate the one safe prompt-delivery retry in the catch.
+function isConnectionRefusedError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { code?: unknown; cause?: { code?: unknown }; message?: unknown };
+  const codes = [e.code, e.cause?.code].filter((c): c is string => typeof c === 'string');
+  if (codes.some((c) => c === 'ECONNREFUSED')) return true;
+  const message = typeof e.message === 'string' ? e.message : '';
+  return /econnrefused|connection refused|failed to connect|unable to connect/i.test(message);
+}
+
 function requestedPromptAgent(body: ArrayBuffer | undefined, incomingHeaders: Headers): string | null {
   if (!body) return null;
   const contentType = incomingHeaders.get('content-type') ?? '';
@@ -514,6 +538,25 @@ export async function forwardToSandbox(
     }
   }
   const serviceKey = record.serviceKey;
+
+  // Dedupe prompt delivery up-front. Prompt POSTs are the only mutating,
+  // non-idempotent calls here, and the CLI mints one Idempotency-Key per logical
+  // prompt. Claim a stable key (the inbound Idempotency-Key, else a content hash
+  // of sandbox+session+body) BEFORE the retry loop so a duplicate inbound prompt
+  // — a client resend, or the other proxy edge (subdomain.ts also calls this) —
+  // short-circuits to a 200 no-op instead of re-POSTing and enqueueing the user's
+  // message twice. First claim within the TTL proceeds; a repeat is deduped.
+  if (isPromptDelivery(method, port, remainingPath)) {
+    const dedupeKey = promptDeliveryKey({
+      idempotencyKey: incomingHeaders.get('idempotency-key'),
+      sandboxId,
+      sessionId: record.sessionId,
+      body,
+    });
+    if (!claimPromptDelivery(dedupeKey)) {
+      return jsonProxyError({ status: 'duplicate', deduplicated: true }, 200, origin);
+    }
+  }
 
   // 2. Forward with auto-wake retry.
   const MAX_RETRIES = 3;
@@ -749,7 +792,13 @@ export async function forwardToSandbox(
       }
 
       if (upstream.status === 502 || upstream.status === 503) {
-        if (attempt < MAX_RETRIES) {
+        // A prompt-delivery POST is NEVER retried on a 5xx: an upstream 502 can
+        // mean the sandbox already accepted the message (the gateway just dropped
+        // the response), so re-POSTing would enqueue it twice. Pass the upstream
+        // response straight through to the passthrough below. GET/idempotent
+        // requests retry as before.
+        const promptDelivery = isPromptDelivery(method, port, remainingPath);
+        if (!promptDelivery && attempt < MAX_RETRIES) {
           // Port not ready yet — sandbox is booting (container running, port down).
           console.warn(
             `[PREVIEW] Sandbox ${sandboxId}:${port} returned ${upstream.status} (port not ready, attempt ${attempt + 1}/${MAX_RETRIES + 1})`,
@@ -761,7 +810,7 @@ export async function forwardToSandbox(
         // Retries exhausted and the port still isn't answering. Show the friendly
         // "port unreachable" page to browsers instead of the upstream's bare 5xx;
         // programmatic clients still get the real status + JSON via passthrough.
-        if (isBrowserNavigation(incomingHeaders)) {
+        if (!promptDelivery && isBrowserNavigation(incomingHeaders)) {
           void markSandboxUsed(sandboxId);
           return portUnreachableResponse({
             port,
@@ -832,6 +881,21 @@ export async function forwardToSandbox(
         isLongTurnCompletionRequest({ method, path: remainingPath })
       ) {
         sawLongTurnTimeout = true;
+        break;
+      }
+
+      // A prompt-delivery POST must NOT be blindly retried on an ambiguous
+      // failure: a timeout / abort / connection reset can mean the sandbox
+      // already received and accepted the message, so re-POSTing would enqueue
+      // it twice. Only retry when the error PROVES nothing reached the box (the
+      // upstream refused the connection). Any other error stops here and returns
+      // the friendly unreachable response below. (The Daytona "no IP / no runner"
+      // 400 branch — a rejection before opencode — retries in the response path
+      // above, which is safe.)
+      if (
+        isPromptDelivery(method, port, remainingPath) &&
+        !isConnectionRefusedError(err)
+      ) {
         break;
       }
 

--- a/apps/cli/src/__tests__/sandbox-proxy-idempotency.test.ts
+++ b/apps/cli/src/__tests__/sandbox-proxy-idempotency.test.ts
@@ -1,0 +1,118 @@
+// The CLI mints one stable Idempotency-Key per logical prompt and threads it to
+// the delivery POST, so the SERVER proxy can dedupe its own 502/timeout retries
+// instead of enqueueing the user's message twice. The CLI itself never retries;
+// the key's only job is server-side dedupe. These tests pin that sendPrompt
+// attaches the header to the prompt_async delivery POST and that ordinary (GET)
+// reads don't.
+//
+// main's sendPrompt submits via `prompt_async` (a POST that returns immediately)
+// then POLLS `/session/:id/message` + `/session/status` for the completed reply,
+// so a successful call makes several fetches. The stub below is URL-aware: it
+// accepts the delivery POST, echoes back a completed assistant reply parented to
+// the generated messageID, and reports the session idle — so sendPrompt resolves
+// and we can assert on the delivery POST specifically rather than a fetch count.
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+
+import { opencodeClient } from '../api/sandbox-proxy.ts';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+interface Captured {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+}
+let captured: Captured[] = [];
+
+function stubFetch() {
+  captured = [];
+  let deliveredMessageId: string | undefined;
+  (globalThis as { fetch: unknown }).fetch = async (url: unknown, init: unknown) => {
+    const i = (init ?? {}) as { method?: string; headers?: Record<string, string>; body?: string };
+    const method = i.method ?? 'GET';
+    const u = String(url);
+    captured.push({
+      url: u,
+      method,
+      headers: (i.headers ?? {}) as Record<string, string>,
+    });
+    // Delivery POST: accept it, remember the client-generated messageID so the
+    // polled reply below can parent itself to this turn.
+    if (u.includes('/prompt_async')) {
+      try {
+        deliveredMessageId = (JSON.parse(i.body ?? '{}') as { messageID?: string }).messageID;
+      } catch {
+        /* ignore */
+      }
+      return new Response(null, { status: 200 });
+    }
+    // Session status map: empty ⇒ the session is idle (sendPrompt returns).
+    if (u.includes('/session/status')) {
+      return new Response('{}', { status: 200 });
+    }
+    // Message list poll: one completed assistant reply for the delivered turn.
+    if (/\/session\/[^/]+\/message(?:$|[/?])/.test(u)) {
+      return new Response(
+        JSON.stringify([
+          {
+            info: {
+              id: 'a-1',
+              role: 'assistant',
+              sessionID: 'oc-sess',
+              parentID: deliveredMessageId,
+              time: { created: 1, completed: 2 },
+              finish: 'stop',
+            },
+            parts: [{ type: 'text', text: 'ok' }],
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    // Anything else (e.g. listSessions) → empty array.
+    return new Response('[]', { status: 200 });
+  };
+}
+
+const auth = {
+  api_base: 'https://api.test',
+  token: 'tok_test',
+  user_id: 'u1',
+  user_email: 'u@test',
+  account_id: 'a1',
+  logged_in_at: '2026-01-01T00:00:00.000Z',
+};
+
+afterEach(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+afterAll(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+
+function deliveryPost(): Captured | undefined {
+  return captured.find((c) => c.method === 'POST' && c.url.includes('/prompt_async'));
+}
+
+describe('sendPrompt idempotency key', () => {
+  test('attaches the supplied Idempotency-Key header to the delivery POST', async () => {
+    stubFetch();
+    const oc = opencodeClient({ auth, sandboxId: 'sb-1' });
+    await oc.sendPrompt('oc-sess', [{ type: 'text', text: 'hi' }], undefined, undefined, 'idem-abc-123');
+    const post = deliveryPost();
+    expect(post).toBeDefined();
+    expect(post!.headers['Idempotency-Key']).toBe('idem-abc-123');
+  });
+
+  test('omits the header when no key is supplied (and on ordinary GET reads)', async () => {
+    stubFetch();
+    const oc = opencodeClient({ auth, sandboxId: 'sb-1' });
+    await oc.sendPrompt('oc-sess', [{ type: 'text', text: 'hi' }]);
+    await oc.listSessions();
+    // No request — the delivery POST, the polls, or the GET — carries the header.
+    expect(captured.length).toBeGreaterThan(0);
+    for (const c of captured) {
+      expect('Idempotency-Key' in c.headers).toBe(false);
+    }
+  });
+});

--- a/apps/cli/src/__tests__/sessions-chat-activity.test.ts
+++ b/apps/cli/src/__tests__/sessions-chat-activity.test.ts
@@ -1,0 +1,72 @@
+// deriveActivity turns a session's recent messages + Kortix status into a "what's
+// it doing" label. The regression these tests guard: a RUNNING session that is
+// actively mid-turn (an in-flight assistant turn, or a running tool from a just-
+// dispatched subagent batch) must NOT be labelled "queued — agent picking up…".
+import { describe, expect, test } from 'bun:test';
+
+import type { OpencodeMessageWithParts } from '../api/sandbox-proxy.ts';
+import { deriveActivity } from '../commands/sessions-chat.ts';
+
+function userMsg(created: number, text = 'do the thing'): OpencodeMessageWithParts {
+  return {
+    info: { id: `u-${created}`, role: 'user', sessionID: 's', time: { created } },
+    parts: [{ type: 'text', text }],
+  };
+}
+function assistantMsg(
+  created: number,
+  opts: { completed?: number; tool?: { name: string; status: string }; text?: string } = {},
+): OpencodeMessageWithParts {
+  const parts: OpencodeMessageWithParts['parts'] = [];
+  if (opts.tool) parts.push({ type: 'tool', tool: opts.tool.name, state: { status: opts.tool.status } });
+  if (opts.text) parts.push({ type: 'text', text: opts.text });
+  return {
+    info: {
+      id: `a-${created}`,
+      role: 'assistant',
+      sessionID: 's',
+      time: { created, ...(opts.completed ? { completed: opts.completed } : {}) },
+    },
+    parts,
+  };
+}
+
+describe('deriveActivity', () => {
+  test('running + a running tool anywhere in the window → not "queued"', () => {
+    // Assistant dispatched a subagent (running `task` tool), and a subagent
+    // user-role prompt is newest — the pre-fix code read this as "queued".
+    const msgs = [
+      assistantMsg(1, { tool: { name: 'task', status: 'running' } }),
+      userMsg(2, 'subagent prompt'),
+    ];
+    const a = deriveActivity(msgs, 'running');
+    expect(a.working).toBe(true);
+    expect(a.summary).toBe('running task…');
+    expect(a.summary).not.toContain('queued');
+  });
+
+  test('running + an in-flight (uncompleted) assistant turn → "working…", not "queued"', () => {
+    const msgs = [assistantMsg(1, {}), userMsg(2)];
+    const a = deriveActivity(msgs, 'running');
+    expect(a.working).toBe(true);
+    expect(a.summary).toBe('working…');
+  });
+
+  test('running + only a fresh user prompt, no assistant activity → stays "queued"', () => {
+    const a = deriveActivity([userMsg(1)], 'running');
+    expect(a.working).toBe(true);
+    expect(a.summary).toBe('queued — agent picking up…');
+  });
+
+  test('running + a completed assistant reply → idle summary of the reply text', () => {
+    const a = deriveActivity([userMsg(1), assistantMsg(2, { completed: 3, text: 'all done' })], 'running');
+    expect(a.working).toBe(false);
+    expect(a.summary).toBe('all done');
+  });
+
+  test('non-running lifecycle states describe the box, not a turn', () => {
+    expect(deriveActivity([], 'provisioning').summary).toBe('provisioning…');
+    expect(deriveActivity([], 'branching').summary).toBe('provisioning…');
+    expect(deriveActivity([], 'queued').summary).toBe('booting…');
+  });
+});

--- a/apps/cli/src/api/sandbox-proxy.ts
+++ b/apps/cli/src/api/sandbox-proxy.ts
@@ -30,6 +30,9 @@ interface RequestOpts {
   query?: Record<string, string | undefined>;
   /** Per-request timeout. */
   timeoutMs?: number;
+  /** Sent as the Idempotency-Key header so the server proxy can dedupe its own
+   *  502/timeout retries and never deliver the same message twice. */
+  idempotencyKey?: string;
 }
 
 function joinProxyUrl(opts: RequestOpts): string {
@@ -57,6 +60,7 @@ export async function sandboxRequest<T>(opts: RequestOpts): Promise<T> {
     Authorization: `Bearer ${opts.token}`,
   };
   if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.idempotencyKey) headers['Idempotency-Key'] = opts.idempotencyKey;
 
   const controller = new AbortController();
   const timeoutMs = opts.timeoutMs ?? 30_000;
@@ -195,6 +199,7 @@ async function submitPromptAsync(
   sessionId: string,
   body: Record<string, unknown>,
   deadline: number,
+  idempotencyKey?: string,
 ): Promise<void> {
   let lastSubmitError: unknown;
 
@@ -206,6 +211,7 @@ async function submitPromptAsync(
         method: 'POST',
         body,
         timeoutMs: Math.max(1, Math.min(30_000, deadline - Date.now())),
+        idempotencyKey,
       });
       return;
     } catch (error) {
@@ -242,11 +248,12 @@ async function sendPromptAsyncAndWait(
   parts: OpencodePromptPart[],
   extra: { agent?: string; model?: { providerID: string; modelID: string } } | undefined,
   timeoutMs: number,
+  idempotencyKey?: string,
 ): Promise<{ info: OpencodeAssistantMessage; parts: OpencodePart[] }> {
   const deadline = Date.now() + timeoutMs;
   const messageID = promptMessageId();
   const body = { parts, messageID, ...(extra ?? {}) };
-  await submitPromptAsync(base, sessionId, body, deadline);
+  await submitPromptAsync(base, sessionId, body, deadline, idempotencyKey);
 
   while (Date.now() < deadline) {
     try {
@@ -345,8 +352,9 @@ export function opencodeClient(opts: SandboxOpencodeOpts) {
       parts: OpencodePromptPart[],
       extra?: { agent?: string; model?: { providerID: string; modelID: string } },
       timeoutMs?: number,
+      idempotencyKey?: string,
     ) =>
-      sendPromptAsyncAndWait(base, sessionId, parts, extra, timeoutMs ?? 5 * 60_000),
+      sendPromptAsyncAndWait(base, sessionId, parts, extra, timeoutMs ?? 5 * 60_000, idempotencyKey),
     abortSession: (sessionId: string) =>
       sandboxRequest<boolean>({
         ...base,

--- a/apps/cli/src/commands/sessions-chat.ts
+++ b/apps/cli/src/commands/sessions-chat.ts
@@ -1,4 +1,5 @@
 import { createInterface } from 'node:readline';
+import { randomUUID } from 'node:crypto';
 
 import { ApiError } from '../api/client.ts';
 import {
@@ -671,11 +672,17 @@ async function sendAndPrint(
 ): Promise<number> {
   // In --json mode keep stdout pure JSON (no "…thinking" spinner).
   if (!json) process.stdout.write(`${C.dim}…thinking${C.reset}\r`);
+  // One stable idempotency key per logical prompt: if the server proxy retries a
+  // 502/timeout on the delivery POST, it dedupes on this key instead of enqueueing
+  // the same user message again. The CLI itself never retries.
+  const idempotencyKey = randomUUID();
   try {
     const reply = await resolved.oc.sendPrompt(
       ocSessionId,
       [{ type: 'text', text }],
       extra,
+      undefined,
+      idempotencyKey,
     );
     if (json) {
       emitJson(messageToJson({ info: reply.info, parts: reply.parts }));
@@ -852,29 +859,51 @@ async function fetchSessionActivity(
       ocId = list[0]?.id ?? null;
     }
     if (!ocId) return null;
-    const msgs = await oc.listMessages(ocId, 2);
-    const last = msgs[msgs.length - 1];
-    if (!last) return { working: false, summary: 'no messages yet' };
-    return deriveActivity(last);
+    // Fetch a small recent window (not just the last message): an assistant turn
+    // can start — or dispatch a subagent batch that leaves a user-role message
+    // newest — after the user's prompt, and classifying off ONLY the last message
+    // then mislabels a busy session as "queued".
+    const msgs = await oc.listMessages(ocId, 6);
+    if (msgs.length === 0) return { working: false, summary: 'no messages yet' };
+    return deriveActivity(msgs, s.status);
   } catch {
     // Sandbox still warming / proxy hiccup — treat as unknown, not fatal.
     return null;
   }
 }
 
-/** Turn the latest message into a compact "what's it doing" summary. */
-function deriveActivity(m: OpencodeMessageWithParts): SessionActivity {
-  const info = m.info as OpencodeMessageWithParts['info'] & {
+/**
+ * Turn a session's recent messages + Kortix status into a compact "what's it
+ * doing" summary. Reads the whole recent window (not just the newest message) so
+ * an in-flight assistant turn is never missed, and honours the lifecycle status
+ * so a still-booting box isn't reported as an idle/queued agent.
+ */
+export function deriveActivity(
+  messages: OpencodeMessageWithParts[],
+  status: ProjectSession['status'],
+): SessionActivity {
+  // Lifecycle states before the agent can run describe the BOX, not a turn.
+  if (status === 'provisioning' || status === 'branching') {
+    return { working: true, summary: 'provisioning…' };
+  }
+  if (status === 'queued') {
+    return { working: true, summary: 'booting…' };
+  }
+
+  const last = messages[messages.length - 1];
+  if (!last) return { working: false, summary: 'no messages yet' };
+  const lastInfo = last.info as OpencodeMessageWithParts['info'] & {
     time?: { created?: number; completed?: number };
   };
-  const at = info.time?.created ? new Date(info.time.created).toISOString() : undefined;
-  if (info.role === 'user') {
-    return { working: true, summary: 'queued — agent picking up…', last_role: 'user', last_at: at };
-  }
+  const at = lastInfo.time?.created ? new Date(lastInfo.time.created).toISOString() : undefined;
+
+  // A running/pending tool ANYWHERE in the window means the agent is actively
+  // working — even when the newest message is a (subagent) user-role prompt.
   let runningTool: string | undefined;
   let lastTool: string | undefined;
-  for (const p of m.parts) {
-    if (p.type === 'tool') {
+  for (const msg of messages) {
+    for (const p of msg.parts) {
+      if (p.type !== 'tool') continue;
       lastTool = (p as { tool?: string }).tool;
       const st = (p as { state?: { status?: string } }).state?.status;
       if (st === 'running' || st === 'pending') runningTool = (p as { tool?: string }).tool;
@@ -883,11 +912,36 @@ function deriveActivity(m: OpencodeMessageWithParts): SessionActivity {
   if (runningTool) {
     return { working: true, tool: runningTool, summary: `running ${runningTool}…`, last_role: 'assistant', last_at: at };
   }
-  const completed = info.time?.completed;
-  if (!completed) {
-    return { working: true, summary: 'thinking…', last_role: 'assistant', last_at: at };
+
+  // The most-recent assistant turn: if it hasn't completed (and didn't error) the
+  // agent is still generating — report "working", not "queued", even if a later
+  // user-role message is technically newest.
+  let latestAssistant:
+    | (OpencodeMessageWithParts['info'] & { time?: { completed?: number }; error?: unknown })
+    | undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const info = messages[i]!.info;
+    if (info.role === 'assistant') {
+      latestAssistant = info as OpencodeMessageWithParts['info'] & {
+        time?: { completed?: number };
+        error?: unknown;
+      };
+      break;
+    }
   }
-  const text = m.parts
+  if (latestAssistant && latestAssistant.time?.completed == null && !latestAssistant.error) {
+    return { working: true, summary: 'working…', last_role: 'assistant', last_at: at };
+  }
+
+  // Newest message is the user's and no assistant turn has started — genuinely
+  // queued, waiting for the agent to pick it up.
+  if (lastInfo.role === 'user') {
+    return { working: true, summary: 'queued — agent picking up…', last_role: 'user', last_at: at };
+  }
+
+  // Otherwise the last assistant turn is done — summarize its reply.
+  const completed = lastInfo.time?.completed;
+  const text = last.parts
     .filter(
       (p) =>
         p.type === 'text' &&
@@ -902,7 +956,7 @@ function deriveActivity(m: OpencodeMessageWithParts): SessionActivity {
     working: false,
     summary: text ? truncate(text, 64) : lastTool ? `idle (last: ${lastTool})` : 'idle',
     last_role: 'assistant',
-    last_at: new Date(completed).toISOString(),
+    last_at: completed ? new Date(completed).toISOString() : at,
   };
 }
 


### PR DESCRIPTION
Fixes the session-chat problems found while operating math-god (2026-07-22).

## Bugs
1. **Duplicate prompt delivery (core).** `forwardToSandbox` (sandbox-proxy/routes/preview.ts) buffers the POST body and blindly retries prompt-delivery on 502/503/timeout — but a 502 doesn't mean the sandbox didn't accept it, so an already-delivered prompt gets re-POSTed up to 3× (observed in prod: the same message queued 3 times).
2. **No idempotency key from the CLI** — so the proxy had no way to dedupe its own retries.
3. **Misleading status label** — `deriveActivity` printed "queued — agent picking up…" whenever the newest message was the user's, even on a `running` session actively mid-turn (e.g. just dispatched a subagent batch).

## Fix
- New `apps/api/src/sandbox-proxy/prompt-dedupe.ts`: bounded TTL cache; `promptDeliveryKey` (Idempotency-Key else sha256(sandboxId+sessionId+body)) + `claimPromptDelivery`.
- `preview.ts`: prompt-delivery POSTs (detected via existing `shouldSyncProjectEnvBeforeProxy`) claim a dedupe key before the retry loop (duplicate → 200 no-op); 502/503 passes straight through (no retry); catch only re-sends on connection-refused (never after ambiguous timeout/abort). GET/idempotent retries unchanged. Covers both proxy edges.
- CLI `sandbox-proxy.ts` + `sessions-chat.ts`: mint one Idempotency-Key per prompt, threaded through `sendPrompt`→`sendPromptAsyncAndWait`→the `prompt_async` POST.
- `deriveActivity(messages, status)`: uses session status + a 6-message window — provisioning/booting vs working/running-tool vs genuinely-queued.

## Tests (per-file, green)
prompt-dedupe (5), forward-prompt-dedupe (4: prompt-502-fetched-once regression + GET-502-still-retries), cli idempotency (2), sessions-chat-activity (5). Typecheck clean (2 pre-existing unrelated llm-catalog dist errors aside).

Composes with #5180 (durable delivery + reconciler + self-heal): together the delivery path is loss-proof, duplicate-proof, and self-healing.