### PR TITLE
fix: refresh webhook trigger manifests

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -69,6 +69,7 @@ const projectRow: typeof projects.$inferSelect = {
 };
 
 function resetState() {
+  resetRateLimiters();
   setTestAuth();
   repoFiles = new Map();
   commitCalls = [];
@@ -541,6 +542,7 @@ const {
   projectWebhooksApp,
   runProjectTriggerSweep,
 } = await import('../projects/index');
+const { resetRateLimiters } = await import('../shared/rate-limit');
 
 function createApp() {
   const app = new Hono();
@@ -1094,6 +1096,18 @@ describe('git-backed triggers — runtime fire paths', () => {
     expect(wrong.status).toBe(401);
     expect(mirrorInvalidationCalls).toBe(1);
     expect(manifestReadCalls).toBe(1);
+
+    const repeated = await app.request(`/v1/webhooks/projects/${PROJECT_ID}/hook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Kortix-Signature': sign(rawBody, 'another-wrong-secret'),
+      },
+      body: rawBody,
+    });
+    expect(repeated.status).toBe(401);
+    expect(mirrorInvalidationCalls).toBe(1);
+    expect(manifestReadCalls).toBe(2);
   });
 
   test('webhook fires with a valid HMAC spawn a session', async () => {

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -38,6 +38,7 @@ let activeSessionCount = 0;
 let provisioningSessionCount = 0;
 let secretRows: Array<typeof projectSecrets.$inferSelect>;
 let manifestReadCalls = 0;
+let mirrorInvalidationCalls = 0;
 let modelDefaults: {
   account: string | null;
   agents: Record<string, string>;
@@ -82,6 +83,7 @@ function resetState() {
   provisioningSessionCount = 0;
   secretRows = [];
   manifestReadCalls = 0;
+  mirrorInvalidationCalls = 0;
   modelDefaults = { account: null, agents: {}, projects: {} };
   projectRow.metadata = {};
   secretValues.clear();
@@ -139,7 +141,9 @@ mock.module('../projects/git', () => ({
   getCommit: async () => null,
   getCommitDiff: async () => null,
   getFileHistory: async () => ({ entries: [], nextCursor: null }),
-  invalidateProjectMirror: () => {},
+  invalidateProjectMirror: () => {
+    mirrorInvalidationCalls += 1;
+  },
   resolveCommitSha: async () => 'a'.repeat(40),
   resolveBranchTip: async () => 'a'.repeat(40),
   getBranchDiff: async () => ({ files: [], diff: '' }),
@@ -1088,6 +1092,7 @@ describe('git-backed triggers — runtime fire paths', () => {
       body: rawBody,
     });
     expect(wrong.status).toBe(401);
+    expect(mirrorInvalidationCalls).toBe(1);
     expect(manifestReadCalls).toBe(1);
   });
 

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -25,6 +25,7 @@ import {
 } from '../seed-files';
 import { getCatalogItemDetail } from '../../marketplace/catalog';
 import { loadProjectTriggers } from '../triggers';
+import { invalidateProjectMirror } from '../git';
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGithubInstallations, projectMembers, projects } from '@kortix/db';
 import { and, desc, eq, inArray } from 'drizzle-orm';
@@ -70,6 +71,10 @@ projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
     .limit(1);
   if (!project) return c.json({ error: 'Not found' }, 404);
 
+  // Trigger CRUD can commit on another API replica. Force this public delivery
+  // path to fetch the current manifest before it authenticates or renders the
+  // webhook. A stale replica must not return 404 or run an older prompt.
+  invalidateProjectMirror(projectId);
   const { specs } = await loadProjectTriggers(await withProjectGitAuth(project));
   const spec = specs.find((s) => s.slug === slug);
   if (!spec || spec.type !== 'webhook' || !spec.enabled) {

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -37,7 +37,10 @@ import { metadataMerge } from '../lib/metadata-merge';
 import { registerGitHubLinkedProject } from '../lib/project-registration';
 import { PROJECT_NAME_MAX_LENGTH, UUID_V4_REGEX, deriveProjectName, normalizeRepoUrl, normalizeString, readBody, requestAuditContext, serializeGitHubInstallation, serializeGitHubInstallations, serializeProject } from '../lib/serializers';
 import { extractWebhookToken, fireGitTrigger, markGitTriggerFired, renderPromptTemplate, triggerFilterMatches, triggersPausedForProject, verifyWebhookSignature, verifyWebhookToken, webhookPayload } from '../lib/triggers';
-import { createProjectWebhookRateLimitMiddleware } from '../../shared/rate-limit';
+import {
+  consumeProjectWebhookManifestRefreshBudget,
+  createProjectWebhookRateLimitMiddleware,
+} from '../../shared/rate-limit';
 
 projectsApp.use('/*', supabaseAuth);
 
@@ -71,10 +74,12 @@ projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
     .limit(1);
   if (!project) return c.json({ error: 'Not found' }, 404);
 
-  // Trigger CRUD can commit on another API replica. Force this public delivery
-  // path to fetch the current manifest before it authenticates or renders the
-  // webhook. A stale replica must not return 404 or run an older prompt.
-  invalidateProjectMirror(projectId);
+  // Trigger CRUD can commit on another API replica. Refresh this replica's
+  // mirror before authentication, but bound the unauthenticated Git work by
+  // project. Rotating source IPs cannot force more than one refresh per 30s.
+  if (consumeProjectWebhookManifestRefreshBudget(projectId)) {
+    invalidateProjectMirror(projectId);
+  }
   const { specs } = await loadProjectTriggers(await withProjectGitAuth(project));
   const spec = specs.find((s) => s.slug === slug);
   if (!spec || spec.type !== 'webhook' || !spec.enabled) {

--- a/apps/api/src/shared/rate-limit.ts
+++ b/apps/api/src/shared/rate-limit.ts
@@ -164,6 +164,7 @@ const publicSessionShareLimiter = new TokenBucketRateLimiter('public_session_sha
 const demoRequestLimiter = new TokenBucketRateLimiter('demo_request');
 const checkEmailLimiter = new TokenBucketRateLimiter('check_email');
 const projectWebhookLimiter = new TokenBucketRateLimiter('project_webhook');
+const projectWebhookManifestRefreshLimiter = new TokenBucketRateLimiter('project_webhook_manifest_refresh');
 export const sessionLlmLimiter = new TokenBucketRateLimiter('session_llm');
 
 export function createInviteAcceptRateLimitMiddleware() {
@@ -335,6 +336,17 @@ export function createProjectWebhookRateLimitMiddleware() {
   };
 }
 
+/**
+ * Bound forced Git mirror refreshes by project, independent of source IP.
+ * Each API replica owns a local mirror, so each replica needs its own budget.
+ */
+export function consumeProjectWebhookManifestRefreshBudget(projectId: string): boolean {
+  return projectWebhookManifestRefreshLimiter.check(projectId, {
+    limit: 1,
+    windowMs: 30_000,
+  }).allowed;
+}
+
 export function resetRateLimiters() {
   inviteAcceptLimiter.reset();
   sandboxProxyLimiter.reset();
@@ -342,5 +354,6 @@ export function resetRateLimiters() {
   demoRequestLimiter.reset();
   checkEmailLimiter.reset();
   projectWebhookLimiter.reset();
+  projectWebhookManifestRefreshLimiter.reset();
   sessionLlmLimiter.reset();
 }


### PR DESCRIPTION
## Cause

Trigger CRUD invalidated only the serving replica's Git mirror. A public webhook could reach another replica with a stale mirror. The valid delivery then returned `404` immediately after trigger creation.

## Change

- Invalidate the local mirror before every public webhook manifest read.
- Add a regression assertion for the refresh boundary.

## Live reproduction

```text
POST /projects/:id/triggers -> 201
invalid HMAC -> 401
valid HMAC -> 404
```

## Verification

```text
KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/e2e-project-triggers.test.ts --test-name-pattern "webhook fires verify"
1 pass
0 fail

pnpm --filter kortix-api typecheck
exit 0
```