### PR TITLE
fix(web): restore compact LLM provider modal

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
@@ -21,4 +21,13 @@ describe('LLM provider modal flow', () => {
     expect(modalSource).toContain('Connecting {pendingProviderLabel}…');
     expect(modalSource).toContain('<Loading');
   });
+
+  test('uses the compact content-sized modal dimensions', () => {
+    expect(modalSource).toContain('max-h-[min(85vh,560px)]');
+    expect(modalSource).toContain('max-w-[520px]');
+    expect(modalSource).toContain('lg:max-w-[520px]');
+    expect(modalSource).toContain('lg:h-auto');
+    expect(modalSource).not.toContain('h-[min(80vh,680px)]');
+    expect(modalSource).not.toContain('max-w-[600px]');
+  });
 });

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -245,7 +245,7 @@ export function ProjectProviderModal({
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <ModalContent className="flex h-[min(80vh,680px)] w-[calc(100vw-2rem)] max-w-[600px] flex-col gap-0 overflow-hidden p-0 lg:max-w-[600px]">
+      <ModalContent className="flex h-auto max-h-[min(85vh,560px)] w-[calc(100vw-2rem)] max-w-[520px] flex-col gap-0 overflow-hidden p-0 lg:h-auto lg:max-w-[520px]">
         <ModalHeader>
           <ModalTitle>
             {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line151JsxTextLlmProviders')}


### PR DESCRIPTION
## Summary
- restore the LLM provider modal to a 520 px compact width
- replace the forced 680 px height with a content-sized 560 px cap
- preserve the Add provider, Connected, Models order and connection loading states
- lock the compact dimensions with a focused regression test

## Verification
- `bun test apps/web/src/features/workspace/customize/sections/llm-provider` — 19 pass, 0 fail
- `pnpm exec eslint src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts` from `apps/web` — 0 findings
- `pnpm --filter Kortix-Computer-Frontend exec tsc --noEmit --pretty false | rg llm-provider-modal` — 0 changed-file diagnostics
- `git diff --check origin/main...HEAD` — pass
- `GET http://localhost:13100` — 200
- `GET http://localhost:13108/v1/health` — 200

## Browser verification
- Blocked because the browser runtime reports 0 available backends.