### PR TITLE
feat(kaab): agents declare connectors_personal — auto-require the user's own connection

### DIFF
--- a/apps/api/src/projects/agents.test.ts
+++ b/apps/api/src/projects/agents.test.ts
@@ -33,7 +33,8 @@ mock.module('./git', () => ({
 }));
 
 const { loadProjectAgents } = await import('./agents');
-const { DEFAULT_AGENT_SENTINEL, resolveGovernedAgentGrant } = await import('./agents');
+const { DEFAULT_AGENT_SENTINEL, resolveGovernedAgentGrant, personalConnectorsForAgent } =
+  await import('./agents');
 
 const fakeProject = () => ({
   projectId: 'proj_blank',
@@ -116,5 +117,62 @@ describe('loadProjectAgents — blank managed project (no manifest committed yet
 
     expect(loaded.defaultAgent).toBe('support');
     expect(loaded.specs.map((s) => s.name)).toEqual(['support']);
+  });
+});
+
+describe('connectors_personal — v2 agent personal-connector declaration', () => {
+  test('parses a valid subset of the connectors grant, resolvable by name AND the default sentinel', async () => {
+    manifestFile = {
+      path: 'kortix.yaml',
+      content: [
+        'kortix_version: 2',
+        'default_agent: support',
+        'agents:',
+        '  support:',
+        '    connectors: [gmail, slack]',
+        '    connectors_personal: [gmail]',
+        '',
+      ].join('\n'),
+    };
+    const loaded = await loadProjectAgents(fakeProject());
+    expect(loaded.errors).toEqual([]);
+    expect(loaded.specs.find((s) => s.name === 'support')?.connectorsPersonal).toEqual(['gmail']);
+    expect(personalConnectorsForAgent('support', loaded)).toEqual(['gmail']);
+    // the `default` sentinel resolves to the manifest's default_agent (support)
+    expect(personalConnectorsForAgent(DEFAULT_AGENT_SENTINEL, loaded)).toEqual(['gmail']);
+  });
+
+  test('rejects a personal connector that is not in the connectors grant', async () => {
+    manifestFile = {
+      path: 'kortix.yaml',
+      content: [
+        'kortix_version: 2',
+        'default_agent: support',
+        'agents:',
+        '  support:',
+        '    connectors: [gmail]',
+        '    connectors_personal: [slack]',
+        '',
+      ].join('\n'),
+    };
+    const loaded = await loadProjectAgents(fakeProject());
+    expect(loaded.errors.length).toBeGreaterThan(0);
+    expect(loaded.errors[0]?.error).toContain('subset of connectors');
+  });
+
+  test('an agent that declares none yields no personal connectors', async () => {
+    manifestFile = {
+      path: 'kortix.yaml',
+      content: [
+        'kortix_version: 2',
+        'default_agent: support',
+        'agents:',
+        '  support:',
+        '    connectors: [gmail]',
+        '',
+      ].join('\n'),
+    };
+    const loaded = await loadProjectAgents(fakeProject());
+    expect(personalConnectorsForAgent('support', loaded)).toEqual([]);
   });
 });

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -84,6 +84,10 @@ export interface AgentSpec {
   enabled: boolean;
   /** Which connector profiles (by slug) this agent may use. `[]` = none (default). */
   connectors: GrantSet;
+  /** Subset of `connectors` that must resolve to the LAUNCHING USER's OWN member
+   *  connection (v2 `connectors_personal`). A session with this agent auto-requires
+   *  these — like the caller passing require_connectors. Omitted/[] = none. */
+  connectorsPersonal?: string[];
   /** Kortix CLI/API powers (project-scoped iam actions). `[]` = none (default). */
   kortixCli: GrantSet;
   /** Project-secret IDENTIFIERS (project_secrets.identifier, not raw env-var
@@ -357,6 +361,24 @@ export function grantFromLoadedAgents(agentName: string, loaded: LoadedAgents): 
 }
 
 /**
+ * The connector aliases this agent declares as PERSONAL (`connectors_personal`) —
+ * a session started with the agent must resolve each to the launching user's OWN
+ * connection. Mirrors grantFromLoadedAgents' agent resolution (a concrete name,
+ * or the `default` sentinel → the manifest's `default_agent`). Returns [] when the
+ * project has no per-agent governance, or the agent isn't found/enabled, or it
+ * declares none. v1 agents never set connectorsPersonal, so this is always [].
+ */
+export function personalConnectorsForAgent(agentName: string, loaded: LoadedAgents): string[] {
+  if (loaded.specs.length === 0 && loaded.errors.length === 0) return [];
+  const spec =
+    loaded.specs.find((s) => s.name === agentName && s.enabled) ??
+    (agentName === DEFAULT_AGENT_SENTINEL && loaded.defaultAgent
+      ? loaded.specs.find((s) => s.name === loaded.defaultAgent && s.enabled)
+      : undefined);
+  return spec?.connectorsPersonal ?? [];
+}
+
+/**
  * Is this project subject to MANDATORY DECLARED AGENTS enforcement?
  * (docs/specs/2026-07-05-agent-first-config-unification.md §2.1/§3 Phase 2)
  *
@@ -619,6 +641,31 @@ function parseAgentEntryV2(name: string, block: unknown, filename: string): Pars
 
   const connectorsResolved = resolveGrantSet(row.connectors, 'none');
 
+  // connectors_personal: a concrete subset of the connectors grant that must
+  // resolve to the launching user's OWN connection. Deny-by-default (omitted → []).
+  let connectorsPersonal: string[] = [];
+  if (row.connectors_personal !== undefined && row.connectors_personal !== null) {
+    if (
+      !Array.isArray(row.connectors_personal) ||
+      !row.connectors_personal.every((a) => typeof a === 'string')
+    ) {
+      return err(name, `agents.${name}.connectors_personal must be a list of connector names`);
+    }
+    connectorsPersonal = Array.from(new Set(row.connectors_personal as string[]));
+    // An ungranted connector can never be personally required (it isn't usable at
+    // all), so connectors_personal must be a subset of the connectors grant.
+    if (connectorsResolved !== 'all') {
+      const granted = new Set<string>(connectorsResolved === 'none' ? [] : connectorsResolved);
+      const notGranted = connectorsPersonal.filter((alias) => !granted.has(alias));
+      if (notGranted.length > 0) {
+        return err(
+          name,
+          `agents.${name}.connectors_personal must be a subset of connectors — not granted: ${notGranted.join(', ')}`,
+        );
+      }
+    }
+  }
+
   const kortixResolved = resolveGrantSet(row.kortix_cli, 'none');
   if (Array.isArray(kortixResolved)) {
     for (const action of kortixResolved) {
@@ -640,6 +687,7 @@ function parseAgentEntryV2(name: string, block: unknown, filename: string): Pars
       path: `${filename}#agents.${name}`,
       enabled,
       connectors: toGrantSet(connectorsResolved),
+      connectorsPersonal,
       kortixCli: toGrantSet(kortixResolved),
       env: toGrantSet(secretsResolved),
       file,

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -35,6 +35,7 @@ import { DEFAULT_SANDBOX_SLUG, resolveTemplate } from '../../snapshots/builder';
 import {
   grantFromLoadedAgents,
   loadProjectAgents,
+  personalConnectorsForAgent,
   projectRequiresDeclaredAgents,
   resolveGovernedAgentGrant,
 } from '../agents';
@@ -776,16 +777,28 @@ export async function createProjectSession(input: {
     }
   }
 
+  // Agent-declared personal connectors (connectors_personal): a session with this
+  // agent auto-requires the launching user's OWN connection for each — but only
+  // for an interactive ('user') session. A backend/service-account session has no
+  // single current user and manages connectors explicitly via connector_bindings,
+  // so its agent's personal declaration is not enforced here.
+  const loadedAgents = await loadProjectAgents(project);
+  const agentPersonalConnectors =
+    origin === 'user' ? personalConnectorsForAgent(agentName, loadedAgents) : [];
+  const effectiveRequireConnectors = Array.from(
+    new Set<string>([...requireConnectors, ...agentPersonalConnectors]),
+  );
+
   // Every connector this session touches — whether the caller bound it explicitly
-  // (connector_bindings) or requires the user's own (require_connectors) — must be
-  // granted to the session's agent.
+  // (connector_bindings) or it's required as the user's own (require_connectors or
+  // the agent's connectors_personal) — must be granted to the session's agent.
   const grantCheckAliases = new Set<string>([
     ...(parsedConnectorBindings.bindings ? Object.keys(parsedConnectorBindings.bindings) : []),
-    ...requireConnectors,
+    ...effectiveRequireConnectors,
   ]);
   let loadedAgentGrant: ReturnType<typeof grantFromLoadedAgents> | undefined;
   if (grantCheckAliases.size > 0) {
-    loadedAgentGrant = grantFromLoadedAgents(agentName, await loadProjectAgents(project));
+    loadedAgentGrant = grantFromLoadedAgents(agentName, loadedAgents);
     for (const alias of grantCheckAliases) {
       if (!agentMayUseConnector(loadedAgentGrant, alias)) {
         return {
@@ -822,13 +835,13 @@ export async function createProjectSession(input: {
   // Resolve require_connectors to THE ACTING USER's own member profiles and merge
   // them into the binding set. A missing/revoked one fails create with a
   // structured CONNECTOR_CONNECTION_REQUIRED so the UI can prompt a connect.
-  if (requireConnectors.length > 0) {
+  if (effectiveRequireConnectors.length > 0) {
     const required = await resolveRequiredMemberConnectorProfiles({
       accountId,
       projectId,
       actingUserId: userId,
       actingPrincipalIsServiceAccount: input.requestingPrincipalType === 'service_account',
-      aliases: requireConnectors,
+      aliases: effectiveRequireConnectors,
     });
     if (!required.ok) {
       return {

--- a/apps/web/public/schema/kortix.schema.json
+++ b/apps/web/public/schema/kortix.schema.json
@@ -902,6 +902,13 @@
                     }
                   ]
                 },
+                "connectors_personal": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
                 "secrets": {
                   "description": "An allowlist of names, or the \"all\" / \"none\" sentinel.",
                   "oneOf": [

--- a/apps/web/public/schema/kortix.v2.schema.json
+++ b/apps/web/public/schema/kortix.v2.schema.json
@@ -54,6 +54,13 @@
               }
             ]
           },
+          "connectors_personal": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
           "secrets": {
             "description": "An allowlist of names, or the \"all\" / \"none\" sentinel.",
             "oneOf": [

--- a/packages/manifest-schema/src/index.v2.ts
+++ b/packages/manifest-schema/src/index.v2.ts
@@ -120,6 +120,14 @@ export interface AgentBlockV2 {
    *  see compile-agent-config.ts. */
   enabled?: boolean;
   connectors?: GrantSetV2;
+  /** Subset of `connectors` that must resolve to the LAUNCHING USER's OWN
+   *  connection (their member profile), never the shared project one. Any session
+   *  started with this agent auto-requires these — server-side, exactly like the
+   *  caller passing `require_connectors`. If the user hasn't connected one,
+   *  session-create is refused with CONNECTOR_CONNECTION_REQUIRED so the UI can
+   *  prompt them to connect it. Must be a subset of this agent's `connectors`
+   *  grant (an alias not granted can never be personally required). */
+  connectors_personal?: string[];
   /** Which project secrets this agent may receive as sandbox env (and read via
    *  the secrets API) — a list of secret IDENTIFIERS (project_secrets.identifier),
    *  NOT raw env-var keys. For a project where every secret's identifier equals

--- a/packages/manifest-schema/src/json-schema.ts
+++ b/packages/manifest-schema/src/json-schema.ts
@@ -520,6 +520,9 @@ function agentBlockV2Schema(): JsonSchemaFragment {
     properties: {
       enabled: { type: 'boolean' },
       connectors: grantSetSchema(),
+      // A concrete subset of `connectors` that must resolve to the launching
+      // user's OWN connection (a list of aliases — never 'all'/'none').
+      connectors_personal: { type: 'array', items: NON_EMPTY_STRING },
       secrets: grantSetSchema(),
       skills: grantSetSchema(),
       kortix_cli: kortixCliGrantSetSchema(2),


### PR DESCRIPTION
Lets an **agent** declare that it needs the user's own connection, so **any interactive session started with that agent auto-requires it** — no caller has to pass `require_connectors`. This is the auto-trigger for the required-connector system.

> **Stacked on #5366** (`kaab-required-connectors`) — it uses that PR's `require_connectors` resolution + `CONNECTOR_CONNECTION_REQUIRED` gate + roster. Merge #5366 first; GitHub retargets this to `main` once you do.

## What it adds

- **Manifest**: `agents.<name>.connectors_personal` — a list of aliases that must be a **subset of** that agent's `connectors` grant. Added to `AgentBlockV2` + the JSON schema (`kortix.v2.schema.json` regenerated) + parser subset-validation (a non-granted alias is a manifest error).
- **`personalConnectorsForAgent(agentName, loaded)`** — resolves an agent's personal set (concrete name, or the `default` sentinel → the manifest's `default_agent`).
- **Session-create enforcement**: for an **interactive** (`origin: user`) session, the agent's `connectors_personal` are unioned into the required set and resolved to the launching user's own member profile — gating with `CONNECTOR_CONNECTION_REQUIRED` if unconnected. **Not** enforced for backend/service-account origin (no single current user — it uses `connector_bindings`).

## Example

```yaml
kortix_version: 2
default_agent: mailer
agents:
  mailer:
    connectors: [gmail, calendar]
    connectors_personal: [gmail]   # every session with `mailer` runs on YOUR Gmail
```

Now any user who starts a `mailer` session and hasn't connected their Gmail is stopped with the connect-to-start gate (from #5366); once connected, the session runs as their own Gmail.

## Safety
- Subset-validated at parse time; interactive-only enforcement; the roster/gate/resolution it drives are the reviewed ones from #5366.
- Editor scope-edits **preserve** `connectors_personal` — `applyAgentScopeV2` spreads the whole agent block, so setting it in `kortix.yaml` is not stripped by the dashboard.

## Tests
- Parser: valid subset parses + resolves (by name and the `default` sentinel); a non-subset is rejected; an agent declaring none yields `[]`.
- Typechecks green (manifest-schema, apps/api); manifest-schema suite 320/320; JSON schema regenerated + in sync.

## Follow-up (not in this PR)
- **Editor toggle**: a dashboard control to mark granted connectors as personal (the scope route + `applyAgentScopeV2` + a small UI). Contained and data-loss-safe (the round-trip already preserves the field); today it's set in `kortix.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
