### PR TITLE
docs: meet->voice channel rename, workspace enforcement

### DIFF
--- a/apps/web/content/docs/connect/slack.mdx
+++ b/apps/web/content/docs/connect/slack.mdx
@@ -19,10 +19,11 @@ Kortix supports four channel platforms today:
   own Azure Bot.
 - **Email** — an AgentMail-backed channel (experimental; enable it under
   Customize → Settings → Experimental).
-- **Meeting bots** — a connector-backed channel for meeting transcription.
+- **Voice** — a realtime voice channel on LiveKit. A connected call is a
+  LiveKit room; the agent speaks through the live media session.
 
 Only Slack and Microsoft Teams connect through the CLI and dashboard. Email
-and meeting bots are managed from the dashboard or SDK. This page covers Slack.
+and voice are managed from the dashboard or SDK. This page covers Slack.
 Teams follows the same session, identity-linking, and credential rules.
 
 ## How a channel starts a session
@@ -130,4 +131,4 @@ the bot gets a session), `owner_approval`, or `owner_only`.
   `/kortix <command>` as plain text there instead.
 - Other chat platforms, including Telegram, are not supported channels today.
   Only Slack and Microsoft Teams connect through the CLI and dashboard; email
-  and meeting bots connect through the dashboard or SDK.
+  and voice connect through the dashboard or SDK.

--- a/apps/web/content/docs/project/manifest.mdx
+++ b/apps/web/content/docs/project/manifest.mdx
@@ -264,10 +264,10 @@ Provider-specific fields:
 | `postman` | `spec` | A Collection JSON URL or path, a `.postman/api` manifest, or a Postman workspace URL. |
 | `graphql` | `endpoint` | `spec` optional (SDL). |
 | `http` | `base_url` | `spec` optional. |
-| `channel` | `platform` | `slack`, `teams`, `email`, or `meet`. |
+| `channel` | `platform` | `slack`, `teams`, `email`, or `voice`. |
 | `computer` | — | Synth-only. You cannot declare it by hand — it appears when a machine connects. See [Computers](/docs/connect/computers). |
 
-`channel` connectors rarely need a hand-written entry — connecting a channel from the dashboard creates one for you. See [Slack & channels](/docs/connect/slack). The slugs `kortix_slack`, `kortix_teams`, `kortix_email`, `kortix_meet`, and `computer` are platform-owned; using one with a different provider is a validation error.
+`channel` connectors rarely need a hand-written entry — connecting a channel from the dashboard creates one for you. See [Slack & channels](/docs/connect/slack). The slugs `kortix_slack`, `kortix_teams`, `kortix_email`, `kortix_voice`, and `computer` are platform-owned; using one with a different provider is a validation error.
 
 `connectors.auth`: optional, for providers other than `pipedream`. `type` is `bearer`, `basic`, `custom`, `api_key`, `oauth1`, `hmac`, `aws_sigv4`, `mtls`, or `none` (default). `oauth1` is restricted to `openapi`, `postman`, and `http` providers. `in` is `header` (default), `query`, or `cookie`. `name` is required when `type` is `custom` or `api_key`.
 
@@ -277,7 +277,7 @@ Provider-specific fields:
 
 ## Channels
 
-v2 removes `channels:` from the schema. Channel-to-agent routing (Slack, Microsoft Teams, email, and meeting bots today) is live operational state, not declarative config. You set it from the dashboard's Channels page or from chat commands, the same boundary that keeps credentials out of git. Connecting a channel still creates a `connectors` entry with `provider: channel` for the agent to call. See [Slack & channels](/docs/connect/slack). The v1 `[[channels]]` table is covered in [Legacy TOML](/docs/project/legacy-toml).
+v2 removes `channels:` from the schema. Channel-to-agent routing (Slack, Microsoft Teams, email, and voice today) is live operational state, not declarative config. You set it from the dashboard's Channels page or from chat commands, the same boundary that keeps credentials out of git. Connecting a channel still creates a `connectors` entry with `provider: channel` for the agent to call. See [Slack & channels](/docs/connect/slack). The v1 `[[channels]]` table is covered in [Legacy TOML](/docs/project/legacy-toml).
 
 ## `agents:`
 
@@ -307,7 +307,7 @@ agents:
 | `secrets` | `none` | Which project secrets this agent receives as sandbox env vars. Renamed from v1's `env`. |
 | `kortix_cli` | `none` | Which Kortix CLI and API actions this agent may perform. `all` means everything the launching user can do — an agent can never exceed its launcher. |
 | `skills` | `none` | Which skills this agent may load. |
-| `workspace` | — | Reserved for future git-boundary controls. Not yet enforced. |
+| `workspace` | — | Git-boundary mode: `runtime`, `read`, or `branch`. Validated against the enum; any other value is rejected. |
 
 v2 is deny-by-default: an omitted `connectors`, `secrets`, `kortix_cli`, or `skills` on a declared agent resolves to `none`. Grant every permission an agent needs explicitly, as the starter's `kortix` agent does above. A project migrating from v1 must re-grant everything by hand — v1 defaults `env` (secrets) to `all` when omitted, the opposite of v2.
 

