### PR TITLE
feat(infra): prepare US West 2 production shadow

### DIFF
--- a/.github/workflows/deploy-prod-us-west-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-west-2-shadow.yml
@@ -1,0 +1,257 @@
+name: Deploy Prod US West 2 Shadow
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Clean production image version.
+        required: true
+        type: string
+      source_sha:
+        description: Release source commit stored in the images.
+        required: true
+        type: string
+      synchronize_database:
+        description: Apply migrations and refresh application replication.
+        required: false
+        default: true
+        type: boolean
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        description: DNS edit token for the `kortix.com` zone.
+        required: false
+      CLOUDFLARE_GLOBAL_API_KEY:
+        description: Global API key fallback.
+        required: false
+      CLOUDFLARE_EMAIL:
+        description: Account email for the global API key fallback.
+        required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing production image version to deploy.
+        required: true
+        type: string
+      source_sha:
+        description: Expected image commit. Leave empty only for a legacy image.
+        required: false
+        type: string
+      synchronize_database:
+        description: Apply migrations and refresh application replication.
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: deploy-prod-us-west-2-shadow
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy API and gateway to US shadow
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: us-west-2
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
+      VERSION: ${{ inputs.version }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      SOURCE_SECRET_ID: kortix-prod-env
+      TARGET_ENV_BLOB: kortix-prod-us-west-2-env
+      API_URL: https://api-usw2-shadow.kortix.com
+      GATEWAY_URL: https://gateway-usw2-shadow.kortix.com
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate inputs
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::version must use X.Y.Z format."
+            exit 1
+          fi
+          if [ -n "${SOURCE_SHA:-}" ] && ! printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::source_sha must be an empty value or a 40-character lowercase Git SHA."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Keep shadow DNS proxied
+        run: bash scripts/prod-us-west-2/ensure-shadow-dns.sh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_GLOBAL_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+
+      - name: Install database tools
+        if: inputs.synchronize_database
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Install Bun
+        if: inputs.synchronize_database
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install database dependencies
+        if: inputs.synchronize_database
+        run: |
+          corepack enable pnpm
+          pnpm install --frozen-lockfile --filter "@kortix/db..." --filter "kortix"
+        env:
+          npm_config_engine_strict: "false"
+
+      - name: Load source and target database URLs
+        if: inputs.synchronize_database
+        run: |
+          set -euo pipefail
+          source_json="$(
+            aws secretsmanager get-secret-value \
+              --secret-id "$SOURCE_SECRET_ID" \
+              --region eu-west-2 \
+              --query SecretString \
+              --output text
+          )"
+          target_json="$(
+            aws secretsmanager get-secret-value \
+              --secret-id "$TARGET_ENV_BLOB" \
+              --region "$AWS_REGION" \
+              --query SecretString \
+              --output text
+          )"
+          source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_json")"
+          target_database_url="$(jq -er '.DATABASE_URL' <<<"$target_json")"
+          echo "::add-mask::$source_database_url"
+          echo "::add-mask::$target_database_url"
+          printf 'SOURCE_DATABASE_URL=%s\n' "$source_database_url" >> "$GITHUB_ENV"
+          printf 'TARGET_DATABASE_URL=%s\n' "$target_database_url" >> "$GITHUB_ENV"
+
+      - name: Apply migrations to the US shadow database
+        if: inputs.synchronize_database
+        run: DATABASE_URL="$TARGET_DATABASE_URL" pnpm --filter @kortix/db migrate
+
+      - name: Refresh application replication
+        if: inputs.synchronize_database
+        run: bash scripts/prod-us-west-2/refresh-replication.sh
+        env:
+          ALLOW_REPLICATION_REFRESH: "1"
+
+      - name: Synchronize current avatar objects
+        if: inputs.synchronize_database
+        run: TARGET_SECRET_ID="$TARGET_ENV_BLOB" bash scripts/prod-us-west-2/storage-sync.sh
+
+      - name: Deploy released images
+        run: |
+          set -euo pipefail
+          bash infra/scripts/ecs-deploy.sh \
+            prod-usw2-shadow \
+            "kortix/kortix-api:${VERSION}" \
+            --version "$VERSION"
+          bash infra/scripts/ecs-deploy.sh \
+            prod-usw2-shadow \
+            "kortix/kortix-gateway:${VERSION}" \
+            --service gateway \
+            --version "$VERSION"
+
+      - name: Verify ECS capacity and task images
+        run: |
+          set -euo pipefail
+          verify_service() {
+            cluster="$1"
+            service="$2"
+            container="$3"
+            expected_image="$4"
+
+            service_json="$(
+              aws ecs describe-services \
+                --region "$AWS_REGION" \
+                --cluster "$cluster" \
+                --services "$service"
+            )"
+            desired="$(jq -r '.services[0].desiredCount' <<<"$service_json")"
+            running="$(jq -r '.services[0].runningCount' <<<"$service_json")"
+            rollout="$(jq -r '.services[0].deployments[] | select(.status == "PRIMARY") | .rolloutState' <<<"$service_json")"
+            failed="$(jq -r '[.services[0].deployments[].failedTasks] | add' <<<"$service_json")"
+            task_definition="$(jq -r '.services[0].taskDefinition' <<<"$service_json")"
+            live_image="$(
+              aws ecs describe-task-definition \
+                --region "$AWS_REGION" \
+                --task-definition "$task_definition" \
+                --query "taskDefinition.containerDefinitions[?name=='$container'].image | [0]" \
+                --output text
+            )"
+
+            if [ "$desired" -lt 2 ] \
+              || [ "$running" != "$desired" ] \
+              || [ "$rollout" != "COMPLETED" ] \
+              || [ "$failed" != "0" ] \
+              || [ "$live_image" != "$expected_image" ]; then
+              echo "::error::$service failed verification: desired=$desired running=$running rollout=$rollout failed=$failed image=$live_image"
+              exit 1
+            fi
+            echo "$service: $running/$desired tasks, rollout=$rollout, image=$live_image"
+          }
+
+          verify_service \
+            kortix-prod-usw2 \
+            kortix-prod-usw2 \
+            api \
+            "kortix/kortix-api:${VERSION}"
+          verify_service \
+            kortix-prod-usw2-gateway \
+            kortix-prod-usw2-gateway \
+            gateway \
+            "kortix/kortix-gateway:${VERSION}"
+
+      - name: Verify shadow endpoints
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 40); do
+            api_body="$(curl -fsS --max-time 10 "$API_URL/v1/health" 2>/dev/null || true)"
+            gateway_live="$(curl -fsS --max-time 10 "$GATEWAY_URL/health/live" 2>/dev/null || true)"
+            gateway_health="$(curl -fsS --max-time 10 "$GATEWAY_URL/health" 2>/dev/null || true)"
+            api_version="$(jq -r '.version // empty' <<<"$api_body" 2>/dev/null || true)"
+            gateway_version="$(jq -r '.version // empty' <<<"$gateway_live" 2>/dev/null || true)"
+            gateway_commit="$(jq -r '.commit // empty' <<<"$gateway_live" 2>/dev/null || true)"
+            api_dependency="$(jq -r '.checks.api.status // empty' <<<"$gateway_health" 2>/dev/null || true)"
+            commit_ok=1
+            if [ -n "${SOURCE_SHA:-}" ] && [ "$gateway_commit" != "$SOURCE_SHA" ]; then
+              commit_ok=0
+            fi
+
+            if [ "$api_version" = "$VERSION" ] \
+              && [ "$gateway_version" = "$VERSION" ] \
+              && [ "$api_dependency" = "up" ] \
+              && [ "$commit_ok" = "1" ]; then
+              echo "US shadow verified: API=$api_version gateway=$gateway_version commit=${gateway_commit:-unavailable} dependency=$api_dependency"
+              exit 0
+            fi
+
+            echo "Shadow verification $attempt/40: API=${api_version:-unreachable} gateway=${gateway_version:-unreachable} commit=${gateway_commit:-unavailable} dependency=${api_dependency:-unavailable}"
+            sleep 15
+          done
+
+          echo "::error::US shadow endpoints did not pass within 10 minutes."
+          exit 1
+
+      - name: Summary
+        run: |
+          {
+            echo "### US West 2 production shadow"
+            echo "- API: \`kortix/kortix-api:${VERSION}\`"
+            echo "- Gateway: \`kortix/kortix-gateway:${VERSION}\`"
+            echo "- API tasks: 2 or more"
+            echo "- Gateway tasks: 2 or more"
+            echo "- Production traffic: unchanged"
+            echo "- Workers and schedulers: disabled in \`kortix-prod-us-west-2-env\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,12 +10,15 @@ name: Deploy Prod
 #      → :X.Y.Z + :latest (multi-arch manifest copy, zero rebuilds). The
 #      self-host `:stable` channel is promoted SEPARATELY and manually via
 #      promote-self-host-stable.yml — a prod release is not auto-shipped to self-hosts.
-#   2. Deploy BOTH prod backends in parallel, with perfect parity:
+#   2. Deploy the production and pre-cutover shadow backends in parallel:
 #      - ECS Fargate (the ACTIVE backend behind api.kortix.com since PR #4683):
 #        deploy-ecs rolls api + gateway task-defs rendered from the prod env
 #        blob, stamped with the clean KORTIX_VERSION.
 #      - EKS (standby): the promote PR merge already bumped infra/k8s/envs/prod,
 #        so Argo CD rolls the prod Deployment — deploy-api WATCHES it reach vX.Y.Z.
+#      - US West 2 ECS shadow: deploy-us-shadow applies the same database
+#        migrations, refreshes logical replication, and rolls the US API and
+#        gateway. It does not change production routing or enable writers.
 #   3. verify-live-version curls the PUBLIC endpoints (router + each origin) and
 #      asserts the live reported version == X.Y.Z. Nothing that announces
 #      success — the GitHub Release, the Slack announce, the banner-lower — runs
@@ -769,6 +772,24 @@ jobs:
           bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-api:${VERSION}" --version "${VERSION}"
           bash infra/scripts/ecs-deploy.sh prod "kortix/kortix-gateway:${VERSION}" --service gateway --version "${VERSION}"
 
+  # ── Deploy the pre-cutover US West 2 production shadow ──────────────────────
+  # The shadow uses the native US West 2 Supabase project and separate ECS
+  # services. This job keeps its database schema, logical publication, API, and
+  # gateway on the same release as production. It does not change Cloudflare
+  # routing, production DNS, desired counts, or worker flags.
+  deploy-us-shadow:
+    name: Deploy API + gateway to US West 2 shadow
+    needs: [version, retag-images, verify-image-commits, migrate-db]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-prod-us-west-2-shadow.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      source_sha: ${{ needs.version.outputs.source_sha }}
+      synchronize_database: true
+    secrets: inherit
+
   # ── Deploy API to prod EKS (the standby backend, kept in perfect parity) ─────
   # The promote PR merge already bumped infra/k8s/envs/prod/values.yaml (image tag
   # + kortixVersion), so Argo CD on the prod-eks cluster rolls the Deployment.
@@ -996,14 +1017,15 @@ jobs:
   #     api-ecs-fargate.kortix.com / api-eks.kortix.com
   #     gateway-ecs-fargate.kortix.com / gateway-eks.kortix.com
   #
+  # The US West 2 shadow endpoints are also hard requirements. A release cannot
+  # leave the prepared cutover stack on an older version.
+  #
   # Everything that announces success (github-release, announce, banner-off)
-  # needs: this job — a release whose live version doesn't match can no longer
-  # be published. This is what would have caught the v0.10.0/v0.10.1 night, where
-  # deploy-ecs failed twice while the release went out and api.kortix.com (ECS
-  # active) kept serving the previous build.
+  # needs this job. A release whose live version does not match cannot be
+  # published.
   verify-live-version:
     name: Verify live version == v${{ needs.version.outputs.version }}
-    needs: [version, deploy-ecs, deploy-api, deploy-gateway]
+    needs: [version, deploy-ecs, deploy-us-shadow, deploy-api, deploy-gateway]
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ needs.version.outputs.version }}
@@ -1028,6 +1050,8 @@ jobs:
             "origin-api-eks|https://api-eks.kortix.com/v1/health|origin|1"
             "origin-gateway-ecs|https://gateway-ecs-fargate.kortix.com/health/live|origin|0"
             "origin-gateway-eks|https://gateway-eks.kortix.com/health/live|origin|0"
+            "shadow-api-usw2|https://api-usw2-shadow.kortix.com/v1/health|required|1"
+            "shadow-gateway-usw2|https://gateway-usw2-shadow.kortix.com/health/live|required|1"
           )
 
           declare -A live
@@ -1058,7 +1082,7 @@ jobs:
               fi
             done
             if [ "$all_ok" = 1 ]; then
-              echo "✅ every endpoint reports v${VERSION} (and the correct commit where checkable) — release is live on both backends."
+              echo "✅ every production and US shadow endpoint reports v${VERSION} with the correct commit where available."
               exit 0
             fi
             sleep 15

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ core/kortix-master/opencode/.kortix/
 # Terraform — never commit local state, provider binaries, lockfile, or tfvars
 infra/terraform/**/.terraform/
 infra/terraform/**/.terraform.lock.hcl
+infra/terraform/**/*.tfplan
 infra/terraform/**/*.tfstate
 infra/terraform/**/*.tfstate.*
 infra/terraform/**/*.tfvars

--- a/docs/runbooks/prod-us-west-2-supabase-migration.md
+++ b/docs/runbooks/prod-us-west-2-supabase-migration.md
@@ -15,7 +15,27 @@
 - Repository migration ledger: 75 migrations applied through
   `20260725003708138_align_nullable_schema_contract`.
 - `pg_cron`: enabled at version 1.6.4 with zero scheduled jobs.
-- Production data copied: none.
+- Application logical replication: `101/101` relations ready.
+- Auth logical replication: `22/22` relations ready.
+- Replication apply errors: `0`.
+- Replication sync errors: `0`.
+- Source WAL retention limit: 32 GB.
+- Replication credential: rotated after the initial copy.
+- Storage copied: all 79 `avatars` objects with byte and SHA-256 verification.
+- Legacy Storage copied: none.
+- US API shadow: two healthy ECS tasks on image `kortix/kortix-api:0.10.14`.
+- US gateway shadow: two healthy ECS tasks on image
+  `kortix/kortix-gateway:0.10.14`.
+- US API task definition: `kortix-prod-usw2:2`.
+- US gateway task definition: `kortix-prod-usw2-gateway:2`.
+- Shadow Terraform state: `prod-us-west-2-shadow/ecs-api.tfstate`.
+- Shadow verification hosts:
+  - `api-usw2-shadow.kortix.com`
+  - `gateway-usw2-shadow.kortix.com`
+- Target Auth email rate limit: 30,000 per hour, equal to the source.
+- Production release workflow: deploys and verifies the US shadow.
+- US shadow worker, scheduler, channel, tunnel, warm-pool, managed-provider,
+  legacy-migration, and Suna-migration flags: disabled.
 - Production traffic still uses the source project.
 
 Do not print or copy secret values into this document, shell output, or Git.
@@ -29,8 +49,10 @@ Do not print or copy secret values into this document, shell output, or Git.
 | Database data | approximately 286 GB |
 | Storage objects | 452,290 |
 | Storage data | approximately 138 GB |
-| Auth users | 405,859 |
+| Auth users | 405,870 |
+| Auth identities | 409,636 |
 | MFA factors | 8,606 |
+| Auth refresh tokens | 9,538,250 |
 | `public` schema | 250 GB |
 | `kortix` schema | 29 GB |
 | `auth` schema | 11 GB |
@@ -88,7 +110,7 @@ the approved retention policy.
 
 1. All `kortix` schema data.
 2. All Supabase Auth users, identities, MFA factors, and required Auth data.
-3. All Supabase Storage metadata and all 452,290 storage objects.
+3. The current `avatars` Storage bucket.
 4. These `public` control tables:
 
    - `daily_refresh_tracking`
@@ -147,39 +169,154 @@ Verified account scope on 2026-07-25:
 
 The 90-day subset is approximately 6.4 GiB with proportional index overhead.
 
-Recommended policy:
+Migration policy:
 
-1. Snapshot the 90-day subset at the replication cutover time.
-2. Load it into a dedicated `legacy_suna` schema on the target.
-3. Update the Suna migration worker to read `legacy_suna`.
-4. Export the complete four-table corpus to encrypted S3 archival storage.
-5. Keep a documented manual restore path for older accounts.
-6. Remove the self-service migration feature after a fixed deprecation date.
+1. Do not copy `public.projects`.
+2. Do not copy `public.resources`.
+3. Do not copy `public.threads`.
+4. Do not copy `public.messages`.
+5. Keep `KORTIX_SUNA_MIGRATION_WORKER_ENABLED=false` on the US shadow.
+6. Keep the EU source unchanged through cutover and rollback.
 
-Do not delete or omit the complete legacy corpus without the archive and
-retention policy.
+The API treats a missing `public.projects` relation as zero eligible projects.
+The retired self-service Suna migration path therefore stays unavailable on the
+US target.
+
+### Product decision: legacy Storage
+
+Do not copy these source buckets:
+
+- `agent-profile-images`
+- `browser-screenshots`
+- `file-uploads`
+- `image-uploads`
+- `legacy-migrations`
+- `staged-files`
+
+The current repository directly reads and writes `avatars`. The migration tool
+therefore defaults to `STORAGE_BUCKETS=avatars`.
 
 ## Supabase support requirements
 
-Open one Supabase support case before the rehearsal.
+Open one Supabase support case before the production cutover.
 
 Request these actions:
 
-1. Assist with a managed-project migration where the source database exceeds
-   150 GB.
-2. Migrate Supabase-owned `auth` and `storage` schemas.
-3. Validate PostgreSQL 15.8 to 17.6 compatibility.
-4. Preserve the legacy JWT secret until all applications use the target keys.
-5. Coordinate the `supa.kortix.com` custom-domain transfer.
-6. Confirm the minimal-downtime logical replication plan.
-7. Confirm the supported Storage object migration method for 452,290 objects
-   and approximately 138 GB.
+1. Validate the live logical replication of all 22 selected Auth relations.
+2. Clone or safely reapply the original Google OAuth, GitHub OAuth, and Twilio
+   Verify plaintext credentials.
+3. Set or explain these platform-managed Auth differences:
+
+   - `mfa_allow_low_aal`: source `true`, target `false`.
+   - `audit_log_disable_postgres`: source `false`, target `true`.
+   - `index_worker_ensure_user_search_indexes_exist`: source `false`, target
+     `true`.
+
+4. Validate the imported source HS256 compatibility key.
+5. Validate PostgreSQL 15.8 to 17.6 compatibility.
+6. Coordinate the `supa.kortix.com` custom-domain transfer.
+7. Confirm the write-freeze, final synchronization, and rollback procedure.
+8. Confirm that no platform action is required for the completed `avatars`
+   object copy.
+
+Submit the request through:
+
+<https://supabase.com/dashboard/support/new>
+
+The Management API personal access token cannot submit this form. The
+`/platform/feedback/send` request returns HTTP `401` without a dashboard JWT.
 
 Official references:
 
 - <https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore>
 - <https://supabase.com/docs/guides/resources/migrating-to-supabase/postgres>
 - <https://supabase.com/docs/guides/platform/custom-domains>
