### PR TITLE
fix(use2): clean recovery flow state after smoke

### DIFF
--- a/scripts/prod-us-east-2/target-smoke.mjs
+++ b/scripts/prod-us-east-2/target-smoke.mjs
@@ -242,6 +242,9 @@ WHERE user_id = :'smoke_user_id'::uuid;
 DELETE FROM auth.one_time_tokens
 WHERE user_id = :'smoke_user_id'::uuid;
 
+DELETE FROM auth.flow_state
+WHERE user_id = :'smoke_user_id'::uuid;
+
 DELETE FROM auth.identities
 WHERE user_id = :'smoke_user_id'::uuid;
 
@@ -297,6 +300,8 @@ SELECT json_build_object(
   (SELECT count(*) FROM auth.mfa_factors WHERE user_id = :'smoke_user_id'::uuid),
   'auth.one_time_tokens',
   (SELECT count(*) FROM auth.one_time_tokens WHERE user_id = :'smoke_user_id'::uuid),
+  'auth.flow_state',
+  (SELECT count(*) FROM auth.flow_state WHERE user_id = :'smoke_user_id'::uuid),
   'auth.refresh_tokens',
   (SELECT count(*) FROM auth.refresh_tokens WHERE user_id = :'smoke_user_id'),
   'auth.sessions',

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -6,6 +6,10 @@ const targetSmoke = readFileSync(
   new URL("./target-smoke.sh", import.meta.url),
   "utf8",
 );
+const targetSmokeProgram = readFileSync(
+  new URL("./target-smoke.mjs", import.meta.url),
+  "utf8",
+);
 const frontendSmoke = readFileSync(
   new URL("./frontend-auth-smoke.sh", import.meta.url),
   "utf8",
@@ -32,5 +36,16 @@ test("shadow smokes can bypass the production custom domain before cutover", () 
       /TARGET_SUPABASE_URL_OVERRIDE="https:\/\/uhrwvisbqjfxhxjvoofd\.supabase\.co"/g,
     )?.length,
     2,
+  );
+});
+
+test("target smoke removes and counts recovery flow state", () => {
+  assert.match(
+    targetSmokeProgram,
+    /DELETE FROM auth\.flow_state\s+WHERE user_id = :'smoke_user_id'::uuid;/,
+  );
+  assert.match(
+    targetSmokeProgram,
+    /'auth\.flow_state',\s+\(SELECT count\(\*\) FROM auth\.flow_state WHERE user_id = :'smoke_user_id'::uuid\)/,
   );
 });


### PR DESCRIPTION
## Change

- Delete `auth.flow_state` rows owned by the target smoke user.
- Include `auth.flow_state` in the cleanup count.

## Evidence

- RED: `node --test scripts/prod-us-east-2/target-smoke.test.mjs` returned 1 pass and 1 fail before the fix.
- GREEN: the same command returned 2 pass and 0 fail after the fix.
- Live US East 2 target smoke passed password, recovery, API auth, TOTP, AAL2, Storage, Google, and GitHub checks.
- Live cleanup reported `auth.flow_state: 0` and total `cleanupRows: 0`.

Production routing and production data were not changed.