### PR TITLE
fix: one canonical connector alias across all three grant gates

### DIFF
--- a/apps/api/src/executor/db-deps.ts
+++ b/apps/api/src/executor/db-deps.ts
@@ -45,6 +45,7 @@ import type { ChannelPlatform } from '../projects/connectors';
 import { invalidateProjectMirror } from '../projects/git';
 import { loadProjectForUser } from '../projects/lib/access';
 import {
+  canonicalConnectorAlias,
   publicConnectorAlias,
   resolveSessionConnectorProfile,
 } from '../projects/lib/session-connector-bindings';
@@ -854,7 +855,8 @@ async function listCatalog(p: ExecutorPrincipal): Promise<CatalogConnector[]> {
     // consistent with the call gate, so it never lists a tool it can't invoke.
     // This is the ONLY access gate — connectors are project-wide visible to
     // every human with project access (no per-connector member scoping).
-    if (!agentMayUseConnector(p.agentGrant ?? null, publicConnectorAlias(row.slug))) continue;
+    // Canonical on both sides — the grant is canonicalized at construction.
+    if (!agentMayUseConnector(p.agentGrant ?? null, canonicalConnectorAlias(row.slug))) continue;
     const profile = await resolveSessionConnectorProfile({
       accountId: p.accountId,
       projectId: p.projectId,

--- a/apps/api/src/executor/router.ts
+++ b/apps/api/src/executor/router.ts
@@ -24,6 +24,7 @@ import {
 import type { AgentGrant } from '@kortix/db';
 import type { Context } from 'hono';
 import { agentMayUseConnector } from '../iam/agent-scope';
+import { canonicalConnectorAlias } from '../projects/lib/session-connector-bindings';
 import { auth, errors, json, makeOpenApiApp } from '../openapi';
 import type { ConnectorAuthDiscovery } from './auth-discovery';
 import { type GatewayDeps, handleCall } from './gateway';
@@ -377,7 +378,7 @@ export function createExecutorRouter(deps: ExecutorRouterDeps): OpenAPIHono {
     }
     // Per-agent connector assignment: a scoped agent may call only the connector
     // profiles its kortix.yaml overlay lists. Default-deny otherwise.
-    if (!agentMayUseConnector(p.agentGrant ?? null, connectorSlug)) {
+    if (!agentMayUseConnector(p.agentGrant ?? null, canonicalConnectorAlias(connectorSlug))) {
       return c.json({ ok: false, status: 'denied', reason: 'connector_not_assigned' }, 403);
     }
     const args =

--- a/apps/api/src/iam/agent-scope.ts
+++ b/apps/api/src/iam/agent-scope.ts
@@ -1,3 +1,4 @@
+import { canonicalConnectorAlias } from '../shared/connector-alias';
 /**
  * Agent-session scope enforcement — the `kortix_cli` half of per-agent
  * authorization.
@@ -45,7 +46,31 @@ export function agentMayPerform(grant: AgentGrant | null, action: string): boole
   return alias ? grant.kortixCli.includes(alias) : false;
 }
 
-/** True if the agent-session grant permits calling connector `slug` (or no grant). */
+/**
+ * Normalize a grant's connector list to CANONICAL slugs.
+ *
+ * Three gates compare this grant, and they historically saw three different
+ * spellings of the same connector: the catalog compared the public alias
+ * (`email`), the call gate the raw slug (`kortix_email`), and session create the
+ * caller's binding key. With an exact `includes()` match, whichever spelling a
+ * manifest author picked satisfied one gate and failed another —
+ * `connectors: ["email"]` made the connector VISIBLE in the catalog and then
+ * 403'd on call, which looks like a platform bug rather than a grant typo.
+ *
+ * Canonicalizing ONCE here means every gate can compare canonical-to-canonical.
+ */
+export function canonicalizeGrantConnectors(grant: AgentGrant | null): AgentGrant | null {
+  if (!grant || grant.connectors === 'all') return grant;
+  const canonical = grant.connectors.map((slug) => canonicalConnectorAlias(slug));
+  return { ...grant, connectors: [...new Set(canonical)] };
+}
+
+/**
+ * True if the agent-session grant permits calling connector `slug` (or no grant).
+ *
+ * `slug` MUST already be canonical — call `canonicalConnectorAlias` on anything
+ * that came from a manifest, a request body, or a stored row first.
+ */
 export function agentMayUseConnector(grant: AgentGrant | null, slug: string): boolean {
   if (!grant) return true; // no grant = no restriction
   if (grant.connectors === 'all') return true;

--- a/apps/api/src/iam/connector-alias-grant.test.ts
+++ b/apps/api/src/iam/connector-alias-grant.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { canonicalConnectorAlias } from '../projects/lib/session-connector-bindings';
+import { agentMayUseConnector, canonicalizeGrantConnectors } from './agent-scope';
+
+/**
+ * A grant is compared at THREE gates that historically used three different
+ * alias spellings:
+ *
+ *   catalog   (db-deps)  -> publicConnectorAlias(row.slug)  => "email"
+ *   call gate (router)   -> raw connectorSlug               => "kortix_email"
+ *   create    (sessions) -> raw caller binding key          => either
+ *
+ * With an exact `includes()` match, whichever spelling the manifest author
+ * picked satisfied one gate and failed another: `email` made the connector
+ * VISIBLE but 403'd on call; `kortix_email` made it invisible (silently skipped)
+ * but callable. Both are broken, and the first is worse — it looks like it works.
+ */
+describe('connector alias spelling must not decide the outcome', () => {
+  const publicSpelling = { agent: 'a', kortixCli: 'all' as const, connectors: ['email'] };
+  const canonicalSpelling = { agent: 'a', kortixCli: 'all' as const, connectors: ['kortix_email'] };
+
+  test('both spellings admit the connector once the grant is canonicalized', () => {
+    for (const grant of [publicSpelling, canonicalSpelling]) {
+      const normalized = canonicalizeGrantConnectors(grant);
+      // The call gate sees the canonical slug…
+      expect(agentMayUseConnector(normalized, canonicalConnectorAlias('kortix_email'))).toBe(true);
+      // …and the catalog, canonicalized the same way, agrees.
+      expect(agentMayUseConnector(normalized, canonicalConnectorAlias('email'))).toBe(true);
+    }
+  });
+
+  test('an ungranted connector is still refused under either spelling', () => {
+    const normalized = canonicalizeGrantConnectors({ agent: 'a', kortixCli: 'all' as const, connectors: ['email'] });
+    expect(agentMayUseConnector(normalized, canonicalConnectorAlias('slack'))).toBe(false);
+    expect(agentMayUseConnector(normalized, canonicalConnectorAlias('kortix_slack'))).toBe(false);
+  });
+
+  test("'all' and a null grant are untouched", () => {
+    expect(canonicalizeGrantConnectors(null)).toBeNull();
+    const all = canonicalizeGrantConnectors({ agent: 'a', kortixCli: 'all' as const, connectors: 'all' });
+    expect(agentMayUseConnector(all, 'anything')).toBe(true);
+  });
+
+  test('a connector with no alias mapping passes through unchanged', () => {
+    const normalized = canonicalizeGrantConnectors({ agent: 'a', kortixCli: 'all' as const, connectors: ['stripe'] });
+    expect(agentMayUseConnector(normalized, canonicalConnectorAlias('stripe'))).toBe(true);
+  });
+
+  test('duplicate spellings of one connector collapse', () => {
+    const normalized = canonicalizeGrantConnectors({
+      agent: 'a',
+      kortixCli: 'all' as const,
+      connectors: ['email', 'kortix_email'],
+    });
+    expect(Array.isArray(normalized?.connectors) ? normalized.connectors : []).toEqual([
+      'kortix_email',
+    ]);
+  });
+});

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -1,3 +1,4 @@
+import { canonicalizeGrantConnectors } from '../iam/agent-scope';
 /**
  * `agents` block parsing for `kortix.yaml` (a legacy v1 project may instead
  * declare `[[agents]]` in `kortix.toml` — both are parsed here).
@@ -328,7 +329,15 @@ export function grantFromLoadedAgents(agentName: string, loaded: LoadedAgents): 
 
   const spec = loaded.specs.find((s) => s.name === agentName && s.enabled);
   if (spec) {
-    return { agent: agentName, kortixCli: spec.kortixCli, connectors: spec.connectors, env: spec.env };
+    // Canonicalize the connector list here so all three gates (catalog, call,
+    // session-create) compare the same spelling — a manifest may say `email` or
+    // `kortix_email` and both must mean the same connector.
+    return canonicalizeGrantConnectors({
+      agent: agentName,
+      kortixCli: spec.kortixCli,
+      connectors: spec.connectors,
+      env: spec.env,
+    });
   }
 
   // The `default` sentinel is non-binding for v1: no agent is ever named

--- a/apps/api/src/projects/lib/session-connector-bindings.ts
+++ b/apps/api/src/projects/lib/session-connector-bindings.ts
@@ -10,6 +10,10 @@ import {
   serviceAccounts,
 } from '@kortix/db';
 import { and, desc, eq } from 'drizzle-orm';
+import {
+  canonicalConnectorAlias,
+  publicConnectorAlias,
+} from '../../shared/connector-alias';
 import { db } from '../../shared/db';
 
 export interface ValidatedSessionConnectorBinding {
@@ -34,23 +38,10 @@ export function mayUseLegacyDefaultProfile(hasAnyDurableBinding: boolean): boole
   return !hasAnyDurableBinding;
 }
 
-const PUBLIC_TO_CANONICAL_CONNECTOR_ALIAS: Readonly<Record<string, string>> = {
-  email: 'kortix_email',
-  slack: 'kortix_slack',
-  meet: 'kortix_voice',
-};
-
-export function canonicalConnectorAlias(alias: string): string {
-  return PUBLIC_TO_CANONICAL_CONNECTOR_ALIAS[alias] ?? alias;
-}
-
-export function publicConnectorAlias(alias: string): string {
-  return (
-    Object.entries(PUBLIC_TO_CANONICAL_CONNECTOR_ALIAS).find(
-      ([, canonical]) => canonical === alias,
-    )?.[0] ?? alias
-  );
-}
+// Canonicalization lives in shared/ so pure IAM code can use it without
+// inheriting this module's database dependency. Imported for local use and
+// re-exported so existing importers are unaffected.
+export { canonicalConnectorAlias, publicConnectorAlias };
 
 export async function loadEmailInstallProfileId(
   projectId: string,

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -66,6 +66,7 @@ import {
   normalizeString,
 } from './serializers';
 import {
+  canonicalConnectorAlias,
   parseSessionConnectorBindings,
   resolveRequiredMemberConnectorProfiles,
   sessionConnectorBindingsRequirePrivateVisibility,
@@ -886,7 +887,7 @@ export async function createProjectSession(input: {
   if (grantCheckAliases.size > 0) {
     loadedAgentGrant = grantFromLoadedAgents(agentName, loadedAgents);
     for (const alias of grantCheckAliases) {
-      if (!agentMayUseConnector(loadedAgentGrant, alias)) {
+      if (!agentMayUseConnector(loadedAgentGrant, canonicalConnectorAlias(alias))) {
         return {
           error: {
             status: 403,

--- a/apps/api/src/shared/connector-alias.ts
+++ b/apps/api/src/shared/connector-alias.ts
@@ -1,0 +1,33 @@
+/**
+ * Connector alias canonicalization — deliberately DEPENDENCY-FREE.
+ *
+ * A connector is addressed by two spellings: the public alias a manifest author
+ * writes (`email`) and the canonical slug the platform stores (`kortix_email`).
+ * Three gates compare an agent's grant — the catalog, the call gate, and session
+ * create — and they must all compare the SAME spelling or a grant satisfies one
+ * and fails another.
+ *
+ * This lives in `shared/` with no imports because `iam/agent-scope` needs it and
+ * `iam/` must stay free of database and project-layer dependencies. Importing it
+ * from `projects/lib/session-connector-bindings` (which pulls in `shared/db`)
+ * dragged a DB dependency into pure IAM code and broke an unrelated suite.
+ */
+const PUBLIC_TO_CANONICAL_CONNECTOR_ALIAS: Readonly<Record<string, string>> = {
+  email: 'kortix_email',
+  slack: 'kortix_slack',
+  meet: 'kortix_voice',
+};
+
+/** The stored slug for an alias written in either spelling. */
+export function canonicalConnectorAlias(alias: string): string {
+  return PUBLIC_TO_CANONICAL_CONNECTOR_ALIAS[alias] ?? alias;
+}
+
+/** The user-facing alias for a stored slug. */
+export function publicConnectorAlias(alias: string): string {
+  return (
+    Object.entries(PUBLIC_TO_CANONICAL_CONNECTOR_ALIAS).find(
+      ([, canonical]) => canonical === alias,
+    )?.[0] ?? alias
+  );
+}


### PR DESCRIPTION
## The bug

An agent's connector grant is compared at **three** gates, each of which used a
different spelling of the same connector:

| Gate | Compared | Sees |
| --- | --- | --- |
| catalog (`db-deps.ts:857`) | `publicConnectorAlias(row.slug)` | `email` |
| call gate (`router.ts:380`) | raw `connectorSlug` | `kortix_email` |
| session create (`sessions.ts:889`) | raw caller binding key | either |

`agentMayUseConnector` is an exact `includes()`. So whichever spelling a manifest
author picks satisfies one gate and fails another:

- `connectors: ["email"]` → connector is **visible** in the catalog, then
  **403s on call**. Reads as a platform bug, not a grant typo.
- `connectors: ["kortix_email"]` → connector is **invisible**, silently
  `continue`d, with no error anywhere.

Both are broken; the first is worse because it looks like it works.

## The fix

Canonicalize the grant **once** at construction (`grantFromLoadedAgents`), then
compare canonical-to-canonical at all three gates.

## The layering mistake I made first

My initial version imported the alias map into `iam/agent-scope` from
`projects/lib/session-connector-bindings` — which imports `shared/db`. That
dragged a **database dependency into pure IAM code** and broke an unrelated
suite.

Caught it by diffing failures against a clean-`main` worktree rather than
eyeballing totals. Verified precisely: `e2e-project-session-branch-git` is
2 pass on clean main, 1 pass / 1 fail with that import, and 2 pass again once the
map moved to a dependency-free `shared/connector-alias.ts`.

## Verification

Full suite (`scripts/test.sh`) diffed test-by-test against clean `main`:

- **45 → 41 failures. Zero new.**
- The four that now pass are exactly the connector-invocation paths this bug
  broke:
  - `CLI face > connectors, discover, describe, and call work as an executable`
  - `MCP face > exposes stable meta-tools and runs the discover→describe→call loop`
  - `Project-explicit gateway face > CLI with KORTIX_PROJECT_ID routes through the project-explicit gateway`
  - `sandbox agent flow > agent can invoke Executor with only injected sandbox env`

Those were failing **before** this change. Nobody noticed because the suite has
no venue in CI (see `docs/KAAB_DEPTH_PLAN.md` Phase 0) — which is the strongest
argument yet for giving it one.

5 new unit cases cover the rule directly, including that both spellings now
admit the connector and that an ungranted one is still refused under either.

**Caveat:** the remaining 41 failures are local-environment artifacts — my `.env`
differs from CI's, and CI is green. The number is quoted for the delta only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
