### PR TITLE
test(migration): verify source refresh on US Auth

### DIFF
--- a/docs/runbooks/prod-us-east-2-supabase-migration.md
+++ b/docs/runbooks/prod-us-east-2-supabase-migration.md
@@ -11,6 +11,9 @@
 - Target PITR: 7 days.
 - Target dedicated IPv4: enabled.
 - Target credentials: AWS Secrets Manager secret `kortix/prod-us-east-2-migration`.
+- Target database password: rotated on 2026-07-25.
+- Migration and runtime database URLs: updated after the password rotation.
+- US API and gateway tasks: restarted after the password rotation.
 - Fresh-project bootstrap: applied.
 - Repository migration ledger: 79 migrations applied through
   `20260725012141489_gateway_cost_precision_sync`.
@@ -22,6 +25,14 @@
 - Auth replication sync errors: `0`.
 - The three application sync errors are historical initial-copy retries.
 - Both subscriptions have active apply workers.
+- A source GoTrue refresh token exchanges successfully on target Auth.
+- The target issues the exchanged token with `HS256` and signing-key ID
+  `9871968b-feba-4720-b80e-ba8ae1bbec17`.
+- The target Auth non-secret Apple, Google, GitHub, SAML, and Twilio identifiers
+  match the source where applicable.
+- Apple Auth and SAML are enabled on both projects.
+- Google Auth, GitHub Auth, and phone MFA remain disabled on the target until
+  their plaintext secrets are installed.
 - Source WAL retention limit: 32 GB.
 - Replication credential: rotated after the initial copy.
 - Storage copied: all 79 `avatars` objects with byte and SHA-256 verification.
@@ -29,8 +40,8 @@
 - US API shadow: two healthy ECS tasks on image `kortix/kortix-api:0.10.14`.
 - US gateway shadow: two healthy ECS tasks on image
   `kortix/kortix-gateway:0.10.14`.
-- US API task definition: `kortix-prod-use2:1`.
-- US gateway task definition: `kortix-prod-use2-gateway:1`.
+- US API task definition: `kortix-prod-use2:2`.
+- US gateway task definition: `kortix-prod-use2-gateway:2`.
 - Shadow Terraform state: `prod-us-east-2-shadow/ecs-api.tfstate`.
 - Shadow Terraform state bucket:
   `kortix-terraform-state-us-east-2-935064898258` in `us-east-2`.
@@ -68,22 +79,22 @@ Do not print or copy secret values into this document, shell output, or Git.
 
 ## Verified source inventory
 
-| Item | Value |
-|---|---:|
-| PostgreSQL version | 15.8 |
-| Provisioned disk | 378 GB |
-| Database data | approximately 286 GB |
-| Storage objects | 452,290 |
-| Storage data | approximately 138 GB |
-| Auth users | 405,870 |
-| Auth identities | 409,636 |
-| MFA factors | 8,606 |
-| Auth refresh tokens | 9,538,250 |
-| `public` schema | 250 GB |
-| `kortix` schema | 29 GB |
-| `auth` schema | 11 GB |
-| `cron` schema | 33 GB |
-| `net` schema | 2.7 GB |
+| Item                |                Value |
+| ------------------- | -------------------: |
+| PostgreSQL version  |                 15.8 |
+| Provisioned disk    |               378 GB |
+| Database data       | approximately 286 GB |
+| Storage objects     |              452,290 |
+| Storage data        | approximately 138 GB |
+| Auth users          |              405,870 |
+| Auth identities     |              409,636 |
+| MFA factors         |                8,606 |
+| Auth refresh tokens |            9,538,250 |
+| `public` schema     |               250 GB |
+| `kortix` schema     |                29 GB |
+| `auth` schema       |                11 GB |
+| `cron` schema       |                33 GB |
+| `net` schema        |               2.7 GB |
 
 The source has `wal_level=logical`. It has 24 replication slots and 24 WAL
 senders. The measured WAL rate is approximately 0.39 MB/s. The current
@@ -98,21 +109,21 @@ Monitor retained WAL until both subscriptions are disabled after cutover.
 The source `pg_stat_statements` counters were reset on 2026-06-24.
 The counters prove that the application still reads these legacy Suna tables:
 
