### PR TITLE
docs: OAuth2 lifecycle, connector auth-type enum, transport-throw retry, example 09

### DIFF
--- a/apps/web/content/docs/connect/connectors.mdx
+++ b/apps/web/content/docs/connect/connectors.mdx
@@ -77,6 +77,43 @@ For Microsoft Graph, use `https://login.microsoftonline.com/{tenant_id}/oauth2/v
 
 For direct SharePoint REST endpoints under `https://{tenant}.sharepoint.com/_api`, use the scope `https://{tenant}.sharepoint.com/.default` instead of the Microsoft Graph scope.
 
+## Connect a user-facing API with OAuth2
+
+For APIs that require a user's consent — Google, Microsoft, GitHub, or any identity provider that speaks standard OAuth2 — use the **Authorization Code with PKCE** or **Device Authorization** grant instead of client credentials. Kortix runs the full lifecycle: discovery, authorization redirect (or device pairing), token exchange, refresh, and revocation.
+
+<Steps>
+<Step>
+### Declare the direct connector and pick a grant
+
+In the Custom connector form, select **OAuth 2.0** under **Auth**, then choose a **Grant**: **Client Credentials** (server-to-server, covered above), **Authorization Code with PKCE**, or **Device Authorization**.
+</Step>
+<Step>
+### Enter the OAuth2 application configuration
+
+Enter the **Token URL**, **Client ID**, and **Scopes**. For **Authorization Code** you also provide an **Authorization URL**; for **Device Authorization** a **Device Authorization URL**.
+
+A **Discovery URL** (RFC 8414 or OpenID metadata) can fill the endpoint URLs for you — paste it and Kortix fetches the authorization, token, device-authorization, and revocation URLs from the metadata.
+</Step>
+<Step>
+### Pick a token-endpoint authentication method
+
+| Method | When to use it |
+| --- | --- |
+| **Public client** (`none`) | A public/native client with no secret. |
+| **Client secret with Basic** (`client_secret_basic`) | The standard server-side client secret, sent in the `Authorization` header. |
+| **Client secret in body** (`client_secret_post`) | Client secret sent in the request body. |
+| **Client secret JWT** (`client_secret_jwt`) | The client asserts itself with an HS256-signed JWT derived from the shared secret. |
+| **Private key JWT** (`private_key_jwt`) | Asymmetric assertion — paste a PKCS#8 private key PEM; Kortix signs RS256 client assertions with it. No shared secret crosses the wire. |
+</Step>
+<Step>
+### Authorize and verify
+
+For **Authorization Code**, Kortix generates a consent URL with a PKCE code challenge — send your user to it; they approve, and Kortix exchanges the code for tokens. For **Device Authorization**, Kortix returns a verification URL and code the user enters on another device; Kortix polls until they complete it.
+
+Kortix encrypts the tokens and refreshes them before they expire. Revoking the profile blocks the next Executor call.
+</Step>
+</Steps>
+
 ## Connect with an API key
 
 <Steps>

--- a/apps/web/content/docs/project/manifest.mdx
+++ b/apps/web/content/docs/project/manifest.mdx
@@ -251,7 +251,7 @@ Provider-specific fields:
 
 `channel` connectors rarely need a hand-written entry — connecting a channel from the dashboard creates one for you. See [Slack & channels](/docs/connect/slack). The slugs `kortix_slack`, `kortix_teams`, `kortix_email`, `kortix_meet`, and `computer` are platform-owned; using one with a different provider is a validation error.
 
-`connectors.auth`: optional, for providers other than `pipedream`. `type` is `bearer`, `basic`, `custom`, `oauth1`, or `none` (default). `oauth1` is restricted to `openapi`, `postman`, and `http` providers. `in` is `header` (default) or `query`. `name` is required when `type` is `custom`.
+`connectors.auth`: optional, for providers other than `pipedream`. `type` is `bearer`, `basic`, `custom`, `api_key`, `oauth1`, `hmac`, `aws_sigv4`, `mtls`, or `none` (default). `oauth1` is restricted to `openapi`, `postman`, and `http` providers. `in` is `header` (default), `query`, or `cookie`. `name` is required when `type` is `custom` or `api_key`.
 
 `connectors.policies`: a list of `{match, action}` pairs. `match` is a glob over tool names. `action` is `always_run`, `require_approval`, or `block`.
 

--- a/apps/web/content/docs/sdk/example.mdx
+++ b/apps/web/content/docs/sdk/example.mdx
@@ -151,4 +151,5 @@ const routing = await project.gateway.routing.get();
 
 The package ships runnable examples that cover each of these steps, in
 `packages/sdk/examples/`. They include a minimal client, streaming, a server
