### PR TITLE
fix(sessions): reset restart readiness clocks

### DIFF
--- a/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
+++ b/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
+import {
+  prepareInPlaceRestartMetadata,
+  staleOpencodeReadyReason,
+} from '../projects/session-lifecycle/readiness-clocks';
 
 const source = readFileSync(
   new URL('../projects/session-lifecycle/actions.ts', import.meta.url),
@@ -15,5 +19,40 @@ describe('session restart URL contract', () => {
     expect(inPlaceStart).toBeGreaterThan(replacementStart);
     expect(source.slice(replacementStart, inPlaceStart)).toContain('sandboxUrl: null');
     expect(source.slice(inPlaceStart)).not.toContain('sandboxUrl: null');
+  });
+
+  test('starts a fresh runtime clock and removes stale OpenCode clocks', () => {
+    const now = new Date('2026-07-24T02:00:00.000Z');
+    const metadata = prepareInPlaceRestartMetadata(
+      {
+        initSucceededAt: '2026-07-24T01:00:00.000Z',
+        opencodeReadyWaitStartedAt: '2026-07-24T01:00:00.000Z',
+        opencodeReadyWaitReason: 'unreachable',
+      },
+      now,
+    );
+
+    expect(metadata.runtimeWakeStartedAt).toBe(now.toISOString());
+    expect(metadata.runtimeWakeProviderStatus).toBe('starting');
+    expect(metadata.opencodeReadyWaitStartedAt).toBeUndefined();
+    expect(metadata.opencodeReadyWaitReason).toBeUndefined();
+  });
+
+  test('does not treat an old initial boot as a stale post-restart OpenCode wait', () => {
+    expect(
+      staleOpencodeReadyReason(
+        { initSucceededAt: '2026-07-24T01:00:00.000Z' },
+        'unreachable',
+        Date.parse('2026-07-24T02:00:00.000Z'),
+      ),
+    ).toBeNull();
+
+    expect(
+      staleOpencodeReadyReason(
+        { opencodeReadyWaitStartedAt: '2026-07-24T01:54:59.000Z' },
+        'unreachable',
+        Date.parse('2026-07-24T02:00:00.000Z'),
+      ),
+    ).toBe('runtime_unreachable_timeout');
   });
 });

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -21,6 +21,11 @@ import {
   retireUnmaterializedRuntime,
   RUNTIME_IDENTITY_UNAVAILABLE,
 } from '../runtime-identity';
