### PR TITLE
fix(web): filter frameless OperationError popErrorScope rejection noise (BS 5e1aca20)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -18,6 +18,7 @@ import {
   isNonErrorUndefinedRejectionNoise,
   isOldBrowserSyntaxParseError,
   isOldWebkitRegexNoiseMessage,
+  isOperationErrorPopErrorScopeNoise,
   isPaperShaderNullContextNoise,
   isRuntimeNotReadyNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
@@ -3857,6 +3858,224 @@ test('does NOT suppress a message that only mentions the non-Error rejection wor
       }),
       false,
       `expected "${message}" to keep reporting`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Browser-internal DOM/binding `OperationError: Instance dropped in
+// popErrorScope` noise (Better Stack pattern
+// 5e1aca208331fa2d7540c9810b815b6c94f1373c470ff54e15f39d389dac7e0c,
+// Kortix Frontend prod, application_id 2346967, `OperationError`). A
+// browser-internal DOM/binding `OperationError` (`popErrorScope` is part of the
+// WebIDL/internal error-scope machinery — DOMQueuingStrategy, ResizeObserver,
+// IntersectionObserver, media streams, GPU, … — NOT a first-party Kortix API)
+// surfaces as a frameless unhandled promise rejection via the global
+// `onunhandledrejection` handler. 2 occurrences EVER across a 90-day window
+// (first 2026-04-28 18:41:18 UTC on `https://www.kortix.com/instances`
+// Chrome/Win, last 2026-07-22 18:26:35 UTC on
+// `https://kortix.com/projects/<id>` reached from Google account sign-in
+// Chrome/Edge/Win), 0 identified users (anonymous), mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (`handled:false` —
+// UNCAUGHT, never reached a React error boundary). The exception payload is
+// `{"values":[{"type":"OperationError","value":"Instance dropped in
+// popErrorScope","mechanism":{"type":"auto.browser.global_handlers.
+// onunhandledrejection","handled":false}}]}` — NO `stacktrace`, NO frames, NO
+// `call_site_file`/`call_site_function`, NO `call_stack_hash`. A real
+// first-party `Promise.reject(new OperationError(...))` carries a stack with
+// `apps/web/src/…` frames, so the frameless shape is the noise signature.
+//
+// Same family as `isNonErrorUndefinedRejectionNoise` (PR #5200, pattern
+// `5cfc90e5…`) and `isFirefoxReactSchedulerReentryNoise` (PR #5185, pattern
+// `0f03b24e…`) — frameless browser-internal rejections dropped by a precise
+// matcher with a negative guard preserving any first-party frame.
+//
+// `OperationError` is the WebIDL type for async DOM operations (NOT a Kortix
+// error class) and is generic enough that a real first-party
+// `new OperationError(...)` could surface with the same type — so the matcher
+// anchors on the EXACT message `/^Instance dropped in popErrorScope$/`
+// (case-sensitive), never on the bare `OperationError` type. It requires the
+// frameless shape as a positive guard and a negative guard preserving any
+// first-party `apps/web/src/…` frame.
+// ---------------------------------------------------------------------------
+
+// The exact exception value from the production event.
+const OPERATION_ERROR_POP_ERROR_SCOPE = 'Instance dropped in popErrorScope'
+
+test('classifies the frameless OperationError popErrorScope noise', () => {
+  // Exact production shape: the canonical message, NO frames (the rejection
+  // carried no stack).
+  assert.equal(
+    isOperationErrorPopErrorScopeNoise({
+      message: OPERATION_ERROR_POP_ERROR_SCOPE,
+      frames: [],
+    }),
+    true,
+  )
+})
+
+test('suppresses the assigned OperationError popErrorScope Sentry event via the beforeSend gate', () => {
+  // Exact shape of the production event: type `OperationError`, mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (uncaught global
+  // unhandledrejection — never reached a React error boundary), NO
+  // stacktrace frames, request URL `https://www.kortix.com/instances` (the
+  // marketing/landing page — first occurrence).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://www.kortix.com/instances' },
+      exception: {
+        values: [
+          {
+            value: OPERATION_ERROR_POP_ERROR_SCOPE,
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the post-OAuth OperationError popErrorScope Sentry event (second occurrence)', () => {
+  // The second occurrence: a project page reached from Google account
+  // sign-in (referer `https://accounts.google.com/`), Chrome/Edge/Win.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/198b319d-b710-4443-a797-d813ba16f07a',
+      },
+      exception: {
+        values: [
+          {
+            value: OPERATION_ERROR_POP_ERROR_SCOPE,
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the OperationError popErrorScope noise when frames are absent entirely (no stacktrace key)', () => {
+  // The production event has no frames at all — Sentry omits the stacktrace
+  // key entirely when there is nothing to serialize. The gate must still drop
+  // it (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/instances' },
+      exception: {
+        values: [{ value: OPERATION_ERROR_POP_ERROR_SCOPE }],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the OperationError popErrorScope rejection when a first-party frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code rejected a promise
+  // with an `OperationError` → actionable; the negative guard MUST preserve it
+  // so the call site can be found + fixed. This is the whole reason the
+  // matcher is frame-aware (`OperationError` is a generic WebIDL type a real
+  // first-party `new OperationError(...)` could surface with).
+  for (const frames of [
+    [{ filename: 'apps/web/src/lib/api/client.ts', function: 'fetchProject' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/features/workspace/index.ts', function: 'loadConfig' },
+    ],
+  ]) {
+    assert.equal(
+      isOperationErrorPopErrorScopeNoise({
+        message: OPERATION_ERROR_POP_ERROR_SCOPE,
+        frames,
+      }),
+      false,
+      `expected first-party OperationError popErrorScope rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: OPERATION_ERROR_POP_ERROR_SCOPE, stacktrace: { frames } }],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party OperationError popErrorScope rejection from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress the OperationError popErrorScope rejection when any resolvable (non-first-party) frame is present', () => {
+  // Any resolvable source location (real chunk / URL / named file) means the
+  // rejection is attributable — a real first-party or third-party
+  // `Promise.reject(new OperationError(...))` with a stack we can trace. Keep
+  // reporting; only the frameless capture (the production noise pattern) is
+  // dropped.
+  for (const frames of [
+    [{ filename: 'app:///_next/static/chunks/123-abc.js', function: 'x' }],
+    [{ filename: 'https://cdn.example.com/lib.js', function: 'init' }],
+  ]) {
+    assert.equal(
+      isOperationErrorPopErrorScopeNoise({
+        message: OPERATION_ERROR_POP_ERROR_SCOPE,
+        frames,
+      }),
+      false,
+      `expected attributable OperationError popErrorScope rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a non-matching message (suffix variant)', () => {
+  // The matcher anchors on the EXACT message; a near-miss wording must not be
+  // matched.
+  for (const message of [
+    'Instance dropped in popErrorScopeX',
+    'Instance dropped in popErrorScope.',
+    'Instance dropped in popErrorScope (extra)',
+    'X Instance dropped in popErrorScope',
+    'popErrorScope',
+  ]) {
+    assert.equal(
+      isOperationErrorPopErrorScopeNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a frameless rejection with a different message', () => {
+  // A frameless rejection carrying a DIFFERENT message is a different class —
+  // keep reporting it via this matcher. (The bare-`undefined` non-Error
+  // rejection class has its own dedicated matcher + tests; not re-tested here.)
+  for (const message of [
+    'Something else entirely',
+    'OperationError: a different operation error',
+  ]) {
+    assert.equal(
+      isOperationErrorPopErrorScopeNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected frameless "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event for frameless "${message}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -1644,6 +1644,95 @@ export function isNonErrorUndefinedRejectionNoise(input: {
   return true;
 }
 
+// Browser-internal DOM/binding `OperationError` noise — `Instance dropped in
+// popErrorScope`. `popErrorScope` is part of the WebIDL/internal error-scope
+// machinery (DOMQueuingStrategy, ResizeObserver, IntersectionObserver, media
+// streams, GPU, …), NOT a first-party Kortix API. Some browser code paths
+// (Firefox-originated; also emitted by some Chromium/Edge paths) surface a
+// frameless `OperationError: Instance dropped in popErrorScope` as an
+// unhandled promise rejection via the global `onunhandledrejection` handler.
+// Better Stack pattern
+// 5e1aca208331fa2d7540c9810b815b6c94f1373c470ff54e15f39d389dac7e0c
+// (Kortix Frontend prod, application_id 2346967): `OperationError`, 2
+// occurrences EVER across a 90-day window (first 2026-04-28 18:41:18 UTC on
+// `https://www.kortix.com/instances` Chrome/Win, last 2026-07-22 18:26:35 UTC
+// on `https://kortix.com/projects/<id>` reached from Google account sign-in
+// Chrome/Edge/Win), 0 identified users (anonymous), mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (`handled:false` —
+// UNCAUGHT, never reached a React error boundary). The exception payload is
+// `{"values":[{"type":"OperationError","value":"Instance dropped in
+// popErrorScope","mechanism":{"type":"auto.browser.global_handlers.
+// onunhandledrejection","handled":false}}]}` — NO `stacktrace`, NO frames, NO
+// `call_site_file`/`call_site_function`, NO `call_stack_hash`. A real
+// first-party `Promise.reject(new OperationError(...))` carries a stack with
+// `apps/web/src/…` frames, so the frameless shape is the noise signature.
+//
+// The same family as the prior frameless browser-internal rejection noise
+// matchers — `isNonErrorUndefinedRejectionNoise` (PR #5200, pattern
+// `5cfc90e5…`) and `isFirefoxReactSchedulerReentryNoise` (PR #5185, pattern
+// `0f03b24e…`).
+//
+// `OperationError` is the WebIDL type for async DOM operations, NOT a Kortix
+// error class, and it is a GENERIC type a real first-party
+// `new OperationError(...)` could also surface with — so the matcher anchors on
+// the EXACT message `/^Instance dropped in popErrorScope$/` (case-sensitive),
+// never on the bare `OperationError` type. It additionally requires the
+// frameless shape as a positive guard (no resolvable frame / no
+// `call_site_file` / no stack) — the production noise pattern carries NO
+// stack — mirroring the negative-guard pattern from PR #5200's
+// `isNonErrorUndefinedRejectionNoise`: any resolved first-party
+// `apps/web/src/…` frame → KEEP reporting (a real first-party `OperationError`
+// rejection with a stack is preserved); any other resolvable frame location →
+// keep reporting. Only the frameless capture is dropped. Deliberately NOT
+// added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no
+// frame context, so a bare-string match there could swallow a real first-party
+// `OperationError` rejection the negative guard exists to preserve; the
+// frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`)
+// is the only safe gate.
+const OPERATION_ERROR_POP_ERROR_SCOPE_PATTERN =
+  /^Instance dropped in popErrorScope$/;
+
+/**
+ * Whether a Sentry event is the browser-internal DOM/binding
+ * `OperationError: Instance dropped in popErrorScope` noise class:
+ * `popErrorScope` is part of the WebIDL/internal error-scope machinery
+ * (DOMQueuingStrategy, ResizeObserver, IntersectionObserver, media streams,
+ * GPU, …), NOT a first-party Kortix API. Some browser code paths surface a
+ * frameless `OperationError` with this exact message as an uncaught global
+ * `onunhandledrejection` — never first-party app code. Requires the EXACT
+ * message (case-sensitive; `OperationError` alone is a generic WebIDL type a
+ * real first-party `new OperationError(...)` could also surface with) AND a
+ * NEGATIVE guard: if any frame resolves to a de-minified first-party
+ * `apps/web/src/…` source path OR any resolvable frame location at all, the
+ * event keeps reporting (a real first-party `OperationError` rejection we can
+ * attribute should still surface). The production noise pattern has NO frames
+ * at all; only the frameless capture is dropped. See
+ * `OPERATION_ERROR_POP_ERROR_SCOPE_PATTERN` for the full rationale.
+ */
+export function isOperationErrorPopErrorScopeNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const message = normalizeString(input.message);
+  if (!OPERATION_ERROR_POP_ERROR_SCOPE_PATTERN.test(message)) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  // Negative guard #1: a resolved first-party `apps/web/src/…` frame means our
+  // own code rejected a promise with an `OperationError` → actionable; keep
+  // reporting so the call site can be found + fixed.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  // Negative guard #2: any resolvable source location (real chunk/URL/named
+  // file) → an attributable error with a real stack; keep reporting. Only the
+  // frameless capture (the production noise pattern) remains → drop it.
+  if (frames.some((frame) => isResolvableFrameSource(frame?.filename))) {
+    return false;
+  }
+  return true;
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -2115,6 +2204,23 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // `isNonErrorUndefinedRejectionNoise`. NOT in `ignoreErrors` (no frame
   // context there).
   if (isNonErrorUndefinedRejectionNoise({ message, frames })) {
+    return true;
+  }
+
+  // Browser-internal DOM/binding `OperationError: Instance dropped in
+  // popErrorScope` noise — `popErrorScope` is part of the WebIDL/internal
+  // error-scope machinery (DOMQueuingStrategy, ResizeObserver,
+  // IntersectionObserver, media streams, GPU, …), NOT a first-party API. Some
+  // browser code paths surface a frameless `OperationError` with this exact
+  // message as an uncaught global `onunhandledrejection`; never first-party
+  // app code. Requires the EXACT message AND NEGATIVE guards: any resolved
+  // first-party `apps/web/src/…` frame OR any resolvable frame location → keep
+  // reporting (a real first-party `OperationError` rejection we can attribute
+  // should still surface). The production noise pattern has NO frames at all;
+  // only the frameless capture is dropped. See
+  // `isOperationErrorPopErrorScopeNoise`. NOT in `ignoreErrors` (no frame
+  // context there).
+  if (isOperationErrorPopErrorScopeNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Adds a precise frameless-rejection noise matcher for the Better Stack error `OperationError — Instance dropped in popErrorScope` (pattern `5e1aca20…`, Kortix Frontend prod, application_id 2346967), wired into Sentry `beforeSend` via `shouldIgnoreSentryBrowserNoise`.

## The error (one — deduped)

- **Better Stack:** https://errors.betterstack.com/team/t502678/errors/5e1aca208331fa2d7540c9810b815b6c94f1373c470ff54e15f39d389dac7e0c?s=2346967
- **Pattern:** `5e1aca208331fa2d7540c9810b815b6c94f1373c470ff54e15f39d389dac7e0c`
- **Type:** `OperationError` — **Message:** `Instance dropped in popErrorScope`
- **Mechanism:** `auto.browser.global_handlers.onunhandledrejection` (`handled:false` — UNCAUGHT, never reached a React error boundary)
- **Count:** 2 occurrences EVER across a 90-day window (first 2026-04-28 18:41:18 UTC, last 2026-07-22 18:26:35 UTC), 0 identified users, anonymous
- **Stack:** NONE — `{"values":[{"type":"OperationError","value":"Instance dropped in popErrorScope","mechanism":{"type":"auto.browser.global_handlers.onunhandledrejection","handled":false}}]}` — NO `stacktrace`, NO frames, NO `call_site_file`/`call_site_function`, NO `call_stack_hash`.
- **Occurrences:**
  1. 2026-04-28: request URL `https://www.kortix.com/instances`, UA Chrome 147 Windows — marketing/landing page
  2. 2026-07-22: request URL `https://kortix.com/projects/198b319d-b710-4443-a797-d813ba16f07a`, Referer `https://accounts.google.com/`, UA Chrome 150 Windows Edg/150 — a project page reached from Google account sign-in

## Root cause (browser noise, not a product bug)

`Instance dropped in popErrorScope` is a **browser-internal DOM/binding `OperationError`** (Firefox-originated; also emitted by some Chromium/Edge paths) that surfaces as a frameless unhandled promise rejection. `popErrorScope` is part of the WebIDL/internal error-scope machinery (DOMQueuingStrategy, ResizeObserver, IntersectionObserver, media streams, GPU, etc.), **NOT a first-party Kortix API**. The signals that confirm this is browser noise:

- **FRAMELESS** — no stack frames at all (`call_site_file`/`call_site_function` null, `call_stack_hash` null). A real first-party `Promise.reject(new OperationError(...))` carries a stack with `apps/web/src/…` frames.
- **`handled:false` UNCAUGHT** global rejection — never reached a React error boundary.
- **2 occurrences in 90 days, 0 users, on unrelated marketing + post-OAuth routes** — not a recurring product flow.
- **`OperationError` type** is the WebIDL type for async DOM operations, not a Kortix error class.

This is the same family as the prior frameless browser-internal rejection noise matchers — `isNonErrorUndefinedRejectionNoise` (PR #5200, pattern `5cfc90e5…`) and `isFirefoxReactSchedulerReentryNoise` (PR #5185, pattern `0f03b24e…`).

## The fix

Add a new matcher `isOperationErrorPopErrorScopeNoise` to `apps/web/src/lib/browser-error-noise.ts`, wired into Sentry `beforeSend` via `shouldIgnoreSentryBrowserNoise` (the same place the other noise matchers are wired). The matcher:

1. **Anchors on the EXACT message:** `/^Instance dropped in popErrorScope$/` (case-sensitive). Does **NOT** match on the bare `OperationError` type alone — that's a generic WebIDL type and a real first-party `new OperationError(...)` could surface with the same type.
2. **Requires the frameless shape** as a positive guard (no resolvable frame / no `call_site_file` / no stack) — the production noise pattern carries NO stack. Uses the same "any resolvable frame → keep reporting" negative-guard pattern as PR #5200's `isNonErrorUndefinedRejectionNoise`.
3. **Negative guard:** any resolved first-party `apps/web/src/…` frame → KEEP reporting (a real first-party `OperationError` rejection with a stack is preserved). Any resolvable frame location → keep reporting. Only the frameless capture is dropped.
4. **Deliberately NOT added** to `sentry.client.config.ts`'s `ignoreErrors` (no frame context there); only the frame-aware `beforeSend` gate.

### Files + lines
- `apps/web/src/lib/browser-error-noise.ts`:
  - `OPERATION_ERROR_POP_ERROR_SCOPE_PATTERN` constant + `isOperationErrorPopErrorScopeNoise` export matcher (~line 1692–1730)
  - Wired into `shouldIgnoreSentryBrowserNoise` right after `isNonErrorUndefinedRejectionNoise` (~line 2213–2225)
- `apps/web/src/lib/browser-error-noise.test.mts`: 8 regression tests appended (+ import)

## Verification

- **Noise tests:** `node --experimental-strip-types --test apps/web/src/lib/browser-error-noise.test.mts` → **161 pass / 0 fail** (153 prior + 8 new). New tests pin:
  - the production event (frameless `OperationError` `Instance dropped in popErrorScope` onunhandledrejection) through BOTH the classifier and the Sentry `beforeSend` gate (both occurrences' URLs), and when the `stacktrace` key is absent entirely;
  - negative cases: a first-party `OperationError` with an `apps/web/src/…` frame is NOT dropped; a non-matching message (`Instance dropped in popErrorScopeX` / `.`-suffix / extra context / prefix / bare `popErrorScope`) is NOT dropped; a frameless rejection with a different message is NOT dropped.
- **Typecheck:** `tsc --noEmit -p apps/web/tsconfig.json` — no errors in `browser-error-noise.ts` or its test file (the only 3 errors are pre-existing and unrelated: `.source` generated module + an unrelated `template-url.test.ts`).
- Did NOT boot the full stack (a noise filter does not require it).

## Confirm

After this merges + promotes, the Better Stack error `5e1aca20…` should drop to zero new occurrences (the frameless `OperationError` `popErrorScope` browser-internal rejection is dropped at the Sentry `beforeSend` gate before it reaches Better Stack). A real first-party `OperationError` rejection (with a stack) is preserved by the negative guard.