### PR TITLE
fix(web): drop iOS WebView WebKit-bridge messageHandlers noise (BS 5b94212b)

### DIFF
--- a/apps/web/src/lib/browser-error-noise.test.mts
+++ b/apps/web/src/lib/browser-error-noise.test.mts
@@ -17,6 +17,7 @@ import {
   isFramelessNetworkErrorNoise,
   isInjectedAppSource,
   isInpageWalletStreamNoise,
+  isIOSWebViewWebKitBridgeNoise,
   isKnownBrowserNoiseMessage,
   isNonErrorUndefinedRejectionNoise,
   isOldBrowserSyntaxParseError,
@@ -3088,6 +3089,283 @@ test('does NOT suppress a same-worded message from a different bridge / non-Andr
       filename: 'app://navigation_performance_logger_androidx',
     }),
     false,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// iOS WebKit (WKWebView) in-app-browser native-bridge `messageHandlers` noise
+// — the iOS sibling of the Android WebView bridge classes above.
+// (Better Stack pattern
+//  5b94212bc682a1ee1d33d67f6517ec95830c63e1ff8a3779d1700dd6091679eb,
+//  Kortix Frontend prod, application_id 2346967): 1 occurrence / 0 identified
+//  users, last_seen 2026-07-27 10:36:24 UTC, release
+//  `5d47baf11708881f1099cdaa875266944e976a78` (POST-`0.10.16`), transaction
+//  `/` (marketing homepage), URL `https://kortix.com/?fbclid=…` (a Facebook
+//  referral), browser `Facebook 571.0.0.55.72` on `iOS (iPhone) 26.5.2` (the
+//  Facebook in-app browser — an iOS WebView). The iOS WebView injects a
+//  synthetic `app:///` (THREE slashes — distinct from the Android bridge's
+//  single-slash `app://navigation_performance_logger_android` source) script
+//  that records navigation/performance timing
+//  (`processLargestContentfulPaintEvent`) and ships it to its native bridge
+//  via `sendDataToNative` → `window.webkit.messageHandlers`. On iOS WebViews
+//  where the WebKit `messageHandlers` bridge is unavailable, `window.webkit`
+//  is `undefined` and the access throws JSC's canonical
+//  `undefined is not an object (evaluating 'window.webkit.messageHandlers')`,
+//  captured as an UNCAUGHT global `onerror` (mechanism
+//  `auto.browser.global_handlers.onerror`, `handled:false` — never reached a
+//  React error boundary). Stack frames (3, all synthetic `app:///` WebView
+//  instrumentation — NO first-party `apps/web/src/…` frame):
+//    app:///   `?`
+//    app:///   `processLargestContentfulPaintEvent`
+//    app:///   `sendDataToNative`  (throw, call_site_function)
+//  The Android matchers (#5181/#4610) anchor on the Android
+//  `app://navigation_performance_logger_android` source and the
+//  `postMessage`/`postEvent` Java-bridge-GC message, so they do NOT catch the
+//  iOS `app:///` + `window.webkit.messageHandlers` variant. The new matcher
+//  anchors on the EXACT `messageHandlers` message + a positive `app:///`/
+//  instrumentation-function anchor, with a first-party negative guard.
+// ---------------------------------------------------------------------------
+
+// The exact raw exception value from the production event, plus the canonical
+// capture-path wrappers Sentry can deliver the same throw through.
+const IOS_WEBVIEW_WEBKIT_BRIDGE_EVENTS = [
+  // The exact raw exception value (the prod event is `onerror`, no prefix).
+  "undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+  // A typed-error wrapper (Sentry exception value with the `TypeError: ` type
+  // prefix the engine prepends).
+  `TypeError: ${"undefined is not an object (evaluating 'window.webkit.messageHandlers')"}`,
+  // An unhandled-rejection wrapper preserving the typed-error form (the other
+  // capture path Sentry's GlobalHandlers can deliver).
+  `Unhandled promise rejection: TypeError: ${"undefined is not an object (evaluating 'window.webkit.messageHandlers')"}`,
+]
+
+// The exact 3-frame production capture (Sentry oldest-first → throwing frame
+// last), all synthetic `app:///` WebView instrumentation frames.
+const IOS_WEBVIEW_PROD_FRAMES = [
+  { filename: 'app:///', function: '?' },
+  { filename: 'app:///', function: 'processLargestContentfulPaintEvent' },
+  { filename: 'app:///', function: 'sendDataToNative' },
+]
+
+test('classifies the iOS WebView WebKit messageHandlers bridge noise (with the prod app:/// frames)', () => {
+  for (const message of IOS_WEBVIEW_WEBKIT_BRIDGE_EVENTS) {
+    assert.equal(
+      isIOSWebViewWebKitBridgeNoise({
+        message,
+        frames: IOS_WEBVIEW_PROD_FRAMES,
+      }),
+      true,
+      `expected "${message}" from the prod app:/// frames to be classified as noise`,
+    )
+  }
+})
+
+test('suppresses the iOS WebView WebKit bridge Sentry event via the beforeSend gate', () => {
+  // Exact frame chain from the raw production event (oldest-first → throwing
+  // frame last).
+  for (const value of IOS_WEBVIEW_WEBKIT_BRIDGE_EVENTS) {
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        request: { url: 'https://kortix.com/?fbclid=abc123' },
+        exception: {
+          values: [
+            {
+              value,
+              stacktrace: { frames: IOS_WEBVIEW_PROD_FRAMES },
+            },
+          ],
+        },
+      }),
+      true,
+      `expected Sentry event for "${value}" to be suppressed`,
+    )
+  }
+})
+
+test('classifies the iOS WebView WebKit bridge noise via the instrumentation-function anchor alone (no app:/// filename)', () => {
+  // The function-name anchor is stable across deploys (mirrors #5181's
+  // `postEvent` anchor). A frame with ONLY the function name (no resolvable
+  // filename) still classifies as noise.
+  for (const message of IOS_WEBVIEW_WEBKIT_BRIDGE_EVENTS) {
+    assert.equal(
+      isIOSWebViewWebKitBridgeNoise({
+        message,
+        frames: [{ filename: '', function: 'sendDataToNative' }],
+      }),
+      true,
+      `expected "${message}" with the sendDataToNative function frame to be noise`,
+    )
+    assert.equal(
+      isIOSWebViewWebKitBridgeNoise({
+        message,
+        frames: [{ filename: 'undefined', function: 'processLargestContentfulPaintEvent' }],
+      }),
+      true,
+      `expected "${message}" with the processLargestContentfulPaintEvent function frame to be noise`,
+    )
+  }
+})
+
+test('suppresses the iOS WebView WebKit bridge noise via the runtime (window.onerror) gate with an app:/// filename', () => {
+  for (const message of IOS_WEBVIEW_WEBKIT_BRIDGE_EVENTS) {
+    assert.equal(
+      shouldIgnoreBrowserRuntimeNoise({
+        message,
+        filename: 'app:///',
+      }),
+      true,
+      `expected runtime gate to suppress "${message}" with an app:/// filename`,
+    )
+  }
+})
+
+test('does NOT suppress a real first-party window.webkit.messageHandlers failure that throws from an apps/web/src frame', () => {
+  // A genuine `window.webkit.messageHandlers` access in our own code throws
+  // the SAME message wording, but from a de-minified `apps/web/src/…` frame
+  // (or an `app:///apps/web/src/…` sourcemap-resolved frame), NEVER from the
+  // synthetic `app:///` WebView instrumentation. It must keep reporting so a
+  // real first-party regression is never hidden.
+  const realFirstPartyFrames: Array<{ filename: unknown; function?: string }> = [
+    { filename: 'apps/web/src/features/native-bridge/webkit-handler.ts' },
+    { filename: 'app:///apps/web/src/features/native-bridge/webkit-handler.ts' },
+  ]
+  for (const frames of [realFirstPartyFrames, [...IOS_WEBVIEW_PROD_FRAMES, realFirstPartyFrames[0]]]) {
+    assert.equal(
+      isIOSWebViewWebKitBridgeNoise({
+        message: "undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+        frames,
+      }),
+      false,
+      `expected real first-party webkit.messageHandlers error from ${JSON.stringify(frames)} to keep reporting`,
+    )
+    assert.equal(
+      shouldIgnoreSentryBrowserNoise({
+        exception: {
+          values: [
+            {
+              value: "undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+              stacktrace: { frames },
+            },
+          ],
+        },
+      }),
+      false,
+      `expected Sentry gate to keep reporting real first-party webkit.messageHandlers error from ${JSON.stringify(frames)}`,
+    )
+  }
+  // And via the runtime gate: a first-party filename keeps reporting.
+  assert.equal(
+    shouldIgnoreBrowserRuntimeNoise({
+      message: "undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+      filename: 'apps/web/src/features/native-bridge/webkit-handler.ts',
+    }),
+    false,
+  )
+})
+
+test('does NOT suppress a near-worded DIFFERENT message (over-match guard — only the exact messageHandlers bridge access is noise)', () => {
+  // Only the EXACT `window.webkit.messageHandlers` bridge access is noise — a
+  // different WebKit API on `window.webkit.<x>` (e.g. `audioWorklet`) throws a
+  // near-worded but DIFFERENT message that must stay observable, even with the
+  // `app:///` frames (a different WebKit API failing could be a real
+  // regression of a feature we depend on).
+  const nearWordedMessage =
+    "undefined is not an object (evaluating 'window.webkit.audioWorklet')"
+  assert.equal(
+    isIOSWebViewWebKitBridgeNoise({
+      message: nearWordedMessage,
+      frames: IOS_WEBVIEW_PROD_FRAMES,
+    }),
+    false,
+    `expected near-worded "${nearWordedMessage}" to keep reporting`,
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: {
+        values: [
+          {
+            value: nearWordedMessage,
+            stacktrace: { frames: IOS_WEBVIEW_PROD_FRAMES },
+          },
+        ],
+      },
+    }),
+    false,
+    `expected Sentry event for near-worded "${nearWordedMessage}" to keep reporting`,
+  )
+})
+
+test('does NOT suppress the exact message with NO frames / a frameless capture (can\'t confirm the app:/// WebView anchor)', () => {
+  // The positive anchor is mandatory — without the `app:///` frame or an
+  // instrumentation function we cannot confirm the iOS WebView origin. A
+  // frameless first-party throw of this exact message must stay observable
+  // (a real `window.webkit.messageHandlers` access with an unresolvable stack
+  // is still attributable to first-party code that needs fixing).
+  const message =
+    "undefined is not an object (evaluating 'window.webkit.messageHandlers')"
+  assert.equal(
+    isIOSWebViewWebKitBridgeNoise({ message }),
+    false,
+    'expected frameless message to keep reporting (no positive anchor)',
+  )
+  assert.equal(
+    isIOSWebViewWebKitBridgeNoise({ message, frames: [] }),
+    false,
+    'expected message with empty frames to keep reporting (no positive anchor)',
+  )
+  assert.equal(
+    isIOSWebViewWebKitBridgeNoise({
+      message,
+      frames: [{ filename: 'app:///_next/static/chunks/main.js' }],
+    }),
+    false,
+    'expected message from an app chunk frame (no app:/// anchor) to keep reporting',
+  )
+  assert.equal(
+    shouldIgnoreSentryBrowserNoise({
+      exception: { values: [{ value: message, stacktrace: { frames: [] } }] },
+    }),
+    false,
+    'expected frameless Sentry event to keep reporting (no positive anchor)',
+  )
+})
+
+test('does NOT suppress the Android bridge messages under the iOS matcher (and vice versa)', () => {
+  // The iOS matcher is message-specific: the Android `postMessage`/`postEvent`
+  // `Java object is gone` messages must not be swallowed by the iOS guard,
+  // and the iOS `window.webkit.messageHandlers` message must not be swallowed
+  // by the Android guards.
+  assert.equal(
+    isIOSWebViewWebKitBridgeNoise({
+      message: 'Error invoking postMessage: Java object is gone',
+      frames: [{ filename: ANDROID_NAV_PERF_LOGGER_FRAME }],
+    }),
+    false,
+    'iOS matcher must not swallow the Android postMessage message',
+  )
+  assert.equal(
+    isIOSWebViewWebKitBridgeNoise({
+      message: 'Error invoking postEvent: Java object is gone',
+      frames: IOS_WEBVIEW_PROD_FRAMES,
+    }),
+    false,
+    'iOS matcher must not swallow the Android postEvent message',
+  )
+  assert.equal(
+    isAndroidWebViewNativeBridgePostMessageNoise({
+      message: "undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+      frames: IOS_WEBVIEW_PROD_FRAMES,
+    }),
+    false,
+    'Android postMessage matcher must not swallow the iOS webkit.messageHandlers message',
+  )
+  assert.equal(
+    isAndroidWebViewNativeBridgePostEventNoise({
+      message: "undefined is not an object (evaluating 'window.webkit.messageHandlers')",
+      frames: IOS_WEBVIEW_PROD_FRAMES,
+    }),
+    false,
+    'Android postEvent matcher must not swallow the iOS webkit.messageHandlers message',
   )
 })
 

