### PR TITLE
fix(web): classify 25s server-processing-deadline as expected (BS a330bea1)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -21,6 +21,7 @@ import {
   isOperationErrorPopErrorScopeNoise,
   isPaperShaderNullContextNoise,
   isRuntimeNotReadyNoiseMessage,
+  isServerDeadlineNoiseMessage,
   isStaleWebpackRuntimeCallNoise,
   isStorageDisabledWebViewNoiseMessage,
   isStorageSecurityErrorNoise,
@@ -1135,11 +1136,13 @@ test('suppresses a client-side request-timeout unhandled rejection from the brow
   )
 })
 
-test('does NOT suppress the API server-deadline 503 message (different wording)', () => {
-  // The API's request-deadline 503 is `Request exceeded the 25s server processing
-  // deadline` — a different, server-side wording that must keep reporting if it
-  // ever reaches the frontend Sentry config (it is de-noised at the API source
-  // by #4524, not here).
+test('the client-timeout matcher does NOT match the API server-deadline 503 wording', () => {
+  // The API's request-deadline 503 is `Request exceeded the <N>s server
+  // processing deadline` — a distinct, server-side wording. The CLIENT-timeout
+  // matcher (`isClientRequestTimeoutMessage`, anchored on the SDK's
+  // `Request timed out after <N>s: ` prefix) must never match it; the
+  // server-deadline wording has its OWN dedicated matcher
+  // (`isServerDeadlineNoiseMessage`, pinned by the test block below).
   for (const value of [
     'Request exceeded the 25s server processing deadline',
     'Request exceeded the 30s server processing deadline',
@@ -1147,12 +1150,149 @@ test('does NOT suppress the API server-deadline 503 message (different wording)'
     assert.equal(
       isClientRequestTimeoutMessage(value),
       false,
-      `expected server-deadline message "${value}" to keep reporting`,
+      `expected server-deadline message "${value}" to not match the client-timeout matcher`,
+    )
+  }
+})
+
+// Reproduces Better Stack error a330bea136a7b5795a57ef5a33ab40381433132e90c34bbabdca66cc3f6d938c
+// (Kortix Frontend prod, application_id 2346967): a single
+// `ApiError: Request exceeded the 25s server processing deadline` at
+// 2026-07-23 18:41:09 UTC, release 470fe6f3c8 (v0.10.13), transaction
+// `/projects/:id/sessions/:sessionId` (co-worker session page actively polling
+// `useSessionAudit`). Mechanism `generic` (handled=true) — the SDK's
+// `makeRequest` caught the 503 response and re-surfaced it as an `ApiError`.
+// The 99 breadcrumbs were almost all 200s, except THREE
+// `GET .../sessions/<sid>/audit -> 503` — the `useSessionAudit` react-query poll
+// hit the audit endpoint while the API/gateway was transiently saturated.
+//
+// The API's `request-deadline.ts` middleware bounds every non-streaming request
+// to a 25s wall-clock deadline; when exceeded, `RequestDeadlineHTTPException`
+// returns a clean 503 + `Retry-After: 10` with the message
+// `Request exceeded the <N>s server processing deadline`. This is an EXPECTED,
+// retryable degradation — the deadline net bounding a slow downstream / a
+// pool-saturated request. PR #4524 de-noised it from the API's OWN Sentry
+// (app 2346961) by skipping `captureException` for
+// `isRequestDeadlineHTTPException(err)`. BUT the 503 RESPONSE crosses the
+// boundary into the frontend: the SDK's `makeRequest` extracts
+// `errorData.message` (the deadline string), wraps it in an `ApiError` with
+// `status: 503`, and fires `onError` → `handleApiError`, which captures it to
+// the FRONTEND Sentry (app 2346967 — a SEPARATE app from the API's). The
+// `TRANSIENT_GATEWAY_STATUSES` retry (#4609) absorbs a SINGLE transient 503 on
+// idempotent reads, but persistent saturation (the 3 non-200 audit 503s)
+// exhausts the 2-retry loop and surfaces the deadline 503 to `onError` →
+// Sentry. That is exactly how `a330bea1…` reached the frontend telemetry
+// despite #4524's API-side classification.
+//
+// This is the SERVER-side mirror of the CLIENT-timeout class (`b1db01e5…`,
+// #4531 — the SDK's 30s fetch abort). Both are the same expected/retryable
+// degradation under momentary API saturation; react-query retries background
+// polls, and the saturation signal stays visible in the per-route
+// `http_request_duration_seconds` metric + the structured
+// `Request completed: … 503 …` warn log on the API. `handleApiError`
+// (`error-handler.tsx`) skips `captureException` for `status === 503 &&`
+// `isServerDeadlineNoiseMessage(message)`; these checks are the
+// telemetry-side backstop for leak paths (ClientErrorBoundary / route-error /
+// app-error / onunhandledrejection).
+const SERVER_DEADLINE_NOISE_EVENTS = [
+  // The exact prod occurrence — the default 25s budget.
+  'Request exceeded the 25s server processing deadline',
+  // The budget is env-tunable (REQUEST_DEADLINE_MS); the seconds value is not
+  // load-bearing.
+  'Request exceeded the 30s server processing deadline',
+  // The ApiError-class-prefixed wrapper (Sentry/Better Stack often prefixes the
+  // captured error's `.message` with the class name).
+  'ApiError: Request exceeded the 25s server processing deadline',
+  // An unhandled-rejection leak path preserving the message.
+  'Unhandled promise rejection: Request exceeded the 25s server processing deadline',
+  'Unhandled promise rejection: ApiError: Request exceeded the 25s server processing deadline',
+]
+
+test('classifies every API server-deadline 503 message as expected noise', () => {
+  for (const message of SERVER_DEADLINE_NOISE_EVENTS) {
+    assert.equal(
+      isServerDeadlineNoiseMessage(message),
+      true,
+      `expected "${message}" to be classified as a server-deadline 503`,
+    )
+  }
+})
+
+test('suppresses an API server-deadline 503 Sentry event regardless of capture path', () => {
+  for (const value of SERVER_DEADLINE_NOISE_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/projects/p/sessions/s' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: {
+                frames: [{ filename: 'app:///_next/static/chunks/26996-0650621935b0e261.js' }],
+              },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('suppresses an API server-deadline 503 unhandled rejection from the browser', () => {
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message:
+        'Unhandled promise rejection: Request exceeded the 25s server processing deadline',
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress a generic 503 message that is not the typed deadline wording', () => {
+  // A generic 503 (`HTTP 503: Service Unavailable`, `sandbox waking up`) must
+  // keep reporting — only the typed `Request exceeded the <N>s server processing
+  // deadline` message the API's `RequestDeadlineHTTPException` emits is
+  // classified as noise.
+  for (const value of [
+    'HTTP 503: Service Unavailable',
+    'Service Unavailable',
+    'sandbox waking up',
+    'Bad Gateway',
+    'Request exceeded the 25s client processing deadline',
+    'Request exceeded the server processing deadline',
+    'Request exceeded the 25s server processing deadline.',
+    'A request exceeded the 25s server processing deadline',
+  ]) {
+    assert.equal(
+      isServerDeadlineNoiseMessage(value),
+      false,
+      `expected generic 503 message "${value}" to keep reporting`,
     )
     assert.equal(
       shouldIgnoreSentryBrowserNoise({ exception: { values: [{ value }] } }),
       false,
-      `expected server-deadline Sentry event "${value}" to keep reporting`,
+      `expected generic 503 Sentry event "${value}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress a real 5xx server ApiError', () => {
+  for (const value of [
+    'Internal server error',
+    'HTTP 500: Internal Server Error',
+    'Service maintenance in progress. Please try again later.',
+  ]) {
+    assert.equal(
+      isServerDeadlineNoiseMessage(value),
+      false,
+      `expected real server error "${value}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({ exception: { values: [{ value }] } }),
+      false,
+      `expected real server error Sentry event "${value}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -443,6 +443,48 @@ const CLIENT_REQUEST_TIMEOUT_WRAPPERS: ReadonlyArray<RegExp> = [
   /^Unhandled promise rejection: (?:ApiError: )?Request timed out after \d+s: /,
 ];
 
+// The API's server-side request-deadline 503.
+// `apps/api/src/middleware/request-deadline.ts` bounds every non-streaming
+// request to a 25s wall-clock deadline (default `REQUEST_DEADLINE_MS`); when a
+// handler exceeds it, the `RequestDeadlineHTTPException` returns a clean 503 +
+// `Retry-After: 10` with the message
+// `Request exceeded the <N>s server processing deadline`. It is an EXPECTED,
+// retryable degradation — the deadline net bounding a slow downstream / a
+// pool-saturated request — and is already de-noised at the API SOURCE
+// (`apps/api/src/index.ts` `onError` skips `captureException` for
+// `isRequestDeadlineHTTPException(err)` — PR #4524, API Sentry app 2346961).
+//
+// BUT the 503 RESPONSE crosses the boundary into the frontend: the SDK's
+// `makeRequest` extracts `errorData.message` (the deadline string), wraps it in
+// an `ApiError` with `status: 503`, and fires `onError` → `handleApiError`,
+// which captures it to the FRONTEND Sentry (app 2346967 — a SEPARATE app from
+// the API's). That is exactly how Better Stack FRONTEND pattern
+// `a330bea1…` (`ApiError: Request exceeded the 25s server processing deadline`,
+// on the `useSessionAudit` background poll, 1 occ / 0 users) reached the
+// frontend telemetry despite #4524's API-side classification. The
+// `TRANSIENT_GATEWAY_STATUSES` retry (#4609) absorbs a SINGLE transient 503 on
+// idempotent reads, but persistent saturation exhausts the 2-retry loop (the
+// prod breadcrumbs showed 3 non-200 audit 503s) and surfaces the deadline 503
+// to `onError` → Sentry.
+//
+// This is the frontend mirror of the API's request-deadline classification,
+// sibling to `isClientRequestTimeoutMessage` (the SDK's 30s CLIENT abort,
+// #4531). The deadline 503 is the SAME expected/retryable degradation class,
+// just observed server-side instead of client-side — react-query retries
+// background polls, and the saturation signal stays visible in the per-route
+// `http_request_duration_seconds` metric + the structured
+// `Request completed: … 503 …` warn log on the API. The match is anchored on
+// the API's exact `Request exceeded the <N>s server processing deadline`
+// wording (with the canonical `ApiError: ` / unhandled-rejection wrappers) so
+// a generic 503 (`HTTP 503: Service Unavailable`, `sandbox waking up`) is
+// never matched — only the typed deadline message the API's
+// `RequestDeadlineHTTPException` emits.
+const SERVER_DEADLINE_NOISE_WRAPPERS: ReadonlyArray<RegExp> = [
+  /^Request exceeded the \d+s server processing deadline$/,
+  /^ApiError: Request exceeded the \d+s server processing deadline$/,
+  /^Unhandled promise rejection: (?:ApiError: )?Request exceeded the \d+s server processing deadline$/,
+];
+
 const INJECTED_APP_SOURCE_PATTERNS = [
   /^app:\/\/\/scripts\/inpage\.js$/,
   /^app:\/\/\/client_data\/[^/]+\/script\.js$/,
@@ -1100,6 +1142,25 @@ export function isStaleWebpackRuntimeCallNoise(input: {
 export function isClientRequestTimeoutMessage(message: unknown): boolean {
   const normalized = normalizeString(message).trim();
   return CLIENT_REQUEST_TIMEOUT_WRAPPERS.some((re) => re.test(normalized));
+}
+
+/**
+ * Whether a message is the API's server-side request-deadline 503 —
+ * `Request exceeded the <N>s server processing deadline` (and its canonical
+ * wrappers). This is the SERVER-side mirror of `isClientRequestTimeoutMessage`
+ * (the SDK's 30s CLIENT abort): the API bounds non-streaming requests to a 25s
+ * deadline that returns a clean 503 + `Retry-After`, de-noised at the API
+ * source by #4524. But the 503 response crosses into the frontend as an
+ * `ApiError(status: 503)` (the SDK extracts `.message`), which `handleApiError`
+ * captures to the FRONTEND Sentry — Better Stack pattern `a330bea1…`. It is
+ * an EXPECTED, retryable degradation (react-query retries background polls; the
+ * saturation signal stays in per-route metrics + the structured 503 warn log),
+ * never an actionable bug. Such a message must NEVER page Better Stack,
+ * regardless of which capture path delivered it.
+ */
+export function isServerDeadlineNoiseMessage(message: unknown): boolean {
+  const normalized = normalizeString(message).trim();
+  return SERVER_DEADLINE_NOISE_WRAPPERS.some((re) => re.test(normalized));
 }
 
 /**
@@ -1813,6 +1874,17 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // Expected server-side request-deadline 503 (API 25s wall-clock deadline) —
+  // the API-side classification (#4524) de-noises it from the API's OWN Sentry,
+  // but the 503 response crosses into the frontend as an `ApiError(status:
+  // 503)` that `handleApiError` captures to the FRONTEND Sentry (Better Stack
+  // pattern `a330bea1…`). It is the SAME expected/retryable degradation class
+  // as the client timeout above; never page Better Stack for it. See
+  // `isServerDeadlineNoiseMessage`.
+  if (isServerDeadlineNoiseMessage(message)) {
+    return true;
+  }
+
   // Expected billing-gate 402 outcomes are user-facing business states handled
   // by a toast/upgrade dialog — never page Better Stack for them, even when the
   // SDK's `ApiError` reaches window.onerror / unhandledrejection before
@@ -2016,6 +2088,19 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // remains in per-route metrics + the structured 503 warn log. Drop it before
   // it pages Better Stack, no matter which capture path delivered it.
   if (isClientRequestTimeoutMessage(message)) {
+    return true;
+  }
+
+  // Expected server-side request-deadline 503 (API 25s wall-clock deadline) —
+  // the server-side mirror of the client timeout above. The API's
+  // `RequestDeadlineHTTPException` returns a clean 503 + `Retry-After` with the
+  // message `Request exceeded the <N>s server processing deadline`; the SDK
+  // surfaces it as an `ApiError(status: 503)` that can leak to Sentry through
+  // capture paths that bypass `handleApiError`'s deadline guard
+  // (`<ClientErrorBoundary>` / route-error / app-error / `onunhandledrejection`).
+  // Drop it so the expected deadline state never pages Better Stack. See
+  // `isServerDeadlineNoiseMessage`.
+  if (isServerDeadlineNoiseMessage(message)) {
     return true;
   }
 

--- a/apps/web/src/lib/error-handler.tsx
+++ b/apps/web/src/lib/error-handler.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { errorToast, infoToast, successToast, warningToast } from '@/components/ui/toast';
 import { isBillingEnabled } from '@/lib/config';
+import { isServerDeadlineNoiseMessage } from '@/lib/browser-error-noise';
 import { useAccountSettingsModalStore } from '@/stores/account-settings-modal-store';
 import { usePricingModalStore } from '@/stores/pricing-modal-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
@@ -177,7 +178,38 @@ export const handleApiError = (error: any, context?: ErrorContext): void => {
   // `Request completed: … 503 …` warn log. Real 5xx server errors and genuine
   // connectivity loss (NETWORK_ERROR) still report. The message-shape backstop
   // for leak paths lives in browser-error-noise.ts (`isClientRequestTimeoutMessage`).
-  if (status >= 500 || error?.code === 'NETWORK_ERROR') {
+  //
+  // The API's server-side request-deadline 503 (`Request exceeded the <N>s server
+  // processing deadline`, from `RequestDeadlineHTTPException`) is ALSO not
+  // captured here. It is the SAME expected/retryable degradation class as the
+  // client timeout above, just observed server-side: the API's deadline net
+  // bounds a slow downstream / pool-saturated request and returns a clean 503 +
+  // Retry-After (de-noised from the API's OWN Sentry by #4524). But the 503
+  // RESPONSE crosses into the frontend as an `ApiError(status: 503)` (the SDK's
+  // `makeRequest` extracts `.message`), and WITHOUT this guard the `status >=
+  // 500` branch below would capture it to the FRONTEND Sentry (app 2346967 — a
+  // SEPARATE app from the API's 2346961). That is exactly how Better Stack
+  // FRONTEND pattern `a330bea1…` (`ApiError: Request exceeded the 25s server
+  // processing deadline`, on the `useSessionAudit` background poll) reached the
+  // frontend telemetry despite #4524's API-side classification — the two Sentry
+  // apps are independent. The `TRANSIENT_GATEWAY_STATUSES` retry (#4609) absorbs
+  // a single transient 503 on idempotent reads, but persistent saturation (the
+  // prod breadcrumbs showed 3 non-200 audit 503s) exhausts the 2-retry loop and
+  // surfaces the deadline 503 to `onError` → here. React-query retries the
+  // background poll; the saturation signal stays in per-route metrics + the
+  // structured 503 warn log. The message-shape backstop for leak paths
+  // (`<ClientErrorBoundary>` / route-error / `onunhandledrejection`) lives in
+  // browser-error-noise.ts (`isServerDeadlineNoiseMessage`). A genuine 503 with
+  // a different message (`sandbox waking up`, `HTTP 503: Service Unavailable`)
+  // still reports — only the typed deadline message the API's
+  // `RequestDeadlineHTTPException` emits is excluded.
+  const errorMessage = typeof error?.message === 'string' ? error.message : '';
+  const isServerDeadline503 =
+    status === 503 && isServerDeadlineNoiseMessage(errorMessage);
+  if (
+    (status >= 500 && !isServerDeadline503) ||
+    error?.code === 'NETWORK_ERROR'
+  ) {
     Sentry.captureException(
       error instanceof Error ? error : new Error(error?.message || String(error)),
       {


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. The verification proof is the test result: `bun test src/lib/browser-error-noise.test.mts` → **166 pass / 0 fail** (5 new tests pin the exact prod message `Request exceeded the 25s server processing deadline` through every capture path, plus 8 negative cases that prove a generic 503 keeps reporting).

## Why
Better Stack frontend pattern `a330bea1…` (app 2346967, 1 occ / 0 users, 2026-07-23 18:41:09 UTC, release `470fe6f3c8` v0.10.13) paged as an `ApiError: Request exceeded the 25s server processing deadline` on the co-worker session page (`/projects/:id/sessions/:sessionId`). The 99 breadcrumbs were almost all 200s except **three** `GET .../sessions/<sid>/audit -> 503` — the `useSessionAudit` react-query background poll hit the audit endpoint while the API/gateway was transiently saturated. This is a **transient gateway/server-deadline** error class — a sibling of the client-timeout (#4531 `b1db01e5…`), the request-deadline 503 (#4524 `29af03…`), and the gateway-502 retry (#4609).

The API already classifies this 503 out of its **own** Sentry (app 2346961) via `isRequestDeadlineHTTPException` (PR #4524). **But the two Sentry apps are independent** — the API returning the 503 to the frontend means the SDK `makeRequest` extracts `errorData.message` (the deadline string), wraps it in an `ApiError(status: 503)`, and fires `onError → handleApiError`, which captures it to the **frontend** Sentry (app 2346967) because `status >= 500`. That is exactly how `a330bea1…` reached the frontend telemetry despite #4524. The `TRANSIENT_GATEWAY_STATUSES` retry (#4609, 2 retries on idempotent GET) absorbs a single transient 503, but the 3 non-200 audit 503s in the breadcrumbs exhausted the loop and surfaced the deadline 503.

## What changed
**Frontend noise classification (option 3, the layer where #4531 handles the client-timeout message — NOT the SDK, which has no message-classification hook):**

1. `apps/web/src/lib/browser-error-noise.ts`:
   - New `SERVER_DEADLINE_NOISE_WRAPPERS` regex list + `isServerDeadlineNoiseMessage(message)` matcher, sibling to `isClientRequestTimeoutMessage`. Anchored on the API's exact `Request exceeded the <N>s server processing deadline` wording (with `ApiError: ` / unhandled-rejection wrappers) so a generic 503 (`HTTP 503: Service Unavailable`, `sandbox waking up`) is **never** matched — only the typed deadline message the API's `RequestDeadlineHTTPException` emits.
   - Wired into `shouldIgnoreSentryBrowserNoise` (Sentry `beforeSend` gate) and `shouldIgnoreBrowserRuntimeNoise` (window.onerror / onunhandledrejection) — the leak-path backstops for `<ClientErrorBoundary>` / route-error / app-error / onunhandledrejection.

2. `apps/web/src/lib/error-handler.tsx` (`handleApiError`):
   - Guard the primary capture path: skip `Sentry.captureException` when `status === 503 && isServerDeadlineNoiseMessage(message)`. This mirrors how the client-timeout (`code === 'TIMEOUT'`, no `.status`) is implicitly skipped because `status >= 500` is false. A genuine 503 with a different message still reports; only the typed deadline message is excluded.

3. `apps/web/src/lib/browser-error-noise.test.mts`:
   - The existing test at the client-timeout block asserted the server-deadline message was NOT suppressed (it assumed #4524's API-side classification was sufficient). That assumption was wrong — the evidence proves the 503 reaches the frontend Sentry. Replaced it with a matcher-negative test (the client-timeout matcher must still not match the server wording) plus 4 new dedicated tests pinning the exact prod message through all capture paths + 8 negative cases.

## Verification
- `bun test src/lib/browser-error-noise.test.mts` → **166 pass / 0 fail** (was 161; +5 new tests).
- `tsc --noEmit -p apps/web/tsconfig.json` → only the 4 pre-existing unrelated errors (`template-url.test.ts` ×2, `source.ts`, `use-cases-source.ts`); zero new errors.
- `bun test packages/sdk/src/core/http/api-client.test.ts` → **17 pass / 0 fail** (SDK untouched — confirms the classification is correctly at the frontend layer, not the SDK).

## Risk / rollback
- Minimal and surgical: a new message-only noise matcher + a `handleApiError` guard that only excludes `status === 503` with the exact deadline string. A genuine 503 (any other message) and all other 5xx still report — the negative tests pin this. Saturation observability is preserved in the per-route `http_request_duration_seconds` metric + the structured `Request completed: … 503 …` warn log on the API.
- Rollback: revert the single commit.

## Confirmation plan
After merge + Promote, the Better Stack frontend group `a330bea1…` should drop to zero new occurrences (the deadline 503 will be silently absorbed at the frontend layer; react-query still retries the background poll). The API-side 503 + metric + warn log remain unchanged.
