### PR TITLE
fix(web): open LLM manager actions in modal

### DIFF
--- a/apps/web/src/features/session/use-model-connection-gate.test.ts
+++ b/apps/web/src/features/session/use-model-connection-gate.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { projectProviderModalTab } from './use-model-connection-gate';
+
+const gateSource = readFileSync(join(import.meta.dir, 'use-model-connection-gate.tsx'), 'utf8');
+const selectorSource = readFileSync(join(import.meta.dir, 'model-selector.tsx'), 'utf8');
+
+describe('model management entry-point routing', () => {
+  test('maps each precise action to the matching project modal tab', () => {
+    expect(projectProviderModalTab('providers')).toBe('catalog');
+    expect(projectProviderModalTab('connected')).toBe('connected');
+    expect(projectProviderModalTab('models')).toBe('models');
+  });
+
+  test('opens the project provider modal without opening Customize', () => {
+    expect(gateSource).toContain('setProjectModalTab(projectProviderModalTab(tab))');
+    expect(gateSource).toContain('setProjectModalOpen(true)');
+    expect(gateSource).not.toContain('useCustomizeStore');
+    expect(gateSource).not.toContain('openCustomize');
+  });
+
+  test('routes each model-selector management action through the modal gate', () => {
+    expect(selectorSource.match(/handleOpenProviderModal\('providers'\)/g)).toHaveLength(2);
+    expect(selectorSource.match(/handleOpenProviderModal\('models'\)/g)).toHaveLength(1);
+    expect(selectorSource).toContain('aria-label="Add provider"');
+    expect(selectorSource).toContain('aria-label="Manage models"');
+    expect(selectorSource).toContain('Connect provider');
+  });
+});

--- a/apps/web/src/features/session/use-model-connection-gate.tsx
+++ b/apps/web/src/features/session/use-model-connection-gate.tsx
@@ -7,25 +7,26 @@ import { useCallback, useMemo, useState } from 'react';
 import { ProjectProviderModal } from '@/features/workspace/customize/sections/llm-provider/llm-provider-modal';
 import { useLlmProviderCatalogRevision } from '@/features/workspace/customize/sections/llm-provider/use-live-catalog';
 import { accountStateSelectors, useAccountState } from '@/hooks/billing';
-import { connectedGatewayProviderIdsFromSecretNames } from '@kortix/sdk/react';
-import { hasUsableModel } from '@kortix/sdk/react';
 import { isBillingEnabled } from '@/lib/config';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useProjectCan } from '@/lib/use-project-can';
-import { useCustomizeStore } from '@/stores/customize-store';
 import type { ProviderModalTab } from '@/stores/provider-modal-store';
 import { useProviderModalStore } from '@/stores/provider-modal-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { getProjectDetail, listProjectSecrets } from '@kortix/sdk';
+import { connectedGatewayProviderIdsFromSecretNames, hasUsableModel } from '@kortix/sdk/react';
 import type { FlatModel } from './session-chat-input';
 
