### PR TITLE
fix(cli): ship falls back to the git proxy when managed push tokens can't be exported

### DIFF
--- a/apps/cli/src/__tests__/ship.test.ts
+++ b/apps/cli/src/__tests__/ship.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { ApiClient } from '../api/client.ts';
+import { ApiError } from '../api/client.ts';
 import type { ProjectSummary } from '../api/types.ts';
 import {
   authHeaderArgs,
+  isManagedTokenExportUnavailable,
   linkGitHubBackedProject,
   reconcileShippedManifest,
   resolveExistingShipGitTarget,
+  resolveManagedProxyFallback,
+  resolveManagedPushPlan,
   resolveProvisionShipGitTarget,
 } from '../commands/ship.ts';
 
@@ -94,6 +98,137 @@ describe('GitHub-backed project linking', () => {
         },
       },
     ]);
+  });
+});
+
+describe('managed push plan (host cannot export a repo-scoped token)', () => {
+  const managed = () =>
+    project({
+      git_origin_url: 'https://api.kortix.com/v1/git/proj_1.git',
+      metadata: { git: { managed: true } },
+    });
+
+  function failingClient(status: number, message: string, calls: string[] = []) {
+    return {
+      post: async <T>(path: string) => {
+        calls.push(path);
+        throw new ApiError(status, message);
+      },
+    } as unknown as Pick<ApiClient, 'post'>;
+  }
+
+  test('reproduces the reported failure: 503 on /git-token used to abort the ship', async () => {
+    // Before the fix this rejected and `kortix ship` exited 1 with
+    // "Managed git push token export requires a repo-scoped installation token".
+    const noProxy = { project_id: 'proj_1', repo_url: 'https://github.com/managed-kortix/demo.git' };
+    await expect(
+      resolveManagedPushPlan(
+        failingClient(503, 'Managed git push token export requires a repo-scoped installation token'),
+        noProxy,
+        'kortix-jwt',
+      ),
+    ).rejects.toThrow('repo-scoped installation token');
+  });
+
+  test('falls back to the project git proxy when the token export is refused (503)', async () => {
+    const calls: string[] = [];
+    const plan = await resolveManagedPushPlan(
+      failingClient(503, 'Managed git push token export requires a repo-scoped installation token', calls),
+      managed(),
+      'kortix-jwt',
+    );
+
+    expect(calls).toEqual(['/projects/proj_1/git-token']);
+    expect(plan).toEqual({
+      repoUrl: 'https://api.kortix.com/v1/git/proj_1.git',
+      pushToken: 'kortix-jwt',
+      pushUsername: 'x-access-token',
+      viaProxy: true,
+    });
+  });
+
+  test('falls back on 409 (project not managed by an App-backed remote)', async () => {
+    const plan = await resolveManagedPushPlan(
+      failingClient(409, 'Project is not a managed repo'),
+      managed(),
+      'kortix-jwt',
+    );
+    expect(plan.viaProxy).toBe(true);
+  });
+
+  test('prefers a minted repo-scoped token over the proxy', async () => {
+    const client = {
+      post: async <T>() =>
+        ({ push_token: 'ghs_app_token', git_username: 'x-access-token', repo_id: 'r', repo_url: 'u' }) as T,
+    } as unknown as Pick<ApiClient, 'post'>;
+
+    const plan = await resolveManagedPushPlan(client, managed(), 'kortix-jwt');
+    expect(plan).toEqual({
+      repoUrl: 'https://github.com/managed-kortix/demo.git',
+      pushToken: 'ghs_app_token',
+      pushUsername: 'x-access-token',
+      viaProxy: false,
+    });
+  });
+
+  test('uses the provision-response token without a second round trip', async () => {
+    const calls: string[] = [];
+    const plan = await resolveManagedPushPlan(
+      failingClient(503, 'should not be called', calls),
+      managed(),
+      'kortix-jwt',
+      { pushToken: 'ghs_from_provision', pushUsername: 'x-access-token' },
+    );
+    expect(calls).toEqual([]);
+    expect(plan.pushToken).toBe('ghs_from_provision');
+    expect(plan.viaProxy).toBe(false);
+  });
+
+  test('rethrows when there is no proxy origin to fall back to', async () => {
+    await expect(
+      resolveManagedPushPlan(
+        failingClient(503, 'no token'),
+        { project_id: 'proj_1', repo_url: 'https://github.com/managed-kortix/demo.git' },
+        'kortix-jwt',
+      ),
+    ).rejects.toThrow('no token');
+  });
+
+  test('rethrows non-recoverable errors (401) even when a proxy exists', async () => {
+    await expect(
+      resolveManagedPushPlan(failingClient(401, 'Token rejected'), managed(), 'kortix-jwt'),
+    ).rejects.toThrow('Token rejected');
+  });
+
+  test('never exports a server-global PAT: the fallback credential is the caller token', async () => {
+    const plan = await resolveManagedPushPlan(
+      failingClient(503, 'pat'),
+      managed(),
+      'kortix-jwt',
+    );
+    expect(plan.pushToken).toBe('kortix-jwt');
+    expect(plan.repoUrl).toStartWith('https://api.kortix.com/v1/git/');
+  });
+
+  test('proxy fallback resolver ignores non-proxy origins', () => {
+    expect(resolveManagedProxyFallback({ git_origin_url: null })).toBeNull();
+    expect(
+      resolveManagedProxyFallback({ git_origin_url: 'https://github.com/acme/demo.git' }),
+    ).toBeNull();
+    expect(
+      resolveManagedProxyFallback({ git_origin_url: 'https://api.kortix.com/v1/git/p.git' }),
+    ).toEqual({
+      repoUrl: 'https://api.kortix.com/v1/git/p.git',
+      credentialMode: 'kortix-token',
+    });
+  });
+
+  test('classifies which failures are recoverable', () => {
+    expect(isManagedTokenExportUnavailable(new ApiError(503, 'x'))).toBe(true);
+    expect(isManagedTokenExportUnavailable(new ApiError(409, 'x'))).toBe(true);
+    expect(isManagedTokenExportUnavailable(new ApiError(401, 'x'))).toBe(false);
+    expect(isManagedTokenExportUnavailable(new ApiError(500, 'x'))).toBe(false);
+    expect(isManagedTokenExportUnavailable(new Error('boom'))).toBe(false);
   });
 });
 

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -131,6 +131,80 @@ export function resolveProvisionShipGitTarget(project: ProvisionResponse): ShipG
   };
 }
 
