### PR TITLE
fix: make session startup and shell recovery reliable

### DIFF
--- a/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
@@ -240,6 +240,32 @@ describe('Daytona snapshot state', () => {
 });
 
 describe('Daytona auto-build self-heal', () => {
+  test('deletes a retained failed snapshot and retries a duplicate snapshot name', async () => {
+    contextPaths.length = 0;
+    let attempt = 0;
+    let built = false;
+    let deleted = false;
+    createImpl = async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error(
+          'Snapshot with name "kortix-default-7f989bb9735b" already exists for this organization',
+        );
+      }
+      built = true;
+    };
+    snapshotState = () => (built ? 'active' : 'failed');
+    deleteSnapshotImpl = async () => {
+      deleted = true;
+    };
+
+    await daytonaProvider.buildSnapshot(buildInput('kortix-default-7f989bb9735b'));
+
+    expect(deleted).toBe(true);
+    expect(attempt).toBe(2);
+    expect(contextPaths.length).toBe(2);
+  }, 15_000);
+
   test('re-stages a FRESH context + retries on a stale-context error, then succeeds', async () => {
     contextPaths.length = 0;
     let attempt = 0;

--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   AGENT_BROWSER_VERSION,
   BUN_SHA256_AMD64,
@@ -49,6 +51,8 @@ describe('buildLayeredDockerfile', () => {
       `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-\${uv_arch}-unknown-linux-gnu.tar.gz`,
     );
     expect(merged).toContain(UV_SHA256_AMD64);
+    expect(merged).toContain(`grep -Eq '^uv ${UV_VERSION}( |$)'`);
+    expect(merged).not.toContain(`test "$(uv --version)" = "uv ${UV_VERSION}"`);
     expect(merged).toContain(
       `https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-\${bun_arch}.zip`,
     );
@@ -70,6 +74,16 @@ describe('buildLayeredDockerfile', () => {
     );
     expect(merged).not.toContain('npm install -g');
     expect(merged).not.toContain('npx -y');
+  });
+
+  test('accepts uv release metadata in the standalone sandbox image', () => {
+    const dockerfile = readFileSync(
+      resolve(import.meta.dir, '../../../sandbox/Dockerfile'),
+      'utf8',
+    );
+
+    expect(dockerfile).toContain('grep -Eq "^uv ${UV_VERSION}( |$)"');
+    expect(dockerfile).not.toContain('test "$(uv --version)" = "uv ${UV_VERSION}"');
   });
 
   test('runs build-time and runtime tools as the standard kortix user', () => {

--- a/apps/api/src/snapshots/providers/daytona.ts
+++ b/apps/api/src/snapshots/providers/daytona.ts
@@ -282,9 +282,11 @@ class DaytonaAdapter implements SandboxProviderAdapter {
           SNAPSHOT_STATE_TIMEOUT_MS,
           `Daytona snapshot.get(${name})`,
         );
-        lastState = String((snap as { state?: string } | null)?.state ?? 'missing').toLowerCase();
-        if (lastState === 'active') return;
-        if (lastState === 'error' || lastState === 'build_failed') {
+        const rawState = (snap as { state?: string } | null)?.state;
+        lastState = String(rawState ?? 'missing').toLowerCase();
+        const state = normalizeExistingProviderState(rawState);
+        if (state === 'active') return;
+        if (state === 'build_failed') {
           throw new Error(`Snapshot ${name} is ${lastState}`);
         }
       } catch (err) {
@@ -315,9 +317,11 @@ class DaytonaAdapter implements SandboxProviderAdapter {
           SNAPSHOT_STATE_TIMEOUT_MS,
           `Daytona snapshot.get(${name})`,
         );
-        const state = (snap as { state?: string } | null | undefined)?.state;
+        const state = normalizeExistingProviderState(
+          (snap as { state?: string } | null | undefined)?.state,
+        );
         if (state === 'active') return 'active';
-        if (state === 'error' || state === 'build_failed') {
+        if (state === 'build_failed') {
           await withTimeout(
             getDaytona().snapshot.delete(snap as never),
             SNAPSHOT_STATE_TIMEOUT_MS,
@@ -379,6 +383,7 @@ function isTransientDaytonaError(err: unknown): boolean {
     m.includes('not read from or written to') ||
     m.includes('socket hang up') ||
     (m.includes('snapshot with name') && m.includes('not found')) ||
+    (m.includes('snapshot with name') && m.includes('already exists')) ||
     m.includes('timeout') ||
     m.includes('timed out') ||
     m.includes('econnreset') ||

--- a/apps/cli/src/__tests__/sandbox-proxy-websocket.test.ts
+++ b/apps/cli/src/__tests__/sandbox-proxy-websocket.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { openKortixPtyWebSocket } from '../api/sandbox-proxy';
+
+let server: ReturnType<typeof Bun.serve> | undefined;
+
+afterEach(() => {
+  server?.stop(true);
+  server = undefined;
+});
+
+describe('Kortix PTY WebSocket', () => {
+  test('sends the CLI User-Agent during the WebSocket upgrade', async () => {
+    let userAgent: string | null = null;
+
+    server = Bun.serve({
+      port: 0,
+      fetch(request, bunServer) {
+        userAgent = request.headers.get('user-agent');
+        if (bunServer.upgrade(request, { data: undefined })) return;
+        return new Response('upgrade failed', { status: 500 });
+      },
+      websocket: {
+        open(websocket) {
+          websocket.close(1000, 'test complete');
+        },
+        message() {},
+      },
+    });
+
+    const websocket = openKortixPtyWebSocket(
+      `ws://127.0.0.1:${server.port}/kortix/pty/test/connect`,
+    );
+    await new Promise<void>((resolve, reject) => {
+      websocket.addEventListener('open', () => resolve(), { once: true });
+      websocket.addEventListener('error', () => reject(new Error('WebSocket upgrade failed')), {
+        once: true,
+      });
+    });
+
+    expect(userAgent).toStartWith('kortix-cli/');
+  });
+});

--- a/apps/cli/src/api/sandbox-proxy.ts
+++ b/apps/cli/src/api/sandbox-proxy.ts
@@ -304,6 +304,23 @@ export function kortixPtyWsUrlForPort(
   return `${wsBase}/kortix/pty/${encodeURIComponent(ptyId)}/connect?token=${encodeURIComponent(auth.token)}`;
 }
 
+/**
+ * Open a PTY WebSocket with an explicit User-Agent.
+ *
+ * Bun's WebSocket client does not send User-Agent by default. Cloudflare
+ * rejects that handshake before it reaches the Kortix API.
+ */
+export function openKortixPtyWebSocket(url: string): WebSocket {
+  const version = process.env.KORTIX_CLI_VERSION ?? 'dev';
+  const BunWebSocket = WebSocket as unknown as new (
+    url: string | URL,
+    options?: Bun.WebSocketOptions,
+  ) => WebSocket;
+  return new BunWebSocket(url, {
+    headers: { 'User-Agent': `kortix-cli/${version}` },
+  });
+}
+
 export interface SandboxOpencodeOpts {
   auth: Auth;
   sandboxId: string;

--- a/apps/cli/src/commands/sessions-shell.ts
+++ b/apps/cli/src/commands/sessions-shell.ts
@@ -1,4 +1,8 @@
-import { kortixPtyWsUrlForPort, type OpencodePty } from '../api/sandbox-proxy.ts';
+import {
+  kortixPtyWsUrlForPort,
+  openKortixPtyWebSocket,
+  type OpencodePty,
+} from '../api/sandbox-proxy.ts';
 import { takeFlagBool, takeFlagValue } from '../command-helpers.ts';
 import { C, help, status } from '../style.ts';
 import { loadSessionForChat, resolveRunningSessionId, type ResolvedSession } from './sessions-chat.ts';
@@ -116,7 +120,7 @@ function createPty(resolved: ResolvedSession): Promise<OpencodePty> {
  *  WebSocket, and forward local resizes. Returns once the connection ends. */
 function runPtySession(resolved: ResolvedSession, pty: OpencodePty): Promise<number> {
   const wsUrl = kortixPtyWsUrlForPort(resolved.auth, resolved.proxyId, resolved.runtimePort, pty.id);
-  const ws = new WebSocket(wsUrl);
+  const ws = openKortixPtyWebSocket(wsUrl);
   ws.binaryType = 'arraybuffer';
 
   let resizeTimer: ReturnType<typeof setTimeout> | null = null;

--- a/apps/sandbox/Dockerfile
+++ b/apps/sandbox/Dockerfile
@@ -120,7 +120,7 @@ RUN UV_VERSION="$(sed -n 's/.*"uv": "\([^"]*\)".*/\1/p' /tmp/kortix-runtime-vers
     && echo "${uv_sha}  /tmp/uv.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/uv.tar.gz --strip-components=1 -C /home/kortix/.local/bin \
     && rm /tmp/uv.tar.gz \
-    && test "$(uv --version)" = "uv ${UV_VERSION}" \
+    && uv --version | grep -Eq "^uv ${UV_VERSION}( |$)" \
     && UV_PYTHON_DOWNLOADS=automatic uv python install --default "$PYTHON_VERSION" \
     && python -c "import sys; assert '.'.join(map(str, sys.version_info[:3])) == '${PYTHON_VERSION}'; print('managed python:', sys.version)" \
     && python3 -c "import sys; assert '.'.join(map(str, sys.version_info[:3])) == '${PYTHON_VERSION}'"

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -4,10 +4,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useCallback, useRef } from 'react';
 
+import { errorToast, loadingToast } from '@/components/ui/toast';
 import { resolveCreateFailure } from '@/hooks/projects/new-session-failure';
 import { useProjectCanRun } from '@/hooks/projects/use-project-can-run';
 import { isBillingEnabled } from '@/lib/config';
-import { toast } from '@/lib/toast';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { markSessionFresh } from '@kortix/sdk/fresh-sessions';
 import { createProjectSession } from '@kortix/sdk/projects-client';
@@ -78,7 +78,11 @@ export function useNewProjectSession(projectId: string | undefined) {
       // Warm the route bundle while the create POST is in flight.
       router.prefetch(`/projects/${projectId}/sessions/${sessionId}`);
 
-      createProjectSession(projectId, { session_id: sessionId, ...opts?.create })
+      loadingToast(
+        'Starting session…',
+        createProjectSession(projectId, { session_id: sessionId, ...opts?.create }),
+        { success: 'Session started' },
+      )
         .then(() => {
           // The row exists — kick provisioning so it overlaps the navigation.
           prefetchSessionStart(queryClient, projectId, sessionId);
@@ -92,7 +96,7 @@ export function useNewProjectSession(projectId: string | undefined) {
           if (action === 'upgrade') {
             openUpgradeDialog({ reason: 'subscription_required', accountId });
           } else if (action === 'toast') {
-            toast.error(err instanceof Error ? err.message : 'Failed to start session');
+            errorToast(err instanceof Error ? err.message : 'Failed to start session');
           }
           // 'silent': the global 429 handler already surfaced the session cap.
           opts?.onError?.();

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -44,7 +44,7 @@ RUN case "$(uname -m)" in \\
     && echo "\${uv_sha}  /tmp/uv.tar.gz" | sha256sum -c - \\
     && tar -xzf /tmp/uv.tar.gz --strip-components=1 -C /home/kortix/.local/bin \\
     && rm /tmp/uv.tar.gz \\
-    && test "$(uv --version)" = "uv 0.11.30" \\
+    && uv --version | grep -Eq '^uv 0.11.30( |$)' \\
     && UV_PYTHON_DOWNLOADS=automatic uv python install --default 3.12.13 \\
     && python -c 'import sys; assert sys.version_info[:3] == (3, 12, 13); print("managed python:", sys.version)' \\
     && python3 -c 'import sys; assert sys.version_info[:3] == (3, 12, 13)'
@@ -198,7 +198,7 @@ RUN case "$(uname -m)" in \\
     && echo "\${uv_sha}  /tmp/uv.tar.gz" | sha256sum -c - \\
     && tar -xzf /tmp/uv.tar.gz --strip-components=1 -C /home/kortix/.local/bin \\
     && rm /tmp/uv.tar.gz \\
-    && test "$(uv --version)" = "uv 0.11.30" \\
+    && uv --version | grep -Eq '^uv 0.11.30( |$)' \\
     && UV_PYTHON_DOWNLOADS=automatic uv python install --default 3.12.13 \\
     && python -c 'import sys; assert sys.version_info[:3] == (3, 12, 13); print("managed python:", sys.version)' \\
     && python3 -c 'import sys; assert sys.version_info[:3] == (3, 12, 13)'
@@ -353,7 +353,7 @@ RUN case "$(uname -m)" in \\
     && echo "\${uv_sha}  /tmp/uv.tar.gz" | sha256sum -c - \\
     && tar -xzf /tmp/uv.tar.gz --strip-components=1 -C /home/kortix/.local/bin \\
     && rm /tmp/uv.tar.gz \\
-    && test "$(uv --version)" = "uv 0.11.30" \\
+    && uv --version | grep -Eq '^uv 0.11.30( |$)' \\
     && UV_PYTHON_DOWNLOADS=automatic uv python install --default 3.12.13 \\
     && python -c 'import sys; assert sys.version_info[:3] == (3, 12, 13); print("managed python:", sys.version)' \\
     && python3 -c 'import sys; assert sys.version_info[:3] == (3, 12, 13)'

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -437,7 +437,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '    && echo "${uv_sha}  /tmp/uv.tar.gz" | sha256sum -c - \\',
     '    && tar -xzf /tmp/uv.tar.gz --strip-components=1 -C /home/kortix/.local/bin \\',
     '    && rm /tmp/uv.tar.gz \\',
-    `    && test "$(uv --version)" = "uv ${UV_VERSION}" \\`,
+    `    && uv --version | grep -Eq '^uv ${UV_VERSION}( |$)' \\`,
     `    && UV_PYTHON_DOWNLOADS=automatic uv python install --default ${PYTHON_VERSION} \\`,
     `    && python -c 'import sys; assert sys.version_info[:3] == (${PYTHON_VERSION.replaceAll('.', ', ')}); print("managed python:", sys.version)' \\`,
     `    && python3 -c 'import sys; assert sys.version_info[:3] == (${PYTHON_VERSION.replaceAll('.', ', ')})'`,


### PR DESCRIPTION
## Summary

- send an explicit Kortix CLI User-Agent on PTY WebSocket upgrades so Cloudflare accepts `sessions shell`
- show immediate `Starting session…` feedback for CMD+J and other new-session entry points
- accept uv release target metadata in sandbox builds
- delete retained failed Daytona snapshots and retry duplicate snapshot names

## Verification

- `bun test apps/cli/src/__tests__/sandbox-proxy-websocket.test.ts apps/api/src/__tests__/unit-dockerfile-layer.test.ts apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts packages/shared/src/sandbox/__tests__/layer-render.test.ts` — 71 pass, 0 fail
- `pnpm --filter @kortix/cli typecheck` — exit 0
- `pnpm --filter kortix-api typecheck` — exit 0
- `pnpm --filter @kortix/shared typecheck` — exit 0
- `cd apps/web && pnpm exec eslint src/hooks/projects/use-new-project-session.ts` — exit 0
- exact linux/amd64 uv probe returns `uv 0.11.30 (x86_64-unknown-linux-gnu)` and passes the new version regex