--- a/apps/web/content/docs/sdk/reference.mdx
+++ b/apps/web/content/docs/sdk/reference.mdx
@@ -346,10 +346,10 @@ A routing policy holds a default model, a vision model, and an ordered
 fallback chain, each model attempted at most once; `fallbackOn` is
 `transient` or `any-error`.
 
-#### `p.channels` — Slack / email / Meet
+#### `p.channels` — Slack / email / voice
 
 Integration surfaces that let an agent act as a Slack app, an email address,
-or a meeting bot.
+or join a realtime voice call.
 
 | method | what |
 | --- | --- |
@@ -358,8 +358,7 @@ or a meeting bot.
 | `slack.getFile(url)` · `slack.uploadFile(input)` | download · upload a file via the server proxy |
 | `email.installation(connectorSlug?)` · `email.mode()` | current install · mode |
 | `email.connect(input)` · `email.disconnect(...)` · `email.updatePolicy(input)` | connect · disconnect · update the send/reply policy |
-| `meet.voices()` · `meet.setVoice(voice)` · `meet.previewVoice(voiceId)` | list · set · preview a bot voice |
-| `meet.setBotName(name)` · `meet.speak(botId, text, voice?)` | rename the bot · make it speak in a live meeting |
+| `voice.setBotName(name)` | rename the bot in a live call |
 
 #### `p.modelDefaults` — default model preferences
 


### PR DESCRIPTION
## docs: meet→voice channel rename, workspace enforcement

Docs-only accuracy sweep from the autonomous `docs-maintainer` run (2026-07-26). Two drifts found by four parallel `docs-maintainer-worker` shards and independently re-verified by the orchestrator against current source before editing.

### Audit window
- `kortix-ai/suna`: `0aa15072c` (2026-07-25 checkpoint) → `579a6ff6d` (origin/main). 143 reachable commits. Full-SHA coverage manifest passes `check-commit-coverage.mjs` (4 `docs-change`, 21 `already-current`, 118 `no-doc-impact`).

### Fixes

**1. `meet` channel → `voice` (HIGH) — 9 sites across 3 files**
The `meet` channel platform was renamed to `voice` — a realtime voice channel on LiveKit that replaces the Recall notetaker. The docs still said `meet`, `kortix_meet`, and "Meeting bots". Source proof: `packages/manifest-schema/src/constants.ts:41` (`CHANNEL_PLATFORMS = ['slack','teams','email','voice']`); `:51` (`kortix_voice: 'channel'`); `apps/api/src/projects/connectors.ts:72,81`; `apps/api/src/channels/voice/runtime.ts:1-16` (LiveKit room). The SDK facade `packages/sdk/src/core/client/kortix.ts:593-595` exposes `channels.voice.setBotName(name)` as current; `channels.meet.*` (`:596-604`) is `@deprecated` (`voices/setVoice/previewVoice/speak` deprecated — realtime voice speaks through its live media session).
- `connect/slack.mdx:22,25,134` — "Meeting bots"→"Voice — a realtime voice channel on LiveKit"; "meeting bots"→"voice".
- `project/manifest.mdx:267,270,280` — `meet`→`voice` in the platform enum; `kortix_meet`→`kortix_voice`; "meeting bots today"→"voice today".
- `sdk/reference.mdx:349,352,361-362` — heading "Slack / email / Meet"→"Slack / email / voice"; "or a meeting bot"→"or join a realtime voice call"; replaced the deprecated `meet.voices()/setVoice()/previewVoice()/setBotName()/speak()` rows with the current `voice.setBotName(name)` row.

**2. `workspace` manifest field now enforced (MEDIUM) — `project/manifest.mdx:310`**
The `agents.<name>.workspace` row said "Reserved for future git-boundary controls. Not yet enforced." Source now validates the field against the enum `runtime`/`read`/`branch` (any other value is a hard error). Source proof: `packages/manifest-schema/src/constants.ts:180` (`WORKSPACE_MODES_V2 = ['runtime', 'read', 'branch']`); `packages/manifest-schema/src/index.v2.ts:437-446` (emits `workspace must be one of: runtime, read, branch` error). Landed in-window via `d20ab8569` (feat(sandbox): bind templates to agents).

### Verification
- `check-fumadocs.mjs` PASS (28 pages, 6 nav, 28 routes).
- `git diff --check` PASS; `test-docs-maintainer-gates.mjs` PASS.
- Grep gates PASS (no `kortix_meet`, no "Meeting bots"/"meeting transcription", no `or meet.`, no `meet.voices`/`meet.setVoice`/`meet.speak`, no "Not yet enforced"; positive markers present: `kortix_voice`, `realtime voice channel on LiveKit`, `Slack / email / voice`, `voice.setBotName`, `runtime, read, or branch`).
- This PR is docs-only — 3 files under `apps/web/content/docs/**`.

