### PR TITLE
fix(use2): harden US shadow session readiness

### DIFF
--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -189,7 +189,7 @@ jobs:
             and .KORTIX_WORKERS_ENABLED == "false"
             and .SCHEDULER_ENABLED == "false"
             and .CHANNELS_ENABLED == "false"
-            and .KORTIX_MANAGED_PROVIDER_ENABLED == "false"
+            and .KORTIX_MANAGED_PROVIDER_ENABLED == "true"
             and .KORTIX_PRERESUME_ENABLED == "false"
             and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
             and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"

--- a/apps/api/src/iam/engine-v2.ts
+++ b/apps/api/src/iam/engine-v2.ts
@@ -32,6 +32,7 @@ import {
   type AgentGrant,
 } from '@kortix/db';
 import { db } from '../shared/db';
+import { retryTransientDatabaseRead } from '../shared/database-errors';
 import { ttlMemo } from '../shared/ttl-memo';
 import { agentMayPerform } from './agent-scope';
 import { registerPrincipalScopedMemo } from './cache-invalidation';
@@ -176,37 +177,39 @@ async function resolveActorV2Uncached(
       .select({ groupId: accountGroupMembers.groupId })
       .from(accountGroupMembers)
       .where(eq(accountGroupMembers.userId, userId)),
-    db
-      .select({
-        scopeType: iamPolicies.scopeType,
-        scopeId: iamPolicies.scopeId,
-        action: iamRoleActions.action,
-      })
-      .from(iamPolicies)
-      .innerJoin(iamRoleActions, eq(iamRoleActions.roleId, iamPolicies.roleId))
-      .where(
-        and(
-          eq(iamPolicies.accountId, accountId),
-          or(isNull(iamPolicies.expiresAt), gt(iamPolicies.expiresAt, sql`now()`)),
-          or(
-            and(eq(iamPolicies.principalType, 'member'), eq(iamPolicies.principalId, userId)),
-            and(
-              eq(iamPolicies.principalType, 'group'),
-              inArray(
-                iamPolicies.principalId,
-                db
-                  .select({ gid: accountGroupMembers.groupId })
-                  .from(accountGroupMembers)
-                  .where(eq(accountGroupMembers.userId, userId)),
+    retryTransientDatabaseRead(async () =>
+      db
+        .select({
+          scopeType: iamPolicies.scopeType,
+          scopeId: iamPolicies.scopeId,
+          action: iamRoleActions.action,
+        })
+        .from(iamPolicies)
+        .innerJoin(iamRoleActions, eq(iamRoleActions.roleId, iamPolicies.roleId))
+        .where(
+          and(
+            eq(iamPolicies.accountId, accountId),
+            or(isNull(iamPolicies.expiresAt), gt(iamPolicies.expiresAt, sql`now()`)),
+            or(
+              and(eq(iamPolicies.principalType, 'member'), eq(iamPolicies.principalId, userId)),
+              and(
+                eq(iamPolicies.principalType, 'group'),
+                inArray(
+                  iamPolicies.principalId,
+                  db
+                    .select({ gid: accountGroupMembers.groupId })
+                    .from(accountGroupMembers)
+                    .where(eq(accountGroupMembers.userId, userId)),
+                ),
               ),
+              // Service-account principal: a token policy keyed on this id. Harmless
+              // for a human request (SA ids and user ids are disjoint uuids, so this
+              // matches nothing), load-bearing for an SA request (its standing role).
+              and(eq(iamPolicies.principalType, 'token'), eq(iamPolicies.principalId, userId)),
             ),
-            // Service-account principal: a token policy keyed on this id. Harmless
-            // for a human request (SA ids and user ids are disjoint uuids, so this
-            // matches nothing), load-bearing for an SA request (its standing role).
-            and(eq(iamPolicies.principalType, 'token'), eq(iamPolicies.principalId, userId)),
           ),
         ),
-      ),
+    ),
   ]);
   const customActions: CustomAction[] = policyRows.map((r) => ({
     scopeType: r.scopeType,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -35,6 +35,7 @@ import { setupApp } from './setup';
 import { supabaseAuth, combinedAuth } from './middleware/auth';
 import { createCorsMiddleware } from './middleware/cors';
 import { requestDeadline, isRequestDeadlineHTTPException } from './middleware/request-deadline';
+import { inspectDatabaseError } from './shared/database-errors';
 import { isPlatinumSandboxNotRunningError } from './shared/platinum';
 import { isDaytonaRateLimitError, primeDaytonaRateLimitClassifier } from './shared/daytona-rate-limit';
 import {
@@ -1016,12 +1017,8 @@ app.onError((err, c) => {
   }
 
   // Database / postgres.js errors — extract the useful info, not the full SQL dump
-  const isDbError =
-    errName === 'PostgresError' ||
-    (err as any).severity ||
-    (err as any).code?.match?.(/^[0-9]{5}$/);
-  if (isDbError) {
-    const pgErr = err as any;
+  const databaseError = inspectDatabaseError(err);
+  if (databaseError) {
     // Pool-exhaustion (Supabase pooler / PgBouncer session-mode saturation on
     // the us-east-2 shadow deployment) is a TRANSIENT infra/pooler-capacity
     // class, NOT a code bug — `(EMAXCONNSESSION) max clients reached in
@@ -1037,29 +1034,39 @@ app.onError((err, c) => {
     // follow-up (raise the shadow pooler's `pool_size` / move to transaction
     // mode) is a human-owned external action recorded in the sweep ledger.
     // Better Stack patterns 721b7efe… (API) + b38179c5… (frontend symptom).
-    const isPoolExhaustion = isSentryIgnoredError(errName, err.message);
+    const databaseMessage =
+      databaseError.causeMessage ?? databaseError.outerMessage;
+    const isPoolExhaustion = isSentryIgnoredError(
+      databaseError.causeName ?? databaseError.outerName,
+      databaseMessage,
+    );
     if (!isPoolExhaustion) {
       captureException(err, {
         method,
         path,
         errorType: 'database',
-        pgCode: pgErr.code,
-        table: pgErr.table,
-        schema: pgErr.schema_name || pgErr.schema,
+        pgCode: databaseError.pgCode,
+        table: databaseError.table,
+        schema: databaseError.schema,
       });
     }
     appLogger.error(
-      `${method} ${path} -> 500 [DB ${pgErr.severity || 'ERROR'} ${pgErr.code || '?'}]`,
+      `${method} ${path} -> 500 [DB ${databaseError.severity || 'ERROR'} ${databaseError.pgCode || '?'}]`,
       {
         method,
         path,
         errorType: isPoolExhaustion ? 'database-pool-exhaustion' : 'database',
         transient: isPoolExhaustion || undefined,
-        pgCode: pgErr.code,
-        table: pgErr.table,
-        hint: pgErr.hint,
-        detail: pgErr.detail,
-        message: err.message.split('\n')[0],
+        outerErrorType: databaseError.outerName,
+        causeErrorType: databaseError.causeName,
+        pgCode: databaseError.pgCode,
+        severity: databaseError.severity,
+        table: databaseError.table,
+        schema: databaseError.schema,
+        hint: databaseError.hint,
+        detail: databaseError.detail,
+        message: databaseError.outerMessage.split('\n')[0],
+        causeMessage: databaseError.causeMessage?.split('\n')[0] ?? null,
       },
     );
   } else {

--- a/apps/api/src/shared/database-errors.test.ts
+++ b/apps/api/src/shared/database-errors.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  inspectDatabaseError,
+  isTransientDatabaseError,
+  retryTransientDatabaseRead,
+} from './database-errors';
+
+function wrappedDatabaseError(code: string, message: string): Error {
+  return new Error('Failed query: select 1', {
+    cause: Object.assign(new Error(message), {
+      name: 'PostgresError',
+      code,
+      severity: 'FATAL',
+      table: 'iam_policies',
+      schema_name: 'kortix',
+      detail: 'provider detail',
+      hint: 'provider hint',
+    }),
+  });
+}
+
+describe('inspectDatabaseError', () => {
+  test('extracts PostgreSQL fields from a wrapped Drizzle cause', () => {
+    const error = wrappedDatabaseError('08006', 'connection failure');
+    error.name = 'DrizzleQueryError';
+
+    expect(inspectDatabaseError(error)).toEqual({
+      isDatabaseError: true,
+      outerName: 'DrizzleQueryError',
+      outerMessage: 'Failed query: select 1',
+      causeName: 'PostgresError',
+      causeMessage: 'connection failure',
+      pgCode: '08006',
+      severity: 'FATAL',
+      table: 'iam_policies',
+      schema: 'kortix',
+      detail: 'provider detail',
+      hint: 'provider hint',
+    });
+  });
+
+  test('rejects an application error with no database signal', () => {
+    expect(inspectDatabaseError(new Error('invalid project state'))).toBeNull();
+  });
+});
+
+describe('isTransientDatabaseError', () => {
+  test.each([
+    ['08006', 'connection failure'],
+    ['40001', 'serialization failure'],
+    ['40P01', 'deadlock detected'],
+    ['53300', 'too many connections'],
+    ['57P03', 'cannot connect now'],
+    ['EMAXCONNSESSION', 'max clients reached in session mode'],
+  ])('accepts retryable PostgreSQL code %s', (code, message) => {
+    expect(isTransientDatabaseError(wrappedDatabaseError(code, message))).toBe(true);
+  });
+
+  test('rejects a schema failure', () => {
+    expect(
+      isTransientDatabaseError(wrappedDatabaseError('42P01', 'relation does not exist')),
+    ).toBe(false);
+  });
+});
+
+describe('retryTransientDatabaseRead', () => {
+  test('retries one transient failure and returns the second result', async () => {
+    let calls = 0;
+    const result = await retryTransientDatabaseRead(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw wrappedDatabaseError('08006', 'connection failure');
+      }
+      return ['allowed'];
+    });
+
+    expect(result).toEqual(['allowed']);
+    expect(calls).toBe(2);
+  });
+
+  test('does not retry a non-transient database failure', async () => {
+    let calls = 0;
+    await expect(
+      retryTransientDatabaseRead(async () => {
+        calls += 1;
+        throw wrappedDatabaseError('42P01', 'relation does not exist');
+      }),
+    ).rejects.toThrow('Failed query');
+    expect(calls).toBe(1);
+  });
+});

--- a/apps/api/src/shared/database-errors.ts
+++ b/apps/api/src/shared/database-errors.ts
@@ -1,0 +1,129 @@
+export interface DatabaseErrorDetails {
+  isDatabaseError: true;
+  outerName: string;
+  outerMessage: string;
+  causeName: string | null;
+  causeMessage: string | null;
+  pgCode: string | null;
+  severity: string | null;
+  table: string | null;
+  schema: string | null;
+  detail: string | null;
+  hint: string | null;
+}
+
+interface ErrorRecord {
+  name?: unknown;
+  message?: unknown;
+  code?: unknown;
+  severity?: unknown;
+  table?: unknown;
+  schema?: unknown;
+  schema_name?: unknown;
+  detail?: unknown;
+  hint?: unknown;
+  cause?: unknown;
+}
+
+const TRANSIENT_DATABASE_CODES = new Set([
+  '40001',
+  '40P01',
+  '53300',
+  '57P01',
+  '57P02',
+  '57P03',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EMAXCONNSESSION',
+]);
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function errorChain(error: unknown): ErrorRecord[] {
+  const chain: ErrorRecord[] = [];
+  const seen = new Set<unknown>();
+  let current = error;
+
+  while (current && typeof current === 'object' && !seen.has(current) && chain.length < 8) {
+    seen.add(current);
+    const record = current as ErrorRecord;
+    chain.push(record);
+    current = record.cause;
+  }
+
+  return chain;
+}
+
+function isPostgresCode(code: string | null): boolean {
+  return code !== null && (/^[0-9A-Z]{5}$/.test(code) || code === 'EMAXCONNSESSION');
+}
+
+export function inspectDatabaseError(error: unknown): DatabaseErrorDetails | null {
+  const chain = errorChain(error);
+  if (chain.length === 0) return null;
+
+  const postgresNode = chain.find((node) => {
+    const name = stringField(node.name);
+    const code = stringField(node.code);
+    return (
+      name === 'PostgresError'
+      || stringField(node.severity) !== null
+      || isPostgresCode(code)
+    );
+  });
+  const databaseNode =
+    postgresNode
+    ?? chain.find((node) => stringField(node.name) === 'DrizzleQueryError');
+  if (!databaseNode) return null;
+
+  const outer = chain[0];
+  const cause = databaseNode === outer ? null : databaseNode;
+  return {
+    isDatabaseError: true,
+    outerName: stringField(outer.name) ?? 'Error',
+    outerMessage: stringField(outer.message) ?? String(error),
+    causeName: cause ? stringField(cause.name) : null,
+    causeMessage: cause ? stringField(cause.message) : null,
+    pgCode: stringField(databaseNode.code),
+    severity: stringField(databaseNode.severity),
+    table: stringField(databaseNode.table),
+    schema: stringField(databaseNode.schema_name) ?? stringField(databaseNode.schema),
+    detail: stringField(databaseNode.detail),
+    hint: stringField(databaseNode.hint),
+  };
+}
+
+export function isTransientDatabaseError(error: unknown): boolean {
+  const chain = errorChain(error);
+  for (const node of chain) {
+    const code = stringField(node.code);
+    if (code?.startsWith('08') || (code && TRANSIENT_DATABASE_CODES.has(code))) {
+      return true;
+    }
+  }
+
+  const text = chain
+    .flatMap((node) => [stringField(node.name), stringField(node.message)])
+    .filter((value): value is string => value !== null)
+    .join(' ')
+    .toLowerCase();
+  return (
+    text.includes('max clients reached')
+    || text.includes('connection terminated unexpectedly')
+    || text.includes('connection reset')
+    || text.includes('socket closed')
+  );
+}
+
+export async function retryTransientDatabaseRead<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isTransientDatabaseError(error)) throw error;
+    return operation();
+  }
+}

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -254,6 +254,8 @@ Single, self-contained changes. Anything multi-step earns a spec instead.
 | B23 | **Prevent ACP prompt results from exposing a false idle window before late protocol updates settle.**                                                                                                                                                                                                                                                                                                                                          | The deployed white-label parity screenshot rendered 4 ACP tool cards and `Agent is working…`, while REST rendered 26 completed tool cards. `applyAcpEnvelope()` marks the projection idle on the prompt result, and later tool or text updates can mark it busy again.                                                                                                  | **IN PROGRESS 2026-07-26** — session `whitelabel-acp-stable-completion`; RED test, SDK fix, strengthened parity gate, merge, Deploy Dev, and deployed proof required                                                                                                                            |
 | B24 | **Accept a server-authorized initial OpenCode session pin in `useSession`.** The SDK must hydrate the cached transcript before runtime readiness without making the initial pin authoritative over the `/start` result.                                                                                                                                                                                                                          | Existing sessions wait for `/start` before `useSessionSync` can hydrate IndexedDB history. The preserved `session-load-latency` work proved the additive option and pin precedence.                                                                                                                       | **IN PROGRESS 2026-07-26** — session `api-latency-refactor`; RED test, implementation port, full SDK gates, browser proof, merge, and Deploy Dev proof required                                                                                                                               |
 | B25 | **Start project model-picker and project-detail reads in parallel.** Gateway projects must not wait for project detail before the SDK starts the compact model-picker request.                                                                                                                                                                                                                                                                   | `src/react/use-opencode-sessions/providers.ts` enables the model query only after `projectDetailQuery.isSuccess`, which creates a sequential request waterfall on project load.                                                                                                                          | **IN PROGRESS 2026-07-26** — session `api-latency-refactor`; RED test, implementation, full SDK gates, browser network proof, merge, and Deploy Dev proof required                                                                                                                            |
+| B26 | **Do not report an expected warm-session configuration mismatch as a global API error.** The web client catches `WARM_SESSION_CONFIGURATION_MISMATCH` and creates a normal session.                                                                                                                                                                                                                                                               | `src/core/rest/projects-client/sessions.ts` calls `/sessions/warm/claim` with the default `showErrors: true`, so the recoverable `409` still reaches the host error handler.                                                                                                                                | **IN PROGRESS 2026-07-26** — session `use2-session-readiness`; RED test, implementation, full SDK gates, dev proof, and US shadow proof required                                                                                                                                             |
+| B27 | **Let all-account project queries retry transient failures without a global error notification.** The projects page can issue one query per account.                                                                                                                                                                                                                                                                                            | Live US shadow evidence at `2026-07-26T20:03:20Z`: one IAM-backed `GET /projects` returned `500`; the identical retry returned `200` after `1.4s`. `listProjectsForAccount` exposes no `ApiClientOptions`, so the host cannot set `showErrors: false`.                                                           | **IN PROGRESS 2026-07-26** — session `use2-session-readiness`; RED test, additive options parameter, full SDK gates, dev proof, and US shadow proof required                                                                                                                                 |
 
 > **Paths above are as of today (pre-Task-4).** After the restructure they move:
 > `platform/api/` → `core/http/api/`, `opencode/` → `core/runtime/`,
@@ -2793,6 +2795,23 @@ Post-repair verification:
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
 and deployed ACP plus REST parity remain.
+
+---
+
+### 2026-07-26 — session `use2-session-readiness` (B26 and B27 claim)
+
+Claimed two notification regressions found during live US shadow verification.
+
+- Warm-session configuration mismatches must remain recoverable without a
+  global error notification.
+- All-account project queries must let React Query retry transient failures
+  without a global error notification.
+
+Implementation will follow RED -> GREEN -> REFACTOR. Required gates are focused
+SDK tests, full SDK typecheck, suite, packed-install smoke, web lint, PR merge,
+Deploy Dev SHA proof, and US shadow verification.
+
+**Status:** IN PROGRESS.
 
 ---
 

--- a/packages/sdk/src/core/rest/projects-client/sessions.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.test.ts
@@ -180,6 +180,37 @@ test('claimWarmProjectSession POSTs the selected warm session and create options
   expect(result.session_id).toBe('WARM-1');
 });
 
+test('claimWarmProjectSession keeps recoverable claim conflicts out of the global error sink', async () => {
+  const onError = mock(() => {});
+  configureKortix({
+    backendUrl: 'http://test.local',
+    getToken: async () => 'tok',
+    onError,
+  });
+  nextResponse = {
+    status: 409,
+    body: {
+      message: 'The warm session does not match the selected agent or sandbox',
+      code: 'WARM_SESSION_CONFIGURATION_MISMATCH',
+    },
+  };
+
+  try {
+    await expect(
+      claimWarmProjectSession('P1', {
+        session_id: 'WARM-1',
+        agent_name: 'reviewer',
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'WARM_SESSION_CONFIGURATION_MISMATCH',
+    });
+    expect(onError).not.toHaveBeenCalled();
+  } finally {
+    configureKortix({ backendUrl: 'http://test.local', getToken: async () => 'tok' });
+  }
+});
+
 test('getProjectSession hits GET /projects/:id/sessions/:sid and forwards showErrors', async () => {
   nextResponse = { status: 200, body: { session_id: 'S1' } };
   await getProjectSession('P1', 'S1', { showErrors: false });

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -302,6 +302,7 @@ export async function claimWarmProjectSession(
     await backendApi.post<ProjectSession>(
       `/projects/${projectId}/sessions/warm/claim`,
       input,
+      { showErrors: false },
     ),
   );
   markSessionFresh(session.session_id);

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -39,6 +39,13 @@ test("shadow smokes can bypass the production custom domain before cutover", () 
   );
 });
 
+test("US shadow exposes the managed model catalog for runtime verification", () => {
+  assert.match(
+    shadowWorkflow,
+    /\.KORTIX_MANAGED_PROVIDER_ENABLED == "true"/,
+  );
+});
+
 test("target smoke removes and counts recovery flow state", () => {
   assert.match(
     targetSmokeProgram,

--- a/tests/e2e/specs/13-sdk-only-session.spec.ts
+++ b/tests/e2e/specs/13-sdk-only-session.spec.ts
@@ -20,6 +20,41 @@ const authOptions = { supabaseUrl, password };
 const databaseUrl = process.env.E2E_DATABASE_URL
   || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
 
+function executeSql(sql: string): string {
+  return execFileSync(
+    'psql',
+    [databaseUrl, '-v', 'ON_ERROR_STOP=1', '-At', '-c', sql],
+    { encoding: 'utf8' },
+  ).trim();
+}
+
+function readAccountTier(accountId: string): string {
+  return executeSql(
+    `SELECT tier FROM kortix.credit_accounts WHERE account_id = '${accountId}'`,
+  );
+}
+
+function fundAccount(accountId: string): void {
+  executeSql(
+    `INSERT INTO kortix.credit_accounts (
+       account_id,
+       balance,
+       balance_precise,
+       non_expiring_credits,
+       non_expiring_credits_precise,
+       tier
+     )
+     VALUES ('${accountId}', 1000, 1000, 1000, 1000, 'tier_2_20')
+     ON CONFLICT (account_id)
+     DO UPDATE SET
+       balance = 1000,
+       balance_precise = 1000,
+       non_expiring_credits = 1000,
+       non_expiring_credits_precise = 1000,
+       tier = 'tier_2_20'`,
+  );
+}
+
 interface AccountSummary {
   account_id: string;
   personal_account?: boolean;
@@ -31,6 +66,21 @@ interface ProjectSummary {
 
 interface ProjectSession {
   session_id: string;
+}
+
+interface BillingState {
+  subscription: {
+    tier_key: string;
+  };
+}
+
+interface ModelDefaults {
+  freeTier: boolean;
+  resolvedForCaller: string | null;
+}
+
+interface ModelPicker {
+  models: Record<string, unknown>;
 }
 
 interface SessionStart {
@@ -74,6 +124,7 @@ test.describe.serial('13 — SDK-only web session', () => {
 
   let user: AuthUser;
   let auth: AuthSession;
+  let accountId = '';
   let projectId = '';
   let sessionId = '';
 
@@ -81,43 +132,53 @@ test.describe.serial('13 — SDK-only web session', () => {
     const email = `sdk-only-${Date.now()}-${randomUUID().slice(0, 8)}@example.test`;
     user = await createAuthUser(email, authOptions);
     auth = await signIn(email, authOptions);
+    accountId = user.id;
 
     const accounts = await api<AccountSummary[]>(auth.access_token, 'GET', '/accounts');
     const account = accounts.find((item) => item.personal_account) ?? accounts[0];
-    expect(account?.account_id).toBeTruthy();
-    execFileSync(
-      'psql',
-      [
-        databaseUrl,
-        '-v',
-        'ON_ERROR_STOP=1',
-        '-c',
-        `INSERT INTO kortix.credit_accounts (account_id, balance, tier)
-         VALUES ('${account.account_id}', 1000, 'tier_2_20')
-         ON CONFLICT (account_id)
-         DO UPDATE SET balance = 1000, tier = 'tier_2_20'`,
-      ],
-      { stdio: 'ignore' },
-    );
+    expect(account?.account_id).toBe(accountId);
+    fundAccount(accountId);
+    expect(readAccountTier(accountId)).toBe('tier_2_20');
 
     const project = await api<ProjectSummary>(
       auth.access_token,
       'POST',
       '/projects/provision',
       {
-        account_id: account.account_id,
+        account_id: accountId,
         name: `SDK-only E2E ${Date.now()}`,
         seed_starter: true,
       },
       201,
     );
     projectId = project.project_id;
+    expect(readAccountTier(accountId)).toBe('tier_2_20');
     await api(
       auth.access_token,
       'PATCH',
       `/projects/${projectId}/onboarding`,
       { completed: true },
     );
+    expect(readAccountTier(accountId)).toBe('tier_2_20');
+    const billing = await api<BillingState>(
+      auth.access_token,
+      'GET',
+      `/billing/account-state?account_id=${accountId}`,
+    );
+    expect(billing.subscription.tier_key).toBe('tier_2_20');
+    const defaults = await api<ModelDefaults>(
+      auth.access_token,
+      'GET',
+      `/projects/${projectId}/model-defaults`,
+    );
+    expect(defaults.freeTier).toBe(false);
+    expect(defaults.resolvedForCaller).toBeTruthy();
+    const picker = await api<ModelPicker>(
+      auth.access_token,
+      'GET',
+      `/projects/${projectId}/model-picker`,
+    );
+    expect(Object.keys(picker.models).length).toBeGreaterThan(0);
 
     const session = await api<ProjectSession>(
       auth.access_token,
@@ -125,7 +186,6 @@ test.describe.serial('13 — SDK-only web session', () => {
       `/projects/${projectId}/sessions`,
       {
         name: 'SDK-only browser session',
-        opencode_model: 'kortix/claude-sonnet-4.6',
       },
       201,
     );
@@ -140,6 +200,19 @@ test.describe.serial('13 — SDK-only web session', () => {
     }
     if (projectId) {
       await api(auth.access_token, 'DELETE', `/projects/${projectId}`).catch(() => {});
+    }
+    if (accountId) {
+      execFileSync(
+        'psql',
+        [
+          databaseUrl,
+          '-v',
+          'ON_ERROR_STOP=1',
+          '-c',
+          `DELETE FROM kortix.accounts WHERE account_id = '${accountId}'`,
+        ],
+        { stdio: 'ignore' },
+      );
     }
     if (user?.id) {
       await deleteAuthUser(user.id, {
@@ -208,5 +281,61 @@ test.describe.serial('13 — SDK-only web session', () => {
     await expect(page.getByText('kortix.yaml', { exact: true }).first()).toBeVisible({
       timeout: 60_000,
     });
+  });
+
+  test('falls back from a warm-session agent mismatch without reporting a global error', async ({
+    page,
+  }) => {
+    const mismatchConsoleErrors: string[] = [];
+    page.on('console', (message) => {
+      const text = message.text();
+      if (
+        message.type() === 'error'
+        && (
+          text.includes('WARM_SESSION_CONFIGURATION_MISMATCH')
+          || text.includes('The warm session does not match the selected agent or sandbox')
+        )
+      ) {
+        mismatchConsoleErrors.push(text);
+      }
+    });
+
+    const warmReady = page.waitForResponse((response) => (
+      response.request().method() === 'POST'
+      && response.url().endsWith(`/projects/${projectId}/sessions/warm`)
+      && response.status() === 200
+    ));
+    await installBrowserSession(page, auth, `/projects/${projectId}`, password);
+    await warmReady;
+
+    const input = page.getByRole('textbox', { name: 'Message input' });
+    await expect(input).toBeVisible({ timeout: 120_000 });
+    await page.getByRole('button', { name: 'Agent picker' }).click();
+    await page.getByText('memory-reflector', { exact: true }).click();
+    await input.fill('Reply with exactly one word: PONG');
+
+    const mismatchResponse = page.waitForResponse((response) => (
+      response.request().method() === 'POST'
+      && response.url().endsWith(`/projects/${projectId}/sessions/warm/claim`)
+      && response.status() === 409
+    ));
+    const fallbackCreate = page.waitForResponse((response) => (
+      response.request().method() === 'POST'
+      && response.url().endsWith(`/projects/${projectId}/sessions`)
+      && response.status() === 201
+    ));
+    const startedAt = Date.now();
+    await page.getByRole('button', { name: 'Send message' }).click();
+    await mismatchResponse;
+    await fallbackCreate;
+    await expect(page).toHaveURL(
+      new RegExp(`/projects/${projectId}/sessions/[0-9a-f-]+$`),
+      { timeout: 60_000 },
+    );
+    await expect(page.getByText('PONG', { exact: true }).last()).toBeVisible({
+      timeout: 180_000,
+    });
+    expect(Date.now() - startedAt).toBeLessThan(180_000);
+    expect(mismatchConsoleErrors).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Retry one transient IAM policy database read without failing open.
- Log nested PostgreSQL details from wrapped Drizzle errors.
- Suppress the global error notification for recoverable warm-session claim conflicts.
- Require managed models in the US East 2 shadow deployment.
- Add a real US shadow session and prompt regression flow.

## Verified

- `pnpm --filter @kortix/sdk typecheck` — exit 0.
- `pnpm --filter @kortix/sdk test` — 1280 pass, 0 fail.
- `pnpm --filter @kortix/sdk smoke:install` — pass.
- `pnpm --filter kortix-api typecheck` — exit 0.
- Focused API suites — 40 pass, 0 fail.
- `bunx tsc --noEmit` in `tests/` — exit 0.
- `node --test scripts/prod-us-east-2/target-smoke.test.mjs` — 5 pass, 0 fail.
- Live `https://us.kortix.com` runtime flow — sandbox started and returned exact `PONG`.
- Live warm mismatch flow — typed `409`, normal session fallback, exact `PONG`, no global mismatch error.

## Safety

- This PR does not change production routing.
- This PR does not enable production maintenance.
- This PR does not modify production data.
