### PR TITLE
fix(connectors): expose OAuth2 during creation

### DIFF
--- a/apps/web/content/docs/connect/connectors.mdx
+++ b/apps/web/content/docs/connect/connectors.mdx
@@ -55,12 +55,12 @@ Use this path for server-to-server APIs that require OAuth2. Microsoft Graph and
 <Step>
 ### Declare the direct connector
 
-Set the connector authentication type to `bearer`. The Executor injects the access token into the configured authentication header.
+In the Custom connector form, select **OAuth 2.0 client credentials** under **Auth**. Kortix configures bearer-token injection and shows the OAuth2 fields before it creates the connector.
 </Step>
 <Step>
-### Open the credential modal
+### Enter the OAuth2 configuration
 
-Open the connector and select **OAuth2 client credentials**. Enter the token URL, client ID, scopes, and client secret.
+Enter the token URL, client ID, scopes, and client secret. Existing connectors expose the same fields under **Set credential**.
 
 For certificate authentication, select **Certificate assertion**. Enter the PKCS#8 private key PEM and the certificate's Base64url SHA-256 thumbprint (`x5t#S256`).
 </Step>

--- a/apps/web/src/features/workspace/customize/sections/connector-oauth2-fields.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connector-oauth2-fields.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import type { OAuth2CredentialForm } from './connector-oauth2';
+
+export function OAuth2CredentialFields({
+  value,
+  onChange,
+  idPrefix,
+  autoFocus = false,
+}: {
+  value: OAuth2CredentialForm;
+  onChange: (value: OAuth2CredentialForm) => void;
+  idPrefix: string;
+  autoFocus?: boolean;
+}) {
+  const set = <K extends keyof OAuth2CredentialForm>(key: K, next: OAuth2CredentialForm[K]) =>
+    onChange({ ...value, [key]: next });
+  const id = (name: string) => `${idPrefix}-${name}`;
+
+  return (
+    <FieldGroup className="grid gap-3 sm:grid-cols-2">
+      <Field className="sm:col-span-2">
+        <FieldLabel htmlFor={id('token-url')}>Token URL</FieldLabel>
+        <Input
+          id={id('token-url')}
+          type="url"
+          value={value.tokenUrl}
+          onChange={(event) => set('tokenUrl', event.target.value)}
+          placeholder="https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+          variant="popover"
+          autoFocus={autoFocus}
+          required
+        />
+      </Field>
+      <Field>
+        <FieldLabel htmlFor={id('client-id')}>Client ID</FieldLabel>
+        <Input
+          id={id('client-id')}
+          value={value.clientId}
+          onChange={(event) => set('clientId', event.target.value)}
+          variant="popover"
+          required
+        />
+      </Field>
+      <Field>
+        <FieldLabel htmlFor={id('auth-method')}>Token authentication</FieldLabel>
+        <Select
+          value={value.authMethod}
+          onValueChange={(next) => set('authMethod', next as OAuth2CredentialForm['authMethod'])}
+        >
+          <SelectTrigger id={id('auth-method')} variant="popover">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="client_secret_post">Client secret in body</SelectItem>
+            <SelectItem value="client_secret_basic">Client secret with Basic</SelectItem>
+            <SelectItem value="private_key_jwt">Certificate assertion</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+      {value.authMethod === 'private_key_jwt' ? (
+        <>
+          <Field className="sm:col-span-2">
+            <FieldLabel htmlFor={id('private-key')}>Private key PEM</FieldLabel>
+            <Textarea
+              id={id('private-key')}
+              value={value.privateKey}
+              onChange={(event) => set('privateKey', event.target.value)}
+              className="min-h-32 font-mono text-xs"
+              required
+            />
+          </Field>
+          <Field className="sm:col-span-2">
+            <FieldLabel htmlFor={id('thumbprint')}>Certificate SHA-256 thumbprint</FieldLabel>
+            <Input
+              id={id('thumbprint')}
+              type="password"
+              value={value.certificateThumbprint}
+              onChange={(event) => set('certificateThumbprint', event.target.value)}
+              placeholder="Base64url x5t#S256 value"
+              variant="popover"
+              required
+            />
+          </Field>
+        </>
+      ) : (
+        <Field className="sm:col-span-2">
+          <FieldLabel htmlFor={id('client-secret')}>Client secret</FieldLabel>
+          <Input
+            id={id('client-secret')}
+            type="password"
+            value={value.clientSecret}
+            onChange={(event) => set('clientSecret', event.target.value)}
+            variant="popover"
+            required
+          />
+        </Field>
+      )}
+      <Field className="sm:col-span-2">
+        <FieldLabel htmlFor={id('scopes')}>Scopes</FieldLabel>
+        <Input
+          id={id('scopes')}
+          value={value.scopes}
+          onChange={(event) => set('scopes', event.target.value)}
+          placeholder="https://graph.microsoft.com/.default"
+          variant="popover"
+        />
+        <FieldDescription>Separate multiple scopes with spaces.</FieldDescription>
+      </Field>
+      <Field>
+        <FieldLabel htmlFor={id('resource')}>Resource</FieldLabel>
+        <Input
+          id={id('resource')}
+          value={value.resource}
+          onChange={(event) => set('resource', event.target.value)}
+          placeholder="Optional"
+          variant="popover"
+        />
+      </Field>
+      <Field>
+        <FieldLabel htmlFor={id('audience')}>Audience</FieldLabel>
+        <Input
+          id={id('audience')}
+          value={value.audience}
+          onChange={(event) => set('audience', event.target.value)}
+          placeholder="Optional"
+          variant="popover"
+        />
+      </Field>
+    </FieldGroup>
+  );
+}