--- a/apps/web/src/lib/browser-error-noise.ts
+++ b/apps/web/src/lib/browser-error-noise.ts
@@ -476,6 +476,88 @@ const ANDROID_WEBVIEW_NATIVE_BRIDGE_POSTEVENT_NOISE_MESSAGES = [
   'Error invoking postEvent: Java object is gone',
 ] as const;
 
+// iOS WebKit (WKWebView) in-app-browser native-bridge instrumentation noise.
+// The iOS sibling of the Android System WebView bridge noise above
+// (`ANDROID_WEBVIEW_NATIVE_BRIDGE_POST{MESSAGE,EVENT}_NOISE_MESSAGES`). The
+// Facebook iOS in-app browser (and iOS WebViews generally — every iOS in-app
+// browser is a WKWebView, all running JavaScriptCore/JSC, not V8) injects a
+// synthetic `app:///` (note: THREE slashes — distinct from the Android bridge's
+// single-slash `app://navigation_performance_logger_android` source) script that
+// records navigation/performance timing (`processLargestContentfulPaintEvent`)
+// and ships it back to its native bridge via `sendDataToNative` →
+// `window.webkit.messageHandlers`. On iOS WebViews where the WebKit
+// `messageHandlers` bridge is unavailable — the host app didn't wire it, or the
+// page is loading/tearing down — `window.webkit` is `undefined`, so the property
+// access `window.webkit.messageHandlers` throws JSC's canonical
+// `undefined is not an object (evaluating 'window.webkit.messageHandlers')`.
+// This is the WebView's OWN instrumentation, never first-party code: the
+// `app:///` frames are the WebView's injected script (NOT an `app:///_next/…`
+// bundle frame and NOT a de-minified `apps/web/src/…` frame), and
+// `sendDataToNative` / `processLargestContentfulPaintEvent` are its internal
+// functions. Sentry's `GlobalHandlers` `onerror` integration captures the throw
+// as an UNCAUGHT global error (mechanism
+// `auto.browser.global_handlers.onerror`, `handled:false` — it never reaches a
+// React error boundary) and leaks it to Better Stack. Better Stack pattern
+// 5b94212bc682a1ee1d33d67f6517ec95830c63e1ff8a3779d1700dd6091679eb
+// (Kortix Frontend prod, application_id 2346967): 1 occurrence / 0 identified
+// users, last_seen 2026-07-27 10:36:24 UTC, release
+// `5d47baf11708881f1099cdaa875266944e976a78` (POST-`0.10.16`),
+// transaction `/` (marketing homepage), URL `https://kortix.com/?fbclid=…`
+// (a Facebook referral), browser `Facebook 571.0.0.55.72` on `iOS (iPhone)
+// 26.5.2` (the Facebook in-app browser — an iOS WebView). Stack frames (3, all
+// synthetic `app:///` WebView instrumentation — NO first-party
+// `apps/web/src/…` frame): `?`, `processLargestContentfulPaintEvent`, and the
+// throwing `sendDataToNative` (call_site_function `sendDataToNative`).
+//
+// The message wording (`undefined is not an object (evaluating
+// 'window.webkit.messageHandlers')`) is JSC's canonical TypeError phrasing for
+// a property access on `undefined` (here `window.webkit` is undefined). The
+// `window.webkit.messageHandlers` token is the STABLE anchor — it names the
+// WebKit native-bridge API the WebView instrumentation is trying to reach; it
+// is never called from first-party app code. Do NOT match just `window.webkit`
+// (too broad — a real first-party `window.webkit.<x>` access, e.g.
+// `window.webkit.audioWorklet`, could throw and must stay observable). The
+// matcher is anchored on BOTH the EXACT `messageHandlers` message AND a
+// POSITIVE frame anchor: at least one frame whose filename is the synthetic
+// `app:///` source (the iOS WebView's injected instrumentation — distinct from
+// Android's `app://navigation_performance_logger_android`) OR whose function is
+// one of the iOS WebView instrumentation internals (`sendDataToNative`,
+// `processLargestContentfulPaintEvent`). The function-name anchor is stable
+// across deploys (mirroring #5181's `postEvent` function-name anchor). A
+// NEGATIVE guard (mandatory — mirrors #5181 / the Paper Shaders matchers): if
+// ANY frame resolves to a de-minified first-party `apps/web/src/…` source, the
+// event keeps reporting (a real first-party `window.webkit.messageHandlers`
+// access regression de-minifies to `apps/web/src/…` and must not be hidden).
+// The prod event carries only `app:///` frames, so the negative guard does not
+// fire for it. Deliberately NOT added to `sentry.client.config.ts`'s
+// `ignoreErrors` list — that gate has no frame context, so a bare-string match
+// there could swallow a real first-party `window.webkit.messageHandlers`
+// access; the frame-aware `beforeSend` hook (which calls
+// `shouldIgnoreSentryBrowserNoise`) is the only safe gate.
+const IOS_WEBVIEW_WEBKIT_BRIDGE_NOISE_MESSAGE =
+  "undefined is not an object (evaluating 'window.webkit.messageHandlers')";
+
+// The iOS WebKit in-app-browser synthetic injected-instrumentation source:
+// the bare empty-host `app:///` (THREE slashes, NO path) — the origin shape
+// iOS WebViews use for their own injected instrumentation scripts. Distinct
+// from (a) the Android bridge's single-slash
+// `app://navigation_performance_logger_android` source, AND (b) a first-party
+// Next.js bundle frame `app:///_next/static/chunks/…` (which shares the
+// `app:///` PREFIX but carries a `_next/…` path). An EXACT match (not a
+// prefix) is required so a first-party `app:///_next/…` chunk frame is never
+// mistaken for the WebView's bare-source instrumentation.
+const IOS_WEBVIEW_INSTRUMENTED_FRAME_SOURCE = 'app:///';
+
+// The iOS WebView instrumentation internal function names — the WebView's own
+// navigation/performance-timing plumbing, never present in first-party
+// `apps/web/src/…` source. `sendDataToNative` is the bridge-call that throws
+// (the prod call_site_function); `processLargestContentfulPaintEvent` is the
+// timing recorder that calls into it.
+const IOS_WEBVIEW_INSTRUMENTED_FUNCTION_NAMES = new Set([
+  'sendDataToNative',
+  'processLargestContentfulPaintEvent',
+]);
+
 const EXTENSION_PROTOCOL_PREFIXES = [
   'chrome-extension://',
   'moz-extension://',
@@ -1487,6 +1569,75 @@ export function isAndroidWebViewNativeBridgePostEventNoise(input: {
   }
   return true;
 }
+
+/**
+ * Whether a Sentry / window.onerror event is the iOS WebKit (WKWebView) in-app-
+ * browser native-bridge instrumentation noise class: the iOS WebView's
+ * injected `app:///` script records navigation/performance timing
+ * (`processLargestContentfulPaintEvent`) and ships it to its native bridge via
+ * `sendDataToNative` → `window.webkit.messageHandlers`. On iOS WebViews where
+ * the WebKit `messageHandlers` bridge is unavailable (host app didn't wire it,
+ * or page load/teardown), `window.webkit` is `undefined` and the property
+ * access throws JSC's canonical
+ * `undefined is not an object (evaluating 'window.webkit.messageHandlers')`.
+ * This is the iOS sibling of the Android WebView bridge noise
+ * (`isAndroidWebViewNativeBridgePost{Message,Event}Noise`, PRs #5181/#4610);
+ * the Android matchers anchor on the synthetic
+ * `app://navigation_performance_logger_android` source and the
+ * `postMessage`/`postEvent` Java-bridge-GC message, so they do NOT catch the
+ * iOS `app:///` + `window.webkit.messageHandlers` variant. This is the
+ * WebView's OWN instrumentation, never first-party code. Requires BOTH the
+ * EXACT `messageHandlers` message AND a POSITIVE frame anchor: at least one
+ * frame whose filename is the synthetic `app:///` source OR whose function is
+ * an iOS WebView instrumentation internal (`sendDataToNative` /
+ * `processLargestContentfulPaintEvent`). A NEGATIVE guard preserves any
+ * resolved first-party `apps/web/src/…` frame so a real first-party
+ * `window.webkit.messageHandlers` access regression keeps reporting. Never page
+ * Better Stack for this class. See `IOS_WEBVIEW_WEBKIT_BRIDGE_NOISE_MESSAGE`
+ * for the full rationale.
+ */
+export function isIOSWebViewWebKitBridgeNoise(input: {
+  message?: unknown;
+  filename?: unknown;
+  frames?: Array<{ filename?: unknown; function?: unknown } | undefined>;
+}): boolean {
+  const stripped = stripErrorWrappers(normalizeString(input.message));
+  if (stripped !== IOS_WEBVIEW_WEBKIT_BRIDGE_NOISE_MESSAGE) {
+    return false;
+  }
+  // Collect every source location — the window.onerror `filename` (runtime
+  // gate) and any stacktrace frames (Sentry gate) — for the anchors.
+  const sources = [
+    input.filename,
+    ...(input.frames ?? []).map((frame) => frame?.filename),
+  ];
+  // Negative guard: a resolved first-party `apps/web/src/…` frame means our own
+  // code accessed `window.webkit.messageHandlers` and threw → a real first-
+  // party regression; keep reporting so the call site can be found + fixed.
+  if (sources.some(isFirstPartyResolvedSource)) {
+    return false;
+  }
+  // Positive anchor: at least one frame is the synthetic `app:///` iOS WebView
+  // injected-instrumentation source, OR whose function is one of the iOS
+  // WebView instrumentation internals (`sendDataToNative` /
+  // `processLargestContentfulPaintEvent`). The function-name anchor is stable
+  // across deploys (mirrors #5181's `postEvent` anchor). Prefer the
+  // function-name check first (it is the prod call_site anchor).
+  const frames = input.frames ?? [];
+  const hasInstrumentedFunction = frames.some((frame) =>
+    IOS_WEBVIEW_INSTRUMENTED_FUNCTION_NAMES.has(normalizeString(frame?.function)),
+  );
+  const hasInstrumentedSource = sources.some((filename) =>
+    normalizeString(filename) === IOS_WEBVIEW_INSTRUMENTED_FRAME_SOURCE,
+  );
+  // Without the positive anchor (no `app:///` frame and no instrumentation
+  // function) we cannot confirm the iOS WebView origin — keep reporting rather
+  // than swallow a possible first-party `window.webkit.messageHandlers`
+  // access. The prod event carries 3 `app:///` frames including the throwing
+  // `sendDataToNative`, so the anchor matches.
+  return hasInstrumentedFunction || hasInstrumentedSource;
+}
+
 // iOS WebKit (Safari, Chrome-on-iOS, Google Search App — all WKWebView/JSC)
 // stack-overflow noise. When iOS WebKit exhausts its (lower-than-desktop) call
 // stack, it surfaces `RangeError: Maximum call stack size exceeded.` through
@@ -2419,6 +2570,28 @@ export function shouldIgnoreBrowserRuntimeNoise(input: {
     return true;
   }
 
+  // iOS WebKit (WKWebView) in-app-browser native-bridge instrumentation noise
+  // — the iOS sibling of the Android bridge classes above. The iOS WebView
+  // injects a synthetic `app:///` script that records navigation/performance
+  // timing and ships it to `window.webkit.messageHandlers`; on iOS WebViews
+  // where the WebKit bridge is unavailable, the access throws JSC's canonical
+  // `undefined is not an object (evaluating 'window.webkit.messageHandlers')`.
+  // Requires the EXACT message AND a positive `app:///`/instrumentation-
+  // function anchor so a real first-party `window.webkit.messageHandlers`
+  // access keeps reporting. The runtime gate sees the window.onerror
+  // `filename`; the prod event carried `app:///` frames in the Sentry
+  // stacktrace (handled by the Sentry gate below), but a runtime capture with
+  // an `app:///` filename is also noise. See
+  // `isIOSWebViewWebKitBridgeNoise`.
+  if (
+    isIOSWebViewWebKitBridgeNoise({
+      message,
+      filename: input.filename,
+    })
+  ) {
+    return true;
+  }
+
   if (isInjectedAppSource(input.filename)) {
     return true;
   }
@@ -2657,6 +2830,27 @@ export function shouldIgnoreSentryBrowserNoise(event: {
   // `postEvent`/`dispatchEvent` failure keeps reporting. Not in `ignoreErrors`
   // (no frame context there).
   if (isAndroidWebViewNativeBridgePostEventNoise({ message, frames })) {
+    return true;
+  }
+
+  // iOS WebKit (WKWebView) in-app-browser native-bridge instrumentation noise
+  // — the iOS sibling of the Android bridge classes above. The iOS WebView
+  // injects a synthetic `app:///` script (THREE slashes — distinct from
+  // Android's single-slash `app://navigation_performance_logger_android`)
+  // that records navigation/performance timing
+  // (`processLargestContentfulPaintEvent`) and ships it to
+  // `window.webkit.messageHandlers`; on iOS WebViews where the WebKit bridge
+  // is unavailable, the access throws JSC's canonical
+  // `undefined is not an object (evaluating 'window.webkit.messageHandlers')`.
+  // Captured as an UNCAUGHT global `onerror` (never reaches a React error
+  // boundary). Requires the EXACT message AND a positive `app:///`/
+  // instrumentation-function anchor (`sendDataToNative` /
+  // `processLargestContentfulPaintEvent`) with a first-party negative guard,
+  // so a real first-party `window.webkit.messageHandlers` access regression
+  // (which de-minifies to `apps/web/src/…`) keeps reporting. Not in
+  // `ignoreErrors` (no frame context there). See
+  // `isIOSWebViewWebKitBridgeNoise`.
+  if (isIOSWebViewWebKitBridgeNoise({ message, frames })) {
     return true;
   }
 


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. A noise-matcher drop is verified by the test suite pinning the exact prod call site (8 new tests, 200 total, all pass) + a focused tsc check.

## Why
Better Stack pattern `5b94212bc682a1ee1d33d67f6517ec95830c63e1ff8a3779d1700dd6091679eb` (Kortix Frontend prod, application_id `2346967`) surfaced a `TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers')` from the **Facebook iOS in-app browser's** native-bridge instrumentation: 1 occurrence / 0 identified users, last 2026-07-27 10:36:24 UTC, release `5d47baf11708881f1099cdaa875266944e976a78` (POST-`0.10.16`), transaction `/` (marketing homepage), URL `https://kortix.com/?fbclid=…` (a Facebook referral), browser `Facebook 571.0.0.55.72` on `iOS (iPhone) 26.5.2` (an iOS WKWebView), mechanism `auto.browser.global_handlers.onerror` (`handled=false` — UNCAUGHT global error, never reached a React error boundary). Stack frames (3, all synthetic `app:///` WebView instrumentation — NO first-party `apps/web/src/…` frame): `?`, `processLargestContentfulPaintEvent`, and the throwing `sendDataToNative` (`call_site_function: "sendDataToNative"`).

The iOS WebView injects a synthetic `app:///` (THREE slashes) script that records navigation/performance timing (`processLargestContentfulPaintEvent`) and ships it back to its native bridge via `sendDataToNative` → `window.webkit.messageHandlers`. On iOS WebViews where the WebKit `messageHandlers` bridge is unavailable (host app didn't wire it, or page load/teardown), `window.webkit` is `undefined` and the access throws JSC's canonical `undefined is not an object (evaluating 'window.webkit.messageHandlers')`. This is the **iOS sibling** of the Android WebView native-bridge noise already covered by PRs #5181 (`isAndroidWebViewNativeBridgePostEventNoise`, `app://navigation_performance_logger_android`) and #4610 (`isAndroidWebViewNativeBridgePostMessageNoise`); the existing matchers anchor on the Android bridge source and `postMessage`/`postEvent` Java-bridge-GC message and do NOT catch the iOS `app:///` + `window.webkit.messageHandlers` variant (confirmed: grep found NO existing matcher for this message — the Paper Shaders `null is not an object (evaluating 'this.gl.<m>')` matchers use `null`, not `undefined`, and `this.gl`, not `window.webkit`).

## What changed
- **New matcher `isIOSWebViewWebKitBridgeNoise`** in `apps/web/src/lib/browser-error-noise.ts`, wired into Sentry `beforeSend` via `shouldIgnoreSentryBrowserNoise` and into the window.onerror runtime gate via `shouldIgnoreBrowserRuntimeNoise` (follows the exact pattern of `isAndroidWebViewNativeBridgePostEventNoise` / `isConnectionClosedNoise` / `isPaperShaderWebGLUnsupportedNoise`). Anchored on:
  1. The EXACT message `undefined is not an object (evaluating 'window.webkit.messageHandlers')` (case-sensitive, after `stripErrorWrappers`; the `window.webkit.messageHandlers` token names the WebKit native-bridge API and is the stable anchor — NOT a broad `window.webkit` prefix that could hide a real first-party `window.webkit.<x>` access).
  2. A POSITIVE frame anchor: at least one frame whose filename is the synthetic bare `app:///` source (EXACT, not a prefix, so a first-party `app:///_next/…` chunk frame is never matched) OR whose function is an iOS WebView instrumentation internal (`sendDataToNative`, `processLargestContentfulPaintEvent`). The function-name anchor is stable across deploys (mirrors #5181's `postEvent` anchor) and is the prod `call_site_function`.
  3. A NEGATIVE guard (mandatory — mirrors #5181 / the Paper Shaders matchers): if ANY frame resolves to a de-minified first-party `apps/web/src/…` source, keep reporting (a real first-party `window.webkit.messageHandlers` access regression de-minifies to `apps/web/src/…` and must not be hidden). The prod event has only `app:///` frames, so the negative guard does not fire for it.
- Deliberately NOT added to `sentry.client.config.ts`'s `ignoreErrors` list — that gate has no frame context, so a bare-string match there could swallow a real first-party `window.webkit.messageHandlers` access; the frame-aware `beforeSend` hook is the only safe gate.

## Verification
```
cd apps/web
bun test src/lib/browser-error-noise.test.mts   # 200 pass (192 baseline + 8 new), 0 fail
./node_modules/.bin/tsc --noEmit -p tsconfig.json # only the 4 pre-existing unrelated errors
                                                  # (source.ts/use-cases-source.ts/api/og/template-url.test.ts)
```
8 new tests pin the exact prod call site:
1. **Positive (prod pattern)**: the exact message + the 3 prod `app:///` frames (`?`/`processLargestContentfulPaintEvent`/`sendDataToNative`) → noise through both `isIOSWebViewWebKitBridgeNoise` and `shouldIgnoreSentryBrowserNoise`.
2. **Capture-path forms**: raw (no prefix), `TypeError: ` prefix, `Unhandled promise rejection: TypeError: ` prefix → all noise (the prod event is `onerror` with no prefix, but Sentry capture paths vary).
3. **Function-name anchor**: frames with ONLY the instrumentation function name (`sendDataToNative` / `processLargestContentfulPaintEvent`) and no resolvable filename → noise (function-name anchor is stable across deploys).
4. **Runtime gate**: an `app:///` window.onerror filename → noise via `shouldIgnoreBrowserRuntimeNoise`.
5. **NEGATIVE — first-party frame**: same message + a de-minified `apps/web/src/…` frame (and the `app:///apps/web/src/…` sourcemap-resolved form) → keep reporting (real regression).
6. **NEGATIVE — over-match guard**: a near-worded DIFFERENT message `undefined is not an object (evaluating 'window.webkit.audioWorklet')` (a different WebKit API) with the `app:///` frames → keep reporting (only the EXACT `messageHandlers` bridge access is noise).
7. **NEGATIVE — no frames**: same message with NO frames / empty frames / an `app:///_next/…` chunk frame (no `app:///` anchor) → keep reporting (can't confirm the WebView origin; a frameless first-party throw must stay observable).
8. **Cross-matcher isolation**: the Android `postMessage`/`postEvent` `Java object is gone` messages are NOT swallowed by the iOS matcher, and the iOS `window.webkit.messageHandlers` message is NOT swallowed by the Android matchers.

## Risk / rollback
Pure telemetry-noise suppression — no behavior change. A misclassification would only under-report a real first-party `window.webkit.messageHandlers` regression, but the first-party negative guard + the mandatory positive anchor (exact `app:///` source or `sendDataToNative`/`processLargestContentfulPaintEvent` function) make a first-party throw keep reporting. Revert the single commit to restore the pre-fix state.

Reference Better Stack pattern `5b94212bc682a1ee1d33d67f6517ec95830c63e1ff8a3779d1700dd6091679eb`.
