### PR TITLE
fix: never re-queue a create whose failure was already returned to the caller

### DIFF
--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -2,6 +2,7 @@ import { executorExecutions, projectSessions, projects, serviceAccounts } from '
 import { and, eq } from 'drizzle-orm';
 import { bindChatThread } from '../../channels/slack/binding';
 import { config } from '../../config';
+import { mayRequeueFailedCreate } from './requeue-policy';
 import { forwardToSandbox } from '../../sandbox-proxy/routes/preview';
 import { db } from '../../shared/db';
 import { connectorBindingPayloadConflicts } from '../lib/session-connector-bindings';
@@ -273,8 +274,16 @@ export async function createSession(
   }
 
   const message = String(result.error?.body?.error ?? result.reason ?? 'Failed to create session');
+  // This is the INLINE path — the queued branch returned above — so `result` is
+  // about to be handed to a waiting caller. Marking it retryable would leave the
+  // command row queued for the drainer as well, and the caller (told by the
+  // guide that a 429/503 is worth retrying) retries with a fresh key: two billed
+  // sandboxes for one intent, same end_user_ref, both running initial_prompt.
   await markCommandFailed(claimed.row.commandId, message, {
-    retryable: result.retryable ?? false,
+    retryable: mayRequeueFailedCreate({
+      answeredSynchronously: true,
+      errorIsRetryable: result.retryable ?? false,
+    }),
     attempts: claimed.row.attempts + 1,
   });
   return { ...result, commandId: claimed.row.commandId };

--- a/apps/api/src/projects/session-lifecycle/requeue-policy.test.ts
+++ b/apps/api/src/projects/session-lifecycle/requeue-policy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { mayRequeueFailedCreate } from './requeue-policy';
+
+describe('mayRequeueFailedCreate', () => {
+  test('a failure ALREADY RETURNED to the caller is never re-queued', () => {
+    // The caller owns the retry now. Keeping our own copy means their retry and
+    // our drainer both run it: two billed sandboxes, same end_user_ref, both
+    // executing the baked initial_prompt — and their retry succeeded, so they
+    // never find out.
+    expect(
+      mayRequeueFailedCreate({ answeredSynchronously: true, errorIsRetryable: true }),
+    ).toBe(false);
+  });
+
+  test('a QUEUED failure retries transient errors — that is the point of the queue', () => {
+    expect(
+      mayRequeueFailedCreate({ answeredSynchronously: false, errorIsRetryable: true }),
+    ).toBe(true);
+  });
+
+  test('a queued failure with a terminal error is not retried', () => {
+    expect(
+      mayRequeueFailedCreate({ answeredSynchronously: false, errorIsRetryable: false }),
+    ).toBe(false);
+  });
+
+  test('retryability follows OWNERSHIP, not the error class', () => {
+    // Same transient error, opposite answers — which is the whole rule.
+    const transient = { errorIsRetryable: true };
+    expect(mayRequeueFailedCreate({ ...transient, answeredSynchronously: true })).toBe(false);
+    expect(mayRequeueFailedCreate({ ...transient, answeredSynchronously: false })).toBe(true);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/requeue-policy.ts
+++ b/apps/api/src/projects/session-lifecycle/requeue-policy.ts
@@ -1,0 +1,30 @@
+/**
+ * May a failed create be re-queued for another attempt?
+ *
+ * A create runs on one of two paths:
+ *
+ * - INLINE — the caller is waiting, and the failure is returned to them in the
+ *   same HTTP response. They then decide what to do: the guide tells them a 429
+ *   or 503 is worth retrying, so they retry, usually with a fresh
+ *   Idempotency-Key.
+ * - QUEUED — nobody is waiting. The queue drainer owns the outcome, and
+ *   retrying transient infrastructure failures is the entire point.
+ *
+ * Re-queueing an INLINE failure means the same request runs twice: once as the
+ * caller's retry, once as the drainer's. Two billed sandboxes for one intent,
+ * with the same end_user_ref, both executing the baked initial_prompt. The
+ * caller cannot detect it — their retry succeeded.
+ *
+ * So retryability is a property of WHO OWNS THE OUTCOME, not of the error.
+ */
+export function mayRequeueFailedCreate(input: {
+  /** True when the failure is being returned to a waiting caller. */
+  answeredSynchronously: boolean;
+  /** Whether the underlying error is transient (429/5xx). */
+  errorIsRetryable: boolean;
+}): boolean {
+  // Answering the caller transfers ownership of the retry to them. Keeping a
+  // copy for ourselves is how one intent becomes two sandboxes.
+  if (input.answeredSynchronously) return false;
+  return input.errorIsRetryable;
+}


### PR DESCRIPTION
## The bug

A create runs on one of two paths:

- **inline** — the caller is waiting, and the failure is returned in the same
  HTTP response
- **queued** — nobody is waiting; the drainer owns the outcome, and retrying
  transient failures is the entire point

The inline path marked the command **retryable** on failure. `store.ts:232`
(`retry = opts.retryable && attempts < 5`) then flips the row back to `queued`,
and `drainSessionLifecycleQueue` re-executes it.

So the same request runs twice. The guide tells wrappers a 429/503 is worth
retrying, so they retry — usually with a fresh `Idempotency-Key` — while the
original silently runs again seconds later. **Two billed sandboxes for one
intent, same `end_user_ref`, both executing the baked `initial_prompt`.** The
caller cannot detect it: their retry succeeded.

## The rule

Retryability is a property of **who owns the outcome**, not of the error class.
Answering the caller transfers the retry to them; keeping a copy is what
duplicates the work. `mayRequeueFailedCreate` states that and is unit-tested,
including the case that makes it concrete: the *same* transient error yields
opposite answers depending on whether anyone was told.

## Verified before fixing

Found by the KaaB audit, but I confirmed the reachability myself rather than
trusting the report — line 225 returns for the queued branch, so the failure
site at 277 is inline-only, and its `result` is handed to the caller two lines
later.

## Verification

| Gate | Result |
| --- | --- |
| `apps/api` tsc | clean |
| `requeue-policy` unit | 4 pass / 0 fail |
| session-lifecycle + session contract | 95 pass / 0 fail |
| full suite (`scripts/test.sh`) | 3925 pass / **56 fail** |

The 56 are **pre-existing** — clean `main` gives 3921 / 56 under the identical
command. They are local-environment artifacts: my `.env` differs from CI's, and
CI is green. I am reporting the number rather than hiding it, but it is not
evidence about CI and should not be read as such.

**Not covered:** no integration test proves a failed inline create leaves the
command row `dead_lettered` rather than `queued`. That is the assertion which
would actually prove the duplicate cannot happen; the unit test covers the
decision, not the row transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
