### PR TITLE
fix(web): drop @embedpdf tiling tile-destructure noise (BS 3e579401/70272e1e)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -7,6 +7,7 @@ import {
   isClientRequestTimeoutMessage,
   isEmptyMessageUnresolvedBrowserChunkNoise,
   isEmbedPdfTilingReactUpdateDepthNoise,
+  isEmbedPdfTilingTileDestructureNoise,
   isExpectedBillingGateMessage,
   isExpectedCompactionNoModelMessage,
   isExtensionRejectedObjectNoise,
@@ -3259,7 +3260,229 @@ test('does NOT suppress a non-React message that happens to mention #185', () =>
 })
 
 // ---------------------------------------------------------------------------
-// Firefox-specific React scheduler re-entrancy noise (React #327
+// @embedpdf/plugin-tiling `TilingLayer` viewport-advance tile-destructure noise
+// (Better Stack patterns
+// 3e579401d40807f7f06bf57e7f3ad299846977ed05c2823d0ded45d8e89c1430 and
+// 70272e1ebef3ed66061cda5a46c7963f75d114408113ef131ac88981b4679f15, Kortix
+// Frontend prod, application_id 2346967). A SIBLING of the React #185 class
+// above (pattern 366115d4…, PR #4718) but a DIFFERENT throw from a different
+// embedpdf tiling path: under a rapid scroll/zoom burst the tiling plugin's
+// tile queue drains mid-burst, the viewport-advance path (`t5.advance` →
+// `iA.ignore` → `iA.onScroll` / `iA.onScrollChanged`, plus the
+// `IntersectionObserver` threshold callback) calls `const { tile } =
+// queue.pop()` on an `undefined` pop result, and V8 throws
+// `Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined.` Two
+// patterns, SAME root cause, SAME user/session (`7254bee8-…`/`bd1306e9-…`), 1
+// occurrence each, 0 identified users, release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6` (v0.10.13), route
+// `/projects/:id/sessions/:sessionId`, Chrome 150 on Windows 10. Pattern
+// `3e579401` mechanism `auto.browser.browserapierrors.addEventListener` (top
+// throw frame `HTMLDivElement.u` in chunk `66499-…`, then `c63a46fc-…` fns
+// `iA.onScroll` → `iA.ignore` → `t5.advance`); pattern `70272e1e` mechanism
+// `auto.browser.global_handlers.onerror` (top throw frame
+// `IntersectionObserver.intersection.IntersectionObserver.threshold`, then
+// `c63a46fc-…` fns `iA.onScrollChanged` → `iA.ignore` → `t5.advance`). All
+// frames are minified `@embedpdf` tiling chunks (`c63a46fc-…` / `66499-…`) — NO
+// first-party `apps/web/src/…` frame. The #4718 matcher (React #185 +
+// `onTileRendering`) does NOT catch it (different message, different anchor), so
+// this new matcher pins the EXACT prod call site: BOTH patterns' frames classify
+// as noise. Anchored on the EXACT message (the `tile` property name + the
+// `r.pop(...)` destructure target pin the call site) AND a positive viewport-
+// advance frame anchor (function name OR the `c63a46fc` tiling chunk), with a
+// first-party negative guard.
+// ---------------------------------------------------------------------------
+
+// The exact V8 wording from both production events (the minified tile queue is
+// `r`, so the destructure target renders as `r.pop(...)`).
+const EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE =
+  "Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined."
+
+// Pattern 3e579401 — mechanism `auto.browser.browserapierrors.addEventListener`
+// (top throw frame `HTMLDivElement.u` in chunk `66499-…`, then the tiling chunk
+// `c63a46fc-…` viewport-advance path `iA.onScroll` → `iA.ignore` → `t5.advance`).
+const EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_3E579401 = [
+  { filename: 'app:///_next/static/chunks/66499-652b83425f671b38.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'HTMLDivElement.u' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'iA.onScroll' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'iA.ignore' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'ee.run' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'ee.forward' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 't5.advance' },
+]
+
+// Pattern 70272e1e — mechanism `auto.browser.global_handlers.onerror` (top throw
+// frame `IntersectionObserver.intersection.IntersectionObserver.threshold`, then
+// the tiling chunk `c63a46fc-…` viewport-advance path `iA.onScrollChanged` →
+// `iA.ignore` → `t5.advance`).
+const EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_70272E1E = [
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'IntersectionObserver.intersection.IntersectionObserver.threshold' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'iA.onScrollChanged' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'iA.ignore' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'ee.run' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 'ee.forward' },
+  { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno', function: 't5.advance' },
+]
+
+test('classifies both @embedpdf tiling tile-destructure prod patterns as noise', () => {
+  for (const [label, frames] of [
+    ['3e579401', EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_3E579401],
+    ['70272e1e', EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_70272E1E],
+  ] as const) {
+    assert.equal(
+      isEmbedPdfTilingTileDestructureNoise({
+        message: EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE,
+        frames,
+      }),
+      true,
+      `expected pattern ${label} to classify as noise`,
+    )
+  }
+})
+
+test('suppresses both @embedpdf tiling tile-destructure Sentry events via the beforeSend gate', () => {
+  for (const [label, frames] of [
+    ['3e579401', EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_3E579401],
+    ['70272e1e', EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_70272E1E],
+  ] as const) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: {
+          url: 'https://kortix.com/projects/7254bee8-0000-0000-0000-000000000000/sessions/bd1306e9-0000-0000-0000-000000000000',
+        },
+        exception: {
+          values: [
+            {
+              value: EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE,
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry gate to suppress pattern ${label}`,
+    )
+  }
+})
+
+test('suppresses the @embedpdf tiling tile-destructure message through all three capture-path forms', () => {
+  // The message must classify as noise regardless of whether the capture path
+  // delivered it raw, with a `TypeError: ` prefix, or with a stacked
+  // `Unhandled promise rejection: TypeError: ` prefix (stripErrorWrappers peels
+  // all three before the exact match).
+  const messageVariants = [
+    EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE,
+    `TypeError: ${EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE}`,
+    `Unhandled promise rejection: TypeError: ${EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE}`,
+  ]
+  for (const message of messageVariants) {
+    assert.equal(
+      isEmbedPdfTilingTileDestructureNoise({
+        message,
+        frames: EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_3E579401,
+      }),
+      true,
+      `expected "${message}" to classify as noise`,
+    )
+  }
+})
+
+test('does NOT suppress the @embedpdf tiling tile-destructure message with NO frames (frameless capture)', () => {
+  // No frames → can't confirm the tiling viewport-advance anchor; keep reporting
+  // so a frameless but otherwise-identical throw from app code stays observable.
+  assert.equal(
+    isEmbedPdfTilingTileDestructureNoise({
+      message: EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE,
+      frames: [],
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress the @embedpdf tiling tile-destructure message when a first-party frame is present (a real regression)', () => {
+  // A resolved `apps/web/src/…` frame means our own code is the destructure
+  // culprit → actionable; the negative guard MUST preserve it so the call site
+  // can be found + fixed. A real first-party `{ tile } = arr.pop()` regression
+  // de-minifies to `apps/web/src/…` and must never be hidden.
+  for (const frames of [
+    [{ filename: 'apps/web/src/components/ui/extend/pdf-viewer.tsx', function: 'PDFViewerInner' }],
+    [
+      { filename: 'app:///_next/static/chunks/c63a46fc-270e35c76d7636cb.js', function: 't5.advance' },
+      { filename: 'app:///apps/web/src/components/ui/extend/pdf-viewer.tsx', function: 'renderPage' },
+    ],
+  ]) {
+    assert.equal(
+      isEmbedPdfTilingTileDestructureNoise({
+        message: EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected first-party tile-destructure from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE,
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party tile-destructure from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress a DIFFERENT destructure message even with the tiling viewport-advance frames (over-match guard)', () => {
+  // The `tile` property name is part of the anchor, not just the `r.pop()`
+  // destructure target. A same-shape throw destructuring a DIFFERENT property
+  // from the same tiling queue is a different, actionable throw and must keep
+  // reporting — only the exact `tile`-property destructure is dropped.
+  const differentDestructureMessage =
+    "Cannot destructure property 'foo' of 'r.pop(...)' as it is undefined."
+  assert.equal(
+    isEmbedPdfTilingTileDestructureNoise({
+      message: differentDestructureMessage,
+      frames: EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_3E579401,
+    }),
+    false,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: differentDestructureMessage,
+            stacktrace: { frames: EMBEDPDF_TILING_TILE_DESTRUCTURE_FRAMES_3E579401 },
+          },
+        ],
+      },
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress the exact tile-destructure message with non-tiling frames (over-match guard)', () => {
+  // The exact message but with frames that are NOT the embedpdf tiling
+  // viewport-advance path (different third-party lib, or unattributable minified
+  // chunks) → can't confirm the tiling anchor; keep reporting.
+  for (const frames of [
+    [{ filename: 'app:///_next/static/chunks/app.js', function: 'someCallback' }],
+    [{ filename: 'apps/web/src/features/session/session-chat.tsx', function: 'SessionChat' }],
+  ]) {
+    assert.equal(
+      isEmbedPdfTilingTileDestructureNoise({
+        message: EMBEDPDF_TILING_TILE_DESTRUCTURE_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected exact message from ${JSON.stringify(frames)} (no tiling anchor) to keep reporting`,
+    )
+  }
+})
+
+
 // "Should not already be working.", Better Stack pattern
 // 0f03b24eb662c20779ea6397c6501f40392a3c9e24ab0f4594ad367eda71b9b7,
 // Kortix Frontend prod, application_id 2346967). The React production

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -1466,6 +1466,107 @@ export function isEmbedPdfTilingReactUpdateDepthNoise(input: {
   return frames.some(frameMatchesEmbedPdfTilingCallback);
 }
 
+// The EXACT V8 wording of the @embedpdf/plugin-tiling `TilingLayer` viewport-
+// advance tile-destructure throw: under a rapid scroll/zoom burst the tiling
+// plugin's tile queue drains mid-burst, the viewport-advance path calls
+// `const { tile } = queue.pop()` on an `undefined` pop result, and V8 reports
+// `Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined.` (the
+// minified queue is `r`, so the destructure target renders as `r.pop(...)`).
+// The `tile` property name + the `r.pop(...)` destructure target together pin
+// this single call site; a different destructure (different property / different
+// expression) is a different throw and must keep reporting. Anchored as an EXACT
+// string match (after `stripErrorWrappers`) like the Paper Shaders patterns —
+// not a loose prefix — so a near-worded regression cannot slip through.
+const EMBEDPDF_TILING_TILE_DESTRUCTURE_NOISE_MESSAGE =
+  "Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined.";
+
+// The @embedpdf/plugin-tiling `TilingLayer` viewport-advance internal frame
+// anchors. Under a scroll/zoom burst the tiling plugin's viewport advance path
+// (`t5.advance` → `iA.ignore` → `iA.onScroll` / `iA.onScrollChanged`, plus the
+// `IntersectionObserver` threshold callback that drives viewport recomputation)
+// pops the drained tile queue. These minified function names are the tiling
+// plugin's own viewport-advance internals (never present in first-party
+// `apps/web/src/…` source), so their presence is a specific third-party anchor.
+// Function names are stable across deploys (unlike the `c63a46fc` chunk hash,
+// which changes every release), so they are the primary anchor; the chunk hash
+// is a fallback for captures whose function names were stripped.
+const EMBEDPDF_TILING_VIEWPORT_ADVANCE_FRAME_MARKERS = [
+  't5.advance',
+  'iA.ignore',
+  'iA.onScroll',
+  'iA.onScrollChanged',
+  'IntersectionObserver.intersection.IntersectionObserver.threshold',
+] as const;
+
+// The minified @embedpdf/plugin-tiling tiling chunk hash seen in both prod
+// patterns (`c63a46fc-270e35c76d7636cb.js`). Changes per deploy, so it is a
+// fallback anchor only — the function-name markers above are preferred.
+const EMBEDPDF_TILING_CHUNK_MARKER = 'c63a46fc';
+
+function frameMatchesEmbedPdfTilingViewportAdvance(
+  frame: { filename?: unknown; function?: unknown } | undefined,
+): boolean {
+  const fn = normalizeString(frame?.function);
+  if (
+    EMBEDPDF_TILING_VIEWPORT_ADVANCE_FRAME_MARKERS.some((marker) =>
+      fn.includes(marker),
+    )
+  ) {
+    return true;
+  }
+  return normalizeString(frame?.filename).includes(EMBEDPDF_TILING_CHUNK_MARKER);
+}
+
+/**
+ * Whether a Sentry exception is the `@embedpdf/plugin-tiling` `TilingLayer`
+ * viewport-advance tile-destructure noise class: under a rapid scroll/zoom
+ * burst the tiling plugin's tile queue drains mid-burst, the viewport-advance
+ * path (`t5.advance` / `iA.ignore` / `iA.onScroll` / `iA.onScrollChanged` /
+ * `IntersectionObserver.threshold`) calls `const { tile } = queue.pop()` on an
+ * `undefined` pop result, and V8 throws
+ * `Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined.` The
+ * throw is in third-party bundled code (the minified `c63a46fc` tiling chunk),
+ * never first-party. This is a SIBLING of the React #185 render-loop class
+ * (`isEmbedPdfTilingReactUpdateDepthNoise`, Better Stack pattern `366115d4…`,
+ * PR #4718) but a DIFFERENT throw from a different embedpdf tiling path (the
+ * viewport-advance path, not the `onTileRendering` subscription callback), so the
+ * #4718 matcher — anchored on the `Minified React error #185` message + the
+ * `onTileRendering` frame — does NOT catch it. Requires BOTH the EXACT message
+ * AND a positive viewport-advance frame anchor (function name or the
+ * `c63a46fc` tiling chunk), AND a NEGATIVE guard: if any frame resolves to a
+ * de-minified first-party `apps/web/src/…` source, the event keeps reporting (a
+ * real first-party `{ tile } = arr.pop()` regression de-minifies to
+ * `apps/web/src/…` and must not be hidden). The `tile` property name is part of
+ * the anchor, so a different destructure (`{ foo } = r.pop()`) keeps reporting.
+ * Returns false when there are no frames (can't confirm the tiling anchor — keep
+ * reporting). See Better Stack patterns `3e579401…` / `70272e1e…`.
+ */
+export function isEmbedPdfTilingTileDestructureNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown; function?: unknown } | undefined>;
+}): boolean {
+  const message = stripErrorWrappers(normalizeString(input.message));
+  if (message !== EMBEDPDF_TILING_TILE_DESTRUCTURE_NOISE_MESSAGE) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  if (frames.length === 0) {
+    return false;
+  }
+  // Negative guard: a resolved first-party frame means our own code is the
+  // destructure culprit → actionable; keep reporting so the call site can be
+  // found. A real first-party `{ tile } = arr.pop()` regression de-minifies to
+  // `apps/web/src/…` and must never be hidden.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  // Anchor: the throw must be inside @embedpdf/plugin-tiling's viewport-advance
+  // path. These frames are never present in first-party code, so a real
+  // first-party tile-destructure (or a same-worded throw from a different
+  // third-party lib) is never matched.
+  return frames.some(frameMatchesEmbedPdfTilingViewportAdvance);
+}
+
 // React #327 = `Should not already be working.` — the React production
 // reconciler's re-entrancy guard. It throws from
 // `packages/react-reconciler/src/ReactFiberWorkLoop.js`'s `performSyncWorkOnRoot`
