### PR TITLE
docs: accuracy sweep — manifest defaults, SDK ensureReady polling, CLI flags, channels

### DIFF
--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -233,7 +233,7 @@ Each session runs in one sandbox on its own branch.
 | `kortix sessions ls` | List every session on the project. |
 | `kortix sessions status [--all] [--json]` | Every session and what its agent is doing right now. Aliases: `overview`, `ps`. |
 | `kortix sessions info <id> [--json]` | Detail view: status, branch, agent, sandbox URL. |
-| `kortix sessions new [--prompt "<text>"] [--agent <name>] [--wait] [--json]` | Start a session. `--wait` blocks until it is running (up to ~5 minutes). |
+| `kortix sessions new [--prompt "<text>"] [--agent <name>] [--model <id>] [--wait] [--json]` | Start a session. `--model <id>` overrides the project's default model. `--wait` blocks until it is running (up to ~5 minutes); a timeout is a hard failure (exit 1), not a silent success. Backend-origin overrides require a backend token (PAT or service account) and 403 otherwise: `--origin-ref <user-id>` (attribute to your end user), `--secret <id>` (narrow injected secrets, repeatable), `--no-secrets` (inject zero project secrets), `--connector <alias>=<profile-id>` (bind a connector to a profile, repeatable), `--context <key>=<value>` (runtime context, repeatable). |
 | `kortix sessions chat [<id>] [--prompt "<text>"] [--new] [--agent <name>] [--json]` | Talk to a session's agent. Interactive by default. Alias: `talk`. Top-level `kortix chat` also works. |
 | `kortix sessions connect [<id>] [-- <opencode args>]` | Attach your local OpenCode TUI to the OpenCode server already running in the sandbox. Alias: `attach`. |
 | `kortix sessions shell [<id>] [--new]` | Open a raw interactive terminal in the sandbox, with no agent. Aliases: `terminal`, `ssh`. |
@@ -476,7 +476,8 @@ See [Manifest reference](/docs/project/manifest).
 | `kortix self-host init` | Create or refresh the self-host config. Does not start the stack. |
 | `kortix self-host configure` | Interactive wizard for integrations and update policy. |
 | `kortix self-host doctor` | Validate local Docker tooling and the rendered config. |
-| `kortix self-host start` | Create config if needed, then start the stack. Alias: `up`. |
+| `kortix self-host plan` | Validate the rendered Compose config; change nothing. |
+| `kortix self-host start` | Create config if needed, then start the stack. Aliases: `up`, `deploy`. |
 | `kortix self-host update [--tag <v>\|--channel stable\|latest]` | Pull images for the configured channel or tag and recreate the stack. Alias: `upgrade`/`reconcile`. |
 | `kortix self-host rollback --release <v>` | Roll back to an explicit older version. |
 | `kortix self-host version` | Show the running version and channel. |
@@ -490,7 +491,7 @@ See [Manifest reference](/docs/project/manifest).
 | `kortix self-host logs [service]` | Tail stack logs. |
 | `kortix self-host uninstall` | Stop the stack and delete this instance's containers, volumes, and config. |
 
-Common flags: `--instance <name>` (default `default`), `--domain <domain>`, `--tunnel cloudflare`, `--version`/`--tag`/`--release <v>`, `--channel stable|latest` (default `stable`), `--auto-update on|off` (default `on`), `--admin-email <email>`, `--json`, `--yes`.
+Common flags: `--instance <name>` (default `default`), `--domain <domain>`, `--tunnel cloudflare`, `--version`/`--tag`/`--release <v>`, `--channel stable|latest` (default `stable`), `--auto-update on|off` (default `on`; forced off by `--local-images`), `--update-time <HH:MM>` / `--update-tz <tz>` (auto-updater schedule), `--local-images` (run locally-built images; dev mode), `--enterprise-license` (unlock SSO/SCIM/RBAC/audit), `--admin-email <email>`, `--no-restrict-account-creation` (let any signed-in user create new accounts/orgs; default is admin-only), `--restrict-account-creation` (re-enable the admin-only default), `--json`, `--yes`.
 
 ### Token scope
 

