### PR TITLE
fix(release): harden US cutover readiness

### DIFF
--- a/.github/workflows/activate-prod-us-east-2-writers.yml
+++ b/.github/workflows/activate-prod-us-east-2-writers.yml
@@ -1,0 +1,92 @@
+name: Activate Prod US East 2 Writers
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Exact US writer action.
+        required: true
+        type: choice
+        options:
+          - status
+          - enable
+          - disable
+      confirm:
+        description: Enter "<action>:prod-us-east-2".
+        required: true
+        type: string
+
+concurrency:
+  group: activate-prod-us-east-2-writers
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  writers:
+    name: Apply guarded US writer state
+    runs-on: ubuntu-latest
+    environment: prod-use2-shadow
+    env:
+      AWS_REGION: us-east-2
+      ROLE: arn:aws:iam::935064898258:role/kortix-gha-prod-use2-terraform
+      ACTION: ${{ inputs.action }}
+      CONFIRM: ${{ inputs.confirm }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate confirmation
+        run: |
+          set -euo pipefail
+          expected="${ACTION}:prod-us-east-2"
+          if [ "$CONFIRM" != "$expected" ]; then
+            echo "::error::confirm must equal '$expected'."
+            exit 64
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install PostgreSQL client
+        if: inputs.action == 'enable'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Apply writer action
+        run: |
+          set -euo pipefail
+          case "$ACTION" in
+            status)
+              bash scripts/prod-us-east-2/target-writers.sh status
+              ;;
+            enable)
+              ENABLE_TARGET_WRITERS_CONFIRM="$CONFIRM" \
+                bash scripts/prod-us-east-2/target-writers.sh enable
+              ;;
+            disable)
+              DISABLE_TARGET_WRITERS_CONFIRM="$CONFIRM" \
+                bash scripts/prod-us-east-2/target-writers.sh disable
+              ;;
+            *)
+              echo "::error::Unsupported writer action: $ACTION"
+              exit 64
+              ;;
+          esac
+
+      - name: Summary
+        run: |
+          {
+            echo "### Prod US East 2 writer control"
+            echo "- Action: \`$ACTION\`"
+            echo "- Confirmation: accepted"
+            if [ "$ACTION" = "enable" ]; then
+              echo "- Legacy migration workers: disabled"
+              echo "- Warm pool and warm snapshot workers: disabled"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/activate-prod-us-east-2-writers.yml
+++ b/.github/workflows/activate-prod-us-east-2-writers.yml
@@ -36,6 +36,16 @@ jobs:
       CONFIRM: ${{ inputs.confirm }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: prod
+
+      - name: Enforce trusted production ref
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/prod" ]; then
+            echo "::error::This workflow runs only from refs/heads/prod."
+            exit 64
+          fi
 
       - name: Validate confirmation
         run: |

--- a/.github/workflows/cutover-prod-us-east-2.yml
+++ b/.github/workflows/cutover-prod-us-east-2.yml
@@ -31,6 +31,7 @@ jobs:
   cloudflare:
     name: Apply guarded Cloudflare production change
     runs-on: ubuntu-latest
+    environment: prod-use2-shadow
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
@@ -40,6 +41,16 @@ jobs:
       CONFIRM: ${{ inputs.confirm }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: prod
+
+      - name: Enforce trusted production ref
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/prod" ]; then
+            echo "::error::This workflow runs only from refs/heads/prod."
+            exit 64
+          fi
 
       - name: Validate production confirmation and credentials
         run: |

--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -385,11 +385,13 @@ jobs:
             gateway_live="$(curl -fsS --max-time 10 "$GATEWAY_URL/health/live" 2>/dev/null || true)"
             gateway_health="$(curl -fsS --max-time 10 "$GATEWAY_URL/health" 2>/dev/null || true)"
             api_version="$(jq -r '.version // empty' <<<"$api_body" 2>/dev/null || true)"
+            api_commit="$(jq -r '.commit // empty' <<<"$api_body" 2>/dev/null || true)"
             gateway_version="$(jq -r '.version // empty' <<<"$gateway_live" 2>/dev/null || true)"
             gateway_commit="$(jq -r '.commit // empty' <<<"$gateway_live" 2>/dev/null || true)"
             api_dependency="$(jq -r '.checks.api.status // empty' <<<"$gateway_health" 2>/dev/null || true)"
             commit_ok=1
-            if [ -n "${SOURCE_SHA:-}" ] && [ "$gateway_commit" != "$SOURCE_SHA" ]; then
+            if [ -n "${SOURCE_SHA:-}" ] \
+              && { [ "$api_commit" != "$SOURCE_SHA" ] || [ "$gateway_commit" != "$SOURCE_SHA" ]; }; then
               commit_ok=0
             fi
 
@@ -397,11 +399,11 @@ jobs:
               && [ "$gateway_version" = "$VERSION" ] \
               && [ "$api_dependency" = "up" ] \
               && [ "$commit_ok" = "1" ]; then
-              echo "US shadow verified: API=$api_version gateway=$gateway_version commit=${gateway_commit:-unavailable} dependency=$api_dependency"
+              echo "US shadow verified: API=$api_version API commit=${api_commit:-unavailable} gateway=$gateway_version gateway commit=${gateway_commit:-unavailable} dependency=$api_dependency"
               exit 0
             fi
 
-            echo "Shadow verification $attempt/40: API=${api_version:-unreachable} gateway=${gateway_version:-unreachable} commit=${gateway_commit:-unavailable} dependency=${api_dependency:-unavailable}"
+            echo "Shadow verification $attempt/40: API=${api_version:-unreachable} API commit=${api_commit:-unavailable} gateway=${gateway_version:-unreachable} gateway commit=${gateway_commit:-unavailable} dependency=${api_dependency:-unavailable}"
             sleep 15
           done
 

--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -75,6 +75,16 @@ jobs:
       CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: prod
+
+      - name: Enforce trusted production ref
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/prod" ]; then
+            echo "::error::This workflow runs only from refs/heads/prod."
+            exit 64
+          fi
 
       - name: Require Cloudflare credentials
         run: |
@@ -184,6 +194,16 @@ jobs:
       GATEWAY_URL: https://gateway-use2-shadow.kortix.com
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: prod
+
+      - name: Enforce trusted production ref
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/prod" ]; then
+            echo "::error::This workflow runs only from refs/heads/prod."
+            exit 64
+          fi
 
       - name: Validate inputs
         run: |

--- a/.github/workflows/finalize-prod-us-east-2-database.yml
+++ b/.github/workflows/finalize-prod-us-east-2-database.yml
@@ -42,6 +42,16 @@ jobs:
       FREEZE_MARKER_PARAMETER: /kortix/prod-use2/source-freeze
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: prod
+
+      - name: Enforce trusted production ref
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/prod" ]; then
+            echo "::error::This workflow runs only from refs/heads/prod."
+            exit 64
+          fi
 
       - name: Validate confirmation
         run: |

--- a/.github/workflows/reconcile-prod-us-east-2-shadow.yml
+++ b/.github/workflows/reconcile-prod-us-east-2-shadow.yml
@@ -21,6 +21,16 @@ jobs:
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-prod-use2-terraform
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: prod
+
+      - name: Enforce trusted production ref
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/prod" ]; then
+            echo "::error::This workflow runs only from refs/heads/prod."
+            exit 64
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -93,6 +93,28 @@ describe('api-router worker', () => {
     );
   });
 
+  test('runs privileged US workflows only from the protected prod branch', () => {
+    const workflows = [
+      'activate-prod-us-east-2-writers.yml',
+      'cutover-prod-us-east-2.yml',
+      'deploy-prod-us-east-2-shadow.yml',
+      'finalize-prod-us-east-2-database.yml',
+      'reconcile-prod-us-east-2-shadow.yml',
+    ];
+
+    for (const workflow of workflows) {
+      const source = readFileSync(
+        new URL(`../../../../.github/workflows/${workflow}`, import.meta.url),
+        'utf8',
+      );
+      expect(source).toContain('ref: prod');
+      expect(source).toContain(
+        'if [ "$GITHUB_REF" != "refs/heads/prod" ]; then',
+      );
+      expect(source).toContain('environment: prod-use2-shadow');
+    }
+  });
+
   test('redirects plaintext API requests to HTTPS before proxying', async () => {
     let fetched = false;
     globalThis.fetch = async () => {

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -69,6 +69,30 @@ describe('api-router worker', () => {
     expect(productionVars).not.toContain('usw2');
   });
 
+  test('removes stale ECS commit overrides and verifies both shadow commits', () => {
+    const ecsDeploy = readFileSync(
+      new URL('../../../scripts/ecs-deploy.sh', import.meta.url),
+      'utf8',
+    );
+    const shadowWorkflow = readFileSync(
+      new URL(
+        '../../../../.github/workflows/deploy-prod-us-east-2-shadow.yml',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+
+    expect(ecsDeploy).toContain(
+      'select(.name != "KORTIX_VERSION" and .name != "KORTIX_COMMIT")',
+    );
+    expect(shadowWorkflow).toContain(
+      'api_commit="$(jq -r \'.commit // empty\'',
+    );
+    expect(shadowWorkflow).toContain(
+      '[ "$api_commit" != "$SOURCE_SHA" ] || [ "$gateway_commit" != "$SOURCE_SHA" ]',
+    );
+  });
+
   test('redirects plaintext API requests to HTTPS before proxying', async () => {
     let fetched = false;
     globalThis.fetch = async () => {

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -150,17 +150,21 @@ NEW_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
       # drop read-only fields register-task-definition rejects
       del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
           .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
-      # override image + full secrets on the target container, and stamp
-      # KORTIX_VERSION as explicit container env (env beats the image-baked
-      # value) so ECS reports the same clean version EKS does. On non-release
-      # tags ($ver == "") any stale stamp from a previous release roll is
-      # REMOVED so the image-baked dev/staging version reports again.
+      # Override image + full secrets on the target container. Stamp
+      # KORTIX_VERSION as explicit container env so ECS reports the same clean
+      # version EKS reports. Always remove KORTIX_COMMIT from the task
+      # definition. The immutable image contains the source commit. Preserving
+      # a task-definition override can make a new image report an old commit.
+      # On non-release tags ($ver == ""), remove any stale version stamp so the
+      # image-baked dev/staging version reports again.
       | .containerDefinitions |= map(
           if .name == $c then
             .image = $img
             | .secrets = $secrets
             | .environment = (
-                ((.environment // []) | map(select(.name != "KORTIX_VERSION")))
+                ((.environment // []) | map(
+                  select(.name != "KORTIX_VERSION" and .name != "KORTIX_COMMIT")
+                ))
                 + (if $ver == "" then [] else [{name: "KORTIX_VERSION", value: $ver}] end))
           else . end)')"
 

--- a/scripts/prod-us-east-2/target-writers.sh
+++ b/scripts/prod-us-east-2/target-writers.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+AWS_REGION="${AWS_REGION:-us-east-2}"
+TARGET_SECRET_ID="${TARGET_SECRET_ID:-kortix-prod-us-east-2-env}"
+TARGET_ECS_CLUSTER="${TARGET_ECS_CLUSTER:-kortix-prod-use2}"
+TARGET_ECS_SERVICE="${TARGET_ECS_SERVICE:-kortix-prod-use2}"
+TARGET_LOG_GROUP="${TARGET_LOG_GROUP:-/ecs/kortix-prod-use2}"
+FREEZE_MARKER_PARAMETER="${FREEZE_MARKER_PARAMETER:-/kortix/prod-use2/source-freeze}"
+PRODUCTION_API_URL="${PRODUCTION_API_URL:-https://api.kortix.com}"
+
+APPLICATION_SUBSCRIPTION="kortix_us_east_2_20260725"
+AUTH_SUBSCRIPTION="kortix_use2_auth_20260725"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+for command_name in aws curl jq; do
+  require_command "$command_name"
+done
+
+load_target_secret() {
+  aws secretsmanager get-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$AWS_REGION" \
+    --query SecretString \
+    --output text
+}
+
+current_target_secret_version() {
+  aws secretsmanager describe-secret \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$AWS_REGION" \
+    --query VersionIdsToStages \
+    --output json \
+    | jq -er 'to_entries[] | select(.value | index("AWSCURRENT")) | .key'
+}
+
+edge_backend() {
+  curl -fsS --max-time 15 -D - -o /dev/null "$PRODUCTION_API_URL/v1/health" \
+    | awk 'BEGIN { IGNORECASE=1 } /^x-backend:/ {
+        gsub("\r", "");
+        print $2
+      }' \
+    | tail -1
+}
+
+require_blocking_maintenance() {
+  local response_file
+  local write_status
+  response_file="$(mktemp)"
+  write_status="$(
+    curl -sS --max-time 15 \
+      -o "$response_file" \
+      -w '%{http_code}' \
+      -X POST \
+      -H 'Content-Type: application/json' \
+      --data '{}' \
+      "$PRODUCTION_API_URL/v1/projects"
+  )"
+  unlink "$response_file"
+  if [[ "$write_status" != "503" ]]; then
+    echo "Production edge writes return HTTP $write_status, expected 503." >&2
+    exit 1
+  fi
+}
+
+require_target_backend() {
+  local backend
+  backend="$(edge_backend)"
+  if [[ "$backend" != "us-east-2" ]]; then
+    echo "Production edge backend is '${backend:-missing}', expected us-east-2." >&2
+    exit 1
+  fi
+}
+
+require_source_frozen() {
+  local marker
+  marker="$(
+    aws ssm get-parameter \
+      --region "$AWS_REGION" \
+      --name "$FREEZE_MARKER_PARAMETER" \
+      --query Parameter.Value \
+      --output text
+  )"
+  jq -e '.state == "frozen" and (.freezeSecretVersion | length > 0)' \
+    <<<"$marker" >/dev/null || {
+      echo "The EU source freeze marker is missing or invalid." >&2
+      exit 1
+    }
+}
+
+require_subscriptions_disabled() {
+  local secret_json
+  local database_url
+  local state
+  require_command psql
+  secret_json="$(load_target_secret)"
+  database_url="$(jq -er '.DATABASE_URL' <<<"$secret_json")"
+  state="$(
+    psql "$database_url" -X -qAt -F $'\t' -v ON_ERROR_STOP=1 \
+      -v app_subscription="$APPLICATION_SUBSCRIPTION" \
+      -v auth_subscription="$AUTH_SUBSCRIPTION" <<'SQL'
+SELECT count(*), count(*) FILTER (WHERE NOT subenabled)
+FROM pg_subscription
+WHERE subname IN (:'app_subscription', :'auth_subscription');
+SQL
+  )"
+  if [[ "$state" != $'2\t2' ]]; then
+    echo "Both target subscriptions must exist and be disabled. Current state: $state" >&2
+    exit 1
+  fi
+}
+
+disabled_flags_filter='
+  .KORTIX_WORKERS_ENABLED == "false"
+  and .SCHEDULER_ENABLED == "false"
+  and .CHANNELS_ENABLED == "false"
+  and .KORTIX_PRERESUME_ENABLED == "false"
+  and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "false"
+  and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "false"
+  and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+  and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+  and .KORTIX_WARM_POOL_ENABLED == "false"
+  and .KORTIX_WARM_SNAPSHOT_ENABLED == "false"
+'
+
+enabled_flags_filter='
+  .KORTIX_WORKERS_ENABLED == "true"
+  and .SCHEDULER_ENABLED == "true"
+  and .CHANNELS_ENABLED == "true"
+  and .KORTIX_PRERESUME_ENABLED == "true"
+  and .KORTIX_TRIGGER_SCHEDULER_ENABLED == "true"
+  and .KORTIX_PROJECT_MAINTENANCE_ENABLED == "true"
+  and .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED == "false"
+  and .KORTIX_SUNA_MIGRATION_WORKER_ENABLED == "false"
+  and .KORTIX_WARM_POOL_ENABLED == "false"
+  and .KORTIX_WARM_SNAPSHOT_ENABLED == "false"
+'
+
+assert_flags() {
+  local expected="$1"
+  local secret_json
+  secret_json="$(load_target_secret)"
+  case "$expected" in
+    disabled)
+      jq -e "$disabled_flags_filter" <<<"$secret_json" >/dev/null
+      ;;
+    enabled)
+      jq -e "$enabled_flags_filter" <<<"$secret_json" >/dev/null
+      ;;
+    *)
+      echo "Unknown flag state: $expected" >&2
+      exit 64
+      ;;
+  esac
+}
+
+write_flags() {
+  local mode="$1"
+  local secret_json
+  local original_version
+  local verified_version
+  local secret_file
+
+  secret_json="$(load_target_secret)"
+  original_version="$(current_target_secret_version)"
+  secret_file="$(mktemp)"
+  trap 'unlink "$secret_file" 2>/dev/null || true' RETURN
+
+  case "$mode" in
+    enabled)
+      jq '
+        .KORTIX_WORKERS_ENABLED = "true"
+        | .SCHEDULER_ENABLED = "true"
+        | .CHANNELS_ENABLED = "true"
+        | .KORTIX_PRERESUME_ENABLED = "true"
+        | .KORTIX_TRIGGER_SCHEDULER_ENABLED = "true"
+        | .KORTIX_PROJECT_MAINTENANCE_ENABLED = "true"
+        | .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED = "false"
+        | .KORTIX_SUNA_MIGRATION_WORKER_ENABLED = "false"
+        | .KORTIX_WARM_POOL_ENABLED = "false"
+        | .KORTIX_WARM_SNAPSHOT_ENABLED = "false"
+      ' <<<"$secret_json" >"$secret_file"
+      ;;
+    disabled)
+      jq '
+        .KORTIX_WORKERS_ENABLED = "false"
+        | .SCHEDULER_ENABLED = "false"
+        | .CHANNELS_ENABLED = "false"
+        | .KORTIX_PRERESUME_ENABLED = "false"
+        | .KORTIX_TRIGGER_SCHEDULER_ENABLED = "false"
+        | .KORTIX_PROJECT_MAINTENANCE_ENABLED = "false"
+        | .KORTIX_LEGACY_MIGRATION_WORKER_ENABLED = "false"
+        | .KORTIX_SUNA_MIGRATION_WORKER_ENABLED = "false"
+        | .KORTIX_WARM_POOL_ENABLED = "false"
+        | .KORTIX_WARM_SNAPSHOT_ENABLED = "false"
+      ' <<<"$secret_json" >"$secret_file"
+      ;;
+    *)
+      echo "Unknown flag mode: $mode" >&2
+      exit 64
+      ;;
+  esac
+
+  verified_version="$(current_target_secret_version)"
+  if [[ "$verified_version" != "$original_version" ]]; then
+    echo "The target secret changed during preparation. Refusing to overwrite it." >&2
+    exit 1
+  fi
+
+  aws secretsmanager put-secret-value \
+    --secret-id "$TARGET_SECRET_ID" \
+    --region "$AWS_REGION" \
+    --secret-string "file://$secret_file" \
+    --query VersionId \
+    --output text
+  unlink "$secret_file"
+  trap - RETURN
+}
+
+restart_target_api() {
+  aws ecs update-service \
+    --region "$AWS_REGION" \
+    --cluster "$TARGET_ECS_CLUSTER" \
+    --service "$TARGET_ECS_SERVICE" \
+    --force-new-deployment >/dev/null
+  aws ecs wait services-stable \
+    --region "$AWS_REGION" \
+    --cluster "$TARGET_ECS_CLUSTER" \
+    --services "$TARGET_ECS_SERVICE"
+}
+
+require_worker_leader_log() {
+  local start_ms
+  local count
+  start_ms="$(( $(date -u +%s) * 1000 - 900000 ))"
+  for attempt in $(seq 1 30); do
+    count="$(
+      aws logs filter-log-events \
+        --region "$AWS_REGION" \
+        --log-group-name "$TARGET_LOG_GROUP" \
+        --start-time "$start_ms" \
+        --filter-pattern '"acquired background-worker leadership"' \
+        --query 'length(events)' \
+        --output text
+    )"
+    if [[ "$count" -ge 1 ]]; then
+      echo "US worker leader acquisition is present in CloudWatch."
+      return
+    fi
+    echo "Worker leader verification $attempt/30: no acquisition log yet."
+    sleep 5
+  done
+  echo "No US worker leader acquisition appeared within 150 seconds." >&2
+  exit 1
+}
+
+enable() {
+  local target_flags_changed=false
+  rollback_failed_enable() {
+    local original_exit="$?"
+    trap - ERR
+    if [[ "$target_flags_changed" == "true" ]]; then
+      echo "US writer activation failed. Restoring disabled flags." >&2
+      set +e
+      write_flags disabled
+      restart_target_api
+      assert_flags disabled
+      set -e
+    fi
+    return "$original_exit"
+  }
+  trap rollback_failed_enable ERR
+
+  if [[ "${ENABLE_TARGET_WRITERS_CONFIRM:-}" != "enable:prod-us-east-2" ]]; then
+    echo "Set ENABLE_TARGET_WRITERS_CONFIRM=enable:prod-us-east-2." >&2
+    exit 64
+  fi
+  require_blocking_maintenance
+  require_target_backend
+  require_source_frozen
+  require_subscriptions_disabled
+  assert_flags disabled
+  write_flags enabled
+  target_flags_changed=true
+  restart_target_api
+  assert_flags enabled
+  require_worker_leader_log
+  trap - ERR
+  echo "US workers and schedulers are enabled. Legacy migration workers remain disabled."
+}
+
+disable() {
+  if [[ "${DISABLE_TARGET_WRITERS_CONFIRM:-}" != "disable:prod-us-east-2" ]]; then
+    echo "Set DISABLE_TARGET_WRITERS_CONFIRM=disable:prod-us-east-2." >&2
+    exit 64
+  fi
+  require_blocking_maintenance
+  write_flags disabled
+  restart_target_api
+  assert_flags disabled
+  echo "US workers and schedulers are disabled."
+}
+
+status() {
+  local secret_json
+  secret_json="$(load_target_secret)"
+  jq '{
+    KORTIX_WORKERS_ENABLED,
+    SCHEDULER_ENABLED,
+    CHANNELS_ENABLED,
+    KORTIX_PRERESUME_ENABLED,
+    KORTIX_TRIGGER_SCHEDULER_ENABLED,
+    KORTIX_PROJECT_MAINTENANCE_ENABLED,
+    KORTIX_LEGACY_MIGRATION_WORKER_ENABLED,
+    KORTIX_SUNA_MIGRATION_WORKER_ENABLED,
+    KORTIX_WARM_POOL_ENABLED,
+    KORTIX_WARM_SNAPSHOT_ENABLED
+  }' <<<"$secret_json"
+  aws ecs describe-services \
+    --region "$AWS_REGION" \
+    --cluster "$TARGET_ECS_CLUSTER" \
+    --services "$TARGET_ECS_SERVICE" \
+    --query 'services[0].{service:serviceName,desired:desiredCount,running:runningCount,pending:pendingCount,taskDefinition:taskDefinition,rollout:deployments[0].rolloutState}' \
+    --output json
+  echo "api.kortix.com backend: $(edge_backend)"
+}
+
+case "${1:-}" in
+  enable)
+    enable
+    ;;
+  disable)
+    disable
+    ;;
+  status)
+    status
+    ;;
+  *)
+    echo "Usage: $0 {enable|disable|status}" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/voice-live-test.ts
+++ b/scripts/voice-live-test.ts
@@ -29,7 +29,9 @@
  */
 
 import { startCall, endCall, readTurns, promptVoiceAgent } from '../apps/api/src/channels/voice/runtime';
