### PR TITLE
fix(secrets): resolve per-user secret overrides as the session owner, not the provisioner

### DIFF
--- a/apps/api/src/__tests__/integration-session-env-grants.test.ts
+++ b/apps/api/src/__tests__/integration-session-env-grants.test.ts
@@ -16,8 +16,10 @@ import { and, eq, sql, inArray } from 'drizzle-orm';
 import { projectSecrets, projectSessions } from '@kortix/db';
 import { db } from '../shared/db';
 import { resolveSandboxEnvSnapshot } from '../projects/lib/sandbox-env-sync';
+import { buildSessionSandboxEnvVars } from '../projects/lib/sessions';
 import {
   AmbiguousSecretGrantError,
+  encryptProjectSecret,
   intersectSecretGrants,
   listProjectSecretsSnapshotForUser,
   writeSharedProjectSecret,
@@ -31,6 +33,13 @@ const KEY = `E2E_GMAPS_${SUFFIX}`;
 const PRIMARY = `${KEY}-primary`;
 const BACKUP = `${KEY}-backup`;
 const UNSCOPED = `E2E_UNSCOPED_${SUFFIX}`;
+// Per-user override scenario: one identifier with a shared row plus two personal
+// (ownerUserId) overrides — the mechanism behind CODEX_AUTH_JSON.
+const OWNER = crypto.randomUUID();
+const RESTARTER = crypto.randomUUID();
+const OVERRIDE_IDENT = `E2E_OVR_${SUFFIX}`;
+const OVERRIDE_KEY = `E2E_OVR_KEY_${SUFFIX}`;
+const PRINCIPAL_SESSION = `e2e-principal-${crypto.randomUUID()}`;
 
 beforeAll(async () => {
   const rows = (await db.execute(
@@ -43,14 +52,62 @@ beforeAll(async () => {
   await writeSharedProjectSecret({ projectId: ctx.projectId, identifier: PRIMARY, name: KEY, value: 'primary-val' });
   await writeSharedProjectSecret({ projectId: ctx.projectId, identifier: BACKUP, name: KEY, value: 'backup-val' });
   await writeSharedProjectSecret({ projectId: ctx.projectId, name: UNSCOPED, value: 'open-val' });
+
+  // One identifier with a shared value plus a distinct personal override for
+  // OWNER and for RESTARTER — so the resolved value differs by principal.
+  await writeSharedProjectSecret({
+    projectId: ctx.projectId,
+    identifier: OVERRIDE_IDENT,
+    name: OVERRIDE_KEY,
+    value: 'shared-val',
+  });
+  const now = new Date();
+  await db.insert(projectSecrets).values([
+    {
+      projectId: ctx.projectId,
+      identifier: OVERRIDE_IDENT,
+      name: OVERRIDE_KEY,
+      ownerUserId: OWNER,
+      active: true,
+      valueEnc: encryptProjectSecret(ctx.projectId, 'owner-val'),
+      scope: 'runtime',
+      updatedAt: now,
+    },
+    {
+      projectId: ctx.projectId,
+      identifier: OVERRIDE_IDENT,
+      name: OVERRIDE_KEY,
+      ownerUserId: RESTARTER,
+      active: true,
+      valueEnc: encryptProjectSecret(ctx.projectId, 'restarter-val'),
+      scope: 'runtime',
+      updatedAt: now,
+    },
+  ]);
+  // A session OWNED by OWNER — used to prove sandbox-boot resolves secrets as the
+  // owner even when some other principal provisions the run.
+  await db.insert(projectSessions).values({
+    sessionId: PRINCIPAL_SESSION,
+    accountId: ctx.accountId,
+    projectId: ctx.projectId,
+    branchName: 'kaab-principal-test',
+    createdBy: OWNER,
+    agentName: 'default',
+  });
 });
 
 afterAll(async () => {
   if (!ctx) return;
   await db.delete(projectSessions).where(eq(projectSessions.sessionId, SESSION_ID));
+  await db.delete(projectSessions).where(eq(projectSessions.sessionId, PRINCIPAL_SESSION));
   await db
     .delete(projectSecrets)
-    .where(and(eq(projectSecrets.projectId, ctx.projectId), inArray(projectSecrets.identifier, [PRIMARY, BACKUP, UNSCOPED])));
+    .where(
+      and(
+        eq(projectSecrets.projectId, ctx.projectId),
+        inArray(projectSecrets.identifier, [PRIMARY, BACKUP, UNSCOPED, OVERRIDE_IDENT]),
+      ),
+    );
 });
 
 describe('listProjectSecretsSnapshotForUser — session env injection by identifier', () => {
@@ -132,6 +189,36 @@ describe('listProjectSecretsSnapshotForUser — session env injection by identif
     const passthroughSnap = await resolveSandboxEnvSnapshot(ctx.projectId, SESSION_ID);
     expect(passthroughSnap?.env[UNSCOPED]).toBe('open-val');
     expect(passthroughSnap?.env[KEY]).toBeDefined();
+  });
+
+  test('sandbox-boot resolves per-user overrides as the session OWNER, not the provisioner', async () => {
+    if (!ctx) return;
+    // Control: the two principals genuinely resolve DIFFERENT values for the same
+    // identifier — so an incorrect principal would be observable.
+    const asOwner = await listProjectSecretsSnapshotForUser(ctx.projectId, OWNER, [OVERRIDE_IDENT]);
+    const asRestarter = await listProjectSecretsSnapshotForUser(ctx.projectId, RESTARTER, [
+      OVERRIDE_IDENT,
+    ]);
+    expect(asOwner.env[OVERRIDE_KEY]).toBe('owner-val');
+    expect(asRestarter.env[OVERRIDE_KEY]).toBe('restarter-val');
+
+    // The full sandbox-boot builder, invoked with userId = RESTARTER (a manager
+    // restarting OWNER's session). It must resolve secrets as the session's
+    // createdBy (OWNER), not the provisioning principal — otherwise the
+    // restarter's personal secret would boot into the owner's session and then
+    // flip-flop on the first prompt's hot-push (which is keyed on createdBy).
+    // `defaultBranch` omitted → agent grant defaults to 'all' (no git/manifest).
+    const env = await buildSessionSandboxEnvVars({
+      accountId: ctx.accountId,
+      projectId: ctx.projectId,
+      sessionId: PRINCIPAL_SESSION,
+      userId: RESTARTER,
+      repoUrl: 'https://example.test/principal.git',
+      baseRef: 'main',
+      agentName: 'default',
+      llmGatewayEnabled: false,
+    });
+    expect(env[OVERRIDE_KEY]).toBe('owner-val');
   });
 });
 

--- a/apps/api/src/__tests__/integration-session-env-grants.test.ts
+++ b/apps/api/src/__tests__/integration-session-env-grants.test.ts
@@ -90,7 +90,7 @@ beforeAll(async () => {
     sessionId: PRINCIPAL_SESSION,
     accountId: ctx.accountId,
     projectId: ctx.projectId,
-    branchName: 'kaab-principal-test',
+    branchName: `kaab-principal-${SUFFIX}`,
     createdBy: OWNER,
     agentName: 'default',
   });
@@ -173,7 +173,7 @@ describe('listProjectSecretsSnapshotForUser — session env injection by identif
       sessionId: SESSION_ID,
       accountId: ctx.accountId,
       projectId: ctx.projectId,
-      branchName: 'kaab-clobber-test',
+      branchName: `kaab-clobber-${SUFFIX}`,
       createdBy: USER,
       agentName: 'default',
       secretsAllowlist: [UNSCOPED],

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -249,10 +249,12 @@ export async function buildSessionSandboxEnvVars(input: {
   // Only user runtime secrets belong here. The sandbox-scoped KORTIX_TOKEN is
   // minted by provisionSessionSandbox() and injected at the provider boundary,
   // then reused by the daemon for both API calls and proxy HMAC validation.
-  // Resolved AS the launching user so their own CODEX_AUTH_JSON override (if
-  // any) wins; every OTHER secret is project-wide (secret sharing was retired —
-  // authorization is centralized on the running agent's `secrets` grant, applied
-  // below by identifier).
+  // Resolved AS the session's OWNER (createdBy, read below) so their own
+  // CODEX_AUTH_JSON override (if any) wins — consistently, whether this run is
+  // provisioned by the owner (create) or by a manager/admin (restart/open); see
+  // secretsPrincipalUserId below. Every OTHER secret is project-wide (secret
+  // sharing was retired — authorization is centralized on the running agent's
+  // `secrets` grant, applied below by identifier).
   let agentGrantEnv: string[] | 'all' | undefined;
 
   // v2-only: compile the manifest's `agents:` map into an OpenCode-native
@@ -299,6 +301,7 @@ export async function buildSessionSandboxEnvVars(input: {
     .select({
       secretsAllowlist: projectSessions.secretsAllowlist,
       originRef: projectSessions.originRef,
+      createdBy: projectSessions.createdBy,
     })
     .from(projectSessions)
     .where(eq(projectSessions.sessionId, input.sessionId))
@@ -308,11 +311,26 @@ export async function buildSessionSandboxEnvVars(input: {
     sessionKaabRow?.secretsAllowlist ?? null,
   );
 
+  // The secrets principal is the session's OWNER (`createdBy`), read here by
+  // sessionId — NOT `input.userId`, which is whoever is provisioning this run.
+  // On create those coincide, but restart/open/ensure-runtime provision on
+  // behalf of any project manager/admin, and a per-user secret override (today
+  // CODEX_AUTH_JSON) resolves per principal (`listResolvedProjectSecrets`). If a
+  // manager restarted another member's session we'd inject the MANAGER's personal
+  // secret at boot, which the first prompt's hot-push (`resolveOwnerRawEnv`, keyed
+  // on `createdBy`) would then clobber back — a cross-principal bleed + flip-flop.
+  // Deriving the principal from `createdBy` here unifies all three provisioning
+  // paths with hot-push and the admin provider-migrate path. Falls back to
+  // `input.userId` only if the row somehow isn't found (create races its own row
+  // in some callers). The agent grant — not the human — remains the authority on
+  // WHICH identifiers are eligible; this only picks the per-user override owner.
+  const secretsPrincipalUserId = sessionKaabRow?.createdBy ?? input.userId;
+
   let runtimeSecrets: { env: Record<string, string>; names: string[]; revision: string };
   try {
     runtimeSecrets = await listProjectSecretsSnapshotForUser(
       input.projectId,
-      input.userId,
+      secretsPrincipalUserId,
       grantEnvForSession,
     );
   } catch (err) {


### PR DESCRIPTION
## Problem

`buildSessionSandboxEnvVars` resolved a session's runtime secrets **as `input.userId`** — whoever is provisioning *this* run. Per-user secret **overrides** (today only `CODEX_AUTH_JSON`, the per-user provider login) resolve **per principal** in `listResolvedProjectSecrets` (`ownerUserId = userId` shadows the shared row), so the principal genuinely matters.

- **create** — `input.userId == createdBy`, so it was correct.
- **restart** / **open / ensure-runtime** — provision on behalf of **any project manager/admin** (`loadProjectForUser` → the acting requester). If a manager restarts another member's session, the sandbox boots with the **manager's** personal secret. Then the first prompt's hot-push (`resolveOwnerRawEnv`, keyed on `createdBy`) re-pushes the **owner's** — so the session's provider identity **flip-flops** between boot and prompt. A cross-principal secret bleed + an inconsistency: an equivalent session gets a different secret set depending on which path provisioned it.

Create/hot-push/admin-provider-migrate all key on `createdBy`; restart/open were the lone deviation.

## Fix

Resolve the secrets principal from the session's **`createdBy`** — already read by `sessionId` in the same `SELECT` that fetches the KaaB fields, so it's a choke-point no caller can bypass (the finder's recommended option). One added column + `sessionKaabRow?.createdBy ?? input.userId`. `input.userId` becomes dead for secrets (its only use in the function), so no caller signature changes.

The agent grant — not the human — remains the sole authority on **which** identifiers are eligible; `resolveGrantedSecretEnv` and its throw-on-ambiguous (`AmbiguousSecretGrantError`) contract are **untouched**. This only picks the per-user override owner.

## Test

`integration-session-env-grants.test.ts`: a session owned by `OWNER`, with distinct personal `CODEX_AUTH_JSON`-style overrides for `OWNER` and `RESTARTER`. The full sandbox-boot builder invoked with `userId = RESTARTER` resolves **`owner-val`**. Verified it **fails** (`restarter-val`) without the fix. `tsc --noEmit` clean; secrets unit/allowlist suites green.

### Noted separately (not fixed here)
For **automation** sessions (triggers), first boot still resolves as the account-owner stand-in before `createdBy` is rewritten to the agent service account — worth an explicit product decision on whether automation sessions should ignore per-user overrides entirely (principal = `null`). Flagged, out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)