### PR TITLE
fix(sdk): reconcile REST prompts before first event

### DIFF
--- a/apps/whitelabel-demo/src/components/chat/message-view.tsx
+++ b/apps/whitelabel-demo/src/components/chat/message-view.tsx
@@ -165,7 +165,7 @@ export function MessageView({ message }: { message: MessageWithParts }) {
     // Bubble sits directly in the row (no min-w-0 column) so it sizes to its
     // content up to max-width — never collapses to a sliver.
     return (
-      <Message align="end">
+      <Message align="end" data-message-role="user">
         <Bubble variant="secondary" align="end">
           <BubbleContent>{text}</BubbleContent>
         </Bubble>
@@ -175,7 +175,7 @@ export function MessageView({ message }: { message: MessageWithParts }) {
 
   if (isEmpty) return null;
   return (
-    <div className="space-y-2.5 text-sm leading-relaxed">
+    <div data-message-role="assistant" className="space-y-2.5 text-sm leading-relaxed">
       {/* Fragment (not a div) so parts that deliberately render `null`
           (step/snapshot/agent/unknown) don't leave behind an empty spacer
           under `space-y-2.5`. */}

--- a/apps/whitelabel-demo/src/components/chat/tool-call.tsx
+++ b/apps/whitelabel-demo/src/components/chat/tool-call.tsx
@@ -325,6 +325,7 @@ export function ToolCall({ tool }: { tool: ToolView }) {
 
   return (
     <Collapsible
+      data-slot="tool-call"
       className={cn(
         'rounded-lg border bg-card/50',
         isError ? 'border-destructive/30 bg-destructive/[0.03]' : 'border-border',

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -2758,3 +2758,69 @@ Post-fix verification:
 
 **Shippable to production: NOT YET.** Follow-up PR merge, Deploy Dev, deployed
 SHA proof, and deployed ACP plus REST parity remain.
+
+---
+
+### 2026-07-26 — session `whitelabel-acp-reference` (deployed parity completion)
+
+The first deployed parity run exposed a fixture funding defect.
+The test changed only `credit_accounts.balance`.
+Billing reads `balance_precise` and `non_expiring_credits_precise`.
+Both precise fields retained the default `$1.00` balance.
+
+The corrected fixture seeds `$100.00` into the rounded and precise wallet
+fields. The test rejects `Out of credits`.
+
+The deployed screenshot comparison also exposed a REST synchronization defect.
+The REST prompt reached `/prompt_async`, but the UI became idle before the first
+SSE status event. The SDK did not start its 10-second reconciliation fallback.
+The transcript therefore contained only the user message at the screenshot
+point.
+
+`useSession()` now marks an accepted REST prompt busy before the first SSE event.
+The session synchronization controller polls the transcript and runtime status
+until the runtime reports idle. Failed sends and explicit cancellation clear the
+optimistic busy state.
+
+The parity specification now requires:
+
+- one rendered assistant message per transport;
+- one rendered tool card per transport;
+- no `Out of credits` transcript;
+- ACP question persistence after 121 seconds and reload;
+- `QUESTION_BETA` after both question replies;
+- zero REST prompt calls from ACP;
+- zero ACP prompt calls from REST.
+
+TDD evidence:
+
+- Deployed screenshot RED: REST had no assistant message or tool card.
+- Focused unit RED: missing `beginRestPromptObservation` export.
+- Focused unit GREEN: **20 pass / 0 fail** with **43** assertions.
+
+Final verification:
+
+- SDK typecheck and example typecheck: exit 0.
+- SDK suite: **1261 pass / 0 fail** with **5632** assertions.
+- SDK packed-install smoke: pass.
+- White-label typecheck and dev-API production build: exit 0.
+- White-label suite: **57 pass / 3 skip / 0 fail** with **182** assertions.
+- White-label SDK boundary: **0 violations**.
+- Test-harness typecheck: exit 0.
+- Strong deployed ACP and REST presentation plus question parity:
+  **1 pass / 0 fail** in **14.1 minutes**.
+- ACP sent **2** ACP prompts and **0** REST prompts.
+- REST sent **2** REST prompts and **0** ACP prompts.
+- ACP rendered **29** real tool cards.
+- REST rendered **32** real tool cards.
+- Both screenshots contain completed presentation tool sequences.
+- Both transports submitted Beta and rendered `QUESTION_BETA`.
+- The stale project `81050937-bc7f-4b05-aafb-914acc019fe4` was archived
+  through `@kortix/sdk`.
+- Post-cleanup database proof: `active_projects=0`, `cleanup_users=0`.
+- `git diff --check`: exit 0.
+
+**Status:** DEPLOYED PARITY COMPLETE.
+
+**Shippable to production: NOT YET.** The synchronization correction still
+requires PR merge, Deploy Dev, deployed SHA proof, and one post-deploy smoke.

--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -41,12 +41,15 @@ import {
   answerPermission,
   classifySendError,
   buildSessionCommandInput,
+  beginRestPromptObservation,
+  endRestPromptObservation,
   sendStateOnStart,
   sendStateOnError,
   shouldRetrySessionStart,
 } from './use-session';
 import { clearSessionFresh, markSessionFresh } from '../core/http/fresh-sessions';
 import { SessionStartError } from '../core/rest/projects-client';
+import { useSyncStore } from '../browser/stores/sync-store';
 
 function seedQuestion(id: string, sessionID = 'sess-1') {
   useOpenCodePendingStore.getState().addQuestion({
@@ -212,6 +215,17 @@ describe('classifySendError', () => {
 });
 
 describe('send state transitions (sendStateOnStart / sendStateOnError)', () => {
+  test('REST prompt observation keeps reconciliation busy until completion', () => {
+    const sessionId = 'sess-rest-observation';
+    useSyncStore.getState().setStatus(sessionId, { type: 'idle' });
+
+    beginRestPromptObservation(sessionId);
+    expect(useSyncStore.getState().sessionStatus[sessionId]).toEqual({ type: 'busy' });
+
+    endRestPromptObservation(sessionId);
+    expect(useSyncStore.getState().sessionStatus[sessionId]).toEqual({ type: 'idle' });
+  });
+
   test('a send failure with a 402-shaped error clears pending and yields a billing sendError', async () => {
     sessionPromptImpl = async () => ({
       error: { data: { message: 'Insufficient credits. Balance: $-0.06' } },

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -28,6 +28,7 @@ import { useOpenCodeCompactionStore } from '../browser/stores/opencode-compactio
 import { useOpenCodePendingStore } from '../browser/stores/opencode-pending-store';
 import { setOpenCodeHealth, setSandboxStatus } from '../browser/stores/sandbox-connection-store';
 import { getSandboxUrlForExternalId } from '../browser/stores/server-store';
+import { useSyncStore } from '../browser/stores/sync-store';
 import { setCurrentRuntime } from '../core/session/current-runtime';
 import {
   isSessionStartError,
@@ -223,6 +224,24 @@ export function sendStateOnStart(text: string): SendState {
  * the error. */
 export function sendStateOnError(error: unknown): SendState {
   return { pending: null, sendError: classifySendError(error) };
+}
+
+/**
+ * Keep the REST compatibility transcript reconciler active after
+ * `promptAsync()` accepts a prompt.
+ *
+ * The runtime can accept the prompt before the browser receives its first SSE
+ * status event. Without this optimistic busy state, the 10-second liveness
+ * reconciliation never starts. The transcript can then stay at the user
+ * message even though the agent completed the turn.
+ */
+export function beginRestPromptObservation(sessionId: string): void {
+  useSyncStore.getState().setStatus(sessionId, { type: 'busy' });
+}
+
+/** Clear the optimistic REST busy state when the prompt never starts or stops. */
+export function endRestPromptObservation(sessionId: string): void {
+  useSyncStore.getState().setStatus(sessionId, { type: 'idle' });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -566,8 +585,10 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   ) => {
     if (!ocSessionId) return;
     pendingBaseCount.current = userMsgCount;
+    if (!usesAcp) beginRestPromptObservation(ocSessionId);
     setSendState(sendStateOnStart(text));
     void sendParts([{ type: 'text', text }], override).catch((error) => {
+      if (!usesAcp) endRestPromptObservation(ocSessionId);
       setSendState(sendStateOnError(error));
     });
   };
@@ -594,7 +615,10 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   const cancel = () => {
     if (ocSessionId) {
       if (usesAcp) void acpRuntime.cancel();
-      else abortMutation.mutate(ocSessionId);
+      else {
+        endRestPromptObservation(ocSessionId);
+        abortMutation.mutate(ocSessionId);
+      }
     }
     questions.forEach((q) => removeQuestion(q.id));
     permissions.forEach((p) => removePermission(p.id));

--- a/tests/e2e/specs/16-whitelabel-acp-rest-parity.spec.ts
+++ b/tests/e2e/specs/16-whitelabel-acp-rest-parity.spec.ts
@@ -19,6 +19,7 @@ const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
 const databaseUrl =
   process.env.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
 const password = 'WhiteLabelParity123!';
+const testCreditBalance = 100;
 const acpQuestionReconnectDelayMs = Number(
   process.env.E2E_WHITELABEL_ACP_QUESTION_RECONNECT_DELAY_MS ?? 121_000,
 );
@@ -115,6 +116,11 @@ async function runSurface(
   await expect(page.getByRole('button', { name: 'Send', exact: true })).toBeVisible({
     timeout: 30_000,
   });
+  await expect(page.locator('[data-message-role="assistant"]').last()).toBeVisible({
+    timeout: 120_000,
+  });
+  const renderedToolCards = page.locator('[data-slot="tool-call"]');
+  await expect(renderedToolCards.first()).toBeVisible({ timeout: 120_000 });
 
   const screenshotPath = testInfo.outputPath(`${fixture.transport}-presentation.png`);
   await page.screenshot({ path: screenshotPath, fullPage: true });
@@ -124,13 +130,12 @@ async function runSurface(
   });
 
   const transcript = await page.locator('main').innerText();
-  const toolCards = await page
-    .locator('main button')
-    .evaluateAll((buttons) =>
-      buttons
-        .map((button) => button.textContent?.replace(/\s+/g, ' ').trim() ?? '')
-        .filter((text) => text.length > 0),
-    );
+  expect(transcript).not.toContain('Out of credits');
+  const toolCards = await renderedToolCards.evaluateAll((cards) =>
+    cards
+      .map((card) => card.textContent?.replace(/\s+/g, ' ').trim() ?? '')
+      .filter((text) => text.length > 0),
+  );
   await testInfo.attach(`${fixture.transport}-transcript`, {
     body: transcript,
     contentType: 'text/plain',
@@ -196,10 +201,29 @@ test.describe.serial('16 — white-label ACP and REST parity', () => {
         '-v',
         'ON_ERROR_STOP=1',
         '-c',
-        `INSERT INTO kortix.credit_accounts (account_id, balance, tier)
-         VALUES ('${account.account_id}', 1000, 'tier_2_20')
+        `INSERT INTO kortix.credit_accounts (
+           account_id,
+           balance,
+           balance_precise,
+           non_expiring_credits,
+           non_expiring_credits_precise,
+           tier
+         )
+         VALUES (
+           '${account.account_id}',
+           ${testCreditBalance},
+           ${testCreditBalance},
+           ${testCreditBalance},
+           ${testCreditBalance},
+           'tier_2_20'
+         )
          ON CONFLICT (account_id)
-         DO UPDATE SET balance = 1000, tier = 'tier_2_20'`,
+         DO UPDATE SET
+           balance = ${testCreditBalance},
+           balance_precise = ${testCreditBalance},
+           non_expiring_credits = ${testCreditBalance},
+           non_expiring_credits_precise = ${testCreditBalance},
+           tier = 'tier_2_20'`,
       ],
       { stdio: 'ignore' },
     );


### PR DESCRIPTION
## Summary

- keep REST compatibility prompts busy before the first SSE status event
- require real assistant messages and tool cards in ACP/REST parity
- seed precise test wallet fields and reject out-of-credit transcripts

## Verification

- `pnpm --filter @kortix/sdk typecheck`
- `pnpm --filter @kortix/sdk test` — 1261 pass, 0 fail
- `pnpm --filter @kortix/sdk run smoke:install`
- `pnpm --filter @kortix/whitelabel-demo test` — 57 pass, 3 skip, 0 fail
- `pnpm --filter @kortix/whitelabel-demo build`
- white-label SDK boundary — 0 violations
- deployed dev ACP/REST parity — 1 pass in 14.1 minutes
- ACP prompts 2/REST prompts 0; REST prompts 2/ACP prompts 0
- ACP tool cards 29; REST tool cards 32
- post-cleanup `active_projects=0`, `cleanup_users=0`