### PR TITLE
Fix project session inventory authorization

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -55,6 +55,8 @@ let runtimeContextRows: Array<typeof projectSessionRuntimeContexts.$inferSelect>
 let secretValues: Map<string, string>;
 let gitConnectionRows: Array<typeof projectGitConnections.$inferSelect>;
 let gitCredentialRows: Array<typeof projectGitCredentials.$inferSelect>;
+let assertedIamActions: string[] = [];
+let deniedIamAction: string | null = null;
 let lastProvisionInput: {
   sandboxId: string;
   accountId: string;
@@ -138,6 +140,8 @@ function resetState() {
   secretValues = new Map();
   gitConnectionRows = [];
   gitCredentialRows = [];
+  assertedIamActions = [];
+  deniedIamAction = null;
 }
 
 const realAuthMiddleware = await import('../middleware/auth');
@@ -417,7 +421,12 @@ mock.module('../shared/resolve-account', () => ({
   resolveScopedAccountId: async () => ACCOUNT_ID,
 }));
 
-mockIamEngineAllowAll();
+mockIamEngineAllowAll((action) => {
+  assertedIamActions.push(action);
+  if (action === deniedIamAction) {
+    throw new HTTPException(403, { message: `Denied ${action}` });
+  }
+});
 
 mockIamMembershipSyncNoop();
 
@@ -859,6 +868,16 @@ describe('project session API contract', () => {
   });
 
   beforeEach(() => resetState());
+
+  test('GET project session inventory rejects callers without project.session.read', async () => {
+    deniedIamAction = 'project.session.read';
+    const app = createApp();
+
+    const response = await app.request(`/v1/projects/${PROJECT_ID}/sessions`);
+
+    expect(response.status).toBe(403);
+    expect(assertedIamActions).toContain('project.session.read');
+  });
 
   test('in-place resume clears stale readiness timers and the prior terminal session error', async () => {
     const staleReadyWaitStartedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();

--- a/apps/api/src/__tests__/helpers/iam-mocks.ts
+++ b/apps/api/src/__tests__/helpers/iam-mocks.ts
@@ -25,10 +25,14 @@ export function mockIamMembershipSyncNoop(): void {
  *  from `../iam` via `./dispatcher` (the V1 engine + flag-routing were retired),
  *  so the mock MUST target the dispatcher — mocking the old `./engine` is a
  *  dead no-op and lets the real V2 engine hit unmocked account-group tables. */
-export function mockIamEngineAllowAll(): void {
+export function mockIamEngineAllowAll(
+  onAssertAuthorized?: (action: string) => void | Promise<void>,
+): void {
   mock.module('../../iam/dispatcher', () => ({
     authorize: async () => ({ allowed: true }),
-    assertAuthorized: async () => {},
+    assertAuthorized: async (_userId: string, _accountId: string, action: string) => {
+      await onAssertAuthorized?.(action);
+    },
     listAccessibleResources: async () => ({ mode: 'all', ids: [] }),
     // Per-resource (agent/skill) list filter, re-exported from the dispatcher.
     // Allow-all → no filtering: every resource id passes through.

--- a/apps/api/src/__tests__/unit-kortix-projects-security.test.ts
+++ b/apps/api/src/__tests__/unit-kortix-projects-security.test.ts
@@ -12,11 +12,16 @@ function readProjectsSource(): string {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const p = join(dir, entry.name);
       if (entry.isDirectory()) walk(p);
-      else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) out.push(readFileSync(p, 'utf8'));
+      else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts'))
+        out.push(readFileSync(p, 'utf8'));
     }
   };
   walk(root);
   return out.join('\n');
+}
+
+function readProjectRoute(name: string): string {
+  return readFileSync(join(import.meta.dir, '../projects/routes', name), 'utf8');
 }
 
 describe('kortix-projects SQL safety', () => {
@@ -30,5 +35,23 @@ describe('kortix-projects SQL safety', () => {
     expect(source).not.toContain("accountId.replace(/'/g");
     expect(source).not.toContain('db.execute(`');
     expect(source).not.toContain("where account_id = '");
+  });
+});
+
+describe('kortix-projects authorization safety', () => {
+  test('session inventory requires project.session.read before querying sessions', () => {
+    const source = readProjectRoute('r7.ts');
+    const routeStart = source.indexOf('// GET /v1/projects/:projectId/sessions');
+    const routeEnd = source.indexOf("path: '/{projectId}/sessions/{sessionId}'", routeStart);
+    const route = source.slice(routeStart, routeEnd);
+    const capabilityGate = route.indexOf(
+      'await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);',
+    );
+    const sessionQuery = route.indexOf('.from(projectSessions)');
+
+    expect(routeStart).toBeGreaterThanOrEqual(0);
+    expect(routeEnd).toBeGreaterThan(routeStart);
+    expect(capabilityGate).toBeGreaterThanOrEqual(0);
+    expect(sessionQuery).toBeGreaterThan(capabilityGate);
   });
 });

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -472,6 +472,7 @@ projectsApp.openapi(
 
   const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
+  await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);
 
   const rows = await db
     .select()


### PR DESCRIPTION
## Security fix

`GET /v1/projects/:projectId/sessions` now requires `project.session.read` after project access validation and before any session query.

## Regression coverage

- A Hono route test denies `project.session.read` and asserts HTTP `403`.
- A source-order test requires the capability gate before `.from(projectSessions)`.

## Verification

- `dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/e2e-project-session-contract.test.ts -t "GET project session inventory rejects callers without project.session.read"` — `1 pass`, `0 fail`.
- `bun test apps/api/src/__tests__/unit-kortix-projects-security.test.ts` — `2 pass`, `0 fail`.
- `pnpm --filter kortix-api typecheck` — exit `0`.
- `git diff --check` — exit `0`.

This fixes the HIGH Strix finding from release PR #5265.