### PR TITLE
fix(web): drop Paper Shaders WebGL-unsupported noise (BS f1abf79e)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -20,6 +20,7 @@ import {
   isOldWebkitRegexNoiseMessage,
   isOperationErrorPopErrorScopeNoise,
   isPaperShaderNullContextNoise,
+  isPaperShaderWebGLUnsupportedNoise,
   isRuntimeNotReadyNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
@@ -1955,6 +1956,246 @@ test('does NOT suppress a real app TypeError with a different null-property name
       }),
       false,
       `expected Sentry gate to keep reporting real app TypeError "${message}" even from a chunk frame`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Paper Shaders (`@paper-design/shaders-react`) WebGL-unsupported deliberate-
+// throw noise — a SIBLING of the null-context crash class above, but a DIFFERENT
+// throw. The library's OWN canonical
+//   "Paper Shaders: WebGL is not supported in this browser"
+// `Error` is thrown from the library's shader-mount constructor when WebGL is
+// unavailable (stripped-down/mobile WebView, headless renderer, WebGL disabled,
+// GPU blacklisted at context creation) — a deliberate library signal, NOT a
+// null-context `TypeError` from calling a WebGL2 method on a `null` context.
+// It escapes `<ShaderSafe>` (the library constructor runs inside a dynamic
+// import / `useEffect` that bypasses the React error boundary) and reaches
+// Sentry as an uncaught global `onunhandledrejection` — an EXPECTED
+// degradation state on WebGL-less browsers, never a product bug.
+//
+// Better Stack pattern
+// f1abf79ece48a86faf8eb32cec8bbb6bf270627f9fd5d423fb1ee43b9abcfb23
+// (Kortix Frontend prod, application_id 2346967): `Error`, message
+// `Paper Shaders: WebGL is not supported in this browser`, 1 occurrence /
+// 0 identified users (anonymous), last 2026-07-23 17:26:32 UTC, release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6` (v0.10.13), route `/`
+// (marketing homepage), mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT global
+// unhandledrejection — never reached a React error boundary). Browser: Chrome
+// 150.0.0.0 on Android 10 (mobile) — a stripped-down/mobile Android browser
+// without WebGL. Stack frames: 2, both minified `@paper-design/shaders`
+// chunk frames (NO first-party `apps/web/src/…` frame):
+//   - `app:///_next/static/chunks/81107-7c84018ef9475be5.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno`
+//     function `?` lineno 251 colno 3276
+//   - same chunk function `new a` lineno 401 colno 1131  (call_site_function)
+//
+// The matcher anchors on the EXACT library message (the `Paper Shaders:`
+// prefix is the library's canonical marker, never emitted by first-party app
+// code) AND a NEGATIVE guard: a resolved first-party `apps/web/src/…` frame
+// means our own code threw this exact message → a real first-party regression
+// (de-minified to `apps/web/src/…`) → keep reporting. The production noise
+// pattern carries only minified `@paper-design/shaders` chunk frames, so the
+// negative guard does not fire for it. A frameless capture with this exact
+// message still classifies as noise (the message alone is specific — the
+// `Paper Shaders:` library prefix is part of the anchor).
+// ---------------------------------------------------------------------------
+
+// The exact exception value + the two production `@paper-design/shaders` chunk
+// frames from Better Stack pattern `f1abf79e…`.
+const PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE =
+  'Paper Shaders: WebGL is not supported in this browser'
+
+const PAPER_SHADER_WEBGL_UNSUPPORTED_PROD_FRAMES = [
+  {
+    filename:
+      'app:///_next/static/chunks/81107-7c84018ef9475be5.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno',
+    function: '?',
+    lineno: 251,
+    colno: 3276,
+  },
+  {
+    filename:
+      'app:///_next/static/chunks/81107-7c84018ef9475be5.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno',
+    function: 'new a',
+    lineno: 401,
+    colno: 1131,
+  },
+]
+
+test('classifies the Paper Shaders WebGL-unsupported prod event as noise (exact message + 2 chunk frames)', () => {
+  // Exact production shape: the canonical library message + the two minified
+  // `@paper-design/shaders` chunk frames. No first-party `apps/web/src/…`
+  // frame, so the negative guard does not fire.
+  assert.equal(
+    isPaperShaderWebGLUnsupportedNoise({
+      message: PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE,
+      frames: PAPER_SHADER_WEBGL_UNSUPPORTED_PROD_FRAMES,
+    }),
+    true,
+  )
+})
+
+test('suppresses the Paper Shaders WebGL-unsupported prod Sentry event via the beforeSend gate', () => {
+  // Exact shape of the production event: mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (uncaught global
+  // unhandledrejection — never reached a React error boundary), request URL
+  // `https://kortix.com/` (the marketing homepage), the two minified
+  // `@paper-design/shaders` chunk frames.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/' },
+      exception: {
+        values: [
+          {
+            value: PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE,
+            stacktrace: {
+              frames: PAPER_SHADER_WEBGL_UNSUPPORTED_PROD_FRAMES,
+            },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('classifies the Paper Shaders WebGL-unsupported message through all three capture-path wrapper forms', () => {
+  // The raw `exception.values[].value` has no `Error: ` prefix, but Sentry
+  // capture paths vary — pin all three forms (raw, `Error: `, and
+  // `Unhandled promise rejection: Error: `) so the matcher classifies
+  // consistently regardless of which path delivered it. Use the production
+  // chunk frames so the matcher runs in its realistic frame context.
+  const wrapperForms = [
+    PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE,
+    `Error: ${PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE}`,
+    `Unhandled promise rejection: Error: ${PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE}`,
+  ]
+  for (const message of wrapperForms) {
+    assert.equal(
+      isPaperShaderWebGLUnsupportedNoise({
+        message,
+        frames: PAPER_SHADER_WEBGL_UNSUPPORTED_PROD_FRAMES,
+      }),
+      true,
+      `expected "${message}" to be classified as Paper Shaders WebGL-unsupported noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: message,
+              stacktrace: {
+                frames: PAPER_SHADER_WEBGL_UNSUPPORTED_PROD_FRAMES,
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry gate to suppress "${message}"`,
+    )
+  }
+})
+
+test('classifies the frameless Paper Shaders WebGL-unsupported capture as noise', () => {
+  // The message alone is specific enough (the `Paper Shaders:` library prefix
+  // is part of the anchor) that a frameless capture with this exact message
+  // still classifies as noise — the library throw never originates from
+  // first-party app code. Verify both the matcher and the Sentry gate.
+  assert.equal(
+    isPaperShaderWebGLUnsupportedNoise({
+      message: PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE,
+      frames: [],
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [{ value: PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE }],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the Paper Shaders WebGL-unsupported message when a first-party apps/web/src frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code threw this exact
+  // message → a real first-party regression (the `Paper Shaders:` prefix is
+  // the library's canonical marker, but a hostile/copy-pasted first-party
+  // throw could share it). The negative guard MUST preserve it so the call
+  // site can be found + fixed. This is the whole reason the matcher is
+  // frame-aware.
+  for (const frames of [
+    [{ filename: 'apps/web/src/components/ui/shader-safe.tsx', function: 'mount' }],
+    [
+      { filename: 'app:///_next/static/chunks/81107-abc.js', function: '?' },
+      { filename: 'app:///apps/web/src/features/marketing/hero.tsx', function: 'render' },
+    ],
+  ]) {
+    assert.equal(
+      isPaperShaderWebGLUnsupportedNoise({
+        message: PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE,
+        frames,
+      }),
+      false,
+      `expected first-party Paper Shaders WebGL-unsupported throw from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: PAPER_SHADER_WEBGL_UNSUPPORTED_MESSAGE,
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party Paper Shaders WebGL-unsupported throw from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress a near-worded message without the Paper Shaders: prefix', () => {
+  // The `Paper Shaders:` library prefix is part of the anchor — a near-worded
+  // message that lacks it (e.g. a real first-party `throw new Error('WebGL is
+  // not supported in this browser')`, or a different library's WebGL check)
+  // must keep reporting. The matcher anchors on the EXACT full library
+  // string, so an over-match guard is in place.
+  for (const message of [
+    'WebGL is not supported in this browser',
+    'Error: WebGL is not supported in this browser',
+    'WebGL is not supported',
+    'Paper Shaders: WebGL is not supported',
+    'Paper Shaders WebGL is not supported in this browser',
+  ]) {
+    assert.equal(
+      isPaperShaderWebGLUnsupportedNoise({
+        message,
+        frames: PAPER_SHADER_WEBGL_UNSUPPORTED_PROD_FRAMES,
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: message,
+              stacktrace: {
+                frames: PAPER_SHADER_WEBGL_UNSUPPORTED_PROD_FRAMES,
+              },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -290,6 +290,78 @@ const PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS = [
   "null is not an object (evaluating 'this.gl.getAttribLocation')",
 ] as const;
 
+// Paper Shaders (`@paper-design/shaders-react`) WebGL-unsupported deliberate
+// throw — a SIBLING of the null-context crash class above, but a DIFFERENT
+// throw. When the library's shader mount detects that WebGL is unavailable
+// (a stripped-down/mobile WebView, a headless renderer, a browser with WebGL
+// disabled, or a GPU blacklisted at context creation), the library throws its
+// OWN deliberate `Error('Paper Shaders: WebGL is not supported in this browser')`
+// from its constructor — NOT a null-context `TypeError` from calling a WebGL2
+// method on a `null` context (the `getSupportedExtensions` / `getAttribLocation`
+// wording covered by `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` above). The
+// `Paper Shaders:` prefix is the library's own canonical marker, so this exact
+// message is the library's deliberate signal that the browser cannot render the
+// decorative shader; it is an EXPECTED degradation state on WebGL-less browsers,
+// never a product bug.
+//
+// Better Stack pattern
+// f1abf79ece48a86faf8eb32cec8bbb6bf270627f9fd5d423fb1ee43b9abcfb23
+// (Kortix Frontend prod, application_id 2346967): `Error`, message
+// `Paper Shaders: WebGL is not supported in this browser`, 1 occurrence /
+// 0 identified users (anonymous), last 2026-07-23 17:26:32 UTC, release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6` (v0.10.13), route `/`
+// (marketing homepage), mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT global
+// unhandledrejection — never reached a React error boundary, `handled:false`).
+// Browser: Chrome 150.0.0.0 on Android 10 (mobile), UA
+// `Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko)
+// Chrome/150.0.0.0 Mobile Safari/537.36` — a stripped-down/mobile Android
+// browser without WebGL. Stack frames: 2, both minified
+// `@paper-design/shaders` chunk frames — NO first-party `apps/web/src/…`
+// frame:
+//   - `app:///_next/static/chunks/81107-7c84018ef9475be5.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno`
+//     function `?` lineno 251 colno 3276
+//   - same chunk function `new a` lineno 401 colno 1131  (call_site_function)
+//
+// The `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard that
+// degrades to the fallback BEFORE this throw fires (it calls
+// `getContext('webgl2')` + `getSupportedExtensions()` on a probe canvas and
+// treats a `null`/throw as unsupported). But the probe is a one-shot memo that
+// runs at first `render` of `<ShaderSafe>`, while the library's own `new a`
+// constructor throws synchronously on a browser where WebGL is `null` — and on
+// some code paths the probe's result is computed after the library has already
+// been dynamically imported and its constructor reached. The residual async
+// throw then escapes as an unhandled rejection (the library constructor runs
+// inside a dynamic import / `useEffect` that bypasses the React error
+// boundary). This matcher is the leak-path backstop for that residual throw,
+// the way `isPaperShaderNullContextNoise` is the backstop for the null-context
+// `TypeError` class.
+//
+// The message is the library's OWN canonical string (the `Paper Shaders:`
+// prefix is the library's deliberate marker, never emitted by first-party app
+// code), so an EXACT-message match is safe — a real first-party
+// `throw new Error('Paper Shaders: WebGL is not supported in this browser')`
+// regression is vanishingly unlikely AND would de-minify to `apps/web/src/…`
+// frames, which the mandatory negative guard below preserves. Unlike
+// `isPaperShaderNullContextNoise` (message-only, no negative guard — safe
+// because WebGL2 API method names are never called from first-party code),
+// this message COULD theoretically be thrown from first-party code, so the
+// first-party-frame negative guard MUST run when frames are present. The prod
+// event has only minified `81107` chunk frames, so the negative guard does
+// not fire for it. A frameless capture with this exact message still
+// classifies as noise (the message alone is specific — the `Paper Shaders:`
+// library prefix is part of the anchor). `Error: ` / `Unhandled promise
+// rejection: ` / `Unhandled promise rejection: Error: ` wrappers are stripped
+// before matching so all capture paths (window.onerror,
+// onunhandledrejection, Sentry exception) classify consistently. Deliberately
+// NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has
+// no frame context, so a bare-string match there could swallow a real
+// first-party throw the negative guard exists to preserve; the frame-aware
+// `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`) is the
+// only safe gate.
+const PAPER_SHADER_WEBGL_UNSUPPORTED_NOISE_MESSAGE =
+  'Paper Shaders: WebGL is not supported in this browser';
+
 // Old-browser / stripped-down-WebView minified-chunk parse failures. When a
 // browser that cannot parse modern minified JS (old Safari/iOS, legacy Android
 // WebView, in-app browsers, mail-client preview WebViews) tries to evaluate a
@@ -1141,6 +1213,71 @@ export function isPaperShaderNullContextNoise(message: unknown): boolean {
   return PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS.some((pattern) =>
     stripped.includes(pattern),
   );
+}
+
+/**
+ * Whether a Sentry event is the Paper Shaders
+ * (`@paper-design/shaders-react`) WebGL-unsupported deliberate-throw noise
+ * class: the library's OWN canonical
+ * `Paper Shaders: WebGL is not supported in this browser` `Error`, thrown from
+ * the library's shader-mount constructor when WebGL is unavailable (a
+ * stripped-down/mobile WebView, a headless renderer, a browser with WebGL
+ * disabled, or a GPU blacklisted at context creation). This is a SIBLING of
+ * the null-context crash class (`isPaperShaderNullContextNoise`), but a
+ * DIFFERENT throw — a deliberate library `Error`, NOT a null-context
+ * `TypeError` from calling a WebGL2 method on a `null` context. The throw
+ * escapes `<ShaderSafe>` (it fires from the library constructor inside a
+ * dynamic import / `useEffect` that bypasses the React error boundary) and
+ * reaches Sentry as an uncaught global `onunhandledrejection` — an EXPECTED
+ * degradation state on WebGL-less browsers, never a product bug. The
+ * `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard that
+ * degrades to the fallback BEFORE the throw; this matcher is the leak-path
+ * backstop for the residual async throw that bypasses the one-shot probe.
+ *
+ * Requires the EXACT library message (case-sensitive; the `Paper Shaders:`
+ * prefix is the library's canonical marker, never emitted by first-party
+ * app code) AND a NEGATIVE guard: if ANY frame resolves to a de-minified
+ * first-party `apps/web/src/…` source path, the event keeps reporting (a
+ * real first-party `throw new Error('Paper Shaders: WebGL is not supported
+ * in this browser')` regression de-minifies to `apps/web/src/…` and must not
+ * be hidden). The production noise pattern carries only minified
+ * `@paper-design/shaders` chunk frames, so the negative guard does not fire
+ * for it. A frameless capture with this exact message still classifies as
+ * noise (the message alone is specific — the `Paper Shaders:` library prefix
+ * is part of the anchor, so a near-worded `WebGL is not supported in this
+ * browser` without the prefix does NOT match). See
+ * `PAPER_SHADER_WEBGL_UNSUPPORTED_NOISE_MESSAGE` for the full rationale.
+ */
+export function isPaperShaderWebGLUnsupportedNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  // `stripErrorWrappers` strips `Unhandled promise rejection: ` and typed
+  // `<Name>Error: ` prefixes (e.g. `TypeError: `), but NOT a bare `Error: `
+  // (its `[A-Za-z]+Error:` requires a leading prefix). Sentry capture paths
+  // can deliver either shape, so additionally strip a leading bare `Error: `
+  // here — mirroring `isBareImageLoadNoiseMessage`'s explicit `Error: ` form.
+  const stripped = stripErrorWrappers(normalizeString(input.message)).replace(
+    /^Error: /,
+    '',
+  );
+  if (stripped !== PAPER_SHADER_WEBGL_UNSUPPORTED_NOISE_MESSAGE) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our
+  // own code threw this exact message → a real first-party regression (even
+  // though the `Paper Shaders:` prefix is the library's canonical marker, a
+  // hostile/copy-pasted first-party throw could share it). Keep reporting so
+  // the call site can be found + fixed. Only the library throw (minified
+  // `@paper-design/shaders` chunk frames, or frameless) is dropped. No second
+  // "any resolvable frame" guard is needed — the message is specific enough
+  // (the library's canonical string) that a frameless capture is safe to
+  // drop, unlike the generic `undefined` / `OperationError` matchers.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  return true;
 }
 
 // Strip the canonical `SyntaxError: ` / `Error: ` / `Unhandled promise
@@ -2057,6 +2194,23 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // the `<ShaderSafe>` error boundary and reaches Sentry as a global error.
   // Decorative-canvas noise on incompatible GPUs; never an app defect.
   if (isPaperShaderNullContextNoise(message)) {
+    return true;
+  }
+
+  // Paper Shaders WebGL-unsupported deliberate-throw noise — the library's
+  // OWN canonical `Paper Shaders: WebGL is not supported in this browser`
+  // `Error`, thrown from the library's shader-mount constructor when WebGL is
+  // unavailable (stripped-down/mobile WebView, headless renderer, WebGL
+  // disabled). A SIBLING of the null-context crash class above, but a
+  // DIFFERENT throw (a deliberate library `Error`, not a null-context
+  // `TypeError`). An EXPECTED degradation state on WebGL-less browsers;
+  // never a product bug. Requires the exact library message AND a NEGATIVE
+  // guard: a resolved first-party `apps/web/src/…` frame means our own code
+  // threw this exact message (a real first-party regression) → keep
+  // reporting. The production noise pattern carries only minified
+  // `@paper-design/shaders` chunk frames. NOT in `ignoreErrors` (no frame
+  // context there). See `isPaperShaderWebGLUnsupportedNoise`.
+  if (isPaperShaderWebGLUnsupportedNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo
Non-visual change — telemetry noise filter. No screen recording applies. Proof: 167/167 unit tests pass in `apps/web/src/lib/browser-error-noise.test.mts` (6 new tests pin the prod pattern, all wrapper forms, the frameless variant, and both negative guards).

## Why
Better Stack pattern `f1abf79ece48a86faf8eb32cec8bbb6bf270627f9fd5d423fb1ee43b9abcfb23` (Kortix Frontend prod, app `2346967`) pages on `Paper Shaders: WebGL is not supported in this browser` — the **`@paper-design/shaders-react`** library's OWN deliberate `Error`, thrown from its shader-mount constructor when WebGL is unavailable (a stripped-down/mobile Android WebView, a headless renderer, or a browser with WebGL disabled). 1 occurrence / 0 users, last 2026-07-23 17:26:32 UTC, release `470fe6f3…` (v0.10.13), route `/` (marketing homepage), mechanism `auto.browser.global_handlers.onunhandledrejection` (UNCAUGHT — never reached a React error boundary, `handled:false`). Browser: Chrome 150 on Android 10 — a mobile browser without WebGL. Stack: 2 frames, both minified `@paper-design/shaders` chunk `81107-…js` (function `?` and `new a`), **no first-party `apps/web/src/…` frame**.

This is an **EXPECTED degradation state** on WebGL-less browsers, not a product bug — a sibling of the null-context crash class already covered by `isPaperShaderNullContextNoise`, but a **DIFFERENT throw** (a deliberate library `Error`, NOT a null-context `TypeError` from calling `getSupportedExtensions`/`getAttribLocation` on a `null` context). The existing `PAPER_SHADER_NULL_CONTEXT_NOISE_PATTERNS` cover ONLY the null-deref wording, NOT this deliberate message, so it escapes the filter and pages Better Stack.

## What changed
- Added `PAPER_SHADER_WEBGL_UNSUPPORTED_NOISE_MESSAGE` constant + `isPaperShaderWebGLUnsupportedNoise(input)` matcher in `apps/web/src/lib/browser-error-noise.ts`, wired into Sentry `beforeSend` via `shouldIgnoreSentryBrowserNoise`.
- Anchors on the **EXACT** library message `Paper Shaders: WebGL is not supported in this browser` (case-sensitive; the `Paper Shaders:` prefix is the library's canonical marker, never emitted by first-party app code). Also strips the `Unhandled promise rejection: ` / typed `Error: ` / bare `Error: ` wrapper forms so all capture paths classify consistently.
- **Negative guard (mandatory):** if ANY frame resolves to a de-minified first-party `apps/web/src/…` source, the event **keeps reporting** — a real first-party `throw new Error('Paper Shaders: WebGL is not supported in this browser')` regression de-minifies to `apps/web/src/…` and must not be hidden. The prod event has only minified `81107` chunk frames, so the negative guard does not fire for it.
- A **frameless** capture with this exact message still classifies as noise (the message alone is specific — the `Paper Shaders:` library prefix is part of the anchor, so a near-worded `WebGL is not supported in this browser` without the prefix does NOT match). This mirrors `isOperationErrorPopErrorScopeNoise`'s exact-message + first-party-frame negative-guard structure (no second "any resolvable frame" guard needed, since the message is the library's canonical string, not a generic `undefined`/`OperationError`).
- Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party throw the negative guard exists to preserve. The frame-aware `beforeSend` hook is the only safe gate.

The `supportsWebGL2()` probe in `shader-safe.tsx` is the primary guard that degrades to the fallback BEFORE the throw; this matcher is the leak-path backstop for the residual async throw that bypasses the one-shot probe (the library constructor runs inside a dynamic import / `useEffect` that escapes the React error boundary).

## Verification
- `bun test src/lib/browser-error-noise.test.mts` → **167 pass / 0 fail** (161 prior + 6 new).
- `tsc --noEmit -p tsconfig.json` → only the 4 pre-existing unrelated errors (`source.ts`, `use-cases-source.ts`, `api/og/template-url.test.ts` ×2); no new errors.

New tests pin:
1. The prod pattern through both `isPaperShaderWebGLUnsupportedNoise` AND `shouldIgnoreSentryBrowserNoise` (with the 2 prod `81107` chunk frames) → noise.
2. All three capture-path wrapper forms (raw, `Error: `, `Unhandled promise rejection: Error: `) → noise.
3. Frameless variant (no frames) → still noise.
4. NEGATIVE: same message with a first-party `apps/web/src/…` frame → keep reporting.
5. NEGATIVE: a near-worded but DIFFERENT message without the `Paper Shaders:` prefix (`WebGL is not supported in this browser`, etc.) → keep reporting.

## Risk / rollback
Telemetry-only: a browser-noise matcher that suppresses one deliberate library throw. Worst case is a real first-party throw with this exact message AND no resolved `apps/web/src/…` frame being hidden — but the negative guard + the message-specificity (library canonical string) make that vanishingly unlikely. Revert the single commit to restore prior behavior.

Better Stack error: https://kortix.ai/e/f1abf79ece48a86faf8eb32cec8bbb6bf270627f9fd5d423fb1ee43b9abcfb23