-| Relation | Calls since reset |
-|---|---:|
-| `public.projects` | 6,206 |
-| `public.resources` | 149 |
-| `public.threads` | 1,086 |
-| `public.messages` | 1,076 |
+| Relation           | Calls since reset |
+| ------------------ | ----------------: |
+| `public.projects`  |             6,206 |
+| `public.resources` |               149 |
+| `public.threads`   |             1,086 |
+| `public.messages`  |             1,076 |
 
 The same counters distinguish the retired and current credit tables:
 
-| Relation | Calls since reset |
-|---|---:|
-| `public.credit_accounts` | 0 |
-| `public.credit_ledger` | 1 |
-| `kortix.credit_accounts` | 4,475,763 |
-| `kortix.credit_ledger` | 311,776 |
+| Relation                 | Calls since reset |
+| ------------------------ | ----------------: |
+| `public.credit_accounts` |                 0 |
+| `public.credit_ledger`   |                 1 |
+| `kortix.credit_accounts` |         4,475,763 |
+| `kortix.credit_ledger`   |           311,776 |
 
 The application also called the public credit RPC functions at least 295,678
 times since the reset. These functions operate on `kortix.credit_accounts` and
@@ -120,12 +131,12 @@ times since the reset. These functions operate on `kortix.credit_accounts` and
 
 The current control-table row counts are:
 
-| Relation | Rows |
-|---|---:|
+| Relation                        |    Rows |
+| ------------------------------- | ------: |
 | `public.daily_refresh_tracking` | 389,009 |
-| `public.renewal_processing` | 3,450 |
-| `public.contact_forms` | 101 |
-| `public.webhook_config` | 1 |
+| `public.renewal_processing`     |   3,450 |
+| `public.contact_forms`          |     101 |
+| `public.webhook_config`         |       1 |
 
 Do not treat the complete `public` schema as one migration unit. Select live
 relations by verified repository dependency, production query activity, and
@@ -186,11 +197,11 @@ repository still exposes these routes:
 
 Verified account scope on 2026-07-25:
 
-| Scope | Accounts | Projects | Resources | Threads | Messages |
-|---|---:|---:|---:|---:|---:|
-| Active in the last 30 days and not migrated | 712 | 6,011 | 4,196 | 5,897 | 706,172 |
-| Active 31 to 90 days ago and not migrated | 2,955 | 88,141 | 17,319 | 86,858 | 2,457,654 |
-| Active in the last 90 days and not migrated | 3,667 | 94,152 | 21,515 | 92,755 | 3,163,826 |
+| Scope                                       | Accounts | Projects | Resources | Threads |  Messages |
+| ------------------------------------------- | -------: | -------: | --------: | ------: | --------: |
+| Active in the last 30 days and not migrated |      712 |    6,011 |     4,196 |   5,897 |   706,172 |
+| Active 31 to 90 days ago and not migrated   |    2,955 |   88,141 |    17,319 |  86,858 | 2,457,654 |
+| Active in the last 90 days and not migrated |    3,667 |   94,152 |    21,515 |  92,755 | 3,163,826 |
 
 The 90-day subset is approximately 6.4 GiB with proportional index overhead.
 
@@ -228,8 +239,8 @@ Open one Supabase support case before the production cutover.
 Request these actions:
 
 1. Validate the live logical replication of all 22 selected Auth relations.
-2. Clone or safely reapply the original Google OAuth, GitHub OAuth, and Twilio
-   Verify plaintext credentials.
+2. Clone or safely reapply the original Google OAuth secret, GitHub OAuth
+   secret, and Twilio Verify auth token.
 3. Set or explain these platform-managed Auth differences:
 
    - `mfa_allow_low_aal`: source `true`, target `false`.
@@ -271,17 +282,19 @@ Do not start the production write freeze until all four blockers close.
 The source Management API returns one-way 64-character representations for
 configured provider secrets. Do not copy those values to another project.
 