--- a/apps/web/src/features/workspace/customize/sections/connector-oauth2.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-oauth2.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, test } from 'bun:test';
-import { buildOAuth2CredentialInput } from './connector-oauth2';
+import {
+  buildOAuth2CredentialInput,
+  createConnectorWithOptionalOAuth2,
+  oauth2CredentialFormValid,
+  type OAuth2CredentialForm,
+} from './connector-oauth2';
+
+const SECRET_FORM: OAuth2CredentialForm = {
+  tokenUrl: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/token',
+  clientId: 'client-id',
+  authMethod: 'client_secret_post',
+  clientSecret: 'client-secret',
+  privateKey: '',
+  certificateThumbprint: '',
+  scopes: 'https://graph.microsoft.com/.default',
+  resource: '',
+  audience: '',
+};
 
 describe('buildOAuth2CredentialInput', () => {
   test('normalizes a Microsoft client-secret configuration', () => {
@@ -52,5 +69,110 @@ describe('buildOAuth2CredentialInput', () => {
         audience: 'https://api.example.com',
       },
     });
+  });
+
+  test('builds HTTP Basic token authentication', () => {
+    expect(
+      buildOAuth2CredentialInput({
+        ...SECRET_FORM,
+        authMethod: 'client_secret_basic',
+      }),
+    ).toEqual({
+      oauth2: {
+        type: 'oauth2_client_credentials',
+        token_url: SECRET_FORM.tokenUrl,
+        client_id: 'client-id',
+        token_endpoint_auth_method: 'client_secret_basic',
+        client_secret: 'client-secret',
+        scopes: ['https://graph.microsoft.com/.default'],
+      },
+    });
+  });
+});
+
+describe('oauth2CredentialFormValid', () => {
+  test('requires the token URL, client ID, and selected client authentication', () => {
+    expect(oauth2CredentialFormValid(SECRET_FORM)).toBe(true);
+    expect(oauth2CredentialFormValid({ ...SECRET_FORM, clientSecret: '' })).toBe(false);
+    expect(
+      oauth2CredentialFormValid({
+        ...SECRET_FORM,
+        authMethod: 'private_key_jwt',
+        clientSecret: '',
+        privateKey: 'private-key',
+        certificateThumbprint: 'thumbprint',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('createConnectorWithOptionalOAuth2', () => {
+  test('creates the connector before it stores the OAuth2 credential', async () => {
+    const calls: string[] = [];
+    await createConnectorWithOptionalOAuth2(
+      'project-1',
+      { slug: 'sharepoint', provider: 'openapi', spec: 'https://example.com/openapi.json' },
+      SECRET_FORM,
+      {
+        createConnector: async () => {
+          calls.push('create');
+        },
+        deleteConnector: async () => {
+          calls.push('delete');
+        },
+        setConnectorCredential: async (_projectId, slug, credential) => {
+          const method =
+            'oauth2' in credential ? credential.oauth2.token_endpoint_auth_method : 'static';
+          calls.push(`credential:${slug}:${method}`);
+        },
+      },
+    );
+
+    expect(calls).toEqual(['create', 'credential:sharepoint:client_secret_post']);
+  });
+
+  test('does not create a credential when OAuth2 is not selected', async () => {
+    let credentialCalls = 0;
+    await createConnectorWithOptionalOAuth2(
+      'project-1',
+      { slug: 'public-api', provider: 'openapi', spec: 'https://example.com/openapi.json' },
+      null,
+      {
+        createConnector: async () => undefined,
+        deleteConnector: async () => undefined,
+        setConnectorCredential: async () => {
+          credentialCalls += 1;
+        },
+      },
+    );
+
+    expect(credentialCalls).toBe(0);
+  });
+
+  test('deletes the connector when OAuth2 credential validation fails', async () => {
+    const calls: string[] = [];
+    const credentialError = new Error('invalid_client');
+
+    await expect(
+      createConnectorWithOptionalOAuth2(
+        'project-1',
+        { slug: 'sharepoint', provider: 'openapi', spec: 'https://example.com/openapi.json' },
+        SECRET_FORM,
+        {
+          createConnector: async () => {
+            calls.push('create');
+          },
+          deleteConnector: async () => {
+            calls.push('delete');
+          },
+          setConnectorCredential: async () => {
+            calls.push('credential');
+            throw credentialError;
+          },
+        },
+      ),
+    ).rejects.toBe(credentialError);
+
+    expect(calls).toEqual(['create', 'credential', 'delete']);
   });
 });

--- a/apps/web/src/features/workspace/customize/sections/connector-oauth2.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-oauth2.ts
@@ -1,5 +1,6 @@
 import type {
   ConnectionProfileCredentialInput,
+  ConnectorDraftInput,
   OAuth2ClientCredentials,
 } from '@kortix/sdk/projects-client';
 
@@ -27,6 +28,13 @@ export const EMPTY_OAUTH2_CREDENTIAL_FORM: OAuth2CredentialForm = {
   audience: '',
 };
 
+export function oauth2CredentialFormValid(form: OAuth2CredentialForm): boolean {
+  if (!form.tokenUrl.trim() || !form.clientId.trim()) return false;
+  return form.authMethod === 'private_key_jwt'
+    ? Boolean(form.privateKey.trim() && form.certificateThumbprint.trim())
+    : Boolean(form.clientSecret.trim());
+}
+
 export function buildOAuth2CredentialInput(
   form: OAuth2CredentialForm,
 ): ConnectionProfileCredentialInput {
@@ -47,4 +55,39 @@ export function buildOAuth2CredentialInput(
   if (form.resource.trim()) oauth2.resource = form.resource.trim();
   if (form.audience.trim()) oauth2.audience = form.audience.trim();
   return { oauth2 };
+}
+
+export async function createConnectorWithOptionalOAuth2(
+  projectId: string,
+  draft: ConnectorDraftInput,
+  oauth2: OAuth2CredentialForm | null,
+  deps: {
+    createConnector: (projectId: string, draft: ConnectorDraftInput) => Promise<unknown>;
+    deleteConnector: (projectId: string, slug: string) => Promise<unknown>;
+    setConnectorCredential: (
+      projectId: string,
+      slug: string,
+      credential: ConnectionProfileCredentialInput,
+    ) => Promise<unknown>;
+  },
+): Promise<void> {
+  await deps.createConnector(projectId, draft);
+  if (!oauth2) return;
+
+  try {
+    await deps.setConnectorCredential(projectId, draft.slug, buildOAuth2CredentialInput(oauth2));
+  } catch (credentialError) {
+    try {
+      await deps.deleteConnector(projectId, draft.slug);
+    } catch (rollbackError) {
+      const credentialMessage =
+        credentialError instanceof Error ? credentialError.message : String(credentialError);
+      const rollbackMessage =
+        rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+      throw new Error(
+        `OAuth2 credential validation failed: ${credentialMessage}. Connector rollback failed: ${rollbackMessage}`,
+      );
+    }
+    throw credentialError;
+  }
 }

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.oauth2.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.oauth2.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = import.meta.dir;
+const connectorsSource = readFileSync(join(dir, 'connectors-view.tsx'), 'utf8');
+const fieldsSource = readFileSync(join(dir, 'connector-oauth2-fields.tsx'), 'utf8');
+
+describe('Custom connector OAuth2 onboarding', () => {
+  test('shows OAuth2 client credentials in the initial Auth selector', () => {
+    expect(connectorsSource).toContain('<SelectItem value="oauth2_client_credentials">');
+    expect(connectorsSource).toContain('OAuth 2.0 client credentials');
+  });
+
+  test('renders the OAuth2 credential fields before connector creation', () => {
+    expect(connectorsSource).toContain('oauth2Selected={oauth2Selected}');
+    expect(connectorsSource).toContain('idPrefix="new-connector-oauth2"');
+    expect(connectorsSource).toContain('createConnectorWithOptionalOAuth2(');
+  });
+
+  test('covers every supported token endpoint authentication strategy', () => {
+    expect(fieldsSource).toContain('value="client_secret_post"');
+    expect(fieldsSource).toContain('value="client_secret_basic"');
+    expect(fieldsSource).toContain('value="private_key_jwt"');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -73,7 +73,6 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Textarea } from '@/components/ui/textarea';
 import { errorToast, successToast, warningToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import {
@@ -107,9 +106,9 @@ import {
   createConnector,
   deleteConnector,
   discoverConnectorAuth,
-  getConnectStatus,
   getConnectorConfig,
   getConnectorPolicies,
+  getConnectStatus,
   getProjectDetail,
   listConnectionProfiles,
   listConnectors,
@@ -128,9 +127,12 @@ import {
 } from '@kortix/sdk/projects-client';
 import {
   buildOAuth2CredentialInput,
+  createConnectorWithOptionalOAuth2,
   EMPTY_OAUTH2_CREDENTIAL_FORM,
   type OAuth2CredentialForm,
+  oauth2CredentialFormValid,
 } from './connector-oauth2';
+import { OAuth2CredentialFields } from './connector-oauth2-fields';
 import { DiscoverCatalogue } from './discover-catalogue';
 
 const PROVIDER_ICON: Record<AdminConnector['provider'], LucideIcon> = {
@@ -3640,6 +3642,8 @@ function ConnectorConfigFields({
   readOnly = false,
   detectedAuth = null,
   detectedTitle = null,
+  oauth2Selected = false,
+  onOAuth2SelectedChange,
 }: {
   draft: ConnectorDraftInput;
   onChange: (d: ConnectorDraftInput) => void;
@@ -3650,6 +3654,9 @@ function ConnectorConfigFields({
   detectedAuth?: { type: string; parameterName: string | null } | null;
   /** The source document's own name, used to propose a slug. */
   detectedTitle?: string | null;
+  /** Exposes native OAuth2 during initial connector creation. */
+  oauth2Selected?: boolean;
+  onOAuth2SelectedChange?: (selected: boolean) => void;
 }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   // Once the slug is typed in by hand, never overwrite it from the source again.
@@ -3878,9 +3885,15 @@ function ConnectorConfigFields({
           <Field>
             <FieldLabel htmlFor="connector-auth">Auth</FieldLabel>
             <Select
-              value={draft.auth?.type ?? 'auto'}
+              value={oauth2Selected ? 'oauth2_client_credentials' : (draft.auth?.type ?? 'auto')}
               disabled={readOnly}
               onValueChange={(v) => {
+                if (v === 'oauth2_client_credentials') {
+                  onOAuth2SelectedChange?.(true);
+                  set({ auth: { type: 'bearer' } });
+                  return;
+                }
+                onOAuth2SelectedChange?.(false);
                 if (v === 'auto') set({ auth: undefined });
                 else setAuth({ type: v as 'none' | 'bearer' | 'basic' | 'custom' | 'oauth1' });
               }}
@@ -3893,6 +3906,11 @@ function ConnectorConfigFields({
                 <SelectItem value="none">None</SelectItem>
                 <SelectItem value="bearer">Bearer</SelectItem>
                 <SelectItem value="basic">Basic</SelectItem>
+                {onOAuth2SelectedChange && (
+                  <SelectItem value="oauth2_client_credentials">
+                    OAuth 2.0 client credentials
+                  </SelectItem>
+                )}
                 <SelectItem value="oauth1">OAuth 1.0</SelectItem>
                 <SelectItem value="custom">
                   {tI18nHardcoded.raw(
@@ -3902,7 +3920,9 @@ function ConnectorConfigFields({
               </SelectContent>
             </Select>
             <FieldDescription>
-              {draft.auth === undefined && detectedAuth ? (
+              {oauth2Selected ? (
+                'Kortix obtains, refreshes, and injects a bearer token for this connector.'
+              ) : draft.auth === undefined && detectedAuth ? (
                 <>
                   Detected <span className="font-medium">{detectedAuth.type}</span>
                   {detectedAuth.parameterName ? (
@@ -4000,6 +4020,8 @@ export function CustomConnectorForm({
     slug: '',
     provider: 'openapi',
   });
+  const [oauth2Selected, setOauth2Selected] = useState(false);
+  const [oauth2, setOauth2] = useState<OAuth2CredentialForm>(EMPTY_OAUTH2_CREDENTIAL_FORM);
   const [discoveryDraft, setDiscoveryDraft] = useState(draft);
   useEffect(() => {
     const timer = window.setTimeout(() => setDiscoveryDraft(draft), 400);
@@ -4010,11 +4032,21 @@ export function CustomConnectorForm({
       setDraft((current) => ({ ...current, platform: 'slack' }));
     }
   }, [draft.platform, draft.provider, emailChannelEnabled]);
+  useEffect(() => {
+    if (draft.provider === 'channel' && oauth2Selected) {
+      setOauth2Selected(false);
+    }
+  }, [draft.provider, oauth2Selected]);
 
   const save = useMutation({
-    mutationFn: () => createConnector(projectId, draft),
+    mutationFn: () =>
+      createConnectorWithOptionalOAuth2(projectId, draft, oauth2Selected ? oauth2 : null, {
+        createConnector,
+        deleteConnector,
+        setConnectorCredential,
+      }),
     onSuccess: () => {
-      successToast(`Added ${draft.slug}`);
+      successToast(oauth2Selected ? `Added and connected ${draft.slug}` : `Added ${draft.slug}`);
       onAdded(draft.slug);
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to add connector'),
@@ -4037,6 +4069,7 @@ export function CustomConnectorForm({
       <form
         onSubmit={(e) => {
           e.preventDefault();
+          if (oauth2Selected && !oauth2CredentialFormValid(oauth2)) return;
           save.mutate();
         }}
       >
@@ -4055,7 +4088,22 @@ export function CustomConnectorForm({
                 : null
             }
             detectedTitle={discovery.data?.title ?? null}
+            oauth2Selected={oauth2Selected}
+            onOAuth2SelectedChange={setOauth2Selected}
           />
+          {oauth2Selected && (
+            <div className="space-y-4">
+              <InfoBanner tone="info" title="OAuth 2.0 client credentials">
+                Kortix requests a token before saving. It encrypts the configuration and refreshes
+                the access token before expiry.
+              </InfoBanner>
+              <OAuth2CredentialFields
+                value={oauth2}
+                onChange={setOauth2}
+                idPrefix="new-connector-oauth2"
+              />
+            </div>
+          )}
           {draft.auth === undefined && discovery.isFetching && (
             <InfoBanner tone="info">Checking the source for authentication settings…</InfoBanner>
           )}
@@ -4073,7 +4121,7 @@ export function CustomConnectorForm({
               Could not inspect authentication: {(discovery.error as Error).message}
             </InfoBanner>
           )}
-          {authActive && (
+          {authActive && !oauth2Selected && (
             <InfoBanner tone="info">
               {tI18nHardcoded.raw(
                 'autoComponentsProjectsCustomizeSectionsConnectorsViewJsxTextYouLle5def626',
@@ -4085,7 +4133,10 @@ export function CustomConnectorForm({
               type="submit"
               size="sm"
               disabled={
-                !draft.slug || save.isPending || !connectionValid(draft, emailChannelEnabled)
+                !draft.slug ||
+                save.isPending ||
+                !connectionValid(draft, emailChannelEnabled) ||
+                (oauth2Selected && !oauth2CredentialFormValid(oauth2))
               }
               className="gap-1.5"
             >
@@ -4118,16 +4169,7 @@ function SetCredentialModal({
   const [credentialType, setCredentialType] = useState<'static' | 'oauth2'>('static');
   const [value, setValue] = useState('');
   const [oauth2, setOauth2] = useState<OAuth2CredentialForm>(EMPTY_OAUTH2_CREDENTIAL_FORM);
-  const setOauth2Field = <K extends keyof OAuth2CredentialForm>(
-    key: K,
-    next: OAuth2CredentialForm[K],
-  ) => setOauth2((current) => ({ ...current, [key]: next }));
-  const oauth2Valid =
-    !!oauth2.tokenUrl.trim() &&
-    !!oauth2.clientId.trim() &&
-    (oauth2.authMethod === 'private_key_jwt'
-      ? !!oauth2.privateKey && !!oauth2.certificateThumbprint.trim()
-      : !!oauth2.clientSecret);
+  const oauth2Valid = oauth2CredentialFormValid(oauth2);
   const save = useMutation({
     mutationFn: () =>
       setConnectorCredential(
@@ -4204,116 +4246,11 @@ function SetCredentialModal({
                   Kortix requests a token now and refreshes it before expiry. Use a Bearer or custom
                   header in the connector authentication settings.
                 </InfoBanner>
-                <FieldGroup className="grid gap-3 sm:grid-cols-2">
-                  <Field className="sm:col-span-2">
-                    <FieldLabel htmlFor="oauth2-token-url">Token URL</FieldLabel>
-                    <Input
-                      id="oauth2-token-url"
-                      type="url"
-                      value={oauth2.tokenUrl}
-                      onChange={(e) => setOauth2Field('tokenUrl', e.target.value)}
-                      placeholder="https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
-                      variant="popover"
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="oauth2-client-id">Client ID</FieldLabel>
-                    <Input
-                      id="oauth2-client-id"
-                      value={oauth2.clientId}
-                      onChange={(e) => setOauth2Field('clientId', e.target.value)}
-                      variant="popover"
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="oauth2-auth-method">Token authentication</FieldLabel>
-                    <Select
-                      value={oauth2.authMethod}
-                      onValueChange={(next) =>
-                        setOauth2Field('authMethod', next as OAuth2CredentialForm['authMethod'])
-                      }
-                    >
-                      <SelectTrigger id="oauth2-auth-method" variant="popover">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="client_secret_post">Client secret in body</SelectItem>
-                        <SelectItem value="client_secret_basic">
-                          Client secret with Basic
-                        </SelectItem>
-                        <SelectItem value="private_key_jwt">Certificate assertion</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                  {oauth2.authMethod === 'private_key_jwt' ? (
-                    <>
-                      <Field className="sm:col-span-2">
-                        <FieldLabel htmlFor="oauth2-private-key">Private key PEM</FieldLabel>
-                        <Textarea
-                          id="oauth2-private-key"
-                          value={oauth2.privateKey}
-                          onChange={(e) => setOauth2Field('privateKey', e.target.value)}
-                          className="min-h-32 font-mono text-xs"
-                        />
-                      </Field>
-                      <Field className="sm:col-span-2">
-                        <FieldLabel htmlFor="oauth2-thumbprint">
-                          Certificate SHA-256 thumbprint
-                        </FieldLabel>
-                        <Input
-                          id="oauth2-thumbprint"
-                          type="password"
-                          value={oauth2.certificateThumbprint}
-                          onChange={(e) => setOauth2Field('certificateThumbprint', e.target.value)}
-                          placeholder="Base64url x5t#S256 value"
-                          variant="popover"
-                        />
-                      </Field>
-                    </>
-                  ) : (
-                    <Field className="sm:col-span-2">
-                      <FieldLabel htmlFor="oauth2-client-secret">Client secret</FieldLabel>
-                      <Input
-                        id="oauth2-client-secret"
-                        type="password"
-                        value={oauth2.clientSecret}
-                        onChange={(e) => setOauth2Field('clientSecret', e.target.value)}
-                        variant="popover"
-                      />
-                    </Field>
-                  )}
-                  <Field className="sm:col-span-2">
-                    <FieldLabel htmlFor="oauth2-scopes">Scopes</FieldLabel>
-                    <Input
-                      id="oauth2-scopes"
-                      value={oauth2.scopes}
-                      onChange={(e) => setOauth2Field('scopes', e.target.value)}
-                      placeholder="https://graph.microsoft.com/.default"
-                      variant="popover"
-                    />
-                    <FieldDescription>Separate multiple scopes with spaces.</FieldDescription>
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="oauth2-resource">Resource</FieldLabel>
-                    <Input
-                      id="oauth2-resource"
-                      value={oauth2.resource}
-                      onChange={(e) => setOauth2Field('resource', e.target.value)}
-                      placeholder="Optional"
-                      variant="popover"
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="oauth2-audience">Audience</FieldLabel>
-                    <Input
-                      id="oauth2-audience"
-                      value={oauth2.audience}
-                      onChange={(e) => setOauth2Field('audience', e.target.value)}
-                      placeholder="Optional"
-                      variant="popover"
-                    />
-                  </Field>
-                </FieldGroup>
+                <OAuth2CredentialFields
+                  value={oauth2}
+                  onChange={setOauth2}
+                  idPrefix="connector-oauth2"
+                />
               </TabsContent>
             </Tabs>
           </ModalBody>

--- a/apps/web/src/lib/seo/content-timestamps.json
+++ b/apps/web/src/lib/seo/content-timestamps.json
@@ -12,7 +12,7 @@
   "docs:backend": "2026-07-24T15:59:11+02:00",
   "docs:cli": "2026-07-22T04:12:30+02:00",
   "docs:connect/computers": "2026-07-22T04:12:30+02:00",
-  "docs:connect/connectors": "2026-07-22T04:12:30+02:00",
+  "docs:connect/connectors": "2026-07-24T21:32:45+02:00",
   "docs:connect": "2026-07-22T04:12:30+02:00",
   "docs:connect/slack": "2026-07-22T04:12:30+02:00",
   "docs:connect/triggers": "2026-07-22T04:12:30+02:00",

--- a/tests/e2e/helpers/session-auth.ts
+++ b/tests/e2e/helpers/session-auth.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { type Page, expect } from '@playwright/test';
 
 import { optionalEnvValue, requireEnvValue } from './env';
 import { json } from './http';
@@ -56,7 +56,10 @@ export async function createAuthUser(email: string, options: AuthOptions): Promi
   return body.user ?? body;
 }
 
-export async function deleteAuthUser(userId: string, options: Omit<AuthOptions, 'password'>): Promise<void> {
+export async function deleteAuthUser(
+  userId: string,
+  options: Omit<AuthOptions, 'password'>,
+): Promise<void> {
   const serviceRoleKey = optionalEnvValue(
     'SUPABASE_SERVICE_ROLE_KEY',
     ...(options.envFiles ?? ['apps/web/.env', 'apps/api/.env']),
@@ -110,7 +113,11 @@ export async function installBrowserSession(
   const lockScreen = page.getByText('Click or press Enter to sign in');
   if (await lockScreen.isVisible({ timeout: 5_000 }).catch(() => false)) {
     const emailInput = page.locator('input[name="email"]');
-    for (let attempt = 0; attempt < 3 && !(await emailInput.isVisible().catch(() => false)); attempt++) {
+    for (
+      let attempt = 0;
+      attempt < 3 && !(await emailInput.isVisible().catch(() => false));
+      attempt++
+    ) {
       await page.locator('div.fixed.inset-0.cursor-pointer').first().click({ force: true });
       await page.keyboard.press('Enter');
       await page.waitForTimeout(750);
@@ -118,14 +125,27 @@ export async function installBrowserSession(
   }
 
   await expect(page.locator('input[name="email"]')).toBeVisible({ timeout: 15_000 });
-  await page.getByRole('tab', { name: /^Sign in$/i }).click();
+  const signInTab = page.getByRole('tab', { name: /^Sign in$/i });
+  if (await signInTab.isVisible().catch(() => false)) {
+    await signInTab.click();
+  }
+  await page.locator('input[name="email"]').fill(session.user.email || '');
+  const continueButton = page.getByRole('button', { name: /^Continue$/i });
+  if (await continueButton.isVisible().catch(() => false)) {
+    await continueButton.click();
+  }
   const usePassword = page.getByRole('button', { name: /Use password instead/i });
+  const passwordInput = page.locator('input[name="password"]');
+  await expect(usePassword.or(passwordInput)).toBeVisible({ timeout: 15_000 });
   if (await usePassword.isVisible().catch(() => false)) {
     await usePassword.click();
   }
-  await page.locator('input[name="email"]').fill(session.user.email || '');
-  await page.locator('input[name="password"]').fill(password);
-  await page.locator('form').getByRole('button', { name: /^Sign in$/i }).click();
+  await expect(passwordInput).toBeVisible({ timeout: 15_000 });
+  await passwordInput.fill(password);
+  await page
+    .locator('form')
+    .getByRole('button', { name: /^(Sign in|Continue)$/i })
+    .click();
   await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 30_000 });
   await page.goto(returnUrl, { waitUntil: 'domcontentloaded' });
 }

--- a/tests/e2e/specs/13-connector-oauth2.spec.ts
+++ b/tests/e2e/specs/13-connector-oauth2.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import { authHeaders, createApiResultClient } from '../helpers/http';
+import {
+  type AuthSession,
+  type AuthUser,
+  createAuthUser,
+  deleteAuthUser,
+  installBrowserSession,
+  signIn,
+} from '../helpers/session-auth';
+
+const apiBase = process.env.E2E_API_URL || 'http://localhost:8008/v1';
+const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
+const password = 'E2eConnectorOauth123!';
+const api = createApiResultClient(apiBase);
+const authOptions = { supabaseUrl, password };
+
+test.describe('13 — Custom connector OAuth2', () => {
+  test.setTimeout(180_000);
+
+  let user: AuthUser;
+  let session: AuthSession;
+  let projectId: string;
+
+  test.beforeAll(async () => {
+    const email = `e2e-connector-oauth-${Date.now()}@kortix.test`;
+    user = await createAuthUser(email, authOptions);
+    session = await signIn(email, authOptions);
+
+    const response = await fetch(`${apiBase}/projects/provision`, {
+      method: 'POST',
+      headers: authHeaders(session.access_token),
+      body: JSON.stringify({
+        name: `e2e-connector-oauth-${Date.now()}`,
+      }),
+    });
+    const body = (await response.json()) as { project_id?: string; error?: string };
+    expect(response.status, JSON.stringify(body)).toBe(201);
+    expect(body.project_id).toBeTruthy();
+    if (!body.project_id)
+      throw new Error(`Project provision returned no project_id: ${JSON.stringify(body)}`);
+    projectId = body.project_id;
+  });
+
+  test.afterAll(async () => {
+    if (projectId && session) {
+      await api(session.access_token, 'DELETE', `/projects/${projectId}`).catch(() => {});
+    }
+    if (user?.id) await deleteAuthUser(user.id, authOptions);
+  });
+
+  test('shows every OAuth2 client-credentials strategy during connector creation', async ({
+    page,
+  }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await installBrowserSession(
+      page,
+      session,
+      `/projects/${projectId}/customize/connectors`,
+      password,
+    );
+    await expect(page.getByRole('dialog', { name: /Customize/i })).toBeVisible();
+    await page.getByRole('tab', { name: /^Custom$/ }).click();
+
+    const authSelect = page.getByRole('combobox', { name: /^Auth$/ });
+    await authSelect.click();
+    await expect(page.getByRole('option', { name: 'OAuth 2.0 client credentials' })).toBeVisible();
+    await page.getByRole('option', { name: 'OAuth 2.0 client credentials' }).click();
+
+    await expect(page.getByLabel('Token URL')).toBeVisible();
+    await expect(page.getByLabel('Client ID')).toBeVisible();
+    await expect(page.getByLabel('Client secret')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Add connector/i })).toBeDisabled();
+
+    const methodSelect = page.getByRole('combobox', { name: 'Token authentication' });
+    await methodSelect.click();
+    await expect(page.getByRole('option', { name: 'Client secret in body' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Client secret with Basic' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Certificate assertion' })).toBeVisible();
+    await page.getByRole('option', { name: 'Certificate assertion' }).click();
+
+    await expect(page.getByLabel('Private key PEM')).toBeVisible();
+    await expect(page.getByLabel('Certificate SHA-256 thumbprint')).toBeVisible();
+    await expect(page.getByLabel('Client secret')).toHaveCount(0);
+    expect(pageErrors, `client errors: ${pageErrors.join(' | ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- add OAuth 2.0 client credentials to the initial Custom connector Auth selector
- collect secret, Basic, or certificate credentials before connector creation
- roll back connector creation when token validation fails
- reuse one OAuth2 field component for creation and credential replacement
- update the browser login helper for the current Continue-based auth flow

## Verification

- `bun test apps/web/src/features/workspace/customize/sections/connector-oauth2.test.ts apps/web/src/features/workspace/customize/sections/connectors-view.oauth2.test.ts` — 10 passed
- focused ESLint — 0 errors
- `pnpm exec biome check tests/e2e/helpers/session-auth.ts tests/e2e/specs/13-connector-oauth2.spec.ts` — clean
- `pnpm --dir tests typecheck` — passed
- `pnpm --dir apps/web build` — passed
- `CONN-7` against local API — 1 passed
- Chromium `13-connector-oauth2.spec.ts` against local stack — 1 passed in 17.6s