### PR TITLE
content(blog): correct DeepSeek output price $0.30 -> $0.28

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -649,7 +649,7 @@ const kortixVsClaudeCowork: BlogPostEntry = {
         {
           dimension: 'Model cost (per 1M output)',
           them: '~$25–30 — frontier only',
-          kortix: '~$4.40 (GLM-5.2) to ~$0.30 (DeepSeek)',
+          kortix: '~$4.40 (GLM-5.2) to ~$0.28 (DeepSeek)',
         },
         {
           dimension: 'Agents, skills & memory shared org-wide',


### PR DESCRIPTION
## What & why

The `kortix-vs-claude-cowork` compare table listed DeepSeek output at `~$0.30/1M tokens`. The official price (api-docs.deepseek.com, V4-Flash) is **$0.28**, matching `competitors.md` L34. Correcting this removes the only inflated-claim defect in the blog.

| Line | Was | Now |
| --- | --- | --- |
| 652 (compare table, Model cost row) | `~$4.40 (GLM-5.2) to ~$0.30 (DeepSeek)` | `~$4.40 (GLM-5.2) to ~$0.28 (DeepSeek)` |

## Scope

Pure content-only edit (1 line, +1/-1) in `apps/web/src/lib/blog-posts.ts`. No renderer, route, import, type, or UI change.

## Verification

- `grep '$0.30' blog-posts.ts` → 0 matches (was 1 at L652).
- `grep '$0.28' blog-posts.ts` → 1 match at L652.
- `grep -c '50×'` → 3 matches (L622, L855, L1260), unchanged. Math: $25 / $0.28 = 89× (still ≥50×).
- `bun` registry import: `kortix-vs-claude-cowork` compare row `Model cost (per 1M output)` kortix cell now reads `~$4.40 (GLM-5.2) to ~$0.28 (DeepSeek)`.
- 0 `kortix.toml` / `black box` / `AI coworker` / `copilot` / `no-code` drift markers.

## Experiment contract (SEO-029)

- **Hypothesis:** correcting the inflated price removes a factual-accuracy defect.
- **Baseline:** L652 `~$0.30` (1 occurrence).
- **Target:** L652 `~$0.28` (matches api-docs.deepseek.com + competitors.md L34).
- **Guardrail:** "50×+" math preserved ($25/$0.28 = 89×); no other line carried the $0.30 figure.
- **Rollback:** revert this PR.

## Notes

- L622, L855, L1260 use the "50×+ cheaper" prose without an explicit price → no edit needed there.
- DeepSeek pricing is subject to change; this matches the official page as of 2026-07-26 (V4-Flash, post-deprecation of `deepseek-chat`/`deepseek-reasoner`).