### PR TITLE
Fix US migration smoke billing cleanup

### DIFF
--- a/scripts/prod-us-east-2/frontend-auth-smoke.sh
+++ b/scripts/prod-us-east-2/frontend-auth-smoke.sh
@@ -51,6 +51,7 @@ target_service_role_key="$(
 smoke_email="use2-browser-smoke-$(date +%s)-$(openssl rand -hex 4)@invalid.kortix.test"
 smoke_password="$(openssl rand -base64 36 | tr -d '\n')aA1!"
 smoke_user_id=""
+smoke_account_ids="{}"
 original_webhook_url="$(
   psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
     -c "SELECT backend_url FROM public.webhook_config WHERE id = 1"
@@ -73,6 +74,27 @@ cleanup() {
     return
   fi
 
+  if [[ "$smoke_account_ids" == "{}" ]]; then
+    smoke_account_ids="$(
+      psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+        -v smoke_user_id="$smoke_user_id" <<'SQL'
+SELECT COALESCE(
+  array_agg(account_id ORDER BY account_id),
+  ARRAY[]::uuid[]
+)
+FROM (
+  SELECT account_id
+  FROM kortix.account_members
+  WHERE user_id = :'smoke_user_id'::uuid
+  UNION
+  SELECT account_id
+  FROM kortix.accounts
+  WHERE account_id = :'smoke_user_id'::uuid
+) AS smoke_accounts;
+SQL
+    )"
+  fi
+
   curl -sS -o /dev/null \
     -X DELETE \
     -H "Authorization: Bearer $target_service_role_key" \
@@ -81,13 +103,20 @@ cleanup() {
 
   psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
     -v smoke_user_id="$smoke_user_id" \
+    -v smoke_account_ids="$smoke_account_ids" \
     -v sequence_headroom="$TARGET_AUTH_SEQUENCE_HEADROOM" \
     >/dev/null <<'SQL' || true
 DELETE FROM kortix.audit_events
 WHERE actor_user_id = :'smoke_user_id'::uuid;
 
+DELETE FROM kortix.credit_ledger
+WHERE account_id = ANY(:'smoke_account_ids'::uuid[]);
+
+DELETE FROM kortix.credit_accounts
+WHERE account_id = ANY(:'smoke_account_ids'::uuid[]);
+
 DELETE FROM kortix.accounts
-WHERE account_id = :'smoke_user_id'::uuid;
+WHERE account_id = ANY(:'smoke_account_ids'::uuid[]);
 
 DELETE FROM auth.audit_log_entries
 WHERE payload::text LIKE '%' || :'smoke_user_id' || '%';
@@ -179,16 +208,23 @@ for attempt in 1 2 3; do
   cleanup
   cleanup_rows="$(
     psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
-      -v smoke_user_id="$smoke_user_id" <<'SQL'
+      -v smoke_user_id="$smoke_user_id" \
+      -v smoke_account_ids="$smoke_account_ids" <<'SQL'
 SELECT
   (SELECT count(*) FROM auth.audit_log_entries
     WHERE payload::text LIKE '%' || :'smoke_user_id' || '%')
   + (SELECT count(*) FROM auth.users
     WHERE id = :'smoke_user_id'::uuid)
-  + (SELECT count(*) FROM kortix.accounts
-    WHERE account_id = :'smoke_user_id'::uuid)
   + (SELECT count(*) FROM kortix.audit_events
-    WHERE actor_user_id = :'smoke_user_id'::uuid);
+    WHERE actor_user_id = :'smoke_user_id'::uuid)
+  + (SELECT count(*) FROM kortix.accounts
+    WHERE account_id = ANY(:'smoke_account_ids'::uuid[]))
+  + (SELECT count(*) FROM kortix.account_members
+    WHERE account_id = ANY(:'smoke_account_ids'::uuid[]))
+  + (SELECT count(*) FROM kortix.credit_accounts
+    WHERE account_id = ANY(:'smoke_account_ids'::uuid[]))
+  + (SELECT count(*) FROM kortix.credit_ledger
+    WHERE account_id = ANY(:'smoke_account_ids'::uuid[]));
 SQL
   )"
   if [[ "$cleanup_rows" == "0" ]]; then

--- a/scripts/prod-us-east-2/target-smoke.mjs
+++ b/scripts/prod-us-east-2/target-smoke.mjs
@@ -42,6 +42,7 @@ if (!Number.isSafeInteger(authSequenceHeadroom) || authSequenceHeadroom < 1) {
 }
 
 let smokeUserId = null;
+let smokeAccountIds = [];
 let originalWebhookUrl = null;
 let signupWebhookSuppressed = false;
 
