### PR TITLE
feat(whitelabel-demo): pick which shared connection a session runs as

### DIFF
--- a/apps/whitelabel-demo/scripts/sdk-boundary.mjs
+++ b/apps/whitelabel-demo/scripts/sdk-boundary.mjs
@@ -13,6 +13,9 @@ const API_ROOT = join(CLIENT_ROOT, 'app', 'api');
 const SERVER_ROOT = join(CLIENT_ROOT, 'server');
 const ALLOWED_CLIENT_BFF_ROUTES = [
   '/api/auth',
+  // Connections this wrapper may bind — pre-filtered server-side to team-owned
+  // ones, so the client never sees an unbindable option.
+  '/api/connections',
   '/api/mode',
   '/api/preview-url',
   // Provider-neutral session model control: the upstream field is named after

--- a/apps/whitelabel-demo/src/app/api/connections/route.ts
+++ b/apps/whitelabel-demo/src/app/api/connections/route.ts
@@ -1,0 +1,49 @@
+/**
+ * Connections this wrapper may bind to a new session.
+ *
+ * Provider-neutral and pre-filtered: a wrapper can only bind TEAM connections
+ * (see `selectBindableConnections`), so the client is never shown an option that
+ * would fail at session create.
+ */
+import { selectBindableConnections } from '@/server/bindable-connections';
+import { getRequestSession } from '@/server/auth';
+import { consumeRateLimit } from '@/server/rate-limit';
+import { isOwner, isValidProjectId } from '@/server/users';
+import { createScopedKortix } from '@kortix/sdk/server';
+import type { NextRequest } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const apiKey = process.env.KORTIX_API_KEY;
+  if (!apiKey) return Response.json({ connections: [] });
+
+  const session = getRequestSession(req);
+  if (!session) return Response.json({ error: 'Not authenticated' }, { status: 401 });
+
+  const limited = consumeRateLimit(session.userId);
+  if (!limited.ok) return Response.json({ error: 'Rate limited' }, { status: 429 });
+
+  const url = new URL(req.url);
+  const projectId = url.searchParams.get('projectId') ?? '';
+  const connector = url.searchParams.get('connector') ?? '';
+  if (!isValidProjectId(projectId) || !connector) {
+    return Response.json({ error: 'Invalid identifiers' }, { status: 400 });
+  }
+  if (!isOwner(session.userId, projectId)) {
+    return Response.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const kortix = createScopedKortix({
+    backendUrl: process.env.KORTIX_API_URL ?? 'https://api.kortix.com/v1',
+    getToken: async () => apiKey,
+  });
+
+  try {
+    const result = await kortix.project(projectId).connectors.profiles.list();
+    return Response.json({
+      connections: selectBindableConnections(result?.profiles, connector),
+    });
+  } catch {
+    // A project with no connectors is the common case, not an error state.
+    return Response.json({ connections: [] });
+  }
+}

--- a/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
@@ -25,6 +25,8 @@ import {
   writeStartStash,
 } from '@kortix/sdk/react';
 import { classifySessionStartFailure } from '@/lib/session-start-error';
+import type { BindableConnection } from '@/server/bindable-connections';
+import { getSessionToken } from '@/lib/session';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowUp, Sparkles } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
@@ -64,6 +66,26 @@ function ProjectHome() {
     connector: string;
     message: string;
   } | null>(null);
