### PR TITLE
fix(ke2e): bound session release gate flows

### DIFF
--- a/apps/api/src/__tests__/unit-admin-account-session-limit.test.ts
+++ b/apps/api/src/__tests__/unit-admin-account-session-limit.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  MAX_ACCOUNT_SESSION_LIMIT,
+  parseAccountSessionLimit,
+  setAccountSessionLimit,
+} from '../admin/account-session-limit';
+
+describe('admin account session limit', () => {
+  test('accepts null and bounded positive integers', () => {
+    expect(parseAccountSessionLimit(null)).toBeNull();
+    expect(parseAccountSessionLimit(1)).toBe(1);
+    expect(parseAccountSessionLimit(MAX_ACCOUNT_SESSION_LIMIT)).toBe(MAX_ACCOUNT_SESSION_LIMIT);
+  });
+
+  test('rejects non-integers and values outside the supported range', () => {
+    for (const value of [undefined, '1', 0, -1, 1.5, MAX_ACCOUNT_SESSION_LIMIT + 1]) {
+      expect(() => parseAccountSessionLimit(value)).toThrow(
+        `max_concurrent_sessions must be null or an integer from 1 to ${MAX_ACCOUNT_SESSION_LIMIT}`,
+      );
+    }
+  });
+
+  test('persists the override, clears the cache, and records the audit event', async () => {
+    const calls: string[] = [];
+    const result = await setAccountSessionLimit(
+      {
+        accountId: 'account-1',
+        actorUserId: 'admin-1',
+        maxConcurrentSessions: 1,
+        ip: '203.0.113.10',
+        userAgent: 'ke2e',
+      },
+      {
+        getCurrent: async () => {
+          calls.push('get');
+          return 25;
+        },
+        persist: async (accountId, value) => {
+          calls.push(`persist:${accountId}:${value}`);
+        },
+        clearCache: () => {
+          calls.push('clear');
+        },
+        recordAudit: async (event) => {
+          calls.push(
+            `audit:${event.action}:${event.before?.max_concurrent_sessions}:${event.after?.max_concurrent_sessions}`,
+          );
+        },
+      },
+    );
+
+    expect(result).toEqual({ previous: 25, current: 1 });
+    expect(calls).toEqual([
+      'get',
+      'persist:account-1:1',
+      'clear',
+      'audit:admin.account.session_limit.set:25:1',
+    ]);
+  });
+
+  test('restores the tier-derived behavior with a null override', async () => {
+    const persisted: Array<number | null> = [];
+    const result = await setAccountSessionLimit(
+      {
+        accountId: 'account-1',
+        actorUserId: 'admin-1',
+        maxConcurrentSessions: null,
+        ip: null,
+        userAgent: null,
+      },
+      {
+        getCurrent: async () => 1,
+        persist: async (_accountId, value) => {
+          persisted.push(value);
+        },
+        clearCache: () => undefined,
+        recordAudit: async () => undefined,
+      },
+    );
+
+    expect(result).toEqual({ previous: 1, current: null });
+    expect(persisted).toEqual([null]);
+  });
+});

--- a/apps/api/src/admin/account-session-limit.ts
+++ b/apps/api/src/admin/account-session-limit.ts
@@ -1,0 +1,62 @@
+import type { AuditEventInput } from '../shared/audit';
+
+export const MAX_ACCOUNT_SESSION_LIMIT = 100_000;
+
+const VALIDATION_MESSAGE = `max_concurrent_sessions must be null or an integer from 1 to ${MAX_ACCOUNT_SESSION_LIMIT}`;
+
+export function parseAccountSessionLimit(value: unknown): number | null {
+  if (value === null) return null;
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > MAX_ACCOUNT_SESSION_LIMIT
+  ) {
+    throw new Error(VALIDATION_MESSAGE);
+  }
+  return value;
+}
+
+interface SetAccountSessionLimitInput {
+  accountId: string;
+  actorUserId: string | null;
+  maxConcurrentSessions: unknown;
+  ip: string | null;
+  userAgent: string | null;
+}
+
+interface SetAccountSessionLimitDependencies {
+  getCurrent(): Promise<number | null>;
+  persist(accountId: string, value: number | null): Promise<void>;
+  clearCache(): void;
+  recordAudit(event: AuditEventInput): Promise<void>;
+}
+
+export async function setAccountSessionLimit(
+  input: SetAccountSessionLimitInput,
+  dependencies: SetAccountSessionLimitDependencies,
+): Promise<{ previous: number | null; current: number | null }> {
+  const current = parseAccountSessionLimit(input.maxConcurrentSessions);
+  const previous = await dependencies.getCurrent();
+
+  await dependencies.persist(input.accountId, current);
+  dependencies.clearCache();
+
+  try {
+    await dependencies.recordAudit({
+      accountId: input.accountId,
+      actorUserId: input.actorUserId,
+      action: 'admin.account.session_limit.set',
+      resourceType: 'credit_account',
+      resourceId: input.accountId,
+      before: { max_concurrent_sessions: previous },
+      after: { max_concurrent_sessions: current },
+      ip: input.ip,
+      userAgent: input.userAgent,
+    });
+  } catch (error) {
+    console.error('[admin] Failed to record account session-limit audit event:', error);
+  }
+
+  return { previous, current };
+}

