### PR TITLE
test(migration): gate US shadow authentication

### DIFF
--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -172,6 +172,36 @@ jobs:
           role-to-assume: ${{ env.ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Validate shadow runtime controls
+        run: |
+          set -euo pipefail
+          secret_json="$(
+            aws secretsmanager get-secret-value \
+              --secret-id "$TARGET_ENV_BLOB" \
+              --region "$AWS_REGION" \
+              --query SecretString \
+              --output text
+          )"
+          jq -e '
+            .ENV_MODE == "cloud"
+            and .INTERNAL_KORTIX_ENV == "prod"
+            and .KORTIX_BILLING_INTERNAL_ENABLED == "true"
+            and .KORTIX_WORKERS_ENABLED == "false"
+            and .SCHEDULER_ENABLED == "false"
+            and .CHANNELS_ENABLED == "false"
+            and .KORTIX_MANAGED_PROVIDER_ENABLED == "false"
+            and .KORTIX_PRERESUME_ENABLED == "false"
+            and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
+            and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"
+            and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+            and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+            and .KORTIX_WARM_POOL_ENABLED == "false"
+            and .KORTIX_WARM_SNAPSHOT_ENABLED == "false"
+            and .TUNNEL_ENABLED == "false"
+            and .POOL_ENABLED == "false"
+          ' <<<"$secret_json" >/dev/null
+          echo "US shadow runtime controls match the prepared cutover state."
+
       - name: Keep shadow DNS proxied
         run: bash scripts/prod-us-east-2/ensure-shadow-dns.sh
         env:
@@ -179,14 +209,12 @@ jobs:
           CLOUDFLARE_GLOBAL_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
 
-      - name: Install database tools
-        if: inputs.synchronize_database
+      - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
       - name: Install Bun
-        if: inputs.synchronize_database
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
@@ -338,6 +366,46 @@ jobs:
 
           echo "::error::US shadow endpoints did not pass within 10 minutes."
           exit 1
+
+      - name: Verify target Auth, API, OAuth, MFA, and Storage
+        run: |
+          set -euo pipefail
+          TARGET_SECRET_ID="$TARGET_ENV_BLOB" \
+          TARGET_AWS_REGION="$AWS_REGION" \
+          TARGET_API_URL="$API_URL" \
+          TARGET_FRONTEND_URL="https://us.kortix.com" \
+          TARGET_AUTH_SEQUENCE_HEADROOM="100000000" \
+          KEEP_TARGET_AUTH_SEQUENCE_HEADROOM="1" \
+            bash scripts/prod-us-east-2/target-smoke.sh
+
+      - name: Install frontend Auth smoke dependencies
+        run: |
+          set -euo pipefail
+          cd tests
+          bun install --frozen-lockfile --ignore-scripts
+          bunx playwright install --with-deps chromium
+
+      - name: Verify public API contracts
+        run: |
+          set -euo pipefail
+          cd tests
+          KE2E_API_URL="$API_URL/v1" \
+          KE2E_BASE_URL="https://us.kortix.com" \
+          KE2E_GATEWAY_URL="$GATEWAY_URL" \
+          KE2E_TARGET="custom" \
+            bun bin/ke2e.ts run \
+              --id ACC-1,ACC-2,ACC-4,DOCS-1,SYS-1,SYS-2,SYS-4,SYS-5,SYS-6,SYS-8 \
+              --workers 1
+
+      - name: Verify frontend password login and authenticated shell
+        run: |
+          set -euo pipefail
+          TARGET_SECRET_ID="$TARGET_ENV_BLOB" \
+          TARGET_AWS_REGION="$AWS_REGION" \
+          TARGET_API_URL="$API_URL/v1" \
+          TARGET_FRONTEND_URL="https://us.kortix.com" \
+          TARGET_AUTH_SEQUENCE_HEADROOM="100000000" \
+            bash scripts/prod-us-east-2/frontend-auth-smoke.sh
 
       - name: Summary
         run: |

--- a/docs/runbooks/prod-us-east-2-supabase-migration.md
+++ b/docs/runbooks/prod-us-east-2-supabase-migration.md
@@ -435,9 +435,11 @@ source of truth.
 7. Monitor replication lag and retained WAL.
 
 Logical replication does not advance target sequences. Do not accept target
-Auth writes while source Auth remains writable. A stale
-`auth.refresh_tokens_id_seq` causes refresh-token rotation to return HTTP `500`
-after a duplicate primary-key insert.
+Auth writes while source Auth remains writable unless the write is a controlled
+smoke test. Each controlled smoke test must reserve 100,000,000 values above
+`max(auth.refresh_tokens.id)`. It must delete its target-only rows after the
+test. A stale `auth.refresh_tokens_id_seq` causes refresh-token rotation to
+return HTTP `500` after a duplicate primary-key insert.
 
 Do not publish Supabase-owned internal tables through a publication owned by
 the application role. Supabase Support must handle those schemas.
@@ -481,6 +483,19 @@ Run the target smoke:
 bash scripts/prod-us-east-2/target-smoke.sh
 ```
 
+The target smoke retains 100,000,000 refresh-token sequence values by default.
+It verifies password Auth, Google and GitHub authorization redirects, MFA,
+Storage, API authentication, and target-only row cleanup.
+
+Run the deployed frontend Auth smoke:
+
+```bash
+bash scripts/prod-us-east-2/frontend-auth-smoke.sh
+```
+
+The frontend Auth smoke verifies the password grant, the visible login form,
+and the authenticated application shell on `https://us.kortix.com`.
+
 Run the source refresh-token compatibility smoke:
 
 ```bash
@@ -494,7 +509,9 @@ The refresh smoke reserves a temporary high target sequence range. It restores
 The production release calls
 `.github/workflows/deploy-prod-us-east-2-shadow.yml`. It applies target
 migrations, refreshes application replication, synchronizes `avatars`, deploys
-the released API and gateway images, and verifies the shadow endpoints.
+the released API and gateway images, verifies the shadow endpoints, validates
+the disabled writer flags, and runs target Auth, OAuth, MFA, Storage, public
+API, and deployed frontend checks.
 
 ## Reconciliation gates
 

--- a/scripts/prod-us-east-2/frontend-auth-smoke.sh
+++ b/scripts/prod-us-east-2/frontend-auth-smoke.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix/prod-us-east-2-migration}"
+TARGET_AWS_REGION="${TARGET_AWS_REGION:-us-east-2}"
+TARGET_FRONTEND_URL="${TARGET_FRONTEND_URL:-https://us.kortix.com}"
+TARGET_API_URL="${TARGET_API_URL:-https://api-use2-shadow.kortix.com/v1}"
+TARGET_AUTH_SEQUENCE_HEADROOM="${TARGET_AUTH_SEQUENCE_HEADROOM:-100000000}"
+REPOSITORY_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+for command_name in aws base64 curl jq openssl psql; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+if ! [[ "$TARGET_AUTH_SEQUENCE_HEADROOM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "TARGET_AUTH_SEQUENCE_HEADROOM must be a positive integer." >&2
+  exit 1
+fi
+
+playwright_command="$REPOSITORY_ROOT/tests/node_modules/.bin/playwright"
+if [[ ! -x "$playwright_command" ]]; then
+  echo "Install tests dependencies before running the frontend Auth smoke." >&2
+  exit 1
+fi
+
+target_secret_json="$(
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$TARGET_AWS_REGION" \
+    --query SecretString \
+    --output text
+)"
+
+target_database_url="$(
+  jq -er '.target_database_url // .DATABASE_URL' <<<"$target_secret_json"
+)"
+target_supabase_url="$(
+  jq -er '.target_supabase_url // .SUPABASE_URL' <<<"$target_secret_json"
+)"
+target_anon_key="$(
+  jq -er '.target_anon_key // .SUPABASE_ANON_KEY' <<<"$target_secret_json"
+)"
+target_service_role_key="$(
+  jq -er '.target_service_role_key // .SUPABASE_SERVICE_ROLE_KEY' \
+    <<<"$target_secret_json"
+)"
+
+smoke_email="use2-browser-smoke-$(date +%s)-$(openssl rand -hex 4)@invalid.kortix.test"
+smoke_password="$(openssl rand -base64 36 | tr -d '\n')aA1!"
+smoke_user_id=""
+original_webhook_url="$(
+  psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+    -c "SELECT backend_url FROM public.webhook_config WHERE id = 1"
+)"
+encoded_webhook_url="$(printf '%s' "$original_webhook_url" | base64)"
+
+restore_webhook() {
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -c "UPDATE public.webhook_config
+        SET backend_url = convert_from(
+          decode('$encoded_webhook_url', 'base64'),
+          'UTF8'
+        )
+        WHERE id = 1" || true
+}
+
+cleanup() {
+  restore_webhook
+  if [[ -z "$smoke_user_id" ]]; then
+    return
+  fi
+
+  curl -sS -o /dev/null \
+    -X DELETE \
+    -H "Authorization: Bearer $target_service_role_key" \
+    -H "apikey: $target_service_role_key" \
+    "$target_supabase_url/auth/v1/admin/users/$smoke_user_id" || true
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v smoke_user_id="$smoke_user_id" \
+    -v sequence_headroom="$TARGET_AUTH_SEQUENCE_HEADROOM" \
+    >/dev/null <<'SQL' || true
+DELETE FROM kortix.audit_events
+WHERE actor_user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM kortix.accounts
+WHERE account_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.audit_log_entries
+WHERE payload::text LIKE '%' || :'smoke_user_id' || '%';
+
+DELETE FROM auth.refresh_tokens
+WHERE user_id = :'smoke_user_id';
+
+DELETE FROM auth.sessions
+WHERE user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.mfa_factors
+WHERE user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.identities
+WHERE user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM auth.users
+WHERE id = :'smoke_user_id'::uuid;
+
+SELECT setval(
+  'auth.refresh_tokens_id_seq'::regclass,
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1)
+    + :'sequence_headroom'::bigint,
+  true
+);
+SQL
+}
+trap cleanup EXIT
+
+psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+  -v sequence_headroom="$TARGET_AUTH_SEQUENCE_HEADROOM" \
+  >/dev/null <<'SQL'
+SELECT setval(
+  'auth.refresh_tokens_id_seq'::regclass,
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1)
+    + :'sequence_headroom'::bigint,
+  true
+);
+SQL
+
+psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+  -c "UPDATE public.webhook_config SET backend_url = '' WHERE id = 1"
+
+create_body="$(
+  jq -cn \
+    --arg email "$smoke_email" \
+    --arg password "$smoke_password" \
+    '{
+      email: $email,
+      password: $password,
+      email_confirm: true,
+      user_metadata: {kortix_use2_browser_smoke: true}
+    }'
+)"
+create_response="$(
+  curl -fsS \
+    -X POST \
+    -H "Authorization: Bearer $target_service_role_key" \
+    -H "apikey: $target_service_role_key" \
+    -H "Content-Type: application/json" \
+    --data-binary "$create_body" \
+    "$target_supabase_url/auth/v1/admin/users"
+)"
+smoke_user_id="$(jq -er '.id // .user.id' <<<"$create_response")"
+restore_webhook
+
+E2E_BASE_URL="$TARGET_FRONTEND_URL" \
+E2E_API_URL="$TARGET_API_URL" \
+E2E_SUPABASE_URL="$target_supabase_url" \
+E2E_OWNER_EMAIL="$smoke_email" \
+E2E_OWNER_PASSWORD="$smoke_password" \
+SUPABASE_ANON_KEY="$target_anon_key" \
+NEXT_PUBLIC_SUPABASE_ANON_KEY="$target_anon_key" \
+SUPABASE_SERVICE_ROLE_KEY="$target_service_role_key" \
+  "$playwright_command" test \
+    -c "$REPOSITORY_ROOT/tests/playwright.config.ts" \
+    "$REPOSITORY_ROOT/tests/e2e/specs/04-auth-flow.spec.ts" \
+    --project chromium \
+    --reporter=line
+
+for attempt in 1 2 3; do
+  cleanup
+  cleanup_rows="$(
+    psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -v smoke_user_id="$smoke_user_id" <<'SQL'
+SELECT
+  (SELECT count(*) FROM auth.audit_log_entries
+    WHERE payload::text LIKE '%' || :'smoke_user_id' || '%')
+  + (SELECT count(*) FROM auth.users
+    WHERE id = :'smoke_user_id'::uuid)
+  + (SELECT count(*) FROM kortix.accounts
+    WHERE account_id = :'smoke_user_id'::uuid)
+  + (SELECT count(*) FROM kortix.audit_events
+    WHERE actor_user_id = :'smoke_user_id'::uuid);
+SQL
+  )"
+  if [[ "$cleanup_rows" == "0" ]]; then
+    break
+  fi
+  sleep "$attempt"
+done
+trap - EXIT
+
+if [[ "$cleanup_rows" != "0" ]]; then
+  echo "Frontend Auth smoke cleanup left $cleanup_rows rows." >&2
+  exit 1
+fi
+
+echo '{"supabasePasswordGrant":true,"browserPasswordLogin":true,"authenticatedShell":true,"cleanupRows":0}'

--- a/scripts/prod-us-east-2/target-smoke.mjs
+++ b/scripts/prod-us-east-2/target-smoke.mjs
@@ -9,6 +9,9 @@ const requiredEnvironment = [
   'TARGET_ANON_KEY',
   'TARGET_SERVICE_ROLE_KEY',
   'TARGET_API_URL',
+  'TARGET_FRONTEND_URL',
+  'TARGET_AUTH_SEQUENCE_HEADROOM',
+  'KEEP_TARGET_AUTH_SEQUENCE_HEADROOM',
 ];
 
 for (const name of requiredEnvironment) {
@@ -22,12 +25,26 @@ const databaseUrl = process.env.TARGET_DATABASE_URL;
 const anonKey = process.env.TARGET_ANON_KEY;
 const serviceRoleKey = process.env.TARGET_SERVICE_ROLE_KEY;
 const apiUrl = process.env.TARGET_API_URL.replace(/\/+$/, '');
+const frontendUrl = process.env.TARGET_FRONTEND_URL.replace(/\/+$/, '');
+const authSequenceHeadroom = Number.parseInt(
+  process.env.TARGET_AUTH_SEQUENCE_HEADROOM,
+  10,
+);
+const keepAuthSequenceHeadroom =
+  process.env.KEEP_TARGET_AUTH_SEQUENCE_HEADROOM === '1';
 const smokePassword = `${randomBytes(32).toString('base64url')}aA1!`;
 const smokeEmail = `migration-smoke-${Date.now()}-${randomUUID().slice(0, 8)}@invalid.kortix.test`;
+
+if (!Number.isSafeInteger(authSequenceHeadroom) || authSequenceHeadroom < 1) {
+  throw new Error(
+    'TARGET_AUTH_SEQUENCE_HEADROOM must be a positive safe integer',
+  );
+}
 
 let smokeUserId = null;
 let originalWebhookUrl = null;
 let signupWebhookSuppressed = false;
+const smokeFlowStateIds = [];
 
 function sql(input, variables = {}) {
   const args = [databaseUrl, '-X', '-qAt', '-v', 'ON_ERROR_STOP=1'];
@@ -87,6 +104,49 @@ async function apiRequest(path, accessToken, expectedStatuses = [200]) {
   return response;
 }
 
+async function verifyProviderAuthorization(provider, expectedHost) {
+  const redirectTo = `${frontendUrl}/auth/callback`;
+  const authorizeUrl = new URL('/auth/v1/authorize', `${targetUrl}/`);
+  authorizeUrl.searchParams.set('provider', provider);
+  authorizeUrl.searchParams.set('redirect_to', redirectTo);
+
+  const response = await fetch(authorizeUrl, {
+    redirect: 'manual',
+    headers: {
+      apikey: anonKey,
+      Referer: `${frontendUrl}/auth`,
+    },
+  });
+  if (response.status !== 302) {
+    throw new Error(
+      `${provider} authorization returned HTTP ${response.status}`,
+    );
+  }
+
+  const location = response.headers.get('location');
+  if (!location) throw new Error(`${provider} authorization omitted Location`);
+  const providerUrl = new URL(location);
+  if (providerUrl.hostname !== expectedHost) {
+    throw new Error(
+      `${provider} authorization used ${providerUrl.hostname}, expected ${expectedHost}`,
+    );
+  }
+  if (providerUrl.searchParams.get('redirect_to') !== redirectTo) {
+    throw new Error(`${provider} authorization changed redirect_to`);
+  }
+  if (
+    providerUrl.searchParams.get('redirect_uri') !==
+    `${targetUrl}/auth/v1/callback`
+  ) {
+    throw new Error(
+      `${provider} authorization used the wrong Supabase callback`,
+    );
+  }
+
+  const state = providerUrl.searchParams.get('state');
+  if (state && /^[0-9a-f-]{36}$/i.test(state)) smokeFlowStateIds.push(state);
+}
+
 function adminHeaders() {
   return {
     Authorization: `Bearer ${serviceRoleKey}`,
@@ -105,7 +165,10 @@ function userHeaders(accessToken) {
 
 function decodeBase32(input) {
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
-  const normalized = input.toUpperCase().replaceAll('=', '').replace(/[^A-Z2-7]/g, '');
+  const normalized = input
+    .toUpperCase()
+    .replaceAll('=', '')
+    .replace(/[^A-Z2-7]/g, '');
   let bits = '';
   for (const character of normalized) {
     const value = alphabet.indexOf(character);
@@ -123,7 +186,9 @@ function currentTotp(secret) {
   const counter = Math.floor(Date.now() / 30_000);
   const counterBuffer = Buffer.alloc(8);
   counterBuffer.writeBigUInt64BE(BigInt(counter));
-  const digest = createHmac('sha1', decodeBase32(secret)).update(counterBuffer).digest();
+  const digest = createHmac('sha1', decodeBase32(secret))
+    .update(counterBuffer)
+    .digest();
   const offset = digest[digest.length - 1] & 0x0f;
   const value =
     ((digest[offset] & 0x7f) << 24) |
@@ -177,11 +242,18 @@ WHERE id = :'smoke_user_id'::uuid;
 
 SELECT setval(
   'auth.refresh_tokens_id_seq'::regclass,
-  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1),
-  EXISTS (SELECT 1 FROM auth.refresh_tokens)
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1)
+    + :'sequence_headroom'::bigint,
+  CASE
+    WHEN :'sequence_headroom'::bigint > 0 THEN true
+    ELSE EXISTS (SELECT 1 FROM auth.refresh_tokens)
+  END
 );
 `,
-    { smoke_user_id: smokeUserId },
+    {
+      smoke_user_id: smokeUserId,
+      sequence_headroom: keepAuthSequenceHeadroom ? authSequenceHeadroom : 0,
+    },
   );
 }
 
