### PR TITLE
fix(sessions): apply project model defaults

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -307,6 +307,7 @@ mock.module('../projects/github', () => ({
   commitFile: async () => undefined,
   createInstallationToken: async () => ({ token: 'installation-token' }),
   verifyGitHubInstallationAdmin: async () => undefined,
+  listLinkableGitHubAppInstallations: async () => [],
   createRepo: async () => {
     throw new Error('not used');
   },

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -38,6 +38,11 @@ let activeSessionCount = 0;
 let provisioningSessionCount = 0;
 let secretRows: Array<typeof projectSecrets.$inferSelect>;
 let manifestReadCalls = 0;
+let modelDefaults: {
+  account: string | null;
+  agents: Record<string, string>;
+  projects: Record<string, string>;
+};
 
 function setTestAuth(userId = USER_ID, userEmail = 'triggers@example.test') {
   (globalThis as any)[TEST_AUTH_KEY] = { userId, userEmail };
@@ -77,6 +82,8 @@ function resetState() {
   provisioningSessionCount = 0;
   secretRows = [];
   manifestReadCalls = 0;
+  modelDefaults = { account: null, agents: {}, projects: {} };
+  projectRow.metadata = {};
   secretValues.clear();
 }
 
@@ -219,6 +226,8 @@ mock.module('../projects/github', () => ({
     description: null,
   }),
   getRepositoryBranch: async ({ branch }: { branch: string }) => ({ name: branch, protected: false }),
+  verifyGitHubInstallationAdmin: async () => undefined,
+  listLinkableGitHubAppInstallations: async () => [],
   listInstallationRepositories: async () => [],
   listOwnerRepositories: async () => [],
   listRepositoryBranches: async () => [],
@@ -511,6 +520,12 @@ mock.module('../shared/db', () => ({
   db: triggerDbMock,
 }));
 
+const realModelPreferences = await import('../repositories/model-preferences');
+mock.module('../repositories/model-preferences', () => ({
+  ...realModelPreferences,
+  getAccountModelDefaults: async () => modelDefaults,
+}));
+
 const {
   drainSessionLifecycleQueue,
   projectsApp,
@@ -613,7 +628,7 @@ describe('git-backed triggers — CRUD', () => {
 
     // Manifest content reflects the new trigger as a `triggers:` entry.
     const written = repoFiles.get(MANIFEST_PATH)!;
-    expect(written).toContain('kortix_version: 1');
+    expect(written).toContain('kortix_version: 2');
     expect(written).toContain('triggers:');
     expect(written).toContain('slug: daily-digest');
     expect(written).toContain('name: Daily Digest');
@@ -902,7 +917,7 @@ describe('git-backed triggers — runtime fire paths', () => {
       slug: 'daily',
       name: 'Daily',
       cron: '* * * * * *',
-      model: 'anthropic/claude-sonnet-4-6',
+      model: 'glm-5.2',
       prompt: 'Run at {{ fired_at }}',
     }));
 
@@ -917,10 +932,12 @@ describe('git-backed triggers — runtime fire paths', () => {
 
     await new Promise((r) => setTimeout(r, 0));
     expect(sandboxProvisionCalls).toBe(1);
-    expect(lastProvisionEnv?.KORTIX_OPENCODE_MODEL).toBe('anthropic/claude-sonnet-4-6');
+    expect(lastProvisionEnv?.KORTIX_OPENCODE_MODEL).toBe('kortix/glm-5.2');
   });
 
-  test('manual fire without a model leaves the default resolution chain untouched', async () => {
+  test('manual fire without overrides resolves the project model and selected agent before provisioning', async () => {
+    modelDefaults.projects[PROJECT_ID] = 'glm-5.2';
+    projectRow.metadata = { default_agent: 'asana-refresher' };
     seedManifest(cronEntry({
       slug: 'daily',
       name: 'Daily',
@@ -938,7 +955,13 @@ describe('git-backed triggers — runtime fire paths', () => {
 
     await new Promise((r) => setTimeout(r, 0));
     expect(sandboxProvisionCalls).toBe(1);
-    expect(lastProvisionEnv?.KORTIX_OPENCODE_MODEL).toBeUndefined();
+    expect(lastProvisionEnv?.KORTIX_OPENCODE_MODEL).toBe('kortix/glm-5.2');
+    expect(lastProvisionEnv?.KORTIX_AGENT_NAME).toBe('asana-refresher');
+    expect(sessionRows.at(-1)?.agentName).toBe('asana-refresher');
+    expect(sessionRows.at(-1)?.metadata).toMatchObject({
+      opencode_model: 'kortix/glm-5.2',
+      opencode_model_source: 'project',
+    });
   });
 
   test('manual fire queues durably under backpressure', async () => {

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -43,9 +43,8 @@ export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<st
     // The sandbox daemon merges this as the BASE of its own composed opencode
     // config (executor MCP / gateway provider / Slack overlays still apply on
     // top — see apps/kortix-sandbox-agent-server/src/opencode.ts). Per-call
-    // model overrides (KORTIX_OPENCODE_MODEL above, or an explicit model on a
-    // prompt request) still win over whatever default model this bakes in —
-    // this only sets the manifest agent's/DEFAULT agent's fallback.
+    // The resolved session model (KORTIX_OPENCODE_MODEL above), or an explicit
+    // model on a prompt request, still wins over this compiled fallback.
     ...(input.compiledAgentConfig
       ? { KORTIX_COMPILED_AGENT_CONFIG: input.compiledAgentConfig }
       : {}),

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -12,8 +12,14 @@ import { tierGrantsAllModels } from '../../billing/services/tiers';
 import { type SandboxProviderName, config } from '../../config';
 import { agentMayUseConnector } from '../../iam/agent-scope';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
-import { isModelServableForAccount } from '../../llm-gateway/resolution/default-model';
-import { toOpencodeModelRef } from '../../llm-gateway/resolution/effective';
+import {
+  isModelServableForAccount,
+  resolveEffectiveModel,
+} from '../../llm-gateway/resolution/default-model';
+import {
+  type ModelSource,
+  toOpencodeModelRef,
+} from '../../llm-gateway/resolution/effective';
 import { nativeProviderEnvNames } from '../../llm-gateway/sandbox-credentials';
 import { auth, json } from '../../openapi';
 import { getProvider } from '../../platform/providers';
@@ -414,8 +420,9 @@ export async function buildSessionSandboxEnvVars(input: {
       apiUrl: deriveKortixApiBase(),
       frontendUrl: sandboxFrontendBaseUrl(),
       initialPrompt: input.initialPrompt,
-      // Per-session model override (e.g. Slack turns pin a specific model).
-      // The sandbox agent reads this and sets it on every opencode prompt call.
+      // Concrete session model after explicit → agent → project → account →
+      // platform resolution. The sandbox uses it for the first OpenCode turn
+      // and as the session's OpenCode config default.
       opencodeModel: input.opencodeModel,
       // Backend-vouched end-user (KaaB) → KORTIX_ORIGIN_REF in the sandbox.
       originRef: sessionKaabRow?.originRef ?? null,
@@ -651,6 +658,24 @@ export async function createProjectSession(input: {
     }
   }
 
+  const baseRef = normalizeString(body.base_ref ?? body.baseRef) ?? project.defaultBranch;
+  // The literal "default" is a non-binding legacy sentinel. It must not block
+  // the configured project default. This rule applies to every caller,
+  // including older triggers and channel adapters that still send the sentinel.
+  const requestedAgent = normalizeString(body.agent_name ?? body.agentName);
+  const projectDefaultAgent = normalizeString(
+    (project.metadata as Record<string, unknown> | null | undefined)?.default_agent,
+  );
+  const agentName =
+    (requestedAgent && requestedAgent !== 'default' ? requestedAgent : null) ??
+    projectDefaultAgent ??
+    'default';
+
+  const freeModelsOnly = config.KORTIX_BILLING_INTERNAL_ENABLED
+    ? !tierGrantsAllModels(await getCachedAccountTier(accountId))
+    : false;
+  const llmGatewayEnabled = projectLlmGatewayEnabled(project.metadata);
+
   // Model: normalize + fail-fast at create. An unservable / retired / typo'd
   // model pin was previously stored verbatim and only failed at prompt time (a
   // dead turn); a bare managed id (`claude-opus-4-8`) silently dropped to the
@@ -659,51 +684,69 @@ export async function createProjectSession(input: {
   // the OPENCODE ref form. Runs BEFORE the billing hold so a bad model never
   // costs a credit reservation. Mirrors the channel-model gate
   // (routes/channel-bindings.ts) and the plan's §4.7 fail-fast.
-  let opencodeModel = normalizeString(body.opencode_model ?? body.opencodeModel);
-  if (opencodeModel) {
-    if (/\s/.test(opencodeModel)) {
+  const requestedModel = normalizeString(body.opencode_model ?? body.opencodeModel);
+  let opencodeModel: string | null = null;
+  let opencodeModelSource: ModelSource | null = null;
+  if (requestedModel) {
+    if (/\s/.test(requestedModel)) {
       return {
         error: {
           status: 400,
-          body: { error: `"${opencodeModel}" doesn't look like a model id`, code: 'INVALID_SESSION_MODEL' },
+          body: { error: `"${requestedModel}" doesn't look like a model id`, code: 'INVALID_SESSION_MODEL' },
         },
       };
     }
-    const freeModelsOnly = config.KORTIX_BILLING_INTERNAL_ENABLED
-      ? !tierGrantsAllModels(await getCachedAccountTier(accountId))
-      : false;
     const servable = await isModelServableForAccount({
       userId,
       accountId,
       projectId,
       freeModelsOnly,
-      model: opencodeModel,
+      model: requestedModel,
     });
     if (!servable) {
       return {
         error: {
           status: 400,
           body: {
-            error: `Model "${opencodeModel}" is not available for this account`,
+            error: `Model "${requestedModel}" is not available for this account`,
             code: 'INVALID_SESSION_MODEL',
           },
         },
       };
     }
-    opencodeModel = toOpencodeModelRef(opencodeModel);
+    opencodeModel = toOpencodeModelRef(requestedModel);
+    opencodeModelSource = 'explicit';
+  } else if (llmGatewayEnabled) {
+    try {
+      const resolved = await resolveEffectiveModel({
+        userId,
+        accountId,
+        projectId,
+        agentName,
+        explicit: null,
+        freeModelsOnly,
+      });
+      const concreteModel =
+        resolved.model ??
+        (!freeModelsOnly ? config.LLM_GATEWAY_DEFAULT_MODEL : null);
+      if (concreteModel) {
+        opencodeModel = toOpencodeModelRef(concreteModel);
+        opencodeModelSource = resolved.model ? resolved.source : 'platform';
+      }
+    } catch (error) {
+      console.error('[projects] Failed to resolve the session default model:', error);
+      return {
+        error: {
+          status: 503,
+          body: {
+            error: 'The session default model could not be resolved',
+            code: 'SESSION_MODEL_RESOLUTION_FAILED',
+          },
+        },
+      };
+    }
   }
 
-  const baseRef = normalizeString(body.base_ref ?? body.baseRef) ?? project.defaultBranch;
-  // Explicit request wins; otherwise fall back to the project's default agent
-  // (a v2 kortix.yaml's top-level `default_agent`, or a legacy v1 kortix.toml's
-  // `[opencode] default_agent` — synced to project metadata, or a UI/Slack
-  // override), so EVERY session — UI, triggers, channels — inherits the
-  // project's chosen agent without each caller passing one. Unset → 'default'.
-  const projectDefaultAgent = normalizeString(
-    (project.metadata as Record<string, unknown> | null | undefined)?.default_agent,
-  );
-  const agentName =
-    normalizeString(body.agent_name ?? body.agentName) ?? projectDefaultAgent ?? 'default';
   let loadedAgentGrant: ReturnType<typeof grantFromLoadedAgents> | undefined;
   if (parsedConnectorBindings.bindings) {
     loadedAgentGrant = grantFromLoadedAgents(agentName, await loadProjectAgents(project));
@@ -896,6 +939,7 @@ export async function createProjectSession(input: {
     ...(sessionName ? { name: sessionName } : {}),
     ...(initialPrompt ? { initial_prompt: initialPrompt } : {}),
     ...(opencodeModel ? { opencode_model: opencodeModel } : {}),
+    ...(opencodeModelSource ? { opencode_model_source: opencodeModelSource } : {}),
     ...(input.metadata ?? {}),
   };
 
@@ -1011,7 +1055,7 @@ export async function createProjectSession(input: {
           agentName,
           initialPrompt,
           opencodeModel,
-          llmGatewayEnabled: projectLlmGatewayEnabled(project.metadata),
+          llmGatewayEnabled,
           freshSession: true,
           baseSha,
           defaultBranch: project.defaultBranch,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/executor-mcp-config.test.ts
@@ -7,6 +7,7 @@ const ENV = { KORTIX_EXECUTOR_TOKEN: 'tok-123', KORTIX_API_URL: 'https://api.kor
 const GATEWAY_CATALOG = {
   'anthropic/claude-opus-4.8': { name: 'Claude Opus 4.8', provider: 'anthropic', reasoning: true, tool_call: true, attachment: true, temperature: true },
   'anthropic/claude-sonnet-4.6': { name: 'Claude Sonnet 4.6', reasoning: true, tool_call: true, attachment: true },
+  'codex/gpt-5.6-sol': { name: 'GPT-5.6 Sol', reasoning: true, tool_call: true },
   'deepseek/deepseek-v4-flash': { name: 'DeepSeek V4 Flash', reasoning: true, tool_call: true },
   'x-ai/grok-4.3': { name: 'Grok 4.3', tool_call: true },
   'minimax/minimax-m3': { name: 'Minimax M3', tool_call: true },
@@ -127,11 +128,21 @@ describe('buildOpencodeConfigContent — Kortix LLM gateway provider', () => {
     expect(models['claude-sonnet-4.6']).toBeDefined()
   }, 20_000) // full backoff (~15.5s) before the minimal-catalog fallback
 
-  test('sets a concrete default model when none exists in pre-existing config', async () => {
+  test('uses the resolved session model as the OpenCode default', async () => {
+    stubGatewayModels(GATEWAY_CATALOG)
+    const config = JSON.parse((await buildOpencodeConfigContent({
+      ...GATEWAY_ENV,
+      KORTIX_OPENCODE_MODEL: 'codex/gpt-5.6-sol',
+    }))!)
+    expect(config.model).toBe('kortix/codex/gpt-5.6-sol')
+    expect(config.small_model).toBe('kortix/codex/gpt-5.6-sol')
+  })
+
+  test('uses an available gateway model for legacy sessions without a resolved model', async () => {
     stubGatewayModels(GATEWAY_CATALOG)
     const config = JSON.parse((await buildOpencodeConfigContent(GATEWAY_ENV))!)
-    expect(config.model).toBe('kortix/glm-5.2')
-    expect(config.small_model).toBe('kortix/glm-5.2')
+    expect(config.model).toBe('kortix/anthropic/claude-opus-4.8')
+    expect(config.small_model).toBe('kortix/anthropic/claude-opus-4.8')
   })
 
   test('routes a user-set default model through the Kortix provider', async () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/resolve-opencode-model.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/resolve-opencode-model.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 
-import { resolveOpencodeModel } from '../main'
+import { buildInitialPromptBody, resolveOpencodeModel } from '../main'
 
 const ORIGINAL_MODEL = process.env.KORTIX_OPENCODE_MODEL
 const ORIGINAL_LLM_BASE_URL = process.env.KORTIX_LLM_BASE_URL
 const ORIGINAL_LLM_API_KEY = process.env.KORTIX_LLM_API_KEY
 const ORIGINAL_LLM_PROXY_URL = process.env.KORTIX_LLM_PROXY_URL
+const ORIGINAL_AGENT = process.env.KORTIX_AGENT_NAME
 
 afterEach(() => {
   if (ORIGINAL_MODEL === undefined) delete process.env.KORTIX_OPENCODE_MODEL
@@ -16,6 +17,8 @@ afterEach(() => {
   else process.env.KORTIX_LLM_API_KEY = ORIGINAL_LLM_API_KEY
   if (ORIGINAL_LLM_PROXY_URL === undefined) delete process.env.KORTIX_LLM_PROXY_URL
   else process.env.KORTIX_LLM_PROXY_URL = ORIGINAL_LLM_PROXY_URL
+  if (ORIGINAL_AGENT === undefined) delete process.env.KORTIX_AGENT_NAME
+  else process.env.KORTIX_AGENT_NAME = ORIGINAL_AGENT
 })
 
 describe('resolveOpencodeModel', () => {
@@ -112,5 +115,31 @@ describe('resolveOpencodeModel', () => {
     } finally {
       delete process.env.KORTIX_COMPILED_AGENT_CONFIG
     }
+  })
+})
+
+describe('buildInitialPromptBody', () => {
+  test('applies the session model and concrete selected agent to an automated first turn', () => {
+    process.env.KORTIX_LLM_PROXY_URL = 'http://127.0.0.1:4319'
+    process.env.KORTIX_OPENCODE_MODEL = 'anthropic/claude-sonnet-4-6'
+    process.env.KORTIX_AGENT_NAME = 'asana-refresher'
+
+    expect(buildInitialPromptBody('Refresh the Asana snapshot.')).toEqual({
+      parts: [{ type: 'text', text: 'Refresh the Asana snapshot.' }],
+      model: {
+        providerID: 'kortix',
+        modelID: 'anthropic/claude-sonnet-4-6',
+      },
+      agent: 'asana-refresher',
+    })
+  })
+
+  test('omits the legacy default agent sentinel', () => {
+    delete process.env.KORTIX_OPENCODE_MODEL
+    process.env.KORTIX_AGENT_NAME = 'default'
+
+    expect(buildInitialPromptBody('Run.')).toEqual({
+      parts: [{ type: 'text', text: 'Run.' }],
+    })
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -815,16 +815,12 @@ async function maybeCreateInitialOpencodeSession(
       ])
       if (timer) clearTimeout(timer)
     }
-    const model = resolveOpencodeModel()
     const promptRes = await fetch(
       `${baseUrl}/session/${sessionId}/prompt_async?directory=${encodeURIComponent(workspace)}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          parts: [{ type: 'text', text: prompt }],
-          ...(model ? { model } : {}),
-        }),
+        body: JSON.stringify(buildInitialPromptBody(prompt)),
         signal: AbortSignal.timeout(15_000),
       },
     )
@@ -1392,7 +1388,7 @@ async function isRootOpencodeSession(
   }
 }
 
-/** Per-session model override from KORTIX_OPENCODE_MODEL.
+/** Concrete session model from KORTIX_OPENCODE_MODEL.
  *
  * Gateway mode exposes one OpenCode provider (`kortix`). Its model ids are the
  * complete gateway wire refs, including nested refs such as
@@ -1415,6 +1411,22 @@ export function resolveOpencodeModel(): { providerID: string; modelID: string } 
   const providerID = raw.slice(0, slash)
   const modelID = raw.slice(slash + 1)
   return { providerID, modelID }
+}
+
+/** Build the first-turn request from the session-bound runtime environment. */
+export function buildInitialPromptBody(prompt: string): {
+  parts: Array<{ type: 'text'; text: string }>
+  model?: { providerID: string; modelID: string }
+  agent?: string
+} {
+  const model = resolveOpencodeModel()
+  const agentName = (process.env.KORTIX_AGENT_NAME ?? '').trim()
+  const agent = agentName && agentName !== 'default' ? agentName : undefined
+  return {
+    parts: [{ type: 'text', text: prompt }],
+    ...(model ? { model } : {}),
+    ...(agent ? { agent } : {}),
+  }
 }
 
 /** Read the pinned opencode session id (set at boot when KORTIX_INITIAL_PROMPT

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -180,32 +180,38 @@ export async function buildOpencodeConfigContent(env: NodeJS.ProcessEnv): Promis
       out.provider && typeof out.provider === 'object' && !Array.isArray(out.provider)
         ? (out.provider as Record<string, unknown>)
         : {}
+    const kortixProvider = await buildKortixProvider({
+      // In proxy mode opencode talks to the localhost proxy with a placeholder
+      // key; the proxy injects the real per-session token upstream. In direct
+      // mode (cold/Daytona) it's the real gateway base + key, as before.
+      baseURL: proxyMode ? llmProxyUrl! : llmBaseUrl!,
+      apiKey: proxyMode ? LLM_PROXY_PLACEHOLDER_KEY : llmApiKey!,
+      // Catalog is org-stable, so prefer the baked file — the full model catalog
+      // ships in every image at BAKED_LLM_CATALOG_PATH. Defaulting to it means a
+      // COLD boot (Daytona + Platinum) reads the file and SKIPS the ~2.2s gateway
+      // /models fetch that otherwise gates opencode's port bind on the critical
+      // path — matching how the warm seed (KORTIX_LLM_CATALOG_FILE) already
+      // behaves. Missing/empty file → readCatalogFile returns null → the fetch
+      // (step 2) still runs as the fallback, so this only ever removes latency.
+      catalogFile: env.KORTIX_LLM_CATALOG_FILE ?? BAKED_LLM_CATALOG_PATH,
+      fetchBaseURL: llmBaseUrl,
+      fetchApiKey: llmApiKey,
+    })
     out.provider = {
       ...provider,
-      kortix: await buildKortixProvider({
-        // In proxy mode opencode talks to the localhost proxy with a placeholder
-        // key; the proxy injects the real per-session token upstream. In direct
-        // mode (cold/Daytona) it's the real gateway base + key, as before.
-        baseURL: proxyMode ? llmProxyUrl! : llmBaseUrl!,
-        apiKey: proxyMode ? LLM_PROXY_PLACEHOLDER_KEY : llmApiKey!,
-        // Catalog is org-stable, so prefer the baked file — the full model catalog
-        // ships in every image at BAKED_LLM_CATALOG_PATH. Defaulting to it means a
-        // COLD boot (Daytona + Platinum) reads the file and SKIPS the ~2.2s gateway
-        // /models fetch that otherwise gates opencode's port bind on the critical
-        // path — matching how the warm seed (KORTIX_LLM_CATALOG_FILE) already
-        // behaves. Missing/empty file → readCatalogFile returns null → the fetch
-        // (step 2) still runs as the fallback, so this only ever removes latency.
-        catalogFile: env.KORTIX_LLM_CATALOG_FILE ?? BAKED_LLM_CATALOG_PATH,
-        fetchBaseURL: llmBaseUrl,
-        fetchApiKey: llmApiKey,
-      }),
+      kortix: kortixProvider,
     }
     normalizeGatewayModelRefs(out)
+    const resolvedSessionModel = env.KORTIX_OPENCODE_MODEL?.trim()
+    const availableGatewayModel = Object.keys(
+      (kortixProvider.models as Record<string, unknown> | undefined) ?? {},
+    )[0]
+    const fallbackModel = resolvedSessionModel || availableGatewayModel
     if (!('model' in out) || typeof out.model !== 'string') {
-      out.model = DEFAULT_KORTIX_MODEL
+      if (fallbackModel) out.model = toKortixOpencodeModelRef(fallbackModel)
     }
     if (!('small_model' in out) || typeof out.small_model !== 'string') {
-      out.small_model = DEFAULT_KORTIX_MODEL
+      if (fallbackModel) out.small_model = toKortixOpencodeModelRef(fallbackModel)
     }
     // Gateway mode allowlists providers so leaked provider keys cannot open
     // native Anthropic/OpenAI/GitHub/etc paths that bypass gateway budgets, logs,
@@ -403,9 +409,6 @@ export async function refreshGatewayCatalogFile(opts: {
   })
   return { changed, catalogFile: opts.targetCatalogFile }
 }
-
-// Concrete fallback for sessions that predate KORTIX_LLM_DEFAULT_MODEL injection.
-const DEFAULT_KORTIX_MODEL = 'kortix/glm-5.2'
 
 // One `reasoning_options` entry (models.dev's shape, mirrored — see
 // @kortix/llm-catalog's CatalogReasoningOption). Present iff the model


### PR DESCRIPTION
## Summary

- Resolve every new session model through explicit, agent, project, account, and platform precedence.
- Preserve explicit trigger and channel model overrides.
- Pass the resolved model and project agent into the initial automated OpenCode prompt.
- Remove the sandbox hard-coded model fallback. Legacy sessions use a registered gateway catalog model.
- Record the resolved model and source in session metadata.

## Verification

- KORTIX_BILLING_INTERNAL_ENABLED=false KORTIX_URL=<public tunnel> dotenvx run -- bun test src/__tests__/e2e-project-triggers.test.ts: 23 pass, 0 fail
- KORTIX_BILLING_INTERNAL_ENABLED=false dotenvx run -- bun test src/__tests__/e2e-project-session-contract.test.ts: 43 pass, 0 fail
- API model resolver and Slack selection tests: 55 pass, 0 fail
- Sandbox agent server: 218 pass, 0 fail
- Gateway frontend test: 16 pass, 0 fail
- API typecheck: exit 0
- Sandbox typecheck: exit 0
- Local real session returned model_source=project and completed with the configured project model and agent.

## Scope

The implementation contains no customer-specific provider or model identifier.