@@ -212,6 +213,26 @@ function jwtPayload(token) {
 async function removeSmokeData() {
   if (!smokeUserId) return;
 
+  if (smokeAccountIds.length === 0) {
+    smokeAccountIds = JSON.parse(
+      sql(
+        `
+SELECT COALESCE(json_agg(account_id ORDER BY account_id), '[]'::json)::text
+FROM (
+  SELECT account_id
+  FROM kortix.account_members
+  WHERE user_id = :'smoke_user_id'::uuid
+  UNION
+  SELECT account_id
+  FROM kortix.accounts
+  WHERE account_id = :'smoke_user_id'::uuid
+) AS smoke_accounts;
+`,
+        { smoke_user_id: smokeUserId },
+      ),
+    );
+  }
+
   try {
     await request(
       `/auth/v1/admin/users/${encodeURIComponent(smokeUserId)}`,
@@ -229,6 +250,15 @@ WHERE payload::text LIKE '%' || :'smoke_user_id' || '%';
 
 DELETE FROM kortix.audit_events
 WHERE actor_user_id = :'smoke_user_id'::uuid;
+
+DELETE FROM kortix.credit_ledger
+WHERE account_id = ANY(:'smoke_account_ids'::uuid[]);
+
+DELETE FROM kortix.credit_accounts
+WHERE account_id = ANY(:'smoke_account_ids'::uuid[]);
+
+DELETE FROM kortix.accounts
+WHERE account_id = ANY(:'smoke_account_ids'::uuid[]);
 
 DELETE FROM auth.refresh_tokens
 WHERE user_id = :'smoke_user_id';
@@ -263,6 +293,7 @@ SELECT setval(
 `,
     {
       smoke_user_id: smokeUserId,
+      smoke_account_ids: `{${smokeAccountIds.join(',')}}`,
       sequence_headroom: keepAuthSequenceHeadroom ? authSequenceHeadroom : 0,
     },
   );
@@ -309,10 +340,21 @@ SELECT json_build_object(
   'auth.users',
   (SELECT count(*) FROM auth.users WHERE id = :'smoke_user_id'::uuid),
   'kortix.audit_events',
-  (SELECT count(*) FROM kortix.audit_events WHERE actor_user_id = :'smoke_user_id'::uuid)
+  (SELECT count(*) FROM kortix.audit_events WHERE actor_user_id = :'smoke_user_id'::uuid),
+  'kortix.accounts',
+  (SELECT count(*) FROM kortix.accounts WHERE account_id = ANY(:'smoke_account_ids'::uuid[])),
+  'kortix.account_members',
+  (SELECT count(*) FROM kortix.account_members WHERE account_id = ANY(:'smoke_account_ids'::uuid[])),
+  'kortix.credit_accounts',
+  (SELECT count(*) FROM kortix.credit_accounts WHERE account_id = ANY(:'smoke_account_ids'::uuid[])),
+  'kortix.credit_ledger',
+  (SELECT count(*) FROM kortix.credit_ledger WHERE account_id = ANY(:'smoke_account_ids'::uuid[]))
 )::text;
 `,
-      { smoke_user_id: smokeUserId },
+      {
+        smoke_user_id: smokeUserId,
+        smoke_account_ids: `{${smokeAccountIds.join(',')}}`,
+      },
     ),
   );
 }

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -49,3 +49,24 @@ test("target smoke removes and counts recovery flow state", () => {
     /'auth\.flow_state',\s+\(SELECT count\(\*\) FROM auth\.flow_state WHERE user_id = :'smoke_user_id'::uuid\)/,
   );
 });
+
+test("shadow smokes remove and count target-only billing state", () => {
+  for (const smokeProgram of [targetSmokeProgram, frontendSmoke]) {
+    assert.match(
+      smokeProgram,
+      /FROM kortix\.account_members[\s\S]*WHERE user_id = :'smoke_user_id'::uuid/,
+    );
+    assert.match(
+      smokeProgram,
+      /DELETE FROM kortix\.credit_ledger\s+WHERE account_id = ANY\(:'smoke_account_ids'::uuid\[\]\);/,
+    );
+    assert.match(
+      smokeProgram,
+      /DELETE FROM kortix\.credit_accounts\s+WHERE account_id = ANY\(:'smoke_account_ids'::uuid\[\]\);/,
+    );
+    assert.match(
+      smokeProgram,
+      /SELECT count\(\*\) FROM kortix\.credit_ledger\s+WHERE account_id = ANY\(:'smoke_account_ids'::uuid\[\]\)/,
+    );
+  }
+});


### PR DESCRIPTION
## Change

- Capture the smoke user account IDs before deleting the Auth user.
- Delete target-only credit ledger and credit account rows.
- Include account and billing rows in both cleanup gates.

## Verification

- `node --test scripts/prod-us-east-2/target-smoke.test.mjs scripts/prod-us-east-2/db-sync.test.mjs scripts/prod-us-east-2/auth-refresh-smoke.test.mjs` -> 11 passed.
- `bash -n scripts/prod-us-east-2/frontend-auth-smoke.sh scripts/prod-us-east-2/target-smoke.sh` -> exit 0.
- Live target smoke -> all checks true and cleanupRows 0 across Auth, account, billing, and audit tables.
- Live frontend smoke against https://us.kortix.com -> 8 passed and cleanupRows 0.
- Post-hourly comparison -> source 21024, target 21024, target-only 0, source-only 0.

Production routing and production deployment remain unchanged.