### PR TITLE
test: prove KaaB session isolation at the list leg

### DIFF
--- a/apps/api/src/projects/lib/session-inventory.test.ts
+++ b/apps/api/src/projects/lib/session-inventory.test.ts
@@ -193,7 +193,7 @@ describe('KaaB: one wrapper credential, many end-users', () => {
   const select = (callerSessionId: string | null) =>
     selectSessionRowsForViewer({
       rows: [alice, bob],
-      scope: 'mine',
+      scope: 'visible',
       canManageProject: false,
       subject: wrapperSubject,
       grantsBySession: new Map(),
@@ -231,7 +231,7 @@ describe('KaaB: one wrapper credential, many end-users', () => {
     const sibling = row('dddd4444-4444-4444-8444-444444444444', { createdBy: VIEWER_ID });
     const selected = selectSessionRowsForViewer({
       rows: [mine, sibling],
-      scope: 'mine',
+      scope: 'visible',
       canManageProject: false,
       subject,
       grantsBySession: new Map(),

--- a/apps/api/src/projects/lib/session-inventory.test.ts
+++ b/apps/api/src/projects/lib/session-inventory.test.ts
@@ -164,3 +164,80 @@ describe('mergeSessionOwnerIdentities', () => {
     });
   });
 });
+
+/**
+ * Kortix-as-a-Backend isolation, at the LIST leg.
+ *
+ * The unit tests for `isSessionVisibleTo` cover the decision. This covers the
+ * scenario the decision exists for, in the shape it actually occurs: a wrapper
+ * creates every end-user's session under ONE credential, so `created_by` is
+ * identical across them and cannot separate anybody.
+ */
+describe('KaaB: one wrapper credential, many end-users', () => {
+  const WRAPPER = '33333333-3333-4333-8333-333333333333';
+  const wrapperSubject = { userId: WRAPPER, groupIds: [] };
+
+  // Two end-users' sessions. Same creator, same visibility — the ONLY thing
+  // distinguishing them is which sandbox is asking.
+  const alice = row('aaaa1111-1111-4111-8111-111111111111', {
+    createdBy: WRAPPER,
+    origin: 'backend',
+    originRef: 'end-user-alice',
+  });
+  const bob = row('bbbb2222-2222-4222-8222-222222222222', {
+    createdBy: WRAPPER,
+    origin: 'backend',
+    originRef: 'end-user-bob',
+  });
+
+  const select = (callerSessionId: string | null) =>
+    selectSessionRowsForViewer({
+      rows: [alice, bob],
+      scope: 'mine',
+      canManageProject: false,
+      subject: wrapperSubject,
+      grantsBySession: new Map(),
+      callerSessionId,
+      runtimeStatusBySession: new Map(),
+    });
+
+  test("alice's sandbox cannot see bob's session", () => {
+    const accessible = select(alice.sessionId)
+      .items.filter((item) => item.canAccess)
+      .map((item) => item.row.sessionId);
+    expect(accessible).toEqual([alice.sessionId]);
+  });
+
+  test("bob's sandbox cannot see alice's session", () => {
+    const accessible = select(bob.sessionId)
+      .items.filter((item) => item.canAccess)
+      .map((item) => item.row.sessionId);
+    expect(accessible).toEqual([bob.sessionId]);
+  });
+
+  test('the wrapper backend itself still sees BOTH — it is the operator', () => {
+    // Not session-bound: this is the wrapper's own credential acting for nobody
+    // in particular, so created_by ownership is legitimate here.
+    const accessible = select(null)
+      .items.filter((item) => item.canAccess)
+      .map((item) => item.row.sessionId);
+    expect(accessible).toEqual([alice.sessionId, bob.sessionId]);
+  });
+
+  test('an INTERACTIVE session is unaffected by the caller binding', () => {
+    // created_by really is one person there, so narrowing would break
+    // `kortix sessions ls` from inside a normal sandbox.
+    const mine = row('cccc3333-3333-4333-8333-333333333333', { createdBy: VIEWER_ID });
+    const sibling = row('dddd4444-4444-4444-8444-444444444444', { createdBy: VIEWER_ID });
+    const selected = selectSessionRowsForViewer({
+      rows: [mine, sibling],
+      scope: 'mine',
+      canManageProject: false,
+      subject,
+      grantsBySession: new Map(),
+      callerSessionId: mine.sessionId,
+      runtimeStatusBySession: new Map(),
+    });
+    expect(selected.items.every((item) => item.canAccess)).toBe(true);
+  });
+})


### PR DESCRIPTION
The isolation fix in #5577 was covered by unit tests of `isSessionVisibleTo` —
the **decision**. This covers the **situation** the decision exists for, in the
shape it actually occurs.

One wrapper credential creates every end-user's session, so `created_by` is
identical across them and separates nobody. The only thing distinguishing
alice's sandbox from bob's is which session the caller is bound to.

Four scenarios:

- alice's sandbox cannot see bob's session
- bob's sandbox cannot see alice's
- the wrapper's own credential still sees **both** — it is the operator, acting
  for nobody in particular, so `created_by` ownership is legitimate there
- an interactive session is untouched, so `kortix sessions ls` from inside a
  normal sandbox keeps working

## The tests can fail

Disabling the guard in `share.ts` gives **6 pass / 2 fail**; restoring it gives
**8 pass / 0 fail**. A green test I have never seen fail proves nothing, and
today produced too many examples of that to skip the check.

## Still unproven

Two legs of the isolation fix remain without end-to-end coverage:

- a session-bound token receiving 404 on another session's transcript over HTTP
- the sandbox-proxy path

Both need the route harness rather than the fixture builder this uses.

## Note

The first commit here shipped with a live tsc error — `'mine'` is not a
`ProjectSessionListScope`. I read the typecheck output from the wrong directory
and reported "tsc clean" directly beneath the errors. Fixed in the follow-up,
and re-verified that the scenarios still bite afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
