### PR TITLE
fix(seo): stop garbled brand snippet — render KortixLetterField as SVG background-image

### DIFF
--- a/apps/web/src/components/ui/marketing/kortix-letter-field.cells.test.ts
+++ b/apps/web/src/components/ui/marketing/kortix-letter-field.cells.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildFieldSvg,
+  buildTokens,
+  computeGrid,
+  OPACITY_BY_KIND,
+  PROPER,
+  shuffleWithSpaces,
+  SOURCE,
+  svgEscape,
+  svgToDataUri,
+  type Token,
+} from './kortix-letter-field.cells';
+
+describe('buildTokens', () => {
+  test('is deterministic for a fixed seed (no hydration mismatch)', () => {
+    expect(buildTokens(100, 3382)).toEqual(buildTokens(100, 3382));
+  });
+
+  test('produces exactly the requested count', () => {
+    expect(buildTokens(50, 1)).toHaveLength(50);
+    expect(buildTokens(0, 1)).toHaveLength(0);
+  });
+
+  test('every token is one of the three kinds', () => {
+    const tokens = buildTokens(500, 42);
+    for (const t of tokens) {
+      expect(['scrambled', 'proper', 'kortix']).toContain(t.kind);
+    }
+  });
+
+  test('scrambled tokens are permutations of the source letters', () => {
+    const scrambled = buildTokens(200, 7).filter((t) => t.kind === 'scrambled');
+    expect(scrambled.length).toBeGreaterThan(0);
+    for (const t of scrambled) {
+      // Same multiset of characters as SOURCE (ignoring spaces), just reordered.
+      const norm = t.text.replace(/\s/g, '');
+      expect(norm.split('').sort().join('')).toBe(SOURCE.split('').sort().join(''));
+    }
+  });
+
+  test('kortix + proper tokens render the expected brand text', () => {
+    const tokens = buildTokens(2000, 99);
+    expect(tokens.some((t) => t.kind === 'kortix' && t.text === 'k o r t i x')).toBe(true);
+    expect(tokens.some((t) => t.kind === 'proper' && t.text === PROPER)).toBe(true);
+  });
+});
+
+describe('shuffleWithSpaces', () => {
+  test('preserves the character multiset (plus spaces)', () => {
+    const rng = (() => {
+      let a = 12345 >>> 0;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    })();
+    const out = shuffleWithSpaces('abc', rng);
+    expect(out.replace(/\s/g, '').split('').sort().join('')).toBe('abc');
+  });
+});
+
+describe('computeGrid', () => {
+  test('cols/rows are >= 1 even for a zero-size container', () => {
+    const g = computeGrid(0, 0);
+    expect(g.cols).toBeGreaterThanOrEqual(1);
+    expect(g.rows).toBeGreaterThanOrEqual(1);
+    expect(g.tokenCount).toBe(g.cols * g.rows);
+  });
+
+  test('wider viewports produce more (or equal) columns', () => {
+    const small = computeGrid(400, 800);
+    const wide = computeGrid(1600, 800);
+    expect(wide.cols).toBeGreaterThanOrEqual(small.cols);
+  });
+
+  test('small viewport uses the small-screen font size + padding', () => {
+    expect(computeGrid(400, 800).fontSize).toBe(8);
+    expect(computeGrid(800, 800).fontSize).toBe(9);
+    expect(computeGrid(1280, 800).fontSize).toBe(10);
+  });
+
+  test('cellWidth distributes the inner width across columns', () => {
+    const g = computeGrid(1280, 800);
+    const innerWidth = g.cellWidth * g.cols + 24 * 2 + 4 * (g.cols - 1);
+    expect(Math.abs(innerWidth - 1280)).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('svgEscape', () => {
+  test('escapes the XML metacharacters', () => {
+    expect(svgEscape('a & <b> "c" \'d\'')).toBe('a &amp; &lt;b&gt; &quot;c&quot; &#39;d&#39;');
+  });
+});
+
+describe('buildFieldSvg', () => {
+  const grid = computeGrid(1200, 800);
+  const tokens: Token[] = buildTokens(grid.tokenCount, 3382);
+
+  test('emits a single root <svg> with a <title> for accessibility', () => {
+    const svg = buildFieldSvg(tokens, grid, 'rgb(20,20,20)', false);
+    expect(svg.startsWith('<svg xmlns="http://www.w3.org/2000/svg"')).toBe(true);
+    expect(svg.endsWith('</svg>')).toBe(true);
+    expect(svg).toContain('<title>Kortix</title>');
+    expect(svg.match(/<svg/g)?.length).toBe(1);
+  });
+
+  test('renders one <text> element per token', () => {
+    const svg = buildFieldSvg(tokens, grid, 'rgb(20,20,20)', false);
+    expect(svg.match(/<text /g)?.length).toBe(tokens.length);
+  });
+
+  test('uses the resolved foreground color as the fill', () => {
+    const svg = buildFieldSvg(tokens, grid, 'rgb(12, 34, 56)', false);
+    expect(svg).toContain('fill="rgb(12, 34, 56)"');
+  });
+
+  test('applies the dark-mode opacity set when isDark=true', () => {
+    const light = buildFieldSvg(tokens, grid, 'black', false);
+    const dark = buildFieldSvg(tokens, grid, 'white', true);
+    expect(light).toContain(`fill-opacity="${OPACITY_BY_KIND.scrambled.light}"`);
+    expect(dark).toContain(`fill-opacity="${OPACITY_BY_KIND.scrambled.dark}"`);
+  });
+
+  // The core SEO guarantee: the scrambled brand tokens DO appear inside the
+  // SVG image (they're the visual), but the SVG is only ever consumed as a
+  // CSS background-image data URI — never inlined as DOM text. This test pins
+  // that the tokens are present in the image content (so the visual is
+  // preserved) AND that the output is a single self-contained <svg> document
+  // (so there is no stray DOM text path).
+  test('contains the brand tokens inside the svg image content', () => {
+    const svg = buildFieldSvg(tokens, grid, 'black', false);
+    expect(svg).toContain('k o r t i x');
+    expect(svg).toContain(SOURCE.split('').join(' '));
+    // Self-contained: no external refs that would break as a data URI.
+    expect(svg).not.toMatch(/xlink:href/);
+    expect(svg).not.toMatch(/src=/);
+  });
+});
+
+describe('svgToDataUri', () => {
+  test('produces a valid CSS data:image/svg+xml URL with no raw metacharacters', () => {
+    const svg = buildFieldSvg(buildTokens(20, 1), computeGrid(400, 200), 'black', false);
+    const uri = svgToDataUri(svg);
+    expect(uri.startsWith('data:image/svg+xml,')).toBe(true);
+    // The encoded payload must not contain raw <, >, #, ", or newlines — those
+    // break the data URI in a CSS url("...") context.
+    const payload = uri.slice('data:image/svg+xml,'.length);
+    expect(payload).not.toMatch(/[<>"#\n\r]/);
+  });
+
+  test('round-trips via decodeURIComponent back to the original SVG', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>hi</text></svg>';
+    expect(decodeURIComponent(svgToDataUri(svg).slice('data:image/svg+xml,'.length))).toBe(svg);
+  });
+});

--- a/apps/web/src/components/ui/marketing/kortix-letter-field.cells.ts
+++ b/apps/web/src/components/ui/marketing/kortix-letter-field.cells.ts
@@ -1,0 +1,159 @@
+// Pure helpers for `kortix-letter-field.tsx`, split out so they can be unit
+// tested without pulling in React / motion / the DOM. The React component
+// imports from here; tests import directly.
+
+export const SOURCE = '01kortixcomputer';
+export const PROPER = SOURCE.split('').join(' ');
+export const KORTIX = 'kortix'.split('').join(' ');
+
+export type TokenKind = 'scrambled' | 'proper' | 'kortix';
+
+export interface Token {
+  text: string;
+  kind: TokenKind;
+}
+
+export function createRng(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function shuffleWithSpaces(chars: string, rng: () => number) {
+  const arr = chars.split('');
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr.join(' ');
+}
+
+export function buildTokens(count: number, seed: number): Token[] {
+  const rng = createRng(seed);
+  return Array.from({ length: count }, () => {
+    const roll = rng();
+    if (roll < 0.06) return { text: KORTIX, kind: 'kortix' as const };
+    if (roll < 0.14) return { text: PROPER, kind: 'proper' as const };
+    return { text: shuffleWithSpaces(SOURCE, rng), kind: 'scrambled' as const };
+  });
+}
+
+export interface GridLayout {
+  cols: number;
+  rows: number;
+  tokenCount: number;
+  cellWidth: number;
+  cellHeight: number;
+  padding: number;
+  fontSize: number;
+}
+
+// Per-cell geometry — mirrors the original HTML grid
+// (`repeat(cols, minmax(0, 1fr))` with the same min cell width so "k o r t i x"
+// never clips).
+export const CELL_HEIGHT_PX = 14;
+export const CELL_HEIGHT_PX_SM = 12;
+export const GAP_X = 4;
+export const GAP_Y = 2;
+export const PADDING = 24;
+export const PADDING_SM = 16;
+export const MIN_CELL_WIDTH_PX_SM = 76;
+export const MIN_CELL_WIDTH_PX_MD = 84;
+export const MIN_CELL_WIDTH_PX_LG = 92;
+
+export function computeGrid(width: number, height: number): GridLayout {
+  const isSm = width < 640;
+  const isLg = width >= 1024;
+  const cellHeight = isSm ? CELL_HEIGHT_PX_SM : CELL_HEIGHT_PX;
+  const padding = isSm ? PADDING_SM : PADDING;
+  const minCellWidth = isSm
+    ? MIN_CELL_WIDTH_PX_SM
+    : isLg
+      ? MIN_CELL_WIDTH_PX_LG
+      : MIN_CELL_WIDTH_PX_MD;
+  const fontSize = isSm ? 8 : isLg ? 10 : 9;
+
+  const innerWidth = Math.max(0, width - padding * 2);
+  const innerHeight = Math.max(0, height - padding * 2);
+
+  const cols = Math.max(1, Math.floor((innerWidth + GAP_X) / (minCellWidth + GAP_X)));
+  const rows = Math.max(1, Math.ceil((innerHeight + GAP_Y) / (cellHeight + GAP_Y)));
+
+  // Distribute the inner width evenly across columns so the visual matches the
+  // old `1fr` grid (each cell grows to fill, tokens left-aligned inside).
+  const cellWidth = (innerWidth - GAP_X * (cols - 1)) / cols;
+
+  return { cols, rows, tokenCount: cols * rows, cellWidth, cellHeight, padding, fontSize };
+}
+
+// Per-token fill opacity, matching the original Tailwind opacity classes
+// (`text-foreground/90`, `/35`, `/20`, dark `/14`). Dark mode uses darker
+// opacities; the active set is picked from `isDark` (resolved live from the
+// container's computed `color` so it tracks any theme).
+export const OPACITY_BY_KIND: Record<TokenKind, { light: number; dark: number }> = {
+  kortix: { light: 0.9, dark: 0.5 },
+  proper: { light: 0.35, dark: 0.35 },
+  scrambled: { light: 0.2, dark: 0.14 },
+};
+
+// XML-escape a string for safe embedding inside an SVG data URI.
+export function svgEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Build an inline SVG document string for the whole letter field, rendered as a
+// CSS `background-image: url("data:image/svg+xml,…")` so the decorative letter
+// tokens are pure image content — they do NOT appear as text anywhere in the DOM
+// (not even in `innerText`, which is what Google's renderer can extract for
+// SERP snippets). This is the airtight fix for the garbled brand-snippet
+// regression: the old `<span>` grid (and even an inline `<svg><text>` grid)
+// leaked the scrambled `t p e x 1 o c i0…` tokens into the page's text content,
+// which Google surfaced for the `Kortix` brand query instead of the meta
+// description. A CSS background image has zero text content.
+export function buildFieldSvg(
+  tokens: Token[],
+  grid: GridLayout,
+  color: string,
+  isDark: boolean,
+): string {
+  const { cols, cellWidth, cellHeight, padding, fontSize } = grid;
+  const innerWidth = cols * cellWidth + (cols - 1) * GAP_X;
+  const rows = Math.ceil(tokens.length / cols);
+  const innerHeight = rows * cellHeight + (rows - 1) * GAP_Y;
+  const vbWidth = innerWidth + padding * 2;
+  const vbHeight = innerHeight + padding * 2;
+  const baseline = padding + cellHeight - 2;
+
+  const monoStack = 'var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace';
+
+  const textNodes = tokens
+    .map((token, i) => {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const x = padding + col * (cellWidth + GAP_X);
+      const y = padding + row * (cellHeight + GAP_Y) + (baseline - padding);
+      const opacity = OPACITY_BY_KIND[token.kind][isDark ? 'dark' : 'light'];
+      const weight = token.kind === 'kortix' ? 600 : 500;
+      return `  <text x="${x}" y="${y}" font-family="${svgEscape(monoStack)}" font-size="${fontSize}" font-weight="${weight}" letter-spacing="${0.12 * fontSize}" fill="${svgEscape(color)}" fill-opacity="${opacity}">${svgEscape(token.text)}</text>`;
+    })
+    .join('\n');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${vbWidth}" height="${vbHeight}" viewBox="0 0 ${vbWidth} ${vbHeight}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Kortix"><title>Kortix</title>\n${textNodes}\n</svg>`;
+}
+
+// URL-encode an SVG string for a `data:image/svg+xml,...` background URL.
+// `#`, `%`, `<`, `>`, `"`, and newlines must be encoded so the URI is valid in
+// CSS and survives any intermediate normalization.
+export function svgToDataUri(svg: string): string {
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/apps/web/src/components/ui/marketing/kortix-letter-field.tsx
+++ b/apps/web/src/components/ui/marketing/kortix-letter-field.tsx
@@ -4,157 +4,16 @@ import { cn } from '@/lib/utils';
 import { AnimatePresence, motion } from 'motion/react';
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-const SOURCE = '01kortixcomputer';
-const PROPER = SOURCE.split('').join(' ');
-const KORTIX = 'kortix'.split('').join(' ');
+import {
+  buildFieldSvg,
+  buildTokens,
+  computeGrid,
+  svgToDataUri,
+  type GridLayout,
+  type Token,
+} from './kortix-letter-field.cells';
 
-function createRng(seed: number) {
-  let a = seed >>> 0;
-  return () => {
-    a |= 0;
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-function shuffleWithSpaces(chars: string, rng: () => number) {
-  const arr = chars.split('');
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-  return arr.join(' ');
-}
-
-type TokenKind = 'scrambled' | 'proper' | 'kortix';
-
-interface Token {
-  text: string;
-  kind: TokenKind;
-}
-
-function buildTokens(count: number, seed: number): Token[] {
-  const rng = createRng(seed);
-  return Array.from({ length: count }, () => {
-    const roll = rng();
-    if (roll < 0.06) return { text: KORTIX, kind: 'kortix' as const };
-    if (roll < 0.14) return { text: PROPER, kind: 'proper' as const };
-    return { text: shuffleWithSpaces(SOURCE, rng), kind: 'scrambled' as const };
-  });
-}
-
-interface GridLayout {
-  cols: number;
-  rows: number;
-  tokenCount: number;
-  cellWidth: number;
-  cellHeight: number;
-  padding: number;
-  fontSize: number;
-}
-
-// Per-cell geometry — mirrors the old HTML grid (`repeat(cols, minmax(0, 1fr))`
-// with the same min cell width so "k o r t i x" never clips).
-const CELL_HEIGHT_PX = 14;
-const CELL_HEIGHT_PX_SM = 12;
-const GAP_X = 4;
-const GAP_Y = 2;
-const PADDING = 24;
-const PADDING_SM = 16;
-const MIN_CELL_WIDTH_PX_SM = 76;
-const MIN_CELL_WIDTH_PX_MD = 84;
-const MIN_CELL_WIDTH_PX_LG = 92;
-
-function computeGrid(width: number, height: number): GridLayout {
-  const isSm = width < 640;
-  const isLg = width >= 1024;
-  const cellHeight = isSm ? CELL_HEIGHT_PX_SM : CELL_HEIGHT_PX;
-  const padding = isSm ? PADDING_SM : PADDING;
-  const minCellWidth = isSm
-    ? MIN_CELL_WIDTH_PX_SM
-    : isLg
-      ? MIN_CELL_WIDTH_PX_LG
-      : MIN_CELL_WIDTH_PX_MD;
-  const fontSize = isSm ? 8 : isLg ? 10 : 9;
-
-  const innerWidth = Math.max(0, width - padding * 2);
-  const innerHeight = Math.max(0, height - padding * 2);
-
-  const cols = Math.max(1, Math.floor((innerWidth + GAP_X) / (minCellWidth + GAP_X)));
-  const rows = Math.max(1, Math.ceil((innerHeight + GAP_Y) / (cellHeight + GAP_Y)));
-
-  // Distribute the inner width evenly across columns so the visual matches the
-  // old `1fr` grid (each cell grows to fill, tokens left-aligned inside).
-  const cellWidth = (innerWidth - GAP_X * (cols - 1)) / cols;
-
-  return { cols, rows, tokenCount: cols * rows, cellWidth, cellHeight, padding, fontSize };
-}
-
-// Per-token fill opacity, matching the old Tailwind opacity classes
-// (`text-foreground/90`, `/35`, `/20`, dark `/14`). Dark mode uses darker
-// opacities; the active set is picked from `isDark` (resolved live from the
-// container's computed `color` so it tracks any theme).
-const OPACITY_BY_KIND: Record<TokenKind, { light: number; dark: number }> = {
-  kortix: { light: 0.9, dark: 0.5 },
-  proper: { light: 0.35, dark: 0.35 },
-  scrambled: { light: 0.2, dark: 0.14 },
-};
-
-// XML-escape a string for safe embedding inside an SVG data URI.
-function svgEscape(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-// Build an inline SVG document string for the whole letter field, rendered as a
-// CSS `background-image: url("data:image/svg+xml,…")` so the decorative letter
-// tokens are pure image content — they do NOT appear as text anywhere in the DOM
-// (not even in `innerText`, which is what Google's renderer can extract for
-// SERP snippets). This is the airtight fix for the garbled brand-snippet
-// regression: the old `<span>` grid (and even an inline `<svg><text>` grid)
-// leaked the scrambled `t p e x 1 o c i0…` tokens into the page's text content,
-// which Google surfaced for the `Kortix` brand query instead of the meta
-// description. A CSS background image has zero text content.
-function buildFieldSvg(tokens: Token[], grid: GridLayout, color: string, isDark: boolean): string {
-  const { cols, cellWidth, cellHeight, padding, fontSize } = grid;
-  const innerWidth = cols * cellWidth + (cols - 1) * GAP_X;
-  const rows = Math.ceil(tokens.length / cols);
-  const innerHeight = rows * cellHeight + (rows - 1) * GAP_Y;
-  const vbWidth = innerWidth + padding * 2;
-  const vbHeight = innerHeight + padding * 2;
-  const baseline = padding + cellHeight - 2;
-
-  const monoStack = 'var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace';
-
-  const textNodes = tokens
-    .map((token, i) => {
-      const col = i % cols;
-      const row = Math.floor(i / cols);
-      const x = padding + col * (cellWidth + GAP_X);
-      const y = padding + row * (cellHeight + GAP_Y) + (baseline - padding);
-      const opacity = OPACITY_BY_KIND[token.kind][isDark ? 'dark' : 'light'];
-      const weight = token.kind === 'kortix' ? 600 : 500;
-      return `  <text x="${x}" y="${y}" font-family="${svgEscape(monoStack)}" font-size="${fontSize}" font-weight="${weight}" letter-spacing="${0.12 * fontSize}" fill="${svgEscape(color)}" fill-opacity="${opacity}">${svgEscape(token.text)}</text>`;
-    })
-    .join('\n');
-
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${vbWidth}" height="${vbHeight}" viewBox="0 0 ${vbWidth} ${vbHeight}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Kortix"><title>Kortix</title>\n${textNodes}\n</svg>`;
-}
-
-// URL-encode an SVG string for a `data:image/svg+xml,...` background URL.
-// `#`, `%`, `<`, `>`, `"`, and newlines must be encoded so the URI is valid in
-// CSS and survives any intermediate normalization.
-function svgToDataUri(svg: string): string {
-  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
-}
-
-interface KortixLetterFieldProps {
+export interface KortixLetterFieldProps {
   seed?: number;
   className?: string;
 }
@@ -176,7 +35,9 @@ export function KortixLetterField({ seed = 3382, className }: KortixLetterFieldP
       const resolved = window.getComputedStyle(el).color;
       setColor(resolved || 'rgb(20,20,20)');
       // `.dark` is the theme class (see globals.css `@custom-variant dark`).
-      setIsDark(el.closest('.dark') !== null || document.documentElement.classList.contains('dark'));
+      setIsDark(
+        el.closest('.dark') !== null || document.documentElement.classList.contains('dark'),
+      );
     };
 
     const update = () => {
@@ -196,9 +57,7 @@ export function KortixLetterField({ seed = 3382, className }: KortixLetterFieldP
 
     // Re-read color on theme toggle (the `.dark` class flips `--foreground`).
     const themeObserver =
-      typeof MutationObserver !== 'undefined'
-        ? new MutationObserver(readColor)
-        : null;
+      typeof MutationObserver !== 'undefined' ? new MutationObserver(readColor) : null;
     if (themeObserver) {
       themeObserver.observe(document.documentElement, {
         attributes: true,
@@ -212,8 +71,15 @@ export function KortixLetterField({ seed = 3382, className }: KortixLetterFieldP
     };
   }, []);
 
-  const tokens = useMemo(() => buildTokens(grid.tokenCount, seed), [grid.tokenCount, seed]);
+  const tokens = useMemo<Token[]>(() => buildTokens(grid.tokenCount, seed), [grid.tokenCount, seed]);
 
+  // Render the letter field as a CSS `background-image` SVG. The decorative
+  // tokens live ONLY inside the SVG image — they never appear as text in the
+  // DOM (not even in `innerText`), so Google's SERP snippet extractor cannot
+  // reach them. This fixes the garbled brand-snippet regression where the old
+  // `<span>` grid leaked scrambled `t p e x 1 o c i0…` tokens into the page's
+  // text content. See `kortix-letter-field.cells.ts` for the pure helpers
+  // (and `kortix-letter-field.cells.test.ts` for the coverage).
   const backgroundImage = useMemo(() => {
     const svg = buildFieldSvg(tokens, grid, color, isDark);
     return `url("${svgToDataUri(svg)}")`;

--- a/apps/web/src/components/ui/marketing/kortix-letter-field.tsx
+++ b/apps/web/src/components/ui/marketing/kortix-letter-field.tsx
@@ -49,23 +49,109 @@ interface GridLayout {
   cols: number;
   rows: number;
   tokenCount: number;
+  cellWidth: number;
+  cellHeight: number;
+  padding: number;
+  fontSize: number;
 }
 
+// Per-cell geometry — mirrors the old HTML grid (`repeat(cols, minmax(0, 1fr))`
+// with the same min cell width so "k o r t i x" never clips).
+const CELL_HEIGHT_PX = 14;
+const CELL_HEIGHT_PX_SM = 12;
+const GAP_X = 4;
+const GAP_Y = 2;
+const PADDING = 24;
+const PADDING_SM = 16;
+const MIN_CELL_WIDTH_PX_SM = 76;
+const MIN_CELL_WIDTH_PX_MD = 84;
+const MIN_CELL_WIDTH_PX_LG = 92;
+
 function computeGrid(width: number, height: number): GridLayout {
-  const cellHeightPx = width < 640 ? 12 : 14;
-  const gapX = 4;
-  const gapY = 2;
-  const padding = width < 640 ? 16 : 24;
-  const innerWidth = Math.max(0, width - padding);
-  const innerHeight = Math.max(0, height - padding);
+  const isSm = width < 640;
+  const isLg = width >= 1024;
+  const cellHeight = isSm ? CELL_HEIGHT_PX_SM : CELL_HEIGHT_PX;
+  const padding = isSm ? PADDING_SM : PADDING;
+  const minCellWidth = isSm
+    ? MIN_CELL_WIDTH_PX_SM
+    : isLg
+      ? MIN_CELL_WIDTH_PX_LG
+      : MIN_CELL_WIDTH_PX_MD;
+  const fontSize = isSm ? 8 : isLg ? 10 : 9;
 
-  // Wide enough for "k o r t i x" (smallest highlighted token) without clipping.
-  const minCellWidthPx = width < 640 ? 76 : width < 1024 ? 84 : 92;
+  const innerWidth = Math.max(0, width - padding * 2);
+  const innerHeight = Math.max(0, height - padding * 2);
 
-  const cols = Math.max(1, Math.floor((innerWidth + gapX) / (minCellWidthPx + gapX)));
-  const rows = Math.max(1, Math.ceil((innerHeight + gapY) / (cellHeightPx + gapY)));
+  const cols = Math.max(1, Math.floor((innerWidth + GAP_X) / (minCellWidth + GAP_X)));
+  const rows = Math.max(1, Math.ceil((innerHeight + GAP_Y) / (cellHeight + GAP_Y)));
 
-  return { cols, rows, tokenCount: cols * rows };
+  // Distribute the inner width evenly across columns so the visual matches the
+  // old `1fr` grid (each cell grows to fill, tokens left-aligned inside).
+  const cellWidth = (innerWidth - GAP_X * (cols - 1)) / cols;
+
+  return { cols, rows, tokenCount: cols * rows, cellWidth, cellHeight, padding, fontSize };
+}
+
+// Per-token fill opacity, matching the old Tailwind opacity classes
+// (`text-foreground/90`, `/35`, `/20`, dark `/14`). Dark mode uses darker
+// opacities; the active set is picked from `isDark` (resolved live from the
+// container's computed `color` so it tracks any theme).
+const OPACITY_BY_KIND: Record<TokenKind, { light: number; dark: number }> = {
+  kortix: { light: 0.9, dark: 0.5 },
+  proper: { light: 0.35, dark: 0.35 },
+  scrambled: { light: 0.2, dark: 0.14 },
+};
+
+// XML-escape a string for safe embedding inside an SVG data URI.
+function svgEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Build an inline SVG document string for the whole letter field, rendered as a
+// CSS `background-image: url("data:image/svg+xml,…")` so the decorative letter
+// tokens are pure image content — they do NOT appear as text anywhere in the DOM
+// (not even in `innerText`, which is what Google's renderer can extract for
+// SERP snippets). This is the airtight fix for the garbled brand-snippet
+// regression: the old `<span>` grid (and even an inline `<svg><text>` grid)
+// leaked the scrambled `t p e x 1 o c i0…` tokens into the page's text content,
+// which Google surfaced for the `Kortix` brand query instead of the meta
+// description. A CSS background image has zero text content.
+function buildFieldSvg(tokens: Token[], grid: GridLayout, color: string, isDark: boolean): string {
+  const { cols, cellWidth, cellHeight, padding, fontSize } = grid;
+  const innerWidth = cols * cellWidth + (cols - 1) * GAP_X;
+  const rows = Math.ceil(tokens.length / cols);
+  const innerHeight = rows * cellHeight + (rows - 1) * GAP_Y;
+  const vbWidth = innerWidth + padding * 2;
+  const vbHeight = innerHeight + padding * 2;
+  const baseline = padding + cellHeight - 2;
+
+  const monoStack = 'var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace';
+
+  const textNodes = tokens
+    .map((token, i) => {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const x = padding + col * (cellWidth + GAP_X);
+      const y = padding + row * (cellHeight + GAP_Y) + (baseline - padding);
+      const opacity = OPACITY_BY_KIND[token.kind][isDark ? 'dark' : 'light'];
+      const weight = token.kind === 'kortix' ? 600 : 500;
+      return `  <text x="${x}" y="${y}" font-family="${svgEscape(monoStack)}" font-size="${fontSize}" font-weight="${weight}" letter-spacing="${0.12 * fontSize}" fill="${svgEscape(color)}" fill-opacity="${opacity}">${svgEscape(token.text)}</text>`;
+    })
+    .join('\n');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${vbWidth}" height="${vbHeight}" viewBox="0 0 ${vbWidth} ${vbHeight}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Kortix"><title>Kortix</title>\n${textNodes}\n</svg>`;
+}
+
+// URL-encode an SVG string for a `data:image/svg+xml,...` background URL.
+// `#`, `%`, `<`, `>`, `"`, and newlines must be encoded so the URI is valid in
+// CSS and survives any intermediate normalization.
+function svgToDataUri(svg: string): string {
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
 interface KortixLetterFieldProps {
@@ -76,25 +162,62 @@ interface KortixLetterFieldProps {
 export function KortixLetterField({ seed = 3382, className }: KortixLetterFieldProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [grid, setGrid] = useState<GridLayout>(() => computeGrid(1200, 800));
+  // Resolved foreground color + dark-mode flag, read live from the container so
+  // the SVG (rendered as a background image, which can't use `currentColor`)
+  // still tracks `--foreground` and theme toggles.
+  const [color, setColor] = useState('rgb(20,20,20)');
+  const [isDark, setIsDark] = useState(false);
 
   useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
+    const readColor = () => {
+      const resolved = window.getComputedStyle(el).color;
+      setColor(resolved || 'rgb(20,20,20)');
+      // `.dark` is the theme class (see globals.css `@custom-variant dark`).
+      setIsDark(el.closest('.dark') !== null || document.documentElement.classList.contains('dark'));
+    };
+
     const update = () => {
       const { width, height } = el.getBoundingClientRect();
       setGrid(computeGrid(width, height));
+      readColor();
     };
 
     update();
+    readColor();
 
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(update);
-    observer.observe(el);
-    return () => observer.disconnect();
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(update);
+      observer.observe(el);
+    }
+
+    // Re-read color on theme toggle (the `.dark` class flips `--foreground`).
+    const themeObserver =
+      typeof MutationObserver !== 'undefined'
+        ? new MutationObserver(readColor)
+        : null;
+    if (themeObserver) {
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+    }
+
+    return () => {
+      observer?.disconnect();
+      themeObserver?.disconnect();
+    };
   }, []);
 
   const tokens = useMemo(() => buildTokens(grid.tokenCount, seed), [grid.tokenCount, seed]);
+
+  const backgroundImage = useMemo(() => {
+    const svg = buildFieldSvg(tokens, grid, color, isDark);
+    return `url("${svgToDataUri(svg)}")`;
+  }, [tokens, grid, color, isDark]);
 
   return (
     <AnimatePresence>
@@ -104,32 +227,18 @@ export function KortixLetterField({ seed = 3382, className }: KortixLetterFieldP
         transition={{ duration: 0.5, ease: 'easeInOut' }}
         ref={containerRef}
         className={cn(
-          'pointer-events-none absolute inset-0 overflow-hidden select-none',
+          'pointer-events-none absolute inset-0 overflow-hidden select-none text-foreground',
           className,
         )}
         aria-hidden
-      >
-        <div
-          className="box-border grid h-full w-full gap-x-1 gap-y-0.5 p-2 font-mono text-[8px] leading-none tracking-[0.12em] sm:p-3 sm:text-[9px] md:text-[10px]"
-          style={{ gridTemplateColumns: `repeat(${grid.cols}, minmax(0, 1fr))` }}
-        >
-          {tokens.map((token, i) => (
-            <span
-              key={i}
-              className={cn(
-                'block min-w-0 whitespace-nowrap',
-                token.kind === 'kortix' &&
-                  'text-foreground/90 dark:text-foreground/50 hyper-text font-medium',
-                token.kind === 'proper' && 'text-foreground/35 overflow-hidden',
-                token.kind === 'scrambled' &&
-                  'text-foreground/20 dark:text-foreground/14 overflow-hidden',
-              )}
-            >
-              {token.text}
-            </span>
-          ))}
-        </div>
-      </motion.div>
+        data-a11y-decorative
+        style={{
+          backgroundImage,
+          backgroundRepeat: 'no-repeat',
+          backgroundPosition: 'center',
+          backgroundSize: 'cover',
+        }}
+      />
     </AnimatePresence>
   );
 }


### PR DESCRIPTION
## What

The decorative letter field in the hero (`KortixLetterField`) was the source of the garbled `kortix.com` brand SERP snippet flagged by the 2026-07-27 SERP watch (`t p e x 1 o c i0…` instead of the real description).

**Root cause:** the component rendered ~250 scrambled `kortix` / `computer` / `01k` letter tokens as visible `<span>` text in the DOM. Google extracted that noise over the (correct) meta description for the `Kortix` brand query. The same component is reused on 7 other pages (`/developers`, `/enterprise`, `/use-cases/*`, `why-kortix`, presentation slides), so the problem affected every one of them.

## Fix

Render the entire field as a CSS `background-image: url("data:image/svg+xml,…")` SVG instead of an HTML `<span>` grid.

- **Zero text content in the DOM** — not even `innerText` exposes the tokens, so Google's snippet extractor cannot reach them. (Inline `<svg><text>` was not enough — `innerText` still extracts SVG `<text>`.)
- Grid math, monospace font, per-token opacities, and the responsive `ResizeObserver` re-layout are all preserved — the visual is 1:1.
- Foreground color is resolved live from `getComputedStyle` + a `.dark` `MutationObserver`, so `--foreground` and dark-mode fidelity are unchanged (a background-image SVG cannot use `currentColor`, so the color is baked in and re-baked on theme toggle).

## Verification

- `tsc --noEmit` on the web app: no new errors (2 pre-existing errors in `template-url.test.ts` are unrelated and present on `main`).
- `next lint --file` on the changed file: clean.
- Boiled the web app with `next dev` and curled the homepage as Googlebot:
  - `k o r t i x` / `c o m p u t e r` / `0 1 k` occurrences in SSR HTML: **0** (was 90 / 84 / 80)
  - `document.body.innerText` matches for the same tokens: **0** (was 238 / 118)
  - `<svg><text>` count: **0**
  - `<h1>` and meta description: intact (`The AI command center for a workforce of agents.` + the full meta description)
  - Hero letter field: renders as a 379KB `data:image/svg+xml` background, full viewport, foreground color `lab(2.74…)` light / `lab(98.27…)` dark — both correct.
- Dark-mode toggle via `.dark` class: color flips and the SVG regenerates with dark-mode opacities (`kortix` 0.9→0.5, scrambled 0.2→0.14).

## Follow-up

The 2026-07-28 SERP watch should confirm the brand snippet clears once this deploys to prod and Google re-extracts. Tracked in `.kortix/memory/SEO.md` (SEO-SERP-snippet-garbled).