-import { bridgePageUrl, mintAccessToken } from '../apps/api/src/channels/voice/livekit';
+import { joinPageUrl } from '../apps/api/src/channels/voice/livekit';
+import { mintJoinLink } from '../apps/api/src/channels/voice/join-links';
+import { kortixSay } from '../apps/api/src/channels/voice/utterance';
 
 interface Args {
   web?: string;
@@ -83,8 +85,8 @@ async function main() {
   });
   console.log(`     up. room=${call.room} voice=${call.voice}`);
 
-  const token = await mintAccessToken({ room: call.room, identity: `human-${callId}`, name: 'Human caller' });
-  const joinUrl = bridgePageUrl(args.web, token);
+  const { token } = await mintJoinLink({ callId, projectId });
+  const joinUrl = joinPageUrl(args.web, token);
   console.log('');
   console.log('2/3  open this in your browser (headphones on):');
   console.log('');
@@ -111,12 +113,18 @@ async function main() {
   // in-process bridge), so this just waits a fixed grace period for the
   // dispatched worker to connect and greet on its own, then nudges once more
   // via the same path a real Kortix turn would use.
-  setTimeout(() => {
-    const said = promptVoiceAgent(
+  setTimeout(async () => {
+    const said = await promptVoiceAgent(
       callId,
-      'Say exactly this out loud now, then stop: "Hey, Kortix here. I can hear you — just talk normally."',
+      kortixSay(
+        'Say exactly this out loud now, then stop: "Hey, Kortix here. I can hear you — just talk normally."',
+      ),
     );
-    console.log(said ? '  [kortix -> call] intro nudge sent' : '  [kortix -> call] call not live');
+    console.log(
+      said.delivered
+        ? '  [kortix -> call] intro nudge sent'
+        : `  [kortix -> call] ${said.reason ?? 'call not live'}`,
+    );
   }, 5000);
 
   const shutdown = async () => {

--- a/tests/src/flows/billing-reads.flow.ts
+++ b/tests/src/flows/billing-reads.flow.ts
@@ -170,13 +170,21 @@ flow(
     await ctx.step("ANON cannot deduct → 401", async () => {
       const r = await ctx.client
         .as(ctx.P.ANON)
-        .post("/v1/billing/deduct", { prompt_tokens: 0, completion_tokens: 0, model: "gpt-4o" });
+        .post("/v1/billing/deduct", {
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          model: "claude-sonnet-4.6",
+        });
       r.status(401);
     });
     await ctx.step("OWNER: zero-token deduct is a real no-op 200 (no balance change)", async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
-        .post("/v1/billing/deduct", { prompt_tokens: 0, completion_tokens: 0, model: "gpt-4o" });
+        .post("/v1/billing/deduct", {
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          model: "claude-sonnet-4.6",
+        });
       r.status([200, 404]);
       if (r.statusCode === 200) {
         r.body().has("$.success", true).has("$.cost", 0);

--- a/tests/src/flows/connectors.flow.ts
+++ b/tests/src/flows/connectors.flow.ts
@@ -694,7 +694,7 @@ flow(
       },
       { params: { projectId: p.id } },
     );
-    connector.status(201);
+    connector.status(200);
     const defaultProfile = await ctx.client.as(ctx.P.OWNER).post(
       '/v1/projects/:projectId/connectors/:slug/oauth2/profile',
       {},

--- a/tests/src/flows/projects-misc.flow.ts
+++ b/tests/src/flows/projects-misc.flow.ts
@@ -757,8 +757,15 @@ flow(
       const r = await ctx.client
         .as(ctx.P.OWNER)
         .get("/v1/projects/:projectId/sandbox-provider/transition", { params: { projectId: p.id } });
-      r.status(200).body().exists("$.active_provider").exists("$.history");
-      const body = r.json<{ latest: unknown; history: unknown[] }>();
+      r.status(200).body().exists("$.history");
+      const body = r.json<{
+        active_provider: string | null;
+        latest: unknown;
+        history: unknown[];
+      }>();
+      if (!Object.hasOwn(body, "active_provider")) {
+        throw new Error("transition view omitted active_provider");
+      }
       assertNoLeak(body.latest);
       if (Array.isArray(body.history)) body.history.forEach(assertNoLeak);
     });

--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -516,19 +516,20 @@ flow(
     }
     const admin = ctx.client.withBearer(ctx.env.adminToken, 'ADMIN_TOKEN');
     let previousLimit: number | null | undefined;
+    const team = await ctx.fixtures.team();
 
     await ctx.step('set the run account concurrent-session override to 1', async () => {
       const r = await admin.post(
         '/v1/admin/api/accounts/:id/session-limit',
         { max_concurrent_sessions: 1 },
-        { params: { id: ctx.P.accountId } },
+        { params: { id: team.id } },
       );
       r.status(200);
       previousLimit = r.json<{ previous: number | null }>().previous;
     });
 
     try {
-      const project = await ctx.fixtures.project({ seed: true });
+      const project = await team.project({ seed: true });
       await ctx.step('first session at limit 1 → 201', async () => {
         const r = await ctx.client
           .as(ctx.P.OWNER)
@@ -560,7 +561,7 @@ flow(
           const r = await admin.post(
             '/v1/admin/api/accounts/:id/session-limit',
             { max_concurrent_sessions: previousLimit },
-            { params: { id: ctx.P.accountId } },
+            { params: { id: team.id } },
           );
           r.status(200);
         });

--- a/tests/src/flows/skills.flow.ts
+++ b/tests/src/flows/skills.flow.ts
@@ -9,12 +9,31 @@
  * to read anything else. Read-only, no fixtures, no sandboxes.
  */
 import { flow } from '../core/flow';
+import type { FlowContext } from '../core/types';
 
 // The one skill guaranteed to exist on every deploy — it is the entry pointer
 // every other Kortix skill and the seeded project scaffold reference by name.
 const KNOWN_SKILL = 'kortix-system';
 
-flow('SKILL-1', { domain: 'skills', tags: ['smoke'], routes: ['GET /v1/skills'] }, async (ctx) => {
+async function createProjectPat(ctx: FlowContext, label: string) {
+  const project = await ctx.fixtures.project();
+  const response = await ctx.client.as(ctx.P.OWNER).post(
+    '/v1/projects/:projectId/cli-token',
+    { name: ctx.fixtures.name(label) },
+    { params: { projectId: project.id } },
+  );
+  response.status(201).body().exists('$.secret_key').exists('$.token_id');
+  const body = response.json<{ secret_key: string; token_id: string }>();
+  ctx.track('token', body.token_id);
+  return ctx.client.withBearer(body.secret_key, 'PAT_PROJ');
+}
+
+flow('SKILL-1', {
+  domain: 'skills',
+  tags: ['smoke'],
+  routes: ['GET /v1/skills', 'POST /v1/projects/:projectId/cli-token'],
+}, async (ctx) => {
+  const projectPat = await createProjectPat(ctx, 'skill-list-pat');
   await ctx.step('ANON cannot list the system skills', async () => {
     const r = await ctx.client.as(ctx.P.ANON).get('/v1/skills');
     r.status(401);
@@ -25,7 +44,7 @@ flow('SKILL-1', { domain: 'skills', tags: ['smoke'], routes: ['GET /v1/skills'] 
     // outside /v1/projects/:id. That is the caller these routes exist for, so
     // it is the one that must be asserted here — an owner JWT passing proves
     // nothing about the sandbox.
-    const r = await ctx.client.as(ctx.P.PAT_PROJ).get('/v1/skills');
+    const r = await projectPat.get('/v1/skills');
     r.status(200);
   });
   await ctx.step('authed list → 200 with descriptions and no bodies', async () => {
@@ -44,8 +63,13 @@ flow('SKILL-1', { domain: 'skills', tags: ['smoke'], routes: ['GET /v1/skills'] 
 
 flow(
   'SKILL-2',
-  { domain: 'skills', tags: ['smoke'], routes: ['GET /v1/skills/:name'] },
+  {
+    domain: 'skills',
+    tags: ['smoke'],
+    routes: ['GET /v1/skills/:name', 'POST /v1/projects/:projectId/cli-token'],
+  },
   async (ctx) => {
+    const projectPat = await createProjectPat(ctx, 'skill-read-pat');
     await ctx.step('ANON cannot read a skill body', async () => {
       const r = await ctx.client.as(ctx.P.ANON).get('/v1/skills/:name', {
         params: { name: KNOWN_SKILL },
@@ -78,9 +102,7 @@ flow(
       }
     });
     await ctx.step('a PROJECT-scoped PAT can read the body (the in-sandbox read)', async () => {
-      const r = await ctx.client
-        .as(ctx.P.PAT_PROJ)
-        .get('/v1/skills/:name', { params: { name: KNOWN_SKILL } });
+      const r = await projectPat.get('/v1/skills/:name', { params: { name: KNOWN_SKILL } });
       r.status(200).body().exists('$.body');
     });
     await ctx.step('a name that is not a managed skill → 404', async () => {
@@ -124,12 +146,12 @@ flow(
         .get('/v1/skills/:name/file', { params: { name: KNOWN_SKILL } });
       r.status(400);
     });
-    await ctx.step('traversal attempt → 404, never a file outside the skill', async () => {
+    await ctx.step('traversal attempt → 403/404, never a file outside the skill', async () => {
       const r = await ctx.client.as(ctx.P.OWNER).get('/v1/skills/:name/file', {
         params: { name: KNOWN_SKILL },
         query: { path: '../../../../etc/passwd' },
       });
-      r.status(404);
+      r.status([403, 404]);
     });
   },
 );


### PR DESCRIPTION
## Summary

- correct seven stale or non-isolated release-gate assertions
- add guarded US East 2 writer activation and rollback controls
- update the voice live test to the current opaque join-link contract

## Production safety

- this PR does not change production routing
- this PR does not enable maintenance
- this PR does not freeze EU writers
- this PR does not enable US writers
- the writer workflow requires exact confirmation, edge maintenance, the US backend, the EU freeze marker, and disabled replication subscriptions

## Verification

- `cd tests && bun run typecheck` — passed
- `cd tests && bun run test:unit` — 24 passed
- `cd tests && bun bin/ke2e.ts coverage` — 497/507 covered, 10 allowlisted, 0 uncovered
- `bun build scripts/voice-live-test.ts --target bun --packages external --outfile /tmp/voice-live-test-main.js` — passed
- `bash -n scripts/prod-us-east-2/target-writers.sh` — passed
- `shellcheck scripts/prod-us-east-2/target-writers.sh` — passed
- `bash scripts/prod-us-east-2/target-writers.sh status` — US tasks 2/2, rollout COMPLETED, all writer flags false
- guarded enable without maintenance — exit 1; target secret version unchanged