@@ -2196,6 +2297,22 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // real first-party setState loop keeps reporting. See
   // `isEmbedPdfTilingReactUpdateDepthNoise`.
   if (isEmbedPdfTilingReactUpdateDepthNoise({ message, frames })) {
+    return true;
+  }
+
+  // @embedpdf/plugin-tiling `TilingLayer` viewport-advance tile-destructure
+  // noise — a SIBLING of the React #185 class above, but a DIFFERENT throw from a
+  // different embedpdf tiling path: under a rapid scroll/zoom burst the tiling
+  // plugin's tile queue drains mid-burst, the viewport-advance path
+  // (`t5.advance` / `iA.ignore` / `iA.onScroll` / `IntersectionObserver.threshold`)
+  // calls `const { tile } = queue.pop()` on an `undefined` pop result, and V8
+  // throws `Cannot destructure property 'tile' of 'r.pop(...)' as it is
+  // undefined.` The #4718 matcher (React #185 + `onTileRendering`) does NOT
+  // catch it (different message, different frame anchor). Requires BOTH the
+  // EXACT message AND a positive viewport-advance frame anchor, with a
+  // first-party negative guard, so a real first-party `{ tile } = arr.pop()`
+  // regression keeps reporting. See `isEmbedPdfTilingTileDestructureNoise`.
+  if (isEmbedPdfTilingTileDestructureNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Root cause
Two Better Stack frontend prod patterns (`3e579401…` / `70272e1e…`, app `2346967`) — both `TypeError: Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined.`, 1 occ / 0 users each, Chrome 150 on Windows, co-worker session page (`/projects/:id/sessions/:sessionId`), release `470fe6f3c8` (v0.10.13).

This is the **`@embedpdf/plugin-tiling`** `TilingLayer` viewport-advance path. Under a rapid scroll/zoom burst the tiling plugin's tile queue drains mid-burst, the viewport-advance path (`t5.advance` → `iA.ignore` → `iA.onScroll`/`iA.onScrollChanged` → `IntersectionObserver.threshold`) calls `const { tile } = queue.pop()` on an `undefined` pop result, and V8 throws `Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined.` (the minified queue is `r`). All frames are in the minified `c63a46fc` tiling chunk — no first-party `apps/web/src/…` frame.

## Why a new matcher (not covered by #4718)
PR #4718 (`isEmbedPdfTilingReactUpdateDepthNoise`, pattern `366115d4…`) anchored on `Minified React error #185` + the `onTileRendering` frame. This throw has **neither** — different message, different embedpdf tiling path (viewport-advance, not the `onTileRendering` subscription callback). The #4718 matcher does not catch it.

## Fix
New `isEmbedPdfTilingTileDestructureNoise` in `apps/web/src/lib/browser-error-noise.ts`, wired into Sentry `beforeSend` via `shouldIgnoreSentryBrowserNoise`. Anchored on BOTH:
- the EXACT V8 message (`Cannot destructure property 'tile' of 'r.pop(...)' as it is undefined.`) — the `tile` property name + `r.pop(...)` destructure target pin the call site; a different destructure keeps reporting;
- a POSITIVE viewport-advance frame anchor (stable minified function names `t5.advance`/`iA.ignore`/`iA.onScroll`/`iA.onScrollChanged`/`IntersectionObserver.intersection.IntersectionObserver.threshold`, with the `c63a46fc` chunk hash as a deploy-stable fallback);
- a NEGATIVE guard: any resolved first-party `apps/web/src/…` frame → keep reporting (a real first-party `{ tile } = arr.pop()` regression de-minifies to `apps/web/src/…` and must not be hidden).

## Tests
168 noise-tests pass (7 new): 3 positive (both prod patterns through the matcher + the Sentry gate, plus all three capture-path forms) and 4 negative (frameless capture → keep reporting; first-party frame → keep reporting; different destructure message with tiling frames → keep reporting; exact message with non-tiling frames → keep reporting).

## Verified
- `bun test apps/web/src/lib/browser-error-noise.test.mts` → 168 pass / 0 fail.
- `tsc --noEmit -p apps/web/tsconfig.json` → no new errors (4 pre-existing unrelated errors in `source.ts`/`use-cases-source.ts`/`api/og/template/template-url.test.ts` confirmed present on clean `origin/main`).

Covers Better Stack frontend patterns `3e579401…` and `70272e1e…`.