@@ -241,18 +313,31 @@ async function run() {
     aal2Token: false,
     signedAvatar: false,
     publicAvatar: null,
+    googleAuthorization: false,
+    githubAuthorization: false,
+    refreshTokenSequenceHeadroom: null,
+    refreshTokenSequenceReady: false,
     cleanupRows: null,
     cleanupByTable: null,
   };
 
   try {
-    sql(`
+    sql(
+      `
 SELECT setval(
   'auth.refresh_tokens_id_seq'::regclass,
-  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1) + 1000000,
+  COALESCE((SELECT max(id) FROM auth.refresh_tokens), 1)
+    + :'sequence_headroom'::bigint,
   true
 );
-`);
+`,
+      { sequence_headroom: authSequenceHeadroom },
+    );
+
+    await verifyProviderAuthorization('google', 'accounts.google.com');
+    result.googleAuthorization = true;
+    await verifyProviderAuthorization('github', 'github.com');
+    result.githubAuthorization = true;
 
     originalWebhookUrl = sql(
       `SELECT backend_url FROM public.webhook_config WHERE id = 1;\n`,
@@ -276,7 +361,8 @@ WHERE id = 1;
     });
     const created = await createResponse.json();
     smokeUserId = created.id ?? created.user?.id;
-    if (!smokeUserId) throw new Error('Auth admin create did not return a user id');
+    if (!smokeUserId)
+      throw new Error('Auth admin create did not return a user id');
 
     await restoreSignupWebhook();
 
