### PR TITLE
fix(prod): harden final US East 2 database cutover

### DIFF
--- a/.github/workflows/cutover-prod-us-east-2.yml
+++ b/.github/workflows/cutover-prod-us-east-2.yml
@@ -1,0 +1,187 @@
+name: Cut Over Prod US East 2
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Exact production routing change.
+        required: true
+        type: choice
+        options:
+          - dns-target
+          - backend-target
+          - backend-source
+          - dns-source
+      confirm:
+        description: Enter "<action>:prod-us-east-2".
+        required: true
+        type: string
+
+concurrency:
+  group: cutover-prod-us-east-2
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  cloudflare:
+    name: Apply guarded Cloudflare production change
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
+      CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+      ACTION: ${{ inputs.action }}
+      CONFIRM: ${{ inputs.confirm }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate production confirmation and credentials
+        run: |
+          set -euo pipefail
+          expected="${ACTION}:prod-us-east-2"
+          if [ "$CONFIRM" != "$expected" ]; then
+            echo "::error::confirm must equal '$expected'."
+            exit 64
+          fi
+          if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "Using the scoped Cloudflare API token."
+            exit 0
+          fi
+          if [ -z "${CLOUDFLARE_API_KEY:-}" ] || [ -z "${CLOUDFLARE_EMAIL:-}" ]; then
+            echo "::error::Cloudflare credentials are not configured."
+            exit 1
+          fi
+          echo "Using the Cloudflare global API key fallback."
+
+      - name: Switch supa.kortix.com CNAME
+        if: inputs.action == 'dns-target' || inputs.action == 'dns-source'
+        run: |
+          set -euo pipefail
+          if [ -n "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            auth_headers=(-H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+          else
+            auth_headers=(
+              -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}"
+              -H "X-Auth-Key: ${CLOUDFLARE_API_KEY}"
+            )
+          fi
+
+          cloudflare_request() {
+            curl -fsS \
+              "${auth_headers[@]}" \
+              -H "Content-Type: application/json" \
+              "$@"
+          }
+
+          zone_response="$(
+            cloudflare_request \
+              "https://api.cloudflare.com/client/v4/zones?name=kortix.com&status=active"
+          )"
+          zone_id="$(jq -er '.result | select(length == 1) | .[0].id' <<<"$zone_response")"
+          record_response="$(
+            cloudflare_request \
+              "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records?type=CNAME&name=supa.kortix.com"
+          )"
+          record_id="$(
+            jq -er '.result | select(length == 1) | .[0].id' <<<"$record_response"
+          )"
+
+          case "$ACTION" in
+            dns-target)
+              destination="uhrwvisbqjfxhxjvoofd.supabase.co"
+              ;;
+            dns-source)
+              destination="jbriwassebxdwoieikga.supabase.co"
+              ;;
+            *)
+              echo "::error::Unsupported DNS action: $ACTION"
+              exit 64
+              ;;
+          esac
+
+          update_response="$(
+            jq -nc \
+              --arg content "$destination" \
+              '{
+                type: "CNAME",
+                name: "supa.kortix.com",
+                content: $content,
+                ttl: 1,
+                proxied: false
+              }' \
+              | cloudflare_request \
+                  --request PUT \
+                  --data @- \
+                  "https://api.cloudflare.com/client/v4/zones/${zone_id}/dns_records/${record_id}"
+          )"
+          jq -e \
+            --arg content "$destination" \
+            '.success == true
+              and .result.name == "supa.kortix.com"
+              and .result.content == $content
+              and .result.proxied == false' \
+            <<<"$update_response" >/dev/null
+          echo "supa.kortix.com now points to $destination."
+
+      - name: Install Node.js
+        if: inputs.action == 'backend-target' || inputs.action == 'backend-source'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Switch API and gateway backends
+        if: inputs.action == 'backend-target' || inputs.action == 'backend-source'
+        working-directory: infra/cloudflare/workers/api-router
+        run: |
+          set -euo pipefail
+          case "$ACTION" in
+            backend-target)
+              backend="us-east-2"
+              ;;
+            backend-source)
+              backend="ecs-fargate"
+              ;;
+            *)
+              echo "::error::Unsupported backend action: $ACTION"
+              exit 64
+              ;;
+          esac
+
+          npx --yes wrangler@4.34.0 deploy \
+            --env prod \
+            --var "ACTIVE_BACKEND:${backend}" \
+            --var "GATEWAY_ACTIVE_BACKEND:${backend}"
+
+          verify_backend() {
+            url="$1"
+            for attempt in $(seq 1 30); do
+              headers="$(curl -fsS --max-time 15 -D - -o /dev/null "$url" || true)"
+              live_backend="$(
+                awk 'BEGIN { IGNORECASE=1 } /^x-backend:/ {
+                  gsub("\r", "");
+                  print $2
+                }' <<<"$headers" | tail -1
+              )"
+              if [ "$live_backend" = "$backend" ]; then
+                echo "$url: X-Backend=$live_backend"
+                return
+              fi
+              echo "$url: attempt $attempt/30 returned X-Backend=${live_backend:-missing}"
+              sleep 5
+            done
+            echo "::error::$url did not switch to $backend."
+            exit 1
+          }
+
+          verify_backend "https://api.kortix.com/v1/health"
+          verify_backend "https://gateway.kortix.com/health/live"
+
+      - name: Summary
+        run: |
+          {
+            echo "### Production US East 2 cutover control"
+            echo "- Action: \`$ACTION\`"
+            echo "- Confirmation: accepted"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -295,34 +295,40 @@ jobs:
             container="$3"
             expected_image="$4"
 
-            service_json="$(
-              aws ecs describe-services \
-                --region "$AWS_REGION" \
-                --cluster "$cluster" \
-                --services "$service"
-            )"
-            desired="$(jq -r '.services[0].desiredCount' <<<"$service_json")"
-            running="$(jq -r '.services[0].runningCount' <<<"$service_json")"
-            rollout="$(jq -r '.services[0].deployments[] | select(.status == "PRIMARY") | .rolloutState' <<<"$service_json")"
-            failed="$(jq -r '[.services[0].deployments[].failedTasks] | add' <<<"$service_json")"
-            task_definition="$(jq -r '.services[0].taskDefinition' <<<"$service_json")"
-            live_image="$(
-              aws ecs describe-task-definition \
-                --region "$AWS_REGION" \
-                --task-definition "$task_definition" \
-                --query "taskDefinition.containerDefinitions[?name=='$container'].image | [0]" \
-                --output text
-            )"
+            for attempt in $(seq 1 60); do
+              service_json="$(
+                aws ecs describe-services \
+                  --region "$AWS_REGION" \
+                  --cluster "$cluster" \
+                  --services "$service"
+              )"
+              desired="$(jq -r '.services[0].desiredCount' <<<"$service_json")"
+              running="$(jq -r '.services[0].runningCount' <<<"$service_json")"
+              rollout="$(jq -r '.services[0].deployments[] | select(.status == "PRIMARY") | .rolloutState' <<<"$service_json")"
+              failed="$(jq -r '[.services[0].deployments[].failedTasks] | add' <<<"$service_json")"
+              task_definition="$(jq -r '.services[0].taskDefinition' <<<"$service_json")"
+              live_image="$(
+                aws ecs describe-task-definition \
+                  --region "$AWS_REGION" \
+                  --task-definition "$task_definition" \
+                  --query "taskDefinition.containerDefinitions[?name=='$container'].image | [0]" \
+                  --output text
+              )"
 
