### PR TITLE
fix(llm-gateway): forward prompt cache writes

### DIFF
--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -52,7 +52,7 @@ const usage = (over: Record<string, unknown> = {}) => ({
   inputTokens: 100,
   outputTokens: 50,
   totalTokens: 150,
-  inputTokenDetails: { cacheReadTokens: 20 },
+  inputTokenDetails: { cacheReadTokens: 20, cacheWriteTokens: 10 },
   outputTokenDetails: { reasoningTokens: 10 },
   ...over,
 });
@@ -60,6 +60,14 @@ const usage = (over: Record<string, unknown> = {}) => ({
 const CTX = { model: 'openai/gpt-5.6', provider: 'openai' };
 
 describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
+  it('maps cache-write usage when the provider reports no cache reads', () => {
+    const mapped = mapUsage(
+      usage({ inputTokenDetails: { cacheReadTokens: 0, cacheWriteTokens: 10 } }) as any,
+    );
+
+    expect(mapped.prompt_tokens_details).toEqual({ cache_write_tokens: 10 });
+  });
+
   it('streams text as OpenAI chat.completion.chunk deltas + usage + [DONE]', async () => {
     const sse = await readAll(
       openAiSseFromFullStream(
@@ -89,6 +97,8 @@ describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
     expect((usageChunk as any).usage.prompt_tokens).toBe(100);
     expect((usageChunk as any).usage.completion_tokens).toBe(50);
     expect((usageChunk as any).usage.prompt_tokens_details.cached_tokens).toBe(20);
+    expect((usageChunk as any).usage.prompt_tokens_details.cache_write_tokens).toBe(10);
+    expect(extractUsageFromSseBuffer(sse)?.cacheWriteTokens).toBe(10);
   });
 
   it('streams tool calls as incremental OpenAI tool_calls deltas', async () => {

--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -13,7 +13,10 @@ export interface OpenAiUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
-  prompt_tokens_details?: { cached_tokens: number };
+  prompt_tokens_details?: {
+    cached_tokens?: number;
+    cache_write_tokens?: number;
+  };
   completion_tokens_details?: { reasoning_tokens: number };
   cost?: number;
 }
@@ -35,10 +38,10 @@ function costFromProviderMetadata(metadata: ProviderMetadata | undefined): numbe
 }
 
 // LanguageModelUsage → OpenAI `usage`. `inputTokens` is the full prompt count
-// (cached included), matching OpenAI's `prompt_tokens`; the cached subset is
-// broken out under `prompt_tokens_details.cached_tokens` exactly as the native
-// path forwards it, so the gateway's usage extractor + pricing table produce the
-// same cost on both engines. `cost`, when present, is the real upstream-billed
+// (cache reads and writes included), matching OpenAI's `prompt_tokens`; both
+// subsets are broken out under `prompt_tokens_details` exactly as the native
+// path forwards them, so the gateway's usage extractor + pricing table produce
+// the same cost on both engines. `cost`, when present, is the real upstream-billed
 // dollar figure (e.g. OpenRouter's `usage.cost`) — the gateway's cost-hint
 // extractor (usage/extract.ts normalizeUsageChunk) reads it as
 // `upstreamCostHint` and pricing.ts prefers it whenever no catalog price is
@@ -51,6 +54,7 @@ export function mapUsage(
   const prompt = usage?.inputTokens ?? 0;
   const completion = usage?.outputTokens ?? 0;
   const cached = usage?.inputTokenDetails?.cacheReadTokens ?? 0;
+  const cacheWrite = usage?.inputTokenDetails?.cacheWriteTokens ?? 0;
   const reasoning = usage?.outputTokenDetails?.reasoningTokens ?? 0;
   const total = usage?.totalTokens ?? prompt + completion;
   const out: OpenAiUsage = {
@@ -58,7 +62,12 @@ export function mapUsage(
     completion_tokens: completion,
     total_tokens: total,
   };
-  if (cached > 0) out.prompt_tokens_details = { cached_tokens: cached };
+  if (cached > 0 || cacheWrite > 0) {
+    out.prompt_tokens_details = {
+      ...(cached > 0 ? { cached_tokens: cached } : {}),
+      ...(cacheWrite > 0 ? { cache_write_tokens: cacheWrite } : {}),
+    };
+  }
   if (reasoning > 0) out.completion_tokens_details = { reasoning_tokens: reasoning };
   const cost = costFromProviderMetadata(providerMetadata);
   if (cost !== undefined) out.cost = cost;


### PR DESCRIPTION
## Change

- Forward AI SDK `cacheWriteTokens` through the OpenAI-shaped usage adapter.
- Preserve cache-write-only usage when no cache reads exist.
- Verify downstream SSE extraction receives `cacheWriteTokens`.

## Verification

- `bun test packages/llm-gateway/src` — 335 pass, 0 fail
- `pnpm --filter @kortix/llm-gateway typecheck` — pass
- Focused regression — 2 pass, 0 fail