### PR TITLE
fix(sandbox-proxy): release prompt-dedupe claim when a forward never delivers

### DIFF
--- a/apps/api/src/sandbox-proxy/prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/prompt-dedupe.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 
-import { __resetPromptDedupe, claimPromptDelivery, promptDeliveryKey } from './prompt-dedupe';
+import {
+  __resetPromptDedupe,
+  claimPromptDelivery,
+  promptDeliveryKey,
+  releasePromptDelivery,
+} from './prompt-dedupe';
 
 beforeEach(() => __resetPromptDedupe());
 
@@ -49,5 +54,22 @@ describe('claimPromptDelivery', () => {
     expect(claimPromptDelivery('bulk-4999', 1_000)).toBe(false);
     // …but the oldest were evicted, so they read as fresh again.
     expect(claimPromptDelivery('bulk-0', 1_000)).toBe(true);
+  });
+});
+
+describe('releasePromptDelivery', () => {
+  test('a released key is immediately re-claimable within the TTL', () => {
+    expect(claimPromptDelivery('k1', 1_000)).toBe(true);
+    expect(claimPromptDelivery('k1', 1_000)).toBe(false); // still claimed
+    // A forward that never delivered releases the claim…
+    releasePromptDelivery('k1');
+    // …so the very next retry (same TTL window) re-attempts instead of deduping.
+    expect(claimPromptDelivery('k1', 1_000)).toBe(true);
+  });
+
+  test('releasing an unknown key is a harmless no-op', () => {
+    expect(() => releasePromptDelivery('never-claimed')).not.toThrow();
+    // A subsequent claim of an unrelated key is unaffected.
+    expect(claimPromptDelivery('k2', 1_000)).toBe(true);
   });
 });

--- a/apps/api/src/sandbox-proxy/prompt-dedupe.ts
+++ b/apps/api/src/sandbox-proxy/prompt-dedupe.ts
@@ -63,6 +63,19 @@ export function claimPromptDelivery(key: string, now: number = Date.now()): bool
   return true;
 }
 
+// Release a claim taken by claimPromptDelivery. Call this ONLY when the prompt
+// turned out never to reach the sandbox — every forward attempt failed before the
+// POST left the proxy (e.g. env sync) or PROVED nothing was accepted (the upstream
+// refused the connection). Dropping the claim lets a client retry under the same
+// key re-attempt delivery instead of short-circuiting to a phantom "duplicate"
+// no-op (silent message loss). Never release on an AMBIGUOUS failure — a fetch
+// that timed out or reset mid-flight — since opencode may already have enqueued
+// the message and re-POSTing it would double-enqueue (the very bug the claim
+// prevents). No-op when the key was already evicted.
+export function releasePromptDelivery(key: string): void {
+  seen.delete(key);
+}
+
 // Test-only: drop all cached claims so cases don't leak into one another.
 export function __resetPromptDedupe(): void {
   seen.clear();

--- a/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
@@ -123,6 +123,76 @@ describe('forwardToSandbox — prompt delivery is never double-sent', () => {
   });
 });
 
