### PR TITLE
fix(scheduler): bound catalog retries after backfill

### DIFF
--- a/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
+++ b/apps/api/src/__tests__/unit-trigger-scheduler-reliability.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { isSweepStale, mapWithConcurrency, withTimeout } from '../projects/lib/triggers';
+import {
+  initialCatalogBackfillIncomplete,
+  isSweepStale,
+  mapWithConcurrency,
+  withTimeout,
+} from '../projects/lib/triggers';
 
 // These primitives are what keep one hung trigger fire from freezing the entire
 // cron scheduler — the 2026-06-21 fleet-wide outage, where a single
@@ -142,5 +147,37 @@ describe('mapWithConcurrency', () => {
     });
 
     expect(peak).toBe(1);
+  });
+});
+
+describe('initialCatalogBackfillIncomplete', () => {
+  test('keeps startup batches continuous until both cursors complete', () => {
+    expect(
+      initialCatalogBackfillIncomplete({
+        catalogCycleCompletedAt: null,
+        discoveryCycleCompletedAt: '2026-07-27T04:00:00.000Z',
+        catalogPendingProjects: 0,
+      }),
+    ).toBe(true);
+  });
+
+  test('keeps startup batches continuous while active runtime rows remain uncataloged', () => {
+    expect(
+      initialCatalogBackfillIncomplete({
+        catalogCycleCompletedAt: '2026-07-27T04:00:00.000Z',
+        discoveryCycleCompletedAt: '2026-07-27T04:00:00.000Z',
+        catalogPendingProjects: 1,
+      }),
+    ).toBe(true);
+  });
+
+  test('returns to the bounded cadence after both cycles complete with no pending rows', () => {
+    expect(
+      initialCatalogBackfillIncomplete({
+        catalogCycleCompletedAt: '2026-07-27T04:00:00.000Z',
+        discoveryCycleCompletedAt: '2026-07-27T04:00:00.000Z',
+        catalogPendingProjects: 0,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -249,6 +249,19 @@ export function getTriggerSchedulerHealth(): TriggerSchedulerHealth {
   return schedulerHealth;
 }
 
+export function initialCatalogBackfillIncomplete(
+  health: Pick<
+    TriggerSchedulerHealth,
+    'catalogCycleCompletedAt' | 'discoveryCycleCompletedAt' | 'catalogPendingProjects'
+  >,
+): boolean {
+  return (
+    health.catalogCycleCompletedAt === null ||
+    health.discoveryCycleCompletedAt === null ||
+    (health.catalogPendingProjects ?? 1) > 0
+  );
+}
+
 // ─── Reliability: timeouts + stall detection ─────────────────────────────────
 // The 2026-06-21 fleet-wide cron outage: one trigger fire (continueSession
 // resuming a dead sandbox) hung forever inside a SEQUENTIAL sweep that awaited
@@ -1296,16 +1309,14 @@ export function startProjectTriggerScheduler(): void {
     if (Date.now() - lastConnectorSweepAt >= connectorSweepIntervalMs()) {
       lastConnectorSweepAt = Date.now();
       runProjectConnectorSweep()
-        .then((result) => {
-          const initialCatalogBackfillIncomplete =
-            schedulerHealth.catalogCycleCompletedAt === null ||
-            schedulerHealth.discoveryCycleCompletedAt === null ||
-            (schedulerHealth.catalogPendingProjects ?? 1) > 0;
-          if (initialCatalogBackfillIncomplete || result.errors > 0) {
+        .then(() => {
+          if (initialCatalogBackfillIncomplete(schedulerHealth)) {
             // On a new scheduler release, drain the bounded catalog batches
             // continuously instead of waiting two minutes between each batch.
             // Once both cursors complete a full cycle with no pending rows, the
-            // normal connector cadence resumes.
+            // normal connector cadence resumes. Individual project failures
+            // retry on that bounded cadence; a permanently inaccessible repo
+            // must not force an unbounded full-fleet reconciliation loop.
             lastConnectorSweepAt = 0;
           }
         })


### PR DESCRIPTION
## Problem

Permanent repository reconciliation errors reset the connector sweep timer. This causes continuous full-fleet Git reconciliation after the initial catalog backfill completes.

## Change

- Keep rapid catalog batching only while a catalog or discovery cycle is incomplete.
- Keep rapid batching while active runtime rows remain uncataloged.
- Retry individual repository failures on the normal two-minute connector cadence.
- Add three regression tests for the startup backfill boundary.

## Verification

- `pnpm --filter kortix-api typecheck`
- Scheduler and trigger suite: 57 passed, 0 failed.
- Real PostgreSQL execution-store integration: 4 passed, 0 failed.
- `git diff --check`

This PR contains no migration and changes no production environment.