+  // Which shared connection this session should run as. Unset = the connector's
+  // default, which is what an unbound alias resolves to server-side anyway.
+  const [boundConnection, setBoundConnection] = useState<string | null>(null);
+
+  // Only TEAM connections are offered: a wrapper has no personal identity
+  // upstream, so a member's private connection cannot be bound at all.
+  const connections = useQuery({
+    queryKey: ['bindable-connections', projectId],
+    queryFn: async () => {
+      const token = getSessionToken();
+      const res = await fetch(
+        `/api/connections?projectId=${encodeURIComponent(projectId)}&connector=gmail`,
+        { headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+      );
+      if (!res.ok) return { connections: [] as BindableConnection[] };
+      return (await res.json()) as { connections: BindableConnection[] };
+    },
+    staleTime: 60_000,
+    retry: false,
+  });
   const [template, setTemplate] = useState('default');
   const [agent, setAgent] = useState<string | null>(null);
   const [model, setModel] = useState<ModelKey | null>(null);
@@ -92,6 +114,12 @@ function ProjectHome() {
         name: text.slice(0, 60),
         ...(template && template !== 'default' ? { sandbox_slug: template } : {}),
         ...(agent ? { agent_name: agent } : {}),
+        // connector_bindings names the exact connection this session runs as.
+        // Omitted entirely when unset, so the server's default resolution applies
+        // rather than us guessing at it.
+        ...(boundConnection
+          ? { connector_bindings: { gmail: { profile_id: boundConnection } } }
+          : {}),
       });
       writeStartStash(sessionId, { prompt: text, model, agent });
       kortix
