### PR TITLE
fix(sessions): preserve runtime URL on restart

### DIFF
--- a/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
+++ b/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(
+  new URL('../projects/session-lifecycle/actions.ts', import.meta.url),
+  'utf8',
+);
+
+describe('session restart URL contract', () => {
+  test('clears sandboxUrl only when a replacement runtime is required', () => {
+    const replacementStart = source.indexOf('const provisionReplacementRuntime');
+    const inPlaceStart = source.indexOf('if (\n    existingSandbox?.externalId');
+
+    expect(replacementStart).toBeGreaterThan(-1);
+    expect(inPlaceStart).toBeGreaterThan(replacementStart);
+    expect(source.slice(replacementStart, inPlaceStart)).toContain('sandboxUrl: null');
+    expect(source.slice(inPlaceStart)).not.toContain('sandboxUrl: null');
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -272,7 +272,6 @@ export async function restartSession(input: {
       .set({
         status: 'provisioning',
         error: null,
-        sandboxUrl: null,
         updatedAt: new Date(),
       })
       .where(eq(projectSessions.sessionId, sessionId));


### PR DESCRIPTION
## Root cause

In-place restart cleared `project_sessions.sandbox_url`. The success path restored `status: running` but never restored the URL. CLI chat then used `session_id` as the proxy key and received `404 sandbox not found`, although the provider sandbox remained active under its external ID.

## Fix

Preserve `sandbox_url` during in-place restart. Replacement provisioning still clears it because that path creates a new external runtime.

## Verification

- `bun test apps/api/src/__tests__/unit-session-restart-url-contract.test.ts apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts`
  - 12 pass, 0 fail
- `pnpm --filter kortix-api typecheck`
  - exit 0
- Live staging evidence before the fix: provider external runtime reported `running`; `project_sessions.sandbox_url` was null; `/v1/p/<session_id>/8000/session` returned 404.
