### PR TITLE
fix(ops): scope Supabase CLI prerequisite

### DIFF
--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -17,7 +17,7 @@ require_command() {
   }
 }
 
-for command_name in aws jq node psql supabase; do
+for command_name in aws jq node psql; do
   require_command "$command_name"
 done
 
@@ -42,6 +42,8 @@ replication_username="$(jq -er '.replication_username' <<<"$target_secret_json")
 replication_password="$(jq -er '.replication_password' <<<"$target_secret_json")"
 
 prepare_source() {
+  require_command supabase
+
   supabase postgres-config update \
     --experimental \
     --project-ref jbriwassebxdwoieikga \

--- a/scripts/prod-us-east-2/db-sync.test.mjs
+++ b/scripts/prod-us-east-2/db-sync.test.mjs
@@ -24,6 +24,17 @@ test("operator can override the target database endpoint", () => {
   );
 });
 
+test("only source preparation requires the Supabase CLI", () => {
+  const globalRequirements = script.match(
+    /for command_name in ([^;]+); do\n  require_command "\$command_name"\ndone/,
+  );
+  assert.ok(globalRequirements, "Missing global command requirements");
+  assert.doesNotMatch(globalRequirements[1], /\bsupabase\b/);
+
+  const body = functionBody("prepare_source", "start_subscription");
+  assert.match(body, /require_command supabase/);
+});
+
 test("reconciliation PL/pgSQL reads psql inputs through transaction settings", () => {
   const functions = [
     functionBody("write_counts", "reconcile_counts"),


### PR DESCRIPTION
The US shadow repair workflow does not use the Supabase CLI. Require that CLI only for source preparation.

Verification: node --test scripts/prod-us-east-2/db-sync.test.mjs: 6 pass, 0 fail; bash -n passed.