### PR TITLE
fix(voice): keep worker bearer out of room metadata

### DIFF
--- a/apps/api/src/__tests__/unit-voice-worker-metadata.test.ts
+++ b/apps/api/src/__tests__/unit-voice-worker-metadata.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+const runtimeSource = await Bun.file(
+  new URL('../channels/voice/runtime.ts', import.meta.url).pathname,
+).text();
+const livekitSource = await Bun.file(
+  new URL('../channels/voice/livekit.ts', import.meta.url).pathname,
+).text();
+
+describe('LiveKit voice metadata boundaries', () => {
+  test('keeps the call-scoped bearer out of public room metadata', () => {
+    const roomMetadataInterface = runtimeSource.match(
+      /export interface VoiceRoomMetadata \{[\s\S]*?\n\}/,
+    )?.[0];
+    const workerMetadataInterface = runtimeSource.match(
+      /export interface VoiceWorkerMetadata extends VoiceRoomMetadata \{[\s\S]*?\n\}/,
+    )?.[0];
+
+    expect(roomMetadataInterface).toBeDefined();
+    expect(roomMetadataInterface).not.toContain('kortix_api_token');
+    expect(workerMetadataInterface).toContain('kortix_api_token');
+  });
+
+  test('passes separate public room and private dispatch metadata', () => {
+    expect(livekitSource).toContain('metadata: roomMetadata');
+    expect(livekitSource).toContain('{ metadata: dispatchMetadata }');
+    expect(livekitSource).not.toContain('{ metadata: roomMetadata }');
+  });
+});