--- a/apps/web/content/docs/connect/slack.mdx
+++ b/apps/web/content/docs/connect/slack.mdx
@@ -11,15 +11,19 @@ same thread.
 
 ## Live channels
 
-Kortix supports two channels today:
+Kortix supports four channel platforms today:
 
 - **Slack** — connect with one click through the Kortix-managed app, or bring
   your own bot token.
 - **Microsoft Teams** — connect through org admin-consent OAuth, or bring your
   own Azure Bot.
+- **Email** — an AgentMail-backed channel (experimental; enable it under
+  Customize → Settings → Experimental).
+- **Meeting bots** — a connector-backed channel for meeting transcription.
 
-This page covers Slack. Teams follows the same session, identity-linking, and
-credential rules.
+Only Slack and Microsoft Teams connect through the CLI and dashboard. Email
+and meeting bots are managed from the dashboard or SDK. This page covers Slack.
+Teams follows the same session, identity-linking, and credential rules.
 
 ## How a channel starts a session
 
@@ -125,4 +129,5 @@ the bot gets a session), `owner_approval`, or `owner_only`.
 - Slash commands do not fire inside the Assistant DM pane. Type
   `/kortix <command>` as plain text there instead.
 - Other chat platforms, including Telegram, are not supported channels today.
-  Only Slack and Microsoft Teams connect through the CLI and dashboard.
+  Only Slack and Microsoft Teams connect through the CLI and dashboard; email
+  and meeting bots connect through the dashboard or SDK.

--- a/apps/web/content/docs/host/index.mdx
+++ b/apps/web/content/docs/host/index.mdx
@@ -79,6 +79,13 @@ optionally a managed-git token. Sign up in the dashboard, then connect your
 own LLM key in the model picker. Self-hosted instances use your own key
 by default.
 
+<Callout type="info">
+By default, only the platform admin can create new organization accounts.
+Any signed-in user can still join by invite or SSO. Opt out with
+`kortix self-host init --no-restrict-account-creation`, or re-enable the
+admin-only default with `--restrict-account-creation`.
+</Callout>
+
 ## Updates
 
 Every instance updates itself automatically. Pin an exact version instead:

--- a/apps/web/content/docs/project/manifest.mdx
+++ b/apps/web/content/docs/project/manifest.mdx
@@ -104,7 +104,7 @@ triggers:
 | `opencode.config_dir` | no | default `.kortix/opencode` |
 | `triggers` | no | list of cron and webhook triggers |
 | `connectors` | no | list of integration definitions |
-| `policy.default_mode` | no | `risk` (default) or `allow_all`; project-wide connector approval mode |
+| `policy.default_mode` | no | `allow_all` (default) or `risk`; project-wide connector approval mode |
 | `agents` | yes | name-to-block governance map; must not be empty |
 
 ## `project:`
@@ -251,15 +251,15 @@ Provider-specific fields:
 
 `channel` connectors rarely need a hand-written entry — connecting a channel from the dashboard creates one for you. See [Slack & channels](/docs/connect/slack). The slugs `kortix_slack`, `kortix_teams`, `kortix_email`, `kortix_meet`, and `computer` are platform-owned; using one with a different provider is a validation error.
 
-`connectors.auth`: optional, for providers other than `pipedream`. `type` is `bearer`, `basic`, `custom`, or `none` (default). `in` is `header` (default) or `query`. `name` is required when `type` is `custom`.
+`connectors.auth`: optional, for providers other than `pipedream`. `type` is `bearer`, `basic`, `custom`, `oauth1`, or `none` (default). `oauth1` is restricted to `openapi`, `postman`, and `http` providers. `in` is `header` (default) or `query`. `name` is required when `type` is `custom`.
 
 `connectors.policies`: a list of `{match, action}` pairs. `match` is a glob over tool names. `action` is `always_run`, `require_approval`, or `block`.
 
