### PR TITLE
fix(sandboxes): separate session runtime from project acceleration

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -182,7 +182,7 @@ jobs:
               KORTIX_URL: $api,
               CORS_ALLOWED_ORIGINS: $frontend,
               LLM_GATEWAY_BASE_URL: $gateway,
-              ALLOWED_SANDBOX_PROVIDERS: "daytona,platinum,e2b",
+              ALLOWED_SANDBOX_PROVIDERS: "daytona,platinum",
               KORTIX_WARM_SNAPSHOT_ENABLED: "false",
               # The staging Supabase database permits 60 connections. ECS can
               # run 3 API tasks and EKS can run 4 API pods at the same time.

--- a/apps/api/src/__tests__/unit-snapshot-build-state.test.ts
+++ b/apps/api/src/__tests__/unit-snapshot-build-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { currentFailedSnapshotBuild } from '../snapshots/build-state';
+import { currentFailedSnapshotBuild, sessionTemplateBuilds } from '../snapshots/build-state';
 
 describe('currentFailedSnapshotBuild', () => {
   test('returns the newest build when it failed', () => {
@@ -27,5 +27,28 @@ describe('currentFailedSnapshotBuild', () => {
         { id: 'failed-older', status: 'failed' as const },
       ]),
     ).toBeNull();
+  });
+});
+
+describe('sessionTemplateBuilds', () => {
+  test('excludes optional per-project accelerator builds', () => {
+    const template = { id: 'template', slug: 'default', status: 'ready' as const };
+    const accelerator = {
+      id: 'accelerator',
+      slug: 'default-warm',
+      status: 'failed' as const,
+    };
+
+    expect(sessionTemplateBuilds([accelerator, template])).toEqual([template]);
+  });
+
+  test('keeps a custom template whose declared slug contains warm text', () => {
+    const template = {
+      id: 'template',
+      slug: 'warm-worker',
+      status: 'failed' as const,
+    };
+
+    expect(sessionTemplateBuilds([template])).toEqual([template]);
   });
 });

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -418,6 +418,15 @@ const envSchema = z.object({
   // template row still references. On by default; boot auto-heal covers the rare
   // cross-env race where another env's row pointed at the reaped (identical) name.
   KORTIX_SNAPSHOT_REAP_PREDECESSOR: optBoolTrue,
+  // Optional per-project accelerator. When enabled, Kortix bakes the project's
+  // default-branch repository into a derivative of the shared platform image.
+  // A disabled or failed accelerator never blocks a session. Sessions boot from
+  // the shared image and clone the repository into /workspace instead.
+  //
+  // This switch controls only automatic session-miss and managed-git-push
+  // bakes. Provider transitions still prepare their target image explicitly.
+  // Default OFF keeps the session path on one shared image per provider.
+  KORTIX_WARM_SNAPSHOT_ENABLED: optBoolFalse,
 
   // ── Platinum — Sandbox provisioning (conditional: required if platinum provider enabled) ──
   // Platinum is our own Cloud Hypervisor microVM API. PLATINUM_API_KEY is a
@@ -954,6 +963,7 @@ export const config = {
   DAYTONA_TARGET: env.DAYTONA_TARGET,
   DAYTONA_WEBHOOK_SECRET: env.DAYTONA_WEBHOOK_SECRET,
   KORTIX_SNAPSHOT_REAP_PREDECESSOR: env.KORTIX_SNAPSHOT_REAP_PREDECESSOR,
+  KORTIX_WARM_SNAPSHOT_ENABLED: env.KORTIX_WARM_SNAPSHOT_ENABLED,
 
   // Sandbox lifecycle intervals (minutes) — see schema comment above.
   KORTIX_SANDBOX_AUTOSTOP_MINUTES: env.KORTIX_SANDBOX_AUTOSTOP_MINUTES,

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -1,7 +1,7 @@
 import { ACCOUNT_ACTIONS, PROJECT_ACTIONS, assertAuthorized } from '../../iam';
 import { auth, errors, json } from '../../openapi';
 import { DEFAULT_SANDBOX_SLUG, deleteSandboxImage, kickPreBuild, kickProjectTemplatePrebuilds, kickRoutedPreBuild, listSandboxTemplates, listSnapshotBuilds, reconcileStaleBuilds, templateBuildProviders } from '../../snapshots/builder';
-import { currentFailedSnapshotBuild } from '../../snapshots/build-state';
+import { currentFailedSnapshotBuild, sessionTemplateBuilds } from '../../snapshots/build-state';
 import { classifySnapshotError, describeSnapshotError } from '../../snapshots/error-classify';
 import { withTimeout } from '../../shared/with-timeout';
 import { isPlatformAdmin } from '../../shared/platform-roles';
@@ -547,8 +547,9 @@ async function buildSandboxHealth(
   }
   const primary = templates[0] ?? null;
   const builds = await listSnapshotBuilds(projectId, { limit: 10 }).catch(() => []);
-  const latest = builds[0] ?? null;
-  const latestFailure = currentFailedSnapshotBuild(builds);
+  const templateBuilds = sessionTemplateBuilds(builds);
+  const latest = templateBuilds[0] ?? null;
+  const latestFailure = currentFailedSnapshotBuild(templateBuilds);
   const isBuilding =
     (latest && latest.status === 'building') ||
     primary?.providerState === 'building';
@@ -731,7 +732,8 @@ projectsApp.openapi(
   const userId = c.get('userId') as string;
 
   const builds = await listSnapshotBuilds(projectId, { limit: 50 }).catch(() => []);
-  const failed = currentFailedSnapshotBuild(builds);
+  const templateBuilds = sessionTemplateBuilds(builds);
+  const failed = currentFailedSnapshotBuild(templateBuilds);
   if (!failed) {
     return c.json({ error: 'No current failed snapshot build to fix.' }, 409);
   }
@@ -756,7 +758,7 @@ projectsApp.openapi(
     );
   }
 
-  const hostBuild = builds.find((b) => b.status === 'ready');
+  const hostBuild = templateBuilds.find((b) => b.status === 'ready');
   if (!hostBuild) {
     return c.json(
       {

--- a/apps/api/src/snapshots/build-state.ts
+++ b/apps/api/src/snapshots/build-state.ts
@@ -1,8 +1,24 @@
 /** Pure helpers for interpreting the append-only snapshot build log. */
 
+import { isWarmBuildSlug } from './ppwarm-names';
+
 export type SnapshotBuildStateLike = {
   status: 'building' | 'ready' | 'failed';
 };
+
+export type SnapshotBuildWithSlug = SnapshotBuildStateLike & {
+  slug: string;
+};
+
+/**
+ * Per-project warm images are optional accelerators. Their build state does not
+ * describe whether a shared or custom session template can launch.
+ */
+export function sessionTemplateBuilds<T extends SnapshotBuildWithSlug>(
+  builds: readonly T[],
+): T[] {
+  return builds.filter((build) => !isWarmBuildSlug(build.slug));
+}
 
 /**
  * `listSnapshotBuilds` returns newest build attempt first. A sandbox is only in a

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -130,7 +130,11 @@ export async function ensureSandboxImage(
   // (no clone at boot). On a MISS, kick a fire-and-forget background bake so the
   // next session on this commit boots warm; this boot never blocks on the bake and
   // falls through to the normal cold path when no warm image exists yet.
-  if ((opts.source ?? 'session-start') === 'session-start' && template.isShared) {
+  if (
+    config.KORTIX_WARM_SNAPSHOT_ENABLED &&
+    (opts.source ?? 'session-start') === 'session-start' &&
+    template.isShared
+  ) {
     try {
       const warmTip = await resolveCommitSha(project, project.defaultBranch);
       if (warmTip) {
@@ -1044,6 +1048,8 @@ export async function kickProjectWarmPrebake(
   project: GitBackedProject,
   opts: { accountId?: string; provider?: string; projectPin?: string | null } = {},
 ): Promise<void> {
+  if (!config.KORTIX_WARM_SNAPSHOT_ENABLED) return;
+
   const providers = opts.provider
     ? [opts.provider]
     : warmPrebakeProviders({

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.test.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.test.tsx
@@ -57,11 +57,11 @@ function renderProviderPresentation({
 
 describe('sandbox template provider coverage presentation', () => {
   test('uses explicit launch-readiness language for every provider state', () => {
-    expect(describeProviderCoverage('ready')).toEqual({ label: 'Latest', tone: 'ok' });
+    expect(describeProviderCoverage('ready')).toEqual({ label: 'Ready', tone: 'ok' });
     expect(describeProviderCoverage('building')).toEqual({ label: 'Building', tone: 'busy' });
     expect(describeProviderCoverage('failed')).toEqual({ label: 'Failed', tone: 'fail' });
     expect(describeProviderCoverage('not_built')).toEqual({
-      label: 'Current image not built',
+      label: 'Not ready',
       tone: 'idle',
     });
     expect(describeProviderCoverage('unavailable')).toEqual({ label: 'Unavailable', tone: 'idle' });
@@ -80,7 +80,7 @@ describe('sandbox template provider coverage presentation', () => {
     expect(sandboxProviderLabel('e2b')).toBe('E2B');
   });
 
-  test('renders automatic mode as neutral without provider names or matrix', () => {
+  test('renders automatic mode with runtime readiness for every routed provider', () => {
     const html = renderProviderPresentation({
       providerMode: 'automatic',
       selectedProvider: 'daytona',
@@ -92,12 +92,13 @@ describe('sandbox template provider coverage presentation', () => {
     });
 
     expect(html).toContain('Automatic');
-    expect(html).not.toContain('Provider images');
-    expect(html).not.toContain('Daytona');
-    expect(html).not.toContain('Platinum');
+    expect(html).toContain('Session runtime');
+    expect(html).toContain('Daytona');
+    expect(html).toContain('Platinum');
     expect(html).not.toContain('E2B');
-    expect(html).not.toContain('Latest');
-    expect(html).not.toContain('Building');
+    expect(html).toContain('Ready');
+    expect(html).toContain('Building');
+    expect(html).not.toContain('Selected');
   });
 
   test('renders pinned matrix with only available providers and their states', () => {
@@ -117,9 +118,9 @@ describe('sandbox template provider coverage presentation', () => {
       ],
     });
 
-    expect(html).toContain('Provider images');
+    expect(html).toContain('Session runtime');
     expect(html).toContain('Daytona');
-    expect(html).toContain('Latest');
+    expect(html).toContain('Ready');
     expect(html).toContain('E2B');
     expect(html).toContain('Building');
     expect(html).not.toContain('Platinum');
@@ -139,7 +140,7 @@ describe('sandbox template provider coverage presentation', () => {
 
     expect(html).toContain('Pinned provider');
     expect(html).toContain('bg-muted/50');
-    expect(html).not.toContain('Provider images');
+    expect(html).not.toContain('Session runtime');
     expect(html).not.toContain('Daytona');
     expect(html).not.toContain('Platinum');
     expect(html).not.toContain('E2B');

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-provider-coverage.tsx
@@ -37,13 +37,13 @@ export function describeProviderCoverage(status: ProviderCoverageStatus): {
 } {
   switch (status) {
     case 'ready':
-      return { label: 'Latest', tone: 'ok' };
+      return { label: 'Ready', tone: 'ok' };
     case 'building':
       return { label: 'Building', tone: 'busy' };
     case 'failed':
       return { label: 'Failed', tone: 'fail' };
     case 'not_built':
-      return { label: 'Current image not built', tone: 'idle' };
+      return { label: 'Not ready', tone: 'idle' };
     case 'unavailable':
       return { label: 'Unavailable', tone: 'idle' };
     case 'unknown':
@@ -77,8 +77,6 @@ export function SandboxTemplateProviderCoverage({
   selectedProvider: SandboxProvider | null;
   formatObservedAt?: (observedAt: string) => string;
 }) {
-  if (providerMode !== 'pinned') return null;
-
   const availableCoverage = availableProviderCoverage(coverage);
   if (availableCoverage.length === 0) return null;
 
@@ -90,11 +88,11 @@ export function SandboxTemplateProviderCoverage({
 
   return (
     <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-      <span className="text-muted-foreground text-xs">Provider images</span>
+      <span className="text-muted-foreground text-xs">Session runtime</span>
       {availableCoverage.map((item) => {
         const state = describeProviderCoverage(item.status);
         const provider = sandboxProviderLabel(item.provider);
-        const selected = item.provider === selectedProvider;
+        const selected = providerMode === 'pinned' && item.provider === selectedProvider;
 
         return (
           <Badge

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.test.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.test.tsx
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import type { ProjectSnapshotBuild } from '@kortix/sdk/projects-client';
 
-import { BuildRow } from './sandbox-view';
+import { BuildRow, isProjectAcceleratorBuild } from './sandbox-view';
 import type { SandboxProviderMode } from './sandbox-provider-coverage';
 
 const build = (overrides: Partial<ProjectSnapshotBuild> = {}): ProjectSnapshotBuild => ({
@@ -22,6 +22,40 @@ const build = (overrides: Partial<ProjectSnapshotBuild> = {}): ProjectSnapshotBu
   started_at: '2026-07-13T10:00:00.000Z',
   finished_at: '2026-07-13T10:05:00.000Z',
   ...overrides,
+});
+
+describe('project accelerator build presentation', () => {
+  test('identifies only ppwarm snapshots as project accelerators', () => {
+    expect(
+      isProjectAcceleratorBuild(
+        build({
+          slug: 'default-warm',
+          template_slug: 'default',
+          snapshot_name: 'kortix-ppwarm-00ead866-f5c859f984f2',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isProjectAcceleratorBuild(
+        build({
+          slug: 'worker-warm',
+          template_slug: 'worker-warm',
+          snapshot_name: 'kortix-tpl-worker',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('labels a ppwarm build as a repository accelerator', () => {
+    const html = renderBuildRow('automatic', {
+      slug: 'default-warm',
+      template_slug: 'default',
+      snapshot_name: 'kortix-ppwarm-00ead866-f5c859f984f2',
+    });
+
+    expect(html).toContain('Repository accelerator');
+    expect(html).not.toContain('>default-warm<');
+  });
 });
 
 function renderBuildRow(providerMode: SandboxProviderMode, overrides?: Partial<ProjectSnapshotBuild>) {

--- a/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/sandbox-view.tsx
@@ -163,6 +163,10 @@ function formatBuildDuration(startedAt: string, finishedAt: string | null): stri
   return `${hours}h`;
 }
 
+export function isProjectAcceleratorBuild(build: ProjectSnapshotBuild): boolean {
+  return build.snapshot_name.startsWith('kortix-ppwarm-');
+}
+
 export function BuildRow({
   build,
   providerMode,
@@ -177,6 +181,7 @@ export function BuildRow({
   const sourceLabel = build.source ? BUILD_SOURCE_LABEL[build.source] : null;
   const timestamp = formatRelative(build.finished_at ?? build.started_at);
   const hasErrorDetails = build.status === 'failed' && !!build.error;
+  const accelerator = isProjectAcceleratorBuild(build);
 
   const row = (
     <>
@@ -187,7 +192,9 @@ export function BuildRow({
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          <span className="text-foreground truncate text-sm font-medium">{build.slug}</span>
+          <span className="text-foreground truncate text-sm font-medium">
+            {accelerator ? 'Repository accelerator' : build.slug}
+          </span>
           <Badge variant={status.badgeVariant} size="xs">
             {status.label}
           </Badge>
@@ -557,8 +564,10 @@ export function SandboxView({ projectId }: { projectId: string }) {
   const providerMode: SandboxProviderMode =
     data?.provider_mode === 'pinned' ? 'pinned' : 'automatic';
   const selectedProvider = data?.selected_provider ?? null;
-  const latestFailure = currentFailedBuild(builds);
-  const latestReady = builds.find((b) => b.status === 'ready') ?? null;
+  const templateBuilds = builds.filter((build) => !isProjectAcceleratorBuild(build));
+  const acceleratorBuilds = builds.filter(isProjectAcceleratorBuild);
+  const latestFailure = currentFailedBuild(templateBuilds);
+  const latestReady = templateBuilds.find((b) => b.status === 'ready') ?? null;
   const canFixWithAgent = !!latestFailure && latestFailure.fixable_by_agent && !!latestReady;
   const isFullyEmpty = templates.length === 0 && builds.length === 0;
 
@@ -700,13 +709,9 @@ export function SandboxView({ projectId }: { projectId: string }) {
                 ) : null}
 
                 <div className="space-y-2">
-                  <Label>
-                    {tI18nHardcoded.raw(
-                      'autoComponentsProjectsSandboxSnapshotCardJsxTextRecentBuildscde18d4a',
-                    )}
-                  </Label>
+                  <Label>Session template builds</Label>
 
-                  {builds.length === 0 ? (
+                  {templateBuilds.length === 0 ? (
                     <div className="border-border rounded-md border">
                       <InlinePanelEmpty
                         message={tI18nHardcoded.raw(
@@ -716,12 +721,33 @@ export function SandboxView({ projectId }: { projectId: string }) {
                     </div>
                   ) : (
                     <ul className="space-y-2">
-                      {builds.slice(0, 10).map((b) => (
+                      {templateBuilds.slice(0, 10).map((b) => (
                         <BuildRow key={b.build_id} build={b} providerMode={providerMode} />
                       ))}
                     </ul>
                   )}
                 </div>
+
+                {acceleratorBuilds.length > 0 ? (
+                  <div className="space-y-2">
+                    <Label>Project accelerator</Label>
+                    <InfoBanner
+                      tone="neutral"
+                      icon={SparklesSolid}
+                      title="Optional repository acceleration"
+                    >
+                      A project accelerator preloads this repository for a later session. A missing
+                      or failed accelerator never blocks a session. Kortix uses the shared session
+                      runtime and clones the repository into{' '}
+                      <code className="font-mono">/workspace</code>.
+                    </InfoBanner>
+                    <ul className="space-y-2">
+                      {acceleratorBuilds.slice(0, 5).map((b) => (
+                        <BuildRow key={b.build_id} build={b} providerMode={providerMode} />
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
               </>
             )}
           </div>

--- a/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.test.ts
@@ -56,6 +56,19 @@ describe('selectCurrentSandboxFailure', () => {
       ),
     ).toBeNull();
   });
+
+  test('drops a failed optional project accelerator', () => {
+    const failed = build({
+      build_id: 'accelerator-failed',
+      slug: 'default-warm',
+      snapshot_name: 'kortix-ppwarm-project-hash',
+      status: 'failed',
+    });
+
+    expect(
+      selectCurrentSandboxFailure(health({ latest_build: failed, latest_failure: failed })),
+    ).toBeNull();
+  });
 });
 
 describe('resolveSandboxAlertSeverity', () => {
@@ -80,6 +93,21 @@ describe('resolveSandboxAlertSeverity', () => {
       ),
     ).toBe('building');
   });
+
+  test('does not show a blocking alert for an optional accelerator build', () => {
+    const accelerator = build({
+      build_id: 'accelerator-building',
+      slug: 'default-warm',
+      snapshot_name: 'kortix-ppwarm-project-hash',
+      status: 'building',
+    });
+
+    expect(
+      resolveSandboxAlertSeverity(
+        health({ latest_build: accelerator, building: true, ready: false }),
+      ),
+    ).toBeNull();
+  });
 });
 
 describe('currentFailedBuild', () => {
@@ -95,5 +123,17 @@ describe('currentFailedBuild', () => {
         build({ build_id: 'failed-older', status: 'failed' }),
       ]),
     ).toBeNull();
+  });
+
+  test('ignores an accelerator failure before a session-template failure', () => {
+    const accelerator = build({
+      build_id: 'accelerator-failed',
+      slug: 'default-warm',
+      snapshot_name: 'kortix-ppwarm-project-hash',
+      status: 'failed',
+    });
+    const template = build({ build_id: 'template-failed', status: 'failed' });
+
+    expect(currentFailedBuild([accelerator, template])).toBe(template);
   });
 });

--- a/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.ts
+++ b/apps/web/src/features/workspace/project-sidebar/footer/sandbox-alert-state.ts
@@ -2,11 +2,16 @@ import type { ProjectSandboxHealth, ProjectSnapshotBuild } from '@kortix/sdk/pro
 
 export type SandboxAlertSeverity = 'critical' | 'building';
 
+function isProjectAcceleratorBuild(build: ProjectSnapshotBuild | null | undefined): boolean {
+  return build?.snapshot_name.startsWith('kortix-ppwarm-') ?? false;
+}
+
 export function selectCurrentSandboxFailure(
   health: ProjectSandboxHealth | null | undefined,
 ): ProjectSnapshotBuild | null {
   const failure = health?.latest_failure ?? null;
   if (!failure) return null;
+  if (isProjectAcceleratorBuild(failure)) return null;
 
   const latest = health?.latest_build ?? null;
   if (latest && latest.build_id !== failure.build_id) return null;
@@ -19,13 +24,23 @@ export function resolveSandboxAlertSeverity(
 ): SandboxAlertSeverity | null {
   if (!health) return null;
   if (selectCurrentSandboxFailure(health) && !health.ready) return 'critical';
-  if (health.building && !health.ready) return 'building';
+  if (health.building && !health.ready && !isProjectAcceleratorBuild(health.latest_build)) {
+    return 'building';
+  }
   return null;
 }
 
 export function currentFailedBuild<T extends { status: ProjectSnapshotBuild['status'] }>(
   builds: readonly T[],
 ): T | null {
-  const latest = builds[0] ?? null;
+  const latest =
+    builds.find(
+      (build) =>
+        !(
+          'snapshot_name' in build &&
+          typeof build.snapshot_name === 'string' &&
+          build.snapshot_name.startsWith('kortix-ppwarm-')
+        ),
+    ) ?? null;
   return latest?.status === 'failed' ? latest : null;
 }

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -20,8 +20,12 @@ extraEnv:
   # the API falls back to its in-API /v1/llm passthrough (OpenRouter-only, wrong
   # catalog shape) and the model picker collapses to a single model.
   LLM_GATEWAY_BASE_URL: "https://gateway-dev.kortix.com/v1/llm"
-  # NOTE: warm-template (warm_snapshot) is NOT an env — it's the admin Providers
-  # panel toggle (DB row), default OFF / opt-in. Don't reintroduce an env knob.
+  # Sessions use only Daytona and Platinum in dev. E2B does not participate in
+  # routing, readiness, or template builds.
+  ALLOWED_SANDBOX_PROVIDERS: "daytona,platinum"
+  # Disable optional per-project accelerator builds. Sessions boot from the
+  # shared provider image and clone the repository into /workspace.
+  KORTIX_WARM_SNAPSHOT_ENABLED: "false"
   # Idle auto-stop for sandboxes (Daytona AND Platinum honor this now — Platinum
   # used to hardcode persistent and depend on the maintenance reaper, which died
   # and let boxes run 24/7 and flood the host). 15min keeps idle cost down; a

--- a/infra/k8s/envs/staging/values.yaml
+++ b/infra/k8s/envs/staging/values.yaml
@@ -15,6 +15,7 @@ extraEnv:
   # per-user account-linking and project-access flow expected before prod.
   SLACK_REQUIRE_USER_IDENTITY: "true"
   LLM_GATEWAY_BASE_URL: "https://gateway-staging.kortix.com/v1/llm"
+  ALLOWED_SANDBOX_PROVIDERS: "daytona,platinum"
   KORTIX_WARM_SNAPSHOT_ENABLED: "false"
   # Staging uses a 60-connection Supabase database. ECS can run 3 API tasks
   # while EKS runs 4 pods. Four app connections plus one leader connection per


### PR DESCRIPTION
## Summary

- honor `KORTIX_WARM_SNAPSHOT_ENABLED=false` for automatic per-project accelerator builds
- keep explicit provider-transition image preparation enabled
- restrict dev and staging session providers to Daytona and Platinum
- separate session runtime readiness from optional accelerator build history in the UI
- ignore accelerator failures in the blocking sandbox-health alert

## Verification

- `bun test src/__tests__/unit-snapshot-build-state.test.ts` — 5 pass, 0 fail
- `bun test src/features/workspace/customize/sections/view/sandbox-provider-coverage.test.tsx src/features/workspace/customize/sections/view/sandbox-view.test.tsx src/features/workspace/project-sidebar/footer/sandbox-alert-state.test.ts` — 19 pass, 0 fail
- `bun tsc --noEmit` in `apps/api` — exit 0
- `pnpm exec eslint ...` for the three changed web modules — exit 0
- relevant `apps/web` TypeScript error filter — no output

## Runtime evidence

- Shared Platinum session `7ad2f531-405b-442c-a587-f3bc91c9ea57` started before its project accelerator build.
- Platinum build log failed only at `rm -f /tmp/kortix-warm-repo-git.tar`: `Operation not permitted`.
- Dev API `0.10.14-dev.f78037af` contains the archive-cleanup fix.
- Daytona provider transition `a206a1be-fb96-45fc-a19d-92f078093c0f` is running against the deployed fix.