### PR TITLE
fix(web): guard PoliciesPanel against missing policies field (BS 236e88fb)

### DIFF
--- a/apps/web/src/components/projects/policies-panel.test.ts
+++ b/apps/web/src/components/projects/policies-panel.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'bun:test';
+
+import { seedDraft } from './policies-panel';
+
+// Regression test for the Better Stack error pattern `236e88fb…` —
+//   `TypeError: Cannot read properties of undefined (reading 'map')`
+// thrown from the project layout's global-view render path
+// (`/projects/:id?c=global` → `GlobalRulesPanel` → `PoliciesPanel`). The seeding
+// `useEffect` previously did `query.data.policies.map(...)` after only guarding
+// `query.data` itself; a `listProjectPolicies` response with a missing/`null`
+// `policies` field (empty/new project, backend shape gap, partial response)
+// slipped past `if (!query.data) return` and `.policies.map` threw. The fix
+// centralizes seeding in the pure `seedDraft` helper with `policies ?? []` +
+// `defaultMode ?? 'allow_all'` defaults. Mirrors the chunk-22256 `toArray()`
+// guard (#4542).
+
+const panelSource = readFileSync(
+  fileURLToPath(new URL('./policies-panel.tsx', import.meta.url)),
+  'utf8',
+);
+
+describe('seedDraft — guards the PoliciesPanel seeding path against a missing policies field', () => {
+  test('does NOT throw on the exact prod failure shape: truthy data, undefined policies + defaultMode', () => {
+    // The exact shape that fired in prod: a truthy `data` object whose `policies`
+    // and `defaultMode` fields are missing. The old `useEffect` threw here.
+    const result = seedDraft({ policies: undefined, defaultMode: undefined });
+    expect(() => seedDraft({ policies: undefined, defaultMode: undefined })).not.toThrow();
+    expect(result.draft).toEqual([]);
+    expect(result.defaultMode).toBe('allow_all');
+    // Signature must be `[]`-stable, not `{"policies":null,...}` (JSON.stringify
+    // turns `undefined` into `null`, which a subsequent save could write back).
+    expect(result.serverSig).toBe(JSON.stringify({ policies: [], defaultMode: 'allow_all' }));
+  });
+
+  test('absorbs a null policies field (another valid HTTP outcome)', () => {
+    const result = seedDraft({ policies: null, defaultMode: null });
+    expect(result.draft).toEqual([]);
+    expect(result.defaultMode).toBe('allow_all');
+    expect(result.serverSig).toBe(JSON.stringify({ policies: [], defaultMode: 'allow_all' }));
+  });
+
+  test('happy path: maps valid policies and preserves defaultMode', () => {
+    const result = seedDraft({
+      policies: [{ match: 'stripe.charges.create', action: 'require_approval' }],
+      defaultMode: 'risk',
+    });
+    expect(result.draft).toHaveLength(1);
+    expect(result.draft[0]).toMatchObject({
+      match: 'stripe.charges.create',
+      action: 'require_approval',
+    });
+    expect(typeof result.draft[0].id).toBe('string');
+    expect(result.defaultMode).toBe('risk');
+    expect(result.serverSig).toBe(
+      JSON.stringify({
+        policies: [{ match: 'stripe.charges.create', action: 'require_approval' }],
+        defaultMode: 'risk',
+      }),
+    );
+  });
+
+  test('happy path: empty policies array is preserved (not coerced away)', () => {
+    const result = seedDraft({ policies: [], defaultMode: 'allow_all' });
+    expect(result.draft).toEqual([]);
+    expect(result.defaultMode).toBe('allow_all');
+    expect(result.serverSig).toBe(JSON.stringify({ policies: [], defaultMode: 'allow_all' }));
+  });
+});
+
+// Source-level guard (same convention as chunk22256-guard.test.ts): keep a
+// future refactor from silently restoring an unguarded `query.data.policies.map`
+// in either the seeding `useEffect` or the `revert` handler.
+describe('PoliciesPanel source guard — no unguarded query.data.policies.map', () => {
+  test('the seeding useEffect + revert handler route through seedDraft, not raw .policies.map', () => {
+    expect(panelSource).not.toContain('query.data.policies.map(');
+    expect(panelSource).toContain('seedDraft(query.data)');
+  });
+});

