### PR TITLE
test(auth): wait for hydrated login form

### DIFF
--- a/tests/e2e/helpers/session-auth.ts
+++ b/tests/e2e/helpers/session-auth.ts
@@ -137,6 +137,18 @@ export async function installBrowserSession(
   }
 
   await expect(page.locator('input[name="email"]')).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    () => {
+      const form = document.querySelector('form');
+      if (!form) return false;
+      const reactPropsKey = Object.keys(form).find((key) => key.startsWith('__reactProps$'));
+      if (!reactPropsKey) return false;
+      const reactProps = (form as unknown as Record<string, { onSubmit?: unknown }>)[reactPropsKey];
+      return typeof reactProps?.onSubmit === 'function';
+    },
+    null,
+    { timeout: 30_000 },
+  );
   const signInTab = page.getByRole('tab', { name: /^Sign in$/i });
   if (await signInTab.isVisible().catch(() => false)) {
     await signInTab.click();


### PR DESCRIPTION
## Summary
- wait for the live React submit handler before browser login input
- prevent the US shadow gate from submitting the server-rendered form natively

## Verification
- `scripts/prod-us-east-2/frontend-auth-smoke.sh`
- result: 8 passed; password login, authenticated shell, Google OAuth, GitHub OAuth, cleanup rows 0
- `pnpm -C tests typecheck`
- result: exit 0
- `git diff --check`
- result: exit 0