### PR TITLE
fix(daytona): tolerate immutable warm archive

### DIFF
--- a/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
+++ b/apps/api/src/__tests__/unit-daytona-snapshot-context.test.ts
@@ -174,6 +174,7 @@ describe('Daytona snapshot build context', () => {
     expect(dockerfileSeen).toContain(
       'tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1',
     );
+    expect(dockerfileSeen).not.toContain('rm -f /tmp/kortix-warm-repo-git.tar');
   }, 30_000);
 });
 

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -436,7 +436,7 @@ RUN cd /opt/kortix/opencode-config-deps \\
 RUN cd / && mkdir -p /workspace && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/
 COPY kortix-warm-repo-git.tar /tmp/kortix-warm-repo-git.tar
-RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && rm -f /tmp/kortix-warm-repo-git.tar && chown -R kortix:kortix /workspace/.git
+RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && chown -R kortix:kortix /workspace/.git
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/
@@ -499,7 +499,7 @@ USER kortix
 RUN cd / && mkdir -p /workspace && find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 COPY --chown=kortix:kortix kortix-warm-repo/ /workspace/
 COPY kortix-warm-repo-git.tar /tmp/kortix-warm-repo-git.tar
-RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && rm -f /tmp/kortix-warm-repo-git.tar && chown -R kortix:kortix /workspace/.git
+RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && chown -R kortix:kortix /workspace/.git
 RUN git -C /workspace rev-parse HEAD >/dev/null 2>&1 && printf 'warm-repo: baked %s on %s\\n' "$(git -C /workspace rev-parse HEAD)" 'main'
 
 COPY --chown=kortix:kortix kortix-opencode-config/ /opt/kortix/warm-config/.kortix/opencode/

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -383,6 +383,7 @@ describe('buildPerProjectWarmFromBaseDockerfile (FROM-base fast path)', () => {
     expect(rendered).toContain(
       'tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1',
     );
+    expect(rendered).not.toContain('rm -f /tmp/kortix-warm-repo-git.tar');
     // … and MAIN's opencode instance re-warm via the cache-only warm-up script,
     // which for a per-project warm keeps the baked /workspace checkout.
     expect(rendered).toContain(

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -297,8 +297,10 @@ function buildWarmRepoCopyLines(warmRepo: WarmRepoConfig | undefined): string[] 
     `COPY --chown=kortix:kortix ${warmRepo.stagedPath}/ /workspace/`,
     // Daytona uploads each COPY source as a separate context object. Transfer
     // Git metadata as one visible file, then restore the canonical directory.
+    // Daytona exposes that copied context object as non-removable during RUN.
+    // Keep the credential-free archive instead of failing the image build.
     `COPY ${warmRepo.stagedGitPath} /tmp/kortix-warm-repo-git.tar`,
-    'RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && rm -f /tmp/kortix-warm-repo-git.tar && chown -R kortix:kortix /workspace/.git',
+    'RUN rm -rf /workspace/.git && mkdir -p /workspace/.git && tar -xf /tmp/kortix-warm-repo-git.tar -C /workspace/.git --strip-components=1 && chown -R kortix:kortix /workspace/.git',
     // Verify the baked checkout is a real repo. The branch is shell-quoted via
     // `shq` (never interpolated raw), so a hostile branch name cannot inject a
     // build-time shell command — closing the latent sink in the old echo.


### PR DESCRIPTION
## Root cause

Daytona exposed `kortix-warm-repo-git.tar` as non-removable during the image build. Git extraction succeeded, then `rm -f /tmp/kortix-warm-repo-git.tar` failed with `Operation not permitted`. The cleanup failure marked the provider transition `auth_terminal`.

## Fix

- keep the credential-free archive after extraction
- preserve the restored `/workspace/.git` verification
- reject reintroduction of the failing cleanup command in the Daytona boundary and renderer tests

## Live failure evidence

- project: `a0e98118-52b6-4e9a-aa3a-74d388b5a421`
- transition: `11986176-c5b7-478d-85ea-69aa686c6446`
- deployed version: `0.10.14-dev.47a0fdb4`
- error: `rm: cannot remove /tmp/kortix-warm-repo-git.tar: Operation not permitted`

## Verification

- regression test failed before the renderer change
- focused suites: `143 pass`, `0 fail`
- `pnpm --filter @kortix/shared typecheck`: exit `0`
- `pnpm --filter kortix-api typecheck`: exit `0`
- `git diff --check`: exit `0`