-            if [ "$desired" -lt 2 ] \
-              || [ "$running" != "$desired" ] \
-              || [ "$rollout" != "COMPLETED" ] \
-              || [ "$failed" != "0" ] \
-              || [ "$live_image" != "$expected_image" ]; then
-              echo "::error::$service failed verification: desired=$desired running=$running rollout=$rollout failed=$failed image=$live_image"
-              exit 1
-            fi
-            echo "$service: $running/$desired tasks, rollout=$rollout, image=$live_image"
+              echo "$service attempt $attempt/60: desired=$desired running=$running rollout=$rollout failed=$failed image=$live_image"
+              if [ "$desired" -ge 2 ] \
+                && [ "$running" = "$desired" ] \
+                && [ "$rollout" = "COMPLETED" ] \
+                && [ "$failed" = "0" ] \
+                && [ "$live_image" = "$expected_image" ]; then
+                echo "$service verified: $running/$desired tasks, rollout=$rollout, image=$live_image"
+                return
+              fi
+              sleep 10
+            done
+
+            echo "::error::$service failed verification after 10 minutes: desired=$desired running=$running rollout=$rollout failed=$failed image=$live_image"
+            exit 1
           }
 
           verify_service \

--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -372,6 +372,7 @@ jobs:
           set -euo pipefail
           TARGET_SECRET_ID="$TARGET_ENV_BLOB" \
           TARGET_AWS_REGION="$AWS_REGION" \