+import {
+  hasRuntimeReadinessClock,
+  RUNTIME_READINESS_CLOCK_KEYS,
+  staleOpencodeReadyReason,
+} from '../session-lifecycle/readiness-clocks';
 
 /**
  * Resume a hibernated (status='stopped') session sandbox IN PLACE instead of
@@ -437,29 +442,6 @@ function staleRuntimeWakeReason(
   return null;
 }
 
-function staleOpencodeReadyReason(
-  row: typeof sessionSandboxes.$inferSelect,
-  reason: string,
-  nowMs = Date.now(),
-): string | null {
-  if (reason !== 'not_ready' && reason !== 'unreachable') return null;
-  const metadata = sandboxMetadata(row);
-  const readyWaitStartedAtMs = parseTimestampMs(metadata.opencodeReadyWaitStartedAt);
-  if (readyWaitStartedAtMs && nowMs - readyWaitStartedAtMs > STALE_OPENCODE_READY_MS) {
-    return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
-  }
-
-  const initSucceededAtMs = parseTimestampMs(metadata.initSucceededAt);
-  if (
-    !readyWaitStartedAtMs &&
-    initSucceededAtMs &&
-    nowMs - initSucceededAtMs > STALE_OPENCODE_READY_MS
-  ) {
-    return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
-  }
-  return null;
-}
-
 function removedRuntimeStillInGrace(
   row: typeof sessionSandboxes.$inferSelect,
   nowMs = Date.now(),
@@ -513,6 +495,30 @@ async function markOpencodeReadyWaitStarted(
       .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
   } catch (err) {
     console.warn(`[start] failed to mark OpenCode wait for ${row.sandboxId}:`, err);
+  }
+}
+
+async function clearRuntimeReadinessClocks(
+  row: typeof sessionSandboxes.$inferSelect,
+): Promise<void> {
+  const metadata = sandboxMetadata(row);
+  if (!hasRuntimeReadinessClock(metadata)) return;
+  try {
+    await db
+      .update(sessionSandboxes)
+      .set({
+        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
+          - ${RUNTIME_READINESS_CLOCK_KEYS[0]}
+          - ${RUNTIME_READINESS_CLOCK_KEYS[1]}
+          - ${RUNTIME_READINESS_CLOCK_KEYS[2]}
+          - ${RUNTIME_READINESS_CLOCK_KEYS[3]}
+          - ${RUNTIME_READINESS_CLOCK_KEYS[4]}
+          - ${RUNTIME_READINESS_CLOCK_KEYS[5]}`,
+        updatedAt: new Date(),
+      })
+      .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+  } catch (err) {
+    console.warn(`[start] failed to clear readiness clocks for ${row.sandboxId}:`, err);
   }
 }
 
@@ -907,7 +913,12 @@ export async function openSession(args: {
   });
   const booting = ensured.reason === 'not_ready' || ensured.reason === 'unreachable';
   if (booting) {
-    const staleBoot = staleOpencodeReadyReason(row, ensured.reason);
+    const staleBoot = staleOpencodeReadyReason(
+      sandboxMetadata(row),
+      ensured.reason,
+      Date.now(),
+      STALE_OPENCODE_READY_MS,
+    );
     if (staleBoot) {
       return preserveEstablishedRuntimeOnOpen(
         loaded,
@@ -919,6 +930,8 @@ export async function openSession(args: {
       );
     }
     await markOpencodeReadyWaitStarted(row, ensured.reason);
+  } else {
+    await clearRuntimeReadinessClocks(row);
   }
   return {
     stage: booting ? 'starting' : 'ready',

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -18,6 +18,7 @@ import {
   RUNTIME_IDENTITY_ERROR,
   RUNTIME_IDENTITY_UNAVAILABLE,
 } from '../runtime-identity';
+import { prepareInPlaceRestartMetadata } from './readiness-clocks';
 
 export async function deleteSession(input: {
   projectId: string;
@@ -263,9 +264,14 @@ export async function restartSession(input: {
       };
     }
 
+    const restartStartedAt = new Date();
     await db
       .update(sessionSandboxes)
-      .set({ status: 'provisioning', updatedAt: new Date() })
+      .set({
+        status: 'provisioning',
+        metadata: prepareInPlaceRestartMetadata(existingSandbox.metadata, restartStartedAt),
+        updatedAt: restartStartedAt,
+      })
       .where(eq(sessionSandboxes.sandboxId, sessionId));
     await db
       .update(projectSessions)

--- a/apps/api/src/projects/session-lifecycle/readiness-clocks.ts
+++ b/apps/api/src/projects/session-lifecycle/readiness-clocks.ts
@@ -1,0 +1,46 @@
+export type RuntimeReadinessMetadata = Record<string, unknown>;
+
+export const RUNTIME_READINESS_CLOCK_KEYS = [
+  'runtimeWakeStartedAt',
+  'runtimeWakeProviderStatus',
+  'runtimeWakeError',
+  'runtimeWakeFailedAt',
+  'opencodeReadyWaitStartedAt',
+  'opencodeReadyWaitReason',
+] as const;
+
+function parseTimestampMs(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function prepareInPlaceRestartMetadata(
+  metadata: RuntimeReadinessMetadata | null | undefined,
+  now = new Date(),
+): RuntimeReadinessMetadata {
+  const next = { ...(metadata ?? {}) };
+  for (const key of RUNTIME_READINESS_CLOCK_KEYS) delete next[key];
+  return {
+    ...next,
+    lastTurnAt: now.toISOString(),
+    runtimeWakeStartedAt: now.toISOString(),
+    runtimeWakeProviderStatus: 'starting',
+  };
+}
+
+export function staleOpencodeReadyReason(
+  metadata: RuntimeReadinessMetadata,
+  reason: string,
+  nowMs = Date.now(),
+  staleAfterMs = 5 * 60 * 1000,
+): string | null {
+  if (reason !== 'not_ready' && reason !== 'unreachable') return null;
+  const readyWaitStartedAtMs = parseTimestampMs(metadata.opencodeReadyWaitStartedAt);
+  if (!readyWaitStartedAtMs || nowMs - readyWaitStartedAtMs <= staleAfterMs) return null;
+  return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
+}
+
+export function hasRuntimeReadinessClock(metadata: RuntimeReadinessMetadata): boolean {
+  return RUNTIME_READINESS_CLOCK_KEYS.some((key) => key in metadata);
+}


### PR DESCRIPTION
## Root cause

An in-place restart preserved the original `initSucceededAt`. The first post-restart OpenCode health miss treated that old boot timestamp as a five-minute timeout. The API stopped a healthy provider runtime with `runtime_unreachable_timeout`.

## Fix

- start a fresh runtime wake clock for each in-place restart
- remove stale OpenCode wait clocks before restart
- start the OpenCode timeout from the first new readiness miss
- clear transient readiness clocks after OpenCode becomes ready

## Verification

- `bun test apps/api/src/__tests__/unit-session-restart-url-contract.test.ts` — 3 pass, 0 fail
- `pnpm --filter kortix-api typecheck` — exit 0
- live staging reproduction: Daytona session `6dc95e68-a6c8-4020-87c7-6c52f90dab40` preserved `sandbox_url`, then failed with `runtime_unreachable_timeout` from the old `initSucceededAt`