### PR TITLE
fix(api): resolve session limits across ECS tasks

### DIFF
--- a/apps/api/src/__tests__/billing/session-limit-resolution.test.ts
+++ b/apps/api/src/__tests__/billing/session-limit-resolution.test.ts
@@ -91,6 +91,23 @@ describe('resolveAccountSessionLimit — tier vs per-account override', () => {
     expect(resolved.source).toBe('tier');
   });
 
+  test('session limit reads a changed override without process-local cache invalidation', async () => {
+    currentTier = 'per_seat';
+    const accountId = nextAccount();
+
+    expect((await resolveAccountSessionLimit(accountId)).limit).toBe(
+      getTier('per_seat').concurrentSessionLimit,
+    );
+
+    currentOverride = 1;
+
+    expect(await resolveAccountSessionLimit(accountId)).toEqual({
+      tier: 'per_seat',
+      limit: 1,
+      source: 'account_override',
+    });
+  });
+
   test('billing disabled → effectively unlimited, override irrelevant', async () => {
     billingEnabled = false;
     currentOverride = 5;

--- a/apps/api/src/shared/account-limits.ts
+++ b/apps/api/src/shared/account-limits.ts
@@ -36,9 +36,14 @@ function tierMultiplier(tier: string | null | undefined) {
   return legacyMultipliers[name] ?? (name !== 'free' && name !== 'none' ? 1 : 0);
 }
 
-async function resolveAccountLimitInfo(accountId: string): Promise<AccountLimitInfo> {
-  const cached = accountLimitCache.get(accountId);
-  if (cached && Date.now() < cached.expiresAt) return cached;
+async function resolveAccountLimitInfo(
+  accountId: string,
+  options: { useCache?: boolean } = {},
+): Promise<AccountLimitInfo> {
+  if (options.useCache !== false) {
+    const cached = accountLimitCache.get(accountId);
+    if (cached && Date.now() < cached.expiresAt) return cached;
+  }
 
   try {
     const subscription = await getSubscriptionInfo(accountId);
@@ -136,15 +141,15 @@ export type AccountSessionLimit = {
  *      override, e.g. enterprise deals or our own dogfood account) → wins over
  *      the tier in both directions;
  *   3. the plan tier's TierConfig.concurrentSessionLimit.
- * Backed by the same 60s cache as resolveAccountTier; operator changes are
- * visible immediately after clearAccountLimitCache() (the admin tier route
- * already clears it).
+ * This path bypasses the process-local tier cache. Session requests can reach
+ * different API tasks, so local cache invalidation cannot make an operator
+ * override consistent across the deployment.
  */
 export async function resolveAccountSessionLimit(accountId: string): Promise<AccountSessionLimit> {
   if (!(config as any).KORTIX_BILLING_INTERNAL_ENABLED) {
     return { tier: null, limit: Number.MAX_SAFE_INTEGER, source: 'billing_disabled' };
   }
-  const { tier, sessionOverride } = await resolveAccountLimitInfo(accountId);
+  const { tier, sessionOverride } = await resolveAccountLimitInfo(accountId, { useCache: false });
   if (sessionOverride !== null) {
     return { tier, limit: sessionOverride, source: 'account_override' };
   }


### PR DESCRIPTION
## Problem

`SESS-2` failed on staging because the admin override invalidated only one ECS task cache. A later session request reached another task and used the stale tier limit.

Evidence: the first session returned `X-RateLimit-Limit: 1`. The second session returned `X-RateLimit-Limit: 50` and status `201`.

## Fix

- Bypass the process-local account-limit cache for concurrent-session enforcement.
- Keep the cache for non-session tier reads.
- Add a regression test for an override change without local cache invalidation.

## Verification

- `KORTIX_URL=http://localhost:18008 dotenvx run -f .env -- bun test src/__tests__/billing/session-limit-resolution.test.ts` -> 7 passed
- `KORTIX_URL=http://localhost:18008 dotenvx run -f .env -- bun test src/__tests__/unit-admin-account-session-limit.test.ts` -> 4 passed
- `KORTIX_URL=http://localhost:18008 dotenvx run -f .env -- bun test src/__tests__/e2e-rate-limits.test.ts` -> 6 passed
- `KORTIX_URL=http://localhost:18008 dotenvx run -f .env -- bun run typecheck` -> exit 0