### PR TITLE
feat(kaab): set connectors_personal from the agent-scope API (with subset pruning)

### DIFF
--- a/apps/api/src/projects/lib/agent-config-v2.test.ts
+++ b/apps/api/src/projects/lib/agent-config-v2.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import { applyAgentScopeV2 } from './agent-config-v2';
+
+/**
+ * `connectors_personal` is the subset of an agent's `connectors` grant that must
+ * resolve to the LAUNCHING USER's own connection. The manifest parser rejects the
+ * whole agent block if that subset rule is violated — and a manifest that fails
+ * to parse breaks session-create for the agent — so the scope editor must never
+ * be able to WRITE an invalid combination, no matter which order the user edits
+ * the two fields in.
+ */
+const manifest = (agents: Record<string, unknown>) => ({
+  schemaVersion: 2,
+  format: 'yaml' as const,
+  path: 'kortix.yaml',
+  raw: { kortix_version: 2, default_agent: 'support', agents },
+});
+
+const blockOf = (result: { ok: boolean; raw?: Record<string, unknown> }, name = 'support') =>
+  (result as { raw: Record<string, unknown> }).raw.agents as Record<
+    string,
+    Record<string, unknown>
+  >;
+
+describe('applyAgentScopeV2 — connectors_personal', () => {
+  test('writes a personal subset alongside the grant', () => {
+    const res = applyAgentScopeV2(manifest({ support: { connectors: ['gmail', 'slack'] } }), 'support', {
+      connectors: ['gmail', 'slack'],
+      connectorsPersonal: ['gmail'],
+    });
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support.connectors_personal).toEqual(['gmail']);
+  });
+
+  test('an empty list CLEARS the field rather than writing []', () => {
+    const res = applyAgentScopeV2(
+      manifest({ support: { connectors: ['gmail'], connectors_personal: ['gmail'] } }),
+      'support',
+      { connectorsPersonal: [] },
+    );
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support).not.toHaveProperty('connectors_personal');
+  });
+
+  test('narrowing the grant PRUNES a personal entry that just lost it', () => {
+    // The user removes `slack` from the grant in an edit that doesn't mention
+    // connectors_personal. Writing the old personal list unchanged would leave
+    // `slack` personal-but-ungranted — a manifest the parser refuses.
+    const res = applyAgentScopeV2(
+      manifest({ support: { connectors: ['gmail', 'slack'], connectors_personal: ['gmail', 'slack'] } }),
+      'support',
+      { connectors: ['gmail'] },
+    );
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support.connectors_personal).toEqual(['gmail']);
+  });
+
+  test('clearing the grant entirely also clears the personal list', () => {
+    const res = applyAgentScopeV2(
+      manifest({ support: { connectors: ['gmail'], connectors_personal: ['gmail'] } }),
+      'support',
+      { connectors: [] },
+    );
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support).not.toHaveProperty('connectors');
+    expect(blockOf(res).support).not.toHaveProperty('connectors_personal');
+  });
+
+  test("a grant of 'all' keeps every personal entry (everything is granted)", () => {
+    const res = applyAgentScopeV2(manifest({ support: { connectors: 'all' } }), 'support', {
+      connectors: 'all',
+      connectorsPersonal: ['gmail', 'slack'],
+    });
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support.connectors_personal).toEqual(['gmail', 'slack']);
+  });
+
+  test('dedupes a repeated personal entry', () => {
+    const res = applyAgentScopeV2(manifest({ support: { connectors: ['gmail'] } }), 'support', {
+      connectors: ['gmail'],
+      connectorsPersonal: ['gmail', 'gmail'],
+    });
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support.connectors_personal).toEqual(['gmail']);
+  });
+
+  test('leaves other governance keys on the block untouched', () => {
+    const res = applyAgentScopeV2(
+      manifest({ support: { connectors: ['gmail'], secrets: 'all', kortix_cli: ['project.read'] } }),
+      'support',
+      { connectorsPersonal: ['gmail'] },
+    );
+    expect(res.ok).toBe(true);
+    expect(blockOf(res).support.secrets).toBe('all');
+    expect(blockOf(res).support.kortix_cli).toEqual(['project.read']);
+  });
+});

