### PR TITLE
hardening(kaab): ensureReady transient-null fix, hot-push SLACK_BOT_TOKEN scrub, tests + docs

### DIFF
--- a/apps/api/src/projects/lib/sandbox-env-names.ts
+++ b/apps/api/src/projects/lib/sandbox-env-names.ts
@@ -3,8 +3,15 @@ const RESERVED_SANDBOX_ENV_NAMES = new Set([
   'TERM', 'TMPDIR', 'NODE_ENV', 'NODE_OPTIONS', 'LD_PRELOAD', 'LD_LIBRARY_PATH',
 ]);
 
+// Secrets the sandbox must NEVER see, even though the platform holds them.
+// Boot (buildSessionSandboxEnvVars) deletes SLACK_BOT_TOKEN explicitly to keep
+// the raw bot token away from a prompt-injectable agent (KORTIX-206). The
+// hot-push path (resolveSandboxEnvSnapshot → sanitizeSandboxEnv) scrubs THIS
+// set, so SLACK_BOT_TOKEN must be here too or a live env re-sync would re-inject
+// what boot withheld.
 const NEVER_IN_SANDBOX = new Set([
   'SLACK_SIGNING_SECRET',
+  'SLACK_BOT_TOKEN',
 ]);
 
 export function isReservedSandboxEnvName(name: string): boolean {

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -514,3 +514,24 @@ describe('session connector profile contracts', () => {
     ).toBe(false);
   });
 });