--- a/apps/api/src/channels/voice/livekit.ts
+++ b/apps/api/src/channels/voice/livekit.ts
@@ -98,12 +98,15 @@ function dispatchClient(): AgentDispatchClient {
  * returns a dispatch id or throws, so `startCall` fails at spawn time rather
  * than handing out a dead link.
  *
- * `metadata` carries everything a freshly dispatched worker needs to bootstrap
- * — see runtime.ts's `VoiceRoomMetadata`. It is passed BOTH as room metadata
- * and as dispatch metadata: the worker reads it from the room today, and the
- * dispatch copy is what survives a room the worker joins late or rejoins.
+ * `roomMetadata` is visible to room participants and must stay non-sensitive.
+ * `dispatchMetadata` is private worker bootstrap state and may carry the
+ * per-call API bearer.
  */
-export async function createRoom(room: string, metadata: string): Promise<void> {
+export async function createRoom(
+  room: string,
+  roomMetadata: string,
+  dispatchMetadata: string,
+): Promise<void> {
   const svc = roomService();
 
   // Delete any existing room of this name first so the call starts from a clean
@@ -117,14 +120,14 @@ export async function createRoom(room: string, metadata: string): Promise<void> 
 
   await svc.createRoom({
     name: room,
-    metadata,
+    metadata: roomMetadata,
     // emptyTimeout covers "created but nobody ever joined". departureTimeout is
     // the one that actually bites: it governs how long the room survives after
     // the LAST participant leaves, and its default (~20s) is short enough that a
     // brief gap — a page reload, a bot reconnect — destroys the room. A
     // participant rejoining then IMPLICITLY recreates it with NO metadata, and
     // the agent worker dies with "room metadata is missing project_id" because
-    // the call context and its API token travel in that metadata.
+    // the non-secret call context still travels in that metadata.
     emptyTimeout: 30 * 60,
     departureTimeout: 15 * 60,
     maxParticipants: 8,
@@ -138,7 +141,7 @@ export async function createRoom(room: string, metadata: string): Promise<void> 
   // Deliberately NOT caught. A call whose agent could not be dispatched is a
   // dead call, and the caller needs to learn that here — while it can still
   // report a failure — rather than by handing someone a link to an empty room.
-  await dispatchClient().createDispatch(room, VOICE_AGENT_NAME, { metadata });
+  await dispatchClient().createDispatch(room, VOICE_AGENT_NAME, { metadata: dispatchMetadata });
 }
 
 /**

--- a/apps/api/src/channels/voice/mcp.ts
+++ b/apps/api/src/channels/voice/mcp.ts
@@ -6,7 +6,7 @@
  * /v1/projects/:projectId/sessions/:sessionId/mcp/voice (routes.ts). The
  * caller is not a Kortix agent — it is a third-party-hosted worker process
  * holding the per-call `kortix_api_token` HMAC minted in `startCall`
- * (worker-token.ts) and handed to it via LiveKit room metadata. That token
+ * (worker-token.ts) and handed to it via private LiveKit dispatch metadata. That token
  * authorizes exactly one call; nothing here accepts session/PAT auth.
  *
  * This used to be the OTHER direction: the Kortix agent's own tool surface

--- a/apps/api/src/channels/voice/runtime.ts
+++ b/apps/api/src/channels/voice/runtime.ts
@@ -93,9 +93,8 @@ export async function isCallLive(callId: string): Promise<boolean> {
 }
 
 /**
- * Everything apps/voice-agent needs to bootstrap a freshly dispatched job,
- * carried in the LiveKit room's metadata so the worker never has to call back
- * into the API just to learn who it's talking to. Field names and shape are
+ * Non-sensitive context for a voice call. LiveKit exposes room metadata to
+ * room participants. Field names and shape are
  * fixed by that app's `call-context.ts` (`RoomMetadataShape`) — snake_case,
  * NOT this codebase's usual camelCase, because the contract is owned jointly
  * with a consumer this file cannot rename.
@@ -105,8 +104,11 @@ export interface VoiceRoomMetadata {
   session_id: string;
   call_id: string;
   kortix_api_url: string;
-  kortix_api_token: string;
   bot_name: string;
+}
+
+export interface VoiceWorkerMetadata extends VoiceRoomMetadata {
+  kortix_api_token: string;
 }
 
 export interface StartCallInput {
@@ -150,19 +152,22 @@ export async function startCall(input: StartCallInput): Promise<VoiceCall> {
     return call;
   }
 
-  const metadata: VoiceRoomMetadata = {
+  const roomMetadata: VoiceRoomMetadata = {
     project_id: input.projectId,
     session_id: input.sessionId,
     call_id: input.callId,
     kortix_api_url: config.KORTIX_URL,
-    kortix_api_token: mintCallApiToken(input.callId),
     bot_name: input.botName,
+  };
+  const workerMetadata: VoiceWorkerMetadata = {
+    ...roomMetadata,
+    kortix_api_token: mintCallApiToken(input.callId),
   };
 
   // Create the room, dispatched to the worker, BEFORE anything tries to join
   // it — same ordering the old code used for the provider connect: if the bot
   // arrives first it must find somewhere real to join.
-  await createRoom(room, JSON.stringify(metadata));
+  await createRoom(room, JSON.stringify(roomMetadata), JSON.stringify(workerMetadata));
 
   return call;
 }

--- a/apps/api/src/channels/voice/worker-token.ts
+++ b/apps/api/src/channels/voice/worker-token.ts
@@ -1,6 +1,6 @@
 /**
  * `kortix_api_token` — the credential the voice-agent worker (apps/voice-agent)
- * carries for one call, room metadata carrying it into `ctx.job.room.metadata`
+ * carries for one call, private dispatch metadata carrying it into `ctx.job.metadata`
  * at dispatch time (see that app's `call-context.ts`). It authenticates the
  * worker's `Authorization: Bearer` header on its single way in, the MCP at
  * `POST /v1/projects/:projectId/sessions/:sessionId/mcp/voice` (routes.ts).

--- a/apps/voice-agent/Dockerfile
+++ b/apps/voice-agent/Dockerfile
@@ -15,7 +15,7 @@
 # No secrets are baked in and none are needed at runtime: LiveKit Cloud injects
 # LIVEKIT_URL / LIVEKIT_API_KEY / LIVEKIT_API_SECRET itself, every model runs
 # through LiveKit Inference, and the per-call Kortix API URL and token arrive in
-# the room metadata. `lk agent create` can be run with an empty secret set.
+# LiveKit job metadata. `lk agent create` can be run with an empty secret set.
 
 ARG BUN_VERSION=1.2
 

--- a/apps/voice-agent/README.md
+++ b/apps/voice-agent/README.md
@@ -34,7 +34,7 @@ with the LiveKit server at `LIVEKIT_URL` and handles reload. There's also
 `pnpm start` (production mode, no reload) and `pnpm console` (an in-process
 text-only session with no real room — useful for iterating on
 instructions/tools without joining a room at all; note this mode cannot
-resolve a `CallContext` from room metadata, since there is no room — see
+resolve a `CallContext` from job metadata, since there is no job — see
 below).
 
 To actually exercise a call end-to-end you need something in the room to
@@ -45,7 +45,7 @@ the same room name as a human participant with any LiveKit client (e.g. the
 local server) and talk to it.
 
 **Required env vars** (see `src/call-context.ts` for the full explanation of
-why call-specific values come from room metadata, not env vars):
+why call-specific values come from job metadata, not env vars):
 
 | Var | Required | Purpose |
 |---|---|---|
@@ -55,17 +55,16 @@ why call-specific values come from room metadata, not env vars):
 | `OPENAI_API_KEY` | yes | Read by `agents-plugin-openai`'s `LLM`/`TTS` constructors when no `apiKey` option is passed. |
 | `KORTIX_API_URL` | no | Fallback Kortix API base URL, used only when a room's metadata omits `kortix_api_url`. Defaults to `http://localhost:8008` (matches `apps/api`'s local dev port). Named to match the existing convention (`apps/cli`, the self-host compose file). |
 
-## Why room metadata, not env vars, for call identity
+## Why job metadata, not env vars, for call identity
 
 A single worker **process** can run many jobs (rooms) concurrently — one
 process, many simultaneous calls, each for a different project/session. An
 env var is process-wide, so anything that differs per call **must** come from
-the room instead, above all the Kortix API credential: a shared static token
-would let any live call impersonate any other project's session.
+the job instead. A shared static token would let any live call impersonate any
+other project's session.
 
 `apps/api`, when it creates the LiveKit room for a call (before dispatching
-this agent into it), is expected to set the room's metadata to JSON shaped
-like:
+this agent into it), sets public room metadata to:
 
 ```json
 {
@@ -73,19 +72,22 @@ like:
   "session_id": "...",
   "call_id": "...",
   "kortix_api_url": "https://api.kortix.com",
-  "kortix_api_token": "<short-lived, call-scoped bearer credential>",
   "bot_name": "Kortix"
 }
 ```
 
-via `RoomServiceClient.createRoom({ name, metadata })`
-(`livekit-server-sdk@2.17.0`). This worker reads it back via
-`ctx.job.room.metadata` — the room's server-side state as of dispatch time,
-readable in the entrypoint immediately, before `ctx.connect()` has actually
-joined (the live `ctx.room` object only populates `.name`/`.metadata` once
-connected). `call_id` defaults to `session_id` when omitted: today there's one
-live call per session (`apps/api/src/channels/voice/routes.ts`: "The call id
-IS the session id"), so the two are normally the same value.
+The private dispatch metadata contains the same fields plus:
+
+```json
+{
+  "kortix_api_token": "<short-lived, call-scoped bearer credential>"
+}
+```
+
+The worker reads public metadata from `ctx.job.room.metadata`. It reads the
+credential from `ctx.job.metadata`. Both values are available before
+`ctx.connect()`. `call_id` defaults to `session_id` when omitted. Today, one
+live call exists per session.
 
 ## The two tools
 
@@ -130,8 +132,8 @@ This app is scoped to the LiveKit worker only — it does not touch
 `apps/api`. It expects ONE endpoint,
 `POST /v1/projects/:projectId/sessions/:sessionId/mcp/voice` — a JSON-RPC 2.0
 voice MCP (`apps/api/src/channels/voice/mcp.ts` + `routes.ts`), authenticated
-with `Authorization: Bearer <kortix_api_token>` (the per-call token from room
-metadata). Every call is a `tools/call` request; the tool surface is:
+with `Authorization: Bearer <kortix_api_token>` (the per-call token from private
+dispatch metadata). Every call is a `tools/call` request; the tool surface is:
 
 | Tool | Args | Behavior |
 |---|---|---|
@@ -143,9 +145,9 @@ metadata). Every call is a `tools/call` request; the tool surface is:
 route resolves them from the URL path (and the HMAC proves the caller owns
 that call), the same way the three REST endpoints this MCP replaced used to.
 
-Plus the reply channel above (`RoomServiceClient.sendData` on the `kortix`
-topic) and setting `kortix_api_token`/`project_id`/`session_id` in room
-metadata at room-creation time.
+The reply channel uses `RoomServiceClient.sendData` on the `kortix` topic.
+Room metadata contains `project_id` and `session_id`. Private dispatch metadata
+contains `kortix_api_token`.
 
 `src/kortix-client.ts` implements the client side of all three tool calls —
 real `fetch()` requests against the MCP endpoint, correctly shaped, with

--- a/apps/voice-agent/src/call-context.ts
+++ b/apps/voice-agent/src/call-context.ts
@@ -4,17 +4,13 @@
  * A single worker process handles many jobs (rooms) concurrently, each one a
  * different project/session/call. So anything call-specific — project id,
  * session id, call id, and above all the per-call API credential — MUST come
- * from the room, not from a process-wide env var: an env var is shared by
+ * from the job, not from a process-wide env var: an env var is shared by
  * every job this process ever runs, and a shared credential would let any
  * call impersonate any other project.
  *
- * The room's metadata is the vehicle: apps/api mints a short-lived credential
- * scoped to this one call and sets it as JSON room metadata when it creates
- * the LiveKit room (`RoomServiceClient.createRoom({ name, metadata })`, see
- * livekit-server-sdk's `CreateOptions.metadata`), before dispatching this
- * agent into it. `ctx.job.room.metadata` carries that JSON straight through —
- * it is a snapshot of the room's server-side state at dispatch time, so it is
- * readable immediately in the entrypoint, before `ctx.connect()` completes.
+ * Room metadata carries non-sensitive call context. Private dispatch metadata
+ * carries the short-lived credential scoped to this call. Both values are
+ * readable from `ctx.job` before `ctx.connect()` completes.
  *
  * Only things that really are the same for every job on this process — how to
  * reach LiveKit itself, and a fallback Kortix API base URL for local dev —
@@ -47,23 +43,24 @@ interface RoomMetadataShape {
   session_id?: unknown;
   call_id?: unknown;
   kortix_api_url?: unknown;
-  kortix_api_token?: unknown;
   bot_name?: unknown;
+}
+
+interface WorkerMetadataShape extends RoomMetadataShape {
+  kortix_api_token?: unknown;
 }
 
 function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function parseMetadata(raw: string | undefined): RoomMetadataShape {
-  if (!raw) return {};
+function parseMetadata<T extends object>(raw: string | undefined): T {
+  if (!raw) return {} as T;
   try {
     const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as RoomMetadataShape) : {};
+    return (parsed && typeof parsed === 'object' ? parsed : {}) as T;
   } catch {
-    // Malformed metadata is treated as absent, not fatal — the caller decides
-    // whether the fields it needed were actually required.
-    return {};
+    return {} as T;
   }
 }
 
@@ -75,36 +72,38 @@ function parseMetadata(raw: string | undefined): RoomMetadataShape {
  */
 export function resolveCallContext(
   roomName: string | undefined,
-  metadataRaw: string | undefined,
+  roomMetadataRaw: string | undefined,
+  workerMetadataRaw: string | undefined,
 ): CallContext {
-  const meta = parseMetadata(metadataRaw);
+  const roomMeta = parseMetadata<RoomMetadataShape>(roomMetadataRaw);
+  const workerMeta = parseMetadata<WorkerMetadataShape>(workerMetadataRaw);
 
-  const sessionId = asNonEmptyString(meta.session_id) ?? asNonEmptyString(roomName);
+  const sessionId = asNonEmptyString(roomMeta.session_id) ?? asNonEmptyString(roomName);
   if (!sessionId) {
     throw new Error(
       'voice-agent: could not resolve a session id — room metadata had no session_id and the room has no name',
     );
   }
 
-  const projectId = asNonEmptyString(meta.project_id);
+  const projectId = asNonEmptyString(roomMeta.project_id);
   if (!projectId) {
     throw new Error('voice-agent: room metadata is missing project_id');
   }
 
-  const kortixApiToken = asNonEmptyString(meta.kortix_api_token);
+  const kortixApiToken = asNonEmptyString(workerMeta.kortix_api_token);
   if (!kortixApiToken) {
-    throw new Error('voice-agent: room metadata is missing kortix_api_token');
+    throw new Error('voice-agent: worker metadata is missing kortix_api_token');
   }
 
   return {
     projectId,
     sessionId,
-    callId: asNonEmptyString(meta.call_id) ?? sessionId,
+    callId: asNonEmptyString(roomMeta.call_id) ?? sessionId,
     kortixApiUrl:
-      asNonEmptyString(meta.kortix_api_url) ??
+      asNonEmptyString(roomMeta.kortix_api_url) ??
       process.env.KORTIX_API_URL ??
       'http://localhost:8008',
     kortixApiToken,
-    botName: asNonEmptyString(meta.bot_name) ?? 'Kortix',
+    botName: asNonEmptyString(roomMeta.bot_name) ?? 'Kortix',
   };
 }

--- a/apps/voice-agent/src/index.ts
+++ b/apps/voice-agent/src/index.ts
@@ -14,7 +14,7 @@
  * LIVEKIT_API_KEY / LIVEKIT_API_SECRET automatically, and every model below runs
  * through LiveKit Inference, so this worker needs NO third-party API keys and no
  * secrets of its own. Everything else it needs (project, session, call id, the
- * Kortix API URL and a per-call token) arrives in the room metadata.
+ * Kortix API URL and a per-call token) arrives in job metadata.
  *
  * Run locally with `bun run src/index.ts dev`.
  */
@@ -33,13 +33,13 @@ import { postUserTurn, wireTranscripts } from './transcripts';
 export default defineAgent({
   entry: async (ctx) => {
 
-    // Read call identity + Kortix credentials from the room BEFORE connecting
-    // — `ctx.job.room` is a snapshot of the room's server-side state at
-    // dispatch time (name + metadata), available immediately, whereas
-    // `ctx.room` (the live rtc-node Room) only populates those fields once
-    // `ctx.connect()` has actually joined. See call-context.ts for why this
-    // has to be per-job room metadata and not a process-wide env var.
-    const callContext: CallContext = resolveCallContext(ctx.job.room?.name, ctx.job.room?.metadata);
+    // Read public call context from the room and the worker bearer from private
+    // dispatch metadata. Both values are available before `ctx.connect()`.
+    const callContext: CallContext = resolveCallContext(
+      ctx.job.room?.name,
+      ctx.job.room?.metadata,
+      ctx.job.metadata,
+    );
 
     const { send_prompt, run_command } = buildTools();
 

--- a/apps/voice-agent/src/voice-agent.test.ts
+++ b/apps/voice-agent/src/voice-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { ACK_LINES, nextAckLine, resetAckRotation } from './ack';
+import { resolveCallContext } from './call-context';
 import { buildInstructions } from './instructions';
 
 /**
@@ -57,6 +58,33 @@ describe('the ack is a fixed string, not something the model writes', () => {
     resetAckRotation();
     const run2 = [nextAckLine(), nextAckLine(), nextAckLine()];
     expect(run2).toEqual(run1);
+  });
+});
+
+describe('call-scoped API credentials stay in private worker metadata', () => {
+  const roomMetadata = JSON.stringify({
+    project_id: 'project-1',
+    session_id: 'session-1',
+    call_id: 'call-1',
+    kortix_api_url: 'https://api.kortix.com',
+    bot_name: 'Kortix',
+    kortix_api_token: 'public-room-token',
+  });
+
+  test('reads the bearer from worker metadata', () => {
+    const context = resolveCallContext(
+      'voice-call-1',
+      roomMetadata,
+      JSON.stringify({ kortix_api_token: 'private-worker-token' }),
+    );
+
+    expect(context.kortixApiToken).toBe('private-worker-token');
+  });
+
+  test('does not accept a bearer from public room metadata', () => {
+    expect(() => resolveCallContext('voice-call-1', roomMetadata, undefined)).toThrow(
+      'voice-agent: worker metadata is missing kortix_api_token',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- remove `kortix_api_token` from public LiveKit room metadata
- pass the call-scoped bearer through private dispatch metadata
- require `ctx.job.metadata` for worker authentication
- document and test the metadata boundary

## Verification

- `pnpm --filter @kortix/voice-agent test` — 15 passed, 0 failed
- `cd apps/voice-agent && bun tsc --noEmit` — passed
- `cd apps/api && bun test src/__tests__/unit-voice-worker-metadata.test.ts` — 2 passed, 0 failed
- `cd apps/api && bun tsc --noEmit` — passed
- `git diff --check origin/staging...HEAD` — passed

This removes the HIGH blocker from release PR #5541 and enables a safe US shadow candidate build.