--- a/apps/api/src/projects/lib/agent-config-v2.ts
+++ b/apps/api/src/projects/lib/agent-config-v2.ts
@@ -181,7 +181,13 @@ export function applyAgentBlockV2(
 export function applyAgentScopeV2(
   manifest: ParsedManifest,
   agentName: string,
-  scope: { env?: string[] | 'all'; connectors?: string[] | 'all' },
+  scope: {
+    env?: string[] | 'all';
+    connectors?: string[] | 'all';
+    /** v2 `connectors_personal` — the subset of `connectors` that must resolve to
+     *  the launching user's OWN connection. `[]` clears it. */
+    connectorsPersonal?: string[];
+  },
 ): ApplyAgentBlockResult & { notFound?: boolean } {
   const rawAgents = manifest.raw.agents;
   const existing =
@@ -208,6 +214,29 @@ export function applyAgentScopeV2(
     if (scope.connectors === 'all') merged.connectors = 'all';
     else if (scope.connectors.length === 0) delete merged.connectors;
     else merged.connectors = scope.connectors;
+  }
+  if (scope.connectorsPersonal !== undefined) {
+    const personal = Array.from(new Set(scope.connectorsPersonal));
+    if (personal.length === 0) delete merged.connectors_personal;
+    else merged.connectors_personal = personal;
+  }
+  // connectors_personal MUST stay a subset of connectors — the parser rejects the
+  // whole agent block otherwise, which would make the manifest unloadable and
+  // break session-create for that agent. Narrowing the grant (here, or in a
+  // separate edit that only touches `connectors`) therefore has to prune any
+  // personal entry that just lost its grant, rather than writing a manifest we
+  // know won't parse. 'all' grants everything, so nothing to prune there.
+  const effectiveConnectors = merged.connectors;
+  const effectivePersonal = merged.connectors_personal;
+  if (Array.isArray(effectivePersonal)) {
+    if (effectiveConnectors === undefined) {
+      delete merged.connectors_personal;
+    } else if (Array.isArray(effectiveConnectors)) {
+      const granted = new Set(effectiveConnectors as string[]);
+      const kept = (effectivePersonal as string[]).filter((alias) => granted.has(alias));
+      if (kept.length === 0) delete merged.connectors_personal;
+      else merged.connectors_personal = kept;
+    }
   }
   return applyAgentBlockV2(manifest, agentName, merged as AgentBlockV2);
 }

--- a/apps/api/src/projects/routes/agent-scope.ts
+++ b/apps/api/src/projects/routes/agent-scope.ts
@@ -32,6 +32,11 @@ const GrantSetSchema = z.union([z.literal('all'), z.array(z.string().min(1).max(
 const AgentScopeBody = z.object({
   env: GrantSetSchema.optional(),
   connectors: GrantSetSchema.optional(),
+  // v2 only: the subset of `connectors` that must resolve to the LAUNCHING
+  // USER's own connection. A concrete list (never the 'all'/'none' sentinels) —
+  // "all connectors are personal" is not a thing you can mean safely, since a
+  // session would then be unstartable for anyone who hasn't connected each one.
+  connectors_personal: z.array(z.string().min(1).max(200)).max(500).optional(),
 });
 
 projectsApp.openapi(
@@ -61,9 +66,12 @@ projectsApp.openapi(
 
     const parsed = AgentScopeBody.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) return c.json({ error: 'Invalid body', code: 'invalid_body' }, 400);
-    const { env, connectors } = parsed.data;
-    if (env === undefined && connectors === undefined) {
-      return c.json({ error: 'Provide env and/or connectors', code: 'nothing_to_update' }, 400);
+    const { env, connectors, connectors_personal: connectorsPersonal } = parsed.data;
+    if (env === undefined && connectors === undefined && connectorsPersonal === undefined) {
+      return c.json(
+        { error: 'Provide env, connectors and/or connectors_personal', code: 'nothing_to_update' },
+        400,
+      );
     }
 
     let manifest;
@@ -82,7 +90,11 @@ projectsApp.openapi(
     // map. The v1-only path treated a v2 map as an empty array, so EVERY scope
     // edit on a YAML project 404'd "agent not found" — branch on the schema.
     if (manifest.schemaVersion >= 2) {
-      const applied = applyAgentScopeV2(manifest, agentName, { env, connectors });
+      const applied = applyAgentScopeV2(manifest, agentName, {
+        env,
+        connectors,
+        connectorsPersonal,
+      });
       if (!applied.ok) {
         return applied.notFound
           ? c.json({ error: applied.error, code: 'agent_not_found' }, 404)
@@ -93,6 +105,17 @@ projectsApp.openapi(
       const current = Array.isArray(manifest.raw.agents)
         ? (manifest.raw.agents as Record<string, unknown>[])
         : [];
+      // connectors_personal is a v2 governance field; a v1 `[[agents]]` array
+      // manifest has no place to put it, so say so rather than dropping it.
+      if (connectorsPersonal !== undefined) {
+        return c.json(
+          {
+            error: 'connectors_personal requires a v2 (kortix.yaml) manifest',
+            code: 'unsupported_in_v1',
+          },
+          400,
+        );
+      }
       const applied = applyAgentScope(current, agentName, { env, connectors }, manifest.path);
       if (!applied.ok) return c.json({ error: applied.error, code: 'agent_not_found' }, 404);
       manifest.raw.agents = applied.agents;


### PR DESCRIPTION
Lets the dashboard set an agent's `connectors_personal` — the subset of its connector grant that must resolve to the **launching user's own** connection. Until now that field could only be set by hand-editing `kortix.yaml`, which made the agent-level "run on YOUR Gmail" feature effectively unreachable for most users.

This is the **API half**; the editor control follows in a second PR on top.

## What changed
- `PUT /:projectId/agents/:agentName/scope` accepts `connectors_personal`.
  - A **concrete list only** — never the `all`/`none` sentinels. "Every connector is personal" isn't a safe thing to express: the session becomes unstartable for anyone who hasn't connected every one of them.
  - `[]` clears the field.
  - A **v1** (`[[agents]]` array) manifest returns `400 unsupported_in_v1` rather than silently dropping it — `connectors_personal` is a v2 governance field.
- `applyAgentScopeV2` writes it, deduped.

## The subtle part: keeping the subset valid
The manifest parser **rejects the whole agent block** when `connectors_personal` isn't a subset of `connectors` — and a manifest that won't parse breaks session-create for that agent. The editor must therefore never be able to *write* an invalid pair, in either edit order.

So narrowing (or clearing) the grant now **prunes** any personal entry that just lost its grant — including when the edit only touches `connectors` and never mentions `connectors_personal`.

## Tests
New `agent-config-v2.test.ts`, **7 pass**: writes a subset; `[]` clears; narrowing the grant prunes; clearing the grant clears both; `'all'` keeps everything; dedupes; leaves other governance keys (`secrets`, `kortix_cli`) untouched.

**RED-verified** — with the pruning removed, the two subset tests fail (5 pass / 2 fail); restored, 7/7. `apps/api` typecheck: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