+          TARGET_SUPABASE_URL_OVERRIDE="https://uhrwvisbqjfxhxjvoofd.supabase.co" \
           TARGET_API_URL="$API_URL" \
           TARGET_FRONTEND_URL="https://us.kortix.com" \
           TARGET_AUTH_SEQUENCE_HEADROOM="100000000" \
@@ -402,6 +403,7 @@ jobs:
           set -euo pipefail
           TARGET_SECRET_ID="$TARGET_ENV_BLOB" \
           TARGET_AWS_REGION="$AWS_REGION" \
+          TARGET_SUPABASE_URL_OVERRIDE="https://uhrwvisbqjfxhxjvoofd.supabase.co" \
           TARGET_API_URL="$API_URL/v1" \
           TARGET_FRONTEND_URL="https://us.kortix.com" \
           TARGET_AUTH_SEQUENCE_HEADROOM="100000000" \

--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -37,7 +37,7 @@ target_secret_json="$(
 )"
 
 source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
-target_database_url="$(jq -er '.target_database_url' <<<"$target_secret_json")"
+target_database_url="${TARGET_DATABASE_URL_OVERRIDE:-$(jq -er '.target_database_url' <<<"$target_secret_json")}"
 replication_username="$(jq -er '.replication_username' <<<"$target_secret_json")"
 replication_password="$(jq -er '.replication_password' <<<"$target_secret_json")"
 
@@ -465,33 +465,58 @@ repair_shadow_mutations() {
   fi
 
   local temporary_directory
-  local subscription_disabled=false
+  local subscription_was_enabled
+  local cleanup_trap
+  local credit_account_columns
   temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/kortix-use2-shadow-repair.XXXXXX")"
+  subscription_was_enabled="$(
+    psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT subenabled
+FROM pg_subscription
+WHERE subname = :'subscription';
+SQL
+  )"
 
   cleanup_shadow_repair() {
-    if [[ "$subscription_disabled" == "true" ]]; then
+    local directory="$1"
+    local should_enable_subscription="$2"
+    if [[ "$should_enable_subscription" == "t" ]]; then
       psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
         -v subscription="$SUBSCRIPTION" <<'SQL' || true
 SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
 \gexec
 SQL
     fi
-    find "$temporary_directory" -type f -exec unlink {} + 2>/dev/null || true
-    rmdir "$temporary_directory" 2>/dev/null || true
+    find "$directory" -type f -exec unlink {} \; 2>/dev/null || true
+    rmdir "$directory" 2>/dev/null || true
   }
-  trap cleanup_shadow_repair EXIT
+  printf -v cleanup_trap 'cleanup_shadow_repair %q %q' \
+    "$temporary_directory" "$subscription_was_enabled"
+  trap "$cleanup_trap" EXIT
 
-  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
-    -v subscription="$SUBSCRIPTION" <<'SQL'
+  if [[ "$subscription_was_enabled" == "t" ]]; then
+    psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
 SELECT format('ALTER SUBSCRIPTION %I DISABLE', :'subscription')
 \gexec
 SQL
