### PR TITLE
fix(whitelabel): prevent zstd proxy corruption

### DIFF
--- a/apps/web/src/lib/model-pricing.test.ts
+++ b/apps/web/src/lib/model-pricing.test.ts
@@ -72,10 +72,10 @@ describe('createModelPricingLookup', () => {
 
   test('resolves kortix managed models through pricingRef and cached models.dev rates', () => {
     const cached = buildModelsDevPricingMap({
-      deepseek: {
+      'z-ai': {
         models: {
-          'deepseek/deepseek-v4-pro': {
-            id: 'deepseek/deepseek-v4-pro',
+          'z-ai/glm-5.2': {
+            id: 'z-ai/glm-5.2',
             cost: { input: 0.435, output: 0.87 },
           },
         },
@@ -83,7 +83,7 @@ describe('createModelPricingLookup', () => {
     });
 
     const lookup = createModelPricingLookup(undefined, cached);
-    expect(lookup('kortix', 'deepseek-v4-pro')).toEqual({
+    expect(lookup('kortix', 'glm-5.2')).toEqual({
       inputPer1M: 0.435,
       outputPer1M: 0.87,
       cacheReadPer1M: undefined,
@@ -117,13 +117,13 @@ describe('createModelPricingLookup', () => {
 
   test('rebuilds from empty pricing to loaded cached pricing', () => {
     const emptyLookup = createModelPricingLookup(undefined, new Map());
-    expect(emptyLookup('kortix', 'deepseek-v4-pro')).toBeNull();
+    expect(emptyLookup('kortix', 'glm-5.2')).toBeNull();
 
     const cached = buildModelsDevPricingMap({
-      deepseek: {
+      'z-ai': {
         models: {
-          'deepseek/deepseek-v4-pro': {
-            id: 'deepseek/deepseek-v4-pro',
+          'z-ai/glm-5.2': {
+            id: 'z-ai/glm-5.2',
             cost: { input: 0.435, output: 0.87 },
           },
         },
@@ -131,7 +131,7 @@ describe('createModelPricingLookup', () => {
     });
 
     const loadedLookup = createModelPricingLookup(undefined, cached);
-    expect(loadedLookup('kortix', 'deepseek-v4-pro')).toEqual({
+    expect(loadedLookup('kortix', 'glm-5.2')).toEqual({
       inputPer1M: 0.435,
       outputPer1M: 0.87,
       cacheReadPer1M: undefined,

--- a/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
+++ b/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
@@ -73,6 +73,10 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ path?: string[]
   headers.delete('content-length');
   headers.delete('cookie'); // the app session cookie is ours, never upstream's
   headers.set('authorization', `Bearer ${apiKey}`);
+  // Browsers can advertise zstd through this BFF. Node's fetch does not decode
+  // zstd, while the response path removes content-encoding before returning
+  // the stream. Request identity so JSON and SSE bytes remain readable.
+  headers.set('accept-encoding', 'identity');
 
   // Buffer the request body instead of streaming it (`body: req.body,
   // duplex: 'half'`): a streamed body has no Content-Length, so undici sends

--- a/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
+++ b/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
@@ -22,6 +22,7 @@ export interface RecordedRequest {
   path: string; // pathname + search, e.g. "/v1/projects/proj_1"
   authorization: string | null;
   cookie: string | null;
+  acceptEncoding: string | null;
   contentLength: string | null;
   transferEncoding: string | null;
   body: unknown;
@@ -116,6 +117,7 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
       const method = req.method.toUpperCase();
       const authorization = req.headers.get('authorization');
       const cookie = req.headers.get('cookie');
+      const acceptEncoding = req.headers.get('accept-encoding');
       const contentLength = req.headers.get('content-length');
       const transferEncoding = req.headers.get('transfer-encoding');
 
@@ -136,6 +138,7 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
         path: `${url.pathname}${url.search}`,
         authorization,
         cookie,
+        acceptEncoding,
         contentLength,
         transferEncoding,
         body,
@@ -226,6 +229,18 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
       }
 
       // ── sandbox runtime proxy: /p/{sandboxId}/{port}/... ───────────────
+      if (p === 'p/sbx_encoding/8000/encoding' && method === 'GET') {
+        if (acceptEncoding !== 'identity') {
+          return Response.json(
+            {
+              error: 'wrapper forwarded unsupported response encoding negotiation',
+            },
+            { status: 502 },
+          );
+        }
+        return Response.json({ ok: true });
+      }
+
       const sseMatch = p.match(/^p\/([^/]+)\/(\d+)\/global\/event$/);
       if (sseMatch && method === 'GET') {
         let interval: ReturnType<typeof setInterval> | undefined;

--- a/apps/whitelabel-demo/tests/e2e/proxy.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/proxy.test.ts
@@ -115,6 +115,24 @@ describe('BFF proxy', () => {
     expect(upstreamReq.contentLength).toBe(String(Buffer.byteLength(bodyText, 'utf8')));
   });
 
+  test('response encoding negotiation: the BFF requests identity instead of forwarding browser zstd support', async () => {
+    mock.reset();
+    const email = uniqueEmail('response-encoding');
+    const token = await loginUser(app, email, DEMO_PASSWORD);
+
+    const res = await fetch(`${app.baseUrl}/api/kortix/p/sbx_encoding/8000/encoding`, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        'accept-encoding': 'gzip, deflate, br, zstd',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mock.requests).toHaveLength(1);
+    expect(mock.requests[0]!.acceptEncoding).toBe('identity');
+  });
+
   test('SSE pass-through: events arrive unbuffered, connection stays open past the first burst', async () => {
     mock.reset();
     const email = uniqueEmail('sse');

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -174,7 +174,7 @@ Also stop if the same failure survives three different fixes (use
 | 5 | Typed platform API coverage | DONE | `frontend-sdk-only` | 2026-07-24 | `65202adea` |
 | 6 | Remove runtime routing knowledge | DONE | `frontend-sdk-only` | 2026-07-24 | `e6241bbfc` |
 | 7 | Local parity proof | DONE | `frontend-sdk-only` | 2026-07-24 | `6c02b601e` |
-| 8 | Delivery and dev proof | IN PROGRESS | `frontend-sdk-only` | 2026-07-24 | — |
+| 8 | Delivery and dev proof | DONE | `frontend-sdk-only` | 2026-07-24 | `aefa2a628` + `8688b8492` |
 
 ---
 
@@ -1817,6 +1817,55 @@ The generic auth spec failed because its default local user credentials were
 absent. The SDK-only regression creates and deletes its own confirmed user.
 
 **Shippable to production: NOT YET.** Task 8 delivery and dev proof remains.
+
+---
+
+### 2026-07-24 — session `frontend-sdk-only` (web SDK boundary Task 8)
+
+Merged the SDK-only web refactor in PR #5388. The merge commit is
+`aefa2a6282ed540a7296e35db2747bce2cc1d3eb`.
+
+Deploy Dev run 30129604715 completed successfully at
+`ae967fdbc6066f3a941a4553c0d21afb10639774`. Git ancestry proves that deployed
+commit contains the refactor merge. The API health route reported
+`0.10.15-dev.ae967fdb`. The tested Vercel deployment reported
+`0.10.14-dev.ae967fdb`.
+
+The deployed Chromium regression passed in 1.2 minutes. It rendered the session
+workspace, sent one `prompt_async` request, displayed `PONG`, observed zero
+failed Kortix project or runtime responses, and opened `kortix.yaml`.
+
+The first protected-dev browser run exposed an E2E harness defect. The shared
+Vercel bypass header reached the cross-origin API and failed its CORS preflight.
+The login helper now converts that header into a web-origin Vercel cookie before
+the browser sends API requests.
+
+The public PTY smoke exposed a Cloudflare WebSocket response defect. PR #5392,
+merged as `8688b8492c9534bb6d43a3282904f19cbd557c78`, preserves Cloudflare
+`response.webSocket` upgrade responses. Dev worker version
+`33ef7b35-3e6d-452f-9165-b00bafd9e9a1` carries the fix.
+
+The final public dev PTY smoke passed against a real Platinum sandbox. It
+created a PTY, opened the WebSocket, sent and observed a marker, reconnected and
+observed replay, listed the running PTY, deleted it, and removed its disposable
+project and session.
+
+**Verification:**
+
+- SDK typecheck: exit 0.
+- SDK suite: **1210 pass / 0 fail**.
+- SDK packed-install smoke: pass.
+- Web suite: **2043 pass / 0 fail**.
+- Web boundary test: **1 pass / 0 fail**.
+- White-label E2E: **44 pass / 0 fail / 3 live-upstream skips**.
+- Managed session HTTP smoke: **25 pass / 0 fail**.
+- SDK-only local Chromium session: **1 pass**.
+- SDK-only dev Chromium session: **1 pass**.
+- Public dev Platinum PTY smoke: pass.
+- Cloudflare API router regression: **5 pass / 0 fail**.
+
+**Shippable to production: YES.** All eight tasks are complete. Local and
+deployed dev paths pass.
 ---
 
 ### 2026-07-24 — session `managed-models-aster` (B18 completion)

--- a/tests/e2e/scripts/terminal-pty-smoke.ts
+++ b/tests/e2e/scripts/terminal-pty-smoke.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env -S node --experimental-strip-types
 
 /**
  * Real provider PTY smoke:
@@ -7,7 +7,7 @@
  *
  * Run with the isolated stack up:
  *   dotenvx run -f apps/api/.env -f apps/web/.env -- \
- *     bun tests/e2e/scripts/terminal-pty-smoke.ts platinum
+ *     node --experimental-strip-types tests/e2e/scripts/terminal-pty-smoke.ts platinum
  */
 
 const provider = process.argv[2];


### PR DESCRIPTION
## Summary

- force identity encoding for white-label BFF upstream requests
- prevent zstd bytes from reaching the SDK as invalid JSON
- add a regression test for browser zstd negotiation

## Verification

- RED: proxy test returned 502 when the BFF forwarded zstd
- GREEN: `7 pass, 0 fail` in `proxy.test.ts`
- white-label suite: `45 pass, 0 fail, 3 live skips`
- white-label typecheck: exit 0
- real dev wrapper smoke: project provision, session create, runtime ready, `kortix/glm-5.2` reply `PONG`, session/project/PAT/user/account cleanup