### PR TITLE
fix(web): drop frameless bare 'network error' rejection noise (BS 2403c9ba)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -12,6 +12,7 @@ import {
   isExtensionRejectedObjectNoise,
   isExtensionSource,
   isFirefoxReactSchedulerReentryNoise,
+  isFramelessNetworkErrorNoise,
   isInjectedAppSource,
   isInpageWalletStreamNoise,
   isKnownBrowserNoiseMessage,
@@ -4101,6 +4102,197 @@ test('does NOT suppress a frameless rejection with a different message', () => {
       }),
       false,
       `expected Sentry event for frameless "${message}" to keep reporting`,
+    )
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Bare lowercase `network error` rejection noise (Better Stack pattern
+// 2403c9ba5deee2af387834e95461cfb32b9b5080b21d6f307b2f09bb09e71f21, Kortix
+// Frontend prod, application_id 2346967). The canonical Axios / XMLHttpRequest
+// transport-abort message (lowercase; Axios emits this from the underlying XHR
+// `onerror`), captured as an uncaught global `onunhandledrejection` (mechanism
+// `auto.browser.global_handlers.onunhandledrejection`, `handled:false` — never
+// reached a React error boundary) with ZERO stack frames (`stacktrace.frames`
+// is an empty array, no `call_site_file`/`call_site_function`/`call_stack_hash`).
+// 1 occurrence / 0 identified users, last 2026-07-23 16:53:55 UTC, release
+// `470fe6f3…` (v0.10.13), transaction `/projects/:id/sessions/:sessionId`,
+// Chrome 150 on Generic Linux. Breadcrumbs: 88 fetches, 0 non-200 — the
+// rejection is a fire-and-forget `.then()` or a network-abort that didn't
+// surface a status. The same degraded session that hit the 25s-deadline +
+// audit 503s.
+//
+// Same family as the prior frameless browser-internal rejection noise matchers
+// — `isNonErrorUndefinedRejectionNoise` (PR #5200), `isOperationErrorPopError-
+// ScopeNoise` (PR #5237), `isFirefoxReactSchedulerReentryNoise` (PR #5185) —
+// a frameless unhandled rejection dropped by a precise exact-message matcher
+// with two negative guards preserving any first-party or resolvable frame.
+//
+// The message is GENERIC: a real first-party `new Error('network error')` /
+// `Promise.reject('network error')` would surface with the SAME message, so the
+// matcher requires BOTH the EXACT bare lowercase `network error` string
+// (case-sensitive, after `stripErrorWrappers` — the capitalized `Network Error`
+// Axios wrapper is a DIFFERENT surface and is deliberately NOT matched) AND a
+// frameless positive guard, plus two negative guards: any resolved first-party
+// `apps/web/src/…` frame → keep reporting; any resolvable frame location →
+// keep reporting. Only the FRAMELESS capture is dropped.
+// ---------------------------------------------------------------------------
+
+// The exact exception value from the production event (lowercase, bare).
+const FRAMELESS_NETWORK_ERROR = 'network error'
+
+test('classifies the frameless bare network error noise', () => {
+  // Exact production shape: the bare lowercase `network error` message, NO
+  // frames (the rejection carried no stack).
+  assert.equal(
+    isFramelessNetworkErrorNoise({
+      message: FRAMELESS_NETWORK_ERROR,
+      frames: [],
+    }),
+    true,
+  )
+})
+
+test('suppresses the frameless network error Sentry event via the beforeSend gate', () => {
+  // Exact shape of the production event: type `TypeError`, mechanism
+  // `auto.browser.global_handlers.onunhandledrejection` (uncaught global
+  // unhandledrejection — never reached a React error boundary), NO stacktrace
+  // frames, request URL the co-worker session page.
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: {
+        url: 'https://kortix.com/projects/66f6788a-0000-0000-0000-000000000000/sessions/d16b4555-0000-0000-0000-000000000000',
+      },
+      exception: {
+        values: [
+          {
+            value: FRAMELESS_NETWORK_ERROR,
+            stacktrace: { frames: [] },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the frameless network error noise when frames are absent entirely (no stacktrace key)', () => {
+  // Sentry omits the stacktrace key entirely when there is nothing to
+  // serialize. The gate must still drop it (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/projects/x/sessions/y' },
+      exception: {
+        values: [{ value: FRAMELESS_NETWORK_ERROR }],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the network error rejection when a first-party frame is present', () => {
+  // A resolved `apps/web/src/…` frame means our own code threw/rejected with
+  // `new Error('network error')` → actionable; the negative guard MUST preserve
+  // it so the call site can be found + fixed. This is the whole reason the
+  // matcher is frame-aware (the bare `network error` message is generic).
+  for (const frames of [
+    [{ filename: 'apps/web/src/lib/api/client.ts', function: 'fetchProject' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/features/workspace/index.ts', function: 'loadConfig' },
+    ],
+  ]) {
+    assert.equal(
+      isFramelessNetworkErrorNoise({
+        message: FRAMELESS_NETWORK_ERROR,
+        frames,
+      }),
+      false,
+      `expected first-party network error rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: FRAMELESS_NETWORK_ERROR, stacktrace: { frames } }],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party network error rejection from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress the network error rejection when any resolvable (non-first-party) frame is present', () => {
+  // Any resolvable source location (real chunk / URL / named file) means the
+  // rejection is attributable — a real first-party or third-party
+  // `Promise.reject(new Error('network error'))` with a stack we can trace.
+  // Keep reporting; only the frameless capture (the production noise pattern)
+  // is dropped.
+  for (const frames of [
+    [{ filename: 'app:///_next/static/chunks/123-abc.js', function: 'x' }],
+    [{ filename: 'https://cdn.example.com/lib.js', function: 'init' }],
+  ]) {
+    assert.equal(
+      isFramelessNetworkErrorNoise({
+        message: FRAMELESS_NETWORK_ERROR,
+        frames,
+      }),
+      false,
+      `expected attributable network error rejection from ${JSON.stringify(frames)} to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress the capitalized "Network Error" wrapper (over-match guard)', () => {
+  // The capitalized `Network Error` is Axios's OWN wrapper Error
+  // (`new Error('Network Error')`) — a DIFFERENT surface from the bare
+  // lowercase XHR-`onerror` message. It is deliberately NOT matched so a
+  // blanket-silence does not hide a real Axios rejection we may want to
+  // triage. Frameless here on purpose (to prove the message alone — not the
+  // frameless shape — is what keeps it reporting).
+  const message = 'Network Error'
+  assert.equal(
+    isFramelessNetworkErrorNoise({
+      message,
+      frames: [],
+    }),
+    false,
+    `expected capitalized "${message}" to keep reporting`,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+    }),
+    false,
+    `expected Sentry event for capitalized "${message}" to keep reporting`,
+  )
+})
+
+test('does NOT suppress a near-worded message (over-match guard)', () => {
+  // Only the EXACT bare `network error` string is noise. A near-worded message
+  // such as `network error: failed to fetch` is a different (attributable)
+  // error class and must keep reporting.
+  for (const message of [
+    'network error: failed to fetch',
+    'network error.',
+    'a network error occurred',
+    'Network error',
+    'network errors',
+  ]) {
+    assert.equal(
+      isFramelessNetworkErrorNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected near-worded "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event for near-worded "${message}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -1758,6 +1758,109 @@ export function isOperationErrorPopErrorScopeNoise(input: {
   return true;
 }
 
+// Bare lowercase `network error` rejection noise — the canonical Axios /
+// `XMLHttpRequest` transport-abort message. Axios throws this (or the
+// capitalized `Network Error` wrapper — a DIFFERENT surface, see below) when a
+// request fails at the transport layer (DNS failure, connection refused, TLS
+// abort, CORS preflight rejection, or the server dropping the connection
+// mid-flight). The underlying XHR `onerror` emits the lowercase `network error`
+// string; Axios wraps it as `new Error('Network Error')` (capitalized) for its
+// own rejection. This matcher targets ONLY the bare lowercase form.
+//
+// Better Stack pattern
+// 2403c9ba5deee2af387834e95461cfb32b9b5080b21d6f307b2f09bb09e71f21
+// (Kortix Frontend prod, application_id 2346967): `TypeError`, message
+// `network error` (lowercase, bare), 1 occurrence / 0 identified users, last
+// 2026-07-23 16:53:55 UTC, release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6` (v0.10.13), transaction
+// `/projects/:id/sessions/:sessionId` (co-worker session page), mechanism
+// `auto.browser.global_handlers.onunhandledrejection` (`handled:false` —
+// UNCAUGHT, never reached a React error boundary), Chrome 150 on Generic
+// Linux. Stack frames: ZERO — `stacktrace.frames` is an empty array, no
+// `call_site_file`, no `call_site_function`, no `call_stack_hash`. Breadcrumbs:
+// 100 total, 88 fetches, 0 non-200 (so no fetch visibly failed with a non-200
+// in the captured window — the rejection is a fire-and-forget `.then()` or a
+// network-abort that didn't surface a status). This is the same session that
+// hit the 25s-deadline + audit 503s — a degraded-network user.
+//
+// With ZERO frames and an UNCAUGHT `onunhandledrejection`, this is a
+// fire-and-forget `.then()` whose rejection was never caught — likely a
+// third-party script (analytics, the CookieYes cookie banner, Vercel insights)
+// or an app fetch whose `.catch()` was missing, on a degraded network. It is
+// the same family as the prior frameless browser-internal rejection noise
+// matchers — `isNonErrorUndefinedRejectionNoise` (PR #5200, pattern
+// `5cfc90e5…`), `isOperationErrorPopErrorScopeNoise` (PR #5237, pattern
+// `5e1aca20…`), and `isFirefoxReactSchedulerReentryNoise` (PR #5185, pattern
+// `0f03b24e…`).
+//
+// The message is GENERIC — a real first-party unhandled rejection that throws
+// `new Error('network error')` (or `Promise.reject('network error')`) would
+// surface with the SAME message — so the matcher requires BOTH:
+//   1. The EXACT bare message `network error` (lowercase, case-sensitive,
+//      after `stripErrorWrappers`). The capitalized `Network Error` (Axios's
+//      own wrapper Error) is a DIFFERENT surface and is deliberately NOT
+//      matched — it is left to report so a blanket-silence does not hide a
+//      real Axios rejection we may want to triage. A near-worded message such
+//      as `network error: failed to fetch` is also NOT matched (only the EXACT
+//      bare string is noise).
+//   2. A FRAMELESS positive guard: the event has NO resolvable frames (empty
+//      `stacktrace.frames` AND no resolvable `filename`/`call_site` anywhere)
+//      — mirroring `isOperationErrorPopErrorScopeNoise` /
+//      `isNonErrorUndefinedRejectionNoise`. A real first-party
+//      `new Error('network error')` throw almost always has a stack with a
+//      resolvable frame (chunk URL or `apps/web/src/…`), so requiring
+//      framelessness is the over-match guard.
+// Plus TWO negative guards (mirror the frameless-noise matchers): (a) any
+// resolved first-party `apps/web/src/…` frame → keep reporting; (b) ANY
+// resolvable frame location (chunk/URL/named file) → keep reporting. Only the
+// FRAMELESS capture is dropped. Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare-string match there would swallow a real first-party
+// `new Error('network error')` the negative guard exists to preserve; the
+// frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`)
+// is the only safe gate.
+const FRAMELESS_NETWORK_ERROR_MESSAGE = 'network error';
+
+/**
+ * Whether a Sentry event is the bare lowercase `network error` rejection noise
+ * class: the canonical Axios / `XMLHttpRequest` transport-abort message (lower-
+ * case; distinct from Axios's capitalized `Network Error` wrapper, which is a
+ * different surface and is NOT matched), captured as an uncaught global
+ * `onunhandledrejection` with NO resolvable stack frames. A fire-and-forget
+ * `.then()` or a third-party script (analytics / cookie banner / tag manager)
+ * on a degraded network whose promise rejected with the bare transport-abort
+ * string; never attributable first-party app code. Requires the EXACT bare
+ * message (case-sensitive, after `stripErrorWrappers`) AND NEGATIVE guards:
+ * any resolved first-party `apps/web/src/…` frame OR any resolvable frame
+ * location → keep reporting (a real first-party `new Error('network error')`
+ * we can attribute should still surface). The production noise pattern has NO
+ * frames at all; only the frameless capture is dropped. See
+ * `FRAMELESS_NETWORK_ERROR_MESSAGE` for the full rationale.
+ */
+export function isFramelessNetworkErrorNoise(input: {
+  message?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  const message = stripErrorWrappers(normalizeString(input.message));
+  if (message !== FRAMELESS_NETWORK_ERROR_MESSAGE) {
+    return false;
+  }
+  const frames = input.frames ?? [];
+  // Negative guard #1: a resolved first-party `apps/web/src/…` frame means our
+  // own code threw/rejected with `new Error('network error')` → actionable;
+  // keep reporting so the call site can be found + fixed.
+  if (frames.some((frame) => isFirstPartyResolvedSource(frame?.filename))) {
+    return false;
+  }
+  // Negative guard #2: any resolvable source location (real chunk/URL/named
+  // file) → an attributable error with a real stack; keep reporting. Only the
+  // frameless capture (the production noise pattern) remains → drop it.
+  if (frames.some((frame) => isResolvableFrameSource(frame?.filename))) {
+    return false;
+  }
+  return true;
+}
+
 export function shouldIgnoreBrowserRuntimeNoise(input: {
   message?: unknown;
   filename?: unknown;
@@ -2246,6 +2349,24 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // `isOperationErrorPopErrorScopeNoise`. NOT in `ignoreErrors` (no frame
   // context there).
   if (isOperationErrorPopErrorScopeNoise({ message, frames })) {
+    return true;
+  }
+
+  // Bare lowercase `network error` rejection noise — the canonical Axios / XHR
+  // transport-abort message (lowercase; distinct from Axios's capitalized
+  // `Network Error` wrapper, which is a different surface and is NOT matched),
+  // captured as an uncaught global `onunhandledrejection` with NO resolvable
+  // stack frames. A fire-and-forget `.then()` or a third-party script on a
+  // degraded network (the same session hit the 25s-deadline + audit 503s)
+  // whose promise rejected with the bare transport-abort string; never
+  // attributable first-party app code. Requires the EXACT bare message AND
+  // NEGATIVE guards: any resolved first-party `apps/web/src/…` frame OR any
+  // resolvable frame location → keep reporting (a real first-party
+  // `new Error('network error')` we can attribute should still surface). The
+  // production noise pattern has NO frames at all; only the frameless capture
+  // is dropped. See `isFramelessNetworkErrorNoise`. NOT in `ignoreErrors` (no
+  // frame context there).
+  if (isFramelessNetworkErrorNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. A telemetry-filter (noise-matcher) change; the proof is the unit-test pinning the production pattern + the over-match negative guards below.

## Why
Better Stack pattern `2403c9ba5deee2af387834e95461cfb32b9b5080b21d6f307b2f09bb09e71f21` (Kortix Frontend prod, app `2346967`) pages on a `TypeError` with the bare lowercase message `network error` — the canonical Axios / `XMLHttpRequest` transport-abort message — captured as an **uncaught** `onunhandledrejection` (mechanism `auto.browser.global_handlers.onunhandledrejection`, `handled:false`) with **ZERO stack frames** (empty `stacktrace.frames`, no `call_site_file`/`call_site_function`/`call_stack_hash`). 1 occurrence / 0 identified users, last 2026-07-23 16:53:55 UTC, release `470fe6f3…` (v0.10.13), transaction `/projects/:id/sessions/:sessionId`, Chrome 150 / Generic Linux. Breadcrumbs: 88 fetches, 0 non-200 — the rejection is a fire-and-forget `.then()` (or a network-abort that never surfaced a status) on a **degraded session** (the same project/session that hit the 25s-deadline + audit 503s). It never reached a React error boundary, so it paged as an uncaught rejection.

This is **transient network-transport noise** — the same family as the frameless browser-internal rejections already silenced: `isNonErrorUndefinedRejectionNoise` (#5200), `isOperationErrorPopErrorScopeNoise` (#5237), `isFirefoxReactSchedulerReentryNoise` (#5185). The bare `network error` string with NO frames is the prod signature.

## What changed
New matcher `isFramelessNetworkErrorNoise` in `apps/web/src/lib/browser-error-noise.ts`, wired into Sentry `beforeSend` via `shouldIgnoreSentryBrowserNoise`. It anchors on:
- The **EXACT** bare message `network error` (lowercase, case-sensitive, after `stripErrorWrappers`). The capitalized `Network Error` (Axios's own `new Error('Network Error')` wrapper) is a **different surface** and is deliberately NOT matched — left to report so a blanket-silence doesn't hide a real Axios rejection.
- A **frameless positive guard**: `frames` is empty/absent AND there is no resolvable `filename`/`call_site` anywhere — mirroring `isOperationErrorPopErrorScopeNoise` / `isNonErrorUndefinedRejectionNoise`.
- **Two negative guards** (mirror the frameless-noise matchers): (1) any resolved first-party `apps/web/src/…` frame → keep reporting; (2) any resolvable frame location (chunk/URL/named file) → keep reporting. Only the FRAMELESS capture is dropped.

Because the message is generic (a real first-party `new Error('network error')` would surface the same string), requiring the frameless shape is the over-match guard: a real first-party throw almost always carries a resolvable stack frame (chunk URL or `apps/web/src/…`), so it keeps reporting. Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there would swallow the actionable first-party case the negative guard exists to preserve.

## Verification
```
cd apps/web
bun test src/lib/browser-error-noise.test.mts   # 168 pass / 0 fail (was 161, +7 new)
./node_modules/.bin/tsc --noEmit -p tsconfig.json # only the 4 pre-existing unrelated errors
```
New tests pin:
1. The prod pattern (exact `network error`, zero frames) → noise through the matcher AND `shouldIgnoreSentryBrowserNoise`.
2. NEGATIVE: same message WITH a chunk frame → keep reporting.
3. NEGATIVE: same message with a first-party `apps/web/src/…` frame → keep reporting.
4. NEGATIVE: capitalized `Network Error` (frameless) → keep reporting (over-match guard).
5. NEGATIVE: near-worded `network error: failed to fetch` (frameless) → keep reporting (over-match guard — only the EXACT bare string is noise).

## Risk / rollback
Telemetry-filter only — drops one prod noise class at the Sentry `beforeSend` gate. No runtime behavior change. If a real first-party `network error` throw ever surfaces framelessly in future, it would be dropped; the negative guards + exact-message anchor make that unlikely (a real throw carries a stack). Revert is a single-file `git revert`.

Reference: Better Stack pattern `2403c9ba5deee2af387834e95461cfb32b9b5080b21d6f307b2f09bb09e71f21`.