+export function projectProviderModalTab(tab: ProviderModalTab): 'connected' | 'catalog' | 'models' {
+  return tab === 'providers' ? 'catalog' : tab;
+}
+
 /**
- * Shared "connect a model" routing — where clicking Upgrade / Connect provider
- * should actually take the user, given the current route context (project with
- * the LLM gateway on, project without it, or no project at all). Extracted from
- * `ModelSelector` so any surface (the picker's empty state, the chat input's
- * full-block gate, onboarding) opens the exact same dialogs.
+ * Shared "connect a model" routing. Project actions open the project-scoped
+ * provider modal in place. Non-project actions use the global provider modal.
+ * Extracted from `ModelSelector` so the picker, chat gate, and onboarding use
+ * the same surface.
  *
  * Also computes `hasSelectableModels` — pass the caller's flattened model list
  * (default `[]` for callers that only need the routing actions). This is
@@ -40,7 +41,6 @@ export function useModelConnectionGate(models: FlatModel[] = []) {
   // module-level LLM_PROVIDERS binding.
   const catalogRevision = useLlmProviderCatalogRevision();
   const openProviderModal = useProviderModalStore((s) => s.openProviderModal);
-  const openCustomize = useCustomizeStore((s) => s.openCustomize);
   const openUpgradeDialog = useUpgradeDialogStore((s) => s.openUpgradeDialog);
 
   const params = useParams<{ id?: string }>();
@@ -109,21 +109,13 @@ export function useModelConnectionGate(models: FlatModel[] = []) {
   const openConnectProvider = useCallback(
     (tab: ProviderModalTab = 'providers') => {
       if (projectId) {
-        if (llmGatewayEnabled) {
-          // Plus → "Add provider" (the core surface); the sliders / manage-models
-          // button → "Models". Both land on LLM → Providers, never Files.
-          openCustomize('llm-providers', {
-            llmProvidersTab: tab === 'models' ? 'models' : 'catalog',
-          });
-        } else {
-          setProjectModalTab(tab === 'providers' ? 'catalog' : tab);
-          setProjectModalOpen(true);
-        }
+        setProjectModalTab(projectProviderModalTab(tab));
+        setProjectModalOpen(true);
         return;
       }
       openProviderModal(tab);
     },
-    [projectId, llmGatewayEnabled, openProviderModal, openCustomize],
+    [projectId, openProviderModal],
   );
 
   const openUpgrade = useCallback(() => {

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
@@ -22,12 +22,10 @@ describe('LLM provider modal flow', () => {
     expect(modalSource).toContain('<Loading');
   });
 
-  test('uses the compact content-sized modal dimensions', () => {
-    expect(modalSource).toContain('max-h-[min(85vh,560px)]');
-    expect(modalSource).toContain('max-w-[520px]');
-    expect(modalSource).toContain('lg:max-w-[520px]');
-    expect(modalSource).toContain('lg:h-auto');
-    expect(modalSource).not.toContain('h-[min(80vh,680px)]');
-    expect(modalSource).not.toContain('max-w-[600px]');
+  test('uses the 600 by 680 modal dimensions', () => {
+    expect(modalSource).toContain('h-[min(80vh,680px)]');
+    expect(modalSource).toContain('max-w-[600px]');
+    expect(modalSource).toContain('lg:max-w-[600px]');
+    expect(modalSource).not.toContain('max-w-[520px]');
   });
 });

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -245,7 +245,7 @@ export function ProjectProviderModal({
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <ModalContent className="flex h-auto max-h-[min(85vh,560px)] w-[calc(100vw-2rem)] max-w-[520px] flex-col gap-0 overflow-hidden p-0 lg:h-auto lg:max-w-[520px]">
+      <ModalContent className="flex h-[min(80vh,680px)] w-[calc(100vw-2rem)] max-w-[600px] flex-col gap-0 overflow-hidden p-0 lg:max-w-[600px]">
         <ModalHeader>
           <ModalTitle>
             {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line151JsxTextLlmProviders')}


### PR DESCRIPTION
## Summary

- Open project model-management actions in ProjectProviderModal.
- Keep Customize → LLM as the full-page manager.
- Restore the provider modal to 600 px by 680 px.
- Preserve Add provider, Connected, Models order and loading states.

## Verification

- bun test src/features/session/model-selector.test.ts src/features/session/use-model-connection-gate.test.ts src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts src/features/workspace/customize/sections/llm-provider/utils.test.ts
  - 38 pass, 0 fail
- pnpm exec eslint src/features/session/use-model-connection-gate.tsx src/features/session/use-model-connection-gate.test.ts src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
  - exit 0
- pnpm exec tsc --noEmit --pretty false filtered to changed files
  - 0 changed-file diagnostics
- git diff --check
  - exit 0
- curl http://localhost:13300/
  - HTTP 200
- curl http://localhost:13308/v1/health
  - status ok

## Browser verification

The browser runtime reports 0 available browser connections. Authenticated click and DOM verification remains pending.