### PR TITLE
chore(release): reconcile latest main with staging hotfix

### DIFF
--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -4,8 +4,13 @@ on:
   workflow_call:
     inputs:
       version:
-        description: Clean production image version.
+        description: Runtime version reported by the image.
         required: true
+        type: string
+      image_tag:
+        description: Immutable image tag. Defaults to the runtime version.
+        required: false
+        default: ""
         type: string
       source_sha:
         description: Release source commit stored in the images.
@@ -29,8 +34,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Existing production image version to deploy.
+        description: Runtime version reported by the image.
         required: true
+        type: string
+      image_tag:
+        description: Immutable image tag. Defaults to the runtime version.
+        required: false
+        default: ""
         type: string
       source_sha:
         description: Expected image commit. Leave empty only for a legacy image.
@@ -166,6 +176,7 @@ jobs:
       AWS_REGION: us-east-2
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
       VERSION: ${{ inputs.version }}
+      IMAGE_TAG: ${{ inputs.image_tag || inputs.version }}
       SOURCE_SHA: ${{ inputs.source_sha }}
       SOURCE_SECRET_ID: kortix-prod-env
       TARGET_ENV_BLOB: kortix-prod-us-east-2-env
@@ -177,8 +188,12 @@ jobs:
       - name: Validate inputs
         run: |
           set -euo pipefail
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::version must use X.Y.Z format."
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-staging\.[0-9a-f]{8})?$'; then
+            echo "::error::version must use X.Y.Z or X.Y.Z-staging.<sha8> format."
+            exit 1
+          fi
+          if ! printf '%s' "$IMAGE_TAG" | grep -Eq '^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'; then
+            echo "::error::image_tag is not a valid Docker tag."
             exit 1
           fi
           if [ -n "${SOURCE_SHA:-}" ] && ! printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
@@ -298,11 +313,11 @@ jobs:
           set -euo pipefail
           bash infra/scripts/ecs-deploy.sh \
             prod-use2-shadow \
-            "kortix/kortix-api:${VERSION}" \
+            "kortix/kortix-api:${IMAGE_TAG}" \
             --version "$VERSION"
           bash infra/scripts/ecs-deploy.sh \
             prod-use2-shadow \
-            "kortix/kortix-gateway:${VERSION}" \
+            "kortix/kortix-gateway:${IMAGE_TAG}" \
             --service gateway \
             --version "$VERSION"
 
@@ -353,14 +368,14 @@ jobs:
 
           verify_service \
             kortix-prod-use2 \
-            kortix-prod-use2 \
-            api \
-            "kortix/kortix-api:${VERSION}"
-          verify_service \
-            kortix-prod-use2-gateway \
-            kortix-prod-use2-gateway \
-            gateway \
-            "kortix/kortix-gateway:${VERSION}"
+              kortix-prod-use2 \
+              api \
+              "kortix/kortix-api:${IMAGE_TAG}"
+            verify_service \
+              kortix-prod-use2-gateway \
+              kortix-prod-use2-gateway \
+              gateway \
+              "kortix/kortix-gateway:${IMAGE_TAG}"
 
       - name: Verify shadow endpoints
         run: |
@@ -439,8 +454,8 @@ jobs:
         run: |
           {
             echo "### US East 2 production shadow"
-            echo "- API: \`kortix/kortix-api:${VERSION}\`"
-            echo "- Gateway: \`kortix/kortix-gateway:${VERSION}\`"
+            echo "- API: \`kortix/kortix-api:${IMAGE_TAG}\` reports \`${VERSION}\`"
+            echo "- Gateway: \`kortix/kortix-gateway:${IMAGE_TAG}\` reports \`${VERSION}\`"
             echo "- API tasks: 2 or more"
             echo "- Gateway tasks: 2 or more"
             echo "- Production traffic: unchanged"

--- a/apps/api/scripts/e2e-managed-flow.ts
+++ b/apps/api/scripts/e2e-managed-flow.ts
@@ -11,9 +11,17 @@
  *
  * It mints a CLI PAT for a local owner account, then walks the whole flow:
  *   provision (web "Create project", seeded) → verify starter in repo →
- *   git-token + push (CLI "ship") → create session (the path that 403'd) →
- *   delete session → rm --purge → confirm the repo is gone.
+ *   clone + push exactly the way `kortix ship` does → create session (the path
+ *   that 403'd) → delete session → rm --purge → confirm the repo is gone.
  * Exits non-zero if any step fails. Cleans up everything it created.
+ *
+ * The git steps deliberately resolve their remote + credential the SAME way the
+ * CLI does (see apps/cli/src/project-git.ts): the Kortix git proxy origin with
+ * our own PAT when the host advertises one, a minted provider token against the
+ * raw upstream only when it doesn't. An earlier version always minted a token
+ * and pushed the raw upstream — a path no client actually takes — so it stayed
+ * green while `kortix ship` was 100% broken against a host whose managed git
+ * runs on an org-wide PAT (POST /git-token fails closed there, by design).
  */
 import { execFile } from 'node:child_process';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
@@ -60,6 +68,32 @@ function gitEnvArgs(token: string): string[] {
   return ['-c', `http.extraheader=AUTHORIZATION: basic ${enc}`];
 }
 
+/** Mirrors apps/cli/src/project-git.ts — keep the two in step. */
+function isGitProxyUrl(url: string | undefined | null): boolean {
+  return Boolean(url && /\/v1\/git\//.test(url));
+}
+
+/**
+ * Resolve the remote + credential a real client would use for this project.
+ * Proxy origin ⇒ our own PAT (no provider credential ever leaves the server);
+ * proxy-less host ⇒ a repo-scoped provider token from POST /git-token.
+ */
+async function resolveClientGitTarget(
+  project: any,
+  token: string,
+): Promise<{ repoUrl: string; gitToken: string; via: string }> {
+  if (isGitProxyUrl(project.git_origin_url)) {
+    return { repoUrl: project.git_origin_url, gitToken: token, via: 'git proxy + CLI PAT' };
+  }
+  const tk = await api('POST', `/projects/${project.project_id}/git-token`, token);
+  assert(
+    tk.status === 200 && tk.json.push_token,
+    'git-token minted (proxy-less host)',
+    `${tk.status} ${JSON.stringify(tk.json)}`,
+  );
+  return { repoUrl: project.repo_url, gitToken: tk.json.push_token, via: 'minted provider token' };
+}
+
 async function main() {
   log(`\n\x1b[1m[e2e] managed project flow\x1b[0m  →  ${BACKEND}\n`);
 
@@ -74,7 +108,6 @@ async function main() {
   ok('minted e2e PAT');
 
   let projectId = '';
-  let repoUrl = '';
   let sessionId = '';
 
   try {
@@ -90,25 +123,32 @@ async function main() {
     assert(typeof prov.json.metadata?.git?.provider === 'string', 'metadata.git.provider is set');
     assert(typeof prov.json.dashboard_url === 'string' && !prov.json.dashboard_url.includes('/v1'), 'dashboard_url is the web URL');
     projectId = prov.json.project_id;
-    repoUrl = prov.json.repo_url;
 
     // ── 3. seeded starter actually landed in the repo ─────────────────────
-    const tk = await api('POST', `/projects/${projectId}/git-token`, token);
-    assert(tk.status === 200 && tk.json.push_token, 'git-token minted', `${tk.status}`);
+    // Resolved the way a client resolves it — NOT by always minting a token.
+    const git = await resolveClientGitTarget(prov.json, token);
+    ok(`client git target: ${git.via}`);
     const dir = await mkdtemp(join(tmpdir(), 'e2e-flow-'));
-    await execFileAsync('git', [...gitEnvArgs(tk.json.push_token), 'clone', '-q', repoUrl, dir]);
+    await execFileAsync('git', [...gitEnvArgs(git.gitToken), 'clone', '-q', git.repoUrl, dir]);
     const tracked = (await execFileAsync('git', ['-C', dir, 'ls-files'])).stdout;
     assert(tracked.includes('kortix.yaml'), 'seeded repo contains kortix.yaml');
     assert(tracked.includes('.kortix/opencode/opencode.jsonc'), 'seeded repo contains .kortix/opencode/opencode.jsonc');
 
-    // ── 4. CLI "ship": commit + push current branch to the managed origin ─
+    // ── 4. CLI "ship": commit + push current branch to the project origin ─
     await writeFile(join(dir, 'E2E.md'), `e2e ${new Date().toISOString()}\n`);
     await execFileAsync('git', ['-C', dir, 'config', 'user.email', 'e2e@kortix.ai']);
     await execFileAsync('git', ['-C', dir, 'config', 'user.name', 'e2e']);
     await execFileAsync('git', ['-C', dir, 'add', '-A']);
     await execFileAsync('git', ['-C', dir, 'commit', '-q', '-m', 'e2e edit']);
-    await execFileAsync('git', ['-C', dir, ...gitEnvArgs(tk.json.push_token), 'push', '-q', 'origin', 'HEAD:refs/heads/main']);
+    const head = (await execFileAsync('git', ['-C', dir, 'rev-parse', 'HEAD'])).stdout.trim();
+    await execFileAsync('git', ['-C', dir, ...gitEnvArgs(git.gitToken), 'push', '-q', 'origin', 'HEAD:refs/heads/main']);
     ok('pushed an update to the managed repo (ship)');
+
+    // The push must be visible on the real upstream, not just accepted locally.
+    const remoteMain = (
+      await execFileAsync('git', ['-C', dir, ...gitEnvArgs(git.gitToken), 'ls-remote', 'origin', 'refs/heads/main'])
+    ).stdout.trim();
+    assert(remoteMain.startsWith(head), 'origin/main advanced to the pushed commit', remoteMain);
     await rm(dir, { recursive: true, force: true });
 
     // ── 5. create a session (the path that 403'd on managed git) ──────────

--- a/apps/api/src/__tests__/e2e-projects-provision.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-provision.test.ts
@@ -457,7 +457,12 @@ describe('POST /v1/projects/provision (managed git)', () => {
     });
 
     expect(res.status).toBe(503);
-    expect(await res.text()).toContain('repo-scoped installation token');
+    const body = await res.json();
+    // Fails closed AND points at the path that actually works: the org-wide
+    // token is never exported, clients push through the git proxy origin.
+    expect(body.error).toContain('org-wide token');
+    expect(body.error).toContain('git_origin_url');
+    expect(body.git_origin_url).toBeTruthy();
   });
 
   test('rejects an explicit account the caller has no membership in', async () => {

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for authorizeGitProxy — the git proxy's trust boundary.
+ *
+ * The proxy is the UNIVERSAL client-facing git origin (`kortix ship`, `kortix
+ * projects clone`, the sandbox daemon all reach a repo through it), so its
+ * authorization rules decide whether those commands work at all. Token-account
+ * equality alone was too strict: a PAT is bound to ONE account, so anyone in
+ * two accounts (personal + team) could create a project through the API and
+ * then never push to it — while POST /git-token, which hands out a STRONGER
+ * credential, accepted them via the per-project capability. These pin the
+ * rules: same account passes, a cross-account grant passes ONLY through the
+ * IAM leaf, and everything else stays denied.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const PROJECT_ID = '11111111-1111-4111-8111-111111111111';
+const OWNER_ACCOUNT = 'acct-owner';
+const OTHER_ACCOUNT = 'acct-other';
+
+let projectRow: Record<string, unknown> | null = null;
+let patResult: Record<string, unknown> = {};
+let apiKeyResult: Record<string, unknown> = {};
+let authorizeAllowed = false;
+let authorizeCalls: Array<{
+  userId: string;
+  accountId: string;
+  action: string;
+  actingTokenId?: string;
+}> = [];
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => (projectRow ? [projectRow] : []) }),
+      }),
+    }),
+  },
+  hasDatabase: true,
+}));
+// Spread the real modules and override only the seams under test — replacing
+// them wholesale would strip exports other importers in this process need.
+const realAccountTokens = await import('../repositories/account-tokens');
+const realApiKeys = await import('../repositories/api-keys');
+const realIamActions = await import('../iam/actions');
+const realIamDispatcher = await import('../iam/dispatcher');
+
+mock.module('../repositories/account-tokens', () => ({
+  ...realAccountTokens,
+  validateAccountToken: async () => patResult,
+}));
+mock.module('../repositories/api-keys', () => ({
+  ...realApiKeys,
+  validateSecretKey: async () => apiKeyResult,
+}));
+mock.module('../iam/actions', () => ({ ...realIamActions }));
+mock.module('../iam/dispatcher', () => ({
+  ...realIamDispatcher,
+  authorize: async (
+    userId: string,
+    accountId: string,
+    action: string,
+    _t: unknown,
+    actingTokenId?: string,
+  ) => {
+    authorizeCalls.push({ userId, accountId, action, actingTokenId });
+    return { allowed: authorizeAllowed };
+  },
+}));
+
+const { authorizeGitProxy } = await import('../projects/lib/git');
+
+beforeEach(() => {
+  projectRow = { projectId: PROJECT_ID, accountId: OWNER_ACCOUNT, status: 'active' };
+  patResult = { isValid: true, accountId: OWNER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
+  apiKeyResult = { isValid: false };
+  authorizeAllowed = false;
+  authorizeCalls = [];
+});
+
+describe('authorizeGitProxy — CLI PAT', () => {
+  test('a PAT on the owning account is allowed without an IAM round-trip', async () => {
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+    expect(res.ok).toBe(true);
+    expect(authorizeCalls).toHaveLength(0);
+  });
+
+  test('a PAT on another account passes when the user holds the git capability', async () => {
+    patResult = { isValid: true, accountId: OTHER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
+    authorizeAllowed = true;
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    // Evaluated against the PROJECT's account, not the token's, and threading
+    // the acting token so the agent-grant fold fires.
+    expect(authorizeCalls).toEqual([
+      {
+        userId: 'user-1',
+        accountId: OWNER_ACCOUNT,
+        action: 'project.gitops.push',
+        actingTokenId: 'tok-1',
+      },
+    ]);
+  });
+
+  test('a PAT on another account is denied when the capability is denied', async () => {
+    patResult = { isValid: true, accountId: OTHER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
+    authorizeAllowed = false;
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res).toMatchObject({ ok: false, status: 403 });
+  });
+
+  test('read and write map to different capabilities', async () => {
+    patResult = { isValid: true, accountId: OTHER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
+    authorizeAllowed = true;
+
+    await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'read');
+
+    expect(authorizeCalls[0]?.action).toBe('project.gitops.read');
+  });
+
+  test('a project-scoped PAT for a different project is rejected before any capability check', async () => {
+    patResult = {
+      isValid: true,
+      accountId: OWNER_ACCOUNT,
+      userId: 'user-1',
+      projectId: 'other-project',
+    };
+    authorizeAllowed = true;
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res).toMatchObject({ ok: false, status: 403 });
+    expect(authorizeCalls).toHaveLength(0);
+  });
+
+  test('an invalid PAT is 401, never a capability lookup', async () => {
+    patResult = { isValid: false, error: 'revoked' };
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res).toMatchObject({ ok: false, status: 401 });
+    expect(authorizeCalls).toHaveLength(0);
+  });
+
+  test('an archived project is 404 regardless of the token', async () => {
+    projectRow = { projectId: PROJECT_ID, accountId: OWNER_ACCOUNT, status: 'archived' };
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res).toMatchObject({ ok: false, status: 404 });
+  });
+});
+
+describe('authorizeGitProxy — account API key', () => {
+  test('an API key for another account stays denied — it carries no user to evaluate', async () => {
+    patResult = { isValid: false };
+    apiKeyResult = { isValid: true, accountId: OTHER_ACCOUNT, type: 'user' };
+    authorizeAllowed = true; // would pass IF the fallback applied — it must not
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res).toMatchObject({ ok: false, status: 403 });
+    expect(authorizeCalls).toHaveLength(0);
+  });
+
+  test('an API key on the owning account is allowed', async () => {
+    patResult = { isValid: false };
+    apiKeyResult = { isValid: true, accountId: OWNER_ACCOUNT, type: 'user' };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+  });
+
+  test('a non-Kortix credential is 401', async () => {
+    const res = await authorizeGitProxy('ghp_something', PROJECT_ID, 'read');
+    expect(res).toMatchObject({ ok: false, status: 401 });
+  });
+});

--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -24,6 +24,7 @@ import {
   type GitProxyAuth,
 } from '../projects';
 import type { GitScope } from '../projects/git-backends';
