### PR TITLE
fix(tests): use one Playwright runtime for US smoke

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,9 +1533,6 @@ importers:
       '@kortix/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
-      '@playwright/test':
-        specifier: ^1.61.0
-        version: 1.61.1
 
 packages:
 

--- a/scripts/prod-us-east-2/target-smoke.test.mjs
+++ b/scripts/prod-us-east-2/target-smoke.test.mjs
@@ -14,6 +14,12 @@ const frontendSmoke = readFileSync(
   new URL("./frontend-auth-smoke.sh", import.meta.url),
   "utf8",
 );
+const nestedE2ePackage = JSON.parse(
+  readFileSync(
+    new URL("../../tests/e2e/package.json", import.meta.url),
+    "utf8",
+  ),
+);
 const shadowWorkflow = readFileSync(
   new URL(
     "../../.github/workflows/deploy-prod-us-east-2-shadow.yml",
@@ -96,6 +102,13 @@ test("frontend smoke removes and counts password-recovery flow state", () => {
   assert.match(
     frontendSmoke,
     /SELECT count\(\*\) FROM auth\.flow_state\s+WHERE user_id = :'smoke_user_id'::uuid/,
+  );
+});
+
+test("frontend smoke uses one Playwright installation", () => {
+  assert.equal(
+    nestedE2ePackage.devDependencies?.["@playwright/test"],
+    undefined,
   );
 });
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@kortix/sdk": "workspace:*",
-    "@playwright/test": "^1.61.0"
+    "@kortix/sdk": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary

- remove the nested Playwright installation from `tests/e2e`
- keep the US frontend smoke on the root `tests` Playwright runtime
- add a regression assertion for the single-runtime invariant

## Verification

- `bun test scripts/prod-us-east-2/target-smoke.test.mjs scripts/prod-us-east-2/source-writers.test.mjs scripts/prod-us-east-2/db-sync.test.mjs scripts/prod-us-east-2/auth-refresh-smoke.test.mjs` — 24 pass, 0 fail
- `bash scripts/prod-us-east-2/frontend-auth-smoke.sh` — 8 Playwright tests passed; password login, authenticated shell, Google OAuth, GitHub OAuth, cleanupRows=0

Production routing and source writers remain unchanged.