-The source JWT header uses `HS256` with no `kid`. The target has the original
-source secret imported as signing key
-`df227db1-e3fe-4295-b86e-6531d85ec88f`.
+The source access-token header uses `HS256` with non-UUID
+`kid=b2pXFwm+imtLLxBI`. Supabase signing-key IDs must be UUIDs. The target has
+the original source secret as the active signing key
+`9871968b-feba-4720-b80e-ba8ae1bbec17`.
 
-- A token signed by the source secret with that `kid` succeeds on target Auth.
-- The same token without a `kid` returns HTTP `403` with
-  `token signature is invalid`.
+- A direct source access token returns HTTP `403` from target Auth.
+- A source refresh token exchanges successfully on target Auth.
+- The exchanged target access token uses `HS256` with
+  `kid=9871968b-feba-4720-b80e-ba8ae1bbec17`.
 
-Supabase Support must enable the source secret as the target legacy no-`kid`
-verification secret. This is required for active source user tokens and cached
-source anon keys during cutover.
+Supabase Support must map the source non-UUID `kid` to the imported target key,
+or approve a cutover that forces active sessions through refresh-token
+exchange. Do not assume active access tokens work directly on target Auth.
 
 The Management API accepted a PATCH for the three platform-managed Auth fields.
 It kept the target values unchanged. Supabase Support must change or approve
@@ -290,9 +303,14 @@ those fields.
 SMTP is complete. The target uses the original Mailtrap token. SMTP
 authentication returns `235 2.7.0 Ok`. Auth recovery returns HTTP `200`.
 
-Google and GitHub initiation currently return HTTP `302`. Completion remains
-blocked by the missing original plaintext provider secrets. Phone MFA remains
-blocked by the missing original Twilio Verify token.
+The target Google and GitHub client IDs match the source. Their providers
+remain disabled because the original plaintext secrets are unavailable. The
+target Twilio Verify account SID and messaging-service SID match the source.
+Phone MFA remains disabled because the original Twilio Verify auth token is
+unavailable.
+
+Apple Auth requires no source provider secret. Its client ID matches, and the
+provider is enabled on the target. SAML is also enabled on the target.
 
 ## Current validation evidence
 
@@ -322,6 +340,25 @@ The cleanup check covers:
 - `auth.sessions`
 - `auth.users`
 - `kortix.audit_events`
+
+The source refresh-token smoke returns:
+
+```json
+{
+  "sourcePasswordLogin": true,
+  "sourceRowsReplicated": true,
+  "targetRefreshToken": true,
+  "targetUserEndpoint": true,
+  "sourceTokenAlg": "HS256",
+  "sourceTokenKid": "<source-non-UUID-kid>",
+  "targetTokenAlg": "HS256",
+  "targetTokenKid": "<target-key-UUID>",
+  "targetSequenceReserved": true,
+  "cleanupSourceRows": 0,
+  "cleanupTargetRows": 0,
+  "error": null
+}
+```
 
 Auth row counts, primary-key hashes, and critical-row hashes match.
 
@@ -387,6 +424,11 @@ source of truth.
 6. Reset every migrated sequence to `max(column) + 1`.
 7. Monitor replication lag and retained WAL.
 
+Logical replication does not advance target sequences. Do not accept target
+Auth writes while source Auth remains writable. A stale
+`auth.refresh_tokens_id_seq` causes refresh-token rotation to return HTTP `500`
+after a duplicate primary-key insert.
+
 Do not publish Supabase-owned internal tables through a publication owned by
 the application role. Supabase Support must handle those schemas.
 
@@ -428,6 +470,16 @@ Run the target smoke:
 ```bash
 bash scripts/prod-us-east-2/target-smoke.sh
 ```
+
+Run the source refresh-token compatibility smoke:
+
+```bash
+ALLOW_SOURCE_AUTH_REFRESH_SMOKE=1 \
+  bash scripts/prod-us-east-2/auth-refresh-smoke.sh
+```
+
+The refresh smoke reserves a temporary high target sequence range. It restores
+`auth.refresh_tokens_id_seq` to the current target maximum after cleanup.
 
 The production release calls
 `.github/workflows/deploy-prod-us-east-2-shadow.yml`. It applies target

