### PR TITLE
fix(dev): preserve API WebSocket upgrades

### DIFF
--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -62,6 +62,11 @@ export default {
     });
 
     const response = await fetch(modifiedRequest);
+    // Cloudflare attaches the accepted socket to response.webSocket. Creating
+    // a new Response drops that non-standard property and breaks the upgrade.
+    if (response.status === 101 || response.webSocket) {
+      return response;
+    }
     const newResponse = new Response(response.body, response);
     newResponse.headers.set('X-Backend', active);
     newResponse.headers.set('X-Backend-Service', isGateway ? 'gateway' : 'api');

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -93,4 +93,34 @@ describe('api-router worker', () => {
     expect(response.headers.get('Location')).toBe('https://gateway.kortix.com/v1/chat/completions');
     expect(fetched).toBe(false);
   });
+
+  test('preserves API WebSocket upgrade responses without wrapping them', async () => {
+    const webSocket = {};
+    const upgradeResponse = {
+      status: 101,
+      headers: new Headers(),
+      webSocket,
+    };
+    let proxiedUrl = '';
+    let proxiedUpgrade = '';
+    globalThis.fetch = async (request) => {
+      proxiedUrl = request.url;
+      proxiedUpgrade = request.headers.get('Upgrade') ?? '';
+      return upgradeResponse;
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/p/sbx_123/8000/kortix/pty/kpty_123/connect', {
+        headers: { Upgrade: 'websocket' },
+      }),
+      env,
+    );
+
+    expect(proxiedUrl).toBe(
+      'https://api-eks.kortix.com/v1/p/sbx_123/8000/kortix/pty/kpty_123/connect',
+    );
+    expect(proxiedUpgrade).toBe('websocket');
+    expect(response).toBe(upgradeResponse);
+    expect(response.webSocket).toBe(webSocket);
+  });
 });

--- a/tests/e2e/helpers/session-auth.ts
+++ b/tests/e2e/helpers/session-auth.ts
@@ -102,7 +102,19 @@ export async function installBrowserSession(
   password: string,
 ): Promise<void> {
   await page.context().clearCookies();
+  const vercelBypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (vercelBypass) {
+    await page.context().setExtraHTTPHeaders({
+      'x-vercel-protection-bypass': vercelBypass,
+      'x-vercel-set-bypass-cookie': 'true',
+    });
+  }
   await page.goto('/favicon.png', { waitUntil: 'domcontentloaded' });
+  if (vercelBypass) {
+    // The first request creates the web-origin _vercel_jwt cookie. Remove the
+    // Vercel-only headers before cross-origin requests reach the Kortix API.
+    await page.context().setExtraHTTPHeaders({});
+  }
   await page.evaluate(() => {
     localStorage.clear();
     sessionStorage.clear();


### PR DESCRIPTION
## Summary

- Preserve Cloudflare WebSocket upgrade responses without wrapping them.
- Add a regression for the response.webSocket object.
- Convert the Vercel bypass header into a web-origin cookie before browser API calls.

## Evidence

- RED: bun test infra/cloudflare/workers/api-router/worker.test.mjs - 4 pass, 1 fail.
- GREEN: bun test infra/cloudflare/workers/api-router/worker.test.mjs - 5 pass, 0 fail.
- pnpm --dir apps/web exec eslint src --quiet - exit 0.
- pnpm --dir tests exec tsc --noEmit - exit 0.
- Dev SDK-only Chromium E2E - 1 pass in 1.2 minutes.

## Live failure

The public dev PTY smoke created a real Platinum PTY. The Cloudflare router returned a non-101 response. new Response(response.body, response) dropped response.webSocket.