### PR TITLE
Fix false Load older messages control

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -2437,7 +2437,6 @@ Non-streaming requests retain the 30-second timeout.
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, and the deployed
 cold Chromium matrix remain.
-
 ---
 
 ### 2026-07-25 — session `acp-opencode-canary` (B21 implementation)
@@ -2469,3 +2468,18 @@ It resets the ACP projection before runtime replay.
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, and the deployed
 cold Chromium ACP plus REST rollback matrix remain.
+
+---
+
+### 2026-07-25 — session `false-load-older` (claim)
+
+Claimed the user-reported false `Load older messages` control on a one-turn
+session. The investigation will verify the runtime pagination response before
+changing the SDK contract. The implementation will follow RED -> GREEN ->
+REFACTOR and preserve all exported names.
+
+Required completion gates are the full SDK typecheck, test suite, packed-install
+smoke, focused web tests, local browser proof, repository merge, Deploy Dev, and
+deployed browser proof.
+
+**Status:** IN PROGRESS.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -824,6 +824,46 @@ REFACTOR and finish on the full typecheck, test, and packed-install smoke gates.
 
 **Status:** IN PROGRESS.
 
+---
+
+### 2026-07-25 — session `false-load-older` (local completion)
+
+OpenCode paginates raw messages in groups of 10. The reported dev session has
+one user message and 43 assistant messages in one logical turn. The initial page
+contained 10 assistant messages and an `x-next-cursor` header. The user message
+was on page 5.
+
+The controller now follows assistant-only pages during the initial load until
+every assistant parent user message is present. It hydrates the complete newest
+turn once in chronological order. It exposes `hasOlder` only when the completed
+turn has an earlier cursor.
+
+Implementation commit: `b759cca6bad8548b54ec3ab80d105f162a1f497d`.
+
+**RED evidence:**
+
+- The focused controller suite reported **13 pass / 1 fail**.
+- The new test expected three page requests. The controller made one request.
+
+**Verification:**
+
+- Focused controller suite: **14 pass / 0 fail** with 32 assertions.
+- SDK typecheck and example typecheck: exit 0.
+- SDK full suite: **1249 pass / 2 skip / 0 fail** across 104 files with 5589
+  assertions.
+- SDK packed-install smoke: pass.
+- Exact dev-session probe: 5 HTTP `200` page requests, 44 hydrated messages,
+  1 user message, 43 assistant messages, and `hasOlder: false`.
+- `git diff --check`: exit 0.
+
+The browser runtime returned `No browser is available` and `[]`. Local and
+deployed DOM proof remains open.
+
+**Status:** IMPLEMENTATION COMPLETE.
+
+**Shippable to production: NOT YET.** PR merge, Deploy Dev, and deployed proof
+remain.
+
 ### 2026-07-13 — session `gateway-routing-ui` (completion)
 
 Completed the additive project LLM routing-policy SDK surface: typed whole-document

--- a/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
@@ -149,6 +149,66 @@ describe('SessionSyncController', () => {
     expect(controller.getSnapshot().hasOlder).toBe(false);
   });
 
