### PR TITLE
feat(web): per-connector 'personal' toggle in the agent editor

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/view/connectors-personal.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/connectors-personal.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { prunePersonalConnectors } from './connectors-personal';
+
+describe('prunePersonalConnectors', () => {
+  test('keeps entries that are still granted', () => {
+    expect(prunePersonalConnectors(['gmail'], ['gmail', 'slack'])).toEqual(['gmail']);
+  });
+
+  test('drops an entry whose grant was just removed', () => {
+    // The exact failure this guards: leaving `slack` personal-but-ungranted
+    // writes an agent block the manifest parser refuses, which breaks
+    // session-create for that agent.
+    expect(prunePersonalConnectors(['gmail', 'slack'], ['gmail'])).toEqual(['gmail']);
+  });
+
+  test("an 'all' grant keeps everything", () => {
+    expect(prunePersonalConnectors(['gmail', 'slack'], 'all')).toEqual(['gmail', 'slack']);
+  });
+
+  test('clearing the grant clears the personal set', () => {
+    expect(prunePersonalConnectors(['gmail'], 'none')).toBeUndefined();
+    expect(prunePersonalConnectors(['gmail'], [])).toBeUndefined();
+    expect(prunePersonalConnectors(['gmail'], undefined)).toBeUndefined();
+  });
+
+  test('returns undefined (not []) so the key is omitted from the YAML', () => {
+    expect(prunePersonalConnectors(['slack'], ['gmail'])).toBeUndefined();
+    expect(prunePersonalConnectors([], ['gmail'])).toBeUndefined();
+    expect(prunePersonalConnectors(undefined, ['gmail'])).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/connectors-personal.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/connectors-personal.ts
@@ -1,0 +1,29 @@
+import type { AgentGrantSetV2 } from '@kortix/sdk';
+
+/**
+ * Keep `connectors_personal` a valid subset of the `connectors` grant.
+ *
+ * The manifest parser REJECTS an agent block whose personal set isn't a subset
+ * of its grant, and a block that fails to parse breaks session-create for that
+ * agent — so narrowing the grant must drop any personal entry that just lost it,
+ * rather than saving a combination we know won't load. The server prunes the
+ * same way; doing it in the editor keeps what the user sees equal to what gets
+ * written.
+ *
+ * Returns `undefined` when nothing should be stored, matching the editor's
+ * convention that an undefined draft key is omitted from the YAML entirely.
+ */
+export function prunePersonalConnectors(
+  personal: string[] | undefined,
+  grant: AgentGrantSetV2 | undefined,
+): string[] | undefined {
+  if (!personal?.length) return undefined;
+  // 'all' grants every connector, so every personal entry stays valid.
+  if (grant === 'all') return personal;
+  // No grant at all (undefined or the 'none' sentinel) means nothing is granted,
+  // so nothing can be personal.
+  if (grant === undefined || grant === 'none') return undefined;
+  const granted = new Set(grant);
+  const kept = personal.filter((alias) => granted.has(alias));
+  return kept.length ? kept : undefined;
+}

--- a/apps/web/src/features/workspace/customize/sections/view/grant-mode-field.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/grant-mode-field.tsx
@@ -11,7 +11,7 @@ import { Segmented } from './agent-editor-primitives';
 import { KORTIX_CLI_CATALOG } from './agent-editor-catalog';
 import { cn } from '@/lib/utils';
 import type { AgentGrantSetV2 } from '@kortix/sdk';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 
 type GrantMode = 'all' | 'pick' | 'none';
 
@@ -80,12 +80,19 @@ export function GrantSetField({
   options,
   emptyLabel,
   allLabel,
+  rowAccessory,
 }: {
   value: AgentGrantSetV2 | undefined;
   onChange: (v: AgentGrantSetV2) => void;
   options: { id: string; label: string }[];
   emptyLabel: string;
   allLabel: string;
+  /** Optional control rendered BESIDE each granted row (e.g. the connectors
+   *  field's "personal" toggle). The row itself is a `<button>`, so an
+   *  interactive accessory cannot be nested inside it — when this returns a
+   *  node the row is wrapped in a flex container and the accessory becomes a
+   *  sibling. Fields that pass nothing render exactly as before. */
+  rowAccessory?: (id: string, isSelected: boolean) => ReactNode;
 }) {
   return (
     <GrantModeField
@@ -105,14 +112,16 @@ export function GrantSetField({
             {rows.map((o) => {
               const isSel = selected.has(o.id);
               const isOrphan = !optionIds.has(o.id);
-              return (
+              const accessory = rowAccessory?.(o.id, isSel);
+              const row = (
                 <button
                   key={o.id}
                   type="button"
                   aria-pressed={isSel}
                   onClick={() => toggle(o.id)}
                   className={cn(
-                    'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-[color,background-color,transform] active:scale-[0.96]',
+                    'flex items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-[color,background-color,transform] active:scale-[0.96]',
+                    accessory ? 'min-w-0 flex-1' : 'w-full',
                     isSel ? 'bg-secondary' : 'hover:bg-muted/50',
                   )}
                 >
@@ -127,6 +136,14 @@ export function GrantSetField({
                   <span className="min-w-0 flex-1 truncate font-mono">{o.label}</span>
                   {isOrphan && <span className="text-kortix-orange">missing</span>}
                 </button>
+              );
+              return accessory ? (
+                <div key={o.id} className="flex items-center gap-1">
+                  {row}
+                  {accessory}
+                </div>
+              ) : (
+                row
               );
             })}
           </div>

--- a/apps/web/src/features/workspace/customize/sections/view/kortix-layer-fields.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/kortix-layer-fields.tsx
@@ -11,11 +11,52 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Bot, ShieldCheck } from 'lucide-react';
+import { Bot, Lock, ShieldCheck } from 'lucide-react';
+import Hint from '@/components/ui/hint';
+import { cn } from '@/lib/utils';
 import { FieldRow, SectionHeader, Segmented } from './agent-editor-primitives';
 import { GrantSetField, KortixCliField } from './grant-mode-field';
 import { WORKSPACE_MODES, WORKSPACE_MODE_HELP } from './agent-editor-catalog';
 import type { AgentConfigBlock, AgentGrantSetV2 } from '@kortix/sdk';
+
+/**
+ * Marks one granted connector as PERSONAL — the session must run on the
+ * launching user's own connected account, not the project's shared one. Renders
+ * beside the connector row (see GrantSetField's `rowAccessory`), because the row
+ * itself is a button and cannot nest one.
+ */
+function PersonalConnectorToggle({
+  active,
+  onToggle,
+}: {
+  active: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Hint
+      label={
+        active
+          ? 'Runs on each user\u2019s OWN connected account. Anyone who hasn\u2019t connected it can\u2019t start a session with this agent.'
+          : 'Use the project\u2019s shared connection. Click to require each user\u2019s own account instead.'
+      }
+    >
+      <button
+        type="button"
+        aria-pressed={active}
+        aria-label={active ? 'Personal connection required' : 'Use the shared connection'}
+        onClick={onToggle}
+        className={cn(
+          'flex size-7 shrink-0 items-center justify-center rounded transition-[color,background-color,transform] active:scale-[0.96]',
+          active
+            ? 'bg-kortix-purple/15 text-kortix-purple'
+            : 'text-muted-foreground/40 hover:text-muted-foreground hover:bg-muted/50',
+        )}
+      >
+        <Lock className="size-3.5" />
+      </button>
+    </Hint>
+  );
+}
 
 export function KortixLayerFields({
   draft,
@@ -93,11 +134,50 @@ export function KortixLayerFields({
         <FieldRow label="Connectors">
           <GrantSetField
             value={draft.connectors}
-            onChange={(v: AgentGrantSetV2) => set('connectors', v)}
+            onChange={(v: AgentGrantSetV2) => {
+              // connectors_personal MUST stay a subset of the grant — the
+              // manifest parser rejects the agent block otherwise, and an
+              // unparseable block breaks session-create for this agent. So
+              // narrowing the grant prunes any personal entry that just lost
+              // it. (The server prunes too; doing it here keeps the UI honest
+              // about what will be saved.)
+              set('connectors', v);
+              const personal = draft.connectors_personal;
+              if (!personal?.length || v === 'all') return;
+              const granted = new Set(v === 'none' ? [] : v);
+              const kept = personal.filter((alias) => granted.has(alias));
+              if (kept.length !== personal.length) {
+                set('connectors_personal', kept.length ? kept : undefined);
+              }
+            }}
             options={connectorOptions}
             allLabel="Every project connector."
             emptyLabel="No connectors in this project yet."
+            rowAccessory={(id, isSelected) =>
+              isSelected ? (
+                <PersonalConnectorToggle
+                  active={draft.connectors_personal?.includes(id) === true}
+                  onToggle={() => {
+                    const current = draft.connectors_personal ?? [];
+                    const next = current.includes(id)
+                      ? current.filter((a) => a !== id)
+                      : [...current, id];
+                    set('connectors_personal', next.length ? next : undefined);
+                  }}
+                />
+              ) : null
+            }
           />
+          {draft.connectors === 'all' && draft.connectors_personal?.length ? (
+            // With an 'all' grant there are no rows to hang toggles on, but a
+            // personal set is still legal (the subset rule is trivially met).
+            // Show it rather than hiding a live setting the user can't see.
+            <p className="text-muted-foreground/60 mt-1.5 text-[11px]">
+              Personal (your own account):{' '}
+              <span className="font-mono">{draft.connectors_personal.join(', ')}</span> — switch to
+              Pick to change.
+            </p>
+          ) : null}
         </FieldRow>
         <FieldRow label="Secrets">
           <GrantSetField

--- a/apps/web/src/features/workspace/customize/sections/view/kortix-layer-fields.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/kortix-layer-fields.tsx
@@ -16,6 +16,7 @@ import Hint from '@/components/ui/hint';
 import { cn } from '@/lib/utils';
 import { FieldRow, SectionHeader, Segmented } from './agent-editor-primitives';
 import { GrantSetField, KortixCliField } from './grant-mode-field';
+import { prunePersonalConnectors } from './connectors-personal';
 import { WORKSPACE_MODES, WORKSPACE_MODE_HELP } from './agent-editor-catalog';
 import type { AgentConfigBlock, AgentGrantSetV2 } from '@kortix/sdk';
 
@@ -135,19 +136,13 @@ export function KortixLayerFields({
           <GrantSetField
             value={draft.connectors}
             onChange={(v: AgentGrantSetV2) => {
-              // connectors_personal MUST stay a subset of the grant — the
-              // manifest parser rejects the agent block otherwise, and an
-              // unparseable block breaks session-create for this agent. So
-              // narrowing the grant prunes any personal entry that just lost
-              // it. (The server prunes too; doing it here keeps the UI honest
-              // about what will be saved.)
               set('connectors', v);
-              const personal = draft.connectors_personal;
-              if (!personal?.length || v === 'all') return;
-              const granted = new Set(v === 'none' ? [] : v);
-              const kept = personal.filter((alias) => granted.has(alias));
-              if (kept.length !== personal.length) {
-                set('connectors_personal', kept.length ? kept : undefined);
+              // Narrowing the grant must drop any personal entry that just lost
+              // it — see prunePersonalConnectors for why an invalid pair is not
+              // merely untidy but unloadable.
+              const pruned = prunePersonalConnectors(draft.connectors_personal, v);
+              if (pruned?.length !== draft.connectors_personal?.length) {
+                set('connectors_personal', pruned);
               }
             }}
             options={connectorOptions}

--- a/packages/sdk/src/core/rest/projects-client/agent-config.ts
+++ b/packages/sdk/src/core/rest/projects-client/agent-config.ts
@@ -54,6 +54,12 @@ export interface AgentConfigBlock {
   enabled?: boolean;
   sandbox?: string;
   connectors?: AgentGrantSetV2;
+  /** The subset of `connectors` that must resolve to the LAUNCHING USER's OWN
+   *  connection rather than the project's shared one. Any interactive session
+   *  with this agent then auto-requires them, refusing to start (and prompting
+   *  the user to connect) when one is missing. Must be a subset of `connectors`
+   *  — a concrete list, never the 'all'/'none' sentinels. */
+  connectors_personal?: string[];
   secrets?: AgentGrantSetV2;
   skills?: AgentGrantSetV2;
   kortix_cli?: AgentGrantSetV2;


### PR DESCRIPTION
Completes the dashboard story for agent-level personal connectors: you can now mark a granted connector as **"run on the user's own account"** from the agent editor, instead of hand-editing `kortix.yaml`.

## The control
A small lock button beside each **granted** connector row. Active = that connector resolves to the launching user's *own* connection; inactive = the project's shared one. Tooltip states the consequence plainly — an active toggle means anyone who hasn't connected that account can't start a session with this agent.

`GrantSetField` gains an optional `rowAccessory` slot. This was necessary rather than cosmetic: each row **is** a `<button>`, so an interactive accessory can't be nested inside it — when `rowAccessory` returns a node the row is wrapped in a flex container and the accessory becomes a sibling. Fields that pass nothing (skills, secrets, CLI) render byte-identically.

## Two correctness details
- **Narrowing the grant prunes personal entries that lost it.** `connectors_personal` must stay a subset of `connectors`; otherwise the agent block fails to parse and session-create breaks for that agent. The server prunes too (#5564) — doing it in the UI keeps what you see equal to what gets saved.
- **The `connectors: 'all'` case.** There are no rows to hang toggles on, yet a personal set is still legal there (the subset rule is trivially satisfied). Rather than hide a live setting the user can't see, it's displayed read-only with a "switch to Pick to change" hint.

## Verification
- `apps/web` typecheck: **0 new errors**; `sdk` typecheck: 0.
- `sdk-boundary` + web unit tests: **5 pass**; `apps/api` agent-config guards: **26 pass**.
- Design-system checked: no banned patterns (raw palette colours, `Loader2`, `transition-all`, `Tooltip`), `Hint` for the tooltip, `kortix-purple` token — matching the private-connection colour used elsewhere in the connectors UI.

Depends on #5565 (which taught the `/config` route to accept the field) — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
