### PR TITLE
docs: accuracy sweep — scoped runtime() throw, channel token injection, provider transition

### DIFF
--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -296,7 +296,7 @@ Per-agent model settings on the linked project.
 
 ### Channels
 
-Manages the project's connection to a chat platform. Tokens are stored encrypted in the project's secrets, and land in the sandbox as environment variables at session start.
+Manages the project's connection to a chat platform. Tokens are stored encrypted in the project's secrets and resolved server-side — they are never injected into the sandbox.
 
 | Command | Effect |
 | --- | --- |

--- a/apps/web/content/docs/sdk/reference.mdx
+++ b/apps/web/content/docs/sdk/reference.mdx
@@ -30,7 +30,7 @@ kortix.connectStatus; // easy-connect (Pipedream) status
 kortix.marketplace; // public marketplace catalog
 kortix.validateToken; // pasted-API-key check
 kortix.config; // platform config in effect
-kortix.runtime(); // OpenCode client for the active runtime
+kortix.runtime(); // OpenCode client for the active runtime — throws on a @kortix/sdk/server scoped client
 ```
 
 ### Accounts — `kortix.accounts`
@@ -390,12 +390,16 @@ handle: Dockerfile/image/warm-pool templates and their snapshot builds.
 | `list()` · `snapshots()` | sandboxes for this project · built snapshots |
 | `rebuildSnapshot(slug?)` · `fixWithAgent()` | rebuild a snapshot · ask an agent to fix a broken build |
 | `createTemplate(input)` · `updateTemplate(...)` · `removeTemplate(...)` · `buildTemplate(...)` | add · edit · delete · build a template |
-| `setProvider(provider)` | pin or clear the sandbox provider (`null` follows the platform default) |
+| `setProvider(provider)` | request a provider switch. `null` (or the platform default / the already-active provider) applies immediately; switching to a different enabled provider starts a durable prepare→verify→activate transition — the current provider keeps serving while the target warm image is built and verified, then activated. The return is a tagged union: `kind:'project'` (immediate) or `kind:'preparation'` (poll `getProjectSandboxProviderTransition()` until `activated`/`failed`) |
 
 ### Escape hatch
 
 `kortix.runtime()` returns the typed OpenCode client for the active runtime.
-Prefer the session-scoped `kortix.session(pid, sid).runtime` instead.
+On a client created by `createScopedKortix` (`@kortix/sdk/server`), it **throws**
+— the process-global "active" runtime is another request's sandbox in a
+multi-tenant server, a cross-tenant leak. Use the session-scoped
+`kortix.session(pid, sid).runtime` (call `ensureReady()` first) instead, which
+resolves that session's own sandbox.
 
 ## Modules
 
@@ -530,6 +534,10 @@ export async function handler(req: Request) {
 `createScopedKortix` and `runWithKortix` isolate config per request with
 Node's `AsyncLocalStorage`. Never import `@kortix/sdk/server` from a browser
 bundle — it statically pulls in `node:async_hooks`.
+
+A scoped client's top-level `runtime()` throws (it would resolve another
+tenant's sandbox). Reach a specific session's runtime via
+`kortix.session(pid, sid).runtime` after `await s.ensureReady()`.
 
 ### Deprecated aliases
 

--- a/apps/web/content/docs/work/sessions.mdx
+++ b/apps/web/content/docs/work/sessions.mdx
@@ -55,9 +55,10 @@ interactive mode.
 ## Providers
 
 Kortix runs sessions on Daytona, Platinum, or E2B Cloud. A project follows
-the platform default, or pins one provider through the SDK — see
-[SDK reference](/docs/sdk/reference). Every provider runs the same sandbox
-image.
+the platform default, or requests a provider switch through the SDK — see
+[SDK reference](/docs/sdk/reference). A switch to a different provider is
+durable: the current provider keeps serving while the target warms, then
+activates. Every provider runs the same sandbox image.
 
 For the full status enum, injected environment variables, and daemon
 endpoints, see [Runtime](/docs/work/runtime). For how a session picks its


### PR DESCRIPTION
## docs: accuracy sweep — scoped runtime() throw, channel token injection, provider transition

Docs-only accuracy sweep from the autonomous `docs-maintainer` run (2026-07-24). Three drifts found by four parallel `docs-maintainer-worker` shards and independently re-verified by the orchestrator against current source before editing.

### Audit window
- `kortix-ai/suna`: `d6eb2cdb` (2026-07-23 checkpoint) → `5862e9567` (origin/main). 154 reachable commits. Full-SHA coverage manifest passes `check-commit-coverage.mjs` (4 `docs-change`, 10 `already-current`, 140 `no-doc-impact`).

### Fixes

**1. Channel tokens are never injected into the sandbox (HIGH) — `cli.mdx:299`**
The Channels intro said tokens "land in the sandbox as environment variables at session start." Source deletes `SLACK_BOT_TOKEN`/`SLACK_SIGNING_SECRET` from the injected env and resolves them server-side. Proof: `apps/api/src/projects/lib/sandbox-env-names.ts:12-15` (`NEVER_IN_SANDBOX = {SLACK_SIGNING_SECRET, SLACK_BOT_TOKEN}`); `apps/api/src/projects/lib/sessions.ts:351,357`. Already correctly documented in `connect/slack.mdx:46-47` and `connect/connectors.mdx:29` — now `cli.mdx` agrees.

**2. Top-level `runtime()` throws on a scoped client (HIGH) — `sdk/reference.mdx:33,397-401,538-540`**
On a `createScopedKortix` (`@kortix/sdk/server`) client, `kortix.runtime()` throws (it resolves the process-global active runtime = a cross-tenant leak); the session-scoped `kortix.session(pid,sid).runtime` is the safe path. The docs only said "Prefer the session-scoped... instead" with no throw warning. Proof: `packages/sdk/src/node/server.ts:134-141` (`scopedRuntimeUnavailable` always throws), `:149` (`scoped.runtime = scopedRuntimeUnavailable`); `packages/sdk/src/core/client/kortix.ts:42-45`.

**3. `setProvider` is a durable prepare→verify→activate transition (MEDIUM) — `sdk/reference.mdx:393`, `work/sessions.mdx:57-60`**
The docs said `setProvider` "pin or clear the sandbox provider" and "pins one provider through the SDK," implying an immediate flip. A cross-provider switch now returns a `kind:'preparation'` durable transition (current provider keeps serving while the target warm image builds + verifies, then activates); the client polls `getProjectSandboxProviderTransition()` until terminal. Proof: `apps/api/src/projects/routes/r6.ts:1238-1263` (`requestProviderTransition` returns `kind:'project'`/`kind:'preparation'`); `:1282-1287` (poll endpoint); `apps/api/src/projects/provider-transition/provider-transition-core.ts:10-18` (status enum); `packages/sdk/src/core/rest/projects-client/projects.ts:439-470` (`UpdateProjectSandboxProviderResult` tagged union + `getProjectSandboxProviderTransition`).

### Verification
- `check-fumadocs.mjs` PASS (27 pages, 6 nav, 27 routes).
- `git diff --check` PASS; `test-docs-maintainer-gates.mjs` PASS.
- Grep gates PASS (no `land in the sandbox as environment variables`, no `pins one provider`, no `pin or clear the sandbox provider`, no stale `Prefer the session-scoped`).
- This PR is docs-only — 3 files under `apps/web/content/docs/**`.

