### PR TITLE
chore(release): sync exact current main into staging

### DIFF
--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-65c707d4"
+  tag: "dev-7b77515d"
 kortixVersion: ""
 env:
   internalKortixEnv: dev


### PR DESCRIPTION
Supersede #5617 because the dev GitOps workflow advanced `main` after that PR merged.

Exact inputs:
- `origin/main`: `0719cd7679098ad5bef5ca3c7d4cd161606c0f0e`
- `origin/staging`: `9a1ed164f565f5906516aa171f70543e56685a07`

This adds the final dev GitOps pin and makes staging contain the exact current main tip.