### PR TITLE
test(use2): wait for selected warm agent

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -254,8 +254,8 @@ Single, self-contained changes. Anything multi-step earns a spec instead.
 | B23 | **Prevent ACP prompt results from exposing a false idle window before late protocol updates settle.**                                                                                                                                                                                                                                                                                                                                          | The deployed white-label parity screenshot rendered 4 ACP tool cards and `Agent is working…`, while REST rendered 26 completed tool cards. `applyAcpEnvelope()` marks the projection idle on the prompt result, and later tool or text updates can mark it busy again.                                                                                                  | **IN PROGRESS 2026-07-26** — session `whitelabel-acp-stable-completion`; RED test, SDK fix, strengthened parity gate, merge, Deploy Dev, and deployed proof required                                                                                                                            |
 | B24 | **Accept a server-authorized initial OpenCode session pin in `useSession`.** The SDK must hydrate the cached transcript before runtime readiness without making the initial pin authoritative over the `/start` result.                                                                                                                                                                                                                          | Existing sessions wait for `/start` before `useSessionSync` can hydrate IndexedDB history. The preserved `session-load-latency` work proved the additive option and pin precedence.                                                                                                                       | **IN PROGRESS 2026-07-26** — session `api-latency-refactor`; RED test, implementation port, full SDK gates, browser proof, merge, and Deploy Dev proof required                                                                                                                               |
 | B25 | **Start project model-picker and project-detail reads in parallel.** Gateway projects must not wait for project detail before the SDK starts the compact model-picker request.                                                                                                                                                                                                                                                                   | `src/react/use-opencode-sessions/providers.ts` enables the model query only after `projectDetailQuery.isSuccess`, which creates a sequential request waterfall on project load.                                                                                                                          | **IN PROGRESS 2026-07-26** — session `api-latency-refactor`; RED test, implementation, full SDK gates, browser network proof, merge, and Deploy Dev proof required                                                                                                                            |
-| B26 | **Do not report an expected warm-session configuration mismatch as a global API error.** The web client catches `WARM_SESSION_CONFIGURATION_MISMATCH` and creates a normal session.                                                                                                                                                                                                                                                               | `src/core/rest/projects-client/sessions.ts` calls `/sessions/warm/claim` with the default `showErrors: true`, so the recoverable `409` still reaches the host error handler.                                                                                                                                | **IN PROGRESS 2026-07-26** — session `use2-session-readiness`; RED test, implementation, full SDK gates, dev proof, and US shadow proof required                                                                                                                                             |
-| B27 | **Let all-account project queries retry transient failures without a global error notification.** The projects page can issue one query per account.                                                                                                                                                                                                                                                                                            | Live US shadow evidence at `2026-07-26T20:03:20Z`: one IAM-backed `GET /projects` returned `500`; the identical retry returned `200` after `1.4s`. `listProjectsForAccount` exposes no `ApiClientOptions`, so the host cannot set `showErrors: false`.                                                           | **IN PROGRESS 2026-07-26** — session `use2-session-readiness`; RED test, additive options parameter, full SDK gates, dev proof, and US shadow proof required                                                                                                                                 |
+| B26 | **Do not report an expected warm-session configuration mismatch as a global API error.** The web client catches `WARM_SESSION_CONFIGURATION_MISMATCH` and creates a normal session.                                                                                                                                                                                                                                                               | `src/core/rest/projects-client/sessions.ts` calls `/sessions/warm/claim` with the default `showErrors: true`, so the recoverable `409` still reaches the host error handler.                                                                                                                                | **DONE 2026-07-26** — PR #5529, merge `5c0ae97ec`; SDK tests `1280/0`; deployed US proof observed the typed `409`, normal-session fallback, exact `PONG`, and no global mismatch error                                                                                                      |
+| B27 | **Retry the transient IAM policy read that caused the all-account project query failure.** The projects page can issue one query per account.                                                                                                                                                                                                                                                                                                     | Live US shadow evidence at `2026-07-26T20:03:20Z`: one IAM-backed `GET /projects` returned `500`; the identical retry returned `200` after `1.4s`. The wrapped `DrizzleQueryError` hid the nested PostgreSQL cause from logs.                                                                                  | **DONE 2026-07-26** — PR #5529, merge `5c0ae97ec`; one bounded transient read retry fails closed; wrapped PostgreSQL details are logged; API tests `40/0`; US API rollout completed with `2/2` tasks                                                                                             |
 
 > **Paths above are as of today (pre-Task-4).** After the restructure they move:
 > `platform/api/` → `core/http/api/`, `opencode/` → `core/runtime/`,
@@ -3293,3 +3293,40 @@ Post-rebase live ACP and REST presentation plus question parity:
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
 and deployed ACP plus REST parity remain.
+
+---
+
+### 2026-07-26 — session `use2-session-readiness` (B26 and B27 completion)
+
+Completed both US shadow readiness fixes in PR #5529.
+
+- `claimWarmProjectSession()` keeps the recoverable configuration `409` out of
+  the global error sink.
+- The IAM custom-policy read retries one transient database failure.
+- Database error logging extracts the nested PostgreSQL cause from a wrapped
+  `DrizzleQueryError`.
+- The US shadow deployment requires managed models.
+
+Verification:
+
+- Merge commit: `5c0ae97ec7676f3cd439f7f19db154b53602feda`.
+- Deploy Dev run `30222230764`: success for the exact merge commit.
+- SDK typecheck: exit 0.
+- SDK suite: **1280 pass / 0 fail** with **5707** assertions.
+- SDK packed-install smoke: pass.
+- API typecheck: exit 0.
+- Focused API tests: **40 pass / 0 fail** with **82** assertions.
+- US API: `0.10.16-dev.5c0ae97e`.
+- US ECS API: task definition revision `11`, desired `2`, running `2`,
+  pending `0`, rollout `COMPLETED`.
+- US frontend: Vercel deployment
+  `dpl_DSe54pvhXpCgUyG7wVWnb7VdNm9M`.
+- Deployed real runtime flow: exact `PONG` and Files view loaded.
+- Deployed warm mismatch flow: typed `409`, normal session creation, exact
+  `PONG`, no global mismatch error, **27.4 seconds**.
+
+Production routing and production data were unchanged.
+
+**Status:** COMPLETE.
+
+**Shippable to production: YES.**

--- a/tests/e2e/specs/13-sdk-only-session.spec.ts
+++ b/tests/e2e/specs/13-sdk-only-session.spec.ts
@@ -310,8 +310,10 @@ test.describe.serial('13 — SDK-only web session', () => {
 
     const input = page.getByRole('textbox', { name: 'Message input' });
     await expect(input).toBeVisible({ timeout: 120_000 });
-    await page.getByRole('button', { name: 'Agent picker' }).click();
+    const agentPicker = page.getByRole('button', { name: 'Agent picker' });
+    await agentPicker.click();
     await page.getByText('memory-reflector', { exact: true }).click();
+    await expect(agentPicker).toContainText('memory-reflector');
     await input.fill('Reply with exactly one word: PONG');
 
     const mismatchResponse = page.waitForResponse((response) => (


### PR DESCRIPTION
## Summary

- Wait until React commits the selected project-home agent before sending.
- Record the completed US shadow readiness verification in the SDK tracker.

## Verified

- Live `https://us.kortix.com` warm-session flow: typed mismatch `409`, normal-session fallback, exact `PONG`, no global error, 27.4 seconds.
- `bunx tsc --noEmit` in `tests/`: exit 0.
- `git diff --check`: exit 0.

## Safety

- This PR changes one test assertion and one progress document.
- Production routing and production data remain unchanged.
