### PR TITLE
release(staging): fix distributed session limit enforcement

### DIFF
--- a/apps/api/src/__tests__/billing/session-limit-resolution.test.ts
+++ b/apps/api/src/__tests__/billing/session-limit-resolution.test.ts
@@ -91,6 +91,23 @@ describe('resolveAccountSessionLimit — tier vs per-account override', () => {
     expect(resolved.source).toBe('tier');
   });
 
+  test('session limit reads a changed override without process-local cache invalidation', async () => {
+    currentTier = 'per_seat';
+    const accountId = nextAccount();
+
+    expect((await resolveAccountSessionLimit(accountId)).limit).toBe(
+      getTier('per_seat').concurrentSessionLimit,
+    );
+
+    currentOverride = 1;
+
+    expect(await resolveAccountSessionLimit(accountId)).toEqual({
+      tier: 'per_seat',
+      limit: 1,
+      source: 'account_override',
+    });
+  });
+
   test('billing disabled → effectively unlimited, override irrelevant', async () => {
     billingEnabled = false;
     currentOverride = 5;

--- a/apps/api/src/shared/account-limits.ts
+++ b/apps/api/src/shared/account-limits.ts
@@ -36,9 +36,14 @@ function tierMultiplier(tier: string | null | undefined) {
   return legacyMultipliers[name] ?? (name !== 'free' && name !== 'none' ? 1 : 0);
 }
 
-async function resolveAccountLimitInfo(accountId: string): Promise<AccountLimitInfo> {
-  const cached = accountLimitCache.get(accountId);
-  if (cached && Date.now() < cached.expiresAt) return cached;
+async function resolveAccountLimitInfo(
+  accountId: string,
+  options: { useCache?: boolean } = {},
+): Promise<AccountLimitInfo> {
+  if (options.useCache !== false) {
+    const cached = accountLimitCache.get(accountId);
+    if (cached && Date.now() < cached.expiresAt) return cached;
+  }
 
   try {
     const subscription = await getSubscriptionInfo(accountId);
@@ -136,15 +141,15 @@ export type AccountSessionLimit = {
  *      override, e.g. enterprise deals or our own dogfood account) → wins over
  *      the tier in both directions;
  *   3. the plan tier's TierConfig.concurrentSessionLimit.
- * Backed by the same 60s cache as resolveAccountTier; operator changes are
- * visible immediately after clearAccountLimitCache() (the admin tier route
- * already clears it).
+ * This path bypasses the process-local tier cache. Session requests can reach
+ * different API tasks, so local cache invalidation cannot make an operator
+ * override consistent across the deployment.
  */
 export async function resolveAccountSessionLimit(accountId: string): Promise<AccountSessionLimit> {
   if (!(config as any).KORTIX_BILLING_INTERNAL_ENABLED) {
     return { tier: null, limit: Number.MAX_SAFE_INTEGER, source: 'billing_disabled' };
   }
-  const { tier, sessionOverride } = await resolveAccountLimitInfo(accountId);
+  const { tier, sessionOverride } = await resolveAccountLimitInfo(accountId, { useCache: false });
   if (sessionOverride !== null) {
     return { tier, limit: sessionOverride, source: 'account_override' };
   }

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-dc0b6c47"
+  tag: "dev-4694319b"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
## Source

Promote current `main` SHA `0003d55e7116102988b17ace1295fccf578cf4f6` to staging.

## Included fix

- PR #5376: bypass the process-local account-limit cache for concurrent-session enforcement across ECS tasks.
- Preserve the latest dev deployment metadata for merge SHA `4694319b0679f1fe18079c511f5a0e55169b12b0`.

## Dev verification

- Deploy Dev run `30113856881`: success.
- Live version: `0.10.14-dev.4694319b`.
- `RUN-8`: passed in `40.33s`.
- `SESS-2`: passed in `14.16s`.
- Total: `2/2 passed`.