### PR TITLE
fix(kaab): make KORTIX_ORIGIN_REF unforgeable + document origin_ref honestly

### DIFF
--- a/apps/api/src/projects/lib/session-runtime-context.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-context.test.ts
@@ -40,4 +40,20 @@ describe('session runtime context boundaries', () => {
       mergeSessionSandboxEnv({ OTHER: 'base' }, { KORTIX_SESSION_CONTEXT: 'invented' }),
     ).toEqual({ OTHER: 'base' });
   });
+
+  test('trusted internal extras cannot shadow or invent KORTIX_ORIGIN_REF', () => {
+    // origin_ref is the end-user a backend session acts for. It is derived
+    // server-side from an origin-gated request field, so a later extraEnvVars
+    // merge must not be able to re-point it at a DIFFERENT end-user...
+    expect(
+      mergeSessionSandboxEnv(
+        { KORTIX_ORIGIN_REF: 'alice', OTHER: 'base' },
+        { KORTIX_ORIGIN_REF: 'bob', OTHER: 'extra' },
+      ),
+    ).toEqual({ KORTIX_ORIGIN_REF: 'alice', OTHER: 'extra' });
+    // ...nor fabricate one on a session the server gave no origin_ref at all.
+    expect(mergeSessionSandboxEnv({ OTHER: 'base' }, { KORTIX_ORIGIN_REF: 'invented' })).toEqual({
+      OTHER: 'base',
+    });
+  });
 });

--- a/apps/api/src/projects/lib/session-runtime-context.ts
+++ b/apps/api/src/projects/lib/session-runtime-context.ts
@@ -6,6 +6,21 @@ import { db } from '../../shared/db';
 /** The only environment variable a public runtime_context request can create. */
 export const SESSION_RUNTIME_CONTEXT_ENV_NAME = 'KORTIX_SESSION_CONTEXT';
 
