### PR TITLE
ops: guard final US East 2 cutover

### DIFF
--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -115,20 +115,40 @@ jobs:
           terraform -chdir="$TF_ROOT" init -input=false
           terraform -chdir="$TF_ROOT" plan -input=false -out=shadow.tfplan
           terraform -chdir="$TF_ROOT" show -json shadow.tfplan > /tmp/shadow-plan.json
-          deletes="$(
-            jq '[.resource_changes[] | select(.change.actions | index("delete"))] | length' \
-              /tmp/shadow-plan.json
+          blocked_destructive_changes="$(
+            jq '[
+              .resource_changes[]
+              | select(.change.actions | index("delete"))
+              | select(
+                  (
+                    .address != "module.api.aws_ecs_task_definition.this"
+                    and .address != "module.gateway.aws_ecs_task_definition.this"
+                  )
+                  or (
+                    .change.actions != ["delete", "create"]
+                    and .change.actions != ["create", "delete"]
+                  )
+                )
+            ] | length' /tmp/shadow-plan.json
           )"
-          replacements="$(
-            jq '[.resource_changes[] | select(
-              .change.actions == ["delete", "create"]
-              or .change.actions == ["create", "delete"]
-            )] | length' /tmp/shadow-plan.json
+          task_definition_replacements="$(
+            jq '[
+              .resource_changes[]
+              | select(
+                  .address == "module.api.aws_ecs_task_definition.this"
+                  or .address == "module.gateway.aws_ecs_task_definition.this"
+                )
+              | select(
+                  .change.actions == ["delete", "create"]
+                  or .change.actions == ["create", "delete"]
+                )
+            ] | length' /tmp/shadow-plan.json
           )"
-          if [ "$deletes" != "0" ] || [ "$replacements" != "0" ]; then
-            echo "::error::US East 2 shadow plan contains deletes=$deletes replacements=$replacements."
+          if [ "$blocked_destructive_changes" != "0" ]; then
+            echo "::error::US East 2 shadow plan contains $blocked_destructive_changes blocked destructive changes."
             exit 1
           fi
+          echo "Allowed immutable ECS task-definition replacements: $task_definition_replacements."
           jq -r '
             [.resource_changes[].change.actions | join(",")]
             | group_by(.)