--- a/scripts/prod-us-east-2/auth-refresh-smoke.mjs
+++ b/scripts/prod-us-east-2/auth-refresh-smoke.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+
+import { randomBytes, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+const requiredEnvironment = [
+  "SOURCE_DATABASE_URL",
+  "SOURCE_SUPABASE_URL",
+  "SOURCE_ANON_KEY",
+  "TARGET_DATABASE_URL",
+  "TARGET_SUPABASE_URL",
+  "TARGET_ANON_KEY",
+];
+
+for (const name of requiredEnvironment) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+if (process.env.ALLOW_SOURCE_AUTH_REFRESH_SMOKE !== "1") {
+  throw new Error("Set ALLOW_SOURCE_AUTH_REFRESH_SMOKE=1");
+}
+
+const sourceDatabaseUrl = process.env.SOURCE_DATABASE_URL;
+const sourceUrl = process.env.SOURCE_SUPABASE_URL.replace(/\/+$/, "");
+const sourceAnonKey = process.env.SOURCE_ANON_KEY;
+const targetDatabaseUrl = process.env.TARGET_DATABASE_URL;
+const targetUrl = process.env.TARGET_SUPABASE_URL.replace(/\/+$/, "");
+const targetAnonKey = process.env.TARGET_ANON_KEY;
+const smokeUserId = randomUUID();
+const smokeIdentityId = randomUUID();
+const smokeEmail =
+  `refresh-compat-${Date.now()}-${smokeUserId.slice(0, 8)}` +
+  "@invalid.kortix.test";
+const smokePassword = `${randomBytes(24).toString("base64url")}aA1!`;
+const variables = {
+  user_id: smokeUserId,
+  identity_id: smokeIdentityId,
+  email: smokeEmail,
+  password: smokePassword,
+};
+
+const result = {
+  sourcePasswordLogin: false,
+  sourceRowsReplicated: false,
+  targetRefreshToken: false,
+  targetUserEndpoint: false,
+  sourceTokenAlg: null,
+  sourceTokenKid: null,
+  targetTokenAlg: null,
+  targetTokenKid: null,
+  targetSequenceReserved: false,
+  cleanupSourceRows: null,
+  cleanupTargetRows: null,
+  error: null,
+};
+
+let sourceInserted = false;
+
+function sql(databaseUrl, input, values = {}) {
+  const args = [databaseUrl, "-X", "-qAt", "-v", "ON_ERROR_STOP=1"];
+  for (const [name, value] of Object.entries(values)) {
+    args.push("-v", `${name}=${value}`);
+  }
+
+  const command = spawnSync("psql", args, {
+    input,
+    encoding: "utf8",
+    timeout: 20_000,
+    maxBuffer: 4 * 1024 * 1024,
+    env: {
+      ...process.env,
+      PGCONNECT_TIMEOUT: "10",
+      PGOPTIONS: "-c statement_timeout=15000",
+    },
+  });
+
+  if (command.error) throw command.error;
+  if (command.status !== 0) {
+    throw new Error(command.stderr.trim() || "psql failed");
+  }
+  return command.stdout.trim();
+}
+
+function authRowCount(databaseUrl) {
+  return Number(
+    sql(
+      databaseUrl,
+      `
+SELECT
+  (SELECT count(*) FROM auth.users WHERE id = :'user_id'::uuid) +
+  (SELECT count(*) FROM auth.identities WHERE user_id = :'user_id'::uuid) +
+  (SELECT count(*) FROM auth.sessions WHERE user_id = :'user_id'::uuid) +
+  (SELECT count(*) FROM auth.refresh_tokens WHERE user_id = :'user_id');
+`,
+      variables,
+    ),
+  );
+}
+
+function decodeJwtHeader(token) {
+  return JSON.parse(
+    Buffer.from(token.split(".")[0], "base64url").toString("utf8"),
+  );
+}
+
+async function responseJson(response) {
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const detail =
+      body.error_description ??
+      body.msg ??
+      body.message ??
+      body.error ??
+      Object.keys(body).join(",");
+    throw new Error(`HTTP ${response.status}: ${detail || "unknown error"}`);
+  }
+  return body;
+}
+
+const sleep = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+try {
+  // Source writers advance this sequence while logical replication copies rows.
+  // Reserve a target-only range so the target refresh does not reuse a source ID.
+  sql(
+    targetDatabaseUrl,
+    `
+SELECT setval(
+  'auth.refresh_tokens_id_seq'::regclass,
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1) + 1000000,
+  true
+);
+`,
+  );
+  result.targetSequenceReserved = true;
+
+  // Insert the source user directly with replica trigger behavior. This avoids
+  // invoking the production welcome-email trigger. GoTrue creates the genuine
+  // session and refresh token through the password login below.
+  sql(
+    sourceDatabaseUrl,
+    `
+BEGIN;
+SET LOCAL session_replication_role = replica;
+INSERT INTO auth.users (
+  instance_id, id, aud, role, email, encrypted_password,
+  email_confirmed_at, confirmation_token, recovery_token,
+  email_change_token_new, email_change, email_change_token_current,
+  phone_change, phone_change_token, reauthentication_token,
+  raw_app_meta_data, raw_user_meta_data, is_super_admin,
+  created_at, updated_at, is_sso_user, is_anonymous
+) VALUES (
+  '00000000-0000-0000-0000-000000000000', :'user_id'::uuid,
+  'authenticated', 'authenticated', :'email',
+  extensions.crypt(:'password', extensions.gen_salt('bf')),
+  now(), '', '', '', '', '', '', '', '',
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"kortix_migration_refresh_smoke":true}'::jsonb,
+  false, now(), now(), false, false
+);
+INSERT INTO auth.identities (
+  id, provider_id, user_id, identity_data, provider,
+  last_sign_in_at, created_at, updated_at
+) VALUES (
+  :'identity_id'::uuid, :'user_id', :'user_id'::uuid,
+  jsonb_build_object(
+    'sub', :'user_id',
+    'email', :'email',
+    'email_verified', true
+  ),
+  'email', now(), now(), now()
+);
+COMMIT;
+`,
+    variables,
+  );
+  sourceInserted = true;
+
+  const sourceLoginResponse = await fetch(
+    `${sourceUrl}/auth/v1/token?grant_type=password`,
+    {
+      method: "POST",
+      headers: {
+        apikey: sourceAnonKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: smokeEmail,
+        password: smokePassword,
+      }),
+    },
+  );
+  const sourceTokens = await responseJson(sourceLoginResponse);
+  if (!sourceTokens.access_token || !sourceTokens.refresh_token) {
+    throw new Error("Source login omitted access or refresh token");
+  }
+  result.sourcePasswordLogin = true;
+  const sourceHeader = decodeJwtHeader(sourceTokens.access_token);
+  result.sourceTokenAlg = sourceHeader.alg ?? null;
+  result.sourceTokenKid = sourceHeader.kid ?? null;
+  variables.refresh_token = sourceTokens.refresh_token;
+
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const targetState = Number(
+      sql(
+        targetDatabaseUrl,
+        `
+SELECT
+  (SELECT count(*) FROM auth.users WHERE id = :'user_id'::uuid) +
+  (SELECT count(*) FROM auth.sessions WHERE user_id = :'user_id'::uuid) +
+  (
+    SELECT count(*)
+    FROM auth.refresh_tokens
+    WHERE user_id = :'user_id'
+      AND token = :'refresh_token'
+  );
+`,
+        variables,
+      ),
+    );
+    if (targetState === 3) {
+      result.sourceRowsReplicated = true;
+      break;
+    }
+    await sleep(1_000);
+  }
+  if (!result.sourceRowsReplicated) {
+    throw new Error("Source login state did not reach target in 60 seconds");
+  }
+
+  const targetRefreshResponse = await fetch(
+    `${targetUrl}/auth/v1/token?grant_type=refresh_token`,
+    {
+      method: "POST",
+      headers: {
+        apikey: targetAnonKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ refresh_token: sourceTokens.refresh_token }),
+    },
+  );
+  const targetTokens = await responseJson(targetRefreshResponse);
+  if (!targetTokens.access_token || !targetTokens.refresh_token) {
+    throw new Error("Target refresh omitted access or refresh token");
+  }
+  result.targetRefreshToken = true;
+  const targetHeader = decodeJwtHeader(targetTokens.access_token);
+  result.targetTokenAlg = targetHeader.alg ?? null;
+  result.targetTokenKid = targetHeader.kid ?? null;
+
+  const targetPayload = JSON.parse(
+    Buffer.from(targetTokens.access_token.split(".")[1], "base64url").toString(
+      "utf8",
+    ),
+  );
+  if (targetPayload.sub !== smokeUserId) {
+    throw new Error("Target refresh returned a token for another user");
+  }
+
+  const targetUserResponse = await fetch(`${targetUrl}/auth/v1/user`, {
+    headers: {
+      apikey: targetAnonKey,
+      Authorization: `Bearer ${targetTokens.access_token}`,
+    },
+  });
+  const targetUser = await responseJson(targetUserResponse);
+  if (targetUser.id !== smokeUserId) {
+    throw new Error("Target user endpoint returned another user");
+  }
+  result.targetUserEndpoint = true;
+} catch (error) {
+  result.error = error instanceof Error ? error.message : String(error);
+} finally {
+  try {
+    if (sourceInserted) {
+      sql(
+        sourceDatabaseUrl,
+        `
+BEGIN;
+SET LOCAL session_replication_role = replica;
+DELETE FROM auth.refresh_tokens WHERE user_id = :'user_id';
+DELETE FROM auth.sessions WHERE user_id = :'user_id'::uuid;
+DELETE FROM auth.identities WHERE user_id = :'user_id'::uuid;
+DELETE FROM auth.users WHERE id = :'user_id'::uuid;
+COMMIT;
+`,
+        variables,
+      );
+    }
+
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      if (authRowCount(targetDatabaseUrl) <= 1) break;
+      await sleep(1_000);
+    }
+
+    sql(
+      targetDatabaseUrl,
+      `
+BEGIN;
+SET LOCAL session_replication_role = replica;
+DELETE FROM auth.refresh_tokens WHERE user_id = :'user_id';
+DELETE FROM auth.sessions WHERE user_id = :'user_id'::uuid;
+DELETE FROM auth.identities WHERE user_id = :'user_id'::uuid;
+DELETE FROM auth.users WHERE id = :'user_id'::uuid;
+SELECT setval(
+  'auth.refresh_tokens_id_seq'::regclass,
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1),
+  EXISTS (SELECT 1 FROM auth.refresh_tokens)
+);
+COMMIT;
+`,
+      variables,
+    );
+
+    result.cleanupSourceRows = authRowCount(sourceDatabaseUrl);
+    result.cleanupTargetRows = authRowCount(targetDatabaseUrl);
+  } catch (cleanupError) {
+    const detail =
+      cleanupError instanceof Error
+        ? cleanupError.message
+        : String(cleanupError);
+    result.error = result.error
+      ? `${result.error}; cleanup: ${detail}`
+      : `cleanup: ${detail}`;
+  }
+}
+
+console.log(JSON.stringify(result, null, 2));
+if (result.error) process.exit(1);

