### PR TITLE
chore(release): sync newest main into staging

### DIFF
--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -4,7 +4,7 @@
 
 # Immutable dev tag (CI bumps to dev-<sha8>). Bootstrap value until the first run.
 image:
-  tag: "dev-974c699e"
+  tag: "dev-7b77515d"
 # Dev sizing (≤100 users): 1-replica floor, burst to 2.
 replicas: 1
 autoscaling:


### PR DESCRIPTION
Supersede #5615 because `main` advanced after that PR merged.

Exact inputs:
- `origin/main`: `c4f74de97a3e8e78e59f6c10372d89dee2d2dd61`
- `origin/staging`: `9f3bc37e1133cf2b713ccefe3b0bc5221167ffdd`

This branch contains both remote commits.