@@ -296,14 +382,16 @@ WHERE id = 1;
     });
     const tokenBody = await tokenResponse.json();
     const accessToken = tokenBody.access_token;
-    if (!accessToken) throw new Error('Password login did not return an access token');
+    if (!accessToken)
+      throw new Error('Password login did not return an access token');
     result.passwordLogin = true;
 
     const userResponse = await request('/auth/v1/user', {
       headers: userHeaders(accessToken),
     });
     const user = await userResponse.json();
-    if (user.id !== smokeUserId) throw new Error('Auth user response returned another user');
+    if (user.id !== smokeUserId)
+      throw new Error('Auth user response returned another user');
 
     const apiResponse = await apiRequest('/v1/user-roles', accessToken);
     const apiIdentity = await apiResponse.json();
@@ -334,7 +422,8 @@ WHERE id = 1;
     const enrolled = await enrollResponse.json();
     const factorId = enrolled.id;
     const totpSecret = enrolled.totp?.secret;
-    if (!factorId || !totpSecret) throw new Error('TOTP enrollment omitted factor data');
+    if (!factorId || !totpSecret)
+      throw new Error('TOTP enrollment omitted factor data');
     result.totpEnrollment = true;
 
     const challengeResponse = await request(
@@ -396,7 +485,8 @@ LIMIT 1;
       ? `${targetUrl}/storage/v1${signedPath}`
       : new URL(signedPath, targetUrl).toString();
     const signedResponse = await request(signedUrl, {}, [200]);
-    result.signedAvatar = Number(signedResponse.headers.get('content-length') ?? 1) > 0;
+    result.signedAvatar =
+      Number(signedResponse.headers.get('content-length') ?? 1) > 0;
 
     if (bucketPublic === 't') {
       const publicResponse = await request(
@@ -404,7 +494,8 @@ LIMIT 1;
         {},
         [200],
       );
-      result.publicAvatar = Number(publicResponse.headers.get('content-length') ?? 1) > 0;
+      result.publicAvatar =
+        Number(publicResponse.headers.get('content-length') ?? 1) > 0;
     }
   } finally {
     await restoreSignupWebhook();
@@ -428,6 +519,26 @@ LIMIT 1;
         0,
       );
     }