+  test('loads the complete newest turn before exposing older pagination', async () => {
+    const requests: Array<{ limit: number; before?: string }> = [];
+    const hydrated: string[][] = [];
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async (request) => {
+        requests.push(request);
+        if (!request.before) {
+          return messagePage(
+            [
+              { id: 'assistant-new-3', role: 'assistant', parentID: 'user-only' },
+              { id: 'assistant-new-4', role: 'assistant', parentID: 'user-only' },
+            ],
+            'cursor-1',
+          );
+        }
+        if (request.before === 'cursor-1') {
+          return messagePage(
+            [
+              { id: 'assistant-new-1', role: 'assistant', parentID: 'user-only' },
+              { id: 'assistant-new-2', role: 'assistant', parentID: 'user-only' },
+            ],
+            'cursor-2',
+          );
+        }
+        return messagePage(
+          [
+            { id: 'user-only', role: 'user' },
+            { id: 'assistant-new-0', role: 'assistant', parentID: 'user-only' },
+          ],
+          undefined,
+        );
+      },
+      hydrate: (messages) => hydrated.push(messages.map((message) => message.info.id)),
+      markLoaded: () => {},
+    });
+
+    await controller.start();
+
+    expect(requests).toEqual([
+      { limit: 10 },
+      { limit: 10, before: 'cursor-1' },
+      { limit: 10, before: 'cursor-2' },
+    ]);
+    expect(hydrated).toEqual([
+      [
+        'user-only',
+        'assistant-new-0',
+        'assistant-new-1',
+        'assistant-new-2',
+        'assistant-new-3',
+        'assistant-new-4',
+      ],
+    ]);
+    expect(controller.getSnapshot()).toMatchObject({
+      freshness: 'fresh',
+      hasOlder: false,
+    });
+  });
+
   test('loads through assistant-only pages until the parent user turn is complete', async () => {
     const requests: Array<{ limit: number; before?: string }> = [];
     const hydrated: string[][] = [];

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -269,7 +269,8 @@ export class SessionSyncController {
 
   private async loadTail(reason: SessionSyncReason): Promise<void> {
     try {
-      const page = await this.loadPage('tail', reason);
+      const firstPage = await this.loadPage('tail', reason);
+      const page = await this.loadCompleteTurn(firstPage, 'tail', reason);
       if (this.destroyed) return;
       this.rememberUserMessages(page.messages);
       this.options.hydrate(page.messages);
@@ -318,13 +319,41 @@ export class SessionSyncController {
   }
 
   private async loadCompleteOlderTurn(before: string): Promise<SessionSyncPage> {
-    const messages: SessionSyncMessage[] = [];
-    const knownUserMessageIds = new Set(this.knownUserMessageIds);
-    const seenCursors = new Set([before]);
-    let cursor: string | undefined = before;
+    const firstPage = await this.loadPage('older', 'manual', before);
+    return this.loadCompleteTurn(firstPage, 'older', 'manual', before);
+  }
 
-    while (cursor) {
-      const page = await this.loadPage('older', 'manual', cursor);
+  private async loadCompleteTurn(
+    firstPage: SessionSyncPage,
+    operation: 'tail' | 'older',
+    reason: SessionSyncReason,
+    initialCursor?: string,
+  ): Promise<SessionSyncPage> {
+    const messages = [...firstPage.messages];
+    const knownUserMessageIds = new Set(this.knownUserMessageIds);
+    const seenCursors = new Set(initialCursor ? [initialCursor] : []);
+    let cursor = firstPage.nextCursor;
+
+    for (const message of firstPage.messages) {
+      if (message.info.role === 'user') {
+        knownUserMessageIds.add(message.info.id);
+      }
+    }
+
+    while (
+      cursor &&
+      messages.some(
+        (message) =>
+          message.info.role === 'assistant' &&
+          Boolean(message.info.parentID) &&
+          !knownUserMessageIds.has(message.info.parentID!),
+      )
+    ) {
+      if (seenCursors.has(cursor)) {
+        throw new Error(`Session history cursor repeated: ${cursor}`);
+      }
+      seenCursors.add(cursor);
+      const page = await this.loadPage(operation, reason, cursor);
       messages.unshift(...page.messages);
       for (const message of page.messages) {
         if (message.info.role === 'user') {
@@ -333,17 +362,6 @@ export class SessionSyncController {
       }
 
       cursor = page.nextCursor;
-      const hasUnresolvedParent = messages.some(
-        (message) =>
-          message.info.role === 'assistant' &&
-          Boolean(message.info.parentID) &&
-          !knownUserMessageIds.has(message.info.parentID!),
-      );
-      if (!hasUnresolvedParent || !cursor) break;
-      if (seenCursors.has(cursor)) {
-        throw new Error(`Session history cursor repeated: ${cursor}`);
-      }
-      seenCursors.add(cursor);
     }
 
     return { messages, nextCursor: cursor };


### PR DESCRIPTION
## Summary

- Complete the newest logical turn during initial session synchronization.
- Follow assistant-only OpenCode pages until each parent user message is loaded.
- Expose `hasOlder` only when a cursor remains before the completed turn.

## Root cause

OpenCode paginates raw messages in groups of 10. The reported session contains 1 user message and 43 assistant messages in one turn. The initial page contained only assistant messages. The user message was on page 5. The controller treated the raw page cursor as an older logical turn.

## Verification

- RED: focused controller suite reported 13 pass and 1 fail.
- GREEN: focused controller suite reported 14 pass and 0 fail.
- `pnpm --filter @kortix/sdk typecheck`: exit 0.
- `pnpm --filter @kortix/sdk test`: 1249 pass, 2 skip, 0 fail.
- `pnpm --filter @kortix/sdk run smoke:install`: pass.
- Exact dev-session probe: 5 HTTP 200 pages, 44 messages, 1 user, 43 assistant, `hasOlder: false`.
- `git diff --check`: exit 0.

## Browser status

The browser runtime returned `No browser is available` and an empty browser list. Deployed DOM proof remains open.