+
+## Pre-cutover blockers
+
+Do not start the production write freeze until all four blockers close.
+
+1. Supabase Support confirms the Auth replication, JWT compatibility, and
+   custom-domain procedure.
+2. The target receives the original plaintext Google OAuth secret, GitHub OAuth
+   secret, and Twilio Verify token.
+3. Google login, GitHub login, and phone MFA complete on the target.
+4. The maintenance window and rollback owner are assigned.
+
+The source Management API returns one-way 64-character representations for
+configured provider secrets. Do not copy those values to another project.
+
+The source JWT header uses `HS256` with no `kid`. The target has the original
+source secret imported as signing key
+`df227db1-e3fe-4295-b86e-6531d85ec88f`.
+
+- A token signed by the source secret with that `kid` succeeds on target Auth.
+- The same token without a `kid` returns HTTP `403` with
+  `token signature is invalid`.
+
+Supabase Support must enable the source secret as the target legacy no-`kid`
+verification secret. This is required for active source user tokens and cached
+source anon keys during cutover.
+
+SMTP is complete. The target uses the original Mailtrap token. SMTP
+authentication returns `235 2.7.0 Ok`. Auth recovery returns HTTP `200`.
+
+Google and GitHub initiation currently return HTTP `302`. Completion remains
+blocked by the missing original plaintext provider secrets. Phone MFA remains
+blocked by the missing original Twilio Verify token.
+
+## Current validation evidence
+
+The target smoke returns:
+
+```json
+{
+  "passwordLogin": true,
+  "emailRecovery": true,
+  "apiAuthenticated": true,
+  "targetSchemaUserVisible": true,
+  "totpEnrollment": true,
+  "totpChallenge": true,
+  "aal2Token": true,
+  "signedAvatar": true,
+  "publicAvatar": true,
+  "cleanupRows": 0
+}
+```
+
+The cleanup check covers:
+
+- `auth.audit_log_entries`
+- `auth.identities`
+- `auth.mfa_factors`
+- `auth.refresh_tokens`
+- `auth.sessions`
+- `auth.users`
+- `kortix.audit_events`
+
+Auth row counts, primary-key hashes, and critical-row hashes match.
+
+Application row counts and hashes change while production accepts writes.
+Observed differences occur on active tables such as:
+
+- `audit_events`
+- `credit_ledger`
+- `stripe_webhook_events_processed`
+- `api_keys.last_used_at`
+- `session_sandboxes.last_used_at`
+- `session_sandboxes.metadata`
+- `session_sandboxes.updated_at`
+
+The repair command removes target-only smoke state and copies the current source
+values for mutable shadow-tested columns. Exact equality remains a cutover gate.
+
+All 79 `avatars` objects pass complete source and target SHA-256 verification.
+
+The US shadow endpoints return:
+
+- API `/v1/health`: HTTP `200`, version `0.10.14`.
+- Gateway `/health/live`: HTTP `200`, version `0.10.14`.
+- Gateway `/health`: HTTP `200`, API dependency `up`.
 
 ## Target preparation
 
@@ -199,14 +336,58 @@ source of truth.
 
 1. Take a consistent initial copy.
 2. Start logical replication for approved application tables.
-3. Copy Auth and Storage through the Supabase-supported path.
-4. Copy Storage objects with checksums and metadata reconciliation.
-5. Copy the approved legacy Suna subset.
+3. Copy Auth through its dedicated logical subscription.
+4. Copy `avatars` with byte and SHA-256 reconciliation.
+5. Do not copy the legacy Suna tables or legacy Storage buckets.
 6. Reset every migrated sequence to `max(column) + 1`.
 7. Monitor replication lag and retained WAL.
 
 Do not publish Supabase-owned internal tables through a publication owned by
 the application role. Supabase Support must handle those schemas.
+
+### Continuous synchronization commands
+
+Inspect both subscriptions:
+
+```bash
+bash scripts/prod-us-west-2/db-sync.sh status
+bash scripts/prod-us-west-2/auth-sync.sh status
+```
+
+Refresh the application publication after source and target migrations:
+
+```bash
+ALLOW_REPLICATION_REFRESH=1 \
+  bash scripts/prod-us-west-2/refresh-replication.sh
+```
+
+Repair target-only smoke mutations:
+
+```bash
+ALLOW_TARGET_SHADOW_REPAIR=1 \
+  bash scripts/prod-us-west-2/db-sync.sh repair-shadow-mutations
+
+ALLOW_TARGET_AUTH_SHADOW_REPAIR=1 \
+  bash scripts/prod-us-west-2/auth-sync.sh repair-shadow-mutations
+```
+
+Synchronize and verify `avatars`:
+
+```bash
+bash scripts/prod-us-west-2/storage-sync.sh
+STORAGE_VERIFY_ALL=1 bash scripts/prod-us-west-2/storage-sync.sh
+```
+
+Run the target smoke:
+
+```bash
+bash scripts/prod-us-west-2/target-smoke.sh
+```
+
+The production release calls
+`.github/workflows/deploy-prod-us-west-2-shadow.yml`. It applies target
+migrations, refreshes application replication, synchronizes `avatars`, deploys
+the released API and gateway images, and verifies the shadow endpoints.
 
 ## Reconciliation gates
 
@@ -216,7 +397,7 @@ The cutover cannot start until all gates pass.
 2. Primary-key set hashes match for every migrated table.
 3. Critical aggregate hashes match for Auth, billing, accounts, projects,
    sessions, API keys, and the legacy Suna subset.
-4. Storage bucket counts, object counts, and total bytes match.
+4. The `avatars` object count and total bytes match.
 5. A deterministic object sample passes content checksum verification.
 6. Auth password login succeeds on the target.
 7. MFA enrollment and challenge succeed on the target.
@@ -228,18 +409,51 @@ The cutover cannot start until all gates pass.
 13. Logical replication lag reaches zero.
 14. The target passes the production smoke suite before DNS changes.
 
+## Application topology
+
+The active production backend uses ECS Fargate in `eu-west-2`.
+
+- EU API: `4/4` tasks.
+- EU gateway: `2/2` tasks.
+- EU EKS: standby.
+
+The prepared US backend uses the same active topology.
+
+- US API: `2/2` tasks, autoscaling range `2..10`.
+- US gateway: `2/2` tasks, autoscaling range `2..6`.
+- US EKS: not provisioned.
+
+US EKS is not required for the database and traffic cutover. The US ECS stack
+matches the current active production backend. Provision US EKS later if the
+post-cutover design requires a same-region standby.
+
 ## Cutover
 
-1. Announce the maintenance window.
-2. Stop all production writers.
-3. Wait for replication lag to reach zero.
-4. Run final row-count, sequence, and checksum reconciliation.
-5. Disable source cron and worker writers.
-6. Switch application secrets to the target project.
-7. Transfer `supa.kortix.com`.
-8. Start the `us-west-2` application stack.
-9. Run authenticated API, web, Auth, Storage, billing, and trigger checks.
-10. Reopen writes.
+1. Confirm all pre-cutover blockers are closed.
+2. Raise the production maintenance notice.
+3. Block new API, gateway, and `supa.kortix.com` requests at Cloudflare.
+4. Stop EU ECS and EKS application writers.
+5. Disable the source scheduler, trigger scheduler, channels, workers, and cron
+   writers.
+6. Wait for both replication slots to reach the source WAL position.
+7. Run both target-only repair commands.
+8. Run exact application and Auth row-count reconciliation.
+9. Run exact application and Auth primary-key hash reconciliation.
+10. Run exact application and Auth critical-row hash reconciliation.
+11. Copy application and Auth sequence state.
+12. Run the final complete `avatars` synchronization and SHA-256 verification.
+13. Disable both target subscriptions only after all final checks pass.
+14. Transfer `supa.kortix.com` to the target project with Supabase Support.
+15. Update the production application secret to the target Supabase URLs and
+    keys.
+16. Confirm all production secret values contain no source project reference.
+17. Roll the US API and gateway with worker flags still disabled.
+18. Switch `api.kortix.com` and `gateway.kortix.com` to the US ECS origins.
+19. Run authenticated API, web, Auth, Storage, billing, OAuth, MFA, scheduler,
+    trigger, and gateway checks.
+20. Enable US schedulers and workers one group at a time.
+21. Remove the Cloudflare maintenance block.
+22. Clear the production maintenance notice.
 
 Target downtime: the final write freeze, final reconciliation, secret switch,
 custom-domain activation, and smoke checks.
@@ -248,11 +462,15 @@ custom-domain activation, and smoke checks.
 
 Rollback is permitted only before target writes reopen.
 
-1. Keep the source project unchanged and writable until the cutover gate.
-2. If a target check fails, point applications and the custom domain back to
-   the source.
-3. Restart source writers.
-4. Discard target writes from the failed rehearsal.
+1. Keep the source project unchanged until all target checks pass.
+2. Keep target schedulers and workers disabled during validation.
+3. If a target check fails, restore the production application secret.
+4. Point `api.kortix.com`, `gateway.kortix.com`, and `supa.kortix.com` back to
+   their source origins.
+5. Start EU ECS and EKS application services.
+6. Re-enable source schedulers, workers, channels, and cron.
+7. Remove the Cloudflare maintenance block.
+8. Discard target writes from the failed rehearsal.
 
 After target writes reopen, use a forward recovery plan. Do not run two
 writable primaries.

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -12,7 +12,7 @@
 #   ecs-deploy.sh <env> <image> [--service api|gateway] [--version X.Y.Z]
 #                 [--no-wait] [--dry-run]
 #
-#   env        dev | staging | prod
+#   env        dev | staging | prod | prod-usw2-shadow
 #   image      full image ref to pin, e.g. kortix/kortix-api:dev-481dc551
 #   --version  explicit KORTIX_VERSION to stamp into the task-def env. When
 #              omitted, it is DERIVED from the image tag if the tag is a clean
@@ -47,7 +47,7 @@ if [ "${KORTIX_ECS_DEPLOY_LIB:-}" = "1" ]; then
   return 0 2>/dev/null || exit 0
 fi
 
-ENV="${1:?env required: dev|staging|prod}"
+ENV="${1:?env required: dev|staging|prod|prod-usw2-shadow}"
 IMAGE="${2:?image required, e.g. kortix/kortix-api:dev-481dc551}"
 shift 2
 
@@ -69,25 +69,41 @@ done
 
 # ── per-environment coordinates ──────────────────────────────────────────────
 case "$ENV" in
-  dev)     REGION="us-west-2" ;;
-  staging) REGION="us-west-2" ;;
-  prod)    REGION="eu-west-2" ;;
+  dev)
+    REGION="us-west-2"
+    SERVICE_PREFIX="kortix-dev"
+    SECRET_NAME="kortix-dev-env"
+    ;;
+  staging)
+    REGION="us-west-2"
+    SERVICE_PREFIX="kortix-staging"
+    SECRET_NAME="kortix-staging-env"
+    ;;
+  prod)
+    REGION="eu-west-2"
+    SERVICE_PREFIX="kortix-prod"
+    SECRET_NAME="kortix-prod-env"
+    ;;
+  prod-usw2-shadow)
+    REGION="us-west-2"
+    SERVICE_PREFIX="kortix-prod-usw2"
+    SECRET_NAME="kortix-prod-us-west-2-env"
+    ;;
   *) echo "unknown env: $ENV" >&2; exit 2 ;;
 esac
 
 # Each service lives in its own cluster (the ecs-api module names cluster==service):
-#   api     → cluster/service kortix-<env>,         container "api"
-#   gateway → cluster/service kortix-<env>-gateway,  container "gateway"
+#   api     → cluster/service <service-prefix>,         container "api"
+#   gateway → cluster/service <service-prefix>-gateway, container "gateway"
 if [ "$SVC_KIND" = "gateway" ]; then
-  CLUSTER="kortix-${ENV}-gateway"
-  SERVICE="kortix-${ENV}-gateway"
+  CLUSTER="${SERVICE_PREFIX}-gateway"
+  SERVICE="${SERVICE_PREFIX}-gateway"
   CONTAINER="gateway"
 else
-  CLUSTER="kortix-${ENV}"
-  SERVICE="kortix-${ENV}"
+  CLUSTER="$SERVICE_PREFIX"
+  SERVICE="$SERVICE_PREFIX"
   CONTAINER="api"
 fi
-SECRET_NAME="kortix-${ENV}-env"
 
 echo "▶ env=$ENV region=$REGION cluster=$CLUSTER service=$SERVICE container=$CONTAINER"
 echo "▶ image=$IMAGE  secrets<-$SECRET_NAME"

--- a/infra/terraform/environments/prod-us-west-2-shadow/README.md
+++ b/infra/terraform/environments/prod-us-west-2-shadow/README.md
@@ -1,0 +1,56 @@
+# Production `us-west-2` shadow stack
+
+This Terraform root creates the parallel production API and gateway in
+`us-west-2`.
+
+It uses separate Terraform state:
+
+`prod-us-west-2-shadow/ecs-api.tfstate`
+
+It does not create or change DNS records.
+
+The pre-cutover shadow records exist outside this Terraform state:
+
+- `api-usw2-shadow.kortix.com`
+- `gateway-usw2-shadow.kortix.com`
+
+The records route only the shadow verification hosts. They do not change
+`api.kortix.com`, `gateway.kortix.com`, or production traffic.
+
+The ALBs accept traffic only from the Cloudflare IPv4 ranges in
+`alb_ingress_cidrs`. The release workflow keeps both shadow CNAME records
+proxied.
+
+The task secret is `kortix-prod-us-west-2-env`.
+Its worker, scheduler, channel, tunnel, warm-pool, and managed-provider flags
+remain disabled until the final production cutover.
+
+Production releases call
+`.github/workflows/deploy-prod-us-west-2-shadow.yml`. That workflow applies
+target migrations, refreshes application replication, and registers new ECS
+task definitions. The ECS module ignores service task-definition drift because
+the release workflow owns task revisions.
+
+Apply with the exact current secret key set:
+
+```bash
+secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id kortix-prod-us-west-2-env \
+    --region us-west-2 \
+    --query SecretString \
+    --output text
+)"
+
+export TF_VAR_secret_arn="$(
+  aws secretsmanager describe-secret \
+    --secret-id kortix-prod-us-west-2-env \
+    --region us-west-2 \
+    --query ARN \
+    --output text
+)"
+export TF_VAR_secret_keys="$(jq -c 'keys' <<<"$secret_json")"
+terraform init
+terraform plan -out=shadow.tfplan
+terraform apply shadow.tfplan
+```

--- a/infra/terraform/environments/prod-us-west-2-shadow/backend.tf
+++ b/infra/terraform/environments/prod-us-west-2-shadow/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "kortix-terraform-state"
+    key            = "prod-us-west-2-shadow/ecs-api.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "kortix-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/terraform/environments/prod-us-west-2-shadow/main.tf
+++ b/infra/terraform/environments/prod-us-west-2-shadow/main.tf
@@ -1,0 +1,113 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  name = "kortix-prod-usw2"
+  tags = {
+    Environment = "prod-usw2-shadow"
+    Project     = "kortix"
+    ManagedBy   = "terraform"
+  }
+  secrets = {
+    for key in var.secret_keys :
+    key => "${var.secret_arn}:${key}::"
+  }
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  name               = local.name
+  cidr               = "10.30.0.0/16"
+  az_count           = 2
+  single_nat_gateway = false
+  tags               = local.tags
+}
+
+module "api" {
+  source = "../../modules/ecs-api"
+
+  name       = local.name
+  aws_region = var.aws_region
+
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.public_subnet_ids
+  private_subnet_ids = module.network.private_subnet_ids
+
+  image             = var.api_image
+  container_name    = "api"
+  container_port    = 8000
+  health_check_path = "/v1/health"
+  certificate_arn   = var.certificate_arn
+  environment = {
+    KORTIX_VERSION = "0.10.14"
+  }
+  secrets = local.secrets
+
+  alb_ingress_cidrs = var.alb_ingress_cidrs
+
+  task_cpu           = 1024
+  task_memory        = 2048
+  desired_count      = 2
+  min_capacity       = 2
+  max_capacity       = 10
+  use_fargate_spot   = false
+  container_insights = true
+  cpu_target         = 55
+  memory_target      = 65
+
+  requests_per_target_target = 600
+  tags = merge(local.tags, {
+    Service = "kortix-api"
+  })
+}
+
+module "gateway" {
+  source = "../../modules/ecs-api"
+
+  name       = "${local.name}-gateway"
+  aws_region = var.aws_region
+
+  vpc_id             = module.network.vpc_id
+  public_subnet_ids  = module.network.public_subnet_ids
+  private_subnet_ids = module.network.private_subnet_ids
+
+  image             = var.gateway_image
+  container_name    = "gateway"
+  container_port    = 8090
+  health_check_path = "/health/live"
+  certificate_arn   = var.certificate_arn
+  environment = {
+    KORTIX_API_URL = "https://${var.api_shadow_hostname}"
+    KORTIX_VERSION = "0.10.14"
+  }
+  secrets = local.secrets
+
+  alb_ingress_cidrs = var.alb_ingress_cidrs
+
+  task_cpu           = 512
+  task_memory        = 1024
+  desired_count      = 2
+  min_capacity       = 2
+  max_capacity       = 6
+  use_fargate_spot   = false
+  container_insights = true
+  cpu_target         = 55
+  memory_target      = 65
+
+  tags = merge(local.tags, {
+    Service = "kortix-gateway"
+  })
+}

