### PR TITLE
fix(web): restore LLM management navigation

### DIFF
--- a/apps/web/src/features/workspace/customize/customize-checkpoints.test.ts
+++ b/apps/web/src/features/workspace/customize/customize-checkpoints.test.ts
@@ -27,4 +27,8 @@ describe('Customize information architecture', () => {
     expect(entry?.label).toBe('Files');
     expect(entry?.href).toBe('/projects/{projectId}/files');
   });
+
+  test('LLM management remains reachable from the Connect rail group', () => {
+    expect(customizePanelSource).toContain('if (llmGatewayAvailable) items.push(LLM_ITEM)');
+  });
 });

--- a/apps/web/src/features/workspace/customize/customize-panel.tsx
+++ b/apps/web/src/features/workspace/customize/customize-panel.tsx
@@ -121,13 +121,10 @@ function railGroups(
       return { ...g, items: [...g.items, MARKETPLACE_ITEM] };
     }
     if (g.label === 'Connect') {
-      // Models lives in the base Connect group (rail-groups.ts) so it's always
-      // in the nav; drop it only where the managed gateway isn't available.
-      const items = g.items.filter(
-        (item) => item.section !== 'llm-management' || llmGatewayAvailable,
-      );
+      const items = [...g.items];
       if (meetEnabled) items.push(MEET_ITEM);
       if (tunnelEnabled) items.push(COMPUTERS_ITEM);
+      if (llmGatewayAvailable) items.push(LLM_ITEM);
       return { ...g, items };
     }
     if (g.label === 'Build' && reviewEnabled) {


### PR DESCRIPTION
## Cause\n\nCommit 68006d113 removed the conditional LLM rail insertion. The remaining filter could not retain an item that no group contained. The section visibility fallback then replaced llm-providers with agents.\n\n## Fix\n\n- Restore the LLM rail item when llm_gateway is available.\n- Add regression coverage for the Connect rail group.\n\n## Verification\n\n- bun test src/features/workspace/customize/customize-checkpoints.test.ts src/features/workspace/customize/rail.test.ts src/stores/customize-store.test.ts src/features/session/model-selector.test.ts: 28 pass, 0 fail\n- npx eslint src/features/workspace/customize/customize-panel.tsx src/features/workspace/customize/customize-checkpoints.test.ts: 0 errors\n- npx tsc --noEmit --pretty false: 0 changed-file diagnostics; 2 existing template-url.test.ts diagnostics\n- curl http://localhost:16508/v1/health: 200\n- curl http://localhost:16500: 200\n\n## Browser\n\nThe browser integration exposed no available browser backend in this run.