### PR TITLE
fix(staging): keep API router on EKS

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -418,18 +418,14 @@ jobs:
             exit 1
           fi
 
-          # DRIFT WARNING: this REST deploy REPLACES the staging Worker's
-          # bindings wholesale on every staging rollout — it re-asserts
-          # ACTIVE_BACKEND=eks and drops any GATEWAY_* vars a `wrangler deploy
-          # --env staging` (wrangler.toml says ecs-fargate) may have set. Live
-          # staging is therefore EKS-active BY THIS JOB. If staging is ever
-          # flipped to ECS-active like prod, change the binding here (and
-          # wrangler.toml) together, or the next staging deploy flips it back.
+          # This REST deploy replaces all staging Worker bindings. Keep these
+          # values equal to the staging defaults in wrangler.toml. The API uses
+          # EKS. The gateway uses ECS Fargate.
           metadata="$(jq -cn '{
             main_module: "worker.mjs",
             compatibility_date: "2026-06-01",
             bindings: [
-              {type:"plain_text", name:"ACTIVE_BACKEND", text:"ecs-fargate"},
+              {type:"plain_text", name:"ACTIVE_BACKEND", text:"eks"},
               {type:"plain_text", name:"BACKEND_EKS", text:"https://staging-api-eks.kortix.com"},
               {type:"plain_text", name:"BACKEND_ECS_FARGATE", text:"https://staging-api-ecs-fargate.kortix.com"},
               {type:"plain_text", name:"GATEWAY_ACTIVE_BACKEND", text:"ecs-fargate"},

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import worker from './worker.mjs';
 
 const env = {
@@ -19,6 +20,22 @@ afterEach(() => {
 });
 
 describe('api-router worker', () => {
+  test('keeps the staging API on EKS in config and deployment metadata', () => {
+    const wrangler = readFileSync(new URL('./wrangler.toml', import.meta.url), 'utf8');
+    const deployWorkflow = readFileSync(
+      new URL('../../../../.github/workflows/deploy-staging.yml', import.meta.url),
+      'utf8',
+    );
+
+    const stagingVars = wrangler.match(
+      /\[env\.staging\.vars\]([\s\S]*?)(?=\n\[env\.|\s*$)/,
+    )?.[1];
+    expect(stagingVars).toContain('ACTIVE_BACKEND = "eks"');
+    expect(deployWorkflow).toContain(
+      '{type:"plain_text", name:"ACTIVE_BACKEND", text:"eks"}',
+    );
+  });
+
   test('redirects plaintext API requests to HTTPS before proxying', async () => {
     let fetched = false;
     globalThis.fetch = async () => {


### PR DESCRIPTION
## Cause

`deploy-staging.yml` wrote `ACTIVE_BACKEND=ecs-fargate` into the Cloudflare Worker. The documented staging topology uses EKS. The ECS API service had zero running tasks. `staging-api.kortix.com/v1/health` returned `503`.

## Change

- Set the staging API Worker binding to `eks`.
- Keep the staging gateway binding on `ecs-fargate`.
- Add a regression test that compares `wrangler.toml` with the deployment metadata.

## Verification

```text
bun test infra/cloudflare/workers/api-router/worker.test.mjs
6 pass
0 fail
```

The live Worker was restored with the checked-in staging defaults.

```text
GET https://staging-api.kortix.com/v1/health -> 200
x-backend: eks
x-backend-service: api
environment: staging
```