### PR TITLE
test(migration): gate US frontend provider redirects

### DIFF
--- a/docs/runbooks/prod-us-east-2-supabase-migration.md
+++ b/docs/runbooks/prod-us-east-2-supabase-migration.md
@@ -389,7 +389,8 @@ The US shadow endpoints return:
 - Gateway `/health/live`: HTTP `200`, version `0.10.14`.
 - Gateway `/health`: HTTP `200`, API dependency `up`.
 - Frontend `/`: HTTP `200` from Vercel `fra1::cle1`.
-- Frontend HTML contains `api-use2-shadow.kortix.com`.
+- Frontend runtime `BACKEND_URL` is
+  `https://api-use2-shadow.kortix.com/v1`.
 - Frontend HTML contains the target project ref `uhrwvisbqjfxhxjvoofd`.
 
 ### Database connection requirement
@@ -493,8 +494,10 @@ Run the deployed frontend Auth smoke:
 bash scripts/prod-us-east-2/frontend-auth-smoke.sh
 ```
 
-The frontend Auth smoke verifies the password grant, the visible login form,
-and the authenticated application shell on `https://us.kortix.com`.
+The frontend Auth smoke verifies the runtime API and Supabase URLs, password
+grant, visible login form, authenticated application shell, and Google and
+GitHub OAuth initiation on `https://us.kortix.com`. The provider gate fails when
+either provider rejects the target Supabase callback URI.
 
 Run the source refresh-token compatibility smoke:
 

--- a/scripts/prod-us-east-2/frontend-auth-smoke.sh
+++ b/scripts/prod-us-east-2/frontend-auth-smoke.sh
@@ -101,6 +101,10 @@ WHERE user_id = :'smoke_user_id'::uuid;
 DELETE FROM auth.mfa_factors
 WHERE user_id = :'smoke_user_id'::uuid;
 
+DELETE FROM auth.flow_state
+WHERE referrer LIKE '%kortix_use2_oauth_smoke%'
+   OR referrer LIKE '%kortix_use2_github_oauth_smoke%';
+
 DELETE FROM auth.identities
 WHERE user_id = :'smoke_user_id'::uuid;
 
@@ -159,12 +163,15 @@ E2E_API_URL="$TARGET_API_URL" \
 E2E_SUPABASE_URL="$target_supabase_url" \
 E2E_OWNER_EMAIL="$smoke_email" \
 E2E_OWNER_PASSWORD="$smoke_password" \
+E2E_OAUTH_PROVIDER_INITIATION=1 \
 SUPABASE_ANON_KEY="$target_anon_key" \
 NEXT_PUBLIC_SUPABASE_ANON_KEY="$target_anon_key" \
 SUPABASE_SERVICE_ROLE_KEY="$target_service_role_key" \
   "$playwright_command" test \
     -c "$REPOSITORY_ROOT/tests/playwright.config.ts" \
+    "$REPOSITORY_ROOT/tests/e2e/specs/03-frontend-config.spec.ts" \
     "$REPOSITORY_ROOT/tests/e2e/specs/04-auth-flow.spec.ts" \
+    "$REPOSITORY_ROOT/tests/e2e/specs/17-oauth-provider-initiation.spec.ts" \
     --project chromium \
     --reporter=line
 

