### PR TITLE
Fix frontend migration smoke Auth flow cleanup

### DIFF
--- a/scripts/prod-us-east-2/frontend-auth-smoke.sh
+++ b/scripts/prod-us-east-2/frontend-auth-smoke.sh
@@ -131,7 +131,8 @@ DELETE FROM auth.mfa_factors
 WHERE user_id = :'smoke_user_id'::uuid;
 
 DELETE FROM auth.flow_state
-WHERE referrer LIKE '%kortix_use2_oauth_smoke%'
+WHERE user_id = :'smoke_user_id'::uuid
+   OR referrer LIKE '%kortix_use2_oauth_smoke%'
    OR referrer LIKE '%kortix_use2_github_oauth_smoke%';
 
 DELETE FROM auth.identities
@@ -215,6 +216,8 @@ SELECT
     WHERE payload::text LIKE '%' || :'smoke_user_id' || '%')
   + (SELECT count(*) FROM auth.users
     WHERE id = :'smoke_user_id'::uuid)
+  + (SELECT count(*) FROM auth.flow_state
+    WHERE user_id = :'smoke_user_id'::uuid)
   + (SELECT count(*) FROM kortix.audit_events
     WHERE actor_user_id = :'smoke_user_id'::uuid)
   + (SELECT count(*) FROM kortix.accounts

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -50,6 +50,17 @@ test("target smoke removes and counts recovery flow state", () => {
   );
 });
 
+test("frontend smoke removes and counts password-recovery flow state", () => {
+  assert.match(
+    frontendSmoke,
+    /DELETE FROM auth\.flow_state\s+WHERE user_id = :'smoke_user_id'::uuid/,
+  );
+  assert.match(
+    frontendSmoke,
+    /SELECT count\(\*\) FROM auth\.flow_state\s+WHERE user_id = :'smoke_user_id'::uuid/,
+  );
+});
+
 test("shadow smokes remove and count target-only billing state", () => {
   for (const smokeProgram of [targetSmokeProgram, frontendSmoke]) {
     assert.match(


### PR DESCRIPTION
## Change

- Delete password-recovery `auth.flow_state` rows owned by the frontend smoke user.
- Include those rows in the frontend cleanup gate.

## Verification

- `node --test scripts/prod-us-east-2/target-smoke.test.mjs` -> 4 passed.
- `bash -n scripts/prod-us-east-2/frontend-auth-smoke.sh` -> exit 0.
- Live browser smoke against `https://us.kortix.com` -> 8 passed and `cleanupRows=0`.
- Auth row counts and primary-key hashes match after target-only smoke cleanup.

Production routing and deployment remain unchanged.