### PR TITLE
fix(web): guard marketing-site scrollTo against non-scrollable ref (BS a0000df8)

### DIFF
--- a/apps/web/src/components/home/interactive-demo-section.tsx
+++ b/apps/web/src/components/home/interactive-demo-section.tsx
@@ -6,6 +6,7 @@ import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { InlineMeta } from '@/components/ui/inline-meta';
 import { UserAvatar } from '@/components/ui/user-avatar';
 import { Icon } from '@/features/icon/icon';
+import { safeScrollTo } from '@/lib/utils/safe-scroll-to';
 import { cn } from '@/lib/utils';
 import {
   ArrowRight,
@@ -1366,7 +1367,7 @@ export function InteractiveDemoSection({
 
     const tabCenter = tab.offsetLeft + tab.offsetWidth / 2;
     const targetLeft = tabCenter - strip.clientWidth / 2;
-    strip.scrollTo({
+    safeScrollTo(strip, {
       left: Math.max(0, Math.min(targetLeft, strip.scrollWidth - strip.clientWidth)),
       behavior: 'smooth',
     });

--- a/apps/web/src/components/home/interactive-demo/pages/skills-page.tsx
+++ b/apps/web/src/components/home/interactive-demo/pages/skills-page.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { safeScrollTo } from '@/lib/utils/safe-scroll-to';
 import { cn } from '@/lib/utils';
 import { Plus, Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -45,7 +46,7 @@ export function SkillsPage({ focusedSkill }: { focusedSkill?: string | null } = 
       const scroller = el?.closest('[data-demo-panel-scroll]');
       if (!el || !(scroller instanceof HTMLElement)) return;
       const top = el.offsetTop - (scroller.clientHeight - el.offsetHeight) / 2;
-      scroller.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+      safeScrollTo(scroller, { top: Math.max(0, top), behavior: 'smooth' });
     }, 150);
     return () => window.clearTimeout(t);
   }, [focusedSkill]);

--- a/apps/web/src/lib/utils/safe-scroll-to.test.ts
+++ b/apps/web/src/lib/utils/safe-scroll-to.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { safeScrollTo } from './safe-scroll-to';
+
+describe('safeScrollTo', () => {
+  // The exact production failure shape: `t.scrollTo is not a function`.
+  // `t` is NOT null — it's a truthy value (a ref object / non-element) that
+  // lacks `.scrollTo`. The guard must swallow this instead of throwing.
+  test('does not throw when the target lacks scrollTo (truthy non-element)', () => {
+    expect(() => safeScrollTo({}, { top: 10 })).not.toThrow();
+    expect(() => safeScrollTo({ current: null } as unknown as never, { top: 10 })).not.toThrow();
+    expect(() =>
+      safeScrollTo({ scrollTo: 'not-a-function' } as unknown as never, { top: 10 }),
+    ).not.toThrow();
+  });
+
+  test('tolerates null and undefined', () => {
+    expect(() => safeScrollTo(null, { top: 10 })).not.toThrow();
+    expect(() => safeScrollTo(undefined, { top: 10 })).not.toThrow();
+  });
+
+  test('calls .scrollTo with the given options on a real scrollable element (happy path)', () => {
+    const scrollTo = mock((_opts?: ScrollToOptions) => {});
+    const el = { scrollTo } as unknown as Element;
+    const options: ScrollToOptions = { top: 42, behavior: 'smooth' };
+    safeScrollTo(el, options);
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(scrollTo).toHaveBeenCalledWith(options);
+  });
+
+  test('does not call .scrollTo when omitted but el is present', () => {
+    const el = {} as { scrollTo?: (opts?: ScrollToOptions) => void };
+    expect(() => safeScrollTo(el, { top: 0 })).not.toThrow();
+  });
+});

--- a/apps/web/src/lib/utils/safe-scroll-to.ts
+++ b/apps/web/src/lib/utils/safe-scroll-to.ts
@@ -1,0 +1,24 @@
+/**
+ * Programmatic smooth-scroll that tolerates non-scrollable targets.
+ *
+ * `.scrollTo()` exists on `Element` / `HTMLElement` in modern browsers, but a
+ * ref can resolve to a value that lacks it — `null`, a plain object, a
+ * component instance, or a DOM node in an edge runtime / stripped WebView.
+ * Calling `.scrollTo()` on such a value throws
+ * `TypeError: t.scrollTo is not a function`, which surfaces in production
+ * (Better Stack) on the marketing homepage when the interactive-demo tab strip
+ * is touched mid-render.
+ *
+ * Every programmatic `.scrollTo()` aimed at a ref / resolved element must go
+ * through here so a non-scrollable target is a silent no-op instead of a throw.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo
+ */
+export function safeScrollTo(
+  el: { scrollTo?: (opts?: ScrollToOptions) => void } | null | undefined,
+  options?: ScrollToOptions,
+): void {
+  if (el && typeof el.scrollTo === 'function') {
+    el.scrollTo(options);
+  }
+}


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. The fix is a defensive guard that converts a `TypeError` thrown mid-interaction on the marketing homepage `/` into a silent no-op; proof is the new unit test pinning the exact prod failure shape (`t.scrollTo is not a function`):

```
apps/web/src/lib/utils/safe-scroll-to.test.ts
  ✓ does not throw when the target lacks scrollTo (truthy non-element)
  ✓ tolerates null and undefined
  ✓ calls .scrollTo with the given options on a real scrollable element (happy path)
  ✓ does not call .scrollTo when omitted but el is present
4 pass, 0 fail
```

## Why

`TypeError: t.scrollTo is not a function` on the marketing homepage `/` (Better Stack pattern `a0000df8…`, Kortix Frontend prod app `2346967`). 2 occurrences / 0 users, last 2026-07-26 14:43:32 UTC, release `5d47baf11708881f1099cdaa875266944e976a78` (post-`0.10.15`), browser Chrome 145 / Windows 10. Transaction `/`, URL `https://kortix.com/`.

This error was previously classified **"covered-by-`0.10.14`"** (0 post-Promote occurrences as of the 2026-07-25 sweep) — that classification was **WRONG**: no actual code guard was ever added, the group simply aged out of the 3-day window, and it **recurred under `0.10.15`/`0.10.16`**. This PR adds the durable guard that was missing.

## What changed

The marketing `/` route renders `Hero → HeroSurfaces → InteractiveDemoSection`, which has a `strip.scrollTo({...})` call (`apps/web/src/components/home/interactive-demo-section.tsx:1369`) that keeps the active demo tab in view on small screens. `strip` is `tabStripRef.current` — an `HTMLDivElement` ref guarded only by a null check (`if (!tab || !strip) return;`). There was **no `typeof … === 'function'` guard**, so when the ref resolved to a truthy value that lacks `.scrollTo` (a non-element, a stripped-WebView `Element`, or a ref-object touched mid-render), `.scrollTo()` threw `t.scrollTo is not a function` (note: "not a function", **not** "cannot read properties of null" — `t` was truthy).

The sibling call site `apps/web/src/components/home/interactive-demo/pages/skills-page.tsx:48` (`scroller.scrollTo(...)`) already had an `instanceof HTMLElement` guard, but `HTMLElement` does **not** guarantee `.scrollTo` exists in every runtime, so it was a partial guard.

Fix (one focused concern — guard the `.scrollTo` call, no UX change):

- New helper `apps/web/src/lib/utils/safe-scroll-to.ts` — `safeScrollTo(el, options)` no-ops when `el` is null/undefined or lacks a `function`-typed `scrollTo`; otherwise calls it. Mirrors the existing defensive-guard style of `apps/web/src/lib/utils/focus-without-scroll.ts` (#5410/#5439 family).
- `interactive-demo-section.tsx:1369` → `safeScrollTo(strip, {...})` (the culprit).
- `skills-page.tsx:48` → `safeScrollTo(scroller, {...})` (defensive consistency — same route, same class of failure).
- New regression test `apps/web/src/lib/utils/safe-scroll-to.test.ts` pinning the exact prod failure shape: `safeScrollTo({}, {...})` (truthy non-element, the `t.scrollTo is not a function` case), null/undefined, the `{ scrollTo: 'not-a-function' }` shape, and the happy-path `.scrollTo` invocation (mocked spy asserting the call + options).

## Verification

```
cd apps/web && bun test src/lib/utils/safe-scroll-to.test.ts src/lib/utils/focus-without-scroll.test.ts
# 6 pass, 0 fail

cd apps/web && ./node_modules/.bin/tsc --noEmit -p tsconfig.json
# 4 pre-existing unrelated errors only (og/template-url.test.ts ×2, source.ts, use-cases-source.ts — all present on `main`);
# confirmed by stashing the change and re-running tsc — identical baseline. Zero new errors from this PR.
```

Preview verification plan (once the `preview` label spins up the ephemeral env):
1. `curl -s https://pr-<N>.preview-api.kortix.com/v1/health | jq .environment` → expect `preview`.
2. Open the Vercel preview frontend (`/`), interact with the interactive demo (click through Agents → Skills → CLI tabs; trigger a focused-skill scroll), confirm no `scrollTo` throw in the console / network and the tab-strip auto-scroll still works.
3. The Better Stack pattern `a0000df8…` should drop to zero new occurrences after this reaches prod.

## Risk / rollback

Minimal — a guard that only adds a `typeof === 'function'` check before an existing `.scrollTo` call; behavior is identical for any real scroll container. Revert the single commit if needed.

Reference: Better Stack error `a0000df8d332a25c2002222c563543e66e822d0459fed4962a8d6ebaa507b539` (Kortix Frontend prod app `2346967`).
