### PR TITLE
fix(staging): cap API database pools

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -183,7 +183,12 @@ jobs:
               CORS_ALLOWED_ORIGINS: $frontend,
               LLM_GATEWAY_BASE_URL: $gateway,
               ALLOWED_SANDBOX_PROVIDERS: "daytona,platinum,e2b",
-              KORTIX_WARM_SNAPSHOT_ENABLED: "false"
+              KORTIX_WARM_SNAPSHOT_ENABLED: "false",
+              # The staging Supabase database permits 60 connections. ECS can
+              # run 3 API tasks and EKS can run 4 API pods at the same time.
+              # Four app connections plus one leader connection per process
+              # leaves 12 slots for Supabase services, migrations, and QA.
+              DB_POOL_MAX: "4"
             }')"
 
           if [ "$staging_secret_exists" = true ]; then

--- a/infra/k8s/envs/staging/values.yaml
+++ b/infra/k8s/envs/staging/values.yaml
@@ -16,6 +16,10 @@ extraEnv:
   SLACK_REQUIRE_USER_IDENTITY: "true"
   LLM_GATEWAY_BASE_URL: "https://gateway-staging.kortix.com/v1/llm"
   KORTIX_WARM_SNAPSHOT_ENABLED: "false"
+  # Staging uses a 60-connection Supabase database. ECS can run 3 API tasks
+  # while EKS runs 4 pods. Four app connections plus one leader connection per
+  # process keeps the combined fleet below the database limit.
+  DB_POOL_MAX: "4"
 # Staging has its own DB/Supabase data plane via `kortix-staging-env`, so the
 # singleton background workers are safe to run here. This makes staging a true
 # production rehearsal instead of a read-only preview.

--- a/tests/unit/staging-secret-workflow.test.ts
+++ b/tests/unit/staging-secret-workflow.test.ts
@@ -22,4 +22,18 @@ describe('staging secret synchronization', () => {
     expect(preservationBlock).toContain('staging_secret_exists=false');
     expect(workflow).toContain('if [ "$staging_secret_exists" = true ]; then');
   });
+
+  it('caps every staging API database pool below the 60-connection database limit', () => {
+    const workflow = readFileSync(
+      resolve(import.meta.dirname, '../../.github/workflows/deploy-staging.yml'),
+      'utf8',
+    );
+    const values = readFileSync(
+      resolve(import.meta.dirname, '../../infra/k8s/envs/staging/values.yaml'),
+      'utf8',
+    );
+
+    expect(workflow).toContain('DB_POOL_MAX: "4"');
+    expect(values).toContain('DB_POOL_MAX: "4"');
+  });
 });


### PR DESCRIPTION
## Incident

Release gate `30016062577` failed 13 API flows after staging exhausted PostgreSQL connections. CloudWatch logged `remaining connection slots are reserved for non-replication superuser connections`.

The staging database permits 60 connections. ECS can run 3 API tasks. EKS can run 4 API pods. The default app pool permits 15 connections per process.

## Change

- Set staging `DB_POOL_MAX=4` in the canonical Secrets Manager sync payload.
- Set the same cap in the EKS staging Helm values.
- Add a unit guard for both deployment paths.

At maximum scale, seven API processes can use 28 app connections and 7 leader-election connections. This leaves 25 connections for Supabase services, migrations, and QA.

## Verification

- `pnpm --dir tests test:unit -- staging-secret-workflow.test.ts` — 22 passed.
- `pnpm --dir tests typecheck` — exit 0.
- Helm template renders `DB_POOL_MAX=4`.
- `pnpm exec prettier --check .github/workflows/deploy-staging.yml infra/k8s/envs/staging/values.yaml` — passed.
- `git diff --check` — passed.