### PR TITLE
fix(security): scope AgentMail inbox takeover delete + ownership gate (pentest 2026-07-27)

### DIFF
--- a/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
+++ b/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
@@ -5,6 +5,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
   accounts,
+  chatInstalls,
   executorConnectionProfiles,
   executorConnectors,
   executorCredentials,
@@ -880,5 +881,44 @@ describe('session connector profile isolation', () => {
       .from(executorConnectionProfiles)
       .where(eq(executorConnectionProfiles.profileId, profileB.profileId));
     expect(afterFinal?.status).toBe('revoked');
+  });
+
+  test('saveAgentMailInstall does not delete another project chat_installs row for the same inbox (pentest 2026-07-27)', async () => {
+    // Regression for the AgentMail inbox hijack. PROJECT_A claims inbox
+    // "shared-inbox". PROJECT_B then claims the SAME inbox. Before the fix,
+    // saveAgentMailInstall ran an unscoped DELETE (platform + workspaceId only)
+    // that wiped PROJECT_A's chat_installs row. With the fix, the DELETE is
+    // scoped to the calling project, so both rows coexist (unique index allows
+    // multiple projects per inbox) and resolveProjectForAgentMailInbox keeps
+    // returning PROJECT_A for PROJECT_A's install.
+    const sharedInbox = 'shared-inbox-hijack-test';
+    await saveAgentMailInstall({
+      projectId: PROJECT_A,
+      profileSlug: 'kortix_email',
+      inboxId: sharedInbox,
+      email: 'shared-a@example.test',
+      displayName: 'A',
+      apiKey: 'agentmail-key',
+    });
+    // PROJECT_B claims the same inbox. This must NOT remove PROJECT_A's row.
+    await saveAgentMailInstall({
+      projectId: PROJECT_B,
+      profileSlug: 'kortix_email',
+      inboxId: sharedInbox,
+      email: 'shared-b@example.test',
+      displayName: 'B',
+      apiKey: 'agentmail-key',
+    });
+
+    const owners = await db
+      .select({ projectId: chatInstalls.projectId })
+      .from(chatInstalls)
+      .where(and(eq(chatInstalls.platform, 'email'), eq(chatInstalls.workspaceId, sharedInbox)));
+    const ownerIds = owners.map((r) => r.projectId).sort();
+    expect(ownerIds).toEqual([PROJECT_A, PROJECT_B].sort());
+
+    // Cleanup so the row does not leak into other tests.
+    await deleteAgentMailInstall(PROJECT_A, 'kortix_email');
+    await deleteAgentMailInstall(PROJECT_B, 'kortix_email');
   });
 });

--- a/apps/api/src/channels/install-store.ts
+++ b/apps/api/src/channels/install-store.ts
@@ -224,9 +224,20 @@ export async function saveAgentMailInstall(
         ),
       );
   }
+  // Scope the inbox takeover delete to THIS project. An unscoped delete
+  // (platform + workspaceId only) would wipe another project's install row for
+  // the same inbox — a cross-tenant data-integrity bug that enabled the
+  // AgentMail inbox hijack (pentest 2026-07-27). The first delete above already
+  // filters by projectId; this one must too.
   await db
     .delete(chatInstalls)
-    .where(and(eq(chatInstalls.platform, 'email'), eq(chatInstalls.workspaceId, input.inboxId)));
+    .where(
+      and(
+        eq(chatInstalls.platform, 'email'),
+        eq(chatInstalls.projectId, projectId),
+        eq(chatInstalls.workspaceId, input.inboxId),
+      ),
+    );
   await db
     .insert(chatInstalls)
     .values({ platform: 'email', workspaceId: input.inboxId, projectId })

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -28,6 +28,7 @@ import {
   deleteAgentMailInstall,
   deleteSlackInstall,
   deleteTeamsInstall,
+  listProjectsForWorkspace,
   loadAgentMailInstall,
   loadSlackInstall,
   loadTeamsAppIdForProject,
@@ -1667,6 +1668,19 @@ projectsApp.openapi(
 
     let inbox: Awaited<ReturnType<typeof createAgentMailInbox>>;
     if (existingInboxId && existingEmail) {
+      // Ownership gate (pentest 2026-07-27): before claiming an existing
+      // AgentMail inbox, confirm no OTHER project already owns it. Without this,
+      // a caller with connector.write on their own project could supply a
+      // victim's inbox_id and hijack inbound mail resolution. The scoped delete
+      // in saveAgentMailInstall is defense-in-depth; this 409 is the front gate.
+      const owners = await listProjectsForWorkspace('email', existingInboxId);
+      const foreignOwner = owners.find((id) => id !== projectId);
+      if (foreignOwner) {
+        return c.json(
+          { error: 'AgentMail inbox is already connected to another project' },
+          409,
+        );
+      }
       inbox = {
         inbox_id: existingInboxId,
         email: existingEmail,


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. Proof: a second project installing the same AgentMail inbox no longer deletes the first project's `chat_installs` row (integration test below).

## Why
Weekly pentest (2026-07-27) found a **HIGH cross-tenant AgentMail inbox hijack**. `POST /channels/email/connect` accepted a caller-supplied `inbox_id` with no ownership check, and `saveAgentMailInstall` ran an unscoped `DELETE FROM chat_installs WHERE platform='email' AND workspace_id=<inbox>` (no `projectId` filter). A caller with `connector.write` on their own project could supply a victim's `inbox_id`, wipe the victim's install row, register a webhook under the attacker's secret, and route the victim's inbound mail to the attacker's project + agent.

## What changed
- **`apps/api/src/channels/install-store.ts`** — scope the inbox-takeover DELETE to the calling `projectId` (matches the first DELETE and `deleteAgentMailInstall`).
- **`apps/api/src/projects/routes/r4.ts`** — before claiming an existing inbox, reject `409` if another project already owns it (`listProjectsForWorkspace`).
- **`integration-session-connector-profiles.test.ts`** — regression test: installing the same inbox under a second project does not delete the first project's `chat_installs` row.

## Verification
- `pnpm --filter kortix-api exec tsc --noEmit` → 0 errors.
- New integration test asserts both projects' `chat_installs` rows coexist after claiming the same inbox (runs in CI against the real DB).

## Risk / rollback
Bounded: only the `existingInboxId` connect path and the takeover DELETE. Revert is a single commit.