### PR TITLE
Complete latest main promotion to staging

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-1ecd7840"
+  tag: "dev-e181b0de"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
## Candidate

- Source `main`: `307f5d42f8bd6bd092aa63749d0ed59c984bbdb7`
- Promotion merge: `e007ed23ab3771d39eba637e78b429cfa09fe510`
- Target: `staging`

PR `#5303` promoted source SHA `e181b0de`. Main then added GitOps pin commit `307f5d42` for the verified dev deployment. This incremental PR makes current `main` an ancestor of `staging`.

The source change updates only `infra/k8s/envs/dev/values.yaml` to `dev-e181b0de`. It does not change staging or production runtime configuration.

Deploy Dev run `30038487561` completed successfully. `https://dev-api.kortix.com/v1/health` reports `0.10.14-dev.e181b0de`.