### PR TITLE
feat(whitelabel-demo): Kortix-as-a-Backend support end to end

### DIFF
--- a/apps/whitelabel-demo/scripts/sdk-boundary.mjs
+++ b/apps/whitelabel-demo/scripts/sdk-boundary.mjs
@@ -11,7 +11,15 @@ const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.mjs', '.ts', '.tsx']);
 const UI_ROOT = join(CLIENT_ROOT, 'components', 'ui');
 const API_ROOT = join(CLIENT_ROOT, 'app', 'api');
 const SERVER_ROOT = join(CLIENT_ROOT, 'server');
-const ALLOWED_CLIENT_BFF_ROUTES = ['/api/auth', '/api/mode', '/api/preview-url', '/api/usage'];
+const ALLOWED_CLIENT_BFF_ROUTES = [
+  '/api/auth',
+  '/api/mode',
+  '/api/preview-url',
+  // Provider-neutral session model control: the upstream field is named after
+  // the runtime, so the translation stays server-side and the client says `model`.
+  '/api/session-model',
+  '/api/usage',
+];
 
 const RULES = [
   {
@@ -103,8 +111,22 @@ function rawFetchViolations(source, client) {
   for (const match of source.matchAll(fetchPattern)) {
     const expression = source.slice((match.index ?? 0) + match[0].length).trimStart();
     const quote = expression[0];
-    const end = quote === "'" || quote === '"' ? expression.indexOf(quote, 1) : -1;
-    const target = end > 0 ? expression.slice(1, end) : null;
+    let target = null;
+    if (quote === "'" || quote === '"') {
+      const end = expression.indexOf(quote, 1);
+      if (end > 0) target = expression.slice(1, end);
+    } else if (quote === '`') {
+      // Template literal: judge it by its STATIC PREFIX — the text before the
+      // first interpolation. `/api/x?id=${v}` is as verifiable as the string
+      // form; a template whose BASE is dynamic (`${base}/api/x`) still has an
+      // empty prefix and is correctly rejected. Without this, an app route with
+      // query params could not be called at all.
+      const end = expression.indexOf('`', 1);
+      const raw = end > 0 ? expression.slice(1, end) : expression.slice(1);
+      const interp = raw.indexOf('${');
+      const prefix = interp >= 0 ? raw.slice(0, interp) : raw;
+      target = prefix.length > 0 ? prefix : null;
+    }
     const isAllowed =
       client &&
       target !== null &&

--- a/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
+++ b/apps/whitelabel-demo/src/app/api/kortix/[...path]/route.ts
@@ -20,6 +20,7 @@
  */
 
 import { getRequestSession } from '@/server/auth';
+import { injectEndUserRef, isSessionCreate } from '@/server/end-user';
 import { evaluatePolicy } from '@/server/policy';
 import { consumeRateLimit } from '@/server/rate-limit';
 import { recordRuntimeProject, resolveRuntimeProject } from '@/server/runtime-access';
@@ -66,8 +67,32 @@ async function handle(req: NextRequest, ctx: { params: Promise<{ path?: string[]
   const url = new URL(req.url);
   const upstreamUrl = `${upstreamBase()}/${upstreamPath}${url.search}`;
 
+  // Kortix-as-a-Backend: every upstream call carries ONE credential (the
+  // wrapper's API key), so upstream cannot tell Lumen's users apart by itself.
+  // Stamp the authenticated user onto session creates so per-end-user usage,
+  // idempotency-replay protection and the per-end-user cap all key on a value
+  // the browser cannot forge.
+  let forwardRequest: NextRequest | Request = req;
+  if (isSessionCreate(req.method, upstreamPath)) {
+    let parsed: unknown = null;
+    try {
+      parsed = await req.clone().json();
+    } catch {
+      parsed = null;
+    }
+    const decision = injectEndUserRef(parsed, session.userId);
+    if (decision.action === 'reject') return jsonError(403, decision.reason);
+    if (decision.action === 'inject') {
+      forwardRequest = new Request(req.url, {
+        method: req.method,
+        headers: req.headers,
+        body: JSON.stringify(decision.body),
+      });
+    }
+  }
+
   const upstreamRes = await forwardKortixRequest({
-    request: req,
+    request: forwardRequest as NextRequest,
     upstreamUrl,
     token: apiKey,
   });

--- a/apps/whitelabel-demo/src/app/api/session-model/route.ts
+++ b/apps/whitelabel-demo/src/app/api/session-model/route.ts
@@ -1,0 +1,89 @@
+/**
+ * Provider-neutral session model control.
+ *
+ * The wire field is named after the runtime, which reference-app CLIENT code
+ * must not know about (see scripts/sdk-boundary.mjs `provider-term`). This route
+ * is the translation seam: the browser speaks `{ model }`, and the runtime's
+ * field name stays server-side.
+ *
+ * GET  → the session's current model.
+ * PUT  → change it; `applied_live` reports whether a running session took it now
+ *        or whether it applies at next start. Those are different outcomes and
+ *        the client must be able to say which.
+ */
+import { getRequestSession } from '@/server/auth';
+import { consumeRateLimit } from '@/server/rate-limit';
+import { isOwner, isValidProjectId } from '@/server/users';
+import { createScopedKortix } from '@kortix/sdk/server';
+import type { NextRequest } from 'next/server';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function upstreamBase(): string {
+  return process.env.KORTIX_API_URL ?? 'https://api.kortix.com/v1';
+}
+
+async function scoped(req: NextRequest) {
+  const apiKey = process.env.KORTIX_API_KEY;
+  if (!apiKey) return { error: Response.json({ error: 'Wrapper mode is off' }, { status: 500 }) };
+
+  const session = getRequestSession(req);
+  if (!session) return { error: Response.json({ error: 'Not authenticated' }, { status: 401 }) };
+
+  const limited = consumeRateLimit(session.userId);
+  if (!limited.ok) return { error: Response.json({ error: 'Rate limited' }, { status: 429 }) };
+
+  const url = new URL(req.url);
+  const projectId = url.searchParams.get('projectId') ?? '';
+  const sessionId = url.searchParams.get('sessionId') ?? '';
+  // Validate before interpolating into an upstream path, and check ownership
+  // before touching anything — both are house rules for this boundary.
+  if (!isValidProjectId(projectId) || !UUID.test(sessionId)) {
+    return { error: Response.json({ error: 'Invalid identifiers' }, { status: 400 }) };
+  }
+  if (!isOwner(session.userId, projectId)) {
+    return { error: Response.json({ error: 'Not found' }, { status: 404 }) };
+  }
+
+  return {
+    kortix: createScopedKortix({ backendUrl: upstreamBase(), getToken: async () => apiKey }),
+    projectId,
+    sessionId,
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const ctx = await scoped(req);
+  if ('error' in ctx) return ctx.error;
+
+  try {
+    const session = await ctx.kortix.session(ctx.projectId, ctx.sessionId).get();
+    const metadata = (session?.metadata ?? {}) as Record<string, unknown>;
+    const model = metadata.opencode_model;
+    return Response.json({ model: typeof model === 'string' ? model : null });
+  } catch {
+    return Response.json({ model: null });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const ctx = await scoped(req);
+  if ('error' in ctx) return ctx.error;
+
+  let model = '';
+  try {
+    const body = (await req.json()) as { model?: unknown };
+    model = typeof body?.model === 'string' ? body.model.trim() : '';
+  } catch {
+    model = '';
+  }
+  if (!model) return Response.json({ error: 'model is required' }, { status: 400 });
+
+  try {
+    const result = await ctx.kortix.session(ctx.projectId, ctx.sessionId).changeModel(model);
+    return Response.json({ model: result.opencode_model, appliedLive: result.applied_live });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Could not change the model';
+    return Response.json({ error: message }, { status: 400 });
+  }
+}

--- a/apps/whitelabel-demo/src/app/api/usage/route.ts
+++ b/apps/whitelabel-demo/src/app/api/usage/route.ts
@@ -12,6 +12,7 @@
 
 import type { GatewaySessionStat } from '@kortix/sdk';
 import { createScopedKortix } from '@kortix/sdk/server';
+import { splitEndUserBills } from '@/server/end-user-billing';
 import { getRequestSession } from '@/server/auth';
 import { consumeRateLimit } from '@/server/rate-limit';
 import { isValidProjectId, listOwnedProjects } from '@/server/users';
@@ -78,6 +79,19 @@ export async function GET(req: NextRequest) {
     }),
   );
 
+  // Kortix-as-a-Backend: upstream bills this account ONCE. end_user_ref — which
+  // the /api/kortix proxy stamps from the signed-in session — is what splits
+  // that bill back out per Lumen user, which is the whole point of running as a
+  // wrapper. Best-effort: an upstream that cannot group this way must not take
+  // the rest of the page down with it.
+  let endUserBills: ReturnType<typeof splitEndUserBills> = { bills: [], unattributedCost: 0 };
+  try {
+    const rollup = await kortix.billing.usageRollup({ groupBy: 'end_user_ref' });
+    endUserBills = splitEndUserBills(rollup.breakdown, markup);
+  } catch {
+    endUserBills = { bills: [], unattributedCost: 0 };
+  }
+
   const totals = projects.reduce(
     (acc, p) => {
       for (const s of p.sessions) {
@@ -92,6 +106,8 @@ export async function GET(req: NextRequest) {
   return Response.json({
     markup,
     totals: { raw: round2(totals.raw), billed: round2(totals.billed) },
+    by_end_user: endUserBills.bills,
+    unattributed_cost: endUserBills.unattributedCost,
     projects,
   });
 }

--- a/apps/whitelabel-demo/src/app/api/usage/route.ts
+++ b/apps/whitelabel-demo/src/app/api/usage/route.ts
@@ -84,8 +84,15 @@ export async function GET(req: NextRequest) {
   // that bill back out per Lumen user, which is the whole point of running as a
   // wrapper. Best-effort: an upstream that cannot group this way must not take
   // the rest of the page down with it.
+  // NARROWED TO THE CALLER. The account-wide rollup is exactly that —
+  // account-wide — so returning it unfiltered would let any signed-in Lumen user
+  // read every OTHER end-user's id and spend from the main nav. `projects` above
+  // is already scoped to owned projects; this has to be scoped too.
+  //
+  // A real operator dashboard would gate the unnarrowed view behind an operator
+  // role. The demo has no such role, so it shows you your own line only.
   const endUserBills = await kortix.billing
-    .usageRollup({ groupBy: 'end_user_ref' })
+    .usageRollup({ groupBy: 'end_user_ref', endUserRef: session.userId })
     .then((rollup) => splitEndUserBills(rollup.breakdown, markup))
     .catch(() => ({ bills: [], unattributedCost: 0 }));
 

--- a/apps/whitelabel-demo/src/app/api/usage/route.ts
+++ b/apps/whitelabel-demo/src/app/api/usage/route.ts
@@ -84,13 +84,10 @@ export async function GET(req: NextRequest) {
   // that bill back out per Lumen user, which is the whole point of running as a
   // wrapper. Best-effort: an upstream that cannot group this way must not take
   // the rest of the page down with it.
-  let endUserBills: ReturnType<typeof splitEndUserBills> = { bills: [], unattributedCost: 0 };
-  try {
-    const rollup = await kortix.billing.usageRollup({ groupBy: 'end_user_ref' });
-    endUserBills = splitEndUserBills(rollup.breakdown, markup);
-  } catch {
-    endUserBills = { bills: [], unattributedCost: 0 };
-  }
+  const endUserBills = await kortix.billing
+    .usageRollup({ groupBy: 'end_user_ref' })
+    .then((rollup) => splitEndUserBills(rollup.breakdown, markup))
+    .catch(() => ({ bills: [], unattributedCost: 0 }));
 
   const totals = projects.reduce(
     (acc, p) => {

--- a/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   useVisibleAgents,
   writeStartStash,
 } from '@kortix/sdk/react';
+import { classifySessionStartFailure } from '@/lib/session-start-error';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowUp, Sparkles } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
@@ -56,6 +57,13 @@ function ProjectHome() {
   const ref = useRef<HTMLTextAreaElement>(null);
 
   const [prompt, setPrompt] = useState('');
+  // A connector this end-user must connect THEMSELVES before the session can
+  // start (409 CONNECTOR_CONNECTION_REQUIRED). Shown as a call to action rather
+  // than an error, because it is one.
+  const [connectPrompt, setConnectPrompt] = useState<{
+    connector: string;
+    message: string;
+  } | null>(null);
   const [template, setTemplate] = useState('default');
   const [agent, setAgent] = useState<string | null>(null);
   const [model, setModel] = useState<ModelKey | null>(null);
@@ -96,7 +104,25 @@ function ProjectHome() {
       invalidateSessions(qc, projectId);
       router.push(`/projects/${projectId}/sessions/${sessionId}`);
     },
-    onError: () => toast.error('Could not start a session'),
+    onError: (err: unknown) => {
+      // Two KaaB refusals need opposite responses, and a single generic toast
+      // told the user to fix something they often could not fix.
+      const body =
+        err && typeof err === 'object' && 'body' in err
+          ? ((err as { body?: unknown }).body as Record<string, unknown> | null)
+          : null;
+      const failure = classifySessionStartFailure(body);
+      if (failure.kind === 'connector_connection_required') {
+        setConnectPrompt({ connector: failure.connector, message: failure.message });
+        return;
+      }
+      if (failure.kind === 'require_connectors_backend_origin') {
+        // Developer-facing: the end-user can do nothing about this.
+        toast.error(failure.message, { duration: 10_000 });
+        return;
+      }
+      toast.error(failure.message);
+    },
   });
 
   const launching = start.isPending;
@@ -114,6 +140,32 @@ function ProjectHome() {
             Pick your template, agent, and model, then describe the task.
           </p>
         </div>
+
+        {/* Kortix-as-a-Backend: the session needs THIS end-user's own connection.
+            A call to action, not a failure — they can resolve it themselves,
+            and the previous generic toast gave them nothing to act on. */}
+        {connectPrompt && (
+          <div className="mb-4 rounded-2xl border border-brand/40 bg-brand/5 p-4 text-left">
+            <div className="text-sm font-medium">
+              Connect {connectPrompt.connector} to continue
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">{connectPrompt.message}</p>
+            <div className="mt-3 flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={() => {
+                  setConnectPrompt(null);
+                  if (prompt.trim()) start.mutate(prompt);
+                }}
+              >
+                I&apos;ve connected it — retry
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setConnectPrompt(null)}>
+                Dismiss
+              </Button>
+            </div>
+          </div>
+        )}
 
         <div className="rounded-2xl border border-border bg-card shadow-sm transition-colors focus-within:border-ring/60">
           <Textarea

--- a/apps/whitelabel-demo/src/app/usage/page.tsx
+++ b/apps/whitelabel-demo/src/app/usage/page.tsx
@@ -157,10 +157,11 @@ function UsageDashboard() {
             {data.by_end_user.length > 0 && (
               <Card className="mt-6 overflow-hidden">
                 <div className="border-b px-4 py-3">
-                  <div className="text-sm font-medium">Charge by end-user</div>
+                  <div className="text-sm font-medium">Your end-user charge</div>
                   <div className="mt-0.5 text-xs text-muted-foreground">
                     Split from one upstream bill using the <code>end_user_ref</code> stamped on each
-                    session.
+                    session. Scoped to you — an operator dashboard would gate the account-wide view
+                    behind an operator role.
                   </div>
                 </div>
                 <table className="w-full text-sm">

--- a/apps/whitelabel-demo/src/app/usage/page.tsx
+++ b/apps/whitelabel-demo/src/app/usage/page.tsx
@@ -38,9 +38,20 @@ interface UsageProject {
   error?: string;
 }
 
+interface EndUserBill {
+  endUserRef: string;
+  rawCost: number;
+  billedCost: number;
+  sessions: number;
+}
+
 interface UsageResponse {
   markup: number;
   totals: { raw: number; billed: number };
+  /** Per-END-USER split, keyed on the end_user_ref the proxy stamps. */
+  by_end_user: EndUserBill[];
+  /** Spend with no end_user_ref — Lumen's own, deliberately not billed to anyone. */
+  unattributed_cost: number;
   projects: UsageProject[];
 }
 
@@ -140,6 +151,51 @@ function UsageDashboard() {
                 </div>
               </Card>
             </div>
+
+            {/* The wrapper's actual invoice: upstream bills this account once,
+                and end_user_ref splits it back out per Lumen user. */}
+            {data.by_end_user.length > 0 && (
+              <Card className="mt-6 overflow-hidden">
+                <div className="border-b px-4 py-3">
+                  <div className="text-sm font-medium">Charge by end-user</div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">
+                    Split from one upstream bill using the <code>end_user_ref</code> stamped on each
+                    session.
+                  </div>
+                </div>
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-xs text-muted-foreground">
+                      <th className="px-4 py-2 text-left font-normal">End-user</th>
+                      <th className="px-4 py-2 text-right font-normal">Sessions</th>
+                      <th className="px-4 py-2 text-right font-normal">Cost</th>
+                      <th className="px-4 py-2 text-right font-normal">You charge</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.by_end_user.map((bill) => (
+                      <tr key={bill.endUserRef} className="border-b last:border-b-0">
+                        <td className="px-4 py-2 font-mono text-xs">{bill.endUserRef}</td>
+                        <td className="px-4 py-2 text-right tabular-nums">{bill.sessions}</td>
+                        <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
+                          {usd(bill.rawCost)}
+                        </td>
+                        <td className="px-4 py-2 text-right font-medium tabular-nums">
+                          {usd(bill.billedCost)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                {data.unattributed_cost > 0 && (
+                  <div className="border-t px-4 py-2 text-xs text-muted-foreground">
+                    {usd(data.unattributed_cost)} is not attributed to any end-user — your own
+                    sessions, and anything from before this was tracked. It is deliberately not
+                    billed to anyone, so these rows will not sum to the total above.
+                  </div>
+                )}
+              </Card>
+            )}
 
             {data.projects.length === 0 && (
               <Card className="mt-6 p-8 text-center text-sm text-muted-foreground">

--- a/apps/whitelabel-demo/src/components/workbench/model-switcher.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/model-switcher.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { qk } from '@/lib/query-keys';
+import { getSessionToken } from '@/lib/session';
+import { useProjectModels } from '@kortix/sdk/react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Check, Cpu } from 'lucide-react';
+import { toast } from 'sonner';
+
+/**
+ * Change the model mid-session.
+ *
+ * A session's model used to be fixed at creation — the runtime read it once at
+ * start, so a live session kept it forever. Changing it now re-points the
+ * running runtime, which RESTARTS it and therefore ends any in-flight turn.
+ * That is why this is a deliberate choice rather than a silent setting.
+ *
+ * Goes through `/api/session-model` rather than the SDK directly: the upstream
+ * field is named after the runtime, and reference-app client code stays
+ * provider-neutral (scripts/sdk-boundary.mjs). The route reports whether the
+ * change took effect NOW or applies at next start, and we say which — a user
+ * told the model changed, whose next answer comes from the old one, has been
+ * lied to.
+ */
+export function ModelSwitcher({ projectId, sessionId }: { projectId: string; sessionId: string }) {
+  const qc = useQueryClient();
+  const models = useProjectModels(projectId);
+
+  // The switcher reads its OWN current model through the neutral route, so no
+  // caller has to touch the runtime-named field to render it.
+  const current = useQuery({
+    queryKey: ['session-model', projectId, sessionId],
+    queryFn: async () => {
+      const token = getSessionToken();
+      const res = await fetch(
+        `/api/session-model?projectId=${encodeURIComponent(projectId)}&sessionId=${encodeURIComponent(sessionId)}`,
+        { headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+      );
+      if (!res.ok) return { model: null as string | null };
+      return (await res.json()) as { model: string | null };
+    },
+    staleTime: 30_000,
+    retry: false,
+  });
+  const currentModel = current.data?.model ?? null;
+
+  const change = useMutation({
+    mutationFn: async (model: string) => {
+      const token = getSessionToken();
+      const res = await fetch(
+        `/api/session-model?projectId=${encodeURIComponent(projectId)}&sessionId=${encodeURIComponent(sessionId)}`,
+        {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ model }),
+        },
+      );
+      const body = (await res.json()) as { model?: string; appliedLive?: boolean; error?: string };
+      if (!res.ok) throw new Error(body.error ?? 'Could not change the model');
+      return body;
+    },
+    onSuccess: (result) => {
+      qc.invalidateQueries({ queryKey: qk.session(projectId, sessionId) });
+      qc.invalidateQueries({ queryKey: ['session-model', projectId, sessionId] });
+      toast.success(
+        result.appliedLive
+          ? `Now running ${result.model}`
+          : `${result.model} saved — applies when this session next starts`,
+      );
+    },
+    onError: (err: Error) => toast.error(err.message || 'Could not change the model'),
+  });
+
+  const options = models;
+  if (options.length === 0) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="gap-1.5" disabled={change.isPending}>
+          <Cpu className="size-3.5 shrink-0" />
+          <span className="max-w-40 truncate text-xs">{currentModel ?? 'Model'}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-56">
+        {options.map((model) => {
+          // Models are addressed `<provider>/<model>` — the same ref form the
+          // server stores, so what we send round-trips unchanged.
+          const id = `${model.providerID}/${model.modelID}`;
+          return (
+            <DropdownMenuItem
+              key={id}
+              onClick={() => id !== currentModel && change.mutate(id)}
+              className="gap-2"
+            >
+              {id === currentModel ? (
+                <Check className="size-3.5 shrink-0" />
+              ) : (
+                <span className="size-3.5 shrink-0" />
+              )}
+              <span className="truncate text-xs">{model.modelName || id}</span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/whitelabel-demo/src/components/workbench/session-header.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/session-header.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { ModelSwitcher } from '@/components/workbench/model-switcher';
 import { kortix } from '@/lib/kortix';
 import { invalidateSessions, qk } from '@/lib/query-keys';
 import { cn } from '@/lib/utils';
@@ -58,6 +59,10 @@ export function SessionHeader({ projectId, sessionId }: { projectId: string; ses
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium">{title}</div>
       </div>
+      {/* Mid-session model change. Placed by the status badge because switching
+          restarts the runtime and ends the in-flight turn — it belongs with the
+          session's live state, not buried in settings. */}
+      <ModelSwitcher projectId={projectId} sessionId={sessionId} />
       {status && (
         <Badge variant="secondary" className="capitalize">
           {status}

--- a/apps/whitelabel-demo/src/lib/session-start-error.ts
+++ b/apps/whitelabel-demo/src/lib/session-start-error.ts
@@ -1,0 +1,60 @@
+/**
+ * Why a session refused to start, in terms a wrapper's user can act on.
+ *
+ * Two Kortix-as-a-Backend outcomes matter and look nothing alike:
+ *
+ * - `409 CONNECTOR_CONNECTION_REQUIRED` — this end-user has not connected their
+ *   own account for a connector the session needs. Actionable BY THEM: connect
+ *   it and retry. This is the flow that makes per-end-user connectors work.
+ *
+ * - `403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY` — the caller asked for
+ *   `require_connectors` from a BACKEND origin. A wrapper key acts for no single
+ *   person, so "the current user's own connection" has no meaning. Not
+ *   actionable by the end-user at all; the wrapper must bind an explicit
+ *   `profile_id` via `connector_bindings` instead.
+ *
+ * Collapsing these into one "couldn't start a session" toast — which is what the
+ * demo did — tells the user to fix something they cannot fix, and hides an
+ * integration mistake from the developer.
+ */
+
+export type SessionStartFailure =
+  | { kind: 'connector_connection_required'; connector: string; message: string }
+  | { kind: 'require_connectors_backend_origin'; message: string }
+  | { kind: 'unknown'; message: string };
+
+interface UpstreamError {
+  status?: number;
+  code?: unknown;
+  error?: unknown;
+  connector?: unknown;
+}
+
+const asText = (value: unknown, fallback: string): string =>
+  typeof value === 'string' && value.trim().length > 0 ? value : fallback;
+
+export function classifySessionStartFailure(body: UpstreamError | null): SessionStartFailure {
+  const code = typeof body?.code === 'string' ? body.code : '';
+
+  if (code === 'CONNECTOR_CONNECTION_REQUIRED') {
+    return {
+      kind: 'connector_connection_required',
+      // The server names the connector so the UI can say WHICH one; without it
+      // the prompt is "connect something", which is not a call to action.
+      connector: asText(body?.connector, 'a connector'),
+      message: asText(body?.error, 'Connect your account to start this session.'),
+    };
+  }
+
+  if (code === 'REQUIRE_CONNECTORS_INTERACTIVE_ONLY') {
+    return {
+      kind: 'require_connectors_backend_origin',
+      message: asText(
+        body?.error,
+        'require_connectors is interactive-only — bind an explicit connection with connector_bindings instead.',
+      ),
+    };
+  }
+
+  return { kind: 'unknown', message: asText(body?.error, 'Could not start a session') };
+}

--- a/apps/whitelabel-demo/src/server/end-user-billing.ts
+++ b/apps/whitelabel-demo/src/server/end-user-billing.ts
@@ -1,0 +1,59 @@
+/**
+ * What Lumen charges each of ITS OWN users.
+ *
+ * Upstream bills Lumen once, for the whole account. `end_user_ref` — which the
+ * proxy stamps from the signed-in session — is what lets us split that bill back
+ * out per end-user, which is the entire point of running as a wrapper.
+ */
+
+export interface UpstreamEndUserRow {
+  end_user_ref?: string;
+  /** Deprecated alias an older upstream may still be the only one sending. */
+  origin_ref?: string;
+  cost?: number;
+  count?: number;
+}
+
+export interface EndUserBill {
+  endUserRef: string;
+  rawCost: number;
+  billedCost: number;
+  sessions: number;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/**
+ * Split an upstream `group_by=end_user_ref` rollup into per-end-user bills.
+ *
+ * Rows with no handle are DROPPED, never spread across users: unattributed
+ * spend is Lumen's own (dashboard sessions, anything predating the field), and
+ * charging it to whoever happens to sort first would be worse than not billing
+ * it at all. The caller is told how much was dropped so the gap is visible
+ * rather than silently absorbed.
+ */
+export function splitEndUserBills(
+  rows: UpstreamEndUserRow[] | undefined,
+  markup: number,
+): { bills: EndUserBill[]; unattributedCost: number } {
+  let unattributed = 0;
+  const bills: EndUserBill[] = [];
+
+  for (const row of rows ?? []) {
+    const ref = (row.end_user_ref ?? row.origin_ref ?? '').trim();
+    const cost = row.cost ?? 0;
+    if (ref.length === 0) {
+      unattributed += cost;
+      continue;
+    }
+    bills.push({
+      endUserRef: ref,
+      rawCost: round2(cost),
+      billedCost: round2(cost * markup),
+      sessions: row.count ?? 0,
+    });
+  }
+
+  bills.sort((a, b) => b.billedCost - a.billedCost || a.endUserRef.localeCompare(b.endUserRef));
+  return { bills, unattributedCost: round2(unattributed) };
+}

--- a/apps/whitelabel-demo/src/server/end-user.ts
+++ b/apps/whitelabel-demo/src/server/end-user.ts
@@ -1,0 +1,59 @@
+/**
+ * Kortix-as-a-Backend: vouching for Lumen's own end-user.
+ *
+ * In wrapper mode every upstream call is made with ONE credential — the
+ * wrapper's `KORTIX_API_KEY` — so upstream cannot tell Lumen's users apart on
+ * its own. `end_user_ref` is how we tell it, and it drives per-end-user usage
+ * attribution, idempotency-replay protection, and the optional per-end-user
+ * concurrency cap.
+ *
+ * It is injected HERE, server-side, from the authenticated session — never
+ * accepted from the browser. A client that could set it could bill another
+ * user, or replay their session through a shared Idempotency-Key.
+ */
+
+/** `POST /projects/{projectId}/sessions` — the only call that opens a session. */
+const SESSION_CREATE = /^projects\/[^/]+\/sessions\/?$/;
+
+export function isSessionCreate(method: string, upstreamPath: string): boolean {
+  return method.toUpperCase() === 'POST' && SESSION_CREATE.test(upstreamPath);
+}
+
+export type EndUserInjection =
+  | { action: 'inject'; body: Record<string, unknown> }
+  | { action: 'reject'; reason: string }
+  | { action: 'passthrough' };
+
+/**
+ * Decide what to send upstream for a session create.
+ *
+ * A browser-supplied `end_user_ref` (or its deprecated `origin_ref` alias) that
+ * disagrees with the signed-in user is REJECTED rather than overwritten: it
+ * means the client is trying to act as somebody else, and silently correcting it
+ * would hide an attack rather than surface it. Agreeing values pass through, so
+ * a client that echoes its own id is not punished for it.
+ */
+export function injectEndUserRef(
+  body: unknown,
+  userId: string,
+): EndUserInjection {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return { action: 'passthrough' };
+  }
+  const record = body as Record<string, unknown>;
+  const claimed = [record.end_user_ref, record.origin_ref].find(
+    (value) => typeof value === 'string' && value.trim().length > 0,
+  );
+  if (typeof claimed === 'string' && claimed.trim() !== userId) {
+    return {
+      action: 'reject',
+      reason: 'end_user_ref must not be set by the client — it is derived from your session',
+    };
+  }
+  return {
+    action: 'inject',
+    // Drop the legacy alias so upstream never sees both spellings and has to
+    // adjudicate; we send exactly one, canonical value.
+    body: { ...record, end_user_ref: userId, origin_ref: undefined },
+  };
+}

--- a/apps/whitelabel-demo/tests/e2e/end-user-billing.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/end-user-billing.test.ts
@@ -54,3 +54,18 @@ describe('splitEndUserBills', () => {
     expect(unattributedCost).toBe(3);
   });
 });
+
+describe('the usage route must narrow the rollup to the caller', () => {
+  // Regression guard. The first version passed only { groupBy: 'end_user_ref' },
+  // which is ACCOUNT-WIDE — any signed-in user could read every other
+  // end-user's id and spend from the main nav. `projects` in the same route was
+  // already scoped to owned projects; this had to be too.
+  test('the route asks upstream for the caller only', async () => {
+    const source = await Bun.file(
+      new URL('../../src/app/api/usage/route.ts', import.meta.url).pathname,
+    ).text();
+    const call = source.slice(source.indexOf('usageRollup'));
+    expect(call).toContain('endUserRef');
+    expect(call.slice(0, 200)).toContain('session.userId');
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/end-user-billing.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/end-user-billing.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { splitEndUserBills } from '../../src/server/end-user-billing';
+
+describe('splitEndUserBills', () => {
+  test('applies the markup per end-user', () => {
+    const { bills } = splitEndUserBills([{ end_user_ref: 'u1', cost: 10, count: 2 }], 1.5);
+    expect(bills[0]).toEqual({ endUserRef: 'u1', rawCost: 10, billedCost: 15, sessions: 2 });
+  });
+
+  test('drops unattributed spend instead of spreading it across users', () => {
+    // It is Lumen's own cost. Charging it to whoever sorts first would be worse
+    // than not billing it — so it is reported separately, not absorbed.
+    const { bills, unattributedCost } = splitEndUserBills(
+      [{ end_user_ref: 'u1', cost: 4 }, { cost: 6 }],
+      1,
+    );
+    expect(bills.map((b) => b.endUserRef)).toEqual(['u1']);
+    expect(unattributedCost).toBe(6);
+  });
+
+  test('reads the deprecated origin_ref when that is all upstream sends', () => {
+    const { bills } = splitEndUserBills([{ origin_ref: 'legacy', cost: 2 }], 1);
+    expect(bills[0]?.endUserRef).toBe('legacy');
+  });
+
+  test('sorts by what the customer is charged, biggest first', () => {
+    const { bills } = splitEndUserBills(
+      [{ end_user_ref: 'small', cost: 1 }, { end_user_ref: 'big', cost: 9 }],
+      2,
+    );
+    expect(bills.map((b) => b.endUserRef)).toEqual(['big', 'small']);
+  });
+
+  test('ties break on id so the invoice order never flickers', () => {
+    const { bills } = splitEndUserBills(
+      [{ end_user_ref: 'b', cost: 5 }, { end_user_ref: 'a', cost: 5 }],
+      1,
+    );
+    expect(bills.map((b) => b.endUserRef)).toEqual(['a', 'b']);
+  });
+
+  test('rounds money to cents rather than leaking float noise onto an invoice', () => {
+    const { bills } = splitEndUserBills([{ end_user_ref: 'u', cost: 0.1 }], 1.15);
+    expect(bills[0]?.billedCost).toBe(0.12);
+  });
+
+  test('no rows is empty, not a crash', () => {
+    expect(splitEndUserBills(undefined, 1.5)).toEqual({ bills: [], unattributedCost: 0 });
+  });
+
+  test('a whitespace-only handle counts as unattributed, not as a user named " "', () => {
+    const { bills, unattributedCost } = splitEndUserBills([{ end_user_ref: '  ', cost: 3 }], 1);
+    expect(bills).toHaveLength(0);
+    expect(unattributedCost).toBe(3);
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/end-user.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/end-user.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { injectEndUserRef, isSessionCreate } from '../../src/server/end-user';
+
+describe('isSessionCreate', () => {
+  test('matches only a session create', () => {
+    expect(isSessionCreate('POST', 'projects/p1/sessions')).toBe(true);
+    expect(isSessionCreate('POST', 'projects/p1/sessions/')).toBe(true);
+  });
+
+  test('does not match reads, or nested session routes', () => {
+    expect(isSessionCreate('GET', 'projects/p1/sessions')).toBe(false);
+    expect(isSessionCreate('POST', 'projects/p1/sessions/s1/model')).toBe(false);
+    expect(isSessionCreate('POST', 'projects/p1/secrets')).toBe(false);
+  });
+});
+
+describe('injectEndUserRef', () => {
+  test('stamps the signed-in user onto a session create', () => {
+    const result = injectEndUserRef({ name: 'hello' }, 'lumen-user-1');
+    expect(result.action).toBe('inject');
+    if (result.action === 'inject') {
+      expect(result.body.end_user_ref).toBe('lumen-user-1');
+      expect(result.body.name).toBe('hello');
+    }
+  });
+
+  test('REJECTS a client claiming to be someone else', () => {
+    // Silently overwriting would hide the attempt. Per-end-user billing and
+    // idempotency-replay protection both key on this value.
+    const result = injectEndUserRef({ end_user_ref: 'someone-else' }, 'lumen-user-1');
+    expect(result.action).toBe('reject');
+  });
+
+  test('rejects the deprecated origin_ref alias just as firmly', () => {
+    expect(injectEndUserRef({ origin_ref: 'someone-else' }, 'me').action).toBe('reject');
+  });
+
+  test('a client echoing its OWN id is fine, not punished', () => {
+    expect(injectEndUserRef({ end_user_ref: 'me' }, 'me').action).toBe('inject');
+  });
+
+  test('drops the legacy alias so upstream never sees both spellings', () => {
+    const result = injectEndUserRef({ origin_ref: 'me', name: 'x' }, 'me');
+    if (result.action === 'inject') {
+      expect(result.body.end_user_ref).toBe('me');
+      expect(result.body.origin_ref).toBeUndefined();
+    }
+  });
+
+  test('a non-object body passes through untouched', () => {
+    expect(injectEndUserRef(null, 'me').action).toBe('passthrough');
+    expect(injectEndUserRef([1, 2], 'me').action).toBe('passthrough');
+  });
+
+  test('a blank claim is not treated as an impersonation attempt', () => {
+    expect(injectEndUserRef({ end_user_ref: '   ' }, 'me').action).toBe('inject');
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/session-start-error.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-start-error.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { classifySessionStartFailure } from '../../src/lib/session-start-error';
+
+describe('classifySessionStartFailure', () => {
+  test('409 CONNECTOR_CONNECTION_REQUIRED names the connector so the prompt is actionable', () => {
+    const result = classifySessionStartFailure({
+      status: 409,
+      code: 'CONNECTOR_CONNECTION_REQUIRED',
+      connector: 'gmail',
+      error: 'Connector "gmail" requires a personal connection',
+    });
+    expect(result.kind).toBe('connector_connection_required');
+    if (result.kind === 'connector_connection_required') {
+      expect(result.connector).toBe('gmail');
+    }
+  });
+
+  test('falls back gracefully when the server names no connector', () => {
+    const result = classifySessionStartFailure({ code: 'CONNECTOR_CONNECTION_REQUIRED' });
+    if (result.kind === 'connector_connection_required') {
+      expect(result.connector).toBe('a connector');
+    }
+  });
+
+  test('403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY is a DEVELOPER error, not a user one', () => {
+    // A wrapper key acts for no single person, so this is not something the
+    // end-user can resolve by connecting anything.
+    const result = classifySessionStartFailure({
+      status: 403,
+      code: 'REQUIRE_CONNECTORS_INTERACTIVE_ONLY',
+      error: 'require_connectors is interactive-only',
+    });
+    expect(result.kind).toBe('require_connectors_backend_origin');
+  });
+
+  test('the two are never conflated — they need opposite responses', () => {
+    const a = classifySessionStartFailure({ code: 'CONNECTOR_CONNECTION_REQUIRED' });
+    const b = classifySessionStartFailure({ code: 'REQUIRE_CONNECTORS_INTERACTIVE_ONLY' });
+    expect(a.kind).not.toBe(b.kind);
+  });
+
+  test('anything else degrades to a plain message rather than a wrong prompt', () => {
+    expect(classifySessionStartFailure({ error: 'boom' })).toEqual({
+      kind: 'unknown',
+      message: 'boom',
+    });
+    expect(classifySessionStartFailure(null).kind).toBe('unknown');
+  });
+
+  test('a blank server message still yields something readable', () => {
+    expect(classifySessionStartFailure({ error: '   ' }).message).toBe('Could not start a session');
+  });
+});

--- a/docs/KAAB_DEPTH_PLAN.md
+++ b/docs/KAAB_DEPTH_PLAN.md
@@ -1,0 +1,95 @@
+# Kortix-as-a-Backend — depth plan
+
+Written 2026-07-27, after a 7-lens adversarial audit (63 agents, 45 findings that
+survived refutation) and a day of shipping against it. Ordered by
+(real user impact × confidence) ÷ effort. Every item cites evidence; anything I
+could not verify is marked as such rather than asserted.
+
+## Phase 0 — the thing that makes every other number untrustworthy
+
+**The `apps/api` suite does not run in CI.** `DOTENV_PRIVATE_KEY` is unset, so
+~1757 tests are green-but-vacuous. Three separate files were found broken *on
+main* in a single day:
+
+| File | State on main |
+| --- | --- |
+| `unit-preview-auth-principal.test.ts` | 0 ran (fixed → 24, #5583) |
+| `e2e-preview-proxy.test.ts` | 0 ran (fixed → 52 pass / 4 fail, #5583) |
+| `e2e-project-session-contract.test.ts` | 18 pass / **26 fail** — still broken |
+
+Two of those cover the sandbox-proxy auth surface, which is exactly where the
+session-isolation fix lives. **Do this first**: every confidence claim below is
+weaker until the suite actually runs.
+
+- Get the decryption key into CI, or make the suite runnable without it.
+- Fix `e2e-project-session-contract` (26 failures, uninvestigated).
+- Decide the 4 `e2e-preview-proxy` failures: they assert a rejected env sync
+  returns 502; current behaviour returns 200. Tests or product — someone who owns
+  that behaviour must choose. Do not force either to green.
+- Add a lint that fails a `mock.module` factory omitting exports the graph needs.
+  That single class of bug silently zeroed two files.
+
+## Phase 1 — correctness holes the audit confirmed
+
+1. **`created_by` is still the isolation boundary for backend rows.** #5577
+   stopped a sandbox token reaching a sibling session, but the underlying model —
+   every KaaB session sharing one creator — remains. Until `origin='backend'`
+   rows stop deriving ownership from `created_by`, each new read path is a fresh
+   chance to leak. *No e2e proof exists yet that the current fix holds.*
+2. **A create whose failure was already returned gets re-queued**
+   (`engine.ts:275` passes `retryable` on the synchronous path; `store.ts:232`
+   flips it to `queued`). The wrapper is told "try again", retries with a fresh
+   key, and the original silently creates a second billed sandbox 2–20s later —
+   same `end_user_ref`, both running the baked prompt. Fix: `retryable: false`
+   on the inline path.
+3. **Three connector-alias forms across three gates** (`db-deps.ts:845`,
+   `router.ts:380`, `sessions.ts:880`). A manifest grant of `kortix_email` makes
+   the connector invisible in the catalog; a grant of `email` makes it visible
+   and then 403s on call. Canonicalize once at grant construction. Folds in the
+   duplicate-alias raw-Postgres 500.
+4. **`403 CONNECTOR_NOT_ASSIGNED` is undocumented** — and it is the first error
+   the public docs' own flagship example hits on any project declaring agents.
+
+## Phase 2 — finish the demo (it is the spec people copy)
+
+Done: `end_user_ref` stamping, charge-by-end-user.
+
+Remaining, in order of what teaches the most:
+
+1. **`409 CONNECTOR_CONNECTION_REQUIRED`.** The one genuinely novel KaaB UX —
+   the session refuses to start until *this end-user* connects their own account.
+   Nothing in the demo models it; without it, wrapper authors will not know the
+   flow exists.
+2. **Connector-binding picker** — choose which connection a session runs as,
+   using the per-row `profile_id`.
+3. **Model switcher** wired to `PUT /sessions/{id}/model`, showing the
+   `applied_live` distinction honestly rather than pretending it is instant.
+4. **Secrets allowlist** — narrow a session to a subset, and show that the
+   allowlist is *immutable* for that session's life.
+5. **Idempotency** — demonstrate that replaying a key under a different
+   end-user is refused, which is the safety property wrapper authors most often
+   get wrong.
+6. **Per-end-user concurrency cap** — currently `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT`
+   defaults to 0 (off) and is set in no chart, so it is dark everywhere.
+
+## Phase 3 — prove it, don't assert it
+
+The two security fixes shipped today are covered by unit tests of their decision
+functions and wiring — not by end-to-end proof:
+
+- A token minted for session A must 404 on session B's transcript.
+- Two connections under one connector must resolve to *different* policies
+  through the gateway.
+- A revoked secret must be absent from a child process spawned after revocation.
+
+Each is a single integration test. Each currently rests on reasoning.
+
+## Naming and docs debt
+
+- `origin_ref` → `end_user_ref` is done at the wire, with the alias permanent.
+  The DB column, the ops env var, and the error codes deliberately keep the old
+  name; that is a defensible boundary but it should be written down where the
+  next person looks.
+- The public page claimed per-end-user metering did not exist for 108 minutes
+  after it shipped, and nobody noticed until an audit read it. Docs drift on the
+  only customer-facing KaaB page deserves a check, not vigilance.

--- a/docs/KAAB_DEPTH_PLAN.md
+++ b/docs/KAAB_DEPTH_PLAN.md
@@ -5,29 +5,58 @@ survived refutation) and a day of shipping against it. Ordered by
 (real user impact × confidence) ÷ effort. Every item cites evidence; anything I
 could not verify is marked as such rather than asserted.
 
-## Phase 0 — the thing that makes every other number untrustworthy
+## Phase 0 — the suite has no venue to run in
 
-**The `apps/api` suite does not run in CI.** `DOTENV_PRIVATE_KEY` is unset, so
-~1757 tests are green-but-vacuous. Three separate files were found broken *on
-main* in a single day:
+**Corrected 2026-07-27 after I got this wrong twice. Read the correction.**
 
-| File | State on main |
-| --- | --- |
-| `unit-preview-auth-principal.test.ts` | 0 ran (fixed → 24, #5583) |
-| `e2e-preview-proxy.test.ts` | 0 ran (fixed → 52 pass / 4 fail, #5583) |
-| `e2e-project-session-contract.test.ts` | 18 pass / **26 fail** — still broken |
+### What is actually true
 
-Two of those cover the sandbox-proxy auth surface, which is exactly where the
-session-isolation fix lives. **Do this first**: every confidence claim below is
-weaker until the suite actually runs.
+`package-tests.yml` triggers on **`pull_request` only** (plus manual dispatch) —
+20 of the last 20 runs were `pull_request`. The `kortix-api` job materializes
+`DOTENV_PRIVATE_KEY` only when `github.event_name != 'pull_request'`, a
+deliberate control added by a pentest the same day:
 
-- Get the decryption key into CI, or make the suite runnable without it.
-- Fix `e2e-project-session-contract` (26 failures, uninvestigated).
-- Decide the 4 `e2e-preview-proxy` failures: they assert a rejected env sync
-  returns 502; current behaviour returns 200. Tests or product — someone who owns
-  that behaviour must choose. Do not force either to green.
-- Add a lint that fails a `mock.module` factory omitting exports the graph needs.
-  That single class of bug silently zeroed two files.
+> exposing DOTENV_PRIVATE_KEY would let a same-repo branch PR read all 80+ prod
+> secrets decryptable with that one key
+
+Both halves are individually correct. Together they mean the condition can never
+be satisfied, so **the env-gated suite never runs anywhere**. This is not
+negligence — it is a security control colliding with a trigger list.
+
+**The fix is small and preserves the security property:** add
+`push: branches: [main]`. PR-head code still never sees the key; the suite gains
+a post-merge venue.
+
+**Risk to weigh first:** locally the suite shows failures under the real CI
+command, but my environment is provably not CI's (see below), so I cannot
+predict whether enabling this turns `main` red. Someone should dry-run it via
+`workflow_dispatch` before wiring the trigger.
+
+### What I got wrong, and why it matters
+
+1. **"26 failures in `e2e-project-session-contract.test.ts`"** — that was my
+   local `KORTIX_BILLING_INTERNAL_ENABLED=true`. With CI's value the file is
+   **44 pass / 0 fail**. I asserted it repeatedly and built a plan section on it.
+2. **"93 failures across the suite"** — I ran `bun test src`, which includes
+   integration and live files that `scripts/test.sh` deliberately excludes.
+3. Even the correct command (`bash scripts/test.sh`) shows 56 local failures
+   while CI is green, which proves my `.env` differs from CI's in more than the
+   billing flag. **Local failure counts from this machine are not evidence about
+   CI** and should not be quoted as such.
+
+The lesson worth keeping: a local test run is evidence about the local
+environment. Treating it as evidence about CI produced a confident, wrong
+priority list.
+
+### Still genuinely true
+
+- Two files (`unit-preview-auth-principal`, `e2e-preview-proxy`) failed to LOAD
+  from incomplete `mock.module` factories — a SyntaxError, environment-independent.
+  Fixed in #5583 (0 → 24 and 0 → 52 tests). That fix stands.
+- `e2e-preview-proxy` still shows 4 failures under CI's billing value, so those
+  are not explained by the env flag. Unresolved.
+- A lint that fails a `mock.module` factory omitting exports the graph needs is
+  still worth adding: that single class of bug zeroed two files silently.
 
 ## Phase 1 — correctness holes the audit confirmed
 

--- a/packages/sdk/src/core/client/kortix.ts
+++ b/packages/sdk/src/core/client/kortix.ts
@@ -878,6 +878,16 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
       setModel: (model: SessionModel | undefined) => {
         _model = model;
       },
+      /**
+       * PERSIST a new model for this session server-side, re-pointing the
+       * running sandbox. Distinct from `setModel`, which only chooses what the
+       * NEXT local `send` asks for and never leaves this handle.
+       *
+       * Restarting the runtime is how the change takes effect, so an in-flight
+       * turn ends. `applied_live` reports whether a running session took it now
+       * or whether it applies at next start.
+       */
+      changeModel: (model: string) => P.setProjectSessionModel(projectId, sessionId, model),
       /** Pick the agent `send` will use for subsequent prompts (until changed). */
       setAgent: (agent: string | undefined) => {
         _agent = agent;

--- a/packages/sdk/src/core/client/kortix.ts
+++ b/packages/sdk/src/core/client/kortix.ts
@@ -182,6 +182,8 @@ export function createKortix(config: KortixPlatformConfig, opts?: { global?: boo
     transactionsSummary: P.getBillingTransactionsSummary,
     creditBreakdown: P.getBillingCreditBreakdown,
     usageHistory: P.getBillingUsageHistory,
+    /** Usage rollup (/v1/usage) — supports group_by 'end_user_ref' for wrappers. */
+    usageRollup: P.getUsageRollup,
     tierConfigurations: P.getBillingTierConfigurations,
 
     /** Stripe checkout — start a subscription and confirm it post-redirect. */


### PR DESCRIPTION
Lumen is the reference implementation people copy, and it had **zero**
Kortix-as-a-Backend awareness: every upstream call went out under one credential,
so upstream could not tell Lumen's users apart. Usage was unattributable,
idempotency replay unguarded across users, the per-end-user cap permanently dark.

Four increments, each with its own tests.

### 1. Vouch for the end-user

`/api/kortix` already forwards with `KORTIX_API_KEY` — a backend-origin call — so
that is the honest place to stamp `end_user_ref` from the authenticated session.
A client supplying a **different** one is rejected `403` rather than silently
corrected: overwriting hides an impersonation attempt instead of surfacing it.
A client echoing its own id passes through.

### 2. Charge by end-user

Upstream bills the account once; `end_user_ref` splits it back out per Lumen
user, which is the whole reason to run as a wrapper. The usage page billed per
*project* and had no end-user dimension.

Unattributed spend is **dropped, not spread**. It is Lumen's own cost, and
charging it to whoever sorts first would be worse than not billing it. The amount
is reported separately and the UI says why the rows will not sum to the total —
a silent gap on an invoice is the kind of thing people find later.

### 3. The connector-connection flow

Every start failure collapsed into one "Could not start a session" toast. Two
KaaB refusals need **opposite** responses:

| | Who can fix it | Now |
| --- | --- | --- |
| `409 CONNECTOR_CONNECTION_REQUIRED` | the end-user | named prompt + retry |
| `403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY` | the developer | long-lived error |

The old toast told users to fix something they frequently could not, while
hiding an integration mistake from the developer. One test asserts specifically
that the two are never conflated.

Worth stating, because the demo now teaches it: **a wrapper cannot use
`require_connectors` at all** — a wrapper key acts for no single person, so it
must bind an explicit `profile_id` via `connector_bindings`.

### 4. Mid-session model switcher

Wires `PUT /sessions/{id}/model` (#5592) into the workbench, next to the status
badge because switching restarts the runtime and ends the in-flight turn.

Reports `applied_live` honestly — "Now running X" vs "X saved, applies when this
session next starts". A user told the model changed, whose next answer comes from
the old one, has been lied to.

Goes through a new `/api/session-model` route: the upstream field is named after
the runtime, and this app forbids that name in **client** code. The route is the
translation seam, matching the app's own rule that its routes return
provider-neutral fields.

### Boundary checker fix

`scripts/sdk-boundary.mjs` parsed only string-literal `fetch` targets, so an
allowed app route could not be called with query params **at all**. It now judges
a template literal by its **static prefix**.

I verified this is a widening where it was too narrow, not a weakening — a
throwaway probe confirmed a dynamic base (`${base}/api/usage`), an unlisted
route, and a direct upstream URL are all still rejected.

### Verification

- `sdk-boundary`: **0 violations**
- demo suite: **80 pass / 0 fail**
- `@kortix/sdk`: 1297 pass / 0 fail; surface snapshot additive only
- tsc clean

**Not covered:** none of this has been exercised against a live upstream. The
units cover the decision logic and wiring; the round trips are unobserved.

Plan for the rest: `docs/KAAB_DEPTH_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
