### PR TITLE
test(ke2e): cover POST connector oauth2/profile route + regen manifest (511)

### DIFF
--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 501,
+  "count": 511,
   "routes": [
     {
       "method": "GET",
@@ -1323,6 +1323,10 @@
       "path": "/v1/projects/:projectId/connector-profiles/me"
     },
     {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/connectors/:slug/oauth2/profile"
+    },
+    {
       "method": "PUT",
       "path": "/v1/projects/:projectId/default-agent"
     },
@@ -1829,6 +1833,42 @@
     {
       "method": "POST",
       "path": "/v1/setup-links/secret/:token"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/bootstrap-owner"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/health"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/install-status"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/sandbox-providers"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/setup-complete"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/setup-status"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/setup-wizard-step"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/setup-wizard-step"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/status"
     },
     {
       "method": "POST",

--- a/tests/src/flows/connectors.flow.ts
+++ b/tests/src/flows/connectors.flow.ts
@@ -532,18 +532,16 @@ flow(
 
     let profileId = '';
     await ctx.step('create (reconcile) a connection profile → 201 with a real shape', async () => {
-      const r = await ctx.client
-        .as(ctx.P.OWNER)
-        .post(
-          '/v1/projects/:projectId/connector-profiles',
-          {
-            connector_alias: slug,
-            owner_type: 'external',
-            owner_id: 'ke2e-external-owner-1',
-            label: 'KE2E connection',
-          },
-          { params: { projectId: p.id } },
-        );
+      const r = await ctx.client.as(ctx.P.OWNER).post(
+        '/v1/projects/:projectId/connector-profiles',
+        {
+          connector_alias: slug,
+          owner_type: 'external',
+          owner_id: 'ke2e-external-owner-1',
+          label: 'KE2E connection',
+        },
+        { params: { projectId: p.id } },
+      );
       r.status(201)
         .body()
         .has('$.connector_alias', slug)
@@ -719,10 +717,11 @@ flow(
         { params: { projectId: p.id, profileId } },
       );
       saved.status(200).body().has('$.ok', true);
-      const read = await ctx.client.as(ctx.P.OWNER).get(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/application',
-        { params: { projectId: p.id, profileId } },
-      );
+      const read = await ctx.client
+        .as(ctx.P.OWNER)
+        .get('/v1/projects/:projectId/connector-profiles/:profileId/oauth2/application', {
+          params: { projectId: p.id, profileId },
+        });
       read
         .status(200)
         .body()
@@ -731,35 +730,38 @@ flow(
     });
 
     await ctx.step('start Authorization Code with PKCE and read ready status', async () => {
-      const started = await ctx.client.as(ctx.P.OWNER).post(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/authorize',
-        {},
-        { params: { projectId: p.id, profileId } },
-      );
-      started
-        .status(200)
-        .body()
-        .exists('$.authorization_url')
-        .exists('$.expires_at');
-      const status = await ctx.client.as(ctx.P.OWNER).get(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/status',
-        { params: { projectId: p.id, profileId } },
-      );
+      const started = await ctx.client
+        .as(ctx.P.OWNER)
+        .post(
+          '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/authorize',
+          {},
+          { params: { projectId: p.id, profileId } },
+        );
+      started.status(200).body().exists('$.authorization_url').exists('$.expires_at');
+      const status = await ctx.client
+        .as(ctx.P.OWNER)
+        .get('/v1/projects/:projectId/connector-profiles/:profileId/oauth2/status', {
+          params: { projectId: p.id, profileId },
+        });
       status.status(200).body().has('$.status', 'ready');
     });
 
     await ctx.step('reject SSRF discovery and unavailable device endpoints', async () => {
-      const discovery = await ctx.client.as(ctx.P.OWNER).post(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/discover',
-        { discovery_url: 'https://127.0.0.1/.well-known/oauth-authorization-server' },
-        { params: { projectId: p.id, profileId } },
-      );
+      const discovery = await ctx.client
+        .as(ctx.P.OWNER)
+        .post(
+          '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/discover',
+          { discovery_url: 'https://127.0.0.1/.well-known/oauth-authorization-server' },
+          { params: { projectId: p.id, profileId } },
+        );
       discovery.status(400);
-      const device = await ctx.client.as(ctx.P.OWNER).post(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/device',
-        {},
-        { params: { projectId: p.id, profileId } },
-      );
+      const device = await ctx.client
+        .as(ctx.P.OWNER)
+        .post(
+          '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/device',
+          {},
+          { params: { projectId: p.id, profileId } },
+        );
       device.status(400);
       const poll = await ctx.client.as(ctx.P.OWNER).post(
         '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/device/:sessionId',
@@ -797,11 +799,9 @@ flow(
   },
   async (ctx) => {
     await ctx.step('GET with a bogus token → 404 (invalid/unknown link)', async () => {
-      const r = await ctx.client
-        .as(ctx.P.ANON)
-        .get('/v1/setup-links/connector/:token', {
-          params: { token: 'bogus-connector-setup-link' },
-        });
+      const r = await ctx.client.as(ctx.P.ANON).get('/v1/setup-links/connector/:token', {
+        params: { token: 'bogus-connector-setup-link' },
+      });
       r.status(404).body().exists('$.error');
     });
     await ctx.step('POST .../start with a bogus token → 404 (invalid/unknown link)', async () => {
@@ -857,5 +857,70 @@ flow(
         );
       r.status([403, 404]);
     });
+  },
+);
+
+// CONN-OAUTH — POST /v1/projects/:projectId/connectors/:slug/oauth2/profile
+// (apps/api/src/projects/routes/oauth2-connectors.ts:91-122). Ensures (or
+// returns) the default OAuth2 profile for a project connector. The route is a
+// recent addition that surfaced as a 1-route coverage gap; this closes it with
+// the auth/validation/boundary assertions the gate requires — it does NOT
+// provision a real connector (ensureDefaultProfile only runs once the connector
+// lookup succeeds, so an unknown slug stops at the 404 "Connector not found"
+// boundary before any write).
+flow(
+  'CONN-OAUTH',
+  {
+    domain: 'connectors',
+    routes: ['POST /v1/projects/:projectId/connectors/:slug/oauth2/profile'],
+  },
+  async (ctx) => {
+    const p = await ctx.fixtures.project();
+    await ctx.step('ANON → 401', async () => {
+      const r = await ctx.client
+        .as(ctx.P.ANON)
+        .post(
+          '/v1/projects/:projectId/connectors/:slug/oauth2/profile',
+          {},
+          { params: { projectId: p.id, slug: 'github' } },
+        );
+      r.status(401);
+    });
+    await ctx.step('unknown projectId → 404 (project not loadable)', async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .post(
+          '/v1/projects/:projectId/connectors/:slug/oauth2/profile',
+          {},
+          { params: { projectId: '00000000-0000-4000-a000-000000000000', slug: 'github' } },
+        );
+      r.status(404);
+    });
+    await ctx.step('NONMEMBER → 403/404 (no project access)', async () => {
+      const r = await ctx.client
+        .as(ctx.P.NONMEMBER)
+        .post(
+          '/v1/projects/:projectId/connectors/:slug/oauth2/profile',
+          {},
+          { params: { projectId: p.id, slug: 'github' } },
+        );
+      r.status([403, 404]);
+    });
+    await ctx.step(
+      'OWNER, unknown connector slug → 404 "Connector not found" (no profile write)',
+      async () => {
+        // OWNER passes the manage-capability gate; the connector lookup by
+        // (account, project, slug) misses → 404 before ensureDefaultProfile runs,
+        // so no OAuth2 profile row is written for a non-existent connector.
+        const r = await ctx.client
+          .as(ctx.P.OWNER)
+          .post(
+            '/v1/projects/:projectId/connectors/:slug/oauth2/profile',
+            {},
+            { params: { projectId: p.id, slug: 'no-such-connector-' + ctx.fixtures.name('x') } },
+          );
+        r.status(404);
+      },
+    );
   },
 );


### PR DESCRIPTION
## What

Closes a 1-route coverage gap that surfaced when main advanced: `POST /v1/projects/:projectId/connectors/:slug/oauth2/profile` (`apps/api/src/projects/routes/oauth2-connectors.ts:91-122`) was uncovered. Also regenerates `tests/spec/routes.generated.json` to 511 routes (was 501).

## Why

Main landed 10 new routes since the last manifest regen. 9 are `/v1/setup/*` (already in the `externalRoutes` allowlist — self-hosted setup app, not mounted when billing is enabled). The 10th — the connector oauth2/profile route — was genuinely uncovered, dropping the gate to `98% · 501/511 · 1 uncovered` (failing). This is exactly the failure mode the gate exists to catch: a new route reaching staging with no e2e proof it works.

## Changes

**`CONN-OAUTH`** (`tests/src/flows/connectors.flow.ts`) — asserts the auth/validation/boundary surfaces without provisioning a real connector (`ensureDefaultProfile` only runs once the connector lookup succeeds, so an unknown slug stops at the 404 boundary before any write):
- ANON → `401`
- unknown projectId → `404` (project not loadable)
- NONMEMBER → `403`/`404` (no project access)
- OWNER, unknown connector slug → `404` "Connector not found" (no profile write — the connector lookup by `(account, project, slug)` misses before `ensureDefaultProfile` runs)

**`tests/spec/routes.generated.json`** — regenerated to 511 routes. Clean regen: 0 routes removed, only the `count` field (501→511) + 10 new route entries.

## Coverage

- Before: `98% · 501/511 routes · 9 allowlisted · 1 uncovered` — **gate FAILED** (`POST /v1/projects/:*/connectors/:*/oauth2/profile`)
- After:  `98.2% · 502/511 routes · 9 allowlisted · 0 uncovered` — **gate passed**

This is **route-gap closure** (the gate was genuinely red on the new route), not edge-case depth.

## Verification

Static (sandbox has no live staging creds):
- `bun bin/ke2e.ts coverage` → gate passes, `CONN-OAUTH` discovered
- `tsc --noEmit` → no errors in the changed file
- `biome format` → clean

Live staging verification runs in CI `qa-release.yml` ke2e lane on merge. `CONN-OAUTH` needs no funded capability — it asserts boundary 4xx responses only.

## Bugs filed

None — the route handler behaves as the code describes; this closes the coverage gap and pins the auth/boundary contract.