### PR TITLE
fix(web): preserve agent discovery link headers

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -300,19 +300,6 @@ const nextConfig = (): NextConfig => ({
   async headers() {
     return [
       {
-        source: '/',
-        headers: [
-          {
-            key: 'Link',
-            value:
-              '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", ' +
-              '<https://api.kortix.com/v1/openapi.json>; rel="service-desc"; type="application/json", ' +
-              '</docs>; rel="service-doc"; type="text/html", ' +
-              '</llms.txt>; rel="describedby"; type="text/plain"',
-          },
-        ],
-      },
-      {
         source: '/:path*',
         headers: [
           {

--- a/apps/web/src/lib/agent-discovery.test.ts
+++ b/apps/web/src/lib/agent-discovery.test.ts
@@ -146,6 +146,16 @@ describe('agent discovery documents', () => {
     expect(await response.text()).toContain('# Kortix');
   });
 
+  test('adds agent discovery links to the homepage middleware response', async () => {
+    const response = await middleware(new NextRequest('https://kortix.com/'));
+    const link = response.headers.get('Link');
+
+    expect(link).toContain('</.well-known/api-catalog>; rel="api-catalog"');
+    expect(link).toContain('rel="service-desc"');
+    expect(link).toContain('</docs>; rel="service-doc"');
+    expect(link).toContain('</llms.txt>; rel="describedby"');
+  });
+
   test('declares content signals and agent discovery routes in robots.txt', () => {
     const robots = fs.readFileSync(path.join(process.cwd(), 'public', 'robots.txt'), 'utf8');
     expect(robots).toContain('Content-Signal: ai-train=no, search=yes, ai-input=yes');

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -97,6 +97,12 @@ const MARKDOWN_NEGOTIATION_ROUTES = new Set([
   '/pricing',
 ]);
 
+const AGENT_DISCOVERY_LINK_HEADER =
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", ' +
+  '<https://api.kortix.com/v1/openapi.json>; rel="service-desc"; type="application/json", ' +
+  '</docs>; rel="service-doc"; type="text/html", ' +
+  '</llms.txt>; rel="describedby"; type="text/plain"';
+
 function supportsMarkdownNegotiation(pathname: string): boolean {
   if (MARKDOWN_NEGOTIATION_ROUTES.has(pathname)) return true;
   return (
@@ -431,6 +437,9 @@ export async function middleware(request: NextRequest) {
   // Returning a fresh NextResponse.next() would discard refreshed auth cookies,
   // causing the session to break on the next navigation.
   if (PUBLIC_ROUTES.some((route) => pathname === route || pathname.startsWith(route + '/'))) {
+    if (pathname === '/') {
+      supabaseResponse.headers.set('Link', AGENT_DISCOVERY_LINK_HEADER);
+    }
     return supabaseResponse;
   }
 


### PR DESCRIPTION
## Summary

- set RFC 8288 agent discovery links in middleware
- remove the conflicting Next.js static Link header
- add a regression test for the homepage middleware response

## Evidence

- `pnpm --dir apps/web test src/lib/agent-discovery.test.ts`: 9 pass, 0 fail
- `pnpm --dir apps/web exec eslint next.config.ts src/middleware.ts src/lib/agent-discovery.test.ts`: exit 0
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --dir apps/web build`: exit 0
- production server `GET /`: 200 with separate discovery and preload Link fields

## Known baseline

`pnpm --dir apps/web exec tsc --noEmit` reports two errors in `src/app/(system)/api/og/template/template-url.test.ts`. This PR does not edit that file.