### PR TITLE
fix(maintenance): fail over independently at the edge

### DIFF
--- a/.github/workflows/cutover-prod-us-east-2.yml
+++ b/.github/workflows/cutover-prod-us-east-2.yml
@@ -8,10 +8,13 @@ on:
         required: true
         type: choice
         options:
+          - maintenance-on
           - dns-target
           - backend-target
           - backend-source
           - dns-source
+          - maintenance-off-target
+          - maintenance-off-source
       confirm:
         description: Enter "<action>:prod-us-east-2".
         required: true
@@ -32,6 +35,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
       CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+      MAINTENANCE_TOKEN: ${{ secrets.PROD_MAINTENANCE_TOKEN }}
       ACTION: ${{ inputs.action }}
       CONFIRM: ${{ inputs.confirm }}
     steps:
@@ -126,25 +130,39 @@ jobs:
           echo "supa.kortix.com now points to $destination."
 
       - name: Install Node.js
-        if: inputs.action == 'backend-target' || inputs.action == 'backend-source'
+        if: inputs.action == 'maintenance-on' || inputs.action == 'backend-target' || inputs.action == 'backend-source' || inputs.action == 'maintenance-off-target' || inputs.action == 'maintenance-off-source'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
       - name: Switch API and gateway backends
-        if: inputs.action == 'backend-target' || inputs.action == 'backend-source'
+        if: inputs.action == 'maintenance-on' || inputs.action == 'backend-target' || inputs.action == 'backend-source' || inputs.action == 'maintenance-off-target' || inputs.action == 'maintenance-off-source'
         working-directory: infra/cloudflare/workers/api-router
         run: |
           set -euo pipefail
           case "$ACTION" in
+            maintenance-on)
+              backend="ecs-fargate"
+              maintenance="blocking"
+              ;;
             backend-target)
               backend="us-east-2"
+              maintenance="blocking"
               ;;
             backend-source)
               backend="ecs-fargate"
+              maintenance="blocking"
+              ;;
+            maintenance-off-target)
+              backend="us-east-2"
+              maintenance="none"
+              ;;
+            maintenance-off-source)
+              backend="ecs-fargate"
+              maintenance="none"
               ;;
             *)
-              echo "::error::Unsupported backend action: $ACTION"
+              echo "::error::Unsupported Worker action: $ACTION"
               exit 64
               ;;
           esac
@@ -152,7 +170,8 @@ jobs:
           npx --yes wrangler@4.34.0 deploy \
             --env prod \
             --var "ACTIVE_BACKEND:${backend}" \
-            --var "GATEWAY_ACTIVE_BACKEND:${backend}"
+            --var "GATEWAY_ACTIVE_BACKEND:${backend}" \
+            --var "MAINTENANCE_LEVEL_OVERRIDE:${maintenance}"
 
           verify_backend() {
             url="$1"
@@ -177,6 +196,59 @@ jobs:
 
           verify_backend "https://api.kortix.com/v1/health"
           verify_backend "https://gateway.kortix.com/health/live"
+
+          if [ "$maintenance" = "blocking" ]; then
+            maintenance_body="$(
+              jq -nc '{
+                level: "blocking",
+                title: "Scheduled maintenance",
+                message: "Kortix is moving production services to US East 2.",
+                startTime: (now | todateiso8601),
+                endTime: null,
+                statusUrl: null,
+                affectedServices: ["app", "api", "authentication"]
+              }'
+            )"
+          else
+            maintenance_body="$(
+              jq -nc '{
+                level: "none",
+                title: "",
+                message: "",
+                startTime: null,
+                endTime: null,
+                statusUrl: null,
+                affectedServices: []
+              }'
+            )"
+          fi
+
+          maintenance_response="$(
+            curl -fsS --max-time 30 \
+              -X PUT \
+              -H "Authorization: Bearer ${MAINTENANCE_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data "$maintenance_body" \
+              https://kortix.com/api/maintenance
+          )"
+          jq -e --arg level "$maintenance" '.level == $level' <<<"$maintenance_response" >/dev/null
+
+          if [ "$maintenance" = "blocking" ]; then
+            write_status="$(
+              curl -sS --max-time 15 \
+                -o /tmp/maintenance-write-response \
+                -w '%{http_code}' \
+                -X POST \
+                -H "Content-Type: application/json" \
+                --data '{}' \
+                https://api.kortix.com/v1/projects
+            )"
+            if [ "$write_status" != "503" ]; then
+              echo "::error::The edge maintenance gate returned HTTP $write_status, expected 503."
+              cat /tmp/maintenance-write-response
+              exit 1
+            fi
+          fi
 
       - name: Summary
         run: |

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -125,6 +125,7 @@
     "@uiw/codemirror-themes": "4.23.10",
     "@uiw/react-codemirror": "^4.23.10",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/edge-config": "^1.4.0",
     "@vercel/speed-insights": "^1.2.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",

--- a/apps/web/src/app/(system)/api/maintenance/edge/route.ts
+++ b/apps/web/src/app/(system)/api/maintenance/edge/route.ts
@@ -1,0 +1,12 @@
+import { getEdgeMaintenanceConfig } from '@/lib/maintenance-store';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET() {
+  const config = await getEdgeMaintenanceConfig();
+  return NextResponse.json(config, {
+    headers: { 'Cache-Control': 'public, max-age=2, must-revalidate' },
+  });
+}

--- a/apps/web/src/app/(system)/api/maintenance/route.ts
+++ b/apps/web/src/app/(system)/api/maintenance/route.ts
@@ -1,12 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
 import {
   getMaintenanceConfig,
   setMaintenanceConfig,
   type MaintenanceConfig,
   type MaintenanceLevel,
 } from '@/lib/maintenance-store';
+import { createClient } from '@/lib/supabase/server';
 import { getUserRolesWithToken } from '@kortix/sdk';
+import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -24,7 +24,12 @@ export async function GET() {
   } catch (err) {
     console.error('[api/maintenance] GET error:', err);
     return NextResponse.json(
-      { level: 'none', title: '', message: '', updatedAt: new Date().toISOString() },
+      {
+        level: 'blocking',
+        title: 'Service maintenance',
+        message: 'Kortix is temporarily unavailable. Service will resume automatically.',
+        updatedAt: new Date().toISOString(),
+      },
       { status: 200 },
     );
   }