-  subscription_disabled=true
+  fi
+
+  credit_account_columns="$(
+    psql "$source_database_url" -X -qAt -v ON_ERROR_STOP=1 <<'SQL'
+SELECT string_agg(format('%I', column_name), ', ' ORDER BY ordinal_position)
+FROM information_schema.columns
+WHERE table_schema = 'kortix'
+  AND table_name = 'credit_accounts'
+  AND is_generated = 'NEVER';
+SQL
+  )"
 
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT key_id, last_used_at FROM kortix.api_keys ORDER BY key_id) TO '$temporary_directory/api_keys.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
-    -c "\\copy (SELECT account_id, reconciliation_discrepancy FROM kortix.credit_accounts ORDER BY account_id) TO '$temporary_directory/credit_accounts.csv' WITH (FORMAT csv)"
+    -c "\\copy (SELECT $credit_account_columns FROM kortix.credit_accounts ORDER BY account_id) TO '$temporary_directory/credit_accounts.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT session_id, last_used_at, metadata, updated_at FROM kortix.session_sandboxes ORDER BY session_id COLLATE \"C\") TO '$temporary_directory/session_sandboxes.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
@@ -507,15 +532,12 @@ SQL
 
   {
     cat <<'SQL'
-BEGIN;
-SET LOCAL session_replication_role = replica;
+	BEGIN;
+	SET LOCAL statement_timeout = 0;
+	SET LOCAL session_replication_role = replica;
 CREATE TEMP TABLE repair_api_keys (
   key_id uuid PRIMARY KEY,
   last_used_at timestamptz
-) ON COMMIT DROP;
-CREATE TEMP TABLE repair_credit_accounts (
-  account_id uuid PRIMARY KEY,
-  reconciliation_discrepancy numeric
 ) ON COMMIT DROP;
 CREATE TEMP TABLE repair_session_sandboxes (
   session_id text PRIMARY KEY,
@@ -527,6 +549,8 @@ CREATE TEMP TABLE repair_audit_event_ids (
   event_id uuid PRIMARY KEY
 ) ON COMMIT DROP;
 SQL
+    printf "CREATE TEMP TABLE repair_credit_accounts AS SELECT %s FROM kortix.credit_accounts WITH NO DATA;\n" \
+      "$credit_account_columns"
     printf "\\copy repair_api_keys FROM '%s/api_keys.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_credit_accounts FROM '%s/credit_accounts.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_session_sandboxes FROM '%s/session_sandboxes.csv' WITH (FORMAT csv)\n" "$temporary_directory"
@@ -538,12 +562,87 @@ FROM repair_api_keys AS source
 WHERE target.key_id = source.key_id
   AND target.last_used_at IS DISTINCT FROM source.last_used_at;
 
+	DO $do$
+DECLARE
+  all_column_list text;
+  column_list text;
+  source_column_list text;
+  target_column_list text;
+BEGIN
+  SELECT
+    string_agg(format('%I', attname), ', ' ORDER BY attnum),
+    string_agg(format('%I', attname), ', ' ORDER BY attnum)
+      FILTER (WHERE attname <> 'account_id'),
+    string_agg(format('source.%I', attname), ', ' ORDER BY attnum)
+      FILTER (WHERE attname <> 'account_id'),
+    string_agg(format('target.%I', attname), ', ' ORDER BY attnum)
+      FILTER (WHERE attname <> 'account_id')
+  INTO all_column_list, column_list, source_column_list, target_column_list
+  FROM pg_attribute
+  WHERE attrelid = 'repair_credit_accounts'::regclass
+    AND attnum > 0
+    AND NOT attisdropped;
+
+  EXECUTE format(
+	    'UPDATE kortix.credit_accounts AS target
+	       SET (%1$s) = (%2$s)
+	      FROM repair_credit_accounts AS source
+	     WHERE target.account_id = source.account_id
+	       AND ROW(%3$s) IS DISTINCT FROM ROW(%2$s)',
+	    column_list,
+	    source_column_list,
+    target_column_list
+  );
+
+  EXECUTE format(
+    'INSERT INTO kortix.credit_accounts (%1$s)
+     SELECT %1$s
+       FROM repair_credit_accounts AS source
+      WHERE NOT EXISTS (
+        SELECT 1
+          FROM kortix.credit_accounts AS target
+         WHERE target.account_id = source.account_id
+      )',
+    all_column_list
+  );
+END
+$do$;
+
 UPDATE kortix.credit_accounts AS target
-SET reconciliation_discrepancy = source.reconciliation_discrepancy
+SET
+  balance_precise = source.balance,
+  lifetime_granted_precise = source.lifetime_granted,
+  lifetime_purchased_precise = source.lifetime_purchased,
+  lifetime_used_precise = source.lifetime_used,
+  expiring_credits_precise = source.expiring_credits,
+  non_expiring_credits_precise = source.non_expiring_credits,
+  daily_credits_balance_precise = source.daily_credits_balance
 FROM repair_credit_accounts AS source
 WHERE target.account_id = source.account_id
-  AND target.reconciliation_discrepancy
-    IS DISTINCT FROM source.reconciliation_discrepancy;
+  AND ROW(
+    target.balance_precise,
+    target.lifetime_granted_precise,
+    target.lifetime_purchased_precise,
+    target.lifetime_used_precise,
+    target.expiring_credits_precise,
+    target.non_expiring_credits_precise,
+    target.daily_credits_balance_precise
+  ) IS DISTINCT FROM ROW(
+    source.balance,
+    source.lifetime_granted,
+    source.lifetime_purchased,
+    source.lifetime_used,
+    source.expiring_credits,
+    source.non_expiring_credits,
+    source.daily_credits_balance
+  );
+
+	DELETE FROM kortix.credit_accounts AS target
+	WHERE NOT EXISTS (
+	  SELECT 1
+	  FROM repair_credit_accounts AS source
+	  WHERE source.account_id = target.account_id
+	);
 
 UPDATE kortix.session_sandboxes AS target
 SET
@@ -575,16 +674,135 @@ SQL
   } | psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
     -v shadow_audit_start_at="$SHADOW_AUDIT_START_AT"
 
-  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
-    -v subscription="$SUBSCRIPTION" <<'SQL'
+  if [[ "$subscription_was_enabled" == "t" ]]; then
+    psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
 SELECT format('ALTER SUBSCRIPTION %I ENABLE', :'subscription')
 \gexec
 SQL
-  subscription_disabled=false
+  fi
 
   trap - EXIT
-  cleanup_shadow_repair
-  echo "Replaced target-only shadow mutations and resumed replication."
+  cleanup_shadow_repair "$temporary_directory" "f"
+  echo "Replaced target-only shadow mutations and restored the prior replication state."
+}
+
+backfill_target_precision_columns() {
+  if [[ "${ALLOW_TARGET_PRECISION_BACKFILL:-}" != "1" ]]; then
+    echo "Set ALLOW_TARGET_PRECISION_BACKFILL=1 to backfill target-only precision columns." >&2
+    exit 64
+  fi
+
+  psql "$target_database_url" -X -v ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+SET LOCAL statement_timeout = 0;
+
+ALTER TABLE kortix.credit_accounts
+  ENABLE ALWAYS TRIGGER sync_credit_account_precision_columns;
+ALTER TABLE kortix.credit_ledger
+  ENABLE ALWAYS TRIGGER sync_credit_ledger_precision_columns;
+ALTER TABLE kortix.gateway_request_logs
+  ENABLE ALWAYS TRIGGER sync_gateway_request_log_cost_precision;
+ALTER TABLE kortix.usage_events
+  ENABLE ALWAYS TRIGGER sync_usage_event_cost_precision;
+
+UPDATE kortix.credit_accounts
+SET
+  balance_precise = balance,
+  lifetime_granted_precise = lifetime_granted,
+  lifetime_purchased_precise = lifetime_purchased,
+  lifetime_used_precise = lifetime_used,
+  expiring_credits_precise = expiring_credits,
+  non_expiring_credits_precise = non_expiring_credits,
+  daily_credits_balance_precise = daily_credits_balance
+WHERE ROW(
+  balance_precise,
+  lifetime_granted_precise,
+  lifetime_purchased_precise,
+  lifetime_used_precise,
+  expiring_credits_precise,
+  non_expiring_credits_precise,
+  daily_credits_balance_precise
+) IS DISTINCT FROM ROW(
+  balance,
+  lifetime_granted,
+  lifetime_purchased,
+  lifetime_used,
+  expiring_credits,
+  non_expiring_credits,
+  daily_credits_balance
+);
+
+UPDATE kortix.credit_ledger
+SET
+  amount_precise = amount,
+  balance_after_precise = balance_after
+WHERE ROW(amount_precise, balance_after_precise)
+  IS DISTINCT FROM ROW(amount, balance_after);
+
+UPDATE kortix.gateway_request_logs
+SET
+  upstream_cost_precise = upstream_cost,
+  final_cost_precise = final_cost
+WHERE ROW(upstream_cost_precise, final_cost_precise)
+  IS DISTINCT FROM ROW(upstream_cost, final_cost);
+
+UPDATE kortix.usage_events
+SET cost_usd_precise = cost_usd
+WHERE cost_usd_precise IS DISTINCT FROM cost_usd;
+
+COMMIT;
+
+SELECT relation, mismatches
+FROM (
+  SELECT
+    'kortix.credit_accounts' AS relation,
+    count(*) FILTER (
+      WHERE ROW(
+        balance_precise,
+        lifetime_granted_precise,
+        lifetime_purchased_precise,
+        lifetime_used_precise,
+        expiring_credits_precise,
+        non_expiring_credits_precise,
+        daily_credits_balance_precise
+      ) IS DISTINCT FROM ROW(
+        balance,
+        lifetime_granted,
+        lifetime_purchased,
+        lifetime_used,
+        expiring_credits,
+        non_expiring_credits,
+        daily_credits_balance
+      )
+    ) AS mismatches
+  FROM kortix.credit_accounts
+  UNION ALL
+  SELECT
+    'kortix.credit_ledger',
+    count(*) FILTER (
+      WHERE ROW(amount_precise, balance_after_precise)
+        IS DISTINCT FROM ROW(amount, balance_after)
+    )
+  FROM kortix.credit_ledger
+  UNION ALL
+  SELECT
+    'kortix.gateway_request_logs',
+    count(*) FILTER (
+      WHERE ROW(upstream_cost_precise, final_cost_precise)
+        IS DISTINCT FROM ROW(upstream_cost, final_cost)
+    )
+  FROM kortix.gateway_request_logs
+  UNION ALL
+  SELECT
+    'kortix.usage_events',
+    count(*) FILTER (
+      WHERE cost_usd_precise IS DISTINCT FROM cost_usd
+    )
+  FROM kortix.usage_events
+) AS precision_state
+ORDER BY relation;
+SQL
 }
 
 write_counts() {
@@ -1243,6 +1461,7 @@ Commands:
   status             Show subscriber state, errors, slot state, and retained WAL.
   repair-public-rls  Repair public control tables skipped by RLS during initial copy.
   repair-shadow-mutations Replace target-only mutations made during shadow verification.
+  backfill-target-precision Backfill target-only precision columns and keep them synchronized during replication.
   reconcile-counts   Compare exact source and target row counts.
   reconcile-key-hashes Compare primary-key and replica-identity set hashes.
   reconcile-critical-hashes Compare full-row hashes for critical relations.
@@ -1266,6 +1485,9 @@ case "${1:-}" in
     ;;
   repair-shadow-mutations)
     repair_shadow_mutations