--- a/.github/workflows/finalize-prod-us-east-2-database.yml
+++ b/.github/workflows/finalize-prod-us-east-2-database.yml
@@ -1,0 +1,320 @@
+name: Finalize Prod US East 2 Database
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Database migration action.
+        required: true
+        type: choice
+        options:
+          - preflight-live
+          - finalize-frozen
+          - reenable-subscriptions
+      confirm:
+        description: Enter "<action>:prod-us-east-2".
+        required: true
+        type: string
+
+concurrency:
+  group: finalize-prod-us-east-2-database
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  database:
+    name: ${{ inputs.action }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    environment: prod-use2-shadow
+    env:
+      ACTION: ${{ inputs.action }}
+      CONFIRM: ${{ inputs.confirm }}
+      AWS_REGION: us-east-2
+      SOURCE_AWS_REGION: eu-west-2
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-prod-use2-terraform
+      SOURCE_SECRET_ID: kortix-prod-env
+      TARGET_RUNTIME_CONFIG_ID: kortix-prod-us-east-2-env
+      TARGET_MIGRATION_SECRET_ID: kortix/prod-us-east-2-migration
+      FREEZE_MARKER_PARAMETER: /kortix/prod-use2/source-freeze
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate confirmation
+        run: |
+          set -euo pipefail
+          expected="${ACTION}:prod-us-east-2"
+          if [ "$CONFIRM" != "$expected" ]; then
+            echo "::error::confirm must equal '$expected'."
+            exit 64
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install PostgreSQL client
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends postgresql-client
+
+      - name: Verify live preflight boundaries
+        if: inputs.action == 'preflight-live'
+        run: |
+          set -euo pipefail
+          backend="$(
+            curl -fsS --max-time 15 -D - -o /dev/null https://api.kortix.com/v1/health \
+              | awk 'BEGIN { IGNORECASE=1 } /^x-backend:/ {
+                  gsub("\r", "");
+                  print $2
+                }' \
+              | tail -1
+          )"
+          if [ "$backend" != "ecs-fargate" ]; then
+            echo "::error::Production backend is '$backend', expected 'ecs-fargate'."
+            exit 1
+          fi
+          echo "Production routing remains on the EU ECS source."
+
+      - name: Verify the source freeze
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          marker="$(
+            aws ssm get-parameter \
+              --region "$AWS_REGION" \
+              --name "$FREEZE_MARKER_PARAMETER" \
+              --query Parameter.Value \
+              --output text
+          )"
+          jq -e '.state == "frozen" and (.capturedAt | length > 0)' <<<"$marker" >/dev/null
+
+          source_secret="$(
+            aws secretsmanager get-secret-value \
+              --region "$SOURCE_AWS_REGION" \
+              --secret-id "$SOURCE_SECRET_ID" \
+              --query SecretString \
+              --output text
+          )"
+          jq -e '
+            .KORTIX_WORKERS_ENABLED == "false"
+            and .SCHEDULER_ENABLED == "false"
+            and .CHANNELS_ENABLED == "false"
+            and .KORTIX_PRERESUME_ENABLED == "false"
+            and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"
+            and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
+            and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+            and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+          ' <<<"$source_secret" >/dev/null
+
+          target_secret="$(
+            aws secretsmanager get-secret-value \
+              --region "$AWS_REGION" \
+              --secret-id "$TARGET_RUNTIME_CONFIG_ID" \
+              --query SecretString \
+              --output text
+          )"
+          jq -e '
+            .KORTIX_WORKERS_ENABLED == "false"
+            and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"
+            and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
+            and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+            and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+          ' <<<"$target_secret" >/dev/null
+
+          for coordinate in \
+            "kortix-prod|kortix-prod" \
+            "kortix-prod-gateway|kortix-prod-gateway"; do
+            IFS='|' read -r cluster service <<<"$coordinate"
+            state="$(
+              aws ecs describe-services \
+                --region "$SOURCE_AWS_REGION" \
+                --cluster "$cluster" \
+                --services "$service" \
+                --query 'services[0].[desiredCount,runningCount]' \
+                --output text
+            )"
+            if [ "$state" != $'0\t0' ]; then
+              echo "::error::$service state is '$state', expected '0 0'."
+              exit 1
+            fi
+          done
+
+          write_status="$(
+            curl -sS --max-time 15 \
+              -o /tmp/maintenance-write-response \
+              -w '%{http_code}' \
+              -X POST \
+              -H 'Content-Type: application/json' \
+              --data '{}' \
+              https://api.kortix.com/v1/projects
+          )"
+          if [ "$write_status" != "503" ]; then
+            echo "::error::Production edge writes return HTTP $write_status, expected 503."
+            exit 1
+          fi
+          echo "Source freeze marker, runtime flags, ECS state, and edge block are valid."
+
+      - name: Inspect live subscriptions
+        if: inputs.action != 'reenable-subscriptions'
+        run: |
+          set -euo pipefail
+          bash scripts/prod-us-east-2/db-sync.sh status
+          bash scripts/prod-us-east-2/auth-sync.sh status
+
+      - name: Reconcile live shadow state
+        if: inputs.action == 'preflight-live'
+        run: |
+          set -euo pipefail
+          PGOPTIONS='-c statement_timeout=0' \
+          ALLOW_TARGET_SHADOW_REPAIR=1 \
+            bash scripts/prod-us-east-2/db-sync.sh repair-shadow-mutations
+          PGOPTIONS='-c statement_timeout=0' \
+          ALLOW_TARGET_AUTH_SHADOW_REPAIR=1 \
+            bash scripts/prod-us-east-2/auth-sync.sh repair-shadow-mutations
+          bash scripts/prod-us-east-2/db-sync.sh wait-caught-up
+          bash scripts/prod-us-east-2/auth-sync.sh wait-caught-up
+
+      - name: Capture replication error counters
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          target_json="$(
+            aws secretsmanager get-secret-value \
+              --secret-id "$TARGET_MIGRATION_SECRET_ID" \
+              --region "$AWS_REGION" \
+              --query SecretString \
+              --output text
+          )"
+          target_database_url="$(jq -er '.target_database_url' <<<"$target_json")"
+          echo "::add-mask::$target_database_url"
+          counters="$(
+            psql "$target_database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 <<'SQL'
+          SELECT
+            COALESCE(sum(apply_error_count), 0),
+            COALESCE(sum(sync_error_count), 0)
+          FROM pg_stat_subscription_stats
+          WHERE subname IN (
+            'kortix_us_east_2_20260725',
+            'kortix_use2_auth_20260725'
+          );
+          SQL
+          )"
+          printf 'BASELINE_REPLICATION_COUNTERS=%s\n' "$counters" >> "$GITHUB_ENV"
+          printf 'TARGET_DATABASE_URL=%s\n' "$target_database_url" >> "$GITHUB_ENV"
+
+      - name: Reach the final source WAL positions
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          bash scripts/prod-us-east-2/db-sync.sh wait-caught-up
+          bash scripts/prod-us-east-2/auth-sync.sh wait-caught-up
+
+      - name: Remove target-only verification state
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          PGOPTIONS='-c statement_timeout=0' \
+          ALLOW_TARGET_SHADOW_REPAIR=1 \
+            bash scripts/prod-us-east-2/db-sync.sh repair-shadow-mutations
+          PGOPTIONS='-c statement_timeout=0' \
+          ALLOW_TARGET_AUTH_SHADOW_REPAIR=1 \
+            bash scripts/prod-us-east-2/auth-sync.sh repair-shadow-mutations
+          bash scripts/prod-us-east-2/db-sync.sh wait-caught-up
+          bash scripts/prod-us-east-2/auth-sync.sh wait-caught-up
+
+      - name: Verify exact row counts
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/db-sync.sh reconcile-counts
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/auth-sync.sh reconcile-counts
+
+      - name: Verify primary-key hashes
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/db-sync.sh reconcile-key-hashes
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/auth-sync.sh reconcile-key-hashes
+
+      - name: Verify critical row hashes
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/db-sync.sh reconcile-critical-hashes
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/auth-sync.sh reconcile-critical-hashes
+
+      - name: Reconcile sequences
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/db-sync.sh reconcile-sequences
+          PGOPTIONS='-c statement_timeout=0' bash scripts/prod-us-east-2/auth-sync.sh reconcile-sequences
+
+      - name: Synchronize and verify all avatar objects
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          STORAGE_VERIFY_ALL=1 bash scripts/prod-us-east-2/storage-sync.sh
+
+      - name: Verify replication counters did not increase
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          current="$(
+            psql "$TARGET_DATABASE_URL" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 <<'SQL'
+          SELECT
+            COALESCE(sum(apply_error_count), 0),
+            COALESCE(sum(sync_error_count), 0)
+          FROM pg_stat_subscription_stats
+          WHERE subname IN (
+            'kortix_us_east_2_20260725',
+            'kortix_use2_auth_20260725'
+          );
+          SQL
+          )"
+          if [ "$current" != "$BASELINE_REPLICATION_COUNTERS" ]; then
+            echo "::error::Replication counters changed from '$BASELINE_REPLICATION_COUNTERS' to '$current'."
+            exit 1
+          fi
+          echo "Replication counters remained at $current."
+
+      - name: Disable finalized subscriptions
+        if: inputs.action == 'finalize-frozen'
+        run: |
+          set -euo pipefail
+          ALLOW_DISABLE_APPLICATION_SUBSCRIPTION=1 \
+            bash scripts/prod-us-east-2/db-sync.sh disable-subscription
+          ALLOW_DISABLE_AUTH_SUBSCRIPTION=1 \
+            bash scripts/prod-us-east-2/auth-sync.sh disable-subscription
+
+      - name: Re-enable subscriptions for rollback
+        if: inputs.action == 'reenable-subscriptions'
+        run: |
+          set -euo pipefail
+          ALLOW_ENABLE_APPLICATION_SUBSCRIPTION=1 \
+            bash scripts/prod-us-east-2/db-sync.sh enable-subscription
+          ALLOW_ENABLE_AUTH_SUBSCRIPTION=1 \
+            bash scripts/prod-us-east-2/auth-sync.sh enable-subscription
+          bash scripts/prod-us-east-2/db-sync.sh status
+          bash scripts/prod-us-east-2/auth-sync.sh status
+
+      - name: Summary
+        run: |
+          {
+            echo "### Prod US East 2 database action"
+            echo "- Action: \`$ACTION\`"
+            echo "- Confirmation: accepted"
+            if [ "$ACTION" = "finalize-frozen" ]; then
+              echo "- Exact application and Auth reconciliation: passed"
+              echo "- Complete avatars verification: passed"
+              echo "- Replication subscriptions: disabled"
+              echo "- Cloudflare routing: unchanged"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ grafana-creds.txt
 botkube-communication.secret.yaml
 botkube-comm-real.yaml
 .env*
+.cutover-state/

--- a/docs/runbooks/prod-us-east-2-supabase-migration.md
+++ b/docs/runbooks/prod-us-east-2-supabase-migration.md
@@ -557,6 +557,57 @@ post-cutover design requires a same-region standby.
 
 ## Cutover
 
+Run the source-writer control from an operator workstation with production AWS
+and EKS access. The command records the exact ECS, EKS, HPA, Argo CD, secret,
+and cron state in the ignored `.cutover-state/` directory.
+
+Do not run this command before Cloudflare returns `503` for a production write:
+
+```bash
+FREEZE_SOURCE_WRITERS_CONFIRM=freeze:prod-eu-west-2 \
+  bash scripts/prod-us-east-2/source-writers.sh freeze
+```
+
+The command stops both EU ECS services and both EU EKS deployments. It suspends
+their autoscalers. It disables source worker flags. It removes
+`kortix_global_tick`. It publishes the guarded SSM freeze marker required by the
+final database workflow.
+
+After the command returns `Source writers are frozen.`, dispatch
+`Finalize Prod US East 2 Database` with:
+
+- `action=finalize-frozen`
+- `confirm=finalize-frozen:prod-us-east-2`
+
+That workflow waits for both subscriptions, repairs target-only shadow data,
+verifies exact counts and hashes, reconciles sequences, verifies every
+`avatars` object, checks replication error counters, and disables both
+subscriptions. It does not change Cloudflare routing or production secrets.
+
+If Supabase Support does not perform the custom-domain transfer, use this
+self-service sequence under blocking maintenance:
+
+```bash
+SUPABASE_DOMAIN_CONFIRM=detach-source:supa.kortix.com \
+  bash scripts/prod-us-east-2/custom-domain.sh detach-source
+```
+
+Dispatch `Cut Over Prod US East 2` with:
+
+- `action=dns-target`
+- `confirm=dns-target:prod-us-east-2`
+
+Then run:
+
+```bash
+SUPABASE_DOMAIN_CONFIRM=attach-target:supa.kortix.com \
+  bash scripts/prod-us-east-2/custom-domain.sh attach-target
+```
+
+The attach command refuses to continue until the CNAME points to
+`uhrwvisbqjfxhxjvoofd.supabase.co`. It reverifies and activates the target
+custom domain before it returns.
+
 1. Confirm all pre-cutover blockers are closed.
 2. Raise the production maintenance notice.
 3. Block new API, gateway, and `supa.kortix.com` requests at Cloudflare.
@@ -596,6 +647,42 @@ Do not set either value before step 18.
 ## Rollback
 
 Rollback is permitted only before target writes reopen.
+
+First dispatch `Finalize Prod US East 2 Database` with:
+
+- `action=reenable-subscriptions`
+- `confirm=reenable-subscriptions:prod-us-east-2`
+
+After both subscriptions are active, keep Cloudflare maintenance blocking and
+run:
+
+```bash
+UNFREEZE_SOURCE_WRITERS_CONFIRM=unfreeze:prod-eu-west-2 \
+  bash scripts/prod-us-east-2/source-writers.sh unfreeze
+```
+
+The rollback command refuses to start EU writers while US writer flags are
+enabled or either target subscription is disabled.
+
+If the target custom domain was activated, restore it before the writer
+rollback:
+
+```bash
+SUPABASE_DOMAIN_CONFIRM=detach-target:supa.kortix.com \
+  bash scripts/prod-us-east-2/custom-domain.sh detach-target
+```
+
+Dispatch `Cut Over Prod US East 2` with:
+
+- `action=dns-source`
+- `confirm=dns-source:prod-us-east-2`
+
+Then run:
+
+```bash
+SUPABASE_DOMAIN_CONFIRM=attach-source:supa.kortix.com \
+  bash scripts/prod-us-east-2/custom-domain.sh attach-source
+```
 
 1. Keep the source project unchanged until all target checks pass.
 2. Keep target schedulers and workers disabled during validation.

--- a/scripts/prod-us-east-2/auth-sync.sh
+++ b/scripts/prod-us-east-2/auth-sync.sh
@@ -249,6 +249,91 @@ WHERE slot_name = :'subscription';
 SQL
 }
 
