### PR TITLE
fix(test): validate every decorative landing element

### DIFF
--- a/tests/accessibility/landing.a11y.spec.ts
+++ b/tests/accessibility/landing.a11y.spec.ts
@@ -38,8 +38,12 @@ test.describe('Accessibility — axe-core', () => {
     await page.goto('/', { waitUntil: 'networkidle' });
 
     const decorativeArtwork = page.locator('[data-a11y-decorative]');
-    await expect(decorativeArtwork).toHaveCount(1);
-    await expect(decorativeArtwork).toHaveAttribute('aria-hidden', 'true');
+    const decorativeArtworkCount = await decorativeArtwork.count();
+    expect(decorativeArtworkCount).toBeGreaterThan(0);
+    const ariaHiddenValues = await decorativeArtwork.evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute('aria-hidden')),
+    );
+    expect(ariaHiddenValues).toEqual(Array(decorativeArtworkCount).fill('true'));
 
     const results = await new AxeBuilder({ page })
       .withTags(WCAG_TAGS)


### PR DESCRIPTION
## Summary
- remove the obsolete exact decorative element count
- require at least one decorative element
- require `aria-hidden=true` on every decorative element

## Verification
- `E2E_BASE_URL=https://us.kortix.com bun run test:a11y` -> 2 passed
- `bunx tsc --noEmit` -> passed
- staging QA trace contains 3 matching elements; all have `aria-hidden=true`