### PR TITLE
test(acp): detach reconnect from Playwright routing

### DIFF
--- a/tests/e2e/specs/14-acp-runtime-canary.spec.ts
+++ b/tests/e2e/specs/14-acp-runtime-canary.spec.ts
@@ -252,34 +252,41 @@ test.describe.serial("14 — OpenCode ACP runtime canary", () => {
     }> = [];
     const acpStreamHeaders: Array<Record<string, string>> = [];
     const restPromptRequests: string[] = [];
-    let replaceFirstAcpStream = true;
 
-    await page.route(/\/kortix\/acp\//, async (route) => {
-      const request = route.request();
-      if (request.method() !== "GET") {
-        await route.continue();
-        return;
-      }
-      acpStreamHeaders.push(request.headers());
-      if (!replaceFirstAcpStream) {
-        await route.continue();
-        return;
-      }
-      replaceFirstAcpStream = false;
-      const origin = request.headers().origin ?? new URL(request.url()).origin;
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "Access-Control-Allow-Credentials": "true",
-          "Access-Control-Allow-Origin": origin,
-          "Cache-Control": "no-cache",
-          "Content-Type": "text/event-stream",
-        },
-        body: 'id: 0\ndata: {"jsonrpc":"2.0","method":"kortix/cursor"}\n\n',
-      });
-    });
+    // Intercept one stream only. Remove the route before the reconnect so
+    // Chromium can consume the deployed SSE response incrementally.
+    const acpRoutePattern = /\/kortix\/acp\//;
+    await page.route(
+      acpRoutePattern,
+      async function interruptFirstAcpStream(route) {
+        const request = route.request();
+        if (request.method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        const origin =
+          request.headers().origin ?? new URL(request.url()).origin;
+        await route.fulfill({
+          status: 200,
+          headers: {
+            "Access-Control-Allow-Credentials": "true",
+            "Access-Control-Allow-Origin": origin,
+            "Cache-Control": "no-cache",
+            "Content-Type": "text/event-stream",
+          },
+          body: 'id: 0\ndata: {"jsonrpc":"2.0","method":"kortix/cursor"}\n\n',
+        });
+        await page.unroute(acpRoutePattern, interruptFirstAcpStream);
+      },
+    );
 
     page.on("request", (request) => {
+      if (
+        request.method() === "GET" &&
+        request.url().includes("/kortix/acp/")
+      ) {
+        acpStreamHeaders.push(request.headers());
+      }
       if (
         request.method() === "POST" &&
         request.url().includes("/kortix/acp/")


### PR DESCRIPTION
## Summary

- intercept only the first ACP SSE request
- remove Playwright routing before the live reconnect
- observe reconnect headers through the request event

## Evidence

- tests typecheck: exit 0
- Prettier and git diff checks: exit 0
- deployed cold Chromium ACP plus REST rollback matrix: 1 passed in 3.3m
- direct dev ACP replay: HTTP 200 with ordered cursor, runtime_ready, session/update, and matching session/load response events

## Local environment

Two local cold attempts stopped during Platinum provisioning before Chromium started. The deployed dev sandbox reached ready and completed the full matrix.