### PR TITLE
fix(sdk): scope the .runtime escape hatch under createScopedKortix

### DIFF
--- a/packages/sdk/src/core/runtime/client.ts
+++ b/packages/sdk/src/core/runtime/client.ts
@@ -54,6 +54,20 @@ export * from "./kortix-master";
 
 
 /**
+ * Brand marking a value as an authenticated opencode runtime client built by
+ * `getClientForUrl`/`getClient` (the `.runtime` / `runtime()` escape hatch).
+ * `@kortix/sdk/server` reads this to recognise the raw `OpencodeClient` its
+ * generic config-scoping wrapper would otherwise pass through untouched, and to
+ * bind each of its method calls to the current request's config. A global
+ * (`Symbol.for`) symbol so a host that ends up with two copies of this module on
+ * disk still agrees on the brand. Not part of the public API. See
+ * `scope-runtime-client.ts`.
+ */
+export const OPENCODE_RUNTIME_CLIENT_BRAND: unique symbol = Symbol.for(
+	'kortix.sdk.opencodeRuntimeClient',
+);
+
+/**
  * Per-URL client cache. Unlike `getClient()` (which tracks only the single
  * active server), this keeps one client alive PER sandbox URL so we can talk to
  * several session sandboxes in parallel — every open session stays connected to
@@ -122,6 +136,10 @@ export function getClientForUrl(url: string): OpencodeClient {
 	}
 
 	const client = createOpencodeClient({ baseUrl: url, fetch: authenticatedFetch as typeof fetch });
+	// Brand it (once, at creation — cached clients return early above and are
+	// never re-branded) so `@kortix/sdk/server` can scope its calls per request.
+	// Non-enumerable so it never shows up in host enumeration of the client.
+	Object.defineProperty(client, OPENCODE_RUNTIME_CLIENT_BRAND, { value: true });
 	clientsByUrl.set(url, client);
 	return client;
 }

--- a/packages/sdk/src/node/scope-runtime-client.test.ts
+++ b/packages/sdk/src/node/scope-runtime-client.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+import type { KortixPlatformConfig } from '../core/http/config';
+// Importing this module registers the AsyncLocalStorage config resolver as an
+// import-time side effect (via ../platform/config-node), so `getScopedConfig()`
+// reflects the scope established by `scopeRuntimeClient`'s per-call `runScoped`.
+import { scopeRuntimeClient } from './scope-runtime-client';
+import { getScopedConfig } from '../platform/config-node';
+
+function cfg(backendUrl: string): KortixPlatformConfig {
+  return { backendUrl, getToken: async () => `tok-${backendUrl}` };
+}
+
+/** A stand-in for the opencode runtime client: nested namespaces whose methods
+ *  report whichever config is active on the current async context — exactly
+ *  what `authenticatedFetch` reads inside the real client. */
+function fakeRuntimeClient() {
+  return {
+    session: {
+      // Reads the ambient config AFTER an await, to prove the scope survives
+      // the async continuation (the real client awaits fetch mid-method).
+      prompt: async () => {
+        await Promise.resolve();
+        return getScopedConfig()?.backendUrl ?? null;
+      },
+    },
+    app: {
+      // `this`-dependent method — the proxy must invoke it with the real
+      // namespace as receiver, not the proxy.
+      base: 'app-base',
+      get(this: { base: string }) {
+        return `${this.base}:${getScopedConfig()?.backendUrl ?? 'none'}`;
+      },
+    },
+  };
+}
+
+describe('scopeRuntimeClient', () => {
+  test('binds every method call to the captured config, even when called out of scope', async () => {
+    const scoped = scopeRuntimeClient(fakeRuntimeClient(), cfg('A'));
+    // No ambient runScoped frame here — the proxy is the only thing that can
+    // supply the config.
+    expect(getScopedConfig()).toBeUndefined();
+    expect(await scoped.session.prompt()).toBe('A');
+    expect(scoped.app.get()).toBe('app-base:A');
+  });
+
+  test('the raw (unscoped) client sees no config out of scope — proves the proxy is what binds it', async () => {
+    const raw = fakeRuntimeClient();
+    expect(await raw.session.prompt()).toBeNull();
+  });
+
+  test('two scoped clients stay isolated under interleaving', async () => {
+    const a = scopeRuntimeClient(fakeRuntimeClient(), cfg('A'));
+    const b = scopeRuntimeClient(fakeRuntimeClient(), cfg('B'));
+    const [ra, rb] = await Promise.all([a.session.prompt(), b.session.prompt()]);
+    expect(ra).toBe('A');
+    expect(rb).toBe('B');
+  });
+
+  test('nested namespaces keep referential identity across accesses', () => {
+    const scoped = scopeRuntimeClient(fakeRuntimeClient(), cfg('A'));
+    expect(scoped.session).toBe(scoped.session);
+  });
+});

