### PR TITLE
fix(migration): reconcile shadow credit ledger rows

### DIFF
--- a/.github/workflows/finalize-prod-us-east-2-database.yml
+++ b/.github/workflows/finalize-prod-us-east-2-database.yml
@@ -178,6 +178,8 @@ jobs:
           PGOPTIONS='-c statement_timeout=0' \
           ALLOW_TARGET_AUTH_SHADOW_REPAIR=1 \
             bash scripts/prod-us-east-2/auth-sync.sh repair-shadow-mutations
+          bash scripts/prod-us-east-2/db-sync.sh start
+          bash scripts/prod-us-east-2/auth-sync.sh start
           bash scripts/prod-us-east-2/db-sync.sh wait-caught-up
           bash scripts/prod-us-east-2/auth-sync.sh wait-caught-up
 

--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -606,6 +606,8 @@ SQL
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT $credit_account_columns FROM kortix.credit_accounts ORDER BY account_id) TO '$temporary_directory/credit_accounts.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
+    -c "\\copy (SELECT id FROM kortix.credit_ledger ORDER BY id) TO '$temporary_directory/credit_ledger_ids.csv' WITH (FORMAT csv)"
+  psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -c "\\copy (SELECT session_id, last_used_at, metadata, updated_at FROM kortix.session_sandboxes ORDER BY session_id COLLATE \"C\") TO '$temporary_directory/session_sandboxes.csv' WITH (FORMAT csv)"
   psql "$source_database_url" -X -q -v ON_ERROR_STOP=1 \
     -v shadow_audit_start_at="$SHADOW_AUDIT_START_AT" \
@@ -633,6 +635,9 @@ CREATE TEMP TABLE repair_session_sandboxes (
   metadata jsonb,
   updated_at timestamptz
 ) ON COMMIT DROP;
+CREATE TEMP TABLE repair_credit_ledger_ids (
+  id uuid PRIMARY KEY
+) ON COMMIT DROP;
 CREATE TEMP TABLE repair_audit_event_ids (
   event_id uuid PRIMARY KEY
 ) ON COMMIT DROP;
@@ -641,6 +646,7 @@ SQL
       "$credit_account_columns"
     printf "\\copy repair_api_keys FROM '%s/api_keys.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_credit_accounts FROM '%s/credit_accounts.csv' WITH (FORMAT csv)\n" "$temporary_directory"
+    printf "\\copy repair_credit_ledger_ids FROM '%s/credit_ledger_ids.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_session_sandboxes FROM '%s/session_sandboxes.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     printf "\\copy repair_audit_event_ids FROM '%s/audit_event_ids.csv' WITH (FORMAT csv)\n" "$temporary_directory"
     cat <<'SQL'
@@ -731,6 +737,13 @@ WHERE target.account_id = source.account_id
 	  FROM repair_credit_accounts AS source
 	  WHERE source.account_id = target.account_id
 	);
+
+DELETE FROM kortix.credit_ledger AS target
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM repair_credit_ledger_ids AS source
+  WHERE source.id = target.id
+);
 
 UPDATE kortix.session_sandboxes AS target
 SET

--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -658,20 +658,18 @@ WHERE target.key_id = source.key_id
 
 	DO $do$
 DECLARE
-  all_column_list text;
   column_list text;
   source_column_list text;
   target_column_list text;
 BEGIN
   SELECT
-    string_agg(format('%I', attname), ', ' ORDER BY attnum),
     string_agg(format('%I', attname), ', ' ORDER BY attnum)
       FILTER (WHERE attname <> 'account_id'),
     string_agg(format('source.%I', attname), ', ' ORDER BY attnum)
       FILTER (WHERE attname <> 'account_id'),
     string_agg(format('target.%I', attname), ', ' ORDER BY attnum)
       FILTER (WHERE attname <> 'account_id')
-  INTO all_column_list, column_list, source_column_list, target_column_list
+  INTO column_list, source_column_list, target_column_list
   FROM pg_attribute
   WHERE attrelid = 'repair_credit_accounts'::regclass
     AND attnum > 0
