### PR TITLE
fix(test): validate every decorative landing element

### DIFF
--- a/tests/accessibility/landing.a11y.spec.ts
+++ b/tests/accessibility/landing.a11y.spec.ts
@@ -38,8 +38,12 @@ test.describe('Accessibility — axe-core', () => {
     await page.goto('/', { waitUntil: 'networkidle' });
 
     const decorativeArtwork = page.locator('[data-a11y-decorative]');
-    await expect(decorativeArtwork).toHaveCount(1);
-    await expect(decorativeArtwork).toHaveAttribute('aria-hidden', 'true');
+    const decorativeArtworkCount = await decorativeArtwork.count();
+    expect(decorativeArtworkCount).toBeGreaterThan(0);
+    const ariaHiddenValues = await decorativeArtwork.evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute('aria-hidden')),
+    );
+    expect(ariaHiddenValues).toEqual(Array(decorativeArtworkCount).fill('true'));
 
     const results = await new AxeBuilder({ page })
       .withTags(WCAG_TAGS)


### PR DESCRIPTION
## Summary
- carry the staging accessibility gate correction from main
- require at least one decorative element
- require `aria-hidden=true` on every decorative element

## Evidence
- QA run `30281815683` found 3 matching elements
- the captured staging trace shows `aria-hidden=true` on all 3 elements
- `E2E_BASE_URL=https://us.kortix.com bun run test:a11y` passed 2/2