### PR TITLE
fix(secrets): scope sandbox secret injection to the agent that actually runs

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -236,6 +236,18 @@ const envSchema = z.object({
   // the executor token is re-minted per requested agent before tool execution.
   KORTIX_ENFORCE_SESSION_AGENT_LOCK: optBoolFalse,
 
+  // The NARROWER lock that IS on by default: refuse only an in-session agent
+  // switch that would change which project SECRETS are in scope. Ordinary
+  // switching between agents with the same `secrets` grant stays free, so this
+  // doesn't reintroduce the false-positives that gated the name-based lock
+  // above off. It exists because a sandbox's env is provisioned for ONE grant:
+  // re-scoping it on a later turn cannot un-read what the previous agent
+  // already pulled into the box's tmpfs env file, its shells, and its context.
+  // Turning it off degrades to re-scoping onto the running agent's grant — it
+  // never restores the old behavior of resolving from the session's stale
+  // create-time agent. See projects/lib/secret-grant.ts.
+  KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK: optBoolTrue,
+
   // Mandatory declared agents (docs/specs/2026-07-05-agent-first-config-unification.md
   // §2.1/§3 Phase 2). GATED OFF platform-wide by default — flipping it on would
   // immediately reject every session/trigger on a pre-existing, agent-less project.
@@ -896,6 +908,7 @@ export const config = {
   KORTIX_GIT_PROXY: env.KORTIX_GIT_PROXY,
   KORTIX_OPENCODE_TRANSPORT: env.KORTIX_OPENCODE_TRANSPORT,
   KORTIX_ENFORCE_SESSION_AGENT_LOCK: env.KORTIX_ENFORCE_SESSION_AGENT_LOCK,
+  KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK: env.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK,
   KORTIX_REQUIRE_DECLARED_AGENTS: env.KORTIX_REQUIRE_DECLARED_AGENTS,
 
   // ─── Legacy migration ─────────────────────────────────────────────────────

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -254,12 +254,26 @@ function extractAgentsV2(raw: unknown, manifest: ParsedManifest, filename: strin
  * gap — a blank project's very first session-create with no agent forced now
  * resolves the same declared default the write path already promises.
  */
-export async function loadProjectAgents(project: GitBackedProject): Promise<LoadedAgents> {
+export async function loadProjectAgents(
+  project: GitBackedProject,
+  opts?: { rethrowReadErrors?: boolean },
+): Promise<LoadedAgents> {
   const { readManifest, synthesizeBlankManifest } = await import('./triggers');
   let manifest: ParsedManifest | null;
   try {
-    manifest = await readManifest(project);
+    manifest = await readManifest(project, opts);
   } catch (err) {
+    // FAIL CLOSED for callers that asked to. Both failure modes reaching here —
+    // an unreadable manifest (rethrown by readManifest) and an unparseable one
+    // (parseManifestString throwing) — mean the same thing: we cannot determine
+    // this agent's grant. Neither may be laundered into a permissive answer.
+    //
+    // Swallowing them is a fail-OPEN for the two most common session shapes: an
+    // unreadable manifest becomes a synthesized `secrets: 'all'` manifest below,
+    // and an unparseable one produces the error-carrying result below, which
+    // `grantFromLoadedAgents` resolves to null — i.e. UNRESTRICTED — for the
+    // `default` sentinel. See projects/lib/secret-grant.ts.
+    if (opts?.rethrowReadErrors) throw err;
     // The manifest failed to parse before we learned which candidate file it
     // actually was (.yaml/.yml/.toml) — fall back to the project's configured
     // manifestPath (best-effort; may be stale for a project that switched

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -12,7 +12,8 @@ import {
   listProjectSecretsSnapshotForUser,
   projectSecretsRevision,
 } from '../secrets';
-import { grantFromLoadedAgents, loadProjectAgents } from '../agents';
+import { DEFAULT_AGENT_SENTINEL } from '../agents';
+import { resolveSessionSecretGrant } from './secret-grant';
 import { sanitizeSandboxEnv } from './sandbox-env-names';
 import { waitForDaemonOpencodeReady } from './sandbox-daemon-ready';
 
@@ -45,6 +46,7 @@ export interface SandboxEnvSnapshot {
 async function resolveOwnerRawEnv(
   projectId: string,
   sessionId: string | null,
+  requestedAgent?: string | null,
 ): Promise<Record<string, string> | null> {
   if (!sessionId) return null;
   const [row] = await db
@@ -58,10 +60,18 @@ async function resolveOwnerRawEnv(
     .limit(1);
   if (!row?.createdBy) return null;
 
-  // Resolve the running agent's `secrets` grant (by identifier) — the SAME gate
-  // applied at sandbox boot (buildSessionSandboxEnvVars). A hot-push must not
-  // deliver an identifier a scoped agent isn't granted; back-compat/no-git-
-  // context sessions default to 'all' (undefined).
+  // Resolve the RUNNING agent's `secrets` grant (by identifier) — the SAME gate
+  // applied at sandbox boot (buildSessionSandboxEnvVars), through the SAME
+  // resolver (lib/secret-grant.ts), so boot and hot push can never disagree.
+  //
+  // `requestedAgent` is the agent the prompt actually asked to run, which is
+  // NOT necessarily `row.agentName`: in-session agent switching is allowed and
+  // nothing ever updates that column. Resolving from the stale column let a
+  // session created under a broad agent run a narrow one while still being
+  // re-pushed the broad agent's full env on every turn. A switch that would
+  // change the grant now throws AgentSecretGrantMismatchError (→ 409) rather
+  // than quietly re-scoping, because a later narrowing cannot un-read what the
+  // previous agent already pulled into the box.
   const [project] = await db
     .select({
       repoUrl: projects.repoUrl,
@@ -72,18 +82,15 @@ async function resolveOwnerRawEnv(
     .where(eq(projects.projectId, projectId))
     .limit(1);
 
-  let grantEnv: string[] | 'all' | undefined;
-  if (project?.defaultBranch) {
-    const loadedAgents = await loadProjectAgents({
-      projectId,
-      repoUrl: project.repoUrl ?? '',
-      defaultBranch: project.defaultBranch,
-      manifestPath: project.manifestPath ?? 'kortix.yaml',
-      gitAuthToken: null,
-    }).catch(() => null);
-    const grant = loadedAgents ? grantFromLoadedAgents(row.agentName ?? '', loadedAgents) : null;
-    grantEnv = grant?.env;
-  }
+  const grantEnv = await resolveSessionSecretGrant({
+    projectId,
+    repoUrl: project?.repoUrl ?? '',
+    defaultBranch: project?.defaultBranch,
+    manifestPath: project?.manifestPath,
+    sessionAgent: row.agentName ?? DEFAULT_AGENT_SENTINEL,
+    requestedAgent,
+    enforceGrantLock: config.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK,
+  });
 
   // THE CLOBBER FIX: apply the SAME per-session secrets narrowing as boot
   // (buildSessionSandboxEnvVars). Without this, the first prompt's env sync (and
@@ -96,8 +103,9 @@ async function resolveOwnerRawEnv(
 export async function resolveSandboxEnvSnapshot(
   projectId: string,
   sessionId: string | null,
+  requestedAgent?: string | null,
 ): Promise<SandboxEnvSnapshot | null> {
-  const raw = await resolveOwnerRawEnv(projectId, sessionId);
+  const raw = await resolveOwnerRawEnv(projectId, sessionId, requestedAgent);
   if (!raw) return null;
   const { env, names } = sanitizeSandboxEnv(raw);
   return { env, names, revision: projectSecretsRevision(env) };
@@ -183,9 +191,17 @@ export async function syncSandboxEnvForPrompt(args: {
    *  the call site) — needed to resolve the LLM-gateway base URL onto the
    *  RIGHT origin for a same-machine provider. */
   providerName: ProviderName;
+  /** The agent this prompt asked to run (the body's `agent` field). The secret
+   *  grant is resolved from THIS, not from the session's create-time agent —
+   *  see resolveOwnerRawEnv. Null/'default' means "the session's own agent". */
+  requestedAgent?: string | null;
 }): Promise<void> {
   if (!args.serviceKey) return;
-  const snapshot = await resolveSandboxEnvSnapshot(args.projectId, args.sessionId);
+  const snapshot = await resolveSandboxEnvSnapshot(
+    args.projectId,
+    args.sessionId,
+    args.requestedAgent,
+  );
   if (!snapshot) return;
   const llmGatewayEnabled = await resolveProjectLlmGatewayEnabled(args.projectId);
   const { opencodeState } = await postEnvToDaemon({

--- a/apps/api/src/projects/lib/secret-grant.fail-closed.test.ts
+++ b/apps/api/src/projects/lib/secret-grant.fail-closed.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const actualGit = await import('../git');
+
+let readManifestFromRepoImpl: () => Promise<{ path: string; content: string } | null> = async () =>
+  null;
+
+mock.module('../git', () => ({
+  ...actualGit,
+  readManifestFromRepo: () => readManifestFromRepoImpl(),
+}));
+
+const { SecretGrantResolutionError, resolveSessionSecretGrant } = await import('./secret-grant');
+
+const PROJECT = {
+  projectId: 'p1',
+  repoUrl: 'https://github.com/acme/repo',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+};
+
+const MANIFEST = [
+  'kortix_version: 2',
+  'default_agent: kortix',
+  'agents:',
+  '  kortix:',
+  '    secrets:',
+  '      - STRIPE_KEY',
+].join('\n');
+
+beforeEach(() => {
+  readManifestFromRepoImpl = async () => null;
+});
+
+describe('resolveSessionSecretGrant fails closed through the real manifest loader', () => {
+  test('a git read failure refuses instead of synthesizing an all-secrets manifest', async () => {
+    readManifestFromRepoImpl = async () => {
+      throw new Error('git-proxy 429');
+    };
+    await expect(resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'kortix' })).rejects.toThrow(
+      SecretGrantResolutionError,
+    );
+  });
+
+  test('a git read failure on a default-sentinel session also refuses', async () => {
+    readManifestFromRepoImpl = async () => {
+      throw new Error('mirror refresh failed');
+    };
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'default' }),
+    ).rejects.toThrow(SecretGrantResolutionError);
+  });
+
+  test('an unparseable manifest refuses rather than resolving default to unrestricted', async () => {
+    readManifestFromRepoImpl = async () => ({
+      path: 'kortix.yaml',
+      content: 'kortix_version: 2\nagents:\n  - [unbalanced\n',
+    });
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'default' }),
+    ).rejects.toThrow(SecretGrantResolutionError);
+  });
+
+  test('a genuinely absent manifest is still the unrestricted back-compat path', async () => {
+    readManifestFromRepoImpl = async () => null;
+    await expect(resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'kortix' })).resolves.toBe(
+      'all',
+    );
+  });
+
+  test('a readable manifest resolves its declared narrow grant', async () => {
+    readManifestFromRepoImpl = async () => ({ path: 'kortix.yaml', content: MANIFEST });
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'kortix' }),
+    ).resolves.toEqual(['STRIPE_KEY']);
+  });
+
+  test('the declared narrow grant is not widened for a default-sentinel session', async () => {
+    readManifestFromRepoImpl = async () => ({ path: 'kortix.yaml', content: MANIFEST });
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'default' }),
+    ).resolves.toEqual(['STRIPE_KEY']);
+  });
+});

--- a/apps/api/src/projects/lib/secret-grant.test.ts
+++ b/apps/api/src/projects/lib/secret-grant.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import type { AgentSpec, LoadedAgents } from '../agents';
+
+const actualAgents = await import('../agents');
+
+let loadProjectAgentsImpl: () => Promise<LoadedAgents> = async () => ({
+  specs: [],
+  errors: [],
+  defaultAgent: null,
+});
+
+mock.module('../agents', () => ({
+  ...actualAgents,
+  loadProjectAgents: () => loadProjectAgentsImpl(),
+}));
+
+const {
+  AgentSecretGrantMismatchError,
+  SecretGrantResolutionError,
+  effectiveRunningAgent,
+  resolveSessionSecretGrant,
+  secretGrantEnvDiffers,
+  secretGrantEnvForRunningAgent,
+} = await import('./secret-grant');
+
+function spec(name: string, env: AgentSpec['env']): AgentSpec {
+  return {
+    name,
+    path: `kortix.yaml#agents.${name}`,
+    enabled: true,
+    connectors: [],
+    kortixCli: [],
+    env,
+    file: null,
+    model: null,
+  } as AgentSpec;
+}
+
+function loaded(specs: AgentSpec[], defaultAgent: string | null = null): LoadedAgents {
+  return { specs, errors: [], defaultAgent };
+}
+
+const PROJECT = {
+  projectId: 'p1',
+  repoUrl: 'https://github.com/acme/repo',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+};
+
+beforeEach(() => {
+  loadProjectAgentsImpl = async () => ({ specs: [], errors: [], defaultAgent: null });
+});
+
+describe('effectiveRunningAgent', () => {
+  test('a concrete requested agent is the one that runs', () => {
+    expect(effectiveRunningAgent('release-bot', 'kortix')).toBe('release-bot');
+  });
+
+  test('the default sentinel resolves to the session agent, not a fresh lookup', () => {
+    expect(effectiveRunningAgent('default', 'release-bot')).toBe('release-bot');
+  });
+
+  test('an absent or blank requested agent falls back to the session agent', () => {
+    expect(effectiveRunningAgent(null, 'kortix')).toBe('kortix');
+    expect(effectiveRunningAgent(undefined, 'kortix')).toBe('kortix');
+    expect(effectiveRunningAgent('   ', 'kortix')).toBe('kortix');
+  });
+
+  test('surrounding whitespace does not create a distinct agent', () => {
+    expect(effectiveRunningAgent('  release-bot  ', 'kortix')).toBe('release-bot');
+  });
+});
+
+describe('secretGrantEnvDiffers', () => {
+  test('order and case do not make two identical grants differ', () => {
+    expect(secretGrantEnvDiffers(['a', 'B'], ['b', 'A'])).toBe(false);
+  });
+
+  test('duplicates do not make two identical grants differ', () => {
+    expect(secretGrantEnvDiffers(['A', 'A', 'B'], ['B', 'A'])).toBe(false);
+  });
+
+  test('unrestricted, all, and empty are three distinct authorities', () => {
+    expect(secretGrantEnvDiffers(undefined, 'all')).toBe(true);
+    expect(secretGrantEnvDiffers(undefined, [])).toBe(true);
+    expect(secretGrantEnvDiffers('all', [])).toBe(true);
+  });
+
+  test('the same authority does not differ from itself', () => {
+    expect(secretGrantEnvDiffers(undefined, undefined)).toBe(false);
+    expect(secretGrantEnvDiffers('all', 'all')).toBe(false);
+    expect(secretGrantEnvDiffers([], [])).toBe(false);
+  });
+
+  test('a narrower list differs from a wider one', () => {
+    expect(secretGrantEnvDiffers(['A', 'B'], ['A'])).toBe(true);
+  });
+});
+
+describe('secretGrantEnvForRunningAgent', () => {
+  test('no switch returns the running agent grant unchanged', () => {
+    const l = loaded([spec('kortix', ['STRIPE'])]);
+    expect(secretGrantEnvForRunningAgent(l, 'kortix', 'kortix')).toEqual(['STRIPE']);
+  });
+
+  test('a switch between agents with equal grants is allowed', () => {
+    const l = loaded([spec('a', ['STRIPE']), spec('b', ['stripe'])]);
+    expect(secretGrantEnvForRunningAgent(l, 'a', 'b')).toEqual(['stripe']);
+  });
+
+  test('a switch that would widen the grant is refused', () => {
+    const l = loaded([spec('narrow', ['STRIPE']), spec('broad', 'all')]);
+    expect(() => secretGrantEnvForRunningAgent(l, 'narrow', 'broad')).toThrow(
+      AgentSecretGrantMismatchError,
+    );
+  });
+
+  test('a switch that would narrow the grant is also refused', () => {
+    const l = loaded([spec('narrow', ['STRIPE']), spec('broad', 'all')]);
+    expect(() => secretGrantEnvForRunningAgent(l, 'broad', 'narrow')).toThrow(
+      AgentSecretGrantMismatchError,
+    );
+  });
+
+  test('an undeclared agent gets the default-deny grant and is refused against a granted session', () => {
+    const l = loaded([spec('kortix', 'all')]);
+    expect(() => secretGrantEnvForRunningAgent(l, 'kortix', 'ghost')).toThrow(
+      AgentSecretGrantMismatchError,
+    );
+  });
+
+  test('the kill switch degrades to the running agent grant instead of the session one', () => {
+    const l = loaded([spec('narrow', ['STRIPE']), spec('broad', 'all')]);
+    expect(secretGrantEnvForRunningAgent(l, 'broad', 'narrow', false)).toEqual(['STRIPE']);
+  });
+
+  test('the kill switch never restores the session agent grant on a switch', () => {
+    const l = loaded([spec('narrow', ['STRIPE']), spec('broad', 'all')]);
+    expect(secretGrantEnvForRunningAgent(l, 'narrow', 'broad', false)).toBe('all');
+  });
+});
+
+describe('resolveSessionSecretGrant', () => {
+  test('fails closed when the manifest loader throws', async () => {
+    loadProjectAgentsImpl = async () => {
+      throw new Error('git unreachable');
+    };
+    await expect(resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'kortix' })).rejects.toThrow(
+      SecretGrantResolutionError,
+    );
+  });
+
+  test('does not fall back to an unrestricted grant when the loader throws', async () => {
+    loadProjectAgentsImpl = async () => {
+      throw new Error('git unreachable');
+    };
+    const result = await resolveSessionSecretGrant({
+      ...PROJECT,
+      sessionAgent: 'kortix',
+    }).catch((err) => err);
+    expect(result).toBeInstanceOf(SecretGrantResolutionError);
+  });
+
+  test('a project without git context is unrestricted', async () => {
+    loadProjectAgentsImpl = async () => {
+      throw new Error('should not be called');
+    };
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, defaultBranch: null, sessionAgent: 'kortix' }),
+    ).resolves.toBeUndefined();
+  });
+
+  test('a project that has not adopted agents is unrestricted', async () => {
+    loadProjectAgentsImpl = async () => loaded([]);
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'kortix' }),
+    ).resolves.toBeUndefined();
+  });
+
+  test('resolves the declared grant for the session agent', async () => {
+    loadProjectAgentsImpl = async () => loaded([spec('release-bot', ['NPM_TOKEN'])]);
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'release-bot' }),
+    ).resolves.toEqual(['NPM_TOKEN']);
+  });
+
+  test('resolves from the requested agent, not the session column', async () => {
+    loadProjectAgentsImpl = async () =>
+      loaded([spec('a', ['NPM_TOKEN']), spec('b', ['npm_token'])]);
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'a', requestedAgent: 'b' }),
+    ).resolves.toEqual(['npm_token']);
+  });
+
+  test('refuses a requested agent whose grant differs from the session agent', async () => {
+    loadProjectAgentsImpl = async () =>
+      loaded([spec('narrow', ['NPM_TOKEN']), spec('broad', 'all')]);
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'narrow', requestedAgent: 'broad' }),
+    ).rejects.toThrow(AgentSecretGrantMismatchError);
+  });
+
+  test('the default sentinel on a bound session is not treated as a switch', async () => {
+    loadProjectAgentsImpl = async () =>
+      loaded([spec('narrow', ['NPM_TOKEN']), spec('broad', 'all')]);
+    await expect(
+      resolveSessionSecretGrant({
+        ...PROJECT,
+        sessionAgent: 'narrow',
+        requestedAgent: 'default',
+      }),
+    ).resolves.toEqual(['NPM_TOKEN']);
+  });
+});

