### PR TITLE
fix(migration): reconcile shadow credit ledger rows

### DIFF
--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -606,6 +606,8 @@ SQL
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT $credit_account_columns FROM kortix.credit_accounts ORDER BY account_id) TO '$temporary_directory/credit_accounts.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -c "\\copy (SELECT id FROM kortix.credit_ledger ORDER BY id COLLATE \"C\") TO '$temporary_directory/credit_ledger_ids.csv' WITH (FORMAT csv)"
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT session_id, last_used_at, metadata, updated_at FROM kortix.session_sandboxes ORDER BY session_id COLLATE \"C\") TO '$temporary_directory/session_sandboxes.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -v shadow_audit_start_at="$SHADOW_AUDIT_START_AT" \
@@ -633,6 +635,9 @@ CREATE TEMP TABLE repair_session_sandboxes (
   metadata jsonb,
   updated_at timestamptz
 ) ON COMMIT DROP;
+CREATE TEMP TABLE repair_credit_ledger_ids (
+  id uuid PRIMARY KEY
+) ON COMMIT DROP;
 CREATE TEMP TABLE repair_audit_event_ids (
   event_id uuid PRIMARY KEY
 ) ON COMMIT DROP;
@@ -641,6 +646,7 @@ SQL
       "$credit_account_columns"
     printf "\\copy repair_api_keys FROM '%s/api_keys.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_credit_accounts FROM '%s/credit_accounts.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy repair_credit_ledger_ids FROM '%s/credit_ledger_ids.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_session_sandboxes FROM '%s/session_sandboxes.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_audit_event_ids FROM '%s/audit_event_ids.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     cat <<'SQL'
@@ -731,6 +737,13 @@ WHERE target.account_id = source.account_id
 	  FROM repair_credit_accounts AS source
 	  WHERE source.account_id = target.account_id
 	);
+
+DELETE FROM kortix.credit_ledger AS target
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM repair_credit_ledger_ids AS source
+  WHERE source.id = target.id
+);
 
 UPDATE kortix.session_sandboxes AS target
 SET

--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -606,7 +606,7 @@ SQL
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT $credit_account_columns FROM kortix.credit_accounts ORDER BY account_id) TO '$temporary_directory/credit_accounts.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
-    -c "\\copy (SELECT id FROM kortix.credit_ledger ORDER BY id COLLATE \"C\") TO '$temporary_directory/credit_ledger_ids.csv' WITH (FORMAT csv)"
+    -c "\\copy (SELECT id FROM kortix.credit_ledger ORDER BY id) TO '$temporary_directory/credit_ledger_ids.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT session_id, last_used_at, metadata, updated_at FROM kortix.session_sandboxes ORDER BY session_id COLLATE \"C\") TO '$temporary_directory/session_sandboxes.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \

--- a/scripts/prod-us-east-2/db-sync.test.mjs
+++ b/scripts/prod-us-east-2/db-sync.test.mjs
@@ -97,6 +97,26 @@ test("shadow repair disables statement timeout and restores the full credit acco
   assert.match(body, /balance_precise = source\.balance/);
 });
 
+test("shadow repair deletes credit ledger rows that do not exist on the source", () => {
+  const body = functionBody(
+    "repair_shadow_mutations",
+    "backfill_target_precision_columns",
+  );
+
+  assert.match(
+    body,
+    /SELECT id FROM kortix\.credit_ledger ORDER BY id COLLATE \\"C\\"/,
+  );
+  assert.match(
+    body,
+    /CREATE TEMP TABLE repair_credit_ledger_ids \(\s*id uuid PRIMARY KEY\s*\)/,
+  );
+  assert.match(
+    body,
+    /DELETE FROM kortix\.credit_ledger AS target\s+WHERE NOT EXISTS \(\s+SELECT 1\s+FROM repair_credit_ledger_ids AS source\s+WHERE source\.id = target\.id\s+\)/,
+  );
+});
+
 test("shadow repair exit trap uses captured cleanup arguments", () => {
   const body = functionBody(
     "repair_shadow_mutations",

--- a/scripts/prod-us-east-2/db-sync.test.mjs
+++ b/scripts/prod-us-east-2/db-sync.test.mjs
@@ -105,7 +105,7 @@ test("shadow repair deletes credit ledger rows that do not exist on the source",
 
   assert.match(
     body,
-    /SELECT id FROM kortix\.credit_ledger ORDER BY id COLLATE \\"C\\"/,
+    /SELECT id FROM kortix\.credit_ledger ORDER BY id/,
   );
   assert.match(
     body,


### PR DESCRIPTION
## Summary

- export authoritative EU `kortix.credit_ledger.id` values during shadow repair
- delete US shadow ledger rows whose IDs do not exist in EU
- add regression coverage for the reconciliation guard

## Verification

- `node --test scripts/prod-us-east-2/*.test.mjs` — 29 passed
- `bash -n scripts/prod-us-east-2/db-sync.sh`
- `git diff --check`

## Production safety

This change does not freeze EU writes or change production routing. The repair mutates only the US shadow when `ALLOW_TARGET_SHADOW_REPAIR=1` is set.