### PR TITLE
fix(daytona): restore warm repository Git metadata from archive

### DIFF
--- a/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { chmod, mkdir, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -63,6 +64,7 @@ beforeEach(() => {
 let dockerfileSeen = '';
 let scaffoldPresentAtDaytonaBoundary = false;
 let executorNodeModulesPresentAtProviderBoundary = false;
+let warmGitArchivePresentAtDaytonaBoundary = false;
 // One push per build attempt — the composed Dockerfile path (== context dir).
 // Each entry is a DISTINCT temp dir iff the adapter re-staged a fresh context.
 const contextPaths: string[] = [];
@@ -81,6 +83,9 @@ mock.module('@daytonaio/sdk', () => ({
       scaffoldPresentAtDaytonaBoundary = existsSync(join(path, '..', 'scaffold.git', 'HEAD'));
       executorNodeModulesPresentAtProviderBoundary = existsSync(
         join(path, '..', 'kortix-executor-sdk', 'node_modules'),
+      );
+      warmGitArchivePresentAtDaytonaBoundary = existsSync(
+        join(path, '..', 'kortix-warm-repo-git.tar'),
       );
       contextPaths.push(path);
       return { kind: 'mock-image', path };
@@ -125,6 +130,51 @@ describe('Daytona snapshot build context', () => {
     expect(scaffoldPresentAtDaytonaBoundary).toBe(true);
     expect(executorNodeModulesPresentAtProviderBoundary).toBe(false);
   });
+
+  test('uploads Git metadata as one visible archive and restores .git in the image', async () => {
+    const source = join(fixtureRoot, 'warm-source');
+    rmSync(source, { recursive: true, force: true });
+    await mkdir(source, { recursive: true });
+    writeFileSync(join(source, 'README.md'), '# warm\n');
+    const gitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Kortix Test',
+      GIT_AUTHOR_EMAIL: 'test@kortix.test',
+      GIT_COMMITTER_NAME: 'Kortix Test',
+      GIT_COMMITTER_EMAIL: 'test@kortix.test',
+    };
+    execFileSync('git', ['init', '-b', 'main'], { cwd: source, env: gitEnv });
+    execFileSync('git', ['add', '-A'], { cwd: source, env: gitEnv });
+    execFileSync('git', ['commit', '-m', 'warm fixture'], { cwd: source, env: gitEnv });
+    const tip = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: source,
+      env: gitEnv,
+      encoding: 'utf8',
+    }).trim();
+
+    warmGitArchivePresentAtDaytonaBoundary = false;
+    await daytonaProvider.buildSnapshot({
+      snapshotName: 'kortix-warm-git-archive',
+      baseImageRef: 'registry.example.test/kortix-default:latest',
+      spec: {},
+      slug: 'default',
+      warmRepo: {
+        cloneUrl: `file://${source}`,
+        cloneHeaders: {},
+        branch: 'main',
+        tip,
+        originUrl: 'https://api.example.test/v1/projects/project-1/git',
+      },
+    });
+
+    expect(warmGitArchivePresentAtDaytonaBoundary).toBe(true);
+    expect(dockerfileSeen).toContain(
+      'COPY kortix-warm-repo-git.tar /tmp/kortix-warm-repo-git.tar',
+    );
+    expect(dockerfileSeen).toContain(
+      'tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1',
+    );
+  }, 30_000);
 });
 
 describe('Daytona snapshot state', () => {

--- a/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
+++ b/apps/api/src/__tests__/unit-dockerfile-layer.test.ts
@@ -182,7 +182,7 @@ describe('buildLayeredDockerfile', () => {
       opencodeConfigPath: 'kortix-opencode-config',
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
-        stagedGitPath: 'kortix-warm-repo-git',
+        stagedGitPath: 'kortix-warm-repo-git.tar',
         branch: 'main',
       },
     });

--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -134,8 +134,14 @@ export interface WarmRepoContext {
 
 /** Basename (in the build context) of the staged credential-free checkout. */
 export const WARM_REPO_STAGED_DIR = 'kortix-warm-repo';
-/** Visible duplicate of `.git` for provider uploaders that omit dot-directories. */
-export const WARM_REPO_STAGED_GIT_DIR = 'kortix-warm-repo-git';
+/**
+ * Visible tar archive of `.git`.
+ *
+ * Daytona uploads each Dockerfile COPY source as a separate context object.
+ * A directory COPY into `/workspace/.git` can complete without restoring a
+ * usable repository. A single visible file crosses that boundary unchanged.
+ */
+export const WARM_REPO_STAGED_GIT_ARCHIVE = 'kortix-warm-repo-git.tar';
 
 /**
  * A conservative safe-subset of git branch/ref names: letters, digits, and
@@ -337,12 +343,16 @@ export async function stageWarmRepoCheckout(
   }
 
   await assertCheckoutHasNoCredentials(dest);
-  const stagedGit = join(contextDir, WARM_REPO_STAGED_GIT_DIR);
-  await rm(stagedGit, { recursive: true, force: true });
-  await cp(join(dest, '.git'), stagedGit, { recursive: true });
+  const stagedGit = join(contextDir, WARM_REPO_STAGED_GIT_ARCHIVE);
+  await rm(stagedGit, { force: true });
+  await execFileAsyncBC('tar', ['-cf', stagedGit, '-C', dest, '.git'], {
+    env: plainEnv,
+    timeout: 300_000,
+    maxBuffer: 64 * 1024 * 1024,
+  });
   return {
     stagedPath: WARM_REPO_STAGED_DIR,
-    stagedGitPath: WARM_REPO_STAGED_GIT_DIR,
+    stagedGitPath: WARM_REPO_STAGED_GIT_ARCHIVE,
     headSha,
   };
 }
@@ -637,7 +647,7 @@ async function assertContextComplete(
   // opaque remote "Path does not exist" mid-build.
   if (warmRepoStagedPath) {
     required.push(join(warmRepoStagedPath, '.git'));
-    required.push(WARM_REPO_STAGED_GIT_DIR);
+    required.push(WARM_REPO_STAGED_GIT_ARCHIVE);
   }
   for (const rel of required) {
     try {

--- a/apps/api/src/snapshots/warm-repo-credential.test.ts
+++ b/apps/api/src/snapshots/warm-repo-credential.test.ts
@@ -36,7 +36,7 @@ const {
   isSafeGitBranchName,
   isSafeGitSha,
   WARM_REPO_STAGED_DIR,
-  WARM_REPO_STAGED_GIT_DIR,
+  WARM_REPO_STAGED_GIT_ARCHIVE,
 } = await import('./build-context');
 
 const exec = promisify(execFile);
@@ -108,7 +108,7 @@ describe('PHASE 1: warm-repo checkout is staged credential-free', () => {
     });
 
     expect(stagedPath).toBe(WARM_REPO_STAGED_DIR);
-    expect(stagedGitPath).toBe(WARM_REPO_STAGED_GIT_DIR);
+    expect(stagedGitPath).toBe(WARM_REPO_STAGED_GIT_ARCHIVE);
     expect(headSha).toBe(src.sha);
     expect(headSha).toMatch(/^[0-9a-f]{40}$/);
 
@@ -116,10 +116,13 @@ describe('PHASE 1: warm-repo checkout is staged credential-free', () => {
     // The checkout is a real repo at the requested tip.
     const gitDir = await stat(join(dest, '.git'));
     expect(gitDir.isDirectory()).toBe(true);
-    const visibleGitDir = await stat(join(ctx, stagedGitPath));
-    expect(visibleGitDir.isDirectory()).toBe(true);
+    const visibleGitArchive = await stat(join(ctx, stagedGitPath));
+    expect(visibleGitArchive.isFile()).toBe(true);
+    const extractedGit = await mkdtemp(join(tmpdir(), 'warm-git-'));
+    cleanup.push(extractedGit);
+    await exec('tar', ['-xf', join(ctx, stagedGitPath), '-C', extractedGit]);
     const { stdout: visibleHead } = await exec('git', [
-      `--git-dir=${join(ctx, stagedGitPath)}`,
+      `--git-dir=${join(extractedGit, '.git')}`,
       `--work-tree=${dest}`,
       'rev-parse',
       'HEAD',

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -435,7 +435,8 @@ RUN cd /opt/kortix/opencode-config-deps \\
 # history, or build logs. See PHASE 1 provider-migration hardening.
 RUN cd / && mkdir -p /workspace && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/
-COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/
+COPY kortix-warm-repo-git.tar /tmp/kortix-warm-repo-git.tar
+RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && rm -f /tmp/kortix-warm-repo-git.tar && chown -R kortix:kortix /workspace/.git
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
@@ -497,7 +498,8 @@ USER kortix
 # history, or build logs. See PHASE 1 provider-migration hardening.
 RUN cd / && mkdir -p /workspace && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/
-COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/
+COPY kortix-warm-repo-git.tar /tmp/kortix-warm-repo-git.tar
+RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && rm -f /tmp/kortix-warm-repo-git.tar && chown -R kortix:kortix /workspace/.git
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -83,7 +83,7 @@ const CASES: Array<{ label: string; opts: BuildLayeredDockerfileOpts }> = [
       ...COMMON,
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
-        stagedGitPath: 'kortix-warm-repo-git',
+        stagedGitPath: 'kortix-warm-repo-git.tar',
         branch: 'main',
       },
     },
@@ -189,7 +189,7 @@ describe('Chromium sits on deterministic parents (cache order is load-bearing)',
       opencodeWarmupScriptPath: 'kortix-opencode-warmup',
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
-        stagedGitPath: 'kortix-warm-repo-git',
+        stagedGitPath: 'kortix-warm-repo-git.tar',
         branch: 'main',
       },
     });
@@ -214,7 +214,7 @@ describe('PHASE 1: no git credential is ever rendered into the Dockerfile', () =
       ...COMMON,
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
-        stagedGitPath: 'kortix-warm-repo-git',
+        stagedGitPath: 'kortix-warm-repo-git.tar',
         branch: 'main',
       },
     });
@@ -224,7 +224,7 @@ describe('PHASE 1: no git credential is ever rendered into the Dockerfile', () =
     expect(warm).not.toContain('git clone');
     expect(warm).toContain('COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/');
     expect(warm).toContain(
-      'COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/',
+      'COPY kortix-warm-repo-git.tar /tmp/kortix-warm-repo-git.tar',
     );
   });
 
@@ -237,7 +237,7 @@ describe('PHASE 1: no git credential is ever rendered into the Dockerfile', () =
       ...COMMON,
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
-        stagedGitPath: 'kortix-warm-repo-git',
+        stagedGitPath: 'kortix-warm-repo-git.tar',
         branch: evil,
       },
     });
@@ -346,7 +346,7 @@ describe('buildPerProjectWarmFromBaseDockerfile (FROM-base fast path)', () => {
     opencodeWarmupScriptPath: 'kortix-opencode-warmup',
     warmRepo: {
       stagedPath: 'kortix-warm-repo',
-      stagedGitPath: 'kortix-warm-repo-git',
+      stagedGitPath: 'kortix-warm-repo-git.tar',
       branch: 'main',
     },
   };
@@ -376,10 +376,12 @@ describe('buildPerProjectWarmFromBaseDockerfile (FROM-base fast path)', () => {
     expect(rendered).toContain('Per-project COLD warm: bake repo checkout into /workspace');
     // MY credential-free COPY of the sanitized staged checkout …
     expect(rendered).toContain('COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/');
-    // Provider uploaders can omit nested dot-directories. Git metadata uses a
-    // visible build-context path and lands at the canonical runtime path.
+    // Provider uploaders transfer the visible archive as one context object.
     expect(rendered).toContain(
-      'COPY --chown=kortix:kortix kortix-warm-repo-git/ /workspace/.git/',
+      'COPY kortix-warm-repo-git.tar /tmp/kortix-warm-repo-git.tar',
+    );
+    expect(rendered).toContain(
+      'tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1',
     );
     // … and MAIN's opencode instance re-warm via the cache-only warm-up script,
     // which for a per-project warm keeps the baked /workspace checkout.

--- a/packages/shared/src/sandbox/__tests__/layer-split.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-split.test.ts
@@ -79,7 +79,7 @@ const OPT_SHAPES: Array<{ label: string; opts: Omit<BuildLayeredDockerfileOpts, 
       opencodeConfigPath: 'kortix-opencode-config',
       warmRepo: {
         stagedPath: 'kortix-warm-repo',
-        stagedGitPath: 'kortix-warm-repo-git',
+        stagedGitPath: 'kortix-warm-repo-git.tar',
         branch: 'main',
       },
     },

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -181,8 +181,8 @@ export interface WarmRepoConfig {
    */
   stagedPath: string;
   /**
-   * Visible build-context path to a copy of the checkout's `.git` directory.
-   * Provider context uploaders can omit nested dot-directories.
+   * Visible build-context path to a tar archive of the checkout's `.git`
+   * directory. Provider uploaders transfer this as one regular file.
    */
   stagedGitPath: string;
   /**
@@ -295,9 +295,10 @@ function buildWarmRepoCopyLines(warmRepo: WarmRepoConfig | undefined): string[] 
     // runtime user (COPY defaults to uid/gid 0). opencode + the daemon run as
     // `kortix` and must be able to write /workspace and its `.git` at runtime.
     `COPY --chown=kortix:kortix ${warmRepo.stagedPath}/ /workspace/`,
-    // Daytona omits nested `.git` directories from uploaded build contexts.
-    // Copy the credential-free visible duplicate explicitly.
-    `COPY --chown=kortix:kortix ${warmRepo.stagedGitPath}/ /workspace/.git/`,
+    // Daytona uploads each COPY source as a separate context object. Transfer
+    // Git metadata as one visible file, then restore the canonical directory.
+    `COPY ${warmRepo.stagedGitPath} /tmp/kortix-warm-repo-git.tar`,
+    'RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && rm -f /tmp/kortix-warm-repo-git.tar && chown -R kortix:kortix /workspace/.git',
     // Verify the baked checkout is a real repo. The branch is shell-quoted via
     // `shq` (never interpolated raw), so a hostile branch name cannot inject a
     // build-time shell command — closing the latent sink in the old echo.


### PR DESCRIPTION
## Defect

Daytona accepts the visible `.git` directory COPY but the resulting image still fails `git -C /workspace rev-parse HEAD` with exit code `128`.

Live transition `87828e7b-f4c9-459b-8e98-f1f6c7527931` reproduced the failure on deployed SHA `493ab7d3`.

## Fix

- Stage sanitized Git metadata as one visible tar file.
- Upload that file as one Daytona context object.
- Extract it into `/workspace/.git` inside the image.
- Preserve `kortix:kortix` ownership.
- Add a Daytona-boundary regression test for the archive and extraction command.

## Verification

```text
bun test apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts apps/api/src/snapshots/warm-repo-credential.test.ts packages/shared/src/sandbox/__tests__/layer-render.test.ts packages/shared/src/sandbox/__tests__/layer-split.test.ts apps/api/src/__tests__/unit-dockerfile-layer.test.ts
143 pass
0 fail
```

```text
pnpm --filter kortix-api typecheck
exit 0

pnpm --filter @kortix/shared typecheck
exit 0
```

## Live acceptance

After merge and dev deployment:

1. Transition project `d855a24c-a488-4195-b08a-47bed3ed4e09` from Platinum to Daytona.
2. Require `status=activated`.
3. Run session create, list, info, ready, PTY, agent, restart, and delete.
4. Re-run the same lifecycle on Platinum.
5. Promote to staging only after both providers pass.