### PR TITLE
test: tolerate staging release gate host transients

### DIFF
--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -174,6 +174,23 @@ export class Res {
   }
 }
 
+/**
+ * Detect a gateway-generated outage response.
+ *
+ * API responses carry x-request-id. Cloudflare host failures do not. This
+ * distinction prevents retries from hiding a real API 5xx contract failure.
+ */
+export function isKe2eTransientGatewayResponse(response: Res): boolean {
+  if (![502, 503, 504].includes(response.statusCode)) return false;
+  if (response.header('x-request-id')) return false;
+  return (
+    response.header('retry-after') !== undefined ||
+    response.header('content-type')?.includes('text/html') === true
+  );
+}
+
+const TRANSIENT_GATEWAY_RETRY_DELAY_MS = 2_000;
+
 export class Client {
   private readonly origin: string;
 
@@ -181,17 +198,27 @@ export class Client {
     apiUrl: string,
     private readonly identity: Identity = ANON,
     private readonly defaultTimeoutMs = 60_000,
+    private readonly transientGatewayRetries = 0,
   ) {
     this.origin = new URL(apiUrl).origin;
   }
 
   /** Clone bound to a principal/identity. */
   as(identity: Identity): Client {
-    return new Client(this.origin, identity, this.defaultTimeoutMs);
+    return new Client(this.origin, identity, this.defaultTimeoutMs, this.transientGatewayRetries);
   }
 
   withBearer(token: string, label = 'raw'): Client {
     return this.as({ label, auth: { mode: 'bearer', token } });
+  }
+
+  /**
+   * Retry marked network errors and gateway-generated 502/503/504 responses.
+   *
+   * Callers must opt in only for requests that are safe to repeat.
+   */
+  withTransientGatewayRetries(retries = 3): Client {
+    return new Client(this.origin, this.identity, this.defaultTimeoutMs, retries);
   }
 
   get(t: string, o?: ReqOpts) {
@@ -261,64 +288,78 @@ export class Client {
 
     const routeTemplate = `${method} ${template}`;
     const timeoutMs = opts?.timeoutMs ?? this.defaultTimeoutMs;
-    const started = performance.now();
+    const maxAttempts = this.transientGatewayRetries + 1;
 
-    let res: Response;
-    try {
-      res = await fetch(url, {
-        method,
-        headers,
-        body: bodyInit,
-        signal: AbortSignal.timeout(timeoutMs),
-        redirect: 'manual',
-      });
-    } catch (err: any) {
-      // Surface as a captured "network" failure (retryable infra signal).
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const started = performance.now();
+      let res: Response;
+      try {
+        res = await fetch(url, {
+          method,
+          headers,
+          body: bodyInit,
+          signal: AbortSignal.timeout(timeoutMs),
+          redirect: 'manual',
+        });
+      } catch (err: any) {
+        // Surface as a captured network failure.
+        const ms = performance.now() - started;
+        const captured: Captured = {
+          routeTemplate,
+          req: { method, url: url.toString(), headers: redactHeaders(headersToObject(headers)) },
+          res: { status: 0, headers: {}, bodyText: String(err?.message ?? err) },
+          ms,
+        };
+        record(captured);
+        if (attempt < maxAttempts) {
+          await new Promise((resolve) => setTimeout(resolve, TRANSIENT_GATEWAY_RETRY_DELAY_MS));
+          continue;
+        }
+        const e = new Error(`network error ${method} ${url}: ${err?.message ?? err}`);
+        (e as any).ke2eRetryable = true;
+        throw e;
+      }
+
+      const bodyText = await res.text();
       const ms = performance.now() - started;
+      const resHeaders: Record<string, string> = {};
+      res.headers.forEach((v, k) => (resHeaders[k] = k.toLowerCase() === 'set-cookie' ? mask(v) : v));
+      let json: unknown;
+      const ct = res.headers.get('content-type') ?? '';
+      if (ct.includes('application/json')) {
+        try {
+          json = JSON.parse(bodyText);
+        } catch {
+          /* leave undefined */
+        }
+      }
+
       const captured: Captured = {
         routeTemplate,
-        req: { method, url: url.toString(), headers: redactHeaders(headersToObject(headers)) },
-        res: { status: 0, headers: {}, bodyText: String(err?.message ?? err) },
+        req: {
+          method,
+          url: url.toString(),
+          headers: redactHeaders(headersToObject(headers)),
+          body: redactBodyText(typeof bodyInit === 'string' ? bodyInit : undefined),
+        },
+        res: {
+          status: res.status,
+          headers: resHeaders,
+          bodyText: redactBodyText(bodyText) ?? '',
+          json,
+        },
         ms,
       };
       record(captured);
-      const e = new Error(`network error ${method} ${url}: ${err?.message ?? err}`);
-      (e as any).ke2eRetryable = true;
-      throw e;
-    }
-
-    const bodyText = await res.text();
-    const ms = performance.now() - started;
-    const resHeaders: Record<string, string> = {};
-    res.headers.forEach((v, k) => (resHeaders[k] = k.toLowerCase() === 'set-cookie' ? mask(v) : v));
-    let json: unknown;
-    const ct = res.headers.get('content-type') ?? '';
-    if (ct.includes('application/json')) {
-      try {
-        json = JSON.parse(bodyText);
-      } catch {
-        /* leave undefined */
+      const response = new Res(captured);
+      if (attempt < maxAttempts && isKe2eTransientGatewayResponse(response)) {
+        await new Promise((resolve) => setTimeout(resolve, TRANSIENT_GATEWAY_RETRY_DELAY_MS));
+        continue;
       }
+      return response;
     }
 
-    const captured: Captured = {
-      routeTemplate,
-      req: {
-        method,
-        url: url.toString(),
-        headers: redactHeaders(headersToObject(headers)),
-        body: redactBodyText(typeof bodyInit === 'string' ? bodyInit : undefined),
-      },
-      res: {
-        status: res.status,
-        headers: resHeaders,
-        bodyText: redactBodyText(bodyText) ?? '',
-        json,
-      },
-      ms,
-    };
-    record(captured);
-    return new Res(captured);
+    throw new Error(`request attempt loop exhausted for ${method} ${url}`);
   }
 }
 

--- a/tests/src/flows/cli-ship.flow.ts
+++ b/tests/src/flows/cli-ship.flow.ts
@@ -586,7 +586,7 @@ flow(
     domain: 'cli',
     requires: ['funded'],
     serial: true,
-    timeoutMs: 900_000,
+    timeoutMs: 1_200_000,
     routes: [
       'GET /v1/accounts/me',
       'POST /v1/projects/provision',
@@ -636,7 +636,7 @@ flow(
         until: (body) =>
           body?.stage === 'ready' &&
           Boolean(body?.sandbox?.external_id ?? body?.sandbox?.externalId),
-        timeoutMs: 420_000,
+        timeoutMs: 660_000,
         intervalMs: 3_000,
         description: `CR-9 session runtime ready for ${session.id}`,
         retryOnError: isKe2eRetryableError,

--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -627,7 +627,7 @@ flow(
       r.status(200).body().has('$.status', 'stopped');
     });
     await ctx.step('stopping an already-stopped session → 409', async () => {
-      const r = await ctx.client.as(ctx.P.OWNER).post(
+      const r = await ctx.client.as(ctx.P.OWNER).withTransientGatewayRetries().post(
         '/v1/projects/:projectId/sessions/:sessionId/stop',
         {},
         {

--- a/tests/src/flows/triggers.flow.ts
+++ b/tests/src/flows/triggers.flow.ts
@@ -415,7 +415,9 @@ flow(
   { domain: 'triggers', routes: ['POST /v1/projects/:projectId/triggers'] },
   async (ctx) => {
     const p = await ctx.fixtures.project();
-    const owner = ctx.client.as(ctx.P.OWNER);
+    // Every payload below is invalid and cannot create a trigger. Retry only
+    // gateway-generated outage responses, not API responses with x-request-id.
+    const owner = ctx.client.as(ctx.P.OWNER).withTransientGatewayRetries();
     const params = { projectId: p.id };
 
     await ctx.step('missing name → 400', async () => {

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { type Client, isKe2eRetryableError } from '../src/core/client';
+import {
+  Client,
+  Res,
+  isKe2eRetryableError,
+  isKe2eTransientGatewayResponse,
+} from '../src/core/client';
 import { waitFor } from '../src/core/poll';
+import type { Captured } from '../src/core/result';
 import { provisionProject } from '../src/fixtures/provision';
 
 function response(statusCode: number, bodyText: string, json?: unknown) {
@@ -20,9 +26,20 @@ function clientWithPost(post: unknown): Client {
   return { post } as unknown as Client;
 }
 
+function capturedResponse(status: number, headers: Record<string, string>): Res {
+  const captured: Captured = {
+    routeTemplate: 'GET /v1/test',
+    req: { method: 'GET', url: 'https://example.test/v1/test', headers: {} },
+    res: { status, headers, bodyText: '' },
+    ms: 1,
+  };
+  return new Res(captured);
+}
+
 describe('release gate transient failure resilience', () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it('retries project provisioning after an HTTP 502 response', async () => {
@@ -113,5 +130,63 @@ describe('release gate transient failure resilience', () => {
       }),
     ).rejects.toThrow('contract failure');
     expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it('identifies only host-level gateway failures as transient', () => {
+    expect(
+      isKe2eTransientGatewayResponse(
+        capturedResponse(502, {
+          'content-type': 'text/html; charset=UTF-8',
+          'retry-after': '60',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isKe2eTransientGatewayResponse(
+        capturedResponse(502, {
+          'content-type': 'application/json',
+          'x-request-id': 'request-1',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isKe2eTransientGatewayResponse(
+        capturedResponse(400, {
+          'content-type': 'application/json',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('retries an opted-in host-level 502 response', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('<html>Bad gateway</html>', {
+          status: 502,
+          headers: {
+            'content-type': 'text/html; charset=UTF-8',
+            'retry-after': '60',
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('{"error":"already stopped"}', {
+          status: 409,
+          headers: {
+            'content-type': 'application/json',
+            'x-request-id': 'request-2',
+          },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = new Client('https://example.test/v1')
+      .withTransientGatewayRetries()
+      .get('/v1/test');
+
+    await expect(settleTimers(result)).resolves.toMatchObject({ statusCode: 409 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- cherry-pick only the release-gate resilience fix from `main`
- retry opt-in host-level gateway failures without hiding API 5xx responses
- extend CR-9 readiness for the measured 532-second image build

## Evidence

- source commit on main: `f671aa532c1216e949e670a1cab2f1f8d8eaac75`
- staging cherry-pick: `f25762b62`
- `pnpm test:unit`: 21 tests passed
- `pnpm typecheck`: exit 0
- `git diff --check`: exit 0

## Release scope

This PR preserves the existing v0.10.14 cutoff. It does not merge later main commits into staging.