+/** The end-user a backend (KaaB) session acts for — derived server-side from the
+ *  validated `origin_ref`, never from caller-supplied env. */
+export const SESSION_ORIGIN_REF_ENV_NAME = 'KORTIX_ORIGIN_REF';
+
+/**
+ * Env vars the SERVER owns end to end. Each is derived from validated,
+ * origin-gated request fields, so a later `extraEnvVars` merge must never be
+ * able to forge or erase one — otherwise the attribution the sandbox sees
+ * (and anything a wrapper reasons about from it) stops being trustworthy.
+ */
+const SERVER_OWNED_ENV_NAMES = [
+  SESSION_RUNTIME_CONTEXT_ENV_NAME,
+  SESSION_ORIGIN_REF_ENV_NAME,
+] as const;
+
 export function parseSessionRuntimeContext(
   value: unknown,
 ): { ok: true; context: SessionRuntimeContext | undefined } | { ok: false; error: string } {
@@ -84,10 +99,14 @@ export function mergeSessionSandboxEnv(
 ): Record<string, string> {
   if (!extra) return base;
   const merged = { ...base, ...extra };
-  if (base[SESSION_RUNTIME_CONTEXT_ENV_NAME] !== undefined) {
-    merged[SESSION_RUNTIME_CONTEXT_ENV_NAME] = base[SESSION_RUNTIME_CONTEXT_ENV_NAME];
-  } else {
-    delete merged[SESSION_RUNTIME_CONTEXT_ENV_NAME];
+  // Re-pin every server-owned var AFTER the spread: `extra` may legitimately add
+  // provider/channel env, but it must never override the server's own identity
+  // envelope. Absent in `base` means the server decided this session has none,
+  // so a supplied value is deleted rather than honoured (forging a
+  // KORTIX_ORIGIN_REF on a session that has none would fabricate attribution).
+  for (const name of SERVER_OWNED_ENV_NAMES) {
+    if (base[name] !== undefined) merged[name] = base[name];
+    else delete merged[name];
   }
   return merged;
 }

--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -87,7 +87,7 @@ never races another request's config.
 
 | Field | What it does |
 | --- | --- |
-| `origin_ref` | An opaque id for *your* end-user. Attribution only — it tags the session and usage; it does **not** resolve that user's connectors or secrets by itself. |
+| `origin_ref` | An opaque id for *your* end-user. A label, not a lever: it tags the session, reaches the agent as `KORTIX_ORIGIN_REF`, and blocks an `Idempotency-Key` replay under a *different* end-user. It does **not** resolve that user's connectors or secrets, grant access, or drive billing — and it isn't queryable, so keep your own mapping. |
 | `connector_bindings` | Map a connector alias → a specific **connection profile** (your end-user's own connected account). Resolved server-side at use time; the credential never enters the sandbox. |
 | `inherit_unbound` | With `connector_bindings` set, keep the project-default fallback for connectors you did *not* bind (instead of all-or-nothing). Only ever inherits the project default. |
 | `secrets` | An allow-list of project secret names to expose to this session. Narrowing only — a session can never see a secret you did not list. |
@@ -195,8 +195,9 @@ starting a second one. Replaying a key with a **different** body — different
   allow-list. The agent's machine never holds an app secret.
 - **Bindings can't cross tenants.** A `profile_id` only resolves for the account and
   project that owns it; a wrong or foreign id is rejected as not-found.
-- **`origin_ref` is attribution, not authorization.** It labels the session and
-  usage; it never grants access to a user's data on its own.
+- **`origin_ref` is attribution, not authorization.** It labels the session and is
+  handed to the agent as `KORTIX_ORIGIN_REF`; it never grants access to a user's
+  data on its own, and it resolves no connectors or secrets.
 - **Personal connections stay private.** A session that binds a member's personal
   connection is forced to `visibility: private` and resolves only for that user.
 

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -259,13 +259,37 @@ manifest grants it no secrets (or not that one), the allowlist can't add it back
 — the session simply gets fewer. Identifiers are validated at create, so a typo
 fails fast rather than silently injecting nothing.
 
-### origin_ref — attribution, not identity
+### origin_ref — a label, not a lever
 
-`origin_ref` records *who* the session is for and hands the sandbox
-`KORTIX_ORIGIN_REF`. It does **not** resolve that user's connectors or secrets by
-itself — pass those explicitly (`connector_bindings`, `secrets`). It exists so
-usage, logs, and the agent can be attributed to your end-user without Kortix ever
-knowing them as a login.
+`origin_ref` records *which of your end-users* a session was started for. It is
+an opaque string you choose; Kortix never resolves it to a login.
+
+**Exactly what it does, today:**
+
+1. **Stored + echoed** on the session (`origin_ref` in every session response).
+2. **Handed to the agent** as the `KORTIX_ORIGIN_REF` sandbox env var, so a
+   prompt/tool can say who it is acting for. (Kortix itself never reads it back.)
+3. **Guards idempotent retries.** Replaying an `Idempotency-Key` with a
+   *different* `origin_ref` is refused with `409 IDEMPOTENCY_ORIGIN_CONFLICT`, so
+   a retry can never hand end-user B the session that belongs to end-user A. This
+   is the one thing that would actually break without it.
+
+**What it does NOT do — do not design around these:**
+
+- **It grants nothing.** It is never an input to an authorization decision. The
+  403 you may hit is about *who may set the field* (backend origin only), not
+  about its value.
+- **It resolves nothing.** It does not pull that user's connectors or secrets —
+  pass those explicitly (`connector_bindings`, `secrets`).
+- **It is not queryable.** There is no index on it and no endpoint filters by it,
+  so "list this end-user's sessions" is not something you can ask Kortix today.
+  Keep your own mapping.
+- **It does not drive billing or usage.** Usage events carry no `origin_ref`, and
+  there are no per-end-user caps — concurrency limits are account-wide. If you
+  need per-user metering or cut-off, meter it in your wrapper.
+
+Treat it as a durable label for correlation and attribution. If you need
+structured per-user context inside the run as well, put it in `runtime_context`.
 
 ---
 


### PR DESCRIPTION
Answers the question "do we actually need `origin_ref`?" — **yes, keep it**, but it was both *overclaimed in the docs* and *forgeable in the sandbox*. This fixes both.

## What `origin_ref` actually does
I traced every read of it. Three consumers, one load-bearing:

1. Stored on the session and echoed in every response.
2. Handed to the agent as `KORTIX_ORIGIN_REF` (Kortix itself never reads it back).
3. **Blocks an `Idempotency-Key` replay under a *different* end-user** → `409 IDEMPOTENCY_ORIGIN_CONFLICT`. This is the one thing that genuinely breaks without it: a retry could otherwise hand end-user B the session belonging to end-user A.

And what it does **not** do — no authorization decision reads it, nothing filters or scopes by it, **there is no index on it**, and `usage_events` carries no `origin_ref` (so per-end-user metering/caps do not exist).

## 🔒 Fix: `KORTIX_ORIGIN_REF` was forgeable
`mergeSessionSandboxEnv` re-pinned only `KORTIX_SESSION_CONTEXT` after spreading caller-supplied `extraEnvVars`. So an internal caller could **override** the server-derived `KORTIX_ORIGIN_REF` — or **invent** one on a session that had none — and the sandbox would report an end-user the server never vouched for, quietly poisoning the only attribution signal the agent sees.

Generalized the pin to a `SERVER_OWNED_ENV_NAMES` set covering both vars: present in base → re-pinned; absent → deleted (so a supplied value can't fabricate attribution).

Verified **RED → GREEN**: with the old one-var pin the new test fails (1 fail); with the fix, 4 pass.

## Docs corrected
Both the internal guide and the public `/docs/backend` page claimed `origin_ref` drives **usage** attribution. It doesn't. Replaced with a precise "a label, not a lever" section: exactly the three things it does (including the idempotency guard, previously undocumented and its main value), and an explicit list of what it does *not* do — grants nothing, resolves nothing, isn't queryable, doesn't bill — so nobody designs around behaviour that isn't there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
