### PR TITLE
fix(sdk): make ACP and REST prompt completion monotonic

### DIFF
--- a/apps/whitelabel-demo/src/components/chat/tool-call.tsx
+++ b/apps/whitelabel-demo/src/components/chat/tool-call.tsx
@@ -270,7 +270,10 @@ function QuestionBody({ vm }: { vm: Extract<ToolViewModel, { kind: 'question' }>
 
 function GenericBody({
   vm,
-}: { vm: Extract<ToolViewModel, { kind: 'generic' }>; isError: boolean }) {
+}: {
+  vm: Extract<ToolViewModel, { kind: 'generic' }>;
+  isError: boolean;
+}) {
   return (
     <div className="space-y-2">
       {vm.inputPretty && (
@@ -326,6 +329,7 @@ export function ToolCall({ tool }: { tool: ToolView }) {
   return (
     <Collapsible
       data-slot="tool-call"
+      data-tool-status={tool.status}
       className={cn(
         'rounded-lg border bg-card/50',
         isError ? 'border-destructive/30 bg-destructive/[0.03]' : 'border-border',

--- a/apps/whitelabel-demo/tests/e2e/preview-url.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/preview-url.test.ts
@@ -210,7 +210,7 @@ describe('/api/preview-url in direct mode', () => {
     app = await startApp({
       KORTIX_API_KEY: undefined,
       SESSION_SECRET: undefined,
-      NEXT_PUBLIC_KORTIX_API_URL: `${mock.url}/v1`,
+      KORTIX_UPSTREAM: `${mock.url}/v1`,
     });
   }, 30_000);
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -3037,3 +3037,58 @@ ke2e coverage, local API proof, browser proof, PR merge, Deploy Dev, deployed SH
 proof, and deployed browser proof.
 
 **Status:** COMPLETE — `13167d7cf`.
+
+---
+
+### 2026-07-26 — session `whitelabel-acp-stable-completion` (B23 local completion)
+
+Completed the monotonic ACP and REST prompt-settlement implementation in
+`7a546585c`.
+
+ACP `send()` now resolves after the prompt result and a 500-millisecond quiet
+period. Late assistant, tool, question, and permission updates restart or block
+that settlement. Prompt queue serialization waits for full settlement.
+
+REST prompt observation now belongs to `SessionSyncController`. Premature idle
+events do not clear the public busy state. Late busy events cancel the
+500-millisecond settlement timer. Status reconciliation and SSE events use the
+same controller.
+
+TDD evidence:
+
+- ACP RED: `send()` resolved before delayed tool updates reached the transcript.
+- REST RED: `beginPromptObservation()` did not exist.
+- Focused REST GREEN: **40 pass / 0 fail** with **113** assertions.
+- Preview RED: expected status `200`; received `502`.
+- Preview GREEN: **7 pass / 0 fail** with **36** assertions.
+
+Post-rebase gates:
+
+- SDK typecheck: exit 0.
+- SDK suite: **1268 pass / 0 fail** with **5662** assertions across **105**
+  files.
+- SDK packed-install smoke: pass.
+- White-label typecheck: exit 0.
+- White-label suite: **57 pass / 3 skip / 0 fail** with **182** assertions.
+- White-label SDK boundary: **0 violations**.
+- White-label dev-API production build: exit 0.
+- Test-harness typecheck: exit 0.
+- `git diff --check`: exit 0.
+
+Post-rebase live ACP and REST presentation plus question parity:
+
+- Playwright: **1 pass / 0 fail** in **13.5 minutes**.
+- ACP sent **2** ACP prompts and **0** REST prompts.
+- REST sent **2** REST prompts and **0** ACP prompts.
+- ACP rendered **34** completed tool cards.
+- REST rendered **28** completed tool cards.
+- Tool-card parity ratio: **0.824**.
+- ACP created `/workspace/marko-kraemer.pptx` at **231,898 bytes**.
+- REST created `/workspace/marko_kraemer.pptx` at **228,064 bytes**.
+- Both transports persisted the question flow and rendered `QUESTION_BETA`.
+- Post-cleanup database proof: `active_projects=0`, `cleanup_users=0`.
+
+**Status:** IMPLEMENTATION COMPLETE.
+
+**Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
+and deployed ACP plus REST parity remain.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -251,6 +251,7 @@ Single, self-contained changes. Anything multi-step earns a spec instead.
 | B20 | **Keep ACP SSE connections outside the shared 30-second authenticated-fetch timeout.** The ACP controller uses `/kortix/acp/:sessionId` as a long-lived SSE stream.                                                                                                                                                                                                                                                                            | `src/platform/auth-core.ts` exempted only `/global/event`; deployed cold Chromium aborted the ACP stream before `session/load` settled.                                                                                                                                                                | **DONE 2026-07-25** — implementation `89b97f4cc`; RED test, full SDK gates, and local cold ACP plus REST browser matrix pass                                                                                                                                                                                                         |
 | B21 | **Serialize ACP sends with runtime restart reloads.** A send that starts while OpenCode restarts can wait forever on `session/set_config_option` and never send `session/prompt`.                                                                                                                                                                                                                                                               | Deployed cold Chromium sent `session/set_config_option` at `13:36:20.250Z`, received `kortix/runtime_ready`, then sent `session/load` at `13:36:20.640Z`; `POST_RESTART_PONG` never produced `session/prompt`.                                                                                              | **DONE 2026-07-25** — implementation `d8537fa2c`; RED tests, full SDK gates, and test-harness typecheck pass                                                                                                                                                                                                                          |
 | B22 | **Expose server-owned warm project-session ensure and claim operations.** The project index needs one reusable empty session without owning session selection or deduplication in app code.                                                                                                                                                                                                                                                   | `apps/web/src/app/(app)/projects/[id]/page.tsx` creates a session only after send. `packages/sdk/src/core/rest/projects-client/sessions.ts` exposes create and list, but no atomic warm-session operation.                                                                                              | **DONE 2026-07-26** — implementation `13167d7cf`; RED tests, full SDK gates, live API/SDK lifecycle, workspace refresh, and maintenance retention proof pass                                                                                                                                                                           |
+| B23 | **Prevent ACP prompt results from exposing a false idle window before late protocol updates settle.**                                                                                                                                                                                                                                                                                                                                          | The deployed white-label parity screenshot rendered 4 ACP tool cards and `Agent is working…`, while REST rendered 26 completed tool cards. `applyAcpEnvelope()` marks the projection idle on the prompt result, and later tool or text updates can mark it busy again.                                                                                                  | **IN PROGRESS 2026-07-26** — session `whitelabel-acp-stable-completion`; RED test, SDK fix, strengthened parity gate, merge, Deploy Dev, and deployed proof required                                                                                                                            |
 
 > **Paths above are as of today (pre-Task-4).** After the restructure they move:
 > `platform/api/` → `core/http/api/`, `opencode/` → `core/runtime/`,
@@ -2902,6 +2903,24 @@ Final verification:
 
 **Shippable to production: NOT YET.** The synchronization correction still
 requires PR merge, Deploy Dev, deployed SHA proof, and one post-deploy smoke.
+
+---
+
+### 2026-07-26 — session `whitelabel-acp-stable-completion` (B23 claim)
+
+Claimed the intermittent ACP false-completion gap exposed by the deployed
+white-label parity screenshots.
+
+The SDK will keep prompt completion monotonic across the JSON-RPC result and
+late ACP tool, text, or reasoning updates. The parity gate will require stable
+completion and a complete presentation artifact on both transports.
+
+Implementation will follow RED -> GREEN -> REFACTOR. Required gates are the
+focused SDK test, full SDK typecheck, suite, packed-install smoke, white-label
+typecheck, build, suite, SDK boundary, test-harness typecheck, local ACP and REST
+parity, PR merge, Deploy Dev, deployed SHA proof, and deployed parity.
+
+**Status:** IN PROGRESS.
 
 ---
 

--- a/packages/sdk/src/browser/session-sync/session-sync-registry.test.ts
+++ b/packages/sdk/src/browser/session-sync/session-sync-registry.test.ts
@@ -3,8 +3,10 @@ import type { Message } from '@opencode-ai/sdk/v2/client';
 import { useSyncStore } from '../stores/sync-store';
 import {
   ACTIVE_SESSION_PREFETCH_SOURCE,
+  beginSessionPromptObservation,
   clearActiveSessionPrefetches,
   getSessionSyncController,
+  noteSessionSyncEvent,
   prefetchSessionSyncOnce,
   readSessionMessagePage,
   resetSessionSyncControllers,
@@ -129,5 +131,31 @@ describe('session sync controller eviction', () => {
     retained[0]?.release();
     expect(getSessionSyncController('session-0')).not.toBe(retained[0]?.controller);
     for (const entry of retained.slice(1)) entry.release();
+  });
+});
+
+describe('REST prompt observation events', () => {
+  test('ignores premature idle and ends observation on a terminal runtime error', () => {
+    const sessionId = 'session-rest-prompt';
+    const controller = getSessionSyncController(sessionId);
+
+    beginSessionPromptObservation(sessionId);
+    noteSessionSyncEvent({
+      type: 'session.idle',
+      properties: { sessionID: sessionId },
+    });
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(true);
+
+    noteSessionSyncEvent({
+      type: 'message.updated',
+      properties: {
+        info: { id: 'assistant-1', sessionID: sessionId, role: 'assistant' },
+      },
+    });
+    noteSessionSyncEvent({
+      type: 'session.error',
+      properties: { sessionID: sessionId, error: { name: 'RuntimeError' } },
+    });
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(false);
   });
 });

--- a/packages/sdk/src/browser/session-sync/session-sync-registry.ts
+++ b/packages/sdk/src/browser/session-sync/session-sync-registry.ts
@@ -80,7 +80,10 @@ function createController(sessionId: string): SessionSyncController {
       const state = useSyncStore.getState();
       if (!(sessionId in state.messages)) state.hydrate(sessionId, []);
     },
-    setStatus: (status) => useSyncStore.getState().setStatus(sessionId, status),
+    setStatus: (status) => {
+      controllers.get(sessionId)?.controller.observePromptStatus(status);
+      useSyncStore.getState().setStatus(sessionId, status);
+    },
     onTelemetry: (event) => reportTelemetry(sessionId, event),
   });
 }
@@ -176,6 +179,14 @@ export function reconcileSessionTail(sessionId: string, reason: SessionSyncReaso
   return getSessionSyncController(sessionId).reconcile(reason);
 }
 
+export function beginSessionPromptObservation(sessionId: string): void {
+  getSessionSyncController(sessionId).beginPromptObservation();
+}
+
+export function endSessionPromptObservation(sessionId: string): void {
+  controllers.get(sessionId)?.controller.endPromptObservation();
+}
+
 export function loadSessionTranscriptMessages(
   sessionId: string,
 ): Promise<SessionSyncPage['messages']> {
@@ -184,16 +195,35 @@ export function loadSessionTranscriptMessages(
   );
 }
 
-export function noteSessionSyncEvent(event: { properties: unknown }): void {
+export function noteSessionSyncEvent(event: { type?: string; properties: unknown }): void {
   const properties = event.properties as Record<string, unknown>;
-  const info = properties.info as { sessionID?: string } | undefined;
+  const info = properties.info as { sessionID?: string; role?: string } | undefined;
   const part = properties.part as { sessionID?: string } | undefined;
   const sessionId =
     (typeof properties.sessionID === 'string' && properties.sessionID) ||
     info?.sessionID ||
     part?.sessionID;
   if (!sessionId) return;
-  controllers.get(sessionId)?.controller.noteActivity();
+  const controller = controllers.get(sessionId)?.controller;
+  if (!controller) return;
+  controller.noteActivity();
+
+  if (event.type === 'session.status') {
+    const status = properties.status as SessionStatus | undefined;
+    if (status) controller.observePromptStatus(status);
+    return;
+  }
+  if (event.type === 'session.idle') {
+    controller.observePromptStatus({ type: 'idle' });
+    return;
+  }
+  if (event.type === 'session.error') {
+    controller.endPromptObservation();
+    return;
+  }
+  if (event.type === 'message.updated' && info?.role === 'assistant') {
+    controller.observePromptActivity();
+  }
 }
 
 export function resetSessionSyncControllers(): void {

--- a/packages/sdk/src/core/acp/session-controller.test.ts
+++ b/packages/sdk/src/core/acp/session-controller.test.ts
@@ -135,9 +135,10 @@ describe('ACP session controller', () => {
         parts: [{ type: 'text', text: 'previous answer' }],
       },
     ]);
-    expect(controller.getSnapshot().projection.status).toEqual({ type: 'idle' });
-    const restoredAssistant =
-      controller.getSnapshot().projection.messages.at(-1)?.info;
+    expect(controller.getSnapshot().projection.status).toEqual({
+      type: 'idle',
+    });
+    const restoredAssistant = controller.getSnapshot().projection.messages.at(-1)?.info;
     expect(restoredAssistant?.role).toBe('assistant');
     if (restoredAssistant?.role === 'assistant') {
       expect(restoredAssistant.time.completed).toEqual(expect.any(Number));
@@ -214,6 +215,107 @@ describe('ACP session controller', () => {
     ]);
   });
 
+  test('does not expose idle before late prompt updates reach the transcript', async () => {
+    const h = harness();
+    let lateToolCompleted = false;
+    h.client.prompt = async (sessionId, prompt) => {
+      h.calls.push({ method: 'prompt', args: [sessionId, prompt] });
+      setTimeout(() => {
+        h.emit({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId: 'late-tool',
+              title: 'web_search',
+              kind: 'fetch',
+              status: 'in_progress',
+              rawInput: { query: 'Marko Kraemer' },
+            },
+          },
+        });
+      }, 0);
+      setTimeout(() => {
+        h.emit({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'Presentation complete' },
+            },
+          },
+        });
+        h.emit({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'late-tool',
+              status: 'completed',
+              rawOutput: { output: 'Research complete' },
+            },
+          },
+        });
+        lateToolCompleted = true;
+      }, 20);
+      const result = {
+        stopReason: 'end_turn',
+        usage: { inputTokens: 4, outputTokens: 2 },
+      };
+      h.emit({
+        jsonrpc: '2.0',
+        id: 'prompt-response',
+        result,
+      });
+      return result;
+    };
+    const controller = createAcpSessionController({
+      sessionId: 'ses_1',
+      client: h.client,
+    });
+    await controller.connect();
+    const busySamples: boolean[] = [];
+    let observedBusy = false;
+    let resolveStableIdle: () => void = () => {};
+    const stableIdle = new Promise<void>((resolve) => {
+      resolveStableIdle = resolve;
+    });
+    controller.subscribe(() => {
+      const snapshot = controller.getSnapshot();
+      const busy = snapshot.sending || snapshot.projection.status.type !== 'idle';
+      busySamples.push(busy);
+      if (busy) observedBusy = true;
+      else if (observedBusy) resolveStableIdle();
+    });
+
+    await controller.send([{ type: 'text', text: 'create a presentation' }]);
+    await stableIdle;
+
+    expect(lateToolCompleted).toBe(true);
+    const firstBusy = busySamples.indexOf(true);
+    expect(firstBusy).toBeGreaterThanOrEqual(0);
+    expect(busySamples.slice(firstBusy, -1).every(Boolean)).toBe(true);
+    expect(busySamples.at(-1)).toBe(false);
+    expect(controller.getSnapshot().projection.messages.at(-1)?.parts).toMatchObject([
+      {
+        type: 'tool',
+        callID: 'late-tool',
+        state: {
+          status: 'completed',
+          output: 'Research complete',
+        },
+      },
+      { type: 'text', text: 'Presentation complete' },
+      { type: 'step-finish', reason: 'end_turn' },
+    ]);
+  });
+
   test('serializes prompts that the busy-message queue drains at a tool boundary', async () => {
     const h = harness();
     let releaseFirst: () => void = () => {};
@@ -238,16 +340,14 @@ describe('ACP session controller', () => {
     const second = controller.send([{ type: 'text', text: 'queued' }]);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(
-      h.calls.filter((call) => call.method === 'prompt').map((call) => call.args[1]),
-    ).toEqual([[{ type: 'text', text: 'first' }]]);
+    expect(h.calls.filter((call) => call.method === 'prompt').map((call) => call.args[1])).toEqual([
+      [{ type: 'text', text: 'first' }],
+    ]);
 
     releaseFirst();
     await Promise.all([first, second]);
 
-    expect(
-      h.calls.filter((call) => call.method === 'prompt').map((call) => call.args[1]),
-    ).toEqual([
+    expect(h.calls.filter((call) => call.method === 'prompt').map((call) => call.args[1])).toEqual([
       [{ type: 'text', text: 'first' }],
       [{ type: 'text', text: 'queued' }],
     ]);

--- a/packages/sdk/src/core/acp/session-controller.ts
+++ b/packages/sdk/src/core/acp/session-controller.ts
@@ -11,6 +11,7 @@ import type {
 import { AcpTransportError } from './types';
 
 const MAX_CONFIG_RESTART_RETRIES = 3;
+const ACP_PROMPT_QUIET_PERIOD_MS = 500;
 
 class AcpRuntimeRestartError extends Error {
   constructor() {
@@ -104,8 +105,8 @@ function questionContent(
   );
 }
 
-function settleLoadedProjection(projection: AcpProjection): AcpProjection {
-  const blocked =
+function hasProjectionBlockers(projection: AcpProjection): boolean {
+  return (
     projection.permissions.length > 0 ||
     projection.questions.length > 0 ||
     projection.messages.some((message) =>
@@ -114,8 +115,21 @@ function settleLoadedProjection(projection: AcpProjection): AcpProjection {
           part.type === 'tool' &&
           (part.state.status === 'pending' || part.state.status === 'running'),
       ),
-    );
-  if (blocked) return projection;
+    )
+  );
+}
+
+function isPromptResult(envelope: AcpEnvelope): boolean {
+  return (
+    'id' in envelope &&
+    !('method' in envelope) &&
+    isObject(envelope.result) &&
+    (asString(envelope.result.stopReason) !== null || isObject(envelope.result.usage))
+  );
+}
+
+function settleLoadedProjection(projection: AcpProjection): AcpProjection {
+  if (hasProjectionBlockers(projection)) return projection;
   const completed = Date.now();
   return {
     ...projection,
@@ -147,6 +161,11 @@ export class AcpSessionController {
   private runtimeGeneration = 0;
   private readonly restartWaiters = new Set<() => void>();
   private promptQueue: Promise<void> = Promise.resolve();
+  private promptSettlement: {
+    result: Record<string, unknown>;
+    timer: ReturnType<typeof setTimeout> | null;
+    resolve(): void;
+  } | null = null;
   private snapshot: AcpSessionControllerSnapshot;
 
   constructor(private readonly options: AcpSessionControllerOptions) {
@@ -291,14 +310,26 @@ export class AcpSessionController {
     prompt: AcpContentBlock[],
     options: { model?: string | null; agent?: string | null } = {},
   ): Promise<void> {
-    const queued = this.promptQueue.then(() => this.executeSend(prompt, options));
+    let resolveRequest: () => void = () => {};
+    let rejectRequest: (error: unknown) => void = () => {};
+    const request = new Promise<void>((resolve, reject) => {
+      resolveRequest = resolve;
+      rejectRequest = reject;
+    });
+    const queued = this.promptQueue.then(() =>
+      this.executeSend(prompt, options, {
+        resolve: resolveRequest,
+        reject: rejectRequest,
+      }),
+    );
     this.promptQueue = queued.catch(() => {});
-    return queued;
+    return request;
   }
 
   private async executeSend(
     prompt: AcpContentBlock[],
     options: { model?: string | null; agent?: string | null },
+    request: { resolve(): void; reject(error: unknown): void },
   ): Promise<void> {
     const text = prompt
       .filter((part): part is Extract<AcpContentBlock, { type: 'text' }> => part.type === 'text')
@@ -365,12 +396,12 @@ export class AcpSessionController {
         }
         throw error;
       }
-      this.onEnvelope({
-        jsonrpc: '2.0',
-        id: `prompt:${Date.now()}`,
-        result,
-      });
+      this.applyPromptResult(result, false);
+      request.resolve();
+      await this.settlePrompt(result);
     } catch (error) {
+      request.reject(error);
+      this.discardPromptSettlement();
       this.patch({
         error: error instanceof Error ? error : new Error(String(error)),
         projection: {
@@ -386,6 +417,7 @@ export class AcpSessionController {
 
   async cancel(): Promise<void> {
     await this.client.cancel(this.options.sessionId);
+    this.discardPromptSettlement();
     this.patch({
       projection: {
         ...this.snapshot.projection,
@@ -450,12 +482,14 @@ export class AcpSessionController {
   }
 
   close(): void {
+    this.discardPromptSettlement();
     this.stream?.close();
     this.stream = null;
     this.patch({ connection: 'closed', ready: false });
   }
 
   private onEnvelope(envelope: AcpEnvelope): void {
+    if (this.snapshot.sending && isPromptResult(envelope)) return;
     if (
       'method' in envelope &&
       envelope.method === 'kortix/runtime_ready' &&
@@ -475,6 +509,57 @@ export class AcpSessionController {
     }
     const projection = applyAcpEnvelope(this.snapshot.projection, envelope);
     if (projection !== this.snapshot.projection) this.patch({ projection });
+    if ('method' in envelope && envelope.method === 'session/update') {
+      this.schedulePromptSettlement();
+    }
+  }
+
+  private settlePrompt(result: Record<string, unknown>): Promise<void> {
+    return new Promise((resolve) => {
+      this.promptSettlement = {
+        result,
+        timer: null,
+        resolve,
+      };
+      this.schedulePromptSettlement();
+    });
+  }
+
+  private schedulePromptSettlement(): void {
+    const settlement = this.promptSettlement;
+    if (!settlement) return;
+    if (settlement.timer) {
+      clearTimeout(settlement.timer);
+      settlement.timer = null;
+    }
+    if (hasProjectionBlockers(this.snapshot.projection)) return;
+    settlement.timer = setTimeout(() => {
+      if (this.promptSettlement !== settlement || hasProjectionBlockers(this.snapshot.projection)) {
+        this.schedulePromptSettlement();
+        return;
+      }
+      this.promptSettlement = null;
+      this.applyPromptResult(settlement.result, true);
+      settlement.resolve();
+    }, ACP_PROMPT_QUIET_PERIOD_MS);
+  }
+
+  private applyPromptResult(result: Record<string, unknown>, settled: boolean): void {
+    const projection = applyAcpEnvelope(this.snapshot.projection, {
+      jsonrpc: '2.0',
+      id: `prompt:${Date.now()}`,
+      result,
+    });
+    const next = settled ? projection : { ...projection, status: { type: 'busy' } as const };
+    if (next !== this.snapshot.projection) this.patch({ projection: next });
+  }
+
+  private discardPromptSettlement(): void {
+    const settlement = this.promptSettlement;
+    if (!settlement) return;
+    this.promptSettlement = null;
+    if (settlement.timer) clearTimeout(settlement.timer);
+    settlement.resolve();
   }
 
   private patch(value: Partial<AcpSessionControllerSnapshot>): void {

--- a/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
@@ -21,7 +21,11 @@ function page(ids: string[], nextCursor?: string): SessionSyncPage {
 }
 
 function messagePage(
-  messages: Array<{ id: string; role: 'user' | 'assistant'; parentID?: string }>,
+  messages: Array<{
+    id: string;
+    role: 'user' | 'assistant';
+    parentID?: string;
+  }>,
   nextCursor?: string,
 ): SessionSyncPage {
   return {
@@ -159,8 +163,16 @@ describe('SessionSyncController', () => {
         if (!request.before) {
           return messagePage(
             [
-              { id: 'assistant-new-3', role: 'assistant', parentID: 'user-only' },
-              { id: 'assistant-new-4', role: 'assistant', parentID: 'user-only' },
+              {
+                id: 'assistant-new-3',
+                role: 'assistant',
+                parentID: 'user-only',
+              },
+              {
+                id: 'assistant-new-4',
+                role: 'assistant',
+                parentID: 'user-only',
+              },
             ],
             'cursor-1',
           );
@@ -168,8 +180,16 @@ describe('SessionSyncController', () => {
         if (request.before === 'cursor-1') {
           return messagePage(
             [
-              { id: 'assistant-new-1', role: 'assistant', parentID: 'user-only' },
-              { id: 'assistant-new-2', role: 'assistant', parentID: 'user-only' },
+              {
+                id: 'assistant-new-1',
+                role: 'assistant',
+                parentID: 'user-only',
+              },
+              {
+                id: 'assistant-new-2',
+                role: 'assistant',
+                parentID: 'user-only',
+              },
             ],
             'cursor-2',
           );
@@ -228,8 +248,16 @@ describe('SessionSyncController', () => {
         if (request.before === 'cursor-1') {
           return messagePage(
             [
-              { id: 'assistant-old-3', role: 'assistant', parentID: 'user-old' },
-              { id: 'assistant-old-4', role: 'assistant', parentID: 'user-old' },
+              {
+                id: 'assistant-old-3',
+                role: 'assistant',
+                parentID: 'user-old',
+              },
+              {
+                id: 'assistant-old-4',
+                role: 'assistant',
+                parentID: 'user-old',
+              },
             ],
             'cursor-2',
           );
@@ -237,8 +265,16 @@ describe('SessionSyncController', () => {
         if (request.before === 'cursor-2') {
           return messagePage(
             [
-              { id: 'assistant-old-1', role: 'assistant', parentID: 'user-old' },
-              { id: 'assistant-old-2', role: 'assistant', parentID: 'user-old' },
+              {
+                id: 'assistant-old-1',
+                role: 'assistant',
+                parentID: 'user-old',
+              },
+              {
+                id: 'assistant-old-2',
+                role: 'assistant',
+                parentID: 'user-old',
+              },
             ],
             'cursor-3',
           );
@@ -299,10 +335,7 @@ describe('SessionSyncController', () => {
     await expect(controller.loadOlder()).rejects.toThrow(
       'Session history cursor repeated: cursor-1',
     );
-    expect(requests).toEqual([
-      { limit: 10 },
-      { limit: 10, before: 'cursor-1' },
-    ]);
+    expect(requests).toEqual([{ limit: 10 }, { limit: 10, before: 'cursor-1' }]);
     expect(controller.getSnapshot().isLoadingOlder).toBe(false);
   });
 
@@ -395,6 +428,65 @@ describe('SessionSyncController', () => {
     await Promise.resolve();
     expect(requests).toHaveLength(2);
     expect(statuses).toEqual([{ type: 'idle' }]);
+  });
+
+  test('keeps REST prompt completion busy until runtime idle is stable after real work starts', () => {
+    let now = 0;
+    let timeout:
+      | {
+          handler: () => void;
+          dueAt: number;
+        }
+      | undefined;
+    const scheduler = {
+      now: () => now,
+      setInterval: () => 1,
+      clearInterval: () => {},
+      setTimeout: (handler: () => void, delayMs: number) => {
+        timeout = { handler, dueAt: now + delayMs };
+        return 2;
+      },
+      clearTimeout: () => {
+        timeout = undefined;
+      },
+    };
+    const advance = (ms: number) => {
+      now += ms;
+      if (timeout && timeout.dueAt <= now) {
+        const handler = timeout.handler;
+        timeout = undefined;
+        handler();
+      }
+    };
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => page([]),
+      hydrate: () => {},
+      markLoaded: () => {},
+      scheduler,
+    });
+
+    controller.beginPromptObservation();
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(true);
+
+    controller.observePromptStatus({ type: 'idle' });
+    advance(1_000);
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(true);
+
+    controller.observePromptStatus({ type: 'busy' });
+    controller.observePromptStatus({ type: 'idle' });
+    advance(400);
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(true);
+
+    controller.observePromptStatus({ type: 'busy' });
+    advance(1_000);
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(true);
+
+    controller.observePromptStatus({ type: 'idle' });
+    advance(499);
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(true);
+    advance(1);
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(false);
   });
 
   test('marks an empty or failed initial read as loaded', async () => {

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -18,22 +18,20 @@ export interface SessionSyncSnapshot {
   freshness: SessionSyncFreshness;
   hasOlder: boolean;
   isLoadingOlder: boolean;
+  /** True while an accepted REST prompt has not reached stable runtime idle. */
+  isPromptObservedBusy?: boolean;
 }
 
 export interface SessionSyncScheduler {
   now: () => number;
   setInterval: (handler: () => void, intervalMs: number) => unknown;
   clearInterval: (handle: unknown) => void;
+  setTimeout?: (handler: () => void, timeoutMs: number) => unknown;
+  clearTimeout?: (handle: unknown) => void;
 }
 
 export type SessionSyncReason =
-  | 'initial'
-  | 'poll'
-  | 'sse-gap'
-  | 'compaction'
-  | 'session-error'
-  | 'send-recovery'
-  | 'manual';
+  'initial' | 'poll' | 'sse-gap' | 'compaction' | 'session-error' | 'send-recovery' | 'manual';
 
 export interface SessionSyncTelemetryEvent {
   operation: 'tail' | 'older';
@@ -45,10 +43,7 @@ export interface SessionSyncTelemetryEvent {
 
 export interface SessionSyncControllerOptions {
   sessionId: string;
-  loadPage: (request: {
-    limit: number;
-    before?: string;
-  }) => Promise<SessionSyncPage>;
+  loadPage: (request: { limit: number; before?: string }) => Promise<SessionSyncPage>;
   loadStatus?: () => Promise<SessionStatus>;
   hydrate: (messages: SessionSyncMessage[]) => void;
   markLoaded: () => void;
@@ -58,17 +53,16 @@ export interface SessionSyncControllerOptions {
   livenessIntervalMs?: number;
 }
 
-export interface HttpSessionSyncControllerOptions
-  extends Pick<
-    SessionSyncControllerOptions,
-    | 'sessionId'
-    | 'hydrate'
-    | 'markLoaded'
-    | 'setStatus'
-    | 'onTelemetry'
-    | 'scheduler'
-    | 'livenessIntervalMs'
-  > {
+export interface HttpSessionSyncControllerOptions extends Pick<
+  SessionSyncControllerOptions,
+  | 'sessionId'
+  | 'hydrate'
+  | 'markLoaded'
+  | 'setStatus'
+  | 'onTelemetry'
+  | 'scheduler'
+  | 'livenessIntervalMs'
+> {
   baseUrl: string;
   getToken?: () => string | null | Promise<string | null>;
   fetch?: SessionSyncFetch;
@@ -165,7 +159,13 @@ const defaultScheduler: SessionSyncScheduler = {
   now: Date.now,
   setInterval: (handler, intervalMs) => setInterval(handler, intervalMs),
   clearInterval: (handle) => clearInterval(handle as ReturnType<typeof setInterval>),
+  setTimeout: (handler, timeoutMs) => setTimeout(handler, timeoutMs),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
 };
+
+const PROMPT_IDLE_SETTLEMENT_MS = 500;
+
+type PromptObservationPhase = 'idle' | 'awaiting-work' | 'running' | 'settling';
 
 /**
  * Owns bounded session history synchronization without depending on React,
@@ -179,6 +179,7 @@ export class SessionSyncController {
     freshness: 'idle',
     hasOlder: false,
     isLoadingOlder: false,
+    isPromptObservedBusy: false,
   };
   private nextCursor: string | undefined;
   private knownUserMessageIds = new Set<string>();
@@ -186,6 +187,8 @@ export class SessionSyncController {
   private tailRequest: Promise<void> | undefined;
   private olderRequest: Promise<void> | undefined;
   private livenessTimer: unknown;
+  private promptSettlementTimer: unknown;
+  private promptObservationPhase: PromptObservationPhase = 'idle';
   private lastActivityAt: number;
   private listeners = new Set<() => void>();
   private destroyed = false;
@@ -248,6 +251,43 @@ export class SessionSyncController {
     }
   }
 
+  /**
+   * Start monotonic completion observation for an accepted REST prompt.
+   *
+   * OpenCode can publish an idle snapshot from before the prompt and publish
+   * the real busy event later. Keep the public projection busy until real work
+   * starts and the following idle state remains quiet.
+   */
+  beginPromptObservation(): void {
+    this.clearPromptSettlementTimer();
+    this.promptObservationPhase = 'awaiting-work';
+    this.update({ isPromptObservedBusy: true });
+  }
+
+  /** Observe an authoritative runtime status from SSE or status reconciliation. */
+  observePromptStatus(status: SessionStatus): void {
+    if (this.promptObservationPhase === 'idle') return;
+    if (status.type !== 'idle') {
+      this.markPromptRunning();
+      return;
+    }
+    if (this.promptObservationPhase === 'awaiting-work') return;
+    this.schedulePromptSettlement();
+  }
+
+  /** Mark assistant output as proof that the accepted prompt started. */
+  observePromptActivity(): void {
+    if (this.promptObservationPhase === 'idle') return;
+    this.markPromptRunning();
+  }
+
+  /** End observation after rejection, cancellation, or a terminal runtime error. */
+  endPromptObservation(): void {
+    this.clearPromptSettlementTimer();
+    this.promptObservationPhase = 'idle';
+    this.update({ isPromptObservedBusy: false });
+  }
+
   setBusy(isBusy: boolean): void {
     if (!isBusy) {
       this.stopLivenessTimer();
@@ -264,6 +304,7 @@ export class SessionSyncController {
   destroy(): void {
     this.destroyed = true;
     this.stopLivenessTimer();
+    this.clearPromptSettlementTimer();
     this.listeners.clear();
   }
 
@@ -403,12 +444,43 @@ export class SessionSyncController {
     this.livenessTimer = undefined;
   }
 
+  private markPromptRunning(): void {
+    this.clearPromptSettlementTimer();
+    this.promptObservationPhase = 'running';
+  }
+
+  private schedulePromptSettlement(): void {
+    if (this.promptObservationPhase === 'settling') return;
+    this.clearPromptSettlementTimer();
+    this.promptObservationPhase = 'settling';
+    const settle = () => {
+      this.promptSettlementTimer = undefined;
+      if (this.destroyed || this.promptObservationPhase !== 'settling') return;
+      this.promptObservationPhase = 'idle';
+      this.update({ isPromptObservedBusy: false });
+    };
+    this.promptSettlementTimer = this.scheduler.setTimeout
+      ? this.scheduler.setTimeout(settle, PROMPT_IDLE_SETTLEMENT_MS)
+      : setTimeout(settle, PROMPT_IDLE_SETTLEMENT_MS);
+  }
+
+  private clearPromptSettlementTimer(): void {
+    if (this.promptSettlementTimer === undefined) return;
+    if (this.scheduler.clearTimeout) {
+      this.scheduler.clearTimeout(this.promptSettlementTimer);
+    } else {
+      clearTimeout(this.promptSettlementTimer as ReturnType<typeof setTimeout>);
+    }
+    this.promptSettlementTimer = undefined;
+  }
+
   private update(next: Partial<SessionSyncSnapshot>): void {
     const snapshot = { ...this.snapshot, ...next };
     if (
       snapshot.freshness === this.snapshot.freshness &&
       snapshot.hasOlder === this.snapshot.hasOlder &&
-      snapshot.isLoadingOlder === this.snapshot.isLoadingOlder
+      snapshot.isLoadingOlder === this.snapshot.isLoadingOlder &&
+      snapshot.isPromptObservedBusy === this.snapshot.isPromptObservedBusy
     ) {
       return;
     }

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -23,6 +23,7 @@ const EMPTY_MESSAGES: MessageWithParts[] = [];
 const EMPTY_DIFFS: FileDiff[] = [];
 const EMPTY_TODOS: Todo[] = [];
 const IDLE_STATUS = { type: 'idle' } as SessionStatus;
+const BUSY_STATUS = { type: 'busy' } as SessionStatus;
 const MESSAGE_CACHE_MAX = 20;
 const messageCache = new Map<
   string,
@@ -99,9 +100,11 @@ export function useSessionSync(sessionId: string) {
     buildMessages(sessionId, state.messages[sessionId], state.parts),
   );
 
-  const status = useSyncStore(
+  const runtimeStatus = useSyncStore(
     (state) => state.sessionStatus[sessionId] ?? IDLE_STATUS,
   ) as SessionStatus;
+  const status =
+    sync.isPromptObservedBusy && runtimeStatus.type === 'idle' ? BUSY_STATUS : runtimeStatus;
   const diffs = useSyncStore((state) => state.diffs[sessionId]) as FileDiff[] | undefined;
   const todos = useSyncStore((state) => state.todos[sessionId]) as Todo[] | undefined;
 

--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -4,14 +4,26 @@ import { describe, expect, test, beforeEach, mock } from 'bun:test';
 // OpenCode SDK client singleton — so the REAL `permissions.ts` wrappers and
 // `promptOpenCodeMessage` run for real, matching session.test.ts's approach of
 // stubbing the boundary rather than the wrapper.
-let permissionReplyImpl: (args: unknown) => Promise<{ data?: unknown; error?: unknown; response?: Response }> =
-  async () => ({ data: {} });
-let questionReplyImpl: (args: unknown) => Promise<{ data?: unknown; error?: unknown; response?: Response }> =
-  async () => ({ data: {} });
-let questionRejectImpl: (args: unknown) => Promise<{ data?: unknown; error?: unknown; response?: Response }> =
-  async () => ({ data: {} });
-let sessionPromptImpl: (args: unknown) => Promise<{ data?: unknown; error?: unknown; response?: Response }> =
-  async () => ({ data: {} });
+let permissionReplyImpl: (args: unknown) => Promise<{
+  data?: unknown;
+  error?: unknown;
+  response?: Response;
+}> = async () => ({ data: {} });
+let questionReplyImpl: (args: unknown) => Promise<{
+  data?: unknown;
+  error?: unknown;
+  response?: Response;
+}> = async () => ({ data: {} });
+let questionRejectImpl: (args: unknown) => Promise<{
+  data?: unknown;
+  error?: unknown;
+  response?: Response;
+}> = async () => ({ data: {} });
+let sessionPromptImpl: (args: unknown) => Promise<{
+  data?: unknown;
+  error?: unknown;
+  response?: Response;
+}> = async () => ({ data: {} });
 
 class RuntimeNotReadyError extends Error {
   constructor(message = '[opencode-sdk] Server URL not ready — sandbox is still loading') {
@@ -50,6 +62,10 @@ import {
 import { clearSessionFresh, markSessionFresh } from '../core/http/fresh-sessions';
 import { SessionStartError } from '../core/rest/projects-client';
 import { useSyncStore } from '../browser/stores/sync-store';
+import {
+  getSessionSyncController,
+  resetSessionSyncControllers,
+} from '../browser/session-sync/session-sync-registry';
 
 function seedQuestion(id: string, sessionID = 'sess-1') {
   useOpenCodePendingStore.getState().addQuestion({
@@ -71,6 +87,7 @@ function seedPermission(id: string, sessionID = 'sess-1') {
 }
 
 beforeEach(() => {
+  resetSessionSyncControllers();
   useOpenCodePendingStore.getState().clear();
   permissionReplyImpl = async () => ({ data: {} });
   questionReplyImpl = async () => ({ data: {} });
@@ -124,7 +141,9 @@ describe('rejectQuestion', () => {
     seedQuestion('q1');
     questionRejectImpl = async () => ({ error: { message: 'nope' } });
 
-    await expect(rejectQuestion('q1')).rejects.toMatchObject({ kind: 'runtime-error' });
+    await expect(rejectQuestion('q1')).rejects.toMatchObject({
+      kind: 'runtime-error',
+    });
     expect(useOpenCodePendingStore.getState().questions['q1']).toBeDefined();
   });
 });
@@ -140,15 +159,23 @@ describe('answerPermission', () => {
 
     await answerPermission('p1', 'once', 'go ahead');
 
-    expect(captured).toEqual({ requestID: 'p1', reply: 'once', message: 'go ahead' });
+    expect(captured).toEqual({
+      requestID: 'p1',
+      reply: 'once',
+      message: 'go ahead',
+    });
     expect(useOpenCodePendingStore.getState().permissions['p1']).toBeUndefined();
   });
 
   test('failure keeps the pending entry and throws a typed error', async () => {
     seedPermission('p1');
-    permissionReplyImpl = async () => ({ error: { message: 'denied by server' } });
+    permissionReplyImpl = async () => ({
+      error: { message: 'denied by server' },
+    });
 
-    await expect(answerPermission('p1', 'always')).rejects.toMatchObject({ kind: 'runtime-error' });
+    await expect(answerPermission('p1', 'always')).rejects.toMatchObject({
+      kind: 'runtime-error',
+    });
     expect(useOpenCodePendingStore.getState().permissions['p1']).toBeDefined();
   });
 });
@@ -167,7 +194,10 @@ describe('classifySendError', () => {
   });
 
   test('classifies a 402-shaped error as billing', () => {
-    const err = new Error('Payment Required') as Error & { status?: number; data?: unknown };
+    const err = new Error('Payment Required') as Error & {
+      status?: number;
+      data?: unknown;
+    };
     err.status = 402;
     err.data = { message: 'Insufficient credits. Balance: $-0.06' };
 
@@ -217,13 +247,20 @@ describe('classifySendError', () => {
 describe('send state transitions (sendStateOnStart / sendStateOnError)', () => {
   test('REST prompt observation keeps reconciliation busy until completion', () => {
     const sessionId = 'sess-rest-observation';
+    const controller = getSessionSyncController(sessionId);
     useSyncStore.getState().setStatus(sessionId, { type: 'idle' });
 
     beginRestPromptObservation(sessionId);
-    expect(useSyncStore.getState().sessionStatus[sessionId]).toEqual({ type: 'busy' });
+    expect(useSyncStore.getState().sessionStatus[sessionId]).toEqual({
+      type: 'busy',
+    });
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(true);
 
     endRestPromptObservation(sessionId);
-    expect(useSyncStore.getState().sessionStatus[sessionId]).toEqual({ type: 'idle' });
+    expect(useSyncStore.getState().sessionStatus[sessionId]).toEqual({
+      type: 'idle',
+    });
+    expect(controller.getSnapshot().isPromptObservedBusy).toBe(false);
   });
 
   test('a send failure with a 402-shaped error clears pending and yields a billing sendError', async () => {

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -29,6 +29,10 @@ import { useOpenCodePendingStore } from '../browser/stores/opencode-pending-stor
 import { setOpenCodeHealth, setSandboxStatus } from '../browser/stores/sandbox-connection-store';
 import { getSandboxUrlForExternalId } from '../browser/stores/server-store';
 import { useSyncStore } from '../browser/stores/sync-store';
+import {
+  beginSessionPromptObservation,
+  endSessionPromptObservation,
+} from '../browser/session-sync/session-sync-registry';
 import { setCurrentRuntime } from '../core/session/current-runtime';
 import {
   isSessionStartError,
@@ -236,11 +240,13 @@ export function sendStateOnError(error: unknown): SendState {
  * message even though the agent completed the turn.
  */
 export function beginRestPromptObservation(sessionId: string): void {
+  beginSessionPromptObservation(sessionId);
   useSyncStore.getState().setStatus(sessionId, { type: 'busy' });
 }
 
 /** Clear the optimistic REST busy state when the prompt never starts or stops. */
 export function endRestPromptObservation(sessionId: string): void {
+  endSessionPromptObservation(sessionId);
   useSyncStore.getState().setStatus(sessionId, { type: 'idle' });
 }
 

--- a/tests/e2e/specs/16-whitelabel-acp-rest-parity.spec.ts
+++ b/tests/e2e/specs/16-whitelabel-acp-rest-parity.spec.ts
@@ -23,13 +23,8 @@ const testCreditBalance = 100;
 const acpQuestionReconnectDelayMs = Number(
   process.env.E2E_WHITELABEL_ACP_QUESTION_RECONNECT_DELAY_MS ?? 121_000,
 );
-if (
-  !Number.isFinite(acpQuestionReconnectDelayMs) ||
-  acpQuestionReconnectDelayMs < 0
-) {
-  throw new Error(
-    'E2E_WHITELABEL_ACP_QUESTION_RECONNECT_DELAY_MS must be a non-negative number',
-  );
+if (!Number.isFinite(acpQuestionReconnectDelayMs) || acpQuestionReconnectDelayMs < 0) {
+  throw new Error('E2E_WHITELABEL_ACP_QUESTION_RECONNECT_DELAY_MS must be a non-negative number');
 }
 const prompt =
   'Research Marko Kraemer using the available web research tools. Create a PowerPoint presentation about Marko Kraemer and save it under /workspace. Do not ask a clarifying question. Complete the presentation, verify the file, and summarize the result.';
@@ -46,11 +41,16 @@ interface SurfaceEvidence {
   restPromptCount: number;
   toolCards: string[];
   transcript: string;
+  presentationPath: string;
+  presentationBytes: number;
 }
 
 async function answerBetaQuestion(page: Page): Promise<void> {
   await page.getByRole('button', { name: /Beta/ }).last().click();
-  const submitAnswer = page.getByRole('button', { name: 'Submit answer', exact: true });
+  const submitAnswer = page.getByRole('button', {
+    name: 'Submit answer',
+    exact: true,
+  });
   if (await submitAnswer.isVisible().catch(() => false)) await submitAnswer.click();
   await expect(page.getByText('QUESTION_BETA', { exact: true }).last()).toBeVisible({
     timeout: 120_000,
@@ -82,9 +82,53 @@ async function waitForReadySession(
   throw new Error(`Session did not become ready: ${last}`);
 }
 
+async function retryCleanup(label: string, operation: () => Promise<unknown>): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      await operation();
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1_000));
+      }
+    }
+  }
+  throw new Error(`${label} failed after 3 attempts`, { cause: lastError });
+}
+
+async function createParityAuth(email: string): Promise<{
+  user: AuthUser;
+  auth: AuthSession;
+}> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      const user = await createAuthUser(email, { supabaseUrl, password });
+      const auth = await signIn(email, { supabaseUrl, password });
+      return { user, auth };
+    } catch (error) {
+      lastError = error;
+      try {
+        const auth = await signIn(email, { supabaseUrl, password });
+        return { user: auth.user, auth };
+      } catch {
+        if (attempt < 5) {
+          await new Promise((resolve) => setTimeout(resolve, attempt * 2_000));
+        }
+      }
+    }
+  }
+  throw new Error('Parity auth fixture failed after 5 attempts', {
+    cause: lastError,
+  });
+}
+
 async function runSurface(
   page: Page,
   auth: AuthSession,
+  kortix: ReturnType<typeof createScopedKortix>,
   fixture: ProjectFixture,
   testInfo: TestInfo,
 ): Promise<SurfaceEvidence> {
@@ -101,10 +145,9 @@ async function runSurface(
   await page.addInitScript((token) => {
     window.localStorage.setItem('kortix_api_key', token);
   }, auth.access_token);
-  await page.goto(
-    `${whiteLabelBase}/projects/${fixture.projectId}/sessions/${fixture.sessionId}`,
-    { waitUntil: 'domcontentloaded' },
-  );
+  await page.goto(`${whiteLabelBase}/projects/${fixture.projectId}/sessions/${fixture.sessionId}`, {
+    waitUntil: 'domcontentloaded',
+  });
 
   const input = page.getByPlaceholder(/Message the agent/);
   await expect(input).toBeVisible({ timeout: 120_000 });
@@ -116,11 +159,57 @@ async function runSurface(
   await expect(page.getByRole('button', { name: 'Send', exact: true })).toBeVisible({
     timeout: 30_000,
   });
+  await expect(page.getByText('Agent is working…', { exact: true })).toBeHidden();
   await expect(page.locator('[data-message-role="assistant"]').last()).toBeVisible({
     timeout: 120_000,
   });
   const renderedToolCards = page.locator('[data-slot="tool-call"]');
   await expect(renderedToolCards.first()).toBeVisible({ timeout: 120_000 });
+  await expect(
+    page.locator(
+      '[data-slot="tool-call"][data-tool-status="pending"], [data-slot="tool-call"][data-tool-status="running"]',
+    ),
+  ).toHaveCount(0);
+  await expect(page.locator('main')).toContainText(/\/workspace\/\S+\.pptx\b/i, {
+    timeout: 120_000,
+  });
+  await expect(page.locator('main')).toContainText(/\b\d+\s+slides?\b/i, {
+    timeout: 120_000,
+  });
+
+  const sessionFiles = kortix.session(fixture.projectId, fixture.sessionId).files;
+  let presentationPath = '';
+  await expect
+    .poll(
+      async () => {
+        try {
+          const files = await sessionFiles.list('/workspace');
+          const presentation = files.find(
+            (file) => file.type === 'file' && file.name.toLowerCase().endsWith('.pptx'),
+          );
+          presentationPath = presentation?.absolute || presentation?.path || '';
+          return presentationPath;
+        } catch {
+          return '';
+        }
+      },
+      { timeout: 120_000 },
+    )
+    .toMatch(/\.pptx$/i);
+  let presentationBytes = 0;
+  await expect
+    .poll(
+      async () => {
+        try {
+          presentationBytes = (await sessionFiles.readBlob(presentationPath)).size;
+          return presentationBytes;
+        } catch {
+          return 0;
+        }
+      },
+      { timeout: 120_000 },
+    )
+    .toBeGreaterThan(10_000);
 
   const screenshotPath = testInfo.outputPath(`${fixture.transport}-presentation.png`);
   await page.screenshot({ path: screenshotPath, fullPage: true });
@@ -149,9 +238,7 @@ async function runSurface(
     timeout: 120_000,
   });
   if (fixture.transport === 'acp') {
-    await new Promise((resolve) =>
-      setTimeout(resolve, acpQuestionReconnectDelayMs),
-    );
+    await new Promise((resolve) => setTimeout(resolve, acpQuestionReconnectDelayMs));
     await page.reload({ waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Choose one', { exact: true }).last()).toBeVisible({
       timeout: 120_000,
@@ -165,6 +252,8 @@ async function runSurface(
     restPromptCount: restPrompts.length,
     toolCards,
     transcript,
+    presentationPath,
+    presentationBytes,
   };
 }
 
@@ -181,8 +270,7 @@ test.describe.serial('16 — white-label ACP and REST parity', () => {
   test.beforeAll(async ({}, testInfo) => {
     testInfo.setTimeout(40 * 60_000);
     const email = `whitelabel-parity-${Date.now()}-${randomUUID().slice(0, 8)}@example.test`;
-    user = await createAuthUser(email, { supabaseUrl, password });
-    auth = await signIn(email, { supabaseUrl, password });
+    ({ user, auth } = await createParityAuth(email));
     kortix = createScopedKortix({
       backendUrl: apiBase,
       getToken: async () => auth.access_token,
@@ -275,19 +363,29 @@ test.describe.serial('16 — white-label ACP and REST parity', () => {
   test.afterAll(async ({}, testInfo) => {
     testInfo.setTimeout(3 * 60_000);
     if (!keepProjects) {
+      const cleanupErrors: Error[] = [];
       for (const fixture of cleanupFixtures) {
-        await kortix.session(fixture.projectId, fixture.sessionId).delete().catch(() => {});
+        await retryCleanup(`delete session ${fixture.sessionId}`, () =>
+          kortix.session(fixture.projectId, fixture.sessionId).delete(),
+        ).catch((error) => {
+          cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+        });
       }
-      for (const projectId of new Set(
-        cleanupFixtures.map((fixture) => fixture.projectId),
-      )) {
-        await kortix.project(projectId).archive().catch(() => {});
+      for (const projectId of new Set(cleanupFixtures.map((fixture) => fixture.projectId))) {
+        await retryCleanup(`archive project ${projectId}`, () =>
+          kortix.project(projectId).archive(),
+        ).catch((error) => {
+          cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+        });
       }
       if (user?.id) {
         await deleteAuthUser(user.id, {
           supabaseUrl,
           envFiles: ['apps/api/.env', 'apps/web/.env'],
         });
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(cleanupErrors, 'White-label parity cleanup failed');
       }
     }
   });
@@ -297,9 +395,11 @@ test.describe.serial('16 — white-label ACP and REST parity', () => {
   }, testInfo) => {
     const evidence: SurfaceEvidence[] = [];
     for (const fixture of fixtures) {
-      const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+      const context = await browser.newContext({
+        viewport: { width: 1440, height: 1000 },
+      });
       const page = await context.newPage();
-      evidence.push(await runSurface(page, auth, fixture, testInfo));
+      evidence.push(await runSurface(page, auth, kortix, fixture, testInfo));
       await context.close();
     }
 
@@ -309,8 +409,12 @@ test.describe.serial('16 — white-label ACP and REST parity', () => {
     expect(acp.restPromptCount).toBe(0);
     expect(rest.acpPromptCount).toBe(0);
     expect(rest.restPromptCount).toBeGreaterThanOrEqual(2);
-    expect(acp.toolCards.length).toBeGreaterThan(0);
-    expect(rest.toolCards.length).toBeGreaterThan(0);
+    expect(acp.toolCards.length).toBeGreaterThanOrEqual(10);
+    expect(rest.toolCards.length).toBeGreaterThanOrEqual(10);
+    expect(
+      Math.min(acp.toolCards.length, rest.toolCards.length) /
+        Math.max(acp.toolCards.length, rest.toolCards.length),
+    ).toBeGreaterThanOrEqual(0.5);
 
     await testInfo.attach('transport-comparison', {
       body: JSON.stringify(
@@ -320,11 +424,15 @@ test.describe.serial('16 — white-label ACP and REST parity', () => {
             acpPromptCount: acp.acpPromptCount,
             restPromptCount: acp.restPromptCount,
             toolCards: acp.toolCards,
+            presentationPath: acp.presentationPath,
+            presentationBytes: acp.presentationBytes,
           },
           rest: {
             acpPromptCount: rest.acpPromptCount,
             restPromptCount: rest.restPromptCount,
             toolCards: rest.toolCards,
+            presentationPath: rest.presentationPath,
+            presentationBytes: rest.presentationBytes,
           },
         },
         null,


### PR DESCRIPTION
## Summary

- settle ACP prompts only after the JSON-RPC result and a 500 ms quiet period
- restart or block ACP settlement for late assistant, tool, question, and permission updates
- move REST prompt observation into `SessionSyncController`
- keep the REST busy state active across premature idle events and late busy events
- require complete tool cards and valid presentation artifacts in ACP/REST parity
- expose tool status to the white-label parity surface
- use server-only `KORTIX_UPSTREAM` for preview URL resolution

## TDD

- ACP RED: `send()` resolved before delayed tool updates reached the transcript
- REST RED: `beginPromptObservation()` did not exist
- focused REST GREEN: 40 pass, 0 fail, 113 assertions
- preview RED: expected 200, received 502
- preview GREEN: 7 pass, 0 fail, 36 assertions

## Verification

- SDK typecheck: exit 0
- SDK suite: 1268 pass, 0 fail, 5662 assertions, 105 files
- SDK packed-install smoke: pass
- white-label typecheck: exit 0
- white-label suite: 57 pass, 3 skip, 0 fail, 182 assertions
- white-label SDK boundary: 0 violations
- white-label production build: pass
- test-harness typecheck: exit 0
- `git diff --check`: exit 0
- live ACP/REST parity: 1 pass in 13.5 minutes

## Live parity

- ACP: 2 ACP prompts, 0 REST prompts, 34 completed tool cards, 231898-byte PPTX
- REST: 0 ACP prompts, 2 REST prompts, 28 completed tool cards, 228064-byte PPTX
- tool-card ratio: 0.824
- both transports rendered `QUESTION_BETA`
- cleanup: `active_projects=0`, `cleanup_users=0`