+/**
+ * A managed project can only be pushed with an exported provider token when the
+ * host's managed-git backend is a GitHub App installation. Hosts backed by a
+ * server-global PAT deliberately refuse to hand that credential out (the API
+ * answers 503 / 409 on `/git-token`) because it is not repo-scoped.
+ *
+ * That refusal is correct, but it is not fatal: the project's own authenticated
+ * git proxy (`git_origin_url`) accepts the caller's Kortix token and is already
+ * scoped to this project. Prefer it over failing the ship.
+ */
+export function isManagedTokenExportUnavailable(err: unknown): boolean {
+  return err instanceof ApiError && (err.status === 503 || err.status === 409);
+}
+
+export function resolveManagedProxyFallback(project: {
+  git_origin_url?: string | null;
+}): ShipGitTarget | null {
+  if (!isGitProxyUrl(project.git_origin_url)) return null;
+  return {
+    repoUrl: project.git_origin_url!,
+    credentialMode: 'kortix-token',
+  };
+}
+
+export interface ManagedPushPlan {
+  repoUrl: string;
+  pushToken: string | null;
+  pushUsername: string;
+  viaProxy: boolean;
+}
+
+/**
+ * Resolve the credential + upstream for a managed push: mint a repo-scoped
+ * provider token when the host can, otherwise fall back to the project git
+ * proxy. Never falls back to a server-global PAT — the API still refuses to
+ * export one; we simply stop treating that refusal as an unrecoverable error.
+ */
+export async function resolveManagedPushPlan(
+  client: Pick<ApiClient, 'post'>,
+  project: { project_id: string; repo_url: string; git_origin_url?: string | null },
+  kortixToken: string,
+  seed?: { pushToken?: string | null; pushUsername?: string | null },
+): Promise<ManagedPushPlan> {
+  if (seed?.pushToken) {
+    return {
+      repoUrl: project.repo_url,
+      pushToken: seed.pushToken,
+      pushUsername: seed.pushUsername ?? 'x-access-token',
+      viaProxy: false,
+    };
+  }
+
+  try {
+    const tok = await client.post<GitTokenResponse>(`/projects/${project.project_id}/git-token`);
+    return {
+      repoUrl: project.repo_url,
+      pushToken: tok.push_token,
+      pushUsername: tok.git_username ?? 'x-access-token',
+      viaProxy: false,
+    };
+  } catch (err) {
+    const fallback = isManagedTokenExportUnavailable(err)
+      ? resolveManagedProxyFallback(project)
+      : null;
+    if (!fallback) throw err;
+    return {
+      repoUrl: fallback.repoUrl,
+      pushToken: kortixToken,
+      pushUsername: 'x-access-token',
+      viaProxy: true,
+    };
+  }
+}
+
 export function resolveExistingShipGitTarget(project: ProjectSummary): ShipGitTarget {
   if (projectIsManaged(project)) {
     return {
@@ -645,18 +719,22 @@ async function shipFirstTime(
     project = prov;
     const target = resolveProvisionShipGitTarget(prov);
     repoUrl = target.repoUrl;
-    pushToken = prov.push_token;
-    pushUsername = prov.git_username ?? pushUsername;
     // Older/self-hosted provision responses may omit an exportable token even
     // though the managed project can mint a repo-scoped App token afterward.
     // Heal that boundary before attempting git push; never fall back to a
-    // server-global PAT.
-    if (!pushToken) {
-      const tok = await client.post<GitTokenResponse>(
-        `/projects/${project.project_id}/git-token`,
+    // server-global PAT — when the host cannot export one at all, push through
+    // the project's own authenticated git proxy instead of failing the ship.
+    const plan = await resolveManagedPushPlan(client, prov, auth.token, {
+      pushToken: prov.push_token,
+      pushUsername: prov.git_username ?? pushUsername,
+    });
+    repoUrl = plan.repoUrl;
+    pushToken = plan.pushToken;
+    pushUsername = plan.pushUsername;
+    if (plan.viaProxy) {
+      process.stdout.write(
+        `  ${C.dim}managed push token unavailable on this host — pushing through the project git proxy${C.reset}\n`,
       );
-      pushToken = tok.push_token;
-      pushUsername = tok.git_username ?? pushUsername;
     }
     setOrigin(repoUrl);
   }
@@ -721,19 +799,28 @@ async function shipExisting(
   // managed upstream URL. Non-managed proxy pushes use the Kortix CLI token.
   let pushToken: string | null = null;
   let pushUsername = 'x-access-token';
+  let repoUrlForPush = repoUrl;
+  let pushedViaProxy = false;
   if (target.credentialMode === 'kortix-token') {
     pushToken = auth.token;
   } else if (target.credentialMode === 'managed-git-token') {
-    const tok = await client.post<GitTokenResponse>(`/projects/${projectId}/git-token`);
-    pushToken = tok.push_token;
-    pushUsername = tok.git_username ?? pushUsername;
+    const plan = await resolveManagedPushPlan(client, project, auth.token);
+    pushToken = plan.pushToken;
+    pushUsername = plan.pushUsername;
+    repoUrlForPush = plan.repoUrl;
+    pushedViaProxy = plan.viaProxy;
+    if (plan.viaProxy) {
+      process.stdout.write(
+        `  ${C.dim}managed push token unavailable on this host — pushing through the project git proxy${C.reset}\n`,
+      );
+    }
   }
   // Managed projects own the remote URL, so keep origin aligned with the
   // upstream that matches the freshly minted provider token. BYO repos may
   // have lost their remote (fresh clone of a linked repo); heal only when
   // missing so user-managed credentials stay untouched.
-  if (managed) setOrigin(repoUrl);
-  else ensureOrigin(repoUrl);
+  if (managed) setOrigin(repoUrlForPush);
+  else ensureOrigin(repoUrlForPush);
 
   const committed = commitIfNeeded(flags);
   if (committed === 'error') return 1;
@@ -1029,7 +1116,8 @@ function surface(err: unknown): number {
     } else if (err.status === 503) {
       process.stderr.write(
         `${status.err(err.message)}\n` +
-          `  ${C.dim}Managed git isn't configured on this host. Pass ${C.reset}${C.cyan}--origin <git-url>${C.reset}${C.dim} to use your own remote.${C.reset}\n`,
+          `  ${C.dim}This host can't export a managed git push credential, and this project has no git proxy origin to fall back to.${C.reset}\n` +
+          `  ${C.dim}Pass ${C.reset}${C.cyan}--origin <git-url>${C.reset}${C.dim} to use your own remote.${C.reset}\n`,
       );
     } else {
       process.stderr.write(`${status.err(`HTTP ${err.status}: ${err.message}`)}\n`);

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -780,7 +780,9 @@ async function shipExisting(
   }
   const target = resolveExistingShipGitTarget(project);
   const managed = target.credentialMode === 'managed-git-token';
-  const repoUrl = target.repoUrl;
+  // Single source of truth for the upstream: the auth header is scoped to this
+  // URL's origin, so origin, push, and report must never diverge from it.
+  let repoUrl = target.repoUrl;
 
   process.stdout.write(
     `\n  ${C.bold}kortix ship${C.reset}  ${C.dim}sync${C.reset}\n` +
@@ -799,16 +801,13 @@ async function shipExisting(
   // managed upstream URL. Non-managed proxy pushes use the Kortix CLI token.
   let pushToken: string | null = null;
   let pushUsername = 'x-access-token';
-  let repoUrlForPush = repoUrl;
-  let pushedViaProxy = false;
   if (target.credentialMode === 'kortix-token') {
     pushToken = auth.token;
   } else if (target.credentialMode === 'managed-git-token') {
     const plan = await resolveManagedPushPlan(client, project, auth.token);
     pushToken = plan.pushToken;
     pushUsername = plan.pushUsername;
-    repoUrlForPush = plan.repoUrl;
-    pushedViaProxy = plan.viaProxy;
+    repoUrl = plan.repoUrl;
     if (plan.viaProxy) {
       process.stdout.write(
         `  ${C.dim}managed push token unavailable on this host — pushing through the project git proxy${C.reset}\n`,
@@ -819,8 +818,8 @@ async function shipExisting(
   // upstream that matches the freshly minted provider token. BYO repos may
   // have lost their remote (fresh clone of a linked repo); heal only when
   // missing so user-managed credentials stay untouched.
-  if (managed) setOrigin(repoUrlForPush);
-  else ensureOrigin(repoUrlForPush);
+  if (managed) setOrigin(repoUrl);
+  else ensureOrigin(repoUrl);
 
   const committed = commitIfNeeded(flags);
   if (committed === 'error') return 1;


### PR DESCRIPTION
## Problem

`kortix ship` cannot push to a **managed** Kortix repo on any host whose managed-git
backend is a server-global PAT rather than a GitHub App installation. Every run fails:

```
kortix ship  sync
project heythere (dec85a0f-47fa-4bc0-bbe1-e4daf9effbfe)
branch  main

✗  Managed git push token export requires a repo-scoped installation token
Managed git isn't configured on this host. Pass --origin <git-url> to use your own remote.
```

Reproduced on kortix CLI v0.10.15 against `https://api.kortix.com` on all three paths:
sync to a linked project, first ship creating a new project, and a fresh `kortix init` dir.

## Root cause

The API refusal is **correct and intentional** — `POST /v1/projects/:id/git-token`
returns 503 when `resolveProjectGitAuth()` reports `authSource === 'pat'`
(`apps/api/src/projects/routes/r1.ts:743`), because a server-global PAT is not
repo-scoped and must never be handed to a client.

The bug is that the CLI treats that refusal as unrecoverable. `resolveExistingShipGitTarget()`
routes every managed project to `repo_url` (the raw `github.com/managed-kortix/...` URL) with
`credentialMode: 'managed-git-token'` and deliberately ignores `git_origin_url` — so when the
mint fails there is no path left, even though the project's own authenticated git proxy is
provisioned and works.

Verified the proxy is healthy on the same host and project that ship fails on:

```
$ kortix projects clone <id> && git push origin HEAD
To https://api.kortix.com/v1/git/cbb15364-....git
   01e3f66..b3691ca  HEAD -> main
```

(That probe commit was reverted with `--force-with-lease`.) The proxy authenticates the
caller's own Kortix token via the `!kortix git-credential` helper and is already scoped to
the project — strictly narrower than the PAT the API refuses to export.

## Secondary damage

Because project creation is not transactional, each failed first ship still creates the
project row and its managed repo, then dies at the push step. On a free account (3-project
cap) three failed ships exhaust the quota and the next attempt reports a misleading
`HTTP 403: Free accounts are limited to 3 projects` instead of the real fault. This PR
removes the failure that leaks the project; making provisioning roll back is left as a
separate server-side change.

## Fix

`apps/cli/src/commands/ship.ts`:

- Add `resolveManagedPushPlan()` — mints the repo-scoped provider token when the host can,
  and on a recoverable refusal (503/409) falls back to `git_origin_url` authenticated with
  the caller's Kortix token. Any other error (401, 500, …) still propagates.
- Wire it into **both** ship paths (provision and sync), preferring a `push_token` already
  present in the provision response so the happy path keeps its single round trip.
- Push and report against the resolved upstream so the `http.<origin>/.extraheader` auth
  header matches the host actually pushed to.
- Replace the blanket 503 hint. `Managed git isn't configured on this host` is false —
  managed git *is* configured and serving; only token export is unavailable. It now says so
  and only appears when there is genuinely no proxy origin to fall back to.

**No credential is widened.** The API still refuses to export the PAT; the fallback uses the
credential the user already holds.

## Tests

10 new cases in `apps/cli/src/__tests__/ship.test.ts`, including one that pins the reported
failure (503 with no proxy origin still aborts) and one asserting the fallback credential is
the caller token, never a PAT.

```
$ bun test src/__tests__/ship.test.ts
 18 pass
 0 fail
$ tsc --noEmit   # clean
```

## End-to-end verification against the failing host

Sync path, patched CLI, same project that fails on v0.10.15:

```
kortix ship  sync
project heythere (dec85a0f-...)

managed push token unavailable on this host — pushing through the project git proxy
clean working tree
✓  Pushed main → origin/main
✓  Shipped heythere
```

First-ship path — previously failed and leaked the project:

```
kortix ship  new project → managed Kortix git
name    shipfix-e2e

managed push token unavailable on this host — pushing through the project git proxy
✓  Committed: kortix: ship
To https://api.kortix.com/v1/git/d7c6e4bf-....git
 * [new branch]      master -> master
✓  Shipped shipfix-e2e
```

The scratch project created for that run was archived afterwards.

---

**Author:** Claude Opus 5 — sole author. Diagnosis, root-cause analysis, fix, tests, and
end-to-end verification were all performed by me (autonomous AI agent, via Kiro CLI),
working from a live reproduction on `api.kortix.com`. No human co-author.
