### PR TITLE
fix(snapshots): preserve git metadata in warm build contexts

### DIFF
--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -182,6 +182,7 @@ describe('buildLayeredDockerfile', () => {
       opencodeConfigPath: 'kortix-opencode-config',
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
+        stagedGitPath: 'kortix-warm-repo-git',
         branch: 'main',
       },
     });

--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -134,6 +134,8 @@ export interface WarmRepoContext {
 
 /** Basename (in the build context) of the staged credential-free checkout. */
 export const WARM_REPO_STAGED_DIR = 'kortix-warm-repo';
+/** Visible duplicate of `.git` for provider uploaders that omit dot-directories. */
+export const WARM_REPO_STAGED_GIT_DIR = 'kortix-warm-repo-git';
 
 /**
  * A conservative safe-subset of git branch/ref names: letters, digits, and
@@ -235,7 +237,7 @@ export function warmCloneProtocolPinArgs(cloneUrl: string): string[] {
 export async function stageWarmRepoCheckout(
   contextDir: string,
   warmRepo: WarmRepoContext,
-): Promise<{ stagedPath: string; headSha: string }> {
+): Promise<{ stagedPath: string; stagedGitPath: string; headSha: string }> {
   if (!isSafeGitBranchName(warmRepo.branch)) {
     throw new Error(
       `refusing to bake per-project warm image: unsafe default branch name ${JSON.stringify(warmRepo.branch)}`,
@@ -335,7 +337,14 @@ export async function stageWarmRepoCheckout(
   }
 
   await assertCheckoutHasNoCredentials(dest);
-  return { stagedPath: WARM_REPO_STAGED_DIR, headSha };
+  const stagedGit = join(contextDir, WARM_REPO_STAGED_GIT_DIR);
+  await rm(stagedGit, { recursive: true, force: true });
+  await cp(join(dest, '.git'), stagedGit, { recursive: true });
+  return {
+    stagedPath: WARM_REPO_STAGED_DIR,
+    stagedGitPath: WARM_REPO_STAGED_GIT_DIR,
+    headSha,
+  };
 }
 
 /**
@@ -457,10 +466,10 @@ export async function stageBuildContext(
   // PHASE 1: for a per-project COLD warm, clone the repo API-side into a
   // SANITIZED, credential-free checkout the Dockerfile only COPYs. The git auth
   // header is used here (Suna host) and NEVER embedded in the built image.
-  let warmRepoBake: { stagedPath: string; branch: string } | undefined;
+  let warmRepoBake: { stagedPath: string; stagedGitPath: string; branch: string } | undefined;
   if (warmRepo) {
-    const { stagedPath } = await stageWarmRepoCheckout(contextDir, warmRepo);
-    warmRepoBake = { stagedPath, branch: warmRepo.branch };
+    const { stagedPath, stagedGitPath } = await stageWarmRepoCheckout(contextDir, warmRepo);
+    warmRepoBake = { stagedPath, stagedGitPath, branch: warmRepo.branch };
   }
 
   // Bake the FULL gateway model catalog into the image. The no-restart warm seed
@@ -551,13 +560,13 @@ export async function stageWarmFromBaseContext(
 
   // PHASE 1: sanitized, credential-free repo checkout — cloned API-side, only
   // COPY'd by the rendered Dockerfile (no git auth header in the image).
-  const { stagedPath } = await stageWarmRepoCheckout(contextDir, warmRepo);
+  const { stagedPath, stagedGitPath } = await stageWarmRepoCheckout(contextDir, warmRepo);
 
   const dockerfileName = '.kortix-snapshot.Dockerfile';
   const composedPath = join(contextDir, dockerfileName);
   const composed = buildPerProjectWarmFromBaseDockerfile({
     baseImageRef,
-    warmRepo: { stagedPath, branch: warmRepo.branch },
+    warmRepo: { stagedPath, stagedGitPath, branch: warmRepo.branch },
     opencodeConfigPath,
     opencodeWarmupScriptPath: 'kortix-opencode-warmup',
   });
@@ -626,7 +635,10 @@ async function assertContextComplete(
   // A per-project warm bake COPYs the staged checkout — verify it (and its
   // baked .git) actually landed, so a staging miss fails HERE rather than as an
   // opaque remote "Path does not exist" mid-build.
-  if (warmRepoStagedPath) required.push(join(warmRepoStagedPath, '.git'));
+  if (warmRepoStagedPath) {
+    required.push(join(warmRepoStagedPath, '.git'));
+    required.push(WARM_REPO_STAGED_GIT_DIR);
+  }
   for (const rel of required) {
     try {
       await stat(join(contextDir, rel));

--- a/apps/api/src/snapshots/warm-repo-credential.test.ts
+++ b/apps/api/src/snapshots/warm-repo-credential.test.ts
@@ -36,6 +36,7 @@ const {
   isSafeGitBranchName,
   isSafeGitSha,
   WARM_REPO_STAGED_DIR,
+  WARM_REPO_STAGED_GIT_DIR,
 } = await import('./build-context');
 
 const exec = promisify(execFile);
@@ -98,7 +99,7 @@ describe('PHASE 1: warm-repo checkout is staged credential-free', () => {
     const ctx = await mkdtemp(join(tmpdir(), 'warm-ctx-'));
     cleanup.push(ctx);
 
-    const { stagedPath, headSha } = await stageWarmRepoCheckout(ctx, {
+    const { stagedPath, stagedGitPath, headSha } = await stageWarmRepoCheckout(ctx, {
       cloneUrl: `file://${src.dir}`,
       cloneHeaders: { Authorization: `Bearer ${SENTINEL}` },
       branch: 'main',
@@ -107,6 +108,7 @@ describe('PHASE 1: warm-repo checkout is staged credential-free', () => {
     });
 
     expect(stagedPath).toBe(WARM_REPO_STAGED_DIR);
+    expect(stagedGitPath).toBe(WARM_REPO_STAGED_GIT_DIR);
     expect(headSha).toBe(src.sha);
     expect(headSha).toMatch(/^[0-9a-f]{40}$/);
 
@@ -114,6 +116,15 @@ describe('PHASE 1: warm-repo checkout is staged credential-free', () => {
     // The checkout is a real repo at the requested tip.
     const gitDir = await stat(join(dest, '.git'));
     expect(gitDir.isDirectory()).toBe(true);
+    const visibleGitDir = await stat(join(ctx, stagedGitPath));
+    expect(visibleGitDir.isDirectory()).toBe(true);
+    const { stdout: visibleHead } = await exec('git', [
+      `--git-dir=${join(ctx, stagedGitPath)}`,
+      `--work-tree=${dest}`,
+      'rev-parse',
+      'HEAD',
+    ]);
+    expect(visibleHead.trim()).toBe(headSha);
     const { stdout: head } = await exec('git', ['-C', dest, 'rev-parse', 'HEAD']);
     expect(head.trim()).toBe(headSha);
 

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -435,6 +435,7 @@ RUN cd /opt/kortix/opencode-config-deps \\
 # history, or build logs. See PHASE 1 provider-migration hardening.
 RUN cd / && mkdir -p /workspace && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/
+COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
@@ -496,6 +497,7 @@ USER kortix
 # history, or build logs. See PHASE 1 provider-migration hardening.
 RUN cd / && mkdir -p /workspace && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/
+COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -83,6 +83,7 @@ const CASES: Array<{ label: string; opts: BuildLayeredDockerfileOpts }> = [
       ...COMMON,
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
+        stagedGitPath: 'kortix-warm-repo-git',
         branch: 'main',
       },
     },
@@ -188,6 +189,7 @@ describe('Chromium sits on deterministic parents (cache order is load-bearing)',
       opencodeWarmupScriptPath: 'kortix-opencode-warmup',
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
+        stagedGitPath: 'kortix-warm-repo-git',
         branch: 'main',
       },
     });
@@ -210,13 +212,20 @@ describe('PHASE 1: no git credential is ever rendered into the Dockerfile', () =
     const warm = buildLayeredDockerfile({
       userDockerfile: PLATFORM_DEFAULT_USER_DOCKERFILE,
       ...COMMON,
-      warmRepo: { stagedPath: 'kortix-warm-repo', branch: 'main' },
+      warmRepo: {
+        stagedPath: 'kortix-warm-repo',
+        stagedGitPath: 'kortix-warm-repo-git',
+        branch: 'main',
+      },
     });
     expect(warm).not.toContain('http.extraHeader');
     expect(warm).not.toContain('Authorization');
     // The build-time clone is gone entirely — the image only COPYs staged bytes.
     expect(warm).not.toContain('git clone');
     expect(warm).toContain('COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/');
+    expect(warm).toContain(
+      'COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/',
+    );
   });
 
   test('a sentinel-shaped branch name is shell-quoted, not interpolated raw', () => {
@@ -226,7 +235,11 @@ describe('PHASE 1: no git credential is ever rendered into the Dockerfile', () =
     const warm = buildLayeredDockerfile({
       userDockerfile: PLATFORM_DEFAULT_USER_DOCKERFILE,
       ...COMMON,
-      warmRepo: { stagedPath: 'kortix-warm-repo', branch: evil },
+      warmRepo: {
+        stagedPath: 'kortix-warm-repo',
+        stagedGitPath: 'kortix-warm-repo-git',
+        branch: evil,
+      },
     });
     // shq single-quotes the whole value and escapes embedded quotes, so the
     // branch appears exactly once, fully quoted — the `; echo …` cannot escape.
@@ -333,6 +346,7 @@ describe('buildPerProjectWarmFromBaseDockerfile (FROM-base fast path)', () => {
     opencodeWarmupScriptPath: 'kortix-opencode-warmup',
     warmRepo: {
       stagedPath: 'kortix-warm-repo',
+      stagedGitPath: 'kortix-warm-repo-git',
       branch: 'main',
     },
   };
@@ -362,6 +376,11 @@ describe('buildPerProjectWarmFromBaseDockerfile (FROM-base fast path)', () => {
     expect(rendered).toContain('Per-project COLD warm: bake repo checkout into /workspace');
     // MY credential-free COPY of the sanitized staged checkout …
     expect(rendered).toContain('COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/');
+    // Provider uploaders can omit nested dot-directories. Git metadata uses a
+    // visible build-context path and lands at the canonical runtime path.
+    expect(rendered).toContain(
+      'COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/',
+    );
     // … and MAIN's opencode instance re-warm via the cache-only warm-up script,
     // which for a per-project warm keeps the baked /workspace checkout.
     expect(rendered).toContain(

--- a/packages/shared/src/sandbox/__tests__/layer-split.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-split.test.ts
@@ -79,6 +79,7 @@ const OPT_SHAPES: Array<{ label: string; opts: Omit<BuildLayeredDockerfileOpts, 
       opencodeConfigPath: 'kortix-opencode-config',
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
+        stagedGitPath: 'kortix-warm-repo-git',
         branch: 'main',
       },
     },

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -181,6 +181,11 @@ export interface WarmRepoConfig {
    */
   stagedPath: string;
   /**
+   * Visible build-context path to a copy of the checkout's `.git` directory.
+   * Provider context uploaders can omit nested dot-directories.
+   */
+  stagedGitPath: string;
+  /**
    * Branch that was checked out (the default-branch tip). Diagnostic only —
    * shell-quoted on render (never interpolated raw), so a hostile branch name
    * cannot inject a build-time shell command.
@@ -290,6 +295,9 @@ function buildWarmRepoCopyLines(warmRepo: WarmRepoConfig | undefined): string[] 
     // runtime user (COPY defaults to uid/gid 0). opencode + the daemon run as
     // `kortix` and must be able to write /workspace and its `.git` at runtime.
     `COPY --chown=kortix:kortix ${warmRepo.stagedPath}/ /workspace/`,
+    // Daytona omits nested `.git` directories from uploaded build contexts.
+    // Copy the credential-free visible duplicate explicitly.
+    `COPY --chown=kortix:kortix ${warmRepo.stagedGitPath}/ /workspace/.git/`,
     // Verify the baked checkout is a real repo. The branch is shell-quoted via
     // `shq` (never interpolated raw), so a hostile branch name cannot inject a
     // build-time shell command — closing the latent sink in the old echo.


### PR DESCRIPTION
## Defect

Daytona omits nested `.git` directories from uploaded snapshot build contexts. Per-project warm builds then fail at `git -C /workspace rev-parse HEAD` with exit code `128`. Provider transitions classify the build as `auth_terminal`.

## Fix

- Stage a visible, credential-free duplicate of `.git`.
- Copy that directory explicitly to `/workspace/.git`.
- Apply the same layer to full and FROM-base warm builds.
- Verify the visible Git directory contains the pinned commit.

## Verification

```text
bun test packages/shared/src/sandbox/__tests__/layer-render.test.ts packages/shared/src/sandbox/__tests__/layer-split.test.ts apps/api/src/snapshots/warm-repo-credential.test.ts apps/api/src/__tests__/unit-dockerfile-layer.test.ts apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
142 pass
0 fail
```

```text
pnpm --filter kortix-api typecheck
exit 0

pnpm --filter @kortix/shared typecheck
exit 0
```

## Live failure evidence

Transition `a782e9cc-5166-44e1-9d6c-793e8c1e9162` failed on dev with `auth_terminal`. The persisted build error ends with `git -C /workspace rev-parse HEAD ... exit code: 128`.