### PR TITLE
fix(api): stop billing rotations on workerless pods

### DIFF
--- a/apps/api/src/__tests__/unit-leader-election.test.ts
+++ b/apps/api/src/__tests__/unit-leader-election.test.ts
@@ -41,6 +41,10 @@ describe('runsSingletonWorkers (dead-weight-leader guard)', () => {
     expect(runsSingletonWorkers({})).toBe(true);
   });
 
+  test('global worker switch off → NOT an owner', () => {
+    expect(runsSingletonWorkers({ KORTIX_WORKERS_ENABLED: 'false' })).toBe(false);
+  });
+
   test('API-only profile (ALL four worker flags "false") → NOT an owner', () => {
     // This is the helm workers.enabled=false profile. Such a pod must never join
     // the election — otherwise it can win the lease and dead-weight-starve crons.

--- a/apps/api/src/billing/index.ts
+++ b/apps/api/src/billing/index.ts
@@ -12,6 +12,7 @@ import { creditsRouter } from './routes/credits';
 import { paymentsRouter } from './routes/payments';
 import { subscriptionsRouter } from './routes/subscriptions';
 import { webhooksRouter } from './routes/webhooks';
+import { billingRotationIntervalsEnabled } from './rotation-schedule';
 
 const billingApp = makeOpenApiApp<AppEnv>();
 const accountDeletionApp = makeOpenApiApp<AppEnv>();
@@ -136,7 +137,7 @@ billingApp.openapi(
   },
 );
 
-if (config.KORTIX_BILLING_INTERNAL_ENABLED) {
+if (billingRotationIntervalsEnabled(config)) {
   const YEARLY_ROTATION_INTERVAL_MS = 60 * 60 * 1000;
   setInterval(async () => {
     try {

--- a/apps/api/src/billing/rotation-schedule.test.ts
+++ b/apps/api/src/billing/rotation-schedule.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { billingRotationIntervalsEnabled } from './rotation-schedule';
+
+describe('billingRotationIntervalsEnabled', () => {
+  test('starts rotations only on a billing-enabled worker deployment', () => {
+    expect(
+      billingRotationIntervalsEnabled({
+        KORTIX_BILLING_INTERNAL_ENABLED: true,
+        KORTIX_WORKERS_ENABLED: true,
+      }),
+    ).toBe(true);
+    expect(
+      billingRotationIntervalsEnabled({
+        KORTIX_BILLING_INTERNAL_ENABLED: true,
+        KORTIX_WORKERS_ENABLED: false,
+      }),
+    ).toBe(false);
+    expect(
+      billingRotationIntervalsEnabled({
+        KORTIX_BILLING_INTERNAL_ENABLED: false,
+        KORTIX_WORKERS_ENABLED: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/billing/rotation-schedule.ts
+++ b/apps/api/src/billing/rotation-schedule.ts
@@ -1,0 +1,8 @@
+interface BillingRotationConfig {
+  KORTIX_BILLING_INTERNAL_ENABLED: boolean;
+  KORTIX_WORKERS_ENABLED: boolean;
+}
+
+export function billingRotationIntervalsEnabled(config: BillingRotationConfig): boolean {
+  return config.KORTIX_BILLING_INTERNAL_ENABLED && config.KORTIX_WORKERS_ENABLED;
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -34,7 +34,7 @@ const optStr = z.string().optional().default('');
 const optStrDefault = (def: string) => z.string().optional().default(def);
 
 /** Optional URL string with a custom default. Not required, just validated if present. */
-const optUrl = (def: string) =>
+  const optUrl = (def: string) =>
   z
     .string()
     .optional()
@@ -126,6 +126,9 @@ const envSchema = z.object({
   // KORTIX_URL fatal-required, mounts the proxy-auth gate, hides /v1/setup.
   // Set to true on managed/cloud deployments; leave false for self-host + dev.
   KORTIX_BILLING_INTERNAL_ENABLED: optBoolFalse,
+  // Global background-worker switch. API-only and migration-shadow deployments
+  // keep request handling active while disabling every recurring write loop.
+  KORTIX_WORKERS_ENABLED: optBoolTrue,
   // EXPERIMENTAL: the "Use this template" install feature — the /v1/templates
   // routes plus the use-case-page button + install wizard. Single kill-switch;
   // off by default so it stays hidden in prod while templates are authored.
@@ -846,6 +849,7 @@ export const config = {
   INTERNAL_KORTIX_ENV: env.INTERNAL_KORTIX_ENV as InternalKortixEnv,
   // Single master switch — see schema docstring above.
   KORTIX_BILLING_INTERNAL_ENABLED: env.KORTIX_BILLING_INTERNAL_ENABLED,
+  KORTIX_WORKERS_ENABLED: env.KORTIX_WORKERS_ENABLED,
   KORTIX_TEMPLATES_ENABLED: env.KORTIX_TEMPLATES_ENABLED,
   OPENAPI_PUBLIC_DOCS: env.OPENAPI_PUBLIC_DOCS,
   ENTERPRISE_LICENSE_AVAILABLE: env.ENTERPRISE_LICENSE_AVAILABLE,

--- a/apps/api/src/shared/leader-election.ts
+++ b/apps/api/src/shared/leader-election.ts
@@ -84,6 +84,7 @@ export function shouldDemote(
  * (unset) = owner, so single-node / self-host is unaffected.
  */
 export function runsSingletonWorkers(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.KORTIX_WORKERS_ENABLED === 'false') return false;
   const on = (v: string | undefined) => v !== 'false';
   return (
     on(env.KORTIX_TRIGGER_SCHEDULER_ENABLED) ||


### PR DESCRIPTION
## Summary
- parse the existing `KORTIX_WORKERS_ENABLED` deployment switch
- prevent billing rotation intervals when workers are disabled
- prevent workerless pods from joining leader election

## Verification
- `pnpm --filter kortix-api typecheck`
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/billing/rotation-schedule.test.ts` -> 1 pass, 0 fail
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/__tests__/unit-leader-election.test.ts` -> 11 pass, 0 fail

## Runtime reason
The US East 2 shadow uses `KORTIX_WORKERS_ENABLED=false`. The existing API ignored that switch for billing intervals and created 788 shadow-only credit ledger rows. Production has `KORTIX_WORKERS_ENABLED=true`, so its behavior remains unchanged.