+
+describe('SessionCreateInputSchema backend overrides (origin_ref + secrets bounds)', () => {
+  test('origin_ref: trims, accepts a normal handle, rejects >256 chars and whitespace-only', () => {
+    expect(SessionCreateInputSchema.safeParse({ origin_ref: 'tenant-42' }).success).toBe(true);
+    expect(SessionCreateInputSchema.safeParse({ origin_ref: 'x'.repeat(257) }).success).toBe(false);
+    expect(SessionCreateInputSchema.safeParse({ origin_ref: '   ' }).success).toBe(false);
+    expect(SessionCreateInputSchema.parse({ origin_ref: '  tenant-7  ' }).origin_ref).toBe('tenant-7');
+  });
+
+  test('secrets: accepts an identifier list and [] (narrow to zero), rejects an over-long list', () => {
+    expect(SessionCreateInputSchema.safeParse({ secrets: ['GMAIL_TOKEN', 'STRIPE_KEY'] }).success).toBe(
+      true,
+    );
+    expect(SessionCreateInputSchema.safeParse({ secrets: [] }).success).toBe(true);
+    expect(
+      SessionCreateInputSchema.safeParse({
+        secrets: Array.from({ length: 129 }, (_, i) => `S${i}`),
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/sdk/GETTING-STARTED.md
+++ b/packages/sdk/GETTING-STARTED.md
@@ -127,6 +127,11 @@ that changes is `import { … } from '@kortix/sdk'`.
 | `06-files-and-secrets.ts` | session-scoped workspace files + project secrets | PAT + project + session |
 | `07-vanilla.ts` | **the whole flow in one file** — list → ready → stream → send → classify | PAT + project + session |
 | `08-cdn.html` | the same thing from a `<script>` tag, **no build step, no framework** | bundles built + browser |
+| `09-kaab-backend-wrapper.ts` | **Kortix as a Backend, end-to-end** — mint a connector → per-user profile → backend-origin session (`origin_ref` + `secrets` + `connector_bindings`) → stream; one-shot CLI **and** an SSE service | PAT + project |
+
+See [`examples/README.md`](./examples/README.md) for the full index and per-example
+env vars, and [`docs/KORTIX_AS_A_BACKEND_GUIDE.md`](../../docs/KORTIX_AS_A_BACKEND_GUIDE.md)
+for the backend concepts (`origin`, overrides, connectors, security model).
 
 Start with:
 

--- a/packages/sdk/examples/09-kaab-backend-wrapper.ts
+++ b/packages/sdk/examples/09-kaab-backend-wrapper.ts
@@ -50,7 +50,7 @@ const includeOverrides = process.env.KAAB_OVERRIDES !== 'off';
 
 // Which connector/agent/model/secret this wrapper drives — all overridable.
 const CONNECTOR_SLUG = process.env.KAAB_CONNECTOR_SLUG ?? 'user-mcp';
-const CONNECTOR_ENDPOINT = process.env.KAAB_CONNECTOR_ENDPOINT ?? 'https://mcp.example.com/mcp';
+const CONNECTOR_URL = process.env.KAAB_CONNECTOR_URL ?? 'https://mcp.example.com/mcp';
 const AGENT_NAME = process.env.KAAB_AGENT; // undefined → project default agent
 const MODEL = process.env.KAAB_MODEL; // undefined → project/agent default model
 const SECRET_ID = process.env.KAAB_SECRET; // one project-secret identifier to narrow to
@@ -93,7 +93,7 @@ async function ensureConnector(kortix: ReturnType<typeof clientFor>): Promise<vo
     slug: CONNECTOR_SLUG,
     provider: 'mcp',
     transport: 'http',
-    url: CONNECTOR_ENDPOINT,
+    url: CONNECTOR_URL,
     credential: 'shared',
     auth: { type: 'bearer', in: 'header', name: 'Authorization', prefix: 'Bearer ' },
   });

--- a/packages/sdk/examples/README.md
+++ b/packages/sdk/examples/README.md
@@ -1,0 +1,63 @@
+# `@kortix/sdk` examples
+
+Runnable, framework-free examples for the Kortix SDK — from a one-line
+`projects.list()` to a full **Kortix-as-a-Backend** wrapper that serves many of
+your own end-users through one shared agent.
+
+Each `.ts` file runs on [Bun](https://bun.sh) and imports the SDK from source
+(`../src/...`), so you can read the exact code path. As an npm consumer the
+imports are `@kortix/sdk`, `@kortix/sdk/server`, `@kortix/sdk/turns`, etc.
+(noted in each file).
+
+## Setup
+
+```bash
+export KORTIX_API_URL=https://api.kortix.com/v1   # your API base, incl. /v1
+export KORTIX_API_KEY=kortix_pat_...              # Settings → Tokens → Create API key
+export KORTIX_PROJECT_ID=...                      # the project your agent lives in
+```
+
+- The API key is a `kortix_pat_…` token. Every session it starts is recorded
+  with `origin: backend`, which is what unlocks the backend-only overrides
+  (`origin_ref`, `secrets`) — see the [Kortix-as-a-Backend
+  guide](../../../docs/KORTIX_AS_A_BACKEND_GUIDE.md).
+- Some examples read extra env vars (a session id, a connector URL); each file's
+  header comment lists what it needs.
+
+## The examples
+
+| # | File | What it shows | Run |
+|---|------|---------------|-----|
+| 01 | [`01-list-projects.ts`](01-list-projects.ts) | Minimum viable client — `createKortix` + a static bearer token, list projects. | `bun run examples/01-list-projects.ts` |
+| 02 | [`02-send-and-stream.ts`](02-send-and-stream.ts) | Provision a session, send a prompt, stream the text deltas — no framework. | `KORTIX_SESSION_ID=… bun run examples/02-send-and-stream.ts "hi"` |
+| 03 | [`03-server-wrapper.ts`](03-server-wrapper.ts) | The multi-tenant seam: `createScopedKortix` from `@kortix/sdk/server` (per-request token, no global bleed). | `MODE=serve bun run examples/03-server-wrapper.ts` |
+| 04 | [`04-render-transcript.ts`](04-render-transcript.ts) | Render a session transcript as plain text with `classifyTurn` (`@kortix/sdk/turns`). | `KORTIX_SESSION_ID=… bun run examples/04-render-transcript.ts` |
+| 05 | [`05-cost-passthrough.ts`](05-cost-passthrough.ts) | A marked-up usage table — the shape a backend uses to re-bill its own users. | `KORTIX_SESSION_ID=… bun run examples/05-cost-passthrough.ts` |
+| 06 | [`06-files-and-secrets.ts`](06-files-and-secrets.ts) | Session-scoped workspace files + project secrets. | `KORTIX_SESSION_ID=… bun run examples/06-files-and-secrets.ts` |
+| 07 | [`07-vanilla.ts`](07-vanilla.ts) | The whole flow in one framework-free file: list → send → stream. | `bun run examples/07-vanilla.ts "hi"` |
+| 08 | [`08-cdn.html`](08-cdn.html) | The SDK in a browser with **no build step** (ESM via CDN). | open in a browser |
+| 09 | [`09-kaab-backend-wrapper.ts`](09-kaab-backend-wrapper.ts) | **Kortix as a Backend, end to end**: mint a connector → per-user profile → backend-origin session (`origin_ref` + `secrets` + `connector_bindings`) → **stream**. One-shot CLI **and** a multi-tenant SSE service. | `bun run examples/09-kaab-backend-wrapper.ts "Summarize my signups"` |
+
+## Kortix as a Backend
+
+Wrapping one shared agent as the backend for many of your users — each bringing
+their connectors, model, secrets, and identity **by reference** — is examples
+**03** (the multi-tenant client seam) and **09** (the complete flow). Read them
+alongside:
+
+- [`docs/KORTIX_AS_A_BACKEND_GUIDE.md`](../../../docs/KORTIX_AS_A_BACKEND_GUIDE.md) — the concepts, overrides, errors, and security model.
+- [`KORTIX-AS-A-BACKEND.pdf`](KORTIX-AS-A-BACKEND.pdf) — the same, as a printable one-pager.
+
+### `09` env knobs
+
+| Var | Effect |
+|-----|--------|
+| `MODE=serve` | Run as a `POST /run {endUserId, prompt}` → SSE service instead of one-shot. |
+| `KAAB_OVERRIDES=off` | Drop the backend-only fields (`origin_ref`, `secrets`) so the connector + session + streaming path still runs against a deployment that doesn't have them yet. |
+| `KAAB_NO_CONNECTOR=1` | Skip the connector layer (a bare project with no `kortix.yaml`). |
+| `KAAB_CONNECTOR_URL` / `KAAB_AGENT` / `KAAB_MODEL` / `KAAB_SECRET` | Point the demo at your own connector URL / agent / model / secret identifier. |
+
+> **Streaming needs the sandbox to reach your API.** A hosted deployment works
+> out of the box. Against a **local** API, a cloud sandbox can't reach
+> `localhost` — front it with a public tunnel (`cloudflared tunnel --url
+> http://localhost:8010`) and start the API with `KORTIX_URL` set to that URL.

--- a/packages/sdk/src/core/client/kortix.test.ts
+++ b/packages/sdk/src/core/client/kortix.test.ts
@@ -1010,14 +1010,16 @@ test('ensureReady() throws RUNTIME_UNAVAILABLE when the runtime never becomes re
   ).rejects.toMatchObject({ code: 'RUNTIME_UNAVAILABLE' });
 });
 
-test('ensureReady() rides transient null /start results (5xx / create→start race) and resolves once ready', async () => {
+test('ensureReady() treats a transient null /start result as retriable and resolves once ready', async () => {
   let n = 0;
   globalThis.fetch = mock(async (input: unknown) => {
     const url = requestUrl(input);
     if (url.includes('/start')) {
       n += 1;
-      // startProjectSession returns null (not throws) for a 5xx / the create→
-      // start 404 race — ensureReady must poll through it, not give up.
+      // startProjectSession returns null (not throws) for a 5xx/408/429/network
+      // blip AND the create→start 404 race — ensureReady only ever sees `null`,
+      // not the cause, so this one 503 stands in for all of them. It must poll
+      // through the null, not give up.
       if (n <= 1) return jsonResponse({ error: 'gateway' }, 503);
       return jsonResponse({
         stage: 'ready',

--- a/packages/sdk/src/core/client/kortix.test.ts
+++ b/packages/sdk/src/core/client/kortix.test.ts
@@ -1009,3 +1009,64 @@ test('ensureReady() throws RUNTIME_UNAVAILABLE when the runtime never becomes re
     k.session('PROJ', 'SESS-TIMEOUT').ensureReady({ readyTimeoutMs: 20 }),
   ).rejects.toMatchObject({ code: 'RUNTIME_UNAVAILABLE' });
 });
+
+test('ensureReady() rides transient null /start results (5xx / create→start race) and resolves once ready', async () => {
+  let n = 0;
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    if (url.includes('/start')) {
+      n += 1;
+      // startProjectSession returns null (not throws) for a 5xx / the create→
+      // start 404 race — ensureReady must poll through it, not give up.
+      if (n <= 2) return jsonResponse({ error: 'gateway' }, 503);
+      return jsonResponse({
+        stage: 'ready',
+        agent_name: 'default',
+        retriable: false,
+        sandbox: { external_id: 'sb-transient' },
+        opencode_session_id: 'ocs-transient',
+      });
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  const ready = await k.session('PROJ', 'SESS-TRANSIENT').ensureReady({ readyTimeoutMs: 10_000 });
+  expect(ready.opencodeSessionId).toBe('ocs-transient');
+  expect(n).toBeGreaterThanOrEqual(3);
+});
+
+test('ensureReady() caps each /start long-poll to the remaining deadline budget', async () => {
+  const waits: number[] = [];
+  let n = 0;
+  globalThis.fetch = mock(async (input: unknown) => {
+    const url = requestUrl(input);
+    if (url.includes('/start')) {
+      const m = url.match(/wait_ms=(\d+)/);
+      if (m) waits.push(Number(m[1]));
+      n += 1;
+      if (n === 1) {
+        return jsonResponse({
+          stage: 'provisioning',
+          agent_name: 'default',
+          retriable: true,
+          sandbox: null,
+          opencode_session_id: null,
+        });
+      }
+      return jsonResponse({
+        stage: 'ready',
+        agent_name: 'default',
+        retriable: false,
+        sandbox: { external_id: 'sb-cap' },
+        opencode_session_id: 'ocs-cap',
+      });
+    }
+    return jsonResponse({ ok: true });
+  }) as unknown as typeof fetch;
+
+  const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  await k.session('PROJ', 'SESS-CAP').ensureReady({ readyTimeoutMs: 5_000 });
+  expect(waits.length).toBeGreaterThan(0);
+  expect(Math.max(...waits)).toBeLessThanOrEqual(5_000);
+});

--- a/packages/sdk/src/core/client/kortix.test.ts
+++ b/packages/sdk/src/core/client/kortix.test.ts
@@ -1018,7 +1018,7 @@ test('ensureReady() rides transient null /start results (5xx / create→start ra
       n += 1;
       // startProjectSession returns null (not throws) for a 5xx / the create→
       // start 404 race — ensureReady must poll through it, not give up.
-      if (n <= 2) return jsonResponse({ error: 'gateway' }, 503);
+      if (n <= 1) return jsonResponse({ error: 'gateway' }, 503);
       return jsonResponse({
         stage: 'ready',
         agent_name: 'default',
@@ -1031,9 +1031,10 @@ test('ensureReady() rides transient null /start results (5xx / create→start ra
   }) as unknown as typeof fetch;
 
   const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
-  const ready = await k.session('PROJ', 'SESS-TRANSIENT').ensureReady({ readyTimeoutMs: 10_000 });
+  // Small budget → the inter-poll pause (min(1000, remaining)) stays small.
+  const ready = await k.session('PROJ', 'SESS-TRANSIENT').ensureReady({ readyTimeoutMs: 300 });
   expect(ready.opencodeSessionId).toBe('ocs-transient');
-  expect(n).toBeGreaterThanOrEqual(3);
+  expect(n).toBeGreaterThanOrEqual(2);
 });
 
 test('ensureReady() caps each /start long-poll to the remaining deadline budget', async () => {
@@ -1066,7 +1067,8 @@ test('ensureReady() caps each /start long-poll to the remaining deadline budget'
   }) as unknown as typeof fetch;
 
   const k = createKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
-  await k.session('PROJ', 'SESS-CAP').ensureReady({ readyTimeoutMs: 5_000 });
+  await k.session('PROJ', 'SESS-CAP').ensureReady({ readyTimeoutMs: 300 });
   expect(waits.length).toBeGreaterThan(0);
-  expect(Math.max(...waits)).toBeLessThanOrEqual(5_000);
+  // Uncapped this would be 30_000; capped to the remaining budget it's ≤ 300.
+  expect(Math.max(...waits)).toBeLessThanOrEqual(300);
 });

--- a/packages/sdk/src/core/client/kortix.ts
+++ b/packages/sdk/src/core/client/kortix.ts
@@ -710,14 +710,18 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
           sessionId,
           Math.min(30_000, remainingMs()),
         );
-        // Keep polling only while the runtime is still coming up
-        // (provisioning/starting) and the server says it's retriable; a
-        // terminal stage (ready/failed/stopped) or the deadline ends the loop.
+        // Keep polling while the runtime is still coming up. A `null` result is
+        // a TRANSIENT tick, not a terminal state: startProjectSession returns
+        // null for a 5xx/408/429/network blip AND the create→start 404 race
+        // (row not yet visible on the read path) — the exact cases a backend
+        // hits calling ensureReady() right after create(). Only a resolved
+        // provisioning/starting+retriable result or the deadline keeps/ends the
+        // loop; ready/failed/stopped fall through to the guard below.
         while (
-          started &&
-          (started.stage === 'provisioning' || started.stage === 'starting') &&
-          started.retriable &&
-          Date.now() < deadline
+          Date.now() < deadline &&
+          (started == null ||
+            ((started.stage === 'provisioning' || started.stage === 'starting') &&
+              started.retriable))
         ) {
           await new Promise((r) => setTimeout(r, Math.min(1_000, remainingMs())));
           started = await P.startProjectSession(


### PR DESCRIPTION
## What

Hardening + docs pass over the merged **Kortix-as-a-Backend** surface (origin gate #5147, secrets allowlist #5154, DX #5201 — all now on main), driven by an adversarial edge-case review across 5 subsystems (origin, secrets, connectors, SDK runtime, test coverage).

## Fixed here

- **`fix(sdk)` — `ensureReady()` rides transient `null` /start results** (was: threw `RUNTIME_UNAVAILABLE` on the first tick). `startProjectSession` returns `null` — not throws — on a 5xx/408/429/network blip **and the create→start 404 race** (the session row isn't yet visible on the read path). That is the exact case a backend hits calling `ensureReady()` right after `sessions.create()`. The poll loop treated `null` as a terminal exit; now it's a retriable tick, and only `ready`/`failed`/`stopped` or the deadline end the loop. + tests for transient-null recovery and the per-poll wait_ms cap.
- **`fix(api)` — scrub `SLACK_BOT_TOKEN` on the hot-push path too.** Boot deletes it (anti-exfil, KORTIX-206), but the live secret-CRUD env re-sync only scrubbed `NEVER_IN_SANDBOX` (`SLACK_SIGNING_SECRET`) — so a hot-push re-injected the raw bot token boot withheld. Added it to `NEVER_IN_SANDBOX` so both paths agree.
- **`test(api-contract)`** — cover the `origin_ref` 256-cap/trim/whitespace-reject and the `secrets` list bounds (were enforced but untested).
- **`refactor(sdk)`** — rename the wrapper's `KAAB_CONNECTOR_ENDPOINT` env → `KAAB_CONNECTOR_URL` (matches the mcp `url` field it sets).
- **`docs(sdk)`** — an `examples/README.md` index for all 9 examples (was missing) + link the KaaB example/guide from `GETTING-STARTED.md`.

Verified: tsc clean (api/sdk/cli/api-contract), drift clean, SDK suite **1156 pass**, e2e contract **42**, integration **7**, secrets **13**.

## Flagged for their own PRs (pre-existing on main, NOT KaaB-introduced)

The review also confirmed two serious pre-existing bugs that need dedicated PRs (one includes a migration), so they are **not** bundled here:

1. **HIGH — cross-tenant session disclosure via unscoped idempotency keys.** The `idx_session_lifecycle_commands_idempotency` unique index is single-column/global; a colliding `Idempotency-Key` (e.g. a predictable channel key `telegram:<projectId>:<update_id>`, or two tenants both using `"1"`) returns *another account's* session row. Needs a composite `(account_id, idempotency_key)` index + account-scoped lookups + defense-in-depth checks.
2. **MEDIUM — prompt-proxy idempotency message loss** (`sandbox-proxy/routes/preview.ts`): the dedupe key is claimed before the forward, so a failed delivery + client retry short-circuits to a fake `200 duplicate`.

## Found but deliberately deferred (rationale)

- **Immutable-allowlist brick on later secret-config drift** — the clean "fail-soft" fix would change `resolveGrantedSecretEnv`'s *intentional, tested* ambiguity contract (it throws by design; there's a test asserting it). A deliberate design decision (mutable allowlist / boot-time drop), not a drive-by change.
- **Email-channel sessions lose non-email connectors** — the auto-injected inbox binding trips the all-or-nothing gate; channels-specific, needs care to distinguish system bindings.
- **`.runtime` opencode escape-hatch not scoped under `createScopedKortix`** — real but off the KaaB happy path (the wrapper never uses `.runtime`); needs a careful transport re-wrap.
- **Session secrets resolve as different principals across the 3 provisioning paths** — a pre-existing multi-path behavior change (restart resolves as the restarter, not `createdBy`); low, touches all sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
