### PR TITLE
fix(web): cover modern JSC Paper Shaders null-WebGL wording (BS a8754de5)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -1796,11 +1796,13 @@ test('does NOT suppress a frameless "No error message" event (origin unverifiabl
 // async callback so the React error boundary can't catch it → global error →
 // Sentry → Better Stack. The matcher is the leak-path backstop; the
 // `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard. Covers
-// all three JS engine wordings for the same bug: V8
+// all four JS engine wordings for the same bug: V8
 // (`Cannot read properties of null (reading '<m>')`), old JSC
-// (`Cannot read property '<m>' of null`), and SpiderMonkey/Firefox
+// (`Cannot read property '<m>' of null`), SpiderMonkey/Firefox
 // (`can't access property "<m>"<…>` — the recurrence that shipped through
-// PR #4544's V8/JSC-only filter).
+// PR #4544's V8/JSC-only filter), and modern JSC (Safari / Chrome-on-iOS CriOS,
+// which uses WebKit/JSC rather than V8: `null is not an object (evaluating
+// 'this.gl.<m>')` — pattern `a8754de5…`).
 const PAPER_SHADER_NULL_CONTEXT_MESSAGES = [
   // V8 (Chrome/Edge).
   "Cannot read properties of null (reading 'getSupportedExtensions')",
@@ -1824,6 +1826,21 @@ const PAPER_SHADER_NULL_CONTEXT_MESSAGES = [
   // SpiderMonkey alternate phrasing seen on some Firefox versions
   // (` of <var>. <var> is null` form) — the prefix anchor still matches.
   'can\'t access property "getSupportedExtensions" of this.gl. this.gl is null',
+  // Modern JSC (JavaScriptCore — Safari / Chrome-on-iOS CriOS, which uses
+  // WebKit/JSC rather than V8). JSC wraps the offending expression as
+  // `null is not an object (evaluating '<expr>')`; the Paper Shaders library
+  // accesses the WebGL2 context as `this.gl.<method>`, so the prod wording
+  // (Better Stack pattern `a8754de5…`, 1 occurrence / 0 users, Chrome 150 on
+  // iOS 26.5.2, route `/projects/:id/sessions/:sessionId`) is the exact full
+  // message per method. The raw `exception.values[].value` has no `TypeError: `
+  // prefix, but Sentry capture paths vary, so pin all three forms like the
+  // SpiderMonkey entries above.
+  "null is not an object (evaluating 'this.gl.getSupportedExtensions')",
+  "TypeError: null is not an object (evaluating 'this.gl.getSupportedExtensions')",
+  "Unhandled promise rejection: TypeError: null is not an object (evaluating 'this.gl.getSupportedExtensions')",
+  "null is not an object (evaluating 'this.gl.getAttribLocation')",
+  "TypeError: null is not an object (evaluating 'this.gl.getAttribLocation')",
+  "Unhandled promise rejection: TypeError: null is not an object (evaluating 'this.gl.getAttribLocation')",
 ]
 
 test('classifies every Paper Shaders null-context WebGL message as noise', () => {
@@ -1884,9 +1901,10 @@ test('does NOT suppress a real app TypeError with a different null-property name
   // `Cannot read properties of null (reading '<name>')` SHAPE but with an
   // app-property name, not a WebGL2 API method — it must keep reporting so a
   // real null-deref regression is never hidden by the Paper Shaders guard.
-  // Covers all three engine wordings (V8, old JSC, SpiderMonkey/Firefox) so
-  // the Firefox `can't access property "<m>"` pattern can't swallow a real
-  // first-party SpiderMonkey null-deref with a non-WebGL property name.
+  // Covers all four engine wordings (V8, old JSC, SpiderMonkey/Firefox,
+  // modern JSC) so the Firefox `can't access property "<m>"` pattern and the
+  // modern-JSC `null is not an object (evaluating '<expr>')` pattern can't
+  // swallow a real first-party null-deref with a non-WebGL property name.
   const realAppNullDerefMessages = [
     "Cannot read properties of null (reading 'map')",
     "Cannot read properties of null (reading 'length')",
@@ -1901,6 +1919,13 @@ test('does NOT suppress a real app TypeError with a different null-property name
     'can\'t access property "map", this.foo is null',
     'TypeError: can\'t access property "id", this.bar is null',
     'can\'t access property "length" of this.baz. this.baz is null',
+    // Modern JSC generic `null is not an object (evaluating '<expr>')` throws
+    // that share the JSC wrapper SHAPE but are NOT the Paper Shaders WebGL2
+    // `this.gl.<method>` expression — must keep reporting so the modern-JSC
+    // patterns can't swallow a real first-party JSC null-deref.
+    "null is not an object (evaluating 'this.gl.someOtherMethod')",
+    "null is not an object (evaluating 'foo.bar')",
+    "TypeError: null is not an object (evaluating 'this.gl.unsupportedMethod')",
   ]
   for (const message of realAppNullDerefMessages) {
     assert.equal(

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -232,7 +232,7 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
 // first-party app code (only from Paper Shaders' library internals), so the
 // message wording alone is specific enough to safely classify as noise without
 // a chunk-frame anchor (unlike the generic old-browser SyntaxError class). The
-// matching covers all three JS engine wordings for the same null-context bug:
+// matching covers all four JS engine wordings for the same null-context bug:
 //   - V8 (Chrome/Edge):          `Cannot read properties of null (reading '<m>')`
 //   - old JSC (old Safari/iOS):  `Cannot read property '<m>' of null`
 //   - SpiderMonkey (Firefox):    `can't access property "<m>"<…>` (the variable
@@ -243,6 +243,14 @@ const OLD_WEBKIT_REGEX_NOISE_PATTERNS = [
 //                                V8/JSC-only filter as
 //                                `can't access property "getSupportedExtensions",
 //                                this.gl is null`).
+//   - modern JSC (Safari / Chrome-on-iOS CriOS, which uses WebKit/JSC rather
+//                                than V8): `null is not an object (evaluating
+//                                'this.gl.<m>')` — the `this.gl.` token and the
+//                                `(evaluating '...')` wrapper are JSC-specific;
+//                                the pattern is the exact full message per
+//                                method so a generic JSC `null is not an object
+//                                (evaluating '<other expr>')` throw does NOT
+//                                match (pattern `a8754de5…`).
 // `TypeError: ` / `Error: ` / `Unhandled promise rejection: ` wrappers are
 // stripped before matching so all capture paths (window.onerror,
 // onunhandledrejection, Sentry exception) classify consistently.
@@ -266,6 +274,20 @@ const PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS = [
   // the null context.
   'can\'t access property "getSupportedExtensions"',
   'can\'t access property "getAttribLocation"',
+  // Modern JSC (JavaScriptCore — Safari / Chrome-on-iOS CriOS, which uses
+  // WebKit/JSC rather than V8). JSC wraps the offending expression as
+  // `null is not an object (evaluating '<expr>')`; the Paper Shaders library
+  // accesses the WebGL2 context as `this.gl.<method>`, so the prod wording is
+  // `null is not an object (evaluating 'this.gl.getSupportedExtensions')` and
+  // the `getAttribLocation` sibling. The `this.gl.` token and the
+  // `(evaluating '...')` wrapper are JSC-specific; the stable anchor is the
+  // exact full JSC message (per-method), so a generic JSC `null is not an
+  // object (evaluating '<other expr>')` throw does NOT match. Seen as pattern
+  // `a8754de5…` (1 occurrence, 0 users) from Chrome 150 on iOS 26.5.2 on
+  // `/projects/:id/sessions/:sessionId`, the fourth engine variant of this
+  // class after V8 (#4544), old JSC, and SpiderMonkey (#5172).
+  "null is not an object (evaluating 'this.gl.getSupportedExtensions')",
+  "null is not an object (evaluating 'this.gl.getAttribLocation')",
 ] as const;
 
 // Old-browser / stripped-down-WebView minified-chunk parse failures. When a
@@ -1104,12 +1126,15 @@ export function isOldWebkitRegexNoiseMessage(message: unknown): boolean {
  * React error boundary, and reach Sentry/Better Stack as global errors. The
  * method names are WebGL2 API — never called from first-party app code — so the
  * message wording alone is specific enough; no chunk-frame anchor is needed.
- * Matches all three JS engine wordings: V8
+ * Matches all four JS engine wordings: V8
  * (`Cannot read properties of null (reading '<m>')`), old JSC
- * (`Cannot read property '<m>' of null`), and SpiderMonkey/Firefox
- * (`can't access property "<m>"<…>`). Never page Better Stack for this class.
- * See `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full rationale and
- * the `supportsWebGL2()` probe in `shader-safe.tsx` for the primary guard.
+ * (`Cannot read property '<m>' of null`), SpiderMonkey/Firefox
+ * (`can't access property "<m>"<…>`), and modern JSC (Safari / Chrome-on-iOS
+ * CriOS, which uses WebKit/JSC rather than V8:
+ * `null is not an object (evaluating 'this.gl.<m>')`). Never page Better Stack
+ * for this class. See `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` for the full
+ * rationale and the `supportsWebGL2()` probe in `shader-safe.tsx` for the
+ * primary guard.
  */
 export function isPaperShaderNullContextNoise(message: unknown): boolean {
   const stripped = stripErrorWrappers(normalizeString(message));


### PR DESCRIPTION
## Summary

Cover the **modern JSC (JavaScriptCore)** wording of the Paper Shaders
(`@paper-design/shaders-react`) null-WebGL-context crash class in the
browser-error-noise filter, so it stops paging Better Stack.

Better Stack pattern `a8754de51a037d567d59023a731e276a99e486ebdf0484ba19e2c3f64830d2f4`
(`a8754de5…`), Kortix Frontend prod app `2346967`, v0.10.13
(release `470fe6f3…`), route `/projects/:id/sessions/:sessionId`:

- **Type:** `TypeError`
- **Message:** `null is not an object (evaluating 'this.gl.getSupportedExtensions')`
- **Mechanism:** `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT —
  escaped the React error boundary)
- **Browser:** Chrome 150 on iOS 26.5.2 (UA `… CriOS/150.0.7871.113 …`) —
  **Chrome-on-iOS**, which uses **WebKit/JSC**, not V8.
- **Stack:** all raw minified chunk frames (`app:///_next/static/chunks/c76173f0.…`,
  call site `b2`) — same chunk/call-site as the prior V8/Firefox recurrences.

## Root cause

This is the **same** null-WebGL-context class already covered for three other
JS engines by `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` in
`apps/web/src/lib/browser-error-noise.ts`:

- V8 (Chrome/Edge): `Cannot read properties of null (reading '<m>')` — PR #4544
- Old JSC (old Safari/iOS): `Cannot read property '<m>' of null`
- SpiderMonkey (Firefox): `can't access property "<m>"<…>` — PR #5172

Chrome-on-iOS (CriOS) uses WebKit/JSC, so it emits the JSC
`null is not an object (evaluating '<expr>')` form rather than V8's
`Cannot read properties of null (reading '<m>')` form. The `this.gl.` prefix
and the `(evaluating '...')` wrapper are JSC-specific, so the existing patterns
did not match and the residual async-context-loss throw leaked to Better Stack
as an uncaught global error. This is exactly the same cross-browser-wording-gap
class as the prior #4544 / #5172 / #5173 fixes.

## The fix (focused, one concern)

In `apps/web/src/lib/browser-error-noise.ts`:

1. Added the two modern-JSC entries to `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS`
   (exact full message per method, mirroring the existing per-engine comments):
   - `"null is not an object (evaluating 'this.gl.getSupportedExtensions')"`
   - `"null is not an object (evaluating 'this.gl.getAttribLocation')"`
   The existing `isPaperShaderNullContextNoise` matcher does
   `stripErrorWrappers(normalizeString(message)).includes(pattern)`, so exact
   substring entries match the raw `exception.values[].value` (no `TypeError: `
   prefix) and the Sentry-wrapped forms. The matcher stays message-only (the
   WebGL2 method names are never called from first-party app code) — no
   first-party-frame negative guard added or removed.
2. Updated the `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` array comment and the
   `isPaperShaderNullContextNoise` docstring to document the modern JSC wording
   as the fourth engine variant (and note Chrome-on-iOS uses WebKit/JSC, not V8).

## Tests (regression pinning the exact prod call site)

In `apps/web/src/lib/browser-error-noise.test.mts`, extended the existing
Paper Shaders null-context test block:

- Added the two modern-JSC messages to the "classify as noise" array, each in
  three capture-path forms (raw, `TypeError: `, `Unhandled promise rejection:
  TypeError: `) — pinning the exact prod event value
  `null is not an object (evaluating 'this.gl.getSupportedExtensions')` and its
  `getAttribLocation` sibling through `isPaperShaderNullContextNoise`,
  `shouldIgnoreBrowserRuntimeNoise`, and `shouldIgnoreSentryBrowserNoise`
  (with and without a chunk frame).
- Added negative cases for the generic JSC wrapper on NON-WebGL2 expressions
  (`this.gl.someOtherMethod`, `foo.bar`, `this.gl.unsupportedMethod`) that must
  keep reporting — guards against over-matching the generic JSC
  `null is not an object (evaluating '<expr>')` wrapper.

## Verification

- `bun test src/lib/browser-error-noise.test.mts` → **161 pass / 0 fail**
  (was 161 before; the new assertions extend the existing
  `PAPER_SHADER_NULL_CONTEXT_MESSAGES` array and the negative-case array, so
  the same 3 test cases now cover more inputs).
- `tsc --noEmit -p apps/web/tsconfig.json` → no new errors (the 4 pre-existing
  errors in `source.ts`, `use-cases-source.ts`, and
  `api/og/template/template-url.test.ts` are present on clean `origin/main`
  and are unrelated to this change).

## Preview verification plan

The fix is a frontend noise-filter change with no runtime/visual behavior
delta, so preview e2e is a no-op for the fix itself. Confirm:

- `gh pr checks` all green.
- Preview backend health: `https://pr-<n>.preview-api.kortix.com/v1/health`
  returns `environment=preview`.

Better Stack pattern: `a8754de51a037d567d59023a731e276a99e486ebdf0484ba19e2c3f64830d2f4`
