### PR TITLE
fix(infra): repair US shadow deploy and reconciliation

### DIFF
--- a/infra/terraform/security-baseline/iam-gha-ecs-deploy.tf
+++ b/infra/terraform/security-baseline/iam-gha-ecs-deploy.tf
@@ -58,8 +58,8 @@ resource "aws_iam_role" "gha_ecs_deploy" {
 }
 
 resource "aws_iam_role_policy" "gha_ecs_deploy" {
-  # checkov:skip=CKV_AWS_355: the TaskDefinitionLifecycle statement's "*" is
-  # required — RegisterTaskDefinition/DescribeTaskDefinition do not support
+  # checkov:skip=CKV_AWS_355: TaskDefinitionLifecycle and
+  # DescribeLoadBalancers require "*" because these APIs do not support
   # resource-level permissions; every other statement is ARN-scoped.
   name = "ecs-deploy"
   role = aws_iam_role.gha_ecs_deploy.id
@@ -106,6 +106,14 @@ resource "aws_iam_role_policy" "gha_ecs_deploy" {
           "ecs:DescribeTaskDefinition",
           "ecs:RegisterTaskDefinition",
         ]
+        Resource = "*"
+      },
+      {
+        # The US shadow workflow resolves each ALB DNS name before updating its
+        # Cloudflare CNAME. DescribeLoadBalancers supports no resource ARN.
+        Sid      = "DescribeLoadBalancers"
+        Effect   = "Allow"
+        Action   = ["elasticloadbalancing:DescribeLoadBalancers"]
         Resource = "*"
       },
       {

--- a/scripts/prod-us-west-2/db-sync.sh
+++ b/scripts/prod-us-west-2/db-sync.sh
@@ -604,8 +604,17 @@ CREATE TEMP TABLE migration_counts (
   row_count bigint NOT NULL
 ) ON COMMIT DROP;
 
+SELECT
+  set_config('kortix.migration_database_side', :'database_side', true),
+  set_config('kortix.migration_publication', :'publication', true),
+  set_config('kortix.migration_subscription', :'subscription', true)
+\gset
+
 DO $do$
 DECLARE
+  database_side text := current_setting('kortix.migration_database_side');
+  publication_name text := current_setting('kortix.migration_publication');
+  subscription_name text := current_setting('kortix.migration_subscription');
   relation record;
 BEGIN
   FOR relation IN
@@ -620,8 +629,8 @@ BEGIN
         ON pg_class.oid = pg_publication_rel.prrelid
       JOIN pg_namespace
         ON pg_namespace.oid = pg_class.relnamespace
-      WHERE :'database_side' = 'source'
-        AND pg_publication.pubname = :'publication'
+      WHERE database_side = 'source'
+        AND pg_publication.pubname = publication_name
 
       UNION ALL
 
@@ -635,8 +644,8 @@ BEGIN
         ON pg_class.oid = pg_subscription_rel.srrelid
       JOIN pg_namespace
         ON pg_namespace.oid = pg_class.relnamespace
-      WHERE :'database_side' = 'target'
-        AND pg_subscription.subname = :'subscription'
+      WHERE database_side = 'target'
+        AND pg_subscription.subname = subscription_name
     )
     SELECT table_schema, table_name
     FROM replicated_tables
@@ -706,8 +715,17 @@ CREATE TEMP TABLE migration_key_hashes (
   hash_b numeric NOT NULL
 ) ON COMMIT DROP;
 
+SELECT
+  set_config('kortix.migration_database_side', :'database_side', true),
+  set_config('kortix.migration_publication', :'publication', true),
+  set_config('kortix.migration_subscription', :'subscription', true)
+\gset
+
 DO $do$
 DECLARE
+  database_side text := current_setting('kortix.migration_database_side');
+  publication_name text := current_setting('kortix.migration_publication');
+  subscription_name text := current_setting('kortix.migration_subscription');
   relation record;
 BEGIN
   FOR relation IN
