### PR TITLE
docs: trigger scheduler cadence, execution lease interval, voice opt-in, voiceTranscript

### DIFF
--- a/apps/web/content/docs/connect/slack.mdx
+++ b/apps/web/content/docs/connect/slack.mdx
@@ -19,8 +19,9 @@ Kortix supports four channel platforms today:
   own Azure Bot.
 - **Email** — an AgentMail-backed channel (experimental; enable it under
   Customize → Settings → Experimental).
-- **Voice** — a realtime voice channel on LiveKit. A connected call is a
-  LiveKit room; the agent speaks through the live media session.
+- **Voice** — a realtime voice channel on LiveKit (experimental; enable it under
+  Customize → Settings → Experimental). A connected call is a LiveKit room;
+  the agent speaks through the live media session.
 
 Only Slack and Microsoft Teams connect through the CLI and dashboard. Email
 and voice are managed from the dashboard or SDK. This page covers Slack.

--- a/apps/web/content/docs/connect/triggers.mdx
+++ b/apps/web/content/docs/connect/triggers.mdx
@@ -213,7 +213,7 @@ A project-level switch stops every trigger in the project at once, independent o
 
 ## Limits and reliability
 
-- The scheduler polls every 60 seconds. Cron precision is best-effort to the minute, even though the expression has a seconds field.
+- The scheduler polls roughly every second (default 1,000 ms; configurable via `KORTIX_TRIGGER_SCHEDULER_INTERVAL_MS`). Cron precision is best-effort to the second, even though the expression has a seconds field.
 - Each project allows 3 triggered sessions provisioning at once, by default. The account's plan-tier active-session cap can also apply. A fire past either limit returns `queued` (`202`) instead of failing, and runs once a slot frees up.
 - A manual or webhook fire has a 45-second timeout. Loading the manifest has a 30-second timeout.
 - A cron fire is keyed on the due schedule slot, so a fire that timed out but actually landed does not duplicate on retry. A webhook fire is keyed on the delivery ID header, or a hash of the body and signature when the sender sends no ID.

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -42,6 +42,7 @@ Three more read methods round out the handle:
 - `s.publicShares.list()` / `.create(input)` / `.revoke(shareId)` — public share links.
 - `s.audit(limit?)` — the session's audit trail of agent actions.
 - `s.transcript(options?)` — a compact server-side transcript (text and tool calls, no tool inputs or outputs). This works with a project-scoped session token.
+- `s.voiceTranscript(options?)` — this session's live voice-call transcript (spoken turns plus `ask_kortix`/`run_command` worker tool calls). Returns an empty list when the session has no live call, not a 404.
 
 ## Readiness is a handshake
 

--- a/apps/web/content/docs/work/runtime.mdx
+++ b/apps/web/content/docs/work/runtime.mdx
@@ -32,7 +32,7 @@ Kortix enforces a concurrent-session limit per account. Exceeding your tier's li
 
 ### Active-turn protection
 
-While an OpenCode turn is `busy` or `retrying`, the sandbox daemon renews a short execution lease with the API every 20 seconds. The lease blocks the idle reaper. Each renewal also touches the provider, so the provider's own inactivity timer cannot hibernate the sandbox mid-run. `session.idle` and `session.error` release the lease.
+While an OpenCode turn is `busy` or `retrying`, the sandbox daemon renews a short execution lease with the API every 60 seconds. The lease blocks the idle reaper. Each renewal also touches the provider, so the provider's own inactivity timer cannot hibernate the sandbox mid-run. `session.idle` and `session.error` release the lease.
 
 An open dashboard tab, preview, SSE connection, or health poll does not create a lease. A passive tab cannot keep an idle sandbox alive.
 


### PR DESCRIPTION
## docs: trigger scheduler cadence, execution lease interval, voice opt-in, voiceTranscript

Docs-only accuracy sweep from the autonomous `docs-maintainer` run (2026-07-27). Four drifts found by four parallel `docs-maintainer-worker` shards and independently re-verified by the orchestrator against current source before editing.

### Audit window
- `kortix-ai/suna`: `d778b0e1e` (2026-07-26 checkpoint) → `eedda985c` (origin/main). 149 reachable commits. Full-SHA coverage manifest passes `check-commit-coverage.mjs` (4 `docs-change`, 11 `already-current`, 134 `no-doc-impact`). Window is heavily voice-channel-focused (Recall notetaker rip-out, LiveKit bridge, env-gate drop) plus scheduler/lease/perf/migration work.

### Fixes

**1. Trigger scheduler cadence (MEDIUM) — `connect/triggers.mdx:216`**
The docs said "The scheduler polls every 60 seconds. Cron precision is best-effort to the minute." Source default is 1,000 ms (1 second). Proof: `apps/api/src/projects/lib/triggers.ts:407-410` (`triggerSchedulerIntervalMs()` default `1_000`, configurable via `KORTIX_TRIGGER_SCHEDULER_INTERVAL_MS`); `:1330` (`setInterval(tick, triggerSchedulerIntervalMs())`).

**2. Execution lease interval (MEDIUM) — `work/runtime.mdx:35`**
The docs said the sandbox daemon renews the execution lease "every 20 seconds." Source is 60 seconds. Proof: `apps/kortix-sandbox-agent-server/src/execution-lease.ts:3` (`EXECUTION_HEARTBEAT_INTERVAL_MS = 60_000`); reporter constructed with no override at `main.ts:386`.

**3. Voice experimental opt-in (LOW, gap) — `connect/slack.mdx:22`**
The voice bullet described the channel but omitted the enable step; the parallel email bullet says "experimental; enable it under Customize → Settings → Experimental." Voice is `stability: 'experimental'`, `available: () => true`, `platformDefault: () => false` ("Explicit opt-in: a project enables voice in Settings"). Proof: `apps/api/src/experimental/features.ts:103-116`; `apps/api/src/executor/channel-materialize.ts:107-117` (connector materializes only when `resolveExperimentalFeature(metadata, 'voice')`).

**4. `voiceTranscript` SDK method undocumented (LOW, gap) — `sdk/sessions.mdx`**
The session handle exposes `s.voiceTranscript(options?)` (live voice-call transcript: spoken turns + `ask_kortix`/`run_command` worker tool calls; empty list when no live call, not a 404) but the read-methods list only documented `s.transcript`. Proof: `packages/sdk/src/core/client/kortix.ts:828-830` (`voiceTranscript: (options?) => P.getVoiceTranscript(...)`); `packages/sdk/src/core/rest/projects-client/sessions.ts:419-460` (`getVoiceTranscript`, `VoiceTranscriptTurn`).

### Verification
- `check-fumadocs.mjs` PASS (28 pages, 6 nav, 28 routes).
- `git diff --check` PASS; `test-docs-maintainer-gates.mjs` PASS.
- Grep gates PASS (no `polls every 60 seconds`, no `best-effort to the minute`, no `every 20 seconds`; positive: `polls roughly every second`, `KORTIX_TRIGGER_SCHEDULER_INTERVAL_MS`, `best-effort to the second`, `every 60 seconds`, `experimental; enable it under` (voice), `voiceTranscript`).
- This PR is docs-only — 4 files under `apps/web/content/docs/**`.