--- a/scripts/prod-us-east-2/auth-refresh-smoke.sh
+++ b/scripts/prod-us-east-2/auth-refresh-smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_SECRET_ID="${SOURCE_SECRET_ID:-kortix-prod-env}"
+SOURCE_AWS_REGION="${SOURCE_AWS_REGION:-eu-west-2}"
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix/prod-us-east-2-migration}"
+TARGET_AWS_REGION="${TARGET_AWS_REGION:-us-east-2}"
+
+if [[ "${ALLOW_SOURCE_AUTH_REFRESH_SMOKE:-}" != "1" ]]; then
+  echo "Set ALLOW_SOURCE_AUTH_REFRESH_SMOKE=1 to run the source Auth refresh smoke." >&2
+  exit 64
+fi
+
+for command_name in aws jq node psql; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+source_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$SOURCE_SECRET_ID" \
+    --region "$SOURCE_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+target_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$TARGET_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+
+export SOURCE_DATABASE_URL
+SOURCE_DATABASE_URL="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+export SOURCE_SUPABASE_URL
+SOURCE_SUPABASE_URL="$(jq -er '.SUPABASE_URL' <<<"$source_secret_json")"
+export SOURCE_ANON_KEY
+SOURCE_ANON_KEY="$(jq -er '.SUPABASE_ANON_KEY' <<<"$source_secret_json")"
+
+export TARGET_DATABASE_URL
+TARGET_DATABASE_URL="$(jq -er '.target_database_url' <<<"$target_secret_json")"
+export TARGET_SUPABASE_URL
+TARGET_SUPABASE_URL="$(jq -er '.target_supabase_url' <<<"$target_secret_json")"
+export TARGET_ANON_KEY
+TARGET_ANON_KEY="$(jq -er '.target_anon_key' <<<"$target_secret_json")"
+
+node "$(dirname "$0")/auth-refresh-smoke.mjs"

