### PR TITLE
test(e2e): wait for REST model readiness

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -2508,7 +2508,6 @@ It resets the ACP projection before runtime replay.
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, and the deployed
 cold Chromium ACP plus REST rollback matrix remain.
-
 ---
 
 ### 2026-07-25 — session `false-load-older` (claim)
@@ -2523,3 +2522,42 @@ smoke, focused web tests, local browser proof, repository merge, Deploy Dev, and
 deployed browser proof.
 
 **Status:** IN PROGRESS.
+
+---
+
+### 2026-07-25 — session `acp-opencode-canary` (B21 delivery completion)
+
+Merged the ACP restart-safe send serialization in PR #5433.
+The merge commit is `aedb8c16b1c11baeb501ea9107dfcac083cb8caa`.
+All 15 PR checks passed.
+
+Deploy Dev run `30160708566` completed successfully.
+The active API reports `0.10.15-dev.85ae91df`.
+The active Vercel deployment is `dpl_9M5yptfdDL48vPASvYDt92kQCFtD`.
+It is `READY` at commit `85ae91df47da26281dc35d098954567b132f192e`.
+Git ancestry proves that both deployed artifacts contain the B21 merge.
+
+The first post-deploy rollback attempt pressed Enter before the REST model list
+loaded. Its trace contains zero `/prompt_async` occurrences.
+The harness now opens the model picker and waits for `Claude Sonnet 4.6` before
+it sends the REST rollback prompt.
+
+The final deployed cold Chromium matrix passed.
+It proved ACP chat, SSE reconnect, transcript reload, tool approval, question
+input, attachments, queueing, cancellation, slash commands, runtime restart,
+post-restart prompt delivery, and REST rollback.
+
+**Final verification:**
+
+- Focused ACP controller suite: **16 pass / 0 fail**.
+- SDK full suite: **1253 pass / 0 fail** across 104 files.
+- SDK assertions: **5603**.
+- SDK typecheck and example typecheck: exit 0.
+- SDK packed-install smoke: pass.
+- Test-harness typecheck: exit 0.
+- PR #5433 checks: **15 pass / 0 fail**.
+- Deployed cold ACP and REST Chromium matrix: **1 pass / 0 fail** in 3.3 minutes.
+
+**Status:** COMPLETE.
+
+**Shippable to production: YES.** ACP and REST rollback pass on deployed dev.

--- a/tests/e2e/specs/14-acp-runtime-canary.spec.ts
+++ b/tests/e2e/specs/14-acp-runtime-canary.spec.ts
@@ -556,6 +556,17 @@ test.describe.serial("14 — OpenCode ACP runtime canary", () => {
     await waitForReadySession(auth.access_token, projectId, sessionId, "rest");
     await page.reload({ waitUntil: "domcontentloaded" });
     await expect(input).toBeVisible({ timeout: 120_000 });
+    const modelPicker = page.getByRole("button", { name: "Model picker" });
+    await expect(modelPicker).toBeVisible({ timeout: 120_000 });
+    await modelPicker.click();
+    const restModel = page
+      .locator('[data-slot="command-item"]')
+      .filter({ hasText: "Claude Sonnet 4.6" })
+      .first();
+    await expect(restModel).toBeVisible({ timeout: 120_000 });
+    await page.keyboard.press("Escape");
+    await expect(restModel).toBeHidden({ timeout: 30_000 });
+    expect(restPromptRequests).toHaveLength(0);
     await input.fill("Reply with exactly: REST_PONG");
     await input.press("Enter");
     await expect(


### PR DESCRIPTION
## Summary

- wait for the REST model picker to expose Claude Sonnet 4.6 after ACP rollback
- assert that no REST prompt was sent before model readiness
- record final ACP restart serialization delivery evidence

## Verification

- `pnpm --dir tests typecheck`
- `git diff --check origin/main...HEAD`
- deployed cold Chromium ACP and REST rollback matrix: `1 passed (3.3m)`
- failed pre-fix trace: `0` `/prompt_async` occurrences