--- a/infra/terraform/environments/prod-us-west-2-shadow/outputs.tf
+++ b/infra/terraform/environments/prod-us-west-2-shadow/outputs.tf
@@ -1,0 +1,42 @@
+output "api_alb_dns_name" {
+  description = "Direct ALB target for SNI-based shadow API verification."
+  value       = module.api.alb_dns_name
+}
+
+output "api_cluster" {
+  value = module.api.cluster_name
+}
+
+output "api_service" {
+  value = module.api.service_name
+}
+
+output "api_task_definition" {
+  value = module.api.task_definition_arn
+}
+
+output "gateway_alb_dns_name" {
+  description = "Direct ALB target for SNI-based shadow gateway verification."
+  value       = module.gateway.alb_dns_name
+}
+
+output "gateway_cluster" {
+  value = module.gateway.cluster_name
+}
+
+output "gateway_service" {
+  value = module.gateway.service_name
+}
+
+output "gateway_task_definition" {
+  value = module.gateway.task_definition_arn
+}
+
+output "vpc_id" {
+  value = module.network.vpc_id
+}
+
+output "dns_managed" {
+  description = "The shadow stack never creates or changes DNS records."
+  value       = false
+}

--- a/infra/terraform/environments/prod-us-west-2-shadow/variables.tf
+++ b/infra/terraform/environments/prod-us-west-2-shadow/variables.tf
@@ -1,0 +1,69 @@
+variable "aws_region" {
+  description = "AWS region for the production shadow stack."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "api_image" {
+  description = "Immutable production API image."
+  type        = string
+  default     = "kortix/kortix-api:0.10.14"
+}
+
+variable "gateway_image" {
+  description = "Immutable production gateway image."
+  type        = string
+  default     = "kortix/kortix-gateway:0.10.14"
+}
+
+variable "certificate_arn" {
+  description = "Existing us-west-2 ACM certificate for *.kortix.com."
+  type        = string
+  default     = "arn:aws:acm:us-west-2:935064898258:certificate/d70f1f49-d981-4add-abb6-971bad1f3755"
+}
+
+variable "secret_arn" {
+  description = "Secrets Manager ARN for the US production shadow environment."
+  type        = string
+}
+
+variable "secret_keys" {
+  description = "JSON keys injected from the US production shadow secret."
+  type        = set(string)
+}
+
+variable "alb_ingress_cidrs" {
+  description = "Cloudflare IPv4 CIDRs permitted to access the shadow ALBs."
+  type        = list(string)
+  default = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+  ]
+
+  validation {
+    condition = (
+      length(var.alb_ingress_cidrs) > 0
+      && !contains(var.alb_ingress_cidrs, "0.0.0.0/0")
+    )
+    error_message = "The shadow ALBs require a non-empty restricted CIDR allowlist."
+  }
+}
+
+variable "api_shadow_hostname" {
+  description = "SNI hostname used for direct shadow API verification. Terraform does not create DNS."
+  type        = string
+  default     = "api-usw2-shadow.kortix.com"
+}

--- a/infra/terraform/modules/ecs-api/outputs.tf
+++ b/infra/terraform/modules/ecs-api/outputs.tf
@@ -18,3 +18,7 @@ output "service_name" {
 output "log_group" {
   value = aws_cloudwatch_log_group.this.name
 }
+
+output "task_definition_arn" {
+  value = aws_ecs_task_definition.this.arn
+}

--- a/infra/terraform/security-baseline/iam-gha-ecs-deploy.tf
+++ b/infra/terraform/security-baseline/iam-gha-ecs-deploy.tf
@@ -11,8 +11,9 @@
 # (the prod gateway task-def that night had to be registered manually by a
 # human). This file is the system-of-record for the CORRECTED policy:
 #   - ECS resources region-wildcarded (dev/staging = us-west-2, prod = eu-west-2)
-#   - PassRole for the task+exec roles of ALL SIX services:
+#   - PassRole for the task+exec roles of all production release services:
 #     kortix-{dev,staging,prod} (api) and kortix-{dev,staging,prod}-gateway
+#     plus the pre-cutover kortix-prod-usw2 API and gateway shadow services
 #     (the ecs-api TF module names roles "<service>-exec"/"<service>-task")
 #   - Secrets Manager read of every kortix-<env>-env blob (the task-def renderer
 #     wires each blob key as a container secret)
@@ -128,6 +129,10 @@ resource "aws_iam_role_policy" "gha_ecs_deploy" {
           "arn:aws:iam::${local.account_id}:role/kortix-prod-exec",
           "arn:aws:iam::${local.account_id}:role/kortix-prod-gateway-task",
           "arn:aws:iam::${local.account_id}:role/kortix-prod-gateway-exec",
+          "arn:aws:iam::${local.account_id}:role/kortix-prod-usw2-task",
+          "arn:aws:iam::${local.account_id}:role/kortix-prod-usw2-exec",
+          "arn:aws:iam::${local.account_id}:role/kortix-prod-usw2-gateway-task",
+          "arn:aws:iam::${local.account_id}:role/kortix-prod-usw2-gateway-exec",
         ]
       },
     ]