--- a/scripts/prod-us-east-2/auth-refresh-smoke.test.mjs
+++ b/scripts/prod-us-east-2/auth-refresh-smoke.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const wrapperUrl = new URL("./auth-refresh-smoke.sh", import.meta.url);
+const smokeScript = readFileSync(
+  new URL("./auth-refresh-smoke.mjs", import.meta.url),
+  "utf8",
+);
+
+test("the wrapper rejects source writes without the explicit gate", () => {
+  const result = spawnSync("bash", [wrapperUrl.pathname], {
+    env: {
+      PATH: process.env.PATH,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /ALLOW_SOURCE_AUTH_REFRESH_SMOKE=1/);
+});
+
+test("the smoke bypasses the welcome trigger and cleans both Auth copies", () => {
+  const replicaMode = smokeScript.indexOf(
+    "SET LOCAL session_replication_role = replica",
+  );
+  const sourceInsert = smokeScript.indexOf("INSERT INTO auth.users");
+  const sourceCleanup = smokeScript.indexOf(
+    "DELETE FROM auth.refresh_tokens WHERE user_id = :'user_id'",
+    sourceInsert,
+  );
+  const targetCleanup = smokeScript.indexOf(
+    "DELETE FROM auth.refresh_tokens WHERE user_id = :'user_id'",
+    sourceCleanup + 1,
+  );
+
+  assert.ok(replicaMode >= 0);
+  assert.ok(replicaMode < sourceInsert);
+  assert.ok(sourceCleanup > sourceInsert);
+  assert.ok(targetCleanup > sourceCleanup);
+});
+
+test("the smoke reserves and restores the target refresh-token sequence", () => {
+  const reservation = smokeScript.indexOf(
+    "COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1) + 1000000",
+  );
+  const targetRefresh = smokeScript.indexOf(
+    "/auth/v1/token?grant_type=refresh_token",
+    smokeScript.indexOf("sourceTokens.refresh_token"),
+  );
+  const restoration = smokeScript.lastIndexOf(
+    "COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1)",
+  );
+
+  assert.ok(reservation >= 0);
+  assert.ok(targetRefresh > reservation);
+  assert.ok(restoration > targetRefresh);
+});


### PR DESCRIPTION
## Summary

- add a gated source-to-target Auth refresh compatibility smoke
- reserve and restore the target refresh-token sequence during the smoke
- document the verified Auth behavior and password-rotation state

## Verification

- `bash -n scripts/prod-us-east-2/auth-refresh-smoke.sh`
- `shellcheck scripts/prod-us-east-2/auth-refresh-smoke.sh`
- `node --check scripts/prod-us-east-2/auth-refresh-smoke.mjs`
- `node --test scripts/prod-us-east-2/auth-refresh-smoke.test.mjs` — 3 passed
- `pnpm --filter @kortix/db migrate:lint` — 80 files passed
- `pnpm --filter @kortix/db lint:squawk` — 0 issues
- `pnpm --filter @kortix/db test` — 120 passed
- dev `migrate:status` — no pending migrations
- live source refresh exchange on target Auth — passed, cleanup 0/0

Production traffic remains unchanged.