+    if (smokeFlowStateIds.length > 0) {
+      sql(
+        `
+DELETE FROM auth.flow_state
+WHERE id = ANY(string_to_array(:'flow_state_ids', ',')::uuid[]);
+`,
+        { flow_state_ids: smokeFlowStateIds.join(',') },
+      );
+    }
+    result.refreshTokenSequenceHeadroom = Number(
+      sql(`
+SELECT
+  last_value - COALESCE((SELECT max(id) FROM auth.refresh_tokens), 0)
+FROM auth.refresh_tokens_id_seq;
+`),
+    );
+    result.refreshTokenSequenceReady =
+      !keepAuthSequenceHeadroom ||
+      result.refreshTokenSequenceHeadroom >=
+        Math.floor(authSequenceHeadroom / 2);
   }
 
   const requiredChecks = [
@@ -439,6 +550,9 @@ LIMIT 1;
     result.totpChallenge,
     result.aal2Token,
     result.signedAvatar,
+    result.googleAuthorization,
+    result.githubAuthorization,
+    result.refreshTokenSequenceReady,
     result.cleanupRows === 0,
   ];
   if (result.publicAvatar !== null) requiredChecks.push(result.publicAvatar);

--- a/scripts/prod-us-east-2/target-smoke.sh
+++ b/scripts/prod-us-east-2/target-smoke.sh
@@ -20,14 +20,29 @@ target_secret_json="$(
 )"
 
 export TARGET_DATABASE_URL