--- a/scripts/prod-us-west-2/auth-sync.sh
+++ b/scripts/prod-us-west-2/auth-sync.sh
@@ -1,0 +1,684 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_SECRET_ID="${SOURCE_SECRET_ID:-kortix-prod-env}"
+SOURCE_AWS_REGION="${SOURCE_AWS_REGION:-eu-west-2}"
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix/prod-us-west-2-migration}"
+TARGET_AWS_REGION="${TARGET_AWS_REGION:-us-west-2}"
+PUBLICATION="${AUTH_PUBLICATION:-kortix_usw2_auth_20260725}"
+SUBSCRIPTION="${AUTH_SUBSCRIPTION:-kortix_usw2_auth_20260725}"
+
+source_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$SOURCE_SECRET_ID" \
+    --region "$SOURCE_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+target_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$TARGET_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+
+source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+target_database_url="$(jq -er '.target_database_url' <<<"$target_secret_json")"
+replication_username="$(jq -er '.replication_username' <<<"$target_secret_json")"
+replication_password="$(jq -er '.replication_password' <<<"$target_secret_json")"
+
+prepare_source() {
+  psql "$source_database_url" -X -v ON_ERROR_STOP=1 -v publication="$PUBLICATION" <<'SQL'
+GRANT pg_read_all_data TO kortix_usw2_repl;
+ALTER ROLE kortix_usw2_repl BYPASSRLS;
+
+SELECT format(
+  'CREATE PUBLICATION %I WITH (publish = %L)',
+  :'publication',
+  'insert,update,delete'
+)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM pg_publication
+  WHERE pubname = :'publication'
+)
+\gexec
+
+SELECT set_config('kortix.auth_migration_publication', :'publication', false);
+
+DO $do$
+DECLARE
+  publication_name text := current_setting('kortix.auth_migration_publication');
+  relation record;
+BEGIN
+  FOR relation IN
+    SELECT
+      table_name,
+      string_agg(
+        format('%I', column_name),
+        ', ' ORDER BY ordinal_position
+      ) AS column_list
+    FROM information_schema.columns
+    WHERE table_schema = 'auth'
+      AND table_name <> 'schema_migrations'
+      AND is_generated = 'NEVER'
+    GROUP BY table_name
+    ORDER BY table_name
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_publication_rel
+      JOIN pg_publication
+        ON pg_publication.oid = pg_publication_rel.prpubid
+      WHERE pg_publication.pubname = publication_name
+        AND pg_publication_rel.prrelid = format(
+          'auth.%I',
+          relation.table_name
+        )::regclass
+    ) THEN
+      EXECUTE format(
+        'ALTER PUBLICATION %I ADD TABLE auth.%I (%s)',
+        publication_name,
+        relation.table_name,
+        relation.column_list
+      );
+    END IF;
+  END LOOP;
+END
+$do$;
+
+SELECT pg_publication.pubname, count(*) AS published_tables
+FROM pg_publication
+JOIN pg_publication_rel
+  ON pg_publication_rel.prpubid = pg_publication.oid
+WHERE pg_publication.pubname = :'publication'
+GROUP BY pg_publication.pubname;
+SQL
+}
+
+reset_target() {
+  if [[ "${ALLOW_TARGET_AUTH_RESET:-}" != "1" ]]; then
+    echo "Set ALLOW_TARGET_AUTH_RESET=1 to reset replicated Auth data on the US target." >&2
+    exit 64
+  fi
+
+  psql "$target_database_url" -X -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT format('DROP SUBSCRIPTION %I', :'subscription')
+WHERE EXISTS (
+  SELECT 1
+  FROM pg_subscription
+  WHERE subname = :'subscription'
+)
+\gexec
+
+DO $do$
+DECLARE
+  relation_list text;
+BEGIN
+  SELECT string_agg(
+    format('%I.%I', table_schema, table_name),
+    ', ' ORDER BY table_name
+  )
+  INTO relation_list
+  FROM information_schema.tables
+  WHERE table_schema = 'auth'
+    AND table_type = 'BASE TABLE'
+    AND table_name <> 'schema_migrations';
+
+  IF relation_list IS NULL THEN
+    RAISE EXCEPTION 'No Auth tables found on the target';
+  END IF;
+
+  EXECUTE format('TRUNCATE TABLE %s CASCADE', relation_list);
+END
+$do$;
+SQL
+
+  echo "Reset replicated Auth data on the US target."
+}
+
+start_subscription() {
+  subscription_exists="$(
+    psql "$target_database_url" -X -At -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_subscription
+  WHERE subname = :'subscription'
+);
+SQL
+  )"
+  if [[ "$subscription_exists" == "t" ]]; then
+    psql "$target_database_url" -X -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I SET (run_as_owner = true)', :'subscription')
+\gexec
+SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
+\gexec
+SQL
+    return
+  fi
+
+  source_replication_url="$(
+    REPLICATION_USERNAME="$replication_username" \
+      REPLICATION_PASSWORD="$replication_password" \
+      node -e '
+        const url = new URL(process.argv[1])
+        url.username = process.env.REPLICATION_USERNAME
+        url.password = process.env.REPLICATION_PASSWORD
+        url.searchParams.set("sslmode", "require")
+        url.searchParams.set("application_name", process.argv[2])
+        url.searchParams.set("options", "-c statement_timeout=0")
+        process.stdout.write(url.toString())
+      ' "$source_database_url" "$SUBSCRIPTION"
+  )"
+  escaped_replication_url="${source_replication_url//\'/\'\'}"
+  {
+    printf "\\set source_replication_url '%s'\n" "$escaped_replication_url"
+    printf "\\set publication '%s'\n" "$PUBLICATION"
+    printf "\\set subscription '%s'\n" "$SUBSCRIPTION"
+    cat <<'SQL'
+SELECT format(
+  'CREATE SUBSCRIPTION %I CONNECTION %L PUBLICATION %I WITH (copy_data = true, create_slot = true, enabled = true, binary = false, streaming = %L, two_phase = false, disable_on_error = true, origin = %L, run_as_owner = true)',
+  :'subscription',
+  :'source_replication_url',
+  :'publication',
+  'parallel',
+  'none'
+)
+\gexec
+SQL
+  } | psql "$target_database_url" -X -v ON_ERROR_STOP=1
+}
+
+status() {
+  psql "$target_database_url" -X -P pager=off -A -F $'\t' \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT
+  pg_subscription.subname,
+  pg_subscription.subenabled,
+  pg_stat_subscription.pid,
+  pg_stat_subscription.worker_type,
+  pg_stat_subscription.relid::regclass AS relation,
+  pg_stat_subscription.received_lsn,
+  pg_stat_subscription.latest_end_lsn,
+  pg_stat_subscription.last_msg_receipt_time
+FROM pg_subscription
+LEFT JOIN pg_stat_subscription
+  ON pg_stat_subscription.subid = pg_subscription.oid
+WHERE pg_subscription.subname = :'subscription'
+ORDER BY pg_stat_subscription.worker_type, pg_stat_subscription.relid::regclass::text;
+
+SELECT pg_subscription_rel.srsubstate, count(*)
+FROM pg_subscription_rel
+WHERE pg_subscription_rel.srsubid = (
+  SELECT oid
+  FROM pg_subscription
+  WHERE subname = :'subscription'
+)
+GROUP BY pg_subscription_rel.srsubstate
+ORDER BY pg_subscription_rel.srsubstate;
+
+SELECT *
+FROM pg_stat_subscription_stats
+WHERE subname = :'subscription';
+
+SELECT 'users', count(*) FROM auth.users
+UNION ALL
+SELECT 'identities', count(*) FROM auth.identities
+UNION ALL
+SELECT 'mfa_factors', count(*) FROM auth.mfa_factors
+UNION ALL
+SELECT 'refresh_tokens', count(*) FROM auth.refresh_tokens;
+SQL
+
+  echo "Publisher:"
+  psql "$source_database_url" -X -P pager=off -A -F $'\t' \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT
+  slot_name,
+  active,
+  confirmed_flush_lsn,
+  pg_size_pretty(
+    pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)
+  ) AS retained_wal
+FROM pg_replication_slots
+WHERE slot_name = :'subscription';
+SQL
+}
+
+write_counts() {
+  local database_url="$1"
+  local output_file="$2"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 >"$output_file" <<'SQL'
+BEGIN;
+CREATE TEMP TABLE auth_migration_counts (
+  table_name text NOT NULL,
+  row_count bigint NOT NULL
+) ON COMMIT DROP;
+
+DO $do$
+DECLARE
+  relation record;
+BEGIN
+  FOR relation IN
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = 'auth'
+      AND table_name <> 'schema_migrations'
+    ORDER BY table_name
+  LOOP
+    EXECUTE format(
+      'INSERT INTO auth_migration_counts SELECT %L, count(*) FROM auth.%I',
+      relation.table_name,
+      relation.table_name
+    );
+  END LOOP;
+END
+$do$;
+
+SELECT table_name, row_count
+FROM auth_migration_counts
+ORDER BY table_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+reconcile_counts() {
+  temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-auth-counts.XXXXXX")"
+  source_counts="$temporary_directory/source.tsv"
+  target_counts="$temporary_directory/target.tsv"
+  cleanup_counts() {
+    [[ -f "$source_counts" ]] && unlink "$source_counts"
+    [[ -f "$target_counts" ]] && unlink "$target_counts"
+    [[ -d "$temporary_directory" ]] && rmdir "$temporary_directory"
+  }
+  trap cleanup_counts EXIT
+
+  write_counts "$source_database_url" "$source_counts" &
+  source_count_pid=$!
+  write_counts "$target_database_url" "$target_counts" &
+  target_count_pid=$!
+  wait "$source_count_pid"
+  wait "$target_count_pid"
+
+  if diff -u "$source_counts" "$target_counts"; then
+    echo "All replicated Auth table row counts match."
+  else
+    echo "Replicated Auth table row counts differ." >&2
+    exit 1
+  fi
+}
+
+write_key_hashes() {
+  local database_url="$1"
+  local output_file="$2"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 >"$output_file" <<'SQL'
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+CREATE TEMP TABLE auth_migration_key_hashes (
+  table_name text NOT NULL,
+  row_count bigint NOT NULL,
+  hash_a numeric NOT NULL,
+  hash_b numeric NOT NULL
+) ON COMMIT DROP;
+
+DO $do$
+DECLARE
+  relation record;
+BEGIN
+  FOR relation IN
+    SELECT
+      information_schema.tables.table_name,
+      string_agg(
+        format('%I', key_attribute.attname),
+        ', ' ORDER BY key_column.ordinality
+      ) AS key_columns
+    FROM information_schema.tables
+    JOIN pg_namespace
+      ON pg_namespace.nspname = information_schema.tables.table_schema
+    JOIN pg_class
+      ON pg_class.relnamespace = pg_namespace.oid
+     AND pg_class.relname = information_schema.tables.table_name
+    JOIN pg_index
+      ON pg_index.indrelid = pg_class.oid
+     AND pg_index.indisprimary
+     AND pg_index.indisvalid
+     AND pg_index.indisready
+    JOIN LATERAL unnest(pg_index.indkey)
+      WITH ORDINALITY AS key_column(attnum, ordinality)
+      ON key_column.ordinality <= pg_index.indnkeyatts
+    JOIN pg_attribute AS key_attribute
+      ON key_attribute.attrelid = pg_class.oid
+     AND key_attribute.attnum = key_column.attnum
+    WHERE information_schema.tables.table_schema = 'auth'
+      AND information_schema.tables.table_type = 'BASE TABLE'
+      AND information_schema.tables.table_name <> 'schema_migrations'
+    GROUP BY information_schema.tables.table_name
+    ORDER BY information_schema.tables.table_name COLLATE "C"
+  LOOP
+    EXECUTE format(
+      $query$
+      INSERT INTO auth_migration_key_hashes
+      SELECT
+        %L,
+        count(*),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              key_value,
+              0
+            )::numeric
+          ),
+          0
+        ),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              key_value,
+              -7046029254386353131
+            )::numeric
+          ),
+          0
+        )
+      FROM (
+        SELECT jsonb_build_array(%s) AS key_value
+        FROM auth.%I
+      ) AS relation_keys
+      $query$,
+      relation.table_name,
+      relation.key_columns,
+      relation.table_name
+    );
+  END LOOP;
+END
+$do$;
+
+SELECT table_name, row_count, hash_a, hash_b
+FROM auth_migration_key_hashes
+ORDER BY table_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+write_critical_hashes() {
+  local database_url="$1"
+  local output_file="$2"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 >"$output_file" <<'SQL'
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+CREATE TEMP TABLE auth_migration_critical_hashes (
+  table_name text NOT NULL,
+  row_count bigint NOT NULL,
+  hash_a numeric NOT NULL,
+  hash_b numeric NOT NULL
+) ON COMMIT DROP;
+
+DO $do$
+DECLARE
+  relation record;
+BEGIN
+  FOR relation IN
+    SELECT
+      information_schema.columns.table_name,
+      string_agg(
+        format('%I', information_schema.columns.column_name),
+        ', ' ORDER BY information_schema.columns.column_name COLLATE "C"
+      ) AS row_columns
+    FROM information_schema.columns
+    WHERE information_schema.columns.table_schema = 'auth'
+      AND information_schema.columns.is_generated = 'NEVER'
+      AND information_schema.columns.table_name IN (
+        'identities',
+        'mfa_factors',
+        'one_time_tokens',
+        'sessions',
+        'sso_domains',
+        'sso_providers',
+        'users'
+      )
+    GROUP BY information_schema.columns.table_name
+    ORDER BY information_schema.columns.table_name COLLATE "C"
+  LOOP
+    EXECUTE format(
+      $query$
+      INSERT INTO auth_migration_critical_hashes
+      SELECT
+        %L,
+        count(*),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              row_value,
+              0
+            )::numeric
+          ),
+          0
+        ),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              row_value,
+              -7046029254386353131
+            )::numeric
+          ),
+          0
+        )
+      FROM (
+        SELECT jsonb_build_array(%s) AS row_value
+        FROM auth.%I
+      ) AS relation_rows
+      $query$,
+      relation.table_name,
+      relation.row_columns,
+      relation.table_name
+    );
+  END LOOP;
+END
+$do$;
+
+SELECT table_name, row_count, hash_a, hash_b
+FROM auth_migration_critical_hashes
+ORDER BY table_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+reconcile_hashes() {
+  local mode="$1"
+  local writer
+  local label
+
+  case "$mode" in
+    keys)
+      writer=write_key_hashes
+      label="primary-key"
+      ;;
+    critical)
+      writer=write_critical_hashes
+      label="critical row"
+      ;;
+    *)
+      echo "Unknown Auth hash reconciliation mode: $mode" >&2
+      exit 64
+      ;;
+  esac
+
+  temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-auth-hashes.XXXXXX")"
+  source_hashes="$temporary_directory/source.tsv"
+  target_hashes="$temporary_directory/target.tsv"
+  cleanup_hashes() {
+    [[ -f "$source_hashes" ]] && unlink "$source_hashes"
+    [[ -f "$target_hashes" ]] && unlink "$target_hashes"
+    [[ -d "$temporary_directory" ]] && rmdir "$temporary_directory"
+  }
+  trap cleanup_hashes EXIT
+
+  "$writer" "$source_database_url" "$source_hashes" &
+  source_hash_pid=$!
+  "$writer" "$target_database_url" "$target_hashes" &
+  target_hash_pid=$!
+  wait "$source_hash_pid"
+  wait "$target_hash_pid"
+
+  if diff -u "$source_hashes" "$target_hashes"; then
+    echo "All replicated Auth $label hashes match."
+  else
+    echo "Replicated Auth $label hashes differ." >&2
+    exit 1
+  fi
+}
+
+write_sequence_state() {
+  local database_url="$1"
+  local output_file="$2"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 >"$output_file" <<'SQL'
+BEGIN;
+CREATE TEMP TABLE auth_migration_sequence_state (
+  schema_name text NOT NULL,
+  sequence_name text NOT NULL,
+  last_value bigint NOT NULL,
+  is_called boolean NOT NULL
+) ON COMMIT DROP;
+
+SELECT format(
+  'INSERT INTO auth_migration_sequence_state SELECT %L, %L, last_value, is_called FROM %I.%I',
+  sequence_namespace.nspname,
+  sequence_class.relname,
+  sequence_namespace.nspname,
+  sequence_class.relname
+)
+FROM pg_class AS sequence_class
+JOIN pg_namespace AS sequence_namespace
+  ON sequence_namespace.oid = sequence_class.relnamespace
+JOIN pg_depend
+  ON pg_depend.objid = sequence_class.oid
+ AND pg_depend.deptype IN ('a', 'i')
+JOIN pg_class AS table_class
+  ON table_class.oid = pg_depend.refobjid
+JOIN pg_namespace AS table_namespace
+  ON table_namespace.oid = table_class.relnamespace
+WHERE sequence_class.relkind = 'S'
+  AND table_namespace.nspname = 'auth'
+  AND table_class.relname <> 'schema_migrations'
+ORDER BY sequence_namespace.nspname, sequence_class.relname
+\gexec
+
+SELECT schema_name, sequence_name, last_value, is_called
+FROM auth_migration_sequence_state
+ORDER BY schema_name COLLATE "C", sequence_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+reconcile_sequences() {
+  sequence_state_file="$(mktemp "${TMPDIR:-/tmp}/kortix-usw2-auth-sequences.XXXXXX")"
+  cleanup_sequence_state() {
+    [[ -f "$sequence_state_file" ]] && unlink "$sequence_state_file"
+  }
+  trap cleanup_sequence_state EXIT
+
+  write_sequence_state "$source_database_url" "$sequence_state_file"
+
+  while IFS=$'\t' read -r schema_name sequence_name last_value is_called; do
+    psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+      -v schema_name="$schema_name" \
+      -v sequence_name="$sequence_name" \
+      -v last_value="$last_value" \
+      -v is_called="$is_called" <<'SQL'
+SELECT setval(
+  format('%I.%I', :'schema_name', :'sequence_name')::regclass,
+  :'last_value'::bigint,
+  :'is_called'::boolean
+)
+\gset
+SQL
+  done <"$sequence_state_file"
+
+  echo "Auth sequence state matches the source."
+}
+
+repair_shadow_mutations() {
+  if [[ "${ALLOW_TARGET_AUTH_SHADOW_REPAIR:-}" != "1" ]]; then
+    echo "Set ALLOW_TARGET_AUTH_SHADOW_REPAIR=1 to remove target-only Auth test state." >&2
+    exit 64
+  fi
+
+  local temporary_directory
+  local source_flow_state_ids
+  temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-auth-shadow-repair.XXXXXX")"
+  source_flow_state_ids="$temporary_directory/source-flow-state-ids.csv"
+
+  cleanup_auth_shadow_repair() {
+    [[ -f "$source_flow_state_ids" ]] && unlink "$source_flow_state_ids"
+    [[ -d "$temporary_directory" ]] && rmdir "$temporary_directory"
+  }
+  trap cleanup_auth_shadow_repair EXIT
+
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -c "\\copy (SELECT id FROM auth.flow_state ORDER BY id) TO '$source_flow_state_ids' WITH (FORMAT csv)"
+
+  {
+    cat <<'SQL'
+BEGIN;
+CREATE TEMP TABLE source_flow_state_ids (
+  id uuid PRIMARY KEY
+) ON COMMIT DROP;
+SQL
+    printf "\\copy source_flow_state_ids FROM '%s' WITH (FORMAT csv)\n" "$source_flow_state_ids"
+    cat <<'SQL'
+DELETE FROM auth.flow_state AS target
+WHERE target.created_at < now() - interval '15 minutes'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM source_flow_state_ids AS source
+    WHERE source.id = target.id
+  );
+COMMIT;
+SQL
+  } | psql "$target_database_url" -X -v ON_ERROR_STOP=1
+
+  trap - EXIT
+  cleanup_auth_shadow_repair
+  echo "Removed target-only Auth flow state older than 15 minutes."
+}
+
+case "${1:-}" in
+  prepare-source)
+    prepare_source
+    ;;
+  reset-target)
+    reset_target
+    ;;
+  start)
+    start_subscription
+    ;;
+  status)
+    status
+    ;;
+  reconcile-counts)
+    reconcile_counts
+    ;;
+  reconcile-key-hashes)
+    reconcile_hashes keys
+    ;;
+  reconcile-critical-hashes)
+    reconcile_hashes critical
+    ;;
+  reconcile-sequences)
+    reconcile_sequences
+    ;;
+  repair-shadow-mutations)
+    repair_shadow_mutations
+    ;;
+  *)
+    echo "Usage: scripts/prod-us-west-2/auth-sync.sh {prepare-source|reset-target|start|status|reconcile-counts|reconcile-key-hashes|reconcile-critical-hashes|reconcile-sequences|repair-shadow-mutations}" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/prod-us-west-2/db-sync.sh
+++ b/scripts/prod-us-west-2/db-sync.sh
@@ -1,0 +1,1271 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_SECRET_ID="${SOURCE_SECRET_ID:-kortix-prod-env}"
+SOURCE_AWS_REGION="${SOURCE_AWS_REGION:-eu-west-2}"
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix/prod-us-west-2-migration}"
+TARGET_AWS_REGION="${TARGET_AWS_REGION:-us-west-2}"
+PUBLICATION="${PUBLICATION:-kortix_us_west_2_20260725}"
+SUBSCRIPTION="${SUBSCRIPTION:-kortix_us_west_2_20260725}"
+AUTH_SUBSCRIPTION="${AUTH_SUBSCRIPTION:-kortix_usw2_auth_20260725}"
+SHADOW_AUDIT_START_AT="${SHADOW_AUDIT_START_AT:-2026-07-25 00:00:00+00}"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+for command_name in aws jq node psql supabase; do
+  require_command "$command_name"
+done
+
+source_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$SOURCE_SECRET_ID" \
+    --region "$SOURCE_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+target_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$TARGET_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+
+source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+target_database_url="$(jq -er '.target_database_url' <<<"$target_secret_json")"
+replication_username="$(jq -er '.replication_username' <<<"$target_secret_json")"
+replication_password="$(jq -er '.replication_password' <<<"$target_secret_json")"
+
+prepare_source() {
+  supabase postgres-config update \
+    --experimental \
+    --project-ref jbriwassebxdwoieikga \
+    --config max_slot_wal_keep_size=32GB \
+    --no-restart \
+    --yes \
+    -o json >/dev/null
+
+  {
+    printf "\\set replication_password '%s'\n" "${replication_password//\'/\'\'}"
+    cat <<'SQL'
+SELECT format(
+  'CREATE ROLE kortix_usw2_repl WITH LOGIN REPLICATION PASSWORD %L',
+  :'replication_password'
+)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM pg_roles
+  WHERE rolname = 'kortix_usw2_repl'
+)
+\gexec
+SELECT format(
+  'ALTER ROLE kortix_usw2_repl WITH LOGIN REPLICATION PASSWORD %L',
+  :'replication_password'
+)
+\gexec
+ALTER ROLE kortix_usw2_repl SET statement_timeout = 0;
+ALTER ROLE kortix_usw2_repl BYPASSRLS;
+GRANT CONNECT ON DATABASE postgres TO kortix_usw2_repl;
+GRANT USAGE ON SCHEMA kortix, public TO kortix_usw2_repl;
+GRANT SELECT ON ALL TABLES IN SCHEMA kortix TO kortix_usw2_repl;
+GRANT SELECT ON
+  public.daily_refresh_tracking,
+  public.renewal_processing,
+  public.contact_forms,
+  public.webhook_config
+TO kortix_usw2_repl;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres
+  IN SCHEMA kortix
+  GRANT SELECT ON TABLES TO kortix_usw2_repl;
+SQL
+  } | psql "$source_database_url" -X -v ON_ERROR_STOP=1
+
+  psql "$source_database_url" -X -v ON_ERROR_STOP=1 -v publication="$PUBLICATION" <<'SQL'
+SET lock_timeout = '5s';
+SELECT set_config('kortix.migration_publication', :'publication', false);
+
+ALTER TABLE kortix.account_members
+  REPLICA IDENTITY USING INDEX idx_account_members_user_account;
+ALTER TABLE kortix.project_members
+  REPLICA IDENTITY USING INDEX idx_project_members_project_user;
+ALTER TABLE kortix.sandbox_members
+  REPLICA IDENTITY USING INDEX idx_sandbox_members_unique;
+ALTER TABLE kortix.sandbox_member_scopes
+  REPLICA IDENTITY USING INDEX idx_sandbox_member_scopes_unique;
+
+SELECT format(
+  'CREATE PUBLICATION %I WITH (publish = %L)',
+  :'publication',
+  'insert,update,delete'
+)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM pg_publication
+  WHERE pubname = :'publication'
+)
+\gexec
+
+DO $do$
+DECLARE
+  publication_name text := current_setting('kortix.migration_publication');
+  relation record;
+BEGIN
+  FOR relation IN
+    WITH selected_tables AS (
+      SELECT table_schema, table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'kortix'
+        AND table_type = 'BASE TABLE'
+        AND table_name NOT IN (
+          'channel_configs',
+          'integration_credentials',
+          'integrations',
+          'sandbox_integrations',
+          'schema_migrations'
+        )
+      UNION ALL
+      SELECT 'public', table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+        AND table_name IN (
+          'daily_refresh_tracking',
+          'renewal_processing',
+          'contact_forms',
+          'webhook_config'
+        )
+    )
+    SELECT
+      selected_tables.table_schema,
+      selected_tables.table_name,
+      string_agg(
+        format('%I', columns.column_name),
+        ', ' ORDER BY columns.ordinal_position
+      ) FILTER (
+        WHERE NOT (
+          selected_tables.table_schema = 'kortix'
+          AND selected_tables.table_name = 'accounts'
+          AND columns.column_name = 'personal_account'
+        )
+      ) AS column_list
+    FROM selected_tables
+    JOIN information_schema.columns AS columns
+      USING (table_schema, table_name)
+    GROUP BY selected_tables.table_schema, selected_tables.table_name
+    ORDER BY selected_tables.table_schema, selected_tables.table_name
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_publication_rel
+      JOIN pg_publication
+        ON pg_publication.oid = pg_publication_rel.prpubid
+      WHERE pg_publication.pubname = publication_name
+        AND pg_publication_rel.prrelid = format(
+          '%I.%I',
+          relation.table_schema,
+          relation.table_name
+        )::regclass
+    ) THEN
+      EXECUTE format(
+        'ALTER PUBLICATION %I ADD TABLE %I.%I (%s)',
+        publication_name,
+        relation.table_schema,
+        relation.table_name,
+        relation.column_list
+      );
+    END IF;
+  END LOOP;
+END
+$do$;
+
+SELECT
+  pg_publication.pubname,
+  count(*) AS published_tables
+FROM pg_publication
+JOIN pg_publication_rel
+  ON pg_publication_rel.prpubid = pg_publication.oid
+WHERE pg_publication.pubname = :'publication'
+GROUP BY pg_publication.pubname;
+SQL
+}
+
+start_subscription() {
+  duplicate_active_deletions="$(
+    psql "$source_database_url" -X -At -v ON_ERROR_STOP=1 -c "
+      SELECT count(*)
+      FROM (
+        SELECT account_id
+        FROM kortix.account_deletion_requests
+        WHERE is_cancelled = false
+          AND is_deleted = false
+        GROUP BY account_id
+        HAVING count(*) > 1
+      ) AS duplicate_accounts
+    "
+  )"
+
+  if [[ "$duplicate_active_deletions" -gt 0 ]]; then
+    psql "$target_database_url" -X -v ON_ERROR_STOP=1 -c \
+      'DROP INDEX IF EXISTS kortix.unique_active_deletion_request'
+  fi
+
+  source_replication_url="$(
+    REPLICATION_USERNAME="$replication_username" \
+      REPLICATION_PASSWORD="$replication_password" \
+      node -e '
+      const url = new URL(process.argv[1])
+      url.username = process.env.REPLICATION_USERNAME
+      url.password = process.env.REPLICATION_PASSWORD
+      url.searchParams.set("sslmode", "require")
+      url.searchParams.set("application_name", process.argv[2])
+      url.searchParams.set("options", "-c statement_timeout=0")
+      process.stdout.write(url.toString())
+    ' "$source_database_url" "$SUBSCRIPTION"
+  )"
+
+  subscription_exists="$(
+    psql "$target_database_url" -X -At -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_subscription
+  WHERE subname = :'subscription'
+);
+SQL
+  )"
+
+  if [[ "$subscription_exists" == "t" ]]; then
+    psql "$target_database_url" -X -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
+\gexec
+SQL
+    return
+  fi
+
+  escaped_replication_url="${source_replication_url//\'/\'\'}"
+  {
+    printf "\\set source_replication_url '%s'\n" "$escaped_replication_url"
+    printf "\\set publication '%s'\n" "$PUBLICATION"
+    printf "\\set subscription '%s'\n" "$SUBSCRIPTION"
+    cat <<'SQL'
+SET statement_timeout = 0;
+SELECT format(
+  'CREATE SUBSCRIPTION %I CONNECTION %L PUBLICATION %I WITH (copy_data = true, create_slot = true, enabled = true, binary = false, streaming = %L, two_phase = false, disable_on_error = true, origin = %L)',
+  :'subscription',
+  :'source_replication_url',
+  :'publication',
+  'parallel',
+  'none'
+)
+\gexec
+SQL
+  } | psql "$target_database_url" -X -v ON_ERROR_STOP=1
+}
+
+status() {
+  echo "Subscriber:"
+  psql "$target_database_url" -X -P pager=off -A -F $'\t' \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT
+  pg_subscription.subname,
+  pg_subscription.subenabled,
+  pg_stat_subscription.pid,
+  pg_stat_subscription.worker_type,
+  pg_stat_subscription.relid::regclass AS relation,
+  pg_stat_subscription.received_lsn,
+  pg_stat_subscription.latest_end_lsn,
+  pg_stat_subscription.last_msg_receipt_time
+FROM pg_subscription
+LEFT JOIN pg_stat_subscription
+  ON pg_stat_subscription.subid = pg_subscription.oid
+WHERE pg_subscription.subname = :'subscription'
+ORDER BY pg_stat_subscription.worker_type, pg_stat_subscription.relid::regclass::text;
+
+SELECT
+  pg_subscription_rel.srsubstate,
+  count(*)
+FROM pg_subscription_rel
+WHERE pg_subscription_rel.srsubid = (
+  SELECT oid
+  FROM pg_subscription
+  WHERE subname = :'subscription'
+)
+GROUP BY pg_subscription_rel.srsubstate
+ORDER BY pg_subscription_rel.srsubstate;
+
+SELECT *
+FROM pg_stat_subscription_stats
+WHERE subname = :'subscription';
+SQL
+
+  echo "Publisher:"
+  psql "$source_database_url" -X -P pager=off -A -F $'\t' \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT
+  slot_name,
+  active,
+  confirmed_flush_lsn,
+  pg_size_pretty(
+    pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)
+  ) AS retained_wal
+FROM pg_replication_slots
+WHERE slot_name = :'subscription';
+
+SELECT name, setting, unit, pending_restart
+FROM pg_settings
+WHERE name = 'max_slot_wal_keep_size';
+SQL
+}
+
+repair_public_rls_tables() {
+  if [[ "${ALLOW_TARGET_PUBLIC_REPAIR:-}" != "1" ]]; then
+    echo "Set ALLOW_TARGET_PUBLIC_REPAIR=1 to repair the RLS-protected public tables on the US target." >&2
+    exit 64
+  fi
+
+  local temporary_directory
+  local source_read_fd
+  local source_write_fd
+  local source_session_pid
+  local snapshot_lsn
+  local marker
+  local line
+  local caught_up=false
+  local subscription_disabled=false
+
+  temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-public-repair.XXXXXX")"
+
+  coproc SOURCE_SESSION {
+    psql "$source_database_url" -X -qAt -v ON_ERROR_STOP=1
+  }
+  source_read_fd="${SOURCE_SESSION[0]}"
+  source_write_fd="${SOURCE_SESSION[1]}"
+  # shellcheck disable=SC2153 # Bash creates <coproc-name>_PID dynamically.
+  source_session_pid="$SOURCE_SESSION_PID"
+
+  cleanup_public_repair() {
+    if [[ "$subscription_disabled" == "true" ]]; then
+      psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+        -v subscription="$SUBSCRIPTION" <<'SQL' || true
+SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
+\gexec
+SQL
+    fi
+
+    if [[ -n "${source_write_fd:-}" ]]; then
+      printf 'ROLLBACK;\n\\q\n' 1>&"$source_write_fd" 2>/dev/null || true
+    fi
+    if [[ -n "${source_session_pid:-}" ]]; then
+      wait "$source_session_pid" 2>/dev/null || true
+    fi
+
+    find "$temporary_directory" -type f -exec unlink {} + 2>/dev/null || true
+    rmdir "$temporary_directory" 2>/dev/null || true
+  }
+  trap cleanup_public_repair EXIT
+
+  {
+    printf 'BEGIN ISOLATION LEVEL REPEATABLE READ;\n'
+    printf 'LOCK TABLE public.contact_forms, public.renewal_processing, public.webhook_config IN SHARE MODE;\n'
+    printf "SELECT 'LOCKED' || E'\\\\t' || pg_current_wal_lsn();\n"
+  } >&"$source_write_fd"
+
+  IFS=$'\t' read -r marker snapshot_lsn <&"$source_read_fd"
+  if [[ "$marker" != "LOCKED" || -z "$snapshot_lsn" ]]; then
+    echo "Failed to lock the source public tables." >&2
+    exit 1
+  fi
+
+  {
+    printf "\\copy public.contact_forms TO '%s/contact_forms.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy public.renewal_processing TO '%s/renewal_processing.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy public.webhook_config TO '%s/webhook_config.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf '\\echo SNAPSHOT_READY\n'
+  } >&"$source_write_fd"
+
+  while IFS= read -r line <&"$source_read_fd"; do
+    if [[ "$line" == "SNAPSHOT_READY" ]]; then
+      break
+    fi
+  done
+  if [[ "$line" != "SNAPSHOT_READY" ]]; then
+    echo "Failed to export the locked source public tables." >&2
+    exit 1
+  fi
+
+  for _ in $(seq 1 120); do
+    caught_up="$(
+      psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+        -v subscription="$SUBSCRIPTION" \
+        -v snapshot_lsn="$snapshot_lsn" <<'SQL'
+SELECT COALESCE(
+  bool_and(latest_end_lsn >= :'snapshot_lsn'::pg_lsn),
+  false
+)
+FROM pg_stat_subscription
+WHERE subname = :'subscription'
+  AND worker_type = 'apply';
+SQL
+    )"
+    if [[ "$caught_up" == "t" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$caught_up" != "t" ]]; then
+    echo "The application subscription did not reach the locked source snapshot." >&2
+    exit 1
+  fi
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I DISABLE', :'subscription')
+\gexec
+SQL
+  subscription_disabled=true
+
+  {
+    printf 'BEGIN;\n'
+    printf 'DELETE FROM public.contact_forms;\n'
+    printf 'DELETE FROM public.renewal_processing;\n'
+    printf 'DELETE FROM public.webhook_config;\n'
+    printf "\\copy public.contact_forms FROM '%s/contact_forms.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy public.renewal_processing FROM '%s/renewal_processing.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy public.webhook_config FROM '%s/webhook_config.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf 'COMMIT;\n'
+  } | psql "$target_database_url" -X -q -v ON_ERROR_STOP=1
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
+\gexec
+SQL
+  subscription_disabled=false
+
+  printf 'ROLLBACK;\n\\q\n' >&"$source_write_fd"
+  wait "$source_session_pid"
+  source_session_pid=""
+  source_write_fd=""
+
+  trap - EXIT
+  cleanup_public_repair
+  echo "Repaired the RLS-protected public tables from a locked source snapshot."
+}
+
+repair_shadow_mutations() {
+  if [[ "${ALLOW_TARGET_SHADOW_REPAIR:-}" != "1" ]]; then
+    echo "Set ALLOW_TARGET_SHADOW_REPAIR=1 to replace target-only shadow mutations." >&2
+    exit 64
+  fi
+
+  local temporary_directory
+  local subscription_disabled=false
+  temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-shadow-repair.XXXXXX")"
+
+  cleanup_shadow_repair() {
+    if [[ "$subscription_disabled" == "true" ]]; then
+      psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+        -v subscription="$SUBSCRIPTION" <<'SQL' || true
+SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
+\gexec
+SQL
+    fi
+    find "$temporary_directory" -type f -exec unlink {} + 2>/dev/null || true
+    rmdir "$temporary_directory" 2>/dev/null || true
+  }
+  trap cleanup_shadow_repair EXIT
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I DISABLE', :'subscription')
+\gexec
+SQL
+  subscription_disabled=true
+
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -c "\\copy (SELECT key_id, last_used_at FROM kortix.api_keys ORDER BY key_id) TO '$temporary_directory/api_keys.csv' WITH (FORMAT csv)"
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -c "\\copy (SELECT account_id, reconciliation_discrepancy FROM kortix.credit_accounts ORDER BY account_id) TO '$temporary_directory/credit_accounts.csv' WITH (FORMAT csv)"
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -c "\\copy (SELECT session_id, last_used_at, metadata, updated_at FROM kortix.session_sandboxes ORDER BY session_id COLLATE \"C\") TO '$temporary_directory/session_sandboxes.csv' WITH (FORMAT csv)"
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v shadow_audit_start_at="$SHADOW_AUDIT_START_AT" \
+    >"$temporary_directory/audit_event_ids.csv" <<'SQL'
+COPY (
+  SELECT event_id
+  FROM kortix.audit_events
+  WHERE occurred_at >= :'shadow_audit_start_at'::timestamptz
+  ORDER BY event_id
+) TO STDOUT WITH (FORMAT csv);
+SQL
+
+  {
+    cat <<'SQL'
+BEGIN;
+SET LOCAL session_replication_role = replica;
+CREATE TEMP TABLE repair_api_keys (
+  key_id uuid PRIMARY KEY,
+  last_used_at timestamptz
+) ON COMMIT DROP;
+CREATE TEMP TABLE repair_credit_accounts (
+  account_id uuid PRIMARY KEY,
+  reconciliation_discrepancy numeric
+) ON COMMIT DROP;
+CREATE TEMP TABLE repair_session_sandboxes (
+  session_id text PRIMARY KEY,
+  last_used_at timestamptz,
+  metadata jsonb,
+  updated_at timestamptz
+) ON COMMIT DROP;
+CREATE TEMP TABLE repair_audit_event_ids (
+  event_id uuid PRIMARY KEY
+) ON COMMIT DROP;
+SQL
+    printf "\\copy repair_api_keys FROM '%s/api_keys.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy repair_credit_accounts FROM '%s/credit_accounts.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy repair_session_sandboxes FROM '%s/session_sandboxes.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy repair_audit_event_ids FROM '%s/audit_event_ids.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    cat <<'SQL'
+UPDATE kortix.api_keys AS target
+SET last_used_at = source.last_used_at
+FROM repair_api_keys AS source
+WHERE target.key_id = source.key_id
+  AND target.last_used_at IS DISTINCT FROM source.last_used_at;
+
+UPDATE kortix.credit_accounts AS target
+SET reconciliation_discrepancy = source.reconciliation_discrepancy
+FROM repair_credit_accounts AS source
+WHERE target.account_id = source.account_id
+  AND target.reconciliation_discrepancy
+    IS DISTINCT FROM source.reconciliation_discrepancy;
+
+UPDATE kortix.session_sandboxes AS target
+SET
+  last_used_at = source.last_used_at,
+  metadata = source.metadata,
+  updated_at = source.updated_at
+FROM repair_session_sandboxes AS source
+WHERE target.session_id = source.session_id
+  AND (
+    target.last_used_at,
+    target.metadata,
+    target.updated_at
+  ) IS DISTINCT FROM (
+    source.last_used_at,
+    source.metadata,
+    source.updated_at
+  );
+
+DELETE FROM kortix.audit_events AS target
+WHERE target.occurred_at >= :'shadow_audit_start_at'::timestamptz
+  AND target.occurred_at < now() - interval '15 minutes'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM repair_audit_event_ids AS source
+    WHERE source.event_id = target.event_id
+  );
+COMMIT;
+SQL
+  } | psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v shadow_audit_start_at="$SHADOW_AUDIT_START_AT"
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
+\gexec
+SQL
+  subscription_disabled=false
+
+  trap - EXIT
+  cleanup_shadow_repair
+  echo "Replaced target-only shadow mutations and resumed replication."
+}
+
+write_counts() {
+  local database_url="$1"
+  local output_file="$2"
+  local database_side="$3"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 \
+    -v database_side="$database_side" \
+    -v publication="$PUBLICATION" \
+    -v subscription="$SUBSCRIPTION" \
+    >"$output_file" <<'SQL'
+BEGIN;
+CREATE TEMP TABLE migration_counts (
+  schema_name text NOT NULL,
+  table_name text NOT NULL,
+  row_count bigint NOT NULL
+) ON COMMIT DROP;
+
+DO $do$
+DECLARE
+  relation record;
+BEGIN
+  FOR relation IN
+    WITH replicated_tables AS (
+      SELECT
+        pg_namespace.nspname AS table_schema,
+        pg_class.relname AS table_name
+      FROM pg_publication
+      JOIN pg_publication_rel
+        ON pg_publication_rel.prpubid = pg_publication.oid
+      JOIN pg_class
+        ON pg_class.oid = pg_publication_rel.prrelid
+      JOIN pg_namespace
+        ON pg_namespace.oid = pg_class.relnamespace
+      WHERE :'database_side' = 'source'
+        AND pg_publication.pubname = :'publication'
+
+      UNION ALL
+
+      SELECT
+        pg_namespace.nspname AS table_schema,
+        pg_class.relname AS table_name
+      FROM pg_subscription
+      JOIN pg_subscription_rel
+        ON pg_subscription_rel.srsubid = pg_subscription.oid
+      JOIN pg_class
+        ON pg_class.oid = pg_subscription_rel.srrelid
+      JOIN pg_namespace
+        ON pg_namespace.oid = pg_class.relnamespace
+      WHERE :'database_side' = 'target'
+        AND pg_subscription.subname = :'subscription'
+    )
+    SELECT table_schema, table_name
+    FROM replicated_tables
+    ORDER BY table_schema, table_name
+  LOOP
+    EXECUTE format(
+      'INSERT INTO migration_counts SELECT %L, %L, count(*) FROM %I.%I',
+      relation.table_schema,
+      relation.table_name,
+      relation.table_schema,
+      relation.table_name
+    );
+  END LOOP;
+END
+$do$;
+
+SELECT schema_name, table_name, row_count
+FROM migration_counts
+ORDER BY schema_name COLLATE "C", table_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+reconcile_counts() {
+  temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-counts.XXXXXX")"
+  source_counts="$temporary_directory/source.tsv"
+  target_counts="$temporary_directory/target.tsv"
+  cleanup_counts() {
+    [[ -f "$source_counts" ]] && unlink "$source_counts"
+    [[ -f "$target_counts" ]] && unlink "$target_counts"
+    [[ -d "$temporary_directory" ]] && rmdir "$temporary_directory"
+  }
+  trap cleanup_counts EXIT
+
+  write_counts "$source_database_url" "$source_counts" source &
+  source_count_pid=$!
+  write_counts "$target_database_url" "$target_counts" target &
+  target_count_pid=$!
+  wait "$source_count_pid"
+  wait "$target_count_pid"
+
+  if diff -u "$source_counts" "$target_counts"; then
+    echo "All replicated table row counts match."
+  else
+    echo "Replicated table row counts differ." >&2
+    exit 1
+  fi
+}
+
+write_key_hashes() {
+  local database_url="$1"
+  local output_file="$2"
+  local database_side="$3"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 \
+    -v database_side="$database_side" \
+    -v publication="$PUBLICATION" \
+    -v subscription="$SUBSCRIPTION" \
+    >"$output_file" <<'SQL'
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+CREATE TEMP TABLE migration_key_hashes (
+  schema_name text NOT NULL,
+  table_name text NOT NULL,
+  row_count bigint NOT NULL,
+  hash_a numeric NOT NULL,
+  hash_b numeric NOT NULL
+) ON COMMIT DROP;
+
+DO $do$
+DECLARE
+  relation record;
+BEGIN
+  FOR relation IN
+    WITH selected_tables AS (
+      SELECT
+        pg_namespace.nspname AS table_schema,
+        pg_class.relname AS table_name
+      FROM pg_publication
+      JOIN pg_publication_rel
+        ON pg_publication_rel.prpubid = pg_publication.oid
+      JOIN pg_class
+        ON pg_class.oid = pg_publication_rel.prrelid
+      JOIN pg_namespace
+        ON pg_namespace.oid = pg_class.relnamespace
+      WHERE :'database_side' = 'source'
+        AND pg_publication.pubname = :'publication'
+
+      UNION ALL
+
+      SELECT
+        pg_namespace.nspname AS table_schema,
+        pg_class.relname AS table_name
+      FROM pg_subscription
+      JOIN pg_subscription_rel
+        ON pg_subscription_rel.srsubid = pg_subscription.oid
+      JOIN pg_class
+        ON pg_class.oid = pg_subscription_rel.srrelid
+      JOIN pg_namespace
+        ON pg_namespace.oid = pg_class.relnamespace
+      WHERE :'database_side' = 'target'
+        AND pg_subscription.subname = :'subscription'
+    )
+    SELECT
+      selected_tables.table_schema,
+      selected_tables.table_name,
+      string_agg(
+        format('%I', key_attribute.attname),
+        ', ' ORDER BY key_column.ordinality
+      ) AS key_columns
+    FROM selected_tables
+    JOIN pg_namespace
+      ON pg_namespace.nspname = selected_tables.table_schema
+    JOIN pg_class
+      ON pg_class.relnamespace = pg_namespace.oid
+     AND pg_class.relname = selected_tables.table_name
+    JOIN LATERAL (
+      SELECT pg_index.*
+      FROM pg_index
+      WHERE pg_index.indrelid = pg_class.oid
+        AND pg_index.indisvalid
+        AND pg_index.indisready
+        AND (pg_index.indisprimary OR pg_index.indisunique)
+        AND pg_index.indpred IS NULL
+      ORDER BY
+        pg_index.indisprimary DESC,
+        pg_index.indisreplident DESC,
+        pg_index.indexrelid::regclass::text COLLATE "C"
+      LIMIT 1
+    ) AS selected_index
+      ON true
+    JOIN LATERAL unnest(selected_index.indkey)
+      WITH ORDINALITY AS key_column(attnum, ordinality)
+      ON key_column.ordinality <= selected_index.indnkeyatts
+    JOIN pg_attribute AS key_attribute
+      ON key_attribute.attrelid = pg_class.oid
+     AND key_attribute.attnum = key_column.attnum
+    GROUP BY selected_tables.table_schema, selected_tables.table_name
+    ORDER BY
+      selected_tables.table_schema COLLATE "C",
+      selected_tables.table_name COLLATE "C"
+  LOOP
+    EXECUTE format(
+      $query$
+      INSERT INTO migration_key_hashes
+      SELECT
+        %L,
+        %L,
+        count(*),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              key_value,
+              0
+            )::numeric
+          ),
+          0
+        ),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              key_value,
+              -7046029254386353131
+            )::numeric
+          ),
+          0
+        )
+      FROM (
+        SELECT jsonb_build_array(%s) AS key_value
+        FROM %I.%I
+      ) AS relation_keys
+      $query$,
+      relation.table_schema,
+      relation.table_name,
+      relation.key_columns,
+      relation.table_schema,
+      relation.table_name
+    );
+  END LOOP;
+END
+$do$;
+
+SELECT schema_name, table_name, row_count, hash_a, hash_b
+FROM migration_key_hashes
+ORDER BY schema_name COLLATE "C", table_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+write_critical_hashes() {
+  local database_url="$1"
+  local output_file="$2"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 >"$output_file" <<'SQL'
+BEGIN;
+SET LOCAL TIME ZONE 'UTC';
+CREATE TEMP TABLE migration_critical_hashes (
+  schema_name text NOT NULL,
+  table_name text NOT NULL,
+  row_count bigint NOT NULL,
+  hash_a numeric NOT NULL,
+  hash_b numeric NOT NULL
+) ON COMMIT DROP;
+
+DO $do$
+DECLARE
+  relation record;
+BEGIN
+  FOR relation IN
+    SELECT
+      information_schema.columns.table_schema,
+      information_schema.columns.table_name,
+      string_agg(
+        format('%I', information_schema.columns.column_name),
+        ', ' ORDER BY information_schema.columns.column_name COLLATE "C"
+      ) FILTER (
+        WHERE NOT (
+          information_schema.columns.table_name = 'accounts'
+          AND information_schema.columns.column_name = 'personal_account'
+        )
+      ) AS row_columns
+    FROM information_schema.columns
+    WHERE information_schema.columns.table_schema = 'kortix'
+      AND information_schema.columns.is_generated = 'NEVER'
+      AND information_schema.columns.table_name IN (
+        'account_members',
+        'accounts',
+        'api_keys',
+        'billing_customer_aliases',
+        'billing_customers',
+        'billing_subscription_anchors',
+        'billing_subscriptions',
+        'credit_accounts',
+        'credit_ledger',
+        'credit_purchases',
+        'gateway_api_keys',
+        'project_members',
+        'project_sessions',
+        'projects',
+        'sandboxes',
+        'session_sandboxes',
+        'stripe_webhook_events_processed'
+      )
+    GROUP BY
+      information_schema.columns.table_schema,
+      information_schema.columns.table_name
+    ORDER BY
+      information_schema.columns.table_schema COLLATE "C",
+      information_schema.columns.table_name COLLATE "C"
+  LOOP
+    EXECUTE format(
+      $query$
+      INSERT INTO migration_critical_hashes
+      SELECT
+        %L,
+        %L,
+        count(*),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              row_value,
+              0
+            )::numeric
+          ),
+          0
+        ),
+        COALESCE(
+          sum(
+            pg_catalog.jsonb_hash_extended(
+              row_value,
+              -7046029254386353131
+            )::numeric
+          ),
+          0
+        )
+      FROM (
+        SELECT jsonb_build_array(%s) AS row_value
+        FROM %I.%I
+      ) AS relation_rows
+      $query$,
+      relation.table_schema,
+      relation.table_name,
+      relation.row_columns,
+      relation.table_schema,
+      relation.table_name
+    );
+  END LOOP;
+END
+$do$;
+
+SELECT schema_name, table_name, row_count, hash_a, hash_b
+FROM migration_critical_hashes
+ORDER BY schema_name COLLATE "C", table_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+reconcile_hashes() {
+  local mode="$1"
+  local writer
+  local label
+
+  case "$mode" in
+    keys)
+      writer=write_key_hashes
+      label="primary-key and replica-identity"
+      ;;
+    critical)
+      writer=write_critical_hashes
+      label="critical row"
+      ;;
+    *)
+      echo "Unknown hash reconciliation mode: $mode" >&2
+      exit 64
+      ;;
+  esac
+
+  temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-hashes.XXXXXX")"
+  source_hashes="$temporary_directory/source.tsv"
+  target_hashes="$temporary_directory/target.tsv"
+  cleanup_hashes() {
+    [[ -f "$source_hashes" ]] && unlink "$source_hashes"
+    [[ -f "$target_hashes" ]] && unlink "$target_hashes"
+    [[ -d "$temporary_directory" ]] && rmdir "$temporary_directory"
+  }
+  trap cleanup_hashes EXIT
+
+  "$writer" "$source_database_url" "$source_hashes" source &
+  source_hash_pid=$!
+  "$writer" "$target_database_url" "$target_hashes" target &
+  target_hash_pid=$!
+  wait "$source_hash_pid"
+  wait "$target_hash_pid"
+
+  if diff -u "$source_hashes" "$target_hashes"; then
+    echo "All replicated $label hashes match."
+  else
+    echo "Replicated $label hashes differ." >&2
+    exit 1
+  fi
+}
+
+write_sequence_state() {
+  local database_url="$1"
+  local output_file="$2"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 >"$output_file" <<'SQL'
+BEGIN;
+CREATE TEMP TABLE migration_sequence_state (
+  schema_name text NOT NULL,
+  sequence_name text NOT NULL,
+  last_value bigint NOT NULL,
+  is_called boolean NOT NULL
+) ON COMMIT DROP;
+
+SELECT format(
+  'INSERT INTO migration_sequence_state SELECT %L, %L, last_value, is_called FROM %I.%I',
+  sequence_namespace.nspname,
+  sequence_class.relname,
+  sequence_namespace.nspname,
+  sequence_class.relname
+)
+FROM pg_class AS sequence_class
+JOIN pg_namespace AS sequence_namespace
+  ON sequence_namespace.oid = sequence_class.relnamespace
+JOIN pg_depend
+  ON pg_depend.objid = sequence_class.oid
+ AND pg_depend.deptype IN ('a', 'i')
+JOIN pg_class AS table_class
+  ON table_class.oid = pg_depend.refobjid
+JOIN pg_namespace AS table_namespace
+  ON table_namespace.oid = table_class.relnamespace
+WHERE sequence_class.relkind = 'S'
+  AND (
+    (
+      table_namespace.nspname = 'kortix'
+      AND table_class.relname NOT IN (
+        'channel_configs',
+        'integration_credentials',
+        'integrations',
+        'sandbox_integrations',
+        'schema_migrations'
+      )
+    ) OR (
+      table_namespace.nspname = 'public'
+      AND table_class.relname IN (
+        'daily_refresh_tracking',
+        'renewal_processing',
+        'contact_forms',
+        'webhook_config'
+      )
+    )
+  )
+ORDER BY sequence_namespace.nspname, sequence_class.relname
+\gexec
+
+SELECT schema_name, sequence_name, last_value, is_called
+FROM migration_sequence_state
+ORDER BY schema_name COLLATE "C", sequence_name COLLATE "C";
+COMMIT;
+SQL
+}
+
+reconcile_sequences() {
+  sequence_state_file="$(mktemp "${TMPDIR:-/tmp}/kortix-usw2-sequences.XXXXXX")"
+  cleanup_sequence_state() {
+    [[ -f "$sequence_state_file" ]] && unlink "$sequence_state_file"
+  }
+  trap cleanup_sequence_state EXIT
+
+  write_sequence_state "$source_database_url" "$sequence_state_file"
+
+  while IFS=$'\t' read -r schema_name sequence_name last_value is_called; do
+    psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+      -v schema_name="$schema_name" \
+      -v sequence_name="$sequence_name" \
+      -v last_value="$last_value" \
+      -v is_called="$is_called" <<'SQL'
+SELECT setval(
+  format('%I.%I', :'schema_name', :'sequence_name')::regclass,
+  :'last_value'::bigint,
+  :'is_called'::boolean
+)
+\gset
+SQL
+  done <"$sequence_state_file"
+
+  echo "Replicated sequence state matches the source."
+}
+
+rotate_replication_password() {
+  if [[ "${ALLOW_REPLICATION_PASSWORD_ROTATION:-}" != "1" ]]; then
+    echo "Set ALLOW_REPLICATION_PASSWORD_ROTATION=1 to rotate the replication credential." >&2
+    exit 64
+  fi
+
+  local new_password
+  local updated_target_secret_json
+  local application_connection_url
+  local auth_connection_url
+  local subscriptions_disabled=false
+
+  new_password="$(
+    node -e 'process.stdout.write(require("node:crypto").randomBytes(48).toString("base64url"))'
+  )"
+  updated_target_secret_json="$(
+    jq -c --arg password "$new_password" \
+      '.replication_password = $password' <<<"$target_secret_json"
+  )"
+
+  printf '%s' "$updated_target_secret_json" |
+    aws secretsmanager put-secret-value \
+      --secret-id "$TARGET_SECRET_ID" \
+      --region "$TARGET_AWS_REGION" \
+      --secret-string file:///dev/stdin \
+      --output json >/dev/null
+
+  build_replication_url() {
+    local subscription_name="$1"
+    REPLICATION_USERNAME="$replication_username" \
+      REPLICATION_PASSWORD="$new_password" \
+      node -e '
+        const url = new URL(process.argv[1]);
+        url.username = process.env.REPLICATION_USERNAME;
+        url.password = process.env.REPLICATION_PASSWORD;
+        url.searchParams.set("sslmode", "require");
+        url.searchParams.set("application_name", process.argv[2]);
+        url.searchParams.set("options", "-c statement_timeout=0");
+        process.stdout.write(url.toString());
+      ' "$source_database_url" "$subscription_name"
+  }
+
+  application_connection_url="$(build_replication_url "$SUBSCRIPTION")"
+  auth_connection_url="$(build_replication_url "$AUTH_SUBSCRIPTION")"
+
+  reenable_subscriptions() {
+    if [[ "$subscriptions_disabled" != "true" ]]; then
+      return
+    fi
+    psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+      -v application_subscription="$SUBSCRIPTION" \
+      -v auth_subscription="$AUTH_SUBSCRIPTION" <<'SQL' || true
+SELECT format('ALTER SUBSCRIPTION %I ENABLE', subscription_name)
+FROM unnest(
+  ARRAY[:'application_subscription', :'auth_subscription']
+) AS subscriptions(subscription_name)
+\gexec
+SQL
+  }
+  trap reenable_subscriptions EXIT
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v application_subscription="$SUBSCRIPTION" \
+    -v auth_subscription="$AUTH_SUBSCRIPTION" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I DISABLE', subscription_name)
+FROM unnest(
+  ARRAY[:'application_subscription', :'auth_subscription']
+) AS subscriptions(subscription_name)
+\gexec
+SQL
+  subscriptions_disabled=true
+
+  {
+    printf "\\set replication_password '%s'\n" "${new_password//\'/\'\'}"
+    cat <<'SQL'
+SELECT format(
+  'ALTER ROLE kortix_usw2_repl WITH LOGIN REPLICATION PASSWORD %L',
+  :'replication_password'
+)
+\gexec
+SQL
+  } | psql "$source_database_url" -X -q -v ON_ERROR_STOP=1
+
+  set_subscription_connection() {
+    local subscription_name="$1"
+    local connection_url="$2"
+    {
+      printf "\\set subscription '%s'\n" "${subscription_name//\'/\'\'}"
+      printf "\\set connection_url '%s'\n" "${connection_url//\'/\'\'}"
+      cat <<'SQL'
+SELECT format(
+  'ALTER SUBSCRIPTION %I CONNECTION %L',
+  :'subscription',
+  :'connection_url'
+)
+\gexec
+SQL
+    } | psql "$target_database_url" -X -q -v ON_ERROR_STOP=1
+  }
+
+  set_subscription_connection "$SUBSCRIPTION" "$application_connection_url"
+  set_subscription_connection "$AUTH_SUBSCRIPTION" "$auth_connection_url"
+  reenable_subscriptions
+  subscriptions_disabled=false
+  trap - EXIT
+
+  for attempt in $(seq 1 60); do
+    read -r active_workers apply_errors sync_errors < <(
+      psql "$target_database_url" -X -qAt -F ' ' -v ON_ERROR_STOP=1 \
+        -v application_subscription="$SUBSCRIPTION" \
+        -v auth_subscription="$AUTH_SUBSCRIPTION" <<'SQL'
+SELECT
+  (
+    SELECT count(*)
+    FROM pg_stat_subscription
+    WHERE subname IN (
+      :'application_subscription',
+      :'auth_subscription'
+    )
+      AND worker_type = 'apply'
+  ),
+  COALESCE(sum(apply_error_count), 0),
+  COALESCE(sum(sync_error_count), 0)
+FROM pg_stat_subscription_stats
+WHERE subname IN (
+  :'application_subscription',
+  :'auth_subscription'
+);
+SQL
+    )
+
+    if [[ "$apply_errors" != "0" || "$sync_errors" != "0" ]]; then
+      echo "Replication errors detected after rotation: apply=$apply_errors sync=$sync_errors" >&2
+      exit 1
+    fi
+    if [[ "$active_workers" -eq 2 ]]; then
+      echo "Replication credential rotated. Both subscriptions have active apply workers."
+      unset new_password updated_target_secret_json application_connection_url auth_connection_url
+      return
+    fi
+    echo "Credential rotation verification $attempt/60: active apply workers=$active_workers/2"
+    sleep 2
+  done
+
+  echo "Both replication subscriptions did not reconnect within two minutes." >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/prod-us-west-2/db-sync.sh <command>
+
+Commands:
+  prepare-source     Set WAL retention, replica identities, and publication.
+  start              Create or enable the target subscription.
+  status             Show subscriber state, errors, slot state, and retained WAL.
+  repair-public-rls  Repair public control tables skipped by RLS during initial copy.
+  repair-shadow-mutations Replace target-only mutations made during shadow verification.
+  reconcile-counts   Compare exact source and target row counts.
+  reconcile-key-hashes Compare primary-key and replica-identity set hashes.
+  reconcile-critical-hashes Compare full-row hashes for critical relations.
+  reconcile-sequences Copy source sequence state to the target.
+  rotate-replication-password Rotate the shared source replication credential.
+EOF
+}
+
+case "${1:-}" in
+  prepare-source)
+    prepare_source
+    ;;
+  start)
+    start_subscription
+    ;;
+  status)
+    status
+    ;;
+  repair-public-rls)
+    repair_public_rls_tables
+    ;;
+  repair-shadow-mutations)
+    repair_shadow_mutations
+    ;;
+  reconcile-counts)
+    reconcile_counts
+    ;;
+  reconcile-key-hashes)
+    reconcile_hashes keys
+    ;;
+  reconcile-critical-hashes)
+    reconcile_hashes critical
+    ;;
+  reconcile-sequences)
+    reconcile_sequences
+    ;;
+  rotate-replication-password)
+    rotate_replication_password
+    ;;
+  *)
+    usage >&2
+    exit 64
+    ;;
+esac

