### PR TITLE
fix(connectors): auto email binding no longer disables default fallback for other connectors

### DIFF
--- a/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
+++ b/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
@@ -52,6 +52,7 @@ const SESSION_B = crypto.randomUUID();
 const SESSION_DEFAULT = crypto.randomUUID();
 const SESSION_IMPERSONATION = crypto.randomUUID();
 const SESSION_SERVICE_ACCOUNT = crypto.randomUUID();
+const SESSION_AUTO_EMAIL = crypto.randomUUID();
 const USER = crypto.randomUUID();
 const OTHER_USER = crypto.randomUUID();
 const SERVICE_ACCOUNT = crypto.randomUUID();
@@ -212,6 +213,13 @@ beforeAll(async () => {
       createdBy: SERVICE_ACCOUNT,
       visibility: 'private',
     },
+    {
+      sessionId: SESSION_AUTO_EMAIL,
+      accountId: ACCOUNT_A,
+      projectId: PROJECT_A,
+      branchName: SESSION_AUTO_EMAIL,
+      createdBy: USER,
+    },
   ]);
   await db.insert(projectSessionConnectorBindings).values([
     {
@@ -253,6 +261,18 @@ beforeAll(async () => {
       profileId: PROFILE_SERVICE_ACCOUNT,
       source: 'request',
       createdBy: SERVICE_ACCOUNT,
+    },
+    // Auto-wired by the platform (ensureEmailSessionBinding), NOT caller-chosen —
+    // source: 'default'. Must not trip the all-or-nothing gate for OTHER aliases.
+    {
+      sessionId: SESSION_AUTO_EMAIL,
+      accountId: ACCOUNT_A,
+      projectId: PROJECT_A,
+      connectorAlias: 'kortix_email',
+      connectorId: EMAIL_CONNECTOR,
+      profileId: EMAIL_PROFILE_DEFAULT,
+      source: 'default',
+      createdBy: null,
     },
   ]);
   await db.insert(executorCredentials).values([
@@ -362,6 +382,33 @@ describe('session connector profile isolation', () => {
     });
     expect(legacySessionEmail).toMatchObject({
       profileId: EMAIL_PROFILE_DEFAULT,
+      isDefault: true,
+      source: 'default',
+    });
+  });
+
+  test('an auto-wired email binding does not disable default fallback for other connectors', async () => {
+    // SESSION_AUTO_EMAIL has ONLY a source: 'default' email binding (as minted by
+    // ensureEmailSessionBinding) — the caller never opted into explicit-only
+    // selection. Its email alias resolves via that bound row…
+    const email = await resolveSessionConnectorProfile({
+      accountId: ACCOUNT_A,
+      projectId: PROJECT_A,
+      sessionId: SESSION_AUTO_EMAIL,
+      alias: 'kortix_email',
+    });
+    expect(email).toMatchObject({ profileId: EMAIL_PROFILE_DEFAULT });
+
+    // …and an UNBOUND alias still falls back to the project default, instead of
+    // failing closed the way a caller-requested (source: 'request') binding would.
+    const veyris = await resolveSessionConnectorProfile({
+      accountId: ACCOUNT_A,
+      projectId: PROJECT_A,
+      sessionId: SESSION_AUTO_EMAIL,
+      alias: 'veyris',
+    });
+    expect(veyris).toMatchObject({
+      profileId: PROFILE_DEFAULT,
       isDefault: true,
       source: 'default',
     });

--- a/apps/api/src/projects/lib/session-connector-bindings.ts
+++ b/apps/api/src/projects/lib/session-connector-bindings.ts
@@ -376,6 +376,15 @@ export async function resolveSessionConnectorProfile(input: {
     // Once a session opts into durable profile selection, every connector must
     // be selected explicitly. Falling back for an unbound alias would let a
     // partially bound session inherit an unrelated project-wide credential.
+    //
+    // Only a caller-REQUESTED binding (`source: 'request'`) counts as opting in.
+    // A `source: 'default'` row is auto-wired by the platform — today only
+    // `ensureEmailSessionBinding` mints one when an inbound email lands on a
+    // session — and must NOT trip the all-or-nothing gate: otherwise auto-binding
+    // the email inbox would silently disable the project-default fallback for
+    // every OTHER connector (slack, meet, …) on that session, which the caller
+    // never chose. The auto email binding still resolves via its own bound row
+    // above; this gate governs only the UNBOUND aliases.
     const [anyBinding] = await db
       .select({ sessionId: projectSessionConnectorBindings.sessionId })
       .from(projectSessionConnectorBindings)
@@ -384,6 +393,7 @@ export async function resolveSessionConnectorProfile(input: {
           eq(projectSessionConnectorBindings.sessionId, input.sessionId),
           eq(projectSessionConnectorBindings.accountId, input.accountId),
           eq(projectSessionConnectorBindings.projectId, input.projectId),
+          eq(projectSessionConnectorBindings.source, 'request'),
         ),
       )
       .limit(1);


### PR DESCRIPTION
## Problem

`resolveSessionConnectorProfile` enforces an **all-or-nothing** rule: once a session has *any* durable connector binding, every *unbound* alias fails closed (returns `null`) rather than inheriting a project-wide default profile. That protects a caller who explicitly bound one profile from silently picking up an unrelated default for a different connector.

But the gate counted **every** binding row — including the `source: 'default'` row that [`ensureEmailSessionBinding`](apps/api/src/projects/lib/session-connector-bindings.ts) auto-wires when an inbound email lands on a session. `ensureEmailSessionBinding` is the **only** producer of `source: 'default'` binding rows, and no other channel auto-binds.

Consequence: a session the caller never opted into explicit-only selection for would, the moment it received an email, flip into explicit-only mode — and every *other* connector (slack, meet, …) that relied on the project default would resolve to `null`. The agent silently loses those connectors.

## Fix

Count only caller-**requested** (`source: 'request'`) bindings toward the all-or-nothing gate. An auto-wired `source: 'default'` email binding no longer trips it. The email alias still resolves via its own bound row; only the fallback decision for *unbound* aliases changes.

One-line change to the gate's `WHERE` clause + a rationale comment.

## Test

`integration-session-connector-profiles.test.ts` gains a session that has **only** an auto `source: 'default'` email binding and asserts an unbound alias still resolves the project default. Verified it **fails** without the fix and passes with it. The existing "partially bound session fails closed" test uses a `source: 'request'` binding and stays green (that path is unchanged). Full file: 19 pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)