-TARGET_DATABASE_URL="$(jq -er '.target_database_url' <<<"$target_secret_json")"
+TARGET_DATABASE_URL="$(
+  jq -er '.target_database_url // .DATABASE_URL' <<<"$target_secret_json"
+)"
 export TARGET_SUPABASE_URL
-TARGET_SUPABASE_URL="$(jq -er '.target_supabase_url' <<<"$target_secret_json")"
+TARGET_SUPABASE_URL="$(
+  jq -er '.target_supabase_url // .SUPABASE_URL' <<<"$target_secret_json"
+)"
 export TARGET_ANON_KEY
-TARGET_ANON_KEY="$(jq -er '.target_anon_key' <<<"$target_secret_json")"
+TARGET_ANON_KEY="$(
+  jq -er '.target_anon_key // .SUPABASE_ANON_KEY' <<<"$target_secret_json"
+)"
 export TARGET_SERVICE_ROLE_KEY
-TARGET_SERVICE_ROLE_KEY="$(jq -er '.target_service_role_key' <<<"$target_secret_json")"
+TARGET_SERVICE_ROLE_KEY="$(
+  jq -er '.target_service_role_key // .SUPABASE_SERVICE_ROLE_KEY' \
+    <<<"$target_secret_json"
+)"
 export TARGET_API_URL
 TARGET_API_URL="${TARGET_API_URL:-https://api-use2-shadow.kortix.com}"
