### PR TITLE
fix(web): drop transient 'Connection closed.' transport noise (BS ecac86df)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -5,6 +5,7 @@ import {
   isAndroidWebViewNativeBridgePostEventNoise,
   isAndroidWebViewNativeBridgePostMessageNoise,
   isClientRequestTimeoutMessage,
+  isConnectionClosedNoise,
   isEmptyMessageUnresolvedBrowserChunkNoise,
   isEmbedPdfTilingReactUpdateDepthNoise,
   isEmbedPdfTilingTileDestructureNoise,
@@ -4897,6 +4898,230 @@ test('does NOT suppress a near-worded message (over-match guard)', () => {
       }),
       false,
       `expected Sentry event for near-worded "${message}" to keep reporting`,
+    )
+  }
+})
+
+
+// ---------------------------------------------------------------------------
+// Transient WebSocket / Server-Sent-Events (SSE) transport-close noise (Better
+// Stack pattern
+// ecac86df82aca61f579836c1b813a0ed02cabd4a480b581db2f1ba5f4e20ab86, Kortix
+// Frontend prod, application_id 2346967). `Connection closed.` is the canonical
+// transport-close message a client-side WebSocket/SSE library throws when the
+// server closes a background realtime connection (deploy / restart / idle-
+// timeout recycle / session end / load-balancer upstream recycle). 1 occurrence
+// / 0 identified users, last 2026-07-23 16:44:09 UTC, release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6` (v0.10.13), transaction
+// `/dashboard`, URL `https://kortix.com/dashboard`, mechanism
+// `auto.browser.global_handlers.onerror` (`handled:false` — UNCAUGHT, never
+// reached a React error boundary), Chrome 150 / Windows 10. The single stack
+// frame is the minified main co-worker runtime chunk
+// `app:///_next/static/chunks/66499-652b83425f671b38.js?dpl=dpl_…` function `t`
+// (lineno 15, colno 73840, in_app) — NO first-party `apps/web/src/…` frame.
+// ZERO breadcrumbs (no fetches, no UI clicks) — a sparse capture consistent
+// with a background transport teardown fired before any user activity was
+// recorded. The connection closing during a deploy/idle-recycle is EXPECTED, not
+// a product bug. Same transient-transport class as the gateway-502 retry
+// (#4609) and the frameless browser-internal rejections (#5200 / #5237 /
+// #5185), but a WebSocket/SSE close on the `/dashboard` realtime surface.
+//
+// The orchestrator's sweep ledger has a HISTORICAL skip-list note about
+// `Connection closed (transient SSE)` (pattern `6c28b5b4…`, ~2026-07-15) with NO
+// code matcher — this codifies that decision into a real, tested gate.
+//
+// `Connection closed.` is generic enough that a real first-party
+// `throw new Error('Connection closed.')` regression would surface with the
+// SAME wording, so the matcher anchors on the EXACT message (case-sensitive,
+// WITH the trailing period) and carries a NEGATIVE guard preserving any
+// resolved first-party `apps/web/src/…` frame.
+// ---------------------------------------------------------------------------
+
+// The exact exception value from the production event (the library's canonical
+// close string, trailing period included).
+const CONNECTION_CLOSED = 'Connection closed.'
+
+// The single production stack frame: the minified main co-worker runtime chunk
+// `66499` function `t` (a `?dpl=dpl_…` Vercel deploy-hash URL). Sentry's
+// sourcemap resolution did NOT rewrite this to a first-party `apps/web/src/…`
+// path, so the negative guard does not fire for it.
+const CONNECTION_CLOSED_PROD_FRAMES = [
+  {
+    filename:
+      'app:///_next/static/chunks/66499-652b83425f671b38.js?dpl=dpl_FWCk2e9rGNxkUxaBwBGi2iMZDfno',
+    function: 't',
+    lineno: 15,
+    colno: 73840,
+    in_app: true,
+  },
+]
+
+test('classifies the production Connection closed. transport noise (exact prod frame)', () => {
+  // Exact production shape: the canonical message + the single minified `66499`
+  // chunk `t` frame. The chunk frame is NOT a first-party `apps/web/src/…`
+  // frame, so the negative guard does not fire.
+  assert.equal(
+    isConnectionClosedNoise({
+      message: CONNECTION_CLOSED,
+      frames: CONNECTION_CLOSED_PROD_FRAMES,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/dashboard' },
+      exception: {
+        values: [
+          {
+            value: CONNECTION_CLOSED,
+            stacktrace: { frames: CONNECTION_CLOSED_PROD_FRAMES },
+          },
+        ],
+      },
+    }),
+    true,
+  )
+})
+
+test('suppresses the Connection closed. noise through all three capture-path wrappers', () => {
+  // The matcher strips the canonical `Error: ` / `Unhandled promise rejection:
+  // ` / `Unhandled promise rejection: Error: ` wrappers before anchoring, so
+  // the SAME underlying message classifies as noise regardless of which capture
+  // path delivered it (window.onerror, onunhandledrejection, Sentry exception).
+  for (const message of [
+    CONNECTION_CLOSED,
+    `Error: ${CONNECTION_CLOSED}`,
+    `Unhandled promise rejection: ${CONNECTION_CLOSED}`,
+    `Unhandled promise rejection: Error: ${CONNECTION_CLOSED}`,
+  ]) {
+    assert.equal(
+      isConnectionClosedNoise({
+        message,
+        frames: CONNECTION_CLOSED_PROD_FRAMES,
+      }),
+      true,
+      `expected "${message}" to be noise`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: message, stacktrace: { frames: CONNECTION_CLOSED_PROD_FRAMES } }],
+        },
+      }),
+      true,
+      `expected Sentry event "${message}" to be noise`,
+    )
+  }
+})
+
+test('classifies the frameless Connection closed. variant as noise (message alone is specific)', () => {
+  // A frameless capture with this exact message still classifies as noise — the
+  // message is the library's canonical close string and is specific enough
+  // (no frameless-positive guard required, unlike the bare-`undefined`
+  // rejection class).
+  assert.equal(
+    isConnectionClosedNoise({
+      message: CONNECTION_CLOSED,
+      frames: [],
+    }),
+    true,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/dashboard' },
+      exception: {
+        values: [{ value: CONNECTION_CLOSED, stacktrace: { frames: [] } }],
+      },
+    }),
+    true,
+  )
+  // Also when the stacktrace key is omitted entirely (frames default to []).
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      request: { url: 'https://kortix.com/dashboard' },
+      exception: {
+        values: [{ value: CONNECTION_CLOSED }],
+      },
+    }),
+    true,
+  )
+})
+
+test('does NOT suppress the Connection closed. throw when a first-party frame is present (real regression)', () => {
+  // A resolved `apps/web/src/…` frame means our own websocket/SSE handling
+  // threw `Connection closed.` → actionable regression; the negative guard
+  // MUST preserve it so the call site can be found + fixed.
+  for (const frames of [
+    [{ filename: 'apps/web/src/features/dashboard/realtime-socket.ts', function: 'onClose' }],
+    [
+      { filename: 'app:///_next/static/chunks/main.js', function: 'f' },
+      { filename: 'app:///apps/web/src/lib/realtime/sse.ts', function: 'stream' },
+    ],
+  ]) {
+    assert.equal(
+      isConnectionClosedNoise({
+        message: CONNECTION_CLOSED,
+        frames,
+      }),
+      false,
+      `expected first-party Connection closed. throw from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [{ value: CONNECTION_CLOSED, stacktrace: { frames } }],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting first-party Connection closed. throw from ${JSON.stringify(frames)}`,
+    )
+  }
+})
+
+test('does NOT suppress a near-worded message without the trailing period (over-match guard)', () => {
+  // The trailing `.` is part of the anchor — a different message `Connection
+  // closed` (no period) must keep reporting so the matcher does not over-match.
+  for (const message of ['Connection closed', 'Connection closed!', 'Connection Closed.']) {
+    assert.equal(
+      isConnectionClosedNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
+    )
+  }
+})
+
+test('does NOT suppress the "Connection closed by server." wording (over-match guard)', () => {
+  // Only the EXACT library close string is noise; a different library's
+  // `Connection closed by server.` keeps reporting.
+  for (const message of [
+    'Connection closed by server.',
+    'Connection closed by peer.',
+    'WebSocket connection closed.',
+  ]) {
+    assert.equal(
+      isConnectionClosedNoise({
+        message,
+        frames: [],
+      }),
+      false,
+      `expected "${message}" to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+      }),
+      false,
+      `expected Sentry event "${message}" to keep reporting`,
     )
   }
 })

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -2057,6 +2057,113 @@ export function isOperationErrorPopErrorScopeNoise(input: {
   return true;
 }
 
+// Transient WebSocket / Server-Sent-Events (SSE) transport-close noise.
+// `Connection closed.` is the CANONICAL transport-close message a client-side
+// WebSocket/SSE library throws when the server closes the connection — a deploy
+// / restart, an idle-timeout recycle, the session ending, or the load balancer
+// recycling the upstream. The `/dashboard` realtime surface holds a background
+// websocket/SSE connection; when the upstream tears the connection down during
+// a deploy/idle-recycle, the library throws `Connection closed.` (the trailing
+// `.` is part of the library's canonical close string). Better Stack pattern
+// ecac86df82aca61f579836c1b813a0ed02cabd4a480b581db2f1ba5f4e20ab86
+// (Kortix Frontend prod, application_id 2346967): `Error`, 1 occurrence / 0
+// identified users, last 2026-07-23 16:44:09 UTC, release
+// `470fe6f3c88460212c3b187f6f86fb4ad456c4d6` (v0.10.13), transaction
+// `/dashboard`, URL `https://kortix.com/dashboard`, mechanism
+// `auto.browser.global_handlers.onerror` (`handled:false` — UNCAUGHT, never
+// reached a React error boundary), browser Chrome 150 / Windows 10. The single
+// stack frame is the minified main co-worker runtime chunk
+// `app:///_next/static/chunks/66499-652b83425f671b38.js?dpl=dpl_…` function `t`
+// (lineno 15, colno 73840, in_app) — NO first-party `apps/web/src/…` frame.
+// ZERO breadcrumbs (no fetches, no UI clicks) — a sparse capture, consistent
+// with a background transport teardown fired before any user activity was
+// recorded. The connection closing during a deploy/idle-recycle is EXPECTED; it
+// is not a product bug. This is the same transient-transport class as the
+// gateway-502 retry (#4609) and the frameless browser-internal rejections
+// (#5200 / #5237 / #5185), but a WebSocket/SSE close on the `/dashboard`
+// realtime surface.
+//
+// The orchestrator's sweep ledger has a HISTORICAL skip-list note about
+// `Connection closed (transient SSE)` (pattern `6c28b5b4…`, noted ~2026-07-15)
+// but NO code matcher existed for it (the note was a manual decision, not code)
+// — this matcher codifies that decision into a real, tested gate.
+//
+// `Connection closed.` is generic enough that a real first-party
+// `throw new Error('Connection closed.')` regression in our own websocket/SSE
+// handling would surface with the SAME wording — so, mirroring
+// `isOperationErrorPopErrorScopeNoise` / the Paper Shaders matchers, this
+// matcher anchors on the EXACT message (case-sensitive, WITH the trailing
+// period — a different message `Connection closed` (no period), or
+// `Connection closed by server`, keeps reporting) and carries a NEGATIVE guard:
+// if ANY frame resolves to a de-minified first-party `apps/web/src/…` source,
+// the event keeps reporting (a real first-party `throw new Error('Connection
+// closed.')` regression de-minifies to `apps/web/src/…` and must not be
+// hidden). The prod event has only a minified `66499` chunk frame, so the
+// negative guard does not fire for it. A frameless capture with this exact
+// message still classifies as noise — the message alone is the library's
+// canonical close string and is specific enough (unlike the bare-`undefined`
+// rejection class, NO frameless-positive guard is required; the message + the
+// first-party negative guard is sufficient). But when frames ARE present, the
+// first-party negative guard MUST run. Deliberately NOT added to
+// `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame
+// context, so a bare-string match there would swallow a real first-party
+// `Connection closed.` regression the negative guard exists to preserve; the
+// frame-aware `beforeSend` hook (which calls `shouldIgnoreSentryBrowserNoise`)
+// is the only safe gate.
+const CONNECTION_CLOSED_NOISE_PATTERN = /^Connection closed\.$/;
+
+/**
+ * Whether a Sentry / window.onerror event is the transient WebSocket /
+ * Server-Sent-Events (SSE) transport-close noise class: a client-side
+ * WebSocket/SSE library threw the canonical `Connection closed.` message when
+ * the server closed a background realtime connection (deploy / restart / idle-
+ * timeout recycle / session end / load-balancer upstream recycle). The
+ * connection closing during a deploy/idle-recycle is EXPECTED, not a product
+ * bug. Requires the EXACT message (case-sensitive, WITH the trailing period —
+ * the library's canonical close string; `Connection closed` without the period,
+ * or `Connection closed by server`, keeps reporting) AND a NEGATIVE guard: if
+ * any frame (or the window.onerror `filename`) resolves to a de-minified
+ * first-party `apps/web/src/…` source path, the event keeps reporting (a real
+ * first-party `throw new Error('Connection closed.')` regression de-minifies to
+ * `apps/web/src/…` and must not be hidden). The prod event carries only a
+ * minified `66499` chunk frame, so the negative guard does not fire for it. A
+ * frameless capture with this exact message still classifies as noise — the
+ * message alone is the library's canonical close string. See
+ * `CONNECTION_CLOSED_NOISE_PATTERN` for the full rationale.
+ */
+export function isConnectionClosedNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown } | undefined>;
+}): boolean {
+  // `stripErrorWrappers` strips `Unhandled promise rejection: ` and
+  // `<Word>Error: ` (e.g. `SyntaxError: `, `TypeError:`) but NOT a bare
+  // `Error: ` prefix (the regex requires ≥1 letter before `Error`). A bare
+  // `Error: Connection closed.` is the form an `onunhandledrejection` of an
+  // `Error` instance serializes to, so strip that leading `Error: ` too before
+  // anchoring on the library's exact canonical close string.
+  const stripped = stripErrorWrappers(normalizeString(input.message))
+    .replace(/^Error: /, '');
+  if (!CONNECTION_CLOSED_NOISE_PATTERN.test(stripped)) {
+    return false;
+  }
+  // Collect every source location — the window.onerror `filename` (runtime
+  // gate) and any stacktrace frames (Sentry gate) — for the first-party
+  // negative guard.
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our
+  // own websocket/SSE handling threw `Connection closed.` → actionable
+  // regression; keep reporting so the call site can be found + fixed.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  return true;
+}
+
+
 // Bare lowercase `network error` rejection noise — the canonical Axios /
 // `XMLHttpRequest` transport-abort message. Axios throws this (or the
 // capitalized `Network Error` wrapper — a DIFFERENT surface, see below) when a
@@ -2191,6 +2298,18 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
   if (isStorageSecurityErrorNoise({ message, filename: input.filename })) {
     return true;
   }
+
+  // Transient WebSocket / SSE transport-close noise — a client-side
+  // websocket/SSE library threw the canonical `Connection closed.` message when
+  // the server closed a background realtime connection during a deploy / idle-
+  // timeout recycle / session end. The connection closing is EXPECTED, not a
+  // product bug. Requires the EXACT message (with trailing `.`) and a NEGATIVE
+  // guard so a real first-party `throw new Error('Connection closed.')`
+  // regression keeps reporting. See `isConnectionClosedNoise`.
+  if (isConnectionClosedNoise({ message, filename: input.filename })) {
+    return true;
+  }
+
 
   // Browser-native <img> / next/image load failures can surface as this exact
   // message through window.onerror. Keep this exact: pptx-react-viewer throws
@@ -2725,6 +2844,27 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   if (isFramelessNetworkErrorNoise({ message, frames })) {
     return true;
   }
+
+  // Transient WebSocket / SSE transport-close noise — a client-side
+  // websocket/SSE library threw the canonical `Connection closed.` message when
+  // the server closed a background realtime connection on `/dashboard` during a
+  // deploy / idle-timeout recycle / session end / load-balancer upstream
+  // recycle. The connection closing is EXPECTED, not a product bug; sibling of
+  // the transient-transport class (#4609 gateway retry). Requires the EXACT
+  // message (case-sensitive, WITH the trailing period — the library's canonical
+  // close string) and a NEGATIVE guard: any resolved first-party
+  // `apps/web/src/…` frame → keep reporting (a real first-party
+  // `throw new Error('Connection closed.')` regression de-minifies to
+  // `apps/web/src/…` and must not be hidden). The prod event carries only a
+  // minified `66499` chunk frame, so the negative guard does not fire for it.
+  // A frameless capture with this exact message still classifies as noise.
+  // This codifies the historical skip-list decision for `6c28b5b4…`-class
+  // patterns into a real, tested matcher. NOT in `ignoreErrors` (no frame
+  // context there). See `isConnectionClosedNoise`.
+  if (isConnectionClosedNoise({ message, frames })) {
+    return true;
+  }
+
 
   if (frames.some((frame) => isExtensionSource(frame.filename))) {
     return true;


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a telemetry-noise filter (Sentry `beforeSend` / window.onerror gate) with no user-visible behavior. Proof: 6 new unit tests pinning the prod pattern + capture-path wrappers + frameless variant + three negative guards (first-party frame, missing trailing period, `Connection closed by server.`), all green (167/167 pass; baseline was 161/161).

## Why

Better Stack pattern `ecac86df82aca61f579836c1b813a0ed02cabd4a480b581db2f1ba5f4e20ab86` (Kortix Frontend prod, application_id 2346967): `Error` `Connection closed.`, 1 occurrence / 0 identified users, last 2026-07-23 16:44:09 UTC, release `470fe6f3…` (v0.10.13), transaction `/dashboard`, URL `https://kortix.com/dashboard`, mechanism `auto.browser.global_handlers.onerror` (`handled:false` — UNCAUGHT). The single stack frame is the minified main co-worker runtime chunk `app:///_next/static/chunks/66499-652b83425f671b38.js?dpl=dpl_…` function `t` (lineno 15, colno 73840) — NO first-party `apps/web/src/…` frame. ZERO breadcrumbs (no fetches, no UI clicks).

`Connection closed.` is the **canonical WebSocket / Server-Sent-Events (SSE) transport-close message** — thrown by a client-side websocket/SSE library when the server closes a background realtime connection (deploy/restart, idle-timeout recycle, the session ending, the load-balancer recycling the upstream). The `/dashboard` route + a single frame in the main runtime chunk + ZERO breadcrumbs (no user activity) = a background transport teardown. The connection closing during a deploy/idle-recycle is EXPECTED; it is not a product bug. This is the same transient-transport class as the gateway-502 retry (#4609) and the frameless browser-internal rejections (#5200/#5237/#5185), but a WebSocket/SSE close on the `/dashboard` real-time surface.

The orchestrator's sweep ledger had a HISTORICAL skip-list note about `Connection closed (transient SSE)` (pattern `6c28b5b4…`, ~2026-07-15) but **no code matcher** existed for it — `grep apps/web/src/lib/browser-error-noise.ts "Connection closed"` returns nothing. This codifies that manual skip-list decision into a real, tested gate.

## What changed

Added a new matcher `isConnectionClosedNoise` in `apps/web/src/lib/browser-error-noise.ts`, wired into both `shouldIgnoreSentryBrowserNoise` (Sentry `beforeSend`) and `shouldIgnoreBrowserRuntimeNoise` (window.onerror / onunhandledrejection):

1. **Exact-message anchor** — `/^Connection closed\.$/` (case-sensitive, WITH the trailing period — the library's canonical close string). Anchored AFTER `stripErrorWrappers` (which strips `Unhandled promise rejection: ` and `<Word>Error: `) plus a local strip of a bare `Error: ` prefix (`stripErrorWrappers`' regex requires ≥1 letter before `Error`, so it does not strip a bare `Error:`; a bare `Error: Connection closed.` is the form an `onunhandledrejection` of an `Error` instance serializes to). A different message — `Connection closed` (no period), `Connection Closed.` (case), `Connection closed by server.`, `Connection closed by peer.`, `WebSocket connection closed.` — keeps reporting.
2. **Negative guard (mandatory)** — if ANY frame (or the window.onerror `filename`) resolves to a de-minified first-party `apps/web/src/…` source, keep reporting. A real first-party `throw new Error('Connection closed.')` regression in our own websocket/SSE handling de-minifies to `apps/web/src/…` and must NOT be hidden. The prod event has only a minified `66499` chunk frame, so the negative guard does not fire for it.
3. **Frameless-OK** — the message is the library's canonical close string, so a frameless capture with this exact message still classifies as noise (NO frameless-positive guard required, unlike `isNonErrorUndefinedRejectionNoise`). But when frames ARE present, the first-party negative guard runs.

This mirrors `isPaperShaderNullContextNoise` / `isOperationErrorPopErrorScopeNoise` (exact library message + first-party-frame negative guard). Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party `Connection closed.` regression the negative guard exists to preserve; the frame-aware `beforeSend` hook is the only safe gate.

## Verification

```
cd apps/web
bun test src/lib/browser-error-noise.test.mts   # 167 pass / 0 fail (was 161; +6 new)
./node_modules/.bin/tsc --noEmit -p tsconfig.json  # only the 4 pre-existing unrelated errors
```

New tests in `browser-error-noise.test.mts`:
1. Pins the prod pattern (exact `Connection closed.` + the 1 prod `66499` chunk `t` frame) → noise through the matcher AND `shouldIgnoreSentryBrowserNoise`.
2. Pins the message through all capture-path forms: raw `Connection closed.`, `Error: Connection closed.`, `Unhandled promise rejection: Error: Connection closed.`.
3. Frameless variant (no frames, and stacktrace key omitted) → still noise.
4. NEGATIVE: same message with a first-party `apps/web/src/…` frame → keep reporting (real regression).
5. NEGATIVE: near-worded `Connection closed` (NO trailing period, frameless) → keep reporting (over-match guard — the `.` is part of the anchor).
6. NEGATIVE: `Connection closed by server.` (frameless) → keep reporting (over-match guard — only the EXACT library string is noise).

## Risk / rollback

Telemetry-gate-only change — no product behavior, no API, no DB. If a real first-party `Connection closed.` regression ships later, the negative guard keeps it reporting (de-minified `apps/web/src/…` frame). Revert the single commit to restore the prior noise. Reference Better Stack pattern `ecac86df…`.