@@ -37,19 +42,31 @@ export async function GET() {
 const VALID_LEVELS: MaintenanceLevel[] = ['none', 'info', 'warning', 'critical', 'blocking'];
 
 export async function PUT(request: NextRequest) {
-  // Authenticate: require a valid Supabase session
-  const supabase = await createClient();
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
+  const bearerToken = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '') || null;
+  let accessToken = bearerToken;
 
-  if (authError || !user) {
+  if (!accessToken) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    accessToken = session?.access_token ?? null;
+  }
+
+  if (!accessToken) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Check admin role via the backend API
-  const isAdmin = await checkAdminRole(request);
+  const isAdmin = await checkAdminRole(accessToken);
   if (!isAdmin) {
     return NextResponse.json({ error: 'Forbidden: admin access required' }, { status: 403 });
   }
@@ -78,18 +95,13 @@ export async function PUT(request: NextRequest) {
     startTime: body.startTime !== undefined ? body.startTime : current.startTime,
     endTime: body.endTime !== undefined ? body.endTime : current.endTime,
     statusUrl: body.statusUrl !== undefined ? body.statusUrl : current.statusUrl,
-    affectedServices: body.affectedServices !== undefined ? body.affectedServices : current.affectedServices,
+    affectedServices:
+      body.affectedServices !== undefined ? body.affectedServices : current.affectedServices,
     updatedAt: new Date().toISOString(),
   };
 
-  // Forward the admin's access token — the API enforces the admin role on the write.
-  const { data: { session } } = await supabase.auth.getSession();
-  if (!session?.access_token) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
   try {
-    const saved = await setMaintenanceConfig(updated, session.access_token);
+    const saved = await setMaintenanceConfig(updated, accessToken);
     return NextResponse.json(saved);
   } catch (err) {
     console.error('[api/maintenance] PUT error:', err);
@@ -105,23 +117,13 @@ export async function PUT(request: NextRequest) {
  * Check admin role by forwarding the user's auth cookies to the backend
  * /user-roles endpoint, matching the client-side useAdminRole hook logic.
  */
-async function checkAdminRole(request: NextRequest): Promise<boolean> {
+async function checkAdminRole(accessToken: string): Promise<boolean> {
   try {
-    // Forward the authorization header from the original request if present,
-    // otherwise extract the Supabase access token from the cookie.
-    const supabase = await createClient();
-    const { data: { session } } = await supabase.auth.getSession();
-
-    if (!session?.access_token) return false;
-
-    const backendUrl =
-      process.env.BACKEND_URL ||
-      process.env.NEXT_PUBLIC_BACKEND_URL ||
-      '';
+    const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
     const data = await getUserRolesWithToken<{ isAdmin?: boolean }>({
       backendUrl,
-      accessToken: session.access_token,
+      accessToken,
     });
     return data.isAdmin === true;
   } catch {

--- a/apps/web/src/components/announcements/maintenance-banner-host.tsx
+++ b/apps/web/src/components/announcements/maintenance-banner-host.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useMaintenanceConfig } from '@/hooks/edge-flags';
+import { isMaintenanceProductRoute } from '@/lib/maintenance-client';
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
 
 import { MaintenanceBanner } from './maintenance-banner';
 
@@ -15,6 +18,15 @@ import { MaintenanceBanner } from './maintenance-banner';
  */
 export function MaintenanceBannerHost() {
   const { data: config } = useMaintenanceConfig();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (config?.level !== 'blocking' || !isMaintenanceProductRoute(pathname)) return;
+
+    const from = `${window.location.pathname}${window.location.search}`;
+    window.location.assign(`/maintenance?from=${encodeURIComponent(from)}`);
+  }, [config?.level, pathname]);
+
   if (!config) return null;
   return <MaintenanceBanner config={config} />;
 }

--- a/apps/web/src/hooks/edge-flags/index.ts
+++ b/apps/web/src/hooks/edge-flags/index.ts
@@ -1,7 +1,8 @@
 'use client';
 
+import { automaticMaintenanceConfig } from '@/lib/maintenance-client';
+import type { MaintenanceConfig } from '@/lib/maintenance-store';
 import { useQuery } from '@tanstack/react-query';
-import type { MaintenanceConfig, MaintenanceLevel } from '@/lib/maintenance-store';
 
 // Re-export types for consumers
 export type { MaintenanceConfig, MaintenanceLevel } from '@/lib/maintenance-store';
@@ -36,12 +37,12 @@ async function fetchMaintenanceConfig(): Promise<MaintenanceConfig> {
     const response = await fetch('/api/maintenance');
     if (!response.ok) {
       console.warn('Failed to fetch maintenance config:', response.status);
-      return { level: 'none', title: '', message: '', updatedAt: new Date().toISOString() };
+      return automaticMaintenanceConfig();
     }
     return await response.json();
   } catch (error) {
     console.warn('Failed to fetch maintenance config:', error);
-    return { level: 'none', title: '', message: '', updatedAt: new Date().toISOString() };
+    return automaticMaintenanceConfig();
   }
 }
 
@@ -50,7 +51,8 @@ async function fetchMaintenanceConfig(): Promise<MaintenanceConfig> {
  * so existing consumers (layout-content.tsx) continue to work during migration.
  */
 function toLegacyFormat(config: MaintenanceConfig): SystemStatusResponse {
-  const isWarningOrAbove = config.level === 'warning' || config.level === 'critical' || config.level === 'blocking';
+  const isWarningOrAbove =
+    config.level === 'warning' || config.level === 'critical' || config.level === 'blocking';
   const isActive = config.level !== 'none';
 
   return {
@@ -64,7 +66,12 @@ function toLegacyFormat(config: MaintenanceConfig): SystemStatusResponse {
       message: config.message || undefined,
       statusUrl: config.statusUrl ?? undefined,
       affectedServices: config.affectedServices,
-      severity: config.level === 'critical' ? 'outage' : config.level === 'warning' ? 'degraded' : undefined,
+      severity:
+        config.level === 'critical'
+          ? 'outage'
+          : config.level === 'warning'
+            ? 'degraded'
+            : undefined,
     },
     updatedAt: config.updatedAt,
     maintenanceConfig: config,
@@ -113,7 +120,12 @@ export const useSystemStatusQuery = (options?: { enabled?: boolean }) => {
     placeholderData: {
       maintenanceNotice: { enabled: false },
       technicalIssue: { enabled: false },
-      maintenanceConfig: { level: 'none', title: '', message: '', updatedAt: new Date().toISOString() },
+      maintenanceConfig: {
+        level: 'none',
+        title: '',
+        message: '',
+        updatedAt: new Date().toISOString(),
+      },
     },
     ...options,
   });

--- a/apps/web/src/lib/maintenance-client.test.ts
+++ b/apps/web/src/lib/maintenance-client.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { automaticMaintenanceConfig, isMaintenanceProductRoute } from './maintenance-client';
+
+describe('maintenance client fallback', () => {
+  test('activates blocking maintenance after a status request failure', () => {
+    expect(automaticMaintenanceConfig()).toMatchObject({
+      level: 'blocking',
+      title: 'Service maintenance',
+    });
+  });
+
+  test('redirects product routes but keeps public and admin routes available', () => {
+    expect(isMaintenanceProductRoute('/projects')).toBe(true);
+    expect(isMaintenanceProductRoute('/projects/project-id')).toBe(true);
+    expect(isMaintenanceProductRoute('/accounts')).toBe(true);
+    expect(isMaintenanceProductRoute('/invites/token')).toBe(true);
+    expect(isMaintenanceProductRoute('/')).toBe(false);
+    expect(isMaintenanceProductRoute('/pricing')).toBe(false);
+    expect(isMaintenanceProductRoute('/admin/utils')).toBe(false);
+    expect(isMaintenanceProductRoute('/maintenance')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/maintenance-client.ts
+++ b/apps/web/src/lib/maintenance-client.ts
@@ -1,0 +1,16 @@
+import type { MaintenanceConfig } from './maintenance-store';
+
+export function automaticMaintenanceConfig(): MaintenanceConfig {
+  return {
+    level: 'blocking',
+    title: 'Service maintenance',
+    message: 'Kortix is temporarily unavailable. Service will resume automatically.',
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function isMaintenanceProductRoute(pathname: string): boolean {
+  return ['/projects', '/accounts', '/invites'].some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}

--- a/apps/web/src/lib/maintenance-store.test.ts
+++ b/apps/web/src/lib/maintenance-store.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type Config = {
+  level: 'none' | 'blocking';
+  title: string;
+  message: string;
+  updatedAt: string;
+};
+
+let databaseConfig: Config;
+let edgeConfig: Config | null;
+let databaseReadFails = false;
+let events: string[] = [];
+
+mock.module('@kortix/sdk', () => ({
+  getMaintenanceConfig: async () => {
+    events.push('database-read');
+    if (databaseReadFails) throw new Error('API unavailable');
+    return databaseConfig;
+  },
+  setMaintenanceConfig: async (config: Config) => {
+    events.push('database-write');
+    databaseConfig = { ...config, updatedAt: 'database-saved' };
+    return databaseConfig;
+  },
+}));
+
+mock.module('@vercel/edge-config', () => ({
+  createClient: () => ({
+    get: async (_key: string, options?: { consistentRead?: boolean }) => {
+      events.push(options?.consistentRead ? 'edge-read-consistent' : 'edge-read');
+      return edgeConfig;
+    },
+  }),
+}));
+
+const originalFetch = globalThis.fetch;
+process.env.EDGE_CONFIG = 'https://edge-config.example.test?token=redacted';
+process.env.EDGE_CONFIG_ID = 'ecfg_test';
+process.env.VERCEL_API_TOKEN = 'vercel-test-token';
+
+const { getMaintenanceConfig, setMaintenanceConfig } = await import('./maintenance-store');
+
+beforeEach(() => {
+  databaseConfig = {
+    level: 'none',
+    title: '',
+    message: '',
+    updatedAt: 'database-current',
+  };
+  edgeConfig = {
+    level: 'blocking',
+    title: 'Old state',
+    message: 'Old state',
+    updatedAt: 'edge-old',
+  };
+  databaseReadFails = false;
+  events = [];
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    events.push('edge-write');
+    const body = JSON.parse(String(init?.body));
+    edgeConfig = body.items[0].value;
+    return Response.json({ status: 'ok' });
+  }) as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.EDGE_CONFIG;
+  delete process.env.EDGE_CONFIG_ID;
+  delete process.env.VERCEL_API_TOKEN;
+});
+
+describe('maintenance store', () => {
+  test('uses the database and reconciles Edge Config', async () => {
+    const config = await getMaintenanceConfig();
+
+    expect(config).toEqual(databaseConfig);
+    expect(edgeConfig).toEqual(databaseConfig);
+    expect(events).toEqual(['database-read', 'edge-read', 'edge-write', 'edge-read-consistent']);
+  });
+
+  test('uses blocking Edge Config when the API is unavailable', async () => {
+    databaseReadFails = true;
+
+    const config = await getMaintenanceConfig();
+
+    expect(config).toEqual(edgeConfig);
+    expect(events).toEqual(['database-read', 'edge-read']);
+  });
+
+  test('activates automatic blocking when the API is unavailable and Edge Config is none', async () => {
+    databaseReadFails = true;
+    edgeConfig = {
+      level: 'none',
+      title: '',
+      message: '',
+      updatedAt: 'edge-none',
+    };
+
+    const config = await getMaintenanceConfig();
+
+    expect(config.level).toBe('blocking');
+    expect(config.title).toBe('Service maintenance');
+  });
+
+  test('writes the database before Edge Config', async () => {
+    const saved = await setMaintenanceConfig(
+      {
+        level: 'blocking',
+        title: 'Database cutover',
+        message: 'Writes are paused.',
+        updatedAt: 'request-time',
+      },
+      'admin-token',
+    );
+
+    expect(saved.updatedAt).toBe('database-saved');
+    expect(edgeConfig).toEqual(saved);
+    expect(events).toEqual(['database-write', 'edge-write', 'edge-read-consistent']);
+  });
+});

--- a/apps/web/src/lib/maintenance-store.ts
+++ b/apps/web/src/lib/maintenance-store.ts
@@ -1,16 +1,16 @@
 /**
  * Maintenance configuration store.
  *
- * Backed by the Kortix API + database (kortix.platform_settings), NOT Vercel
- * Edge Config. Reads hit the public `GET /v1/system/maintenance`; writes hit the
- * admin-only `PUT /v1/system/maintenance` (the API enforces the admin role).
- * Set it from the admin panel at /admin/utils.
+ * Production reads and writes use Vercel Edge Config. This keeps maintenance
+ * control available when the Kortix API or production database is unavailable.
+ * Local development uses an in-memory store.
  */
 
 import {
   getMaintenanceConfig as sdkGetMaintenanceConfig,
   setMaintenanceConfig as sdkSetMaintenanceConfig,
 } from '@kortix/sdk';
+import { createClient, type EdgeConfigClient } from '@vercel/edge-config';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -44,6 +44,26 @@ const DEFAULT_CONFIG: MaintenanceConfig = {
   updatedAt: new Date(0).toISOString(),
 };
 
+const AUTOMATIC_MAINTENANCE: MaintenanceConfig = {
+  ...DEFAULT_CONFIG,
+  level: 'blocking',
+  title: 'Service maintenance',
+  message: 'Kortix is temporarily unavailable. Service will resume automatically.',
+};
+
+const EDGE_CONFIG_KEY = 'maintenance_config';
+
+let edgeClient: EdgeConfigClient | null = null;
+let memoryStore: MaintenanceConfig = { ...DEFAULT_CONFIG };
+
+function getEdgeClient(): EdgeConfigClient | null {
+  if (edgeClient) return edgeClient;
+  const connectionString = process.env.EDGE_CONFIG;
+  if (!connectionString) return null;
+  edgeClient = createClient(connectionString);
+  return edgeClient;
+}
+
 function backendUrl(): string {
   return (
     process.env.BACKEND_URL ||
@@ -52,34 +72,121 @@ function backendUrl(): string {
   ).replace(/\/$/, '');
 }
 
+async function readEdgeConfig(): Promise<MaintenanceConfig | null> {
+  const client = getEdgeClient();
+  if (!client) return null;
+  return (await client.get<MaintenanceConfig>(EDGE_CONFIG_KEY)) ?? null;
+}
+
+async function writeEdgeConfig(config: MaintenanceConfig): Promise<MaintenanceConfig> {
+  const edgeConfigId = process.env.EDGE_CONFIG_ID;
+  const vercelToken = process.env.VERCEL_API_TOKEN;
+  if (!edgeConfigId || !vercelToken) {
+    throw new Error('Edge Config writes require EDGE_CONFIG_ID and VERCEL_API_TOKEN');
+  }
+
+  const response = await fetch(`https://api.vercel.com/v1/edge-config/${edgeConfigId}/items`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${vercelToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      items: [
+        {
+          operation: 'upsert',
+          key: EDGE_CONFIG_KEY,
+          value: config,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Edge Config write failed (${response.status}): ${body}`);
+  }
+
+  const persisted = await getEdgeClient()?.get<MaintenanceConfig>(EDGE_CONFIG_KEY, {
+    consistentRead: true,
+  });
+  if (!persisted || persisted.updatedAt !== config.updatedAt) {
+    throw new Error('Edge Config write verification failed');
+  }
+
+  return persisted;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Read the current maintenance configuration (public). */
+/**
+ * Read the database first. Reconcile Edge Config after every successful
+ * database read. Use blocking Edge Config only when the API is unavailable.
+ */
 export async function getMaintenanceConfig(): Promise<MaintenanceConfig> {
+  if (!process.env.EDGE_CONFIG) return { ...memoryStore };
+
   try {
-    const config = await sdkGetMaintenanceConfig<MaintenanceConfig | null>({
+    const databaseConfig = await sdkGetMaintenanceConfig<MaintenanceConfig>({
       backendUrl: backendUrl(),
       cache: 'no-store',
+      signal: AbortSignal.timeout(2_000),
     });
-    return config ?? { ...DEFAULT_CONFIG };
-  } catch (err) {
-    console.warn('[maintenance-store] read failed, using defaults:', err);
-    return { ...DEFAULT_CONFIG };
+    const edgeConfig = await readEdgeConfig().catch(() => null);
+    if (JSON.stringify(edgeConfig) !== JSON.stringify(databaseConfig)) {
+      await writeEdgeConfig(databaseConfig).catch((error) => {
+        console.error('[maintenance-store] Edge Config reconciliation failed:', error);
+      });
+    }
+    return databaseConfig;
+  } catch (databaseError) {
+    console.warn('[maintenance-store] database read failed:', databaseError);
+    const edgeConfig = await readEdgeConfig().catch((edgeError) => {
+      console.error('[maintenance-store] Edge Config fallback failed:', edgeError);
+      return null;
+    });
+    if (edgeConfig?.level === 'blocking') return edgeConfig;
+    return { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() };
   }
 }
 
 /**
- * Write maintenance configuration. Requires the caller's Supabase access token —
- * the API enforces the admin role on `PUT /v1/system/maintenance`.
+ * Return only the independent Edge Config state for the Cloudflare write gate.
+ */
+export async function getEdgeMaintenanceConfig(): Promise<MaintenanceConfig> {
+  if (!process.env.EDGE_CONFIG) return { ...memoryStore };
+
+  try {
+    return (
+      (await readEdgeConfig()) ?? {
+        ...AUTOMATIC_MAINTENANCE,
+        updatedAt: new Date().toISOString(),
+      }
+    );
+  } catch (error) {
+    console.error('[maintenance-store] independent Edge Config read failed:', error);
+    return { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() };
+  }
+}
+
+/**
+ * Write the database first. Then write the exact saved value to Edge Config.
  */
 export async function setMaintenanceConfig(
   config: MaintenanceConfig,
   accessToken: string,
 ): Promise<MaintenanceConfig> {
-  return sdkSetMaintenanceConfig(config, {
+  if (!process.env.EDGE_CONFIG) {
+    memoryStore = { ...config };
+    return { ...memoryStore };
+  }
+
+  const saved = await sdkSetMaintenanceConfig<MaintenanceConfig>(config, {
     backendUrl: backendUrl(),
     accessToken,
   });
+  await writeEdgeConfig(saved);
+  return saved;
 }

--- a/infra/cloudflare/workers/api-router/README.md
+++ b/infra/cloudflare/workers/api-router/README.md
@@ -3,11 +3,11 @@
 Cloudflare Worker that fronts the public API hostnames and forwards to whichever
 backend `ACTIVE_BACKEND` names. One source (`worker.mjs`), three envs (`wrangler.toml`):
 
-| Env    | Custom domain        | Worker script           | `eks` backend          | `ecs-fargate` backend          | `us-east-2` backend |
-| ------ | -------------------- | ----------------------- | ---------------------- | ------------------------------ | ------------------- |
-| `prod` | `api.kortix.com`     | `api-kortix-router`     | `api-eks.kortix.com`     | `api-ecs-fargate.kortix.com`     | `api-use2-shadow.kortix.com` |
-| `staging` | `staging-api.kortix.com` | `staging-api-kortix-router` | `staging-api-eks.kortix.com` | `staging-api-ecs-fargate.kortix.com` | — |
-| `dev`  | `dev-api.kortix.com` | `dev-api-kortix-router` | `dev-api-eks.kortix.com` | `dev-api-ecs-fargate.kortix.com` | — |
+| Env       | Custom domain            | Worker script               | `eks` backend                | `ecs-fargate` backend                | `us-east-2` backend          |
+| --------- | ------------------------ | --------------------------- | ---------------------------- | ------------------------------------ | ---------------------------- |
+| `prod`    | `api.kortix.com`         | `api-kortix-router`         | `api-eks.kortix.com`         | `api-ecs-fargate.kortix.com`         | `api-use2-shadow.kortix.com` |
+| `staging` | `staging-api.kortix.com` | `staging-api-kortix-router` | `staging-api-eks.kortix.com` | `staging-api-ecs-fargate.kortix.com` | —                            |
+| `dev`     | `dev-api.kortix.com`     | `dev-api-kortix-router`     | `dev-api-eks.kortix.com`     | `dev-api-ecs-fargate.kortix.com`     | —                            |
 
 **ECS Fargate is the ACTIVE backend for prod and dev** (`ACTIVE_BACKEND` /
 `GATEWAY_ACTIVE_BACKEND` = `ecs-fargate` since PR #4683); EKS is the warm
@@ -54,6 +54,20 @@ curl -s -D - https://api.kortix.com/v1/health -o /dev/null | grep -i x-backend
 The prepared production cutover value is `us-east-2`. Set both
 `ACTIVE_BACKEND` and `GATEWAY_ACTIVE_BACKEND` during the maintenance window.
 The checked-in values remain `ecs-fargate` until that cutover.
+
+## Independent maintenance gate
+
+Production reads `MAINTENANCE_STATE_URL` from Vercel Edge Config through
+`https://kortix.com/api/maintenance/edge`. The Worker caches this state for two
+seconds.
+
+When the level is `blocking`, the Worker returns `503 MAINTENANCE_MODE` for
+mutating API and gateway requests. `GET`, `HEAD`, and `OPTIONS` remain
+available. The API origin and production database do not serve this state.
+
+`GET /v1/system/maintenance` returns the same independent state directly from
+the Worker. The Worker activates automatic blocking maintenance if the state
+endpoint or active origin is unavailable.
 
 ## Backend hostnames (proxied CNAMEs → ALBs, Full-strict TLS)
 

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -13,6 +13,30 @@
 // single global DB lease — see apps/api/src/shared/leader-election.ts — so only
 // one side ever runs cron). Flipping is instant and instantly reversible.
 const STRICT_TRANSPORT_SECURITY = 'max-age=31536000';
+const MAINTENANCE_LEVELS = new Set([
+  'none',
+  'info',
+  'warning',
+  'critical',
+  'blocking',
+]);
+const DEFAULT_MAINTENANCE = {
+  level: 'none',
+  title: '',
+  message: '',
+  startTime: null,
+  endTime: null,
+  statusUrl: null,
+  affectedServices: [],
+  updatedAt: new Date(0).toISOString(),
+};
+const AUTOMATIC_MAINTENANCE = {
+  ...DEFAULT_MAINTENANCE,
+  level: 'blocking',
+  title: 'Service maintenance',
+  message:
+    'Kortix is temporarily unavailable. Service will resume automatically.',
+};
 
 function addSecurityHeaders(response) {
   response.headers.set('Strict-Transport-Security', STRICT_TRANSPORT_SECURITY);
@@ -20,12 +44,100 @@ function addSecurityHeaders(response) {
   return response;
 }
 
+function isReadOnlyRequest(request) {
+  return (
+    request.method === 'GET' ||
+    request.method === 'HEAD' ||
+    request.method === 'OPTIONS'
+  );
+}
+
+async function readMaintenanceConfig(env) {
+  if (env.MAINTENANCE_LEVEL_OVERRIDE === 'blocking') {
+    return {
+      ...DEFAULT_MAINTENANCE,
+      level: 'blocking',
+      title: env.MAINTENANCE_TITLE_OVERRIDE || 'Scheduled maintenance',
+      message:
+        env.MAINTENANCE_MESSAGE_OVERRIDE ||
+        'Kortix is temporarily unavailable for maintenance.',
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  if (!env.MAINTENANCE_STATE_URL) return null;
+
+  try {
+    const response = await fetch(env.MAINTENANCE_STATE_URL, {
+      headers: { Accept: 'application/json' },
+      cf: { cacheEverything: true, cacheTtl: 2 },
+    });
+    if (!response.ok) {
+      return { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() };
+    }
+
+    const config = await response.json();
+    if (!config || !MAINTENANCE_LEVELS.has(config.level)) {
+      return { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() };
+    }
+    return { ...DEFAULT_MAINTENANCE, ...config };
+  } catch {
+    return { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() };
+  }
+}
+
+function maintenanceResponse(config, active, isGateway, request) {
+  const origin = request.headers.get('Origin');
+  const headers = new Headers({
+    'Cache-Control': 'no-store',
+    'Content-Type': 'application/json',
+    'Retry-After': '30',
+    'X-Backend': active,
+    'X-Backend-Service': isGateway ? 'gateway' : 'api',
+    'X-Maintenance-Mode': 'blocking',
+  });
+  if (origin) {
+    headers.set('Access-Control-Allow-Credentials', 'true');
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Vary', 'Origin');
+  }
+
+  return addSecurityHeaders(
+    new Response(
+      JSON.stringify({
+        error: 'MAINTENANCE_MODE',
+        message:
+          config.message ||
+          'Kortix is temporarily unavailable for maintenance.',
+        maintenance: config,
+      }),
+      { status: 503, headers },
+    ),
+  );
+}
+
+function maintenanceConfigResponse(config, active, source) {
+  return addSecurityHeaders(
+    new Response(JSON.stringify(config), {
+      status: 200,
+      headers: {
+        'Cache-Control': 'public, max-age=2, must-revalidate',
+        'Content-Type': 'application/json',
+        'X-Backend': active,
+        'X-Backend-Service': 'router',
+        'X-Maintenance-Source': source,
+      },
+    }),
+  );
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     const isGateway = url.hostname.includes('gateway');
 
-    const active = (isGateway ? env.GATEWAY_ACTIVE_BACKEND : env.ACTIVE_BACKEND) || 'eks';
+    const active =
+      (isGateway ? env.GATEWAY_ACTIVE_BACKEND : env.ACTIVE_BACKEND) || 'eks';
     const backends = isGateway
       ? {
           eks: env.GATEWAY_BACKEND_EKS,
@@ -41,7 +153,9 @@ export default {
     const backendUrl = backends[active];
     if (!backendUrl) {
       const svc = isGateway ? 'gateway' : 'api';
-      return new Response(`Invalid ${svc} backend configuration: ${active}`, { status: 500 });
+      return new Response(`Invalid ${svc} backend configuration: ${active}`, {
+        status: 500,
+      });
     }
 
     if (url.protocol !== 'https:') {
@@ -55,6 +169,59 @@ export default {
     }
 
     const targetUrl = new URL(url.pathname + url.search, backendUrl);
+    const isMaintenanceConfigRead =
+      !isGateway &&
+      request.method === 'GET' &&
+      url.pathname === '/v1/system/maintenance';
+
+    if (isMaintenanceConfigRead) {
+      try {
+        const primaryResponse = await fetch(
+          new Request(targetUrl, {
+            method: 'GET',
+            headers: request.headers,
+            redirect: 'manual',
+            signal: AbortSignal.timeout(2_000),
+          }),
+        );
+        if (primaryResponse.ok) {
+          const primaryConfig = await primaryResponse.json();
+          if (primaryConfig && MAINTENANCE_LEVELS.has(primaryConfig.level)) {
+            return maintenanceConfigResponse(
+              { ...DEFAULT_MAINTENANCE, ...primaryConfig },
+              active,
+              'database',
+            );
+          }
+        }
+      } catch {
+        // The independent store or automatic blocking response is returned below.
+      }
+
+      const fallback = await readMaintenanceConfig(env);
+      if (fallback?.level === 'blocking') {
+        return maintenanceConfigResponse(fallback, active, 'edge-config');
+      }
+      return maintenanceConfigResponse(
+        { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() },
+        active,
+        'automatic',
+      );
+    }
+
+    const maintenance = await readMaintenanceConfig(env);
+    const isMaintenanceConfigWrite =
+      !isGateway &&
+      request.method === 'PUT' &&
+      url.pathname === '/v1/system/maintenance';
+
+    if (
+      maintenance?.level === 'blocking' &&
+      !isReadOnlyRequest(request) &&
+      !isMaintenanceConfigWrite
+    ) {
+      return maintenanceResponse(maintenance, active, isGateway, request);
+    }
 
     // `manual` so backend 3xx responses are passed straight through to the
     // browser. With `follow`, the worker would chase a browser-facing redirect
@@ -69,7 +236,29 @@ export default {
       redirect: 'manual',
     });
 
-    const response = await fetch(modifiedRequest);
+    let response;
+    try {
+      response = await fetch(modifiedRequest);
+    } catch {
+      return maintenanceResponse(
+        { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() },
+        active,
+        isGateway,
+        request,
+      );
+    }
+    if (
+      response.status === 502 ||
+      response.status === 503 ||
+      response.status === 504
+    ) {
+      return maintenanceResponse(
+        { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() },
+        active,
+        isGateway,
+        request,
+      );
+    }
     // Cloudflare attaches the accepted socket to response.webSocket. Creating
     // a new Response drops that non-standard property and breaks the upgrade.
     if (response.status === 101 || response.webSocket) {

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -17,15 +17,25 @@ const env = {
 
 const originalFetch = globalThis.fetch;
 
+function fetchUrl(input) {
+  return typeof input === 'string' ? input : input.url;
+}
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
 describe('api-router worker', () => {
   test('keeps the staging API on EKS in config and deployment metadata', () => {
-    const wrangler = readFileSync(new URL('./wrangler.toml', import.meta.url), 'utf8');
+    const wrangler = readFileSync(
+      new URL('./wrangler.toml', import.meta.url),
+      'utf8',
+    );
     const deployWorkflow = readFileSync(
-      new URL('../../../../.github/workflows/deploy-staging.yml', import.meta.url),
+      new URL(
+        '../../../../.github/workflows/deploy-staging.yml',
+        import.meta.url,
+      ),
       'utf8',
     );
 
@@ -39,7 +49,10 @@ describe('api-router worker', () => {
   });
 
   test('keeps the prepared US East 2 origins inactive in production config', () => {
-    const wrangler = readFileSync(new URL('./wrangler.toml', import.meta.url), 'utf8');
+    const wrangler = readFileSync(
+      new URL('./wrangler.toml', import.meta.url),
+      'utf8',
+    );
     const productionVars = wrangler.match(
       /\[env\.prod\.vars\]([\s\S]*?)(?=\n\[env\.|\s*$)/,
     )?.[1];
@@ -69,7 +82,9 @@ describe('api-router worker', () => {
     );
 
     expect(response.status).toBe(308);
-    expect(response.headers.get('Location')).toBe('https://api.kortix.com/v1/health/live?x=1');
+    expect(response.headers.get('Location')).toBe(
+      'https://api.kortix.com/v1/health/live?x=1',
+    );
     expect(fetched).toBe(false);
   });
 
@@ -90,7 +105,9 @@ describe('api-router worker', () => {
 
     expect(proxiedUrl).toBe('https://api-eks.kortix.com/v1/health/live');
     expect(response.status).toBe(200);
-    expect(response.headers.get('Strict-Transport-Security')).toBe('max-age=31536000');
+    expect(response.headers.get('Strict-Transport-Security')).toBe(
+      'max-age=31536000',
+    );
     expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
     expect(response.headers.get('X-Backend')).toBe('eks');
     expect(response.headers.get('X-Backend-Service')).toBe('api');
@@ -143,6 +160,275 @@ describe('api-router worker', () => {
     expect(gatewayResponse.headers.get('X-Backend')).toBe('us-east-2');
   });
 
+  test('serves the independent maintenance state without contacting the API origin', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_STATE_URL: 'https://kortix.com/api/maintenance',
+    };
+    const fetchedUrls = [];
+    globalThis.fetch = async (request) => {
+      fetchedUrls.push(fetchUrl(request));
+      if (
+        fetchUrl(request) === 'https://api-eks.kortix.com/v1/system/maintenance'
+      ) {
+        return new Response('unavailable', { status: 503 });
+      }
+      return Response.json({
+        level: 'blocking',
+        title: 'Database maintenance',
+        message: 'Writes are paused.',
+        updatedAt: '2026-07-26T15:00:00.000Z',
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/system/maintenance'),
+      maintenanceEnv,
+    );
+
+    expect(fetchedUrls).toEqual([
+      'https://api-eks.kortix.com/v1/system/maintenance',
+      'https://kortix.com/api/maintenance',
+    ]);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Maintenance-Source')).toBe('edge-config');
+    expect(await response.json()).toMatchObject({
+      level: 'blocking',
+      message: 'Writes are paused.',
+    });
+  });
+
+  test('serves the database maintenance state before Edge Config', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_STATE_URL: 'https://kortix.com/api/maintenance/edge',
+    };
+    const fetchedUrls = [];
+    globalThis.fetch = async (request) => {
+      fetchedUrls.push(fetchUrl(request));
+      return Response.json({
+        level: 'none',
+        title: '',
+        message: '',
+        updatedAt: '2026-07-26T15:00:00.000Z',
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/system/maintenance'),
+      maintenanceEnv,
+    );
+
+    expect(fetchedUrls).toEqual([
+      'https://api-eks.kortix.com/v1/system/maintenance',
+    ]);
+    expect(response.headers.get('X-Maintenance-Source')).toBe('database');
+    expect(await response.json()).toMatchObject({ level: 'none' });
+  });
+
+  test('returns automatic maintenance when the database is unavailable and Edge Config is none', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_STATE_URL: 'https://kortix.com/api/maintenance/edge',
+    };
+    globalThis.fetch = async (request) => {
+      if (
+        fetchUrl(request) === 'https://api-eks.kortix.com/v1/system/maintenance'
+      ) {
+        return new Response('unavailable', { status: 503 });
+      }
+      return Response.json({
+        level: 'none',
+        title: '',
+        message: '',
+        updatedAt: '2026-07-26T15:00:00.000Z',
+      });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/system/maintenance'),
+      maintenanceEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Maintenance-Source')).toBe('automatic');
+    expect(await response.json()).toMatchObject({ level: 'blocking' });
+  });
+
+  test('allows the authenticated maintenance update route through the blocking gate', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_LEVEL_OVERRIDE: 'blocking',
+    };
+    const fetchedUrls = [];
+    globalThis.fetch = async (request) => {
+      fetchedUrls.push(fetchUrl(request));
+      return Response.json({ level: 'none' });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/system/maintenance', {
+        method: 'PUT',
+        body: JSON.stringify({ level: 'none' }),
+      }),
+      maintenanceEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchedUrls).toEqual([
+      'https://api-eks.kortix.com/v1/system/maintenance',
+    ]);
+  });
+
+  test('blocks API and gateway writes while blocking maintenance is active', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_STATE_URL: 'https://kortix.com/api/maintenance',
+    };
+    const fetchedUrls = [];
+    globalThis.fetch = async (request) => {
+      fetchedUrls.push(fetchUrl(request));
+      return Response.json({
+        level: 'blocking',
+        title: 'Database maintenance',
+        message: 'Writes are paused.',
+        updatedAt: '2026-07-26T15:00:00.000Z',
+      });
+    };
+
+    const apiResponse = await worker.fetch(
+      new Request('https://api.kortix.com/v1/projects', {
+        method: 'POST',
+        headers: { Origin: 'https://kortix.com' },
+      }),
+      maintenanceEnv,
+    );
+    const gatewayResponse = await worker.fetch(
+      new Request('https://gateway.kortix.com/v1/chat/completions', {
+        method: 'POST',
+      }),
+      maintenanceEnv,
+    );
+
+    expect(fetchedUrls).toEqual([
+      'https://kortix.com/api/maintenance',
+      'https://kortix.com/api/maintenance',
+    ]);
+    expect(apiResponse.status).toBe(503);
+    expect(apiResponse.headers.get('X-Maintenance-Mode')).toBe('blocking');
+    expect(apiResponse.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://kortix.com',
+    );
+    expect(gatewayResponse.status).toBe(503);
+    expect(await gatewayResponse.json()).toMatchObject({
+      error: 'MAINTENANCE_MODE',
+      message: 'Writes are paused.',
+    });
+  });
+
+  test('uses the blocking override without contacting the independent state endpoint', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_STATE_URL: 'https://kortix.com/api/maintenance',
+      MAINTENANCE_LEVEL_OVERRIDE: 'blocking',
+      MAINTENANCE_MESSAGE_OVERRIDE:
+        'Final database synchronization is running.',
+    };
+    let fetched = false;
+    globalThis.fetch = async () => {
+      fetched = true;
+      return new Response('unexpected');
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/projects', { method: 'POST' }),
+      maintenanceEnv,
+    );
+
+    expect(fetched).toBe(false);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      message: 'Final database synchronization is running.',
+      maintenance: { level: 'blocking' },
+    });
+  });
+
+  test('keeps read-only API requests available during blocking maintenance', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_STATE_URL: 'https://kortix.com/api/maintenance',
+    };
+    const fetchedUrls = [];
+    globalThis.fetch = async (request) => {
+      fetchedUrls.push(fetchUrl(request));
+      if (fetchUrl(request) === maintenanceEnv.MAINTENANCE_STATE_URL) {
+        return Response.json({
+          level: 'blocking',
+          title: 'Database maintenance',
+          message: 'Writes are paused.',
+          updatedAt: '2026-07-26T15:00:00.000Z',
+        });
+      }
+      return Response.json({ accounts: [] });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts'),
+      maintenanceEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchedUrls).toEqual([
+      'https://kortix.com/api/maintenance',
+      'https://api-eks.kortix.com/v1/accounts',
+    ]);
+  });
+
+  test('fails closed when the independent maintenance state is unavailable', async () => {
+    const maintenanceEnv = {
+      ...env,
+      MAINTENANCE_STATE_URL: 'https://kortix.com/api/maintenance',
+    };
+    const fetchedUrls = [];
+    globalThis.fetch = async (request) => {
+      fetchedUrls.push(fetchUrl(request));
+      if (fetchUrl(request) === maintenanceEnv.MAINTENANCE_STATE_URL) {
+        return new Response('unavailable', { status: 503 });
+      }
+      return Response.json({ created: true }, { status: 201 });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/projects', { method: 'POST' }),
+      maintenanceEnv,
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('X-Maintenance-Mode')).toBe('blocking');
+    expect(fetchedUrls).toEqual(['https://kortix.com/api/maintenance']);
+  });
+
+  test('converts an unavailable API origin into a maintenance response', async () => {
+    const fetchedUrls = [];
+    globalThis.fetch = async (request) => {
+      fetchedUrls.push(fetchUrl(request));
+      return new Response('Service Temporarily Unavailable', { status: 503 });
+    };
+
+    const response = await worker.fetch(
+      new Request('https://api.kortix.com/v1/accounts'),
+      env,
+    );
+
+    expect(fetchedUrls).toEqual(['https://api-eks.kortix.com/v1/accounts']);
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    expect(await response.json()).toMatchObject({
+      error: 'MAINTENANCE_MODE',
+      maintenance: { level: 'blocking' },
+    });
+  });
+
   test('gateway HTTPS redirect keeps the gateway hostname', async () => {
     let fetched = false;
     globalThis.fetch = async () => {
@@ -156,7 +442,9 @@ describe('api-router worker', () => {
     );
 
     expect(response.status).toBe(308);
-    expect(response.headers.get('Location')).toBe('https://gateway.kortix.com/v1/chat/completions');
+    expect(response.headers.get('Location')).toBe(
+      'https://gateway.kortix.com/v1/chat/completions',
+    );
     expect(fetched).toBe(false);
   });
 
@@ -176,9 +464,12 @@ describe('api-router worker', () => {
     };
 
     const response = await worker.fetch(
-      new Request('https://api.kortix.com/v1/p/sbx_123/8000/kortix/pty/kpty_123/connect', {
-        headers: { Upgrade: 'websocket' },
-      }),
+      new Request(
+        'https://api.kortix.com/v1/p/sbx_123/8000/kortix/pty/kpty_123/connect',
+        {
+          headers: { Upgrade: 'websocket' },
+        },
+      ),
       env,
     );
 

--- a/infra/cloudflare/workers/api-router/wrangler.toml
+++ b/infra/cloudflare/workers/api-router/wrangler.toml
@@ -43,6 +43,15 @@ GATEWAY_ACTIVE_BACKEND = "ecs-fargate"
 GATEWAY_BACKEND_EKS = "https://gateway-eks.kortix.com"
 GATEWAY_BACKEND_ECS_FARGATE = "https://gateway-ecs-fargate.kortix.com"
 GATEWAY_BACKEND_US_EAST_2 = "https://gateway-use2-shadow.kortix.com"
+# Vercel Edge Config is exposed through this web route. The Worker caches it
+# for two seconds and blocks mutating API/gateway requests at the edge when the
+# level is "blocking". The API origin and database are not part of this read.
+MAINTENANCE_STATE_URL = "https://kortix.com/api/maintenance/edge"
+# The cutover workflow sets this to "blocking" before the final database drain.
+# It keeps the edge write gate closed if Vercel is unavailable during cutover.
+MAINTENANCE_LEVEL_OVERRIDE = "none"
+MAINTENANCE_TITLE_OVERRIDE = "Scheduled maintenance"
+MAINTENANCE_MESSAGE_OVERRIDE = "Kortix is moving production services to US East 2."
 
 # ── STAGING: staging-api.kortix.com + gateway-staging.kortix.com ──────────────
 [env.staging]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -973,6 +973,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.6.1(next@15.5.21)(react@19.1.0)(svelte@5.56.4)(vue@3.5.39)
+      '@vercel/edge-config':
+        specifier: ^1.4.0
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@15.5.21)
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.3.1(next@15.5.21)(react@19.1.0)(svelte@5.56.4)(vue@3.5.39)
@@ -12418,6 +12421,27 @@ packages:
       react: 19.1.0
       svelte: 5.56.4
       vue: 3.5.39(typescript@5.9.3)
+    dev: false
+
+  /@vercel/edge-config-fs@0.1.0:
+    resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
+    dev: false
+
+  /@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@15.5.21):
+    resolution: {integrity: sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==}
+    engines: {node: '>=14.6'}
+    peerDependencies:
+      '@opentelemetry/api': 1.9.0
+      next: 15.5.21
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      next:
+        optional: true
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@vercel/edge-config-fs': 0.1.0
+      next: 15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.1.0)(react@19.1.0)
     dev: false
 
   /@vercel/oidc@3.2.0:

--- a/scripts/ci-maintenance-banner.sh
+++ b/scripts/ci-maintenance-banner.sh
@@ -9,8 +9,8 @@
 #                   rollout, so every user sees it for the whole window.
 #   off             clear it (level none) — only called AFTER the rollout is green.
 #
-# It writes the same maintenance config the admin console does, via
-# `PUT /v1/system/maintenance` (platform-admin bearer required).
+# It writes the same dual database + Vercel Edge Config state the admin console
+# uses, via `PUT /api/maintenance` on the web app.
 #
 # SAFETY — it never clobbers a human-set incident banner. Since the rollout banner
 # is itself `critical` now, "ours" is identified by its title, not its level:
@@ -20,16 +20,15 @@
 #           and `critical` level); if an admin changed it mid-rollout, we leave it.
 #
 # Env:
-#   MAINTENANCE_TOKEN     (required) platform-admin bearer (kortix_pat_/kortix_sa_ or JWT)
-#   MAINTENANCE_API_BASE  (optional) API base incl. /v1, default https://api.kortix.com/v1
+#   MAINTENANCE_TOKEN     (required) platform-admin bearer
+#   MAINTENANCE_URL       (optional) full endpoint, default https://kortix.com/api/maintenance
 #
 # Best-effort: the caller runs this with continue-on-error so a banner hiccup
 # never fails the release.
 
 set -euo pipefail
 
-API_BASE="${MAINTENANCE_API_BASE:-https://api.kortix.com/v1}"
-ENDPOINT="${API_BASE%/}/system/maintenance"
+ENDPOINT="${MAINTENANCE_URL:-https://kortix.com/api/maintenance}"
 ROLLOUT_TITLE="Release in progress"
 
 CMD="${1:-}"


### PR DESCRIPTION
## Change

- Use the production database as the primary maintenance source.
- Reconcile every successful database read and write into Vercel Edge Config.
- Use blocking Edge Config when the API is unavailable.
- Activate automatic blocking when the API and fallback state are unavailable.
- Add a Cloudflare edge write gate for blocking maintenance.
- Convert origin 502, 503, and 504 responses into structured maintenance responses.
- Redirect active product pages when client-side status polling detects blocking maintenance.
- Add guarded maintenance actions to the US East 2 cutover workflow.

## Verification

- `bun test infra/cloudflare/workers/api-router/worker.test.mjs` -> 17 passed, 0 failed.
- `pnpm --filter Kortix-Computer-Frontend test -- src/lib/maintenance-store.test.ts src/lib/maintenance-client.test.ts src/lib/maintenance-bypass.test.ts` -> 11 passed, 0 failed.
- Targeted ESLint -> exit 0.
- Targeted TypeScript diagnostics -> 0 matching errors.
- Initial Next.js production build reached compilation and then exceeded the default 4 GiB Node heap. A retry uses an 8 GiB heap.