+export TARGET_FRONTEND_URL
+TARGET_FRONTEND_URL="${TARGET_FRONTEND_URL:-https://us.kortix.com}"
+export TARGET_AUTH_SEQUENCE_HEADROOM
+TARGET_AUTH_SEQUENCE_HEADROOM="${TARGET_AUTH_SEQUENCE_HEADROOM:-100000000}"
+export KEEP_TARGET_AUTH_SEQUENCE_HEADROOM
+KEEP_TARGET_AUTH_SEQUENCE_HEADROOM="${KEEP_TARGET_AUTH_SEQUENCE_HEADROOM:-1}"
 
 node "$(dirname "$0")/target-smoke.mjs"


### PR DESCRIPTION
## Summary

- retain a 100,000,000-ID `auth.refresh_tokens` sequence reserve during logical replication
- verify Google and GitHub authorization redirects use the US Supabase callback and `us.kortix.com` return URL
- run password Auth, API authentication, MFA, Storage, public API, and browser login gates after each US shadow deployment
- verify all US shadow writer flags remain disabled
- delete every target-only smoke user, account, audit event, session, token, factor, identity, and OAuth flow row

## Live verification

- `target-smoke.sh`: all Auth, API, OAuth, MFA, Storage, sequence, and cleanup checks passed
- `frontend-auth-smoke.sh`: `2 passed (10.1s)` and `cleanupRows=0`
- `ke2e`: `10/10 passed` for the non-mutating public contract selection
- `db-sync.sh status`: `101/101` relations ready, `apply_error_count=0`
- `auth-sync.sh status`: `22/22` relations ready, `apply_error_count=0`
- ECS API: `2/2`, rollout `COMPLETED`, failed tasks `0`
- ECS gateway: `2/2`, rollout `COMPLETED`, failed tasks `0`

## Production safety

- production routing remains unchanged
- US workers, schedulers, channels, tunnels, warm pools, and migration workers remain disabled
- no production cutover is part of this PR