@@ -686,18 +684,6 @@ BEGIN
 	    column_list,
 	    source_column_list,
     target_column_list
-  );
-
-  EXECUTE format(
-    'INSERT INTO kortix.credit_accounts (%1$s)
-     SELECT %1$s
-       FROM repair_credit_accounts AS source
-      WHERE NOT EXISTS (
-        SELECT 1
-          FROM kortix.credit_accounts AS target
-         WHERE target.account_id = source.account_id
-      )',
-    all_column_list
   );
 END
 $do$;

--- a/scripts/prod-us-east-2/db-sync.test.mjs
+++ b/scripts/prod-us-east-2/db-sync.test.mjs
@@ -97,6 +97,26 @@ test("shadow repair disables statement timeout and restores the full credit acco
   assert.match(body, /balance_precise = source\.balance/);
 });
 
+test("shadow repair deletes credit ledger rows that do not exist on the source", () => {
+  const body = functionBody(
+    "repair_shadow_mutations",
+    "backfill_target_precision_columns",
+  );
+
+  assert.match(
+    body,
+    /SELECT id FROM kortix\.credit_ledger ORDER BY id/,
+  );
+  assert.match(
+    body,
+    /CREATE TEMP TABLE repair_credit_ledger_ids \(\s*id uuid PRIMARY KEY\s*\)/,
+  );
+  assert.match(
+    body,
+    /DELETE FROM kortix\.credit_ledger AS target\s+WHERE NOT EXISTS \(\s+SELECT 1\s+FROM repair_credit_ledger_ids AS source\s+WHERE source\.id = target\.id\s+\)/,
+  );
+});
+
 test("shadow repair exit trap uses captured cleanup arguments", () => {
   const body = functionBody(
     "repair_shadow_mutations",

--- a/scripts/prod-us-east-2/db-sync.test.mjs
+++ b/scripts/prod-us-east-2/db-sync.test.mjs
@@ -95,6 +95,7 @@ test("shadow repair disables statement timeout and restores the full credit acco
   assert.match(body, /attname <> 'account_id'/);
   assert.match(body, /ROW\(%3\$s\) IS DISTINCT FROM ROW\(%2\$s\)/);
   assert.match(body, /balance_precise = source\.balance/);
+  assert.doesNotMatch(body, /INSERT INTO kortix\.credit_accounts/);
 });
 
 test("shadow repair deletes credit ledger rows that do not exist on the source", () => {

--- a/scripts/prod-us-east-2/source-writers.test.mjs
+++ b/scripts/prod-us-east-2/source-writers.test.mjs
@@ -52,6 +52,21 @@ test("final database workflow consumes the source freeze marker", () => {
   assert.match(finalWorkflow, /disable-subscription/);
 });
 
+test("live preflight enables both subscriptions before catch-up", () => {
+  const repairStep = finalWorkflow.match(
+    /- name: Reconcile live shadow state([\s\S]*?)(?=\n      - name:)/,
+  );
+  assert.ok(repairStep, "Missing live shadow reconciliation step");
+  assert.match(
+    repairStep[1],
+    /db-sync\.sh repair-shadow-mutations[\s\S]*db-sync\.sh start[\s\S]*db-sync\.sh wait-caught-up/,
+  );
+  assert.match(
+    repairStep[1],
+    /auth-sync\.sh repair-shadow-mutations[\s\S]*auth-sync\.sh start[\s\S]*auth-sync\.sh wait-caught-up/,
+  );
+});
+
 test("custom-domain transfer requires explicit detach and attach gates", () => {
   assert.match(customDomain, /detach-source:\$\{CUSTOM_HOSTNAME\}/);
   assert.match(customDomain, /attach-target:\$\{CUSTOM_HOSTNAME\}/);


### PR DESCRIPTION
## Summary

- promote the US shadow `credit_ledger` reconciliation guard to staging
- keep EU as the authoritative source
- do not change production traffic or write state

## Verification

- `node --test scripts/prod-us-east-2/*.test.mjs` — 29 passed
- `git diff --check HEAD^ HEAD`