### PR TITLE
Refresh staging with latest main — v0.10.14 final candidate

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -300,19 +300,6 @@ const nextConfig = (): NextConfig => ({
   async headers() {
     return [
       {
-        source: '/',
-        headers: [
-          {
-            key: 'Link',
-            value:
-              '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", ' +
-              '<https://api.kortix.com/v1/openapi.json>; rel="service-desc"; type="application/json", ' +
-              '</docs>; rel="service-doc"; type="text/html", ' +
-              '</llms.txt>; rel="describedby"; type="text/plain"',
-          },
-        ],
-      },
-      {
         source: '/:path*',
         headers: [
           {

--- a/apps/web/src/lib/agent-discovery.test.ts
+++ b/apps/web/src/lib/agent-discovery.test.ts
@@ -146,6 +146,16 @@ describe('agent discovery documents', () => {
     expect(await response.text()).toContain('# Kortix');
   });
 
+  test('adds agent discovery links to the homepage middleware response', async () => {
+    const response = await middleware(new NextRequest('https://kortix.com/'));
+    const link = response.headers.get('Link');
+
+    expect(link).toContain('</.well-known/api-catalog>; rel="api-catalog"');
+    expect(link).toContain('rel="service-desc"');
+    expect(link).toContain('</docs>; rel="service-doc"');
+    expect(link).toContain('</llms.txt>; rel="describedby"');
+  });
+
   test('declares content signals and agent discovery routes in robots.txt', () => {
     const robots = fs.readFileSync(path.join(process.cwd(), 'public', 'robots.txt'), 'utf8');
     expect(robots).toContain('Content-Signal: ai-train=no, search=yes, ai-input=yes');

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -97,6 +97,12 @@ const MARKDOWN_NEGOTIATION_ROUTES = new Set([
   '/pricing',
 ]);
 
+const AGENT_DISCOVERY_LINK_HEADER =
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", ' +
+  '<https://api.kortix.com/v1/openapi.json>; rel="service-desc"; type="application/json", ' +
+  '</docs>; rel="service-doc"; type="text/html", ' +
+  '</llms.txt>; rel="describedby"; type="text/plain"';
+
 function supportsMarkdownNegotiation(pathname: string): boolean {
   if (MARKDOWN_NEGOTIATION_ROUTES.has(pathname)) return true;
   return (
@@ -431,6 +437,9 @@ export async function middleware(request: NextRequest) {
   // Returning a fresh NextResponse.next() would discard refreshed auth cookies,
   // causing the session to break on the next navigation.
   if (PUBLIC_ROUTES.some((route) => pathname === route || pathname.startsWith(route + '/'))) {
+    if (pathname === '/') {
+      supabaseResponse.headers.set('Link', AGENT_DISCOVERY_LINK_HEADER);
+    }
     return supabaseResponse;
   }
 


### PR DESCRIPTION
## Release candidate refresh

Promote the new current `main` tip after PR #5234 merged.

## Added since PR #5233

- Preserve separate RFC 8288 agent-discovery `Link` headers in middleware.
- Remove the conflicting static Next.js `Link` header.
- Add the homepage middleware regression test.

## Existing candidate content

- Fix the project-page query-cache `.length` crash.
- Resolve all open critical and high CodeQL and Trivy findings.
- Update vulnerable Next.js, `fast-uri`, `sharp`, and `fast-xml-parser` versions.
- Remove the unused mobile `agentpress-shared` package.
- Include session delivery, status, performance, billing, and model-resolution fixes.

This PR supersedes the source SHA from PR #5233. Staging must build and deploy this PR's merge SHA before production promotion.