--- a/apps/api/src/admin/index.ts
+++ b/apps/api/src/admin/index.ts
@@ -16,6 +16,7 @@ import type { AppEnv } from '../types';
 import { supabaseAuth } from '../middleware/auth';
 import { requireAdmin } from '../middleware/require-admin';
 import { makeOpenApiApp, json, errors, auth } from '../openapi';
+import { MAX_ACCOUNT_SESSION_LIMIT, setAccountSessionLimit } from './account-session-limit';
 
 export const adminApp = makeOpenApiApp<AppEnv>();
 
@@ -174,7 +175,6 @@ adminApp.openapi(
   }
   },
 );
-
 // ── Account members ──────────────────────────────────────────────────────────
 adminApp.openapi(
   createRoute({
@@ -487,6 +487,78 @@ adminApp.openapi(
     }
 
     return c.json({ ok: true, tier });
+  } catch (e: any) {
+    return c.json({ error: e?.message || String(e) }, 500);
+  }
+  },
+);
+
+// ── Set account concurrent-session override ─────────────────────────────────
+// `null` restores the tier-derived limit. Operators use this route for account
+// policy changes and for bounded end-to-end limit verification.
+adminApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/api/accounts/{id}/session-limit',
+    tags: ['admin'],
+    summary: "Set an account's concurrent-session override",
+    ...auth,
+    request: {
+      params: z.object({ id: z.string() }),
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              max_concurrent_sessions: z.number().int().min(1).max(MAX_ACCOUNT_SESSION_LIMIT).nullable(),
+            }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: json(
+        z.object({
+          ok: z.boolean(),
+          previous: z.number().int().nullable(),
+          current: z.number().int().nullable(),
+        }),
+        'Updated concurrent-session override',
+      ),
+      400: json(z.record(z.string(), z.any()), 'Bad request'),
+      500: json(z.record(z.string(), z.any()), 'Server error'),
+      ...errors(401, 403),
+    },
+  }),
+  async (c: any) => {
+  try {
+    const accountId = c.req.param('id');
+    const actorUserId = (c.get('userId') as string | undefined) ?? null;
+    const body = c.req.valid('json') as { max_concurrent_sessions: number | null };
+    const { getSubscriptionInfo, upsertCreditAccount } = await import(
+      '../billing/repositories/credit-accounts'
+    );
+    const { clearAccountLimitCache } = await import('../shared/account-limits');
+    const { recordAuditEvent } = await import('../shared/audit');
+
+    const result = await setAccountSessionLimit(
+      {
+        accountId,
+        actorUserId,
+        maxConcurrentSessions: body.max_concurrent_sessions,
+        ip: c.req.header('x-forwarded-for')?.split(',')[0]?.trim() || null,
+        userAgent: c.req.header('user-agent') || null,
+      },
+      {
+        getCurrent: async () => (await getSubscriptionInfo(accountId))?.maxConcurrentSessions ?? null,
+        persist: async (id, value) => {
+          await upsertCreditAccount(id, { maxConcurrentSessions: value });
+        },
+        clearCache: clearAccountLimitCache,
+        recordAudit: recordAuditEvent,
+      },
+    );
+
+    return c.json({ ok: true, ...result });
   } catch (e: any) {
     return c.json({ error: e?.message || String(e) }, 500);
   }

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 501,
+  "count": 502,
   "routes": [
     {
       "method": "GET",
@@ -481,6 +481,10 @@
     {
       "method": "GET",
       "path": "/v1/admin/api/accounts/:id/projects"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/admin/api/accounts/:id/session-limit"
     },
     {
       "method": "POST",

--- a/tests/src/core/session-runtime-retry.ts
+++ b/tests/src/core/session-runtime-retry.ts
@@ -1,0 +1,9 @@
+export function markSessionReadinessTimeoutRetryable(error: unknown, sessionId: string): unknown {
+  if (
+    error instanceof Error &&
+    error.message === `Timed out waiting for session runtime ready for ${sessionId}`
+  ) {
+    (error as Error & { ke2eRetryable?: boolean }).ke2eRetryable = true;
+  }
+  return error;
+}

--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -29,6 +29,7 @@
 import { flow } from '../core/flow';
 import { isKe2eRetryableError } from '../core/client';
 import { waitFor, sleep } from '../core/poll';
+import { markSessionReadinessTimeoutRetryable } from '../core/session-runtime-retry';
 import type { FlowContext } from '../core/types';
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
@@ -40,32 +41,36 @@ async function waitForSessionReady(
   sessionId: string,
   timeoutMs = 300_000,
 ): Promise<any> {
-  return waitFor(
-    async () => {
-      const r = await ctx.client.as(ctx.P.OWNER).post(
-        '/v1/projects/:projectId/sessions/:sessionId/start',
-        {},
-        {
-          params: { projectId, sessionId },
-          query: { wait_ms: '8000' },
-          // The server may hold the request for the full 8s wait window, and
-          // Cloudflare/ECS transit can add several more seconds under load.
-          timeoutMs: 25_000,
-        },
-      );
-      if (r.statusCode >= 500 && r.statusCode <= 599) return null;
-      r.status(200);
-      return r.json<any>();
-    },
-    {
-      until: (s) =>
-        s?.stage === 'ready' && Boolean(s?.sandbox?.external_id ?? s?.sandbox?.externalId),
-      timeoutMs,
-      intervalMs: 3_000,
-      description: `session runtime ready for ${sessionId}`,
-      retryOnError: isKe2eRetryableError,
-    },
-  );
+  try {
+    return await waitFor(
+      async () => {
+        const r = await ctx.client.as(ctx.P.OWNER).post(
+          '/v1/projects/:projectId/sessions/:sessionId/start',
+          {},
+          {
+            params: { projectId, sessionId },
+            query: { wait_ms: '8000' },
+            // The server may hold the request for the full 8s wait window, and
+            // Cloudflare/ECS transit can add several more seconds under load.
+            timeoutMs: 25_000,
+          },
+        );
+        if (r.statusCode >= 500 && r.statusCode <= 599) return null;
+        r.status(200);
+        return r.json<any>();
+      },
+      {
+        until: (s) =>
+          s?.stage === 'ready' && Boolean(s?.sandbox?.external_id ?? s?.sandbox?.externalId),
+        timeoutMs,
+        intervalMs: 3_000,
+        description: `session runtime ready for ${sessionId}`,
+        retryOnError: isKe2eRetryableError,
+      },
+    );
+  } catch (error) {
+    throw markSessionReadinessTimeoutRetryable(error, sessionId);
+  }
 }
 
 /**
@@ -439,6 +444,7 @@ flow(
     domain: 'agent-run',
     requires: ['funded', 'daytona'],
     timeoutMs: 360_000,
+    retry: { attempts: 2 },
     routes: [
       'POST /v1/projects/:projectId/sessions',
       'POST /v1/projects/:projectId/sessions/:sessionId/start',
@@ -491,24 +497,39 @@ flow(
   },
 );
 
-// ─── SESS-2: concurrency cap — Nth session over tier cap → 429 + RateLimit hdrs
+// ─── SESS-2: concurrency cap — second session at limit 1 → 429 + headers ────
 flow(
   'SESS-2',
   {
     domain: 'sessions',
-    requires: ['funded', 'daytona'],
+    requires: ['admin', 'funded', 'daytona'],
     serial: true,
     timeoutMs: 300_000,
-    routes: ['POST /v1/projects/:projectId/sessions'],
+    routes: [
+      'POST /v1/admin/api/accounts/:id/session-limit',
+      'POST /v1/projects/:projectId/sessions',
+    ],
   },
   async (ctx) => {
-    const project = await ctx.fixtures.project({ seed: true });
-    await ctx.step('creating sessions past the tier cap → 429 + X-RateLimit headers', async () => {
-      // Fire sessions until one is rejected with 429 (the concurrency cap). The
-      // cap is tier-bound and modest; we bound the loop so a misconfigured (very
-      // high) cap doesn't run away.
-      let capped: any = null;
-      for (let i = 0; i < 25 && !capped; i++) {
+    if (!ctx.env.adminToken) {
+      throw new Error('SESS-2 requires the run-scoped platform-admin token');
+    }
+    const admin = ctx.client.withBearer(ctx.env.adminToken, 'ADMIN_TOKEN');
+    let previousLimit: number | null | undefined;
+
+    await ctx.step('set the run account concurrent-session override to 1', async () => {
+      const r = await admin.post(
+        '/v1/admin/api/accounts/:id/session-limit',
+        { max_concurrent_sessions: 1 },
+        { params: { id: ctx.P.accountId } },
+      );
+      r.status(200);
+      previousLimit = r.json<{ previous: number | null }>().previous;
+    });
+
+    try {
+      const project = await ctx.fixtures.project({ seed: true });
+      await ctx.step('first session at limit 1 → 201', async () => {
         const r = await ctx.client
           .as(ctx.P.OWNER)
           .post(
@@ -516,17 +537,35 @@ flow(
             { initial_prompt: 'noop' },
             { params: { projectId: project.id } },
           );
-        if (r.statusCode === 201) {
-          const id = r.json<any>()?.session_id ?? r.json<any>()?.id;
-          if (id) ctx.track('session', id, { projectId: project.id });
-          continue;
-        }
-        if (r.statusCode === 429) capped = r;
-        else break; // any other status (402/403/…) ends the probe
+        r.status(201);
+        const body = r.json<{ session_id?: string; id?: string }>();
+        const id = body.session_id ?? body.id;
+        if (!id) throw new Error(`session create returned no id: ${r.text()}`);
+        ctx.track('session', id, { projectId: project.id });
+      });
+
+      await ctx.step('second session over limit 1 → 429 + X-RateLimit headers', async () => {
+        const r = await ctx.client
+          .as(ctx.P.OWNER)
+          .post(
+            '/v1/projects/:projectId/sessions',
+            { initial_prompt: 'noop' },
+            { params: { projectId: project.id } },
+          );
+        r.status(429).headerExists('x-ratelimit-limit').headerExists('x-ratelimit-remaining');
+      });
+    } finally {
+      if (previousLimit !== undefined) {
+        await ctx.step('restore the previous concurrent-session override', async () => {
+          const r = await admin.post(
+            '/v1/admin/api/accounts/:id/session-limit',
+            { max_concurrent_sessions: previousLimit },
+            { params: { id: ctx.P.accountId } },
+          );
+          r.status(200);
+        });
       }
-      if (!capped) ctx.skip('concurrency cap not reached within probe budget on this tier');
-      capped.status(429).headerExists('x-ratelimit-limit').headerExists('x-ratelimit-remaining');
-    });
+    }
   },
 );
 

--- a/tests/unit/session-runtime-retry.test.ts
+++ b/tests/unit/session-runtime-retry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { markSessionReadinessTimeoutRetryable } from '../src/core/session-runtime-retry';
+
+describe('session runtime retry classification', () => {
+  it('marks only the named session readiness timeout as retryable', () => {
+    const sessionId = 'session-1';
+    const readinessTimeout = new Error(
+      `Timed out waiting for session runtime ready for ${sessionId}`,
+    );
+
+    expect(markSessionReadinessTimeoutRetryable(readinessTimeout, sessionId)).toBe(
+      readinessTimeout,
+    );
+    expect((readinessTimeout as Error & { ke2eRetryable?: boolean }).ke2eRetryable).toBe(true);
+  });
+
+  it('does not mark contract errors or another session timeout', () => {
+    const contractError = new Error('status expected 200, received 400');
+    const otherSession = new Error('Timed out waiting for session runtime ready for session-2');
+
+    expect(markSessionReadinessTimeoutRetryable(contractError, 'session-1')).toBe(contractError);
+    expect(markSessionReadinessTimeoutRetryable(otherSession, 'session-1')).toBe(otherSession);
+    expect((contractError as Error & { ke2eRetryable?: boolean }).ke2eRetryable).toBeUndefined();
+    expect((otherSession as Error & { ke2eRetryable?: boolean }).ke2eRetryable).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add an admin-only account session-limit route.
- Refactor `SESS-2` to create one session and assert the second request returns `429`.
- Restore the previous account override in `finally`.
- Retry `RUN-8` once only when session runtime readiness times out.
- Preserve cleanup between retry attempts.

## Verification

- `pnpm typecheck` in `apps/api`: passed.
- `pnpm typecheck` in `tests`: passed.
- `pnpm coverage` in `tests`: `493/502` routes covered, `9` allowlisted, `0` uncovered.
- Focused API tests: `10 passed, 0 failed`.
- Focused release-gate tests: `10 passed, 0 failed`.
- Local HTTP set override: `200`, previous `null`, current `1`.
- Local HTTP restore override: `200`, previous `1`, current `null`.

## Live verification

- Run `SESS-2` and `RUN-8` against dev after deployment.
- Local session creation stopped at `503 KORTIX_URL_UNREACHABLE` because the isolated API used a loopback callback URL.