### PR TITLE
fix(staging): preserve session runtime URL on restart

### DIFF
--- a/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
+++ b/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(
+  new URL('../projects/session-lifecycle/actions.ts', import.meta.url),
+  'utf8',
+);
+
+describe('session restart URL contract', () => {
+  test('clears sandboxUrl only when a replacement runtime is required', () => {
+    const replacementStart = source.indexOf('const provisionReplacementRuntime');
+    const inPlaceStart = source.indexOf('if (\n    existingSandbox?.externalId');
+
+    expect(replacementStart).toBeGreaterThan(-1);
+    expect(inPlaceStart).toBeGreaterThan(replacementStart);
+    expect(source.slice(replacementStart, inPlaceStart)).toContain('sandboxUrl: null');
+    expect(source.slice(inPlaceStart)).not.toContain('sandboxUrl: null');
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -272,7 +272,6 @@ export async function restartSession(input: {
       .set({
         status: 'provisioning',
         error: null,
-        sandboxUrl: null,
         updatedAt: new Date(),
       })
       .where(eq(projectSessions.sessionId, sessionId));

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-3956467f"
+  tag: "dev-228b3cde"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
## Summary

- promote the session restart URL fix from `main`
- keep `sandbox_url` while restarting the existing provider runtime
- preserve post-restart PTY routing for Daytona and Platinum

## Verification

- `bun test apps/api/src/__tests__/unit-session-restart-url-contract.test.ts` — 1 pass, 0 fail
- `pnpm --filter kortix-api typecheck` — exit 0
- Deploy Dev run `30058569837` — success
- live dev restart retained `sandbox_url` and returned `DEV_RESTART_PTY_OK`