+wait_caught_up() {
+  local source_lsn
+  local caught_up
+  local latest_end_lsn
+
+  source_lsn="$(
+    psql "$source_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -c 'SELECT pg_current_wal_lsn()'
+  )"
+  if [[ -z "$source_lsn" ]]; then
+    echo "Could not read the source WAL position." >&2
+    exit 1
+  fi
+
+  for attempt in $(seq 1 180); do
+    IFS=$'\t' read -r caught_up latest_end_lsn < <(
+      psql "$target_database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 \
+        -v subscription="$SUBSCRIPTION" \
+        -v source_lsn="$source_lsn" <<'SQL'
+SELECT
+  COALESCE(bool_and(latest_end_lsn >= :'source_lsn'::pg_lsn), false),
+  COALESCE(max(latest_end_lsn)::text, '')
+FROM pg_stat_subscription
+WHERE subname = :'subscription'
+  AND worker_type = 'apply';
+SQL
+    )
+    if [[ "$caught_up" == "t" ]]; then
+      echo "Auth subscription reached source WAL position $source_lsn."
+      return
+    fi
+    echo "Auth catch-up $attempt/180: target=${latest_end_lsn:-missing} source=$source_lsn"
+    sleep 2
+  done
+
+  echo "Auth subscription did not reach source WAL position $source_lsn within six minutes." >&2
+  exit 1
+}
+
+set_subscription_enabled() {
+  local enabled="$1"
+  local guard_name
+  local guard_value
+  local action
+  local actual
+  local expected
+
+  if [[ "$enabled" == "true" ]]; then
+    guard_name="ALLOW_ENABLE_AUTH_SUBSCRIPTION"
+    guard_value="${ALLOW_ENABLE_AUTH_SUBSCRIPTION:-}"
+    action="ENABLE"
+  else
+    guard_name="ALLOW_DISABLE_AUTH_SUBSCRIPTION"
+    guard_value="${ALLOW_DISABLE_AUTH_SUBSCRIPTION:-}"
+    action="DISABLE"
+  fi
+  if [[ "$guard_value" != "1" ]]; then
+    echo "Set $guard_name=1 to ${action,,} the Auth subscription." >&2
+    exit 64
+  fi
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" \
+    -v action="$action" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I %s', :'subscription', :'action')
+\gexec
+SQL
+
+  actual="$(
+    psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT subenabled
+FROM pg_subscription
+WHERE subname = :'subscription';
+SQL
+  )"
+  expected="f"
+  [[ "$enabled" == "true" ]] && expected="t"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Auth subscription state is $actual, expected $expected." >&2
+    exit 1
+  fi
+  echo "Auth subscription is $([[ "$enabled" == "true" ]] && echo enabled || echo disabled)."
+}
+
 write_counts() {
   local database_url="$1"
   local output_file="$2"
@@ -662,6 +747,15 @@ case "${1:-}" in
   status)
     status
     ;;
+  wait-caught-up)
+    wait_caught_up
+    ;;
+  disable-subscription)
+    set_subscription_enabled false
+    ;;
+  enable-subscription)
+    set_subscription_enabled true
+    ;;
   reconcile-counts)
     reconcile_counts
     ;;
@@ -678,7 +772,7 @@ case "${1:-}" in
     repair_shadow_mutations
     ;;
   *)
-    echo "Usage: scripts/prod-us-east-2/auth-sync.sh {prepare-source|reset-target|start|status|reconcile-counts|reconcile-key-hashes|reconcile-critical-hashes|reconcile-sequences|repair-shadow-mutations}" >&2
+    echo "Usage: scripts/prod-us-east-2/auth-sync.sh {prepare-source|reset-target|start|status|wait-caught-up|disable-subscription|enable-subscription|reconcile-counts|reconcile-key-hashes|reconcile-critical-hashes|reconcile-sequences|repair-shadow-mutations}" >&2
     exit 64
     ;;
 esac

--- a/scripts/prod-us-east-2/custom-domain.sh
+++ b/scripts/prod-us-east-2/custom-domain.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_PROJECT_REF="${SOURCE_PROJECT_REF:-jbriwassebxdwoieikga}"
+TARGET_PROJECT_REF="${TARGET_PROJECT_REF:-uhrwvisbqjfxhxjvoofd}"
+CUSTOM_HOSTNAME="${CUSTOM_HOSTNAME:-supa.kortix.com}"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+for command_name in dig supabase; do
+  require_command "$command_name"
+done
+
+domain_exists() {
+  local project_ref="$1"
+  supabase domains get \
+    --project-ref "$project_ref" \
+    --output json >/dev/null 2>&1
+}
+
+status() {
+  for project_ref in "$SOURCE_PROJECT_REF" "$TARGET_PROJECT_REF"; do
+    if domain_exists "$project_ref"; then
+      echo "$project_ref: custom domain configured"
+      supabase domains get --project-ref "$project_ref" --output json
+    else
+      echo "$project_ref: no custom domain configured"
+    fi
+  done
+  echo "$CUSTOM_HOSTNAME CNAME: $(dig +short CNAME "$CUSTOM_HOSTNAME" | tail -1)"
+}
+
+detach_domain() {
+  local side="$1"
+  local project_ref
+  local confirmation
+  if [[ "$side" == "source" ]]; then
+    project_ref="$SOURCE_PROJECT_REF"
+    confirmation="detach-source:${CUSTOM_HOSTNAME}"
+  else
+    project_ref="$TARGET_PROJECT_REF"
+    confirmation="detach-target:${CUSTOM_HOSTNAME}"
+  fi
+
+  if [[ "${SUPABASE_DOMAIN_CONFIRM:-}" != "$confirmation" ]]; then
+    echo "Set SUPABASE_DOMAIN_CONFIRM=$confirmation." >&2
+    exit 64
+  fi
+  if ! domain_exists "$project_ref"; then
+    echo "$project_ref has no custom domain configuration."
+    return
+  fi
+
+  supabase domains delete --project-ref "$project_ref" --yes
+  if domain_exists "$project_ref"; then
+    echo "$project_ref still has a custom domain configuration." >&2
+    exit 1
+  fi
+  echo "Detached $CUSTOM_HOSTNAME from $project_ref."
+}
+
+attach_domain() {
+  local side="$1"
+  local project_ref
+  local expected_cname
+  local confirmation
+  local live_cname
+
+  if [[ "$side" == "source" ]]; then
+    project_ref="$SOURCE_PROJECT_REF"
+    expected_cname="${SOURCE_PROJECT_REF}.supabase.co."
+    confirmation="attach-source:${CUSTOM_HOSTNAME}"
+  else
+    project_ref="$TARGET_PROJECT_REF"
+    expected_cname="${TARGET_PROJECT_REF}.supabase.co."
+    confirmation="attach-target:${CUSTOM_HOSTNAME}"
+  fi
+
+  if [[ "${SUPABASE_DOMAIN_CONFIRM:-}" != "$confirmation" ]]; then
+    echo "Set SUPABASE_DOMAIN_CONFIRM=$confirmation." >&2
+    exit 64
+  fi
+  live_cname="$(dig +short CNAME "$CUSTOM_HOSTNAME" | tail -1)"
+  if [[ "$live_cname" != "$expected_cname" ]]; then
+    echo "$CUSTOM_HOSTNAME points to '${live_cname:-missing}', expected '$expected_cname'." >&2
+    exit 1
+  fi
+
+  if ! domain_exists "$project_ref"; then
+    supabase domains create \
+      --project-ref "$project_ref" \
+      --custom-hostname "$CUSTOM_HOSTNAME" \
+      --yes
+  fi
+
+  for attempt in $(seq 1 60); do
+    supabase domains reverify \
+      --project-ref "$project_ref" \
+      --yes >/dev/null 2>&1 || true
+    if supabase domains activate \
+      --project-ref "$project_ref" \
+      --yes >/dev/null 2>&1; then
+      supabase domains get --project-ref "$project_ref" --output json
+      echo "Activated $CUSTOM_HOSTNAME on $project_ref."
+      return
+    fi
+    echo "Custom-domain activation $attempt/60 is not ready."
+    sleep 5
+  done
+
+  echo "$CUSTOM_HOSTNAME did not activate on $project_ref within five minutes." >&2
+  exit 1
+}
+
+case "${1:-}" in
+  status)
+    status
+    ;;
+  detach-source)
+    detach_domain source
+    ;;
+  attach-target)
+    attach_domain target
+    ;;
+  detach-target)
+    detach_domain target
+    ;;
+  attach-source)
+    attach_domain source
+    ;;
+  *)
+    echo "Usage: scripts/prod-us-east-2/custom-domain.sh {status|detach-source|attach-target|detach-target|attach-source}" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -325,6 +325,91 @@ WHERE name = 'max_slot_wal_keep_size';
 SQL
 }
 
