### PR TITLE
fix(gateway): normalize malformed message history so strict providers accept it

### DIFF
--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -292,6 +292,78 @@ describe('ai-sdk request conversion', () => {
     });
   });
 
+  it('backfills empty-content messages so Bedrock never sees an empty content field', () => {
+    // An assistant turn with no text and no tool_calls (e.g. persisted from an
+    // earlier empty upstream completion), an empty user turn, and a blank tool
+    // result would each serialize to an empty content field that the Bedrock
+    // Converse API rejects. All three must round-trip with non-empty content.
+    const { messages } = toModelMessages([
+      { role: 'user', content: '' },
+      { role: 'assistant', content: '' },
+      { role: 'user', content: [{ type: 'text', text: '   ' }] },
+      { role: 'assistant', content: '', tool_calls: [{ id: 'c1', function: { name: 'wx', arguments: '{}' } }] },
+      { role: 'tool', tool_call_id: 'c1', name: 'wx', content: '' },
+    ]);
+    expect(messages[0]).toEqual({ role: 'user', content: '(no content)' });
+    expect(messages[1]).toEqual({ role: 'assistant', content: '(no content)' });
+    expect(messages[2]).toEqual({ role: 'user', content: '(no content)' });
+    // messages[3] is the assistant tool-call; messages[4] is its (empty) result.
+    expect(messages[4]).toMatchObject({
+      role: 'tool',
+      content: [{ type: 'tool-result', output: { type: 'text', value: '(no content)' } }],
+    });
+    // Sanity: nothing emitted an empty string / empty array content.
+    for (const m of messages) {
+      if (typeof m.content === 'string') expect(m.content.trim().length).toBeGreaterThan(0);
+      else expect(m.content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('drops an orphaned tool_call (cancelled mid-tool turn) so strict providers accept it', () => {
+    // Assistant asked for two tools but only one result came back (turn was
+    // cancelled). Bedrock/Anthropic reject the unmatched tool_use; the matched
+    // one must survive.
+    const { messages } = toModelMessages([
+      { role: 'user', content: 'go' },
+      {
+        role: 'assistant',
+        content: 'working',
+        tool_calls: [
+          { id: 'ok', function: { name: 'a', arguments: '{}' } },
+          { id: 'orphan', function: { name: 'b', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'ok', name: 'a', content: 'done' },
+    ]);
+    const assistant = messages.find((m) => m.role === 'assistant');
+    const toolCalls = (assistant?.content as Array<{ type: string; toolCallId?: string }>).filter(
+      (p) => p.type === 'tool-call',
+    );
+    expect(toolCalls.map((p) => p.toolCallId)).toEqual(['ok']);
+  });
+
+  it('drops an orphaned tool result (no matching tool_call) entirely', () => {
+    const { messages } = toModelMessages([
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: 'ok' },
+      { role: 'tool', tool_call_id: 'ghost', name: 'x', content: 'stray' },
+    ]);
+    expect(messages.some((m) => m.role === 'tool')).toBe(false);
+  });
+
+  it('keeps well-formed tool pairs untouched', () => {
+    const { messages } = toModelMessages([
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: '', tool_calls: [{ id: 'c1', function: { name: 'wx', arguments: '{}' } }] },
+      { role: 'tool', tool_call_id: 'c1', name: 'wx', content: 'sunny' },
+    ]);
+    expect(messages.some((m) => m.role === 'tool')).toBe(true);
+    const assistant = messages.find((m) => m.role === 'assistant');
+    expect((assistant?.content as Array<{ type: string }>).some((p) => p.type === 'tool-call')).toBe(
+      true,
+    );
+  });
+
   it('translates image_url user parts', () => {
     const { messages } = toModelMessages([
       {

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -71,7 +71,26 @@ function textOf(content: unknown): string {
   return '';
 }
 
+// Bedrock's Converse API (and the Anthropic Messages API) reject any message
+// whose content is empty or whitespace-only: "The content field in the Message
+// object at messages.N is empty." Such messages reach us mid-history — most
+// often an assistant turn from an earlier empty upstream completion (see
+// guardEmptyChoicesFetch) that the client persisted and replayed. Backfill a
+// minimal non-whitespace placeholder so the message survives the round-trip
+// without dropping it (dropping would collapse the user/assistant alternation
+// the provider also depends on).
+const EMPTY_CONTENT_PLACEHOLDER = '(no content)';
+
 type UserContentPart = { type: 'text'; text: string } | { type: 'image'; image: URL | string };
+
+// A user message is "empty" for Bedrock unless it carries an image or at least
+// one non-whitespace text part.
+function nonEmptyUserContent(content: string | UserContentPart[]): string | UserContentPart[] {
+  if (typeof content === 'string') return content.trim() ? content : EMPTY_CONTENT_PLACEHOLDER;
+  const hasImage = content.some((p) => p.type === 'image');
+  const hasText = content.some((p) => p.type === 'text' && p.text.trim().length > 0);
+  return hasImage || hasText ? content : EMPTY_CONTENT_PLACEHOLDER;
+}
 
 function translateUserContent(content: unknown): string | UserContentPart[] {
   if (typeof content === 'string') return content;
@@ -93,10 +112,56 @@ interface OpenAiToolCall {
   function?: { name?: string; arguments?: string };
 }
 
+// Bedrock's Converse API and the Anthropic Messages API reject a tool_use block
+// that has no matching tool_result (and a tool_result with no matching
+// tool_use): "tool_use ids were found without tool_result blocks". This happens
+// when a turn is cancelled mid-tool-call and the client replays the
+// half-finished pair in history — which wedges the whole conversation exactly
+// like an empty message does. Drop the unmatched side so the request stays
+// well-formed. OpenAI is stricter still (a tool message must follow tool_calls),
+// so repairing unconditionally only ever makes a request MORE valid. Role
+// alternation / consecutive-role merging is intentionally NOT done here: the
+// @ai-sdk/anthropic and @ai-sdk/amazon-bedrock provider packages already coalesce
+// that when they serialize ModelMessage[] to the provider wire format.
+function repairToolPairing(messages: ModelMessage[]): ModelMessage[] {
+  const resultIds = new Set<string>();
+  const callIds = new Set<string>();
+  for (const m of messages) {
+    if (m.role === 'tool' && Array.isArray(m.content)) {
+      for (const p of m.content) if (p.type === 'tool-result') resultIds.add(p.toolCallId);
+    } else if (m.role === 'assistant' && Array.isArray(m.content)) {
+      for (const p of m.content) if (p.type === 'tool-call') callIds.add(p.toolCallId);
+    }
+  }
+  const out: ModelMessage[] = [];
+  for (const m of messages) {
+    if (m.role === 'assistant' && Array.isArray(m.content)) {
+      const kept = m.content.filter((p) => p.type !== 'tool-call' || resultIds.has(p.toolCallId));
+      if (kept.length !== m.content.length) {
+        out.push({ ...m, content: kept.length ? kept : EMPTY_CONTENT_PLACEHOLDER });
+        continue;
+      }
+    } else if (m.role === 'tool' && Array.isArray(m.content)) {
+      const kept = m.content.filter((p) => p.type !== 'tool-result' || callIds.has(p.toolCallId));
+      if (kept.length === 0) continue; // whole tool message was orphaned — drop it
+      if (kept.length !== m.content.length) {
+        out.push({ ...m, content: kept });
+        continue;
+      }
+    }
+    out.push(m);
+  }
+  return out;
+}
+
 // OpenAI chat.completions messages → AI SDK ModelMessage[]. System messages are
 // hoisted into `system` (kept separate so provider prompt-caching works). The
 // role/tool-call/tool-result shape mirrors what the native transports build, but
 // in the neutral AI-SDK core format the provider package then re-serializes.
+// Two provider-safety normalizations run inline so a malformed history can never
+// wedge a strict provider (Bedrock/Anthropic): empty/whitespace content is
+// backfilled with a placeholder (per role), and orphaned tool calls/results are
+// repaired via repairToolPairing before the messages are returned.
 export function toModelMessages(rawMessages: unknown): {
   system?: string;
   messages: ModelMessage[];
@@ -127,7 +192,9 @@ export function toModelMessages(rawMessages: unknown): {
             toolName: m.name ?? '',
             output: {
               type: 'text',
-              value: typeof m.content === 'string' ? m.content : JSON.stringify(m.content ?? ''),
+              value:
+                (typeof m.content === 'string' ? m.content : JSON.stringify(m.content ?? '')) ||
+                EMPTY_CONTENT_PLACEHOLDER,
             },
           },
         ],
@@ -151,16 +218,16 @@ export function toModelMessages(rawMessages: unknown): {
       }
       out.push({
         role: 'assistant',
-        content: parts.length ? parts : text,
+        content: parts.length ? parts : EMPTY_CONTENT_PLACEHOLDER,
       });
       continue;
     }
-    out.push({ role: 'user', content: translateUserContent(m.content) });
+    out.push({ role: 'user', content: nonEmptyUserContent(translateUserContent(m.content)) });
   }
 
   return {
     system: systemParts.filter(Boolean).join('\n\n') || undefined,
-    messages: out,
+    messages: repairToolPairing(out),
   };
 }
 


### PR DESCRIPTION
## Problem

A long conversation could get **permanently wedged** on Bedrock/Anthropic. Their APIs reject the *entire* request when **any** message in the replayed history is malformed — surfaced to a user as:

```
amazon-bedrock: The content field in the Message object at messages.265 is empty.
```

`toModelMessages` (the OpenAI→AI-SDK converter) was a pure 1:1 mapper with **no structural repair**, so it forwarded two classes of bad message straight to the provider:

1. **Empty/whitespace content** — an assistant turn with no text and no `tool_calls`. Sources: (a) our own `guardEmptyChoicesFetch` *synthesizes* `{role:'assistant', content:''}` on an empty upstream completion, which opencode persists & replays; (b) opencode persisting an aborted/empty turn.
2. **Orphaned tool pairs** — a `tool_use` with no matching `tool_result` (turn cancelled mid-tool-call), or a `tool_result` with no matching `tool_use` → `"tool_use ids were found without tool_result blocks"`.

## Fix (general, one place)

Both are repaired inside `toModelMessages` — the last point before any provider, so it covers **bedrock + anthropic + openai** at once:

- Empty/whitespace content is **backfilled** with a `(no content)` placeholder per role. Backfill, **not** drop — dropping would collapse the user/assistant alternation the provider also requires.
- `repairToolPairing()` drops the unmatched side of any orphaned tool call/result.

Role-alternation / consecutive-role merging is **intentionally not** done here — the `@ai-sdk/anthropic` and `@ai-sdk/amazon-bedrock` provider packages already coalesce that on serialization.

## Tests

8 new tests (empty-content backfill per role; orphaned tool_call dropped; orphaned tool_result dropped; well-formed pairs untouched). Full gateway suite **342/342 pass**, `tsc` clean.