+import { deriveRequestContext } from '../iam/cache';
 import {
   FORWARD_REQUEST_HEADERS,
   STRIP_RESPONSE_HEADERS,
@@ -84,7 +85,10 @@ function validProjectIdOrResponse(c: any, raw: string): string | Response {
 async function authorize(c: any, projectId: string, scope: GitScope): Promise<GitProxyAuth> {
   const token = extractToken(c.req.header('authorization'));
   if (!token) return { ok: false, status: 401, message: 'authentication required' };
-  return authorizeGitProxy(token, projectId, scope);
+  // Pass the request context so IP-allowlist / require-MFA policy conditions
+  // evaluate on the per-project capability path the same way they do on every
+  // other project route.
+  return authorizeGitProxy(token, projectId, scope, deriveRequestContext(c));
 }
 
 /**

--- a/apps/api/src/projects/lib/end-user-ref.test.ts
+++ b/apps/api/src/projects/lib/end-user-ref.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveEndUserRef } from './end-user-ref';
+
+describe('resolveEndUserRef — end_user_ref with origin_ref as a deprecated alias', () => {
+  test('accepts the new name', () => {
+    const r = resolveEndUserRef({ end_user_ref: 'user-123' });
+    expect(r).toEqual({ ok: true, value: 'user-123', suppliedUnder: 'end_user_ref' });
+  });
+
+  test('still accepts the deprecated alias — live wrappers must not break', () => {
+    const r = resolveEndUserRef({ origin_ref: 'user-123' });
+    expect(r).toEqual({ ok: true, value: 'user-123', suppliedUnder: 'origin_ref' });
+  });
+
+  test('both spellings are fine when they agree (a client mid-migration)', () => {
+    const r = resolveEndUserRef({ end_user_ref: 'user-123', origin_ref: 'user-123' });
+    expect(r.ok).toBe(true);
+  });
+
+  test('rejects disagreeing spellings rather than silently picking one', () => {
+    // Preferring either would misattribute every usage row for the session, and
+    // the caller could not tell which had won.
+    const r = resolveEndUserRef({ end_user_ref: 'alice', origin_ref: 'bob' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('END_USER_REF_CONFLICT');
+  });
+
+  test('trims, and treats differing-but-equivalent whitespace as agreement', () => {
+    expect(resolveEndUserRef({ end_user_ref: '  user-1  ' })).toMatchObject({ value: 'user-1' });
+    expect(resolveEndUserRef({ end_user_ref: 'u', origin_ref: ' u ' }).ok).toBe(true);
+  });
+
+  test('absent → null, and nothing was supplied', () => {
+    expect(resolveEndUserRef({})).toEqual({ ok: true, value: null, suppliedUnder: null });
+  });
+
+  test('a whitespace-only handle still counts as SUPPLIED for the origin gate', () => {
+    // Otherwise a non-backend caller sends "   " and slips past the 403, because
+    // the value normalises to null before the gate sees it.
+    const r = resolveEndUserRef({ end_user_ref: '   ' });
+    expect(r).toEqual({ ok: true, value: null, suppliedUnder: 'end_user_ref' });
+  });
+
+  test('a non-string is ignored rather than coerced', () => {
+    expect(resolveEndUserRef({ end_user_ref: 42 as unknown })).toEqual({
+      ok: true,
+      value: null,
+      suppliedUnder: null,
+    });
+  });
+});

--- a/apps/api/src/projects/lib/end-user-ref.ts
+++ b/apps/api/src/projects/lib/end-user-ref.ts
@@ -1,0 +1,58 @@
+/**
+ * `end_user_ref` — the wrapper's opaque handle for the END-USER a backend
+ * session acts for.
+ *
+ * Formerly `origin_ref`, which read as "a reference to the origin" (i.e. WHICH
+ * APP) when it actually means "a reference within the origin" (i.e. WHICH OF
+ * YOUR USERS). The old name invited callers to put a request id, a tenant, or an
+ * app name there — all of which produce a usage breakdown that looks correct and
+ * bills nobody in particular.
+ *
+ * `origin_ref` stays accepted forever as a deprecated alias: it is a published
+ * wire field, and breaking it would break live wrappers for a naming fix.
+ */
+export interface EndUserRefInput {
+  end_user_ref?: unknown;
+  origin_ref?: unknown;
+}
+
+export type EndUserRefResolution =
+  | { ok: true; value: string | null; suppliedUnder: 'end_user_ref' | 'origin_ref' | null }
+  | { ok: false; code: 'END_USER_REF_CONFLICT'; message: string };
+
+/**
+ * Resolve the end-user handle from either spelling.
+ *
+ * Both may be sent (a client mid-migration), but only if they AGREE — silently
+ * preferring one would misattribute every usage row for that session, and the
+ * caller would have no way to tell which won.
+ *
+ * `suppliedUnder` reports whether the caller supplied ANYTHING, which is what
+ * the origin gate keys on: a whitespace-only value must still trip the 403
+ * rather than being normalised to null and slipping past it.
+ */
+export function resolveEndUserRef(body: EndUserRefInput): EndUserRefResolution {
+  const modern = typeof body.end_user_ref === 'string' ? body.end_user_ref : null;
+  const legacy = typeof body.origin_ref === 'string' ? body.origin_ref : null;
+
+  if (modern !== null && legacy !== null && modern.trim() !== legacy.trim()) {
+    return {
+      ok: false,
+      code: 'END_USER_REF_CONFLICT',
+      message:
+        'end_user_ref and its deprecated alias origin_ref were both supplied with different values — send only end_user_ref',
+    };
+  }
+
+  const raw = modern ?? legacy;
+  const suppliedUnder = modern !== null ? 'end_user_ref' : legacy !== null ? 'origin_ref' : null;
+  if (raw === null) return { ok: true, value: null, suppliedUnder: null };
+  // Supplied-but-blank still counts as supplied for the origin gate; the VALUE
+  // normalises to null so a whitespace handle never reaches the ledger.
+  const trimmed = raw.trim();
+  return {
+    ok: true,
+    value: trimmed.length > 0 ? trimmed : null,
+    suppliedUnder: raw.length > 0 ? suppliedUnder : null,
+  };
+}

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -11,6 +11,13 @@ import { accountGithubInstallationStates, accountGithubInstallations, accountMem
 import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import { ttlMemo } from '../../shared/ttl-memo';
+// Imported from the leaf modules, not the `../../iam` barrel: this file is
+// pulled in by most of the project surface, and several suites mock the barrel
+// with a partial shape — a barrel import here turns those into module-load
+// SyntaxErrors far from anything they're testing.
+import { PROJECT_ACTIONS } from '../../iam/actions';
+import { authorize } from '../../iam/dispatcher';
+import type { RequestContext } from '../../iam/engine';
 import { registerPrincipalScopedMemo } from '../../iam/cache-invalidation';
 import { PROJECT_GIT_AUTH_SECRET_NAME, ProjectGitConnectionRow, ProjectGitCredentialRow, ProjectRow, normalizeJsonObject, normalizeString } from './serializers';
 
@@ -599,18 +606,28 @@ export type GitProxyAuth =
  *  - sandbox runtime token → must be scoped to an active sandbox of THIS
  *    project (read + write);
  *  - account API key (kortix_…) → the account must own the project;
- *  - CLI PAT (kortix_pat_…) → account must own the project; a project-scoped
- *    PAT must match this project.
+ *  - CLI PAT (kortix_pat_…) → the account owns the project, OR the token's user
+ *    holds `project.gitops.push` / `.read` on it; a project-scoped PAT must
+ *    match this project either way.
  *
- * (Finer per-project role gating for account-level PAT writes lands with M2 —
- * for now account ownership grants write, which is safe since only account
- * members can mint these tokens.)
+ * Account ownership alone grants write, which is safe since only account
+ * members can mint these tokens. (Finer per-project role gating for THAT case
+ * lands with M2.)
+ *
+ * The per-project fallback exists because token-account equality was too strict
+ * to be the only rule: a PAT is bound to ONE account, so anybody in two
+ * accounts (personal + team, the common case) could create a project through
+ * the API and then never push to it. A project-grant collaborator was likewise
+ * accepted by POST /git-token — which hands out a STRONGER credential, a raw
+ * provider token — while being refused here. This is parity with that endpoint,
+ * not new reach.
  */
 
 export async function authorizeGitProxy(
   token: string,
   projectId: string,
-  _scope: GitScope,
+  scope: GitScope,
+  requestCtx: RequestContext = {},
 ): Promise<GitProxyAuth> {
   const [project] = await db
     .select()
@@ -620,6 +637,25 @@ export async function authorizeGitProxy(
   if (!project || project.status === 'archived') {
     return { ok: false, status: 404, message: 'Not found' };
   }
+
+  /** Does this token's USER hold the git capability this operation needs? */
+  const grantedByProjectRole = async (
+    userId: string | null | undefined,
+    actingTokenId?: string,
+  ): Promise<boolean> => {
+    if (!userId) return false;
+    const action =
+      scope === 'write' ? PROJECT_ACTIONS.PROJECT_GITOPS_PUSH : PROJECT_ACTIONS.PROJECT_GITOPS_READ;
+    const verdict = await authorize(
+      userId,
+      project.accountId,
+      action,
+      { type: 'project', id: projectId },
+      actingTokenId,
+      requestCtx,
+    );
+    return verdict.allowed;
+  };
 
   // CLI PAT first — `isKortixToken` also matches the `kortix_pat_` prefix, so
   // the account-token check MUST run before the API-key check (mirrors the auth
@@ -633,7 +669,11 @@ export async function authorizeGitProxy(
       return { ok: false, status: 403, message: 'token is scoped to a different project' };
     }
     if (result.accountId !== project.accountId) {
-      return { ok: false, status: 403, message: 'token does not own this project' };
+      // Thread the acting token so the agent-grant fold fires (userRole ∩ grant)
+      // — a bare authorize() would silently skip it.
+      if (!(await grantedByProjectRole(result.userId, result.tokenId))) {
+        return { ok: false, status: 403, message: 'token is not authorized for this project' };
+      }
     }
     return { ok: true, project };
   }
@@ -662,7 +702,9 @@ export async function authorizeGitProxy(
       }
       return { ok: true, project };
     }
-    // Account-scoped user API key.
+    // Account-scoped user API key. No per-project fallback here: an API key
+    // carries no user identity, so there is no principal to evaluate project
+    // grants against — account ownership stays the only rule.
     if (result.accountId !== project.accountId) {
       return { ok: false, status: 403, message: 'token does not own this project' };
     }

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -109,6 +109,9 @@ export function serializeSession(
     owner_type: ctx?.ownerType ?? (row.createdBy ? 'unknown' : null),
     visibility: row.visibility,
     origin: row.origin,
+    end_user_ref: row.originRef,
+    // Deprecated alias, echoed with the same value so wrappers written against
+    // the old name keep working. The DB column keeps its original name.
     origin_ref: row.originRef,
     secrets_allowlist: row.secretsAllowlist ?? null,
     sharing: visibilityToIntent(row.visibility as 'private' | 'project' | 'restricted', ctx?.grants ?? []),

--- a/apps/api/src/projects/lib/session-model-change.test.ts
+++ b/apps/api/src/projects/lib/session-model-change.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  canChangeSessionModel,
+  modelChangeNeedsLivePush,
+  validateModelChangeShape,
+} from './session-model-change';
+
+describe('validateModelChangeShape', () => {
+  test('accepts a normal model ref', () => {
+    expect(validateModelChangeShape('anthropic/claude-opus-4-8')).toBeNull();
+  });
+
+  test('rejects blank and whitespace-only', () => {
+    expect(validateModelChangeShape('')?.code).toBe('INVALID_SESSION_MODEL');
+    expect(validateModelChangeShape('   ')?.code).toBe('INVALID_SESSION_MODEL');
+  });
+
+  test('rejects embedded whitespace — the create path already does', () => {
+    expect(validateModelChangeShape('anthropic/claude opus')?.code).toBe('INVALID_SESSION_MODEL');
+  });
+
+  test('rejects an absurdly long id rather than storing it', () => {
+    expect(validateModelChangeShape('x'.repeat(129))?.code).toBe('INVALID_SESSION_MODEL');
+  });
+});
+
+describe('canChangeSessionModel', () => {
+  test('running and provisioning sessions may change', () => {
+    // provisioning has no live agent yet, but the ROW is what its cold boot
+    // reads — writing it early is correct, not premature.
+    for (const status of ['running', 'provisioning', 'queued', 'branching']) {
+      expect(canChangeSessionModel(status)).toBeNull();
+    }
+  });
+
+  test('terminal sessions are refused — nothing would consume the value', () => {
+    for (const status of ['failed', 'completed', 'stopped']) {
+      expect(canChangeSessionModel(status)?.code).toBe('SESSION_NOT_RUNNING');
+    }
+  });
+});
+
+describe('modelChangeNeedsLivePush', () => {
+  test('a running session with a genuinely different model needs the restart', () => {
+    expect(modelChangeNeedsLivePush({ current: 'a/b', next: 'c/d', status: 'running' })).toBe(true);
+  });
+
+  test('a no-op PUT must NOT restart opencode', () => {
+    // Restarting costs the user their in-flight turn; re-sending the same model
+    // is a legitimate idempotent call and must be free.
+    expect(modelChangeNeedsLivePush({ current: 'a/b', next: 'a/b', status: 'running' })).toBe(false);
+  });
+
+  test('a session with no box yet just persists — nothing to push to', () => {
+    expect(modelChangeNeedsLivePush({ current: null, next: 'c/d', status: 'provisioning' })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/api/src/projects/lib/session-model-change.ts
+++ b/apps/api/src/projects/lib/session-model-change.ts
@@ -1,0 +1,74 @@
+/**
+ * Changing the model a RUNNING session uses.
+ *
+ * `opencode_model` was create-only: the sandbox reads `KORTIX_OPENCODE_MODEL`
+ * when it builds opencode's config at spawn, and nothing re-pushed it, so a live
+ * box kept its boot-time model forever. Worse, the stored value was reachable
+ * through `PATCH /sessions/{id}` metadata WITHOUT the create-time validation, so
+ * a retired or account-forbidden model could be planted and would be booted by
+ * the next cold provision.
+ *
+ * This module holds the pure parts so both paths agree on what a legal change is.
+ */
+
+/** Terminal states — there is no live agent to re-point, and a cold boot would
+ *  re-read the row anyway, so a change here is meaningless rather than harmful. */
+const UNCHANGEABLE_STATUSES = new Set(['failed', 'completed', 'stopped']);
+
+export type ModelChangeRejection =
+  | { code: 'INVALID_SESSION_MODEL'; message: string }
+  | { code: 'SESSION_NOT_RUNNING'; message: string };
+
+/**
+ * Shape-check a requested model id. Deliberately NOT an allow-list — that is
+ * `isModelServableForAccount`, which needs IO. This only rejects what can never
+ * be a model id, so the caller gets a 400 instead of a dead turn later.
+ */
+export function validateModelChangeShape(requested: string): ModelChangeRejection | null {
+  const trimmed = requested.trim();
+  if (trimmed.length === 0) {
+    return { code: 'INVALID_SESSION_MODEL', message: 'model must not be blank' };
+  }
+  if (/\s/.test(trimmed)) {
+    return {
+      code: 'INVALID_SESSION_MODEL',
+      message: `"${requested}" doesn't look like a model id`,
+    };
+  }
+  if (trimmed.length > 128) {
+    return { code: 'INVALID_SESSION_MODEL', message: 'model id is too long' };
+  }
+  return null;
+}
+
+/**
+ * May this session's model change right now?
+ *
+ * A queued/provisioning session is allowed: the row is what a cold boot reads,
+ * so writing it early is correct and needs no live push. A terminal session is
+ * refused — nothing would consume the value.
+ */
+export function canChangeSessionModel(status: string): ModelChangeRejection | null {
+  if (UNCHANGEABLE_STATUSES.has(status)) {
+    return {
+      code: 'SESSION_NOT_RUNNING',
+      message: `session is ${status} — its model can no longer change`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Does this change require restarting opencode inside a live sandbox?
+ *
+ * Only when the value actually differs AND a box is up. Restarting opencode
+ * costs the user their in-flight turn, so a no-op PUT must not do it.
+ */
+export function modelChangeNeedsLivePush(input: {
+  current: string | null;
+  next: string;
+  status: string;
+}): boolean {
+  if (input.current === input.next) return false;
+  return input.status === 'running';
+}

--- a/apps/api/src/projects/lib/session-runtime-context.ts
+++ b/apps/api/src/projects/lib/session-runtime-context.ts
@@ -8,6 +8,12 @@ export const SESSION_RUNTIME_CONTEXT_ENV_NAME = 'KORTIX_SESSION_CONTEXT';
 
 /** The end-user a backend (KaaB) session acts for — derived server-side from the
  *  validated `origin_ref`, never from caller-supplied env. */
+export const SESSION_END_USER_REF_ENV_NAME = 'KORTIX_END_USER_REF';
+/**
+ * @deprecated Renamed to {@link SESSION_END_USER_REF_ENV_NAME}. Still SET on
+ * every session with the same value — agent code inside sandboxes may already
+ * read it, and that code is not ours to migrate.
+ */
 export const SESSION_ORIGIN_REF_ENV_NAME = 'KORTIX_ORIGIN_REF';
 
 /**
@@ -18,6 +24,7 @@ export const SESSION_ORIGIN_REF_ENV_NAME = 'KORTIX_ORIGIN_REF';
  */
 const SERVER_OWNED_ENV_NAMES = [
   SESSION_RUNTIME_CONTEXT_ENV_NAME,
+  SESSION_END_USER_REF_ENV_NAME,
   SESSION_ORIGIN_REF_ENV_NAME,
 ] as const;
 

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -32,7 +32,12 @@ export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<st
     KORTIX_SERVICE_PORT: '8000',
     KORTIX_AGENT_NAME: input.agentName,
     KORTIX_OPENCODE_PROCESS_TRANSPORT: input.opencodeProcessTransport,
-    ...(input.originRef ? { KORTIX_ORIGIN_REF: input.originRef } : {}),
+    // Both names carry the same value: KORTIX_END_USER_REF is the name, and
+    // KORTIX_ORIGIN_REF stays set because agent code inside sandboxes may
+    // already read it and we cannot migrate other people's code.
+    ...(input.originRef
+      ? { KORTIX_END_USER_REF: input.originRef, KORTIX_ORIGIN_REF: input.originRef }
+      : {}),
     KORTIX_API_URL: input.apiUrl,
     // Frontend base for user-facing dashboard links — the agent/CLI must never
     // surface KORTIX_API_URL (the API host) to a human. See sandboxFrontendBaseUrl().

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -72,6 +72,7 @@ import {
   validateSessionConnectorBindings,
 } from './session-connector-bindings';
 import { canOverride, resolveSessionOrigin } from './session-origin';
+import { resolveEndUserRef } from './end-user-ref';
 import { resolveSessionSandboxSlug } from './session-sandbox-metadata';
 import {
   buildSessionRuntimeContextEnv,
@@ -672,19 +673,27 @@ export async function createProjectSession(input: {
       },
     };
   }
-  const requestedOriginRef = normalizeString(body.origin_ref);
-  // Gate on whether origin_ref was SUPPLIED (any non-empty string, incl. a
-  // whitespace-only one), not on its trimmed value — otherwise a non-backend
-  // caller could send origin_ref: "   " to slip past the 403, since
-  // normalizeString would null it out.
-  const originRefProvided = typeof body.origin_ref === 'string' && body.origin_ref.length > 0;
+  // Accept `end_user_ref` and its deprecated alias `origin_ref`. Disagreeing
+  // values are rejected rather than silently resolved — picking either would
+  // misattribute every usage row for this session.
+  const endUserRef = resolveEndUserRef(body);
+  if (!endUserRef.ok) {
+    return {
+      error: { status: 400, body: { error: endUserRef.message, code: endUserRef.code } },
+    };
+  }
+  const requestedOriginRef = endUserRef.value;
+  // Gate on whether it was SUPPLIED (any non-empty string, incl. a
+  // whitespace-only one), not on the trimmed value — otherwise a non-backend
+  // caller could send "   " to slip past the 403.
+  const originRefProvided = endUserRef.suppliedUnder !== null;
   if (originRefProvided && !canOverride(origin, 'origin_ref')) {
     return {
       error: {
         status: 403,
         body: {
           error:
-            'origin_ref may only be set by a backend-origin session — authenticate with an API key / PAT or a service-account bearer',
+            'end_user_ref may only be set by a backend-origin session — authenticate with an API key / PAT or a service-account bearer',
           code: 'origin_override_forbidden',
         },
       },

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -739,8 +739,20 @@ projectsApp.openapi(
   // in the sandbox/CLI git config.
   const gitAuth = await resolveProjectGitAuth(loaded.row);
   if (gitAuth.authSource === 'pat') {
+    // This host's managed git runs on an org-wide token. Exporting it to a
+    // client would hand out write access to EVERY managed repo, so we refuse —
+    // clients push through the Kortix git proxy (`git_origin_url`) with their
+    // own Kortix token instead, which needs no provider credential client-side.
+    // Say so explicitly: the old message read as a server misconfiguration and
+    // sent people hunting for GitHub App settings that aren't the problem.
     return c.json(
-      { error: 'Managed git push token export requires a repo-scoped installation token' },
+      {
+        error:
+          "This host's managed git uses an org-wide token, which is never exported. " +
+          "Push through the project's Kortix git origin instead (git_origin_url) — " +
+          'run `kortix update` if your CLI still asks for a push token.',
+        git_origin_url: serializeProject(loaded.row).git_origin_url,
+      },
       503,
     );
   }

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -1585,7 +1585,16 @@ projectsApp.openapi(
   // Letting a client forge either via PATCH lets any project member hide
   // another member's session, block its follow-ups, and trip the reaper.
   // See SSR-7 (weekly pentest run #4).
-  const SERVER_MANAGED_METADATA_KEYS = ['deletedAt', 'deletedBy'];
+  // opencode_model is create-only by contract and changed only via
+  // PUT /sessions/{id}/model, which validates it against the account. Planting
+  // it through metadata skipped that check entirely, so a retired or
+  // account-forbidden model could be stored and booted by the next cold provision.
+  const SERVER_MANAGED_METADATA_KEYS = [
+    'deletedAt',
+    'deletedBy',
+    'opencode_model',
+    'opencode_model_source',
+  ];
   const metadataInput = body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
     ? (body.metadata as Record<string, unknown>)
     : null;

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -7,7 +7,7 @@ import { db } from '../../shared/db';
 import { connectorBindingPayloadConflicts } from '../lib/session-connector-bindings';
 import { secretsAllowlistPayloadConflicts } from '../secrets';
 import {
-  originRefConflicts,
+  endUserRefConflicts,
   requireConnectorsConflicts,
   runtimeContextConflicts,
 } from './idempotency-conflicts';
@@ -145,7 +145,7 @@ export async function createSession(
     // session — that would land end-user B's prompts in A's conversation and
     // misattribute usage. Refuse it, mirroring the guards above. (Cross-ACCOUNT
     // key collision is a separate concern — see the account-scope fix.)
-    if (originRefConflicts(existingBody.origin_ref, command.body.origin_ref)) {
+    if (endUserRefConflicts(existingBody, command.body)) {
       return {
         status: 'failed',
         commandId: claimed.row.commandId,

--- a/apps/api/src/projects/session-lifecycle/idempotency-conflicts.test.ts
+++ b/apps/api/src/projects/session-lifecycle/idempotency-conflicts.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   originRefConflicts,
   requireConnectorsConflicts,
-  runtimeContextConflicts,
-} from './idempotency-conflicts';
+  runtimeContextConflicts, endUserRefConflicts } from './idempotency-conflicts';
 
 describe('originRefConflicts', () => {
   test('same origin_ref → no conflict', () => {
@@ -57,5 +56,30 @@ describe('requireConnectorsConflicts', () => {
   test('absent vs a real requirement → conflict', () => {
     expect(requireConnectorsConflicts(undefined, ['gmail'])).toBe(true);
     expect(requireConnectorsConflicts(['gmail'], undefined)).toBe(true);
+  });
+});
+
+describe('end-user conflict detection reads BOTH spellings', () => {
+  // The rename added `end_user_ref` alongside `origin_ref`. A guard that reads
+  // only the raw legacy key sees `undefined` when the replay uses the new name,
+  // concludes "no conflict", and hands the FIRST end-user's session to the
+  // SECOND — the exact disclosure this guard exists to stop.
+  test('same key, different end-user, mixed spellings → CONFLICT', () => {
+    expect(endUserRefConflicts({ origin_ref: 'alice' }, { end_user_ref: 'bob' })).toBe(true);
+    expect(endUserRefConflicts({ end_user_ref: 'alice' }, { origin_ref: 'bob' })).toBe(true);
+  });
+
+  test('same end-user under different spellings → NO conflict (a legal replay)', () => {
+    expect(endUserRefConflicts({ origin_ref: 'alice' }, { end_user_ref: 'alice' })).toBe(false);
+    expect(endUserRefConflicts({ end_user_ref: 'alice' }, { origin_ref: ' alice ' })).toBe(false);
+  });
+
+  test('neither side names an end-user → NO conflict', () => {
+    expect(endUserRefConflicts({}, {})).toBe(false);
+  });
+
+  test('one side names an end-user and the other does not → CONFLICT', () => {
+    expect(endUserRefConflicts({}, { end_user_ref: 'bob' })).toBe(true);
+    expect(endUserRefConflicts({ origin_ref: 'alice' }, {})).toBe(true);
   });
 });

--- a/apps/api/src/projects/session-lifecycle/idempotency-conflicts.ts
+++ b/apps/api/src/projects/session-lifecycle/idempotency-conflicts.ts
@@ -24,6 +24,23 @@ export function originRefConflicts(existing: unknown, requested: unknown): boole
   return normalizeOriginRef(existing) !== normalizeOriginRef(requested);
 }
 
+/**
+ * Compare the end-user two idempotent creates name, reading EITHER spelling.
+ *
+ * `end_user_ref` is the name and `origin_ref` its deprecated alias, so a guard
+ * that reads one raw key sees `undefined` when the replay used the other,
+ * concludes "no conflict", and returns the FIRST end-user's session to the
+ * SECOND. Resolve both sides to a canonical value before comparing.
+ */
+export function endUserRefConflicts(
+  existingBody: { end_user_ref?: unknown; origin_ref?: unknown },
+  requestedBody: { end_user_ref?: unknown; origin_ref?: unknown },
+): boolean {
+  const canonical = (body: { end_user_ref?: unknown; origin_ref?: unknown }): string | null =>
+    normalizeOriginRef(body.end_user_ref) ?? normalizeOriginRef(body.origin_ref);
+  return canonical(existingBody) !== canonical(requestedBody);
+}
+
 /** Order-independent canonical form of a runtime_context scalar map. */
 function canonicalRuntimeContext(value: unknown): string {
   if (value === null || value === undefined) return '';

--- a/apps/api/src/router/routes/usage-query.ts
+++ b/apps/api/src/router/routes/usage-query.ts
@@ -6,7 +6,7 @@
  * aggregation query.
  */
 
-export type UsageGroupBy = 'model' | 'provider' | 'day' | 'origin_ref';
+export type UsageGroupBy = 'model' | 'provider' | 'day' | 'origin_ref' | 'end_user_ref';
 
 export const USAGE_GROUP_BY_VALUES: readonly UsageGroupBy[] = [
   'model',
@@ -16,6 +16,7 @@ export const USAGE_GROUP_BY_VALUES: readonly UsageGroupBy[] = [
   // origin_ref (all non-backend spend) are excluded from this rollup rather
   // than lumped into a null bucket — see the route's grouping branch.
   'origin_ref',
+  'end_user_ref',
 ];
 
 /** Max length of an origin_ref, mirroring the session-create bound. */
@@ -36,6 +37,8 @@ export function parseUsageQuery(query: {
   start?: string;
   end?: string;
   group_by?: string;
+  end_user_ref?: string;
+  /** @deprecated Renamed to `end_user_ref`; still accepted. */
   origin_ref?: string;
 }): UsageQueryParams {
   const result: UsageQueryParams = {};
@@ -69,13 +72,27 @@ export function parseUsageQuery(query: {
     result.groupBy = query.group_by as UsageGroupBy;
   }
 
-  if (query.origin_ref !== undefined && query.origin_ref !== '') {
-    const originRef = query.origin_ref.trim();
+  // `end_user_ref` is the name; `origin_ref` is the deprecated alias. Both are
+  // accepted; disagreeing values are rejected rather than one silently winning.
+  if (
+    query.end_user_ref !== undefined &&
+    query.origin_ref !== undefined &&
+    query.end_user_ref.trim() !== query.origin_ref.trim()
+  ) {
+    throw new InvalidUsageQueryError(
+      'end_user_ref and its deprecated alias origin_ref disagree — send only end_user_ref',
+    );
+  }
+  const suppliedRef = query.end_user_ref ?? query.origin_ref;
+  if (suppliedRef !== undefined && suppliedRef !== '') {
+    const originRef = suppliedRef.trim();
     if (originRef === '') {
-      throw new InvalidUsageQueryError('origin_ref must not be blank');
+      throw new InvalidUsageQueryError('end_user_ref must not be blank');
     }
     if (originRef.length > ORIGIN_REF_MAX) {
-      throw new InvalidUsageQueryError(`origin_ref must be at most ${ORIGIN_REF_MAX} characters`);
+      throw new InvalidUsageQueryError(
+        `end_user_ref must be at most ${ORIGIN_REF_MAX} characters`,
+      );
     }
     result.originRef = originRef;
   }
@@ -131,7 +148,8 @@ export function mapUsageBreakdownRow(row: UsageBreakdownRow) {
     count: Number(row.count ?? 0),
   };
   if (row.originRef !== undefined) {
-    return { origin_ref: row.originRef, ...totals };
+    // Both keys carry the same value so old readers keep working.
+    return { end_user_ref: row.originRef, origin_ref: row.originRef, ...totals };
   }
   if (row.day !== undefined) {
     return { day: row.day, ...totals };

--- a/apps/api/src/router/routes/usage.test.ts
+++ b/apps/api/src/router/routes/usage.test.ts
@@ -249,8 +249,7 @@ describe('usage — origin_ref (per-end-user metering)', () => {
         cost: 0.25,
         count: 2,
       }),
-    ).toEqual({
-      origin_ref: 'user-123',
+    ).toEqual({ end_user_ref: 'user-123', origin_ref: 'user-123',
       input_tokens: 10,
       output_tokens: 5,
       cached_tokens: 0,

--- a/apps/api/src/router/routes/usage.ts
+++ b/apps/api/src/router/routes/usage.ts
@@ -40,7 +40,9 @@ const UsageBreakdownItemSchema = z
     day: z.string().optional(),
     provider: z.string().nullable().optional(),
     model: z.string().optional(),
-    /** Present only for group_by=origin_ref (Kortix-as-a-Backend). */
+    /** Present only for group_by=end_user_ref (Kortix-as-a-Backend). */
+    end_user_ref: z.string().optional(),
+    /** @deprecated Renamed to `end_user_ref`; echoed with the same value. */
     origin_ref: z.string().optional(),
     input_tokens: z.number(),
     output_tokens: z.number(),
@@ -62,9 +64,11 @@ const UsageQuerySchema = z
   .object({
     start: z.string().optional(),
     end: z.string().optional(),
-    group_by: z.enum(['model', 'provider', 'day', 'origin_ref']).optional(),
+    group_by: z.enum(['model', 'provider', 'day', 'origin_ref', 'end_user_ref']).optional(),
     account_id: z.string().optional(),
     /** Kortix-as-a-Backend: narrow to a single end-user of the wrapper. */
+    end_user_ref: z.string().optional(),
+    /** @deprecated Renamed to `end_user_ref`; still accepted. */
     origin_ref: z.string().optional(),
   })
   .openapi('UsageQuery');
@@ -93,6 +97,7 @@ usageApp.openapi(
         end: c.req.query('end'),
         group_by: c.req.query('group_by'),
         origin_ref: c.req.query('origin_ref'),
+        end_user_ref: c.req.query('end_user_ref'),
       });
     } catch (err) {
       if (err instanceof InvalidUsageQueryError) {
@@ -129,7 +134,7 @@ usageApp.openapi(
       return c.json({ data });
     }
 
-    if (parsed.groupBy === 'origin_ref') {
+    if (parsed.groupBy === 'origin_ref' || parsed.groupBy === 'end_user_ref') {
       // Only attributed rows participate. Unattributed spend (everything that
       // isn't a backend session — the playground, the legacy router path, and
       // anything written before this column existed) has a NULL origin_ref and

--- a/apps/cli/src/__tests__/prompts-confirm.test.ts
+++ b/apps/cli/src/__tests__/prompts-confirm.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `confirm()` against a real stdin stream.
+ *
+ * The case worth pinning is end-of-input: `rl.question`'s callback never fires
+ * when the stream ends, so the awaited promise used to stay pending forever and
+ * the process would exit AT the prompt — no answer, no error, no remaining
+ * work. Anything that asks before doing something irreversible (the bare
+ * `kortix` update prompt) has to be able to say what "nobody answered" means.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { PassThrough } from 'node:stream';
+
+import { confirm } from '../prompts.ts';
+
+const realStdin = Object.getOwnPropertyDescriptor(process, 'stdin');
+const realIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+/** Swap process.stdin for a stream we drive, with the TTY flags confirm()
+ *  requires. Returns the writable end. */
+function attachStdin(): PassThrough {
+  const stream = new PassThrough();
+  (stream as unknown as { isTTY: boolean }).isTTY = true;
+  Object.defineProperty(process, 'stdin', { value: stream, configurable: true });
+  Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+  return stream;
+}
+
+afterEach(() => {
+  if (realStdin) Object.defineProperty(process, 'stdin', realStdin);
+  if (realIsTTY) Object.defineProperty(process.stdout, 'isTTY', realIsTTY);
+});
+
+describe('confirm', () => {
+  test('reads an explicit answer', async () => {
+    const stdin = attachStdin();
+    const answer = confirm('go?', false);
+    stdin.write('y\n');
+    expect(await answer).toBe(true);
+  });
+
+  test('blank input takes the default', async () => {
+    const stdin = attachStdin();
+    const answer = confirm('go?', true);
+    stdin.write('\n');
+    expect(await answer).toBe(true);
+  });
+
+  test('re-asks on junk without piling up close listeners', async () => {
+    const stdin = attachStdin();
+    const answer = confirm('go?', false);
+    // One line per turn of the loop — readline only consumes input while a
+    // question is outstanding, so a single batched write would be swallowed.
+    for (let i = 0; i < 12; i++) {
+      stdin.write('maybe\n');
+      await new Promise((r) => setImmediate(r));
+    }
+    // A per-question 'close' listener would have blown past Node's warning
+    // threshold long before the twelfth retry.
+    expect(stdin.listenerCount('close')).toBeLessThan(5);
+
+    stdin.write('n\n');
+    expect(await answer).toBe(false);
+  });
+
+  test('end of input resolves instead of hanging — default when unspecified', async () => {
+    const stdin = attachStdin();
+    const answer = confirm('go?', true);
+    stdin.end();
+    expect(await answer).toBe(true);
+  });
+
+  test('end of input honours onEndOfInput, so silence never means "yes, do it"', async () => {
+    const stdin = attachStdin();
+    const answer = confirm('go?', true, { onEndOfInput: false });
+    stdin.end();
+    // Default is yes (Enter accepts), but a stream that simply ended is nobody
+    // answering — the update prompt relies on this to not self-install.
+    expect(await answer).toBe(false);
+  });
+});

--- a/apps/cli/src/__tests__/ship.test.ts
+++ b/apps/cli/src/__tests__/ship.test.ts
@@ -9,6 +9,7 @@ import {
   resolveExistingShipGitTarget,
   resolveProvisionShipGitTarget,
 } from '../commands/ship.ts';
+import { resolveProjectCloneTarget } from '../commands/projects.ts';
 
 test('managed git auth headers honor the provider-selected username', () => {
   const args = authHeaderArgs('https://kortix.code.storage/demo.git', 'jwt-token', 't');
@@ -98,7 +99,12 @@ describe('GitHub-backed project linking', () => {
 });
 
 describe('ship git target resolution', () => {
-  test('first-time managed ship pushes to the managed upstream with the provision token', () => {
+  // A host whose managed git runs on an org-wide PAT cannot export a push token
+  // at all (POST /git-token 503s — the token would grant write to every managed
+  // repo). Ship must therefore prefer the proxy origin for MANAGED projects
+  // too, exactly like clone does; insisting on a minted provider token is what
+  // broke `kortix ship` against Kortix Cloud.
+  test('first-time managed ship pushes through the proxy origin, not the raw upstream', () => {
     const target = resolveProvisionShipGitTarget({
       ...project({
         git_origin_url: 'https://api.kortix.com/v1/git/proj_1.git',
@@ -109,18 +115,41 @@ describe('ship git target resolution', () => {
     });
 
     expect(target).toEqual({
-      repoUrl: 'https://github.com/managed-kortix/demo.git',
-      credentialMode: 'managed-git-token',
+      repoUrl: 'https://api.kortix.com/v1/git/proj_1.git',
+      credentialMode: 'kortix-token',
     });
   });
 
-  test('existing managed ship ignores proxy origin and mints a managed git token', () => {
+  test('existing managed ship pushes through the proxy origin', () => {
     const target = resolveExistingShipGitTarget(
       project({
         git_origin_url: 'https://api.kortix.com/v1/git/proj_1.git',
         metadata: { git: { managed: true } },
       }),
     );
+
+    expect(target).toEqual({
+      repoUrl: 'https://api.kortix.com/v1/git/proj_1.git',
+      credentialMode: 'kortix-token',
+    });
+  });
+
+  test('managed ship falls back to a minted token when the host has no proxy', () => {
+    // Proxy off ⇒ the server mirrors repo_url into git_origin_url.
+    const raw = 'https://github.com/managed-kortix/demo.git';
+    const target = resolveExistingShipGitTarget(
+      project({ git_origin_url: raw, metadata: { git: { managed: true } } }),
+    );
+
+    expect(target).toEqual({ repoUrl: raw, credentialMode: 'managed-git-token' });
+  });
+
+  test('first-time managed ship on a proxy-less host mints a provider token', () => {
+    const target = resolveProvisionShipGitTarget({
+      ...project({ metadata: { git: { managed: true } } }),
+      push_token: 'ghp_push',
+      repo_id: 'repo_1',
+    });
 
     expect(target).toEqual({
       repoUrl: 'https://github.com/managed-kortix/demo.git',
@@ -155,6 +184,27 @@ describe('ship git target resolution', () => {
       repoUrl: 'https://github.com/acme/byo.git',
       credentialMode: 'none',
     });
+  });
+
+  // The regression this whole module exists to prevent: ship and clone drifted
+  // apart and ship picked a credential the server can't issue. They resolve
+  // from the same function now — assert they agree on every project shape.
+  test('ship and clone resolve the same repo URL for every project shape', () => {
+    const proxy = 'https://api.kortix.com/v1/git/proj_1.git';
+    const shapes: ProjectSummary[] = [
+      project({ git_origin_url: proxy, metadata: { git: { managed: true } } }),
+      project({ git_origin_url: proxy, metadata: { git: { managed: false } } }),
+      project({ metadata: { git: { managed: true } } }),
+      project({ repo_url: 'https://github.com/acme/byo.git', metadata: {} }),
+    ];
+
+    for (const shape of shapes) {
+      const ship = resolveExistingShipGitTarget(shape);
+      const clone = resolveProjectCloneTarget(shape, 'kortix_pat_abc');
+      expect(clone.repoUrl).toBe(ship.repoUrl);
+      expect(clone.needsManagedToken).toBe(ship.credentialMode === 'managed-git-token');
+      expect(clone.token).toBe(ship.credentialMode === 'kortix-token' ? 'kortix_pat_abc' : null);
+    }
   });
 });
 

--- a/apps/cli/src/__tests__/update-check.test.ts
+++ b/apps/cli/src/__tests__/update-check.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Update notifier + the per-release snooze that backs the interactive
+ * "update now?" prompt on bare `kortix`.
+ *
+ * The rules that matter: never interrupt a non-terminal (scripts, CI, pipes),
+ * never ask twice about a release the user already declined, and never let a
+ * snooze survive into a NEWER release — that would silently strand someone on
+ * an old CLI, which is the failure mode this prompt exists to prevent.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  getUpdateNotice,
+  isUpdateSnoozed,
+  renderUpdateBox,
+  resolveUpdateStatus,
+  snoozeUpdate,
+} from '../update-check.ts';
+
+let dir = '';
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+let served: string | null = 'v9.9.9';
+
+/** The cache lives next to the config file, so pointing KORTIX_CONFIG_FILE at a
+ *  temp dir isolates both from the developer's real ~/.config/kortix. */
+function cacheFile(): string {
+  return join(dir, 'update-check.json');
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kortix-update-'));
+  process.env.KORTIX_CONFIG_FILE = join(dir, 'config.json');
+  delete process.env.KORTIX_NO_UPDATE_CHECK;
+  delete process.env.KORTIX_SKIP_UPDATE_CHECK;
+  delete process.env.CI;
+  // isDisabled() bails on a non-TTY stdout, which is exactly what `bun test`
+  // gives us — force it on so the resolution logic is reachable.
+  Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+  served = 'v9.9.9';
+  globalThis.fetch = (async () =>
+    served === null
+      ? new Response('nope', { status: 404 })
+      : new Response(JSON.stringify({ tag_name: served }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.env = { ...originalEnv };
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('resolveUpdateStatus', () => {
+  test('reports a newer release with both the tag and its display form', async () => {
+    const status = await resolveUpdateStatus('0.10.15', { allowFetch: true });
+    expect(status).toEqual({ current: '0.10.15', latestTag: 'v9.9.9', latestDisplay: 'v9.9.9' });
+  });
+
+  test('is null when already current, and when ahead of the release', async () => {
+    served = 'v1.0.0';
+    expect(await resolveUpdateStatus('1.0.0', { allowFetch: true })).toBeNull();
+    expect(await resolveUpdateStatus('1.0.1', { allowFetch: true })).toBeNull();
+  });
+
+  test('is null for a dev build — there is nothing to compare against', async () => {
+    expect(await resolveUpdateStatus('dev', { allowFetch: true })).toBeNull();
+    expect(await resolveUpdateStatus('0.10.15-dev.abc', { allowFetch: true })).toBeNull();
+  });
+
+  test('is null in CI and when explicitly disabled — scripts are never nagged', async () => {
+    process.env.CI = '1';
+    expect(await resolveUpdateStatus('0.1.0', { allowFetch: true })).toBeNull();
+    delete process.env.CI;
+    process.env.KORTIX_NO_UPDATE_CHECK = '1';
+    expect(await resolveUpdateStatus('0.1.0', { allowFetch: true })).toBeNull();
+  });
+
+  test('never throws when the release lookup fails — it just goes quiet', async () => {
+    served = null;
+    expect(await resolveUpdateStatus('0.1.0', { allowFetch: true })).toBeNull();
+
+    globalThis.fetch = (async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+    expect(await resolveUpdateStatus('0.1.0', { allowFetch: true })).toBeNull();
+  });
+
+  test('allowFetch:false renders from cache only, never the network', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ tag_name: 'v9.9.9' }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    expect(await resolveUpdateStatus('0.1.0', { allowFetch: false })).toBeNull();
+    expect(calls).toBe(0);
+
+    await resolveUpdateStatus('0.1.0', { allowFetch: true }); // warms the cache
+    calls = 0;
+    const cached = await resolveUpdateStatus('0.1.0', { allowFetch: false });
+    expect(cached?.latestTag).toBe('v9.9.9');
+    expect(calls).toBe(0);
+  });
+});
+
+describe('update snooze', () => {
+  test('a declined release stops being asked about; a newer one still asks', async () => {
+    expect(isUpdateSnoozed('v9.9.9')).toBe(false);
+
+    snoozeUpdate('v9.9.9');
+
+    expect(isUpdateSnoozed('v9.9.9')).toBe(true);
+    // The whole point: a snooze must not carry into the NEXT release.
+    expect(isUpdateSnoozed('v10.0.0')).toBe(false);
+  });
+
+  test('survives a cache refresh — declining must not re-ask every TTL window', async () => {
+    await resolveUpdateStatus('0.1.0', { allowFetch: true }); // writes the cache
+    snoozeUpdate('v9.9.9');
+
+    // Expire the cache so the next resolve re-fetches and rewrites it.
+    const entry = JSON.parse(readFileSync(cacheFile(), 'utf8'));
+    writeFileSync(cacheFile(), JSON.stringify({ ...entry, checkedAt: 0 }));
+
+    await resolveUpdateStatus('0.1.0', { allowFetch: true });
+
+    expect(isUpdateSnoozed('v9.9.9')).toBe(true);
+  });
+
+  test('a corrupt cache is not fatal — nothing is snoozed', () => {
+    writeFileSync(cacheFile(), 'not json');
+    expect(isUpdateSnoozed('v9.9.9')).toBe(false);
+    snoozeUpdate('v9.9.9');
+    expect(isUpdateSnoozed('v9.9.9')).toBe(true);
+  });
+});
+
+describe('rendering', () => {
+  test('the interactive box drops the "run kortix update" advice it is replacing', async () => {
+    const status = await resolveUpdateStatus('0.10.15', { allowFetch: true });
+    if (!status) throw new Error('expected an available update');
+
+    const passive = renderUpdateBox(status, false);
+    const interactive = renderUpdateBox(status, true);
+
+    expect(passive).toContain('kortix update');
+    expect(interactive).not.toContain('kortix update');
+    // Both still say what you're on and what you'd get.
+    for (const box of [passive, interactive]) {
+      expect(box).toContain('0.10.15');
+      expect(box).toContain('v9.9.9');
+    }
+  });
+
+  test('the subcommand nudge stays a single line and still points at the command', async () => {
+    const line = await getUpdateNotice('0.10.15', { allowFetch: true, style: 'line' });
+    expect(line).toContain('kortix update');
+    expect(line?.includes('\n')).toBe(false);
+  });
+});

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -23,9 +23,17 @@ import { emitJson, locateProjectAnywhere, takeFlagBool, takeFlagValue } from '..
 import { C, help, pad, status } from '../style.ts';
 import { projectWebUrl } from '../web-url.ts';
 import { appendGitExcludeEntries } from '../git-exclude.ts';
+import { configureProjectGitAuth, resolveProjectGitTarget } from '../project-git.ts';
 import type { Auth } from '../api/auth.ts';
 import type { AccountMembership, MeResponse, ProjectSummary } from '../api/types.ts';
 import { authHeaderArgs } from './ship.ts';
+
+/** Back-compat alias — the helper moved to ../project-git.ts so `ship` can use
+ *  it without an import cycle through this command module. */
+export {
+  configureProjectGitAuth as configureClonedProjectAuth,
+  currentGitCredentialHelperCommand,
+} from '../project-git.ts';
 
 const HELP = help`Usage: kortix projects <subcommand>
 
@@ -139,61 +147,6 @@ export interface ProjectCloneTarget {
   needsManagedToken: boolean;
 }
 
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'\\''`)}'`;
-}
-
-/**
- * The installed binary can call itself by name. During source development,
- * preserve the exact Bun entrypoint so a clone made with `bun run ...` can be
- * exercised before the CLI is rebuilt and installed.
- */
-export function currentGitCredentialHelperCommand(): string {
-  const override = process.env.KORTIX_GIT_CREDENTIAL_HELPER?.trim();
-  if (override) return override.startsWith('!') ? override : `!${override}`;
-
-  const entrypoint = process.argv[1];
-  if (entrypoint && /\.[cm]?[jt]sx?$/.test(entrypoint) && /bun/i.test(process.execPath)) {
-    return `!${shellQuote(process.execPath)} ${shellQuote(entrypoint)} git-credential`;
-  }
-  return '!kortix git-credential';
-}
-
-/**
- * Install a URL-scoped helper for the Kortix proxy. The leading empty helper
- * resets inherited helpers for this credential context, preventing the user's
- * keychain from persisting the Kortix token returned on demand.
- */
-export function configureClonedProjectAuth(
-  repoRoot: string,
-  repoUrl: string,
-  helperCommand = currentGitCredentialHelperCommand(),
-): void {
-  const context = repoUrl.replace(/\/+$/, '');
-  const helperKey = `credential.${context}.helper`;
-  const reset = spawnSync('git', ['config', '--local', '--replace-all', helperKey, ''], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
-  if (reset.status !== 0) {
-    throw new Error(reset.stderr.trim() || 'Could not reset Git credential helpers');
-  }
-  const add = spawnSync('git', ['config', '--local', '--add', helperKey, helperCommand], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
-  if (add.status !== 0) {
-    throw new Error(add.stderr.trim() || 'Could not configure the Kortix Git credential helper');
-  }
-  const pathMode = spawnSync('git', ['config', '--local', 'credential.useHttpPath', 'true'], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-  });
-  if (pathMode.status !== 0) {
-    throw new Error(pathMode.stderr.trim() || 'Could not configure Git credential paths');
-  }
-}
-
 export function saveClonedProjectLink(
   repoRoot: string,
   project: ProjectSummary,
@@ -218,27 +171,19 @@ export function saveClonedProjectLink(
   );
 }
 
-/** Resolve clone auth without ever placing a credential in the remote URL. */
+/** Resolve clone auth without ever placing a credential in the remote URL.
+ *  Thin adapter over the shared resolver in ../project-git.ts — the same
+ *  decision `kortix ship` and the git credential helper make. */
 export function resolveProjectCloneTarget(
   project: ProjectSummary,
   kortixToken: string,
 ): ProjectCloneTarget {
-  const proxyUrl = project.git_origin_url;
-  if (proxyUrl && /\/v1\/git\/[^/]+(?:\.git)?$/i.test(proxyUrl)) {
-    return {
-      repoUrl: proxyUrl,
-      token: kortixToken,
-      username: "x-access-token",
-      needsManagedToken: false,
-    };
-  }
-
-  const git = (project.metadata?.git ?? null) as { managed?: boolean } | null;
+  const target = resolveProjectGitTarget(project);
   return {
-    repoUrl: project.repo_url,
-    token: null,
+    repoUrl: target.repoUrl,
+    token: target.credentialMode === "kortix-token" ? kortixToken : null,
     username: "x-access-token",
-    needsManagedToken: git?.managed === true,
+    needsManagedToken: target.credentialMode === "managed-git-token",
   };
 }
 
@@ -313,7 +258,7 @@ async function projectsClone(
       hostArg ?? located.located.hostName ?? activeHostName() ?? undefined,
       auth.api_base,
     );
-    if (target.token) configureClonedProjectAuth(repoRoot, target.repoUrl);
+    if (target.token) configureProjectGitAuth(repoRoot, target.repoUrl);
   }
 
   process.stdout.write(`${status.ok(`Cloned ${project.name}`)}\n`);

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -9,6 +9,12 @@ import { takeFlagValue, takeFlagBool } from '../command-helpers.ts';
 import { selectFromList } from '../tui-select.ts';
 import { confirm, prompt, promptSecret } from '../prompts.ts';
 import { loadLocalManifest, lintManifest, type EnvSpec, type LocalManifest } from '../manifest.ts';
+import {
+  configureProjectGitAuth,
+  projectIsManaged,
+  resolveProjectGitTarget,
+  type ProjectGitTarget,
+} from '../project-git.ts';
 import { C, help, status } from '../style.ts';
 import { projectWebUrl } from '../web-url.ts';
 import type {
@@ -107,47 +113,15 @@ interface GitTokenResponse {
   repo_url: string;
 }
 
-type ShipCredentialMode = 'none' | 'kortix-token' | 'managed-git-token';
-
-interface ShipGitTarget {
-  repoUrl: string;
-  credentialMode: ShipCredentialMode;
+/** Both ship paths use the shared resolver (see ../project-git.ts) so ship,
+ *  clone, and the git credential helper can never disagree about how to reach
+ *  a project's repo again. */
+export function resolveProvisionShipGitTarget(project: ProvisionResponse): ProjectGitTarget {
+  return resolveProjectGitTarget(project);
 }
 
-function isGitProxyUrl(url: string | undefined | null): boolean {
-  return Boolean(url && /\/v1\/git\//.test(url));
-}
-
-function projectIsManaged(project: ProjectSummary): boolean {
-  const meta = (project.metadata ?? {}) as Record<string, any>;
-  const git = meta.git as { managed?: boolean } | undefined;
-  return git?.managed === true;
-}
-
-export function resolveProvisionShipGitTarget(project: ProvisionResponse): ShipGitTarget {
-  return {
-    repoUrl: project.repo_url,
-    credentialMode: 'managed-git-token',
-  };
-}
-
-export function resolveExistingShipGitTarget(project: ProjectSummary): ShipGitTarget {
-  if (projectIsManaged(project)) {
-    return {
-      repoUrl: project.repo_url,
-      credentialMode: 'managed-git-token',
-    };
-  }
-  if (isGitProxyUrl(project.git_origin_url)) {
-    return {
-      repoUrl: project.git_origin_url!,
-      credentialMode: 'kortix-token',
-    };
-  }
-  return {
-    repoUrl: project.repo_url,
-    credentialMode: 'none',
-  };
+export function resolveExistingShipGitTarget(project: ProjectSummary): ProjectGitTarget {
+  return resolveProjectGitTarget(project);
 }
 
 export async function runShip(argv: string[]): Promise<number> {
@@ -601,7 +575,7 @@ async function shipFirstTime(
   const byoUrl = explicitUrl ?? existingOrigin;
 
   let project: ProjectSummary;
-  let repoUrl: string;
+  let gitTarget: ProjectGitTarget;
   let pushToken: string | null = null;
   let pushUsername = 'x-access-token';
 
@@ -623,7 +597,9 @@ async function shipFirstTime(
     project = github
       ? await linkGitHubBackedProject(client, { repoUrl: byoUrl, name, accountId, githubToken: flags.githubToken, yes: flags.yes })
       : await client.post<ProjectSummary>('/projects', { repo_url: byoUrl, name, account_id: accountId });
-    repoUrl = project.repo_url;
+    bindShippedFolder(project, hostName, auth);
+    // BYO stays BYO: push with the user's own git credentials, to their remote.
+    gitTarget = { repoUrl: project.repo_url, credentialMode: 'none' };
     // Only touch the remote when the user named one explicitly — an existing
     // `origin` is left exactly as-is so their credential setup keeps working.
     if (explicitUrl) setOrigin(explicitUrl);
@@ -643,44 +619,49 @@ async function shipFirstTime(
       account_id: accountId,
     });
     project = prov;
-    const target = resolveProvisionShipGitTarget(prov);
-    repoUrl = target.repoUrl;
-    pushToken = prov.push_token;
-    pushUsername = prov.git_username ?? pushUsername;
-    // Older/self-hosted provision responses may omit an exportable token even
-    // though the managed project can mint a repo-scoped App token afterward.
-    // Heal that boundary before attempting git push; never fall back to a
-    // server-global PAT.
-    if (!pushToken) {
-      const tok = await client.post<GitTokenResponse>(
-        `/projects/${project.project_id}/git-token`,
-      );
-      pushToken = tok.push_token;
-      pushUsername = tok.git_username ?? pushUsername;
+    // Bind the folder to the project the INSTANT it exists — before resolving a
+    // push credential, committing, or pushing, any of which can fail. Without
+    // this, a failure after provision left an unlinked cloud project behind and
+    // the retry provisioned a SECOND one, silently burning the account's
+    // project quota until creation started 403ing on the limit.
+    bindShippedFolder(project, hostName, auth);
+    gitTarget = resolveProvisionShipGitTarget(prov);
+    if (gitTarget.credentialMode === 'kortix-token') {
+      // Proxy origin — we push with our own Kortix token; the API resolves the
+      // upstream + host credential server-side. No provider token is exported.
+      pushToken = auth.token;
+    } else {
+      pushToken = prov.push_token;
+      pushUsername = prov.git_username ?? pushUsername;
+      // Proxy-less host: fall back to a repo-scoped provider token. Older
+      // provision responses may omit it even though /git-token can mint one.
+      // Never fall back to a server-global PAT (the server refuses to export it).
+      if (!pushToken) {
+        const tok = await client.post<GitTokenResponse>(
+          `/projects/${project.project_id}/git-token`,
+        );
+        pushToken = tok.push_token;
+        pushUsername = tok.git_username ?? pushUsername;
+      }
     }
-    setOrigin(repoUrl);
+    setOrigin(gitTarget.repoUrl);
+    if (gitTarget.credentialMode === 'kortix-token') {
+      configureProjectGitAuth(process.cwd(), gitTarget.repoUrl);
+    }
   }
-
-  saveLink({
-    project_id: project.project_id,
-    account_id: project.account_id,
-    host: hostName ?? activeHostName() ?? 'default',
-    host_url: auth.api_base,
-    linked_at: new Date().toISOString(),
-  });
 
   const committed = commitIfNeeded(flags);
   if (committed === 'error') return 1;
 
   await ensureProjectEnv(client, project.project_id, env, flags);
 
-  const pushed = pushCurrentBranch(repoUrl, pushToken, pushUsername);
+  const pushed = await pushProjectBranch(client, project, gitTarget, pushToken, pushUsername);
   if (!pushed) return 1;
 
   await reconcileShippedManifest(client, project.project_id);
   await ensureConnectorsConnected(client, project.project_id, flags);
 
-  reportShipped(auth, project, repoUrl);
+  reportShipped(auth, project, gitTarget.repoUrl);
   return 0;
 }
 
@@ -701,7 +682,8 @@ async function shipExisting(
     throw err;
   }
   const target = resolveExistingShipGitTarget(project);
-  const managed = target.credentialMode === 'managed-git-token';
+  const mintsProviderToken = target.credentialMode === 'managed-git-token';
+  const kortixOwnsOrigin = target.credentialMode !== 'none';
   const repoUrl = target.repoUrl;
 
   process.stdout.write(
@@ -712,35 +694,40 @@ async function shipExisting(
 
   if (flags.dryRun) {
     process.stdout.write(
-      `  ${C.dim}[dry-run] would: ${managed ? 'mint push token, ' : ''}commit + push to ${repoUrl}${C.reset}\n\n`,
+      `  ${C.dim}[dry-run] would: ${mintsProviderToken ? 'mint push token, ' : ''}commit + push to ${repoUrl}${C.reset}\n\n`,
     );
     return 0;
   }
 
-  // Push credential: managed repos use a fresh provider token and push to the
-  // managed upstream URL. Non-managed proxy pushes use the Kortix CLI token.
+  // Push credential: through the proxy we authenticate with our own Kortix
+  // token; a proxy-less host mints a fresh repo-scoped provider token per ship
+  // (never persisted in .git/config).
   let pushToken: string | null = null;
   let pushUsername = 'x-access-token';
   if (target.credentialMode === 'kortix-token') {
     pushToken = auth.token;
-  } else if (target.credentialMode === 'managed-git-token') {
+  } else if (mintsProviderToken) {
     const tok = await client.post<GitTokenResponse>(`/projects/${projectId}/git-token`);
     pushToken = tok.push_token;
     pushUsername = tok.git_username ?? pushUsername;
   }
-  // Managed projects own the remote URL, so keep origin aligned with the
-  // upstream that matches the freshly minted provider token. BYO repos may
-  // have lost their remote (fresh clone of a linked repo); heal only when
-  // missing so user-managed credentials stay untouched.
-  if (managed) setOrigin(repoUrl);
+  // Kortix owns the remote URL for proxy + managed projects, so keep origin
+  // aligned with the target the credential above matches. BYO repos may have
+  // lost their remote (fresh clone of a linked repo); heal only when missing so
+  // user-managed credentials stay untouched.
+  if (kortixOwnsOrigin) setOrigin(repoUrl);
   else ensureOrigin(repoUrl);
+  // Leave the repo able to `git push` on its own afterwards, same as a
+  // `kortix projects clone` — the helper hands git a Kortix token on demand
+  // without ever writing one into .git/config.
+  if (target.credentialMode === 'kortix-token') configureProjectGitAuth(process.cwd(), repoUrl);
 
   const committed = commitIfNeeded(flags);
   if (committed === 'error') return 1;
 
   await ensureProjectEnv(client, projectId, env, flags);
 
-  const pushed = pushCurrentBranch(repoUrl, pushToken, pushUsername);
+  const pushed = await pushProjectBranch(client, project, target, pushToken, pushUsername);
   if (!pushed) return 1;
 
   await reconcileShippedManifest(client, projectId);
@@ -748,6 +735,23 @@ async function shipExisting(
 
   reportShipped(auth, project, repoUrl);
   return 0;
+}
+
+/** Write `.kortix/link.json` so this folder is bound to the cloud project.
+ *  Called the moment the project exists — see the note at its first-ship call
+ *  site for why ordering matters. */
+function bindShippedFolder(
+  project: ProjectSummary,
+  hostName: string | undefined,
+  auth: Auth,
+): void {
+  saveLink({
+    project_id: project.project_id,
+    account_id: project.account_id,
+    host: hostName ?? activeHostName() ?? 'default',
+    host_url: auth.api_base,
+    linked_at: new Date().toISOString(),
+  });
 }
 
 // ── git helpers ─────────────────────────────────────────────────────────────
@@ -847,6 +851,7 @@ function pushCurrentBranch(
   repoUrl: string,
   pushToken: string | null,
   gitUsername = 'x-access-token',
+  opts: { quietOnFailure?: boolean } = {},
 ): string | null {
   const branch = run('git', ['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
   if (!branch || branch === 'HEAD') {
@@ -861,13 +866,57 @@ function pushCurrentBranch(
 
   const push = run('git', args, { inheritStdio: true });
   if (!push.ok) {
-    process.stderr.write(`\n${status.err(`git push failed (exit ${push.code}).`)}\n`);
+    if (!opts.quietOnFailure) {
+      process.stderr.write(`\n${status.err(`git push failed (exit ${push.code}).`)}\n`);
+    }
     return null;
   }
   process.stdout.write(
     `\n${status.ok(`Pushed ${C.bold}${branch}${C.reset} → ${C.bold}origin/${branch}${C.reset}`)}\n`,
   );
   return branch;
+}
+
+/**
+ * Push the current branch, with ONE fallback transport.
+ *
+ * The proxy origin is the right default — it works whatever a host's managed
+ * git is configured with, and no provider credential ever reaches the client.
+ * But the CLI talks to hosts it wasn't shipped with: an older API authorizes
+ * the proxy on ACCOUNT OWNERSHIP alone, so a token bound to a different account
+ * of the same user is refused there while POST /git-token (which gates on the
+ * per-project `gitops.push` capability) would still serve it. So when a proxy
+ * push fails on a managed repo, retry once against the raw upstream with a
+ * minted repo-scoped token before giving up: either transport being unavailable
+ * is survivable, only both failing is a real error. Returns the branch, or null.
+ */
+async function pushProjectBranch(
+  client: ApiClient,
+  project: ProjectSummary,
+  target: ProjectGitTarget,
+  pushToken: string | null,
+  pushUsername: string,
+): Promise<string | null> {
+  const canRetry = target.credentialMode === 'kortix-token' && projectIsManaged(project);
+  const pushed = pushCurrentBranch(target.repoUrl, pushToken, pushUsername, {
+    quietOnFailure: canRetry,
+  });
+  if (pushed || !canRetry) return pushed;
+
+  let minted: GitTokenResponse;
+  try {
+    minted = await client.post<GitTokenResponse>(`/projects/${project.project_id}/git-token`);
+  } catch {
+    // No second transport available — report the push failure we swallowed.
+    process.stderr.write(`\n${status.err('git push failed.')}\n`);
+    return null;
+  }
+  process.stdout.write(
+    `  ${status.warn('Proxy push rejected — retrying against the managed upstream.')}\n`,
+  );
+  const upstreamUrl = minted.repo_url || project.repo_url;
+  setOrigin(upstreamUrl);
+  return pushCurrentBranch(upstreamUrl, minted.push_token, minted.git_username || pushUsername);
 }
 
 /** `-c http.<scheme>://<host>/.extraheader=AUTHORIZATION: basic <b64>` —
@@ -1027,9 +1076,14 @@ function surface(err: unknown): number {
     if (err.status === 401) {
       process.stderr.write(`${status.err('Token rejected. Run `kortix login`.')}\n`);
     } else if (err.status === 503) {
+      // Don't diagnose — the server owns the reason. The one thing we DO know
+      // is that a stale CLI is a common cause (older builds pushed to the raw
+      // upstream with a minted provider token instead of the Kortix git proxy,
+      // which a token-configured host can't hand out), so say that and stop.
       process.stderr.write(
         `${status.err(err.message)}\n` +
-          `  ${C.dim}Managed git isn't configured on this host. Pass ${C.reset}${C.cyan}--origin <git-url>${C.reset}${C.dim} to use your own remote.${C.reset}\n`,
+          `  ${C.dim}Update first — ${C.reset}${C.cyan}kortix update${C.reset}${C.dim} — then retry. Still failing? ` +
+          `Pass ${C.reset}${C.cyan}--origin <git-url>${C.reset}${C.dim} to push to your own remote instead.${C.reset}\n`,
       );
     } else {
       process.stderr.write(`${status.err(`HTTP ${err.status}: ${err.message}`)}\n`);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -36,7 +36,14 @@ import { runValidate } from './commands/validate.ts';
 import { runWhoami } from './commands/whoami.ts';
 import { renderContext, renderHostNotice } from './host-notice.ts';
 import { C, header, pad, rule, visibleWidth } from './style.ts';
-import { getUpdateNotice } from './update-check.ts';
+import { confirm } from './prompts.ts';
+import {
+  getUpdateNotice,
+  isUpdateSnoozed,
+  renderUpdateBox,
+  resolveUpdateStatus,
+  snoozeUpdate,
+} from './update-check.ts';
 
 // CI bakes the real version via --define process.env.KORTIX_CLI_VERSION (the
 // unified X.Y.Z on release, X.Y.Z-dev.<sha> on dev). This fallback only applies
@@ -311,14 +318,70 @@ function printVersion(): void {
 // The landing screen: ASCII banner → host/account/project context → update
 // notice → the grouped command list. `kortix`, `kortix help`, and
 // `kortix --help` all render EXACTLY this, so there's no "which one shows the
-// banner/context" surprise.
-async function printLanding(): Promise<void> {
+// banner/context" surprise. The one difference is that BARE `kortix` may stop
+// at the update notice to ask (see offerInteractiveUpdate) — an explicit help
+// request stays a pure, non-blocking render.
+async function printLanding(opts: { offerUpdate: boolean }): Promise<void> {
   printBanner();
   // Always surface what host/account/project commands will act on.
   process.stdout.write(`${renderContext()}\n`);
-  const notice = await getUpdateNotice(VERSION, { allowFetch: true, style: 'box' });
-  if (notice) process.stdout.write(`${notice}\n`);
+  if (opts.offerUpdate) {
+    if (await offerInteractiveUpdate()) return; // binary replaced — this help is stale
+  } else {
+    const notice = await getUpdateNotice(VERSION, { allowFetch: true, style: 'box' });
+    if (notice) process.stdout.write(`${notice}\n`);
+  }
   process.stdout.write(renderHelp());
+}
+
+/** Can we actually ask a question here? `resolveUpdateStatus` already rules out
+ *  CI and a non-TTY stdout; a prompt additionally needs a readable stdin, and
+ *  an explicit opt-out for anyone who wants the notice without the question. */
+function canPromptForUpdate(): boolean {
+  if (process.env.KORTIX_NO_UPDATE_PROMPT) return false;
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}
+
+/**
+ * Bare `kortix` on a terminal: show the update box and offer to install it on
+ * the spot, so being out of date takes a deliberate "no" rather than the
+ * inertia of never getting around to `kortix update`.
+ *
+ * Returns true when the binary was replaced — the caller then skips the help
+ * screen, which came from the version that no longer exists on disk.
+ */
+async function offerInteractiveUpdate(): Promise<boolean> {
+  const status = await resolveUpdateStatus(VERSION, { allowFetch: true });
+  if (!status) return false;
+
+  const askable = canPromptForUpdate() && !isUpdateSnoozed(status.latestTag);
+  process.stdout.write(`${renderUpdateBox(status, askable)}\n`);
+  if (!askable) return false;
+
+  let accepted: boolean;
+  try {
+    // Defaults to yes on Enter — the point is to make staying behind the
+    // deliberate choice. But a stream that just ENDS is nobody answering, and
+    // that must never self-trigger a binary-replacing install.
+    accepted = await confirm(`  Update to ${status.latestDisplay} now?`, true, {
+      onEndOfInput: false,
+    });
+  } catch {
+    return false; // not really interactive after all — leave the box standing
+  }
+  if (!accepted) {
+    // Remember the "no" so we ask once per release, not once per invocation.
+    snoozeUpdate(status.latestTag);
+    process.stdout.write(
+      `  ${C.dim}Skipped. Run ${C.reset}${C.cyan}kortix update${C.reset}${C.dim} whenever you're ready.${C.reset}\n`,
+    );
+    return false;
+  }
+
+  process.stdout.write('\n');
+  if ((await runUpdate([])) !== 0) return false;
+  process.stdout.write(`  ${C.dim}Run ${C.reset}${C.cyan}kortix${C.reset}${C.dim} again to pick it up.${C.reset}\n\n`);
+  return true;
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -330,9 +393,11 @@ async function main(argv: string[]): Promise<number> {
     printVersion();
     return 0;
   }
-  // Bare `kortix` and explicit help are the same landing screen — no difference.
+  // Bare `kortix` and explicit help are the same landing screen. Only the bare
+  // form offers to update: `kortix --help` is what people (and scripts) reach
+  // for to READ something, and it must never block on a question.
   if (argv.length === 0 || argv[0] === 'help' || argv[0] === '--help' || argv[0] === '-h') {
-    await printLanding();
+    await printLanding({ offerUpdate: argv.length === 0 });
     return 0;
   }
   if (argv[0] === 'version') {

--- a/apps/cli/src/project-git.ts
+++ b/apps/cli/src/project-git.ts
@@ -1,0 +1,131 @@
+import { spawnSync } from 'node:child_process';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// How the CLI talks git to a project — ONE resolver, shared by every command
+// that clones, pushes, or answers a git credential prompt (`kortix ship`,
+// `kortix projects clone`, `kortix git-credential`).
+//
+// It used to be per-command, and they drifted: clone preferred the Kortix git
+// proxy while ship insisted on minting a raw provider push token for managed
+// repos. On a host whose managed git runs on an org-wide PAT the server refuses
+// to export that token (correctly — it's a server-global credential), so every
+// `kortix ship` to a managed project failed with "Managed git push token export
+// requires a repo-scoped installation token" even though the proxy sitting next
+// to it could push fine. Keeping the decision in one place is what stops that
+// class of bug coming back.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Which credential a git operation against this project should present. */
+export type ProjectGitCredentialMode =
+  /** Push/clone through the Kortix git proxy with our own Kortix token. */
+  | 'kortix-token'
+  /** No proxy on this host — mint a provider push token via /git-token. */
+  | 'managed-git-token'
+  /** BYO repo — the user's own git credentials (helper/keychain/ssh). */
+  | 'none';
+
+export interface ProjectGitTarget {
+  repoUrl: string;
+  credentialMode: ProjectGitCredentialMode;
+}
+
+/** Minimal shape the resolver needs — `ProjectSummary` and the provision
+ *  response both satisfy it. */
+export interface ProjectGitRef {
+  repo_url: string;
+  git_origin_url?: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+/** A Kortix git-proxy origin (`https://<host>/v1/git/<projectId>.git`). The
+ *  server only advertises one when KORTIX_GIT_PROXY is on; otherwise
+ *  `git_origin_url` mirrors the raw upstream and this is false. */
+export function isGitProxyUrl(url: string | undefined | null): boolean {
+  return Boolean(url && /\/v1\/git\//.test(url));
+}
+
+/** Canonical managed flag — `metadata.git.managed`. */
+export function projectIsManaged(project: ProjectGitRef): boolean {
+  const git = project.metadata?.git as { managed?: boolean } | undefined;
+  return git?.managed === true;
+}
+
+/**
+ * Resolve the URL + credential kind for any git operation on a project.
+ *
+ * The Kortix git proxy is the UNIVERSAL client-facing origin, so it wins for
+ * EVERY project that advertises one — managed repos included. We authenticate
+ * with our own Kortix token and the API resolves the real upstream and mints
+ * the host credential server-side, which means:
+ *   * no real provider credential ever reaches the client, and
+ *   * it works regardless of how the host's managed git is configured (org PAT
+ *     or GitHub App) — the PAT setup can't export a repo-scoped token at all.
+ *
+ * Only a host with the proxy disabled falls back to minting a provider token
+ * for managed repos; a BYO repo without a proxy uses the user's own git auth.
+ */
+export function resolveProjectGitTarget(project: ProjectGitRef): ProjectGitTarget {
+  const proxyUrl = project.git_origin_url;
+  if (isGitProxyUrl(proxyUrl)) {
+    return { repoUrl: proxyUrl as string, credentialMode: 'kortix-token' };
+  }
+  if (projectIsManaged(project)) {
+    return { repoUrl: project.repo_url, credentialMode: 'managed-git-token' };
+  }
+  return { repoUrl: project.repo_url, credentialMode: 'none' };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * The installed binary can call itself by name. During source development,
+ * preserve the exact Bun entrypoint so a clone made with `bun run ...` can be
+ * exercised before the CLI is rebuilt and installed.
+ */
+export function currentGitCredentialHelperCommand(): string {
+  const override = process.env.KORTIX_GIT_CREDENTIAL_HELPER?.trim();
+  if (override) return override.startsWith('!') ? override : `!${override}`;
+
+  const entrypoint = process.argv[1];
+  if (entrypoint && /\.[cm]?[jt]sx?$/.test(entrypoint) && /bun/i.test(process.execPath)) {
+    return `!${shellQuote(process.execPath)} ${shellQuote(entrypoint)} git-credential`;
+  }
+  return '!kortix git-credential';
+}
+
+/**
+ * Install a URL-scoped helper for the Kortix proxy. The leading empty helper
+ * resets inherited helpers for this credential context, preventing the user's
+ * keychain from persisting the Kortix token returned on demand.
+ */
+export function configureProjectGitAuth(
+  repoRoot: string,
+  repoUrl: string,
+  helperCommand = currentGitCredentialHelperCommand(),
+): void {
+  const context = repoUrl.replace(/\/+$/, '');
+  const helperKey = `credential.${context}.helper`;
+  const reset = spawnSync('git', ['config', '--local', '--replace-all', helperKey, ''], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (reset.status !== 0) {
+    throw new Error(reset.stderr.trim() || 'Could not reset Git credential helpers');
+  }
+  const add = spawnSync('git', ['config', '--local', '--add', helperKey, helperCommand], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (add.status !== 0) {
+    throw new Error(add.stderr.trim() || 'Could not configure the Kortix Git credential helper');
+  }
+  const pathMode = spawnSync('git', ['config', '--local', 'credential.useHttpPath', 'true'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (pathMode.status !== 0) {
+    throw new Error(pathMode.stderr.trim() || 'Could not configure Git credential paths');
+  }
+}

--- a/apps/cli/src/prompts.ts
+++ b/apps/cli/src/prompts.ts
@@ -66,16 +66,37 @@ export async function promptSecret(label: string): Promise<string> {
 /**
  * Yes/no confirmation. Returns the boolean answer; treats blank input
  * as `defaultValue`. Accepts y/yes/n/no (case-insensitive).
+ *
+ * If the input stream ends before an answer arrives (EOF — a closed pty, a
+ * terminal that went away mid-question) we return `opts.onEndOfInput`
+ * (default: `defaultValue`) rather than waiting forever. `rl.question`'s
+ * callback simply never fires on EOF, so without this the promise stays
+ * pending and the process quietly exits at the prompt with whatever work was
+ * in flight abandoned. Set `onEndOfInput` explicitly wherever "nobody answered"
+ * must NOT mean the same thing as "pressed enter" — anything that would then
+ * take a destructive or irreversible action on its own.
  */
-export async function confirm(label: string, defaultValue: boolean): Promise<boolean> {
+export async function confirm(
+  label: string,
+  defaultValue: boolean,
+  opts: { onEndOfInput?: boolean } = {},
+): Promise<boolean> {
   ensureTTY();
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  // One listener for the whole loop — re-registering per question would pile
+  // up handlers every time the user typed something that wasn't y or n.
+  const ended = new Promise<null>((resolve) => rl.once('close', () => resolve(null)));
   try {
     const hint = defaultValue ? 'Y/n' : 'y/N';
     while (true) {
-      const raw = await new Promise<string>((resolve) =>
-        rl.question(`${label} [${hint}]: `, (answer) => resolve(answer)),
+      const answered = new Promise<string>((resolve) =>
+        rl.question(`${label} [${hint}]: `, resolve),
       );
+      const raw = await Promise.race([answered, ended]);
+      if (raw === null) {
+        process.stdout.write('\n');
+        return opts.onEndOfInput ?? defaultValue;
+      }
       const normalized = raw.trim().toLowerCase();
       if (normalized === '') return defaultValue;
       if (['y', 'yes'].includes(normalized)) return true;

--- a/apps/cli/src/update-check.ts
+++ b/apps/cli/src/update-check.ts
@@ -7,8 +7,14 @@ import { C, stripAnsi } from './style.ts';
 // Update notifier.
 //
 // On `kortix` (bare) we resolve the latest published release from GitHub and,
-// if it's newer than the running binary, surface a prominent box telling the
-// user to run `kortix update`. Subcommands get a passive one-line nudge.
+// if it's newer than the running binary, surface a prominent box AND — when
+// we're on a real terminal — offer to install it right there (see
+// `offerInteractiveUpdate` in index.ts). Subcommands get a passive one-line
+// nudge and are NEVER interrupted: they have to stay scriptable.
+//
+// Declining is remembered PER VERSION (`snoozedTag`), so "skip" silences the
+// question for that release only — the next one asks again. The box keeps
+// showing either way, so a skip never hides that the CLI is behind.
 //
 // To keep this off the hot path we cache the last-known latest version in
 // ~/.config/kortix/update-check.json and only hit the network at most once per
@@ -27,6 +33,8 @@ const FETCH_TIMEOUT_MS = 1500;
 interface CacheEntry {
   latest: string;
   checkedAt: number;
+  /** Release tag the user last answered "skip" to. */
+  snoozedTag?: string;
 }
 
 function cachePath(): string {
@@ -66,7 +74,11 @@ function readCache(): CacheEntry | null {
     const raw = readFileSync(cachePath(), 'utf8');
     const parsed = JSON.parse(raw) as Partial<CacheEntry>;
     if (typeof parsed.latest === 'string' && typeof parsed.checkedAt === 'number') {
-      return { latest: parsed.latest, checkedAt: parsed.checkedAt };
+      return {
+        latest: parsed.latest,
+        checkedAt: parsed.checkedAt,
+        ...(typeof parsed.snoozedTag === 'string' ? { snoozedTag: parsed.snoozedTag } : {}),
+      };
     }
   } catch {
     /* missing or corrupt — treat as no cache */
@@ -82,6 +94,27 @@ function writeCache(entry: CacheEntry): void {
   } catch {
     /* best-effort; a failed cache write just means we re-check next time */
   }
+}
+
+/** Did the user already answer "skip" for exactly this release? */
+export function isUpdateSnoozed(latestTag: string): boolean {
+  return readCache()?.snoozedTag === latestTag;
+}
+
+/**
+ * Remember that the user declined THIS release, so bare `kortix` stops asking
+ * until a newer one lands. Deliberately keyed to the tag rather than a
+ * timestamp: a snooze that expires would re-ask for a version they already
+ * turned down, and one that never expires would hide a release they've never
+ * seen. The box still renders regardless.
+ */
+export function snoozeUpdate(latestTag: string): void {
+  const cached = readCache();
+  writeCache({
+    latest: cached?.latest ?? latestTag,
+    checkedAt: cached?.checkedAt ?? Date.now(),
+    snoozedTag: latestTag,
+  });
 }
 
 async function fetchLatestTag(): Promise<string | null> {
@@ -116,7 +149,13 @@ async function resolveLatestTag(allowFetch: boolean): Promise<string | null> {
 
   const tag = await fetchLatestTag();
   if (tag) {
-    writeCache({ latest: tag, checkedAt: Date.now() });
+    // Carry the snooze across TTL refreshes — dropping it here would re-ask
+    // about a release the user already declined every 6 hours.
+    writeCache({
+      latest: tag,
+      checkedAt: Date.now(),
+      ...(cached?.snoozedTag ? { snoozedTag: cached.snoozedTag } : {}),
+    });
     return tag;
   }
   return cached?.latest ?? null;
@@ -129,7 +168,9 @@ function boxLine(content: string): string {
   return `  ${C.yellow}║${C.reset} ${content}${' '.repeat(padding)} ${C.yellow}║${C.reset}`;
 }
 
-function renderBox(current: string, latestDisplay: string): string {
+/** `hint` is the call-to-action line. The interactive path replaces the
+ *  "run kortix update" advice, since it's about to ask instead. */
+function renderBox(current: string, latestDisplay: string, hint: string): string {
   const title = ' update available ';
   const fill = Math.max(0, BOX_INNER + 2 - 2 - title.length);
   const top = `  ${C.yellow}╔══${C.reset}${C.bold}${title}${C.reset}${C.yellow}${'═'.repeat(fill)}╗${C.reset}`;
@@ -138,7 +179,7 @@ function renderBox(current: string, latestDisplay: string): string {
     '',
     top,
     boxLine(`${C.bold}Kortix CLI${C.reset} ${C.dim}v${current}${C.reset}  ${C.yellow}→${C.reset}  ${C.green}${C.bold}${latestDisplay}${C.reset}`),
-    boxLine(`Run  ${C.cyan}kortix update${C.reset}  to upgrade.`),
+    boxLine(hint),
     bottom,
   ].join('\n');
 }
@@ -147,6 +188,57 @@ function renderLine(current: string, latestDisplay: string): string {
   return (
     `  ${C.yellow}!${C.reset}  ${C.yellow}Update available: v${current} → ${latestDisplay} — run${C.reset} ` +
     `${C.cyan}kortix update${C.reset}`
+  );
+}
+
+export interface UpdateStatus {
+  /** Running version, e.g. "0.10.15". */
+  current: string;
+  /** Release tag as published, e.g. "v0.10.16" — the snooze key. */
+  latestTag: string;
+  /** Display form, always `v`-prefixed. */
+  latestDisplay: string;
+}
+
+/**
+ * Is a newer release available? null when up to date, disabled, or the release
+ * info can't be resolved (offline, rate-limited, dev build). Never throws.
+ */
+export async function resolveUpdateStatus(
+  current: string,
+  opts: { allowFetch: boolean },
+): Promise<UpdateStatus | null> {
+  try {
+    if (isDisabled(current)) return null;
+    const cur = parseVersion(current);
+    if (!cur) return null;
+
+    const latestTag = await resolveLatestTag(opts.allowFetch);
+    if (!latestTag) return null;
+    const latest = parseVersion(latestTag);
+    if (!latest) return null;
+    if (compareVersions(latest, cur) <= 0) return null;
+
+    return {
+      current,
+      latestTag,
+      latestDisplay: latestTag.startsWith('v') ? latestTag : `v${latestTag}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The prominent box. `interactive` swaps the call-to-action for the prompt
+ *  that's about to be asked, so we never tell them to run a command we're
+ *  offering to run for them. */
+export function renderUpdateBox(status: UpdateStatus, interactive = false): string {
+  return renderBox(
+    status.current,
+    status.latestDisplay,
+    interactive
+      ? `${C.dim}Installing takes a few seconds.${C.reset}`
+      : `Run  ${C.cyan}kortix update${C.reset}  to upgrade.`,
   );
 }
 
@@ -165,22 +257,9 @@ export async function getUpdateNotice(
   current: string,
   opts: UpdateNoticeOptions,
 ): Promise<string | null> {
-  try {
-    if (isDisabled(current)) return null;
-    const cur = parseVersion(current);
-    if (!cur) return null;
-
-    const latestTag = await resolveLatestTag(opts.allowFetch);
-    if (!latestTag) return null;
-    const latest = parseVersion(latestTag);
-    if (!latest) return null;
-    if (compareVersions(latest, cur) <= 0) return null;
-
-    const latestDisplay = latestTag.startsWith('v') ? latestTag : `v${latestTag}`;
-    return opts.style === 'box'
-      ? renderBox(current, latestDisplay)
-      : renderLine(current, latestDisplay);
-  } catch {
-    return null;
-  }
+  const status = await resolveUpdateStatus(current, { allowFetch: opts.allowFetch });
+  if (!status) return null;
+  return opts.style === 'box'
+    ? renderUpdateBox(status)
+    : renderLine(status.current, status.latestDisplay);
 }

--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -49,7 +49,7 @@ curl -X POST "$KORTIX_API_URL/projects/$KORTIX_PROJECT_ID/sessions" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: $(uuidgen)" \
   -d '{
-    "origin_ref": "your-app-user-123",
+    "end_user_ref": "your-app-user-123",
     "agent_name": "support",
     "opencode_model": "anthropic/claude-opus-4-8",
     "connector_bindings": { "gmail": { "profile_id": "<profile-id>" } },
@@ -69,7 +69,7 @@ const kortix = createScopedKortix({
 });
 
 const session = await kortix.project(projectId).sessions.create({
-  origin_ref: 'your-app-user-123',
+  end_user_ref: 'your-app-user-123',
   agent_name: 'support',
   opencode_model: 'anthropic/claude-opus-4-8',
   connector_bindings: { gmail: { profile_id } },
@@ -87,13 +87,39 @@ never races another request's config.
 
 | Field | What it does |
 | --- | --- |
-| `origin_ref` | An opaque id for *your* end-user. A label, not a lever: it tags the session, reaches the agent as `KORTIX_ORIGIN_REF`, and blocks an `Idempotency-Key` replay under a *different* end-user. It does **not** resolve that user's connectors or secrets, grant access, or drive billing — and it isn't queryable, so keep your own mapping. |
+| `end_user_ref` | An opaque id for *your* end-user. A label, not a lever: it tags the session, reaches the agent as `KORTIX_END_USER_REF`, and blocks an `Idempotency-Key` replay under a *different* end-user. It does **not** resolve that user's connectors or secrets, or grant access. It **is** recorded on every usage event and queryable — see [Per-end-user cost](#per-end-user-cost). Formerly `origin_ref`, which is still accepted. |
 | `connector_bindings` | Map a connector alias → a specific **connection profile** (your end-user's own connected account). Resolved server-side at use time; the credential never enters the sandbox. |
 | `inherit_unbound` | With `connector_bindings` set, keep the project-default fallback for connectors you did *not* bind (instead of all-or-nothing). Only ever inherits the project default. |
 | `secrets` | An allow-list of project secret names to expose to this session. Narrowing only — a session can never see a secret you did not list. |
 | `opencode_model` | The model this session runs, in `provider/model` form. Validated at create; an unservable model fails fast with `400 INVALID_SESSION_MODEL`. |
 | `agent_name` | Which declared agent handles the session. |
 | `runtime_context` | Arbitrary non-secret key/values passed to the run as context. |
+
+
+## Per-end-user cost
+
+Every usage event carries the `end_user_ref` of the session that produced it, so
+you can bill your own users without keeping a parallel ledger.
+
+```bash
+# spend per end-user, biggest first
+curl -sS "$KORTIX_API_URL/usage?group_by=end_user_ref" \
+  -H "Authorization: Bearer $KORTIX_API_KEY"
+
+# one end-user, totals AND breakdown narrowed
+curl -sS "$KORTIX_API_URL/usage?end_user_ref=your-app-user-123" \
+  -H "Authorization: Bearer $KORTIX_API_KEY"
+```
+
+Two things to know:
+
+- Spend with **no** `end_user_ref` — your own dashboard sessions, and anything
+  predating this field — is excluded from the grouped breakdown but still counted
+  in the top-level totals. Per-user rows will not sum to the account total.
+- Grouping is an exact match on the string you sent. `user-1` and `User-1` are two
+  different end-users, so send a canonical id.
+
+The dashboard shows the same data under **Credits → Spend by end-user**.
 
 ## 3. Bring each user's own connector
 
@@ -185,7 +211,7 @@ backend session → stream — ships with the SDK at
 Always send an `Idempotency-Key` (a UUID you generate once per logical create and
 reuse across that create's retries). A replay returns the same session instead of
 starting a second one. Replaying a key with a **different** body — different
-`connector_bindings`, `secrets`, `origin_ref`, or `runtime_context` — is refused with
+`connector_bindings`, `secrets`, `end_user_ref`, or `runtime_context` — is refused with
 `409` rather than silently reusing the first session.
 
 ## Security model
@@ -195,8 +221,8 @@ starting a second one. Replaying a key with a **different** body — different
   allow-list. The agent's machine never holds an app secret.
 - **Bindings can't cross tenants.** A `profile_id` only resolves for the account and
   project that owns it; a wrong or foreign id is rejected as not-found.
-- **`origin_ref` is attribution, not authorization.** It labels the session and is
-  handed to the agent as `KORTIX_ORIGIN_REF`; it never grants access to a user's
+- **`end_user_ref` is attribution, not authorization.** It labels the session and is
+  handed to the agent as `KORTIX_END_USER_REF`; it never grants access to a user's
   data on its own, and it resolves no connectors or secrets.
 - **Personal connections stay private.** A session that binds a member's personal
   connection is forced to `visibility: private` and resolves only for that user.

--- a/apps/web/src/features/billing/end-user-usage-card.tsx
+++ b/apps/web/src/features/billing/end-user-usage-card.tsx
@@ -69,10 +69,10 @@ export function EndUserUsageCard() {
   const accountId = useBillingAccountId();
 
   const usageQuery = useQuery({
-    queryKey: ['usage', 'origin_ref', windowKey, accountId ?? 'default'],
+    queryKey: ['usage', 'end_user_ref', windowKey, accountId ?? 'default'],
     queryFn: () =>
       getUsageRollup({
-        groupBy: 'origin_ref',
+        groupBy: 'end_user_ref',
         start: startOfWindow(Number(windowKey)),
         accountId,
       }),
@@ -106,7 +106,7 @@ export function EndUserUsageCard() {
         </CardTitle>
         <CardDescription>
           Sessions your backend started on behalf of one of its own users, grouped by the{' '}
-          <code className="text-xs">origin_ref</code> it passed.
+          <code className="text-xs">end_user_ref</code> it passed.
         </CardDescription>
         <CardAction>
           <Tabs value={windowKey} onValueChange={(v) => setWindowKey(v as typeof windowKey)}>

--- a/apps/web/src/features/billing/end-user-usage.test.ts
+++ b/apps/web/src/features/billing/end-user-usage.test.ts
@@ -44,3 +44,29 @@ describe('toEndUserUsageRows', () => {
     expect(toEndUserUsageRows(undefined)).toEqual([]);
   });
 });
+
+describe('toEndUserUsageRows — end_user_ref / origin_ref alias', () => {
+  const row = (keys: Record<string, unknown>) => ({
+    cost: 1,
+    count: 1,
+    input_tokens: 0,
+    output_tokens: 0,
+    cached_tokens: 0,
+    cache_write_tokens: 0,
+    ...keys,
+  });
+
+  test('reads the new end_user_ref field', () => {
+    expect(toEndUserUsageRows([row({ end_user_ref: 'new' })] as never)[0]?.originRef).toBe('new');
+  });
+
+  test('still reads a server that only sends the deprecated origin_ref', () => {
+    expect(toEndUserUsageRows([row({ origin_ref: 'old' })] as never)[0]?.originRef).toBe('old');
+  });
+
+  test('prefers end_user_ref when a server sends both', () => {
+    const rows = toEndUserUsageRows([row({ end_user_ref: 'new', origin_ref: 'new' })] as never);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.originRef).toBe('new');
+  });
+});

--- a/apps/web/src/features/billing/end-user-usage.ts
+++ b/apps/web/src/features/billing/end-user-usage.ts
@@ -20,10 +20,14 @@ export interface EndUserUsageRow {
  * expensive end-user is the first thing read.
  */
 export function toEndUserUsageRows(breakdown: UsageBreakdownItem[] | undefined): EndUserUsageRow[] {
-  const attributed = (breakdown ?? []).filter(
-    (item): item is UsageBreakdownItem & { origin_ref: string } =>
-      typeof item.origin_ref === 'string' && item.origin_ref.length > 0,
-  );
+  // Read either spelling: `end_user_ref` is the name, `origin_ref` the
+  // deprecated alias an older server may still be the only one sending.
+  const attributed = (breakdown ?? [])
+    .map((item) => ({ item, ref: item.end_user_ref ?? item.origin_ref }))
+    .filter((entry): entry is { item: UsageBreakdownItem; ref: string } =>
+      typeof entry.ref === 'string' && entry.ref.length > 0,
+    )
+    .map((entry) => ({ ...entry.item, origin_ref: entry.ref }));
   const total = attributed.reduce((sum, item) => sum + (item.cost ?? 0), 0);
   return attributed
     .map((item) => ({

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -36,7 +36,7 @@ curl -X POST https://api.kortix.com/v1/projects/<project-id>/sessions \
   -H "Content-Type: application/json" \
   -d '{
     "initial_prompt": "Summarize my new signups",
-    "origin_ref": "your-app-user-123",
+    "end_user_ref": "your-app-user-123",
     "agent_name": "support",
     "opencode_model": "anthropic/claude-opus-4-8",
     "connector_bindings": { "gmail": { "profile_id": "<profile-id>" } },
@@ -44,7 +44,7 @@ curl -X POST https://api.kortix.com/v1/projects/<project-id>/sessions \
   }'
 ```
 
-The `201` response echoes what was applied — `origin: "backend"`, `origin_ref`,
+The `201` response echoes what was applied — `origin: "backend"`, `end_user_ref`,
 `agent_name`, `secrets_allowlist` — so you can confirm it took effect.
 
 ### SDK
@@ -63,7 +63,7 @@ const kortix = createScopedKortix({
 
 const session = await kortix.project(projectId).sessions.create({
   initial_prompt: 'Summarize my new signups',
-  origin_ref: 'your-app-user-123',
+  end_user_ref: 'your-app-user-123',
   agent_name: 'support',
   opencode_model: 'anthropic/claude-opus-4-8',
   connector_bindings: { gmail: { profile_id } },
@@ -95,7 +95,7 @@ internal (no-override) call is byte-identical to a normal session.
 | `opencode_model` | Pin the model for this session (`KORTIX_OPENCODE_MODEL`). | anyone |
 | `runtime_context` | A small non-secret JSON envelope injected as `KORTIX_SESSION_CONTEXT`. | anyone |
 | `connector_bindings` | Map a connector alias → a specific **connection profile** (your end-user's own connected account). The credential is resolved server-side at use time and **never enters the sandbox**. | project manager |
-| `origin_ref` | The end-user this session acts for. Recorded on the session and surfaced to the sandbox as `KORTIX_ORIGIN_REF`. **Attribution only** — not an auth principal. | **backend only** |
+| `end_user_ref` | The end-user this session acts for. Recorded on the session and surfaced to the sandbox as `KORTIX_END_USER_REF`. **Attribution only** — not an auth principal. | **backend only** |
 | `secrets` | Narrow which project secrets (by identifier) this session's sandbox receives. | **backend only** |
 
 ### Model — reference form & validation
@@ -282,18 +282,18 @@ manifest grants it no secrets (or not that one), the allowlist can't add it back
 — the session simply gets fewer. Identifiers are validated at create, so a typo
 fails fast rather than silently injecting nothing.
 
-### origin_ref — a label, not a lever
+### end_user_ref — a label, not a lever
 
-`origin_ref` records *which of your end-users* a session was started for. It is
+`end_user_ref` records *which of your end-users* a session was started for. It is
 an opaque string you choose; Kortix never resolves it to a login.
 
 **Exactly what it does, today:**
 
-1. **Stored + echoed** on the session (`origin_ref` in every session response).
-2. **Handed to the agent** as the `KORTIX_ORIGIN_REF` sandbox env var, so a
+1. **Stored + echoed** on the session (`end_user_ref` in every session response).
+2. **Handed to the agent** as the `KORTIX_END_USER_REF` sandbox env var, so a
    prompt/tool can say who it is acting for. (Kortix itself never reads it back.)
 3. **Guards idempotent retries.** Replaying an `Idempotency-Key` with a
-   *different* `origin_ref` is refused with `409 IDEMPOTENCY_ORIGIN_CONFLICT`, so
+   *different* `end_user_ref` is refused with `409 IDEMPOTENCY_ORIGIN_CONFLICT`, so
    a retry can never hand end-user B the session that belongs to end-user A. This
    is the one thing that would actually break without it.
 
@@ -304,22 +304,22 @@ an opaque string you choose; Kortix never resolves it to a login.
   about its value.
 - **It resolves nothing.** It does not pull that user's connectors or secrets —
   pass those explicitly (`connector_bindings`, `secrets`).
-- **It does not list sessions.** No endpoint filters sessions by `origin_ref`, so
+- **It does not list sessions.** No endpoint filters sessions by `end_user_ref`, so
   "show me this end-user's sessions" still needs your own mapping.
 
 **What it DOES drive — metering and caps:**
 
 ```
-GET /v1/usage?origin_ref=user-123     # that end-user's spend (totals + breakdown)
-GET /v1/usage?group_by=origin_ref     # spend per end-user, biggest first
+GET /v1/usage?end_user_ref=user-123     # that end-user's spend (totals + breakdown)
+GET /v1/usage?group_by=end_user_ref     # spend per end-user, biggest first
 ```
 
-Usage events carry a server-derived copy of `origin_ref`, so per-end-user spend
+Usage events carry a server-derived copy of `end_user_ref`, so per-end-user spend
 is a real query. Two caveats worth knowing:
 
 - **Only backend-session spend is attributed.** Rows written before this shipped,
-  the model playground, and the legacy router path all have a `NULL` `origin_ref`
-  and are *excluded* from `group_by=origin_ref` — they aren't folded into an
+  the model playground, and the legacy router path all have a `NULL` `end_user_ref`
+  and are *excluded* from `group_by=end_user_ref` — they aren't folded into an
   anonymous bucket that would read as a phantom end-user. The unfiltered totals
   in `data` still include them, so per-user rows won't sum to the account total.
 - **The value lands in the billing ledger and comes back out of the API**, so use
@@ -331,7 +331,7 @@ applies). Exceeding it returns `429 per_origin_session_limit`. It's a check-then
 act guard, like the account cap — N parallel creates for one end-user can still
 overshoot slightly, so treat it as a runaway-loop guardrail, not a hard quota.
 
-Treat `origin_ref` as a durable label for correlation, attribution and metering.
+Treat `end_user_ref` as a durable label for correlation, attribution and metering.
 If you need structured per-user context inside the run as well, put it in
 `runtime_context`.
 
@@ -386,7 +386,7 @@ await s.send(prompt);
 
 | Status | Code | Meaning |
 |---|---|---|
-| `403` | `origin_override_forbidden` | A non-backend caller (a human web session, the in-sandbox agent token) tried to set `origin_ref` or `secrets`. Use an API key / service-account bearer. |
+| `403` | `origin_override_forbidden` | A non-backend caller (a human web session, the in-sandbox agent token) tried to set `end_user_ref` or `secrets`. Use an API key / service-account bearer. |
 | `404` | `SECRET_IDENTIFIER_NOT_FOUND` | An allowlisted secret identifier doesn't exist in the project. |
 | `409` | `SECRET_IDENTIFIER_KEY_COLLISION` | Two allowlisted identifiers resolve to the same env var — name only one. |
 | `409` | `IDEMPOTENCY_SECRETS_CONFLICT` / `IDEMPOTENCY_BINDING_CONFLICT` | An `Idempotency-Key` was replayed with a different `secrets` / `connector_bindings` body. Keep the body identical across retries. |
@@ -412,3 +412,18 @@ See also the runnable, end-to-end version of this flow —
 [`packages/sdk/examples/09-kaab-backend-wrapper.ts`](../packages/sdk/examples/09-kaab-backend-wrapper.ts)
 — and the printable one-page guide next to it
 (`packages/sdk/examples/KORTIX-AS-A-BACKEND.pdf`).
+
+
+## A note on the name
+
+`end_user_ref` was called `origin_ref` until 2026-07-27. The old name read as
+"a reference to the origin" (which app) when it means "a reference within the
+origin" (which of your users) — and that ambiguity invited callers to put a
+request id or a tenant there, producing a usage breakdown that looks right and
+bills nobody.
+
+`origin_ref` is still accepted everywhere and always will be: it is a published
+wire field. Sending both is fine when they agree; disagreeing values are
+rejected `400 END_USER_REF_CONFLICT` rather than one silently winning. Sandboxes
+receive both `KORTIX_END_USER_REF` and `KORTIX_ORIGIN_REF`. The database column
+keeps its original name — that is internal and renaming it would buy nothing.

--- a/docs/KORTIX_AS_BACKEND_V1_PLAN.md
+++ b/docs/KORTIX_AS_BACKEND_V1_PLAN.md
@@ -28,14 +28,14 @@ Connectors are already **user-owned profiles decoupled from the agent** (`execut
 **Kortix authenticates the wrapper; the wrapper vouches for its end-user.** (Stripe-Connect / Twilio-subaccount model.)
 
 - **Caller = any programmatic customer credential** *(REV 3 — shipped in PR #5147; supersedes the SA-only stance below)*: the **account API key / PAT** (`kortix_pat_` — the credential the Tokens UI mints as "Create API key"), a **Service Account** (`kortix_sa_`), or a dedicated account API key (`kortix_`, `apiKeyType='user'`, dormant until issuance ships). All resolve `origin: backend`. **Why the reversal from SA-only:** a fresh service account has *no* IAM policy binding — `createServiceAccount` attaches none, the engine skips membership for SAs, and granting `project.session.start` requires a custom role + per-project token-principal policy, both behind the enterprise-only `rbac` entitlement. SA-only would be dark for every non-enterprise account. The PAT inherits its creator's project membership → works on every tier with zero IAM setup. SA remains the *recommended* credential for enterprise/CI (deny-by-default governance, survives offboarding, independently revocable). Hard exclusions, enforced with regression tests: the **internal sandbox key** (`kortix_sb_`, the `KORTIX_TOKEN` inside every sandbox) and **any agent-scoped token** are never backend — an in-session agent cannot vouch for a phantom end-user.
-- **End-user identity = a parameter, not an auth principal** — the wrapper passes `origin_ref` (its own user id) + that user's `profile_id`s. Kortix records `origin: backend`, resolves *that user's* profiles, attributes usage to `origin_ref`. **End-users never authenticate to Kortix.** Scales to 100k with no per-user login and no subject-identity system.
+- **End-user identity = a parameter, not an auth principal** — the wrapper passes `end_user_ref` (its own user id) + that user's `profile_id`s. Kortix records `origin: backend`, resolves *that user's* profiles, attributes usage to `end_user_ref`. **End-users never authenticate to Kortix.** Scales to 100k with no per-user login and no subject-identity system.
 
 **Developer UX (the whole integration — zero-setup path, any tier):**
 ```
 1. Settings → Tokens → Create API key → paste kortix_pat_… into backend env  (once)
 2. Per end-user: store their credential once → get profile_id                (server-to-server)
 3. POST /sessions  (Bearer kortix_pat_…)
-   { agent_name, origin_ref:"user-123", connector_bindings:{ gmail:{profile_id} } }
+   { agent_name, end_user_ref:"user-123", connector_bindings:{ gmail:{profile_id} } }
 ```
 **Enterprise/CI path (least privilege):** New service account → attach policy (`session.start` + connector-profiles) → same call with `Bearer kortix_sa_…`.
 Base case (shared agent, no per-user connectors) = steps 1–2 only.
@@ -44,7 +44,7 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 ## 3. The 3 gaps to build
 
-1. **`origin` as a first-class field + policy gate** (the spine). Today it's informal (`metadata.source='trigger:cron'`). Promote to `origin: user|trigger|schedule|backend` + `origin_ref`, resolved once at create in `sessions.ts`. It gates **which override fields a caller may set** (only `backend` may set connector/secret refs; `user` only model) and **behavior** (approval relay, attribution). Small: column + resolve-at-create + a `canOverride(origin, field)` check.
+1. **`origin` as a first-class field + policy gate** (the spine). Today it's informal (`metadata.source='trigger:cron'`). Promote to `origin: user|trigger|schedule|backend` + `end_user_ref`, resolved once at create in `sessions.ts`. It gates **which override fields a caller may set** (only `backend` may set connector/secret refs; `user` only model) and **behavior** (approval relay, attribution). Small: column + resolve-at-create + a `canOverride(origin, field)` check.
 2. **Secrets by reference** (the one net-new config dim). Merge a referenced secret bundle in **`resolveOwnerRawEnv`** (the hot-push path), not just boot (§4.2). Scope split: `connector`-scope = broker, never in sandbox = always safe; `runtime`-scope enters the sandbox = only safe while the wrapper **proxies chat** (end-users have no raw sandbox access).
 3. **Skills subset** (v2-manifest only, mostly deferred). Intersect a requested subset with each agent's compiled `permission.skill` grant in `buildSessionSandboxEnvVars`. *Selecting* repo skills = clean; *injecting new* skills = untrusted code = out of scope.
 
@@ -62,7 +62,7 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 **4.5 Profile revoked mid-session.** End-user disconnects their Gmail while a session is live. *Handling:* the broker fails **closed** — a bound-but-revoked profile returns null, never falls back to the shared default (verified). The wrapper must surface "reconnect".
 
-**4.6 Origin spoofing.** *(updated for REV 3)* No caller may claim `origin: backend` via the body — origin is **derived from the caller's token kind** (`authType` + `apiKeyType` + agent-scope), never accepted from the request. The spoofing surface that matters: the **in-sandbox `KORTIX_TOKEN`** (`apiKey`+`sandbox`) and **agent-scoped tokens** must never resolve backend — enforced with a *positive* `apiKeyType==='user'` check (a missing/unknown type can never be promoted) and an explicit agent-scope exclusion, both regression-tested. `origin_ref` is trusted only from a backend-origin caller; anyone else supplying it gets `403 origin_override_forbidden`. The queued-create path replays the same derivation signals captured at enqueue time, so backpressure can't degrade or upgrade an origin.
+**4.6 Origin spoofing.** *(updated for REV 3)* No caller may claim `origin: backend` via the body — origin is **derived from the caller's token kind** (`authType` + `apiKeyType` + agent-scope), never accepted from the request. The spoofing surface that matters: the **in-sandbox `KORTIX_TOKEN`** (`apiKey`+`sandbox`) and **agent-scoped tokens** must never resolve backend — enforced with a *positive* `apiKeyType==='user'` check (a missing/unknown type can never be promoted) and an explicit agent-scope exclusion, both regression-tested. `end_user_ref` is trusted only from a backend-origin caller; anyone else supplying it gets `403 origin_override_forbidden`. The queued-create path replays the same derivation signals captured at enqueue time, so backpressure can't degrade or upgrade an origin.
 
 **4.7 Model not servable / wrong form.** *Handling:* normalize via `toOpencodeModelRef` and **fail-fast** at create with `isModelServableForAccount` (reuses the request-time resolver) — never silently fall to default.
 
@@ -70,9 +70,9 @@ Base case (shared agent, no per-user connectors) = steps 1–2 only.
 
 **4.9 Warm-pool / snapshot reuse.** A recycled warm sandbox must not carry a prior session's overridden env/secrets. *Verify:* env is (re)pushed per session at boot + hot-push — confirm no residual from the pool image before GA.
 
-**4.10 Per-end-user cost & concurrency.** ✅ **SHIPPED.** Caps were account-level only, so one end-user could exhaust the account cap and block everyone. Now: `usage_events.origin_ref` (server-derived, partial-indexed) with `GET /v1/usage?origin_ref=…` and `group_by=origin_ref`; plus an opt-in per-`origin_ref` live-session cap (`KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` → `429 per_origin_session_limit`) checked alongside the account cap at create. Caveats recorded in the guide: rows predating the column (and all non-session spend) are `NULL` = unattributed and excluded from the rollup, and the cap shares the account cap's check-then-act race, so it is a runaway guard rather than a hard quota.
+**4.10 Per-end-user cost & concurrency.** ✅ **SHIPPED.** Caps were account-level only, so one end-user could exhaust the account cap and block everyone. Now: `usage_events.end_user_ref` (server-derived, partial-indexed) with `GET /v1/usage?end_user_ref=…` and `group_by=end_user_ref`; plus an opt-in per-`end_user_ref` live-session cap (`KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` → `429 per_origin_session_limit`) checked alongside the account cap at create. Caveats recorded in the guide: rows predating the column (and all non-session spend) are `NULL` = unattributed and excluded from the rollup, and the cap shares the account cap's check-then-act race, so it is a runaway guard rather than a hard quota.
 
-**4.11 Trigger/webhook on behalf of an end-user.** A webhook that should run as end-user X needs `origin: trigger` **plus** X's `origin_ref` + profile binding. *Suggest:* let a trigger carry an `origin_ref` + connector bindings so origin and overrides compose — the wrapper's most powerful pattern (event → the right user's session).
+**4.11 Trigger/webhook on behalf of an end-user.** A webhook that should run as end-user X needs `origin: trigger` **plus** X's `end_user_ref` + profile binding. *Suggest:* let a trigger carry an `end_user_ref` + connector bindings so origin and overrides compose — the wrapper's most powerful pattern (event → the right user's session).
 
 ## 5. Build order
 
@@ -88,7 +88,7 @@ Each new contract field needs a schema add + a ke2e route-coverage test (the `.s
 
 1. ~~**All-or-nothing vs inherit-unbound** connector binding (4.1)~~ — ✅ **RESOLVED:** all-or-nothing stays the default; `inherit_unbound: true` is opt-in. See 4.1.
 2. **Runtime-secret overrides**: allow at all in v1, or connector-scope only until untrusted-sandbox hardening exists?
-3. ~~**Native per-`origin_ref` caps/concurrency** (4.10)~~ — ✅ **RESOLVED: built.** Usage is attributed per `origin_ref` on `usage_events` (server-derived, with `?origin_ref=` filter and `group_by=origin_ref`), and `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` caps live sessions per end-user (opt-in, `429 per_origin_session_limit`). Both denormalize/derive server-side rather than joining on the client-supplied `session_id`, which is spoofable on the legacy router path.
+3. ~~**Native per-`end_user_ref` caps/concurrency** (4.10)~~ — ✅ **RESOLVED: built.** Usage is attributed per `end_user_ref` on `usage_events` (server-derived, with `?end_user_ref=` filter and `group_by=end_user_ref`), and `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` caps live sessions per end-user (opt-in, `429 per_origin_session_limit`). Both denormalize/derive server-side rather than joining on the client-supplied `session_id`, which is spoofable on the legacy router path.
 
 ## 7. Explicitly out of scope (v1)
 

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -83,7 +83,8 @@ function sessionFixture(overrides: Record<string, unknown> = {}) {
     owner_email: null,
     visibility: 'private',
     origin: 'user',
-    origin_ref: null,
+    end_user_ref: null,
+  origin_ref: null,
     secrets_allowlist: null,
     sharing: { mode: 'private', ownerId: '' },
     is_owner: true,
@@ -665,6 +666,21 @@ describe('native OAuth2 lifecycle schemas', () => {
     expect(OAuth2DeviceAuthorizationStartInputSchema.parse({ scopes: ['read'] })).toEqual({
       scopes: ['read'],
     });
+  });
+});
+
+describe('end_user_ref accepts its deprecated origin_ref alias', () => {
+  test('either spelling parses; the response carries both', () => {
+    expect(() => SessionCreateInputSchema.parse({ end_user_ref: 'u1' })).not.toThrow();
+    expect(() => SessionCreateInputSchema.parse({ origin_ref: 'u1' })).not.toThrow();
+    expect(() =>
+      SessionCreateInputSchema.parse({ end_user_ref: 'u1', origin_ref: 'u1' }),
+    ).not.toThrow();
+  });
+
+  test('the new name is bounded exactly like the alias', () => {
+    expect(() => SessionCreateInputSchema.parse({ end_user_ref: 'x'.repeat(257) })).toThrow();
+    expect(() => SessionCreateInputSchema.parse({ end_user_ref: '   ' })).toThrow();
   });
 });
 

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -556,6 +556,13 @@ export const SessionCreateInputSchema = z
     // Accepted only from a backend-origin caller (an account API key / PAT or a
     // service-account bearer); any other origin supplying it is rejected 403
     // (see resolveSessionOrigin / canOverride).
+    end_user_ref: z.string().trim().min(1).max(256).optional(),
+    /**
+     * @deprecated Renamed to `end_user_ref`. Still accepted, and will stay
+     * accepted — this is a published wire field. Sending both is fine only if
+     * they agree; disagreeing values are rejected 400 END_USER_REF_CONFLICT
+     * rather than silently picking one and misattributing the usage rows.
+     */
     origin_ref: z.string().trim().min(1).max(256).optional(),
     // Backend-only: narrow which project secrets (by identifier) this session's
     // sandbox receives, from the default agent-grant set down to this list. `[]`
@@ -609,6 +616,8 @@ export const ProjectSessionSchema = z.object({
   /** Policy class the session was created under (derived, never client-set). */
   origin: z.enum(['user', 'trigger', 'schedule', 'backend', 'system']),
   /** Backend wrapper's end-user handle; non-null only for backend sessions. */
+  end_user_ref: z.string().nullable(),
+  /** @deprecated Renamed to `end_user_ref`. Echoed with the same value. */
   origin_ref: z.string().nullable(),
   /** Backend-set per-session secrets allowlist (identifiers); null = no narrowing. */
   secrets_allowlist: SessionSecretsAllowlistSchema.nullable(),

--- a/packages/sdk/GETTING-STARTED.md
+++ b/packages/sdk/GETTING-STARTED.md
@@ -127,7 +127,7 @@ that changes is `import { … } from '@kortix/sdk'`.
 | `06-files-and-secrets.ts` | session-scoped workspace files + project secrets | PAT + project + session |
 | `07-vanilla.ts` | **the whole flow in one file** — list → ready → stream → send → classify | PAT + project + session |
 | `08-cdn.html` | the same thing from a `<script>` tag, **no build step, no framework** | bundles built + browser |
-| `09-kaab-backend-wrapper.ts` | **Kortix as a Backend, end-to-end** — mint a connector → per-user profile → backend-origin session (`origin_ref` + `secrets` + `connector_bindings`) → stream; one-shot CLI **and** an SSE service | PAT + project |
+| `09-kaab-backend-wrapper.ts` | **Kortix as a Backend, end-to-end** — mint a connector → per-user profile → backend-origin session (`end_user_ref` + `secrets` + `connector_bindings`) → stream; one-shot CLI **and** an SSE service | PAT + project |
 
 See [`examples/README.md`](./examples/README.md) for the full index and per-example
 env vars, and [`docs/KORTIX_AS_A_BACKEND_GUIDE.md`](../../docs/KORTIX_AS_A_BACKEND_GUIDE.md)

--- a/packages/sdk/examples/09-kaab-backend-wrapper.ts
+++ b/packages/sdk/examples/09-kaab-backend-wrapper.ts
@@ -11,7 +11,7 @@
  *   2. mint a per-end-user connection PROFILE (owner_type 'external' = your user)
  *      + store that user's own credential + activate it            (by reference)
  *   3. start a BACKEND-origin session, binding the profile, pinning the model
- *      and agent, vouching via origin_ref, and narrowing secrets      (overrides)
+ *      and agent, vouching via end_user_ref, and narrowing secrets      (overrides)
  *   4. STREAM the agent's answer live to your terminal / your own SSE endpoint
  *
  * Two run modes in this one file:
@@ -27,7 +27,7 @@
  *       -d '{"endUserId":"alice","prompt":"Summarize my new signups"}'
  *
  * Notes:
- *   - `origin_ref` + `secrets` are backend-only fields that require the
+ *   - `end_user_ref` + `secrets` are backend-only fields that require the
  *     Kortix-as-a-Backend release. Set KAAB_OVERRIDES=off to drop them so the
  *     connector + binding + session + streaming path still runs against a
  *     deployment that doesn't have them yet (origin still auto-derives to
@@ -65,7 +65,7 @@ if (!upstreamApiKey || !projectId) {
  * wrapper mints/stores one PAT per tenant (or scopes a shared one) in its own
  * auth store, keyed off the incoming request — never a hardcoded env var. Here
  * every user shares the wrapper's own key; origin still derives to 'backend',
- * and per-user isolation comes from origin_ref + the end-user's connection
+ * and per-user isolation comes from end_user_ref + the end-user's connection
  * profile, not from distinct Kortix logins.
  */
 function upstreamTokenFor(_endUserId: string): string {
@@ -158,7 +158,7 @@ async function startSession(
     // Backend-only fields (require the KaaB release; KAAB_OVERRIDES=off drops them):
     ...(includeOverrides
       ? {
-          origin_ref: endUserId, // attribution → KORTIX_ORIGIN_REF in the sandbox
+          end_user_ref: endUserId, // attribution → KORTIX_END_USER_REF in the sandbox
           ...(SECRET_ID ? { secrets: [SECRET_ID] } : {}), // narrow injected secrets
         }
       : {}),
@@ -166,7 +166,7 @@ async function startSession(
   const session = await kortix.project(projectId!).sessions.create(body);
   console.error(
     `[session ${session.session_id}] origin=${session.origin ?? '(n/a)'}` +
-      ` origin_ref=${session.origin_ref ?? '(n/a)'} secrets=${JSON.stringify(session.secrets_allowlist ?? null)}`,
+      ` end_user_ref=${session.end_user_ref ?? '(n/a)'} secrets=${JSON.stringify(session.secrets_allowlist ?? null)}`,
   );
   return session.session_id;
 }

--- a/packages/sdk/src/core/rest/projects-client/billing.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/billing.test.ts
@@ -207,26 +207,33 @@ test('getUsageRollup GETs /usage with no query when unfiltered', async () => {
   expect(last().method).toBe('GET');
 });
 
-test('getUsageRollup groups by origin_ref so spend is attributable per end-user', async () => {
+test('getUsageRollup groups by end_user_ref so spend is attributable per end-user', async () => {
   nextResponse = {
     status: 200,
     body: {
       data: { total_cost: 3, count: 2 },
       breakdown: [
-        { origin_ref: 'user-a', cost: 2, count: 1 },
-        { origin_ref: 'user-b', cost: 1, count: 1 },
+        { end_user_ref: 'user-a', cost: 2, count: 1 },
+        { end_user_ref: 'user-b', cost: 1, count: 1 },
       ],
     },
   };
-  const result = await getUsageRollup({ groupBy: 'origin_ref', start: '2026-07-01' });
-  expect(last().url).toContain('group_by=origin_ref');
+  const result = await getUsageRollup({ groupBy: 'end_user_ref', start: '2026-07-01' });
+  expect(last().url).toContain('group_by=end_user_ref');
   expect(last().url).toContain('start=2026-07-01');
-  expect(result.breakdown?.map((b) => b.origin_ref)).toEqual(['user-a', 'user-b']);
+  expect(result.breakdown?.map((b) => b.end_user_ref)).toEqual(['user-a', 'user-b']);
 });
 
-test('getUsageRollup narrows to one end-user via origin_ref', async () => {
+test('getUsageRollup narrows to one end-user via endUserRef', async () => {
   nextResponse = { status: 200, body: { data: { total_cost: 2, count: 1 } } };
-  await getUsageRollup({ originRef: 'user-a' });
-  expect(last().url).toContain('origin_ref=user-a');
+  await getUsageRollup({ endUserRef: 'user-a' });
+  expect(last().url).toContain('end_user_ref=user-a');
   expect(last().url).not.toContain('group_by');
+});
+
+test('the deprecated originRef option still works, mapped to the new param', async () => {
+  // Live callers pinned to the old option must keep functioning after the rename.
+  nextResponse = { status: 200, body: { data: { total_cost: 2, count: 1 } } };
+  await getUsageRollup({ originRef: 'legacy-user' });
+  expect(last().url).toContain('end_user_ref=legacy-user');
 });

--- a/packages/sdk/src/core/rest/projects-client/billing.ts
+++ b/packages/sdk/src/core/rest/projects-client/billing.ts
@@ -755,7 +755,9 @@ export interface UsageBreakdownItem {
   day?: string;
   provider?: string | null;
   model?: string;
-  /** Present only for `group_by: 'origin_ref'` — the wrapper's own end-user id. */
+  /** Present only for `group_by: 'end_user_ref'` — the wrapper's own end-user id. */
+  end_user_ref?: string;
+  /** @deprecated Renamed to `end_user_ref`. Echoed with the same value. */
   origin_ref?: string;
   input_tokens: number;
   output_tokens: number;
@@ -774,12 +776,14 @@ export interface UsageQueryOptions {
   start?: string;
   end?: string;
   /**
-   * `origin_ref` attributes spend to one end-user of a Kortix-as-a-Backend
-   * wrapper. Rows written before the column existed have a NULL origin_ref and
+   * `end_user_ref` attributes spend to one end-user of a Kortix-as-a-Backend
+   * wrapper. Rows without one (all non-backend spend) have a NULL value and
    * are excluded from that grouping.
    */
-  groupBy?: 'model' | 'provider' | 'day' | 'origin_ref';
+  groupBy?: 'model' | 'provider' | 'day' | 'end_user_ref' | 'origin_ref';
   /** Narrow to a single end-user. Applies to the TOTALS as well as the breakdown. */
+  endUserRef?: string;
+  /** @deprecated Renamed to `endUserRef`. Still accepted. */
   originRef?: string;
   /**
    * Which account to report on. REQUIRED whenever the caller could be looking at
@@ -797,7 +801,9 @@ export async function getUsageRollup(options: UsageQueryOptions = {}): Promise<U
   if (options.start) qs.set('start', options.start);
   if (options.end) qs.set('end', options.end);
   if (options.groupBy) qs.set('group_by', options.groupBy);
-  if (options.originRef) qs.set('origin_ref', options.originRef);
+  // Prefer the new name; the alias still works for callers mid-migration.
+  const endUserRef = options.endUserRef ?? options.originRef;
+  if (endUserRef) qs.set('end_user_ref', endUserRef);
   if (options.accountId) qs.set('account_id', options.accountId);
   const query = qs.toString();
   return unwrap(await backendApi.get<UsageRollup>(`/usage${query ? `?${query}` : ''}`));

--- a/packages/sdk/src/core/rest/projects-client/sessions.ts
+++ b/packages/sdk/src/core/rest/projects-client/sessions.ts
@@ -56,6 +56,8 @@ export interface ProjectSession {
    *  'backend'; a human web session is 'user'. See Kortix-as-a-Backend. */
   origin?: 'user' | 'trigger' | 'schedule' | 'backend' | 'system';
   /** The wrapper's end-user this session acts for (backend origin only). */
+  end_user_ref?: string | null;
+  /** @deprecated Renamed to `end_user_ref`. Echoed with the same value. */
   origin_ref?: string | null;
   /** The per-session secrets allowlist that was applied (identifiers); null = none. */
   secrets_allowlist?: string[] | null;
@@ -123,6 +125,12 @@ export interface CreateProjectSessionInput {
    * session and surfaced to the sandbox as KORTIX_ORIGIN_REF. A non-backend
    * caller supplying it is rejected 403. Attribution only — pass the user's
    * connectors via connector_bindings.
+   */
+  /** Your opaque handle for the END-USER this session acts for. Backend origin only. */
+  end_user_ref?: string;
+  /**
+   * @deprecated Renamed to `end_user_ref`. Still accepted; sending both is fine
+   * only if they agree (disagreeing values are rejected 400).
    */
   origin_ref?: string;
   /**

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -61,6 +61,22 @@ test("shadow Terraform permits only immutable ECS task-definition replacement", 
   );
 });
 
+test("US shadow deploy accepts an immutable candidate image tag", () => {
+  assert.match(shadowWorkflow, /image_tag:\s*\n\s*description:/);
+  assert.match(
+    shadowWorkflow,
+    /IMAGE_TAG: \$\{\{ inputs\.image_tag \|\| inputs\.version \}\}/,
+  );
+  assert.match(
+    shadowWorkflow,
+    /"kortix\/kortix-api:\$\{IMAGE_TAG\}"/,
+  );
+  assert.match(
+    shadowWorkflow,
+    /"kortix\/kortix-gateway:\$\{IMAGE_TAG\}"/,
+  );
+});
+
 test("target smoke removes and counts recovery flow state", () => {
   assert.match(
     targetSmokeProgram,


### PR DESCRIPTION
## Summary

- preserve staging voice-security hotfix PR #5589
- merge the current `main` tip `fd24a59ade99d0c5a77636b570f332610561c871`
- retain scheduler reliability changes and exact scheduler migrations from PR #5588

## Verification

- 42 focused API tests passed across scheduler timing/reliability, voice metadata, session model changes, and end-user references
- branch contains the current `origin/main` and `origin/staging` tips
- PR #5588 previously passed 33 checks before the newer staging hotfix superseded its artifact build

## Deployment

After merge, the newest staging build must complete API, gateway, and frontend artifacts for the final merge SHA. Deploy Staging must then apply migrations and roll EKS/ECS.