--- a/scripts/prod-us-west-2/ensure-shadow-dns.sh
+++ b/scripts/prod-us-west-2/ensure-shadow-dns.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN:-}"
+CLOUDFLARE_GLOBAL_API_KEY="${CLOUDFLARE_GLOBAL_API_KEY:-}"
+CLOUDFLARE_EMAIL="${CLOUDFLARE_EMAIL:-}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+CLOUDFLARE_ZONE_NAME="${CLOUDFLARE_ZONE_NAME:-kortix.com}"
+
+for command_name in aws curl jq; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+if [[ -n "$CLOUDFLARE_API_TOKEN" ]]; then
+  cloudflare_auth_headers=(
+    -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  )
+elif [[ -n "$CLOUDFLARE_GLOBAL_API_KEY" && -n "$CLOUDFLARE_EMAIL" ]]; then
+  cloudflare_auth_headers=(
+    -H "X-Auth-Email: $CLOUDFLARE_EMAIL"
+    -H "X-Auth-Key: $CLOUDFLARE_GLOBAL_API_KEY"
+  )
+else
+  echo "Cloudflare API token or global API key credentials are required." >&2
+  exit 1
+fi
+
+cloudflare_request() {
+  curl -fsS \
+    "${cloudflare_auth_headers[@]}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+zone_response="$(
+  cloudflare_request \
+    "https://api.cloudflare.com/client/v4/zones?name=${CLOUDFLARE_ZONE_NAME}&status=active"
+)"
+zone_id="$(jq -er '.result | select(length == 1) | .[0].id' <<<"$zone_response")"
+
+api_origin="$(
+  aws elbv2 describe-load-balancers \
+    --region "$AWS_REGION" \
+    --names kortix-prod-usw2-alb \
+    --query 'LoadBalancers[0].DNSName' \
+    --output text
+)"
+gateway_origin="$(
+  aws elbv2 describe-load-balancers \
+    --region "$AWS_REGION" \
+    --names kortix-prod-usw2-gateway-alb \
+    --query 'LoadBalancers[0].DNSName' \
+    --output text
+)"
+
+ensure_record() {
+  local hostname="$1"
+  local expected_origin="$2"
+  local record_response
+  local record_id
+  local update_response
+
+  record_response="$(
+    cloudflare_request \
+      "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records?type=CNAME&name=${hostname}"
+  )"
+  record_id="$(jq -er '.result | select(length == 1) | .[0].id' <<<"$record_response")"
+
+  update_response="$(
+    cloudflare_request \
+      --request PUT \
+      --data "$(
+        jq -nc \
+          --arg name "$hostname" \
+          --arg content "$expected_origin" \
+          '{
+            type: "CNAME",
+            name: $name,
+            content: $content,
+            ttl: 1,
+            proxied: true
+          }'
+      )" \
+      "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records/${record_id}"
+  )"
+
+  jq -e \
+    --arg name "$hostname" \
+    --arg content "$expected_origin" \
+    '.success == true
+      and .result.name == $name
+      and .result.content == $content
+      and .result.proxied == true' \
+    <<<"$update_response" >/dev/null
+
+  echo "$hostname: proxied CNAME to $expected_origin"
+}
+
+ensure_record api-usw2-shadow.kortix.com "$api_origin"
+ensure_record gateway-usw2-shadow.kortix.com "$gateway_origin"

