### PR TITLE
fix(migration): scope Node SSL mode to database runner

### DIFF
--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -226,7 +226,14 @@ jobs:
 
       - name: Apply migrations to the US shadow database
         if: inputs.synchronize_database
-        run: DATABASE_URL="$TARGET_DATABASE_URL" pnpm --filter @kortix/db migrate
+        run: |
+          set -euo pipefail
+          migration_database_url="$(
+            DATABASE_URL="$TARGET_DATABASE_URL" \
+              node scripts/prod-us-east-2/node-pg-database-url.mjs
+          )"
+          echo "::add-mask::$migration_database_url"
+          DATABASE_URL="$migration_database_url" pnpm --filter @kortix/db migrate
 
       - name: Refresh application replication
         if: inputs.synchronize_database

--- a/docs/runbooks/prod-us-east-2-supabase-migration.md
+++ b/docs/runbooks/prod-us-east-2-supabase-migration.md
@@ -15,8 +15,8 @@
 - Migration and runtime database URLs: updated after the password rotation.
 - US API and gateway tasks: restarted after the password rotation.
 - Fresh-project bootstrap: applied.
-- Repository migration ledger: 79 migrations applied through
-  `20260725012141489_gateway_cost_precision_sync`.
+- Repository migration ledger: 80 migrations applied through
+  `20260725012200000_voice_call_turns`.
 - `pg_cron`: enabled at version 1.6.4 with zero scheduled jobs.
 - Application logical replication: `101/101` relations ready.
 - Auth logical replication: `22/22` relations ready.
@@ -24,6 +24,8 @@
 - Application replication sync errors: `3`.
 - Auth replication sync errors: `0`.
 - The three application sync errors are historical initial-copy retries.
+- Replication refreshes compare cumulative error counters with a pre-refresh
+  baseline and fail if either counter increases.
 - Both subscriptions have active apply workers.
 - A source GoTrue refresh token exchanges successfully on target Auth.
 - The target issues the exchanged token with `HS256` and signing-key ID
@@ -395,6 +397,11 @@ host. A Fargate probe returned `ECONNREFUSED` for the same endpoint.
 The regional session pooler accepted the Fargate connection. The
 `kortix-prod-us-east-2-env` secret therefore uses the session pooler on port
 `5432` with user `postgres.uhrwvisbqjfxhxjvoofd`.
+
+Keep the stored pooler URL compatible with both `psql` and Node. Store
+`sslmode=require` without the Node-only `uselibpqcompat` query parameter. The
+shadow workflow adds `uselibpqcompat=true` only for the `node-postgres`
+migration process.
 
 Do not replace the runtime `DATABASE_URL` with the direct database endpoint.
 Keep the direct endpoint in `kortix/prod-us-east-2-migration` for logical

--- a/scripts/prod-us-east-2/node-pg-database-url.mjs
+++ b/scripts/prod-us-east-2/node-pg-database-url.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  console.error("DATABASE_URL is required");
+  process.exit(64);
+}
+
+let parsed;
+try {
+  parsed = new URL(databaseUrl);
+} catch {
+  console.error("DATABASE_URL must be a valid URL");
+  process.exit(64);
+}
+
+if (!["postgres:", "postgresql:"].includes(parsed.protocol)) {
+  console.error("DATABASE_URL must use the postgres or postgresql protocol");
+  process.exit(64);
+}
+
+parsed.searchParams.set("uselibpqcompat", "true");
+process.stdout.write(parsed.toString());

--- a/scripts/prod-us-east-2/node-pg-database-url.test.mjs
+++ b/scripts/prod-us-east-2/node-pg-database-url.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptUrl = new URL("./node-pg-database-url.mjs", import.meta.url);
+
+function run(databaseUrl) {
+  return spawnSync(process.execPath, [scriptUrl.pathname], {
+    env: databaseUrl === undefined ? {} : { DATABASE_URL: databaseUrl },
+    encoding: "utf8",
+  });
+}
+
+test("adds Node libpq compatibility without changing the connection target", () => {
+  const input =
+    "postgresql://postgres.example:password@db.example.test:5432/postgres" +
+    "?sslmode=require&application_name=shadow";
+  const result = run(input);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, "");
+
+  const transformed = new URL(result.stdout);
+  assert.equal(transformed.protocol, "postgresql:");
+  assert.equal(transformed.username, "postgres.example");
+  assert.equal(transformed.password, "password");
+  assert.equal(transformed.hostname, "db.example.test");
+  assert.equal(transformed.port, "5432");
+  assert.equal(transformed.pathname, "/postgres");
+  assert.equal(transformed.searchParams.get("sslmode"), "require");
+  assert.equal(transformed.searchParams.get("application_name"), "shadow");
+  assert.equal(transformed.searchParams.get("uselibpqcompat"), "true");
+});
+
+test("replaces an incorrect compatibility value", () => {
+  const result = run(
+    "postgres://postgres:password@db.example.test/postgres" +
+      "?sslmode=verify-full&uselibpqcompat=false",
+  );
+
+  assert.equal(result.status, 0);
+  const transformed = new URL(result.stdout);
+  assert.equal(transformed.searchParams.get("sslmode"), "verify-full");
+  assert.equal(transformed.searchParams.get("uselibpqcompat"), "true");
+});
+
+test("rejects a missing database URL", () => {
+  const result = run(undefined);
+
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /DATABASE_URL is required/);
+});
+
+test("rejects a non-Postgres URL", () => {
+  const result = run("https://db.example.test/postgres");
+
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /postgres or postgresql protocol/);
+});