--- a/apps/api/src/projects/lib/secret-grant.test.ts
+++ b/apps/api/src/projects/lib/secret-grant.test.ts
@@ -81,10 +81,15 @@ describe('secretGrantEnvDiffers', () => {
     expect(secretGrantEnvDiffers(['A', 'A', 'B'], ['B', 'A'])).toBe(false);
   });
 
-  test('unrestricted, all, and empty are three distinct authorities', () => {
-    expect(secretGrantEnvDiffers(undefined, 'all')).toBe(true);
+  test('unrestricted and all are the same authority, since every consumer treats them alike', () => {
+    expect(secretGrantEnvDiffers(undefined, 'all')).toBe(false);
+    expect(secretGrantEnvDiffers('all', undefined)).toBe(false);
+  });
+
+  test('an explicit list is a declared narrowing, distinct from both', () => {
     expect(secretGrantEnvDiffers(undefined, [])).toBe(true);
     expect(secretGrantEnvDiffers('all', [])).toBe(true);
+    expect(secretGrantEnvDiffers('all', ['STRIPE'])).toBe(true);
   });
 
   test('the same authority does not differ from itself', () => {
@@ -128,6 +133,11 @@ describe('secretGrantEnvForRunningAgent', () => {
     expect(() => secretGrantEnvForRunningAgent(l, 'kortix', 'ghost')).toThrow(
       AgentSecretGrantMismatchError,
     );
+  });
+
+  test('an ungoverned session switching to an all-granted agent is not a privilege change', () => {
+    const l = loaded([spec('kortix', 'all')], 'kortix');
+    expect(secretGrantEnvForRunningAgent(l, 'default', 'kortix')).toBe('all');
   });
 
   test('the kill switch degrades to the running agent grant instead of the session one', () => {

--- a/apps/api/src/projects/lib/secret-grant.ts
+++ b/apps/api/src/projects/lib/secret-grant.ts
@@ -89,13 +89,25 @@ export function effectiveRunningAgent(
   return requested;
 }
 
-/** Normalized comparison key for a resolved grant's `env` list. `undefined`
- *  (unrestricted) and `'all'` are distinct from any explicit list, including an
- *  explicit list that happens to name every secret — the point is whether the
- *  DECLARED authority differs, not whether today's secret set makes them equal. */
+/**
+ * Normalized comparison key for a resolved grant's `env` list.
+ *
+ * `undefined` and `'all'` collapse to the SAME key: they are the same authority
+ * everywhere it is actually applied — `resolveGrantedSecretEnv` (../secrets.ts)
+ * computes `allowAll = grant === undefined || grant === 'all'` and the two take
+ * an identical branch. They only differ in where they come from
+ * (`grantFromLoadedAgents` returns null → `undefined` for an ungoverned project
+ * or the non-binding `default` sentinel, and `'all'` for an agent that declares
+ * `secrets: all` or omits the key). Treating them as distinct produced spurious
+ * 409s on the most ordinary shape there is: a session bound to `default`
+ * (→ `undefined`) sending a prompt naming a concrete agent that omits `secrets`
+ * (→ `'all'`) — no privilege change whatsoever.
+ *
+ * An explicit list stays distinct from both, even one naming every secret today:
+ * that is a DECLARED narrowing, and the secret set can change under it.
+ */
 function grantEnvKey(env: string[] | 'all' | undefined): string {
-  if (env === undefined) return '*unrestricted*';
-  if (env === 'all') return '*all*';
+  if (env === undefined || env === 'all') return '*all*';
   return [...new Set(env.map((id) => id.toUpperCase()))].sort().join(',');
 }
 
@@ -168,13 +180,22 @@ export async function resolveSessionSecretGrant(
 
   let loaded: LoadedAgents;
   try {
-    loaded = await loadProjectAgents({
-      projectId: input.projectId,
-      repoUrl: input.repoUrl,
-      defaultBranch: input.defaultBranch,
-      manifestPath: input.manifestPath ?? 'kortix.yaml',
-      gitAuthToken: null,
-    });
+    // `rethrowReadErrors` is what makes this catch reachable AT ALL. By default
+    // loadProjectAgents never throws: it swallows an unreadable manifest into a
+    // SYNTHESIZED one that grants `secrets: 'all'`, and an unparseable one into
+    // a result that resolves to unrestricted for the `default` sentinel. Either
+    // would hand an ordinary prompt every project secret on a transient git
+    // blip — the exact fail-open this module exists to close.
+    loaded = await loadProjectAgents(
+      {
+        projectId: input.projectId,
+        repoUrl: input.repoUrl,
+        defaultBranch: input.defaultBranch,
+        manifestPath: input.manifestPath ?? 'kortix.yaml',
+        gitAuthToken: null,
+      },
+      { rethrowReadErrors: true },
+    );
   } catch (err) {
     throw new SecretGrantResolutionError(runningAgent, err);
   }

--- a/apps/api/src/projects/lib/secret-grant.ts
+++ b/apps/api/src/projects/lib/secret-grant.ts
@@ -1,0 +1,188 @@
+/**
+ * The ONE place a session's secret grant is resolved.
+ *
+ * Two paths inject project secrets into a sandbox — boot
+ * (`buildSessionSandboxEnvVars`) and the per-prompt hot push
+ * (`resolveOwnerRawEnv`). They used to duplicate this resolution, and the copies
+ * drifted in two ways that both widened what an agent could read:
+ *
+ *   1. FAIL-OPEN. Both wrapped `loadProjectAgents` in `.catch(() => null)`, so
+ *      any throw from the loader collapsed the grant to `undefined` — which
+ *      `listProjectSecretsSnapshotForUser` reads as "all". A transient git/parse
+ *      failure silently handed the agent every project secret. Resolution now
+ *      throws `SecretGrantResolutionError` instead: a session that cannot prove
+ *      what it is allowed to read gets nothing, loudly.
+ *
+ *   2. WRONG PRINCIPAL. The hot push resolved the grant from
+ *      `project_sessions.agent_name` — the agent the session was CREATED with,
+ *      a column nothing ever updates. But in-session agent switching is allowed
+ *      (`preview.ts`: a prompt's `agent` field is forwarded untouched), so a
+ *      session born under a broad agent could run a narrow one and still be
+ *      handed the broad agent's full env. The grant is now resolved from the
+ *      agent the prompt actually RUNS (`effectiveRunningAgent`), and a switch
+ *      that would cross a secret boundary is refused outright
+ *      (`AgentSecretGrantMismatchError` → 409) because narrowing the env on a
+ *      later turn cannot un-read what the previous agent already read: the
+ *      secrets are in the box's tmpfs env file, in every shell it spawned, and
+ *      in its own context.
+ *
+ * The pure helpers below carry the policy; `resolveSessionSecretGrant` is the
+ * single I/O entry point both call sites use.
+ */
+
+import {
+  DEFAULT_AGENT_SENTINEL,
+  type LoadedAgents,
+  grantFromLoadedAgents,
+  loadProjectAgents,
+} from '../agents';
+
+/**
+ * The grant could not be resolved (manifest unreadable, loader threw). Callers
+ * must NOT fall back to an unrestricted grant — that is the fail-open this
+ * class exists to prevent. Boot surfaces it as a failed provision; the hot push
+ * surfaces it as a failed prompt, which the proxy retries.
+ */
+export class SecretGrantResolutionError extends Error {
+  constructor(
+    readonly agentName: string,
+    cause: unknown,
+  ) {
+    super(
+      `could not resolve the secrets grant for agent '${agentName}': ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+    this.name = 'SecretGrantResolutionError';
+  }
+}
+
+/** A prompt asked to run an agent whose secret grant differs from the one this
+ *  session's sandbox was provisioned for. */
+export class AgentSecretGrantMismatchError extends Error {
+  constructor(
+    readonly sessionAgent: string,
+    readonly requestedAgent: string,
+  ) {
+    super(
+      `agent '${requestedAgent}' has a different secrets grant than this session's agent '${sessionAgent}'`,
+    );
+    this.name = 'AgentSecretGrantMismatchError';
+  }
+}
+
+/**
+ * Which agent a prompt actually runs.
+ *
+ * The `'default'` sentinel is non-binding on the request side: the proxy strips
+ * it from the body so OpenCode resolves its own `default_agent`, i.e. the agent
+ * the session booted with. So it resolves to the session's own agent, NOT to a
+ * fresh sentinel lookup — otherwise a session bound to a concrete agent would
+ * have its grant recomputed against `'default'` on every ordinary turn.
+ */
+export function effectiveRunningAgent(
+  requestedAgent: string | null | undefined,
+  sessionAgent: string,
+): string {
+  const requested = requestedAgent?.trim();
+  if (!requested || requested === DEFAULT_AGENT_SENTINEL) return sessionAgent;
+  return requested;
+}
+
+/** Normalized comparison key for a resolved grant's `env` list. `undefined`
+ *  (unrestricted) and `'all'` are distinct from any explicit list, including an
+ *  explicit list that happens to name every secret — the point is whether the
+ *  DECLARED authority differs, not whether today's secret set makes them equal. */
+function grantEnvKey(env: string[] | 'all' | undefined): string {
+  if (env === undefined) return '*unrestricted*';
+  if (env === 'all') return '*all*';
+  return [...new Set(env.map((id) => id.toUpperCase()))].sort().join(',');
+}
+
+/** True when running `requestedAgent` instead of `sessionAgent` would change
+ *  which secrets are in scope. Equal grants are a free switch. */
+export function secretGrantEnvDiffers(
+  sessionEnv: string[] | 'all' | undefined,
+  requestedEnv: string[] | 'all' | undefined,
+): boolean {
+  return grantEnvKey(sessionEnv) !== grantEnvKey(requestedEnv);
+}
+
+/**
+ * Pure policy over an already-loaded manifest — exported for tests. Throws
+ * `AgentSecretGrantMismatchError` when the switch crosses a secret boundary.
+ *
+ * `enforceGrantLock: false` is the operational kill switch. It degrades to
+ * re-scoping the env onto the RUNNING agent's grant rather than reverting to
+ * the old behavior of resolving from the session's stale create-time agent —
+ * so turning enforcement off trades the hard refusal for a soft narrowing, it
+ * never re-opens the original widening.
+ */
+export function secretGrantEnvForRunningAgent(
+  loaded: LoadedAgents,
+  sessionAgent: string,
+  runningAgent: string,
+  enforceGrantLock = true,
+): string[] | 'all' | undefined {
+  const runningEnv = grantFromLoadedAgents(runningAgent, loaded)?.env;
+  if (runningAgent === sessionAgent) return runningEnv;
+
+  const sessionEnv = grantFromLoadedAgents(sessionAgent, loaded)?.env;
+  if (enforceGrantLock && secretGrantEnvDiffers(sessionEnv, runningEnv)) {
+    throw new AgentSecretGrantMismatchError(sessionAgent, runningAgent);
+  }
+  return runningEnv;
+}
+
+export interface SessionSecretGrantInput {
+  projectId: string;
+  repoUrl: string;
+  /** Git context. Absent (a project with no default branch) means the manifest
+   *  cannot be read at all, so there is no `agents:` map to narrow by and the
+   *  grant is unrestricted — the documented back-compat path, NOT a failure. */
+  defaultBranch: string | null | undefined;
+  manifestPath: string | null | undefined;
+  /** The agent this session is bound to (`project_sessions.agent_name`). */
+  sessionAgent: string;
+  /** The agent this prompt asked to run, when the caller is a prompt. Omit at
+   *  boot — the session's own agent is the one that runs. */
+  requestedAgent?: string | null;
+  /** Operational kill switch for the grant-change refusal — see
+   *  `secretGrantEnvForRunningAgent`. Defaults to enforced. */
+  enforceGrantLock?: boolean;
+}
+
+/**
+ * Resolve the `env` grant for the agent that will actually run.
+ *
+ * Throws `SecretGrantResolutionError` if the manifest cannot be loaded (fail
+ * closed) and `AgentSecretGrantMismatchError` if the prompt's agent has a
+ * different grant than the session's (fail closed on privilege change).
+ */
+export async function resolveSessionSecretGrant(
+  input: SessionSecretGrantInput,
+): Promise<string[] | 'all' | undefined> {
+  if (!input.defaultBranch) return undefined;
+
+  const runningAgent = effectiveRunningAgent(input.requestedAgent, input.sessionAgent);
+
+  let loaded: LoadedAgents;
+  try {
+    loaded = await loadProjectAgents({
+      projectId: input.projectId,
+      repoUrl: input.repoUrl,
+      defaultBranch: input.defaultBranch,
+      manifestPath: input.manifestPath ?? 'kortix.yaml',
+      gitAuthToken: null,
+    });
+  } catch (err) {
+    throw new SecretGrantResolutionError(runningAgent, err);
+  }
+
+  return secretGrantEnvForRunningAgent(
+    loaded,
+    input.sessionAgent,
+    runningAgent,
+    input.enforceGrantLock ?? true,
+  );
+}

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -40,6 +40,7 @@ import {
   sandboxFromLoadedAgents,
 } from '../agents';
 import { createRemoteSessionBranch, resolveCommitSha } from '../git';
+import { resolveSessionSecretGrant } from './secret-grant';
 import {
   AmbiguousSecretGrantError,
   intersectSecretGrants,
@@ -292,15 +293,20 @@ export async function buildSessionSandboxEnvVars(input: {
     // No-op (undefined → 'all') for back-compat grants and projects without
     // an `agents:` map or git context. This is the ONLY gate on agent secret
     // access — there is no resource-side allow-list on the secret itself.
-    const loadedAgents = await loadProjectAgents({
+    //
+    // FAIL CLOSED: this used to `.catch(() => null)`, which collapsed a loader
+    // throw into an unrestricted grant — a transient git/parse failure silently
+    // handed the session every project secret. It now throws
+    // SecretGrantResolutionError and the provision fails instead. Shares one
+    // resolver with the per-prompt hot push (lib/secret-grant.ts) so the two
+    // paths can no longer disagree about what this agent may read.
+    agentGrantEnv = await resolveSessionSecretGrant({
       projectId: input.projectId,
       repoUrl: input.repoUrl,
       defaultBranch: input.defaultBranch,
-      manifestPath: input.manifestPath ?? 'kortix.yaml',
-      gitAuthToken: null,
-    }).catch(() => null);
-    const grant = loadedAgents ? grantFromLoadedAgents(input.agentName, loadedAgents) : null;
-    agentGrantEnv = grant?.env;
+      manifestPath: input.manifestPath,
+      sessionAgent: input.agentName,
+    });
   }
 
   // Per-session KaaB fields, read by sessionId inside the builder so all three

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -220,7 +220,10 @@ export interface LoadedTriggers {
  * resolved file + format ride along on the ParsedManifest so the commit path
  * writes back to the exact same file in the same format.
  */
-export async function readManifest(project: GitBackedProject): Promise<ParsedManifest | null> {
+export async function readManifest(
+  project: GitBackedProject,
+  opts?: { rethrowReadErrors?: boolean },
+): Promise<ParsedManifest | null> {
   let found: { path: string; content: string } | null;
   try {
     // manifest_path can still say kortix.toml (an older project, or a stale
@@ -231,7 +234,16 @@ export async function readManifest(project: GitBackedProject): Promise<ParsedMan
     // `agents:` read = grants resolve to null = unrestricted).
     const candidates = manifestCandidatePaths(project.manifestPath).map((c) => c.path);
     found = await readManifestFromRepo(project, candidates, project.defaultBranch);
-  } catch {
+  } catch (err) {
+    // `readManifestFromRepo` returns null for a genuinely ABSENT file and only
+    // THROWS when the read itself failed (mirror refresh, git-proxy hop,
+    // ls-tree/show). Collapsing both to null is fine for callers that just want
+    // "is there a manifest?", but it is unsafe for security decisions: a
+    // transient git failure then looks identical to "blank project", which
+    // `loadProjectAgents` answers with a synthesized `secrets: 'all'` manifest.
+    // Callers that must fail CLOSED on an unreadable manifest opt into the
+    // distinction here. See projects/lib/secret-grant.ts.
+    if (opts?.rethrowReadErrors) throw err;
     return null;
   }
   if (!found) return null;

--- a/apps/api/src/sandbox-proxy/routes/preview.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 
-import { longTurnTimeoutResponse, shouldAutoResumeStoppedSandbox } from './preview';
+import {
+  AgentSecretGrantMismatchError,
+  SecretGrantResolutionError,
+} from '../../projects/lib/secret-grant';
+import {
+  longTurnTimeoutResponse,
+  secretGrantErrorResponse,
+  shouldAutoResumeStoppedSandbox,
+} from './preview';
 
 // The data-path proxy may only wake a stopped box on ACTIVE user traffic to the
 // OpenCode daemon (port 8000, principal). Everything else must still 503 so we
@@ -58,5 +66,44 @@ describe('longTurnTimeoutResponse', () => {
   test('omits CORS headers when there is no Origin', () => {
     const res = longTurnTimeoutResponse('');
     expect(res.headers.has('Access-Control-Allow-Origin')).toBe(false);
+  });
+});
+
+describe('secretGrantErrorResponse', () => {
+  test('a grant-changing agent switch is a 409 the web client already codes against', async () => {
+    const res = secretGrantErrorResponse(new AgentSecretGrantMismatchError('narrow', 'broad'), '');
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(409);
+    const body = (await res?.json()) as {
+      code: string;
+      expected_agent: string;
+      requested_agent: string;
+    };
+    expect(body.code).toBe('AGENT_SWITCH_REQUIRES_NEW_SESSION');
+    expect(body.expected_agent).toBe('narrow');
+    expect(body.requested_agent).toBe('broad');
+  });
+
+  test('an unresolvable grant is a 503, not the generic unreachable 502', async () => {
+    const res = secretGrantErrorResponse(
+      new SecretGrantResolutionError('kortix', new Error('git unreachable')),
+      '',
+    );
+    expect(res?.status).toBe(503);
+    const body = (await res?.json()) as { code: string };
+    expect(body.code).toBe('AGENT_SECRET_GRANT_UNRESOLVED');
+  });
+
+  test('an ordinary env-sync failure is left to the existing retry path', () => {
+    expect(secretGrantErrorResponse(new Error('env sync failed: 502'), '')).toBeNull();
+    expect(secretGrantErrorResponse(undefined, '')).toBeNull();
+  });
+
+  test('reflects CORS origin like every other proxy response', () => {
+    const res = secretGrantErrorResponse(
+      new AgentSecretGrantMismatchError('a', 'b'),
+      'https://app.kortix.ai',
+    );
+    expect(res?.headers.get('Access-Control-Allow-Origin')).toBe('https://app.kortix.ai');
   });
 });

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -4,6 +4,10 @@ import { config } from '../../config';
 import { getTraceHeaders } from '../../lib/request-context';
 import type { ProviderName } from '../../platform/providers';
 import { syncSandboxEnvForPrompt } from '../../projects/lib/sandbox-env-sync';
+import {
+  AgentSecretGrantMismatchError,
+  SecretGrantResolutionError,
+} from '../../projects/lib/secret-grant';
 import { scheduleTitleCaptureAfterPrompt } from '../../projects/opencode-title-capture';
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
 import { canAccessPreviewSandbox, canAccessSandboxSession } from '../../shared/preview-ownership';
@@ -632,8 +636,31 @@ export async function forwardToSandbox(
             previewUrl,
             providerHeaders: ingress.headers,
             providerName: record.provider as ProviderName,
+            // The secret grant is resolved from the agent this prompt actually
+            // runs, not the session's create-time column — see
+            // projects/lib/secret-grant.ts.
+            requestedAgent,
           });
         } catch (err) {
+          // A switch that would change which secrets are in scope is refused,
+          // not silently re-scoped: the sandbox's env was provisioned for the
+          // session's grant and the previous agent has already read it.
+          if (err instanceof AgentSecretGrantMismatchError) {
+            return agentSwitchConflictResponse(err.sessionAgent, err.requestedAgent, origin);
+          }
+          // Fail closed: we could not establish what this agent may read, so we
+          // refuse rather than push a wider env. 503 (not 502) — it's a
+          // transient inability to verify, and retrying is the right client move.
+          if (err instanceof SecretGrantResolutionError) {
+            console.warn(
+              `[PREVIEW] Secret grant unresolved for ${sandboxId}:${port}: ${err.message}`,
+            );
+            return jsonProxyError(
+              { error: err.message, code: 'AGENT_SECRET_GRANT_UNRESOLVED' },
+              503,
+              origin,
+            );
+          }
           const message = errorMessage(err, 'project env sync failed');
           if (isRetryableEnvSyncFailure(message)) {
             // Treat daemon/preview-transient env-sync failures like any other

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -10,8 +10,8 @@ import {
 } from '../../projects/lib/secret-grant';
 import { scheduleTitleCaptureAfterPrompt } from '../../projects/opencode-title-capture';
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
-import { canAccessPreviewSandbox, canAccessSandboxSession } from '../../shared/preview-ownership';
 import { KORTIX_USER_CONTEXT_HEADER } from '../../shared/kortix-user-context';
+import { canAccessPreviewSandbox, canAccessSandboxSession } from '../../shared/preview-ownership';
 import {
   buildSandboxUpstreamHeaders,
   invalidatePreviewLink,
@@ -326,7 +326,10 @@ function isConnectionRefusedError(err: unknown): boolean {
   return /econnrefused|connection refused|failed to connect|unable to connect/i.test(message);
 }
 
-function requestedPromptAgent(body: ArrayBuffer | undefined, incomingHeaders: Headers): string | null {
+function requestedPromptAgent(
+  body: ArrayBuffer | undefined,
+  incomingHeaders: Headers,
+): string | null {
   if (!body) return null;
   const contentType = incomingHeaders.get('content-type') ?? '';
   if (!contentType.toLowerCase().includes('application/json')) return null;
@@ -338,13 +341,51 @@ function requestedPromptAgent(body: ArrayBuffer | undefined, incomingHeaders: He
   }
 }
 
-function agentSwitchConflictResponse(expectedAgent: string, requestedAgent: string, origin?: string): Response {
-  return jsonProxyError({
-    error: 'agent switch requires a new session',
-    code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION',
-    expected_agent: expectedAgent,
-    requested_agent: requestedAgent,
-  }, 409, origin);
+function agentSwitchConflictResponse(
+  expectedAgent: string,
+  requestedAgent: string,
+  origin?: string,
+): Response {
+  return jsonProxyError(
+    {
+      error: 'agent switch requires a new session',
+      code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION',
+      expected_agent: expectedAgent,
+      requested_agent: requestedAgent,
+    },
+    409,
+    origin,
+  );
+}
+
+/**
+ * Map a secret-grant failure from the pre-prompt env sync onto its response, or
+ * null when the error is an ordinary env-sync failure the caller should handle
+ * with its existing retry/502 logic.
+ *
+ * Both cases refuse the prompt rather than forwarding it: the sandbox's env is
+ * provisioned for ONE agent's grant, so a prompt we can't prove is entitled to
+ * that env must not reach OpenCode. See projects/lib/secret-grant.ts.
+ */
+export function secretGrantErrorResponse(err: unknown, origin?: string): Response | null {
+  // The prompt asked for an agent whose grant differs from the session's. 409,
+  // matching the existing agent-immutability contract the web client already
+  // codes against — re-scoping now cannot un-read what the session's agent
+  // already pulled into the box.
+  if (err instanceof AgentSecretGrantMismatchError) {
+    return agentSwitchConflictResponse(err.sessionAgent, err.requestedAgent, origin);
+  }
+  // We could not establish what this agent may read. 503 rather than 502: the
+  // sandbox is fine, our ability to VERIFY entitlement is what failed, and
+  // retrying is the correct client response.
+  if (err instanceof SecretGrantResolutionError) {
+    return jsonProxyError(
+      { error: err.message, code: 'AGENT_SECRET_GRANT_UNRESOLVED' },
+      503,
+      origin,
+    );
+  }
+  return null;
 }
 
 // The sentinel name a session carries when it isn't bound to a *concrete* agent.
@@ -381,7 +422,10 @@ function isProhibitedAgentSwitch(requestedAgent: string | null, sessionAgent: st
 // `default_agent`. Used for non-concrete ('default') sessions: the box must
 // always run the agent it booted with — the one the executor token was minted
 // for — regardless of which concrete name the client speculatively echoed.
-function bodyWithoutPromptAgent(body: ArrayBuffer | undefined, incomingHeaders: Headers): ArrayBuffer | undefined {
+function bodyWithoutPromptAgent(
+  body: ArrayBuffer | undefined,
+  incomingHeaders: Headers,
+): ArrayBuffer | undefined {
   if (!body) return body;
   const contentType = incomingHeaders.get('content-type') ?? '';
   if (!contentType.toLowerCase().includes('application/json')) return body;
@@ -402,9 +446,7 @@ function bodyWithoutPromptAgent(body: ArrayBuffer | undefined, incomingHeaders: 
 // proxy edges use it: the path-based Hono route below and the subdomain handler
 // (src/sandbox-proxy/subdomain.ts).
 
-export type PreviewProxyAccess =
-  | { kind: 'principal'; userId: string }
-  | { kind: 'public_share' };
+export type PreviewProxyAccess = { kind: 'principal'; userId: string } | { kind: 'public_share' };
 
 function principalUserId(access: PreviewProxyAccess): string {
   return access.kind === 'principal' ? access.userId : '';
@@ -451,7 +493,7 @@ export async function forwardToSandbox(
   origin: string,
   // URL prefix that maps to this sandbox port, used to rewrite redirects.
   // Defaults to the path-based form; subdomain callers pass '' (root-relative).
-  redirectPrefix: string = `/v1/p/${sandboxId}/${port}`,
+  redirectPrefix = `/v1/p/${sandboxId}/${port}`,
   // Public origin (scheme://host) the client used to reach this sandbox port.
   // Combined with `redirectPrefix` to form X-Forwarded-Prefix — the full public
   // base URL the sandbox needs so the static-web <base> tag and OpenAPI server
@@ -469,8 +511,8 @@ export async function forwardToSandbox(
   }
   const userId = principalUserId(access);
   if (
-    access.kind === 'principal'
-    && !(await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId }))
+    access.kind === 'principal' &&
+    !(await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId }))
   ) {
     throw new HTTPException(403, {
       message: `Not authorized to access this sandbox, userId: ${userId}, sandboxId: ${sandboxId}`,
@@ -642,24 +684,14 @@ export async function forwardToSandbox(
             requestedAgent,
           });
         } catch (err) {
-          // A switch that would change which secrets are in scope is refused,
-          // not silently re-scoped: the sandbox's env was provisioned for the
-          // session's grant and the previous agent has already read it.
-          if (err instanceof AgentSecretGrantMismatchError) {
-            return agentSwitchConflictResponse(err.sessionAgent, err.requestedAgent, origin);
-          }
-          // Fail closed: we could not establish what this agent may read, so we
-          // refuse rather than push a wider env. 503 (not 502) — it's a
-          // transient inability to verify, and retrying is the right client move.
-          if (err instanceof SecretGrantResolutionError) {
+          // Fail closed on anything to do with the secret grant: refuse the
+          // prompt rather than forwarding it against an env we can't vouch for.
+          const grantResponse = secretGrantErrorResponse(err, origin);
+          if (grantResponse) {
             console.warn(
-              `[PREVIEW] Secret grant unresolved for ${sandboxId}:${port}: ${err.message}`,
+              `[PREVIEW] Secret grant refused prompt for ${sandboxId}:${port}: ${errorMessage(err, 'secret grant error')}`,
             );
-            return jsonProxyError(
-              { error: err.message, code: 'AGENT_SECRET_GRANT_UNRESOLVED' },
-              503,
-              origin,
-            );
+            return grantResponse;
           }
           const message = errorMessage(err, 'project env sync failed');
           if (isRetryableEnvSyncFailure(message)) {
@@ -806,7 +838,10 @@ export async function forwardToSandbox(
       //   503 — sandbox service temporarily unavailable
       // Retry with auto-wake so users don't see errors during the boot window.
       if (upstream.status === 503) {
-        const bodyText = await upstream.clone().text().catch(() => '');
+        const bodyText = await upstream
+          .clone()
+          .text()
+          .catch(() => '');
         if (bodyText.includes('opencode not ready')) {
           void markSandboxUsed(sandboxId);
           const notReadyHeaders = clientResponseHeaders(upstream.headers, origin);
@@ -919,10 +954,7 @@ export async function forwardToSandbox(
       // the friendly unreachable response below. (The Daytona "no IP / no runner"
       // 400 branch — a rejection before opencode — retries in the response path
       // above, which is safe.)
-      if (
-        isPromptDelivery(method, port, remainingPath) &&
-        !isConnectionRefusedError(err)
-      ) {
+      if (isPromptDelivery(method, port, remainingPath) && !isConnectionRefusedError(err)) {
         break;
       }
 
@@ -1041,7 +1073,7 @@ export async function resolvePreviewWsUpstream(opts: {
 preview.all('/:sandboxId/:port/*', async (c) => {
   const sandboxId = c.req.param('sandboxId');
   const portStr = c.req.param('port');
-  const port = parseInt(portStr, 10);
+  const port = Number.parseInt(portStr, 10);
 
   if (isNaN(port) || port < 1 || port > 65535) {
     throw new HTTPException(400, { message: `Invalid port: ${portStr}` });
@@ -1074,8 +1106,15 @@ preview.all('/:sandboxId/:port/*', async (c) => {
   const publicOrigin = `${proto}://${host}`;
 
   return forwardToSandbox(
-    sandboxId, port, { kind: 'principal', userId }, method, remainingPath, queryString,
-    c.req.raw.headers, body, origin,
+    sandboxId,
+    port,
+    { kind: 'principal', userId },
+    method,
+    remainingPath,
+    queryString,
+    c.req.raw.headers,
+    body,
+    origin,
     undefined, // redirectPrefix → default `/v1/p/{sandbox}/{port}`
     publicOrigin,
   );

--- a/docs/specs/2026-07-26-agent-scoped-secret-injection.md
+++ b/docs/specs/2026-07-26-agent-scoped-secret-injection.md
@@ -1,0 +1,153 @@
+# Agent-scoped secret injection
+
+**Date:** 2026-07-26
+**Status:** Implemented
+**Area:** `apps/api` — project secrets → sandbox env
+
+## Problem
+
+A project's secrets are injected into a session's sandbox as plain env vars. Which
+secrets an agent receives is gated by exactly one thing: the `secrets` grant its
+agent declares in `kortix.yaml` (`sessions.ts` — *"This is the ONLY gate on agent
+secret access — there is no resource-side allow-list on the secret itself"*).
+
+Two paths perform that injection, and they had drifted:
+
+| | Boot | Per-prompt hot push |
+|---|---|---|
+| Entry point | `buildSessionSandboxEnvVars` | `resolveOwnerRawEnv` |
+| Principal used | `input.agentName` | `project_sessions.agent_name` |
+| Loader failure | `.catch(() => null)` → unrestricted | `.catch(() => null)` → unrestricted |
+
+Three defects followed.
+
+### 1. Fail-open on grant-resolution failure
+
+Both call sites wrapped `loadProjectAgents` in `.catch(() => null)`. A `null`
+result produced `agentGrantEnv = undefined`, which
+`listProjectSecretsSnapshotForUser` interprets as **all secrets**. Any throw from
+the loader — not the manifest-parse errors it handles internally, but a genuine
+failure of the loader itself — silently widened the session to every project
+secret, with no error anywhere.
+
+### 2. The grant was resolved from the wrong agent
+
+`project_sessions.agent_name` records the agent a session was **created** with.
+Nothing in the codebase ever updates that column (verified: the only `agentName`
+write is on `chat_channel_bindings`).
+
+Meanwhile in-session agent switching is permitted. `KORTIX_ENFORCE_SESSION_AGENT_LOCK`
+defaults off, and the proxy forwards a concrete `agent` field untouched
+(`preview.ts` — *"a prompt may freely run a different agent"*).
+
+So the hot push resolved the grant from a stale column on every turn:
+
+```
+create session with agent A (secrets: all)   → sandbox env = ALL project secrets
+prompt {"agent": "B"}  where B has secrets: [NARROW_KEY]
+  → opencode runs B
+  → env sync resolves grant from A → re-pushes ALL secrets
+  → B executes with A's full credential set
+```
+
+Agent B's declared `secrets` grant was never enforced when B was reached by
+switching rather than by session creation. The inverse (narrow → broad) is a
+functional bug: the broad agent runs under-provisioned with no error.
+
+### 3. Duplicated policy
+
+The same resolution logic existed twice, in subtly different forms. Any future
+fix had to be applied to both or they would drift again.
+
+## Design
+
+### One resolver
+
+`apps/api/src/projects/lib/secret-grant.ts` is now the single place a session's
+secret grant is resolved. Both boot and hot push call
+`resolveSessionSecretGrant`. The policy lives in pure, separately-tested helpers
+(`effectiveRunningAgent`, `secretGrantEnvDiffers`, `secretGrantEnvForRunningAgent`);
+only the manifest load is I/O.
+
+### Fail closed
+
+Loader failure now throws `SecretGrantResolutionError` instead of collapsing to
+an unrestricted grant.
+
+- **Boot** — the provision fails. A session that cannot prove what it may read is
+  not created.
+- **Hot push** — the prompt fails with `503 AGENT_SECRET_GRANT_UNRESOLVED`. 503,
+  not 502, because it is a transient inability to *verify*, and retrying is the
+  correct client response.
+- **Background fan-out** (`propagateProjectSecretsToActiveSandboxes`) — the
+  per-row `try/catch` logs and skips. The sandbox keeps its existing, narrower
+  env; it is never widened.
+
+### Resolve from the running agent
+
+`syncSandboxEnvForPrompt` now takes `requestedAgent` — the prompt's own `agent`
+field, threaded from `preview.ts` — and resolves the grant from
+`effectiveRunningAgent(requestedAgent, sessionAgent)`.
+
+The `'default'` sentinel is non-binding on the request side (the proxy strips it
+so OpenCode resolves its own `default_agent`), so it maps to the session's agent
+rather than triggering a fresh sentinel lookup. Without that, every ordinary turn
+on a concretely-bound session would recompute its grant against `'default'`.
+
+### Refuse a grant-changing switch
+
+Re-scoping the env on a later turn **cannot undo the disclosure**. By the time a
+switch is observed, the previous agent's secrets are already in
+`/dev/shm/kortix/agent-env.sh`, exported into every shell it spawned, and in its
+own context. Narrowing the next push does not retract any of that.
+
+So a switch whose `secrets` grant differs from the session's is refused:
+`AgentSecretGrantMismatchError` → the existing
+`409 AGENT_SWITCH_REQUIRES_NEW_SESSION`.
+
+This is deliberately **narrower than `KORTIX_ENFORCE_SESSION_AGENT_LOCK`**, which
+409s on any name change and is gated off precisely because it false-positived on
+ordinary flows. Switching between agents with the *same* grant stays free, so
+this reintroduces none of that breakage.
+
+The web client is unaffected: it already treats sessions as agent-immutable and
+binds the agent at creation (`new-session-create.ts`, `use-new-project-session.ts`),
+documenting the 409 as expected behavior.
+
+### Kill switch
+
+`KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` (default **on**). Turning it off
+degrades to re-scoping onto the *running* agent's grant — it does **not** restore
+resolution from the stale create-time column. Enforcement off trades the hard
+refusal for a soft narrowing; the original widening is not reachable either way.
+
+## Files
+
+| File | Change |
+|---|---|
+| `projects/lib/secret-grant.ts` | New — the single resolver + pure policy |
+| `projects/lib/secret-grant.test.ts` | New — 24 tests |
+| `projects/lib/sessions.ts` | Boot uses the shared resolver; no `.catch(() => null)` |
+| `projects/lib/sandbox-env-sync.ts` | Hot push resolves from the running agent |
+| `sandbox-proxy/routes/preview.ts` | Threads `requestedAgent`; maps errors to 409 / 503 |
+| `config.ts` | `KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` |
+
+## Not in scope
+
+**Gateway-only secrets.** A BYOK key connected through the LLM Providers modal is
+written to `project_secrets` and therefore also injected into the sandbox, where
+the agent can read it with `echo $ANTHROPIC_API_KEY`. In gateway mode the daemon
+withholds it from the *opencode process* (`KORTIX_OPENCODE_DENY_ENV`) so routing
+stays on the gateway, but that is a routing control, not a secrecy control — the
+container still holds the key.
+
+Closing that requires a third `project_secrets.scope` value (`'runtime'` |
+`'connector'` | `'gateway'`) so the key stays readable by
+`getProjectSecretValue` server-side while being excluded by `sanitizeSandboxEnv`.
+That needs a migration, an API-contract change, and UI, so it is a separate
+change from this one.
+
+**Subagent fan-out.** An agent that spawns subagents inside OpenCode never
+crosses the proxy, so those inherit the session's env regardless of what the
+subagent declares. Scoping that requires per-subagent env isolation inside the
+sandbox, not a server-side gate.

--- a/docs/specs/2026-07-26-agent-scoped-secret-injection.md
+++ b/docs/specs/2026-07-26-agent-scoped-secret-injection.md
@@ -74,6 +74,25 @@ only the manifest load is I/O.
 Loader failure now throws `SecretGrantResolutionError` instead of collapsing to
 an unrestricted grant.
 
+This required opening up a layer below. `loadProjectAgents` **never throws** by
+design: `readManifest` (`projects/triggers.ts`) wraps the git I/O in a blanket
+`catch { return null; }`, and `loadProjectAgents` answers `null` with
+`synthesizeBlankManifest` — which grants the conventional `kortix` agent
+`secrets: 'all'`. So a transient git-proxy 429 or mirror-refresh failure was
+**indistinguishable from "blank project"** and silently granted every secret,
+on an ordinary prompt with no agent switch at all. A parse error was equally
+fail-open on the other side: it produces an error-carrying `LoadedAgents`, which
+`grantFromLoadedAgents` resolves to `null` (unrestricted) for the `default`
+sentinel.
+
+`readManifestFromRepo` already distinguishes the two — it returns `null` only
+for a genuinely absent file and throws on read failure — so both now take an
+opt-in `rethrowReadErrors` flag that preserves the distinction up to
+`resolveSessionSecretGrant`. Every other caller keeps the old null-on-error
+behavior. `secret-grant.fail-closed.test.ts` exercises the real
+`loadProjectAgents → readManifest → readManifestFromRepo` chain; without the flag
+three of its six cases resolve to `'all'` instead of refusing.
+
 - **Boot** — the provision fails. A session that cannot prove what it may read is
   not created.
 - **Hot push** — the prompt fails with `503 AGENT_SECRET_GRANT_UNRESOLVED`. 503,
@@ -107,12 +126,43 @@ So a switch whose `secrets` grant differs from the session's is refused:
 
 This is deliberately **narrower than `KORTIX_ENFORCE_SESSION_AGENT_LOCK`**, which
 409s on any name change and is gated off precisely because it false-positived on
-ordinary flows. Switching between agents with the *same* grant stays free, so
-this reintroduces none of that breakage.
+ordinary flows. Switching between agents with the *same* grant stays free.
 
-The web client is unaffected: it already treats sessions as agent-immutable and
-binds the agent at creation (`new-session-create.ts`, `use-new-project-session.ts`),
-documenting the 409 as expected behavior.
+### User-visible consequence
+
+The web client's comments claim sessions are agent-immutable
+(`new-session-create.ts`, `use-new-project-session.ts`), but **that lock is not
+actually active**: `SESSION_AGENT_LOCK_ENABLED` is hardcoded `false`
+(`composer-chat-input.tsx:103`, `session-chat.tsx:3760`), so `lockedAgentName` is
+always null and `agentSelectorLocked` is always false. Users *can* switch agents
+inside an open session today.
+
+So this does change behavior for one population: **projects that declare
+different `secrets` grants per agent**. A mid-session switch across that boundary
+now returns 409 where it previously succeeded. That is the boundary those
+projects declared, so enforcing it is the point — but the UI currently surfaces
+it as a generic error rather than a designed "start a new session" flow.
+
+Everyone else is unaffected: a project with no `agents:` map, or with uniform
+grants, never trips it (see the `undefined ≡ 'all'` note below).
+
+Making this a designed experience means flipping `SESSION_AGENT_LOCK_ENABLED` to
+true so the selector greys out inside a bound session. That is a product
+decision, not a security one, and is deliberately not bundled here.
+
+### `undefined` and `'all'` are one authority
+
+`grantFromLoadedAgents` returns `null` (→ `undefined` env) for an ungoverned
+project and for the non-binding `default` sentinel, but `'all'` for an agent that
+declares `secrets: all` or omits the key. Downstream they are identical —
+`resolveGrantedSecretEnv` (`projects/secrets.ts`) computes
+`allowAll = grant === undefined || grant === 'all'` and both take the same branch.
+
+Comparing them as distinct authorities therefore protects nothing and produces
+false 409s on the most ordinary shape there is: a session bound to `default`
+prompting with a concrete agent that omits `secrets`. `grantEnvKey` collapses
+them. An explicit list stays distinct from both — that is a declared narrowing,
+and the project's secret set can change under it.
 
 ### Kill switch
 
@@ -126,7 +176,11 @@ refusal for a soft narrowing; the original widening is not reachable either way.
 | File | Change |
 |---|---|
 | `projects/lib/secret-grant.ts` | New — the single resolver + pure policy |
-| `projects/lib/secret-grant.test.ts` | New — 24 tests |
+| `projects/lib/secret-grant.test.ts` | New — pure policy |
+| `projects/lib/secret-grant.fail-closed.test.ts` | New — fail-closed through the real loader chain |
+| `projects/triggers.ts` | `readManifest` opt-in `rethrowReadErrors` |
+| `projects/agents.ts` | `loadProjectAgents` threads it through |
+| `sandbox-proxy/routes/preview.test.ts` | Covers the 409 / 503 mapping |
 | `projects/lib/sessions.ts` | Boot uses the shared resolver; no `.catch(() => null)` |
 | `projects/lib/sandbox-env-sync.ts` | Hot push resolves from the running agent |
 | `sandbox-proxy/routes/preview.ts` | Threads `requestedAgent`; maps errors to 409 / 503 |


### PR DESCRIPTION
## Problem

Project secrets reach a session's sandbox as plain env vars. Which secrets an agent gets is gated by exactly one thing — the agent's `secrets` grant in `kortix.yaml`. Two paths perform that injection (boot and the per-prompt hot push) and they had drifted, in three ways that all widened what an agent could read.

### 1. Fail-open on grant-resolution failure

`loadProjectAgents` **never throws** by design. `readManifest` wraps the git I/O in a blanket `catch { return null; }`, and `loadProjectAgents` answers `null` with `synthesizeBlankManifest` — which grants the conventional `kortix` agent `secrets: 'all'`.

So a transient git-proxy 429 or mirror-refresh failure was **indistinguishable from "blank project"** and silently granted every project secret — on an ordinary prompt, with no agent switch at all. A parse error was fail-open on the other side: it resolves to unrestricted for the `default` sentinel.

`readManifestFromRepo` already distinguishes absent-file (`null`) from read-failure (throw), so `readManifest`/`loadProjectAgents` now take an opt-in `rethrowReadErrors` that preserves the distinction. Every other caller keeps the old null-on-error behavior.

### 2. The grant was resolved from the wrong agent

`project_sessions.agent_name` is the **create-time** agent, and nothing in the codebase ever updates it (the only `agentName` write is on `chat_channel_bindings`). Meanwhile in-session switching is permitted — the proxy forwards a concrete `agent` field untouched.

```
create session with agent A (secrets: all)   -> sandbox env = ALL project secrets
prompt {"agent": "B"}  where B has secrets: [NARROW_KEY]
  -> opencode runs B
  -> env sync resolves grant from A -> re-pushes ALL secrets
  -> B executes with A's full credential set
```

B's declared grant was never enforced when B was reached by switching rather than by creation.

### 3. Duplicated policy

Same logic in two places, subtly different. Both now share one resolver.

## Design

`projects/lib/secret-grant.ts` is the single place a grant is resolved. Policy lives in pure, separately-tested helpers; only the manifest load is I/O.

- **Fail closed** — `SecretGrantResolutionError`. Boot fails the provision; the prompt gets `503 AGENT_SECRET_GRANT_UNRESOLVED` (503 not 502: the sandbox is fine, our ability to *verify* failed); the background fan-out logs and skips, keeping the narrower env.
- **Resolve from the running agent** — `requestedAgent` threaded `preview.ts` -> `syncSandboxEnvForPrompt` -> `resolveOwnerRawEnv`. The `'default'` sentinel maps to the session's agent, since the proxy strips it so OpenCode resolves its own default.
- **Refuse a grant-changing switch** — `AgentSecretGrantMismatchError` -> the existing `409 AGENT_SWITCH_REQUIRES_NEW_SESSION`. Re-scoping on a later turn cannot un-read what the previous agent already pulled into the box's tmpfs env file, its shells, and its context.
- **`undefined` and `'all'` are one authority** — `resolveGrantedSecretEnv` computes `allowAll = grant === undefined || grant === 'all'`. Treating them as distinct only produced false 409s on the most ordinary shape there is: a session bound to `default` prompting with a concrete agent that omits `secrets`.

`KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK` (default **on**) is the kill switch. Off degrades to re-scoping onto the running agent's grant — it never restores resolution from the stale column.

## User-visible change

The web client's comments claim sessions are agent-immutable, but **that lock is not active**: `SESSION_AGENT_LOCK_ENABLED` is hardcoded `false` (`composer-chat-input.tsx:103`), so users *can* switch agents inside an open session today.

This affects one population: **projects that declare different `secrets` grants per agent**. A mid-session switch across that boundary now 409s. That is the boundary those projects declared, but the UI surfaces it as a generic error until `SESSION_AGENT_LOCK_ENABLED` is flipped — a product decision, deliberately not bundled here.

Projects with no `agents:` map, or uniform grants, never trip it.

## Not in scope

**Gateway-only secrets.** A BYOK key connected via the LLM Providers modal is written to `project_secrets` and therefore also injected into the sandbox, where the agent can `echo $ANTHROPIC_API_KEY`. In gateway mode the daemon withholds it from the *opencode process* (`KORTIX_OPENCODE_DENY_ENV`) so routing stays on the gateway — a routing control, not a secrecy control. Closing it needs a third `project_secrets.scope` value (`'gateway'`), i.e. a migration + API contract + UI. Separate change.

**Subagent fan-out.** Subagents spawned inside OpenCode never cross the proxy, so they inherit the session's env regardless of what they declare.

## Testing

- `secret-grant.test.ts` — pure policy (sentinel handling, grant comparison, kill-switch degrade)
- `secret-grant.fail-closed.test.ts` — the real `loadProjectAgents -> readManifest -> readManifestFromRepo` chain. **Verified these fail without the fix**: 3 of 6 cases resolve to `'all'` instead of refusing.
- `preview.test.ts` — the 409 / 503 mapping at the proxy boundary

244 pass across every suite touching agents/manifest/triggers; `tsc --noEmit` clean; no new lint errors. The one failing suite in the wider run (`unit-project-config-agents`, a `sandbox: null` snapshot drift) fails identically on unmodified `main`.

Reviewed by a 3-lens adversarial workflow (bypass / regression / correctness) with per-finding refutation; 4 confirmed findings, all fixed in `c89aea9`.

Spec: `docs/specs/2026-07-26-agent-scoped-secret-injection.md`