--- a/scripts/prod-us-west-2/refresh-replication.sh
+++ b/scripts/prod-us-west-2/refresh-replication.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_DATABASE_URL="${SOURCE_DATABASE_URL:?SOURCE_DATABASE_URL is required}"
+TARGET_DATABASE_URL="${TARGET_DATABASE_URL:?TARGET_DATABASE_URL is required}"
+PUBLICATION="${PUBLICATION:-kortix_us_west_2_20260725}"
+SUBSCRIPTION="${SUBSCRIPTION:-kortix_us_west_2_20260725}"
+
+if [[ "${ALLOW_REPLICATION_REFRESH:-}" != "1" ]]; then
+  echo "Set ALLOW_REPLICATION_REFRESH=1 to refresh the US shadow publication." >&2
+  exit 64
+fi
+
+for command_name in comm cut mktemp psql sort; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-usw2-publication.XXXXXX")"
+source_manifest="$temporary_directory/source.tsv"
+target_manifest="$temporary_directory/target.tsv"
+
+# shellcheck disable=SC2329 # The EXIT trap invokes this function.
+cleanup() {
+  find "$temporary_directory" -type f -exec unlink {} + 2>/dev/null || true
+  rmdir "$temporary_directory" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+write_manifest() {
+  local database_url="$1"
+  local output_file="$2"
+
+  psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 >"$output_file" <<'SQL'
+WITH selected_tables AS (
+  SELECT table_schema, table_name
+  FROM information_schema.tables
+  WHERE table_schema = 'kortix'
+    AND table_type = 'BASE TABLE'
+    AND table_name NOT IN (
+      'channel_configs',
+      'integration_credentials',
+      'integrations',
+      'sandbox_integrations',
+      'schema_migrations'
+    )
+  UNION ALL
+  SELECT 'public', table_name
+  FROM information_schema.tables
+  WHERE table_schema = 'public'
+    AND table_type = 'BASE TABLE'
+    AND table_name IN (
+      'daily_refresh_tracking',
+      'renewal_processing',
+      'contact_forms',
+      'webhook_config'
+    )
+)
+SELECT
+  format('%I.%I', selected_tables.table_schema, selected_tables.table_name),
+  columns.column_name
+FROM selected_tables
+JOIN information_schema.columns AS columns
+  USING (table_schema, table_name)
+WHERE columns.is_generated = 'NEVER'
+  AND NOT (
+    selected_tables.table_schema = 'kortix'
+    AND selected_tables.table_name = 'accounts'
+    AND columns.column_name = 'personal_account'
+  )
+ORDER BY
+  selected_tables.table_schema COLLATE "C",
+  selected_tables.table_name COLLATE "C",
+  columns.column_name COLLATE "C";
+SQL
+}
+
+write_manifest "$SOURCE_DATABASE_URL" "$source_manifest" &
+source_manifest_pid=$!
+write_manifest "$TARGET_DATABASE_URL" "$target_manifest" &
+target_manifest_pid=$!
+wait "$source_manifest_pid"
+wait "$target_manifest_pid"
+
+missing_target_columns="$(comm -23 "$source_manifest" "$target_manifest")"
+if [[ -n "$missing_target_columns" ]]; then
+  echo "The target lacks selected source columns:" >&2
+  printf '%s\n' "$missing_target_columns" >&2
+  echo "The publication was not changed." >&2
+  exit 1
+fi
+
+source_relation_count="$(cut -f1 "$source_manifest" | sort -u | wc -l | tr -d '[:space:]')"
+if [[ "$source_relation_count" -eq 0 ]]; then
+  echo "The selected publication relation set is empty." >&2
+  exit 1
+fi
+
+unsafe_relations="$(
+  psql "$SOURCE_DATABASE_URL" -X -qAt -v ON_ERROR_STOP=1 <<'SQL'
+WITH selected_tables AS (
+  SELECT table_schema, table_name
+  FROM information_schema.tables
+  WHERE table_schema = 'kortix'
+    AND table_type = 'BASE TABLE'
+    AND table_name NOT IN (
+      'channel_configs',
+      'integration_credentials',
+      'integrations',
+      'sandbox_integrations',
+      'schema_migrations'
+    )
+  UNION ALL
+  SELECT 'public', table_name
+  FROM information_schema.tables
+  WHERE table_schema = 'public'
+    AND table_type = 'BASE TABLE'
+    AND table_name IN (
+      'daily_refresh_tracking',
+      'renewal_processing',
+      'contact_forms',
+      'webhook_config'
+    )
+)
+SELECT string_agg(
+  format('%I.%I', selected_tables.table_schema, selected_tables.table_name),
+  ', ' ORDER BY selected_tables.table_schema, selected_tables.table_name
+)
+FROM selected_tables
+JOIN pg_namespace
+  ON pg_namespace.nspname = selected_tables.table_schema
+JOIN pg_class
+  ON pg_class.relnamespace = pg_namespace.oid
+ AND pg_class.relname = selected_tables.table_name
+WHERE pg_class.relreplident = 'n'
+   OR (
+     pg_class.relreplident = 'd'
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_index
+       WHERE pg_index.indrelid = pg_class.oid
+         AND pg_index.indisprimary
+         AND pg_index.indisvalid
+         AND pg_index.indisready
+     )
+   );
+SQL
+)"
+
+if [[ -n "$unsafe_relations" ]]; then
+  echo "Selected relations lack a usable replica identity: $unsafe_relations" >&2
+  exit 1
+fi
+
+psql "$SOURCE_DATABASE_URL" -X -q -v ON_ERROR_STOP=1 \
+  -v publication="$PUBLICATION" <<'SQL'
+SELECT set_config('kortix.migration_publication', :'publication', false)
+\gset
+
+DO $do$
+DECLARE
+  publication_name text := current_setting('kortix.migration_publication');
+  relation_list text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_publication
+    WHERE pubname = publication_name
+  ) THEN
+    RAISE EXCEPTION 'Publication % does not exist', publication_name;
+  END IF;
+
+  WITH selected_tables AS (
+    SELECT table_schema, table_name
+    FROM information_schema.tables
+    WHERE table_schema = 'kortix'
+      AND table_type = 'BASE TABLE'
+      AND table_name NOT IN (
+        'channel_configs',
+        'integration_credentials',
+        'integrations',
+        'sandbox_integrations',
+        'schema_migrations'
+      )
+    UNION ALL
+    SELECT 'public', table_name
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_type = 'BASE TABLE'
+      AND table_name IN (
+        'daily_refresh_tracking',
+        'renewal_processing',
+        'contact_forms',
+        'webhook_config'
+      )
+  ),
+  relation_columns AS (
+    SELECT
+      selected_tables.table_schema,
+      selected_tables.table_name,
+      string_agg(
+        format('%I', columns.column_name),
+        ', ' ORDER BY columns.ordinal_position
+      ) FILTER (
+        WHERE columns.is_generated = 'NEVER'
+          AND NOT (
+            selected_tables.table_schema = 'kortix'
+            AND selected_tables.table_name = 'accounts'
+            AND columns.column_name = 'personal_account'
+          )
+      ) AS column_list
+    FROM selected_tables
+    JOIN information_schema.columns AS columns
+      USING (table_schema, table_name)
+    GROUP BY selected_tables.table_schema, selected_tables.table_name
+  )
+  SELECT string_agg(
+    format('%I.%I (%s)', table_schema, table_name, column_list),
+    ', ' ORDER BY table_schema COLLATE "C", table_name COLLATE "C"
+  )
+  INTO relation_list
+  FROM relation_columns;
+
+  EXECUTE format(
+    'ALTER PUBLICATION %I SET TABLE %s',
+    publication_name,
+    relation_list
+  );
+END
+$do$;
+SQL
+
+psql "$TARGET_DATABASE_URL" -X -q -v ON_ERROR_STOP=1 \
+  -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT set_config('kortix.migration_subscription', :'subscription', false)
+\gset
+
+SELECT format(
+  'ALTER SUBSCRIPTION %I REFRESH PUBLICATION WITH (copy_data = true)',
+  :'subscription'
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM pg_subscription
+  WHERE subname = :'subscription'
+    AND subenabled
+)
+\gexec
+
+DO $do$
+DECLARE
+  subscription_name text := current_setting('kortix.migration_subscription');
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_subscription
+    WHERE subname = subscription_name
+      AND subenabled
+  ) THEN
+    RAISE EXCEPTION 'Subscription % is missing or disabled', subscription_name;
+  END IF;
+END
+$do$;
+SQL
+
+for attempt in $(seq 1 240); do
+  read -r ready_relations total_relations apply_errors sync_errors apply_workers < <(
+    psql "$TARGET_DATABASE_URL" -X -qAt -F ' ' -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT
+  count(*) FILTER (WHERE pg_subscription_rel.srsubstate = 'r'),
+  count(*),
+  COALESCE(pg_stat_subscription_stats.apply_error_count, 0),
+  COALESCE(pg_stat_subscription_stats.sync_error_count, 0),
+  (
+    SELECT count(*)
+    FROM pg_stat_subscription
+    WHERE pg_stat_subscription.subid = pg_subscription.oid
+      AND pg_stat_subscription.worker_type = 'apply'
+  )
+FROM pg_subscription
+JOIN pg_subscription_rel
+  ON pg_subscription_rel.srsubid = pg_subscription.oid
+LEFT JOIN pg_stat_subscription_stats
+  ON pg_stat_subscription_stats.subid = pg_subscription.oid
+WHERE pg_subscription.subname = :'subscription'
+GROUP BY
+  pg_subscription.oid,
+  pg_stat_subscription_stats.apply_error_count,
+  pg_stat_subscription_stats.sync_error_count;
+SQL
+  )
+
+  if [[ "$apply_errors" != "0" || "$sync_errors" != "0" ]]; then
+    echo "Replication errors detected: apply=$apply_errors sync=$sync_errors" >&2
+    exit 1
+  fi
+
+  if [[ "$ready_relations" == "$total_relations" \
+    && "$total_relations" == "$source_relation_count" \
+    && "$apply_workers" -ge 1 ]]; then
+    echo "US shadow replication is ready: $ready_relations/$total_relations relations."
+    exit 0
+  fi
+
+  echo "Replication refresh $attempt/240: ready=$ready_relations/$total_relations apply_workers=$apply_workers"
+  sleep 5
+done
+
+echo "US shadow replication did not become ready within 20 minutes." >&2
+exit 1