--- a/scripts/prod-us-east-2/target-smoke.mjs
+++ b/scripts/prod-us-east-2/target-smoke.mjs
@@ -44,7 +44,6 @@ if (!Number.isSafeInteger(authSequenceHeadroom) || authSequenceHeadroom < 1) {
 let smokeUserId = null;
 let originalWebhookUrl = null;
 let signupWebhookSuppressed = false;
-const smokeFlowStateIds = [];
 
 function sql(input, variables = {}) {
   const args = [databaseUrl, '-X', '-qAt', '-v', 'ON_ERROR_STOP=1'];
@@ -143,8 +142,14 @@ async function verifyProviderAuthorization(provider, expectedHost) {
     );
   }
 
-  const state = providerUrl.searchParams.get('state');
-  if (state && /^[0-9a-f-]{36}$/i.test(state)) smokeFlowStateIds.push(state);
+  sql(
+    `
+DELETE FROM auth.flow_state
+WHERE referrer = :'redirect_to'
+  AND NULLIF(code_challenge, '') IS NULL;
+`,
+    { redirect_to: redirectTo },
+  );
 }
 
 function adminHeaders() {
@@ -234,6 +239,9 @@ WHERE user_id = :'smoke_user_id'::uuid;
 DELETE FROM auth.mfa_factors
 WHERE user_id = :'smoke_user_id'::uuid;
 
+DELETE FROM auth.one_time_tokens
+WHERE user_id = :'smoke_user_id'::uuid;
+
 DELETE FROM auth.identities
 WHERE user_id = :'smoke_user_id'::uuid;
 
@@ -287,6 +295,8 @@ SELECT json_build_object(
   (SELECT count(*) FROM auth.identities WHERE user_id = :'smoke_user_id'::uuid),
   'auth.mfa_factors',
   (SELECT count(*) FROM auth.mfa_factors WHERE user_id = :'smoke_user_id'::uuid),
+  'auth.one_time_tokens',
+  (SELECT count(*) FROM auth.one_time_tokens WHERE user_id = :'smoke_user_id'::uuid),
   'auth.refresh_tokens',
   (SELECT count(*) FROM auth.refresh_tokens WHERE user_id = :'smoke_user_id'),
   'auth.sessions',
@@ -517,15 +527,6 @@ LIMIT 1;
       result.cleanupRows = Object.values(result.cleanupByTable).reduce(
         (total, rowCount) => total + Number(rowCount),
         0,
-      );
-    }
-    if (smokeFlowStateIds.length > 0) {
-      sql(
-        `
-DELETE FROM auth.flow_state
-WHERE id = ANY(string_to_array(:'flow_state_ids', ',')::uuid[]);
-`,
-        { flow_state_ids: smokeFlowStateIds.join(',') },
       );
     }
     result.refreshTokenSequenceHeadroom = Number(

--- a/tests/e2e/specs/17-oauth-provider-initiation.spec.ts
+++ b/tests/e2e/specs/17-oauth-provider-initiation.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+
+const frontendUrl = process.env.E2E_BASE_URL || 'http://localhost:13737';
+const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://localhost:13740';
+const verifyOAuthProviders = process.env.E2E_OAUTH_PROVIDER_INITIATION === '1';
+
+test.describe('17 — OAuth provider initiation', () => {
+  test.skip(
+    !verifyOAuthProviders,
+    'Set E2E_OAUTH_PROVIDER_INITIATION=1 for the deployed OAuth gate.',
+  );
+
+  test('Google accepts the target Supabase callback URI', async ({ page }) => {
+    const authUrl = new URL('/auth', frontendUrl);
+    authUrl.searchParams.set(
+      'returnUrl',
+      '/projects?kortix_use2_oauth_smoke=1',
+    );
+    await page.goto(authUrl.toString());
+
+    const authorizeResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().startsWith(`${supabaseUrl}/auth/v1/authorize`) &&
+        response.request().method() === 'GET',
+    );
+    const googleRequestPromise = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        url.hostname === 'accounts.google.com' &&
+        url.pathname === '/o/oauth2/v2/auth'
+      );
+    });
+
+    await page.getByRole('button', { name: /continue with google/i }).click();
+
+    const [authorizeResponse, googleRequest] = await Promise.all([
+      authorizeResponsePromise,
+      googleRequestPromise,
+    ]);
+    expect(authorizeResponse.status()).toBe(302);
+
+    const authorizeUrl = new URL(authorizeResponse.url());
+    expect(authorizeUrl.searchParams.get('provider')).toBe('google');
+    expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('s256');
+    expect(authorizeUrl.searchParams.get('code_challenge')).toBeTruthy();
+
+    const frontendCallback = new URL(
+      authorizeUrl.searchParams.get('redirect_to')!,
+    );
+    expect(frontendCallback.origin).toBe(frontendUrl);
+    expect(frontendCallback.pathname).toBe('/auth/callback');
+    expect(frontendCallback.searchParams.get('returnUrl')).toBe(
+      '/projects?kortix_use2_oauth_smoke=1',
+    );
+
+    const googleUrl = new URL(googleRequest.url());
+    expect(googleUrl.searchParams.get('client_id')).toMatch(
+      /\.apps\.googleusercontent\.com$/,
+    );
+    expect(googleUrl.searchParams.get('redirect_uri')).toBe(
+      `${supabaseUrl}/auth/v1/callback`,
+    );
+
+    await page.waitForURL(
+      (url) =>
+        url.hostname === 'accounts.google.com' &&
+        url.pathname !== '/o/oauth2/v2/auth',
+      { timeout: 30_000 },
+    );
+    await page.waitForLoadState('domcontentloaded');
+
+    expect(new URL(page.url()).pathname).not.toBe('/signin/oauth/error');
+    await expect(page.locator('body')).not.toContainText(
+      'redirect_uri_mismatch',
+    );
+  });
+
+  test('GitHub accepts the target Supabase callback URI', async ({ page }) => {
+    const frontendCallback = new URL('/auth/callback', frontendUrl);
+    frontendCallback.searchParams.set(
+      'returnUrl',
+      '/projects?kortix_use2_github_oauth_smoke=1',
+    );
+    const authorizeUrl = new URL('/auth/v1/authorize', supabaseUrl);
+    authorizeUrl.searchParams.set('provider', 'github');
+    authorizeUrl.searchParams.set('redirect_to', frontendCallback.toString());
+
+    const githubRequestPromise = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        url.hostname === 'github.com' &&
+        url.pathname === '/login/oauth/authorize'
+      );
+    });
+
+    const authorizeResponse = await page.goto(authorizeUrl.toString());
+    const githubRequest = await githubRequestPromise;
+
+    expect(authorizeResponse?.status()).toBe(200);
+    const githubUrl = new URL(githubRequest.url());
+    expect(githubUrl.searchParams.get('client_id')).toBeTruthy();
+    expect(githubUrl.searchParams.get('redirect_uri')).toBe(
+      `${supabaseUrl}/auth/v1/callback`,
+    );
+
+    await page.waitForURL((url) => url.hostname === 'github.com', {
+      timeout: 30_000,
+    });
+    await page.waitForLoadState('domcontentloaded');
+
+    expect(new URL(page.url()).pathname).toBe('/login');
+    await expect(page.locator('body')).not.toContainText(
+      /redirect_uri|incorrect client|application suspended/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- require the US frontend smoke to validate the exact `/v1` backend URL
- verify Google and GitHub accept the target Supabase callback URI
- delete target-only OAuth flow state and password-recovery tokens
- document the expanded US East 2 frontend gate

## Verification

- `bash -n scripts/prod-us-east-2/frontend-auth-smoke.sh`
- `node --check scripts/prod-us-east-2/target-smoke.mjs`
- `pnpm --dir tests exec tsc --noEmit --pretty false`
- target Auth/API/MFA/Storage smoke: all checks true; `cleanupRows=0`
- frontend config: `4/4` passed
- password Auth and authenticated shell: `2/2` passed
- GitHub provider initiation: `1/1` passed
- Google provider initiation: fails on Google's `/signin/oauth/error` with `redirect_uri_mismatch`; this PR makes that external configuration defect a release gate