+wait_caught_up() {
+  local source_lsn
+  local caught_up
+  local latest_end_lsn
+
+  source_lsn="$(
+    psql "$source_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -c 'SELECT pg_current_wal_lsn()'
+  )"
+  if [[ -z "$source_lsn" ]]; then
+    echo "Could not read the source WAL position." >&2
+    exit 1
+  fi
+
+  for attempt in $(seq 1 180); do
+    IFS=$'\t' read -r caught_up latest_end_lsn < <(
+      psql "$target_database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 \
+        -v subscription="$SUBSCRIPTION" \
+        -v source_lsn="$source_lsn" <<'SQL'
+SELECT
+  COALESCE(bool_and(latest_end_lsn >= :'source_lsn'::pg_lsn), false),
+  COALESCE(max(latest_end_lsn)::text, '')
+FROM pg_stat_subscription
+WHERE subname = :'subscription'
+  AND worker_type = 'apply';
+SQL
+    )
+    if [[ "$caught_up" == "t" ]]; then
+      echo "Application subscription reached source WAL position $source_lsn."
+      return
+    fi
+    echo "Application catch-up $attempt/180: target=${latest_end_lsn:-missing} source=$source_lsn"
+    sleep 2
+  done
+
+  echo "Application subscription did not reach source WAL position $source_lsn within six minutes." >&2
+  exit 1
+}
+
+set_subscription_enabled() {
+  local enabled="$1"
+  local guard_name
+  local guard_value
+  local action
+  local actual
+  local expected
+
+  if [[ "$enabled" == "true" ]]; then
+    guard_name="ALLOW_ENABLE_APPLICATION_SUBSCRIPTION"
+    guard_value="${ALLOW_ENABLE_APPLICATION_SUBSCRIPTION:-}"
+    action="ENABLE"
+  else
+    guard_name="ALLOW_DISABLE_APPLICATION_SUBSCRIPTION"
+    guard_value="${ALLOW_DISABLE_APPLICATION_SUBSCRIPTION:-}"
+    action="DISABLE"
+  fi
+  if [[ "$guard_value" != "1" ]]; then
+    echo "Set $guard_name=1 to ${action,,} the application subscription." >&2
+    exit 64
+  fi
+
+  psql "$target_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v subscription="$SUBSCRIPTION" \
+    -v action="$action" <<'SQL'
+SELECT format('ALTER SUBSCRIPTION %I %s', :'subscription', :'action')
+\gexec
+SQL
+
+  actual="$(
+    psql "$target_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -v subscription="$SUBSCRIPTION" <<'SQL'
+SELECT subenabled
+FROM pg_subscription
+WHERE subname = :'subscription';
+SQL
+  )"
+  expected="f"
+  [[ "$enabled" == "true" ]] && expected="t"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Application subscription state is $actual, expected $expected." >&2
+    exit 1
+  fi
+  echo "Application subscription is $([[ "$enabled" == "true" ]] && echo enabled || echo disabled)."
+}
+
 repair_public_rls_tables() {
   if [[ "${ALLOW_TARGET_PUBLIC_REPAIR:-}" != "1" ]]; then
     echo "Set ALLOW_TARGET_PUBLIC_REPAIR=1 to repair the RLS-protected public tables on the US target." >&2
@@ -495,6 +580,7 @@ SQL
   }
   printf -v cleanup_trap 'cleanup_shadow_repair %q %q' \
     "$temporary_directory" "$subscription_was_enabled"
+  # shellcheck disable=SC2064 # The caller supplies the complete deferred cleanup command.
   trap "$cleanup_trap" EXIT
 
   if [[ "$subscription_was_enabled" == "t" ]]; then
@@ -1461,6 +1547,9 @@ Commands:
   prepare-source     Set WAL retention, replica identities, and publication.
   start              Create or enable the target subscription.
   status             Show subscriber state, errors, slot state, and retained WAL.
+  wait-caught-up     Wait until the target apply worker reaches the current source WAL position.
+  disable-subscription Disable the target subscription after every final gate passes.
+  enable-subscription Re-enable the target subscription during a pre-write rollback.
   repair-public-rls  Repair public control tables skipped by RLS during initial copy.
   repair-shadow-mutations Replace target-only mutations made during shadow verification.
   backfill-target-precision Backfill target-only precision columns and keep them synchronized during replication.
@@ -1481,6 +1570,15 @@ case "${1:-}" in
     ;;
   status)
     status
+    ;;
+  wait-caught-up)
+    wait_caught_up
+    ;;
+  disable-subscription)
+    set_subscription_enabled false
+    ;;
+  enable-subscription)
+    set_subscription_enabled true
     ;;
   repair-public-rls)
     repair_public_rls_tables