--- a/scripts/prod-us-west-2/storage-sync.mjs
+++ b/scripts/prod-us-west-2/storage-sync.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+const requiredEnvironment = [
+  'SOURCE_DATABASE_URL',
+  'SOURCE_SUPABASE_URL',
+  'SOURCE_SERVICE_ROLE_KEY',
+  'TARGET_DATABASE_URL',
+  'TARGET_SUPABASE_URL',
+  'TARGET_SERVICE_ROLE_KEY',
+];
+
+for (const name of requiredEnvironment) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+const buckets = (process.env.STORAGE_BUCKETS ?? 'avatars')
+  .split(',')
+  .map((bucket) => bucket.trim())
+  .filter(Boolean);
+const chunkSize = Number(process.env.STORAGE_CHUNK_SIZE ?? 6 * 1024 * 1024);
+const limit = Number(process.env.STORAGE_LIMIT ?? 0);
+const verifyAll = process.env.STORAGE_VERIFY_ALL === '1';
+
+function sqlString(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function queryObjects(databaseUrl, selectedBuckets) {
+  const bucketList = selectedBuckets.map(sqlString).join(', ');
+  const query = `
+    COPY (
+      SELECT
+        bucket_id,
+        name,
+        (metadata->>'size')::bigint AS size,
+        coalesce(metadata->>'mimetype', 'application/octet-stream') AS content_type,
+        coalesce(metadata->>'cacheControl', '3600') AS cache_control,
+        coalesce(metadata->>'eTag', '') AS source_etag,
+        coalesce(metadata->>'sourceETag', '') AS migrated_source_etag,
+        coalesce(metadata->>'sourceSha256', '') AS source_sha256
+      FROM storage.objects
+      WHERE bucket_id IN (${bucketList})
+      ORDER BY bucket_id, name
+    ) TO STDOUT WITH (FORMAT csv, HEADER true)
+  `;
+  const result = spawnSync('psql', [databaseUrl, '-X', '-v', 'ON_ERROR_STOP=1', '-c', query], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`psql object inventory failed: ${result.stderr.trim()}`);
+  }
+  return parseCsv(result.stdout);
+}
+
+function parseCsv(input) {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let quoted = false;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index];
+    if (quoted) {
+      if (character === '"' && input[index + 1] === '"') {
+        field += '"';
+        index += 1;
+      } else if (character === '"') {
+        quoted = false;
+      } else {
+        field += character;
+      }
+    } else if (character === '"') {
+      quoted = true;
+    } else if (character === ',') {
+      row.push(field);
+      field = '';
+    } else if (character === '\n') {
+      row.push(field.replace(/\r$/, ''));
+      rows.push(row);
+      row = [];
+      field = '';
+    } else {
+      field += character;
+    }
+  }
+
+  const [header, ...data] = rows;
+  if (!header) return [];
+  return data
+    .filter((values) => values.length === header.length)
+    .map((values) => Object.fromEntries(header.map((name, index) => [name, values[index]])));
+}
+
+function objectUrl(projectUrl, bucket, name) {
+  const encodedName = name
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `${projectUrl}/storage/v1/object/authenticated/${encodeURIComponent(bucket)}/${encodedName}`;
+}
+
+function base64(value) {
+  return Buffer.from(String(value)).toString('base64');
+}
+
+async function request(url, options, expectedStatuses) {
+  let lastError;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      const response = await fetch(url, options);
+      if (expectedStatuses.includes(response.status)) return response;
+      const body = await response.text();
+      throw new Error(`HTTP ${response.status}: ${body.slice(0, 500)}`);
+    } catch (error) {
+      lastError = error;
+      if (attempt < 5) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function createTusUpload(object) {
+  const metadata = [
+    ['bucketName', object.bucket_id],
+    ['objectName', object.name],
+    ['contentType', object.content_type],
+    ['cacheControl', object.cache_control],
+    [
+      'metadata',
+      JSON.stringify({
+        sourceETag: object.source_etag,
+        sourceSize: Number(object.size),
+      }),
+    ],
+  ]
+    .map(([name, value]) => `${name} ${base64(value)}`)
+    .join(',');
+
+  const response = await request(
+    `${process.env.TARGET_SUPABASE_URL}/storage/v1/upload/resumable`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.TARGET_SERVICE_ROLE_KEY}`,
+        apikey: process.env.TARGET_SERVICE_ROLE_KEY,
+        'Tus-Resumable': '1.0.0',
+        'Upload-Length': object.size,
+        'Upload-Metadata': metadata,
+        'x-upsert': 'true',
+      },
+    },
+    [201],
+  );
+
+  const location = response.headers.get('location');
+  if (!location) throw new Error('TUS create response did not include Location');
+  return new URL(location, process.env.TARGET_SUPABASE_URL).toString();
+}
+
+async function uploadObject(object) {
+  const uploadUrl = await createTusUpload(object);
+  const digest = createHash('sha256');
+  const totalSize = Number(object.size);
+  let offset = 0;
+
+  while (offset < totalSize) {
+    const end = Math.min(offset + chunkSize, totalSize) - 1;
+    const sourceResponse = await request(
+      objectUrl(
+        process.env.SOURCE_SUPABASE_URL,
+        object.bucket_id,
+        object.name,
+      ),
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.SOURCE_SERVICE_ROLE_KEY}`,
+          apikey: process.env.SOURCE_SERVICE_ROLE_KEY,
+          Range: `bytes=${offset}-${end}`,
+        },
+      },
+      [200, 206],
+    );
+    const chunk = Buffer.from(await sourceResponse.arrayBuffer());
+    const expectedLength = end - offset + 1;
+    if (chunk.length !== expectedLength) {
+      throw new Error(
+        `${object.bucket_id}/${object.name}: expected ${expectedLength} source bytes, received ${chunk.length}`,
+      );
+    }
+    digest.update(chunk);
+
+    const targetResponse = await request(
+      uploadUrl,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${process.env.TARGET_SERVICE_ROLE_KEY}`,
+          apikey: process.env.TARGET_SERVICE_ROLE_KEY,
+          'Tus-Resumable': '1.0.0',
+          'Upload-Offset': String(offset),
+          'Content-Type': 'application/offset+octet-stream',
+        },
+        body: chunk,
+      },
+      [204],
+    );
+    offset = Number(targetResponse.headers.get('upload-offset'));
+    if (!Number.isFinite(offset)) {
+      throw new Error(`${object.bucket_id}/${object.name}: TUS response omitted Upload-Offset`);
+    }
+  }
+
+  return digest.digest('hex');
+}
+
+async function hashRemoteObject(projectUrl, serviceRoleKey, object) {
+  const digest = createHash('sha256');
+  const response = await request(
+    objectUrl(projectUrl, object.bucket_id, object.name),
+    {
+      headers: {
+        Authorization: `Bearer ${serviceRoleKey}`,
+        apikey: serviceRoleKey,
+      },
+    },
+    [200],
+  );
+  if (!response.body) {
+    throw new Error(`${object.bucket_id}/${object.name}: response has no body`);
+  }
+  for await (const chunk of response.body) {
+    digest.update(chunk);
+  }
+  return digest.digest('hex');
+}
+
+function writeTargetChecksum(object, checksum) {
+  const query = `
+    UPDATE storage.objects
+    SET metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+      'sourceETag', ${sqlString(object.source_etag)},
+      'sourceSize', ${Number(object.size)},
+      'sourceSha256', ${sqlString(checksum)}
+    )
+    WHERE bucket_id = ${sqlString(object.bucket_id)}
+      AND name = ${sqlString(object.name)}
+  `;
+  const result = spawnSync(
+    'psql',
+    [process.env.TARGET_DATABASE_URL, '-X', '-v', 'ON_ERROR_STOP=1', '-q', '-c', query],
+    { encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    throw new Error(`Failed to persist object checksum: ${result.stderr.trim()}`);
+  }
+}
+
+const sourceObjects = queryObjects(process.env.SOURCE_DATABASE_URL, buckets);
+const targetObjects = queryObjects(process.env.TARGET_DATABASE_URL, buckets);
+const targetByPath = new Map(
+  targetObjects.map((object) => [`${object.bucket_id}/${object.name}`, object]),
+);
+const selectedObjects = limit > 0 ? sourceObjects.slice(0, limit) : sourceObjects;
+let copied = 0;
+let skipped = 0;
+let verified = 0;
+let copiedBytes = 0;
+
+for (const [index, object] of selectedObjects.entries()) {
+  const path = `${object.bucket_id}/${object.name}`;
+  const target = targetByPath.get(path);
+  const targetMatchesManifest =
+    target &&
+    target.size === object.size &&
+    target.migrated_source_etag === object.source_etag &&
+    target.source_sha256;
+
+  if (targetMatchesManifest && !verifyAll) {
+    skipped += 1;
+    console.log(
+      `[${index + 1}/${selectedObjects.length}] skip ${path} (${object.size} bytes)`,
+    );
+    continue;
+  }
+
+  if (!targetMatchesManifest) {
+    console.log(
+      `[${index + 1}/${selectedObjects.length}] copy ${path} (${object.size} bytes)`,
+    );
+    const sourceChecksum = await uploadObject(object);
+    const targetChecksum = await hashRemoteObject(
+      process.env.TARGET_SUPABASE_URL,
+      process.env.TARGET_SERVICE_ROLE_KEY,
+      object,
+    );
+    if (sourceChecksum !== targetChecksum) {
+      throw new Error(`${path}: target checksum does not match source checksum`);
+    }
+    writeTargetChecksum(object, sourceChecksum);
+    copied += 1;
+    copiedBytes += Number(object.size);
+    verified += 1;
+    continue;
+  }
+
+  console.log(
+    `[${index + 1}/${selectedObjects.length}] verify ${path} (${object.size} bytes)`,
+  );
+  const [sourceChecksum, targetChecksum] = await Promise.all([
+    hashRemoteObject(
+      process.env.SOURCE_SUPABASE_URL,
+      process.env.SOURCE_SERVICE_ROLE_KEY,
+      object,
+    ),
+    hashRemoteObject(
+      process.env.TARGET_SUPABASE_URL,
+      process.env.TARGET_SERVICE_ROLE_KEY,
+      object,
+    ),
+  ]);
+  if (sourceChecksum !== targetChecksum) {
+    throw new Error(`${path}: target checksum does not match source checksum`);
+  }
+  writeTargetChecksum(object, sourceChecksum);
+  verified += 1;
+}
+
+console.log(
+  JSON.stringify({
+    buckets,
+    sourceObjects: sourceObjects.length,
+    selectedObjects: selectedObjects.length,
+    copied,
+    skipped,
+    verified,
+    copiedBytes,
+  }),
+);

--- a/scripts/prod-us-west-2/storage-sync.sh
+++ b/scripts/prod-us-west-2/storage-sync.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_SECRET_ID="${SOURCE_SECRET_ID:-kortix-prod-env}"
+SOURCE_AWS_REGION="${SOURCE_AWS_REGION:-eu-west-2}"
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix/prod-us-west-2-migration}"
+TARGET_AWS_REGION="${TARGET_AWS_REGION:-us-west-2}"
+
+source_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$SOURCE_SECRET_ID" \
+    --region "$SOURCE_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+target_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$TARGET_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+
+export SOURCE_DATABASE_URL
+SOURCE_DATABASE_URL="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+export SOURCE_SUPABASE_URL
+SOURCE_SUPABASE_URL="$(jq -er '.SUPABASE_URL' <<<"$source_secret_json")"
+export SOURCE_SERVICE_ROLE_KEY
+SOURCE_SERVICE_ROLE_KEY="$(jq -er '.SUPABASE_SERVICE_ROLE_KEY' <<<"$source_secret_json")"
+export TARGET_DATABASE_URL
+TARGET_DATABASE_URL="$(
+  jq -er '.target_database_url // .DATABASE_URL' <<<"$target_secret_json"
+)"
+export TARGET_SUPABASE_URL
+TARGET_SUPABASE_URL="$(
+  jq -er '.target_supabase_url // .SUPABASE_URL' <<<"$target_secret_json"
+)"
+export TARGET_SERVICE_ROLE_KEY
+TARGET_SERVICE_ROLE_KEY="$(
+  jq -er \
+    '.target_service_role_key // .SUPABASE_SERVICE_ROLE_KEY' \
+    <<<"$target_secret_json"
+)"
+
+node "$(dirname "$0")/storage-sync.mjs"

--- a/scripts/prod-us-west-2/target-smoke.mjs
+++ b/scripts/prod-us-west-2/target-smoke.mjs
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+
+import { createHmac, randomBytes, randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+const requiredEnvironment = [
+  'TARGET_DATABASE_URL',
+  'TARGET_SUPABASE_URL',
+  'TARGET_ANON_KEY',
+  'TARGET_SERVICE_ROLE_KEY',
+  'TARGET_API_URL',
+];
+
+for (const name of requiredEnvironment) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+const targetUrl = process.env.TARGET_SUPABASE_URL.replace(/\/+$/, '');
+const databaseUrl = process.env.TARGET_DATABASE_URL;
+const anonKey = process.env.TARGET_ANON_KEY;
+const serviceRoleKey = process.env.TARGET_SERVICE_ROLE_KEY;
+const apiUrl = process.env.TARGET_API_URL.replace(/\/+$/, '');
+const smokePassword = `${randomBytes(32).toString('base64url')}aA1!`;
+const smokeEmail = `migration-smoke-${Date.now()}-${randomUUID().slice(0, 8)}@invalid.kortix.test`;
+
+let smokeUserId = null;
+let originalWebhookUrl = null;
+let signupWebhookSuppressed = false;
+
+function sql(input, variables = {}) {
+  const args = [databaseUrl, '-X', '-qAt', '-v', 'ON_ERROR_STOP=1'];
+  for (const [name, value] of Object.entries(variables)) {
+    args.push('-v', `${name}=${value}`);
+  }
+  const result = spawnSync('psql', args, {
+    input,
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`Target SQL failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+async function request(pathOrUrl, options, expectedStatuses = [200]) {
+  const response = await fetch(
+    pathOrUrl.startsWith('http') ? pathOrUrl : `${targetUrl}${pathOrUrl}`,
+    options,
+  );
+  if (!expectedStatuses.includes(response.status)) {
+    let message = '';
+    try {
+      const body = await response.json();
+      message = body.message ?? body.error_description ?? body.error ?? '';
+    } catch {
+      message = '';
+    }
+    throw new Error(
+      `HTTP ${response.status} for ${new URL(response.url).pathname}${message ? `: ${message}` : ''}`,
+    );
+  }
+  return response;
+}
+
+async function apiRequest(path, accessToken, expectedStatuses = [200]) {
+  const response = await fetch(`${apiUrl}${path}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'User-Agent': 'kortix-us-west-2-migration-smoke',
+    },
+  });
+  if (!expectedStatuses.includes(response.status)) {
+    let message = '';
+    try {
+      const body = await response.json();
+      message = body.message ?? body.error ?? '';
+    } catch {
+      message = '';
+    }
+    throw new Error(
+      `API HTTP ${response.status} for ${path}${message ? `: ${message}` : ''}`,
+    );
+  }
+  return response;
+}
+
+function adminHeaders() {
+  return {
+    Authorization: `Bearer ${serviceRoleKey}`,
+    apikey: serviceRoleKey,
+    'Content-Type': 'application/json',
+  };
+}
+
+function userHeaders(accessToken) {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    apikey: anonKey,
+    'Content-Type': 'application/json',
+  };
+}
+
+function decodeBase32(input) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const normalized = input.toUpperCase().replaceAll('=', '').replace(/[^A-Z2-7]/g, '');
+  let bits = '';
+  for (const character of normalized) {
+    const value = alphabet.indexOf(character);
+    if (value < 0) throw new Error('TOTP secret contains invalid Base32 data');
+    bits += value.toString(2).padStart(5, '0');
+  }
+  const bytes = [];
+  for (let offset = 0; offset + 8 <= bits.length; offset += 8) {
+    bytes.push(Number.parseInt(bits.slice(offset, offset + 8), 2));
+  }
+  return Buffer.from(bytes);
+}
+
+function currentTotp(secret) {
+  const counter = Math.floor(Date.now() / 30_000);
+  const counterBuffer = Buffer.alloc(8);
+  counterBuffer.writeBigUInt64BE(BigInt(counter));
+  const digest = createHmac('sha1', decodeBase32(secret)).update(counterBuffer).digest();
+  const offset = digest[digest.length - 1] & 0x0f;
+  const value =
+    ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff);
+  return String(value % 1_000_000).padStart(6, '0');
+}
+
+function jwtPayload(token) {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('Auth response did not return a JWT');
+  return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+}
+
+async function removeSmokeData() {
+  if (!smokeUserId) return;
+
+  try {
+    await request(
+      `/auth/v1/admin/users/${encodeURIComponent(smokeUserId)}`,
+      { method: 'DELETE', headers: adminHeaders() },
+      [200, 204, 404],
+    );
+  } catch {
+    // Continue with direct, smoke-scoped cleanup below.
+  }
+
+  sql(
+    `
+DELETE FROM auth.audit_log_entries
+WHERE payload::text LIKE '%' || :'smoke_user_id' || '%';
+
+DELETE FROM kortix.audit_events
+WHERE actor_user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.refresh_tokens
+WHERE user_id = :'smoke_user_id';
+
+DELETE FROM auth.sessions
+WHERE user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.mfa_factors
+WHERE user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.identities
+WHERE user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.users
+WHERE id = :'smoke_user_id'::uuid;
+
+SELECT setval(
+  'auth.refresh_tokens_id_seq'::regclass,
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1),
+  EXISTS (SELECT 1 FROM auth.refresh_tokens)
+);
+`,
+    { smoke_user_id: smokeUserId },
+  );
+}
+
+async function restoreSignupWebhook() {
+  if (!signupWebhookSuppressed) return;
+  sql(
+    `
+UPDATE public.webhook_config
+SET backend_url = :'webhook_url'
+WHERE id = 1;
+`,
+    { webhook_url: originalWebhookUrl },
+  );
+  signupWebhookSuppressed = false;
+}
+
+function readSmokeRows() {
+  if (!smokeUserId) return {};
+
+  return JSON.parse(
+    sql(
+      `
+SELECT json_build_object(
+  'auth.audit_log_entries',
+  (
+    SELECT count(*)
+    FROM auth.audit_log_entries
+    WHERE payload::text LIKE '%' || :'smoke_user_id' || '%'
+  ),
+  'auth.identities',
+  (SELECT count(*) FROM auth.identities WHERE user_id = :'smoke_user_id'::uuid),
+  'auth.mfa_factors',
+  (SELECT count(*) FROM auth.mfa_factors WHERE user_id = :'smoke_user_id'::uuid),
+  'auth.refresh_tokens',
+  (SELECT count(*) FROM auth.refresh_tokens WHERE user_id = :'smoke_user_id'),
+  'auth.sessions',
+  (SELECT count(*) FROM auth.sessions WHERE user_id = :'smoke_user_id'::uuid),
+  'auth.users',
+  (SELECT count(*) FROM auth.users WHERE id = :'smoke_user_id'::uuid),
+  'kortix.audit_events',
+  (SELECT count(*) FROM kortix.audit_events WHERE actor_user_id = :'smoke_user_id'::uuid)
+)::text;
+`,
+      { smoke_user_id: smokeUserId },
+    ),
+  );
+}
+
+async function run() {
+  const result = {
+    passwordLogin: false,
+    emailRecovery: false,
+    apiAuthenticated: false,
+    targetSchemaUserVisible: false,
+    totpEnrollment: false,
+    totpChallenge: false,
+    aal2Token: false,
+    signedAvatar: false,
+    publicAvatar: null,
+    cleanupRows: null,
+    cleanupByTable: null,
+  };
+
+  try {
+    sql(`
+SELECT setval(
+  'auth.refresh_tokens_id_seq'::regclass,
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1) + 1000000,
+  true
+);
+`);
+
+    originalWebhookUrl = sql(
+      `SELECT backend_url FROM public.webhook_config WHERE id = 1;\n`,
+    );
+    sql(`
+UPDATE public.webhook_config
+SET backend_url = ''
+WHERE id = 1;
+`);
+    signupWebhookSuppressed = true;
+
+    const createResponse = await request('/auth/v1/admin/users', {
+      method: 'POST',
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        email: smokeEmail,
+        password: smokePassword,
+        email_confirm: true,
+        user_metadata: { kortix_migration_smoke: true },
+      }),
+    });
+    const created = await createResponse.json();
+    smokeUserId = created.id ?? created.user?.id;
+    if (!smokeUserId) throw new Error('Auth admin create did not return a user id');
+
+    await restoreSignupWebhook();
+
+    result.targetSchemaUserVisible =
+      sql(
+        `SELECT count(*) FROM auth.users WHERE id = :'smoke_user_id'::uuid;\n`,
+        { smoke_user_id: smokeUserId },
+      ) === '1';
+
+    const tokenResponse = await request('/auth/v1/token?grant_type=password', {
+      method: 'POST',
+      headers: {
+        apikey: anonKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email: smokeEmail, password: smokePassword }),
+    });
+    const tokenBody = await tokenResponse.json();
+    const accessToken = tokenBody.access_token;
+    if (!accessToken) throw new Error('Password login did not return an access token');
+    result.passwordLogin = true;
+
+    const userResponse = await request('/auth/v1/user', {
+      headers: userHeaders(accessToken),
+    });
+    const user = await userResponse.json();
+    if (user.id !== smokeUserId) throw new Error('Auth user response returned another user');
+
+    const apiResponse = await apiRequest('/v1/user-roles', accessToken);
+    const apiIdentity = await apiResponse.json();
+    if (typeof apiIdentity.isAdmin !== 'boolean') {
+      throw new Error('API user-roles response omitted isAdmin');
+    }
+    result.apiAuthenticated = true;
+
+    await request('/auth/v1/recover', {
+      method: 'POST',
+      headers: {
+        apikey: anonKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email: smokeEmail }),
+    });
+    result.emailRecovery = true;
+
+    const enrollResponse = await request('/auth/v1/factors', {
+      method: 'POST',
+      headers: userHeaders(accessToken),
+      body: JSON.stringify({
+        friendly_name: 'kortix-us-west-2-migration-smoke',
+        factor_type: 'totp',
+        issuer: 'Kortix migration smoke',
+      }),
+    });
+    const enrolled = await enrollResponse.json();
+    const factorId = enrolled.id;
+    const totpSecret = enrolled.totp?.secret;
+    if (!factorId || !totpSecret) throw new Error('TOTP enrollment omitted factor data');
+    result.totpEnrollment = true;
+
+    const challengeResponse = await request(
+      `/auth/v1/factors/${encodeURIComponent(factorId)}/challenge`,
+      {
+        method: 'POST',
+        headers: userHeaders(accessToken),
+        body: '{}',
+      },
+    );
+    const challenge = await challengeResponse.json();
+    if (!challenge.id) throw new Error('TOTP challenge omitted its id');
+    result.totpChallenge = true;
+
+    const verifyResponse = await request(
+      `/auth/v1/factors/${encodeURIComponent(factorId)}/verify`,
+      {
+        method: 'POST',
+        headers: userHeaders(accessToken),
+        body: JSON.stringify({
+          challenge_id: challenge.id,
+          code: currentTotp(totpSecret),
+        }),
+      },
+    );
+    const verified = await verifyResponse.json();
+    result.aal2Token = jwtPayload(verified.access_token).aal === 'aal2';
+
+    const objectRow = sql(`
+SELECT
+  storage.objects.name,
+  storage.buckets.public
+FROM storage.objects
+JOIN storage.buckets
+  ON storage.buckets.id = storage.objects.bucket_id
+WHERE storage.objects.bucket_id = 'avatars'
+ORDER BY storage.objects.name COLLATE "C"
+LIMIT 1;
+`);
+    const [objectName, bucketPublic] = objectRow.split('|');
+    if (!objectName) throw new Error('The target avatars bucket is empty');
+    const encodedObjectName = objectName
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+
+    const signResponse = await request(
+      `/storage/v1/object/sign/avatars/${encodedObjectName}`,
+      {
+        method: 'POST',
+        headers: adminHeaders(),
+        body: JSON.stringify({ expiresIn: 60 }),
+      },
+    );
+    const signed = await signResponse.json();
+    const signedPath = signed.signedURL ?? signed.signedUrl;
+    if (!signedPath) throw new Error('Storage did not return a signed URL');
+    const signedUrl = signedPath.startsWith('/object/')
+      ? `${targetUrl}/storage/v1${signedPath}`
+      : new URL(signedPath, targetUrl).toString();
+    const signedResponse = await request(signedUrl, {}, [200]);
+    result.signedAvatar = Number(signedResponse.headers.get('content-length') ?? 1) > 0;
+
+    if (bucketPublic === 't') {
+      const publicResponse = await request(
+        `/storage/v1/object/public/avatars/${encodedObjectName}`,
+        {},
+        [200],
+      );
+      result.publicAvatar = Number(publicResponse.headers.get('content-length') ?? 1) > 0;
+    }
+  } finally {
+    await restoreSignupWebhook();
+    if (result.apiAuthenticated) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      await removeSmokeData();
+      result.cleanupByTable = readSmokeRows();
+      result.cleanupRows = Object.values(result.cleanupByTable).reduce(
+        (total, rowCount) => total + Number(rowCount),
+        0,
+      );
+      if (result.cleanupRows === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, attempt * 500));
+    }
+    if (smokeUserId) {
+      result.cleanupByTable = readSmokeRows();
+      result.cleanupRows = Object.values(result.cleanupByTable).reduce(
+        (total, rowCount) => total + Number(rowCount),
+        0,
+      );
+    }
+  }
+
+  const requiredChecks = [
+    result.passwordLogin,
+    result.emailRecovery,
+    result.apiAuthenticated,
+    result.targetSchemaUserVisible,
+    result.totpEnrollment,
+    result.totpChallenge,
+    result.aal2Token,
+    result.signedAvatar,
+    result.cleanupRows === 0,
+  ];
+  if (result.publicAvatar !== null) requiredChecks.push(result.publicAvatar);
+  if (!requiredChecks.every(Boolean)) {
+    throw new Error(`Target smoke failed: ${JSON.stringify(result)}`);
+  }
+
+  console.log(JSON.stringify(result));
+}
+
+await run();

--- a/scripts/prod-us-west-2/target-smoke.sh
+++ b/scripts/prod-us-west-2/target-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix/prod-us-west-2-migration}"
+TARGET_AWS_REGION="${TARGET_AWS_REGION:-us-west-2}"
+
+for command_name in aws jq node psql; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+target_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$TARGET_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+
+export TARGET_DATABASE_URL
+TARGET_DATABASE_URL="$(jq -er '.target_database_url' <<<"$target_secret_json")"
+export TARGET_SUPABASE_URL
+TARGET_SUPABASE_URL="$(jq -er '.target_supabase_url' <<<"$target_secret_json")"
+export TARGET_ANON_KEY
+TARGET_ANON_KEY="$(jq -er '.target_anon_key' <<<"$target_secret_json")"
+export TARGET_SERVICE_ROLE_KEY
+TARGET_SERVICE_ROLE_KEY="$(jq -er '.target_service_role_key' <<<"$target_secret_json")"
+export TARGET_API_URL
+TARGET_API_URL="${TARGET_API_URL:-https://api-usw2-shadow.kortix.com}"
+
+node "$(dirname "$0")/target-smoke.mjs"


### PR DESCRIPTION
## Summary

- Add the native Supabase `us-west-2` migration and reconciliation tools.
- Add the `us-west-2` production API and gateway ECS shadow stack.
- Add the reusable US shadow deployment workflow.
- Gate future production releases on the US shadow version.
- Keep all US workers, schedulers, channels, tunnels, and legacy migration workers disabled.
- Keep production traffic, production DNS, production secrets, and `supa.kortix.com` unchanged.

## Live preparation evidence

- Target Supabase project: `iaepefxnmhjqhilaxevk`, PostgreSQL 17.6, XL, 500 GB, 7-day PITR.
- Application replication: `101/101` relations ready, `0` apply errors, `0` sync errors.
- Auth replication: `22/22` relations ready, `0` apply errors, `0` sync errors.
- Auth counts, primary-key hashes, and critical-row hashes match.
- Storage: all `79` avatar objects pass complete source and target SHA-256 verification.
- API ECS shadow: `2/2` tasks, task definition `kortix-prod-usw2:2`.
- Gateway ECS shadow: `2/2` tasks, task definition `kortix-prod-usw2-gateway:2`.
- Target smoke passes password Auth, recovery email, authenticated API, TOTP/AAL2, signed Storage, public Storage, and zero-row cleanup.
- The replication credential was rotated after the initial copy.
- The deployment IAM policy matches Terraform with an empty targeted plan.

## Verification

- `bash -n infra/scripts/ecs-deploy.sh scripts/prod-us-west-2/*.sh`
- `shellcheck infra/scripts/ecs-deploy.sh scripts/prod-us-west-2/*.sh`
- `node --check scripts/prod-us-west-2/storage-sync.mjs`
- `node --check scripts/prod-us-west-2/target-smoke.mjs`
- `actionlint .github/workflows/deploy-prod-us-west-2-shadow.yml`
- `actionlint .github/workflows/deploy-prod.yml` with the existing `SC2035` and disabled-schema-job warnings ignored
- `terraform fmt -check -recursive`
- `terraform validate` for the shadow and security-baseline roots
- `git diff --check origin/main...HEAD`
- Actual no-traffic rollout of API and gateway image `0.10.14`
- Actual target smoke and complete Storage checksum run

## Cutover blockers

This PR prepares the cutover. It does not authorize the cutover.

- Supabase Support must enable the source HS256 secret for legacy tokens without a `kid`.
- The target needs the original Google OAuth secret.
- The target needs the original GitHub OAuth secret.
- The target needs the original Twilio Verify token.
- Supabase Support must coordinate `supa.kortix.com`.

The runbook records the exact write-freeze, reconciliation, cutover, and rollback sequence.
