### PR TITLE
fix(kaab): agent editor could not save any project using connectors_personal

### DIFF
--- a/apps/api/src/__tests__/unit-agent-config-v2.test.ts
+++ b/apps/api/src/__tests__/unit-agent-config-v2.test.ts
@@ -22,6 +22,7 @@ import {
   readAgentBlockV2,
 } from '../projects/lib/agent-config-v2';
 import { parseManifestString, synthesizeBlankManifest } from '../projects/triggers';
+import { extractAgents } from '../projects/agents';
 
 const V2 = `
 kortix_version: 2
@@ -272,5 +273,51 @@ describe('the raw path `loadManifestForEdit` actually produces for a blank proje
     });
     const applied = applyDefaultAgentV2(manifest, manifest.raw.default_agent as string);
     expect(applied.ok).toBe(true);
+  });
+});
+
+/**
+ * The PUT /agents/:name/config route accepts `connectors_personal` and then
+ * re-parses the RESULT through `extractAgents` before committing. That guard
+ * matters because `validateManifest` (which applyAgentBlockV2 gates on) does not
+ * inspect `connectors_personal` at all — only the agent parser enforces the
+ * subset rule, and a block that violates it fails to parse, which would break
+ * session-create for that agent.
+ */
+describe('connectors_personal — the guard the config route commits behind', () => {
+  const manifestWith = (connectors: string[]) =>
+    parseManifestString(
+      ['kortix_version: 2', 'default_agent: support', 'agents:', '  support:', `    connectors: [${connectors.join(', ')}]`, ''].join('\n'),
+      'yaml',
+      'kortix.yaml',
+    );
+
+  test('a valid subset survives apply + re-parse with no errors', () => {
+    const manifest = manifestWith(['gmail', 'slack']);
+    const applied = applyAgentBlockV2(manifest, 'support', {
+      connectors: ['gmail', 'slack'],
+      connectors_personal: ['gmail'],
+    } as never);
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+    const parsed = extractAgents({ ...manifest, raw: applied.raw });
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.specs.find((s) => s.name === 'support')?.connectorsPersonal).toEqual(['gmail']);
+  });
+
+  test('a NON-subset is caught by the re-parse (applyAgentBlockV2 alone would let it through)', () => {
+    const manifest = manifestWith(['gmail']);
+    const applied = applyAgentBlockV2(manifest, 'support', {
+      connectors: ['gmail'],
+      connectors_personal: ['slack'],
+    } as never);
+    // The schema validator does NOT know about connectors_personal, so the apply
+    // itself succeeds — this is exactly why the route needs the extra guard.
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+    const parsed = extractAgents({ ...manifest, raw: applied.raw });
+    const problem = parsed.errors.find((e) => e.name === 'support');
+    expect(problem).toBeDefined();
+    expect(problem?.error).toContain('subset of connectors');
   });
 });

--- a/apps/api/src/projects/routes/agent-config.ts
+++ b/apps/api/src/projects/routes/agent-config.ts
@@ -43,6 +43,7 @@ import { resolveTemplateBySlug } from '../../snapshots/templates';
 import { readRepoFile } from '../git';
 import { commitMultipleFilesToBranch } from '../git/branches';
 import { assertProjectCapability, loadProjectForUser } from '../lib/access';
+import { extractAgents } from '../agents';
 import { applyAgentBlockV2, applyDefaultAgentV2, readAgentBlockV2 } from '../lib/agent-config-v2';
 import { metadataMerge } from '../lib/metadata-merge';
 import { parseAgentMarkdown, serializeAgentMarkdown } from '../lib/agent-markdown';
@@ -75,6 +76,13 @@ const AgentBlockSchema = z
     enabled: z.boolean().optional(),
     sandbox: z.string().min(1).max(128).regex(SLUG_RE).optional(),
     connectors: GrantSetSchema.optional(),
+    // The subset of `connectors` that must resolve to the LAUNCHING USER's own
+    // connection. GET already returns this key verbatim from the manifest, so
+    // omitting it here made `.strict()` reject EVERY save on any project that
+    // declares it — the editor could read the agent but never write it back.
+    // A concrete list only: 'all' would make the agent unstartable for anyone
+    // who hasn't personally connected every one of its connectors.
+    connectors_personal: z.array(z.string().min(1).max(200)).max(500).optional(),
     secrets: GrantSetSchema.optional(),
     skills: GrantSetSchema.optional(),
     kortix_cli: GrantSetSchema.optional(),
@@ -351,6 +359,17 @@ projectsApp.openapi(
     const applied = applyAgentBlockV2(manifest, agentName, governanceBlock);
     if (!applied.ok) {
       return c.json({ error: applied.error, code: 'invalid_config', issues: applied.issues }, 400);
+    }
+
+    // Shape-validate through the REAL parser before committing, exactly as the
+    // scope route does. `validateManifest` (which applyAgentBlockV2 gates on)
+    // does not check `connectors_personal` at all, so without this a save could
+    // commit an agent whose personal set isn't a subset of its grant — a block
+    // that then fails to parse, breaking session-create for that agent.
+    const parsedCheck = extractAgents({ ...manifest, raw: applied.raw });
+    const parseProblem = parsedCheck.errors.find((e) => e.name === agentName);
+    if (parseProblem) {
+      return c.json({ error: parseProblem.error, code: 'invalid_config' }, 400);
     }
 
     // Validate the behavior half (if the request touches it at all) BEFORE


### PR DESCRIPTION
Fixes a **live regression** introduced by the agent-level `connectors_personal` feature (#5370/#5561), plus the validation gap that made it dangerous.

## The bug
`GET /projects/:id/agents/:name/config` returns the raw manifest block **verbatim** ([agent-config.ts:177](apps/api/src/projects/routes/agent-config.ts)), so `connectors_personal` reaches the editor draft and is posted straight back on save. But `PUT` validates with an `AgentBlockSchema` that is **`.strict()`** and never listed the field — so the round-trip fails with `400 invalid_body`.

Net effect: **any project that declares `connectors_personal` in `kortix.yaml` could not save agent config from the dashboard at all** — not the connectors, not the prompt, nothing. Exactly the projects using the feature were the ones locked out.

## The validation gap (why this needed more than one line)
`validateManifest` — which `applyAgentBlockV2` gates on — **does not inspect `connectors_personal`**. Only the agent parser (`parseAgentEntryV2`) enforces the subset rule, and the config route never re-parsed. So simply accepting the field would let the route commit a block whose personal set isn't a subset of its grant → that agent's block then **fails to parse**, breaking session-create for it.

So the route now re-parses the applied manifest through `extractAgents` before committing, mirroring what the scope route already does.

## Tests (19 pass in `unit-agent-config-v2.test.ts`)
- a valid subset survives apply + re-parse cleanly, with `connectorsPersonal` resolved;
- a **non-subset** is caught by the re-parse — and the test asserts `applyAgentBlockV2` alone returns `ok: true`, documenting precisely why the extra guard is load-bearing rather than belt-and-braces.

`apps/api` typecheck: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
