### PR TITLE
Remove stale Auto output from agents CLI

### DIFF
--- a/apps/cli/src/__tests__/agents-command.test.ts
+++ b/apps/cli/src/__tests__/agents-command.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const CLI_ROOT = resolve(import.meta.dir, '..', '..');
+const CLI_ENTRY = join(CLI_ROOT, 'src', 'index.ts');
+const ORIGINAL_ENV = { ...process.env };
+const PROJECT = 'agents_project';
+
+let tmp: string;
+let server: ReturnType<typeof Bun.serve> | null = null;
+
+function writeConfig(apiBase: string): string {
+  const path = join(tmp, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      active: 'test',
+      hosts: {
+        test: {
+          url: apiBase,
+          token: 'tok_agents',
+          user_id: 'user_1',
+          user_email: 'user@example.test',
+          account_id: 'account_1',
+          logged_in_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+  return path;
+}
+
+function startServer(): string {
+  server = Bun.serve({
+    port: 0,
+    fetch: () =>
+      Response.json({
+        platformDefault: null,
+        accountDefault: null,
+        projectDefault: null,
+        agentDefaults: {},
+        resolvedForCaller: null,
+      }),
+  });
+  return `http://127.0.0.1:${server.port}`;
+}
+
+async function runCli(args: string[], configFile?: string) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    KORTIX_NO_UPDATE_CHECK: '1',
+    NO_COLOR: '1',
+    FORCE_COLOR: '0',
+    KORTIX_DISABLE_SANDBOX_ENV_FILE: '1',
+    KORTIX_CONFIG_FILE: configFile,
+  };
+  for (const key of [
+    'KORTIX_API_URL',
+    'KORTIX_CLI_TOKEN',
+    'KORTIX_EXECUTOR_TOKEN',
+    'KORTIX_FRONTEND_URL',
+    'KORTIX_PROJECT_ID',
+    'KORTIX_TOKEN',
+    'BASH_ENV',
+  ]) {
+    delete env[key];
+  }
+  const proc = Bun.spawn({
+    cmd: [process.execPath, CLI_ENTRY, ...args],
+    cwd: tmp,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const timeout = setTimeout(() => proc.kill(), 10_000);
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]).finally(() => clearTimeout(timeout));
+  return { code, stdout, stderr };
+}
+
+describe('kortix agents command', () => {
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'kortix-agents-command-'));
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    server?.stop(true);
+    server = null;
+    rmSync(tmp, { recursive: true, force: true });
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test('help describes concrete defaults without exposing the removed Auto model', async () => {
+    const result = await runCli(['agents', '--help']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('explicit concrete model');
+    expect(result.stdout.toLowerCase()).not.toContain('auto');
+  });
+
+  test('models does not invent Auto when a malformed server omits every default', async () => {
+    const config = writeConfig(startServer());
+    const result = await runCli(
+      ['agents', 'models', '--project', PROJECT],
+      config,
+    );
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('unavailable');
+    expect(result.stdout.toLowerCase()).not.toContain('auto');
+  });
+});

--- a/apps/cli/src/commands/agents.ts
+++ b/apps/cli/src/commands/agents.ts
@@ -19,10 +19,10 @@ interface ModelDefaults {
 const HELP = help`Usage: kortix agents <subcommand> [options]
 
 Per-agent settings on the linked Kortix project. Today: which MODEL each agent
-runs on — the dynamic gateway default (scope=agent), applied instantly with no
-kortix.yaml commit. A session an agent runs that asks for the synthetic \`auto\`
-model resolves to this pick, falling back to the project → account → platform
-default. (The declarative default lives in kortix.yaml as [[agents]].model.)
+runs on — an explicit concrete model (scope=agent), applied instantly with no
+kortix.yaml commit. An agent without a pin follows the project → account →
+platform default. (The declarative default lives in kortix.yaml as
+[[agents]].model.)
 
 Subcommands:
   models [--json]                 Show every agent's pinned model + the fallback default.
@@ -73,7 +73,7 @@ export async function runAgents(argv: string[]): Promise<number> {
           return 0;
         }
         const fallback =
-          d.projectDefault ?? d.accountDefault ?? d.platformDefault ?? 'auto';
+          d.projectDefault ?? d.accountDefault ?? d.platformDefault ?? 'unavailable';
         const entries = Object.entries(d.agentDefaults ?? {});
         process.stdout.write('\n');
         process.stdout.write(


### PR DESCRIPTION
## Summary

- remove synthetic `auto` language from `kortix agents --help`
- stop `kortix agents models` from inventing `auto` when a server omits all defaults
- add black-box CLI coverage for both output paths

## Verification

- `bun test src/__tests__/agents-command.test.ts` — 2 pass, 0 fail
- `bun test src/__tests__` — 350 pass, 0 fail
- `pnpm typecheck` — pass
- `git diff --check` — pass

Follow-up to #5341.