### PR TITLE
Fix trigger scheduler fleet scans

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -467,10 +467,14 @@ const triggerDbMock: any = {
               const idx = runtimeRows.findIndex(
                 (r) => r.projectId === values.projectId && r.slug === values.slug,
               );
+              const existing = idx >= 0 ? runtimeRows[idx] : undefined;
               const next = {
                 projectId: values.projectId,
                 slug: values.slug,
-                lastFiredAt: (set.lastFiredAt ?? values.lastFiredAt) as Date | null,
+                lastFiredAt: (set.lastFiredAt ??
+                  values.lastFiredAt ??
+                  existing?.lastFiredAt ??
+                  null) as Date | null,
                 updatedAt: (set.updatedAt ?? values.updatedAt ?? new Date()) as Date,
               };
               if (idx >= 0) runtimeRows[idx] = next;
@@ -647,6 +651,9 @@ describe('git-backed triggers — CRUD', () => {
       enabled: true,
       agent: 'default',
     });
+    expect(runtimeRows).toHaveLength(1);
+    expect(runtimeRows[0]!.slug).toBe('daily-digest');
+    expect(runtimeRows[0]!.lastFiredAt).toBeNull();
   });
 
   test('POST /triggers commits a webhook trigger and exposes the URL on listing', async () => {
@@ -753,6 +760,26 @@ describe('git-backed triggers — CRUD', () => {
     expect(body.triggers[0].slug).toBe('good');
     expect(body.errors).toHaveLength(1);
     expect(body.errors[0].slug).toBe('broken');
+  });
+
+  test('GET /triggers preserves runtime rows when the manifest is not parseable', async () => {
+    repoFiles.set(MANIFEST_PATH, 'kortix_version: [invalid');
+    runtimeRows.push({
+      projectId: PROJECT_ID,
+      slug: 'existing',
+      lastFiredAt: null,
+      updatedAt: new Date('2026-01-03T12:00:00Z'),
+    });
+
+    const app = createApp();
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.triggers).toEqual([]);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0].slug).toBe('(manifest)');
+    expect(runtimeRows.map((row) => row.slug)).toEqual(['existing']);
   });
 
   test('PATCH /triggers/:slug rewrites the manifest entry with the merged spec', async () => {

--- a/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { isSweepStale, withTimeout } from '../projects/lib/triggers';
+import { isSweepStale, mapWithConcurrency, withTimeout } from '../projects/lib/triggers';
 
 // These primitives are what keep one hung trigger fire from freezing the entire
 // cron scheduler — the 2026-06-21 fleet-wide outage, where a single
@@ -13,7 +13,9 @@ describe('withTimeout', () => {
 
   test('rejects with a labelled timeout error when the promise hangs past ms', async () => {
     const hang = new Promise<never>(() => {}); // never settles — models a hung fire
-    await expect(withTimeout(hang, 20, 'stuck fire')).rejects.toThrow(/stuck fire timed out after 20ms/);
+    await expect(withTimeout(hang, 20, 'stuck fire')).rejects.toThrow(
+      /stuck fire timed out after 20ms/,
+    );
   });
 
   test('a slow-but-completing promise still resolves (no false timeout)', async () => {
@@ -33,13 +35,25 @@ describe('isSweepStale (scheduler stall detection)', () => {
 
   test('never stale when this pod is not the leader', () => {
     expect(
-      isSweepStale({ isLeader: false, lastSweepStartedAt: null, lastSweepCompletedAt: null, nowMs: T0, staleMs: STALE }),
+      isSweepStale({
+        isLeader: false,
+        lastSweepStartedAt: null,
+        lastSweepCompletedAt: null,
+        nowMs: T0,
+        staleMs: STALE,
+      }),
     ).toBe(false);
   });
 
   test('grace: leader but the scheduler has not ticked yet (no start) → not stale', () => {
     expect(
-      isSweepStale({ isLeader: true, lastSweepStartedAt: null, lastSweepCompletedAt: null, nowMs: T0, staleMs: STALE }),
+      isSweepStale({
+        isLeader: true,
+        lastSweepStartedAt: null,
+        lastSweepCompletedAt: null,
+        nowMs: T0,
+        staleMs: STALE,
+      }),
     ).toBe(false);
   });
 
@@ -92,5 +106,41 @@ describe('isSweepStale (scheduler stall detection)', () => {
         staleMs: STALE,
       }),
     ).toBe(true);
+  });
+});
+
+describe('mapWithConcurrency', () => {
+  test('processes every item without exceeding the configured worker count', async () => {
+    let active = 0;
+    let peak = 0;
+
+    const results = await mapWithConcurrency(
+      Array.from({ length: 12 }, (_, index) => index),
+      3,
+      async (index) => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return index * 2;
+      },
+    );
+
+    expect(peak).toBe(3);
+    expect(results).toEqual(Array.from({ length: 12 }, (_, index) => index * 2));
+  });
+
+  test('uses one worker when the configured count is invalid', async () => {
+    let active = 0;
+    let peak = 0;
+
+    await mapWithConcurrency([1, 2, 3], 0, async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+    });
+
+    expect(peak).toBe(1);
   });
 });

--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -38,6 +38,7 @@ import { deriveWakeWord, resolveProjectBotName } from '../channels/meet-voices';
 import { authorize } from '../iam';
 import { agentMayUseConnector } from '../iam/agent-scope';
 import type { ChannelPlatform } from '../projects/connectors';
+import { invalidateProjectMirror } from '../projects/git';
 import { loadProjectForUser } from '../projects/lib/access';
 import {
   publicConnectorAlias,
@@ -999,8 +1000,10 @@ export const dbExecutorRouterDeps: ExecutorRouterDeps = {
   listConnectors,
   // The manual "Sync" button re-pulls catalogs unconditionally (force) — the
   // user is explicitly asking to refresh, e.g. an MCP server gained new tools.
-  syncConnectors: (projectId, accountId) =>
-    syncProjectConnectors(projectId, accountId, { force: true }),
+  syncConnectors: (projectId, accountId) => {
+    invalidateProjectMirror(projectId);
+    return syncProjectConnectors(projectId, accountId, { force: true });
+  },
   createConnector: (projectId, accountId, draft) =>
     upsertConnectorInManifest(projectId, accountId, draft as unknown as ConnectorDraft),
   deleteConnector: (projectId, slug) => deleteConnectorFromManifest(projectId, slug),

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -23,6 +23,7 @@ import { listAgentMailInstalls, loadSlackInstall } from '../channels/install-sto
 import { resolveExperimentalFeature } from '../experimental/features';
 import { assertAllowedSourceAddress } from '../marketplace/catalog';
 import { safeEgressFetch } from '../shared/ssrf-guard';
+import { configuredTimeoutMs, withTimeout } from '../shared/with-timeout';
 import { config } from '../config';
 import {
   type ConnectorSpec,
@@ -32,7 +33,8 @@ import {
 import { type GitBackedProject, readRepoFile } from '../projects/git';
 import { withProjectGitAuth } from '../projects/index';
 import { extractProjectPolicies } from '../projects/policies';
-import { readManifest } from '../projects/triggers';
+import { extractTriggers, readManifest } from '../projects/triggers';
+import { reconcileProjectTriggerRuntime } from '../projects/trigger-runtime-catalog';
 import { db } from '../shared/db';
 import { ensureChannelConnectorDeclared, removeChannelConnectorDeclared } from './channel-manifest';
 import { synthesizeChannelConnectors } from './channel-materialize';
@@ -65,6 +67,14 @@ import type { HttpRouteSpec, NormalizedAction } from './types';
 export interface SyncResult {
   synced: number;
   errors: Array<{ slug: string; error: string }>;
+}
+
+function connectorAuthTimeoutMs(): number {
+  return configuredTimeoutMs('KORTIX_CONNECTOR_AUTH_TIMEOUT_MS', 15_000, 1_000);
+}
+
+function connectorManifestTimeoutMs(): number {
+  return configuredTimeoutMs('KORTIX_CONNECTOR_MANIFEST_TIMEOUT_MS', 30_000, 1_000);
 }
 
 const EMPTY_AUTH_DISCOVERY: ConnectorAuthDiscovery = {
@@ -237,16 +247,45 @@ export async function syncProjectConnectors(
   if (!row) return { synced: 0, errors: [{ slug: '(project)', error: 'project not found' }] };
   const accountId = row.accountId;
 
-  const gitProject = await withProjectGitAuth(row);
-  const manifest = await readManifest(gitProject).catch(() => null);
+  const errors: SyncResult['errors'] = [];
+  let gitProject: GitBackedProject = row;
+  try {
+    gitProject = await withTimeout(
+      withProjectGitAuth(row),
+      connectorAuthTimeoutMs(),
+      `resolve git auth ${projectId}`,
+    );
+  } catch (error) {
+    errors.push({
+      slug: '(git-auth)',
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  let manifest: Awaited<ReturnType<typeof readManifest>> = null;
+  try {
+    manifest = await withTimeout(
+      readManifest(gitProject),
+      connectorManifestTimeoutMs(),
+      `read manifest ${projectId}`,
+    );
+  } catch (error) {
+    errors.push({
+      slug: '(manifest)',
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   // Manifest-declared connectors + project policies are only reconciled when the
   // kortix.yaml is actually readable. A NULL manifest can mean "no repo / no
   // kortix.yaml" OR a transient git error — either way we must not treat it as
   // "zero declared connectors" and delete the project's real ones below.
-  const errors: SyncResult['errors'] = [];
   let declaredSpecs: ConnectorSpec[] = [];
   if (manifest) {
+    const triggers = extractTriggers(manifest);
+    await reconcileProjectTriggerRuntime(projectId, triggers.specs);
+    errors.push(...triggers.errors.map((e) => ({ slug: e.slug, error: e.error })));
+
     const parsed = extractConnectors(manifest);
     declaredSpecs = parsed.specs;
     errors.push(...parsed.errors.map((e) => ({ slug: e.slug, error: e.error })));

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -1,8 +1,13 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { TriggerList } from '@kortix/api-contract';
-import { projectSessions, projectTriggerRuntime, projects } from '@kortix/db';
+import {
+  executorConnectors,
+  projectSessions,
+  projectTriggerRuntime,
+  projects,
+} from '@kortix/db';
 import { Cron } from 'croner';
-import { and, desc, eq, ne, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, ne, or, sql } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { config } from '../../config';
 import { auth, errors } from '../../openapi';
@@ -22,14 +27,16 @@ import {
   GIT_TRIGGER_SESSION_MODES,
   type GitTriggerSessionMode,
   type GitTriggerSpec,
+  type LoadedTriggers,
   MANIFEST_FILENAME,
   type ParsedManifest,
-  loadProjectTriggers,
+  extractTriggers,
   readManifest,
   serializeManifest,
   synthesizeBlankManifest,
   triggerSpecToTomlEntry,
 } from '../triggers';
+import { reconcileProjectTriggerRuntime } from '../trigger-runtime-catalog';
 import { parseGitHubRepoUrl, resolveProjectGitAuth, withProjectGitAuth } from './git';
 import {
   type ProjectRow,
@@ -163,10 +170,6 @@ export const globalForProjectTriggers = globalThis as typeof globalThis & {
 export let triggerSchedulerTimer: TriggerSchedulerTimer | null = null;
 
 export let triggerSweepRunning = false;
-// When the in-flight sweep started (epoch ms). Used to reclaim a stuck guard if
-// a sweep hangs past its hard cap, so a single frozen pass can't wedge the
-// scheduler forever (root cause of the 2026-06-21 fleet-wide cron outage).
-export let triggerSweepStartedMs = 0;
 
 // In-memory heartbeat for the trigger scheduler, surfaced at /health so an
 // operator can tell at a glance whether the leader's sweep is alive and what
@@ -177,6 +180,8 @@ export interface TriggerSchedulerHealth {
   lastSweepCompletedAt: string | null;
   lastSweepDurationMs: number | null;
   lastResult: {
+    projects: number;
+    projectFailures: number;
     scanned: number;
     fired: number;
     queued: number;
@@ -214,17 +219,41 @@ export function triggerLoadTimeoutMs(): number {
   const raw = Number(process.env.KORTIX_TRIGGER_LOAD_TIMEOUT_MS);
   return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 30_000;
 }
-/** Hard cap on a whole sweep pass — backstop so nothing can wedge the guard. */
-export function triggerSweepTimeoutMs(): number {
-  // GENEROUS backstop, not a routine cap. A full sweep loads every active
-  // project's manifest sequentially (~1.7k projects → ~11min/pass observed), and
-  // the per-fire/per-load timeouts already guarantee no single op hangs forever.
-  // A short cap here would GUILLOTINE a legit long sweep and drop cron coverage
-  // for projects late in the pass (a 4min cap reached only ~10 of ~39 due
-  // triggers). Keep this well above a real sweep so it only fires on a true hang
-  // not bounded by the per-op timeouts (e.g. a wedged DB call); tune via env.
-  const raw = Number(process.env.KORTIX_TRIGGER_SWEEP_TIMEOUT_MS);
-  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 20 * 60_000;
+
+/** Hard cap on resolving git credentials for one project. */
+export function triggerAuthTimeoutMs(): number {
+  const raw = Number(process.env.KORTIX_TRIGGER_AUTH_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 15_000;
+}
+
+/** Number of projects whose trigger manifests can load in parallel. */
+export function triggerProjectConcurrency(): number {
+  const raw = Number(process.env.KORTIX_TRIGGER_PROJECT_CONCURRENCY);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 8;
+}
+
+/** Number of project manifests the connector reconciler processes in parallel. */
+export function connectorProjectConcurrency(): number {
+  const raw = Number(process.env.KORTIX_CONNECTOR_PROJECT_CONCURRENCY);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 6;
+}
+
+/** Maximum wall time for one connector reconciliation. */
+export function connectorProjectTimeoutMs(): number {
+  const raw = Number(process.env.KORTIX_CONNECTOR_PROJECT_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 120_000;
+}
+
+/** Rotating raw-git discovery batch size. */
+export function manifestDiscoveryBatchSize(): number {
+  const raw = Number(process.env.KORTIX_MANIFEST_DISCOVERY_BATCH_SIZE);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 50;
+}
+
+/** Known manifest projects reconciled per connector sweep. */
+export function manifestCatalogBatchSize(): number {
+  const raw = Number(process.env.KORTIX_MANIFEST_CATALOG_BATCH_SIZE);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 100;
 }
 
 /**
@@ -244,6 +273,36 @@ export async function withTimeout<T>(p: Promise<T>, ms: number, label: string): 
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+/**
+ * Map all items through a bounded worker pool.
+ *
+ * The output order matches the input order.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  configuredConcurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const concurrency = Math.max(
+    1,
+    Math.min(items.length, Math.floor(configuredConcurrency) || 1),
+  );
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const runWorker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index]!, index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, () => runWorker()));
+  return results;
 }
 
 /**
@@ -276,12 +335,7 @@ export function isSweepStale(opts: {
 }
 
 function schedulerStaleMs(): number {
-  // Generous: several intervals OR one full sweep-timeout window, whichever is
-  // larger, so we never false-alarm on a legitimately long (but completing) pass.
-  return Math.max(
-    5 * triggerSchedulerIntervalMs(),
-    triggerSweepTimeoutMs() + triggerSchedulerIntervalMs(),
-  );
+  return Math.max(5 * triggerSchedulerIntervalMs(), 5 * 60_000);
 }
 
 /** Is the leader's trigger sweep stalled right now? (Wraps the pure check.) */
@@ -339,47 +393,51 @@ export function withTriggersPaused(metadata: unknown, paused: boolean): Record<s
 }
 
 /**
- * Walks every active project's git repo for `.opencode/triggers/*.md` and
- * fires due cron triggers. Triggers are 100% file-defined now (kortix.yaml,
- * or kortix.toml for a legacy v1 project); the old DB-backed trigger tables
- * have been removed.
+ * Loads cataloged trigger projects and fires due cron triggers.
+ *
+ * Trigger configuration stays in git. The runtime table is the project catalog
+ * and the last-fire state store.
  */
 
 export async function runProjectTriggerSweep(now = new Date()): Promise<{
+  projects: number;
+  projectFailures: number;
   scanned: number;
   fired: number;
   queued: number;
   failed: number;
   skipped: number;
 }> {
-  // In-flight guard with SELF-HEAL: a sweep that hangs past the hard cap must
-  // not freeze the scheduler forever. If the guard is held but the running sweep
-  // is older than its timeout, reclaim it so this tick starts a fresh pass.
   if (triggerSweepRunning) {
-    if (Date.now() - triggerSweepStartedMs < triggerSweepTimeoutMs()) {
-      return { scanned: 0, fired: 0, queued: 0, failed: 0, skipped: 0 };
-    }
-    console.error(
-      `[project-triggers] reclaiming stuck sweep guard — previous sweep exceeded ${triggerSweepTimeoutMs()}ms without completing (self-heal)`,
-    );
+    return {
+      projects: 0,
+      projectFailures: 0,
+      scanned: 0,
+      fired: 0,
+      queued: 0,
+      failed: 0,
+      skipped: 0,
+    };
   }
   triggerSweepRunning = true;
   const startedMs = Date.now();
-  triggerSweepStartedMs = startedMs;
   schedulerHealth.lastSweepStartedAt = now.toISOString();
-  const result = { scanned: 0, fired: 0, queued: 0, failed: 0, skipped: 0 };
+  const result = {
+    projects: 0,
+    projectFailures: 0,
+    scanned: 0,
+    fired: 0,
+    queued: 0,
+    failed: 0,
+    skipped: 0,
+  };
+  let status: 'completed' | 'failed' = 'completed';
   try {
-    // Overall hard cap so a hang anywhere (project scan, mirror load, fire) can
-    // never block the guard indefinitely. The per-item timeouts inside the sweep
-    // keep one bad project/trigger from starving the rest within a single pass.
-    await withTimeout(
-      runGitTriggerSweep(now, result),
-      triggerSweepTimeoutMs(),
-      'project trigger sweep',
-    );
+    await runGitTriggerSweep(now, result);
     schedulerHealth.lastError = null;
     return result;
   } catch (err) {
+    status = 'failed';
     schedulerHealth.lastError = err instanceof Error ? err.message : String(err);
     console.error('[project-triggers/git] sweep failed', err);
     return result;
@@ -388,39 +446,99 @@ export async function runProjectTriggerSweep(now = new Date()): Promise<{
     schedulerHealth.lastSweepDurationMs = Date.now() - startedMs;
     schedulerHealth.lastResult = result;
     triggerSweepRunning = false;
+    console.log('[project-triggers] sweep completed', {
+      status,
+      durationMs: schedulerHealth.lastSweepDurationMs,
+      ...result,
+      error: schedulerHealth.lastError,
+    });
   }
 }
 
 /**
- * Reconcile every active project's connector DB cache against its kortix.yaml.
- * This is the reliability backstop for connectors: the UI CRUD path and the
- * CR-merge hook reconcile inline, but a raw `git push` / `kortix` CLI edit that
- * bypasses both is only caught here. We invalidate the git mirror per project
- * so an out-of-band manifest edit is seen this sweep (not up to a minute later,
- * behind the mirror refresh throttle). `syncProjectConnectors` is hash-aware,
- * so unchanged connectors cost a manifest read, not a catalog re-fetch.
+ * Reconcile bounded, rotating batches of manifest projects.
+ *
+ * UI CRUD and `kortix ship` reconcile inline. The discovery batch catches raw
+ * git pushes. The catalog batch refreshes known trigger and connector projects.
  */
 
+/** Select only active projects that have at least one trigger catalog row. */
+async function selectTriggerCatalogProjects(): Promise<ProjectRow[]> {
+  return db
+    .select()
+    .from(projects)
+    .where(
+      and(
+        eq(projects.status, 'active'),
+        sql`exists (
+          select 1
+          from ${projectTriggerRuntime}
+          where ${projectTriggerRuntime.projectId} = ${projects.projectId}
+        )`,
+      ),
+    )
+    .orderBy(projects.projectId);
+}
+
+let manifestCatalogCursor: string | null = null;
+
+/** Select one keyset-paginated batch of known trigger or connector projects. */
+async function selectManifestCatalogProjects(): Promise<ProjectRow[]> {
+  const limit = manifestCatalogBatchSize();
+  const catalogPredicate = or(
+    sql`exists (
+      select 1
+      from ${projectTriggerRuntime}
+      where ${projectTriggerRuntime.projectId} = ${projects.projectId}
+    )`,
+    sql`exists (
+      select 1
+      from ${executorConnectors}
+      where ${executorConnectors.projectId} = ${projects.projectId}
+    )`,
+  );
+  const rows = await db
+    .select()
+    .from(projects)
+    .where(
+      and(
+        eq(projects.status, 'active'),
+        manifestCatalogCursor ? gt(projects.projectId, manifestCatalogCursor) : undefined,
+        catalogPredicate,
+      ),
+    )
+    .orderBy(projects.projectId)
+    .limit(limit);
+
+  manifestCatalogCursor =
+    rows.length < limit ? null : (rows.at(-1)?.projectId ?? null);
+  return rows;
+}
+
+let manifestDiscoveryCursor: string | null = null;
+
 /**
- * Page through EVERY active project. The sweeps used to `LIMIT 200`, which
- * silently dropped every active project past the 200th once the platform grew
- * beyond that many — their triggers / connectors just never ran, with no error
- * and no log. Paging keeps coverage complete while bounding each query.
+ * Select one keyset-paginated batch for raw git pushes.
+ *
+ * CRUD and `kortix ship` reconcile immediately. This rotating batch is the
+ * backstop for pushes that bypass both paths.
  */
-async function selectActiveProjects(pageSize = 500): Promise<ProjectRow[]> {
-  const all: ProjectRow[] = [];
-  for (let offset = 0; ; offset += pageSize) {
-    const batch = await db
-      .select()
-      .from(projects)
-      .where(eq(projects.status, 'active'))
-      .orderBy(projects.projectId)
-      .limit(pageSize)
-      .offset(offset);
-    all.push(...batch);
-    if (batch.length < pageSize) break;
-  }
-  return all;
+async function selectManifestDiscoveryProjects(): Promise<ProjectRow[]> {
+  const limit = manifestDiscoveryBatchSize();
+  const rows = await db
+    .select()
+    .from(projects)
+    .where(
+      manifestDiscoveryCursor
+        ? and(eq(projects.status, 'active'), gt(projects.projectId, manifestDiscoveryCursor))
+        : eq(projects.status, 'active'),
+    )
+    .orderBy(projects.projectId)
+    .limit(limit);
+
+  manifestDiscoveryCursor =
+    rows.length < limit ? null : (rows.at(-1)?.projectId ?? null);
+  return rows;
 }
 
 export async function runProjectConnectorSweep(): Promise<{
@@ -430,29 +548,64 @@ export async function runProjectConnectorSweep(): Promise<{
 }> {
   if (connectorSweepRunning) return { scanned: 0, synced: 0, errors: 0 };
   connectorSweepRunning = true;
+  const startedMs = Date.now();
   const out = { scanned: 0, synced: 0, errors: 0 };
+  let status: 'completed' | 'failed' = 'completed';
   try {
     const { syncProjectConnectors } = await import('../../executor/sync');
-    const projectsForSweep = await selectActiveProjects();
-    for (const project of projectsForSweep) {
-      out.scanned += 1;
-      try {
-        invalidateProjectMirror(project.projectId);
-        const res = await syncProjectConnectors(project.projectId, project.accountId);
-        out.synced += res.synced;
-        out.errors += res.errors.length;
-      } catch (err) {
-        out.errors += 1;
-        console.warn(
-          '[project-connectors] sweep failed',
-          project.projectId,
-          err instanceof Error ? err.message : err,
-        );
-      }
+    const [catalogProjects, discoveryProjects] = await Promise.all([
+      selectManifestCatalogProjects(),
+      selectManifestDiscoveryProjects(),
+    ]);
+    const uniqueProjects = new Map<string, ProjectRow>();
+    for (const project of [...catalogProjects, ...discoveryProjects]) {
+      uniqueProjects.set(project.projectId, project);
     }
+    const projectsForSweep = [...uniqueProjects.values()];
+
+    const results = await mapWithConcurrency(
+      projectsForSweep,
+      connectorProjectConcurrency(),
+      async (project) => {
+        invalidateProjectMirror(project.projectId);
+        try {
+          const result = await withTimeout(
+            syncProjectConnectors(project.projectId, project.accountId),
+            connectorProjectTimeoutMs(),
+            `sync connectors ${project.projectId}`,
+          );
+          return { synced: result.synced, errors: result.errors.length };
+        } catch (error) {
+          console.warn('[project-connectors] project reconcile failed', {
+            projectId: project.projectId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return { synced: 0, errors: 1 };
+        }
+      },
+    );
+    out.scanned = projectsForSweep.length;
+    for (const result of results) {
+      out.synced += result.synced;
+      out.errors += result.errors;
+    }
+    return out;
+  } catch (error) {
+    status = 'failed';
+    out.errors += 1;
+    console.error('[project-connectors] sweep failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return out;
   } finally {
     connectorSweepRunning = false;
+    console.log('[project-connectors] sweep completed', {
+      status,
+      durationMs: Date.now() - startedMs,
+      ...out,
+      catalogCursor: manifestCatalogCursor,
+      discoveryCursor: manifestDiscoveryCursor,
+    });
   }
 }
 
@@ -960,6 +1113,8 @@ export function summarizeTriggerPayload(payload: Record<string, unknown>): Recor
 export async function runGitTriggerSweep(
   now: Date,
   accumulator: {
+    projects: number;
+    projectFailures: number;
     scanned: number;
     fired: number;
     queued: number;
@@ -967,119 +1122,166 @@ export async function runGitTriggerSweep(
     skipped: number;
   },
 ): Promise<void> {
-  const projectsForSweep = await selectActiveProjects();
+  const projectsForSweep = await selectTriggerCatalogProjects();
+  const results = await mapWithConcurrency(
+    projectsForSweep,
+    triggerProjectConcurrency(),
+    (project) => runGitTriggerProject(project, now),
+  );
 
-  for (const project of projectsForSweep) {
-    // Server-side per-project kill-switch — skip the whole project (no manifest
-    // read, no session spin) when its triggers are paused, so a repo deployed
-    // to two control planes only fires on the un-paused one. See
-    // triggersPausedForProject.
-    if (triggersPausedForProject(project.metadata)) continue;
-    let specs: GitTriggerSpec[];
-    try {
-      // Time-bound the mirror load: a hung clone/fetch for one project must not
-      // stall the sweep for everyone else.
-      const loaded = await withTimeout(
-        loadProjectTriggers(await withProjectGitAuth(project)),
-        triggerLoadTimeoutMs(),
-        `load triggers ${project.projectId}`,
-      );
-      specs = loaded.specs;
-      // Surface parse errors instead of dropping them: record each bad entry
-      // against its slug so it shows up in the triggers API/UI, and log it.
-      // Previously a malformed `[[triggers]]` entry just vanished from the
-      // sweep with zero feedback — a prime "my trigger isn't running" trap.
-      for (const e of loaded.errors) {
-        console.warn('[project-triggers/git] parse error', project.projectId, e.slug, e.error);
+  for (const result of results) {
+    accumulator.projects += 1;
+    accumulator.projectFailures += result.projectFailures;
+    accumulator.scanned += result.scanned;
+    accumulator.fired += result.fired;
+    accumulator.queued += result.queued;
+    accumulator.failed += result.failed;
+    accumulator.skipped += result.skipped;
+  }
+}
+
+export async function runGitTriggerProject(
+  project: ProjectRow,
+  now: Date,
+): Promise<{
+  projectFailures: number;
+  scanned: number;
+  fired: number;
+  queued: number;
+  failed: number;
+  skipped: number;
+}> {
+  const out = {
+    projectFailures: 0,
+    scanned: 0,
+    fired: 0,
+    queued: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  if (triggersPausedForProject(project.metadata)) return out;
+
+  let specs: GitTriggerSpec[];
+  try {
+    const gitProject = await withTimeout(
+      withProjectGitAuth(project),
+      triggerAuthTimeoutMs(),
+      `resolve git auth ${project.projectId}`,
+    );
+    const manifest = await withTimeout(
+      readManifest(gitProject),
+      triggerLoadTimeoutMs(),
+      `load manifest ${project.projectId}`,
+    );
+    if (!manifest) {
+      throw new Error('kortix manifest not found or unreadable');
+    }
+
+    const loaded = extractTriggers(manifest);
+    specs = loaded.specs;
+    await reconcileProjectTriggerRuntime(project.projectId, specs);
+
+    for (const error of loaded.errors) {
+      console.warn('[project-triggers/git] parse error', {
+        projectId: project.projectId,
+        slug: error.slug,
+        error: error.error,
+      });
+      if (/^[a-z0-9][a-z0-9_-]{0,127}$/.test(error.slug)) {
         await markGitTriggerAttemptFailed(
           project.projectId,
-          e.slug,
+          error.slug,
           now,
-          `parse error: ${e.error}`,
+          `parse error: ${error.error}`,
         );
       }
-    } catch (err) {
-      console.warn(
-        '[project-triggers/git] load failed',
-        project.projectId,
-        err instanceof Error ? err.message : err,
-      );
+    }
+  } catch (error) {
+    out.projectFailures = 1;
+    console.warn('[project-triggers/git] manifest load failed', {
+      projectId: project.projectId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return out;
+  }
+
+  const runtimeRows = await db
+    .select()
+    .from(projectTriggerRuntime)
+    .where(eq(projectTriggerRuntime.projectId, project.projectId));
+  const runtimeBySlug = new Map(runtimeRows.map((row) => [row.slug, row]));
+
+  for (const spec of specs) {
+    if (spec.type !== 'cron' || !spec.enabled) continue;
+    out.scanned += 1;
+
+    const lastFired = runtimeBySlug.get(spec.slug)?.lastFiredAt ?? null;
+    if (!isGitCronSpecDue(spec, lastFired, now)) {
+      out.skipped += 1;
       continue;
     }
 
-    for (const spec of specs) {
-      if (spec.type !== 'cron' || !spec.enabled) continue;
-      accumulator.scanned += 1;
+    const payload = {
+      cron: {
+        schedule: spec.cron ?? spec.runAt,
+        timezone: spec.timezone,
+        fired_at: now.toISOString(),
+        last_fired_at: lastFired?.toISOString() ?? null,
+      },
+      trigger: { slug: spec.slug, type: spec.type, kind: 'git' },
+    };
+    const renderedPrompt = renderPromptTemplate(spec.promptTemplate, payload);
+    const scheduledAt = now.toISOString();
+    const dueSlotKey =
+      (spec.cron
+        ? nextCronRun(spec.cron, lastFired ?? new Date(0), spec.timezone)?.toISOString()
+        : spec.runAt) ?? scheduledAt;
 
-      const runtime = await getGitTriggerRuntime(project.projectId, spec.slug);
-      const lastFired = runtime?.lastFiredAt ?? null;
-      if (!isGitCronSpecDue(spec, lastFired, now)) {
-        accumulator.skipped += 1;
-        continue;
-      }
+    let result: Awaited<ReturnType<typeof fireGitTrigger>>;
+    try {
+      result = await withTimeout(
+        fireGitTrigger({
+          spec,
+          project,
+          payload,
+          renderedPrompt,
+          source: 'cron',
+          idempotencyKey: `trigger:cron:${project.projectId}:${spec.slug}:${dueSlotKey}`,
+        }),
+        triggerFireTimeoutMs(),
+        `fire ${spec.slug} ${project.projectId}`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[project-triggers/git] fire failed', {
+        projectId: project.projectId,
+        slug: spec.slug,
+        error: message,
+      });
+      await markGitTriggerAttemptFailed(project.projectId, spec.slug, now, message).catch(() => {});
+      out.failed += 1;
+      continue;
+    }
 
-      const payload = {
-        cron: {
-          schedule: spec.cron ?? spec.runAt,
-          timezone: spec.timezone,
-          fired_at: now.toISOString(),
-          last_fired_at: lastFired?.toISOString() ?? null,
-        },
-        trigger: { slug: spec.slug, type: spec.type, kind: 'git' },
-      };
-      const renderedPrompt = renderPromptTemplate(spec.promptTemplate, payload);
-      const scheduledAt = now.toISOString();
-      // Stable idempotency key per DUE SLOT (the cron boundary that made this
-      // trigger due), not per sweep tick — so a fire we timed out on but that
-      // actually lands late isn't duplicated when the next tick retries.
-      const dueSlotKey =
-        (spec.cron
-          ? nextCronRun(spec.cron, lastFired ?? new Date(0), spec.timezone)?.toISOString()
-          : spec.runAt) ?? scheduledAt;
-
-      let result: Awaited<ReturnType<typeof fireGitTrigger>>;
-      try {
-        // Time-bound the fire (createSession/continueSession). A hung or throwing
-        // fire must NOT abort the sweep or wedge the scheduler: record it
-        // (diagnosable, retries next tick) and move on to the next trigger.
-        result = await withTimeout(
-          fireGitTrigger({
-            spec,
-            project,
-            payload,
-            renderedPrompt,
-            source: 'cron',
-            idempotencyKey: `trigger:cron:${project.projectId}:${spec.slug}:${dueSlotKey}`,
-          }),
-          triggerFireTimeoutMs(),
-          `fire ${spec.slug} ${project.projectId}`,
-        );
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error('[project-triggers/git] fire errored', project.projectId, spec.slug, msg);
-        await markGitTriggerAttemptFailed(project.projectId, spec.slug, now, msg).catch(() => {});
-        accumulator.failed += 1;
-        continue;
-      }
-      if (result.status === 'fired') {
-        await markGitTriggerFired(project.projectId, spec.slug, now, 'fired');
-        accumulator.fired += 1;
-      } else if (result.status === 'queued') {
-        await markGitTriggerFired(project.projectId, spec.slug, now, 'queued');
-        accumulator.queued += 1;
-      } else {
-        // A failed fire is NOT stamped as fired, so it retries next tick — but
-        // we record why so "trigger isn't running" is diagnosable from the API.
-        await markGitTriggerAttemptFailed(
-          project.projectId,
-          spec.slug,
-          now,
-          result.error ?? result.reason ?? 'trigger fire failed',
-        );
-        accumulator.failed += 1;
-      }
+    if (result.status === 'fired') {
+      await markGitTriggerFired(project.projectId, spec.slug, now, 'fired');
+      out.fired += 1;
+    } else if (result.status === 'queued') {
+      await markGitTriggerFired(project.projectId, spec.slug, now, 'queued');
+      out.queued += 1;
+    } else {
+      await markGitTriggerAttemptFailed(
+        project.projectId,
+        spec.slug,
+        now,
+        result.error ?? result.reason ?? 'trigger fire failed',
+      );
+      out.failed += 1;
     }
   }
+
+  return out;
 }
 
 export function startProjectTriggerScheduler(): void {
@@ -1087,12 +1289,10 @@ export function startProjectTriggerScheduler(): void {
   if (globalForProjectTriggers.__kortixProjectTriggerSchedulerTimer) {
     clearInterval(globalForProjectTriggers.__kortixProjectTriggerSchedulerTimer);
   }
-  triggerSchedulerTimer = setInterval(() => {
+  const tick = () => {
     // Watchdog: if we're the leader but the sweep has stalled (started and never
     // completed within the stale window), make it LOUD. A silent dead scheduler
-    // is what turned a single hung fire into an ~18h fleet-wide outage. The
-    // self-heal guard in runProjectTriggerSweep reclaims the stuck sweep on this
-    // same tick; this console.error is the alert signal for log-based monitoring.
+    // is what turned a single hung fire into an ~18h fleet-wide outage.
     if (schedulerSweepIsStale(isLeader())) {
       console.error(
         '[project-triggers] SCHEDULER STALLED — leader but last sweep has not completed',
@@ -1114,11 +1314,6 @@ export function startProjectTriggerScheduler(): void {
       });
 
     runProjectTriggerSweep()
-      .then((result) => {
-        if (result.fired || result.queued || result.failed) {
-          console.log('[project-triggers] sweep completed', result);
-        }
-      })
       .catch((error) => {
         console.error('[project-triggers] sweep failed:', error);
       });
@@ -1129,16 +1324,13 @@ export function startProjectTriggerScheduler(): void {
     if (Date.now() - lastConnectorSweepAt >= connectorSweepIntervalMs()) {
       lastConnectorSweepAt = Date.now();
       runProjectConnectorSweep()
-        .then((result) => {
-          if (result.synced || result.errors) {
-            console.log('[project-connectors] sweep completed', result);
-          }
-        })
         .catch((error) => {
           console.error('[project-connectors] sweep failed:', error);
         });
     }
-  }, triggerSchedulerIntervalMs());
+  };
+  tick();
+  triggerSchedulerTimer = setInterval(tick, triggerSchedulerIntervalMs());
   globalForProjectTriggers.__kortixProjectTriggerSchedulerTimer = triggerSchedulerTimer;
 }
 
@@ -1168,7 +1360,28 @@ export async function loadTriggersForResponse(
   projectId: string,
   project: ProjectRow,
 ): Promise<TriggerList> {
-  const { specs, errors } = await loadProjectTriggers(await withProjectGitAuth(project));
+  const gitProject = await withProjectGitAuth(project);
+  let manifest: ParsedManifest | null = null;
+  let loaded: LoadedTriggers;
+  try {
+    manifest = await readManifest(gitProject);
+    loaded = manifest ? extractTriggers(manifest) : { specs: [], errors: [] };
+  } catch (error) {
+    loaded = {
+      specs: [],
+      errors: [
+        {
+          slug: '(manifest)',
+          path: gitProject.manifestPath || MANIFEST_FILENAME,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
+  }
+  const { specs, errors } = loaded;
+  if (manifest) {
+    await reconcileProjectTriggerRuntime(projectId, specs);
+  }
   const runtimeRows =
     specs.length === 0
       ? []

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -126,6 +126,7 @@ import {
   upsertTriggerInManifest,
 } from '../lib/triggers';
 import { listProjectSecretsSnapshot } from '../secrets';
+import { reconcileProjectTriggerRuntime } from '../trigger-runtime-catalog';
 import { type ParsedManifest, extractTriggers, loadProjectTriggers } from '../triggers';
 
 // Body keys that change the trigger's *repo manifest* (committed to git). A PATCH
@@ -850,6 +851,7 @@ projectsApp.openapi(
     if ('error' in result) {
       return c.json({ error: result.error }, result.status as 400 | 502);
     }
+    await reconcileProjectTriggerRuntime(projectId, extractTriggers(next).specs);
 
     return c.json(await loadTriggersForResponse(projectId, loaded.row), 201);
   },
@@ -1001,6 +1003,7 @@ projectsApp.openapi(
       if ('error' in result) {
         return c.json({ error: result.error }, result.status as 400 | 502);
       }
+      await reconcileProjectTriggerRuntime(projectId, extractTriggers(next).specs);
     }
 
     return c.json(await loadTriggersForResponse(projectId, loaded.row));

--- a/apps/api/src/projects/trigger-runtime-catalog-core.ts
+++ b/apps/api/src/projects/trigger-runtime-catalog-core.ts
@@ -1,0 +1,39 @@
+import type { GitTriggerSpec } from './triggers';
+
+export interface TriggerRuntimeCatalogStore {
+  list(projectId: string): Promise<Array<{ slug: string; sessionId?: string | null }>>;
+  upsert(projectId: string, spec: GitTriggerSpec): Promise<void>;
+  remove(projectId: string, slug: string): Promise<void>;
+}
+
+/**
+ * Reconcile runtime catalog rows from one successfully parsed manifest.
+ *
+ * The caller must not call this function when the manifest is unreadable.
+ * A transient git failure must not delete valid runtime rows.
+ */
+export async function reconcileProjectTriggerRuntimeWithStore(
+  projectId: string,
+  specs: readonly GitTriggerSpec[],
+  store: TriggerRuntimeCatalogStore,
+): Promise<{ upserted: number; removed: number }> {
+  const existing = await store.list(projectId);
+  const existingBySlug = new Map(existing.map((row) => [row.slug, row]));
+  const declaredSlugs = new Set(specs.map((spec) => spec.slug));
+  let upserted = 0;
+
+  for (const spec of specs) {
+    const current = existingBySlug.get(spec.slug);
+    if (!current || (current.sessionId ?? null) !== spec.pinnedSessionId) {
+      await store.upsert(projectId, spec);
+      upserted += 1;
+    }
+  }
+
+  const stale = existing.filter((row) => !declaredSlugs.has(row.slug));
+  for (const row of stale) {
+    await store.remove(projectId, row.slug);
+  }
+
+  return { upserted, removed: stale.length };
+}

--- a/apps/api/src/projects/trigger-runtime-catalog.test.ts
+++ b/apps/api/src/projects/trigger-runtime-catalog.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type TriggerRuntimeCatalogStore,
+  reconcileProjectTriggerRuntimeWithStore,
+} from './trigger-runtime-catalog-core';
+import type { GitTriggerSpec } from './triggers';
+
+function trigger(slug: string, pinnedSessionId: string | null = null): GitTriggerSpec {
+  return {
+    slug,
+    path: `kortix.yaml#triggers.${slug}`,
+    name: slug,
+    type: 'cron',
+    agent: 'kortix',
+    model: null,
+    enabled: true,
+    promptTemplate: 'Run',
+    cron: '* * * * *',
+    runAt: null,
+    timezone: 'UTC',
+    secretEnv: null,
+    sessionMode: pinnedSessionId ? 'pinned' : 'fresh',
+    pinnedSessionId,
+    sessionKey: null,
+    filter: null,
+  };
+}
+
+describe('reconcileProjectTriggerRuntime', () => {
+  test('upserts every readable trigger and removes only proven stale rows', async () => {
+    const upserted: Array<{ slug: string; sessionId: string | null }> = [];
+    const removed: string[] = [];
+    const store: TriggerRuntimeCatalogStore = {
+      list: async () => [{ slug: 'keep', sessionId: null }, { slug: 'stale' }],
+      upsert: async (_projectId, spec) => {
+        upserted.push({ slug: spec.slug, sessionId: spec.pinnedSessionId });
+      },
+      remove: async (_projectId, slug) => {
+        removed.push(slug);
+      },
+    };
+
+    const result = await reconcileProjectTriggerRuntimeWithStore(
+      'project-1',
+      [trigger('keep'), trigger('new-pinned', 'session-1')],
+      store,
+    );
+
+    expect(upserted).toEqual([{ slug: 'new-pinned', sessionId: 'session-1' }]);
+    expect(removed).toEqual(['stale']);
+    expect(result).toEqual({ upserted: 1, removed: 1 });
+  });
+
+  test('removes all rows when a readable manifest declares no triggers', async () => {
+    const removed: string[] = [];
+    const store: TriggerRuntimeCatalogStore = {
+      list: async () => [{ slug: 'existing' }],
+      upsert: async () => {},
+      remove: async (_projectId, slug) => {
+        removed.push(slug);
+      },
+    };
+
+    await expect(reconcileProjectTriggerRuntimeWithStore('project-1', [], store)).resolves.toEqual({
+      upserted: 0,
+      removed: 1,
+    });
+    expect(removed).toEqual(['existing']);
+  });
+});

--- a/apps/api/src/projects/trigger-runtime-catalog.ts
+++ b/apps/api/src/projects/trigger-runtime-catalog.ts
@@ -1,0 +1,57 @@
+import { projectTriggerRuntime } from '@kortix/db';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../shared/db';
+import {
+  type TriggerRuntimeCatalogStore,
+  reconcileProjectTriggerRuntimeWithStore,
+} from './trigger-runtime-catalog-core';
+import type { GitTriggerSpec } from './triggers';
+
+const databaseStore: TriggerRuntimeCatalogStore = {
+  async list(projectId) {
+    return db
+      .select({
+        slug: projectTriggerRuntime.slug,
+        sessionId: projectTriggerRuntime.sessionId,
+      })
+      .from(projectTriggerRuntime)
+      .where(eq(projectTriggerRuntime.projectId, projectId));
+  },
+
+  async upsert(projectId, spec) {
+    const now = new Date();
+    await db
+      .insert(projectTriggerRuntime)
+      .values({
+        projectId,
+        slug: spec.slug,
+        sessionId: spec.pinnedSessionId,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [projectTriggerRuntime.projectId, projectTriggerRuntime.slug],
+        set: {
+          sessionId: spec.pinnedSessionId,
+          updatedAt: now,
+        },
+      });
+  },
+
+  async remove(projectId, slug) {
+    await db
+      .delete(projectTriggerRuntime)
+      .where(
+        and(eq(projectTriggerRuntime.projectId, projectId), eq(projectTriggerRuntime.slug, slug)),
+      );
+  },
+};
+
+export async function reconcileProjectTriggerRuntime(
+  projectId: string,
+  specs: readonly GitTriggerSpec[],
+  store: TriggerRuntimeCatalogStore = databaseStore,
+): Promise<{ upserted: number; removed: number }> {
+  return reconcileProjectTriggerRuntimeWithStore(projectId, specs, store);
+}
+
+export type { TriggerRuntimeCatalogStore } from './trigger-runtime-catalog-core';

--- a/apps/cli/src/__tests__/ship.test.ts
+++ b/apps/cli/src/__tests__/ship.test.ts
@@ -5,6 +5,7 @@ import type { ProjectSummary } from '../api/types.ts';
 import {
   authHeaderArgs,
   linkGitHubBackedProject,
+  reconcileShippedManifest,
   resolveExistingShipGitTarget,
   resolveProvisionShipGitTarget,
 } from '../commands/ship.ts';
@@ -114,10 +115,12 @@ describe('ship git target resolution', () => {
   });
 
   test('existing managed ship ignores proxy origin and mints a managed git token', () => {
-    const target = resolveExistingShipGitTarget(project({
-      git_origin_url: 'https://api.kortix.com/v1/git/proj_1.git',
-      metadata: { git: { managed: true } },
-    }));
+    const target = resolveExistingShipGitTarget(
+      project({
+        git_origin_url: 'https://api.kortix.com/v1/git/proj_1.git',
+        metadata: { git: { managed: true } },
+      }),
+    );
 
     expect(target).toEqual({
       repoUrl: 'https://github.com/managed-kortix/demo.git',
@@ -126,11 +129,13 @@ describe('ship git target resolution', () => {
   });
 
   test('non-managed proxy projects still push through the Kortix git proxy', () => {
-    const target = resolveExistingShipGitTarget(project({
-      repo_url: 'https://github.com/acme/byo.git',
-      git_origin_url: 'https://api.kortix.com/v1/git/proj_1.git',
-      metadata: { git: { managed: false } },
-    }));
+    const target = resolveExistingShipGitTarget(
+      project({
+        repo_url: 'https://github.com/acme/byo.git',
+        git_origin_url: 'https://api.kortix.com/v1/git/proj_1.git',
+        metadata: { git: { managed: false } },
+      }),
+    );
 
     expect(target).toEqual({
       repoUrl: 'https://api.kortix.com/v1/git/proj_1.git',
@@ -139,14 +144,30 @@ describe('ship git target resolution', () => {
   });
 
   test('plain BYO projects rely on local git credentials', () => {
-    const target = resolveExistingShipGitTarget(project({
-      repo_url: 'https://github.com/acme/byo.git',
-      metadata: { git: { managed: false } },
-    }));
+    const target = resolveExistingShipGitTarget(
+      project({
+        repo_url: 'https://github.com/acme/byo.git',
+        metadata: { git: { managed: false } },
+      }),
+    );
 
     expect(target).toEqual({
       repoUrl: 'https://github.com/acme/byo.git',
       credentialMode: 'none',
     });
   });
+});
+
+test('ship reconciles the remote manifest independently of connector prompts', async () => {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const client = recordingClient(calls, project());
+
+  await reconcileShippedManifest(client, 'proj_1');
+
+  expect(calls).toEqual([
+    {
+      path: '/executor/projects/proj_1/connectors/sync',
+      body: undefined,
+    },
+  ]);
 });

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -383,14 +383,6 @@ async function ensureConnectorsConnected(
   if (flags.noConnect) return;
   const ex = `/executor/projects/${projectId}`;
 
-  // The catalog materializes from the manifest we just pushed — sync first so
-  // the cloud knows about freshly-added connectors. Best-effort.
-  try {
-    await client.post(`${ex}/connectors/sync`);
-  } catch {
-    // A sync failure shouldn't block the ship; connectors can be set up later.
-  }
-
   let connectors: ShipConnector[];
   try {
     const resp = await client.get<{ connectors: ShipConnector[] }>(`${ex}/connectors`);
@@ -437,6 +429,23 @@ async function ensureConnectorsConnected(
     process.stdout.write(
       `  ${C.dim}${connected} connector${connected === 1 ? '' : 's'} connected.${C.reset}\n`,
     );
+  }
+}
+
+/**
+ * Reconcile the pushed manifest into the server runtime catalog.
+ *
+ * This step always runs. The --no-connect flag only skips credential prompts.
+ */
+export async function reconcileShippedManifest(
+  client: ApiClient,
+  projectId: string,
+): Promise<void> {
+  try {
+    await client.post(`/executor/projects/${projectId}/connectors/sync`);
+  } catch {
+    // A reconcile failure does not invalidate the completed git push.
+    // The rotating server discovery sweep retries the project.
   }
 }
 
@@ -668,6 +677,7 @@ async function shipFirstTime(
   const pushed = pushCurrentBranch(repoUrl, pushToken, pushUsername);
   if (!pushed) return 1;
 
+  await reconcileShippedManifest(client, project.project_id);
   await ensureConnectorsConnected(client, project.project_id, flags);
 
   reportShipped(auth, project, repoUrl);
@@ -733,6 +743,7 @@ async function shipExisting(
   const pushed = pushCurrentBranch(repoUrl, pushToken, pushUsername);
   if (!pushed) return 1;
 
+  await reconcileShippedManifest(client, projectId);
   await ensureConnectorsConnected(client, projectId, flags);
 
   reportShipped(auth, project, repoUrl);


### PR DESCRIPTION
## Cause

Production has 4,241 active projects. The scheduler loaded every project repository sequentially. The sweep reached its 1,200,000 ms timeout after scanning only 8 to 9 cron triggers. The connector sweep repeated the same fleet scan.

## Change

- Use `project_trigger_runtime` as the trigger-project catalog.
- Reconcile catalog rows after trigger CRUD, trigger reads, connector sync, and `kortix ship`.
- Select only cataloged trigger projects during the minute sweep.
- Process projects through a bounded worker pool.
- Bound git-auth, manifest-load, trigger-fire, and connector-sync work separately.
- Rotate keyset-paginated discovery batches for raw git pushes.
- Remove the non-cancelling whole-sweep timeout.
- Start the first tick immediately after leader acquisition.
- Emit one structured completion event for every trigger and connector sweep.
- Add project and project-failure counts to scheduler health.

## Local black-box proof

A disposable managed project used the running local API and shared local Postgres.

- Cron trigger create: `201`
- Webhook trigger create: `201`
- Runtime placeholders before fire: `2`
- Project-scoped cron result: `fired=1`, `failed=0`
- Invalid HMAC: `401`
- Valid HMAC: `202`
- Persisted sessions: `2`
- Persisted exact prompt markers: `2`
- Runtime rows with `last_fired_at`: `2`
- Project archive: `200`
- Auth-user delete: `200`

## Gates

```text
46 pass
0 fail
168 expect() calls
```

```text
pnpm --filter kortix-api typecheck
exit 0

pnpm --filter @kortix/cli typecheck
exit 0

git diff --check origin/main...HEAD
exit 0

biome check new and focused files
exit 0
```

The full API test command exposes existing `main` failures outside this diff. Examples include missing `getTraceHeaders` exports, stale sandbox-reaper imports, and a maintenance DB mock without `orderBy()`.
