### PR TITLE
test(shared): de-flake url-autolink ReDoS perf bound (2s → 10s)

### DIFF
--- a/packages/shared/src/utils/url-autolink.test.ts
+++ b/packages/shared/src/utils/url-autolink.test.ts
@@ -120,8 +120,11 @@ describe('autoLinkUrls', () => {
     // Before the quantifiers were bounded, these repetitive strings drove the
     // email / markdown-link / angle-link regexes into polynomial backtracking
     // (seconds+) on user-controlled chat content. Bounded quantifiers keep every
-    // match attempt constant-work, so the whole scan stays linear. A generous
-    // time budget still fails hard if the super-linear behaviour ever returns.
+    // match attempt constant-work, so the whole scan stays linear (single-digit
+    // ms per input). The time budget is deliberately GENEROUS — a regression to
+    // super-linear behaviour on these 50k-char inputs costs seconds-to-minutes
+    // (or hangs), which still trips this bound (or the test timeout), while the
+    // slack keeps a loaded CI runner from flaking on ordinary scheduling jitter.
     const cases = [
       '%'.repeat(50_000), // email local-part run that never reaches '@'
       'a.'.repeat(30_000), // dotted run with no '@' and no TLD
@@ -133,7 +136,7 @@ describe('autoLinkUrls', () => {
       const start = Date.now();
       const out = autoLinkUrls(input);
       expect(typeof out).toBe('string');
-      expect(Date.now() - start).toBeLessThan(2_000);
+      expect(Date.now() - start).toBeLessThan(10_000);
     }
   });
 });


### PR DESCRIPTION
The adversarial (ReDoS-shaped) test in `packages/shared/src/utils/url-autolink.test.ts` asserted a per-input wall-clock budget of **2s**. A loaded CI runner hit **2130ms** and failed, intermittently blocking *every* PR that touches `packages/` (e.g. #5288, #5273) on the `bun unit tests (packages + apps)` job.

The guard exists to catch a regression to **super-linear backtracking** — which on these 50k-char inputs costs seconds-to-minutes (or hangs), orders of magnitude beyond the bound. Raising it to a generous **10s** keeps that guard sharp (a real regression still trips the bound or the test timeout) while absorbing ordinary CI scheduling jitter. Correctness assertions unchanged.

Verified: `bun test src/utils/url-autolink.test.ts` → 23 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)