### PR TITLE
Promote release cutoff main to staging (v0.10.14 performance refresh)

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -37,6 +37,7 @@ let lifecycleCommandRows: Array<typeof sessionLifecycleCommands.$inferSelect>;
 let activeSessionCount = 0;
 let provisioningSessionCount = 0;
 let secretRows: Array<typeof projectSecrets.$inferSelect>;
+let manifestReadCalls = 0;
 
 function setTestAuth(userId = USER_ID, userEmail = 'triggers@example.test') {
   (globalThis as any)[TEST_AUTH_KEY] = { userId, userEmail };
@@ -74,6 +75,7 @@ function resetState() {
   activeSessionCount = 0;
   provisioningSessionCount = 0;
   secretRows = [];
+  manifestReadCalls = 0;
   secretValues.clear();
 }
 
@@ -116,6 +118,7 @@ mock.module('../projects/git', () => ({
     return content;
   },
   readManifestFromRepo: async (_p: any, candidatePaths: string[]) => {
+    manifestReadCalls += 1;
     for (const path of candidatePaths) {
       const content = repoFiles.get(path);
       if (content !== undefined) return { path, content };
@@ -1014,6 +1017,7 @@ describe('git-backed triggers — runtime fire paths', () => {
       body: rawBody,
     });
     expect(missing.status).toBe(401);
+    expect(manifestReadCalls).toBe(0);
     expect(sandboxProvisionCalls).toBe(0);
 
     const wrong = await app.request(`/v1/webhooks/projects/${PROJECT_ID}/hook`, {
@@ -1025,6 +1029,7 @@ describe('git-backed triggers — runtime fire paths', () => {
       body: rawBody,
     });
     expect(wrong.status).toBe(401);
+    expect(manifestReadCalls).toBe(1);
   });
 
   test('webhook fires with a valid HMAC spawn a session', async () => {

--- a/apps/api/src/__tests__/e2e-rate-limits.test.ts
+++ b/apps/api/src/__tests__/e2e-rate-limits.test.ts
@@ -10,6 +10,7 @@ mock.module('../config', () => ({
     KORTIX_LLM_ROUTER_REQS_PER_MIN_FREE: 1,
     KORTIX_LLM_ROUTER_REQS_PER_MIN_PAID: 2,
     KORTIX_PROXY_REQS_PER_MIN: 1,
+    KORTIX_PROJECT_WEBHOOK_REQS_PER_MIN: 1,
     KORTIX_PUBLIC_SESSION_SHARE_REQS_PER_MIN: 1,
   },
 }));
@@ -29,6 +30,7 @@ const {
   createInviteAcceptRateLimitMiddleware,
   createSandboxProxyRateLimitMiddleware,
   createPublicSessionShareRateLimitMiddleware,
+  createProjectWebhookRateLimitMiddleware,
   resetRateLimiters,
 } = await import('../shared/rate-limit');
 const { sessionLlmPolicyForTier } = await import('../shared/account-limits');
@@ -161,6 +163,34 @@ describe('audited rate limits', () => {
       ip: '203.0.113.30',
       metadata: { limiter: 'check_email' },
     });
+  });
+
+  test('limits project webhooks by project and client IP without database audit work', async () => {
+    const app = new Hono();
+    app.use('/v1/webhooks/projects/:projectId/:slug', createProjectWebhookRateLimitMiddleware());
+    app.post('/v1/webhooks/projects/:projectId/:slug', (c) => c.json({ ok: true }));
+
+    const headers = { 'X-Forwarded-For': '203.0.113.40' };
+    const first = await app.request('/v1/webhooks/projects/project-1/hook', {
+      method: 'POST',
+      headers,
+    });
+    expect(first.status).toBe(200);
+
+    const second = await app.request('/v1/webhooks/projects/project-1/hook', {
+      method: 'POST',
+      headers,
+    });
+    expect(second.status).toBe(429);
+    expect(second.headers.get('Retry-After')).toBeTruthy();
+    expect(await second.json()).toMatchObject({ error: 'rate_limit_exceeded' });
+    expect(auditRows).toHaveLength(0);
+
+    const otherProject = await app.request('/v1/webhooks/projects/project-2/hook', {
+      method: 'POST',
+      headers,
+    });
+    expect(otherProject.status).toBe(200);
   });
 
   test('scales session LLM router policy by tier', () => {

--- a/apps/api/src/__tests__/unit-managed-git-auth-order.test.ts
+++ b/apps/api/src/__tests__/unit-managed-git-auth-order.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+describe("managed GitHub authentication order", () => {
+  test("checks the managed PAT before minting a GitHub App token", async () => {
+    const source = await Bun.file(
+      new URL("../projects/lib/git.ts", import.meta.url),
+    ).text();
+    const start = source.indexOf("export async function resolveProjectGitAuth");
+    const end = source.indexOf(
+      "export async function withProjectGitAuth",
+      start,
+    );
+    const resolver = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(resolver.indexOf("const pat = managedGithubToken()")).toBeLessThan(
+      resolver.indexOf("createInstallationToken("),
+    );
+  });
+});

--- a/apps/api/src/__tests__/unit-session-read-latency.test.ts
+++ b/apps/api/src/__tests__/unit-session-read-latency.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+describe("session read latency boundary", () => {
+  test("session list and detail routes do not contact sandbox runtimes", async () => {
+    const source = await Bun.file(
+      new URL("../projects/routes/r7.ts", import.meta.url),
+    ).text();
+    expect(source).not.toContain("syncOpenCodeTitlesForSessions");
+  });
+});

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -436,12 +436,19 @@ export async function resolveProjectGitAuth(project: ProjectRow): Promise<{
 }> {
   const remote = getProjectGitRemote(project, await getProjectGitConnection(project.projectId));
 
-  // Managed GitHub repos (Kortix-provisioned, under the managed org). Prefer a
-  // short-lived App installation token scoped to THIS repo whenever the App is
-  // available. A configured PAT remains the internal fallback for self-hosted
-  // installs that deliberately use the one-server-key model, but it is never
-  // exported by the API/CLI push-token boundary.
+  // Managed GitHub repos use the server PAT first. The managed GitHub App can
+  // exist without access to every repository. Repeated failed token minting
+  // adds remote latency to every Git-backed project read. The PAT is internal
+  // and is never exported by the API/CLI push-token boundary.
   if (remote.provider === 'github' && remote.managed) {
+    const pat = managedGithubToken();
+    if (pat) {
+      return {
+        auth: { token: pat, source: 'pat', owner: remote.repoOwner ?? undefined, ownerType: 'Organization' },
+        authSource: 'pat',
+      };
+    }
+
     const installId = remote.installationId ?? managedGithubInstallId();
     if (installId && isGithubAppConfigured()) {
       const repoName = remote.repoName ?? parseGitHubRepoUrl(remote.upstreamUrl ?? project.repoUrl)?.repo;
@@ -459,18 +466,10 @@ export async function resolveProjectGitAuth(project: ProjectRow): Promise<{
         };
       } catch (err) {
         console.warn(
-          `[projects] failed to mint managed GitHub installation token for ${project.projectId}; falling back to the server PAT if configured:`,
+          `[projects] failed to mint managed GitHub installation token for ${project.projectId}:`,
           err,
         );
       }
-    }
-
-    const pat = managedGithubToken();
-    if (pat) {
-      return {
-        auth: { token: pat, source: 'pat', owner: remote.repoOwner ?? undefined, ownerType: 'Organization' },
-        authSource: 'pat',
-      };
     }
     return { authSource: 'none' };
   }

--- a/apps/api/src/projects/opencode-title-capture.ts
+++ b/apps/api/src/projects/opencode-title-capture.ts
@@ -8,14 +8,10 @@ import type { ProjectSessionRow } from './lib/serializers';
 
 // Deferred title capture, scheduled off the prompt proxy path.
 //
-// The list-time sync (opencode-title-sync.ts) only reads titles from ACTIVE
-// sandboxes — a session whose sandbox goes to sleep before the user next opens
-// the session list never gets its real title and shows as untitled forever
-// (the wall of "New session - <date>" rows). The one moment a sandbox is
-// GUARANTEED awake is right after it served a prompt, and OpenCode's
-// summarizer produces the real title within seconds of the first reply — so
-// the proxy schedules a capture here instead of hoping a list request happens
-// to race the sandbox's nap.
+// Session read routes do not contact sandbox runtimes. The one moment a sandbox
+// is guaranteed awake is after it served a prompt. OpenCode's summarizer
+// produces the real title after the first reply. The proxy schedules capture
+// here so title enrichment never delays a session list or detail response.
 //
 // Fire-and-forget by design: never blocks or fails the prompt request, one
 // pending capture per session, a single retry when the summarizer hasn't
@@ -88,7 +84,7 @@ export function scheduleTitleCaptureAfterPrompt(
       await attempt();
     } catch (err) {
       // Best-effort enrichment: a failed capture must never surface — the
-      // list-time sync remains as the fallback path.
+      // The next prompt schedules another capture attempt.
       appLogger.warn('[title-capture] deferred capture failed', {
         sessionId: input.sessionId,
         projectId: input.projectId,

--- a/apps/api/src/projects/opencode-title-sync.ts
+++ b/apps/api/src/projects/opencode-title-sync.ts
@@ -10,10 +10,9 @@ import {
 } from './opencode-mapping';
 import type { ProjectSessionRow } from './lib/serializers';
 
-// Title-sync is best-effort enrichment that runs on every session list/read. It
-// fans out one sandbox round-trip per active sandbox (preview-link resolution +
-// an OpenCode `/session` fetch). Two hard rules keep it from taking down the
-// list endpoint or the shared sandbox provider:
+// Title-sync is best-effort enrichment for deferred post-prompt capture. It can
+// fan out one sandbox round-trip per active sandbox when an explicit maintenance
+// caller invokes the batch helper. Two hard rules protect the sandbox provider:
 //   1. BOUNDED concurrency — never fire N unbounded provider calls at once. A
 //      busy project can hold dozens of active sandboxes; an unbounded `Promise.all`
 //      burst-hammers the (org-shared) provider API and trips its rate limiter

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -28,9 +28,11 @@ import { GitHubInstallationRequiredError, buildConnectionRef, consumeGitHubInsta
 import { registerGitHubLinkedProject } from '../lib/project-registration';
 import { PROJECT_NAME_MAX_LENGTH, UUID_V4_REGEX, deriveProjectName, normalizeRepoUrl, normalizeString, readBody, requestAuditContext, serializeGitHubInstallation, serializeGitHubInstallations, serializeProject } from '../lib/serializers';
 import { extractWebhookToken, fireGitTrigger, markGitTriggerFired, renderPromptTemplate, triggerFilterMatches, triggersPausedForProject, verifyWebhookSignature, verifyWebhookToken, webhookPayload } from '../lib/triggers';
+import { createProjectWebhookRateLimitMiddleware } from '../../shared/rate-limit';
 
 projectsApp.use('/*', supabaseAuth);
 
+projectWebhooksApp.use('/projects/:projectId/:slug', createProjectWebhookRateLimitMiddleware());
 
 projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
   const projectId = c.req.param('projectId');
@@ -38,6 +40,16 @@ projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
   if (!UUID_V4_REGEX.test(projectId)) return c.json({ error: 'Invalid project id' }, 400);
   if (!/^[a-z0-9][a-z0-9_-]{0,127}$/.test(slug)) {
     return c.json({ error: 'Invalid trigger slug' }, 400);
+  }
+
+  const hasCredentialHeader = Boolean(
+    c.req.header('x-kortix-signature') ||
+      c.req.header('x-hub-signature-256') ||
+      c.req.header('x-kortix-token') ||
+      c.req.header('authorization'),
+  );
+  if (!hasCredentialHeader) {
+    return c.json({ error: 'Invalid webhook signature' }, 401);
   }
 
   const [project] = await db

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -23,7 +23,6 @@ import { UUID_V4_REGEX, hasOwn, normalizeString, readBody, requestAuditContext, 
 import { sendSessionCreateError } from '../lib/sessions';
 import { sessionHasMemberConnectorBinding } from '../lib/session-connector-bindings';
 import { buildSessionTranscriptDigest } from '../lib/session-transcript';
-import { syncOpenCodeTitlesForSessions } from '../opencode-title-sync';
 import {
   createSession,
   deleteSession,
@@ -511,19 +510,6 @@ projectsApp.openapi(
     return c.json({ error: 'Project manager access is required to list every session' }, 403);
   }
 
-  // Inventory metadata must not become a side door into a private runtime.
-  // Only title-sync rows the viewer could already open, and never revive or
-  // inspect a soft-deleted session merely because an admin opened inventory.
-  const syncableRows = selected.items
-    .filter((item) => item.canAccess && !item.deletedAt)
-    .map((item) => item.row);
-  const syncedRows = await syncOpenCodeTitlesForSessions({
-    rows: syncableRows,
-    projectId,
-    accountId: loaded.row.accountId,
-    userId: loaded.userId,
-  });
-  const syncedBySession = new Map(syncedRows.map((row) => [row.sessionId, row]));
   const ownerIds = selected.items
     .map((item) => item.row.createdBy)
     .filter((ownerId): ownerId is string => Boolean(ownerId));
@@ -531,7 +517,7 @@ projectsApp.openapi(
 
   return c.json(
     selected.items.map((item) => {
-      const row = syncedBySession.get(item.row.sessionId) ?? item.row;
+      const row = item.row;
       const owner = row.createdBy ? ownerIdentities.get(row.createdBy) : null;
       return serializeSession(row, {
         grants: grantsBySession.get(row.sessionId) ?? [],
@@ -576,17 +562,10 @@ projectsApp.openapi(
 
   const visible = await loadVisibleSession(loaded, sessionId);
   if (!visible) return c.json({ error: 'Not found' }, 404);
-  const [row] = await syncOpenCodeTitlesForSessions({
-    rows: [visible.row],
-    projectId,
-    accountId: loaded.row.accountId,
-    userId: loaded.userId,
-  });
-
   const ownerEmail = visible.row.createdBy && !visible.isOwner
     ? (await lookupEmailsByUserIds([visible.row.createdBy])).get(visible.row.createdBy) ?? null
     : null;
-  return c.json(serializeSession(row ?? visible.row, {
+  return c.json(serializeSession(visible.row, {
     grants: visible.grants,
     viewerId: loaded.userId,
     canManageProject: visible.canManageProject,

--- a/apps/api/src/shared/rate-limit.ts
+++ b/apps/api/src/shared/rate-limit.ts
@@ -163,6 +163,7 @@ const sandboxProxyLimiter = new TokenBucketRateLimiter('sandbox_proxy');
 const publicSessionShareLimiter = new TokenBucketRateLimiter('public_session_share');
 const demoRequestLimiter = new TokenBucketRateLimiter('demo_request');
 const checkEmailLimiter = new TokenBucketRateLimiter('check_email');
+const projectWebhookLimiter = new TokenBucketRateLimiter('project_webhook');
 export const sessionLlmLimiter = new TokenBucketRateLimiter('session_llm');
 
 export function createInviteAcceptRateLimitMiddleware() {
@@ -310,11 +311,36 @@ export function createCheckEmailRateLimitMiddleware() {
   };
 }
 
+/**
+ * Guards public project webhooks before the handler loads Git-backed trigger
+ * configuration. The rejection path does not write an audit row. An attacker
+ * must not convert a request flood into a database-write flood.
+ */
+export function createProjectWebhookRateLimitMiddleware() {
+  return async (c: Context, next: Next) => {
+    const projectId = c.req.param('projectId') || 'unknown';
+    const result = projectWebhookLimiter.check(`${projectId}:${clientIp(c)}`, {
+      limit: positiveInt((config as any).KORTIX_PROJECT_WEBHOOK_REQS_PER_MIN, 120),
+      windowMs: 60_000,
+    });
+    setHeaders(c, result);
+    if (!result.allowed) {
+      return c.json({
+        error: 'rate_limit_exceeded',
+        message: 'Rate limit exceeded. Please retry shortly.',
+        retry_after_seconds: Math.ceil((result.retryAfterMs ?? result.resetMs) / 1000),
+      }, 429);
+    }
+    await next();
+  };
+}
+
 export function resetRateLimiters() {
   inviteAcceptLimiter.reset();
   sandboxProxyLimiter.reset();
   publicSessionShareLimiter.reset();
   demoRequestLimiter.reset();
   checkEmailLimiter.reset();
+  projectWebhookLimiter.reset();
   sessionLlmLimiter.reset();
 }

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -33,7 +33,7 @@ import { WallpaperBackground } from '@/components/ui/wallpaper-background';
 import { useAuth } from '@/features/providers/auth-provider';
 import { useAdminRole } from '@/hooks/admin/use-admin-role';
 import { setAdminBypass } from '@/lib/api-client';
-import { getProjectDetail, requestProjectAccess } from '@kortix/sdk/projects-client';
+import { getProject, requestProjectAccess } from '@kortix/sdk/projects-client';
 import { cn } from '@/lib/utils';
 
 interface ProjectAccessBoundaryProps {
@@ -51,8 +51,8 @@ function errorStatus(error: unknown): number | undefined {
 export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoundaryProps) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const query = useQuery({
-    queryKey: ['project-detail', projectId],
-    queryFn: () => getProjectDetail(projectId, { showErrors: false }),
+    queryKey: ['project-access', projectId],
+    queryFn: () => getProject(projectId, { showErrors: false }),
     enabled: !!projectId,
     retry: false,
   });
@@ -140,7 +140,7 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
     onMutate: () => setInlineError(null),
     onSuccess: (result) => {
       if (result.status === 'already_has_access') {
-        void queryClient.invalidateQueries({ queryKey: ['project-detail', projectId] });
+        void queryClient.invalidateQueries({ queryKey: ['project-access', projectId] });
         return;
       }
       setSent(true);
@@ -151,7 +151,7 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
   });
 
   // Platform-admin escape hatch: flips the client-wide admin-bypass header
-  // on, then re-fetches this same ['project-detail', projectId] query so the
+  // on, then re-fetches this same ['project-access', projectId] query so the
   // boundary above (which shares this query cache) picks up the result and
   // renders the actual project. Read-only server-side (see
   // apps/api/src/projects/lib/access.ts) and audit-logged against the
@@ -160,8 +160,8 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
     mutationFn: async () => {
       setAdminBypass(true);
       return queryClient.fetchQuery({
-        queryKey: ['project-detail', projectId],
-        queryFn: () => getProjectDetail(projectId, { showErrors: false }),
+        queryKey: ['project-access', projectId],
+        queryFn: () => getProject(projectId, { showErrors: false }),
       });
     },
     onMutate: () => setBypassError(null),

--- a/apps/web/src/features/review-center/hooks/use-review-session-summary.ts
+++ b/apps/web/src/features/review-center/hooks/use-review-session-summary.ts
@@ -60,9 +60,8 @@ export function useReviewSessionSummary(
     queryFn: () => listReviewItems(projectId),
     enabled,
     staleTime: 5_000,
-    // Slower than the open inbox's 8s poll — the sidebar only needs the count to
-    // feel live, not instant. When disabled the query never runs, so no poll.
-    refetchInterval: enabled ? 20_000 : false,
+    // Mutations invalidate this key. The background poll catches external work.
+    refetchInterval: enabled ? 60_000 : false,
     refetchOnWindowFocus: false,
     // `select` transforms per-observer without touching the shared cache entry, so
     // the Review Center view still reads the raw `{ review_items }` off the same key.

--- a/apps/web/src/features/session/sandbox-loading-boundary.test.ts
+++ b/apps/web/src/features/session/sandbox-loading-boundary.test.ts
@@ -30,4 +30,10 @@ describe('session navigation loading boundaries', () => {
     expect(projectAccessSource).toContain('<KortixHyperLogo');
     expect(projectAccessSource).toContain('min-h-screen');
   });
+
+  test('the access boundary uses the lightweight project route', () => {
+    expect(projectAccessSource).toContain('getProject(projectId');
+    expect(projectAccessSource).not.toContain('getProjectDetail(projectId');
+    expect(projectAccessSource).toContain("queryKey: ['project-access', projectId]");
+  });
 });

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-change-requests-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-change-requests-nav.tsx
@@ -27,7 +27,7 @@ interface CrController {
 }
 
 function useOpenCrController(): CrController {
-  const { data } = useChangeRequests('open', { refetchInterval: 20_000 });
+  const { data } = useChangeRequests('open', { refetchInterval: 60_000 });
   const crs = useMemo(() => data?.change_requests ?? [], [data?.change_requests]);
   const count = crs.length;
 

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-sandbox-alert.tsx
@@ -64,12 +64,12 @@ export function useSandboxHealth(projectId: string) {
   return useQuery<ProjectSandboxHealth>({
     queryKey: SANDBOX_HEALTH_QUERY_KEY(projectId),
     queryFn: () => getProjectSandboxHealth(projectId),
-    staleTime: 8_000,
+    staleTime: 30_000,
     refetchInterval: (query) => {
       const data = query.state.data;
-      if (!data) return 15_000;
+      if (!data) return 30_000;
       if (data.building || selectCurrentSandboxFailure(data)) return 8_000;
-      return 30_000;
+      return 120_000;
     },
     refetchOnWindowFocus: true,
   });

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar-polling.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar-polling.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const sandboxSource = readFileSync(
+  join(import.meta.dir, 'footer/project-sandbox-alert.tsx'),
+  'utf8',
+);
+const changeRequestSource = readFileSync(
+  join(import.meta.dir, 'footer/project-change-requests-nav.tsx'),
+  'utf8',
+);
+const reviewSource = readFileSync(
+  join(import.meta.dir, '../../review-center/hooks/use-review-session-summary.ts'),
+  'utf8',
+);
+
+describe('project sidebar polling', () => {
+  test('healthy background queries use low-frequency polling', () => {
+    expect(sandboxSource).toContain('return 120_000;');
+    expect(changeRequestSource).toContain("useChangeRequests('open', { refetchInterval: 60_000 })");
+    expect(reviewSource).toContain('refetchInterval: enabled ? 60_000 : false');
+  });
+
+  test('active sandbox builds retain the eight-second status poll', () => {
+    expect(sandboxSource).toContain('return 8_000;');
+  });
+});

--- a/docs/incidents/2026-07-23-platinum-provisioning-and-lifecycle-report.md
+++ b/docs/incidents/2026-07-23-platinum-provisioning-and-lifecycle-report.md
@@ -1,0 +1,172 @@
+# Platinum provisioning and lifecycle incident report
+
+Date: 2026-07-23
+
+Audience: Platinum engineering
+
+Status: Open
+
+## Incident summary
+
+Kortix observes high latency and failure rates in Platinum sandbox creation and template builds.
+
+The measurements below exclude Kortix database queries and application request processing.
+They measure Platinum provider operations and persisted provider outcomes.
+
+The highest-priority failure is `sandbox_not_found` during sandbox lifecycle calls.
+Platinum returned this error `35,112` times during the seven-day provider-log window.
+
+## Customer impact
+
+- A new Platinum sandbox can take up to `43.117 s` to create.
+- `18` Platinum sessions entered a failed provisioning state during seven days.
+- `20` additional stopped sessions report that the original sandbox is unavailable.
+- `82` Platinum template builds failed during seven days.
+- A successful template build reached `3,497.7 s`.
+- A failed template build remained unresolved for up to `75,365.0 s`.
+
+These failures block session startup, restart, terminal access, and OpenCode access.
+
+## Sandbox create latency
+
+The data covers direct provider-create calls. It excludes snapshot preparation and Kortix queue time.
+
+### Rolling 24-hour window ending 2026-07-23
+
+| Attempts |        p50 |         p90 |         p95 |     Maximum |
+| -------: | ---------: | ----------: | ----------: | ----------: |
+|       26 | `2,922 ms` | `27,383 ms` | `33,475 ms` | `43,117 ms` |
+
+### Rolling seven-day window ending 2026-07-23
+
+| Attempts |        p50 |         p90 |         p95 |     Maximum |
+| -------: | ---------: | ----------: | ----------: | ----------: |
+|      303 | `2,903 ms` | `12,592 ms` | `15,304 ms` | `43,117 ms` |
+
+The p90 is `4.34` times the p50 in the seven-day window.
+The p95 is `5.27` times the p50 in the seven-day window.
+
+## Session outcomes
+
+The seven-day session sample contains these terminal states:
+
+| Outcome               | Count |
+| --------------------- | ----: |
+| Stopped               |   298 |
+| Running at query time |     9 |
+| Failed                |    18 |
+
+All `18` failed sessions contain `Provisioning failed via platinum`.
+
+Another `20` stopped sessions contain this message:
+
+```text
+The original sandbox is unavailable. Its identity was preserved and no replacement sandbox was created.
+```
+
+Kortix preserves the original provider identity in this state.
+Kortix does not silently create a replacement sandbox.
+
+## Template build outcomes
+
+The seven-day sample contains `263` Platinum template builds.
+
+| Outcome | Count |       p50 |         p95 |      Maximum |
+| ------- | ----: | --------: | ----------: | -----------: |
+| Ready   |   181 | `589.3 s` | `1,482.0 s` |  `3,497.7 s` |
+| Failed  |    82 | `284.8 s` | `2,941.3 s` | `75,365.0 s` |
+
+The observed build success rate is `68.8%`.
+The observed build failure rate is `31.2%`.
+
+### Failure classification
+
+| Failure message                                           | Count |
+| --------------------------------------------------------- | ----: |
+| `Platinum template <template> build failed`               |    54 |
+| `Build did not finish — provider state: platinum=missing` |    14 |
+| `did not become ready (last state: building)`             |     9 |
+| `did not become ready (last state: missing)`              |     3 |
+| Socket closed unexpectedly                                |     1 |
+| Provider state `build_failed`                             |     1 |
+
+### Affected Kortix project
+
+The reported project has `34` recorded Platinum template builds.
+
+| Outcome | Count |       p50 |            p95 |        Maximum |
+| ------- | ----: | --------: | -------------: | -------------: |
+| Ready   |    25 | `541.5 s` |    `1,483.6 s` |    `3,497.7 s` |
+| Failed  |     9 | `911.1 s` | Not calculated | Not calculated |
+
+## Platinum API error distribution
+
+The rolling seven-day Platinum log query matched `41,984` error events.
+These counts represent events, not distinct sandboxes.
+
+| Method       |       Status | Error code            | Events |
+| ------------ | -----------: | --------------------- | -----: |
+| `POST`       |          404 | `sandbox_not_found`   | 35,112 |
+| `POST`       |          409 | `sandbox_not_running` |  2,988 |
+| `POST`       |          409 | `conflict`            |  2,612 |
+| `POST`       |          503 | `capacity`            |    671 |
+| `POST`       |          404 | `not_found`           |    490 |
+| `DELETE`     |          409 | `template_in_use`     |     46 |
+| `POST`       |          409 | `in_progress`         |     37 |
+| `POST`       |          503 | `shutting_down`       |     13 |
+| Unclassified | Unclassified | Unclassified          |      8 |
+| `POST`       |          503 | `unavailable`         |      3 |
+| `POST`       |          413 | `payload_too_large`   |      2 |
+| `DELETE`     |          404 | `not_found`           |      1 |
+| `DELETE`     |          409 | `build_in_progress`   |      1 |
+
+## Confirmed response contracts
+
+Kortix observed these live Platinum responses:
+
+```text
+POST /v1/sandboxes/:id/start -> 404 sandbox_not_found
+POST /v1/sandboxes/:id/start -> 409 conflict
+POST /v1/sandboxes/:id/expose -> 409 sandbox_not_running
+POST /v1/sandboxes/:id/expose -> 404 sandbox_not_found
+DELETE /v1/templates/:id -> 409 template_in_use
+```
+
+The `start` conflict response occurred while the sandbox state was `starting` or `running`.
+
+## Requested Platinum actions
+
+1. Trace the `35,112` `sandbox_not_found` events to sandbox deletion or metadata-loss events.
+2. Identify every automatic deletion path that can remove a persistent Kortix sandbox.
+3. Return a durable deletion reason and deletion timestamp for missing sandboxes.
+4. Make `POST /sandboxes/:id/start` idempotent for `starting` and `running` states.
+5. Investigate the `671` capacity failures by region, host pool, and template.
+6. Add a terminal failure deadline for template builds that remain `building` or `missing`.
+7. Explain the `75,365.0 s` failed-build duration and the missing stale-build transition.
+8. Provide a provider incident identifier for the `82` failed template builds.
+9. Provide per-request trace identifiers in every non-2xx response.
+
+## Requested response data
+
+Please return these items for closure:
+
+- Root cause for `sandbox_not_found`.
+- Root cause for the template failure rate.
+- Affected hosts, regions, and time ranges.
+- Repair status for missing persistent sandboxes.
+- Capacity remediation and completion date.
+- Template-build timeout remediation and completion date.
+- An idempotent lifecycle API contract or migration plan.
+- A queryable audit record for sandbox deletion and host migration.
+
+## Kortix-side facts
+
+- Kortix retains established Platinum sandbox identities after provider loss.
+- Kortix does not replace a missing established sandbox automatically.
+- The current API deployment has two ready pods and zero pod restarts.
+- API CPU usage was approximately `28%` during investigation.
+- API memory usage was approximately `66%` during investigation.
+- No API `5xx` responses appeared in the last-ten-minute infrastructure sample.
+- The database query that lists sessions executed in `0.333 ms`.
+
+These facts rule out current Kortix compute saturation and session-list SQL execution as causes of the provider outcomes above.


### PR DESCRIPTION
Promotes the release cutoff `main` tip to `staging`.

Cutoff SHA: `696a74796549079e0236c9c2774b3f5d208472e3`

### Included since staging source `577c02ced`

- Reduce project and session read latency.
- Reduce sidebar and review-summary polling work.
- Improve managed Git authentication ordering.
- Add rate-limit and latency regression coverage.

This SHA is the v0.10.14 release cutoff.