### PR TITLE
content(docs): add persistent "Get started" CTA to docs nav rail

### DIFF
--- a/apps/web/src/app/docs/layout.tsx
+++ b/apps/web/src/app/docs/layout.tsx
@@ -52,6 +52,14 @@ export default function Layout({ children }: { children: ReactNode }) {
         links={[
           {
             type: 'icon',
+            text: 'Get started',
+            label: 'Get started',
+            icon: <Icon.Sparkles />,
+            url: '/auth',
+            external: false,
+          },
+          {
+            type: 'icon',
             text: 'GitHub',
             label: 'GitHub',
             icon: <Icon.Github />,


### PR DESCRIPTION
## What & why

`/docs` is a high-intent developer surface — GSC shows it earns **862 impressions + 6 clicks in the last 7 days** — but its Fumadocs nav rail had only a GitHub link. Docs readers who wanted to try Kortix had no 1-click path to signup; they had to find the navbar CTA. This PR adds a persistent **"Get started" → `/auth`** CTA to the docs nav rail, recovering the docs→trial funnel.

| Before | After |
| --- | --- |
| `/docs` nav rail: GitHub link only | `/docs` nav rail: "Get started" → `/auth` + GitHub |

This completes the **SEO-008** conversion sub-item: the CTA label renames shipped in #5363 (`/contact` + `/pricing`); this is the docs-CTA half that needed the Fumadocs layout edit.

## Scope

Pure layout-chrome addition in `apps/web/src/app/docs/layout.tsx` (+8 lines). Adds one entry to the Fumadocs `links` array, before the existing GitHub entry. Same `type: 'icon'` shape as the GitHub link, with the on-brand `Icon.Sparkles` icon (already exported from `@/features/icon/icon`). No route, handler, type, import, or behavior change.

`/auth` is the sanctioned primary CTA destination (`START_URL = '/auth'`) per the `positioning.md` CTA standard (primary = "Get started" → `/auth`).

## Experiment contract (SEO-008-docs)

- **Hypothesis:** a persistent docs CTA recovers the docs→trial funnel for high-intent developer traffic.
- **Baseline:** `/docs` has 0 money-page CTAs (only GitHub link); GSC 7d = 862 impressions, 6 clicks.
- **Primary metric:** PostHog CTA-click events from docs (once configured) + GSC docs→`/auth` referral flow.
- **Guardrails:** matches existing GitHub entry shape; no behavior/route change; self-mergeable metadata/layout edit.
- **Rollback:** revert this PR.

## Verification

- `bun run tsc --noEmit` clean (no typecheck errors in `docs/layout.tsx`).
- `Icon.Sparkles` confirmed exported (`features/icon/icon.tsx:1022`); `Icon` import unchanged.
- Exact-head preview gates to be run after `preview` builds: `/docs` renders "Get started" in the nav rail, links to `/auth`; GitHub link intact.