### PR TITLE
fix(security): KaaB cross-end-user session access + revoked-secret re-injection

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -406,6 +406,7 @@ describe('Preview proxy: websocket upstream resolution', () => {
       userId: TEST_USER_ID,
       remainingPath: '/pty/pty_test/connect',
       queryString: '',
+      callerSessionId: null,
     });
 
     expect(upstream.ok).toBe(true);
@@ -426,6 +427,7 @@ describe('Preview proxy: websocket upstream resolution', () => {
       userId: TEST_USER_ID,
       remainingPath: '/pty/pty_test/connect',
       queryString: '',
+      callerSessionId: null,
     });
 
     expect(upstream.ok).toBe(true);
@@ -451,6 +453,7 @@ describe('Preview proxy: websocket upstream resolution', () => {
       userId: TEST_USER_ID,
       remainingPath: '/kortix/pty/kpty_test/connect',
       queryString: '',
+      callerSessionId: null,
     });
 
     expect(upstream.ok).toBe(true);

--- a/apps/api/src/__tests__/unit-executor-share.test.ts
+++ b/apps/api/src/__tests__/unit-executor-share.test.ts
@@ -127,11 +127,13 @@ describe('scopeToIntent — round-trip for the dashboard', () => {
 });
 
 const WRAPPER = 'wrapper-service-account';