--- a/scripts/prod-us-east-2/refresh-replication.sh
+++ b/scripts/prod-us-east-2/refresh-replication.sh
@@ -154,6 +154,25 @@ if [[ -n "$unsafe_relations" ]]; then
   exit 1
 fi
 
+read -r baseline_apply_errors baseline_sync_errors < <(
+  psql "$TARGET_DATABASE_URL" -X -qAt -F ' ' -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT
+  COALESCE(pg_stat_subscription_stats.apply_error_count, 0),
+  COALESCE(pg_stat_subscription_stats.sync_error_count, 0)
+FROM pg_subscription
+LEFT JOIN pg_stat_subscription_stats
+  ON pg_stat_subscription_stats.subid = pg_subscription.oid
+WHERE pg_subscription.subname = :'subscription'
+  AND pg_subscription.subenabled;
+SQL
+)
+
+if [[ -z "${baseline_apply_errors:-}" || -z "${baseline_sync_errors:-}" ]]; then
+  echo "The enabled target subscription is missing." >&2
+  exit 1
+fi
+
 psql "$SOURCE_DATABASE_URL" -X -q -v ON_ERROR_STOP=1 \
   -v publication="$PUBLICATION" <<'SQL'
 SELECT set_config('kortix.migration_publication', :'publication', false)
@@ -293,15 +312,16 @@ GROUP BY
 SQL
   )
 
-  if [[ "$apply_errors" != "0" || "$sync_errors" != "0" ]]; then
-    echo "Replication errors detected: apply=$apply_errors sync=$sync_errors" >&2
+  if [[ "$apply_errors" -gt "$baseline_apply_errors" \
+    || "$sync_errors" -gt "$baseline_sync_errors" ]]; then
+    echo "New replication errors detected: apply=$apply_errors baseline=$baseline_apply_errors sync=$sync_errors baseline=$baseline_sync_errors" >&2
     exit 1
   fi
 
   if [[ "$ready_relations" == "$total_relations" \
     && "$total_relations" == "$source_relation_count" \
     && "$apply_workers" -ge 1 ]]; then
-    echo "US shadow replication is ready: $ready_relations/$total_relations relations."
+    echo "US shadow replication is ready: $ready_relations/$total_relations relations; errors unchanged at apply=$apply_errors sync=$sync_errors."
     exit 0
   fi
 

--- a/scripts/prod-us-east-2/refresh-replication.test.mjs
+++ b/scripts/prod-us-east-2/refresh-replication.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const script = readFileSync(
+  new URL("./refresh-replication.sh", import.meta.url),
+  "utf8",
+);
+
+test("captures cumulative error counters before refreshing the subscription", () => {
+  const baseline = script.indexOf(
+    "read -r baseline_apply_errors baseline_sync_errors",
+  );
+  const refresh = script.indexOf("ALTER SUBSCRIPTION %I REFRESH PUBLICATION");
+
+  assert.ok(baseline >= 0);
+  assert.ok(refresh > baseline);
+});
+
+test("rejects only replication errors added by the current refresh", () => {
+  assert.match(script, /"\$apply_errors" -gt "\$baseline_apply_errors"/);
+  assert.match(script, /"\$sync_errors" -gt "\$baseline_sync_errors"/);
+  assert.doesNotMatch(script, /"\$sync_errors" != "0"/);
+});
+
+test("requires an enabled target subscription before changing the publication", () => {
+  const missingSubscription = script.indexOf(
+    "The enabled target subscription is missing.",
+  );
+  const sourcePublicationChange = script.indexOf(
+    'psql "$SOURCE_DATABASE_URL"',
+    missingSubscription,
+  );
+
+  assert.ok(missingSubscription >= 0);
+  assert.ok(sourcePublicationChange > missingSubscription);
+});


### PR DESCRIPTION
## Summary

- keep the stored US shadow database URL compatible with `psql`
- add `uselibpqcompat=true` only for the Node migration process
- compare cumulative replication errors with a pre-refresh baseline
- record the applied voice migration in the US migration runbook

## Verification

- `node --check scripts/prod-us-east-2/node-pg-database-url.mjs`
- `node --test scripts/prod-us-east-2/node-pg-database-url.test.mjs scripts/prod-us-east-2/refresh-replication.test.mjs` — 7 passed
- `bash -n scripts/prod-us-east-2/refresh-replication.sh`
- `shellcheck scripts/prod-us-east-2/refresh-replication.sh`
- raw AWS secret URL through `psql` — PostgreSQL 17.6
- transformed URL through `pnpm --filter @kortix/db migrate:status` — no pending migrations
- live replication refresh — 101/101, apply errors 0, sync errors unchanged at 3
- `git diff --check`

Production traffic remains unchanged.