--- a/packages/sdk/src/node/scope-runtime-client.ts
+++ b/packages/sdk/src/node/scope-runtime-client.ts
@@ -1,0 +1,70 @@
+/**
+ * Per-request config scoping for the `.runtime` / `runtime()` escape hatch.
+ *
+ * `createScopedKortix` (see `./server.ts`) wraps every facade method so it runs
+ * inside `runScoped(config, …)` — each incoming request's config is isolated on
+ * an `AsyncLocalStorage` context. That generic wrapper recurses into plain
+ * objects/functions but DELIBERATELY passes class instances through untouched,
+ * so it never mis-clones a vendor object whose correctness depends on its
+ * prototype/internal slots (`Response`, `Blob`, `Map`, …).
+ *
+ * The raw opencode `OpencodeClient` returned by `session.runtime` (and the
+ * top-level `runtime()`) is exactly such a class instance — so the generic
+ * wrapper leaves it alone. But its methods authenticate through
+ * `authenticatedFetch`, which reads the AMBIENT platform config at call time. A
+ * caller holds the returned client and invokes its methods OUTSIDE any
+ * `runScoped` frame, so without help those calls resolve the process-global
+ * config — the wrong tenant in a multi-tenant server (config bleed), or an
+ * unconfigured 401 in a pure-scoped one (`createScopedKortix` never writes the
+ * global). This module bridges that gap: it wraps the branded client in a Proxy
+ * that re-enters `runScoped(config, …)` around every method call, so the fetch
+ * always sees THIS request's config regardless of the caller's ambient frame.
+ *
+ * Scope of the fix: request/response methods (`runtime.session.prompt`,
+ * `runtime.file.read`, `runtime.app.get`, …) are fully covered. A method's
+ * RETURN VALUE is left untouched — it is plain data, not a further call. The one
+ * known gap is a lazily-connecting async iterable returned by the raw client
+ * (e.g. a hand-rolled `runtime.event.subscribe()` whose network I/O happens only
+ * once the caller starts iterating, after the wrapped call has returned); for
+ * scoped event streaming use the SDK's first-class `session.stream()`, which is
+ * already correctly scoped.
+ */
+import type { KortixPlatformConfig } from '../core/http/config';
+import { runScoped } from '../platform/config-node';
+
+/**
+ * Recursively wrap a branded opencode runtime client so every method call runs
+ * inside `runScoped(config, …)`. Nested namespaces (`client.session`,
+ * `client.file`, …) are proxied on access; the `cache` (one per top-level call)
+ * preserves referential identity so repeated access to the same namespace yields
+ * the same proxy. Methods are invoked with the REAL target as their receiver, so
+ * the client's own `this`-binding is preserved.
+ */
+export function scopeRuntimeClient<T extends object>(
+  client: T,
+  config: KortixPlatformConfig,
+  cache: WeakMap<object, object> = new WeakMap(),
+): T {
+  const cached = cache.get(client);
+  if (cached) return cached as T;
+
+  const proxy = new Proxy(client, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === 'function') {
+        const fn = value as (...args: unknown[]) => unknown;
+        return (...args: unknown[]): unknown => runScoped(config, () => fn.apply(target, args));
+      }
+      // Recurse into the client's own namespace objects (session, file, …) so
+      // `client.session.prompt(…)` is scoped too. Return values are NOT proxied
+      // — they are plain data the caller consumes, not further scoped calls.
+      if (value !== null && typeof value === 'object') {
+        return scopeRuntimeClient(value as object, config, cache);
+      }
+      return value;
+    },
+  });
+
+  cache.set(client, proxy);
+  return proxy as T;
+}

--- a/packages/sdk/src/node/server.ts
+++ b/packages/sdk/src/node/server.ts
@@ -27,8 +27,10 @@
  * isolated from any other concurrent call in the same process.
  */
 import { createKortix, type Kortix } from '../core/client/kortix';
+import { OPENCODE_RUNTIME_CLIENT_BRAND } from '../core/runtime/client';
 import { runScoped, runWithKortix, getScopedConfig } from '../platform/config-node';
 import type { KortixPlatformConfig } from '../core/http/config';
