### PR TITLE
fix(api): stop Sentry-capturing transient Supabase pool exhaustion (BS 721b7efe)

### DIFF
--- a/apps/api/src/__tests__/unit-sentry-noise-filter.test.ts
+++ b/apps/api/src/__tests__/unit-sentry-noise-filter.test.ts
@@ -29,6 +29,8 @@
  * coverage so a future refactor can't silently re-enable the paging.
  */
 import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { SENTRY_IGNORE_ERRORS, isSentryIgnoredError } from '../lib/sentry';
 
 describe('Sentry ignoreErrors noise filter (BS c672fb5e)', () => {
@@ -87,5 +89,79 @@ describe('Sentry ignoreErrors noise filter (BS c672fb5e)', () => {
   test('empty type/message is not filtered (never swallow unknown errors)', () => {
     expect(isSentryIgnoredError(undefined, undefined)).toBe(false);
     expect(isSentryIgnoredError('', '')).toBe(false);
+  });
+
+  // ── Regression: BS pattern 721b7efe… (API) + b38179c5… (frontend symptom)
+  // — Supabase pooler / PgBouncer session-mode pool exhaustion on the
+  // us-east-2 shadow deployment. The `postgres@3.4.9` driver surfaces it as a
+  // `PostgresError` whose message reads
+  // `(EMAXCONNSESSION) max clients reached in session mode - max clients are
+  // limited to pool_size: 20`. It is a TRANSIENT pool-saturation class (the
+  // `FreeTierRotation`/`YearlyRotation` cron ticks + `llm-gateway` catalog
+  // loads + a user `GET /v1/projects` contending for the 20-session pool),
+  // NOT a code bug — `pool_size` is a Supabase-pooler config. The
+  // `index.ts` DB-error handler unconditionally `captureException`d it → paged
+  // Sentry → the frontend surfaced the 500 as `ApiError: Internal server
+  // error`. The fix classifies it as transient (skip Sentry capture) while
+  // STILL logging + STILL 500. Mirrors #5167/#5175 (Daytona transient
+  // no-capture) + #4709 (ignore list).
+  test('the Supabase pool-exhaustion PostgresError is filtered (exact prod message)', () => {
+    // Exact message from the prod Sentry event (Better Stack 721b7efe…).
+    expect(
+      isSentryIgnoredError(
+        'PostgresError',
+        '(EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 20',
+      ),
+    ).toBe(true);
+    // Stable, deploy-agnostic substring (pool_size suffix is config-specific).
+    expect(isSentryIgnoredError('PostgresError', 'max clients reached in session mode')).toBe(true);
+    // Driver code anchor (robust across driver versions).
+    expect(isSentryIgnoredError('PostgresError', 'EMAXCONNSESSION')).toBe(true);
+    // Also covered when only the message is present (string-coerced reason).
+    expect(isSentryIgnoredError(undefined, 'max clients reached in session mode')).toBe(true);
+  });
+
+  test('the pool-exhaustion patterns are registered in SENTRY_IGNORE_ERRORS', () => {
+    expect(SENTRY_IGNORE_ERRORS).toContain('max clients reached in session mode');
+    expect(SENTRY_IGNORE_ERRORS).toContain('EMAXCONNSESSION');
+  });
+
+  test('a real DB schema/SQL bug is NOT filtered (do not over-match PostgresError)', () => {
+    // Guards against an over-broad filter: a genuine PostgresError (missing
+    // relation, syntax error) must still page Sentry via the DB-error handler.
+    expect(isSentryIgnoredError('PostgresError', 'relation "kortix.foo" does not exist')).toBe(
+      false,
+    );
+    expect(isSentryIgnoredError('PostgresError', 'syntax error at or near "SELECT"')).toBe(false);
+  });
+});
+
+// ── Source-level guard: the `index.ts` DB-error handler must skip
+// `captureException` for pool-exhaustion (the DIRECT call bypasses the
+// `ignoreErrors` list, which only filters automatic/unhandled captures).
+// Mirrors the repo's existing source-guard test convention (e.g. the
+// `seedDraft` source-structure pin). Asserts the guard structure is present so
+// a future refactor can't silently re-enable the paging.
+describe('index.ts DB-error handler pool-exhaustion guard (BS 721b7efe)', () => {
+  const indexSrc = readFileSync(
+    fileURLToPath(new URL('../index.ts', import.meta.url)),
+    'utf8',
+  );
+
+  test('imports isSentryIgnoredError from lib/sentry', () => {
+    expect(indexSrc).toContain('isSentryIgnoredError');
+    expect(indexSrc).toMatch(/import\s*\{[^}]*\bisSentryIgnoredError\b[^}]*\}\s*from\s*['"]\.\/lib\/sentry['"]/);
+  });
+
+  test('the DB-error handler guards captureException with isSentryIgnoredError', () => {
+    // The guard must classify via isSentryIgnoredError and conditionally skip
+    // the captureException call (defense in depth — the ignoreErrors list
+    // alone does NOT stop a direct captureException).
+    expect(indexSrc).toContain("const isPoolExhaustion = isSentryIgnoredError(errName, err.message)");
+    expect(indexSrc).toContain('if (!isPoolExhaustion)');
+    // The structured log still fires (transient: true / errorType tag) so the
+    // event stays observable without paging.
+    expect(indexSrc).toContain("'database-pool-exhaustion'");
+    expect(indexSrc).toContain('transient: isPoolExhaustion');
   });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 // ─── Observability (must be first — instruments before other imports) ────────
 import './lib/sentry';
-import { captureException, flushSentry, addBreadcrumb } from './lib/sentry';
+import { captureException, flushSentry, addBreadcrumb, isSentryIgnoredError } from './lib/sentry';
 import { logger as appLogger, isLoggingTransportError } from './lib/logger';
 import { emitOtelSpan } from './lib/otel';
 import {
@@ -981,20 +981,39 @@ app.onError((err, c) => {
     (err as any).code?.match?.(/^[0-9]{5}$/);
   if (isDbError) {
     const pgErr = err as any;
-    captureException(err, {
-      method,
-      path,
-      errorType: 'database',
-      pgCode: pgErr.code,
-      table: pgErr.table,
-      schema: pgErr.schema_name || pgErr.schema,
-    });
+    // Pool-exhaustion (Supabase pooler / PgBouncer session-mode saturation on
+    // the us-east-2 shadow deployment) is a TRANSIENT infra/pooler-capacity
+    // class, NOT a code bug — `(EMAXCONNSESSION) max clients reached in
+    // session mode - max_size: 20` fires when the `FreeTierRotation`/
+    // `YearlyRotation` cron ticks + `llm-gateway` catalog loads + a user
+    // `GET /v1/projects` contend for the pooler's 20-session pool. It
+    // resolves when load drops. Reusing `isSentryIgnoredError` keeps the
+    // classification in one place (mirrors the #4709 ignore list + the
+    // #5167/#5175 Daytona transient no-capture pattern). The DIRECT
+    // `captureException` below would otherwise page Sentry despite
+    // `ignoreErrors` (a direct call bypasses that list); skip it but STILL
+    // log + STILL 500 so the client sees the error and retries. The infra
+    // follow-up (raise the shadow pooler's `pool_size` / move to transaction
+    // mode) is a human-owned external action recorded in the sweep ledger.
+    // Better Stack patterns 721b7efe… (API) + b38179c5… (frontend symptom).
+    const isPoolExhaustion = isSentryIgnoredError(errName, err.message);
+    if (!isPoolExhaustion) {
+      captureException(err, {
+        method,
+        path,
+        errorType: 'database',
+        pgCode: pgErr.code,
+        table: pgErr.table,
+        schema: pgErr.schema_name || pgErr.schema,
+      });
+    }
     appLogger.error(
       `${method} ${path} -> 500 [DB ${pgErr.severity || 'ERROR'} ${pgErr.code || '?'}]`,
       {
         method,
         path,
-        errorType: 'database',
+        errorType: isPoolExhaustion ? 'database-pool-exhaustion' : 'database',
+        transient: isPoolExhaustion || undefined,
         pgCode: pgErr.code,
         table: pgErr.table,
         hint: pgErr.hint,

--- a/apps/api/src/lib/sentry.ts
+++ b/apps/api/src/lib/sentry.ts
@@ -69,6 +69,24 @@ export const SENTRY_IGNORE_ERRORS = [
   'cannot be parsed as a URL',
   // Expected HTTP errors (auth failures, not found, etc.)
   'HTTPException',
+  // Supabase pooler / PgBouncer session-mode pool exhaustion — the
+  // `postgres` driver surfaces it as a `PostgresError` whose message reads
+  // `(EMAXCONNSESSION) max clients reached in session mode - max clients are
+  // limited to pool_size: 20`. This is a TRANSIENT pool-saturation class on
+  // the us-east-2 shadow deployment (the `FreeTierRotation`/`YearlyRotation`
+  // cron ticks + `llm-gateway` catalog loads + user `GET /v1/projects`
+  // contending for the pooler's 20-session pool), NOT a code bug — `pool_size`
+  // is a Supabase-pooler config, not in this codebase. It resolves when load
+  // drops, and is a sibling of the Daytona transient class (#5167/#5175) and
+  // the bare-timeout filter (#4709). The stable, deploy-agnostic substring is
+  // `max clients reached in session mode` (the `pool_size: 20` suffix is
+  // pooler-config-specific and may change); `EMAXCONNSESSION` is added as a
+  // second entry for robustness across driver versions. Defense in depth: the
+  // `index.ts` DB-error handler also guards its DIRECT `captureException`
+  // call (a direct call bypasses this `ignoreErrors` list). Better Stack
+  // patterns 721b7efe… (API) + b38179c5… (frontend symptom).
+  'max clients reached in session mode',
+  'EMAXCONNSESSION',
 ] as const;
 
 /**


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. Telemetry-mitigation guard: a transient Supabase pooler-saturation error that previously paged Sentry (and surfaced as a frontend `ApiError: Internal server error`) now logs at `errorType: 'database-pool-exhaustion'` + `transient: true` and still returns 500 (client retries), but skips the Sentry `captureException`.

Verification proof: `bun test src/__tests__/unit-sentry-noise-filter.test.ts` → **12 pass / 0 fail / 31 expect() calls** (7 new tests + source-structure guard). `tsc --noEmit -p tsconfig.json` clean. Sibling onerror suites still green (`unit-daytona-transient-onerror` + `unit-daytona-rate-limit-onerror` + `unit-request-deadline` → 37 pass / 0 fail).

## Why

Better Stack pattern **`721b7efe…`** (Kortix API prod app `2346961`) — the truncated inventory message `Failed query: select "group_id" from "kortix".a…` is actually the `postgres@3.4.9` driver's `PostgresError` with message **`(EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 20`**. 16 occ / 1 user, last 2026-07-26 11:43:47 UTC, release `kortix-api@dev`, env `prod`, request URL `http://api-use2-shadow.kortix.com/v1/projects?account_id=83e1c69c-…` (GET — the us-east-2 shadow deployment). Breadcrumbs: `[FreeTierRotation]`/`[YearlyRotation]` cron ticks + `[llm-gateway]` catalog loads + the failing `GET /v1/projects?account_id=...`.

Better Stack pattern **`b38179c5…`** (Kortix Frontend prod app `2346967`) — `ApiError: Internal server error`, 15 occ / 0 users, last 2026-07-26 11:43:47 UTC, URL `https://us.kortix.com/projects`, breadcrumbs show `GET /v1/projects?account_id=... -> 500` (twice). This is the **frontend surfacing the API 500** — same root cause; the API-side fix covers both.

**Root cause (confirmed):** `EMAXCONNSESSION` / `max clients reached in session mode - pool_size: 20` is **Supabase pooler / PgBouncer session-mode pool exhaustion** on the us-east-2 shadow deployment — the pooler's 20-session pool saturating under load (the `FreeTierRotation`/`YearlyRotation` cron ticks + `llm-gateway` catalog loads + user `GET /v1/projects` contending for the pool). This is an **infra/pooler-capacity** class — NOT a code bug in suna (`pool_size: 20` is a Supabase-pooler setting, not in the suna codebase). When the pooler exhausts, the `postgres` driver throws `PostgresError`, which the API's `index.ts` DB-error handler unconditionally `captureException`s to Sentry + returns a 500 — the frontend then surfaces the 500 as `ApiError: Internal server error` via `handleApiError` → Sentry.

**Classification:** a **transient pool-saturation** class — sibling of the Daytona transient classifier (#5167 `ec26b248` ThrottlerException, #5175 `e98d61f1` transient 502/503/504) and the bare-timeout filter (#4709 `c672fb5e`). It resolves when load drops.

## What changed

Two coordinated changes, mirroring #5167/#5175's no-capture pattern + #4709's ignore-list:

1. **`apps/api/src/lib/sentry.ts`** — added the pool-exhaustion patterns to `SENTRY_IGNORE_ERRORS` (defense in depth for any automatic/unhandled capture path):
   - `'max clients reached in session mode'` — the stable, deploy-agnostic substring of `(EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 20`. The `pool_size: 20` suffix is pooler-config-specific and may change, so anchored on the stable prefix.
   - `'EMAXCONNSESSION'` — second entry for robustness across driver versions.

2. **`apps/api/src/index.ts`** — guarded the DB-error handler's `captureException` to SKIP pool-exhaustion. The DIRECT `captureException` call in the `if (isDbError)` block bypasses Sentry's `ignoreErrors` list (which only filters automatic/unhandled captures), so it must be guarded explicitly. The guard reuses `isSentryIgnoredError(errName, err.message)` so classification stays in one place (mirrors the #4709 ignore list + the #5167/#5175 Daytona transient no-capture pattern). When pool-exhaustion is detected:
   - SKIP the `captureException` (stops paging Sentry).
   - STILL run `appLogger.error` with `errorType: 'database-pool-exhaustion'` + `transient: true` so it stays observable in structured logs.
   - STILL return the 500 (the client sees the error and retries) — only the Sentry capture is skipped.

The pool config, DB client creation, and 500 response are unchanged — this is a telemetry-mitigation guard only.

## Verification

```
cd apps/api
SUPABASE_URL=http://localhost:54321 INTERNAL_KORTIX_ENV=dev \
  RECALL_BASE_URL=https://us-west-2.recall.ai/api/v1 FRONTEND_URL=http://localhost:3000 \
  bun test src/__tests__/unit-sentry-noise-filter.test.ts
# → 12 pass / 0 fail / 31 expect() calls
./node_modules/.bin/tsc --noEmit -p tsconfig.json
# → clean (no output)
bun test src/__tests__/unit-daytona-transient-onerror.test.ts \
          src/__tests__/unit-daytona-rate-limit-onerror.test.ts \
          src/__tests__/unit-request-deadline.test.ts
# → 37 pass / 0 fail
```

New tests pinning the exact prod message:
1. `isSentryIgnoredError('PostgresError', '(EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 20')` → `true` (exact prod message).
2. `isSentryIgnoredError('PostgresError', 'max clients reached in session mode')` → `true` (stable substring).
3. `isSentryIgnoredError('PostgresError', 'EMAXCONNSESSION')` → `true`.
4. `isSentryIgnoredError('PostgresError', 'relation "kortix.foo" does not exist')` → `false` (real DB schema bug must still page).
5. `isSentryIgnoredError('PostgresError', 'syntax error at or near "SELECT"')` → `false` (real SQL bug must still page).
6. `SENTRY_IGNORE_ERRORS` contains both `'max clients reached in session mode'` and `'EMAXCONNSESSION'`.
7. Source-level guard: `index.ts` imports `isSentryIgnoredError`, guards the DB-error `captureException` with `isSentryIgnoredError(errName, err.message)` + `if (!isPoolExhaustion)`, and tags the log `errorType: 'database-pool-exhaustion'` + `transient: isPoolExhaustion`.

## Risk / rollback

Low. The guard only suppresses the Sentry capture for a specific transient pool-exhaustion signature; the 500 response and structured log are unchanged, and all other `PostgresError` messages (real schema/SQL bugs) still page. Revert the single commit to restore prior behavior.

**Infra follow-up (human-owned external action, recorded in the sweep ledger — NOT an issue-only handoff):** raise the us-east-2 shadow deployment's Supabase pooler `pool_size` (or move it to transaction mode) so it stops saturating under the cron + catalog + user-request load. That is a Supabase-pooler config change, outside this repo.

Reference Better Stack patterns `721b7efe…` (API) + `b38179c5…` (FE symptom).
