### PR TITLE
Fix session history pagination scroll restoration

### DIFF
--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -108,6 +108,10 @@ import {
 } from '@kortix/sdk/react';
 import { useSessionSync, type UseSessionResult } from '@kortix/sdk/react';
 import { useAutoScroll } from '@/hooks/use-auto-scroll';
+import {
+  captureTurnScrollAnchor,
+  restoreTurnScrollAnchor,
+} from './session-history-scroll';
 import { useModelPricingLookup } from '@/lib/model-pricing';
 import {
   type AgentRefLike,
@@ -4152,11 +4156,11 @@ export function SessionChat({
   });
   const handleLoadOlder = useCallback(async () => {
     const node = scrollRef.current;
-    const previousHeight = node?.scrollHeight ?? 0;
+    const anchor = node ? captureTurnScrollAnchor(node) : null;
     await loadOlder();
     if (!node) return;
     requestAnimationFrame(() => {
-      node.scrollTop += node.scrollHeight - previousHeight;
+      restoreTurnScrollAnchor(node, anchor);
     });
   }, [loadOlder, scrollRef]);
 

--- a/apps/web/src/features/session/session-history-scroll.test.ts
+++ b/apps/web/src/features/session/session-history-scroll.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  captureTurnScrollAnchor,
+  restoreTurnScrollAnchor,
+} from './session-history-scroll';
+
+function rect(top: number, bottom = top + 100): DOMRect {
+  return { top, bottom } as DOMRect;
+}
+
+describe('session history scroll restoration', () => {
+  test('does not move when older messages grow inside the anchored turn', () => {
+    let turnTop = 120;
+    const turn = {
+      isConnected: true,
+      getBoundingClientRect: () => rect(turnTop),
+    } as HTMLElement;
+    const container = {
+      scrollTop: 0,
+      contains: (node: Node) => node === turn,
+      getBoundingClientRect: () => rect(0, 600),
+      querySelectorAll: () => [turn],
+    } as unknown as HTMLElement;
+
+    const anchor = captureTurnScrollAnchor(container);
+    turnTop = 120;
+
+    expect(restoreTurnScrollAnchor(container, anchor)).toBe(true);
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test('keeps the anchored turn at the same viewport offset when older turns prepend', () => {
+    let turnTop = 120;
+    const turn = {
+      isConnected: true,
+      getBoundingClientRect: () => rect(turnTop),
+    } as HTMLElement;
+    const container = {
+      scrollTop: 40,
+      contains: (node: Node) => node === turn,
+      getBoundingClientRect: () => rect(0, 600),
+      querySelectorAll: () => [turn],
+    } as unknown as HTMLElement;
+
+    const anchor = captureTurnScrollAnchor(container);
+    turnTop = 480;
+
+    expect(restoreTurnScrollAnchor(container, anchor)).toBe(true);
+    expect(container.scrollTop).toBe(400);
+  });
+});

--- a/apps/web/src/features/session/session-history-scroll.ts
+++ b/apps/web/src/features/session/session-history-scroll.ts
@@ -1,0 +1,26 @@
+export interface TurnScrollAnchor {
+  element: HTMLElement;
+  viewportTop: number;
+}
+
+export function captureTurnScrollAnchor(container: HTMLElement): TurnScrollAnchor | null {
+  const containerTop = container.getBoundingClientRect().top;
+  const turns = container.querySelectorAll<HTMLElement>('[data-turn-id]');
+  const element =
+    Array.from(turns).find((turn) => turn.getBoundingClientRect().bottom >= containerTop) ??
+    turns.item(turns.length - 1);
+  if (!element) return null;
+  return {
+    element,
+    viewportTop: element.getBoundingClientRect().top,
+  };
+}
+
+export function restoreTurnScrollAnchor(
+  container: HTMLElement,
+  anchor: TurnScrollAnchor | null,
+): boolean {
+  if (!anchor?.element.isConnected || !container.contains(anchor.element)) return false;
+  container.scrollTop += anchor.element.getBoundingClientRect().top - anchor.viewportTop;
+  return true;
+}

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -1886,3 +1886,17 @@ packed-install smoke built, packed, installed, imported, and constructed
 **Shippable to production: YES** for B18 and the published SDK surface.
 Repository delivery and live-dev verification remain part of the repository
 lifecycle.
+
+---
+
+### 2026-07-25 — session `session-history-pagination` (claim)
+
+Claimed the user-directed session-history pagination repair. The SDK will load
+complete turns across fixed-size runtime pages. The web host will preserve a
+stable visible DOM anchor instead of applying total `scrollHeight` growth.
+Existing exports and session synchronization contracts remain backward
+compatible. Work will follow RED -> GREEN -> REFACTOR and finish with the full
+SDK typecheck, test, and packed-install smoke gates, focused web tests, browser
+verification, repository merge, Deploy Dev, and live-dev proof.
+
+**Status:** IN PROGRESS.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -559,7 +559,46 @@ removing public SDK symbols. TDD will be RED-watched before implementation; the
 full SDK typecheck, test, and packed-install smoke gates are required before this
 claim is closed.
 
-**Status:** IN PROGRESS.
+**Status:** COMPLETE.
+
+### 2026-07-25 — session `session-history-pagination` (completion)
+
+Fixed complete-turn history pagination and stable scroll restoration.
+
+The controller now follows assistant-only pages until it loads each referenced
+parent user message. It hydrates the collected pages once in chronological
+order. Tail reconciliation no longer resets a cursor after older-history
+pagination starts. Repeated cursors stop with an explicit error.
+
+The web host now captures the first visible `[data-turn-id]` element before the
+request. It restores that element to the same viewport offset after React
+commits. It no longer applies total `scrollHeight` growth.
+
+**RED evidence:**
+
+- The complete-turn test expected requests through `cursor-3`. The controller
+  stopped after `cursor-1`.
+- The cursor-invariant test expected the next request to use `cursor-2`. Tail
+  reconciliation reset the cursor to `cursor-1`.
+- The scroll tests failed because `session-history-scroll.ts` did not exist.
+
+**Verification:**
+
+- Focused SDK and web tests: **15 pass / 0 fail / 33 assertions**.
+- SDK typecheck: exit 0.
+- SDK suite: **1210 pass / 2 skip / 0 fail** across 98 files and 5461
+  assertions.
+- SDK packed-install smoke: pass.
+- Focused ESLint: 0 errors. One pre-existing
+  `react-hooks/exhaustive-deps` warning remains at `session-chat.tsx:3635`.
+- Changed-file web TypeScript output: empty.
+- Web suite: **2054 pass / 2 unrelated baseline failures**. Both failures expect
+  the retired `deepseek-v4-pro` model in `src/lib/model-pricing.test.ts`.
+- Browser discovery returned no available browser. Local DOM and network
+  verification remains open.
+
+**Shippable to production: NOT YET.** Repository delivery, Deploy Dev, and
+deployed browser verification remain open.
 
 ---
 

--- a/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
@@ -20,6 +20,24 @@ function page(ids: string[], nextCursor?: string): SessionSyncPage {
   };
 }
 
+function messagePage(
+  messages: Array<{ id: string; role: 'user' | 'assistant'; parentID?: string }>,
+  nextCursor?: string,
+): SessionSyncPage {
+  return {
+    messages: messages.map(({ id, role, parentID }) => ({
+      info: {
+        id,
+        sessionID: 'session-1',
+        role,
+        ...(parentID ? { parentID } : {}),
+      } as Message,
+      parts: [],
+    })),
+    nextCursor,
+  };
+}
+
 function createScheduler() {
   let now = 0;
   let callback: (() => void) | undefined;
@@ -129,6 +147,103 @@ describe('SessionSyncController', () => {
       'message-older',
     ]);
     expect(controller.getSnapshot().hasOlder).toBe(false);
+  });
+
+  test('loads through assistant-only pages until the parent user turn is complete', async () => {
+    const requests: Array<{ limit: number; before?: string }> = [];
+    const hydrated: string[][] = [];
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async (request) => {
+        requests.push(request);
+        if (!request.before) {
+          return messagePage(
+            [
+              { id: 'user-new', role: 'user' },
+              { id: 'assistant-new', role: 'assistant', parentID: 'user-new' },
+            ],
+            'cursor-1',
+          );
+        }
+        if (request.before === 'cursor-1') {
+          return messagePage(
+            [
+              { id: 'assistant-old-3', role: 'assistant', parentID: 'user-old' },
+              { id: 'assistant-old-4', role: 'assistant', parentID: 'user-old' },
+            ],
+            'cursor-2',
+          );
+        }
+        if (request.before === 'cursor-2') {
+          return messagePage(
+            [
+              { id: 'assistant-old-1', role: 'assistant', parentID: 'user-old' },
+              { id: 'assistant-old-2', role: 'assistant', parentID: 'user-old' },
+            ],
+            'cursor-3',
+          );
+        }
+        return messagePage(
+          [
+            { id: 'user-old', role: 'user' },
+            { id: 'assistant-old-0', role: 'assistant', parentID: 'user-old' },
+          ],
+          'cursor-4',
+        );
+      },
+      hydrate: (messages) => hydrated.push(messages.map((message) => message.info.id)),
+      markLoaded: () => {},
+    });
+
+    await controller.start();
+    await controller.loadOlder();
+
+    expect(requests).toEqual([
+      { limit: 10 },
+      { limit: 10, before: 'cursor-1' },
+      { limit: 10, before: 'cursor-2' },
+      { limit: 10, before: 'cursor-3' },
+    ]);
+    expect(hydrated).toEqual([
+      ['user-new', 'assistant-new'],
+      [
+        'user-old',
+        'assistant-old-0',
+        'assistant-old-1',
+        'assistant-old-2',
+        'assistant-old-3',
+        'assistant-old-4',
+      ],
+    ]);
+    expect(controller.getSnapshot().hasOlder).toBe(true);
+  });
+
+  test('rejects a repeated cursor while loading a complete older turn', async () => {
+    const requests: Array<{ limit: number; before?: string }> = [];
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async (request) => {
+        requests.push(request);
+        if (!request.before) return page(['message-newest'], 'cursor-1');
+        return messagePage(
+          [{ id: 'assistant-old', role: 'assistant', parentID: 'user-old' }],
+          'cursor-1',
+        );
+      },
+      hydrate: () => {},
+      markLoaded: () => {},
+    });
+
+    await controller.start();
+
+    await expect(controller.loadOlder()).rejects.toThrow(
+      'Session history cursor repeated: cursor-1',
+    );
+    expect(requests).toEqual([
+      { limit: 10 },
+      { limit: 10, before: 'cursor-1' },
+    ]);
+    expect(controller.getSnapshot().isLoadingOlder).toBe(false);
   });
 
   test('deduplicates initial and reconciliation reads', async () => {
@@ -271,6 +386,33 @@ describe('SessionSyncController', () => {
       limit: 10,
       before: 'cursor-older',
     });
+  });
+
+  test('does not reset an advanced older-page cursor during tail reconciliation', async () => {
+    const requests: Array<{ limit: number; before?: string }> = [];
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async (request) => {
+        requests.push(request);
+        if (!request.before) return page(['message-newest'], 'cursor-1');
+        if (request.before === 'cursor-1') return page(['message-older-1'], 'cursor-2');
+        return page(['message-older-2']);
+      },
+      hydrate: () => {},
+      markLoaded: () => {},
+    });
+
+    await controller.start();
+    await controller.loadOlder();
+    await controller.reconcile('poll');
+    await controller.loadOlder();
+
+    expect(requests).toEqual([
+      { limit: 10 },
+      { limit: 10, before: 'cursor-1' },
+      { limit: 10 },
+      { limit: 10, before: 'cursor-2' },
+    ]);
   });
 
   test('does not hydrate an older page after destruction', async () => {

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -181,6 +181,8 @@ export class SessionSyncController {
     isLoadingOlder: false,
   };
   private nextCursor: string | undefined;
+  private knownUserMessageIds = new Set<string>();
+  private olderHistoryStarted = false;
   private tailRequest: Promise<void> | undefined;
   private olderRequest: Promise<void> | undefined;
   private livenessTimer: unknown;
@@ -224,10 +226,12 @@ export class SessionSyncController {
     if (this.olderRequest) return this.olderRequest;
     const before = this.nextCursor;
     this.update({ isLoadingOlder: true });
-    this.olderRequest = this.loadPage('older', 'manual', before)
+    this.olderRequest = this.loadCompleteOlderTurn(before)
       .then((page) => {
         if (this.destroyed) return;
+        this.rememberUserMessages(page.messages);
         this.options.hydrate(page.messages);
+        this.olderHistoryStarted = true;
         this.setCursor(page.nextCursor);
       })
       .finally(() => {
@@ -267,8 +271,11 @@ export class SessionSyncController {
     try {
       const page = await this.loadPage('tail', reason);
       if (this.destroyed) return;
+      this.rememberUserMessages(page.messages);
       this.options.hydrate(page.messages);
-      this.setCursor(page.nextCursor);
+      if (!this.olderHistoryStarted) {
+        this.setCursor(page.nextCursor);
+      }
       this.update({ freshness: 'fresh' });
     } catch {
       if (!this.destroyed) {
@@ -307,6 +314,46 @@ export class SessionSyncController {
         succeeded: false,
       });
       throw error;
+    }
+  }
+
+  private async loadCompleteOlderTurn(before: string): Promise<SessionSyncPage> {
+    const messages: SessionSyncMessage[] = [];
+    const knownUserMessageIds = new Set(this.knownUserMessageIds);
+    const seenCursors = new Set([before]);
+    let cursor: string | undefined = before;
+
+    while (cursor) {
+      const page = await this.loadPage('older', 'manual', cursor);
+      messages.unshift(...page.messages);
+      for (const message of page.messages) {
+        if (message.info.role === 'user') {
+          knownUserMessageIds.add(message.info.id);
+        }
+      }
+
+      cursor = page.nextCursor;
+      const hasUnresolvedParent = messages.some(
+        (message) =>
+          message.info.role === 'assistant' &&
+          Boolean(message.info.parentID) &&
+          !knownUserMessageIds.has(message.info.parentID!),
+      );
+      if (!hasUnresolvedParent || !cursor) break;
+      if (seenCursors.has(cursor)) {
+        throw new Error(`Session history cursor repeated: ${cursor}`);
+      }
+      seenCursors.add(cursor);
+    }
+
+    return { messages, nextCursor: cursor };
+  }
+
+  private rememberUserMessages(messages: SessionSyncMessage[]): void {
+    for (const message of messages) {
+      if (message.info.role === 'user') {
+        this.knownUserMessageIds.add(message.info.id);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- load all runtime pages required to complete an older user turn
- preserve the advanced history cursor during tail reconciliation
- restore a stable visible turn after older messages render
- reject repeated runtime cursors instead of looping

## Root cause

The runtime can split one user turn across multiple 10-message pages. The prior controller loaded one page per click. The web host restored position from total scroll height growth. Messages added inside the visible turn increased that height and moved the viewport toward the bottom. Tail reconciliation also reset the advanced cursor.

## Verification

- RED: complete-turn pagination stopped at cursor-1 instead of cursor-3
- RED: tail reconciliation reset cursor-2 to cursor-1
- RED: scroll helper module did not exist
- SDK typecheck: exit 0
- SDK suite: 1210 pass, 2 skip, 0 fail, 5461 assertions
- SDK packed-install smoke: pass
- focused pagination tests: 15 pass, 0 fail, 33 assertions
- focused ESLint: 0 errors; one pre-existing hook warning at session-chat.tsx:3635
- changed-file web TypeScript output: empty
- web suite: 2054 pass, 2 unrelated baseline failures in model-pricing.test.ts for retired deepseek-v4-pro
- git diff --check: pass

## Browser status

Local browser discovery returned no available browser. DOM and network verification will run against dev after deployment when the browser connection is available.