--- a/scripts/prod-us-east-2/source-writers.sh
+++ b/scripts/prod-us-east-2/source-writers.sh
@@ -1,0 +1,796 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_AWS_REGION="${SOURCE_AWS_REGION:-eu-west-2}"
+TARGET_AWS_REGION="${TARGET_AWS_REGION:-us-east-2}"
+SOURCE_SECRET_ID="${SOURCE_SECRET_ID:-kortix-prod-env}"
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix-prod-us-east-2-env}"
+SOURCE_EKS_CLUSTER="${SOURCE_EKS_CLUSTER:-kortix-prod-eks}"
+SOURCE_EKS_NAMESPACE="${SOURCE_EKS_NAMESPACE:-kortix-prod}"
+STATE_DIRECTORY="${STATE_DIRECTORY:-.cutover-state}"
+STATE_FILE="${STATE_FILE:-$STATE_DIRECTORY/prod-use2-source-writers.json}"
+KUBECONFIG_FILE="${KUBECONFIG_FILE:-$STATE_DIRECTORY/prod-use2-kubeconfig}"
+FREEZE_MARKER_PARAMETER="${FREEZE_MARKER_PARAMETER:-/kortix/prod-use2/source-freeze}"
+
+SOURCE_ECS_RESOURCES=(
+  "kortix-prod|kortix-prod"
+  "kortix-prod-gateway|kortix-prod-gateway"
+)
+SOURCE_EKS_DEPLOYMENTS=("kortix-api" "kortix-gateway")
+SOURCE_ARGO_APPLICATIONS=("kortix-prod" "kortix-gateway-prod")
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+for command_name in aws curl jq kubectl psql; do
+  require_command "$command_name"
+done
+
+umask 077
+mkdir -p "$STATE_DIRECTORY"
+
+load_source_secret() {
+  aws secretsmanager get-secret-value \
+    --secret-id "$SOURCE_SECRET_ID" \
+    --region "$SOURCE_AWS_REGION" \
+    --query SecretString \
+    --output text
+}
+
+load_target_secret() {
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$TARGET_AWS_REGION" \
+    --query SecretString \
+    --output text
+}
+
+current_source_secret_version() {
+  aws secretsmanager describe-secret \
+    --secret-id "$SOURCE_SECRET_ID" \
+    --region "$SOURCE_AWS_REGION" \
+    --query VersionIdsToStages \
+    --output json \
+    | jq -er 'to_entries[] | select(.value | index("AWSCURRENT")) | .key'
+}
+
+prepare_kubeconfig() {
+  aws eks update-kubeconfig \
+    --name "$SOURCE_EKS_CLUSTER" \
+    --region "$SOURCE_AWS_REGION" \
+    --kubeconfig "$KUBECONFIG_FILE" >/dev/null
+  export KUBECONFIG="$KUBECONFIG_FILE"
+}
+
+edge_backend() {
+  curl -fsS --max-time 15 -D - -o /dev/null https://api.kortix.com/v1/health \
+    | awk 'BEGIN { IGNORECASE=1 } /^x-backend:/ {
+        gsub("\r", "");
+        print $2
+      }' \
+    | tail -1
+}
+
+require_blocking_maintenance() {
+  local write_status
+  write_status="$(
+    curl -sS --max-time 15 \
+      -o "$STATE_DIRECTORY/maintenance-write-response" \
+      -w '%{http_code}' \
+      -X POST \
+      -H 'Content-Type: application/json' \
+      --data '{}' \
+      https://api.kortix.com/v1/projects
+  )"
+  if [[ "$write_status" != "503" ]]; then
+    echo "Production edge writes return HTTP $write_status, expected 503." >&2
+    exit 1
+  fi
+}
+
+target_subscription_state() {
+  local target_secret_json
+  local target_database_url
+  target_secret_json="$(load_target_secret)"
+  target_database_url="$(jq -er '.DATABASE_URL' <<<"$target_secret_json")"
+  psql "$target_database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 <<'SQL'
+SELECT subname, subenabled
+FROM pg_subscription
+WHERE subname IN (
+  'kortix_us_east_2_20260725',
+  'kortix_use2_auth_20260725'
+)
+ORDER BY subname;
+SQL
+}
+
+write_state() {
+  local payload="$1"
+  local temporary_file="$STATE_FILE.tmp"
+  printf '%s\n' "$payload" >"$temporary_file"
+  mv "$temporary_file" "$STATE_FILE"
+}
+
+update_state() {
+  local temporary_file="$STATE_FILE.tmp"
+  jq "$@" "$STATE_FILE" >"$temporary_file"
+  mv "$temporary_file" "$STATE_FILE"
+}
+
+capture_state() {
+  local source_secret_version
+  local ecs_services='[]'
+  local autoscaling_targets
+  local eks_deployments
+  local hpas
+  local argo_applications
+  local cron_exists
+  local cluster
+  local service
+  local service_json
+  local source_secret_json
+  local source_database_url
+  local payload
+  local phase
+
+  if [[ -f "$STATE_FILE" ]]; then
+    phase="$(jq -er '.phase' "$STATE_FILE")"
+    if [[ "$phase" == "prepared" || "$phase" == "frozen" ]]; then
+      return
+    fi
+    if [[ "$phase" == "restored" ]]; then
+      mv "$STATE_FILE" "$STATE_FILE.restored.$(date -u +%s)"
+    else
+      echo "Unknown source-writer state phase: $phase" >&2
+      exit 1
+    fi
+  fi
+
+  prepare_kubeconfig
+  source_secret_version="$(current_source_secret_version)"
+
+  for coordinate in "${SOURCE_ECS_RESOURCES[@]}"; do
+    IFS='|' read -r cluster service <<<"$coordinate"
+    service_json="$(
+      aws ecs describe-services \
+        --region "$SOURCE_AWS_REGION" \
+        --cluster "$cluster" \
+        --services "$service" \
+        --query 'services[0].{cluster:clusterArn,service:serviceName,desiredCount:desiredCount}' \
+        --output json
+    )"
+    ecs_services="$(jq -c --argjson item "$service_json" '. + [$item]' <<<"$ecs_services")"
+  done
+
+  autoscaling_targets="$(
+    aws application-autoscaling describe-scalable-targets \
+      --region "$SOURCE_AWS_REGION" \
+      --service-namespace ecs \
+      --resource-ids \
+        service/kortix-prod/kortix-prod \
+        service/kortix-prod-gateway/kortix-prod-gateway \
+      --scalable-dimension ecs:service:DesiredCount \
+      --output json \
+      | jq -c '[.ScalableTargets[] | {
+          resourceId: .ResourceId,
+          minCapacity: .MinCapacity,
+          maxCapacity: .MaxCapacity,
+          suspendedState: .SuspendedState
+        }]'
+  )"
+
+  eks_deployments="$(
+    kubectl -n "$SOURCE_EKS_NAMESPACE" get deployment \
+      "${SOURCE_EKS_DEPLOYMENTS[@]}" -o json \
+      | jq -c '[.items[] | {
+          name: .metadata.name,
+          replicas: (.spec.replicas // 1)
+        }]'
+  )"
+  hpas="$(
+    kubectl -n "$SOURCE_EKS_NAMESPACE" get hpa \
+      "${SOURCE_EKS_DEPLOYMENTS[@]}" -o json \
+      | jq -c '{
+          apiVersion,
+          kind,
+          metadata: {},
+          items: [.items[] |
+            del(
+              .metadata.creationTimestamp,
+              .metadata.generation,
+              .metadata.managedFields,
+              .metadata.resourceVersion,
+              .metadata.uid,
+              .status
+            )
+          ]
+        }'
+  )"
+  argo_applications="$(
+    kubectl -n argocd get application \
+      "${SOURCE_ARGO_APPLICATIONS[@]}" -o json \
+      | jq -c '[.items[] | {
+          name: .metadata.name,
+          syncPolicy: .spec.syncPolicy
+        }]'
+  )"
+
+  source_secret_json="$(load_source_secret)"
+  source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+  cron_exists="$(
+    psql "$source_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -c "SELECT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'kortix_global_tick')"
+  )"
+  if [[ "$cron_exists" == "t" ]]; then
+    cron_exists=true
+  else
+    cron_exists=false
+  fi
+
+  payload="$(
+    jq -nc \
+      --arg capturedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg phase "prepared" \
+      --arg sourceSecretVersion "$source_secret_version" \
+      --argjson ecsServices "$ecs_services" \
+      --argjson autoscalingTargets "$autoscaling_targets" \
+      --argjson eksDeployments "$eks_deployments" \
+      --argjson hpas "$hpas" \
+      --argjson argoApplications "$argo_applications" \
+      --argjson cronExisted "$cron_exists" \
+      '{
+        capturedAt: $capturedAt,
+        phase: $phase,
+        sourceSecretVersion: $sourceSecretVersion,
+        freezeSecretVersion: null,
+        ecsServices: $ecsServices,
+        autoscalingTargets: $autoscalingTargets,
+        eksDeployments: $eksDeployments,
+        hpas: $hpas,
+        argoApplications: $argoApplications,
+        cronExisted: $cronExisted
+      }'
+  )"
+  write_state "$payload"
+}
+
+freeze_secret_flags() {
+  local source_secret_json
+  local current_version
+  local previous_version
+  local freeze_version
+  local secret_file="$STATE_DIRECTORY/frozen-source-secret.json"
+
+  source_secret_json="$(load_source_secret)"
+  current_version="$(current_source_secret_version)"
+  previous_version="$(jq -er '.sourceSecretVersion' "$STATE_FILE")"
+
+  if jq -e '
+    .KORTIX_WORKERS_ENABLED == "false"
+    and .SCHEDULER_ENABLED == "false"
+    and .CHANNELS_ENABLED == "false"
+    and .KORTIX_PRERESUME_ENABLED == "false"
+    and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"
+    and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
+    and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+    and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+    and .KORTIX_WARM_POOL_ENABLED == "false"
+    and .KORTIX_WARM_SNAPSHOT_ENABLED == "false"
+  ' <<<"$source_secret_json" >/dev/null; then
+    # shellcheck disable=SC2016 # $version is a jq variable.
+    update_state --arg version "$current_version" '.freezeSecretVersion = $version'
+    return
+  fi
+
+  if [[ "$current_version" != "$previous_version" ]]; then
+    echo "The source secret changed after state capture. Refusing to overwrite it." >&2
+    exit 1
+  fi
+
+  jq '
+    .KORTIX_WORKERS_ENABLED = "false"
+    | .SCHEDULER_ENABLED = "false"
+    | .CHANNELS_ENABLED = "false"
+    | .KORTIX_PRERESUME_ENABLED = "false"
+    | .KORTIX_TRIGGER_SCHEDULER_ENABLED = "false"
+    | .KORTIX_PROJECT_MAINTENANCE_ENABLED = "false"
+    | .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED = "false"
+    | .KORTIX_SUNA_MIGRATION_WORKER_ENABLED = "false"
+    | .KORTIX_WARM_POOL_ENABLED = "false"
+    | .KORTIX_WARM_SNAPSHOT_ENABLED = "false"
+  ' <<<"$source_secret_json" >"$secret_file"
+
+  freeze_version="$(
+    aws secretsmanager put-secret-value \
+      --secret-id "$SOURCE_SECRET_ID" \
+      --region "$SOURCE_AWS_REGION" \
+      --secret-string "file://$secret_file" \
+      --query VersionId \
+      --output text
+  )"
+  unlink "$secret_file"
+  # shellcheck disable=SC2016 # $version is a jq variable.
+  update_state --arg version "$freeze_version" '.freezeSecretVersion = $version'
+}
+
+suspend_argo() {
+  local application
+  for application in "${SOURCE_ARGO_APPLICATIONS[@]}"; do
+    if kubectl -n argocd get application "$application" -o json \
+      | jq -e '.spec.syncPolicy.automated != null' >/dev/null; then
+      kubectl -n argocd patch application "$application" --type json \
+        -p '[{"op":"remove","path":"/spec/syncPolicy/automated"}]' >/dev/null
+    fi
+  done
+}
+
+freeze_ecs() {
+  local cluster
+  local service
+  local resource_id
+  local target
+
+  for resource_id in \
+    service/kortix-prod/kortix-prod \
+    service/kortix-prod-gateway/kortix-prod-gateway; do
+    target="$(
+      jq -cer --arg id "$resource_id" \
+        '.autoscalingTargets[] | select(.resourceId == $id)' "$STATE_FILE"
+    )"
+    aws application-autoscaling register-scalable-target \
+      --region "$SOURCE_AWS_REGION" \
+      --service-namespace ecs \
+      --resource-id "$resource_id" \
+      --scalable-dimension ecs:service:DesiredCount \
+      --min-capacity "$(jq -r '.minCapacity' <<<"$target")" \
+      --max-capacity "$(jq -r '.maxCapacity' <<<"$target")" \
+      --suspended-state \
+        DynamicScalingInSuspended=true,DynamicScalingOutSuspended=true,ScheduledScalingSuspended=true \
+      >/dev/null
+  done
+
+  for coordinate in "${SOURCE_ECS_RESOURCES[@]}"; do
+    IFS='|' read -r cluster service <<<"$coordinate"
+    aws ecs update-service \
+      --region "$SOURCE_AWS_REGION" \
+      --cluster "$cluster" \
+      --service "$service" \
+      --desired-count 0 >/dev/null
+  done
+}
+
+freeze_eks() {
+  kubectl -n "$SOURCE_EKS_NAMESPACE" delete hpa \
+    "${SOURCE_EKS_DEPLOYMENTS[@]}" --ignore-not-found >/dev/null
+  kubectl -n "$SOURCE_EKS_NAMESPACE" scale deployment \
+    "${SOURCE_EKS_DEPLOYMENTS[@]}" --replicas=0 >/dev/null
+}
+
+wait_for_zero_writers() {
+  local cluster
+  local service
+  local running
+  local ready
+  local application
+  local count
+
+  for attempt in $(seq 1 120); do
+    running=0
+    for coordinate in "${SOURCE_ECS_RESOURCES[@]}"; do
+      IFS='|' read -r cluster service <<<"$coordinate"
+      count="$(
+        aws ecs describe-services \
+          --region "$SOURCE_AWS_REGION" \
+          --cluster "$cluster" \
+          --services "$service" \
+          --query 'services[0].runningCount' \
+          --output text
+      )"
+      running=$((running + count))
+    done
+    ready="$(
+      kubectl -n "$SOURCE_EKS_NAMESPACE" get deployment \
+        "${SOURCE_EKS_DEPLOYMENTS[@]}" -o json \
+        | jq '[.items[].status.readyReplicas // 0] | add'
+    )"
+    if [[ "$running" == "0" && "$ready" == "0" ]]; then
+      echo "EU ECS and EKS application tasks are stopped."
+      return
+    fi
+    echo "Source stop $attempt/120: ECS running=$running EKS ready=$ready"
+    sleep 5
+  done
+
+  echo "Source application tasks did not stop within ten minutes." >&2
+  exit 1
+}
+
+unschedule_source_cron() {
+  local source_secret_json
+  local source_database_url
+  source_secret_json="$(load_source_secret)"
+  source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 <<'SQL'
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'kortix_global_tick';
+SQL
+}
+
+assert_source_frozen() {
+  local source_secret_json
+  local source_database_url
+  local cron_count
+  local cluster
+  local service
+  local desired
+  local running
+  local ready
+
+  source_secret_json="$(load_source_secret)"
+  jq -e '
+    .KORTIX_WORKERS_ENABLED == "false"
+    and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"
+    and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
+    and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+    and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+  ' <<<"$source_secret_json" >/dev/null
+
+  for coordinate in "${SOURCE_ECS_RESOURCES[@]}"; do
+    IFS='|' read -r cluster service <<<"$coordinate"
+    IFS=$'\t' read -r desired running < <(
+      aws ecs describe-services \
+        --region "$SOURCE_AWS_REGION" \
+        --cluster "$cluster" \
+        --services "$service" \
+        --query 'services[0].[desiredCount,runningCount]' \
+        --output text
+    )
+    [[ "$desired" == "0" && "$running" == "0" ]] || {
+      echo "$service is desired=$desired running=$running, expected 0/0." >&2
+      exit 1
+    }
+  done
+
+  prepare_kubeconfig
+  ready="$(
+    kubectl -n "$SOURCE_EKS_NAMESPACE" get deployment \
+      "${SOURCE_EKS_DEPLOYMENTS[@]}" -o json \
+      | jq '[.items[] | (.spec.replicas // 0) + (.status.readyReplicas // 0)] | add'
+  )"
+  [[ "$ready" == "0" ]] || {
+    echo "EU EKS still has desired or ready application pods." >&2
+    exit 1
+  }
+  if kubectl -n "$SOURCE_EKS_NAMESPACE" get hpa \
+    "${SOURCE_EKS_DEPLOYMENTS[@]}" --ignore-not-found -o name \
+    | grep -q .; then
+    echo "EU EKS application autoscalers remain active." >&2
+    exit 1
+  fi
+  for application in "${SOURCE_ARGO_APPLICATIONS[@]}"; do
+    if kubectl -n argocd get application "$application" -o json \
+      | jq -e '.spec.syncPolicy.automated != null' >/dev/null; then
+      echo "$application automated sync remains active." >&2
+      exit 1
+    fi
+  done
+
+  source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+  cron_count="$(
+    psql "$source_database_url" -X -qAt -v ON_ERROR_STOP=1 \
+      -c "SELECT count(*) FROM cron.job WHERE jobname = 'kortix_global_tick'"
+  )"
+  [[ "$cron_count" == "0" ]] || {
+    echo "kortix_global_tick remains scheduled on the source." >&2
+    exit 1
+  }
+  echo "Source writers are frozen."
+}
+
+publish_freeze_marker() {
+  local marker
+  marker="$(
+    jq -c '{
+      state: "frozen",
+      capturedAt,
+      sourceSecretVersion,
+      freezeSecretVersion
+    }' "$STATE_FILE"
+  )"
+  aws ssm put-parameter \
+    --region "$TARGET_AWS_REGION" \
+    --name "$FREEZE_MARKER_PARAMETER" \
+    --type String \
+    --overwrite \
+    --value "$marker" >/dev/null
+}
+
+remove_freeze_marker() {
+  aws ssm delete-parameter \
+    --region "$TARGET_AWS_REGION" \
+    --name "$FREEZE_MARKER_PARAMETER" >/dev/null 2>&1 || true
+}
+
+restore_source_secret() {
+  local previous_version
+  local freeze_version
+  local current_version
+
+  previous_version="$(jq -er '.sourceSecretVersion' "$STATE_FILE")"
+  freeze_version="$(jq -er '.freezeSecretVersion' "$STATE_FILE")"
+  current_version="$(current_source_secret_version)"
+  if [[ "$current_version" == "$previous_version" ]]; then
+    return
+  fi
+  if [[ "$current_version" != "$freeze_version" ]]; then
+    echo "The source secret changed after the freeze. Refusing to restore an older version." >&2
+    exit 1
+  fi
+
+  aws secretsmanager update-secret-version-stage \
+    --secret-id "$SOURCE_SECRET_ID" \
+    --region "$SOURCE_AWS_REGION" \
+    --version-stage AWSCURRENT \
+    --move-to-version-id "$previous_version" \
+    --remove-from-version-id "$freeze_version" >/dev/null
+}
+
+restore_ecs() {
+  local resource_id
+  local cluster
+  local service
+
+  while IFS= read -r target; do
+    resource_id="$(jq -r '.resourceId' <<<"$target")"
+    aws application-autoscaling register-scalable-target \
+      --region "$SOURCE_AWS_REGION" \
+      --service-namespace ecs \
+      --resource-id "$resource_id" \
+      --scalable-dimension ecs:service:DesiredCount \
+      --min-capacity "$(jq -r '.minCapacity' <<<"$target")" \
+      --max-capacity "$(jq -r '.maxCapacity' <<<"$target")" \
+      --suspended-state "$(
+        jq -r '
+          .suspendedState |
+          "DynamicScalingInSuspended=\(.DynamicScalingInSuspended)," +
+          "DynamicScalingOutSuspended=\(.DynamicScalingOutSuspended)," +
+          "ScheduledScalingSuspended=\(.ScheduledScalingSuspended)"
+        ' <<<"$target"
+      )" >/dev/null
+  done < <(jq -c '.autoscalingTargets[]' "$STATE_FILE")
+
+  while IFS= read -r service_state; do
+    cluster="$(jq -r '.cluster | split("/")[-1]' <<<"$service_state")"
+    service="$(jq -r '.service' <<<"$service_state")"
+    aws ecs update-service \
+      --region "$SOURCE_AWS_REGION" \
+      --cluster "$cluster" \
+      --service "$service" \
+      --desired-count "$(jq -r '.desiredCount' <<<"$service_state")" \
+      --force-new-deployment >/dev/null
+  done < <(jq -c '.ecsServices[]' "$STATE_FILE")
+}
+
+restore_eks_and_argo() {
+  local hpa_file="$STATE_DIRECTORY/source-hpas.json"
+  local name
+  local replicas
+  local patch
+
+  jq '.hpas' "$STATE_FILE" >"$hpa_file"
+  kubectl apply -f "$hpa_file" >/dev/null
+  unlink "$hpa_file"
+
+  while IFS=$'\t' read -r name replicas; do
+    kubectl -n "$SOURCE_EKS_NAMESPACE" scale deployment "$name" \
+      --replicas="$replicas" >/dev/null
+    kubectl -n "$SOURCE_EKS_NAMESPACE" rollout restart deployment "$name" >/dev/null
+  done < <(jq -r '.eksDeployments[] | [.name, (.replicas | tostring)] | @tsv' "$STATE_FILE")
+
+  while IFS= read -r application; do
+    name="$(jq -r '.name' <<<"$application")"
+    patch="$(jq -c '{spec:{syncPolicy:.syncPolicy}}' <<<"$application")"
+    kubectl -n argocd patch application "$name" --type merge -p "$patch" >/dev/null
+  done < <(jq -c '.argoApplications[]' "$STATE_FILE")
+}
+
+wait_for_restored_writers() {
+  local cluster
+  local service
+  local expected
+  local running
+  local desired
+  local ready
+  local expected_eks
+  local all_ready
+
+  for attempt in $(seq 1 120); do
+    all_ready=true
+    while IFS= read -r service_state; do
+      cluster="$(jq -r '.cluster | split("/")[-1]' <<<"$service_state")"
+      service="$(jq -r '.service' <<<"$service_state")"
+      expected="$(jq -r '.desiredCount' <<<"$service_state")"
+      IFS=$'\t' read -r desired running < <(
+        aws ecs describe-services \
+          --region "$SOURCE_AWS_REGION" \
+          --cluster "$cluster" \
+          --services "$service" \
+          --query 'services[0].[desiredCount,runningCount]' \
+          --output text
+      )
+      if [[ "$desired" -lt "$expected" || "$running" -lt "$expected" ]]; then
+        all_ready=false
+      fi
+    done < <(jq -c '.ecsServices[]' "$STATE_FILE")
+    ready="$(
+      kubectl -n "$SOURCE_EKS_NAMESPACE" get deployment \
+        "${SOURCE_EKS_DEPLOYMENTS[@]}" -o json \
+        | jq '[.items[] | (.status.readyReplicas // 0)] | add'
+    )"
+    expected_eks="$(jq '[.eksDeployments[].replicas] | add' "$STATE_FILE")"
+    if [[ "$all_ready" == "true" && "$ready" -ge "$expected_eks" ]]; then
+      echo "EU ECS and EKS application tasks are restored."
+      return
+    fi
+    echo "Source restore $attempt/120: ECS ready=$all_ready EKS ready=$ready/$expected_eks"
+    sleep 5
+  done
+
+  echo "Source application tasks did not restore within ten minutes." >&2
+  exit 1
+}
+
+restore_source_cron() {
+  local source_secret_json
+  local source_database_url
+  local cron_api_url
+  local cron_tick_secret
+
+  if [[ "$(jq -r '.cronExisted' "$STATE_FILE")" != "true" ]]; then
+    return
+  fi
+  source_secret_json="$(load_source_secret)"
+  source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+  cron_api_url="$(jq -er '.CRON_API_URL' <<<"$source_secret_json")"
+  cron_tick_secret="$(jq -er '.CRON_TICK_SECRET' <<<"$source_secret_json")"
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -v api_url="$cron_api_url" \
+    -v tick_secret="$cron_tick_secret" <<'SQL'
+SELECT kortix.configure_scheduler(:'api_url', :'tick_secret');
+SQL
+}
+
+freeze() {
+  if [[ "${FREEZE_SOURCE_WRITERS_CONFIRM:-}" != "freeze:prod-eu-west-2" ]]; then
+    echo "Set FREEZE_SOURCE_WRITERS_CONFIRM=freeze:prod-eu-west-2." >&2
+    exit 64
+  fi
+  require_blocking_maintenance
+  if [[ "$(edge_backend)" != "ecs-fargate" ]]; then
+    echo "api.kortix.com does not point to the EU ECS source." >&2
+    exit 1
+  fi
+
+  capture_state
+  prepare_kubeconfig
+  freeze_secret_flags
+  suspend_argo
+  freeze_eks
+  freeze_ecs
+  wait_for_zero_writers
+  unschedule_source_cron
+  update_state '.phase = "frozen"'
+  assert_source_frozen
+  publish_freeze_marker
+}
+
+unfreeze() {
+  local target_secret_json
+  local subscriptions
+
+  if [[ "${UNFREEZE_SOURCE_WRITERS_CONFIRM:-}" != "unfreeze:prod-eu-west-2" ]]; then
+    echo "Set UNFREEZE_SOURCE_WRITERS_CONFIRM=unfreeze:prod-eu-west-2." >&2
+    exit 64
+  fi
+  [[ -f "$STATE_FILE" ]] || {
+    echo "Missing freeze state: $STATE_FILE" >&2
+    exit 1
+  }
+  require_blocking_maintenance
+
+  target_secret_json="$(load_target_secret)"
+  jq -e '
+    .KORTIX_WORKERS_ENABLED == "false"
+    and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"
+    and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
+    and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+    and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+  ' <<<"$target_secret_json" >/dev/null || {
+    echo "US writers are enabled. Refusing to reopen the EU source." >&2
+    exit 1
+  }
+
+  subscriptions="$(target_subscription_state)"
+  if [[ "$(awk '$2 != "t" { count++ } END { print count + 0 }' <<<"$subscriptions")" != "0" ]] \
+    || [[ "$(wc -l <<<"$subscriptions" | tr -d ' ')" != "2" ]]; then
+    echo "Both target subscriptions must be enabled before EU rollback." >&2
+    printf '%s\n' "$subscriptions" >&2
+    exit 1
+  fi
+
+  prepare_kubeconfig
+  restore_source_secret
+  restore_ecs
+  restore_eks_and_argo
+  wait_for_restored_writers
+  restore_source_cron
+  update_state '.phase = "restored"'
+  remove_freeze_marker
+  echo "EU source writers are restored under blocking maintenance."
+}
+
+status() {
+  local source_secret_json
+  local source_database_url
+  local cluster
+  local service
+
+  source_secret_json="$(load_source_secret)"
+  jq '{
+    KORTIX_WORKERS_ENABLED,
+    SCHEDULER_ENABLED,
+    CHANNELS_ENABLED,
+    KORTIX_PRERESUME_ENABLED,
+    KORTIX_TRIGGER_SCHEDULER_ENABLED,
+    KORTIX_PROJECT_MAINTENANCE_ENABLED,
+    KORTIX_LEGACY_MIGRATION_WORKER_ENABLED,
+    KORTIX_SUNA_MIGRATION_WORKER_ENABLED,
+    KORTIX_WARM_POOL_ENABLED,
+    KORTIX_WARM_SNAPSHOT_ENABLED
+  }' <<<"$source_secret_json"
+
+  for coordinate in "${SOURCE_ECS_RESOURCES[@]}"; do
+    IFS='|' read -r cluster service <<<"$coordinate"
+    aws ecs describe-services \
+      --region "$SOURCE_AWS_REGION" \
+      --cluster "$cluster" \
+      --services "$service" \
+      --query 'services[0].{service:serviceName,desired:desiredCount,running:runningCount,pending:pendingCount,taskDefinition:taskDefinition}' \
+      --output json
+  done
+
+  prepare_kubeconfig
+  kubectl -n "$SOURCE_EKS_NAMESPACE" get deployment,hpa -o wide
+  source_database_url="$(jq -er '.DATABASE_URL' <<<"$source_secret_json")"
+  psql "$source_database_url" -X -P pager=off -v ON_ERROR_STOP=1 <<'SQL'
+SELECT jobid, jobname, schedule, active
+FROM cron.job
+WHERE jobname = 'kortix_global_tick';
+SQL
+  echo "api.kortix.com backend: $(edge_backend)"
+  [[ -f "$STATE_FILE" ]] && jq '{capturedAt,phase}' "$STATE_FILE"
+}
+
+case "${1:-}" in
+  status)
+    status
+    ;;
+  freeze)
+    freeze
+    ;;
+  assert-frozen)
+    assert_source_frozen
+    ;;
+  unfreeze)
+    unfreeze
+    ;;
+  *)
+    echo "Usage: scripts/prod-us-east-2/source-writers.sh {status|freeze|assert-frozen|unfreeze}" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/prod-us-east-2/source-writers.test.mjs
+++ b/scripts/prod-us-east-2/source-writers.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sourceWriters = readFileSync(
+  new URL("./source-writers.sh", import.meta.url),
+  "utf8",
+);
+const finalWorkflow = readFileSync(
+  new URL(
+    "../../.github/workflows/finalize-prod-us-east-2-database.yml",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const customDomain = readFileSync(
+  new URL("./custom-domain.sh", import.meta.url),
+  "utf8",
+);
+
+test("source freeze requires maintenance and an exact confirmation", () => {
+  assert.match(
+    sourceWriters,
+    /FREEZE_SOURCE_WRITERS_CONFIRM:-}" != "freeze:prod-eu-west-2"/,
+  );
+  assert.match(sourceWriters, /require_blocking_maintenance/);
+  assert.match(sourceWriters, /write_status" != "503"/);
+});
+
+test("source freeze covers ECS, EKS, autoscaling, worker flags, and cron", () => {
+  assert.match(sourceWriters, /kortix-prod-gateway\|kortix-prod-gateway/);
+  assert.match(sourceWriters, /SOURCE_EKS_DEPLOYMENTS=\("kortix-api" "kortix-gateway"\)/);
+  assert.match(sourceWriters, /application-autoscaling register-scalable-target/);
+  assert.match(sourceWriters, /\.KORTIX_WORKERS_ENABLED = "false"/);
+  assert.match(sourceWriters, /cron\.unschedule\(jobid\)/);
+});
+
+test("rollback refuses disabled replication or enabled US writers", () => {
+  assert.match(sourceWriters, /US writers are enabled\. Refusing to reopen the EU source/);
+  assert.match(sourceWriters, /Both target subscriptions must be enabled before EU rollback/);
+});
+
+test("final database workflow consumes the source freeze marker", () => {
+  assert.match(finalWorkflow, /FREEZE_MARKER_PARAMETER: \/kortix\/prod-use2\/source-freeze/);
+  assert.match(finalWorkflow, /action == 'finalize-frozen'/);
+  assert.match(finalWorkflow, /repair-shadow-mutations/);
+  assert.match(finalWorkflow, /reconcile-counts/);
+  assert.match(finalWorkflow, /reconcile-key-hashes/);
+  assert.match(finalWorkflow, /reconcile-critical-hashes/);
+  assert.match(finalWorkflow, /reconcile-sequences/);
+  assert.match(finalWorkflow, /STORAGE_VERIFY_ALL=1/);
+  assert.match(finalWorkflow, /disable-subscription/);
+});
+
+test("custom-domain transfer requires explicit detach and attach gates", () => {
+  assert.match(customDomain, /detach-source:\$\{CUSTOM_HOSTNAME\}/);
+  assert.match(customDomain, /attach-target:\$\{CUSTOM_HOSTNAME\}/);
+  assert.match(customDomain, /expected_cname="\$\{TARGET_PROJECT_REF\}\.supabase\.co\."/);
+  assert.match(customDomain, /supabase domains reverify/);
+  assert.match(customDomain, /supabase domains activate/);
+});

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -46,6 +46,21 @@ test("US shadow exposes the managed model catalog for runtime verification", () 
   );
 });
 
