### PR TITLE
Reconcile security baseline apply

### DIFF
--- a/infra/terraform/security-baseline/imports.tf
+++ b/infra/terraform/security-baseline/imports.tf
@@ -102,6 +102,10 @@ import {
   id = "0f55c185-2a80-467e-95dd-e0d969c93f52"
 }
 import {
+  to = aws_backup_selection.daily
+  id = "0f55c185-2a80-467e-95dd-e0d969c93f52|c997845c-aeae-459e-8de1-0c405e0c5627"
+}
+import {
   to = aws_iam_role.flow_logs
   id = "vpc-flow-logs-role"
 }

--- a/infra/terraform/security-baseline/main.tf
+++ b/infra/terraform/security-baseline/main.tf
@@ -103,8 +103,17 @@ resource "aws_sns_topic" "cloudtrail" {
 
 data "aws_iam_policy_document" "cloudtrail_sns" {
   statement {
-    sid       = "AccountAdministration"
-    actions   = ["SNS:*"]
+    sid = "AccountAdministration"
+    actions = [
+      "SNS:AddPermission",
+      "SNS:DeleteTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:Publish",
+      "SNS:RemovePermission",
+      "SNS:SetTopicAttributes",
+      "SNS:Subscribe",
+    ]
     resources = [aws_sns_topic.cloudtrail.arn]
     principals {
       type        = "AWS"


### PR DESCRIPTION
## Summary

- replace the invalid `SNS:*` topic-policy action with the supported SNS action set
- import the existing AWS Backup selection into the security-baseline state

## Verification

- `terraform validate`: success
- `git diff --check`: success
- live Terraform plan: `1 to import, 1 to add, 1 to change, 0 to destroy`
- Checkov: `972 passed, 0 failed`