+// The mirror image of "never double-sent": a prompt that NEVER reaches the
+// sandbox must not leave its dedupe claim stuck, or a client that retries on the
+// transport failure would short-circuit to a 200 "duplicate" for a message the
+// sandbox never saw — silent message loss. The claim is released ONLY when the
+// failure PROVES non-delivery (connection refused / pre-fetch), and KEPT on an
+// ambiguous mid-flight failure where opencode may already hold the message.
+describe('forwardToSandbox — an undelivered prompt does not stay claimed', () => {
+  // fetch is overridden per test and restored by the file-level afterAll; the
+  // GET-retry suite that follows re-sets it via queueFetch, so no leak either way.
+  test('every attempt refused (nothing reached the box) → claim released, retry re-delivers', async () => {
+    let attempts = 0;
+    (globalThis as { fetch: unknown }).fetch = async () => {
+      attempts += 1;
+      // First forwardToSandbox: attempts 1..4 all refuse (PROVES nothing landed).
+      // The retry's attempt (5) succeeds — only reachable if the claim was
+      // released, since a still-claimed key would short-circuit BEFORE any fetch.
+      if (attempts <= 4) {
+        const err = new Error('connect ECONNREFUSED 127.0.0.1:8000') as Error & { code?: string };
+        err.code = 'ECONNREFUSED';
+        throw err;
+      }
+      return new Response('{"info":{},"parts":[]}', { status: 200 });
+    };
+    const args = [
+      'sb-1', 8000, { kind: 'principal', userId: 'u1' } as const,
+      'POST', '/session/sess-1/message', '', jsonHeaders({ 'idempotency-key': 'refused-1' }),
+      PROMPT_BODY, 'http://app.local',
+    ] as const;
+
+    const first = await forwardToSandbox(...args);
+    expect(first.status).toBe(502); // friendly unreachable — never delivered
+    const attemptsAfterFirst = attempts;
+    expect(attemptsAfterFirst).toBeGreaterThan(1); // it really did retry, not short-circuit
+
+    const second = await forwardToSandbox(...args);
+    // Claim was released: the retry RE-ATTEMPTS delivery (fetch is hit again)
+    // rather than returning a phantom "duplicate".
+    expect(attempts).toBeGreaterThan(attemptsAfterFirst);
+    expect(second.status).toBe(200);
+    expect(await second.json()).not.toEqual({ status: 'duplicate', deduplicated: true });
+  }, 20_000);
+
+  test('an AMBIGUOUS mid-flight failure (reset) KEEPS the claim — retry must not re-POST', async () => {
+    let attempts = 0;
+    (globalThis as { fetch: unknown }).fetch = async () => {
+      attempts += 1;
+      const err = new Error('read ECONNRESET') as Error & { code?: string };
+      err.code = 'ECONNRESET'; // reset ≠ refused → ambiguous: opencode may hold it
+      throw err;
+    };
+    const args = [
+      'sb-1', 8000, { kind: 'principal', userId: 'u1' } as const,
+      'POST', '/session/sess-1/message', '', jsonHeaders({ 'idempotency-key': 'reset-1' }),
+      PROMPT_BODY, 'http://app.local',
+    ] as const;
+
+    const first = await forwardToSandbox(...args);
+    // Ambiguous → not retried and not released; exactly one POST left the proxy.
+    expect(first.status).toBe(502);
+    expect(attempts).toBe(1);
+
+    const second = await forwardToSandbox(...args);
+    // Claim kept → the retry short-circuits to a duplicate no-op WITHOUT a second
+    // POST, so a message opencode may already hold is never enqueued twice.
+    expect(attempts).toBe(1);
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({ status: 'duplicate', deduplicated: true });
+  });
+});
+
 describe('forwardToSandbox — idempotent GET retry is unchanged', () => {
   test('a GET that 502s then 200s is retried and returns the eventual success', async () => {
     queueFetch(

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -23,7 +23,7 @@ import {
   isLongTurnCompletionRequest,
   proxyAttemptTimeoutMs,
 } from '../preview-retry-budget';
-import { claimPromptDelivery, promptDeliveryKey } from '../prompt-dedupe';
+import { claimPromptDelivery, promptDeliveryKey, releasePromptDelivery } from '../prompt-dedupe';
 
 // `userId` is set by combinedAuth (mounted in ../index.ts) before this route.
 const preview = new Hono<{ Variables: { userId: string; userEmail: string } }>();
@@ -546,14 +546,28 @@ export async function forwardToSandbox(
   // — a client resend, or the other proxy edge (subdomain.ts also calls this) —
   // short-circuits to a 200 no-op instead of re-POSTing and enqueueing the user's
   // message twice. First claim within the TTL proceeds; a repeat is deduped.
+  //
+  // The key is hoisted (and `promptMayHaveBeenDelivered` tracked) so the retry
+  // loop's terminal failure path can RELEASE the claim when the prompt is NEVER
+  // delivered — otherwise a caller that retries on transport failure would
+  // short-circuit to the 200 "duplicate" for a message the sandbox never saw
+  // (silent message loss). See the release before the final unreachable response.
+  let promptDedupeKey: string | null = null;
+  // Flips true once a prompt POST may have reached opencode: the fetch was put on
+  // the wire and either got a response or failed AMBIGUOUSLY (timeout/reset
+  // mid-flight). In that case the claim MUST be kept even on failure, because
+  // opencode may already have enqueued the message and re-POSTing would double-
+  // enqueue. Stays false for pre-fetch failures (env sync) and connection-refused
+  // errors — both of which PROVE nothing was accepted, so the claim is released.
+  let promptMayHaveBeenDelivered = false;
   if (isPromptDelivery(method, port, remainingPath)) {
-    const dedupeKey = promptDeliveryKey({
+    promptDedupeKey = promptDeliveryKey({
       idempotencyKey: incomingHeaders.get('idempotency-key'),
       sandboxId,
       sessionId: record.sessionId,
       body,
     });
-    if (!claimPromptDelivery(dedupeKey)) {
+    if (!claimPromptDelivery(promptDedupeKey)) {
       return jsonProxyError({ status: 'duplicate', deduplicated: true }, 200, origin);
     }
   }
@@ -589,6 +603,11 @@ export async function forwardToSandbox(
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     const budgetRemainingMs = PROXY_RETRY_BUDGET_MS - (Date.now() - proxyStartedAt);
     if (budgetRemainingMs <= 500) break; // out of budget → friendly page below
+    // Flips true the instant the upstream fetch is initiated this attempt, so the
+    // catch below can tell a prompt POST that made it onto the wire (ambiguous —
+    // opencode may have enqueued it) from a pre-fetch failure like env sync
+    // (nothing was ever sent). Reset per attempt.
+    let upstreamFetchStarted = false;
     try {
       const ingress = await resolveSandboxIngress(record, ingressRequest);
       const previewUrl = ingress.url;
@@ -737,6 +756,9 @@ export async function forwardToSandbox(
       );
       let upstream: Response;
       try {
+        // From here the prompt body is on the wire — a subsequent ambiguous
+        // failure (timeout/reset) may mean opencode already accepted it.
+        upstreamFetchStarted = true;
         upstream = await fetch(targetUrl, {
           method,
           headers,
@@ -881,6 +903,9 @@ export async function forwardToSandbox(
         isLongTurnCompletionRequest({ method, path: remainingPath })
       ) {
         sawLongTurnTimeout = true;
+        // The turn is still computing on the sandbox — the message WAS delivered.
+        // Keep the dedupe claim so a retry can't re-enqueue it.
+        promptMayHaveBeenDelivered = true;
         break;
       }
 
@@ -896,6 +921,10 @@ export async function forwardToSandbox(
         isPromptDelivery(method, port, remainingPath) &&
         !isConnectionRefusedError(err)
       ) {
+        // If the POST was already on the wire when it failed ambiguously, opencode
+        // may have enqueued it — keep the claim. Only a PRE-fetch failure here
+        // (e.g. env sync threw before any bytes were sent) leaves it releasable.
+        if (upstreamFetchStarted) promptMayHaveBeenDelivered = true;
         break;
       }
 
@@ -921,6 +950,16 @@ export async function forwardToSandbox(
   // health-check loop owns liveness and will retry the box.
   if (sawDeadSignal) {
     await markSandboxErrored(sandboxId);
+  }
+  // We're about to return the unreachable page having NEVER delivered the prompt:
+  // this point is reached only after every attempt failed before the POST left
+  // the proxy or with a connection-refused error (both PROVE nothing was accepted)
+  // — the ambiguous "maybe enqueued" paths set promptMayHaveBeenDelivered and are
+  // excluded. Release the up-front claim so a client that retries on this failure
+  // re-attempts delivery instead of short-circuiting to a phantom 200 "duplicate"
+  // for a message the sandbox never saw (silent message loss).
+  if (promptDedupeKey && !promptMayHaveBeenDelivered) {
+    releasePromptDelivery(promptDedupeKey);
   }
   return portUnreachableResponse({
     port,


### PR DESCRIPTION
## Problem

Prompt delivery on the sandbox proxy (`forwardToSandbox`) is deduped by an `Idempotency-Key` (or content-hash) claim taken **up-front**, before the forward/retry loop:

```ts
if (!claimPromptDelivery(dedupeKey)) {
  return jsonProxyError({ status: 'duplicate', deduplicated: true }, 200, origin);
}
```

The claim was never released. If the forward **never reached opencode** — every retry hit a connection-refused error, or a pre-fetch env-sync failure — the key stayed claimed for its full 60s TTL. A client that retries on the transport failure (the CLI reuses the same `Idempotency-Key`) then short-circuits to `200 { status: 'duplicate', deduplicated: true }` for a message the sandbox **never saw** → **silent message loss**.

Flagged by Copilot on #5201, but it's pre-existing `main` code (not a KaaB change), so it ships on its own.

## Fix

Release the claim on the terminal "sandbox unreachable" path — but **only when non-delivery is proven**. The tricky part is that this proxy deliberately treats *ambiguous* failures (a fetch that timed out or reset mid-flight, or any upstream 5xx) as "opencode may already have enqueued it" and must **keep** the claim to avoid a double-enqueue (the 3x-queued bug the dedupe exists to prevent). So the fix is not a blanket release:

- New `releasePromptDelivery(key)` helper in `prompt-dedupe.ts`.
- `forwardToSandbox` tracks `promptMayHaveBeenDelivered`, set the moment a prompt POST is on the wire and fails **ambiguously** (timeout/reset), or on a long-turn timeout.
- Before the final `portUnreachableResponse`, release the claim **iff** `!promptMayHaveBeenDelivered`. That point is reached only after every attempt failed pre-fetch or with a connection-refused error — both of which prove nothing was accepted.

Net: **connection-refused / pre-fetch** exhaustion → claim released → a retry re-delivers. **Ambiguous mid-flight** failure or any upstream response → claim kept → a retry can never double-enqueue. No change to the happy path or the existing "never double-sent" guarantees.

### Known, intentionally-scoped-out
A few other early-return not-delivered paths (opencode `503 not ready`, a `401` auth rejection, the Daytona `400 no-runner` last-attempt passthrough, non-retryable env-sync `502`) still retain the claim. They return distinct non-200 error statuses (not the misleading `200 duplicate`), and erring toward *keeping* there avoids any double-enqueue risk. The reported bug was specifically the transport-failure path returning a phantom `200` on retry.

## Tests
- `prompt-dedupe.test.ts` — `releasePromptDelivery` makes a key re-claimable within the TTL; releasing an unknown key is a no-op.
- `forward-prompt-dedupe.test.ts`:
  - **regression**: every attempt refused → claim released → the retry re-attempts delivery (fetches again) instead of returning a phantom duplicate.
  - **safety**: an ambiguous reset keeps the claim → the retry short-circuits to a duplicate **without** a second POST.

`bunx tsc --noEmit` clean; the two dedupe suites pass (13 tests). Env-dependent sibling suites (`preview.test.ts`) were not run locally (Dotenv Armor key unavailable in this environment) and are covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