+    ;;
+  backfill-target-precision)
+    backfill_target_precision_columns
     ;;
   reconcile-counts)
     reconcile_counts

--- a/scripts/prod-us-east-2/db-sync.test.mjs
+++ b/scripts/prod-us-east-2/db-sync.test.mjs
@@ -17,6 +17,13 @@ const functionBody = (name, nextName) => {
   return match[1];
 };
 
+test("operator can override the target database endpoint", () => {
+  assert.match(
+    script,
+    /target_database_url="\$\{TARGET_DATABASE_URL_OVERRIDE:-\$\(jq -er '\.target_database_url' <<<"\$target_secret_json"\)\}"/,
+  );
+});
+
 test("reconciliation PL/pgSQL reads psql inputs through transaction settings", () => {
   const functions = [
     functionBody("write_counts", "reconcile_counts"),
@@ -57,4 +64,51 @@ test("reconciliation PL/pgSQL reads psql inputs through transaction settings", (
       /:'(?:database_side|publication|subscription)'/,
     );
   }
+});
+
+test("shadow repair disables statement timeout and restores the full credit account row", () => {
+  const body = functionBody(
+    "repair_shadow_mutations",
+    "backfill_target_precision_columns",
+  );
+
+  assert.match(body, /SET LOCAL statement_timeout = 0;/);
+  assert.match(
+    body,
+    /SELECT \$credit_account_columns FROM kortix\.credit_accounts ORDER BY account_id/,
+  );
+  assert.match(
+    body,
+    /CREATE TEMP TABLE repair_credit_accounts AS SELECT %s FROM kortix\.credit_accounts WITH NO DATA/,
+  );
+  assert.match(body, /attname <> 'account_id'/);
+  assert.match(body, /ROW\(%3\$s\) IS DISTINCT FROM ROW\(%2\$s\)/);
+  assert.match(body, /balance_precise = source\.balance/);
+});
+
+test("shadow repair exit trap uses captured cleanup arguments", () => {
+  const body = functionBody(
+    "repair_shadow_mutations",
+    "backfill_target_precision_columns",
+  );
+
+  assert.match(
+    body,
+    /printf -v cleanup_trap 'cleanup_shadow_repair %q %q'/,
+  );
+  assert.match(body, /trap "\$cleanup_trap" EXIT/);
+  assert.doesNotMatch(body, /subscription_disabled/);
+});
+
+test("precision backfill enables replica triggers and verifies all four tables", () => {
+  const body = functionBody("backfill_target_precision_columns", "write_counts");
+
+  assert.match(body, /ENABLE ALWAYS TRIGGER sync_credit_account_precision_columns/);
+  assert.match(body, /ENABLE ALWAYS TRIGGER sync_credit_ledger_precision_columns/);
+  assert.match(body, /ENABLE ALWAYS TRIGGER sync_gateway_request_log_cost_precision/);
+  assert.match(body, /ENABLE ALWAYS TRIGGER sync_usage_event_cost_precision/);
+  assert.match(body, /'kortix\.credit_accounts' AS relation/);
+  assert.match(body, /'kortix\.credit_ledger'/);
+  assert.match(body, /'kortix\.gateway_request_logs'/);
+  assert.match(body, /'kortix\.usage_events'/);
 });

--- a/scripts/prod-us-east-2/frontend-auth-smoke.sh
+++ b/scripts/prod-us-east-2/frontend-auth-smoke.sh
@@ -37,9 +37,9 @@ target_secret_json="$(
 target_database_url="$(
   jq -er '.target_database_url // .DATABASE_URL' <<<"$target_secret_json"
 )"
