### PR TITLE
test(release): stabilize v0.10.14 production gate

### DIFF
--- a/tests/src/flows/projects-misc.flow.ts
+++ b/tests/src/flows/projects-misc.flow.ts
@@ -757,7 +757,11 @@ flow(
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .get("/v1/projects/:projectId/sandbox-provider/transition", { params: { projectId: p.id } });
-      r.status(200).body().exists("$.active_provider").exists("$.history");
+      r.status(200)
+        .body()
+        .has("$.active_provider", null)
+        .has("$.latest", null)
+        .exists("$.history");
       const body = r.json<{ latest: unknown; history: unknown[] }>();
       assertNoLeak(body.latest);
       if (Array.isArray(body.history)) body.history.forEach(assertNoLeak);

--- a/tests/src/flows/sandboxes.flow.ts
+++ b/tests/src/flows/sandboxes.flow.ts
@@ -157,6 +157,7 @@ flow(
   "SBX-4",
   {
     domain: "sandboxes",
+    serial: true,
     routes: [
       "POST /v1/projects/:projectId/sandbox-templates",
       "PATCH /v1/projects/:projectId/sandbox-templates/:templateId",

--- a/tests/src/flows/scim.flow.ts
+++ b/tests/src/flows/scim.flow.ts
@@ -37,6 +37,7 @@ flow(
   'SCIM-1',
   {
     domain: 'scim',
+    serial: true,
     tags: ['smoke'],
     routes: [
       'GET /scim/v2/accounts/:accountId/ServiceProviderConfig',
@@ -109,6 +110,7 @@ flow(
   'SCIM-2',
   {
     domain: 'scim',
+    serial: true,
     routes: [
       'GET /scim/v2/accounts/:accountId/Users',
       'POST /scim/v2/accounts/:accountId/Users',
@@ -225,6 +227,7 @@ flow(
   'SCIM-3',
   {
     domain: 'scim',
+    serial: true,
     routes: [
       'GET /scim/v2/accounts/:accountId/Groups',
       'POST /scim/v2/accounts/:accountId/Groups',
@@ -349,6 +352,7 @@ flow(
   'SCIM-4',
   {
     domain: 'scim',
+    serial: true,
     routes: ['GET /scim/v2/accounts/:accountId/ServiceProviderConfig'],
   },
   async (ctx) => {
@@ -384,6 +388,7 @@ flow(
   'SCIM-5',
   {
     domain: 'scim',
+    serial: true,
     routes: [
       'GET /scim/v2/accounts/:accountId/ResourceTypes/:id',
       'GET /scim/v2/accounts/:accountId/Schemas/:id',


### PR DESCRIPTION
Fixes the failed v0.10.14 release gate without changing runtime code.

- Assert the documented `active_provider: null` response in PROJ-33.
- Run sandbox-template CRUD and SCIM flows in the serial lane.
- Preserve strict API-generated `503` failures.

Verification:
- Targeted staging ke2e: 7/7 passed with `--workers 4`.
- `cd tests && bun run typecheck`: passed.
- Failed release run evidence: 358/376 passed; the six 25-second deadline failures passed when isolated.