### PR TITLE
content(blog): wire 4 orphan posts into the internal-link graph

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -552,12 +552,12 @@ connectors:
     },
     {
       type: 'p',
-      text: 'Because it’s all open, you can read exactly how isolation, review, and credential brokering work — not trust a description. No lock-in: your projects are git repos, your config is plain files, and the platform running them is yours to host.',
+      text: 'Because it’s all open, you can read exactly how isolation, review, and credential brokering work — not trust a description. No lock-in: your projects are git repos, your config is plain files, and the platform running them is yours to host. (If you’re weighing Kortix against personal open-source agents like OpenClaw or Hermes, [personal AI agents vs a company OS](/blog/personal-ai-agents-vs-company-os) draws that line.)',
     },
     { type: 'h2', text: 'It compounds' },
     {
       type: 'p',
-      text: 'Because your whole setup is version-controlled files, none of it resets tomorrow. Every agent you shape, every skill you teach, every tool you connect, every bit of memory your agents carry forward accumulates in the repo and gets more capable week over week. The routine work that used to fill calendars runs quietly in the background, 24/7, and your team spends its time on the decisions that need a human.',
+      text: 'Because your whole setup is version-controlled files, none of it resets tomorrow. Every agent you shape, every skill you teach, every tool you connect, every bit of memory your agents carry forward accumulates in the repo and gets more capable week over week. The routine work that used to fill calendars runs quietly in the background, 24/7, and your team spends its time on the decisions that need a human. For the architecture that makes that compounding safe — state kept out of the model, identity and isolation as first-class, durable review — the [AGI-ready architecture post](/blog/agi-ready-architecture) is the deeper read.',
     },
     {
       type: 'cta',
@@ -623,7 +623,7 @@ const kortixVsClaudeCowork: BlogPostEntry = {
     },
     {
       type: 'callout',
-      text: 'Same agents, [a fraction of the bill](/pricing) — and you can run them on your own infrastructure, even your own GPUs, with your data never leaving your walls.',
+      text: 'Same agents, [a fraction of the bill](/pricing) — and you can run them on your own infrastructure, even your own GPUs, with your data never leaving your walls. For the wider landscape, [the best self-hosted AI agent platforms](/blog/best-self-hosted-ai-agent-platforms) compares Kortix to CrewAI, AutoGen, Dify, LangGraph, and n8n.',
     },
     { type: 'h2', text: 'Side by side' },
     {
@@ -1325,7 +1325,7 @@ const kortixVsGlean: BlogPostEntry = {
     },
     {
       type: 'p',
-      text: 'They can coexist, too. Plenty of companies will keep Glean as the search layer and run the work itself on Kortix — agents that read, decide, and act, with the operating layer they need to do it governed as code. If that operating layer is what you’re missing, the [company OS post](/blog/ai-transformation-company-os) and the [secure connector model](/blog/secure-ai-agent-tool-access) are the next reads.',
+      text: 'They can coexist, too. Plenty of companies will keep Glean as the search layer and run the work itself on Kortix — agents that read, decide, and act, with the operating layer they need to do it governed as code. (The desktop side has its own parallel: [how Kortix compares to Claude Cowork](/blog/kortix-vs-claude-cowork).) If that operating layer is what you’re missing, the [company OS post](/blog/ai-transformation-company-os) and the [secure connector model](/blog/secure-ai-agent-tool-access) are the next reads.',
     },
     {
       type: 'cta',


### PR DESCRIPTION
## What & why

Four high-intent blog posts had **zero inbound `/blog/<slug>` links** from other posts, isolating them from the internal-link graph and weakening crawl-depth / PageRank flow to the comparison and category pages that need it most. This PR adds one natural-anchor contextual inbound link to each, from a related hub post where the argument already supports it.

| Orphan target | Now linked from | Natural anchor |
| --- | --- | --- |
| `kortix-vs-claude-cowork` | `kortix-vs-glean` | the desktop side of the same "they can coexist" argument |
| `personal-ai-agents-vs-company-os` | `introducing-kortix` | the "open & self-hostable" section (OpenClaw/Hermes are the personal-vs-company open-source comparison) |
| `agi-ready-architecture` | `introducing-kortix` | the "It compounds" section (the AGI-readiness architecture thesis) |
| `best-self-hosted-ai-agent-platforms` | `kortix-vs-claude-cowork` | the self-hostable landscape (the 2026-07-19 listicle) |

## Scope

Pure content-only data edit in the typed blog registry (`apps/web/src/lib/blog-posts.ts`). 4 lines changed (+4/-4). No renderer, route, import, type, or UI changes. One link per target, natural anchors, no link stuffing. `0` `kortix.toml` / `black box` / `AI coworker` / `copilot` / `no-code` drift markers.

## Experiment contract (SEO-016)

- **Hypothesis:** wiring these 4 orphans into the link graph improves crawl depth + PageRank flow to high-intent comparison/category pages.
- **Baseline:** 4 orphans with 0 inbound `/blog/<slug>` links (verified via source grep + bun registry import).
- **Primary metric:** GSC canonical-page cohort impressions/position for the 4 target slugs at 7d + 28d after production promotion.
- **Guardrails:** no cannibalization; links are natural-anchor, one per target; no link stuffing; content-only diff.
- **Rollback:** revert this PR.

## Verification

- `bun` registry import confirms 9 posts, newest-first sort intact, and all 4 targets now receive exactly 1 inbound link each:
  - `kortix-vs-claude-cowork` <- `kortix-vs-glean`
  - `personal-ai-agents-vs-company-os` <- `introducing-kortix`
  - `agi-ready-architecture` <- `introducing-kortix`
  - `best-self-hosted-ai-agent-platforms` <- `kortix-vs-claude-cowork`
- Exact-head preview gates to be run after `preview` builds: `/blog/kortix-vs-glean`, `/blog/introducing-kortix`, `/blog/kortix-vs-claude-cowork` return 200 with the new anchors rendered as `<a href="/blog/...">`; `/blog` index unchanged; canonicals unchanged.

## Notes

- This is a follow-on to the SEO-008-partial inline money-page links (PR #4714) and the listicle (PR #5041). It does not duplicate either.
- The full route source-to-route and exact-head preview matrix will be verified against the Vercel head before merge.