+import { scopeRuntimeClient } from './scope-runtime-client';
 
 export { runWithKortix, getScopedConfig };
 
@@ -60,6 +62,21 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function wrapScoped<T>(value: T, config: KortixPlatformConfig, seen: WeakSet<object>, depth = 0): T {
   if (depth > MAX_WRAP_DEPTH) return value;
 
+  // The `.runtime` / `runtime()` escape hatch returns a raw opencode client — a
+  // class instance the plain-object/function recursion below would (correctly,
+  // for a vendor object) pass through untouched. But its methods authenticate
+  // with the AMBIENT config at call time, and the caller invokes them outside
+  // any scope. Scope the branded client's method calls to THIS config so the
+  // escape hatch is as tenant-isolated as the first-class facade methods. See
+  // `scope-runtime-client.ts`.
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    (value as Record<PropertyKey, unknown>)[OPENCODE_RUNTIME_CLIENT_BRAND]
+  ) {
+    return scopeRuntimeClient(value as object, config) as unknown as T;
+  }
+
   if (typeof value === 'function') {
     const fn = value as (...args: unknown[]) => unknown;
     const wrapped = (...args: unknown[]): unknown => {
@@ -87,7 +104,14 @@ function wrapScoped<T>(value: T, config: KortixPlatformConfig, seen: WeakSet<obj
       if (desc.get) {
         Object.defineProperty(out, key, {
           enumerable: true,
-          get: () => wrapScoped(desc.get!.call(value), config, new WeakSet(), 0),
+          // Run the getter itself inside the scope, not just its result: a getter
+          // like `session.runtime` builds its client via `getClientForUrl`, whose
+          // `isConfigured()` guard must see THIS request's config — a scoped-only
+          // server never writes the process-global one, so an out-of-scope build
+          // would throw "no auth token provider configured". The built (branded)
+          // client is then scoped by `wrapScoped`'s branded-client branch above.
+          get: () =>
+            runScoped(config, () => wrapScoped(desc.get!.call(value), config, new WeakSet(), 0)),
         });
       } else {
         out[key] = wrapScoped(desc.value, config, seen, depth + 1);


### PR DESCRIPTION
## Problem

`createScopedKortix` (the `@kortix/sdk/server` multi-tenant seam) isolates each request's platform config on an `AsyncLocalStorage` scope by wrapping every facade method in `runScoped()`. That wrapper **deliberately** passes class instances through untouched, so it never mis-clones a vendor object whose correctness depends on its prototype/internal slots (`Response`, `Blob`, `Map`, …).

The `.runtime` getter (and the top-level `runtime()`) return exactly such a class instance — the raw opencode `OpencodeClient`. Its methods authenticate through `authenticatedFetch`, which reads the **ambient** platform config at call time. A caller holds the returned client and invokes its methods **outside** any `runScoped` frame, so those calls resolve the process-global config:

- **multi-tenant server** → the wrong tenant's token (config bleed), and
- **pure-scoped server** → `createScopedKortix` never writes the global, so `getClientForUrl`'s `isConfigured()` build check throws *"no auth token provider configured"* — the escape hatch is simply broken.

The first-class methods (`.send`, `.stream`, `.files.*`) are unaffected — they're wrapped functions that call the client *inside* their own scoped frame.

## Fix

1. **Brand** the client at construction in `getClientForUrl` (a global `Symbol.for`), once, non-enumerable.
2. In the server wrapper, when `wrapScoped` meets a branded client, wrap it in a recursive **Proxy** (`scope-runtime-client.ts`) that re-enters `runScoped(config, …)` around every method call — invoking each method with the real namespace as receiver so `this` is preserved. Now `.runtime.session.prompt(…)`, `.runtime.file.read(…)`, etc. are as tenant-isolated as the first-class methods.
3. Run facade **getters inside the scope** too, so `session.runtime`'s build-time `isConfigured()` check sees the request config in a pure-scoped server.

Method **return values** are left untouched (plain data, not further calls). The one known gap — a lazily-connecting async iterable returned by the raw client — is documented; scoped event streaming should use the already-correct first-class `session.stream()`.

## Test

`scope-runtime-client.test.ts`: a branded-client stand-in whose nested methods report the ambient config proves the proxy (a) binds calls to the captured config when invoked out of scope, (b) leaves the raw client seeing nothing out of scope (control), (c) keeps two scoped clients isolated under interleaving, (d) preserves nested-namespace identity and `this`. SDK `tsc --noEmit` clean; 176 node/runtime/client/config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)