### PR TITLE
fix(kaab): require_connectors picks the member's default connection, skips revoked

### DIFF
--- a/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
+++ b/apps/api/src/__tests__/integration-session-connector-profiles.test.ts
@@ -974,6 +974,71 @@ describe('resolveRequiredMemberConnectorProfiles (require_connectors)', () => {
     }
   });
 
+  test("picks the member's OWN DEFAULT when they hold several connections on one connector", async () => {
+    // A member may now hold several personal connections on one connector
+    // ("Work", "Personal"). "Use my veyris" must not be a coin flip between them
+    // — the one they marked default wins, deterministically.
+    const SECOND = crypto.randomUUID();
+    await db.insert(executorConnectionProfiles).values({
+      profileId: SECOND,
+      accountId: ACCOUNT_A,
+      projectId: PROJECT_A,
+      connectorId: CONNECTOR_A,
+      ownerType: 'member',
+      ownerId: USER,
+      label: 'My second workspace',
+      isDefault: true,
+    });
+    try {
+      const res = await resolveRequiredMemberConnectorProfiles({
+        accountId: ACCOUNT_A,
+        projectId: PROJECT_A,
+        actingUserId: USER,
+        actingPrincipalIsServiceAccount: false,
+        aliases: ['veyris'],
+      });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.bindings[0]?.profileId).toBe(SECOND);
+    } finally {
+      await db
+        .delete(executorConnectionProfiles)
+        .where(eq(executorConnectionProfiles.profileId, SECOND));
+    }
+  });
+
+  test('skips a REVOKED connection and uses the active one instead of failing closed', async () => {
+    // The lookup must filter to usable rows IN the query. Fetching an arbitrary
+    // row first and then rejecting it would report "connect your account" while
+    // a perfectly good active connection exists.
+    const REVOKED = crypto.randomUUID();
+    await db.insert(executorConnectionProfiles).values({
+      profileId: REVOKED,
+      accountId: ACCOUNT_A,
+      projectId: PROJECT_A,
+      connectorId: CONNECTOR_A,
+      ownerType: 'member',
+      ownerId: USER,
+      label: 'Revoked workspace',
+      status: 'revoked',
+      isDefault: true, // even as the "default", a revoked row must never win
+    });
+    try {
+      const res = await resolveRequiredMemberConnectorProfiles({
+        accountId: ACCOUNT_A,
+        projectId: PROJECT_A,
+        actingUserId: USER,
+        actingPrincipalIsServiceAccount: false,
+        aliases: ['veyris'],
+      });
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.bindings[0]?.profileId).toBe(PROFILE_A);
+    } finally {
+      await db
+        .delete(executorConnectionProfiles)
+        .where(eq(executorConnectionProfiles.profileId, REVOKED));
+    }
+  });
+
   test('resolves DISTINCT users to their own member profiles (never each other)', async () => {
     // OTHER_USER owns PROFILE_B for the same connector — must not get USER's.
     const res = await resolveRequiredMemberConnectorProfiles({

--- a/apps/api/src/projects/lib/session-connector-bindings.ts
+++ b/apps/api/src/projects/lib/session-connector-bindings.ts
@@ -9,7 +9,7 @@ import {
   projectSessions,
   serviceAccounts,
 } from '@kortix/db';
-import { and, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { db } from '../../shared/db';
 
 export interface ValidatedSessionConnectorBinding {
@@ -293,8 +293,6 @@ export async function resolveRequiredMemberConnectorProfiles(input: {
         profileId: executorConnectionProfiles.profileId,
         connectorId: executorConnectionProfiles.connectorId,
         ownerId: executorConnectionProfiles.ownerId,
-        status: executorConnectionProfiles.status,
-        connectorEnabled: executorConnectors.enabled,
       })
       .from(executorConnectionProfiles)
       .innerJoin(
@@ -312,10 +310,21 @@ export async function resolveRequiredMemberConnectorProfiles(input: {
           eq(executorConnectionProfiles.ownerType, 'member'),
           eq(executorConnectionProfiles.ownerId, input.actingUserId),
           eq(executorConnectors.slug, alias),
+          // Filter to USABLE rows in the query, not after LIMIT 1. A member may
+          // now hold several connections on one connector, so fetching an
+          // arbitrary row and then rejecting it would report "connect your
+          // account" while a perfectly good active connection sits right there.
+          eq(executorConnectionProfiles.status, 'active'),
+          eq(executorConnectors.enabled, true),
         ),
       )
+      // Deterministic pick: the member's own DEFAULT wins. Without this, "use my
+      // gmail" would choose arbitrarily between e.g. their "Work" and "Personal"
+      // accounts — i.e. act as the wrong account on a coin flip. Tie-break on
+      // profileId so the choice is stable across calls when no default is set.
+      .orderBy(desc(executorConnectionProfiles.isDefault), executorConnectionProfiles.profileId)
       .limit(1);
-    if (!row || row.status !== 'active' || !row.connectorEnabled) {
+    if (!row) {
       return {
         ok: false,
         connector: publicAlias,


### PR DESCRIPTION
Fixes two bugs that the multi-connection work (#5556) created in `require_connectors` (#5366) — they only appear now that a member can hold **several** personal connections on one connector.

`resolveRequiredMemberConnectorProfiles` fetched the member's connection with `LIMIT 1`, **no ordering** and **no status filter**:

1. **Wrong-account on a coin flip.** "Use my gmail" chose *arbitrarily* between the member's `Work` and `Personal` accounts. For a connector like Gmail that means sending as the wrong identity, non-deterministically.
2. **Spurious "connect your account".** If the arbitrary row happened to be **revoked**, create failed with `CONNECTOR_CONNECTION_REQUIRED` even though the member had a perfectly good active connection — the status was checked *after* `LIMIT 1` instead of in the query.

## Fix
- Filter to `status = 'active'` **and** `connector.enabled` **inside** the query, so a revoked row can never crowd out a usable one.
- `ORDER BY is_default DESC, profile_id` — the member's own marked default wins, with a stable tie-break when they haven't marked one.

This lines up `require_connectors` with the per-owner default model #5556 introduced: each member marks one default, and that's what "my connection" resolves to.

## Tests
- `picks the member's OWN DEFAULT when they hold several connections on one connector`
- `skips a REVOKED connection and uses the active one instead of failing closed` (asserts a revoked row still loses even when flagged default)

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