@@ -140,6 +168,32 @@ function ProjectHome() {
             Pick your template, agent, and model, then describe the task.
           </p>
         </div>
+
+        {/* Which shared connection this session runs as. Only shown when there
+            is a genuine choice — one connection means the default is the only
+            answer, and a picker with a single option is noise. */}
+        {(connections.data?.connections.length ?? 0) > 1 && (
+          <div className="mb-3 flex items-center gap-2 text-left">
+            <span className="text-xs text-muted-foreground">Run as</span>
+            <Select
+              value={boundConnection ?? 'default'}
+              onValueChange={(v) => setBoundConnection(v === 'default' ? null : v)}
+            >
+              <SelectTrigger className="h-7 w-auto gap-1.5 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Default connection</SelectItem>
+                {connections.data?.connections.map((connection) => (
+                  <SelectItem key={connection.profileId} value={connection.profileId}>
+                    {connection.label}
+                    {connection.isDefault ? ' (default)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
 
         {/* Kortix-as-a-Backend: the session needs THIS end-user's own connection.
             A call to action, not a failure — they can resolve it themselves,

--- a/apps/whitelabel-demo/src/server/bindable-connections.ts
+++ b/apps/whitelabel-demo/src/server/bindable-connections.ts
@@ -1,0 +1,50 @@
+import type { ConnectionProfile } from '@kortix/sdk';
+
+/**
+ * Which connections a WRAPPER may bind to a session it starts.
+ *
+ * A wrapper acts under one credential for many end-users, so it has no personal
+ * identity upstream. It can therefore bind only TEAM (`project`-owned)
+ * connections — never a member's private one, and never another wrapper's
+ * `external` one. `require_connectors`, which resolves the *acting user's own*
+ * connection, is refused outright for the same reason
+ * (403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY).
+ *
+ * Offering an unbindable connection in a picker would produce a session-create
+ * failure the user cannot act on, so the filtering belongs here rather than in
+ * an error message.
+ */
+export interface BindableConnection {
+  profileId: string;
+  connectorAlias: string;
+  label: string;
+  isDefault: boolean;
+}
+
+export function selectBindableConnections(
+  profiles: ConnectionProfile[] | undefined,
+  connectorAlias: string,
+): BindableConnection[] {
+  return (profiles ?? [])
+    .filter(
+      (profile) =>
+        profile.connector_alias === connectorAlias &&
+        // Team-shared only — see above.
+        profile.owner_type === 'project' &&
+        // A revoked or errored connection binds "successfully" and then fails at
+        // the first tool call, which is a worse experience than not offering it.
+        profile.status === 'active',
+    )
+    .map((profile) => ({
+      profileId: profile.profile_id,
+      connectorAlias: profile.connector_alias,
+      label: profile.label,
+      isDefault: profile.is_default,
+    }))
+    .sort((a, b) => {
+      // Default first — it is what an unbound alias resolves to anyway, so it is
+      // the honest pre-selection.
+      if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+      return a.label.localeCompare(b.label);
+    });
+}

--- a/apps/whitelabel-demo/tests/e2e/bindable-connections.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/bindable-connections.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { selectBindableConnections } from '../../src/server/bindable-connections';
+
+const profile = (over: Record<string, unknown> = {}) =>
+  ({
+    profile_id: 'p1',
+    connector_alias: 'gmail',
+    owner_type: 'project',
+    owner_id: null,
+    label: 'Support',
+    status: 'active',
+    is_default: false,
+    metadata: {},
+    ...over,
+  }) as never;
+
+describe('selectBindableConnections', () => {
+  test('offers team connections for the requested connector', () => {
+    const rows = selectBindableConnections([profile()], 'gmail');
+    expect(rows.map((r) => r.label)).toEqual(['Support']);
+  });
+
+  test('never offers a member PRIVATE connection', () => {
+    // A wrapper has no personal identity upstream, so binding one is impossible
+    // — offering it would produce a create failure the user cannot act on.
+    const rows = selectBindableConnections(
+      [profile({ owner_type: 'member', owner_id: 'u1' })],
+      'gmail',
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  test("never offers another wrapper's external connection", () => {
+    expect(
+      selectBindableConnections([profile({ owner_type: 'external', owner_id: 'x' })], 'gmail'),
+    ).toHaveLength(0);
+  });
+
+  test('drops revoked and errored connections', () => {
+    // These bind "successfully" and then fail at the first tool call.
+    expect(selectBindableConnections([profile({ status: 'revoked' })], 'gmail')).toHaveLength(0);
+    expect(selectBindableConnections([profile({ status: 'error' })], 'gmail')).toHaveLength(0);
+  });
+
+  test('ignores other connectors', () => {
+    expect(selectBindableConnections([profile({ connector_alias: 'slack' })], 'gmail')).toHaveLength(
+      0,
+    );
+  });
+
+  test('puts the default first — it is what an unbound alias resolves to anyway', () => {
+    const rows = selectBindableConnections(
+      [
+        profile({ profile_id: 'a', label: 'Aaa' }),
+        profile({ profile_id: 'b', label: 'Zzz', is_default: true }),
+      ],
+      'gmail',
+    );
+    expect(rows.map((r) => r.label)).toEqual(['Zzz', 'Aaa']);
+  });
+
+  test('sorts the rest by label so the order never flickers', () => {
+    const rows = selectBindableConnections(
+      [profile({ profile_id: 'b', label: 'Bbb' }), profile({ profile_id: 'a', label: 'Aaa' })],
+      'gmail',
+    );
+    expect(rows.map((r) => r.label)).toEqual(['Aaa', 'Bbb']);
+  });
+
+  test('no profiles is empty, not a crash', () => {
+    expect(selectBindableConnections(undefined, 'gmail')).toEqual([]);
+  });
+});


### PR DESCRIPTION
`connector_bindings` names the exact connection a session runs as. The demo
passed none, so every session got the connector's default — and there was no way
to show that a wrapper can target a specific account.

## Only team connections are offered

A wrapper acts under **one** credential for many end-users, so it has no personal
identity upstream. It therefore cannot bind:

- a member's **private** connection (`owner_type: 'member'`)
- another wrapper's **external** one

The filtering lives in `selectBindableConnections`, server-side — **not** in an
error message. Offering an unbindable option would produce a session-create
failure the user can do nothing about.

Revoked and errored connections are dropped for the same reason: they bind
"successfully" and then fail at the first tool call, which is worse than not
offering them.

## Restraint

- The picker appears **only when there is a real choice**. One connection means
  the default is the only answer, and a single-option picker is noise.
- When unset, **no `connector_bindings` is sent at all**, so the server's own
  default resolution applies rather than the client guessing at it.
- The default sorts first — it is what an unbound alias resolves to anyway, so
  it is the honest pre-selection.

## Verification

- 8 unit cases on the selection rule, including that private and external
  connections are never offered
- `sdk-boundary`: **0 violations** — this needed registering the new
  `/api/connections` route and swapping a native `<select>` for the
  design-system `Select`; both are house rules I tripped first
- demo suite: 89 pass / 0 fail
- tsc clean

**Not covered:** the connector alias is hard-coded to `gmail` for the demo. A
production wrapper would iterate the agent's granted connectors; that is a
larger change to the start form and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
