### PR TITLE
ops: support candidate tags in US shadow

### DIFF
--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -4,8 +4,13 @@ on:
   workflow_call:
     inputs:
       version:
-        description: Clean production image version.
+        description: Runtime version reported by the image.
         required: true
+        type: string
+      image_tag:
+        description: Immutable image tag. Defaults to the runtime version.
+        required: false
+        default: ""
         type: string
       source_sha:
         description: Release source commit stored in the images.
@@ -29,8 +34,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Existing production image version to deploy.
+        description: Runtime version reported by the image.
         required: true
+        type: string
+      image_tag:
+        description: Immutable image tag. Defaults to the runtime version.
+        required: false
+        default: ""
         type: string
       source_sha:
         description: Expected image commit. Leave empty only for a legacy image.
@@ -166,6 +176,7 @@ jobs:
       AWS_REGION: us-east-2
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
       VERSION: ${{ inputs.version }}
+      IMAGE_TAG: ${{ inputs.image_tag || inputs.version }}
       SOURCE_SHA: ${{ inputs.source_sha }}
       SOURCE_SECRET_ID: kortix-prod-env
       TARGET_ENV_BLOB: kortix-prod-us-east-2-env
@@ -177,8 +188,12 @@ jobs:
       - name: Validate inputs
         run: |
           set -euo pipefail
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::version must use X.Y.Z format."
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-staging\.[0-9a-f]{8})?$'; then
+            echo "::error::version must use X.Y.Z or X.Y.Z-staging.<sha8> format."
+            exit 1
+          fi
+          if ! printf '%s' "$IMAGE_TAG" | grep -Eq '^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'; then
+            echo "::error::image_tag is not a valid Docker tag."
             exit 1
           fi
           if [ -n "${SOURCE_SHA:-}" ] && ! printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
@@ -298,11 +313,11 @@ jobs:
           set -euo pipefail
           bash infra/scripts/ecs-deploy.sh \
             prod-use2-shadow \
-            "kortix/kortix-api:${VERSION}" \
+            "kortix/kortix-api:${IMAGE_TAG}" \
             --version "$VERSION"
           bash infra/scripts/ecs-deploy.sh \
             prod-use2-shadow \
-            "kortix/kortix-gateway:${VERSION}" \
+            "kortix/kortix-gateway:${IMAGE_TAG}" \
             --service gateway \
             --version "$VERSION"
 
@@ -353,14 +368,14 @@ jobs:
 
           verify_service \
             kortix-prod-use2 \
-            kortix-prod-use2 \
-            api \
-            "kortix/kortix-api:${VERSION}"
-          verify_service \
-            kortix-prod-use2-gateway \
-            kortix-prod-use2-gateway \
-            gateway \
-            "kortix/kortix-gateway:${VERSION}"
+              kortix-prod-use2 \
+              api \
+              "kortix/kortix-api:${IMAGE_TAG}"
+            verify_service \
+              kortix-prod-use2-gateway \
+              kortix-prod-use2-gateway \
+              gateway \
+              "kortix/kortix-gateway:${IMAGE_TAG}"
 
       - name: Verify shadow endpoints
         run: |
@@ -439,8 +454,8 @@ jobs:
         run: |
           {
             echo "### US East 2 production shadow"
-            echo "- API: \`kortix/kortix-api:${VERSION}\`"
-            echo "- Gateway: \`kortix/kortix-gateway:${VERSION}\`"
+            echo "- API: \`kortix/kortix-api:${IMAGE_TAG}\` reports \`${VERSION}\`"
+            echo "- Gateway: \`kortix/kortix-gateway:${IMAGE_TAG}\` reports \`${VERSION}\`"
             echo "- API tasks: 2 or more"
             echo "- Gateway tasks: 2 or more"
             echo "- Production traffic: unchanged"

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -61,6 +61,22 @@ test("shadow Terraform permits only immutable ECS task-definition replacement", 
   );
 });
 
+test("US shadow deploy accepts an immutable candidate image tag", () => {
+  assert.match(shadowWorkflow, /image_tag:\s*\n\s*description:/);
+  assert.match(
+    shadowWorkflow,
+    /IMAGE_TAG: \$\{\{ inputs\.image_tag \|\| inputs\.version \}\}/,
+  );
+  assert.match(
+    shadowWorkflow,
+    /"kortix\/kortix-api:\$\{IMAGE_TAG\}"/,
+  );
+  assert.match(
+    shadowWorkflow,
+    /"kortix\/kortix-gateway:\$\{IMAGE_TAG\}"/,
+  );
+});
+
 test("target smoke removes and counts recovery flow state", () => {
   assert.match(
     targetSmokeProgram,


### PR DESCRIPTION
## Summary

- accept an immutable candidate `image_tag` separately from the runtime version
- validate semantic staging versions and Docker tags
- deploy and verify the exact candidate API and gateway tags
- keep production semantic-version behavior unchanged

## Verification

- `node --test scripts/prod-us-east-2/*.test.mjs` — 28 passed, 0 failed
- workflow YAML parse — passed
- `git diff --check` — passed

This changes only the US shadow workflow. It does not change production routing.