### PR TITLE
fix(migration): preserve replication backlog ownership

### DIFF
--- a/.github/workflows/finalize-prod-us-east-2-database.yml
+++ b/.github/workflows/finalize-prod-us-east-2-database.yml
@@ -178,6 +178,8 @@ jobs:
           PGOPTIONS='-c statement_timeout=0' \
           ALLOW_TARGET_AUTH_SHADOW_REPAIR=1 \
             bash scripts/prod-us-east-2/auth-sync.sh repair-shadow-mutations
+          bash scripts/prod-us-east-2/db-sync.sh start
+          bash scripts/prod-us-east-2/auth-sync.sh start
           bash scripts/prod-us-east-2/db-sync.sh wait-caught-up
           bash scripts/prod-us-east-2/auth-sync.sh wait-caught-up
 

--- a/scripts/prod-us-east-2/db-sync.sh
+++ b/scripts/prod-us-east-2/db-sync.sh
@@ -658,20 +658,18 @@ WHERE target.key_id = source.key_id
 
 	DO $do$
 DECLARE
-  all_column_list text;
   column_list text;
   source_column_list text;
   target_column_list text;
 BEGIN
   SELECT
-    string_agg(format('%I', attname), ', ' ORDER BY attnum),
     string_agg(format('%I', attname), ', ' ORDER BY attnum)
       FILTER (WHERE attname <> 'account_id'),
     string_agg(format('source.%I', attname), ', ' ORDER BY attnum)
       FILTER (WHERE attname <> 'account_id'),
     string_agg(format('target.%I', attname), ', ' ORDER BY attnum)
       FILTER (WHERE attname <> 'account_id')
-  INTO all_column_list, column_list, source_column_list, target_column_list
+  INTO column_list, source_column_list, target_column_list
   FROM pg_attribute
   WHERE attrelid = 'repair_credit_accounts'::regclass
     AND attnum > 0
@@ -686,18 +684,6 @@ BEGIN
 	    column_list,
 	    source_column_list,
     target_column_list
-  );
-
-  EXECUTE format(
-    'INSERT INTO kortix.credit_accounts (%1$s)
-     SELECT %1$s
-       FROM repair_credit_accounts AS source
-      WHERE NOT EXISTS (
-        SELECT 1
-          FROM kortix.credit_accounts AS target
-         WHERE target.account_id = source.account_id
-      )',
-    all_column_list
   );
 END
 $do$;

--- a/scripts/prod-us-east-2/db-sync.test.mjs
+++ b/scripts/prod-us-east-2/db-sync.test.mjs
@@ -95,6 +95,7 @@ test("shadow repair disables statement timeout and restores the full credit acco
   assert.match(body, /attname <> 'account_id'/);
   assert.match(body, /ROW\(%3\$s\) IS DISTINCT FROM ROW\(%2\$s\)/);
   assert.match(body, /balance_precise = source\.balance/);
+  assert.doesNotMatch(body, /INSERT INTO kortix\.credit_accounts/);
 });
 
 test("shadow repair deletes credit ledger rows that do not exist on the source", () => {

--- a/scripts/prod-us-east-2/source-writers.test.mjs
+++ b/scripts/prod-us-east-2/source-writers.test.mjs
@@ -52,6 +52,21 @@ test("final database workflow consumes the source freeze marker", () => {
   assert.match(finalWorkflow, /disable-subscription/);
 });
 
+test("live preflight enables both subscriptions before catch-up", () => {
+  const repairStep = finalWorkflow.match(
+    /- name: Reconcile live shadow state([\s\S]*?)(?=\n      - name:)/,
+  );
+  assert.ok(repairStep, "Missing live shadow reconciliation step");
+  assert.match(
+    repairStep[1],
+    /db-sync\.sh repair-shadow-mutations[\s\S]*db-sync\.sh start[\s\S]*db-sync\.sh wait-caught-up/,
+  );
+  assert.match(
+    repairStep[1],
+    /auth-sync\.sh repair-shadow-mutations[\s\S]*auth-sync\.sh start[\s\S]*auth-sync\.sh wait-caught-up/,
+  );
+});
+
 test("custom-domain transfer requires explicit detach and attach gates", () => {
   assert.match(customDomain, /detach-source:\$\{CUSTOM_HOSTNAME\}/);
   assert.match(customDomain, /attach-target:\$\{CUSTOM_HOSTNAME\}/);


### PR DESCRIPTION
## Summary

- stop shadow repair from inserting source-only `credit_accounts` rows
- let logical replication own all source-only inserts
- explicitly enable both subscriptions before live preflight catch-up
- add regression coverage for both guards

## Verification

- `node --test scripts/prod-us-east-2/*.test.mjs` — 30 passed
- `bash -n scripts/prod-us-east-2/db-sync.sh`
- `git diff --check`

## Production safety

This change does not freeze EU writes or change production routing.