### PR TITLE
Fix model provider connection UX

### DIFF
--- a/apps/web/src/components/markdown/copy-button.tsx
+++ b/apps/web/src/components/markdown/copy-button.tsx
@@ -5,7 +5,7 @@ import { Check, Copy } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useState } from 'react';
 
-export function CopyButton({ code }: { code: string }) {
+export function CopyButton({ code, className }: { code: string; className?: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
@@ -20,6 +20,7 @@ export function CopyButton({ code }: { code: string }) {
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
       aria-label={copied ? 'Copied' : 'Copy code'}
       className={cn(
@@ -27,6 +28,7 @@ export function CopyButton({ code }: { code: string }) {
         'text-foreground hover:text-foreground hover:bg-muted-foreground/10',
         'cursor-pointer transition-colors active:scale-[0.97]',
         'outline-none focus-visible:outline-none',
+        className,
       )}
     >
       <span className="relative inline-flex size-3.5 items-center justify-center">

--- a/apps/web/src/components/projects/chatgpt-device-challenge.test.ts
+++ b/apps/web/src/components/projects/chatgpt-device-challenge.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const challengeSource = readFileSync(join(import.meta.dir, 'chatgpt-device-challenge.tsx'), 'utf8');
+const sidebarConnectSource = readFileSync(
+  join(import.meta.dir, 'chatgpt-subscription-connect.tsx'),
+  'utf8',
+);
+const providerConnectSource = readFileSync(
+  join(
+    import.meta.dir,
+    '../../features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx',
+  ),
+  'utf8',
+);
+
+describe('ChatGPT device authorization', () => {
+  test('shows the device code before the explicit auth-page action', () => {
+    const code = challengeSource.indexOf('{code}');
+    const authPage = challengeSource.indexOf('Open auth page');
+
+    expect(code).toBeGreaterThan(-1);
+    expect(authPage).toBeGreaterThan(code);
+  });
+
+  test('provides a device-code copy action', () => {
+    expect(challengeSource).toContain('<CopyButton code={code}');
+    expect(challengeSource).toContain('label="Copy code"');
+  });
+
+  test('does not open the auth page from either connection request', () => {
+    expect(sidebarConnectSource).not.toContain('window.open');
+    expect(providerConnectSource).not.toContain('window.open');
+    expect(sidebarConnectSource).toContain('<ChatGptDeviceChallenge');
+    expect(providerConnectSource).toContain('<ChatGptDeviceChallenge');
+  });
+});

--- a/apps/web/src/components/projects/chatgpt-device-challenge.tsx
+++ b/apps/web/src/components/projects/chatgpt-device-challenge.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { CopyButton } from '@/components/markdown/copy-button';
+import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
+import { ExternalLink } from 'lucide-react';
+
+export function ChatGptDeviceChallenge({ url, code }: { url: string; code: string | null }) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <p className="text-foreground text-xs font-medium">Copy your device code</p>
+        <p className="text-muted-foreground text-xs leading-5 text-pretty">
+          Copy this code. Then open the auth page and enter it to connect ChatGPT.
+        </p>
+      </div>
+
+      {code ? (
+        <div className="border-border bg-muted flex min-h-10 items-center gap-2 rounded-sm border py-1 pr-1 pl-3">
+          <code className="text-foreground min-w-0 flex-1 font-mono text-lg font-semibold tracking-widest tabular-nums">
+            {code}
+          </code>
+          <Hint label="Copy code">
+            <CopyButton code={code} className="size-10 shrink-0" />
+          </Hint>
+        </div>
+      ) : null}
+
+      {url ? (
+        <Button type="button" size="sm" variant="outline" className="h-8 gap-1.5 px-3" asChild>
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="size-3.5 shrink-0" />
+            Open auth page
+          </a>
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/projects/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/components/projects/chatgpt-subscription-connect.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { AlertCircle, ExternalLink, Loader2 } from 'lucide-react';
+import { CheckCircle2, TriangleAlert } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { ChatGptDeviceChallenge } from '@/components/projects/chatgpt-device-challenge';
 import { Button } from '@/components/ui/button';
+import { InfoBanner } from '@/components/ui/info-banner';
+import Loading from '@/components/ui/loading';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+  Modal,
+  ModalContent,
+  ModalDescription,
+  ModalHeader,
+  ModalTitle,
+} from '@/components/ui/modal';
+import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
 import {
   type SharingSelection,
@@ -20,15 +24,14 @@ import {
   selectionToIntent,
 } from '@/features/workspace/shared/sharing-picker';
 import { accountStateSelectors, useAccountState } from '@/hooks/billing';
-import { refreshProjectProviderState } from '@kortix/sdk/react';
 import { isBillingEnabled } from '@/lib/config';
+import { useBillingAccountId } from '@/stores/billing-account-context';
 import {
   listProjectSecrets,
   pollProjectProviderOAuth,
   startProjectProviderOAuth,
 } from '@kortix/sdk';
-import { toast } from '@/lib/toast';
-import { useBillingAccountId } from '@/stores/billing-account-context';
+import { refreshProjectProviderState } from '@kortix/sdk/react';
 
 export const CODEX_AUTH_JSON_SECRET_NAME = 'CODEX_AUTH_JSON';
 export const LEGACY_RUNTIME_AUTH_JSON_SECRET_NAME = 'OPENCODE_AUTH_JSON';
@@ -141,9 +144,6 @@ export function ChatGptSubscriptionConnect({
       });
       if (cancelledRef.current) return;
       setChallenge({ url: start.verification_url, code: start.user_code });
-      if (start.verification_url) {
-        window.open(start.verification_url, '_blank', 'noopener,noreferrer');
-      }
 
       const interval = Math.max(2000, start.interval_ms || 3000);
       const deadline = start.expires_at || Date.now() + 10 * 60_000;
@@ -159,7 +159,7 @@ export function ChatGptSubscriptionConnect({
         if (cancelledRef.current) return;
         if (res.status === 'success') {
           setPhase('done');
-          toast.success('ChatGPT subscription connected to this project');
+          successToast('ChatGPT subscription connected to this project');
           queryClient.invalidateQueries({ queryKey: ['project-secrets', projectId] });
           refreshProjectProviderState(queryClient, projectId, { expectProviderId: 'codex' });
           onConnected?.();
@@ -200,7 +200,7 @@ export function ChatGptSubscriptionConnect({
   const waiting = phase === 'waiting';
 
   return (
-    <div className="border-border/50 bg-muted/20 rounded-2xl border p-4">
+    <div className="bg-popover rounded-md border p-4">
       <div className="flex items-start gap-3">
         <ProviderLogo providerID="openai" name="OpenAI" size="default" />
         <div className="min-w-0 flex-1">
@@ -218,7 +218,7 @@ export function ChatGptSubscriptionConnect({
       </div>
 
       {waiting && (
-        <div className="border-border/50 bg-background/70 mt-3 rounded-2xl border p-3">
+        <div className="border-border bg-muted/30 mt-3 rounded-md border p-3">
           {challenge ? (
             <>
               <div className="text-foreground text-xs font-medium">
@@ -226,32 +226,9 @@ export function ChatGptSubscriptionConnect({
                   'autoComponentsProjectsProjectProviderModalJsxTextAuthorizeInThed882ae47',
                 )}
               </div>
-              {challenge.url && (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="mt-2 h-8 gap-1.5 px-3"
-                  onClick={() => window.open(challenge.url, '_blank', 'noopener,noreferrer')}
-                >
-                  <ExternalLink className="h-3.5 w-3.5" />
-                  {tI18nHardcoded.raw(
-                    'autoComponentsProjectsProjectProviderModalJsxTextOpenAuthPaged0381841',
-                  )}
-                </Button>
-              )}
-              {challenge.code ? (
-                <div className="mt-3">
-                  <div className="text-muted-foreground text-xs">
-                    {tI18nHardcoded.raw(
-                      'autoComponentsProjectsProjectProviderModalJsxTextEnterThisCodee346992b',
-                    )}
-                  </div>
-                  <div className="border-border/60 bg-muted text-foreground mt-1 w-fit rounded-2xl border px-3 py-2 font-mono text-lg font-semibold tracking-normal">
-                    {challenge.code}
-                  </div>
-                </div>
-              ) : null}
+              <div className="mt-3">
+                <ChatGptDeviceChallenge url={challenge.url} code={challenge.code} />
+              </div>
             </>
           ) : (
             <div className="text-foreground text-xs font-medium">
@@ -261,25 +238,24 @@ export function ChatGptSubscriptionConnect({
             </div>
           )}
           <div className="text-muted-foreground mt-3 flex items-center gap-2 text-xs">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loading className="size-3.5 shrink-0" />
             {challenge ? 'Waiting for you to finish in the browser…' : 'Connecting to OpenAI…'}
           </div>
         </div>
       )}
 
       {phase === 'done' && (
-        <div className="text-foreground/80 mt-3 flex items-start gap-2 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] px-3 py-2.5 text-xs">
+        <InfoBanner tone="success" icon={CheckCircle2} className="mt-3 text-xs">
           {tI18nHardcoded.raw(
             'autoComponentsProjectsProjectProviderModalJsxTextChatGPTSubscriptionConnectedcf12bc87',
           )}
-        </div>
+        </InfoBanner>
       )}
 
       {error && (
-        <div className="bg-destructive/5 text-destructive mt-3 flex items-start gap-2 rounded-2xl px-3 py-2 text-xs">
-          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
-          <span>{error}</span>
-        </div>
+        <InfoBanner tone="destructive" icon={TriangleAlert} className="mt-3 text-xs">
+          {error}
+        </InfoBanner>
       )}
 
       {!autoStartOnOpen && (
@@ -333,14 +309,14 @@ export function ChatGptSubscriptionConnectDialog({
   }, [onOpenChange]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-0 space-y-0 overflow-hidden p-0 sm:max-w-md">
-        <DialogHeader className="space-y-1 px-5 pt-5 pb-3">
-          <DialogTitle className="text-base font-semibold">Connect GPT subscription</DialogTitle>
-          <DialogDescription className="text-xs">
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent className="gap-0 space-y-0 overflow-hidden p-0 lg:max-w-md">
+        <ModalHeader className="space-y-1 pb-3">
+          <ModalTitle>Connect GPT subscription</ModalTitle>
+          <ModalDescription className="text-xs">
             Use your ChatGPT Plus or Pro subscription for premium models on the free plan.
-          </DialogDescription>
-        </DialogHeader>
+          </ModalDescription>
+        </ModalHeader>
         <div className="px-5 pb-5">
           {open ? (
             <ChatGptSubscriptionConnect
@@ -350,7 +326,7 @@ export function ChatGptSubscriptionConnectDialog({
             />
           ) : null}
         </div>
-      </DialogContent>
-    </Dialog>
+      </ModalContent>
+    </Modal>
   );
 }

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
 import {
   CommandGroup,
   CommandInput,
@@ -153,6 +154,8 @@ export interface ModelSelectorProps {
    */
   unsetLabel?: string;
   disabled?: boolean;
+  /** True while the runtime provider catalog request has not resolved. */
+  modelsLoading?: boolean;
 }
 
 export function ModelSelector({
@@ -162,6 +165,7 @@ export function ModelSelector({
   defaultControls,
   unsetLabel = 'No model',
   disabled = false,
+  modelsLoading = false,
 }: ModelSelectorProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const [open, setOpen] = useState(false);
@@ -173,6 +177,7 @@ export function ModelSelector({
     openConnectProvider,
     openUpgrade,
     modal: connectionModal,
+    entitlementsPending,
     showUpgradeOption,
   } = useModelConnectionGate();
 
@@ -412,7 +417,15 @@ export function ModelSelector({
               />
 
               <CommandList className="max-h-[380px]">
-                {grouped.length > 0 ? (
+                {modelsLoading || entitlementsPending ? (
+                  <div
+                    className="flex min-h-32 items-center justify-center"
+                    role="status"
+                    aria-label="Loading models"
+                  >
+                    <Loading className="text-muted-foreground size-4 shrink-0" />
+                  </div>
+                ) : grouped.length > 0 ? (
                   <>
                     {grouped.map((group) => (
                       <CommandGroup

--- a/apps/web/src/features/session/session-chat-input.tsx
+++ b/apps/web/src/features/session/session-chat-input.tsx
@@ -2249,6 +2249,7 @@ function SessionChatInputImpl({
               {(models.length > 0 || modelRequired) && onModelChange && (
                 <ModelSelector
                   models={models}
+                  modelsLoading={modelsLoading}
                   selectedModel={selectedModel}
                   onSelect={onModelChange}
                   providers={providers}

--- a/apps/web/src/features/session/use-model-connection-gate.test.ts
+++ b/apps/web/src/features/session/use-model-connection-gate.test.ts
@@ -28,4 +28,10 @@ describe('model management entry-point routing', () => {
     expect(selectorSource).toContain('aria-label="Manage models"');
     expect(selectorSource).toContain('Connect provider');
   });
+
+  test('keeps the model picker in a loading state until all model inputs resolve', () => {
+    expect(selectorSource).toContain('modelsLoading || entitlementsPending');
+    expect(selectorSource).toContain('aria-label="Loading models"');
+    expect(selectorSource).toContain('<Loading');
+  });
 });

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -1,14 +1,15 @@
 'use client';
 
+import { ChatGptDeviceChallenge } from '@/components/projects/chatgpt-device-challenge';
 import { Button } from '@/components/ui/button';
 import { InfoBanner } from '@/components/ui/info-banner';
 import Loading from '@/components/ui/loading';
 import { successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
-import { refreshProjectProviderState } from '@kortix/sdk/react';
 import { pollProjectProviderOAuth, startProjectProviderOAuth } from '@kortix/sdk';
+import { refreshProjectProviderState } from '@kortix/sdk/react';
 import { useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, ExternalLink, TriangleAlert } from 'lucide-react';
+import { CheckCircle2, TriangleAlert } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -54,9 +55,6 @@ export function ChatGptSubscriptionConnect({
       const start = await startProjectProviderOAuth(projectId, 'openai', {});
       if (cancelledRef.current) return;
       setChallenge({ url: start.verification_url, code: start.user_code });
-      if (start.verification_url) {
-        window.open(start.verification_url, '_blank', 'noopener,noreferrer');
-      }
 
       const interval = Math.max(2000, start.interval_ms || 3000);
       const deadline = start.expires_at || Date.now() + 10 * 60_000;
@@ -133,32 +131,9 @@ export function ChatGptSubscriptionConnect({
                   'autoComponentsProjectsProjectProviderModalJsxTextAuthorizeInThed882ae47',
                 )}
               </div>
-              {challenge.url && (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="mt-2 h-8 gap-1.5 px-3"
-                  onClick={() => window.open(challenge.url, '_blank', 'noopener,noreferrer')}
-                >
-                  <ExternalLink className="h-3.5 w-3.5" />
-                  {tHardcodedUi.raw(
-                    'autoComponentsProjectsProjectProviderModalJsxTextOpenAuthPaged0381841',
-                  )}
-                </Button>
-              )}
-              {challenge.code ? (
-                <div className="mt-3">
-                  <div className="text-muted-foreground text-xs">
-                    {tHardcodedUi.raw(
-                      'autoComponentsProjectsProjectProviderModalJsxTextEnterThisCodee346992b',
-                    )}
-                  </div>
-                  <div className="border-border bg-muted text-foreground mt-1 w-fit rounded-md border px-3 py-2 font-mono text-lg font-semibold tracking-widest tabular-nums">
-                    {challenge.code}
-                  </div>
-                </div>
-              ) : null}
+              <div className="mt-3">
+                <ChatGptDeviceChallenge url={challenge.url} code={challenge.code} />
+              </div>
             </>
           ) : (
             <div className="text-foreground text-xs font-medium">

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
@@ -17,13 +17,13 @@ describe('LLM provider modal flow', () => {
 
   test('renders pending and query-refresh loading states with the shared Loading component', () => {
     expect(modalSource).toContain('pendingProviderId &&');
-    expect(modalSource).toContain('secretsQuery.isLoading || secretsQuery.isFetching');
+    expect(modalSource).toContain('providerStateLoading');
     expect(modalSource).toContain('Connecting {pendingProviderLabel}…');
     expect(modalSource).toContain('<Loading');
   });
 
   test('uses the 600 by 680 modal dimensions', () => {
-    expect(modalSource).toContain('h-[min(80vh,680px)]');
+    expect(modalSource).toContain('h-[min(680px,calc(100dvh-2rem))]');
     expect(modalSource).toContain('max-w-[600px]');
     expect(modalSource).toContain('lg:max-w-[600px]');
     expect(modalSource).not.toContain('max-w-[520px]');

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -43,7 +43,7 @@ export function ProjectProviderModal({
   canWrite = false,
 }: ProjectProviderModalProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
-  const { secretsQuery, connectedProviders, llmGatewayEnabled } = useConnectedProviders(
+  const { connectedProviders, llmGatewayEnabled, providerStateLoading } = useConnectedProviders(
     projectId,
     open || asPanel,
   );
@@ -192,7 +192,7 @@ export function ProjectProviderModal({
           </div>
         )}
 
-        {!pendingProviderId && (secretsQuery.isLoading || secretsQuery.isFetching) && (
+        {!pendingProviderId && providerStateLoading && (
           <div
             className="flex min-h-[200px] items-center justify-center"
             role="status"
@@ -202,7 +202,7 @@ export function ProjectProviderModal({
           </div>
         )}
 
-        {!pendingProviderId && !secretsQuery.isLoading && !secretsQuery.isFetching && (
+        {!pendingProviderId && !providerStateLoading && (
           <>
             <TabsContent value="connected" className="mt-0">
               <ConnectedTab
@@ -245,8 +245,8 @@ export function ProjectProviderModal({
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <ModalContent className="flex h-[min(80vh,680px)] w-[calc(100vw-2rem)] max-w-[600px] flex-col gap-0 overflow-hidden p-0 lg:max-w-[600px]">
-        <ModalHeader>
+      <ModalContent className="flex h-[min(680px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-[600px] flex-col gap-0 overflow-hidden p-0 lg:max-w-[600px]">
+        <ModalHeader className="shrink-0 pb-3">
           <ModalTitle>
             {tHardcodedUi.raw('componentsProjectsProjectProviderModal.line151JsxTextLlmProviders')}
           </ModalTitle>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/use-connected-providers.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/use-connected-providers.ts
@@ -1,11 +1,11 @@
 'use client';
 
-import { useRuntimeProviders } from '@kortix/sdk/react';
 import { isManagedProviderEnabled } from '@/lib/config';
 import { isLlmGatewayEnabled } from '@/lib/llm-gateway';
 import { LLM_PROVIDERS, type LlmProviderEntry, type LlmProviderModel } from '@/lib/llm-providers';
 import { getManagedModel, isProviderAuthSatisfied } from '@kortix/llm-catalog';
 import { getProjectDetail, listProjectSecrets } from '@kortix/sdk';
+import { useRuntimeProviders } from '@kortix/sdk/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -47,7 +47,8 @@ export function useConnectedProviders(projectId: string, enabled: boolean) {
   // into the LLM Gateway. Native OpenCode projects should show only providers
   // backed by project secrets, even if an old running sandbox still exposes a
   // stale `kortix` provider.
-  const { data: ocProviders } = useRuntimeProviders();
+  const runtimeProvidersQuery = useRuntimeProviders();
+  const { data: ocProviders } = runtimeProvidersQuery;
 
   const kortixProvider = useMemo<LlmProviderEntry | null>(() => {
     // CLOUD-ONLY: the served catalog already excludes every managed model on a
@@ -113,5 +114,8 @@ export function useConnectedProviders(projectId: string, enabled: boolean) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- catalogRevision drives a re-read of the module-level LLM_PROVIDERS binding, not a value used directly here
   }, [secretNames, kortixProvider, ocProviders, catalogRevision]);
 
-  return { secretsQuery, connectedProviders, llmGatewayEnabled };
+  const providerStateLoading =
+    projectDetailQuery.isLoading || secretsQuery.isLoading || runtimeProvidersQuery.isLoading;
+
+  return { secretsQuery, connectedProviders, llmGatewayEnabled, providerStateLoading };
 }


### PR DESCRIPTION
## Summary

- keep the model picker in a loading state until runtime models and entitlement inputs resolve
- keep the provider modal at a stable 600 by 680 desktop shell with a scroll-only body
- show the ChatGPT device code before an explicit auth-page action
- add an accessible device-code copy control and remove both automatic redirects

## Verification

- `bun test src/features/session/model-selector.test.ts src/features/session/use-model-connection-gate.test.ts src/features/workspace/customize/sections/llm-provider src/components/projects/chatgpt-device-challenge.test.ts` — 42 pass, 0 fail
- focused ESLint for all changed implementation files — 0 errors
- focused TypeScript output — 0 errors for changed files
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter Kortix-Computer-Frontend build` — passed
- local `GET http://localhost:13708/v1/health` — 200
- local `GET http://localhost:13700/auth` — 200

## Browser verification

The browser runtime reported zero available browser sessions. UI interaction remains unverified.