### PR TITLE
perf(api): remove turn-stream request amplification

### DIFF
--- a/apps/api/scripts/verify-execution-lease-live.ts
+++ b/apps/api/scripts/verify-execution-lease-live.ts
@@ -1,0 +1,172 @@
+import {
+  accounts,
+  kortixApiKeys,
+  projectSessions,
+  projects,
+  sessionSandboxes,
+} from "@kortix/db";
+import { eq } from "drizzle-orm";
+import { createApiKey } from "../src/repositories/api-keys";
+import { db } from "../src/shared/db";
+
+const apiBaseUrl = (
+  process.env.KORTIX_API_URL ?? "http://localhost:8008/v1"
+).replace(/\/$/, "");
+const accountId = crypto.randomUUID();
+const projectId = crypto.randomUUID();
+const sessionId = crypto.randomUUID();
+const sandboxId = crypto.randomUUID();
+
+interface LeaseResponse {
+  ok: boolean;
+  lease_until?: string | null;
+  provider_url?: string | null;
+  provider_headers?: Record<string, string> | null;
+}
+
+interface LeaseProof {
+  action: "acquire" | "renew" | "release";
+  status: number;
+  elapsed_ms: number;
+  response: LeaseResponse;
+  stored_lease_until: string | null;
+}
+
+function storedLeaseUntil(
+  metadata: Record<string, unknown> | null,
+): string | null {
+  const value = metadata?.executionLeaseUntil;
+  return typeof value === "string" ? value : null;
+}
+
+async function readStoredLeaseUntil(): Promise<string | null> {
+  const [row] = await db
+    .select({ metadata: sessionSandboxes.metadata })
+    .from(sessionSandboxes)
+    .where(eq(sessionSandboxes.sandboxId, sandboxId))
+    .limit(1);
+  if (!row) throw new Error("The disposable sandbox row is missing");
+  return storedLeaseUntil(row.metadata);
+}
+
+async function callLease(
+  token: string,
+  action: LeaseProof["action"],
+): Promise<LeaseProof> {
+  const startedAt = performance.now();
+  const response = await fetch(
+    `${apiBaseUrl}/projects/${projectId}/execution-lease`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        action,
+        session_id: sessionId,
+        lease_ttl_seconds: 180,
+      }),
+    },
+  );
+  const elapsedMs = performance.now() - startedAt;
+  const body = (await response.json()) as LeaseResponse;
+  return {
+    action,
+    status: response.status,
+    elapsed_ms: Math.round(elapsedMs * 10) / 10,
+    response: body,
+    stored_lease_until: await readStoredLeaseUntil(),
+  };
+}
+
+function assertLeaseProof(proof: LeaseProof): void {
+  if (proof.status !== 200 || !proof.response.ok) {
+    throw new Error(`${proof.action} failed: ${JSON.stringify(proof)}`);
+  }
+  if (proof.action === "release") {
+    if (proof.stored_lease_until !== null) {
+      throw new Error(`release retained lease ${proof.stored_lease_until}`);
+    }
+    return;
+  }
+  if (!proof.response.lease_until) {
+    throw new Error(`${proof.action} returned no lease_until`);
+  }
+  if (proof.stored_lease_until !== proof.response.lease_until) {
+    throw new Error(
+      `${proof.action} response/database mismatch: ` +
+        `${proof.response.lease_until} !== ${proof.stored_lease_until}`,
+    );
+  }
+}
+
+let keyId: string | null = null;
+
+try {
+  await db
+    .insert(accounts)
+    .values({ accountId, name: "Execution lease live proof" });
+  await db.insert(projects).values({
+    projectId,
+    accountId,
+    name: "Execution lease live proof",
+    repoUrl: `https://example.invalid/${projectId}.git`,
+  });
+  await db.insert(projectSessions).values({
+    sessionId,
+    accountId,
+    projectId,
+    branchName: `proof-${sessionId}`,
+    sandboxId,
+    status: "running",
+  });
+  await db.insert(sessionSandboxes).values({
+    sandboxId,
+    sessionId,
+    accountId,
+    projectId,
+    provider: "daytona",
+    status: "provisioning",
+  });
+  const key = await createApiKey({
+    sandboxId,
+    accountId,
+    title: "Execution lease live proof",
+    type: "sandbox",
+  });
+  keyId = key.keyId;
+
+  const proofs: LeaseProof[] = [];
+  for (const action of ["acquire", "renew", "release"] as const) {
+    const proof = await callLease(key.secretKey, action);
+    assertLeaseProof(proof);
+    proofs.push(proof);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        api_base_url: apiBaseUrl,
+        project_id: projectId,
+        session_id: sessionId,
+        sandbox_id: sandboxId,
+        proofs,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  if (keyId) {
+    await db.delete(kortixApiKeys).where(eq(kortixApiKeys.keyId, keyId));
+  }
+  await db
+    .delete(sessionSandboxes)
+    .where(eq(sessionSandboxes.sandboxId, sandboxId));
+  await db
+    .delete(projectSessions)
+    .where(eq(projectSessions.sessionId, sessionId));
+  await db.delete(projects).where(eq(projects.projectId, projectId));
+  await db.delete(accounts).where(eq(accounts.accountId, accountId));
+}

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -879,6 +879,66 @@ describe('project session API contract', () => {
 
   beforeEach(() => resetState());
 
+  test('sandbox token acquires, renews, and releases the execution lease route', async () => {
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'daytona',
+        externalId: null,
+        baseUrl: null,
+        status: 'active',
+        config: {},
+        metadata: {},
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+    const app = createApp();
+    const request = (action: 'acquire' | 'renew' | 'release', token: string) =>
+      app.request(`/v1/projects/${PROJECT_ID}/execution-lease`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          action,
+          session_id: SESSION_ID,
+          lease_ttl_seconds: 180,
+        }),
+      });
+
+    const acquire = await request('acquire', PROJECT_SANDBOX_TOKEN);
+    expect(acquire.status).toBe(200);
+    expect(await acquire.json()).toMatchObject({
+      ok: true,
+      provider_url: null,
+      provider_headers: null,
+    });
+
+    const renew = await request('renew', PROJECT_SANDBOX_TOKEN);
+    expect(renew.status).toBe(200);
+    expect(await renew.json()).toMatchObject({
+      ok: true,
+      provider_url: null,
+      provider_headers: null,
+    });
+
+    const release = await request('release', PROJECT_SANDBOX_TOKEN);
+    expect(release.status).toBe(200);
+    expect(await release.json()).toEqual({ ok: true });
+
+    const forbidden = await request('renew', PROJECT_RUNTIME_PAT);
+    expect(forbidden.status).toBe(403);
+    expect(await forbidden.json()).toMatchObject({
+      error: 'execution lease requires a sandbox token',
+    });
+  });
+
   test('GET project session inventory rejects callers without project.session.read', async () => {
     deniedIamAction = 'project.session.read';
     const app = createApp();

--- a/apps/api/src/__tests__/unit-execution-lease-discover.test.ts
+++ b/apps/api/src/__tests__/unit-execution-lease-discover.test.ts
@@ -39,13 +39,23 @@ const chainable = {
   where: () => chainable,
   limit: () => leaseRow,
 };
+const updateChainable = {
+  set: () => updateChainable,
+  where: () => updateChainable,
+  returning: () => leaseRow,
+};
 mock.module('../shared/db', () => ({
   db: {
     select: () => chainable,
+    update: () => updateChainable,
   },
 }));
 
-const { discoverExecutionKeepAliveEndpoint } = await import('../projects/execution-lease');
+const {
+  acquireExecutionLease,
+  discoverExecutionKeepAliveEndpoint,
+  renewExecutionLease,
+} = await import('../projects/execution-lease');
 
 beforeEach(() => {
   resolveEndpointThrow = null;
@@ -64,6 +74,7 @@ describe('discoverExecutionKeepAliveEndpoint Daytona 429 guard', () => {
       sandboxId: 'sb-1',
       sessionId: 'ses-1',
       projectId: 'proj-1',
+      accountId: 'acct-1',
     });
     expect(result).toBeNull();
     expect(resolveEndpointCalls).toBe(1);
@@ -78,6 +89,7 @@ describe('discoverExecutionKeepAliveEndpoint Daytona 429 guard', () => {
       sandboxId: 'sb-1',
       sessionId: 'ses-1',
       projectId: 'proj-1',
+      accountId: 'acct-1',
     });
     expect(result).toBeNull();
   });
@@ -87,6 +99,7 @@ describe('discoverExecutionKeepAliveEndpoint Daytona 429 guard', () => {
       sandboxId: 'sb-1',
       sessionId: 'ses-1',
       projectId: 'proj-1',
+      accountId: 'acct-1',
     });
     expect(result).not.toBeNull();
     expect(result?.url).toBe('https://upstream.example.test');
@@ -94,5 +107,31 @@ describe('discoverExecutionKeepAliveEndpoint Daytona 429 guard', () => {
     // contract preserved across the guard.
     expect(result?.headers.authorization).toBeUndefined();
     expect(result?.headers['x-test']).toBe('1');
+  });
+
+  it('renews the database lease without resolving or touching the provider', async () => {
+    const result = await renewExecutionLease({
+      sandboxId: 'sb-1',
+      sessionId: 'ses-1',
+      projectId: 'proj-1',
+      accountId: 'acct-1',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.providerUrl).toBeNull();
+    expect(result.providerHeaders).toBeNull();
+    expect(resolveEndpointCalls).toBe(0);
+  });
+
+  it('resolves the provider endpoint once when the lease is acquired', async () => {
+    const result = await acquireExecutionLease({
+      sandboxId: 'sb-1',
+      sessionId: 'ses-1',
+      projectId: 'proj-1',
+      accountId: 'acct-1',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.providerUrl).toBe('https://upstream.example.test');
+    expect(result.providerHeaders).toEqual({ 'x-test': '1' });
+    expect(resolveEndpointCalls).toBe(1);
   });
 });

--- a/apps/api/src/__tests__/unit-project-access-side-effects.test.ts
+++ b/apps/api/src/__tests__/unit-project-access-side-effects.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test';
+
+const accessSource = await Bun.file(
+  new URL('../projects/lib/access.ts', import.meta.url),
+).text();
+
+describe('project authorization side effects', () => {
+  it('does not resume a sandbox during generic project authorization', () => {
+    expect(accessSource).not.toContain('preResumeRecentStoppedSessions');
+    expect(accessSource).not.toContain('KORTIX_PRERESUME');
+  });
+});

--- a/apps/api/src/__tests__/unit-request-deadline.test.ts
+++ b/apps/api/src/__tests__/unit-request-deadline.test.ts
@@ -29,7 +29,7 @@ function makeApp() {
   };
   app.get('/v1/projects/x/change-requests', slow); // bounded
   app.get('/v1/p/sandbox/3000/index.html', slow);  // exempt prefix
-  app.get('/v1/projects/x/turn-stream', slow);      // exempt fragment
+  app.get('/v1/projects/x/turn-stream', slow);      // JSON relay, bounded
   app.get('/v1/router/chat/completions', slow);      // exempt prefix
   app.get('/v1/llm/chat/completions', slow);          // exempt prefix (LLM streaming)
   app.post('/v1/billing/webhooks/stripe', slow);      // exempt prefix (webhook)
@@ -58,9 +58,9 @@ describe('requestDeadline', () => {
     expect(res.status).toBe(200); // would be 503 if bounded
   });
 
-  it('exempts streaming fragments (turn-stream) from the deadline', async () => {
+  it('bounds the JSON turn-stream relay', async () => {
     const res = await makeApp().request('/v1/projects/x/turn-stream');
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
   });
 
   it('exempts the LLM router prefix from the deadline', async () => {

--- a/apps/api/src/__tests__/unit-sandbox-execution-lease-auth.test.ts
+++ b/apps/api/src/__tests__/unit-sandbox-execution-lease-auth.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+
+mock.module('../shared/crypto', () => ({
+  isAccountToken: () => false,
+  isServiceAccountToken: () => false,
+  isKortixToken: (token: string) => token === 'kortix_sb_execution_lease',
+}));
+
+mock.module('../repositories/account-tokens', () => ({
+  validateAccountToken: async () => ({ isValid: false }),
+}));
+
+mock.module('../repositories/service-accounts', () => ({
+  validateServiceAccountToken: async () => ({ isValid: false }),
+}));
+
+mock.module('../repositories/api-keys', () => ({
+  validateSecretKey: async (token: string) =>
+    token === 'kortix_sb_execution_lease'
+      ? {
+          isValid: true,
+          type: 'sandbox',
+          sandboxId: 'sandbox-1',
+          accountId: 'account-1',
+          keyId: 'key-1',
+        }
+      : { isValid: false, error: 'Invalid token' },
+}));
+
+mock.module('../shared/jwt-verify', () => ({
+  decodeSupabaseJwtPayload: () => null,
+  verifySupabaseJwt: async () => ({ ok: false, reason: 'no-keys' }),
+}));
+
+mock.module('../shared/supabase', () => ({
+  getSupabase: () => ({
+    auth: {
+      getUser: async () => ({
+        data: { user: null },
+        error: { message: 'invalid' },
+      }),
+    },
+  }),
+}));
+
+mock.module('../shared/auth-audit', () => ({
+  auditLoginSuccess: () => {},
+  auditLoginFail: () => {},
+}));
+
+mock.module('../lib/sentry', () => ({ setSentryUser: () => {} }));
+mock.module('../lib/request-context', () => ({ setContextField: () => {} }));
+mock.module('../iam/sso-sync', () => ({ syncSsoMembership: async () => {} }));
+
+const { supabaseAuth } = await import('../middleware/auth');
+
+function createApp() {
+  const app = new Hono();
+  app.use('/*', supabaseAuth);
+  app.post('/v1/projects/:projectId/execution-lease', (c) =>
+    c.json({
+      authType: c.get('authType' as never),
+      apiKeyType: c.get('apiKeyType' as never),
+      accountId: c.get('accountId' as never),
+      sandboxId: c.get('sandboxId' as never),
+    }),
+  );
+  app.post('/v1/projects/:projectId/not-sandbox-enabled', (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe('sandbox execution-lease authentication', () => {
+  test('accepts a valid sandbox token and sets its scoped identity', async () => {
+    const response = await createApp().request(
+      '/v1/projects/project-1/execution-lease',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer kortix_sb_execution_lease' },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      authType: 'apiKey',
+      apiKeyType: 'sandbox',
+      accountId: 'account-1',
+      sandboxId: 'sandbox-1',
+    });
+  });
+
+  test('rejects the same sandbox token on an unrelated project route', async () => {
+    const response = await createApp().request(
+      '/v1/projects/project-1/not-sandbox-enabled',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer kortix_sb_execution_lease' },
+      },
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -223,14 +223,6 @@ const envSchema = z.object({
   // (consumed by daytonaLifecycle()). Main's 3-day auto-archive default already
   // keeps a hibernated box in the fast-resume "stopped" tier far longer than the
   // earlier 120m, so the pause/resume win is subsumed there.
-  // Pre-resume: on a user returning to a project, proactively provider.start
-  // their most-recently-stopped session(s) so the ~8s resume overlaps the
-  // user's navigation and the session is ready by the time they open it. Reuses
-  // resumeStoppedSandbox (idempotent with the on-open resume). GATED OFF by
-  // default (speculative compute — starts a box the user might not open). Enable
-  // after validating; tune how many recent sessions to pre-resume per project.
-  KORTIX_PRERESUME_ENABLED: optBoolFalse,
-  KORTIX_PRERESUME_MAX_PER_PROJECT: optInt(1),
   // OpenCode client transport. REST remains the default until the project
   // experimental flag enables ACP after parity verification.
   KORTIX_OPENCODE_TRANSPORT: z.enum(['acp', 'rest']).default('rest'),
@@ -913,8 +905,6 @@ export const config = {
   CODE_STORAGE_API_BASE: env.CODE_STORAGE_API_BASE,
   CODE_STORAGE_GIT_HOST: env.CODE_STORAGE_GIT_HOST,
   KORTIX_GIT_PROXY: env.KORTIX_GIT_PROXY,
-  KORTIX_PRERESUME_ENABLED: env.KORTIX_PRERESUME_ENABLED,
-  KORTIX_PRERESUME_MAX_PER_PROJECT: env.KORTIX_PRERESUME_MAX_PER_PROJECT,
   KORTIX_OPENCODE_TRANSPORT: env.KORTIX_OPENCODE_TRANSPORT,
   KORTIX_ENFORCE_SESSION_AGENT_LOCK: env.KORTIX_ENFORCE_SESSION_AGENT_LOCK,
   KORTIX_REQUIRE_DECLARED_AGENTS: env.KORTIX_REQUIRE_DECLARED_AGENTS,

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -211,6 +211,7 @@ export async function supabaseAuth(c: Context, next: Next) {
   const path = c.req.path;
   const sandboxTokenPathAllowed =
     path.endsWith('/git/clone-credential') ||
+    path.endsWith('/execution-lease') ||
     path.endsWith('/turn-stream') ||
     path.endsWith('/turn-question') ||
     // The seed daemon fetches the org model catalog at PARK with its sandbox

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -71,7 +71,6 @@ const EXEMPT_PREFIXES = [
 // can exceed the deadline while behaving correctly. Enumerated from 7 days of
 // prod duration data (2026-06-12).
 const EXEMPT_FRAGMENTS = [
-  '/turn-stream',
   '/turn-question',
   '/provision-stream',
   '/provision',               // managed repo create + sandbox boot

--- a/apps/api/src/projects/execution-lease.ts
+++ b/apps/api/src/projects/execution-lease.ts
@@ -6,12 +6,12 @@ import { db } from '../shared/db';
 export const DEFAULT_EXECUTION_LEASE_SECONDS = 120;
 export const MIN_EXECUTION_LEASE_SECONDS = 30;
 export const MAX_EXECUTION_LEASE_SECONDS = 300;
-const PROVIDER_TOUCH_TIMEOUT_MS = 5_000;
 
 export interface ExecutionLeaseTarget {
   sandboxId: string;
   sessionId: string;
   projectId: string;
+  accountId: string;
 }
 
 export interface ExecutionKeepAliveEndpoint {
@@ -61,6 +61,7 @@ async function loadLeaseSandbox(target: ExecutionLeaseTarget) {
         eq(sessionSandboxes.sandboxId, target.sandboxId),
         eq(sessionSandboxes.sessionId, target.sessionId),
         eq(sessionSandboxes.projectId, target.projectId),
+        eq(sessionSandboxes.accountId, target.accountId),
         inArray(sessionSandboxes.status, ['provisioning', 'active']),
       ),
     )
@@ -80,7 +81,7 @@ export async function discoverExecutionKeepAliveEndpoint(
   // provider 429 must NOT bubble up to `app.onError` → Sentry → Better Stack
   // (the recurring `ec26b248…` fingerprint). Degrade to `null` — the caller
   // treats null as "no keep-alive endpoint yet" and the DB lease remains
-  // authoritative, exactly like `touchProvider`'s own catch below.
+  // authoritative.
   try {
     const endpoint = await getProvider(row.provider as ProviderName).resolveEndpoint(
       row.externalId,
@@ -95,36 +96,31 @@ export async function discoverExecutionKeepAliveEndpoint(
   }
 }
 
-async function touchProvider(
+async function resolveKeepAliveEndpoint(
   provider: ProviderName,
   externalId: string,
 ): Promise<ExecutionKeepAliveEndpoint | null> {
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      const endpoint = await getProvider(provider).resolveEndpoint(externalId);
-      const keepAlive = keepAliveEndpoint(endpoint.url, endpoint.headers);
-      const response = await fetch(`${keepAlive.url}/kortix/health`, {
-        headers: endpoint.headers,
-        signal: AbortSignal.timeout(PROVIDER_TOUCH_TIMEOUT_MS),
-      });
-      if (response.ok || response.status === 503) return keepAlive;
-    } catch {
-      /* the next heartbeat retries; the DB lease remains authoritative */
-    }
+  try {
+    const endpoint = await getProvider(provider).resolveEndpoint(externalId);
+    return keepAliveEndpoint(endpoint.url, endpoint.headers);
+  } catch (err) {
+    console.warn(
+      `[execution-lease] resolve keep-alive endpoint failed for sandbox ${externalId}:`,
+      err instanceof Error ? err.message : err,
+    );
+    return null;
   }
-  return null;
 }
 
-export async function renewExecutionLease(
+async function writeExecutionLease(
   target: ExecutionLeaseTarget,
   requestedTtlSeconds?: number,
   now = new Date(),
 ): Promise<{
-  ok: boolean;
-  leaseUntil: string | null;
-  providerUrl: string | null;
-  providerHeaders: Record<string, string> | null;
-}> {
+  leaseUntil: string;
+  provider: string;
+  externalId: string | null;
+} | null> {
   const leaseUntil = new Date(
     now.getTime() + clampLeaseSeconds(requestedTtlSeconds) * 1_000,
   ).toISOString();
@@ -145,21 +141,55 @@ export async function renewExecutionLease(
         eq(sessionSandboxes.sandboxId, target.sandboxId),
         eq(sessionSandboxes.sessionId, target.sessionId),
         eq(sessionSandboxes.projectId, target.projectId),
+        eq(sessionSandboxes.accountId, target.accountId),
         inArray(sessionSandboxes.status, ['provisioning', 'active']),
       ),
     )
     .returning({ provider: sessionSandboxes.provider, externalId: sessionSandboxes.externalId });
+  return row ? { ...row, leaseUntil } : null;
+}
+
+export async function acquireExecutionLease(
+  target: ExecutionLeaseTarget,
+  requestedTtlSeconds?: number,
+  now = new Date(),
+): Promise<{
+  ok: boolean;
+  leaseUntil: string | null;
+  providerUrl: string | null;
+  providerHeaders: Record<string, string> | null;
+}> {
+  const row = await writeExecutionLease(target, requestedTtlSeconds, now);
   if (!row) {
     return { ok: false, leaseUntil: null, providerUrl: null, providerHeaders: null };
   }
   const providerEndpoint = row.externalId
-    ? await touchProvider(row.provider as ProviderName, row.externalId)
+    ? await resolveKeepAliveEndpoint(row.provider as ProviderName, row.externalId)
     : null;
   return {
     ok: true,
-    leaseUntil,
+    leaseUntil: row.leaseUntil,
     providerUrl: providerEndpoint?.url ?? null,
     providerHeaders: providerEndpoint?.headers ?? null,
+  };
+}
+
+export async function renewExecutionLease(
+  target: ExecutionLeaseTarget,
+  requestedTtlSeconds?: number,
+  now = new Date(),
+): Promise<{
+  ok: boolean;
+  leaseUntil: string | null;
+  providerUrl: null;
+  providerHeaders: null;
+}> {
+  const row = await writeExecutionLease(target, requestedTtlSeconds, now);
+  return {
+    ok: row !== null,
+    leaseUntil: row?.leaseUntil ?? null,
+    providerUrl: null,
+    providerHeaders: null,
   };
 }
 
@@ -179,6 +209,7 @@ export async function releaseExecutionLease(
         eq(sessionSandboxes.sandboxId, target.sandboxId),
         eq(sessionSandboxes.sessionId, target.sessionId),
         eq(sessionSandboxes.projectId, target.projectId),
+        eq(sessionSandboxes.accountId, target.accountId),
       ),
     )
     .returning({ sandboxId: sessionSandboxes.sandboxId });

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -3,7 +3,6 @@ import { authorize, assertAuthorized } from '../../iam';
 import { deriveRequestContext } from '../../iam/cache';
 import { invalidateIamCacheForUser, registerPrincipalScopedMemo } from '../../iam/cache-invalidation';
 import { auth } from '../../openapi';
-import { preResumeRecentStoppedSessions } from '../routes/shared';
 import { recordAuditEvent } from '../../shared/audit';
 import { db } from '../../shared/db';
 import { isPlatformAdmin } from '../../shared/platform-roles';
@@ -593,12 +592,6 @@ export async function loadProjectForUser(c: Context, projectId: string, action: 
   const effectiveRole =
     (accountRole ? effectiveProjectRole(accountRole, projectRole) : projectRole) ?? 'member';
   (c as any).set('accountId', row.accountId);
-
-  if (action !== 'read' || roleAllows(effectiveRole as ProjectRole, 'write')) {
-    // Proactively wake the user's most recently-stopped session(s) so the resume
-    // overlaps their navigation. No-op unless KORTIX_PRERESUME_ENABLED.
-    preResumeRecentStoppedSessions(projectId, userId);
-  }
 
   return {
     row,

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -85,6 +85,7 @@ import {
 import { getProjectRoutingPolicy } from '../../repositories/project-routing-policies';
 import { db } from '../../shared/db';
 import {
+  acquireExecutionLease,
   discoverExecutionKeepAliveEndpoint,
   releaseExecutionLease,
   renewExecutionLease,
@@ -1911,6 +1912,87 @@ function agentMailConnectErrorBody(stage: 'inbox_create' | 'webhook_create', err
   };
 }
 
+// POST /v1/projects/:projectId/execution-lease
+// The sandbox agent reports active OpenCode work through this bounded JSON
+// route. Acquire returns the provider endpoint once. Renew and release each
+// execute one conditional database update.
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/execution-lease',
+    tags: ['projects'],
+    summary: 'POST /:projectId/execution-lease',
+    ...auth,
+    request: {
+      params: z.object({ projectId: z.string() }),
+      body: {
+        content: {
+          'application/json': {
+            schema: z.object({
+              action: z.enum(['acquire', 'renew', 'release']),
+              session_id: z.string().min(1),
+              lease_ttl_seconds: z.number().optional(),
+            }),
+          },
+        },
+      },
+    },
+    responses: {
+      200: json(
+        z
+          .object({
+            ok: z.boolean(),
+            lease_until: z.string().nullable().optional(),
+            provider_url: z.string().nullable().optional(),
+            provider_headers: z.record(z.string(), z.string()).nullable().optional(),
+          })
+          .passthrough(),
+        'Lease operation result',
+      ),
+      ...errors(400, 403),
+    },
+  }),
+  async (c: any) => {
+    const authType = c.get('authType') as string | undefined;
+    const apiKeyType = c.get('apiKeyType') as string | undefined;
+    const accountId = c.get('accountId') as string | undefined;
+    const sandboxId = c.get('sandboxId') as string | undefined;
+    if (
+      authType !== 'apiKey' ||
+      apiKeyType !== 'sandbox' ||
+      !accountId ||
+      !sandboxId
+    ) {
+      return c.json({ error: 'execution lease requires a sandbox token' }, 403);
+    }
+    const projectId = c.req.param('projectId');
+    const body = c.req.valid('json') as {
+      action: 'acquire' | 'renew' | 'release';
+      session_id: string;
+      lease_ttl_seconds?: number;
+    };
+    const target = {
+      sandboxId,
+      sessionId: body.session_id.trim(),
+      projectId,
+      accountId,
+    };
+    if (body.action === 'release') {
+      return c.json({ ok: await releaseExecutionLease(target) });
+    }
+    const result =
+      body.action === 'acquire'
+        ? await acquireExecutionLease(target, body.lease_ttl_seconds)
+        : await renewExecutionLease(target, body.lease_ttl_seconds);
+    return c.json({
+      ok: result.ok,
+      lease_until: result.leaseUntil,
+      provider_url: result.providerUrl,
+      provider_headers: result.providerHeaders,
+    });
+  },
+);
+
 // POST /v1/projects/:projectId/turn-stream
 // Agent-cli relay for the live Slack plan: kind=step appends a checkpoint,
 // kind=answer finalizes the turn's streamed message with the agent's reply.
@@ -1928,54 +2010,14 @@ projectsApp.openapi(
     },
     responses: {
       200: {
-        description: 'Event stream',
-        content: { 'text/event-stream': { schema: z.any() } },
+        description: 'Relay result',
+        content: { 'application/json': { schema: z.any() } },
       },
       ...errors(400, 403, 404),
     },
   }),
   async (c: any) => {
     const projectId = c.req.param('projectId');
-
-    // Two valid callers: a project/session-scoped PAT (dashboard, operator, or
-    // in-sandbox agent CLI) and the session sandbox's own service credential.
-    // Each is scoped back to this projectId before a turn event is accepted.
-    const authType = (c as any).get('authType') as string | undefined;
-    let authenticatedSandboxId: string | null = null;
-    if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
-      const accountId = (c as any).get('accountId') as string | undefined;
-      const sandboxId = (c as any).get('sandboxId') as string | undefined;
-      if (!accountId || !sandboxId) {
-        return c.json({ error: 'turn-stream requires a sandbox token' }, 403);
-      }
-      const [sandbox] = await db
-        .select({ sandboxId: sessionSandboxes.sandboxId, sessionId: sessionSandboxes.sessionId })
-        .from(sessionSandboxes)
-        .where(
-          and(
-            eq(sessionSandboxes.sandboxId, sandboxId),
-            eq(sessionSandboxes.projectId, projectId),
-            eq(sessionSandboxes.accountId, accountId),
-            inArray(sessionSandboxes.status, ['provisioning', 'active']),
-          ),
-        )
-        .limit(1);
-      if (!sandbox) {
-        return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
-      }
-      authenticatedSandboxId = sandbox.sandboxId;
-    } else {
-      const loaded = await loadProjectForUser(c, projectId, 'read');
-      if (!loaded) return c.json({ error: 'Not found' }, 404);
-      await assertProjectCapability(
-        c,
-        loaded.userId,
-        loaded.row.accountId,
-        projectId,
-        PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
-      );
-    }
-
     let body: {
       session_id?: string;
       kind?: string;
@@ -2003,6 +2045,75 @@ projectsApp.openapi(
     const sessionId = body.session_id?.trim();
     if (!sessionId) {
       return c.json({ error: 'session_id is required' }, 400);
+    }
+
+    // Two valid callers: a project/session-scoped PAT (dashboard, operator, or
+    // in-sandbox agent CLI) and the session sandbox's own service credential.
+    // Each is scoped back to this projectId before a turn event is accepted.
+    const authType = (c as any).get('authType') as string | undefined;
+    const apiKeyType = (c as any).get('apiKeyType') as string | undefined;
+    const legacyExecutionLeaseKind =
+      body.kind === 'execution_heartbeat' ||
+      body.kind === 'execution_lease_release' ||
+      body.kind === 'execution_lease_discover';
+    if (legacyExecutionLeaseKind && (authType !== 'apiKey' || apiKeyType !== 'sandbox')) {
+      return c.json({ error: 'execution lease requires a sandbox token' }, 403);
+    }
+    let authenticatedSandboxId: string | null = null;
+    if (authType === 'apiKey' && apiKeyType === 'sandbox') {
+      const accountId = (c as any).get('accountId') as string | undefined;
+      const sandboxId = (c as any).get('sandboxId') as string | undefined;
+      if (!accountId || !sandboxId) {
+        return c.json({ error: 'turn-stream requires a sandbox token' }, 403);
+      }
+      if (legacyExecutionLeaseKind) {
+        const target = { sandboxId, sessionId, projectId, accountId };
+        if (body.kind === 'execution_lease_release') {
+          return c.json({ ok: await releaseExecutionLease(target) });
+        }
+        if (body.kind === 'execution_lease_discover') {
+          const provider = await discoverExecutionKeepAliveEndpoint(target);
+          return c.json({
+            ok: provider !== null,
+            provider_url: provider?.url ?? null,
+            provider_headers: provider?.headers ?? null,
+          });
+        }
+        const result = await renewExecutionLease(target, body.lease_ttl_seconds);
+        return c.json({
+          ok: result.ok,
+          lease_until: result.leaseUntil,
+          provider_url: null,
+          provider_headers: null,
+          provider_touched: false,
+        });
+      }
+      const [sandbox] = await db
+        .select({ sandboxId: sessionSandboxes.sandboxId, sessionId: sessionSandboxes.sessionId })
+        .from(sessionSandboxes)
+        .where(
+          and(
+            eq(sessionSandboxes.sandboxId, sandboxId),
+            eq(sessionSandboxes.projectId, projectId),
+            eq(sessionSandboxes.accountId, accountId),
+            inArray(sessionSandboxes.status, ['provisioning', 'active']),
+          ),
+        )
+        .limit(1);
+      if (!sandbox) {
+        return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
+      }
+      authenticatedSandboxId = sandbox.sandboxId;
+    } else {
+      const loaded = await loadProjectForUser(c, projectId, 'read');
+      if (!loaded) return c.json({ error: 'Not found' }, 404);
+      await assertProjectCapability(
+        c,
+        loaded.userId,
+        loaded.row.accountId,
+        projectId,
+        PROJECT_ACTIONS.PROJECT_CONNECTOR_WRITE,
+      );
     }
 
     if (authenticatedSandboxId) {
@@ -2033,34 +2144,6 @@ projectsApp.openapi(
       .limit(1);
     if (!turnStreamSession) {
       return c.json({ error: 'Not found' }, 404);
-    }
-
-    if (
-      body.kind === 'execution_heartbeat' ||
-      body.kind === 'execution_lease_release' ||
-      body.kind === 'execution_lease_discover'
-    ) {
-      if (!authenticatedSandboxId)
-        return c.json({ error: 'execution lease requires a sandbox token' }, 403);
-      const target = { sandboxId: authenticatedSandboxId, sessionId, projectId };
-      if (body.kind === 'execution_lease_release')
-        return c.json({ ok: await releaseExecutionLease(target) });
-      if (body.kind === 'execution_lease_discover') {
-        const provider = await discoverExecutionKeepAliveEndpoint(target);
-        return c.json({
-          ok: provider !== null,
-          provider_url: provider?.url ?? null,
-          provider_headers: provider?.headers ?? null,
-        });
-      }
-      const result = await renewExecutionLease(target, body.lease_ttl_seconds);
-      return c.json({
-        ok: result.ok,
-        lease_until: result.leaseUntil,
-        provider_url: result.providerUrl,
-        provider_headers: result.providerHeaders,
-        provider_touched: result.providerUrl !== null,
-      });
     }
 
     // `end` / `turn_end` carry no text — the sandbox observed the opencode turn

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -7,7 +7,7 @@ import { db } from '../../shared/db';
 import { resolveBranchTip } from '../git';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
-import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { withProjectGitAuth } from '../lib/git';
 import { ProjectRow, serializeSessionSandboxConfig } from '../lib/serializers';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
@@ -202,99 +202,6 @@ export async function resumeStoppedSandboxByExternalId(externalId: string): Prom
     externalId: row.externalId,
     metadata: row.metadata,
   });
-}
-
-// ── Pre-resume on presence ───────────────────────────────────────────────────
-// Throttle pre-resume per project so portal activity doesn't re-kick on every
-// request. The resume itself is idempotent (resumeStoppedSandbox only acts on a
-// stopped→active transition), so this is purely to avoid wasted DB lookups.
-const preResumeThrottle = new Map<string, number>();
-const PRERESUME_THROTTLE_MS = 30_000;
-
-/**
- * When a user returns to a project, proactively resume their most-recently-used
- * STOPPED session sandbox(es) so the ~8s in-place resume (VM restart + opencode
- * re-warm) overlaps the user's navigation and the session is ready by the time
- * they open it. Reuses resumeStoppedSandbox (idempotent with the on-open resume:
- * if the box is already resuming/active, the conditional stopped→active lock
- * simply no-ops). Best-effort + fire-and-forget; GATED OFF by default
- * (KORTIX_PRERESUME_ENABLED) since it spends compute on a box the user might not
- * open. Scoped to the user's OWN sessions (never speculatively resumes someone
- * else's). Most-recent-first, capped at KORTIX_PRERESUME_MAX_PER_PROJECT.
- */
-/**
- * The pre-resume candidates: the user's OWN most-recently-used STOPPED session
- * sandboxes in a project (status='stopped', a provider box still attached).
- * Most-recent-first, capped at `limit`. Pure DB read, no side effects —
- * exported so the selection is testable without provisioning real sandboxes.
- */
-export async function selectPreResumeTargets(
-  projectId: string,
-  userId: string,
-  limit: number,
-): Promise<
-  Array<{
-    sandboxId: string;
-    sessionId: string;
-    accountId: string;
-    provider: string;
-    externalId: string | null;
-    metadata: Record<string, unknown> | null;
-  }>
-> {
-  return db
-    .select({
-      sandboxId: sessionSandboxes.sandboxId,
-      sessionId: sessionSandboxes.sessionId,
-      accountId: sessionSandboxes.accountId,
-      provider: sessionSandboxes.provider,
-      externalId: sessionSandboxes.externalId,
-      metadata: sessionSandboxes.metadata,
-    })
-    .from(sessionSandboxes)
-    .innerJoin(projectSessions, eq(projectSessions.sessionId, sessionSandboxes.sessionId))
-    .where(
-      and(
-      eq(sessionSandboxes.projectId, projectId),
-      eq(sessionSandboxes.status, 'stopped'),
-      isNotNull(sessionSandboxes.externalId),
-      eq(projectSessions.createdBy, userId),
-      ),
-    )
-    .orderBy(desc(sessionSandboxes.lastUsedAt))
-    .limit(Math.max(1, limit));
-}
-
-export function preResumeRecentStoppedSessions(projectId: string, userId?: string | null): void {
-  if (!config.KORTIX_PRERESUME_ENABLED || !projectId || !userId) return;
-  const nowMs = Date.now();
-  if (nowMs - (preResumeThrottle.get(projectId) ?? 0) < PRERESUME_THROTTLE_MS) return;
-  preResumeThrottle.set(projectId, nowMs);
-  void (async () => {
-    try {
-      const rows = await selectPreResumeTargets(
-        projectId,
-        userId,
-        config.KORTIX_PRERESUME_MAX_PER_PROJECT,
-      );
-      let kicked = 0;
-      for (const row of rows) {
-        const won = await resumeStoppedSandbox(row).catch((err) => {
-          console.warn(
-            `[pre-resume] resume ${row.sandboxId.slice(0, 8)} failed:`,
-            err instanceof Error ? err.message : err,
-          );
-          return false;
-        });
-        if (won) kicked++;
-      }
-      if (kicked)
-        console.log(`[pre-resume] kicked ${kicked} resume(s) for project ${projectId.slice(0, 8)}`);
-    } catch (err) {
-      console.warn('[pre-resume] failed:', err instanceof Error ? err.message : err);
-      preResumeThrottle.delete(projectId); // let the next presence retry
-    }
-  })();
 }
 
 export async function allocateRuntimeOnOpen(

--- a/apps/kortix-sandbox-agent-server/src/__tests__/execution-lease.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/execution-lease.test.ts
@@ -11,12 +11,12 @@ const response = (body: unknown) =>
   new Response(JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
 
 describe('ExecutionLeaseReporter', () => {
-  test('touches both provider and API while busy', async () => {
-    const calls: Array<{ url: string; kind?: string; headers?: RequestInit['headers'] }> = [];
+  test('stays silent while idle, then acquires, renews, and releases while busy', async () => {
+    const calls: Array<{ url: string; action?: string; headers?: RequestInit['headers'] }> = [];
     const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input);
-      const body = init?.body ? (JSON.parse(String(init.body)) as { kind?: string }) : {};
-      calls.push({ url, kind: body.kind, headers: init?.headers });
+      const body = init?.body ? (JSON.parse(String(init.body)) as { action?: string }) : {};
+      calls.push({ url, action: body.action, headers: init?.headers });
       return url.startsWith('https://api.test/')
         ? response({
             provider_url: 'https://edge.test',
@@ -25,14 +25,17 @@ describe('ExecutionLeaseReporter', () => {
         : response({ status: 'ok' });
     }) as typeof fetch;
     const reporter = new ExecutionLeaseReporter(context, { fetchFn, heartbeatIntervalMs: 5 });
-    reporter.discover();
+    await reporter.settled();
+    expect(calls).toEqual([]);
     reporter.markBusy('root');
     await reporter.settled();
     await Bun.sleep(12);
     reporter.markInactive('root');
     await reporter.settled();
-    expect(calls.some((call) => call.kind === 'execution_heartbeat')).toBe(true);
-    expect(calls.some((call) => call.kind === 'execution_lease_release')).toBe(true);
+    expect(calls.some((call) => call.url.endsWith('/execution-lease'))).toBe(true);
+    expect(calls.some((call) => call.action === 'acquire')).toBe(true);
+    expect(calls.some((call) => call.action === 'renew')).toBe(true);
+    expect(calls.some((call) => call.action === 'release')).toBe(true);
     const direct = calls.find((call) => call.url === 'https://edge.test/kortix/health');
     expect(direct).toBeDefined();
     expect(direct?.headers).toMatchObject({
@@ -41,10 +44,10 @@ describe('ExecutionLeaseReporter', () => {
     });
   });
   test('holds the lease until every root/subagent is inactive', async () => {
-    const kinds: string[] = [];
+    const actions: string[] = [];
     const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
-      const body = init?.body ? (JSON.parse(String(init.body)) as { kind?: string }) : {};
-      if (body.kind) kinds.push(body.kind);
+      const body = init?.body ? (JSON.parse(String(init.body)) as { action?: string }) : {};
+      if (body.action) actions.push(body.action);
       return response({ ok: true });
     }) as typeof fetch;
     const reporter = new ExecutionLeaseReporter(context, { fetchFn, heartbeatIntervalMs: 60_000 });
@@ -52,9 +55,32 @@ describe('ExecutionLeaseReporter', () => {
     reporter.markBusy('child');
     reporter.markInactive('root');
     await reporter.settled();
-    expect(kinds).toEqual(['execution_heartbeat']);
+    expect(actions).toEqual(['acquire']);
     reporter.markInactive('child');
     await reporter.settled();
-    expect(kinds).toEqual(['execution_heartbeat', 'execution_lease_release']);
+    expect(actions).toEqual(['acquire', 'release']);
+  });
+
+  test('coalesces timer renewals while one renewal is pending', async () => {
+    const actions: string[] = [];
+    let releaseRenewal!: () => void;
+    const renewalBlocked = new Promise<void>((resolve) => {
+      releaseRenewal = resolve;
+    });
+    const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = init?.body ? (JSON.parse(String(init.body)) as { action?: string }) : {};
+      if (body.action) actions.push(body.action);
+      if (body.action === 'renew') await renewalBlocked;
+      return response({ ok: true });
+    }) as typeof fetch;
+    const reporter = new ExecutionLeaseReporter(context, { fetchFn, heartbeatIntervalMs: 5 });
+    reporter.markBusy('root');
+    await reporter.settled();
+    await Bun.sleep(18);
+    reporter.markInactive('root');
+    releaseRenewal();
+    await reporter.settled();
+    expect(actions.filter((action) => action === 'renew')).toHaveLength(1);
+    expect(actions.at(-1)).toBe('release');
   });
 });

--- a/apps/kortix-sandbox-agent-server/src/execution-lease.ts
+++ b/apps/kortix-sandbox-agent-server/src/execution-lease.ts
@@ -1,7 +1,7 @@
 import { logger } from './logger';
 
-export const EXECUTION_HEARTBEAT_INTERVAL_MS = 20_000;
-export const EXECUTION_LEASE_TTL_SECONDS = 120;
+export const EXECUTION_HEARTBEAT_INTERVAL_MS = 60_000;
+export const EXECUTION_LEASE_TTL_SECONDS = 180;
 export interface ExecutionLeaseContext {
   projectId: string;
   sessionId: string;
@@ -32,6 +32,7 @@ export class ExecutionLeaseReporter {
   private providerUrl: string | null = null;
   private providerHeaders: Record<string, string> = {};
   private queue: Promise<void> = Promise.resolve();
+  private renewalPending = false;
   constructor(
     private readonly context: ExecutionLeaseContext,
     options: ExecutionLeaseReporterOptions = {},
@@ -40,41 +41,38 @@ export class ExecutionLeaseReporter {
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? EXECUTION_HEARTBEAT_INTERVAL_MS;
     this.leaseTtlSeconds = options.leaseTtlSeconds ?? EXECUTION_LEASE_TTL_SECONDS;
   }
-  discover(): void {
-    this.enqueue('execution_lease_discover');
-  }
   markBusy(sessionId: string): void {
     if (!sessionId) return;
     const wasIdle = this.busySessions.size === 0;
     this.busySessions.add(sessionId);
     if (!wasIdle) return;
-    this.enqueue('execution_heartbeat');
-    this.timer = setInterval(() => this.enqueue('execution_heartbeat'), this.heartbeatIntervalMs);
+    this.enqueue('acquire');
+    this.timer = setInterval(() => this.enqueueRenewal(), this.heartbeatIntervalMs);
   }
   markInactive(sessionId: string): void {
     if (!sessionId) return;
-    this.busySessions.delete(sessionId);
+    if (!this.busySessions.delete(sessionId)) return;
     if (this.busySessions.size > 0) return;
     this.clearTimer();
-    this.enqueue('execution_lease_release');
+    this.enqueue('release');
   }
   replaceBusySessions(sessionIds: string[]): void {
     const wasBusy = this.busySessions.size > 0;
     this.busySessions.clear();
     for (const id of sessionIds.filter(Boolean)) this.busySessions.add(id);
     if (!wasBusy && this.busySessions.size > 0) {
-      this.enqueue('execution_heartbeat');
-      this.timer = setInterval(() => this.enqueue('execution_heartbeat'), this.heartbeatIntervalMs);
+      this.enqueue('acquire');
+      this.timer = setInterval(() => this.enqueueRenewal(), this.heartbeatIntervalMs);
     } else if (wasBusy && this.busySessions.size === 0) {
       this.clearTimer();
-      this.enqueue('execution_lease_release');
+      this.enqueue('release');
     }
   }
   close(): void {
     this.clearTimer();
     if (this.busySessions.size > 0) {
       this.busySessions.clear();
-      this.enqueue('execution_lease_release');
+      this.enqueue('release');
     }
   }
   async settled(): Promise<void> {
@@ -84,19 +82,57 @@ export class ExecutionLeaseReporter {
     if (this.timer) clearInterval(this.timer);
     this.timer = null;
   }
-  private enqueue(
-    kind: 'execution_heartbeat' | 'execution_lease_release' | 'execution_lease_discover',
-  ): void {
+  private enqueue(action: 'acquire' | 'renew' | 'release'): void {
     this.queue = this.queue
-      .then(() => this.send(kind))
+      .then(() => this.send(action))
       .catch((err) =>
         logger.warn('[execution-lease] reporter failed', { err: (err as Error).message }),
       );
   }
-  private async send(
-    kind: 'execution_heartbeat' | 'execution_lease_release' | 'execution_lease_discover',
-  ): Promise<void> {
-    if (kind === 'execution_heartbeat' && this.providerUrl) {
+  private enqueueRenewal(): void {
+    if (this.busySessions.size === 0 || this.renewalPending) return;
+    this.renewalPending = true;
+    this.queue = this.queue
+      .then(() => this.send('renew'))
+      .catch((err) =>
+        logger.warn('[execution-lease] reporter failed', { err: (err as Error).message }),
+      )
+      .finally(() => {
+        this.renewalPending = false;
+      });
+  }
+  private async send(action: 'acquire' | 'renew' | 'release'): Promise<void> {
+    const response = await this.fetchFn(
+      `${this.context.apiRoot}/projects/${encodeURIComponent(this.context.projectId)}/execution-lease`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.context.token}`,
+        },
+        body: JSON.stringify({
+          session_id: this.context.sessionId,
+          action,
+          lease_ttl_seconds: this.leaseTtlSeconds,
+        }),
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) throw new Error(`${action} returned ${response.status}`);
+    const body = (await response.json().catch(() => ({}))) as {
+      provider_url?: unknown;
+      provider_headers?: unknown;
+    };
+    if (typeof body.provider_url === 'string' && body.provider_url.startsWith('https://'))
+      this.providerUrl = body.provider_url.replace(/\/$/, '');
+    if (body.provider_headers && typeof body.provider_headers === 'object' && !Array.isArray(body.provider_headers)) {
+      this.providerHeaders = Object.fromEntries(
+        Object.entries(body.provider_headers as Record<string, unknown>).filter(
+          ([name, value]) => name.toLowerCase() !== 'authorization' && typeof value === 'string',
+        ),
+      ) as Record<string, string>;
+    }
+    if (action !== 'release' && this.providerUrl) {
       try {
         await this.fetchFn(`${this.providerUrl}/kortix/health`, {
           headers: {
@@ -110,36 +146,6 @@ export class ExecutionLeaseReporter {
           err: (err as Error).message,
         });
       }
-    }
-    const response = await this.fetchFn(
-      `${this.context.apiRoot}/projects/${encodeURIComponent(this.context.projectId)}/turn-stream`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.context.token}`,
-        },
-        body: JSON.stringify({
-          session_id: this.context.sessionId,
-          kind,
-          lease_ttl_seconds: this.leaseTtlSeconds,
-        }),
-        signal: AbortSignal.timeout(15_000),
-      },
-    );
-    if (!response.ok) throw new Error(`${kind} returned ${response.status}`);
-    const body = (await response.json().catch(() => ({}))) as {
-      provider_url?: unknown;
-      provider_headers?: unknown;
-    };
-    if (typeof body.provider_url === 'string' && body.provider_url.startsWith('https://'))
-      this.providerUrl = body.provider_url.replace(/\/$/, '');
-    if (body.provider_headers && typeof body.provider_headers === 'object' && !Array.isArray(body.provider_headers)) {
-      this.providerHeaders = Object.fromEntries(
-        Object.entries(body.provider_headers as Record<string, unknown>).filter(
-          ([name, value]) => name.toLowerCase() !== 'authorization' && typeof value === 'string',
-        ),
-      ) as Record<string, string>;
     }
   }
 }

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -384,7 +384,6 @@ async function startSessionRuntime(
 ): Promise<void> {
   const leaseContext = executionLeaseContextFromEnv()
   const executionLease = leaseContext ? new ExecutionLeaseReporter(leaseContext) : null
-  executionLease?.discover()
   const onSessionStatus = (opencodeSessionId: string, status: string) => {
     if (status === 'busy' || status === 'retry') executionLease?.markBusy(opencodeSessionId)
     else if (status === 'idle') executionLease?.markInactive(opencodeSessionId)
@@ -414,7 +413,6 @@ async function startSessionRuntime(
   // and this reconcile collapse to a single finalize; a reconnect after the turn
   // relayed is a no-op.
   const onConnected = () => {
-    executionLease?.discover()
     void reconcileExecutionLease(opencode, cfg, executionLease).catch((err) =>
       logger.warn('[execution-lease] status reconcile failed', { err: (err as Error).message }),
     )

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -15,6 +15,11 @@ import { InstantSessionShell } from '@/features/session/instant-session-shell';
 import { SandboxLoadingBoundary } from '@/features/session/sandbox-loading-boundary';
 import { SessionChat } from '@/features/session/session-chat';
 import { SessionLayout } from '@/features/session/session-layout';
+import {
+  canMountSessionChat,
+  canShowSessionChat,
+  findInitialSessionPin,
+} from '@/features/session/session-load-state';
 import { isAutoResuming, isSandboxResumable } from '@/features/session/session-resume';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { isUnmaterializedSessionFailure } from '@/features/session/session-terminal-state';
@@ -33,6 +38,7 @@ import { setActiveInstanceCookie } from '@kortix/sdk/instance-routes';
 import { formatRuntimeError } from '@kortix/sdk';
 import {
   getProjectDetail,
+  listProjectSessions,
   restartProjectSession,
   sessionStartKey,
 } from '@kortix/sdk';
@@ -64,6 +70,7 @@ export default function ProjectSessionPage() {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const { id: projectId, sessionId } = useParams<{ id: string; sessionId: string }>();
   const { user, isLoading: authLoading } = useAuth();
+  const queryClient = useQueryClient();
 
   // Billing gate. An account that cannot run should not start a session — the
   // backend would never provision a sandbox, so polling for one spins forever.
@@ -85,6 +92,14 @@ export default function ProjectSessionPage() {
   const billingGatePending =
     isBillingEnabled() && !!projectAccountId && (accountStateLoading || !accountLoaded);
   const noPlan = isBillingEnabled() && accountLoaded && !accountState.credits?.can_run;
+  const { data: projectSessions } = useQuery({
+    queryKey: ['project-sessions', projectId],
+    queryFn: () => listProjectSessions(projectId),
+    enabled: !!user && !!projectId,
+    staleTime: 10_000,
+    refetchOnWindowFocus: false,
+  });
+  const initialOpenCodeSessionId = findInitialSessionPin(projectSessions, sessionId);
 
   // ONE hook owns the runtime: POST /start (idempotent provision/resume + the
   // server-resolved OpenCode pin), the sandbox switch, the SSE stream, readiness
@@ -96,6 +111,7 @@ export default function ProjectSessionPage() {
   const session = useSession(projectId, sessionId, {
     enabled: !!user && !billingGatePending && !noPlan,
     replayStartStash: false,
+    initialOpenCodeSessionId,
   });
   const sandbox = session.sandbox;
   const startStage = session.stage ?? 'provisioning';
@@ -110,7 +126,6 @@ export default function ProjectSessionPage() {
   // dead-end "open a new session" card — yet a hard refresh's fresh /start hits
   // the resume path and wakes the box. So: re-issue /start ourselves a few times
   // (what the refresh did) before ever surfacing a manual control.
-  const queryClient = useQueryClient();
   const sandboxResumable = isSandboxResumable(sandbox);
   const MAX_AUTO_RESUME = 3;
   const [resumeAttempts, setResumeAttempts] = useState(0);
@@ -210,28 +225,40 @@ export default function ProjectSessionPage() {
       hasStartError: !!session.startError,
       sandboxStatus: sandbox?.status,
     });
+  const sessionContentAvailable = canMountSessionChat({
+    switched: session.switched,
+    opencodeSessionId: session.opencodeSessionId,
+  });
   const sessionSwitchLoading = shouldShowSessionSwitchLoading(
     switchingToSessionId,
     sessionId,
-    session.switched,
+    sessionContentAvailable,
   );
   useEffect(() => {
     if (switchingToSessionId !== sessionId) return;
-    if (session.switched || session.startError || unmaterializedFailure || fatal || gated) {
+    if (
+      sessionContentAvailable ||
+      session.startError ||
+      unmaterializedFailure ||
+      fatal ||
+      gated
+    ) {
       completeSessionSwitch(sessionId);
     }
   }, [
     switchingToSessionId,
     sessionId,
-    session.switched,
+    sessionContentAvailable,
     session.startError,
     unmaterializedFailure,
     fatal,
     gated,
     completeSessionSwitch,
   ]);
-  // The chat subtree mounts once useSession reports the runtime is switched in.
-  const canMountChat = session.switched;
+  // Existing sessions can mount from their server-owned pin before the runtime
+  // switch completes. SessionChat hydrates IndexedDB first, then revalidates
+  // over the live runtime after useSession finishes the switch.
+  const canMountChat = sessionContentAvailable;
   // For a fresh session, hold the real chat until the user actually sends their
   // first message — the instant shell is the typing surface until then.
   const mountChat = canMountChat && (!isFresh || shellSubmitted);
@@ -564,8 +591,11 @@ function ActiveSessionChat({
     finishSessionTiming(sessionId, sb?.metadata?.provisionTimeline);
   }, [chatSessionId, sessionId, projectId, queryClient]);
 
-  const chatShowable =
-    (!!chatSessionId && runtimeReady) || !!runtimeError || (!runtimeReady && !!runtimeBootError);
+  const chatShowable = canShowSessionChat({
+    chatSessionId,
+    runtimeError,
+    runtimeBootError,
+  });
   useEffect(() => {
     if (chatShowable) onChatReady?.();
   }, [chatShowable, onChatReady]);

--- a/apps/web/src/features/session/session-load-state.test.ts
+++ b/apps/web/src/features/session/session-load-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  canMountSessionChat,
+  canShowSessionChat,
+  findInitialSessionPin,
+} from './session-load-state';
+
+describe('session load state', () => {
+  test('uses the authorized project-session list as an initial transcript pin', () => {
+    expect(
+      findInitialSessionPin(
+        [
+          { session_id: 'session-a', opencode_session_id: 'ses_a' },
+          { session_id: 'session-b', opencode_session_id: 'ses_b' },
+        ],
+        'session-b',
+      ),
+    ).toBe('ses_b');
+    expect(findInitialSessionPin(undefined, 'session-b')).toBeNull();
+  });
+
+  test('mounts cached transcript content before the runtime switch completes', () => {
+    expect(
+      canMountSessionChat({
+        switched: false,
+        opencodeSessionId: 'opencode-cached',
+      }),
+    ).toBe(true);
+  });
+
+  test('keeps a session without a known transcript pin on the boot surface', () => {
+    expect(
+      canMountSessionChat({
+        switched: false,
+        opencodeSessionId: null,
+      }),
+    ).toBe(false);
+  });
+
+  test('shows the chat as soon as a transcript pin is available', () => {
+    expect(
+      canShowSessionChat({
+        chatSessionId: 'opencode-cached',
+        runtimeError: null,
+        runtimeBootError: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/features/session/session-load-state.ts
+++ b/apps/web/src/features/session/session-load-state.ts
@@ -1,0 +1,26 @@
+export function canMountSessionChat(input: {
+  switched: boolean;
+  opencodeSessionId: string | null;
+}) {
+  return input.switched || Boolean(input.opencodeSessionId);
+}
+
+export function findInitialSessionPin(
+  sessions:
+    | Array<{
+        session_id: string;
+        opencode_session_id: string | null;
+      }>
+    | undefined,
+  sessionId: string,
+) {
+  return sessions?.find((session) => session.session_id === sessionId)?.opencode_session_id ?? null;
+}
+
+export function canShowSessionChat(input: {
+  chatSessionId: string | null;
+  runtimeError: unknown;
+  runtimeBootError: unknown;
+}) {
+  return Boolean(input.chatSessionId || input.runtimeError || input.runtimeBootError);
+}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/provider-loading-state.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/provider-loading-state.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isProviderStateLoading } from './provider-loading-state';
+
+describe('isProviderStateLoading', () => {
+  test('waits for project detail and project secrets', () => {
+    expect(
+      isProviderStateLoading({
+        projectDetailLoading: true,
+        secretsLoading: false,
+      }),
+    ).toBe(true);
+    expect(
+      isProviderStateLoading({
+        projectDetailLoading: false,
+        secretsLoading: true,
+      }),
+    ).toBe(true);
+  });
+
+  test('does not wait for runtime providers after BYOK state resolves', () => {
+    expect(
+      isProviderStateLoading({
+        projectDetailLoading: false,
+        secretsLoading: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/provider-loading-state.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/provider-loading-state.ts
@@ -1,0 +1,6 @@
+export function isProviderStateLoading(input: {
+  projectDetailLoading: boolean;
+  secretsLoading: boolean;
+}): boolean {
+  return input.projectDetailLoading || input.secretsLoading;
+}

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/use-connected-providers.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/use-connected-providers.ts
@@ -14,6 +14,7 @@ import {
   LEGACY_RUNTIME_AUTH_JSON_SECRET_NAME,
   MANAGED_MODEL_ID_SET,
 } from './constants';
+import { isProviderStateLoading } from './provider-loading-state';
 import { useLlmProviderCatalogRevision } from './use-live-catalog';
 import { buildCodexProvider } from './utils';
 
@@ -114,8 +115,10 @@ export function useConnectedProviders(projectId: string, enabled: boolean) {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- catalogRevision drives a re-read of the module-level LLM_PROVIDERS binding, not a value used directly here
   }, [secretNames, kortixProvider, ocProviders, catalogRevision]);
 
-  const providerStateLoading =
-    projectDetailQuery.isLoading || secretsQuery.isLoading || runtimeProvidersQuery.isLoading;
+  const providerStateLoading = isProviderStateLoading({
+    projectDetailLoading: projectDetailQuery.isLoading,
+    secretsLoading: secretsQuery.isLoading,
+  });
 
   return { secretsQuery, connectedProviders, llmGatewayEnabled, providerStateLoading };
 }

--- a/docs/plans/2026-07-26-api-hot-path-latency.md
+++ b/docs/plans/2026-07-26-api-hot-path-latency.md
@@ -1,0 +1,58 @@
+# API hot-path latency implementation plan
+
+## Phase 1: Baseline
+
+1. Record current dev and production route counts and percentiles.
+2. Record ECS and Supabase regions.
+3. Trace execution-lease, project-access, model, and session request graphs.
+
+## Phase 2: Execution leases
+
+1. Add failing sandbox reporter tests.
+2. Add failing API lease-operation tests.
+3. Add the dedicated JSON execution-lease route.
+4. Remove API provider touches from renewals.
+5. add legacy `turn-stream` compatibility delegation.
+6. Remove idle and reconnect discovery.
+7. Add single-flight renewal coalescing.
+8. Set the heartbeat interval to 60 seconds.
+9. Set the lease TTL to 180 seconds.
+10. Correct OpenAPI and request-deadline classification.
+
+## Phase 3: Session resume
+
+1. Add a failing authorization side-effect contract test.
+2. Remove speculative resume from `loadProjectForUser()`.
+3. Delete unused speculative-resume selection and throttle code.
+4. Keep explicit session-open allocation unchanged.
+
+## Phase 4: Client readiness
+
+1. Claim each SDK task in `packages/sdk/PROGRESS.md`.
+2. Port the preserved initial-session-pin change onto current `main`.
+3. Add RED then GREEN SDK tests.
+4. Start model-picker and project-detail requests in parallel.
+5. Stop gating provider-management loading on runtime provider completion.
+6. Update the SDK progress log.
+
+## Phase 5: Verification
+
+1. Run focused API and sandbox daemon tests.
+2. Run API and sandbox daemon typechecks.
+3. Run SDK typecheck, full suite, and packed-install smoke.
+4. Run focused web tests, ESLint, and changed-file type output.
+5. Run authenticated local HTTP requests.
+6. Run Chromium network and DOM assertions.
+7. Compare request counts and latency to the baseline.
+
+## Phase 6: Delivery
+
+1. Rebase on current `origin/main`.
+2. Push the branch.
+3. Open a PR.
+4. Wait for required checks.
+5. Merge the PR.
+6. Follow Deploy Dev to completion.
+7. Prove the deployed API and web artifacts contain the merge SHA.
+8. Re-run the deployed API and Chromium checks.
+

--- a/docs/specs/2026-07-26-api-hot-path-latency.md
+++ b/docs/specs/2026-07-26-api-hot-path-latency.md
@@ -1,0 +1,196 @@
+# API hot-path latency and request amplification
+
+## Status
+
+Approved by the user on 2026-07-26 for end-to-end implementation and delivery
+to `main`.
+
+## Problem
+
+The dev API and dev database run in different AWS regions.
+
+- The API runs on ECS in `us-west-2`.
+- Supabase project `heprlhlltebrxydgtsjs` runs in `us-east-2`.
+- Each sequential database statement adds a cross-region network round trip.
+- The production API and database now both run in `us-east-2`.
+
+The 24-hour dev sample on 2026-07-26 reports:
+
+| Route | Requests | p50 | p95 | p99 |
+| --- | ---: | ---: | ---: | ---: |
+| `POST /v1/projects/:id/turn-stream` | 24,095 | 1,294 ms | 4,192 ms | 5,419 ms |
+| `GET /v1/projects/:id/sessions` | 1,195 | 703 ms | 2,500 ms | 3,487 ms |
+| `GET /v1/projects/:id/secrets` | 895 | 1,237 ms | 5,601 ms | 7,112 ms |
+| `GET /v1/projects/:id/detail` | 238 | 1,449 ms | 5,176 ms | 6,999 ms |
+| `GET /v1/projects/:id/model-picker` | 213 | 448 ms | 1,888 ms | 2,896 ms |
+
+The new `us-east-2` production sample reports ordinary project reads mainly
+between 40 ms and 115 ms. This comparison isolates the dev region mismatch.
+
+`turn-stream` also amplifies traffic independent of the region mismatch.
+
+- It is a JSON relay, but OpenAPI declares `text/event-stream`.
+- The request-deadline middleware treats it as an unbounded stream.
+- The sandbox calls execution-lease discovery during idle startup.
+- The sandbox calls discovery after each OpenCode event reconnect.
+- A busy sandbox sends a heartbeat every 20 seconds.
+- The sandbox touches `/kortix/health` directly before the heartbeat.
+- The API resolves the provider and touches `/kortix/health` again.
+- The legacy route performs repeated sandbox and session ownership reads.
+
+Generic project authorization also triggers speculative session resumes.
+
+- `loadProjectForUser()` runs on every project route.
+- Authorized write-capable reads call `preResumeRecentStoppedSessions()`.
+- The selector chooses another stopped historical session after each wake.
+- Each ECS process owns an independent 30-second throttle.
+- The behavior spends sandbox compute before the user opens a session.
+
+Model and transcript readiness contain independent client waterfalls.
+
+- `useOpenCodeProviders()` waits for project detail before it starts the
+  project model-picker request.
+- The project model-picker can answer before any sandbox runtime is ready.
+- Existing session rows can already contain the authorized OpenCode session
+  pin needed for IndexedDB transcript hydration.
+- `useSession()` waits for `/start` before it supplies that pin to the sync
+  engine.
+
+## Goals
+
+1. Remove idle and reconnect execution-lease requests.
+2. Reduce busy lease traffic from one request per 20 seconds to one request per
+   60 seconds.
+3. Keep at most one pending lease renewal per sandbox.
+4. Remove provider network calls from API lease renewal.
+5. Keep legacy `turn-stream` lease kinds compatible during sandbox image
+   rotation.
+6. Move execution leases to a JSON endpoint with a bounded request deadline.
+7. Remove speculative resume from generic authorization.
+8. Start the project model-picker request without waiting for project detail.
+9. Hydrate an existing session transcript before `/start` completes.
+10. Keep all caches optional for self-hosted deployments.
+11. Add request-count and latency evidence before and after deployment.
+
+## Non-goals
+
+- Redis is not required for correctness.
+- Sticky ECS sessions are not required for correctness.
+- Authorization revocation does not depend on a distributed cache.
+- This change does not move the dev ECS service between AWS regions.
+- This change does not alter LLM completion latency inside model providers.
+- This change does not recreate retired legacy trigger cron jobs.
+
+## Design
+
+### Execution lease endpoint
+
+Add:
+
+`POST /v1/projects/:projectId/execution-lease`
+
+The route accepts a sandbox token and this body:
+
+```json
+{
+  "session_id": "uuid",
+  "action": "acquire | renew | release",
+  "lease_ttl_seconds": 180
+}
+```
+
+The route returns JSON. It is not a stream.
+
+- `acquire` updates the database lease and resolves the direct provider
+  keep-alive endpoint once.
+- `renew` performs one conditional database update.
+- `release` clears the lease with one conditional database update.
+- The update predicates include `sandbox_id`, `session_id`, `project_id`,
+  `account_id`, and an allowed sandbox status.
+- The API does not call provider `/kortix/health`.
+
+Keep the legacy `turn-stream` execution kinds during image rotation.
+
+- Handle lease kinds before Slack and Teams relay lookups.
+- Use the same database operations as the new route.
+- Keep legacy discovery available for old reporters.
+- Correct the route response content type to JSON.
+- Remove `turn-stream` from the request-deadline exemption.
+
+### Sandbox reporter
+
+- Do not discover during idle startup.
+- Do not discover on an event-stream reconnect.
+- Reconcile OpenCode status on reconnect.
+- Acquire the lease only when the first busy session appears.
+- Renew every 60 seconds with a 180-second lease.
+- Keep one renewal pending at most.
+- Touch the direct provider endpoint from the sandbox only.
+- Release when the last busy session becomes inactive.
+
+### Session resume
+
+- Remove speculative resume from `loadProjectForUser()`.
+- Keep runtime allocation and resume inside explicit session-open paths.
+- Do not select a stopped historical session from ordinary project activity.
+
+### Model readiness
+
+- Start `GET /model-picker` in parallel with `GET /detail`.
+- Use the model-picker response immediately for gateway projects.
+- Preserve the native runtime-provider fallback for non-gateway projects.
+- Do not report BYOK provider state as loading after project detail and secrets
+  have resolved.
+
+### Transcript readiness
+
+- Add an optional authorized initial OpenCode session pin to `useSession()`.
+- Use the initial pin only for local transcript hydration.
+- Keep the `/start` response authoritative when it arrives.
+- Do not accept an untrusted tenant selector as the initial pin.
+
+### Caching
+
+The first optimization removes duplicate work and serial depth.
+
+Existing IAM memoization remains optional:
+
+- `IAM_CACHE_TTL_MS=0` disables it.
+- The default in-memory TTL is 15 seconds.
+- No correctness path requires cache affinity.
+
+The runtime model catalog already uses an in-process atomic last-known-good
+snapshot. It does not require Redis.
+
+Do not add a token-validation cache in this change. Revocation freshness is
+more important than one database read. Re-evaluate distributed caching only
+after post-deploy measurements show a remaining stable-read bottleneck.
+
+### Legacy trigger traffic
+
+The old routes are:
+
+- `/api/triggers/:id/webhook`
+- `/v1/triggers/:id/webhook`
+
+The prod migration runbook proves that 3,537 legacy PostgreSQL cron jobs called
+these removed routes. The latest 24,538 responses were all `404`. The
+`us-east-2` production migration intentionally did not recreate these jobs.
+No compatibility route is required.
+
+## Verification
+
+1. RED then GREEN unit tests for the sandbox reporter.
+2. RED then GREEN API tests for acquire, renew, release, and legacy
+   compatibility.
+3. A source contract test that forbids speculative resume in authorization.
+4. SDK RED then GREEN tests for initial-pin precedence and provider query
+   planning.
+5. Full API, sandbox daemon, SDK, and web focused gates.
+6. Real local authenticated API requests.
+7. Chromium assertions for model request ordering and transcript visibility.
+8. PR checks and merge to `main`.
+9. Deploy Dev workflow completion.
+10. Deployed SHA ancestry proof.
+11. A new 24-hour or bounded post-deploy CloudWatch sample.
+

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -2818,6 +2818,53 @@ proof.
 
 ---
 
+### 2026-07-26 — session `api-latency-refactor` (B24 and B25 local completion)
+
+Completed the additive initial-session pin and parallel model-picker changes.
+
+RED evidence:
+
+- The initial-pin test failed because `resolveSessionPin()` did not exist.
+- The provider plan test failed because the model-picker waited for project
+  detail.
+- The web session-load test failed because cached transcript content could not
+  mount before the runtime switch completed.
+- The provider-loading test failed because the modal waited for runtime
+  provider discovery after project detail and secrets had resolved.
+
+Post-rebase gates:
+
+- SDK typecheck: exit 0.
+- SDK suite: **1275 pass / 0 fail** with **5669** assertions across **107**
+  files.
+- SDK packed-install smoke: pass.
+- Web suite: **2207 pass / 0 fail** with **5970** assertions across **244**
+  files.
+- Focused web ESLint: exit 0.
+- API typecheck: exit 0.
+- Focused isolated API tests: **67 pass / 0 fail**.
+- Sandbox-agent typecheck: exit 0.
+- Sandbox-agent suite: **298 pass / 0 fail** with **720** assertions.
+
+Live local execution-lease proof:
+
+- `acquire`: HTTP 200 in **33.9 ms**. The response and database stored the same
+  `executionLeaseUntil`.
+- `renew`: HTTP 200 in **20.8 ms**. The response and database stored the same
+  `executionLeaseUntil`.
+- `release`: HTTP 200 in **21.3 ms**. The database stored
+  `executionLeaseUntil = null`.
+
+Browser discovery returned no available browser. Local DOM and browser-network
+verification remains open.
+
+**Status:** IMPLEMENTATION COMPLETE.
+
+**Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
+and deployed browser verification remain open.
+
+---
+
 ### 2026-07-26 — session `whitelabel-acp-stable-completion` (B23 delivery completion)
 
 Merged B23 in PR #5477.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -252,6 +252,8 @@ Single, self-contained changes. Anything multi-step earns a spec instead.
 | B21 | **Serialize ACP sends with runtime restart reloads.** A send that starts while OpenCode restarts can wait forever on `session/set_config_option` and never send `session/prompt`.                                                                                                                                                                                                                                                               | Deployed cold Chromium sent `session/set_config_option` at `13:36:20.250Z`, received `kortix/runtime_ready`, then sent `session/load` at `13:36:20.640Z`; `POST_RESTART_PONG` never produced `session/prompt`.                                                                                              | **DONE 2026-07-25** — implementation `d8537fa2c`; RED tests, full SDK gates, and test-harness typecheck pass                                                                                                                                                                                                                          |
 | B22 | **Expose server-owned warm project-session ensure and claim operations.** The project index needs one reusable empty session without owning session selection or deduplication in app code.                                                                                                                                                                                                                                                   | `apps/web/src/app/(app)/projects/[id]/page.tsx` creates a session only after send. `packages/sdk/src/core/rest/projects-client/sessions.ts` exposes create and list, but no atomic warm-session operation.                                                                                              | **DONE 2026-07-26** — implementation `13167d7cf`; RED tests, full SDK gates, live API/SDK lifecycle, workspace refresh, and maintenance retention proof pass                                                                                                                                                                           |
 | B23 | **Prevent ACP prompt results from exposing a false idle window before late protocol updates settle.**                                                                                                                                                                                                                                                                                                                                          | The deployed white-label parity screenshot rendered 4 ACP tool cards and `Agent is working…`, while REST rendered 26 completed tool cards. `applyAcpEnvelope()` marks the projection idle on the prompt result, and later tool or text updates can mark it busy again.                                                                                                  | **IN PROGRESS 2026-07-26** — session `whitelabel-acp-stable-completion`; RED test, SDK fix, strengthened parity gate, merge, Deploy Dev, and deployed proof required                                                                                                                            |
+| B24 | **Accept a server-authorized initial OpenCode session pin in `useSession`.** The SDK must hydrate the cached transcript before runtime readiness without making the initial pin authoritative over the `/start` result.                                                                                                                                                                                                                          | Existing sessions wait for `/start` before `useSessionSync` can hydrate IndexedDB history. The preserved `session-load-latency` work proved the additive option and pin precedence.                                                                                                                       | **IN PROGRESS 2026-07-26** — session `api-latency-refactor`; RED test, implementation port, full SDK gates, browser proof, merge, and Deploy Dev proof required                                                                                                                               |
+| B25 | **Start project model-picker and project-detail reads in parallel.** Gateway projects must not wait for project detail before the SDK starts the compact model-picker request.                                                                                                                                                                                                                                                                   | `src/react/use-opencode-sessions/providers.ts` enables the model query only after `projectDetailQuery.isSuccess`, which creates a sequential request waterfall on project load.                                                                                                                          | **IN PROGRESS 2026-07-26** — session `api-latency-refactor`; RED test, implementation, full SDK gates, browser network proof, merge, and Deploy Dev proof required                                                                                                                            |
 
 > **Paths above are as of today (pre-Task-4).** After the restructure they move:
 > `platform/api/` → `core/http/api/`, `opencode/` → `core/runtime/`,
@@ -2791,6 +2793,28 @@ Post-repair verification:
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
 and deployed ACP plus REST parity remain.
+
+---
+
+### 2026-07-26 — session `api-latency-refactor` (B24 and B25 claims)
+
+Claimed two additive React SDK changes.
+
+B24 adds an optional server-authorized initial OpenCode session pin. The pin
+starts IndexedDB transcript hydration before `/start` completes. The `/start`
+pin remains authoritative.
+
+B25 starts the compact project model-picker request in parallel with project
+detail. Native projects continue to wait for runtime readiness.
+
+Implementation follows RED -> GREEN -> REFACTOR. Required gates are SDK
+typecheck, the full SDK suite, packed-install smoke, focused web tests, local
+browser proof, PR merge, Deploy Dev, deployed SHA proof, and deployed browser
+proof.
+
+**Status:** IN PROGRESS.
+
+**Shippable to production: NOT YET.**
 
 ---
 

--- a/packages/sdk/src/react/initial-session-pin.test.ts
+++ b/packages/sdk/src/react/initial-session-pin.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveSessionPin } from "./initial-session-pin";
+
+describe("resolveSessionPin", () => {
+  test("uses the server-authorized initial pin before readiness resolves", () => {
+    expect(
+      resolveSessionPin({
+        startPin: null,
+        initialPin: "opencode-cached",
+        persistedPin: null,
+      }),
+    ).toBe("opencode-cached");
+  });
+
+  test("replaces a stale initial pin with the authoritative start pin", () => {
+    expect(
+      resolveSessionPin({
+        startPin: "opencode-live",
+        initialPin: "opencode-cached",
+        persistedPin: "opencode-row",
+      }),
+    ).toBe("opencode-live");
+  });
+
+  test("falls back to the persisted session row when no pin was seeded", () => {
+    expect(
+      resolveSessionPin({
+        startPin: null,
+        initialPin: null,
+        persistedPin: "opencode-row",
+      }),
+    ).toBe("opencode-row");
+  });
+});

--- a/packages/sdk/src/react/initial-session-pin.ts
+++ b/packages/sdk/src/react/initial-session-pin.ts
@@ -1,0 +1,13 @@
+interface SessionPinSources {
+  startPin?: string | null;
+  initialPin?: string | null;
+  persistedPin?: string | null;
+}
+
+export function resolveSessionPin({
+  startPin,
+  initialPin,
+  persistedPin,
+}: SessionPinSources): string | null {
+  return startPin ?? initialPin ?? persistedPin ?? null;
+}

--- a/packages/sdk/src/react/use-canonical-opencode-session.ts
+++ b/packages/sdk/src/react/use-canonical-opencode-session.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getProjectSession } from '../core/rest/projects-client';
 
+import { resolveSessionPin } from './initial-session-pin';
 import { useOpenCodeSessions, type Session } from './use-opencode-sessions';
 
 /**
@@ -43,10 +44,12 @@ export function useCanonicalOpenCodeSession(params: {
   sessionId: string;
   /** The pin POST /start resolved server-side this render (preferred source). */
   pinFromStart?: string | null;
+  /** A server-authorized pin supplied by the host for pre-readiness cache hydration. */
+  initialPin?: string | null;
   /** Disable the legacy OpenCode REST session list for ACP sessions. */
   listRuntimeSessions?: boolean;
 }): CanonicalOpenCodeSession {
-  const { projectId, sessionId, pinFromStart, listRuntimeSessions = true } = params;
+  const { projectId, sessionId, pinFromStart, initialPin, listRuntimeSessions = true } = params;
   const sessionsQuery = useOpenCodeSessions(listRuntimeSessions);
 
   // The Kortix session row carries the authoritative, server-managed pin — used
@@ -60,11 +63,15 @@ export function useCanonicalOpenCodeSession(params: {
   const projectSessionQuery = useQuery({
     queryKey: ['project-session', projectId, sessionId],
     queryFn: () => getProjectSession(projectId, sessionId, { showErrors: false }),
-    enabled: !!projectId && !!sessionId && !pinFromStart,
+    enabled: !!projectId && !!sessionId && !pinFromStart && !initialPin,
     staleTime: 10_000,
   });
   const pin = projectSessionQuery.data?.opencode_session_id ?? null;
-  const rootSessionId = pinFromStart ?? pin ?? null;
+  const rootSessionId = resolveSessionPin({
+    startPin: pinFromStart,
+    initialPin,
+    persistedPin: pin,
+  });
 
   return {
     rootSessionId,

--- a/packages/sdk/src/react/use-opencode-sessions/provider-load-plan.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/provider-load-plan.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldLoadProjectModelPicker } from "./provider-load-plan";
+
+describe("shouldLoadProjectModelPicker", () => {
+  test("starts the model-picker request while project detail is unresolved", () => {
+    expect(
+      shouldLoadProjectModelPicker({
+        projectId: "project-1",
+        projectModeKnown: false,
+        projectGatewayEnabled: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps the model-picker request enabled for a gateway project", () => {
+    expect(
+      shouldLoadProjectModelPicker({
+        projectId: "project-1",
+        projectModeKnown: true,
+        projectGatewayEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not request the gateway model-picker for a known native project", () => {
+    expect(
+      shouldLoadProjectModelPicker({
+        projectId: "project-1",
+        projectModeKnown: true,
+        projectGatewayEnabled: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not request a project model-picker outside a project route", () => {
+    expect(
+      shouldLoadProjectModelPicker({
+        projectId: null,
+        projectModeKnown: true,
+        projectGatewayEnabled: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/sdk/src/react/use-opencode-sessions/provider-load-plan.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/provider-load-plan.ts
@@ -1,0 +1,9 @@
+export function shouldLoadProjectModelPicker(input: {
+  projectId: string | null;
+  projectModeKnown: boolean;
+  projectGatewayEnabled: boolean;
+}): boolean {
+  return Boolean(
+    input.projectId && (!input.projectModeKnown || input.projectGatewayEnabled),
+  );
+}

--- a/packages/sdk/src/react/use-opencode-sessions/providers.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/providers.ts
@@ -21,6 +21,7 @@ import {
   projectLlmCatalogToProviderList,
   providerListHasModels,
 } from '../provider-selection';
+import { shouldLoadProjectModelPicker } from './provider-load-plan';
 
 // ============================================================================
 // Provider Hooks
@@ -40,23 +41,39 @@ export function useOpenCodeProviders() {
   const projectGatewayEnabled =
     projectId ? projectDetailQuery.data?.project.experimental?.llm_gateway === true : false;
   const projectModeKnown = !projectId || projectDetailQuery.isSuccess;
-  // BYOK makes the connected model set project-specific (a provider connected
-  // in one project must NOT leak into another, nor linger after removal), so
-  // the persisted placeholder is scoped per project — not the old global scope.
-  const cacheScope = projectId
-    ? `proj:${projectId}:${projectGatewayEnabled ? 'gateway' : 'native'}`
-    : CACHE_SCOPE_GLOBAL;
-  return useQuery<ProviderListResponse>({
-    queryKey: projectId
-      ? ['project-providers', projectId, projectGatewayEnabled ? 'gateway' : 'native']
-      : opencodeKeys.providers(),
+  const gatewayCacheScope = projectId ? `proj:${projectId}:gateway` : CACHE_SCOPE_GLOBAL;
+  const gatewayProvidersQuery = useQuery<ProviderListResponse>({
+    queryKey: ['project-providers', projectId, 'gateway'],
     queryFn: async () => {
-      if (projectId && projectGatewayEnabled) {
-        const catalog = await getProjectModelPicker(projectId);
-        const providers = projectLlmCatalogToProviderList(catalog);
-        setLSCache(LS_PROVIDERS, providers, cacheScope);
-        return providers;
-      }
+      const catalog = await getProjectModelPicker(projectId!);
+      const providers = projectLlmCatalogToProviderList(catalog);
+      setLSCache(LS_PROVIDERS, providers, gatewayCacheScope);
+      return providers;
+    },
+    placeholderData: () => {
+      const cached = getLSCache<ProviderListResponse>(LS_PROVIDERS, gatewayCacheScope);
+      if (!providerListHasModels(cached)) return undefined;
+      const providers = filterToGatewayProviders(cached as ProviderListResponse);
+      return providerListHasModels(providers) ? providers : undefined;
+    },
+    enabled: shouldLoadProjectModelPicker({
+      projectId,
+      projectModeKnown,
+      projectGatewayEnabled,
+    }),
+    staleTime: Infinity,
+    gcTime: 10 * 60 * 1000,
+    retry: (failureCount) =>
+      (!projectModeKnown || projectGatewayEnabled) && failureCount < 10,
+    retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 8000),
+  });
+
+  // BYOK makes the connected model set project-specific. A provider connected
+  // in one project must not leak into another or remain after removal.
+  const nativeCacheScope = projectId ? `proj:${projectId}:native` : CACHE_SCOPE_GLOBAL;
+  const nativeProvidersQuery = useQuery<ProviderListResponse>({
+    queryKey: projectId ? ['project-providers', projectId, 'native'] : opencodeKeys.providers(),
+    queryFn: async () => {
       const client = getClient();
       const result = await client.provider.list();
       let rawProviders = normalizeProviderList(unwrap(result));
@@ -91,28 +108,23 @@ export function useOpenCodeProviders() {
       // server id) so a fresh session paints the right models instantly. Only
       // genuine, model-bearing responses reach here, so the placeholder cache
       // is never poisoned with an empty list.
-      setLSCache(LS_PROVIDERS, providers, cacheScope);
+      setLSCache(LS_PROVIDERS, providers, nativeCacheScope);
       return providers;
     },
     // Only ever serve a model-bearing placeholder. A previously-poisoned cache
     // (written before this guard existed) is ignored so it can't paint empty.
     placeholderData: () => {
-      const cached = getLSCache<ProviderListResponse>(LS_PROVIDERS, cacheScope);
+      const cached = getLSCache<ProviderListResponse>(LS_PROVIDERS, nativeCacheScope);
       if (!providerListHasModels(cached)) return undefined;
-      // Old gateway caches may have been persisted before the source filter —
-      // clean them on read, but native-mode projects must see the runtime's
-      // actual provider list for v0.9.68/backward-compatible fallback.
-      if (projectGatewayEnabled) {
-        const gatewayProviders = filterToGatewayProviders(cached as ProviderListResponse);
-        return providerListHasModels(gatewayProviders) ? gatewayProviders : undefined;
-      }
-      if (projectId && !projectGatewayEnabled) {
+      if (projectId) {
         const nativeProviders = filterToNativeProviders(cached as ProviderListResponse);
         return providerListHasModels(nativeProviders) ? nativeProviders : undefined;
       }
       return cached;
     },
-    enabled: projectId ? projectModeKnown && (projectGatewayEnabled || runtimeReady) : runtimeReady,
+    enabled: projectId
+      ? projectModeKnown && !projectGatewayEnabled && runtimeReady
+      : runtimeReady,
     staleTime: Infinity,
     gcTime: 10 * 60 * 1000,
     // The boot race (sandbox up, providers not yet wired) self-heals: keep
@@ -120,4 +132,5 @@ export function useOpenCodeProviders() {
     retry: (failureCount) => failureCount < 10,
     retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 8000),
   });
+  return projectId && projectGatewayEnabled ? gatewayProvidersQuery : nativeProvidersQuery;
 }

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -312,6 +312,14 @@ export interface UseSessionOptions {
    */
   enabled?: boolean;
   /**
+   * A server-authorized OpenCode session pin already associated with this
+   * Kortix session. The hook uses it only to hydrate cached transcript content
+   * while `/start` runs. The pin returned by `/start` remains authoritative.
+   *
+   * Do not accept this value from an untrusted browser tenant selector.
+   */
+  initialOpenCodeSessionId?: string | null;
+  /**
    * Mount the chat-consumption engine — `useSessionSync` (messages/status/diffs/
    * todos, including its 10s busy-poll SSE-stall fallback) and `useQuestionSelfHeal`
    * (the 2s missed-`question.asked` self-heal poll) — on top of the boot/lifecycle
@@ -353,7 +361,13 @@ const DISABLED_CHAT_ENGINE_SYNC = {
 };
 
 export function useSession(projectId: string, sessionId: string, options: UseSessionOptions = {}) {
-  const { waitMs = 15_000, replayStartStash = true, enabled = true, chatEngine = true } = options;
+  const {
+    waitMs = 15_000,
+    replayStartStash = true,
+    enabled = true,
+    chatEngine = true,
+    initialOpenCodeSessionId = null,
+  } = options;
 
   // 1. Drive /start until the runtime is ready (the server long-polls each tick).
   const start = useQuery({
@@ -427,6 +441,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     projectId,
     sessionId,
     pinFromStart: startData?.opencode_session_id ?? null,
+    initialPin: initialOpenCodeSessionId,
     listRuntimeSessions: runtimePolicy.listOpenCodeSessions,
   });
   const { rootSessionId } = canonicalSession;


### PR DESCRIPTION
## Scope

- Add `POST /v1/projects/:projectId/execution-lease` for sandbox `acquire`, `renew`, and `release` operations.
- Reduce lease renewal cadence from 20 seconds to 60 seconds.
- Remove idle-start and reconnect discovery requests.
- Remove API-side provider health calls from lease renewal.
- Preserve legacy `turn-stream` lease kinds during sandbox image rotation.
- Remove speculative sandbox resume from generic project authorization.
- Start project model-picker and project-detail reads in parallel.
- Hydrate cached session transcripts before `/start` completes.
- Stop provider-modal loading after project detail and secrets resolve.
- Add no Redis or sticky-session correctness dependency.

## Production evidence

The 24-hour sample contained 729,236 `turn-stream` requests. This route represented 76.3 percent of API traffic. Its p50 was 549 ms and p95 was 3,005 ms.

The implementation changes continuous busy traffic from three renewals per minute to one renewal per minute. It removes idle and reconnect discovery calls.

## Verification

- SDK typecheck: pass.
- SDK suite: 1,275 pass, 0 fail, 5,669 assertions.
- SDK packed-install smoke: pass.
- API typecheck: pass.
- Focused isolated API tests: 67 pass, 0 fail.
- Sandbox-agent typecheck: pass.
- Sandbox-agent suite: 298 pass, 0 fail, 720 assertions.
- Web suite: 2,207 pass, 0 fail, 5,970 assertions.
- Focused web ESLint: pass.
- Live local `acquire`: HTTP 200, 33.9 ms, response and database lease matched.
- Live local `renew`: HTTP 200, 20.8 ms, response and database lease matched.
- Live local `release`: HTTP 200, 21.3 ms, database lease cleared.

## Open verification

The browser-control runtime exposed no browser binding. Local DOM and browser-network assertions remain open. Deploy Dev and deployed browser proof follow after merge.