-`policy.default_mode`: a top-level key, separate from `connectors:`, that sets the project-wide connector approval mode. It takes `risk` (default; require approval per each connector's own policy) or `allow_all`. Set it with `kortix connectors policy set --default <risk|allow_all>` — see [CLI](/docs/cli).
+`policy.default_mode`: a top-level key, separate from `connectors:`, that sets the project-wide connector approval mode. It takes `allow_all` (default; every unmatched tool runs) or `risk` (require approval for write and destructive unmatched calls). Set it with `kortix connectors policy set --default <risk|allow_all>` — see [CLI](/docs/cli).
 
 ## Channels
 
-v2 removes `channels:` from the schema. Channel-to-agent routing (Slack and Microsoft Teams today) is live operational state, not declarative config. You set it from the dashboard's Channels page or from chat commands, the same boundary that keeps credentials out of git. Connecting a channel still creates a `connectors` entry with `provider: channel` for the agent to call. See [Slack & channels](/docs/connect/slack). The v1 `[[channels]]` table is covered in [Legacy TOML](/docs/project/legacy-toml).
+v2 removes `channels:` from the schema. Channel-to-agent routing (Slack, Microsoft Teams, email, and meeting bots today) is live operational state, not declarative config. You set it from the dashboard's Channels page or from chat commands, the same boundary that keeps credentials out of git. Connecting a channel still creates a `connectors` entry with `provider: channel` for the agent to call. See [Slack & channels](/docs/connect/slack). The v1 `[[channels]]` table is covered in [Legacy TOML](/docs/project/legacy-toml).
 
 ## `agents:`
 

--- a/apps/web/content/docs/sdk/example.mdx
+++ b/apps/web/content/docs/sdk/example.mdx
@@ -34,9 +34,11 @@ async function main() {
   const session = kortix.session(project.project_id, created.session_id);
 
   // 4. Ready the session. This provisions (or resumes) the real cloud
-  //    sandbox. Each ensureReady() call is one bounded long-poll — on a
-  //    cold boot it throws a typed RUNTIME_UNAVAILABLE ApiError while the
-  //    sandbox is still coming up, so retry until it resolves.
+  //    sandbox. ensureReady() polls /start (each call long-polls up to 30s)
+  //    until the runtime is ready or its deadline (~3 min) elapses, so a
+  //    cold boot just takes longer rather than throwing. The
+  //    retryUntilReady wrapper below is optional — keep it only if you want
+  //    a longer total budget than the default.
   const { opencodeSessionId } = await retryUntilReady(() => session.ensureReady());
 
   // 5. Connect the event stream before you send, so no early events are
@@ -81,7 +83,7 @@ async function main() {
   }
 }
 
-/** Retry ensureReady() while the sandbox is provisioning (cold boots take a while). */
+/** Optional outer-budget wrapper — ensureReady() already polls internally. */
 async function retryUntilReady<T>(ensure: () => Promise<T>): Promise<T> {
   const deadline = Date.now() + 300_000;
   for (;;) {

--- a/apps/web/content/docs/sdk/index.mdx
+++ b/apps/web/content/docs/sdk/index.mdx
@@ -47,7 +47,7 @@ Create an API key at **User settings → API keys**. The key starts with `kortix
    await session.ensureReady();
    ```
 
-   `ensureReady()` starts or resumes the session sandbox. If the sandbox is still starting, it throws an `ApiError` with `code: 'RUNTIME_UNAVAILABLE'`. Retry after a short delay. See [Sessions](/docs/sdk/sessions).
+   `ensureReady()` starts or resumes the session sandbox. It polls the session's `/start` endpoint — each call long-polls up to 30 s — until the runtime is ready, hits a terminal stage, or its deadline elapses (default ~3 min, configurable via `{ readyTimeoutMs }`). On a cold boot it keeps polling while the sandbox reports `retriable: true`; it only throws an `ApiError` with `code: 'RUNTIME_UNAVAILABLE'` if the runtime is still not ready when the deadline expires. See [Sessions](/docs/sdk/sessions).
 
 3. Send a message to the agent.
 

--- a/apps/web/content/docs/sdk/reference.mdx
+++ b/apps/web/content/docs/sdk/reference.mdx
@@ -219,7 +219,7 @@ agent, a skill, a secret) instead of the whole project.
 | `profiles.updateCredential(profileId, input)` | rotate a profile's credential |
 | `profiles.revoke(profileId)` · `profiles.activate(profileId)` | deny · restore the identity live |
 
-`p.connectors.discover` browses the direct-integration catalog.
+`p.connectors.discover` browses the direct-integration catalog. It is **experimental** and off by default — enable it per project under Customize → Settings → Experimental → "Connectors API Discover". Easy Connect (Pipedream) remains the default connector marketplace.
 
 | method | what |
 | --- | --- |

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -154,14 +154,19 @@ Turn raw messages and parts into renderable output with `classifyTurn`. See
 
 ## Retry on a cold boot
 
-`ensureReady()` sends one long-poll request to the session's `/start`
-endpoint. On a warm session it resolves right away. On a cold boot, the
-sandbox can still be provisioning when the long-poll returns. In that case,
-`ensureReady()` throws an `ApiError` with `code: 'RUNTIME_UNAVAILABLE'`.
+`ensureReady()` polls the session's `/start` endpoint — each call long-polls up
+to 30 s — until the runtime reaches a terminal `ready`/`failed`/`stopped` stage
+or its deadline (`readyTimeoutMs`, default ~180 s) elapses. On a warm session
+the first poll resolves `ready` immediately. On a cold boot it keeps polling
+while the sandbox reports `retriable: true`, so a slow start just takes longer
+rather than throwing. It only throws an `ApiError` with `code:
+'RUNTIME_UNAVAILABLE'` if the runtime is still not `ready` when the deadline
+expires.
 
-This code means the sandbox is not ready yet, not that it failed. Retry the
-call. `ensureReady()` is idempotent, so concurrent calls for the same session
-share one `/start` request instead of sending several.
+`ensureReady()` is idempotent, so concurrent calls for the same session share
+one `/start` request instead of sending several. The `retryUntilReady` helper
+below is now optional — `ensureReady()` already retries internally — but stays
+useful if you want a longer total budget than the default `readyTimeoutMs`.
 
 ```ts
 async function retryUntilReady<T>(ensure: () => Promise<T>): Promise<T> {

--- a/apps/web/content/docs/work/runtime.mdx
+++ b/apps/web/content/docs/work/runtime.mdx
@@ -192,7 +192,7 @@ sandbox:
       disk: 50
 ```
 
-`cpu` takes 1–32 cores, `memory` takes 1–128 GiB, and `disk` takes 1–500 GiB. Kortix clamps any value above these limits down to the limit. Kortix does not support GPUs; a `gpu` key on a template is rejected.
+`cpu` takes 1–32 cores, `memory` takes 1–128 GiB, and `disk` takes 1–500 GiB. Kortix clamps any value above these limits down to the limit. Kortix does not support GPUs; a `gpu` key on a template produces a warning, not an error.
 
 The spec is part of the template's snapshot, not a per-session setting. Changing it rebuilds the snapshot and applies to the next session. The current session keeps its already-booted spec.
 


### PR DESCRIPTION
## What

Source-backed docs accuracy fixes for the 2026-07-23 docs-maintainer sweep. Audit window: `3304c7ab` → `5f6164dce` (805 reachable commits, all with evidence-backed dispositions). The Fumadocs tree was rebuilt on 2026-07-22 (`89637e9b1`, journey-based STE rewrite); this sweep verifies the rebuilt pages against current source and fixes drift introduced by in-window behavior changes.

Docs-only — 9 MDX files under `apps/web/content/docs/**`.

## Fixes (every claim re-verified against current source)

**`policy.default_mode` default (HIGH)** — `project/manifest.mdx` said `risk` (default); source default is `allow_all`.
- Source: `apps/api/src/projects/policies.ts:48` `DEFAULT_SETTINGS = { defaultMode: 'allow_all' }`; `:11` "allow_all — legacy default for back-compat". Matches `connect/connectors.mdx:31` which was already correct.

**SDK `ensureReady()` polling (HIGH)** — `sdk/index.mdx`, `sdk/sessions.mdx`, `sdk/example.mdx` described a single long-poll that throws `RUNTIME_UNAVAILABLE` on a cold boot. The SDK now polls `/start` until ready or deadline.
- Source: `packages/sdk/src/core/client/kortix.ts:695-728` (while-loop polls while `retriable` && before deadline; `:698-702` comment: "A single check would spuriously throw RUNTIME_UNAVAILABLE on a slow boot"). Commits `6ded19338` + `286c5289d`.

**`gpu` produces a warning, not a rejection (MEDIUM)** — `work/runtime.mdx` said a `gpu` key "is rejected".
- Source: `packages/manifest-schema/src/index.ts:706-711` `severity: 'warning'`. `manifest.mdx:157` was already correct; now both agree.

**Connector auth `oauth1` (MEDIUM)** — `project/manifest.mdx` omitted `oauth1`.
- Source: `packages/manifest-schema/src/constants.ts:29` `CONNECTOR_AUTH_TYPES = ['bearer','basic','custom','oauth1','none']`; `index.ts:1123` restricts `oauth1` to `openapi`/`postman`/`http`.

**Channels: four platforms, not two (MEDIUM)** — `connect/slack.mdx` + `project/manifest.mdx` said "two channels" (Slack + Teams).
- Source: `packages/manifest-schema/src/constants.ts:31` `CHANNEL_PLATFORMS = ['slack','teams','email','meet']`. Email (AgentMail) and meet are now documented; CLI/dashboard still only connects Slack + Teams.

**SDK `p.connectors.discover` experimental (MEDIUM)** — `sdk/reference.mdx` presented Discover as an unconditional SDK method.
- Source: `apps/api/src/experimental/features.ts:83-91` `connectors_api_discover` stability `experimental`, `platformDefault: () => false`. Easy Connect (Pipedream) remains the default marketplace. Commits `73a5f2822` + `14e31468b`.

**CLI `sessions new` flags (MEDIUM)** — `cli.mdx` omitted `--model` and the backend-origin overrides; `--wait` timeout was not marked as a failure.
- Source: `apps/cli/src/commands/sessions.ts:36-50` (HELP), `:362-373` (timeout → exit 1), `:217-237` (overrides). Commit `d9016bbe5`.

**CLI self-host flags + subcommands (MEDIUM/LOW)** — `cli.mdx` omitted `plan` subcommand, `deploy` alias, and the common flags `--local-images`, `--enterprise-license`, `--restrict-account-creation`/`--no-restrict-account-creation`, `--update-time`/`--update-tz`.
- Source: `apps/cli/src/commands/self-host.ts:85-101` (HELP), `:246-296` (subcommands), `:296-355` (global flags). Commits `104d6b85f` + `504304209`.

**Self-host account-creation restriction (MEDIUM)** — `host/index.mdx` did not document the admin-only default.
- Source: `apps/api/src/accounts/core/accounts.ts:134-141`; `apps/cli/src/self-host/shared-runtime-defaults.ts:75` `KORTIX_RESTRICT_ACCOUNT_CREATION: 'true'`. Commit `504304209`.

## Verification

- `check-fumadocs.mjs` PASS (27 pages, 6 navigation files, 27 unique routes)
- `git diff --check` PASS (no whitespace errors)
- grep gates PASS (no `risk (default)`, no `gpu.*rejected`, no `two channels`, no `one long-poll`/`one bounded long-poll`, `oauth1` present, `restrict-account-creation` in host+cli, discover marked experimental)
- `check-commit-coverage.mjs` PASS (805 reachable commits, full-SHA manifest)
- Every source claim re-verified against the current `origin/main` worktree

Docs-only. No runtime/UI code changes.