### PR TITLE
fix(kaab): re-land connectors_personal onto main (#5370 merged into its base branch, not main)

### DIFF
--- a/apps/api/src/projects/agents.test.ts
+++ b/apps/api/src/projects/agents.test.ts
@@ -33,7 +33,8 @@ mock.module('./git', () => ({
 }));
 
 const { loadProjectAgents } = await import('./agents');
-const { DEFAULT_AGENT_SENTINEL, resolveGovernedAgentGrant } = await import('./agents');
+const { DEFAULT_AGENT_SENTINEL, resolveGovernedAgentGrant, personalConnectorsForAgent } =
+  await import('./agents');
 
 const fakeProject = () => ({
   projectId: 'proj_blank',
@@ -116,5 +117,62 @@ describe('loadProjectAgents — blank managed project (no manifest committed yet
 
     expect(loaded.defaultAgent).toBe('support');
     expect(loaded.specs.map((s) => s.name)).toEqual(['support']);
+  });
+});
+
+describe('connectors_personal — v2 agent personal-connector declaration', () => {
+  test('parses a valid subset of the connectors grant, resolvable by name AND the default sentinel', async () => {
+    manifestFile = {
+      path: 'kortix.yaml',
+      content: [
+        'kortix_version: 2',
+        'default_agent: support',
+        'agents:',
+        '  support:',
+        '    connectors: [gmail, slack]',
+        '    connectors_personal: [gmail]',
+        '',
+      ].join('\n'),
+    };
+    const loaded = await loadProjectAgents(fakeProject());
+    expect(loaded.errors).toEqual([]);
+    expect(loaded.specs.find((s) => s.name === 'support')?.connectorsPersonal).toEqual(['gmail']);
+    expect(personalConnectorsForAgent('support', loaded)).toEqual(['gmail']);
+    // the `default` sentinel resolves to the manifest's default_agent (support)
+    expect(personalConnectorsForAgent(DEFAULT_AGENT_SENTINEL, loaded)).toEqual(['gmail']);
+  });
+
+  test('rejects a personal connector that is not in the connectors grant', async () => {
+    manifestFile = {
+      path: 'kortix.yaml',
+      content: [
+        'kortix_version: 2',
+        'default_agent: support',
+        'agents:',
+        '  support:',
+        '    connectors: [gmail]',
+        '    connectors_personal: [slack]',
+        '',
+      ].join('\n'),
+    };
+    const loaded = await loadProjectAgents(fakeProject());
+    expect(loaded.errors.length).toBeGreaterThan(0);
+    expect(loaded.errors[0]?.error).toContain('subset of connectors');
+  });
+
+  test('an agent that declares none yields no personal connectors', async () => {
+    manifestFile = {
+      path: 'kortix.yaml',
+      content: [
+        'kortix_version: 2',
+        'default_agent: support',
+        'agents:',
+        '  support:',
+        '    connectors: [gmail]',
+        '',
+      ].join('\n'),
+    };
+    const loaded = await loadProjectAgents(fakeProject());
+    expect(personalConnectorsForAgent('support', loaded)).toEqual([]);
   });
 });

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -84,6 +84,10 @@ export interface AgentSpec {
   enabled: boolean;
   /** Which connector profiles (by slug) this agent may use. `[]` = none (default). */
   connectors: GrantSet;
+  /** Subset of `connectors` that must resolve to the LAUNCHING USER's OWN member
+   *  connection (v2 `connectors_personal`). A session with this agent auto-requires
+   *  these — like the caller passing require_connectors. Omitted/[] = none. */
+  connectorsPersonal?: string[];
   /** Kortix CLI/API powers (project-scoped iam actions). `[]` = none (default). */
   kortixCli: GrantSet;
   /** Project-secret IDENTIFIERS (project_secrets.identifier, not raw env-var
@@ -382,6 +386,24 @@ export function sandboxFromLoadedAgents(agentName: string, loaded: LoadedAgents)
 }
 
 /**
+ * The connector aliases this agent declares as PERSONAL (`connectors_personal`) —
+ * a session started with the agent must resolve each to the launching user's OWN
+ * connection. Mirrors grantFromLoadedAgents' agent resolution (a concrete name,
+ * or the `default` sentinel → the manifest's `default_agent`). Returns [] when the
+ * project has no per-agent governance, or the agent isn't found/enabled, or it
+ * declares none. v1 agents never set connectorsPersonal, so this is always [].
+ */
+export function personalConnectorsForAgent(agentName: string, loaded: LoadedAgents): string[] {
+  if (loaded.specs.length === 0 && loaded.errors.length === 0) return [];
+  const spec =
+    loaded.specs.find((s) => s.name === agentName && s.enabled) ??
+    (agentName === DEFAULT_AGENT_SENTINEL && loaded.defaultAgent
+      ? loaded.specs.find((s) => s.name === loaded.defaultAgent && s.enabled)
+      : undefined);
+  return spec?.connectorsPersonal ?? [];
+}
+
+/**
  * Is this project subject to MANDATORY DECLARED AGENTS enforcement?
  * (docs/specs/2026-07-05-agent-first-config-unification.md §2.1/§3 Phase 2)
  *
@@ -647,6 +669,31 @@ function parseAgentEntryV2(name: string, block: unknown, filename: string): Pars
 
   const connectorsResolved = resolveGrantSet(row.connectors, 'none');
 
+  // connectors_personal: a concrete subset of the connectors grant that must
+  // resolve to the launching user's OWN connection. Deny-by-default (omitted → []).
+  let connectorsPersonal: string[] = [];
+  if (row.connectors_personal !== undefined && row.connectors_personal !== null) {
+    if (
+      !Array.isArray(row.connectors_personal) ||
+      !row.connectors_personal.every((a) => typeof a === 'string')
+    ) {
+      return err(name, `agents.${name}.connectors_personal must be a list of connector names`);
+    }
+    connectorsPersonal = Array.from(new Set(row.connectors_personal as string[]));
+    // An ungranted connector can never be personally required (it isn't usable at
+    // all), so connectors_personal must be a subset of the connectors grant.
+    if (connectorsResolved !== 'all') {
+      const granted = new Set<string>(connectorsResolved === 'none' ? [] : connectorsResolved);
+      const notGranted = connectorsPersonal.filter((alias) => !granted.has(alias));
+      if (notGranted.length > 0) {
+        return err(
+          name,
+          `agents.${name}.connectors_personal must be a subset of connectors — not granted: ${notGranted.join(', ')}`,
+        );
+      }
+    }
+  }
+
   const kortixResolved = resolveGrantSet(row.kortix_cli, 'none');
   if (Array.isArray(kortixResolved)) {
     for (const action of kortixResolved) {
@@ -668,6 +715,7 @@ function parseAgentEntryV2(name: string, block: unknown, filename: string): Pars
       path: `${filename}#agents.${name}`,
       enabled,
       connectors: toGrantSet(connectorsResolved),
+      connectorsPersonal,
       kortixCli: toGrantSet(kortixResolved),
       env: toGrantSet(secretsResolved),
       file,

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -35,6 +35,7 @@ import { DEFAULT_SANDBOX_SLUG, resolveTemplate } from '../../snapshots/builder';
 import {
   grantFromLoadedAgents,
   loadProjectAgents,
+  personalConnectorsForAgent,
   projectRequiresDeclaredAgents,
   resolveGovernedAgentGrant,
   sandboxFromLoadedAgents,
@@ -794,12 +795,24 @@ export async function createProjectSession(input: {
     }
   }
 
+  // Agent-declared personal connectors (connectors_personal): a session with this
+  // agent auto-requires the launching user's OWN connection for each — but only
+  // for an interactive ('user') session. A backend/service-account session has no
+  // single current user and manages connectors explicitly via connector_bindings,
+  // so its agent's personal declaration is not enforced here.
+  const loadedAgents = await loadProjectAgents(project);
+  const agentPersonalConnectors =
+    origin === 'user' ? personalConnectorsForAgent(agentName, loadedAgents) : [];
+  const effectiveRequireConnectors = Array.from(
+    new Set<string>([...requireConnectors, ...agentPersonalConnectors]),
+  );
+
   // Every connector this session touches — whether the caller bound it explicitly
-  // (connector_bindings) or requires the user's own (require_connectors) — must be
-  // granted to the session's agent.
+  // (connector_bindings) or it's required as the user's own (require_connectors or
+  // the agent's connectors_personal) — must be granted to the session's agent.
   const grantCheckAliases = new Set<string>([
     ...(parsedConnectorBindings.bindings ? Object.keys(parsedConnectorBindings.bindings) : []),
-    ...requireConnectors,
+    ...effectiveRequireConnectors,
   ]);
   let loadedAgentGrant: ReturnType<typeof grantFromLoadedAgents> | undefined;
   if (grantCheckAliases.size > 0) {
@@ -840,13 +853,13 @@ export async function createProjectSession(input: {
   // Resolve require_connectors to THE ACTING USER's own member profiles and merge
   // them into the binding set. A missing/revoked one fails create with a
   // structured CONNECTOR_CONNECTION_REQUIRED so the UI can prompt a connect.
-  if (requireConnectors.length > 0) {
+  if (effectiveRequireConnectors.length > 0) {
     const required = await resolveRequiredMemberConnectorProfiles({
       accountId,
       projectId,
       actingUserId: userId,
       actingPrincipalIsServiceAccount: input.requestingPrincipalType === 'service_account',
-      aliases: requireConnectors,
+      aliases: effectiveRequireConnectors,
     });
     if (!required.ok) {
       return {

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -799,8 +799,8 @@ export async function createProjectSession(input: {
   // agent auto-requires the launching user's OWN connection for each — but only
   // for an interactive ('user') session. A backend/service-account session has no
   // single current user and manages connectors explicitly via connector_bindings,
-  // so its agent's personal declaration is not enforced here.
-  const loadedAgents = await loadProjectAgents(project);
+  // so its agent's personal declaration is not enforced here. (`loadedAgents` is
+  // already resolved above — reuse it rather than re-reading the manifest.)
   const agentPersonalConnectors =
     origin === 'user' ? personalConnectorsForAgent(agentName, loadedAgents) : [];
   const effectiveRequireConnectors = Array.from(

--- a/apps/web/public/schema/kortix.schema.json
+++ b/apps/web/public/schema/kortix.schema.json
@@ -910,6 +910,13 @@
                     }
                   ]
                 },
+                "connectors_personal": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
                 "secrets": {
                   "description": "An allowlist of names, or the \"all\" / \"none\" sentinel.",
                   "oneOf": [

--- a/apps/web/public/schema/kortix.v2.schema.json
+++ b/apps/web/public/schema/kortix.v2.schema.json
@@ -58,6 +58,13 @@
               }
             ]
           },
+          "connectors_personal": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
           "secrets": {
             "description": "An allowlist of names, or the \"all\" / \"none\" sentinel.",
             "oneOf": [

--- a/packages/manifest-schema/src/index.v2.ts
+++ b/packages/manifest-schema/src/index.v2.ts
@@ -122,6 +122,14 @@ export interface AgentBlockV2 {
   /** Sandbox template slug for sessions that start with this agent. */
   sandbox?: string;
   connectors?: GrantSetV2;
+  /** Subset of `connectors` that must resolve to the LAUNCHING USER's OWN
+   *  connection (their member profile), never the shared project one. Any session
+   *  started with this agent auto-requires these — server-side, exactly like the
+   *  caller passing `require_connectors`. If the user hasn't connected one,
+   *  session-create is refused with CONNECTOR_CONNECTION_REQUIRED so the UI can
+   *  prompt them to connect it. Must be a subset of this agent's `connectors`
+   *  grant (an alias not granted can never be personally required). */
+  connectors_personal?: string[];
   /** Which project secrets this agent may receive as sandbox env (and read via
    *  the secrets API) — a list of secret IDENTIFIERS (project_secrets.identifier),
    *  NOT raw env-var keys. For a project where every secret's identifier equals

--- a/packages/manifest-schema/src/json-schema.ts
+++ b/packages/manifest-schema/src/json-schema.ts
@@ -521,6 +521,9 @@ function agentBlockV2Schema(): JsonSchemaFragment {
       enabled: { type: 'boolean' },
       sandbox: SLUG_SCHEMA,
       connectors: grantSetSchema(),
+      // A concrete subset of `connectors` that must resolve to the launching
+      // user's OWN connection (a list of aliases — never 'all'/'none').
+      connectors_personal: { type: 'array', items: NON_EMPTY_STRING },
       secrets: grantSetSchema(),
       skills: grantSetSchema(),
       kortix_cli: kortixCliGrantSetSchema(2),


### PR DESCRIPTION
**Re-lands #5370, which never actually reached `main`.**

#5370 was stacked on `kaab-required-connectors` (#5366). GitHub only re-targets a stacked PR to `main` when the base branch is *deleted* — I merged #5366 with `--merge` and kept the branch, so #5370 merged into **`kaab-required-connectors`** instead. It shows "MERGED", but `main` has zero occurrences of `connectors_personal`. This PR cherry-picks that work onto `main` properly.

## What it delivers (unchanged from #5370)
An **agent** can declare `connectors_personal` — a subset of its `connectors` grant that must resolve to the **launching user's own** connection. Any *interactive* session started with that agent then auto-requires it, gating with `CONNECTOR_CONNECTION_REQUIRED` if the user hasn't connected. Not enforced for backend/service-account origin (no single "current user" — those use `connector_bindings`).

```yaml
agents:
  mailer:
    connectors: [gmail, calendar]
    connectors_personal: [gmail]   # every session with `mailer` runs on YOUR Gmail
```

Manifest field + JSON schema + parse-time subset validation, `personalConnectorsForAgent`, and session-create enforcement unioned with any caller-supplied `require_connectors`.

## Rebase fix
`main` now resolves `loadedAgents` earlier in `createProjectSession`, so the cherry-picked block re-declared it. Reuses the existing binding instead of re-reading the manifest.

## Verification
- `apps/api` typecheck: **0 errors**
- `packages/manifest-schema`: **324 pass / 0 fail** (includes the committed-JSON-schema sync check)
- `apps/api` agent parser: **7 pass / 0 fail** — valid subset resolves by name *and* via the `default` sentinel; a non-subset is rejected; an agent declaring none yields `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
