### PR TITLE
test: retry transient release gate failures

### DIFF
--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -6,23 +6,33 @@
  *
  *   await client.as(P.OWNER).get("/v1/projects/:id", { params: { id } }).then(r => r.status(200))
  */
-import { currentRecorder } from "./context";
-import { assert, BodyAssert } from "./expect";
-import type { Captured } from "./result";
+import { currentRecorder } from './context';
+import { assert, BodyAssert } from './expect';
+import type { Captured } from './result';
 
 export type Auth =
-  | { mode: "none" }
-  | { mode: "bearer"; token: string }
-  | { mode: "query-token"; token: string } // ?token= (preview proxy / WS)
-  | { mode: "header-token"; token: string } // X-Kortix-Token
-  | { mode: "cookie"; cookie: string }; // raw Cookie header
+  | { mode: 'none' }
+  | { mode: 'bearer'; token: string }
+  | { mode: 'query-token'; token: string } // ?token= (preview proxy / WS)
+  | { mode: 'header-token'; token: string } // X-Kortix-Token
+  | { mode: 'cookie'; cookie: string }; // raw Cookie header
 
 export interface Identity {
   label: string;
   auth: Auth;
 }
 
-export const ANON: Identity = { label: "ANON", auth: { mode: "none" } };
+export const ANON: Identity = { label: 'ANON', auth: { mode: 'none' } };
+
+/** True when the HTTP client marked an error as a transient network failure. */
+export function isKe2eRetryableError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'ke2eRetryable' in error &&
+    (error as { ke2eRetryable?: unknown }).ke2eRetryable === true
+  );
+}
 
 export interface ReqOpts {
   /** `:param` substitutions for the URL (template stays the coverage key). */
@@ -38,18 +48,19 @@ export interface ReqOpts {
 }
 
 const SENSITIVE_HEADERS = new Set([
-  "authorization",
-  "apikey",
-  "cookie",
-  "set-cookie",
-  "x-kortix-token",
-  "x-kortix-signature",
-  "x-hub-signature",
-  "x-hub-signature-256",
-  "stripe-signature",
+  'authorization',
+  'apikey',
+  'cookie',
+  'set-cookie',
+  'x-kortix-token',
+  'x-kortix-signature',
+  'x-hub-signature',
+  'x-hub-signature-256',
+  'stripe-signature',
 ]);
 
-const SENSITIVE_BODY_KEYS = /(token|secret|password|api[_-]?key|push_token|private[_-]?key|access_token|refresh_token|client_secret)/i;
+const SENSITIVE_BODY_KEYS =
+  /(token|secret|password|api[_-]?key|push_token|private[_-]?key|access_token|refresh_token|client_secret)/i;
 
 function mask(value: string): string {
   if (!value) return value;
@@ -73,10 +84,10 @@ function redactHeaders(h: Record<string, string>): Record<string, string> {
 
 function redactJson(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(redactJson);
-  if (value && typeof value === "object") {
+  if (value && typeof value === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (SENSITIVE_BODY_KEYS.test(k) && typeof v === "string") out[k] = mask(v);
+      if (SENSITIVE_BODY_KEYS.test(k) && typeof v === 'string') out[k] = mask(v);
       else out[k] = redactJson(v);
     }
     return out;
@@ -90,7 +101,10 @@ function redactBodyText(text: string | undefined): string | undefined {
     return JSON.stringify(redactJson(JSON.parse(text)));
   } catch {
     // Not JSON — best-effort mask of obvious token-looking substrings.
-    return text.replace(/(kortix_[a-z]*_?[A-Za-z0-9]{6,}|sk-[A-Za-z0-9]{6,}|eyJ[A-Za-z0-9_.-]{10,})/g, (m) => mask(m));
+    return text.replace(
+      /(kortix_[a-z]*_?[A-Za-z0-9]{6,}|sk-[A-Za-z0-9]{6,}|eyJ[A-Za-z0-9_.-]{10,})/g,
+      (m) => mask(m),
+    );
   }
 }
 
@@ -118,8 +132,8 @@ export class Res {
   status(code: number | number[]): this {
     const codes = Array.isArray(code) ? code : [code];
     assert({
-      kind: "status",
-      description: `status in [${codes.join(", ")}]`,
+      kind: 'status',
+      description: `status in [${codes.join(', ')}]`,
       expected: codes,
       actual: this.statusCode,
       pass: codes.includes(this.statusCode),
@@ -129,10 +143,13 @@ export class Res {
 
   headerEquals(name: string, expected: string | RegExp): this {
     const actual = this.header(name);
-    const pass = expected instanceof RegExp ? typeof actual === "string" && expected.test(actual) : actual === expected;
+    const pass =
+      expected instanceof RegExp
+        ? typeof actual === 'string' && expected.test(actual)
+        : actual === expected;
     assert({
-      kind: "header",
-      description: `header ${name} ${expected instanceof RegExp ? "matches " + expected : "=== " + expected}`,
+      kind: 'header',
+      description: `header ${name} ${expected instanceof RegExp ? 'matches ' + expected : '=== ' + expected}`,
       expected: expected.toString(),
       actual,
       pass,
@@ -143,9 +160,9 @@ export class Res {
   headerExists(name: string): this {
     const actual = this.header(name);
     assert({
-      kind: "header.exists",
+      kind: 'header.exists',
       description: `header ${name} present`,
-      expected: "<present>",
+      expected: '<present>',
       actual,
       pass: actual !== undefined,
     });
@@ -173,42 +190,42 @@ export class Client {
     return new Client(this.origin, identity, this.defaultTimeoutMs);
   }
 
-  withBearer(token: string, label = "raw"): Client {
-    return this.as({ label, auth: { mode: "bearer", token } });
+  withBearer(token: string, label = 'raw'): Client {
+    return this.as({ label, auth: { mode: 'bearer', token } });
   }
 
   get(t: string, o?: ReqOpts) {
-    return this.request("GET", t, o);
+    return this.request('GET', t, o);
   }
   post(t: string, body?: unknown, o?: ReqOpts) {
-    return this.request("POST", t, { ...o, body });
+    return this.request('POST', t, { ...o, body });
   }
   put(t: string, body?: unknown, o?: ReqOpts) {
-    return this.request("PUT", t, { ...o, body });
+    return this.request('PUT', t, { ...o, body });
   }
   patch(t: string, body?: unknown, o?: ReqOpts) {
-    return this.request("PATCH", t, { ...o, body });
+    return this.request('PATCH', t, { ...o, body });
   }
   del(t: string, o?: ReqOpts) {
-    return this.request("DELETE", t, o);
+    return this.request('DELETE', t, o);
   }
 
   private applyAuth(headers: Headers, url: URL): void {
     const a = this.identity.auth;
     switch (a.mode) {
-      case "bearer":
-        headers.set("authorization", `Bearer ${a.token}`);
+      case 'bearer':
+        headers.set('authorization', `Bearer ${a.token}`);
         break;
-      case "header-token":
-        headers.set("x-kortix-token", a.token);
+      case 'header-token':
+        headers.set('x-kortix-token', a.token);
         break;
-      case "cookie":
-        headers.set("cookie", a.cookie);
+      case 'cookie':
+        headers.set('cookie', a.cookie);
         break;
-      case "query-token":
-        url.searchParams.set("token", a.token);
+      case 'query-token':
+        url.searchParams.set('token', a.token);
         break;
-      case "none":
+      case 'none':
         break;
     }
   }
@@ -217,7 +234,7 @@ export class Client {
     let path = template;
     if (opts?.params) {
       for (const [k, v] of Object.entries(opts.params)) {
-        path = path.replace(new RegExp(`:${k}(?=/|$|\\.)`, "g"), encodeURIComponent(String(v)));
+        path = path.replace(new RegExp(`:${k}(?=/|$|\\.)`, 'g'), encodeURIComponent(String(v)));
       }
     }
     const url = new URL(this.origin + path);
@@ -230,12 +247,12 @@ export class Client {
     const headers = new Headers();
     let bodyInit: BodyInit | undefined;
     if (opts?.body !== undefined) {
-      if (opts.raw || typeof opts.body === "string") {
+      if (opts.raw || typeof opts.body === 'string') {
         bodyInit = opts.body as string;
       } else if (opts.body instanceof FormData) {
         bodyInit = opts.body;
       } else {
-        headers.set("content-type", "application/json");
+        headers.set('content-type', 'application/json');
         bodyInit = JSON.stringify(opts.body);
       }
     }
@@ -253,7 +270,7 @@ export class Client {
         headers,
         body: bodyInit,
         signal: AbortSignal.timeout(timeoutMs),
-        redirect: "manual",
+        redirect: 'manual',
       });
     } catch (err: any) {
       // Surface as a captured "network" failure (retryable infra signal).
@@ -273,10 +290,10 @@ export class Client {
     const bodyText = await res.text();
     const ms = performance.now() - started;
     const resHeaders: Record<string, string> = {};
-    res.headers.forEach((v, k) => (resHeaders[k] = k.toLowerCase() === "set-cookie" ? mask(v) : v));
+    res.headers.forEach((v, k) => (resHeaders[k] = k.toLowerCase() === 'set-cookie' ? mask(v) : v));
     let json: unknown;
-    const ct = res.headers.get("content-type") ?? "";
-    if (ct.includes("application/json")) {
+    const ct = res.headers.get('content-type') ?? '';
+    if (ct.includes('application/json')) {
       try {
         json = JSON.parse(bodyText);
       } catch {
@@ -290,9 +307,14 @@ export class Client {
         method,
         url: url.toString(),
         headers: redactHeaders(headersToObject(headers)),
-        body: redactBodyText(typeof bodyInit === "string" ? bodyInit : undefined),
+        body: redactBodyText(typeof bodyInit === 'string' ? bodyInit : undefined),
       },
-      res: { status: res.status, headers: resHeaders, bodyText: redactBodyText(bodyText) ?? "", json },
+      res: {
+        status: res.status,
+        headers: resHeaders,
+        bodyText: redactBodyText(bodyText) ?? '',
+        json,
+      },
       ms,
     };
     record(captured);

--- a/tests/src/core/poll.ts
+++ b/tests/src/core/poll.ts
@@ -9,16 +9,28 @@ export async function waitFor<T>(
     timeoutMs: number;
     intervalMs: number;
     description?: string;
+    retryOnError?: (error: unknown) => boolean;
   },
 ): Promise<T> {
   const deadline = Date.now() + opts.timeoutMs;
-  let last: T;
+  let last!: T;
+  let lastRetryableError: unknown;
 
   while (true) {
-    last = await read();
-    if (opts.until(last)) return last;
+    try {
+      last = await read();
+      lastRetryableError = undefined;
+      if (opts.until(last)) return last;
+    } catch (error) {
+      if (!opts.retryOnError?.(error)) throw error;
+      lastRetryableError = error;
+    }
     if (Date.now() >= deadline) {
-      throw new Error(`Timed out waiting for ${opts.description ?? 'condition'}`);
+      const detail =
+        lastRetryableError instanceof Error
+          ? `; last retryable error: ${lastRetryableError.message}`
+          : '';
+      throw new Error(`Timed out waiting for ${opts.description ?? 'condition'}${detail}`);
     }
     await sleep(opts.intervalMs);
   }

--- a/tests/src/fixtures/provision.ts
+++ b/tests/src/fixtures/provision.ts
@@ -4,7 +4,7 @@
  * cap concurrent provisions with a semaphore and retry on rate-limit with backoff.
  * Everything else in the suite stays fully parallel.
  */
-import type { Client } from '../core/client';
+import { type Client, isKe2eRetryableError } from '../core/client';
 import { sleep } from '../core/poll';
 
 const MAX = Number(process.env.KE2E_PROVISION_CONCURRENCY ?? 2);
@@ -26,27 +26,57 @@ function release(): void {
 
 const RATE_LIMIT_RE = /rate limit|secondary rate|temporarily blocked|abuse/i;
 const PROVISION_REQUEST_TIMEOUT_MS = 180_000;
+const MAX_PROVISION_ATTEMPTS = 5;
 
-/** Provision a project via /v1/projects/provision, throttled + rate-limit-retried. */
+function isRetryableProvisionStatus(status: number): boolean {
+  return status >= 500 && status <= 599;
+}
+
+function retryDelayMs(attempt: number): number {
+  return Math.min(5_000 * 2 ** attempt, 30_000);
+}
+
+/**
+ * Provision a project via /v1/projects/provision.
+ *
+ * The retry policy accepts only transient network failures, HTTP 5xx responses,
+ * and explicit rate-limit responses. Other HTTP 4xx responses fail immediately.
+ */
 export async function provisionProject(
   client: Client,
   body: Record<string, unknown>,
 ): Promise<string> {
   await acquire();
   try {
-    let lastText = '';
-    for (let attempt = 0; attempt < 5; attempt++) {
-      const r = await client.post('/v1/projects/provision', body, {
-        timeoutMs: PROVISION_REQUEST_TIMEOUT_MS,
-      });
-      const id = (r.json<any>() ?? {})?.project_id;
-      if (id) return id as string;
-      lastText = r.text();
-      if (!RATE_LIMIT_RE.test(lastText) || attempt === 4) break;
-      // GitHub secondary rate limit — back off increasingly before retrying.
-      await sleep(10_000 * (attempt + 1));
+    let lastFailure = '';
+    let attempts = 0;
+    for (let attempt = 0; attempt < MAX_PROVISION_ATTEMPTS; attempt++) {
+      attempts = attempt + 1;
+      let r: Awaited<ReturnType<Client['post']>>;
+      try {
+        r = await client.post('/v1/projects/provision', body, {
+          timeoutMs: PROVISION_REQUEST_TIMEOUT_MS,
+        });
+      } catch (error) {
+        if (!isKe2eRetryableError(error) || attempt === MAX_PROVISION_ATTEMPTS - 1) {
+          throw error;
+        }
+        await sleep(retryDelayMs(attempt));
+        continue;
+      }
+
+      const id = r.json<{ project_id?: unknown }>()?.project_id;
+      if (typeof id === 'string' && id.length > 0) return id;
+      const responseText = r.text();
+      lastFailure = `HTTP ${r.statusCode}: ${responseText}`;
+      const retryable =
+        isRetryableProvisionStatus(r.statusCode) || RATE_LIMIT_RE.test(responseText);
+      if (!retryable || attempt === MAX_PROVISION_ATTEMPTS - 1) break;
+      await sleep(retryDelayMs(attempt));
     }
-    throw new Error(`project provision returned no id: ${lastText}`);
+    throw new Error(
+      `project provision returned no id after ${attempts} attempt(s): ${lastFailure}`,
+    );
   } finally {
     release();
   }

--- a/tests/src/flows/cli-ship.flow.ts
+++ b/tests/src/flows/cli-ship.flow.ts
@@ -36,6 +36,7 @@
  * are green-or-skipped locally and exercise the real path on dev-api.
  */
 import { flow } from '../core/flow';
+import { isKe2eRetryableError } from '../core/client';
 import { assert } from '../core/expect';
 import { waitFor } from '../core/poll';
 import { CliSandbox } from '../fixtures/cli';
@@ -585,7 +586,7 @@ flow(
     domain: 'cli',
     requires: ['funded'],
     serial: true,
-    timeoutMs: 600_000,
+    timeoutMs: 900_000,
     routes: [
       'GET /v1/accounts/me',
       'POST /v1/projects/provision',
@@ -627,6 +628,7 @@ flow(
             timeoutMs: 25_000,
           },
         );
+        if (r.statusCode >= 500 && r.statusCode <= 599) return null;
         r.status(200);
         return r.json<any>();
       },
@@ -634,9 +636,10 @@ flow(
         until: (body) =>
           body?.stage === 'ready' &&
           Boolean(body?.sandbox?.external_id ?? body?.sandbox?.externalId),
-        timeoutMs: 300_000,
+        timeoutMs: 420_000,
         intervalMs: 3_000,
         description: `CR-9 session runtime ready for ${session.id}`,
+        retryOnError: isKe2eRetryableError,
       },
     );
     const sandboxId = String(started.sandbox.external_id ?? started.sandbox.externalId);

--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -27,6 +27,7 @@
  * proxy's auth boundary is additionally covered transitively by PRX-1/PRX-2.
  */
 import { flow } from '../core/flow';
+import { isKe2eRetryableError } from '../core/client';
 import { waitFor, sleep } from '../core/poll';
 import type { FlowContext } from '../core/types';
 
@@ -37,6 +38,7 @@ async function waitForSessionReady(
   ctx: FlowContext,
   projectId: string,
   sessionId: string,
+  timeoutMs = 300_000,
 ): Promise<any> {
   return waitFor(
     async () => {
@@ -51,15 +53,17 @@ async function waitForSessionReady(
           timeoutMs: 25_000,
         },
       );
+      if (r.statusCode >= 500 && r.statusCode <= 599) return null;
       r.status(200);
       return r.json<any>();
     },
     {
       until: (s) =>
         s?.stage === 'ready' && Boolean(s?.sandbox?.external_id ?? s?.sandbox?.externalId),
-      timeoutMs: 300_000,
+      timeoutMs,
       intervalMs: 3_000,
       description: `session runtime ready for ${sessionId}`,
+      retryOnError: isKe2eRetryableError,
     },
   );
 }
@@ -70,11 +74,11 @@ async function waitForSessionReady(
  */
 async function bootSandbox(
   ctx: FlowContext,
-  opts?: { prompt?: string },
+  opts?: { prompt?: string; readinessTimeoutMs?: number },
 ): Promise<{ projectId: string; sessionId: string; sandboxId: string; sandbox: any }> {
   const project = await ctx.fixtures.project({ seed: true });
   const session = await ctx.fixtures.session(project, { prompt: opts?.prompt ?? 'say hello' });
-  const started = await waitForSessionReady(ctx, project.id, session.id);
+  const started = await waitForSessionReady(ctx, project.id, session.id, opts?.readinessTimeoutMs);
 
   const sandbox = started.sandbox;
   const sandboxId = String(sandbox.external_id ?? sandbox.externalId);
@@ -140,9 +144,7 @@ async function waitForAssistantOutput(
 ): Promise<any[]> {
   return waitFor(
     async () => {
-      const r = await ctx.client
-        .as(ctx.P.OWNER)
-        .get(ocPath(sandboxId, `/session/${ocId}/message`));
+      const r = await ctx.client.as(ctx.P.OWNER).get(ocPath(sandboxId, `/session/${ocId}/message`));
       return r.statusCode === 200 ? r.json<any[]>() : [];
     },
     {
@@ -411,12 +413,10 @@ flow(
       // a specific commit count since timing of the agent commit is LLM-bound.
       await waitFor(
         async () => {
-          const r = await ctx.client
-            .as(ctx.P.OWNER)
-            .get('/v1/projects/:projectId/commits', {
-              params: { projectId },
-              query: { ref: sessionId },
-            });
+          const r = await ctx.client.as(ctx.P.OWNER).get('/v1/projects/:projectId/commits', {
+            params: { projectId },
+            query: { ref: sessionId },
+          });
           return r.statusCode;
         },
         {
@@ -481,12 +481,10 @@ flow(
         r.status([200, 204, 404]); // 404 = path-not-served-by-OpenCode but auth passed
       });
       await ctx.step('revoke the share token → 200', async () => {
-        const r = await ctx.client
-          .as(ctx.P.OWNER)
-          .del('/v1/p/share/:token', {
-            params: { token: shareToken },
-            query: { sandbox_id: sandboxId },
-          });
+        const r = await ctx.client.as(ctx.P.OWNER).del('/v1/p/share/:token', {
+          params: { token: shareToken },
+          query: { sandbox_id: sandboxId },
+        });
         r.status([200, 204, 404]);
       });
     }
@@ -677,12 +675,10 @@ flow(
       r.status(200).body().exists('$.files_changed');
     });
     await ctx.step('missing into/base → 400', async () => {
-      const r = await ctx.client
-        .as(ctx.P.OWNER)
-        .get('/v1/projects/:projectId/version-diff', {
-          params: { projectId },
-          query: { from: sessionId },
-        });
+      const r = await ctx.client.as(ctx.P.OWNER).get('/v1/projects/:projectId/version-diff', {
+        params: { projectId },
+        query: { from: sessionId },
+      });
       r.status(400);
     });
   },
@@ -697,14 +693,14 @@ flow(
   {
     domain: 'files',
     requires: ['funded', 'daytona'],
-    timeoutMs: 360_000,
+    timeoutMs: 600_000,
     routes: [
       'POST /v1/projects/:projectId/sessions',
       'POST /v1/projects/:projectId/sessions/:sessionId/start',
     ],
   },
   async (ctx) => {
-    const { sandboxId } = await bootSandbox(ctx);
+    const { sandboxId } = await bootSandbox(ctx, { readinessTimeoutMs: 420_000 });
     // The daemon file routes 503 ("opencode not ready") until OpenCode is up;
     // block on readiness first.
     await createOcConversation(ctx, sandboxId);

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type Client, isKe2eRetryableError } from '../src/core/client';
+import { waitFor } from '../src/core/poll';
+import { provisionProject } from '../src/fixtures/provision';
+
+function response(statusCode: number, bodyText: string, json?: unknown) {
+  return {
+    statusCode,
+    text: () => bodyText,
+    json: <T>() => json as T,
+  };
+}
+
+async function settleTimers<T>(promise: Promise<T>): Promise<T> {
+  await vi.runAllTimersAsync();
+  return promise;
+}
+
+function clientWithPost(post: unknown): Client {
+  return { post } as unknown as Client;
+}
+
+describe('release gate transient failure resilience', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries project provisioning after an HTTP 502 response', async () => {
+    vi.useFakeTimers();
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(response(502, '<html>Bad gateway</html>'))
+      .mockResolvedValueOnce(
+        response(200, '{"project_id":"project-1"}', { project_id: 'project-1' }),
+      );
+
+    const result = provisionProject(clientWithPost(post), { name: 'release-gate-test' });
+
+    await expect(settleTimers(result)).resolves.toBe('project-1');
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries project provisioning after a marked network error', async () => {
+    vi.useFakeTimers();
+    const networkError = Object.assign(new Error('request timed out'), {
+      ke2eRetryable: true,
+    });
+    const post = vi
+      .fn()
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce(
+        response(200, '{"project_id":"project-2"}', { project_id: 'project-2' }),
+      );
+
+    const result = provisionProject(clientWithPost(post), { name: 'release-gate-test' });
+
+    await expect(settleTimers(result)).resolves.toBe('project-2');
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a persistent HTTP 400 response', async () => {
+    const post = vi.fn().mockResolvedValue(response(400, '{"error":"invalid request"}'));
+
+    await expect(
+      provisionProject(clientWithPost(post), { name: 'release-gate-test' }),
+    ).rejects.toThrow('HTTP 400');
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries an explicit HTTP 403 rate-limit response', async () => {
+    vi.useFakeTimers();
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(response(403, '{"error":"secondary rate limit"}'))
+      .mockResolvedValueOnce(
+        response(200, '{"project_id":"project-3"}', { project_id: 'project-3' }),
+      );
+
+    const result = provisionProject(clientWithPost(post), { name: 'release-gate-test' });
+
+    await expect(settleTimers(result)).resolves.toBe('project-3');
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues polling after a marked network error', async () => {
+    vi.useFakeTimers();
+    const networkError = Object.assign(new Error('request timed out'), {
+      ke2eRetryable: true,
+    });
+    const read = vi.fn().mockRejectedValueOnce(networkError).mockResolvedValueOnce('ready');
+
+    const result = waitFor(read, {
+      until: (value) => value === 'ready',
+      timeoutMs: 10_000,
+      intervalMs: 1_000,
+      retryOnError: isKe2eRetryableError,
+    });
+
+    await expect(settleTimers(result)).resolves.toBe('ready');
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails polling immediately for an unmarked error', async () => {
+    const error = new Error('contract failure');
+    const read = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      waitFor(read, {
+        until: () => false,
+        timeoutMs: 10_000,
+        intervalMs: 1_000,
+        retryOnError: () => false,
+      }),
+    ).rejects.toThrow('contract failure');
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

This PR applies the release-gate resilience fix directly to the v0.10.14 staging cutoff.

- Retry project provisioning after marked network errors, HTTP 5xx responses, and explicit rate-limit responses.
- Keep persistent HTTP 4xx contract failures strict.
- Continue session readiness polling after transient network errors and HTTP 5xx responses.
- Extend the CR-9 and FILE-9 runtime readiness budgets.
- Add six focused unit tests for retry and failure behavior.

## Verification

- `cd tests && bunx vitest run --config unit/vitest.config.ts`: 19 passed.
- `cd tests && bunx tsc --noEmit`: passed.
- `cd tests && bun bin/ke2e.ts list`: 375 flows loaded.