@@ -722,8 +740,8 @@ BEGIN
         ON pg_class.oid = pg_publication_rel.prrelid
       JOIN pg_namespace
         ON pg_namespace.oid = pg_class.relnamespace
-      WHERE :'database_side' = 'source'
-        AND pg_publication.pubname = :'publication'
+      WHERE database_side = 'source'
+        AND pg_publication.pubname = publication_name
 
       UNION ALL
 
@@ -737,8 +755,8 @@ BEGIN
         ON pg_class.oid = pg_subscription_rel.srrelid
       JOIN pg_namespace
         ON pg_namespace.oid = pg_class.relnamespace
-      WHERE :'database_side' = 'target'
-        AND pg_subscription.subname = :'subscription'
+      WHERE database_side = 'target'
+        AND pg_subscription.subname = subscription_name
     )
     SELECT
       selected_tables.table_schema,

--- a/scripts/prod-us-west-2/db-sync.test.mjs
+++ b/scripts/prod-us-west-2/db-sync.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const script = readFileSync(
+  new URL("./db-sync.sh", import.meta.url),
+  "utf8",
+);
+
+const functionBody = (name, nextName) => {
+  const match = script.match(
+    new RegExp(
+      `\\n${name}\\(\\) \\{([\\s\\S]*?)\\n\\}\\n\\n${nextName}\\(\\) \\{`,
+    ),
+  );
+  assert.ok(match, `Missing ${name} function`);
+  return match[1];
+};
+
+test("reconciliation PL/pgSQL reads psql inputs through transaction settings", () => {
+  const functions = [
+    functionBody("write_counts", "reconcile_counts"),
+    functionBody("write_key_hashes", "write_critical_hashes"),
+  ];
+
+  for (const body of functions) {
+    assert.match(
+      body,
+      /set_config\('kortix\.migration_database_side', :'database_side', true\)/,
+    );
+    assert.match(
+      body,
+      /set_config\('kortix\.migration_publication', :'publication', true\)/,
+    );
+    assert.match(
+      body,
+      /set_config\('kortix\.migration_subscription', :'subscription', true\)/,
+    );
+
+    const block = body.match(/DO \$do\$([\s\S]*?)\$do\$;/);
+    assert.ok(block, "Missing PL/pgSQL block");
+
+    assert.match(
+      block[1],
+      /current_setting\('kortix\.migration_database_side'\)/,
+    );
+    assert.match(
+      block[1],
+      /current_setting\('kortix\.migration_publication'\)/,
+    );
+    assert.match(
+      block[1],
+      /current_setting\('kortix\.migration_subscription'\)/,
+    );
+    assert.doesNotMatch(
+      block[1],
+      /:'(?:database_side|publication|subscription)'/,
+    );
+  }
+});


### PR DESCRIPTION
The US shadow deployment failed before deployment because `kortix-gha-ecs-deploy` could not call `elasticloadbalancing:DescribeLoadBalancers`.

This PR adds the required read-only IAM action. AWS does not support resource-level scoping for this API.

The DB reconciliation commands also failed because `psql` does not substitute variables inside dollar-quoted PL/pgSQL blocks. This PR stores the inputs in transaction-local settings and reads them with `current_setting(...)`.

Verification:
- `terraform -chdir=infra/terraform/security-baseline validate`
- `tflint --recursive --format compact`
- `checkov -d infra/terraform/security-baseline --quiet`: 188 passed, 0 failed
- Targeted Terraform apply: 0 added, 1 changed, 0 destroyed
- `bash -n scripts/prod-us-west-2/db-sync.sh`
- `node --test scripts/prod-us-west-2/db-sync.test.mjs`: 1 passed, 0 failed
- `bash scripts/prod-us-west-2/db-sync.sh reconcile-counts`: reached comparison; only live `kortix.audit_events` differed
- `bash scripts/prod-us-west-2/db-sync.sh reconcile-key-hashes`: reached comparison; only live `kortix.audit_events` differed