--- a/apps/web/src/components/projects/policies-panel.tsx
+++ b/apps/web/src/components/projects/policies-panel.tsx
@@ -78,6 +78,42 @@ function newRuleId() {
   return Math.random().toString(36).slice(2, 10);
 }
 
+/**
+ * Seeded draft rules + default mode + canonical server signature derived from a
+ * `listProjectPolicies` response.
+ *
+ * Extracted as a pure helper so the exact prod failure shape
+ * (Better Stack pattern `236e88fb…` — `Cannot read properties of undefined
+ * (reading 'map')` in the project layout's `?c=global` → `GlobalRulesPanel` →
+ * `PoliciesPanel` path) can be unit-tested directly without a react-query
+ * harness. `listProjectPolicies` is typed to always return `policies` /
+ * `defaultMode`, but a 200 with a missing/`null` `policies` field (empty/new
+ * project, a backend shape gap, a partial response) is a valid HTTP outcome; the
+ * prior `if (!query.data) return` guard only covered `query.data` itself, so
+ * `query.data`'s `policies` field accessed via `.map` threw. The `?? []` / `?? 'allow_all'`
+ * absorb that without changing the happy path. Mirrors the chunk-22256
+ * `toArray()` guard (#4542).
+ */
+export function seedDraft(data: {
+  policies?: ProjectPolicy[] | null;
+  defaultMode?: PolicyDefaultMode | null;
+}): {
+  draft: DraftRule[];
+  defaultMode: PolicyDefaultMode;
+  serverSig: string;
+} {
+  const policies = data.policies ?? [];
+  const defaultMode = data.defaultMode ?? 'allow_all';
+  return {
+    draft: policies.map((p) => ({ id: newRuleId(), match: p.match, action: p.action })),
+    defaultMode,
+    // `JSON.stringify` drops `undefined` values to `null`, so coercing here
+    // keeps the signature `[]`-stable (a subsequent save would otherwise write
+    // `policies: null`).
+    serverSig: JSON.stringify({ policies, defaultMode }),
+  };
+}
+
 export function PoliciesPanel({ projectId }: { projectId: string }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -94,16 +130,10 @@ export function PoliciesPanel({ projectId }: { projectId: string }) {
 
   useEffect(() => {
     if (!query.data) return;
-    const seeded = query.data.policies.map((p) => ({
-      id: newRuleId(),
-      match: p.match,
-      action: p.action,
-    }));
-    setDraft(seeded);
-    setDefaultMode(query.data.defaultMode);
-    setServerSig(
-      JSON.stringify({ policies: query.data.policies, defaultMode: query.data.defaultMode }),
-    );
+    const seeded = seedDraft(query.data);
+    setDraft(seeded.draft);
+    setDefaultMode(seeded.defaultMode);
+    setServerSig(seeded.serverSig);
   }, [query.data]);
 
   const currentSig = JSON.stringify({
@@ -139,10 +169,9 @@ export function PoliciesPanel({ projectId }: { projectId: string }) {
   }
   function revert() {
     if (!query.data) return;
-    setDraft(
-      query.data.policies.map((p) => ({ id: newRuleId(), match: p.match, action: p.action })),
-    );
-    setDefaultMode(query.data.defaultMode);
+    const seeded = seedDraft(query.data);
+    setDraft(seeded.draft);
+    setDefaultMode(seeded.defaultMode);
   }
 
   if (isForbidden) {


### PR DESCRIPTION
## Demo
Non-visual change — defensive-shape guard. Proof: the new `policies-panel.test.ts` exercises the exact prod failure shape (`{ policies: undefined, defaultMode: undefined }`) and asserts `seedDraft` does not throw and returns the empty state, plus the happy path still renders rules.

## Why
`Cannot read properties of undefined (reading 'map')` thrown from the project layout's global-view render path (`/projects/:id?c=global` → `GlobalRulesPanel` → `PoliciesPanel`). The seeding `useEffect` did `query.data.policies.map(...)` after only guarding `query.data` itself; a `listProjectPolicies` response with a missing/`null` `policies` field (empty/new project, backend shape gap, partial response) slipped past `if (!query.data) return` and `.policies.map` threw into the React error boundary.

- **Better Stack pattern:** `236e88fb11668c3fb8aefe0cfd95937eff7bed049154bc7f884b8d8fef7d197c` (Kortix Frontend prod app `2346967`)
- **Type:** `TypeError` — `Cannot read properties of undefined (reading 'map')`
- **Transaction:** `/projects/:id`, URL `/projects/02d138e2-…?c=global`, release `480a21c07…` (post-`0.10.14`)
- **Stack tail:** project layout boundary (`app/(app)/projects/[id]/layout-…`) — render-phase `.map()` on undefined.

## What changed
`apps/web/src/components/projects/policies-panel.tsx`:
- Extracted the seeding logic (draft rules + default mode + canonical server signature) into a pure `seedDraft(data)` helper that defensively coerces `data.policies ?? []` and `data.defaultMode ?? 'allow_all'` (`useState` initial for `defaultMode` is already `'allow_all'` — consistent).
- The seeding `useEffect` and the `revert` handler now both route through `seedDraft(query.data)` instead of calling `.policies.map` directly — both call sites had the same shape-risk.
- The `serverSig` is now `[]`-stable when `policies` is missing. `JSON.stringify({ policies: undefined })` would otherwise emit `{"policies":null,...}`, and a subsequent save could write `policies: null` back to `kortix.yaml`.
- No change to `listProjectPolicies`, the mutation, or render logic — pure defensive-shape guard.

Sibling of the chunk-22256 `toArray()` guard (#4542) that fixed the same `.filter`/`.map`-on-undefined class in `customize/`.

## Verification
- New regression test `apps/web/src/components/projects/policies-panel.test.ts` (5 tests, `bun test`):
  - `seedDraft({ policies: undefined, defaultMode: undefined })` — the **exact prod failure shape** — does NOT throw; returns `draft: []`, `defaultMode: 'allow_all'`, `serverSig: '{"policies":[],"defaultMode":"allow_all"}'`.
  - `null` policies + `null` defaultMode absorbed.
  - Happy path: a valid `policies` array is mapped (rule renders), `defaultMode` preserved, signature stable.
  - Empty `policies: []` preserved (not coerced away).
  - Source-level guard (chunk22256-guard convention): asserts `policies-panel.tsx` no longer contains an unguarded `query.data.policies.map(` and routes through `seedDraft(query.data)` — keeps a future refactor from silently restoring the bug.
  - Result: `5 pass, 0 fail, 17 expect() calls`.
- Typecheck (`tsc --noEmit -p tsconfig.json`): only the 4 pre-existing unrelated errors (`source.ts` / `use-cases-source.ts` `@/.source` module, `template-url.test.ts`) — no new errors from this change.

Approach taken: **pure-helper extraction** (`seedDraft`) rather than a react-query mock harness — the repo's existing component tests (`session-cache-warmer-targets.test.ts`, `chunk22256-guard.test.ts`) test pure logic / source-level guards, not mounted react-query components, so this matches the established convention.

## Risk / rollback
Minimal — defensive default only changes behavior for the previously-crashing shape (missing/`null` `policies`). Happy path output is byte-identical (`serverSig` is `JSON.stringify({ policies, defaultMode })` with the same array contents). Revert is a single-file revert.

## Confirm resolution
After merge + Promote, the `236e88fb…` Better Stack pattern should record no new occurrences (opening `/projects/:id?c=global` on a new/empty project, or any project whose `listProjectPolicies` returns a missing `policies` field, no longer throws into the error boundary).