+test("shadow Terraform permits only immutable ECS task-definition replacement", () => {
+  assert.match(
+    shadowWorkflow,
+    /\.address != "module\.api\.aws_ecs_task_definition\.this"[\s\S]*\.change\.actions != \["delete", "create"\]/,
+  );
+  assert.match(
+    shadowWorkflow,
+    /\.address != "module\.gateway\.aws_ecs_task_definition\.this"[\s\S]*\.change\.actions != \["create", "delete"\]/,
+  );
+  assert.match(
+    shadowWorkflow,
+    /if \[ "\$blocked_destructive_changes" != "0" \]/,
+  );
+});
+
 test("target smoke removes and counts recovery flow state", () => {
   assert.match(
     targetSmokeProgram,


### PR DESCRIPTION
## Summary

- add an exact, reversible EU ECS/EKS writer freeze with state capture and a required maintenance gate
- add final application/Auth reconciliation, hash, sequence, Storage, and subscription controls
- allow only immutable ECS task-definition replacement in the US shadow Terraform guard
- add guarded Supabase custom-domain detach, attach, activation, and rollback controls
- document the exact freeze, finalize, domain transfer, and rollback sequence

## Production safety

- this PR does not enable maintenance
- this PR does not stop EU writers
- this PR does not change Cloudflare routing
- this PR does not disable replication
- the freeze requires `freeze:prod-eu-west-2` and an existing HTTP 503 write gate
- the finalizer requires the source freeze SSM marker and `finalize-frozen:prod-us-east-2`
- each Supabase domain action requires its own exact hostname confirmation

## Verification

- `node --test scripts/prod-us-east-2/*.test.mjs` -> 27 passed, 0 failed
- `bash -n` for all changed migration shell scripts -> pass
- `shellcheck` for all changed migration shell scripts -> pass
- both workflow YAML files parse with Ruby Psych
- `db-sync.sh wait-caught-up` -> reached `688/CCACEFF0`
- `auth-sync.sh wait-caught-up` -> reached `688/CCB23418`
- freeze guard under live non-maintenance state -> exit 1, HTTP 401 instead of required 503
- subscription disable guards without confirmation -> exit 64 for application and Auth
- source domain -> configured on `jbriwassebxdwoieikga`
- target domain -> no configuration on `uhrwvisbqjfxhxjvoofd`
- live CNAME -> `jbriwassebxdwoieikga.supabase.co`