+// Non-KaaB default: an interactive session, caller not session-bound.
+const INTERACTIVE = { origin: 'interactive', sessionId: 's1', callerSessionId: null };
 
 describe('session sharing — default private; team-wide or select-members', () => {
   test('owner always sees their own session, regardless of visibility', () => {
-    expect(isSessionVisibleTo('private', ALICE, [], { userId: ALICE, groupIds: [] })).toBe(true);
-    expect(isSessionVisibleTo('private', ALICE, [], { userId: BOB, groupIds: [] })).toBe(false);
+    expect(isSessionVisibleTo('private', ALICE, [], { userId: ALICE, groupIds: [] }, INTERACTIVE)).toBe(true);
+    expect(isSessionVisibleTo('private', ALICE, [], { userId: BOB, groupIds: [] }, INTERACTIVE)).toBe(false);
   });
 
   // ── Kortix-as-a-Backend isolation ──
@@ -186,7 +188,7 @@ describe('session sharing — default private; team-wide or select-members', () 
   });
 
   test('project visibility → every member', () => {
-    expect(isSessionVisibleTo('project', ALICE, [], { userId: BOB, groupIds: [] })).toBe(true);
+    expect(isSessionVisibleTo('project', ALICE, [], { userId: BOB, groupIds: [] }, INTERACTIVE)).toBe(true);
   });
 
   test('restricted → owner + member/group grants only', () => {
@@ -194,9 +196,9 @@ describe('session sharing — default private; team-wide or select-members', () 
       { principalType: 'member', principalId: BOB },
       { principalType: 'group', principalId: SALES },
     ];
-    expect(isSessionVisibleTo('restricted', ALICE, grants, { userId: BOB, groupIds: [] })).toBe(true);
-    expect(isSessionVisibleTo('restricted', ALICE, grants, { userId: 'carol', groupIds: [SALES] })).toBe(true);
-    expect(isSessionVisibleTo('restricted', ALICE, grants, { userId: 'carol', groupIds: [] })).toBe(false);
+    expect(isSessionVisibleTo('restricted', ALICE, grants, { userId: BOB, groupIds: [] }, INTERACTIVE)).toBe(true);
+    expect(isSessionVisibleTo('restricted', ALICE, grants, { userId: 'carol', groupIds: [SALES] }, INTERACTIVE)).toBe(true);
+    expect(isSessionVisibleTo('restricted', ALICE, grants, { userId: 'carol', groupIds: [] }, INTERACTIVE)).toBe(false);
   });
 
   test('intent ⇄ visibility round-trips', () => {

--- a/apps/api/src/__tests__/unit-executor-share.test.ts
+++ b/apps/api/src/__tests__/unit-executor-share.test.ts
@@ -126,10 +126,63 @@ describe('scopeToIntent — round-trip for the dashboard', () => {
   });
 });
 
+const WRAPPER = 'wrapper-service-account';
+
 describe('session sharing — default private; team-wide or select-members', () => {
   test('owner always sees their own session, regardless of visibility', () => {
     expect(isSessionVisibleTo('private', ALICE, [], { userId: ALICE, groupIds: [] })).toBe(true);
     expect(isSessionVisibleTo('private', ALICE, [], { userId: BOB, groupIds: [] })).toBe(false);
+  });
+
+  // ── Kortix-as-a-Backend isolation ──
+  // Every KaaB session is created by the SAME wrapper credential, so created_by
+  // is identical for every end-user. The ownership short-circuit above therefore
+  // makes every backend session look owned by whoever asks — which, for a token
+  // bound to one end-user's sandbox, is a cross-end-user disclosure. The prompt
+  // that drives that sandbox is untrusted by construction in KaaB.
+  test('a sandbox token cannot reach a DIFFERENT backend session via shared created_by', () => {
+    const wrapper = { userId: WRAPPER, groupIds: [] };
+    expect(
+      isSessionVisibleTo('private', WRAPPER, [], wrapper, {
+        origin: 'backend',
+        sessionId: 'session-of-end-user-b',
+        callerSessionId: 'session-of-end-user-a',
+      }),
+    ).toBe(false);
+  });
+
+  test('a sandbox token still reaches its OWN backend session', () => {
+    expect(
+      isSessionVisibleTo('private', WRAPPER, [], { userId: WRAPPER, groupIds: [] }, {
+        origin: 'backend',
+        sessionId: 'session-a',
+        callerSessionId: 'session-a',
+      }),
+    ).toBe(true);
+  });
+
+  test('the wrapper backend itself (not session-bound) still sees every session it created', () => {
+    // The operator API must keep working — this is the wrapper's own credential,
+    // acting for nobody in particular, so created_by ownership is legitimate.
+    expect(
+      isSessionVisibleTo('private', WRAPPER, [], { userId: WRAPPER, groupIds: [] }, {
+        origin: 'backend',
+        sessionId: 'session-b',
+        callerSessionId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test('interactive sessions are untouched — a sandbox token still lists its siblings', () => {
+    // created_by genuinely IS one person for interactive sessions, so narrowing
+    // here would break `kortix sessions ls` from inside a normal sandbox.
+    expect(
+      isSessionVisibleTo('private', ALICE, [], { userId: ALICE, groupIds: [] }, {
+        origin: 'interactive',
+        sessionId: 'other-session',
+        callerSessionId: 'my-session',
+      }),
+    ).toBe(true);
   });
 
   test('project visibility → every member', () => {

--- a/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
@@ -84,7 +84,7 @@ mock.module('../shared/preview-ownership', () => ({
   resolveSandboxProjectId: async () => null,
 }));
 
-const { authenticatePreviewPrincipal, extractPreviewToken } = await import('../sandbox-proxy/preview-auth');
+const { authenticatePreviewPrincipal, authenticatePreviewPrincipalDetailed, extractPreviewToken } = await import('../sandbox-proxy/preview-auth');
 const { previewSubdomainAuthCacheKeyForTest } = await import('../sandbox-proxy/subdomain');
 
 beforeEach(() => {
@@ -198,5 +198,26 @@ describe('preview subdomain auth cache key', () => {
     expect(previewSubdomainAuthCacheKeyForTest('sbx', 3000, c)).not.toBe(
       previewSubdomainAuthCacheKeyForTest('sbx', 3000, a),
     );
+  });
+});
+
+describe('authenticatePreviewPrincipalDetailed — session binding', () => {
+  test('a sandbox PAT reports the session it is bound to', async () => {
+    // This is what separates one KaaB end-user from another: every session
+    // shares the wrapper's userId, so only the token's own sessionId can.
+    const p = await authenticatePreviewPrincipalDetailed('kortix_pat_owner', SANDBOX_ID);
+    expect(p?.userId).toBe('pat-user-owner');
+    expect(p).toHaveProperty('sessionId');
+  });
+
+  test('non-PAT credentials report no session binding', async () => {
+    expect((await authenticatePreviewPrincipalDetailed('kortix_sa_owner', SANDBOX_ID))?.sessionId).toBeNull();
+    expect((await authenticatePreviewPrincipalDetailed('kortix_owner', SANDBOX_ID))?.sessionId).toBeNull();
+    expect((await authenticatePreviewPrincipalDetailed('jwt-owner', SANDBOX_ID))?.sessionId).toBeNull();
+  });
+
+  test('the string wrapper still behaves exactly as before', async () => {
+    expect(await authenticatePreviewPrincipal('kortix_pat_owner', SANDBOX_ID)).toBe('pat-user-owner');
+    expect(await authenticatePreviewPrincipal('kortix_pat_bad', SANDBOX_ID)).toBeNull();
   });
 });

--- a/apps/api/src/executor/share.ts
+++ b/apps/api/src/executor/share.ts
@@ -147,7 +147,9 @@ export interface SessionOwnershipContext {
   sessionId: string;
   /** The CALLER's own session, when the credential is bound to one (a sandbox
    *  token). Null for the wrapper's own backend credential, which acts for
-   *  nobody in particular and legitimately sees everything it created. */
+   *  nobody in particular and legitimately sees everything it created.
+   *  REQUIRED — never optional. An omitted binding would default to the
+   *  permissive value and silently reopen the hole on any edge that forgets it. */
   callerSessionId: string | null;
 }
 
@@ -157,14 +159,13 @@ export function isSessionVisibleTo(
   ownerId: string | null,
   grants: SecretGrant[],
   subject: ShareSubject,
-  ownership?: SessionOwnershipContext,
+  ownership: SessionOwnershipContext,
 ): boolean {
   // A sandbox token acts for ONE end-user. It must not reach a sibling backend
   // session just because the wrapper credential created them both. Interactive
   // sessions are deliberately excluded: there created_by really is one person,
   // and narrowing would break `kortix sessions ls` from inside a normal sandbox.
   const sharedCreatorIsMeaningless =
-    ownership != null &&
     ownership.origin === 'backend' &&
     ownership.callerSessionId != null &&
     ownership.callerSessionId !== ownership.sessionId;

--- a/apps/api/src/executor/share.ts
+++ b/apps/api/src/executor/share.ts
@@ -132,13 +132,44 @@ export async function resolveShareSubject(userId: string): Promise<ShareSubject>
 
 export type SessionVisibility = 'private' | 'project' | 'restricted';
 
+/**
+ * Context needed to decide whether `created_by` may confer ownership.
+ *
+ * For an INTERACTIVE session created_by is one human, so ownership is real. For
+ * a Kortix-as-a-Backend session it is the WRAPPER's credential — identical for
+ * every one of that wrapper's end-users — so it identifies nobody, and letting
+ * it short-circuit would make every end-user's session visible to every other.
+ */
+export interface SessionOwnershipContext {
+  /** The target session's `origin` (`'backend'` for a wrapper-created session). */
+  origin: string | null;
+  /** The target session's id. */
+  sessionId: string;
+  /** The CALLER's own session, when the credential is bound to one (a sandbox
+   *  token). Null for the wrapper's own backend credential, which acts for
+   *  nobody in particular and legitimately sees everything it created. */
+  callerSessionId: string | null;
+}
+
 /** Pure: can this subject see/open the session? The owner always can. */
 export function isSessionVisibleTo(
   visibility: SessionVisibility,
   ownerId: string | null,
   grants: SecretGrant[],
   subject: ShareSubject,
+  ownership?: SessionOwnershipContext,
 ): boolean {
+  // A sandbox token acts for ONE end-user. It must not reach a sibling backend
+  // session just because the wrapper credential created them both. Interactive
+  // sessions are deliberately excluded: there created_by really is one person,
+  // and narrowing would break `kortix sessions ls` from inside a normal sandbox.
+  const sharedCreatorIsMeaningless =
+    ownership != null &&
+    ownership.origin === 'backend' &&
+    ownership.callerSessionId != null &&
+    ownership.callerSessionId !== ownership.sessionId;
+  if (sharedCreatorIsMeaningless) return false;
+
   if (ownerId && ownerId === subject.userId) return true;
   if (visibility === 'project') return true;
   if (visibility === 'restricted') {

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -73,6 +73,14 @@ async function loadProjectSessionRow(
 export async function loadVisibleSession(
   loaded: { row: ProjectRow; userId: string; effectiveRole: ProjectRole; adminBypass?: boolean },
   sessionId: string,
+  /**
+   * The CALLER's own session, when the credential is bound to one (a sandbox
+   * token: `c.get('sessionId')`). Null/undefined for a human or for a wrapper's
+   * own backend credential. Required to stop a sandbox reaching a SIBLING
+   * backend session — every KaaB session shares one `created_by`, so ownership
+   * alone cannot separate them. See isSessionVisibleTo.
+   */
+  callerSessionId?: string | null,
 ): Promise<{
   row: ProjectSessionRow;
   subject: ShareSubject;
@@ -85,7 +93,13 @@ export async function loadVisibleSession(
   if (!row) return null;
   const subject = await resolveShareSubject(loaded.userId);
   const grants = (await loadSessionGrants([sessionId])).get(sessionId) ?? [];
-  if (!isSessionVisibleTo(row.visibility as 'private' | 'project' | 'restricted', row.createdBy, grants, subject)) {
+  if (
+    !isSessionVisibleTo(row.visibility as 'private' | 'project' | 'restricted', row.createdBy, grants, subject, {
+      origin: row.origin ?? null,
+      sessionId,
+      callerSessionId: callerSessionId ?? null,
+    })
+  ) {
     // A platform-admin bypass already verified for the parent project (see
     // loadProjectForUser) also covers a session that would otherwise be
     // invisible (private / not-my-grant). Audit every use — this is a real

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -80,7 +80,7 @@ export async function loadVisibleSession(
    * backend session — every KaaB session shares one `created_by`, so ownership
    * alone cannot separate them. See isSessionVisibleTo.
    */
-  callerSessionId?: string | null,
+  callerSessionId: string | null,
 ): Promise<{
   row: ProjectSessionRow;
   subject: ShareSubject;
@@ -97,7 +97,7 @@ export async function loadVisibleSession(
     !isSessionVisibleTo(row.visibility as 'private' | 'project' | 'restricted', row.createdBy, grants, subject, {
       origin: row.origin ?? null,
       sessionId,
-      callerSessionId: callerSessionId ?? null,
+      callerSessionId,
     })
   ) {
     // A platform-admin bypass already verified for the parent project (see

--- a/apps/api/src/projects/lib/session-inventory.test.ts
+++ b/apps/api/src/projects/lib/session-inventory.test.ts
@@ -59,7 +59,8 @@ describe('selectSessionRowsForViewer', () => {
       canManageProject: true,
       subject,
       grantsBySession: new Map(),
-      runtimeStatusBySession: new Map(),
+      callerSessionId: null,
+    runtimeStatusBySession: new Map(),
     });
 
     expect(selected.authorized).toBe(true);
@@ -90,7 +91,8 @@ describe('selectSessionRowsForViewer', () => {
       canManageProject: false,
       subject,
       grantsBySession: new Map(),
-      runtimeStatusBySession: new Map(),
+      callerSessionId: null,
+    runtimeStatusBySession: new Map(),
     });
 
     expect(selected).toEqual({ authorized: false, items: [] });
@@ -111,7 +113,8 @@ describe('selectSessionRowsForViewer', () => {
       canManageProject: false,
       subject,
       grantsBySession: new Map(),
-      runtimeStatusBySession: new Map([['stopped-resumable', 'stopped']]),
+      callerSessionId: null,
+    runtimeStatusBySession: new Map([['stopped-resumable', 'stopped']]),
     });
 
     expect(selected.authorized).toBe(true);

--- a/apps/api/src/projects/lib/session-inventory.ts
+++ b/apps/api/src/projects/lib/session-inventory.ts
@@ -76,6 +76,10 @@ export function selectSessionRowsForViewer(input: {
   scope: ProjectSessionListScope;
   canManageProject: boolean;
   subject: ShareSubject;
+  /** The caller's own session when the credential is bound to one (sandbox
+   *  token). Stops a sandbox listing SIBLING backend sessions, which all share
+   *  one `created_by`. */
+  callerSessionId?: string | null;
   grantsBySession: Map<string, SecretGrant[]>;
   runtimeStatusBySession: Map<string, RuntimeStatus>;
 }): { authorized: boolean; items: SessionInventoryItem[] } {
@@ -96,6 +100,11 @@ export function selectSessionRowsForViewer(input: {
       row.createdBy,
       input.grantsBySession.get(row.sessionId) ?? [],
       input.subject,
+      {
+        origin: row.origin ?? null,
+        sessionId: row.sessionId,
+        callerSessionId: input.callerSessionId ?? null,
+      },
     );
     return { row, canAccess, runtimeStatus, deletedAt, deletedBy };
   });

--- a/apps/api/src/projects/lib/session-inventory.ts
+++ b/apps/api/src/projects/lib/session-inventory.ts
@@ -79,7 +79,7 @@ export function selectSessionRowsForViewer(input: {
   /** The caller's own session when the credential is bound to one (sandbox
    *  token). Stops a sandbox listing SIBLING backend sessions, which all share
    *  one `created_by`. */
-  callerSessionId?: string | null;
+  callerSessionId: string | null;
   grantsBySession: Map<string, SecretGrant[]>;
   runtimeStatusBySession: Map<string, RuntimeStatus>;
 }): { authorized: boolean; items: SessionInventoryItem[] } {
@@ -103,7 +103,7 @@ export function selectSessionRowsForViewer(input: {
       {
         origin: row.origin ?? null,
         sessionId: row.sessionId,
-        callerSessionId: input.callerSessionId ?? null,
+        callerSessionId: input.callerSessionId,
       },
     );
     return { row, canAccess, runtimeStatus, deletedAt, deletedBy };

--- a/apps/api/src/projects/routes/public-shares.ts
+++ b/apps/api/src/projects/routes/public-shares.ts
@@ -37,7 +37,7 @@ projectsApp.openapi(
 
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const visible = await loadVisibleSession(loaded, sessionId);
+    const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
 
     return c.json({

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -719,6 +719,7 @@ projectsApp.openapi(
     subject,
     grantsBySession,
     runtimeStatusBySession,
+    callerSessionId: c.get('sessionId') ?? null,
   });
   if (!selected.authorized) {
     return c.json({ error: 'Project manager access is required to list every session' }, 403);
@@ -774,7 +775,7 @@ projectsApp.openapi(
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);
 
-  const visible = await loadVisibleSession(loaded, sessionId);
+  const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
   if (!visible) return c.json({ error: 'Not found' }, 404);
   const ownerEmail = visible.row.createdBy && !visible.isOwner
     ? (await lookupEmailsByUserIds([visible.row.createdBy])).get(visible.row.createdBy) ?? null
@@ -827,7 +828,7 @@ projectsApp.openapi(
   if (!loaded) return c.json({ error: 'Not found' }, 404);
   await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);
 
-  const visible = await loadVisibleSession(loaded, sessionId);
+  const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
   if (!visible) return c.json({ error: 'Not found' }, 404);
 
   const transcript = await buildSessionTranscriptDigest({
@@ -879,7 +880,7 @@ projectsApp.openapi(
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);
-    const visible = await loadVisibleSession(loaded, sessionId);
+    const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     // The historical trail is Enterprise (`auditAccess`), but this endpoint is
     // also the approval CONTROL PLANE: write/destructive connector actions
@@ -1034,7 +1035,7 @@ projectsApp.openapi(
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
     await assertProjectCapability(c, loaded.userId, loaded.row.accountId, projectId, PROJECT_ACTIONS.PROJECT_SESSION_READ);
-    const visible = await loadVisibleSession(loaded, sessionId);
+    const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
 
     const [page, live] = await Promise.all([
@@ -1491,7 +1492,7 @@ projectsApp.openapi(
   const loaded = await loadProjectForUser(c, projectId, 'read');
   if (!loaded) return c.json({ error: 'Not found' }, 404);
 
-  const visible = await loadVisibleSession(loaded, sessionId);
+  const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
   if (!visible) return c.json({ error: 'Not found' }, 404);
   if (!visible.canManageSharing) {
     return c.json({ error: 'Only the session owner or a project manager can change sharing' }, 403);
@@ -1519,7 +1520,7 @@ projectsApp.openapi(
 
   await setSessionSharing(sessionId, intent);
 
-  const fresh = await loadVisibleSession(loaded, sessionId);
+  const fresh = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
   return c.json(fresh ? serializeSession(fresh.row, {
     grants: fresh.grants,
     viewerId: loaded.userId,
@@ -1595,7 +1596,7 @@ projectsApp.openapi(
     }
   }
 
-  const visible = await loadVisibleSession(loaded, sessionId);
+  const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
   if (!visible) return c.json({ error: 'Not found' }, 404);
   const existing = visible.row;
 
@@ -1672,7 +1673,7 @@ projectsApp.openapi(
   assertAgentScope(c, PROJECT_ACTIONS.PROJECT_SESSION_STOP);
 
   // Stopping a session is reserved for its owner or a project manager.
-  const visible = await loadVisibleSession(loaded, sessionId);
+  const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
   if (!visible) return c.json({ error: 'Not found' }, 404);
   if (!visible.canManageSharing) {
     return c.json({ error: 'Only the session owner or a project manager can stop this session' }, 403);

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -66,7 +66,7 @@ projectsApp.openapi(
     // Per-agent gate: resuming a session provisions compute. A scoped agent
     // token must hold project.session.start (no-op for human/PAT tokens).
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_SESSION_START);
-    const visible = await loadVisibleSession(loaded, sessionId);
+    const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
 
     // Same gate as wake/create: resuming or provisioning spends compute.
@@ -133,7 +133,7 @@ projectsApp.openapi(
     assertAgentScope(c, PROJECT_ACTIONS.PROJECT_SESSION_START);
 
     // Restart is reserved for the session owner or an account owner/admin.
-    const visible = await loadVisibleSession(loaded, sessionId);
+    const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json(
@@ -191,7 +191,7 @@ projectsApp.openapi(
 
     // Stop is reserved for the session owner or an account owner/admin, same policy
     // as restart.
-    const visible = await loadVisibleSession(loaded, sessionId);
+    const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json(

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -430,7 +430,7 @@ export async function continueSession(
       return healed ? toTarget(healed) : null;
     },
     send: (externalId, opencodeSessionId) =>
-      postPrompt(externalId, opencodeSessionId, text, userId),
+      postPrompt(externalId, opencodeSessionId, text, userId, sessionId),
   });
 }
 
@@ -746,13 +746,16 @@ async function postPrompt(
   opencodeSessionId: string,
   text: string,
   userId: string,
+  /** The session this prompt is FOR. Passed as the caller binding so the
+   *  isolation guard proves the target matches, rather than being waived. */
+  callerSessionId: string,
 ): Promise<boolean> {
   const body = new TextEncoder().encode(JSON.stringify({ parts: [{ type: 'text', text }] }));
   try {
     const res = await forwardToSandbox(
       externalId,
       DAEMON_PORT,
-      { kind: 'principal', userId },
+      { kind: 'principal', userId, callerSessionId },
       'POST',
       `/session/${encodeURIComponent(opencodeSessionId)}/prompt_async`,
       `?directory=${encodeURIComponent(WORKSPACE)}`,

--- a/apps/api/src/sandbox-proxy/preview-auth.ts
+++ b/apps/api/src/sandbox-proxy/preview-auth.ts
@@ -35,18 +35,36 @@ import { canAccessPreviewSandbox } from '../shared/preview-ownership';
  * principal id to forward downstream. Returns null on any failure (invalid
  * token, or valid token without access to this sandbox).
  */
-export async function authenticatePreviewPrincipal(
+export interface PreviewPrincipal {
+  /** The principal's id (user, service account, or account for a kortix key). */
+  userId: string;
+  /**
+   * The session this credential is BOUND to, when it is a sandbox token. Null
+   * for a laptop CLI PAT, a service account, or a JWT. Kortix-as-a-Backend
+   * shares one `created_by` across every end-user, so this is the only thing
+   * that distinguishes one end-user's sandbox from another's.
+   */
+  sessionId: string | null;
+}
+
+/**
+ * Same authentication as {@link authenticatePreviewPrincipal}, but also returns
+ * the session the credential is bound to. Prefer this on any surface that then
+ * makes a session-visibility decision.
+ */
+export async function authenticatePreviewPrincipalDetailed(
   token: string | null | undefined,
   sandboxId: string,
-): Promise<string | null> {
+): Promise<PreviewPrincipal | null> {
   if (!token) return null;
   try {
-    // CLI Personal Access Token — carries the minting user's real id.
+    // CLI Personal Access Token — carries the minting user's real id, and for a
+    // SANDBOX token also the session it was minted for.
     if (isAccountToken(token)) {
       const r = await validateAccountToken(token);
       if (!r.isValid || !r.userId) return null;
       return (await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId: r.userId }))
-        ? r.userId
+        ? { userId: r.userId, sessionId: r.sessionId ?? null }
         : null;
     }
 
@@ -55,7 +73,7 @@ export async function authenticatePreviewPrincipal(
       const r = await validateServiceAccountToken(token);
       if (!r.isValid || !r.serviceAccountId) return null;
       return (await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId: r.serviceAccountId }))
-        ? r.serviceAccountId
+        ? { userId: r.serviceAccountId, sessionId: null }
         : null;
     }
 
@@ -64,7 +82,7 @@ export async function authenticatePreviewPrincipal(
       const r = await validateSecretKey(token);
       if (!r.isValid || !r.accountId) return null;
       return (await canAccessPreviewSandbox({ previewSandboxId: sandboxId, accountId: r.accountId }))
-        ? r.accountId
+        ? { userId: r.accountId, sessionId: null }
         : null;
     }
 
@@ -72,7 +90,7 @@ export async function authenticatePreviewPrincipal(
     const local = await verifySupabaseJwt(token);
     if (local.ok) {
       return (await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId: local.userId }))
-        ? local.userId
+        ? { userId: local.userId, sessionId: null }
         : null;
     }
     if (local.reason !== 'no-keys' && local.reason !== 'no-key-for-kid') return null;
@@ -81,7 +99,7 @@ export async function authenticatePreviewPrincipal(
     const { data: { user }, error } = await supabase.auth.getUser(token);
     if (error || !user) return null;
     return (await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId: user.id }))
-      ? user.id
+      ? { userId: user.id, sessionId: null }
       : null;
   } catch (err) {
     console.warn('[preview-auth] token validation error:', (err as Error)?.message || err);
@@ -105,4 +123,15 @@ export function extractPreviewToken(req: Request, url: URL): string | null {
   const m = cookieHeader.match(/(?:^|;\s*)__preview_session=([^;]+)/);
   if (m) return decodeURIComponent(m[1]);
   return null;
+}
+
+/**
+ * Back-compat wrapper: the principal id only. Existing callers that make no
+ * session-scoped decision (subdomain gate) keep using this.
+ */
+export async function authenticatePreviewPrincipal(
+  token: string | null | undefined,
+  sandboxId: string,
+): Promise<string | null> {
+  return (await authenticatePreviewPrincipalDetailed(token, sandboxId))?.userId ?? null;
 }

--- a/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
@@ -88,7 +88,7 @@ describe('forwardToSandbox — prompt delivery is never double-sent', () => {
   test('a prompt POST that 502s is delivered to the sandbox at most once', async () => {
     queueFetch(new Response('bad gateway', { status: 502 }));
     const res = await forwardToSandbox(
-      'sb-1', 8000, { kind: 'principal', userId: 'u1' },
+      'sb-1', 8000, { kind: 'principal', userId: 'u1', callerSessionId: null },
       'POST', '/session/sess-1/message', '', jsonHeaders(), PROMPT_BODY, 'http://app.local',
     );
     // Exactly ONE upstream attempt — the 502 is passed straight through, never retried.
@@ -99,7 +99,7 @@ describe('forwardToSandbox — prompt delivery is never double-sent', () => {
   test('a prompt POST that succeeds is forwarded once (happy path unchanged)', async () => {
     queueFetch(new Response('{"info":{},"parts":[]}', { status: 200 }));
     const res = await forwardToSandbox(
-      'sb-1', 8000, { kind: 'principal', userId: 'u1' },
+      'sb-1', 8000, { kind: 'principal', userId: 'u1', callerSessionId: null },
       'POST', '/session/sess-1/message', '', jsonHeaders(), PROMPT_BODY, 'http://app.local',
     );
     expect(fetchCalls).toBe(1);
@@ -109,7 +109,7 @@ describe('forwardToSandbox — prompt delivery is never double-sent', () => {
   test('a duplicate inbound prompt under the same Idempotency-Key short-circuits', async () => {
     queueFetch(new Response('{"info":{},"parts":[]}', { status: 200 }));
     const args = [
-      'sb-1', 8000, { kind: 'principal', userId: 'u1' } as const,
+      'sb-1', 8000, { kind: 'principal', userId: 'u1', callerSessionId: null } as const,
       'POST', '/session/sess-1/message', '', jsonHeaders({ 'idempotency-key': 'dup-1' }),
       PROMPT_BODY, 'http://app.local',
     ] as const;
@@ -130,7 +130,7 @@ describe('forwardToSandbox — idempotent GET retry is unchanged', () => {
       new Response('ok', { status: 200 }),
     );
     const res = await forwardToSandbox(
-      'sb-1', 8000, { kind: 'principal', userId: 'u1' },
+      'sb-1', 8000, { kind: 'principal', userId: 'u1', callerSessionId: null },
       'GET', '/session', '', new Headers(), undefined, 'http://app.local',
     );
     expect(fetchCalls).toBe(2);

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -30,7 +30,9 @@ import {
 import { claimPromptDelivery, promptDeliveryKey } from '../prompt-dedupe';
 
 // `userId` is set by combinedAuth (mounted in ../index.ts) before this route.
-const preview = new Hono<{ Variables: { userId: string; userEmail: string } }>();
+const preview = new Hono<{
+  Variables: { userId: string; userEmail: string; sessionId?: string };
+}>();
 
 // Hop-by-hop + caller-controlled headers we never forward upstream. Auth is
 // replaced with the sandbox service key, trace headers are regenerated, and
@@ -446,7 +448,16 @@ function bodyWithoutPromptAgent(
 // proxy edges use it: the path-based Hono route below and the subdomain handler
 // (src/sandbox-proxy/subdomain.ts).
 
-export type PreviewProxyAccess = { kind: 'principal'; userId: string } | { kind: 'public_share' };
+export type PreviewProxyAccess =
+  | {
+      kind: 'principal';
+      userId: string;
+      /** The caller's own session when the credential is bound to one (a sandbox
+       *  token). Kortix-as-a-Backend shares ONE userId across every end-user, so
+       *  this is what separates them. */
+      callerSessionId?: string | null;
+    }
+  | { kind: 'public_share' };
 
 function principalUserId(access: PreviewProxyAccess): string {
   return access.kind === 'principal' ? access.userId : '';
@@ -510,6 +521,7 @@ export async function forwardToSandbox(
     return jsonProxyError({ error: 'sandbox not found' }, 404, origin);
   }
   const userId = principalUserId(access);
+  const callerSessionId = access.kind === 'principal' ? (access.callerSessionId ?? null) : null;
   if (
     access.kind === 'principal' &&
     !(await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId }))
@@ -541,6 +553,7 @@ export async function forwardToSandbox(
       projectId: record.projectId,
       accountId: record.accountId,
       userId,
+      callerSessionId: callerSessionId ?? null,
     }))
   ) {
     throw new HTTPException(403, { message: 'Not authorized to access this session' });
@@ -1003,11 +1016,14 @@ export async function resolvePreviewWsUpstream(opts: {
   userId: string;
   remainingPath: string;
   queryString: string;
+  /** The caller's own session when the credential is bound to one. */
+  callerSessionId?: string | null;
 }): Promise<
   | { ok: true; url: string; headers: Record<string, string> }
   | { ok: false; status: number; message: string }
 > {
   const { sandboxId, userId, remainingPath, queryString } = opts;
+  const callerSessionId = opts.callerSessionId ?? null;
 
   const record = await loadSandbox(sandboxId);
   if (!record) return { ok: false, status: 404, message: 'sandbox not found' };
@@ -1031,6 +1047,7 @@ export async function resolvePreviewWsUpstream(opts: {
       projectId: record.projectId,
       accountId: record.accountId,
       userId,
+      callerSessionId: callerSessionId ?? null,
     }))
   ) {
     return { ok: false, status: 403, message: 'not authorized for this session' };
@@ -1108,7 +1125,7 @@ preview.all('/:sandboxId/:port/*', async (c) => {
   return forwardToSandbox(
     sandboxId,
     port,
-    { kind: 'principal', userId },
+    { kind: 'principal', userId, callerSessionId: c.get('sessionId') ?? null },
     method,
     remainingPath,
     queryString,

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -454,8 +454,9 @@ export type PreviewProxyAccess =
       userId: string;
       /** The caller's own session when the credential is bound to one (a sandbox
        *  token). Kortix-as-a-Backend shares ONE userId across every end-user, so
-       *  this is what separates them. */
-      callerSessionId?: string | null;
+       *  this is what separates them. Null means a non-session-bound principal.
+       *  REQUIRED so a new entry point cannot silently omit it and fail open. */
+      callerSessionId: string | null;
     }
   | { kind: 'public_share' };
 
@@ -521,7 +522,7 @@ export async function forwardToSandbox(
     return jsonProxyError({ error: 'sandbox not found' }, 404, origin);
   }
   const userId = principalUserId(access);
-  const callerSessionId = access.kind === 'principal' ? (access.callerSessionId ?? null) : null;
+  const callerSessionId = access.kind === 'principal' ? access.callerSessionId : null;
   if (
     access.kind === 'principal' &&
     !(await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId }))
@@ -1016,14 +1017,15 @@ export async function resolvePreviewWsUpstream(opts: {
   userId: string;
   remainingPath: string;
   queryString: string;
-  /** The caller's own session when the credential is bound to one. */
-  callerSessionId?: string | null;
+  /** The caller's own session when the credential is bound to one, or null for a
+   *  principal that is not session-bound. REQUIRED — fail closed, never default. */
+  callerSessionId: string | null;
 }): Promise<
   | { ok: true; url: string; headers: Record<string, string> }
   | { ok: false; status: number; message: string }
 > {
   const { sandboxId, userId, remainingPath, queryString } = opts;
-  const callerSessionId = opts.callerSessionId ?? null;
+  const callerSessionId = opts.callerSessionId;
 
   const record = await loadSandbox(sandboxId);
   if (!record) return { ok: false, status: 404, message: 'sandbox not found' };

--- a/apps/api/src/sandbox-proxy/subdomain.ts
+++ b/apps/api/src/sandbox-proxy/subdomain.ts
@@ -18,7 +18,7 @@
  * fan-out was removed earlier in this refactor. WS plumbing is a follow-up.
  */
 
-import { authenticatePreviewPrincipal, extractPreviewToken } from './preview-auth';
+import { authenticatePreviewPrincipalDetailed, extractPreviewToken } from './preview-auth';
 import { forwardToSandbox } from './routes/preview';
 import {
   PUBLIC_SHARE_BLOCKED_PORTS,
@@ -46,7 +46,7 @@ export function parsePreviewSubdomain(host: string): { port: number; sandboxId: 
 // identity (the agent-server's auth gate verifies that header).
 
 type AuthState =
-  | { kind: 'principal'; userId: string; expiresAt: number }
+  | { kind: 'principal'; userId: string; callerSessionId: string | null; expiresAt: number }
   | { kind: 'public_share'; shareId: string; mode: string; expiresAt: number };
 
 // In-memory subdomain auth gate (see authenticatePreviewPrincipal / markAuthedSubdomain).
@@ -83,10 +83,19 @@ function getAuthedSubdomain(sandboxId: string, port: number, req: Request): Auth
   return entry;
 }
 
-function markAuthedSubdomain(sandboxId: string, port: number, req: Request, userId: string): void {
+function markAuthedSubdomain(
+  sandboxId: string,
+  port: number,
+  req: Request,
+  userId: string,
+  // Cached alongside the user because the cache is what later forwards get their
+  // principal from — dropping it here would re-open the bypass on every cache hit.
+  callerSessionId: string | null,
+): void {
   authedSubdomains.set(key(sandboxId, port, req), {
     kind: 'principal',
     userId,
+    callerSessionId,
     expiresAt: Date.now() + AUTH_SESSION_TTL_MS,
   });
 }
@@ -196,8 +205,9 @@ export async function handleSubdomainRequest(
   }
   if (!authed) {
     const token = extractPreviewToken(req, url);
-    const validatedUserId = await authenticatePreviewPrincipal(token, sandboxId);
-    if (!validatedUserId) {
+    const principal = await authenticatePreviewPrincipalDetailed(token, sandboxId);
+    const validatedUserId = principal?.userId ?? null;
+    if (!principal || !validatedUserId) {
       return new Response(
         JSON.stringify({ error: 'Unauthorized' }),
         {
@@ -210,8 +220,13 @@ export async function handleSubdomainRequest(
         },
       );
     }
-    markAuthedSubdomain(sandboxId, port, req, validatedUserId);
-    authed = { kind: 'principal', userId: validatedUserId, expiresAt: Date.now() + AUTH_SESSION_TTL_MS };
+    markAuthedSubdomain(sandboxId, port, req, validatedUserId, principal.sessionId);
+    authed = {
+      kind: 'principal',
+      userId: validatedUserId,
+      callerSessionId: principal.sessionId,
+      expiresAt: Date.now() + AUTH_SESSION_TTL_MS,
+    };
   }
 
   // Body (read once, before retries inside forwardToSandbox).
@@ -247,7 +262,7 @@ export async function handleSubdomainRequest(
       sandboxId,
       port,
       authed.kind === 'principal'
-        ? { kind: 'principal', userId: authed.userId }
+        ? { kind: 'principal', userId: authed.userId, callerSessionId: authed.callerSessionId }
         : { kind: 'public_share' },
       req.method,
       url.pathname,

--- a/apps/api/src/sandbox-proxy/ws-proxy.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy.ts
@@ -22,7 +22,7 @@
 // 8000.
 // ════════════════════════════════════════════════════════════════════════════
 
-import { authenticatePreviewPrincipal } from './preview-auth';
+import { authenticatePreviewPrincipalDetailed } from './preview-auth';
 import { resolvePreviewWsUpstream } from './routes/preview';
 import { classifyPtyWebSocketPath } from '../platform/providers/pty-ingress';
 
@@ -77,8 +77,12 @@ export async function preparePreviewWsUpgrade(
 
   const { sandboxId, port, remainingPath } = match;
 
-  const userId = await authenticatePreviewPrincipal(url.searchParams.get('token'), sandboxId);
-  if (!userId) return { ok: false, status: 401, message: 'unauthorized' };
+  const principal = await authenticatePreviewPrincipalDetailed(
+    url.searchParams.get('token'),
+    sandboxId,
+  );
+  if (!principal) return { ok: false, status: 401, message: 'unauthorized' };
+  const userId = principal.userId;
 
   // opencode PTY (and any other opencode endpoint) must reach opencode directly
   // on 4096 — the daemon on 8000 can't carry a WebSocket. Everything else is
@@ -99,6 +103,7 @@ export async function preparePreviewWsUpgrade(
       userId,
       remainingPath,
       queryString,
+      callerSessionId: principal.sessionId,
     });
     if (!upstream.ok) {
       return { ok: false, status: upstream.status, message: upstream.message };

--- a/apps/api/src/shared/preview-ownership.ts
+++ b/apps/api/src/shared/preview-ownership.ts
@@ -47,15 +47,16 @@ export async function canAccessSandboxSession(input: {
   projectId: string;
   accountId: string;
   userId: string;
-  /** The caller's own session when the credential is bound to one. */
-  callerSessionId?: string | null;
+  /** The caller's own session when the credential is bound to one, or null.
+   *  REQUIRED — an omitted binding would fail open. */
+  callerSessionId: string | null;
 }): Promise<boolean> {
   // callerSessionId MUST be in the key. In Kortix-as-a-Backend every end-user
   // shares one `userId` (the wrapper credential), so without it end-user A and
   // end-user B collide on one entry for the same target session — and the first
   // `true` would be served to everyone else for the whole TTL, silently
   // defeating the isolation check below.
-  const key = `${input.sessionId}|${input.userId}|${input.callerSessionId ?? ''}`;
+  const key = `${input.sessionId}|${input.userId}|${input.callerSessionId ?? '-'}`;
   const cached = sessionVisibilityCache.get(key);
   if (cached && cached.expiresAt > Date.now()) return cached.allowed;
 
@@ -87,7 +88,7 @@ export async function canAccessSandboxSession(input: {
       {
         origin: row.origin ?? null,
         sessionId: input.sessionId,
-        callerSessionId: input.callerSessionId ?? null,
+        callerSessionId: input.callerSessionId,
       },
     );
   }

--- a/apps/api/src/shared/preview-ownership.ts
+++ b/apps/api/src/shared/preview-ownership.ts
@@ -47,13 +47,24 @@ export async function canAccessSandboxSession(input: {
   projectId: string;
   accountId: string;
   userId: string;
+  /** The caller's own session when the credential is bound to one. */
+  callerSessionId?: string | null;
 }): Promise<boolean> {
-  const key = `${input.sessionId}|${input.userId}`;
+  // callerSessionId MUST be in the key. In Kortix-as-a-Backend every end-user
+  // shares one `userId` (the wrapper credential), so without it end-user A and
+  // end-user B collide on one entry for the same target session — and the first
+  // `true` would be served to everyone else for the whole TTL, silently
+  // defeating the isolation check below.
+  const key = `${input.sessionId}|${input.userId}|${input.callerSessionId ?? ''}`;
   const cached = sessionVisibilityCache.get(key);
   if (cached && cached.expiresAt > Date.now()) return cached.allowed;
 
   const [row] = await db
-    .select({ visibility: projectSessions.visibility, createdBy: projectSessions.createdBy })
+    .select({
+      visibility: projectSessions.visibility,
+      createdBy: projectSessions.createdBy,
+      origin: projectSessions.origin,
+    })
     .from(projectSessions)
     .where(
       and(
@@ -73,6 +84,11 @@ export async function canAccessSandboxSession(input: {
       row.createdBy,
       grants,
       subject,
+      {
+        origin: row.origin ?? null,
+        sessionId: input.sessionId,
+        callerSessionId: input.callerSessionId ?? null,
+      },
     );
   }
   sessionVisibilityCache.set(key, { allowed, expiresAt: Date.now() + SESSION_VISIBILITY_TTL_MS });

--- a/apps/kortix-sandbox-agent-server/src/__tests__/project-env-revocation.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/project-env-revocation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createProjectEnvStore, mergeProjectEnv } from '../project-env'
+
+/**
+ * A revoked secret must not survive into the environment opencode is spawned
+ * with (opencode.ts:932 / :1203 both build it via mergeProjectEnv(process.env, …)).
+ *
+ * The shell path already handles this — agent-env.sh emits an explicit
+ * `unset NAME`, covered by agent-env-file.test.ts. But opencode's own process
+ * env, and therefore every MCP server and direct child spawn it makes, never
+ * passes through BASH_ENV. If mergeProjectEnv only deletes the names still
+ * granted, a revoked value survives from the daemon's process.env and is
+ * re-injected on the next restart.
+ */
+describe('mergeProjectEnv — revocation', () => {
+  test('a revoked BOOT secret is cleared, not carried over from process.env', () => {
+    const bootEnv = {
+      KORTIX_PROJECT_SECRETS_REVISION: 'r1',
+      KORTIX_PROJECT_SECRET_NAMES: 'STRIPE_KEY,GITHUB_TOKEN',
+      STRIPE_KEY: 'sk_live_boot',
+      GITHUB_TOKEN: 'ghp_boot',
+    }
+    const store = createProjectEnvStore(bootEnv)
+
+    // Owner deletes STRIPE_KEY. The server re-derives and pushes only what is
+    // still granted — a revoked name is never in `names` (sandbox-env-names.ts:35).
+    store.apply({ revision: 'r2', env: { GITHUB_TOKEN: 'ghp_boot' }, names: ['GITHUB_TOKEN'] })
+
+    const merged = mergeProjectEnv(bootEnv, store)
+    expect(merged.STRIPE_KEY).toBeUndefined()
+    expect(merged.GITHUB_TOKEN).toBe('ghp_boot')
+  })
+
+  test('a secret ADDED mid-session and then revoked is also cleared', () => {
+    // Not covered by the boot-name list: this name never existed at boot, so an
+    // unset derived from KORTIX_PROJECT_SECRET_NAMES would miss it entirely.
+    const bootEnv = {
+      KORTIX_PROJECT_SECRETS_REVISION: 'r1',
+      KORTIX_PROJECT_SECRET_NAMES: 'GITHUB_TOKEN',
+      GITHUB_TOKEN: 'ghp_boot',
+    }
+    const store = createProjectEnvStore(bootEnv)
+
+    store.apply({
+      revision: 'r2',
+      env: { GITHUB_TOKEN: 'ghp_boot', ADDED_KEY: 'added_value' },
+      names: ['ADDED_KEY', 'GITHUB_TOKEN'],
+    })
+    // …then removed again.
+    store.apply({ revision: 'r3', env: { GITHUB_TOKEN: 'ghp_boot' }, names: ['GITHUB_TOKEN'] })
+
+    // Simulate the value having reached the live process env while it was granted.
+    const liveEnv = { ...bootEnv, ADDED_KEY: 'added_value' }
+    const merged = mergeProjectEnv(liveEnv, store)
+    expect(merged.ADDED_KEY).toBeUndefined()
+    expect(merged.GITHUB_TOKEN).toBe('ghp_boot')
+  })
+
+  test('a rotated secret takes the new value, not the boot one', () => {
+    const bootEnv = {
+      KORTIX_PROJECT_SECRETS_REVISION: 'r1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'old',
+    }
+    const store = createProjectEnvStore(bootEnv)
+    store.apply({ revision: 'r2', env: { API_KEY: 'new' }, names: ['API_KEY'] })
+    expect(mergeProjectEnv(bootEnv, store).API_KEY).toBe('new')
+  })
+
+  test('unrelated environment is left alone', () => {
+    const bootEnv = {
+      KORTIX_PROJECT_SECRETS_REVISION: 'r1',
+      KORTIX_PROJECT_SECRET_NAMES: 'API_KEY',
+      API_KEY: 'v',
+      PATH: '/usr/bin',
+      HOME: '/root',
+    }
+    const store = createProjectEnvStore(bootEnv)
+    store.apply({ revision: 'r2', env: {}, names: [] })
+    const merged = mergeProjectEnv(bootEnv, store)
+    expect(merged.API_KEY).toBeUndefined()
+    expect(merged.PATH).toBe('/usr/bin')
+    expect(merged.HOME).toBe('/root')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/project-env.ts
+++ b/apps/kortix-sandbox-agent-server/src/project-env.ts
@@ -4,6 +4,8 @@ type ProjectEnvSnapshot = {
   revision: string | null
   env: Record<string, string>
   names: string[]
+  /** Union of every name this store has managed, including revoked ones. */
+  knownNames: string[]
 }
 
 type ProjectEnvUpdate = {
@@ -56,6 +58,9 @@ export function createProjectEnvStore(initialEnv: NodeJS.ProcessEnv = process.en
     const value = initialEnv[name]
     if (typeof value === 'string') env[name] = value
   }
+  // Every name this store has ever managed. A revoked secret drops out of
+  // `names`, so this is the only record that it must be actively cleared.
+  const knownNames = new Set<string>(names)
 
   return {
     snapshot() {
@@ -63,6 +68,7 @@ export function createProjectEnvStore(initialEnv: NodeJS.ProcessEnv = process.en
         revision,
         env: { ...env },
         names: [...names],
+        knownNames: [...knownNames].sort(),
       }
     },
 
@@ -77,6 +83,9 @@ export function createProjectEnvStore(initialEnv: NodeJS.ProcessEnv = process.en
         revision !== nextRevision ||
         JSON.stringify(env) !== JSON.stringify(nextEnv) ||
         JSON.stringify(names) !== JSON.stringify(nextNames)
+
+      for (const name of nextNames) knownNames.add(name)
+      for (const name of Object.keys(nextEnv)) knownNames.add(name)
 
       if (changed) {
         revision = nextRevision
@@ -96,7 +105,14 @@ export function createProjectEnvStore(initialEnv: NodeJS.ProcessEnv = process.en
 export function mergeProjectEnv(baseEnv: NodeJS.ProcessEnv, store: ProjectEnvStore): NodeJS.ProcessEnv {
   const snapshot = store.snapshot()
   const merged: NodeJS.ProcessEnv = { ...baseEnv }
-  for (const name of snapshot.names) {
+  // Clear every name this store has EVER managed, not just the ones still
+  // granted. The server pushes only currently-granted names, so a revoked
+  // secret never appears in `names` — deleting only those would leave its value
+  // in place, inherited from the daemon's own process.env, and re-inject it into
+  // opencode on the next restart (opencode.ts spawns from mergeProjectEnv).
+  // MCP servers and direct child spawns never pass through BASH_ENV, so the
+  // `unset` written to agent-env.sh does not cover them.
+  for (const name of snapshot.knownNames) {
     delete merged[name]
   }
   for (const [name, value] of Object.entries(snapshot.env)) {

--- a/apps/web/src/features/billing/end-user-usage-card.tsx
+++ b/apps/web/src/features/billing/end-user-usage-card.tsx
@@ -27,6 +27,7 @@ import { getUsageRollup } from '@kortix/sdk';
 import { useQuery } from '@tanstack/react-query';
 import { Copy, Users } from 'lucide-react';
 import { useState } from 'react';
+import { useBillingAccountId } from '@/stores/billing-account-context';
 import { toEndUserUsageRows } from './end-user-usage';
 
 const WINDOWS = [
@@ -62,10 +63,19 @@ function formatUsd(value: number): string {
 export function EndUserUsageCard() {
   const [windowKey, setWindowKey] = useState<(typeof WINDOWS)[number]['key']>('30');
 
+  // Scope to the account being VIEWED, not the caller's default. For a browser
+  // session the server takes the account from this query param, so omitting it
+  // would show your personal spend on a team account's page.
+  const accountId = useBillingAccountId();
+
   const usageQuery = useQuery({
-    queryKey: ['usage', 'origin_ref', windowKey],
+    queryKey: ['usage', 'origin_ref', windowKey, accountId ?? 'default'],
     queryFn: () =>
-      getUsageRollup({ groupBy: 'origin_ref', start: startOfWindow(Number(windowKey)) }),
+      getUsageRollup({
+        groupBy: 'origin_ref',
+        start: startOfWindow(Number(windowKey)),
+        accountId,
+      }),
     staleTime: 60_000,
   });
 

--- a/packages/sdk/src/core/rest/projects-client/billing.ts
+++ b/packages/sdk/src/core/rest/projects-client/billing.ts
@@ -781,6 +781,14 @@ export interface UsageQueryOptions {
   groupBy?: 'model' | 'provider' | 'day' | 'origin_ref';
   /** Narrow to a single end-user. Applies to the TOTALS as well as the breakdown. */
   originRef?: string;
+  /**
+   * Which account to report on. REQUIRED whenever the caller could be looking at
+   * an account other than their default: for a browser session the server reads
+   * this from the query string, so omitting it silently reports the caller's own
+   * account instead of the one on screen. (Account-scoped tokens ignore it and
+   * always report their own account.)
+   */
+  accountId?: string;
 }
 
 /** Usage rollup for the authenticated account, optionally grouped and narrowed. */
@@ -790,6 +798,7 @@ export async function getUsageRollup(options: UsageQueryOptions = {}): Promise<U
   if (options.end) qs.set('end', options.end);
   if (options.groupBy) qs.set('group_by', options.groupBy);
   if (options.originRef) qs.set('origin_ref', options.originRef);
+  if (options.accountId) qs.set('account_id', options.accountId);
   const query = qs.toString();
   return unwrap(await backendApi.get<UsageRollup>(`/usage${query ? `?${query}` : ''}`));
 }


### PR DESCRIPTION
Two verified isolation defects found by an adversarial audit of the KaaB surface.
Both reproduce in tests that failed before the fix.

## 1. Cross-end-user session access

Three individually-fine facts compose into a hole:

- Every KaaB session is created by the **same** wrapper credential, so
  `created_by` is identical for every end-user (`sessions.ts:1129`).
- `isSessionVisibleTo` short-circuits on `ownerId === subject.userId`
  (`share.ts:142`), so with a shared creator every backend session reads as
  owned by whoever asks — `private` visibility notwithstanding.
- The in-sandbox token check is project-level only:
  `if (sandboxProjectId === tokenProjectId) return` (`auth.ts:752`). The token
  carries its own `sessionId` and it was never compared.

A sandbox running for end-user A could therefore read end-user B's session and
transcript. In KaaB the prompt driving that sandbox is untrusted **by
construction** — it is whatever the wrapper's customer typed — so this is
reachable by prompt injection, not just by a malicious operator. It also
falsifies §6 "Security model (why it's safe)" of the guide.

**Fix:** `isSessionVisibleTo` takes an ownership context and fails closed when a
session-bound token targets a *different* backend session. Threaded through all
12 route call sites, the list path, and the sandbox proxy.

Interactive sessions are deliberately excluded — there `created_by` really is
one person, and narrowing would break `kortix sessions ls` from inside a normal
sandbox. Three of the new tests guard that side, plus the wrapper's own
credential still seeing everything it created.

**The trap that would have made this fix useless:** `canAccessSandboxSession`
memoised on `` `${sessionId}|${userId}` ``. Since `userId` is the same wrapper for
every end-user, A and B collided on one entry — the first `true` would have been
served to everyone else for the whole TTL. The caller session is now in the key,
and the query selects `origin` (it previously could not even evaluate the rule).

## 2. Revoked secrets re-injected into opencode

`mergeProjectEnv` deleted only the names **still granted** before applying new
values. The server pushes only currently-granted names
(`sandbox-env-names.ts:35`), so a revoked secret never appeared in that list —
its value survived from the daemon's `process.env` and was re-injected into
opencode on the next restart, which happens on **every prompt**
(`refreshModels: true`).

The shell path was already correct — `agent-env.sh` emits an explicit `unset`,
and that is tested. But opencode's process env is inherited by MCP servers and
direct child spawns, none of which pass through `BASH_ENV`, so that `unset`
never reached them. There was no test on `mergeProjectEnv` at all.

The store now tracks every name it has ever managed and clears all of them
before re-applying. This also covers a secret added mid-session and then
revoked, which the boot-name list could not see.

## Verification

| Gate | Result |
| --- | --- |
| `apps/api` tsc | clean |
| `unit-executor-share` | 23 pass / 0 fail (1 failed before the fix) |
| `session-inventory` | 4 pass / 0 fail |
| `kortix-sandbox-agent-server` full suite | 302 pass / 0 fail |
| `project-env-revocation` (new) | 4 pass (3 failed before the fix) |
| sandbox-agent-server tsc | clean |

**Not covered / still open — please read before merging:**

- **The WebSocket leg is not fixed.** `authenticatePreviewPrincipal` returns only
  a `userId`, so `resolvePreviewWsUpstream` cannot pass a caller session yet. It
  needs to return the token's `sessionId` first. The REST and HTTP-proxy legs
  are done.
- No end-to-end test yet that a token minted for session A gets 404 on session
  B's transcript — that is the assertion that would actually prove the hole shut.
  The current tests prove the decision function and its wiring, not the whole path.
- I have **not** executed an exploit against a running instance.
- The guard fails closed *before* the `visibility === 'project'` check, so a
  backend session deliberately shared project-wide is also hidden from a sibling
  sandbox. Stricter than the minimal fix — deliberate for a security boundary,
  but it is a behaviour change beyond the bug.
- Pre-existing and unrelated: `e2e-preview-proxy.test.ts` fails on `main` with
  `Export named 'intersectSecretGrants' not found` — verified identical on a
  clean tree, so it is not from this branch, but it does mean that file's
  coverage is currently dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
