### PR TITLE
Keep ACP sessions on the current daemon snapshot

### DIFF
--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -74,6 +74,7 @@ let providerCreateCalls = 0;
 let providerFallbackEnabled = false;
 let providerNamesRequested: string[] = [];
 let providerCreateErrors: Record<string, string | undefined> = {};
+let imageRequests: Array<Record<string, unknown>> = [];
 
 function compile(condition: unknown): { sql: string; params: unknown[] } {
   try {
@@ -213,13 +214,16 @@ mock.module('./provider-balancer', () => ({
 
 mock.module('../../snapshots/builder', () => ({
   DEFAULT_SANDBOX_SLUG: 'default',
-  ensureSandboxImage: async (_gitProject: unknown, _opts: unknown) => ({
-    snapshotName: 'snap-test-1',
-    slug: 'default',
-    contentHash: 'hash-1',
-    isDefault: true,
-    built: false,
-  }),
+  ensureSandboxImage: async (_gitProject: unknown, opts: Record<string, unknown>) => {
+    imageRequests.push(opts);
+    return {
+      snapshotName: 'snap-test-1',
+      slug: 'default',
+      contentHash: 'hash-1',
+      isDefault: true,
+      built: false,
+    };
+  },
   deleteSandboxImage: async () => {},
   resolveTemplate: async (_project: unknown, _slug: unknown) => ({}),
 }));
@@ -303,6 +307,7 @@ beforeEach(() => {
   providerFallbackEnabled = false;
   providerNamesRequested = [];
   providerCreateErrors = {};
+  imageRequests = [];
 });
 
 function baseOpts() {
@@ -320,6 +325,40 @@ function baseOpts() {
 }
 
 describe('provisionSessionSandbox — mid-provision delete race', () => {
+  test('ACP sessions require the current sandbox runtime identity', async () => {
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+
+    await provisionSessionSandbox({
+      ...baseOpts(),
+      projectMetadata: { experimental: { acp_runtime: true } },
+    });
+    await opened;
+
+    expect(imageRequests[0]).toMatchObject({
+      source: 'session-start',
+      requireCurrentRuntime: true,
+    });
+  });
+
+  test('REST sessions retain last-known-good runtime compatibility', async () => {
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+
+    await provisionSessionSandbox({
+      ...baseOpts(),
+      projectMetadata: { experimental: { acp_runtime: false } },
+    });
+    await opened;
+
+    expect(imageRequests[0]).toMatchObject({
+      source: 'session-start',
+      requireCurrentRuntime: false,
+    });
+  });
+
   test('E2B success records only provider-neutral lifecycle metadata and E2B billing attribution', async () => {
     const opened = waitFor((resolve) => {
       onComputeOpened = resolve;

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -56,6 +56,7 @@ import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { resolveLlmGatewayBaseUrl } from '../../llm-gateway/sandbox-base-url';
 import { RuntimeIdentityConflictError } from '../../projects/runtime-identity-error';
 import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
+import { resolveProjectRuntimeTransport } from '../../experimental/features';
 
 /**
  * Bound for the pre-active hook. Generous, because the hook is a data restore and
@@ -258,6 +259,7 @@ export async function provisionSessionSandbox(opts: {
 }): Promise<ProvisionSessionSandboxResult> {
   const { sandboxId, accountId, projectId, userId, serverType, location } = opts;
   const providerWasExplicitlySelected = opts.provider !== undefined;
+  const requireCurrentRuntime = resolveProjectRuntimeTransport(opts.projectMetadata) === 'acp';
   // Resolution order:
   //   1. Explicit per-request `opts.provider` (set by callers that need a
   //      specific runtime, e.g. when restarting an existing sandbox).
@@ -294,6 +296,7 @@ export async function provisionSessionSandbox(opts: {
       accountId,
       source: 'session-start',
       provider: providerName,
+      requireCurrentRuntime,
     });
     return { ...image, gitProject };
   })();
@@ -515,6 +518,7 @@ export async function provisionSessionSandbox(opts: {
           accountId,
           source: 'session-start',
           provider: providerName,
+          requireCurrentRuntime,
         });
       }
       imageInfo = {

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -42,6 +42,7 @@ import {
   type SandboxTemplateProvider,
   type SandboxTemplateProviderCoverage,
 } from './provider-coverage';
+import { canServeLastKnownGoodRuntime } from './runtime-freshness';
 
 export { resolveCommitSha };
 export { DEFAULT_SANDBOX_SLUG };
@@ -145,6 +146,12 @@ export async function ensureSandboxImage(
     slug?: string;
     accountId?: string;
     source?: SnapshotBuildSource;
+    /**
+     * Reject the previous active snapshot when the runtime identity changed.
+     * ACP sessions set this because the daemon is part of the JSON-RPC
+     * transport contract.
+     */
+    requireCurrentRuntime?: boolean;
     /**
      * The provider the SESSION will run on (its sandbox provider). Build there,
      * not on the template row's last-built provider — otherwise a template built
@@ -302,7 +309,10 @@ export async function ensureSandboxImage(
   // path above. Pre-builds and explicit manual/CR builds skip this and build
   // inline, since their whole job is to produce the new image up front.
   if (
-    (opts.source ?? 'session-start') === 'session-start' &&
+    canServeLastKnownGoodRuntime({
+      source: opts.source ?? 'session-start',
+      requireCurrentRuntime: opts.requireCurrentRuntime ?? false,
+    }) &&
     template.providerSnapshotName &&
     template.providerSnapshotName !== identity.snapshotName
   ) {

--- a/apps/api/src/snapshots/runtime-freshness.test.ts
+++ b/apps/api/src/snapshots/runtime-freshness.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+
+import { canServeLastKnownGoodRuntime } from './runtime-freshness';
+
+describe('canServeLastKnownGoodRuntime', () => {
+  test('rejects a stale runtime for ACP sessions', () => {
+    expect(
+      canServeLastKnownGoodRuntime({
+        source: 'session-start',
+        requireCurrentRuntime: true,
+      }),
+    ).toBe(false);
+  });
+
+  test('keeps the non-blocking compatibility path for REST sessions', () => {
+    expect(
+      canServeLastKnownGoodRuntime({
+        source: 'session-start',
+        requireCurrentRuntime: false,
+      }),
+    ).toBe(true);
+  });
+
+  test('never serves a stale runtime for explicit build operations', () => {
+    for (const source of ['project-create', 'cr-merge', 'manual', 'background', 'startup'] as const) {
+      expect(
+        canServeLastKnownGoodRuntime({
+          source,
+          requireCurrentRuntime: false,
+        }),
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/snapshots/runtime-freshness.ts
+++ b/apps/api/src/snapshots/runtime-freshness.ts
@@ -1,0 +1,19 @@
+export type RuntimeSnapshotBuildSource =
+  | 'session-start'
+  | 'project-create'
+  | 'cr-merge'
+  | 'manual'
+  | 'background'
+  | 'startup';
+
+/**
+ * A compatibility session can boot the previous active runtime while the new
+ * content-addressed image builds. ACP sessions require the current daemon
+ * because pending JSON-RPC request replay is part of the transport contract.
+ */
+export function canServeLastKnownGoodRuntime(input: {
+  source: RuntimeSnapshotBuildSource;
+  requireCurrentRuntime: boolean;
+}): boolean {
+  return input.source === 'session-start' && !input.requireCurrentRuntime;
+}

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -2711,3 +2711,50 @@ Post-repair verification:
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
 and deployed ACP plus REST parity remain.
+
+---
+
+### 2026-07-25 — session `whitelabel-acp-reference` (runtime freshness follow-up)
+
+The merged reference app exposed two live-path defects.
+
+Project provisioning used the shared 30-second request timeout. Real sandbox
+provisioning exceeded that limit. `projects.provision()` now accepts request
+options and defaults to 120 seconds.
+
+ACP startup accepted a stale last-known-good daemon snapshot while rebuilding the
+current snapshot. That daemon dropped unresolved ACP questions after 120 seconds.
+ACP sessions now require the current content-addressed runtime snapshot. REST
+sessions retain the last-known-good compatibility policy.
+
+TDD evidence:
+
+- Provisioning request options and default timeout: RED before `6c9db9051`,
+  GREEN after `6c9db9051`.
+- Runtime-freshness module: **0 pass / 1 fail** before implementation.
+- Session-sandbox policy: **9 pass / 2 fail** before implementation.
+- Runtime-freshness module: **3 pass / 0 fail** after implementation.
+- Session-sandbox policy: **11 pass / 0 fail** after implementation.
+
+Post-fix verification:
+
+- SDK typecheck: exit 0.
+- SDK suite: **1260 pass / 0 fail** with **5630** assertions.
+- SDK packed-install smoke: pass.
+- API typecheck: exit 0.
+- White-label typecheck and production build: exit 0.
+- White-label suite: **57 pass / 3 skip / 0 fail** with **182** assertions.
+- White-label SDK boundary: **0 violations**.
+- Real local ACP and REST presentation plus question parity: **1 pass** in
+  **12.4 minutes**.
+- The ACP question remained visible after 121 seconds and a page reload.
+- Both transports submitted Beta and rendered `QUESTION_BETA`.
+- ACP used `session/prompt` and sent zero `/prompt_async` requests.
+- REST used `/prompt_async` and sent zero `/kortix/acp/` requests.
+- Post-cleanup database proof: `active_projects=0`, `cleanup_users=0`.
+- `git diff --check`: exit 0.
+
+**Status:** FOLLOW-UP IMPLEMENTATION COMPLETE.
+
+**Shippable to production: NOT YET.** Follow-up PR merge, Deploy Dev, deployed
+SHA proof, and deployed ACP plus REST parity remain.

--- a/packages/sdk/src/core/rest/projects-client/projects.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, mock, test } from 'bun:test';
 
 import {
   getProjectDetail,
+  provisionProject,
   provisionProjectWithToken,
   type CreateProjectRepoInput,
 } from './projects';
@@ -36,6 +37,49 @@ test('returns ok:true with the parsed project on a real 200 body', async () => {
   const result = await provisionProjectWithToken(opts, input);
   expect(result.ok).toBe(true);
   expect(result.ok && result.project.project_id).toBe('proj-1');
+});
+
+test('provisionProject applies the caller timeout to slow managed-git provisioning', async () => {
+  configureKortix({
+    backendUrl: 'http://backend.test/v1',
+    getToken: async () => 'tok',
+  });
+  globalThis.fetch = mock(
+    async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
+      await new Promise<Response>((resolve, reject) => {
+        const timer = setTimeout(
+          () =>
+            resolve(
+              new Response(JSON.stringify({ project_id: 'proj-too-late' }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+              }),
+            ),
+          50,
+        );
+        init?.signal?.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timer);
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          },
+          { once: true },
+        );
+      }),
+  ) as unknown as typeof fetch;
+
+  await expect(
+    provisionProject(
+      { account_id: 'acc-1', name: 'Slow Project', seed_starter: true },
+      { timeout: 5 },
+    ),
+  ).rejects.toMatchObject({
+    code: 'TIMEOUT',
+    endpoint: '/projects/provision',
+    timeout: 5,
+  });
 });
 
 // Regression: a 200 whose body has no project_id used to be reported as a

--- a/packages/sdk/src/core/rest/projects-client/projects.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.ts
@@ -360,12 +360,22 @@ export async function createProjectRepo(input: CreateProjectRepoInput) {
  * default. No GitHub account or repo-name uniqueness needed; the starter is
  * seeded server-side so the project boots immediately.
  */
-export async function provisionProject(input: ProvisionProjectInput) {
+export async function provisionProject(
+  input: ProvisionProjectInput,
+  options: ApiClientOptions = {},
+) {
   return unwrap(
-    await backendApi.post<KortixProject>('/projects/provision', {
-      seed_starter: true,
-      ...input,
-    }),
+    await backendApi.post<KortixProject>(
+      '/projects/provision',
+      {
+        seed_starter: true,
+        ...input,
+      },
+      {
+        timeout: 120_000,
+        ...options,
+      },
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary

- add SDK request options to `projects.provision()` and use a 120-second provisioning timeout
- require ACP sessions to boot the current content-addressed daemon snapshot
- keep the last-known-good runtime policy for REST compatibility sessions
- record local ACP and REST parity evidence in `packages/sdk/PROGRESS.md`

## Why

The first deployed ACP parity run booted a stale daemon snapshot while the current snapshot rebuilt. The stale daemon removed an unresolved ACP question after 120 seconds. ACP now waits for the current runtime. REST keeps the existing compatibility behavior.

## Verification

- `pnpm --filter @kortix/sdk typecheck` — exit 0
- `pnpm --filter @kortix/sdk test` — 1260 pass, 0 fail, 5630 assertions
- `pnpm --filter @kortix/sdk run smoke:install` — pass
- API typecheck — exit 0
- white-label typecheck and production build — exit 0
- white-label suite — 57 pass, 3 skip, 0 fail, 182 assertions
- white-label SDK boundary — 0 violations
- local ACP and REST presentation plus question parity — 1 pass in 12.4 minutes
- ACP question persisted for 121 seconds and across page reload
- ACP sent zero `/prompt_async` requests
- REST sent zero `/kortix/acp/` requests
- cleanup — 0 active parity projects and 0 parity users
- `git diff --check` — exit 0