### PR TITLE
Fix release infra gate for Lambda Python 3.13

### DIFF
--- a/tests/infra/.tflint.hcl
+++ b/tests/infra/.tflint.hcl
@@ -10,7 +10,7 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.34.0"
+  version = "0.48.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/tests/infra/README.md
+++ b/tests/infra/README.md
@@ -9,7 +9,7 @@ Static validation of `infra/terraform` and `infra/k8s`. Every check is OSS and
 
 | Suite | Tool | Image | Target | Output |
 |-------|------|-------|--------|--------|
-| `tflint` | tflint + AWS ruleset | `ghcr.io/terraform-linters/tflint:v0.55.1` | `infra/terraform` (recursive) | `tflint.junit.xml` |
+| `tflint` | tflint + AWS ruleset | `ghcr.io/terraform-linters/tflint:v0.64.0` | `infra/terraform` (recursive) | `tflint.junit.xml` |
 | `checkov` | checkov | `bridgecrew/checkov:3.2.334` | `infra/terraform` | `checkov.sarif`, `checkov.junit.xml` |
 | `kubeconform` | kubeconform | `ghcr.io/yannh/kubeconform:v0.6.7` | `infra/k8s` (raw, excl. `charts/`) | `kubeconform.junit.xml` |
 | `helm` | helm + kubeconform | `alpine/helm:3.16.3` + kubeconform | `infra/k8s/charts/*` rendered per env | `helm-<chart>-<env>.junit.xml` |

--- a/tests/infra/scripts/env.sh
+++ b/tests/infra/scripts/env.sh
@@ -12,7 +12,7 @@ export CHARTS_DIR="${K8S_DIR}/charts"
 export TESTS_INFRA_DIR="${REPO_ROOT}/tests/infra"
 export RESULTS_DIR="${RESULTS_DIR:-${REPO_ROOT}/tests/test-results/infra}"
 
-export TFLINT_IMAGE="ghcr.io/terraform-linters/tflint:v0.55.1"
+export TFLINT_IMAGE="ghcr.io/terraform-linters/tflint:v0.64.0"
 export CHECKOV_IMAGE="bridgecrew/checkov:3.2.334"
 export KUBECONFORM_IMAGE="ghcr.io/yannh/kubeconform:v0.6.7"
 export HELM_IMAGE="alpine/helm:3.16.3"


### PR DESCRIPTION
## Problem

Release gate run `30041296446` passed all API, browser, migration, Checkov, kubeconform, and Helm checks. It failed because AWS ruleset `0.34.0` rejected the supported Lambda runtime `python3.13` at `infra/terraform/compliance-monitoring/ec2-cpu-reconciler.tf:97` and `:125`.

## Change

- Update TFLint from `0.55.1` to `0.64.0`.
- Update the TFLint AWS ruleset from `0.34.0` to `0.48.0`.
- Update the infra test documentation.

## Verification

- `bash tests/infra/scripts/tflint.sh` -> exit `0`; JUnit `0` failures.
- `npm --prefix tests run test:infra` -> `All infra checks passed`.
- Checkov -> exit `0`.
- kubeconform -> exit `0`.
- All rendered API and gateway Helm environments -> exit `0`.