### PR TITLE
Adjust compute pricing

### DIFF
--- a/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
+++ b/apps/api/src/__tests__/billing/e2e-compute-metering.test.ts
@@ -307,13 +307,12 @@ describe('compute metering — cost calculation', () => {
     expect(calculateComputeCost(SPEC, 0)).toBe(0);
   });
 
-  test('hourly cost is in the expected range for a 2/4/20 sandbox', () => {
+  test('hourly cost is $0.201312 for a 2/4/20 sandbox', () => {
     const c = calculateComputeCost(SPEC, 3600);
-    expect(c).toBeGreaterThan(0.10);
-    expect(c).toBeLessThan(0.15);
+    expect(c).toBeCloseTo(0.201312, 8);
   });
 
-  test('provider attribution is persisted and E2B uses its own rate card', async () => {
+  test('provider attribution is persisted and hosted providers use one customer rate', async () => {
     await startComputeSession({
       sandboxId: 'sb_e2b',
       accountId: 'acc_test_123',
@@ -322,8 +321,14 @@ describe('compute metering — cost calculation', () => {
     });
 
     expect(sessions[0].provider).toBe('e2b');
-    expect(calculateComputeCost(SPEC, 3600, 'e2b')).toBeGreaterThan(
+    expect(calculateComputeCost(SPEC, 3600, 'e2b')).toBeCloseTo(
       calculateComputeCost(SPEC, 3600, 'daytona'),
+      8,
     );
+    expect(calculateComputeCost(SPEC, 3600, 'platinum')).toBeCloseTo(
+      calculateComputeCost(SPEC, 3600, 'daytona'),
+      8,
+    );
+    expect(calculateComputeCost(SPEC, 3600, 'local-docker')).toBe(0);
   });
 });

--- a/apps/api/src/__tests__/billing/per-seat-pricing.test.ts
+++ b/apps/api/src/__tests__/billing/per-seat-pricing.test.ts
@@ -3,14 +3,13 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
+  CREDITS_PER_DOLLAR,
   PER_SEAT_PRICE_USD,
   TYPICAL_COMPUTE_BUDGET_PER_SEAT_USD,
   TYPICAL_LLM_BUDGET_PER_SEAT_USD,
   COMPUTE_CPU_PRICE_PER_CORE_SECOND,
   COMPUTE_MEMORY_PRICE_PER_GB_SECOND,
   COMPUTE_DISK_PRICE_PER_GB_SECOND,
-  COMPUTE_PRICE_MARKUP,
-  DAYTONA_DISCOUNT,
   AUTO_TOPUP_DEFAULT_THRESHOLD_PER_SEAT,
   AUTO_TOPUP_DEFAULT_AMOUNT_PER_SEAT,
   DEFAULT_LLM_PRICE_MARKUP,
@@ -129,23 +128,33 @@ describe('Compute cost calculation', () => {
     expect(calculateComputeCost(spec, -5)).toBe(0);
   });
 
-  test('cost matches reserved-spec × time × markup formula', () => {
+  test('cost matches 1.2× the published Daytona resource rates', () => {
     const seconds = 3600; // one hour
     const expected =
       (spec.cpuCores * COMPUTE_CPU_PRICE_PER_CORE_SECOND * seconds +
         spec.memoryGb * COMPUTE_MEMORY_PRICE_PER_GB_SECOND * seconds +
-        spec.diskGb * COMPUTE_DISK_PRICE_PER_GB_SECOND * seconds) *
-      DAYTONA_DISCOUNT *
-      COMPUTE_PRICE_MARKUP;
+        spec.diskGb * COMPUTE_DISK_PRICE_PER_GB_SECOND * seconds);
 
     const actual = calculateComputeCost(spec, seconds);
     expect(Math.abs(actual - expected)).toBeLessThan(1e-9);
   });
 
-  test('hourly cost for a 2vCPU/4GB/20GB sandbox is roughly $0.10–0.15', () => {
+  test('hourly cost for a 2vCPU/4GB/20GB sandbox is exactly $0.201312', () => {
     const hourCost = calculateComputeCost(spec, 3600);
-    expect(hourCost).toBeGreaterThan(0.10);
-    expect(hourCost).toBeLessThan(0.15);
+    expect(hourCost).toBeCloseTo(0.201312, 8);
+  });
+
+  test('2,500 credits covers about 125 hours of default compute', () => {
+    const creditValueUsd = 2500 / CREDITS_PER_DOLLAR;
+    const computeHours = creditValueUsd / calculateComputeCost(spec, 3600);
+    expect(computeHours).toBeCloseTo(124.1853, 4);
+  });
+
+  test('all hosted providers use the same customer compute price', () => {
+    const daytona = calculateComputeCost(spec, 3600, 'daytona');
+    expect(calculateComputeCost(spec, 3600, 'platinum')).toBeCloseTo(daytona, 8);
+    expect(calculateComputeCost(spec, 3600, 'e2b')).toBeCloseTo(daytona, 8);
+    expect(calculateComputeCost(spec, 3600, 'local-docker')).toBe(0);
   });
 
   test('cost scales linearly with both spec and time', () => {
@@ -160,13 +169,14 @@ describe('Compute cost calculation', () => {
     expect(doubleSpec / baseline).toBeCloseTo(2, 5);
   });
 
-  test('monthly heavy usage exceeds typical compute budget (overage funded via topup)', () => {
+  test('monthly heavy usage exceeds the typical compute budget', () => {
     // 8h × 22 days of compute exceeds the $15 typical compute budget per seat,
     // funded from the fungible seat wallet.
     const monthlySeconds = 8 * 3600 * 22;
     const monthlyCost = calculateComputeCost(spec, monthlySeconds);
     expect(monthlyCost).toBeGreaterThan(TYPICAL_COMPUTE_BUDGET_PER_SEAT_USD);
     expect(monthlyCost).toBeLessThan(PER_SEAT_PRICE_USD);
+    expect(monthlyCost).toBeCloseTo(35.430912, 5);
   });
 });
 

--- a/apps/api/src/billing/services/compute-metering.ts
+++ b/apps/api/src/billing/services/compute-metering.ts
@@ -33,10 +33,7 @@ import {
 } from '../repositories/compute-sessions';
 import { getCreditAccount } from '../repositories/credit-accounts';
 import { deductCredits } from './credits';
-import {
-  COMPUTE_PRICE_MARKUP,
-  isPerSeatAccount,
-} from './tiers';
+import { isPerSeatAccount } from './tiers';
 
 const PARTIAL_BILL_INTERVAL_MS = 60 * 60 * 1000; // 1h
 
@@ -52,8 +49,8 @@ export interface StartComputeOpts {
 
 /**
  * Compute the cost (in USD, pre-balance-deduction) for a window.
- * Provider rate cards hold list cost plus any provider-specific discount; this
- * function applies the shared Kortix markup after selecting the owning provider.
+ * Hosted providers use one public customer rate. local-docker uses zero rates
+ * because it runs on operator-owned hardware.
  */
 export function calculateComputeCost(
   spec: SandboxSpec,
@@ -65,7 +62,7 @@ export function calculateComputeCost(
   const cpuCost = spec.cpuCores * rate.cpuPerCoreSecond * durationSeconds;
   const memCost = spec.memoryGb * rate.memoryPerGbSecond * durationSeconds;
   const diskCost = spec.diskGb * rate.diskPerGbSecond * durationSeconds;
-  return (cpuCost + memCost + diskCost) * rate.providerCostMultiplier * COMPUTE_PRICE_MARKUP;
+  return cpuCost + memCost + diskCost;
 }
 
 /**

--- a/apps/api/src/billing/services/tiers.ts
+++ b/apps/api/src/billing/services/tiers.ts
@@ -9,9 +9,6 @@ export const CREDITS_PER_DOLLAR = 100;
 /** One-time credit grant per machine provisioned ($5 = 500 display credits). */
 export const MACHINE_CREDIT_BONUS = 5;
 
-/** Markup applied to managed VPS prices for additional instances. */
-export const COMPUTE_PRICE_MARKUP = 1.2;
-
 /**
  * Margin multiplier applied to the live models.dev cost on every LLM gateway
  * call. 1.2 = 20% profit (default). Override per-environment with
@@ -55,13 +52,9 @@ export const TYPICAL_COMPUTE_BUDGET_PER_SEAT_USD = 15;
 /** Display-only split of INCLUDED_CREDITS_PER_SEAT_USD for pricing-page copy. */
 export const TYPICAL_LLM_BUDGET_PER_SEAT_USD = 10;
 
-// Per-second sandbox compute pricing, keyed off the reserved spec (kortix.yaml's
-// `sandbox:` block). The constants below are Daytona's PUBLISHED LIST rates (kept as
-// list so they're easy to re-sync from the pricing page). Our ACTUAL cost is
-// list × the volume discount Daytona gives us (DAYTONA_DISCOUNT). The debit
-// emitter charges:
-//     cost = spec × list_rate × DAYTONA_DISCOUNT × COMPUTE_PRICE_MARKUP
-// i.e. we pass the discount through (cheaper for users) and keep a margin on top.
+// Per-second customer pricing for the reserved sandbox spec in kortix.yaml.
+// These rates apply to every hosted provider. Each rate is 1.2× Daytona's
+// published list rate.
 // Daytona list (https://www.daytona.io/pricing, as of 2026-06):
 //   vCPU  $0.0504 / core-hour → 0.000014   per core-second
 //   RAM   $0.0162 / GiB-hour  → 0.0000045  per GB-second
@@ -69,13 +62,9 @@ export const TYPICAL_LLM_BUDGET_PER_SEAT_USD = 10;
 // We bill the full reserved spec — Daytona's first-5-GiB-free RAM/disk allowance
 // is an ORG-level promo to us, not a per-sandbox grant, so passing it per sandbox
 // would under-bill.
-export const COMPUTE_CPU_PRICE_PER_CORE_SECOND = 0.000014;
-export const COMPUTE_MEMORY_PRICE_PER_GB_SECOND = 0.0000045;
-export const COMPUTE_DISK_PRICE_PER_GB_SECOND = 0.00000003;
-/** Volume discount Daytona gives us off list (≈50%) → our real cost = list ×
- *  this. Applied before the markup so users are billed on our actual (discounted)
- *  cost, not Daytona's list. Bump toward 1.0 if the discount shrinks. */
-export const DAYTONA_DISCOUNT = 0.5;
+export const COMPUTE_CPU_PRICE_PER_CORE_SECOND = 0.0000168;
+export const COMPUTE_MEMORY_PRICE_PER_GB_SECOND = 0.0000054;
+export const COMPUTE_DISK_PRICE_PER_GB_SECOND = 0.000000036;
 /** Stopped-but-not-destroyed sandboxes pay a fraction of the disk rate. v2: not billed; reserved for future. */
 export const COMPUTE_ARCHIVE_DISK_MULTIPLIER = 0.25;
 

--- a/apps/api/src/platform/providers/compute-rates.ts
+++ b/apps/api/src/platform/providers/compute-rates.ts
@@ -4,43 +4,30 @@ export interface ProviderComputeRateCard {
   cpuPerCoreSecond: number;
   memoryPerGbSecond: number;
   diskPerGbSecond: number;
-  providerCostMultiplier: number;
 }
 
 const PROVIDER_COMPUTE_RATE_CARDS: Record<ProviderName, ProviderComputeRateCard> = {
-  // Published list rates with Kortix's current Daytona volume discount.
+  // Hosted providers use one customer price at 1.2× Daytona's list rates.
   daytona: {
-    cpuPerCoreSecond: 0.000014,
-    memoryPerGbSecond: 0.0000045,
-    diskPerGbSecond: 0.00000003,
-    providerCostMultiplier: 0.5,
+    cpuPerCoreSecond: 0.0000168,
+    memoryPerGbSecond: 0.0000054,
+    diskPerGbSecond: 0.000000036,
   },
-  // Internal Platinum chargeback uses the same resource list basis, without a
-  // third-party volume discount.
   platinum: {
-    cpuPerCoreSecond: 0.000014,
-    memoryPerGbSecond: 0.0000045,
-    diskPerGbSecond: 0.00000003,
-    providerCostMultiplier: 1,
+    cpuPerCoreSecond: 0.0000168,
+    memoryPerGbSecond: 0.0000054,
+    diskPerGbSecond: 0.000000036,
   },
-  // E2B Cloud Pro published compute rates. Persistent sandbox disk is included
-  // in the sandbox compute price; snapshot storage is a separate provider cost.
   e2b: {
-    cpuPerCoreSecond: 0.000014,
-    memoryPerGbSecond: 0.0000045,
-    diskPerGbSecond: 0,
-    providerCostMultiplier: 1,
+    cpuPerCoreSecond: 0.0000168,
+    memoryPerGbSecond: 0.0000054,
+    diskPerGbSecond: 0.000000036,
   },
-  // local-docker runs on the operator's OWN hardware — there is no third-party
-  // bill to pass through. Zero-rate, same modeling approach as Platinum's
-  // internal chargeback (a real rate card, just multiplied by zero) rather
-  // than special-casing this provider out of the billing/metering path
-  // entirely — usage is still recorded, simply at no cost.
+  // local-docker uses operator hardware. Meter usage without debiting credits.
   'local-docker': {
     cpuPerCoreSecond: 0,
     memoryPerGbSecond: 0,
     diskPerGbSecond: 0,
-    providerCostMultiplier: 0,
   },
 };
 

--- a/apps/api/src/platform/providers/provider-parity.test.ts
+++ b/apps/api/src/platform/providers/provider-parity.test.ts
@@ -53,7 +53,6 @@ describe('sandbox provider parity across shared subsystems', () => {
       expect(typeof card.cpuPerCoreSecond).toBe('number');
       expect(typeof card.memoryPerGbSecond).toBe('number');
       expect(typeof card.diskPerGbSecond).toBe('number');
-      expect(typeof card.providerCostMultiplier).toBe('number');
     });
 
     test(`${name}: has a registered snapshot-build adapter`, () => {

--- a/apps/web/src/app/(public)/(marketing)/pricing/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/pricing/page.tsx
@@ -3,6 +3,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/marketing/button';
 import KortixGrid from '@/components/ui/marketing/gridder';
+import { ComputeCreditCalculator } from '@/features/billing/compute-credit-calculator';
 import { PricingPlanCard } from '@/features/billing/pricing-plan-card';
 import { PRICING_PLANS } from '@/features/billing/pricing-plans';
 import { ArrowRight } from 'lucide-react';
@@ -29,7 +30,7 @@ const CREDIT_POINTS: { title: string; body: string }[] = [
   },
   {
     title: 'Compute by the second',
-    body: 'Billed per resource, per second: $0.0000084/vCPU, $0.0000027/GiB RAM, $0.000000018/GiB disk. The default 2 vCPU / 4 GiB / 20 GiB machine runs about $0.10/hour, and auto-stops when idle so you pay $0 the moment it’s not running.',
+    body: 'Billed per resource, per second: $0.0000168/vCPU, $0.0000054/GiB RAM, $0.000000036/GiB storage. The default 2 vCPU / 4 GiB / 20 GiB machine runs about $0.20/hour, and auto-stops when idle so you pay $0 the moment it’s not running.',
   },
 ];
 
@@ -41,7 +42,7 @@ const CREDIT_EXAMPLES: { label: string; body: string }[] = [
   },
   {
     label: 'Team scale',
-    body: 'Upgrade when you want the latest AI models, pooled credits, and seats for the whole team.',
+    body: 'Each Team seat includes 2,500 pooled credits. Used only for compute, that covers about 125 hours on the default Agent Computer.',
   },
 ];
 
@@ -56,7 +57,7 @@ const FAQ: [string, string][] = [
   ],
   [
     'How are models and compute priced?',
-    'Free credits are sandbox-only. Team credits cover managed models and compute from one wallet. Bring your own key or connect ChatGPT and you pay the provider directly. Agent Computer compute is billed per second, per resource — $0.0000084/vCPU, $0.0000027/GiB RAM, $0.000000018/GiB disk — about $0.10/hour for the default 2 vCPU / 4 GiB / 20 GiB machine, and $0 while stopped.',
+    'Free credits are sandbox-only. Team credits cover managed models and compute from one wallet. Bring your own key or connect ChatGPT and you pay the provider directly. Agent Computer compute is billed per second, per resource — $0.0000168/vCPU, $0.0000054/GiB RAM, $0.000000036/GiB storage — about $0.20/hour for the default 2 vCPU / 4 GiB / 20 GiB machine, and $0 while stopped.',
   ],
   [
     'Do I pay per seat or per usage?',
@@ -118,6 +119,9 @@ export default function PricingPage() {
                 'autoAppPublicMarketingPricingPageJsxTextOneSimpleBalancef877f3a6',
               )}
             </p>
+          </div>
+          <div className="mt-10">
+            <ComputeCreditCalculator />
           </div>
           <div className="mt-12 grid gap-8 md:grid-cols-3">
             {CREDIT_POINTS.map((p) => (

--- a/apps/web/src/features/billing/compute-credit-calculator.tsx
+++ b/apps/web/src/features/billing/compute-credit-calculator.tsx
@@ -3,6 +3,7 @@
 import { Input } from '@/components/ui/input';
 import { Slider } from '@/components/ui/slider';
 import {
+  CREDITS_PER_USD,
   DEFAULT_COMPUTE_HOURLY_PRICE_USD,
   estimateTeamCompute,
 } from '@/features/billing/compute-pricing';
@@ -81,18 +82,20 @@ export function ComputeCreditCalculator() {
               })}
             </div>
             <div className="text-muted-foreground mt-1 text-xs leading-relaxed">
-              Agent Computer hours each month
+              Total Agent Computer hours each month
             </div>
           </div>
         </div>
       </div>
 
       <p className="text-muted-foreground border-border mt-6 border-t pt-4 text-xs leading-relaxed">
-        Agent Computer runtime costs about{' '}
+        Compute is billed by the second. The default Agent Computer has 2 vCPU, 4 GiB RAM, and 20
+        GiB storage. It uses about{' '}
         <span className="text-foreground font-medium tabular-nums">
-          ${DEFAULT_COMPUTE_HOURLY_PRICE_USD.toFixed(2)}/hour
+          {`${(DEFAULT_COMPUTE_HOURLY_PRICE_USD * CREDITS_PER_USD).toFixed(0)} credits ($${DEFAULT_COMPUTE_HOURLY_PRICE_USD.toFixed(2)}) per hour`}
         </span>
-        . Managed model usage uses the same pooled Team credits.
+        . Auto-stop pauses compute charges, so stopped time uses 0 credits. Managed model usage uses
+        the same pooled Team credits.
       </p>
     </div>
   );

--- a/apps/web/src/features/billing/compute-credit-calculator.tsx
+++ b/apps/web/src/features/billing/compute-credit-calculator.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Slider } from '@/components/ui/slider';
+import {
+  DEFAULT_COMPUTE_HOURLY_PRICE_USD,
+  estimateTeamCompute,
+} from '@/features/billing/compute-pricing';
+import { useState } from 'react';
+
+const MIN_TEAM_MEMBERS = 1;
+const MAX_TEAM_MEMBERS = 100;
+
+function clampTeamMembers(value: number): number {
+  return Math.min(MAX_TEAM_MEMBERS, Math.max(MIN_TEAM_MEMBERS, Math.floor(value)));
+}
+
+export function ComputeCreditCalculator() {
+  const [teamMembers, setTeamMembers] = useState(1);
+  const estimate = estimateTeamCompute(teamMembers);
+
+  const setClampedTeamMembers = (value: number) => {
+    setTeamMembers(clampTeamMembers(Number.isFinite(value) ? value : MIN_TEAM_MEMBERS));
+  };
+
+  return (
+    <div className="bg-card rounded-md border px-5 py-6 sm:px-6">
+      <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(260px,0.8fr)] md:items-end">
+        <div className="space-y-5">
+          <div className="flex items-end justify-between gap-4">
+            <div className="space-y-1">
+              <label htmlFor="team-members-input" className="text-foreground text-sm font-medium">
+                Team members
+              </label>
+              <p className="text-muted-foreground text-xs">
+                Each member adds 2,500 pooled credits each month.
+              </p>
+            </div>
+            <Input
+              id="team-members-input"
+              type="number"
+              min={MIN_TEAM_MEMBERS}
+              max={MAX_TEAM_MEMBERS}
+              step={1}
+              value={teamMembers}
+              onChange={(event) => setClampedTeamMembers(Number(event.target.value))}
+              className="w-28 text-right tabular-nums"
+              aria-label="Team members"
+            />
+          </div>
+
+          <Slider
+            min={MIN_TEAM_MEMBERS}
+            max={MAX_TEAM_MEMBERS}
+            step={1}
+            value={[teamMembers]}
+            onValueChange={([value]) => setClampedTeamMembers(value)}
+            aria-label="Team members"
+          />
+
+          <div className="text-muted-foreground flex justify-between text-xs tabular-nums">
+            <span>{MIN_TEAM_MEMBERS} member</span>
+            <span>{MAX_TEAM_MEMBERS} members</span>
+          </div>
+        </div>
+
+        <div className="border-border grid grid-cols-2 gap-5 border-t pt-5 md:border-t-0 md:border-l md:pt-0 md:pl-6">
+          <div>
+            <div className="text-foreground text-3xl font-medium tracking-tight tabular-nums">
+              {estimate.monthlyCredits.toLocaleString()}
+            </div>
+            <div className="text-muted-foreground mt-1 text-xs leading-relaxed">
+              Pooled credits each month
+            </div>
+          </div>
+          <div>
+            <div className="text-foreground text-3xl font-medium tracking-tight tabular-nums">
+              {estimate.runtimeHours.toLocaleString(undefined, {
+                maximumFractionDigits: 1,
+                minimumFractionDigits: 1,
+              })}
+            </div>
+            <div className="text-muted-foreground mt-1 text-xs leading-relaxed">
+              Agent Computer hours each month
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-muted-foreground border-border mt-6 border-t pt-4 text-xs leading-relaxed">
+        Agent Computer runtime costs about{' '}
+        <span className="text-foreground font-medium tabular-nums">
+          ${DEFAULT_COMPUTE_HOURLY_PRICE_USD.toFixed(2)}/hour
+        </span>
+        . Managed model usage uses the same pooled Team credits.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/billing/compute-pricing.test.ts
+++ b/apps/web/src/features/billing/compute-pricing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_COMPUTE_HOURLY_PRICE_USD,
+  estimateDefaultCompute,
+  estimateTeamCompute,
+} from './compute-pricing';
+
+describe('compute pricing estimates', () => {
+  test('uses the billed default-machine hourly rate', () => {
+    expect(DEFAULT_COMPUTE_HOURLY_PRICE_USD).toBeCloseTo(0.201312, 8);
+  });
+
+  test('2,500 credits equals $25 and 124.2 hours of default compute', () => {
+    const estimate = estimateDefaultCompute(2500);
+    expect(estimate.creditValueUsd).toBe(25);
+    expect(estimate.runtimeHours).toBeCloseTo(124.1853, 4);
+  });
+
+  test('negative credits return zero value and runtime', () => {
+    expect(estimateDefaultCompute(-100)).toEqual({
+      creditValueUsd: 0,
+      runtimeHours: 0,
+    });
+  });
+
+  test('team estimates scale pooled credits and runtime by seat count', () => {
+    const oneSeat = estimateTeamCompute(1);
+    expect(oneSeat.monthlyCredits).toBe(2500);
+    expect(oneSeat.runtimeHours).toBeCloseTo(124.1853, 4);
+
+    const tenSeats = estimateTeamCompute(10);
+    expect(tenSeats.monthlyCredits).toBe(25_000);
+    expect(tenSeats.runtimeHours).toBeCloseTo(1241.8534, 4);
+  });
+});

--- a/apps/web/src/features/billing/compute-pricing.test.ts
+++ b/apps/web/src/features/billing/compute-pricing.test.ts
@@ -31,5 +31,9 @@ describe('compute pricing estimates', () => {
     const tenSeats = estimateTeamCompute(10);
     expect(tenSeats.monthlyCredits).toBe(25_000);
     expect(tenSeats.runtimeHours).toBeCloseTo(1241.8534, 4);
+
+    const hundredSeats = estimateTeamCompute(100);
+    expect(hundredSeats.monthlyCredits).toBe(250_000);
+    expect(hundredSeats.runtimeHours).toBeCloseTo(12_418.5344, 4);
   });
 });

--- a/apps/web/src/features/billing/compute-pricing.ts
+++ b/apps/web/src/features/billing/compute-pricing.ts
@@ -1,0 +1,29 @@
+export const CREDITS_PER_USD = 100;
+export const DEFAULT_COMPUTE_HOURLY_PRICE_USD = 0.201312;
+export const TEAM_CREDITS_PER_SEAT = 2500;
+
+export function estimateDefaultCompute(credits: number): {
+  creditValueUsd: number;
+  runtimeHours: number;
+} {
+  const normalizedCredits = Math.max(0, credits);
+  const creditValueUsd = normalizedCredits / CREDITS_PER_USD;
+
+  return {
+    creditValueUsd,
+    runtimeHours: creditValueUsd / DEFAULT_COMPUTE_HOURLY_PRICE_USD,
+  };
+}
+
+export function estimateTeamCompute(seatCount: number): {
+  monthlyCredits: number;
+  runtimeHours: number;
+} {
+  const normalizedSeatCount = Math.max(1, Math.floor(seatCount));
+  const monthlyCredits = normalizedSeatCount * TEAM_CREDITS_PER_SEAT;
+
+  return {
+    monthlyCredits,
+    runtimeHours: estimateDefaultCompute(monthlyCredits).runtimeHours,
+  };
+}

--- a/apps/web/src/features/billing/pricing-plan-card.tsx
+++ b/apps/web/src/features/billing/pricing-plan-card.tsx
@@ -56,7 +56,14 @@ export function PricingPlanCard({
           {plan.features.map((feature) => (
             <li key={feature} className="flex items-start justify-start gap-2 first:font-medium">
               <Check className="text-foreground mt-0.5 size-4 shrink-0" />
-              <span>{feature}</span>
+              <span>
+                <span>{feature}</span>
+                {plan.featureDetails?.[feature] ? (
+                  <span className="text-muted-foreground mt-0.5 block text-xs leading-relaxed font-normal">
+                    {plan.featureDetails[feature]}
+                  </span>
+                ) : null}
+              </span>
             </li>
           ))}
         </ul>

--- a/apps/web/src/features/billing/pricing-plans.ts
+++ b/apps/web/src/features/billing/pricing-plans.ts
@@ -11,6 +11,7 @@ export type PricingPlan = {
   highlight?: boolean;
   badge?: string;
   features: string[];
+  featureDetails?: Record<string, string>;
 };
 
 export const PRICING_PLANS: PricingPlan[] = [
@@ -43,6 +44,10 @@ export const PRICING_PLANS: PricingPlan[] = [
       'Top up credits anytime',
       'Support via email',
     ],
+    featureDetails: {
+      '2,500 credits / month per seat, pooled':
+        'About 125 default Agent Computer hours when used only for compute.',
+    },
   },
   {
     id: 'enterprise',


### PR DESCRIPTION
Summary:
- Price hosted Agent Computer runtime at 1.2 times the Daytona list rate.
- Show about $0.20 per hour and about 125 hours per Team seat.
- Add a team-size calculator to the pricing page.
- Keep local-docker usage unbilled.

Verification:
- 51 billing and provider tests passed.
- 4 calculator tests passed.
- API typecheck passed.
- Changed web files passed ESLint and Prettier.
- Local pricing page returned 200 with the expected calculator output.