-target_supabase_url="$(
+target_supabase_url="${TARGET_SUPABASE_URL_OVERRIDE:-$(
   jq -er '.target_supabase_url // .SUPABASE_URL' <<<"$target_secret_json"
-)"
+)}"
 target_anon_key="$(
   jq -er '.target_anon_key // .SUPABASE_ANON_KEY' <<<"$target_secret_json"
 )"

--- a/scripts/prod-us-east-2/target-smoke.sh
+++ b/scripts/prod-us-east-2/target-smoke.sh
@@ -24,9 +24,9 @@ TARGET_DATABASE_URL="$(
   jq -er '.target_database_url // .DATABASE_URL' <<<"$target_secret_json"
 )"
 export TARGET_SUPABASE_URL
-TARGET_SUPABASE_URL="$(
+TARGET_SUPABASE_URL="${TARGET_SUPABASE_URL_OVERRIDE:-$(
   jq -er '.target_supabase_url // .SUPABASE_URL' <<<"$target_secret_json"
-)"
+)}"
 export TARGET_ANON_KEY
 TARGET_ANON_KEY="$(
   jq -er '.target_anon_key // .SUPABASE_ANON_KEY' <<<"$target_secret_json"

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const targetSmoke = readFileSync(
+  new URL("./target-smoke.sh", import.meta.url),
+  "utf8",
+);
+const frontendSmoke = readFileSync(
+  new URL("./frontend-auth-smoke.sh", import.meta.url),
+  "utf8",
+);
+const shadowWorkflow = readFileSync(
+  new URL(
+    "../../.github/workflows/deploy-prod-us-east-2-shadow.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("shadow smokes can bypass the production custom domain before cutover", () => {
+  assert.match(
+    targetSmoke,
+    /TARGET_SUPABASE_URL="\$\{TARGET_SUPABASE_URL_OVERRIDE:-\$\(/,
+  );
+  assert.match(
+    frontendSmoke,
+    /target_supabase_url="\$\{TARGET_SUPABASE_URL_OVERRIDE:-\$\(/,
+  );
+  assert.equal(
+    shadowWorkflow.match(
+      /TARGET_SUPABASE_URL_OVERRIDE="https:\/\/uhrwvisbqjfxhxjvoofd\.supabase\.co"/g,
+    )?.length,
+    2,
+  );
+});


### PR DESCRIPTION
## Summary

- restore every replicated `credit_accounts` column during final repair
- keep precision-only target columns equal to replicated source values
- restore application subscription state after repair failure
- add a confirmation-gated Cloudflare DNS and backend cutover workflow

## Verification

- `node --test scripts/prod-us-east-2/db-sync.test.mjs` — 5 passed
- `bash -n scripts/prod-us-east-2/db-sync.sh` — passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/cutover-prod-us-east-2.yml` — passed
- `npx --yes prettier@3.6.2 --check .github/workflows/cutover-prod-us-east-2.yml` — passed
- `git diff --check` — passed

The production cutover workflow remains inert until an operator supplies the exact action confirmation.
