### PR TITLE
fix(web): clarify LLM provider connection flow

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/api-key-connect-form.tsx
@@ -34,7 +34,7 @@ export function ApiKeyConnectForm({
   projectId: string;
   provider: LlmProviderEntry;
   onBack: () => void;
-  onConnected: () => void;
+  onConnected: (providerId: string) => void;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -56,7 +56,7 @@ export function ApiKeyConnectForm({
       successToast(`${provider.label} connected`);
       queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
       refreshProjectProviderState(queryClient, projectId, { expectProviderId: provider.id });
-      onConnected();
+      onConnected(provider.id);
     },
     onError: (err) => setError(err instanceof Error ? err.message : 'Failed to save credentials'),
   });

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/catalog-tab.tsx
@@ -35,6 +35,7 @@ export function CatalogTab({
   search,
   subview,
   setSubview,
+  onProviderConnected,
   canWrite = false,
 }: {
   projectId: string;
@@ -42,6 +43,7 @@ export function CatalogTab({
   search: string;
   subview: CatalogSubview;
   setSubview: (next: CatalogSubview) => void;
+  onProviderConnected: (providerId: string) => void;
   canWrite?: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
@@ -91,7 +93,10 @@ export function CatalogTab({
         projectId={projectId}
         provider={provider}
         onBack={() => setSubview({ kind: 'detail', providerId: provider.id })}
-        onConnected={() => setSubview({ kind: 'list' })}
+        onConnected={(providerId) => {
+          setSubview({ kind: 'list' });
+          onProviderConnected(providerId);
+        }}
       />
     );
   }

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -23,7 +23,7 @@ export function ChatGptSubscriptionConnect({
   onConnected,
 }: {
   projectId: string;
-  onConnected: () => void;
+  onConnected: (providerId: string) => void;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const queryClient = useQueryClient();
@@ -75,7 +75,7 @@ export function ChatGptSubscriptionConnect({
           successToast('ChatGPT subscription connected to this project');
           queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
           refreshProjectProviderState(queryClient, projectId, { expectProviderId: 'codex' });
-          onConnected();
+          onConnected('codex');
           return;
         }
         if (res.status === 'failed') {

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const modalSource = readFileSync(join(import.meta.dir, 'llm-provider-modal.tsx'), 'utf8');
+
+describe('LLM provider modal flow', () => {
+  test('orders Add provider before Connected and Models', () => {
+    const catalog = modalSource.indexOf('<TabsTrigger value="catalog"');
+    const connected = modalSource.indexOf('<TabsTrigger value="connected"');
+    const models = modalSource.indexOf('<TabsTrigger value="models"');
+
+    expect(catalog).toBeGreaterThan(-1);
+    expect(connected).toBeGreaterThan(catalog);
+    expect(models).toBeGreaterThan(connected);
+  });
+
+  test('renders pending and query-refresh loading states with the shared Loading component', () => {
+    expect(modalSource).toContain('pendingProviderId &&');
+    expect(modalSource).toContain('secretsQuery.isLoading || secretsQuery.isFetching');
+    expect(modalSource).toContain('Connecting {pendingProviderLabel}…');
+    expect(modalSource).toContain('<Loading');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -15,6 +15,8 @@ import {
   ModalTitle,
 } from '@/components/ui/modal';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { warningToast } from '@/components/ui/toast';
+import { LLM_PROVIDER_BY_ID } from '@/lib/llm-providers';
 import { cn } from '@/lib/utils';
 import { Search } from '@mynaui/icons-react';
 import { useTranslations } from 'next-intl';
@@ -27,6 +29,8 @@ import { useConnectedProviders } from './use-connected-providers';
 import { pickInitialTab } from './utils';
 
 export type { ProjectProviderModalProps } from './types';
+
+const CONNECTION_REFRESH_TIMEOUT_MS = 45_000;
 
 export function ProjectProviderModal({
   projectId,
@@ -60,9 +64,17 @@ export function ProjectProviderModal({
   );
   const [subview, setSubview] = useState<CatalogSubview>({ kind: 'list' });
   const [search, setSearch] = useState('');
+  const [pendingProviderId, setPendingProviderId] = useState<string | null>(null);
+
+  const switchTab = useCallback((next: ActiveTab) => {
+    setActiveTab(next);
+    setSubview({ kind: 'list' });
+    setSearch('');
+  }, []);
 
   useEffect(() => {
     if (open) {
+      setPendingProviderId(null);
       if (initialProviderId && canWrite) {
         setActiveTab(clampTab('catalog'));
         setSubview({ kind: 'connect', providerId: initialProviderId });
@@ -75,13 +87,31 @@ export function ProjectProviderModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, defaultTab]);
 
-  const switchTab = useCallback((next: ActiveTab) => {
-    setActiveTab(next);
-    setSubview({ kind: 'list' });
-    setSearch('');
-  }, []);
+  useEffect(() => {
+    if (!pendingProviderId) return;
 
-  const inSubflow = activeTab === 'catalog' && subview.kind !== 'list';
+    if (connectedProviders.some((provider) => provider.id === pendingProviderId)) {
+      setPendingProviderId(null);
+      switchTab('connected');
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setPendingProviderId(null);
+      warningToast('The key was saved, but the connected provider list did not refresh.');
+    }, CONNECTION_REFRESH_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [connectedProviders, pendingProviderId, switchTab]);
+
+  const inSubflow =
+    activeTab === 'catalog' && (subview.kind !== 'list' || pendingProviderId !== null);
+  const pendingProviderLabel =
+    pendingProviderId === 'codex'
+      ? 'ChatGPT'
+      : pendingProviderId
+        ? (LLM_PROVIDER_BY_ID.get(pendingProviderId)?.label ?? pendingProviderId)
+        : null;
 
   const searchPlaceholder =
     activeTab === 'connected'
@@ -109,16 +139,16 @@ export function ProjectProviderModal({
         >
           {showTabBar && (
             <TabsList className="shrink-0">
-              {showTab('connected') && (
-                <TabsTrigger value="connected" className="text-xs">
-                  Connected
-                </TabsTrigger>
-              )}
               {showTab('catalog') && (
                 <TabsTrigger value="catalog" className="text-xs">
                   {tHardcodedUi.raw(
                     'componentsProjectsProjectProviderModal.line178JsxTextAddProvider',
                   )}
+                </TabsTrigger>
+              )}
+              {showTab('connected') && (
+                <TabsTrigger value="connected" className="text-xs">
+                  Connected
                 </TabsTrigger>
               )}
               {showTab('models') && (
@@ -146,13 +176,33 @@ export function ProjectProviderModal({
       )}
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {secretsQuery.isLoading && (
-          <div className="flex min-h-[200px] items-center justify-center">
+        {pendingProviderId && (
+          <div
+            className="flex min-h-[240px] flex-col items-center justify-center gap-2 px-5 text-center"
+            role="status"
+            aria-live="polite"
+          >
+            <Loading className="text-muted-foreground size-5 shrink-0" />
+            <p className="text-foreground text-sm font-medium">
+              Connecting {pendingProviderLabel}…
+            </p>
+            <p className="text-muted-foreground max-w-xs text-xs text-pretty">
+              Refreshing the provider and model list. This can take a few seconds.
+            </p>
+          </div>
+        )}
+
+        {!pendingProviderId && (secretsQuery.isLoading || secretsQuery.isFetching) && (
+          <div
+            className="flex min-h-[200px] items-center justify-center"
+            role="status"
+            aria-label="Loading providers"
+          >
             <Loading className="text-muted-foreground size-4 shrink-0" />
           </div>
         )}
 
-        {!secretsQuery.isLoading && (
+        {!pendingProviderId && !secretsQuery.isLoading && !secretsQuery.isFetching && (
           <>
             <TabsContent value="connected" className="mt-0">
               <ConnectedTab
@@ -171,6 +221,7 @@ export function ProjectProviderModal({
                 search={search}
                 subview={subview}
                 setSubview={setSubview}
+                onProviderConnected={setPendingProviderId}
                 canWrite={canWrite}
               />
             </TabsContent>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/utils.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/utils.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, test } from 'bun:test';
 
-import { formatPricePerMillion, formatTokenCount, gatewayModelId } from './utils';
+import {
+  formatPricePerMillion,
+  formatTokenCount,
+  gatewayModelId,
+  pickInitialTab,
+} from './utils';
+
+describe('pickInitialTab', () => {
+  test('opens Add provider by default when providers are connected', () => {
+    expect(pickInitialTab(undefined, true)).toBe('catalog');
+  });
+
+  test('opens Add provider by default when no providers are connected', () => {
+    expect(pickInitialTab(undefined, false)).toBe('catalog');
+  });
+
+  test('honors an explicit Connected tab when providers are connected', () => {
+    expect(pickInitialTab('connected', true)).toBe('connected');
+  });
+
+  test('folds unavailable Connected and Models tabs back to Add provider', () => {
+    expect(pickInitialTab('connected', false)).toBe('catalog');
+    expect(pickInitialTab('models', false)).toBe('catalog');
+  });
+});
 
 describe('gatewayModelId', () => {
   test('BYOK provider gets a provider/model wire id', () => {

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/utils.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/utils.ts
@@ -74,7 +74,7 @@ export function pickInitialTab(
   if (defaultTab === 'catalog') return 'catalog';
   if (defaultTab === 'connected') return hasConnections ? 'connected' : 'catalog';
   if (defaultTab === 'models') return hasConnections ? 'models' : 'catalog';
-  return hasConnections ? 'connected' : 'catalog';
+  return 'catalog';
 }
 
 export function helpHostnameFromUrl(helpUrl: string | null): string | null {


### PR DESCRIPTION
## Summary
- open LLM provider management on Add provider by default
- order tabs as Add provider, Connected, Models
- keep a visible loading state until a new provider appears in connected state
- switch to Connected after provider state converges
- show query refresh loading and a 45-second stale-state warning

## Verification
- `bun test apps/web/src/features/workspace/customize/sections/llm-provider` — 18 pass, 0 fail
- `pnpm exec eslint <7 changed files>` — 0 findings
- `pnpm exec tsc --noEmit --pretty false` — 0 changed-file diagnostics
- `GET http://localhost:16500` — 200
- `GET http://localhost:16508/v1/health` — 200

## Browser verification
- Blocked locally because the browser runtime reports 0 available backends.
- Dev UI verification will remain open after deployment.