### PR TITLE
fix(git): refresh staging mirror after missing branch

### DIFF
--- a/apps/api/src/__tests__/e2e-cr-empty-guard-git.test.ts
+++ b/apps/api/src/__tests__/e2e-cr-empty-guard-git.test.ts
@@ -39,6 +39,10 @@ function mergeModuleUrl(): string {
   return pathToFileURL(join(import.meta.dir, '..', 'projects', 'git', 'merge.ts')).href;
 }
 
+function commitsModuleUrl(): string {
+  return pathToFileURL(join(import.meta.dir, '..', 'projects', 'git', 'commits.ts')).href;
+}
+
 function makeFixture() {
   projectCounter += 1;
   const source = join(root, `source-${projectCounter}`);
@@ -135,6 +139,32 @@ describe('resolveBranchAheadState — the empty-CR guard', () => {
     );
     expect(result.before).toBe(false);
     expect(result.after).toBe(true);
+  });
+
+  test('a branch created AFTER the mirror warmed is resolved after one forced re-fetch', () => {
+    const { source, project } = makeFixture();
+    git(['push', '--quiet', 'origin', '--delete', 'session-branch'], source);
+
+    const result = JSON.parse(
+      bunEval(`
+        const { execFileSync } = await import('node:child_process');
+        const { resolveCommitSha } = await import(${JSON.stringify(commitsModuleUrl())});
+        const { resolveBranchAheadState } = await import(${JSON.stringify(mergeModuleUrl())});
+        const project = ${JSON.stringify(project)};
+        await resolveCommitSha(project, 'main');
+        const run = (args, cwd) => execFileSync('git', args, { cwd, encoding: 'utf8' });
+        run(['checkout', '-B', 'session-branch', 'main'], ${JSON.stringify(source)});
+        await (await import('node:fs/promises')).writeFile(${JSON.stringify(join(source, 'new-branch.txt'))}, 'new branch\\n');
+        run(['add', 'new-branch.txt'], ${JSON.stringify(source)});
+        run(['commit', '-m', 'create session branch'], ${JSON.stringify(source)});
+        run(['push', '--quiet', 'origin', 'session-branch'], ${JSON.stringify(source)});
+        const state = await resolveBranchAheadState(project, 'main', 'session-branch');
+        process.stdout.write(JSON.stringify(state));
+      `),
+    );
+
+    expect(result.ahead).toBe(true);
+    expect(result.headSha).not.toBe(result.baseSha);
   });
 
   test('a stale branch strictly behind an advanced base (merge-base == head) is not ahead', () => {

--- a/apps/api/src/projects/git/merge.ts
+++ b/apps/api/src/projects/git/merge.ts
@@ -79,7 +79,18 @@ export async function resolveBranchAheadState(
     const mergeBase = await getMergeBase(project, baseRef, headRef);
     return { ahead: mergeBase !== headSha, baseSha, headSha };
   };
-  const cached = await resolve();
+  let cached: BranchAheadState;
+  try {
+    cached = await resolve();
+  } catch {
+    // A session branch can be pushed while another caller owns the project's
+    // mirror-refresh lock. That refresh can finish before the push reaches the
+    // remote, which leaves the warm mirror without the new ref. Re-fetch once
+    // after the first lookup fails. Persistent missing refs and auth failures
+    // still fail on the second lookup.
+    await refreshMirror(project, true);
+    return resolve();
+  }
   if (cached.ahead) return cached;
   await refreshMirror(project, true);
   return resolve();

--- a/tests/src/flows/cli-ship.flow.ts
+++ b/tests/src/flows/cli-ship.flow.ts
@@ -687,7 +687,7 @@ flow(
         const r = await sb.run(['cr', 'open', '--head', session.id, '--title', 'ke2e cli CR'], {
           env: crEnv,
         });
-        check('exit 0', r.exitCode === 0, 0, r.exitCode);
+        checkExit('exit 0', r, 0);
         check('reports the opened CR number', /CR #\d+/.test(r.all), true, r.stdout.slice(0, 200));
         const m = r.stdout.match(/CR #(\d+)/);
         crNumber = m ? m[1] : '';


### PR DESCRIPTION
## Summary

- retry branch-ahead resolution after one forced mirror refresh
- keep persistent missing refs and authentication failures fatal
- add a regression test for session branches created after mirror warm-up
- include CLI ship stdout and stderr when `CR-9` fails

## Verification

- focused git regression: 6 passed
- API typecheck: passed
- release unit tests: 19 passed
- test typecheck: passed
- flow catalog: 375 flows
- main PR #5280 checks: passed, including CodeQL, Trivy, API unit tests, and package unit tests

## Release scope

This PR targets the existing v0.10.14 staging candidate. It does not include later `main` commits.