-wrapper, transcript rendering, and files and secrets.
+wrapper, a Kortix-as-a-Backend multi-tenant wrapper, transcript rendering, and
+files and secrets.

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -257,7 +257,7 @@ try {
 
 For any other failure, `status` holds the HTTP status code. `code` comes from the backend's `error_code`, or falls back to the status as a string. `message` is an enumerable own property on `ApiError`, so it survives `JSON.stringify` and object spread.
 
-Kortix retries some requests before your code sees an error. If a `GET` or `HEAD` request returns `502`, `503`, or `504`, Kortix retries it up to 2 times, with a 250ms then 500ms delay. A retry that succeeds never reaches `onError`. Kortix never retries `POST`, `PUT`, `PATCH`, or `DELETE` requests, or a `500` response.
+Kortix retries some requests before your code sees an error. If a `GET` or `HEAD` request returns `502`, `503`, or `504`, Kortix retries it up to 2 times, with a 250ms then 500ms delay. A transient transport failure on a `GET` or `HEAD` — a network error, not a status code — is retried the same way. A retry that succeeds never reaches `onError`. Kortix never retries `POST`, `PUT`, `PATCH`, or `DELETE` requests, or a `500` response.
 
 Kortix throws `AuthError` on the client, before it sends a request, when `getToken()` returns `null`. `AuthError` extends `ApiError`, so `err instanceof ApiError` still matches. Check `err instanceof AuthError`, or `err.code === 'NO_SESSION'`, to treat "not signed in" as a separate case from a backend failure.
 


### PR DESCRIPTION
## docs: OAuth2 lifecycle, connector auth-type enum, transport-throw retry, example 09

Docs-only accuracy sweep from the autonomous `docs-maintainer` run (2026-07-25). Five drifts found by four parallel `docs-maintainer-worker` shards and independently re-verified by the orchestrator against current source before editing.

### Audit window
- `kortix-ai/suna`: `b4d8eea13` (2026-07-24 checkpoint) → `f8968d3e1` (origin/main). 136 reachable commits. Full-SHA coverage manifest passes `check-commit-coverage.mjs` (11 `docs-change`, 31 `already-current`, 94 `no-doc-impact`).

### Fixes

**1. Connector auth-type enum + `in` + `name` rule (MEDIUM) — `project/manifest.mdx:254`**
The manifest reference listed only `bearer`, `basic`, `custom`, `oauth1`, `none` and said `in` is `header`/`query` and `name` is required only for `custom`. Source accepts nine auth types and `in` can also be `cookie`; `name` is required for `custom` **or** `api_key`. Proof: `packages/manifest-schema/src/constants.ts:29-39` (`CONNECTOR_AUTH_TYPES = [bearer, basic, custom, api_key, oauth1, hmac, aws_sigv4, mtls, none]`); `apps/api/src/projects/connectors.ts:83-103` (`ConnectorAuthType` union); `:109` (`in: 'header' | 'query' | 'cookie'`); `:527-529` (`if ((type === 'custom' || type === 'api_key') && !name)`).

**2. User-facing OAuth2 lifecycle (HIGH) — `connect/connectors.mdx` (new section)**
The existing "Connect a direct API with OAuth2 client credentials" section covered only the machine-to-machine grant. Kortix now runs the full OAuth2 lifecycle for user-consent APIs: **Authorization Code with PKCE**, **Device Authorization**, RFC 8414 **Discovery**, token refresh, and **revocation** — plus five token-endpoint auth methods (`none`/`client_secret_basic`/`client_secret_post`/`client_secret_jwt`/`private_key_jwt`). Proof: `apps/api/src/executor/oauth2-lifecycle.ts:178-380` (buildOAuth2AuthorizationRequest with PKCE S256, exchangeOAuth2AuthorizationCode, startOAuth2DeviceAuthorization, pollOAuth2DeviceAuthorization, revokeOAuth2Token, discoverOAuth2Metadata); `apps/api/src/projects/routes/oauth2-connectors.ts:91-251` (routes `/oauth2/profile`, `/application`, `/discover`, `/authorize`, `/device`, `/status`); `packages/api-contract/src/index.ts:366-485` (`OAuth2ApplicationInput` + `OAuth2TokenEndpointAuthMethodSchema`); `apps/web/src/features/workspace/customize/sections/connector-oauth2-application-fields.tsx` (UI grant select + discovery + auth-method select); `apps/web/src/features/workspace/customize/sections/connectors-view.tsx:4454-4471` (grant options: client_credentials/authorization_code/device_authorization).

**3. Transport-throw retry (LOW) — `sdk/sessions.mdx:260`**
The retry paragraph only covered `502`/`503`/`504` status retries. The SDK also retries a transient transport failure (network error, `fetch()` throw) on an idempotent `GET`/`HEAD` the same way. Proof: `packages/sdk/src/core/http/api-client.ts:181-190` (catches fetch throw, `continue`s to next attempt unless abort/last); test `api-client.test.ts:243-302` ("retries transient transport failures on idempotent reads", "a POST transport failure is not retried").

**4. KaaB example not enumerated (LOW) — `sdk/example.mdx:154`**
The examples list omitted the Kortix-as-a-Backend multi-tenant wrapper (`examples/09-kaab-backend-wrapper.ts`), which `backend.mdx:181` links to. Proof: `packages/sdk/examples/09-kaab-backend-wrapper.ts` exists; `packages/sdk/examples/README.md:39` documents it.

### Verification
- `check-fumadocs.mjs` PASS (28 pages, 6 nav, 28 routes).
- `git diff --check` PASS; `test-docs-maintainer-gates.mjs` PASS.
- Grep gates PASS (all positive markers present; `api_key`/`hmac`/`aws_sigv4`/`mtls`/`cookie` in manifest; `Authorization Code with PKCE`/`Device Authorization`/`Discovery URL`/`Private key JWT` in connectors; `transient transport failure` in sessions; `Kortix-as-a-Backend multi-tenant wrapper` in example).
- This PR is docs-only — 4 files under `apps/web/content/docs/**`.

