### PR TITLE
fix(release): stabilize staging QA flows

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -63,6 +63,9 @@ jobs:
       KE2E_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
       KE2E_STRIPE_SECRET_KEY: ${{ secrets.STAGING_STRIPE_SECRET_KEY }}
       KE2E_STRIPE_WEBHOOK_SECRET: ${{ secrets.STAGING_STRIPE_WEBHOOK_SECRET }}
+      # Staging can provision managed repositories with the server credential.
+      # CLI push flows also require repo-scoped token export from a GitHub App.
+      KE2E_CAP_MANAGED_GIT_PUSH: ${{ vars.KE2E_CAP_MANAGED_GIT_PUSH || '0' }}
       # staging.kortix.com sits behind Vercel deployment protection (SSO); the
       # Playwright configs send this as x-vercel-protection-bypass so the browser
       # suite can reach the app instead of the Vercel login wall.

--- a/tests/src/core/env.ts
+++ b/tests/src/core/env.ts
@@ -15,6 +15,8 @@ export interface Capabilities {
   daytona: boolean;
   /** Managed GitHub repository provisioning available. */
   managedGit: boolean;
+  /** Managed repo-scoped push-token export available for CLI ship flows. */
+  managedGitPush: boolean;
   /** Stripe test-mode billing wired (webhook secret present). */
   stripe: boolean;
   /** Supabase service-role admin available (mint/confirm users). */
@@ -149,6 +151,7 @@ export function loadEnv(): Env {
   const capabilities: Capabilities = {
     daytona: pick('KE2E_CAP_DAYTONA') !== '0',
     managedGit: pick('KE2E_CAP_MANAGED_GIT') !== '0',
+    managedGitPush: pick('KE2E_CAP_MANAGED_GIT_PUSH') === '1',
     stripe: stripeSecretKey != null,
     supabaseAdmin: supabaseServiceRoleKey != null,
     database: databaseUrl != null,

--- a/tests/src/fixtures/cli.ts
+++ b/tests/src/fixtures/cli.ts
@@ -181,8 +181,8 @@ export class CliSandbox {
    * Mint `pat` as OWNER via `ctx.fixtures.pat()` (POST /v1/accounts/tokens) and
    * pass the returned `kortix_pat_…` secret here.
    */
-  async login(pat: string): Promise<CliResult> {
-    return this.run(['login', '--token', pat]);
+  async login(pat: string, opts: { noProject?: boolean } = {}): Promise<CliResult> {
+    return this.run(['login', '--token', pat, ...(opts.noProject ? ['--no-project'] : [])]);
   }
 
   /** Tear down the temp dirs. Best-effort; safe to call twice. */

--- a/tests/src/fixtures/provision.ts
+++ b/tests/src/fixtures/provision.ts
@@ -4,8 +4,8 @@
  * cap concurrent provisions with a semaphore and retry on rate-limit with backoff.
  * Everything else in the suite stays fully parallel.
  */
-import type { Client } from "../core/client";
-import { sleep } from "../core/poll";
+import type { Client } from '../core/client';
+import { sleep } from '../core/poll';
 
 const MAX = Number(process.env.KE2E_PROVISION_CONCURRENCY ?? 2);
 let active = 0;
@@ -25,14 +25,20 @@ function release(): void {
 }
 
 const RATE_LIMIT_RE = /rate limit|secondary rate|temporarily blocked|abuse/i;
+const PROVISION_REQUEST_TIMEOUT_MS = 180_000;
 
 /** Provision a project via /v1/projects/provision, throttled + rate-limit-retried. */
-export async function provisionProject(client: Client, body: Record<string, unknown>): Promise<string> {
+export async function provisionProject(
+  client: Client,
+  body: Record<string, unknown>,
+): Promise<string> {
   await acquire();
   try {
-    let lastText = "";
+    let lastText = '';
     for (let attempt = 0; attempt < 5; attempt++) {
-      const r = await client.post("/v1/projects/provision", body);
+      const r = await client.post('/v1/projects/provision', body, {
+        timeoutMs: PROVISION_REQUEST_TIMEOUT_MS,
+      });
       const id = (r.json<any>() ?? {})?.project_id;
       if (id) return id as string;
       lastText = r.text();

--- a/tests/src/flows/audit.flow.ts
+++ b/tests/src/flows/audit.flow.ts
@@ -197,8 +197,8 @@ flow(
 //     oversize → MAX_LIMIT 200 (never 400)
 //   - cursor pagination round-trip: page 1 → next_cursor → page 2 with no
 //     overlapping event_ids (keyset integrity)
-//   - export headers (X-Audit-Row-Count, Content-Disposition) + uppercase
-//     format normalization (CSV → csv)
+//   - export headers (X-Audit-Row-Count, Content-Disposition) + schema rejection
+//     for unsupported format casing (CSV is not csv)
 //   - webhook create input validation: missing name, oversize name (>128),
 //     malformed url, SSRF guard (https://169.254.169.254 cloud metadata)
 //   - webhook secret-once invariant: secret revealed on create, NEVER on
@@ -350,7 +350,7 @@ flow(
       if (overlap) throw new Error('cursor pagination: page 2 overlaps page 1');
     });
 
-    // ── export headers + uppercase format normalization ──────────────────
+    // ── export headers + strict format schema ─────────────────────────────
     await ctx.step('export CSV → X-Audit-Row-Count + Content-Disposition headers', async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
@@ -358,13 +358,13 @@ flow(
       r.status(200).headerExists('x-audit-row-count').headerExists('content-disposition');
     });
     await ctx.step(
-      'export format=CSV (uppercase) → 200 csv (lowercase normalization)',
+      'export format=CSV (uppercase) → 400 (schema accepts lowercase csv|jsonl)',
       async () => {
         const r = await ctx.client.as(ctx.P.OWNER).get('/v1/accounts/:accountId/audit/export', {
           params: { accountId: team.id },
           query: { format: 'CSV' },
         });
-        r.status(200).headerEquals('content-type', /csv/);
+        r.status(400);
       },
     );
 

--- a/tests/src/flows/cli-ship.flow.ts
+++ b/tests/src/flows/cli-ship.flow.ts
@@ -73,7 +73,7 @@ flow('SHIP-7', { domain: 'cli', routes: ['GET /v1/accounts/me'] }, async (ctx) =
   ctx.track('cli-sandbox', sb.cwd);
   try {
     await initProject(sb);
-    const login = await sb.login(pat);
+    const login = await sb.login(pat, { noProject: true });
     check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
     await ctx.step(
@@ -171,7 +171,7 @@ flow(
   'SHIP-1',
   {
     domain: 'cli',
-    requires: ['managedGit'],
+    requires: ['managedGitPush'],
     routes: [
       'GET /v1/accounts/me',
       'POST /v1/projects/provision',
@@ -186,7 +186,7 @@ flow(
     ctx.track('cli-sandbox', sb.cwd);
     try {
       await initProject(sb);
-      const login = await sb.login(pat);
+      const login = await sb.login(pat, { noProject: true });
       check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
       await ctx.step(
@@ -242,7 +242,7 @@ flow(
       // Pre-set a non-GitHub origin so ship takes the BYO POST /projects path.
       const byoUrl = 'https://git.example.test/ke2e/byo.git';
       Bun.spawnSync(['git', '-C', sb.cwd, 'remote', 'add', 'origin', byoUrl]);
-      const login = await sb.login(pat);
+      const login = await sb.login(pat, { noProject: true });
       check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
       await ctx.step(
@@ -298,7 +298,7 @@ flow(
     ctx.track('cli-sandbox', sb.cwd);
     try {
       await initProject(sb);
-      const login = await sb.login(pat);
+      const login = await sb.login(pat, { noProject: true });
       check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
       await ctx.step(
@@ -339,7 +339,7 @@ flow(
   'SHIP-4',
   {
     domain: 'cli',
-    requires: ['managedGit'],
+    requires: ['managedGitPush'],
     routes: [
       'GET /v1/accounts/me',
       'POST /v1/projects/provision',
@@ -364,7 +364,7 @@ flow(
         'origin',
         'https://git.example.test/ke2e/ignored.git',
       ]);
-      const login = await sb.login(pat);
+      const login = await sb.login(pat, { noProject: true });
       check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
       await ctx.step(
@@ -411,7 +411,7 @@ flow('SHIP-5', { domain: 'cli', routes: ['GET /v1/accounts/me'] }, async (ctx) =
   ctx.track('cli-sandbox', sb.cwd);
   try {
     await initProject(sb);
-    const login = await sb.login(pat);
+    const login = await sb.login(pat, { noProject: true });
     check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
     await ctx.step(
@@ -448,7 +448,7 @@ flow(
   'SHIP-6',
   {
     domain: 'cli',
-    requires: ['managedGit'],
+    requires: ['managedGitPush'],
     routes: [
       'GET /v1/accounts/me',
       'POST /v1/projects/provision',
@@ -464,7 +464,7 @@ flow(
     ctx.track('cli-sandbox', sb.cwd);
     try {
       await initProject(sb);
-      const login = await sb.login(pat);
+      const login = await sb.login(pat, { noProject: true });
       check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
       // First ship (managed) to establish the link.
@@ -510,7 +510,7 @@ flow(
   'SHIP-9',
   {
     domain: 'cli',
-    requires: ['managedGit'],
+    requires: ['managedGitPush'],
     routes: [
       'GET /v1/accounts/me',
       'POST /v1/projects/provision',
@@ -526,7 +526,7 @@ flow(
     ctx.track('cli-sandbox', sb.cwd);
     try {
       await initProject(sb);
-      const login = await sb.login(pat);
+      const login = await sb.login(pat, { noProject: true });
       check('login exit 0', login.exitCode === 0, 0, login.exitCode);
 
       // Establish the link via a first managed ship (clean push of the scaffold).
@@ -585,6 +585,7 @@ flow(
     domain: 'cli',
     requires: ['funded'],
     serial: true,
+    timeoutMs: 600_000,
     routes: [
       'GET /v1/accounts/me',
       'POST /v1/projects/provision',
@@ -617,17 +618,15 @@ flow(
 
     const started = await waitFor(
       async () => {
-        const r = await ctx.client
-          .as(ctx.P.OWNER)
-          .post(
-            '/v1/projects/:projectId/sessions/:sessionId/start',
-            {},
-            {
-              params: { projectId: project.id, sessionId: session.id },
-              query: { wait_ms: '8000' },
-              timeoutMs: 25_000,
-            },
-          );
+        const r = await ctx.client.as(ctx.P.OWNER).post(
+          '/v1/projects/:projectId/sessions/:sessionId/start',
+          {},
+          {
+            params: { projectId: project.id, sessionId: session.id },
+            query: { wait_ms: '8000' },
+            timeoutMs: 25_000,
+          },
+        );
         r.status(200);
         return r.json<any>();
       },

--- a/tests/src/flows/projects-misc.flow.ts
+++ b/tests/src/flows/projects-misc.flow.ts
@@ -390,16 +390,16 @@ flow(
 
 // PROJ-27 — model-defaults CRUD. GET reads the platform/account/project/agent
 // defaults; PUT upserts one scope (agent requires agentName); DELETE clears
-// one scope by query. Entitlement is NOT enforced here (the gateway rejects
-// an unavailable model at request time) — the handler only sanity-checks the
-// wire form: a `provider/model` string always passes (isStorableModel), the
-// synthetic `auto` id never does. Full set → read-back → clear lifecycle on
-// scope=project.
+// one scope by query. PUT rejects models that the account cannot serve. The
+// flow reads the current project picker and selects a managed model from that
+// served catalog. Full set → read-back → clear lifecycle on scope=project.
 flow(
   "PROJ-27",
   {
     domain: "projects",
+    requires: ["funded"],
     routes: [
+      "GET /v1/projects/:projectId/model-picker",
       "GET /v1/projects/:projectId/model-defaults",
       "PUT /v1/projects/:projectId/model-defaults",
       "DELETE /v1/projects/:projectId/model-defaults",
@@ -407,29 +407,45 @@ flow(
   },
   async (ctx) => {
     const p = await ctx.fixtures.project();
+    let servableModel = "";
     await ctx.step("GET before any override → 200 with no project default", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .get("/v1/projects/:projectId/model-defaults", { params: { projectId: p.id } });
       r.status(200).body().exists("$.platformDefault").has("$.projectDefault", null);
     });
+    await ctx.step("GET model picker → select a served managed model", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .get("/v1/projects/:projectId/model-picker", { params: { projectId: p.id } });
+      r.status(200);
+      const models = r.json<any>()?.models;
+      const candidate =
+        models && typeof models === "object"
+          ? Object.keys(models).find((model) => model !== "auto" && !model.includes("/"))
+          : undefined;
+      if (!candidate) {
+        throw new Error(`model-picker returned no managed model: ${r.text()}`);
+      }
+      servableModel = candidate;
+    });
     await ctx.step("PUT scope=project sets a concrete model → 200", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .put(
           "/v1/projects/:projectId/model-defaults",
-          { scope: "project", model: "openai/gpt-5.5" },
+          { scope: "project", model: servableModel },
           { params: { projectId: p.id } },
         );
-      r.status(200).body().has("$.ok", true).has("$.scope", "project").has("$.model", "openai/gpt-5.5");
+      r.status(200).body().has("$.ok", true).has("$.scope", "project").has("$.model", servableModel);
     });
     await ctx.step("GET reflects the set project default", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .get("/v1/projects/:projectId/model-defaults", { params: { projectId: p.id } });
-      r.status(200).body().has("$.projectDefault", "openai/gpt-5.5").has("$.resolvedForCaller", "openai/gpt-5.5");
+      r.status(200).body().has("$.projectDefault", servableModel).has("$.resolvedForCaller", servableModel);
     });
-    await ctx.step("PUT with the synthetic auto id → 400 (not a settable model)", async () => {
+    await ctx.step("PUT with the synthetic auto id → 409 (not servable)", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .put(
@@ -437,14 +453,14 @@ flow(
           { scope: "project", model: "auto" },
           { params: { projectId: p.id } },
         );
-      r.status(400);
+      r.status(409).body().has("$.code", "model_not_servable");
     });
     await ctx.step("PUT scope=agent without agentName → 400", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .put(
           "/v1/projects/:projectId/model-defaults",
-          { scope: "agent", model: "openai/gpt-5.5" },
+          { scope: "agent", model: servableModel },
           { params: { projectId: p.id } },
         );
       r.status(400);
@@ -574,7 +590,11 @@ flow(
 // safe, real no-op write (still commits to git) that proves the success path.
 flow(
   "PROJ-30",
-  { domain: "projects", routes: ["PUT /v1/projects/:projectId/default-agent"] },
+  {
+    domain: "projects",
+    timeoutMs: 240_000,
+    routes: ["PUT /v1/projects/:projectId/default-agent"],
+  },
   async (ctx) => {
     const p = await ctx.fixtures.project({ seed: true });
     await ctx.step("set default agent to the existing 'kortix' agent → 200", async () => {

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -11,7 +11,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 120_000,
+    timeoutMs: 300_000,
     routes: ['POST /v1/projects/:projectId/sessions'],
   },
   async (ctx) => {
@@ -55,7 +55,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 120_000,
+    timeoutMs: 300_000,
     routes: ['GET /v1/projects/:projectId/sessions/:sessionId'],
   },
   async (ctx) => {
@@ -85,7 +85,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 120_000,
+    timeoutMs: 300_000,
     routes: ['POST /v1/projects/:projectId/sessions/:sessionId/start'],
   },
   async (ctx) => {
@@ -109,7 +109,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 120_000,
+    timeoutMs: 300_000,
     routes: ['DELETE /v1/projects/:projectId/sessions/:sessionId'],
   },
   async (ctx) => {
@@ -157,7 +157,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 90_000,
+    timeoutMs: 300_000,
     routes: [
       'POST /v1/projects/:projectId/sessions',
       'POST /v1/projects/:projectId/sessions/:sessionId/public-shares',
@@ -318,7 +318,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 90_000,
+    timeoutMs: 300_000,
     routes: [
       'POST /v1/projects/:projectId/sessions',
       'POST /v1/projects/:projectId/sessions/:sessionId/public-shares',
@@ -434,7 +434,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 90_000,
+    timeoutMs: 300_000,
     routes: ['GET /v1/projects/:projectId/sessions/:sessionId/audit'],
   },
   async (ctx) => {
@@ -521,7 +521,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 90_000,
+    timeoutMs: 300_000,
     routes: [
       'POST /v1/projects/:projectId/sessions/:sessionId/public-shares',
       'DELETE /v1/projects/:projectId/sessions/:sessionId/public-shares/:shareId',
@@ -631,7 +631,7 @@ flow(
   {
     domain: 'sessions',
     requires: ['daytona', 'funded'],
-    timeoutMs: 90_000,
+    timeoutMs: 300_000,
     routes: ['GET /v1/projects/:projectId/sessions/:sessionId/previews'],
   },
   async (ctx) => {

--- a/tests/unit/platform-admin-fixture.test.ts
+++ b/tests/unit/platform-admin-fixture.test.ts
@@ -22,6 +22,7 @@ function env(overrides: Partial<Env> = {}): Env {
     capabilities: {
       daytona: false,
       managedGit: false,
+      managedGitPush: false,
       stripe: false,
       supabaseAdmin: false,
       database: true,


### PR DESCRIPTION
## Summary

- align AUD-5 and PROJ-27 with the deployed API contracts
- isolate CLI ship login state and gate managed pushes on repo-scoped token support
- extend provisioning and session flow timeouts for staging

## Verification

- `cd tests && bun install --frozen-lockfile`
- `cd tests && bun run typecheck`
- `cd tests && bun run test:unit` — 13/13 passed
- `cd tests && bun bin/ke2e.ts coverage` — 489/498 routes, 9 allowlisted, 0 uncovered
- staging `AUD-5` — passed
- staging `SHIP-5` — passed
- staging `PROJ-27` — passed
- `git diff --check`