### PR TITLE
feat(web): per-connection IDs + tabbed connector detail

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -158,6 +158,7 @@ import {
 import { OAuth2ApplicationFields } from './connector-oauth2-application-fields';
 import { OAuth2CredentialFields } from './connector-oauth2-fields';
 import { DiscoverCatalogue } from './discover-catalogue';
+import { connectorConnectionRows } from './view/connector-connections';
 
 const PROVIDER_ICON: Record<AdminConnector['provider'], LucideIcon> = {
   pipedream: Zap,
@@ -930,11 +931,7 @@ function ConnectionsList({
     onChanged();
   };
 
-  // The API scopes this list to the caller: every project-owned connection, plus
-  // only the caller's OWN member connections — never another member's.
-  const rows = (profilesQuery.data?.profiles ?? []).filter(
-    (p) => p.connector_alias === connector.slug && p.owner_type !== 'agent',
-  );
+  const rows = connectorConnectionRows(profilesQuery.data?.profiles, connector.slug);
 
   const copyConnectionId = (profileId: string) => {
     // The Clipboard API is absent in insecure contexts (navigator.clipboard is
@@ -1256,6 +1253,32 @@ function ConnectorDetail({
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const displayName = connector.name?.trim() || connector.slug;
+
+  // Which tabs this connector actually has. Pipedream connectors hold many
+  // connections (team + per-member), so they get Connections; everything else
+  // has at most one shared credential, which lives under Connection.
+  const showConnections = isPipedream && !isChannel && !isComputer;
+  const showProfileTab = !isPipedream && !isManaged;
+  const showRoster = showConnections && canManageProfiles;
+  const defaultDetailTab = showConnections
+    ? 'connections'
+    : showProfileTab
+      ? 'profile'
+      : 'permissions';
+
+  // Same query key + filter as ConnectionsList, so the badge can never disagree
+  // with the rows it counts (react-query dedupes the fetch).
+  const detailProfilesQuery = useQuery({
+    queryKey: ['connector-profiles', projectId],
+    queryFn: () => listConnectionProfiles(projectId),
+    staleTime: 30_000,
+    enabled: showConnections,
+  });
+  const connectionCount = connectorConnectionRows(
+    detailProfilesQuery.data?.profiles,
+    connector.slug,
+  ).length;
+
   const [editingName, setEditingName] = useState(false);
   const [nameDraft, setNameDraft] = useState(displayName);
   useEffect(() => {
@@ -1452,46 +1475,57 @@ function ConnectorDetail({
               : `One shared credential that everyone on this project uses — the agent and your triggers run on it.`}
           </InfoBanner>
         )}
-        {/* Connected + shared: state the scope explicitly, so "Connected" is never
-            mistaken for the user's own private connection. */}
-        {connector.authSecret && connected && !isChannel && !isComputer && (
-          <InfoBanner tone="neutral" icon={Users} title="Shared with the whole team">
-            Everyone on this project uses this {displayName} connection. Your own private connection,
-            if you add one, is separate and stays yours.
-          </InfoBanner>
-        )}
-        {/* Every connection under this connector — the team's shared accounts and
-            this member's own. A connector can hold several of each; the DEFAULT
-            in each scope is what a session uses when it names no connection. */}
-        {isPipedream && !isChannel && !isComputer && (
-          <ConnectionsList
-            projectId={projectId}
-            connector={connector}
-            displayName={displayName}
-            canManageProfiles={canManageProfiles}
-            onChanged={onChanged}
-            onStartSession={startPrivateSession}
-          />
-        )}
-        {isPipedream && !isChannel && !isComputer && canManageProfiles && (
-          <ConnectionRoster
-            projectId={projectId}
-            connectorSlug={connector.slug}
-            displayName={displayName}
-          />
-        )}
-        {/* The sensitive toggle lives under Permissions (it IS a permission
-            default), so Profile only exists when there's a connection to
-            manage — for Pipedream/managed connectors it would be empty. */}
-        <Tabs
-          defaultValue={!isPipedream && !isManaged ? 'profile' : 'permissions'}
-          className="gap-3"
-        >
-          <TabsList>
-            {!isPipedream && !isManaged && <TabsTrigger value="profile">Profile</TabsTrigger>}
-            <TabsTrigger value="permissions">Permissions</TabsTrigger>
+        {/* One tab per question this page answers: what can I use (Connections),
+            what may the agent do with it (Permissions), who on the team has
+            connected their own (Team members). Before this, everything stacked
+            into one long scroll above a lone "Permissions" tab, because the only
+            other trigger — Profile — is hidden for Pipedream connectors. */}
+        <Tabs defaultValue={defaultDetailTab} className="gap-3">
+          <TabsList type="underline" className="flex w-full items-center justify-start">
+            {showConnections && (
+              <TabsTrigger value="connections" className="w-fit flex-none gap-2">
+                Connections
+                {connectionCount > 0 ? (
+                  <Badge variant="secondary" size="sm">
+                    {connectionCount}
+                  </Badge>
+                ) : null}
+              </TabsTrigger>
+            )}
+            {showProfileTab && (
+              <TabsTrigger value="profile" className="w-fit flex-none">
+                Connection
+              </TabsTrigger>
+            )}
+            <TabsTrigger value="permissions" className="w-fit flex-none">
+              Permissions
+            </TabsTrigger>
+            {showRoster && (
+              <TabsTrigger value="roster" className="w-fit flex-none">
+                Team members
+              </TabsTrigger>
+            )}
           </TabsList>
-          {!isPipedream && !isManaged && (
+          {/* Every connection under this connector — the team's shared accounts and
+              this member's own. A connector can hold several of each; the DEFAULT
+              in each scope is what a session uses when it names no connection. */}
+          {showConnections && (
+            <TabsContent value="connections" className="space-y-5">
+              <ConnectionsList
+                projectId={projectId}
+                connector={connector}
+                displayName={displayName}
+                canManageProfiles={canManageProfiles}
+                onChanged={onChanged}
+                onStartSession={startPrivateSession}
+              />
+            </TabsContent>
+          )}
+          {/* The sensitive toggle lives under Permissions (it IS a permission
+              default), so this tab only exists when there's a single shared
+              credential to manage — for Pipedream connectors the Connections
+              tab owns that, and this one would be empty. */}
+          {showProfileTab && (
             <TabsContent value="profile" className="space-y-5">
               {isChannel ? (
                 <ChannelConnectionSection
@@ -1520,6 +1554,15 @@ function ConnectorDetail({
               canWrite={canWrite}
             />
           </TabsContent>
+          {showRoster && (
+            <TabsContent value="roster" className="space-y-5">
+              <ConnectionRoster
+                projectId={projectId}
+                connectorSlug={connector.slug}
+                displayName={displayName}
+              />
+            </TabsContent>
+          )}
         </Tabs>
 
         {canWrite && !isManaged && !isChannel && (

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -1265,6 +1265,9 @@ function ConnectorDetail({
     : showProfileTab
       ? 'profile'
       : 'permissions';
+  // Permissions is always present; the other three are conditional.
+  const detailTabCount =
+    1 + (showConnections ? 1 : 0) + (showProfileTab ? 1 : 0) + (showRoster ? 1 : 0);
 
   // Same query key + filter as ConnectionsList, so the badge can never disagree
   // with the rows it counts (react-query dedupes the fetch).
@@ -1481,7 +1484,16 @@ function ConnectorDetail({
             into one long scroll above a lone "Permissions" tab, because the only
             other trigger — Profile — is hidden for Pipedream connectors. */}
         <Tabs defaultValue={defaultDetailTab} className="gap-3">
-          <TabsList type="underline" className="flex w-full items-center justify-start">
+          {/* A single trigger is not a choice — it reads as a broken tab bar.
+              Computer connectors are managed in Computers, so Permissions is
+              all they have left here. */}
+          <TabsList
+            type="underline"
+            className={cn(
+              'flex w-full items-center justify-start',
+              detailTabCount < 2 && 'hidden',
+            )}
+          >
             {showConnections && (
               <TabsTrigger value="connections" className="w-fit flex-none gap-2">
                 Connections

--- a/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/connectors-view.tsx
@@ -801,56 +801,6 @@ function RailItem({
   );
 }
 
-/**
- * Read-only display of a connector's connection `profile_id` — the id a backend
- * passes in `connector_bindings` (Kortix as a Backend) to run a session AS this
- * connection. Surfaced nowhere else in the product, so we show + copy it here.
- */
-function ConnectionIdField({ profileId }: { profileId: string }) {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    // The Clipboard API is absent in insecure contexts (navigator.clipboard is
-    // undefined → a synchronous throw) and writeText can also reject (denied
-    // permission). Guard both so a copy attempt never crashes the handler.
-    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
-    if (!clipboard) {
-      errorToast('Could not copy — select and copy the ID manually.');
-      return;
-    }
-    clipboard.writeText(profileId).then(
-      () => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      },
-      () => errorToast('Could not copy — select and copy the ID manually.'),
-    );
-  };
-  return (
-    <div className="bg-muted/40 rounded-md border px-4 py-3">
-      <div className="flex items-center gap-1.5">
-        <span className="text-muted-foreground text-xs font-medium">Connection ID</span>
-        <Hint label="Use this ID in the backend (connector_bindings) to run a session as this connection — see Kortix as a Backend.">
-          <span className="inline-flex cursor-help">
-            <Info className="text-muted-foreground size-3.5" />
-          </span>
-        </Hint>
-      </div>
-      <div className="mt-1.5 flex items-center gap-2">
-        <code className="min-w-0 flex-1 truncate font-mono text-xs">{profileId}</code>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="size-7 shrink-0"
-          onClick={copy}
-          aria-label="Copy connection ID"
-        >
-          {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 /** One row in the connections list — a single connected account. */
 function ConnectionRow({
   profile,
@@ -859,6 +809,7 @@ function ConnectionRow({
   onSetDefault,
   onDisconnect,
   onStartSession,
+  onCopyId,
   pending,
 }: {
   profile: ConnectionProfile;
@@ -867,6 +818,7 @@ function ConnectionRow({
   onSetDefault: () => void;
   onDisconnect: () => void;
   onStartSession?: () => void;
+  onCopyId: (profileId: string) => void;
   pending: boolean;
 }) {
   const isTeam = profile.owner_type === 'project';
@@ -900,36 +852,45 @@ function ConnectionRow({
         <InlineMeta>
           {isTeam ? 'Shared with the team' : 'Private — only you'}
           {active ? null : profile.status === 'revoked' ? 'Disconnected' : 'Error'}
+          {/* Every connection carries its own id — this is what a backend passes
+              in connector_bindings to run as THIS account. Truncated to keep the
+              row readable; the row menu copies the full value. */}
+          <Hint label="Connection ID — use it in the backend (connector_bindings) to run as this connection.">
+            <code className="cursor-help font-mono">{profile.profile_id.slice(0, 8)}…</code>
+          </Hint>
         </InlineMeta>
       </div>
-      {mayMutate && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-8 shrink-0"
-              aria-label={`Actions for ${profile.label}`}
-              disabled={pending}
-            >
-              {pending ? <Loading className="size-4 shrink-0" /> : <ChevronDown className="size-4" />}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-44">
-            {isMine && active && onStartSession && (
-              <DropdownMenuItem onClick={onStartSession}>Use in a new session</DropdownMenuItem>
-            )}
-            {!profile.is_default && active && (
-              <DropdownMenuItem onClick={onSetDefault}>
-                Use by default{isTeam ? ' for the team' : ''}
-              </DropdownMenuItem>
-            )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0"
+            aria-label={`Actions for ${profile.label}`}
+            disabled={pending}
+          >
+            {pending ? <Loading className="size-4 shrink-0" /> : <ChevronDown className="size-4" />}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-48">
+          <DropdownMenuItem onClick={() => onCopyId(profile.profile_id)}>
+            Copy connection ID
+          </DropdownMenuItem>
+          {mayMutate && isMine && active && onStartSession && (
+            <DropdownMenuItem onClick={onStartSession}>Use in a new session</DropdownMenuItem>
+          )}
+          {mayMutate && !profile.is_default && active && (
+            <DropdownMenuItem onClick={onSetDefault}>
+              Use by default{isTeam ? ' for the team' : ''}
+            </DropdownMenuItem>
+          )}
+          {mayMutate && (
             <DropdownMenuItem variant="destructive" onClick={onDisconnect}>
               Disconnect
             </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </li>
   );
 }
@@ -974,6 +935,20 @@ function ConnectionsList({
   const rows = (profilesQuery.data?.profiles ?? []).filter(
     (p) => p.connector_alias === connector.slug && p.owner_type !== 'agent',
   );
+
+  const copyConnectionId = (profileId: string) => {
+    // The Clipboard API is absent in insecure contexts (navigator.clipboard is
+    // undefined -> a synchronous throw) and writeText can also reject.
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+    if (!clipboard) {
+      errorToast('Could not copy — open the connection and copy the ID manually.');
+      return;
+    }
+    clipboard.writeText(profileId).then(
+      () => successToast('Connection ID copied'),
+      () => errorToast('Could not copy — open the connection and copy the ID manually.'),
+    );
+  };
 
   const addTeam = usePipedreamConnectTeam(projectId, connector.slug, () => {
     setAddScope(null);
@@ -1055,6 +1030,7 @@ function ConnectionsList({
               onSetDefault={() => setDefault.mutate(profile.profile_id)}
               onDisconnect={() => setConfirmDisconnect(profile)}
               onStartSession={onStartSession}
+              onCopyId={copyConnectionId}
             />
           ))}
         </ul>
@@ -1423,9 +1399,6 @@ function ConnectorDetail({
       </div>
 
       <div className="mt-7 space-y-5">
-        {connected && connectionProfile && !isChannel && !isComputer && (
-          <ConnectionIdField profileId={connectionProfile.profile_id} />
-        )}
         {/* Computer connectors are connected + permissioned in the Computers tab
             (device pairing, per-capability grants, audit) — point management
             there instead of the generic credential / connection / remove UI. */}

--- a/apps/web/src/features/workspace/customize/sections/view/connector-connections.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/connector-connections.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { connectorConnectionRows } from './connector-connections';
+
+const profile = (connector_alias: string, owner_type: string, profile_id: string) => ({
+  connector_alias,
+  owner_type,
+  profile_id,
+});
+
+describe('connectorConnectionRows', () => {
+  test('keeps only the connector being viewed', () => {
+    const rows = connectorConnectionRows(
+      [profile('gmail', 'project', 'a'), profile('slack', 'project', 'b')],
+      'gmail',
+    );
+    expect(rows.map((r) => r.profile_id)).toEqual(['a']);
+  });
+
+  test('keeps both team-shared and the caller’s own private connections', () => {
+    const rows = connectorConnectionRows(
+      [profile('gmail', 'project', 'team'), profile('gmail', 'member', 'mine')],
+      'gmail',
+    );
+    expect(rows.map((r) => r.owner_type)).toEqual(['project', 'member']);
+  });
+
+  test('drops agent-owned profiles, which are a binding artifact and not a connection', () => {
+    const rows = connectorConnectionRows(
+      [profile('gmail', 'agent', 'bound'), profile('gmail', 'project', 'team')],
+      'gmail',
+    );
+    expect(rows.map((r) => r.profile_id)).toEqual(['team']);
+  });
+
+  test('treats a missing list as empty, so the tab count never renders NaN', () => {
+    expect(connectorConnectionRows(undefined, 'gmail')).toEqual([]);
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/view/connector-connections.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/connector-connections.ts
@@ -1,0 +1,20 @@
+/**
+ * Which connection profiles belong to one connector's detail view.
+ *
+ * The API already scopes the list to the caller — every project-owned
+ * connection plus only the caller's OWN member connections, never another
+ * member's. This narrows that to a single connector and drops agent-owned
+ * profiles, which are an internal binding artifact rather than something a
+ * person connected.
+ *
+ * Shared by the Connections list and the tab's count badge so the number on
+ * the tab can never disagree with the rows underneath it.
+ */
+export function connectorConnectionRows<T extends { connector_alias: string; owner_type: string }>(
+  profiles: readonly T[] | undefined,
+  connectorSlug: string,
+): T[] {
+  return (profiles ?? []).filter(
+    (profile) => profile.connector_alias === connectorSlug && profile.owner_type !== 'agent',
+  );
+}

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -224,6 +224,29 @@ both mintable with your API key:
    > the first tool call. Use `pipedreamConnect` + `pipedreamFinalize`; the OAuth
    > tokens live in Pipedream's custody, never in Kortix as a raw provider token.
 
+**Picking a SPECIFIC connection.** One connector can hold several connections —
+team-shared accounts (support@, sales@) and each member's own. List them to get
+the id you want:
+
+```bash
+curl -sS "$KORTIX_API_URL/projects/$PROJECT_ID/connector-profiles" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" \
+  | jq '.profiles[] | {label, owner_type, is_default, profile_id}'
+```
+
+(The dashboard shows each connection's id on its row — **⋯ → Copy connection ID**.)
+Then bind that id: `connector_bindings: { gmail: { profile_id: "<id>" } }`.
+
+⚠️ **A backend can only bind TEAM connections.** A member's *private* connection
+(`owner_type: "member"`) is bindable only by that member's own token — a service
+account gets `404 CONNECTOR_PROFILE_NOT_FOUND` (deliberately identical to
+not-found, so an id can't be used to probe who connected what). That is the point
+of "private": it means *runs as me*, and a service account is not a person. If a
+backend needs a particular mailbox, add it as a **team** connection.
+
+Omit `connector_bindings` for an alias and it resolves the team **default** —
+which is what the `Default` badge in the dashboard marks.
+
 > **All-or-nothing binding:** if a session's `connector_bindings` sets *any*
 > alias, every *unbound* alias resolves to null for that session. Bind every
 > connector the agent needs in the one call — **or** pass **`inherit_unbound: true`**

--- a/docs/KORTIX_AS_BACKEND_V1_PLAN.md
+++ b/docs/KORTIX_AS_BACKEND_V1_PLAN.md
@@ -52,7 +52,7 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 ## 4. Edge cases (the parts that bite)
 
-**4.1 Connector all-or-nothing (verified).** Bind one connector and every unbound alias resolves null → that connector goes dark for the session. *Handling:* v1 — the mint API returns the agent's full connector set so the wrapper binds all; v1.1 — add an `inherit_unbound: true` mode. **Decide which.**
+**4.1 Connector all-or-nothing (verified).** ✅ **DECIDED + SHIPPED.** Bind one connector and every unbound alias resolves null → that connector goes dark for the session. *Resolution:* `inherit_unbound: true` shipped as an **opt-in** session-create flag (contract + `project_sessions.connector_bindings_inherit_unbound` + the resolver gate), and **all-or-nothing remains the DEFAULT** — the resolver still fails closed unless the flag is set. Opt-in was chosen over flipping the default so that adding a connection can never silently change what an existing session resolves; the safe-but-surprising behaviour stays the one you get without asking. `require_connectors` sets the flag automatically, since requiring one personal connector must not null the agent's others.
 
 **4.2 Secret hot-push clobber (verified, the killer).** Every prompt re-pushes the project snapshot; a boot-only secret override reverts on turn 1. *Handling:* the merge MUST live in `resolveOwnerRawEnv`, not only boot. Non-negotiable.
 
@@ -70,7 +70,7 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 **4.9 Warm-pool / snapshot reuse.** A recycled warm sandbox must not carry a prior session's overridden env/secrets. *Verify:* env is (re)pushed per session at boot + hot-push — confirm no residual from the pool image before GA.
 
-**4.10 Per-end-user cost & concurrency.** Caps are account-level (`enforceAccountCap`); one end-user could exhaust the account cap and block others. *v1:* usage is attributed per `origin_ref`; the wrapper reads it and cuts off upstream. *Later:* native per-`origin_ref` cap + concurrency in the gateway pre-flight (the one thing the earlier subject-metering idea is still good for).
+**4.10 Per-end-user cost & concurrency.** ✅ **SHIPPED.** Caps were account-level only, so one end-user could exhaust the account cap and block everyone. Now: `usage_events.origin_ref` (server-derived, partial-indexed) with `GET /v1/usage?origin_ref=…` and `group_by=origin_ref`; plus an opt-in per-`origin_ref` live-session cap (`KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` → `429 per_origin_session_limit`) checked alongside the account cap at create. Caveats recorded in the guide: rows predating the column (and all non-session spend) are `NULL` = unattributed and excluded from the rollup, and the cap shares the account cap's check-then-act race, so it is a runaway guard rather than a hard quota.
 
 **4.11 Trigger/webhook on behalf of an end-user.** A webhook that should run as end-user X needs `origin: trigger` **plus** X's `origin_ref` + profile binding. *Suggest:* let a trigger carry an `origin_ref` + connector bindings so origin and overrides compose — the wrapper's most powerful pattern (event → the right user's session).
 
@@ -78,7 +78,7 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 1. ✅ **SHIPPED (PR #5147)** — `origin` field + resolver + `canOverride` policy gate, incl. REV 3 backend credentials (PAT/SA/user-apiKey), sandbox+agent-scope exclusions, queued-create signal carry, and the Tokens-UI "Using the API" story.
 2. Document + expose the shipping path (connectors/model/agent/context) as the "backend" contract, with §4 gotchas. **This alone makes base-agent wrapping real today.**
-3. Server-to-server connector-profile mint + all-or-nothing softening (4.1).
+3. ✅ **SHIPPED** — Server-to-server connector-profile mint + all-or-nothing softening (4.1): `inherit_unbound` (opt-in, default unchanged), multiple connections per connector (team + per-member, label-keyed, per-owner defaults), `require_connectors` + the `CONNECTOR_CONNECTION_REQUIRED` gate, agent-declared `connectors_personal`, and the owner/admin roster.
 4. ✅ **SHIPPED (PR #5154, stacked on #5147)** — Secret-bundle by reference: a backend-only per-session `secrets` allowlist by identifier. Pure NARROWING — injected env = (agent grant) ∩ (allowlist), enforced at BOTH sandbox boot and hot-push (the clobber fix); `[]` = zero secrets; null = byte-identical to today. Immutable first-class column, 403/400/404/409 validation. (Deferred: create-time ambiguity 409, silent-drop warning, web UX.)
 5. Skills subset (v2, optional).
 
@@ -86,9 +86,9 @@ Each new contract field needs a schema add + a ke2e route-coverage test (the `.s
 
 ## 6. Open decisions
 
-1. **All-or-nothing vs inherit-unbound** connector binding (4.1) — pick the default.
+1. ~~**All-or-nothing vs inherit-unbound** connector binding (4.1)~~ — ✅ **RESOLVED:** all-or-nothing stays the default; `inherit_unbound: true` is opt-in. See 4.1.
 2. **Runtime-secret overrides**: allow at all in v1, or connector-scope only until untrusted-sandbox hardening exists?
-3. **Native per-`origin_ref` caps/concurrency** (4.10) — v1 (wrapper-enforced) or build now?
+3. ~~**Native per-`origin_ref` caps/concurrency** (4.10)~~ — ✅ **RESOLVED: built.** Usage is attributed per `origin_ref` on `usage_events` (server-derived, with `?origin_ref=` filter and `group_by=origin_ref`), and `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` caps live sessions per end-user (opt-in, `429 per_origin_session_limit`). Both denormalize/derive server-side rather than joining on the client-supplied `session_id`, which is spoofable on the legacy router path.
 
 ## 7. Explicitly out of scope (v1)
 


### PR DESCRIPTION
Two changes to the connector detail page, both about making a connector's
connections usable from the backend.

### Per-row connection IDs

Each connection row exposes its `profile_id` with a copy action. That is the id
you pass to point a session at **one specific** connection:

```jsonc
{ "connector_bindings": { "gmail": "<profile_id>" } }
```

Without it there was no way to reach the "work" connection from the API — you
got whichever one was the default.

### Tabbed detail page

The page stacked banners, the connections list and the member roster into one
long scroll **above** a `Tabs` block whose only other trigger (Profile) is
hidden for Pipedream connectors — so a connector like `gmail` rendered a single
lone tab, which reads as a bug.

Each tab now answers one question:

| Tab | Answers | Shown for |
| --- | --- | --- |
| **Connections** | what can I use (team-shared + my own, with the default marked) | Pipedream connectors |
| **Connection** | the one shared credential | non-Pipedream, non-managed |
| **Permissions** | what may the agent do with it | always |
| **Team members** | who on the team has connected their own | owners/admins |

The "Shared with the whole team" banner is dropped — every row now states its
own scope, so it was repeating itself.

`connectorConnectionRows` is extracted so the Connections tab's count badge and
the rows beneath it are filtered by the same code and can never disagree.

### Verification

- `tsc --noEmit` on apps/web — 0 errors in the touched files
- `bun test` on the new + sibling helper tests — 9 pass
- Prettier clean on the new files; `connectors-view.tsx` edits kept
  hand-localized (that file is ~2k lines out of format at HEAD, so a `--write`
  would bury the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
