### PR TITLE
Fix ACP final idle state and add ?acp override

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -71,6 +71,8 @@ export default function ProjectSessionPage() {
   const { id: projectId, sessionId } = useParams<{ id: string; sessionId: string }>();
   const { user, isLoading: authLoading } = useAuth();
   const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
+  const forceAcp = searchParams.has('acp');
 
   // Billing gate. An account that cannot run should not start a session — the
   // backend would never provision a sandbox, so polling for one spins forever.
@@ -112,6 +114,7 @@ export default function ProjectSessionPage() {
     enabled: !!user && !billingGatePending && !noPlan,
     replayStartStash: false,
     initialOpenCodeSessionId,
+    runtimeTransport: forceAcp ? 'acp' : undefined,
   });
   const sandbox = session.sandbox;
   const startStage = session.stage ?? 'provisioning';

--- a/apps/web/src/features/session/session-chat.acp-routing.test.ts
+++ b/apps/web/src/features/session/session-chat.acp-routing.test.ts
@@ -11,9 +11,12 @@ test('the root session composer sends through the SDK useSession result', () => 
   expect(source).toContain('await sessionState.sendParts(mappedParts');
 });
 
-test('the frontend does not select a runtime transport', () => {
+test('the session page delegates its page-scoped ACP override to the SDK', () => {
   expect(source).not.toContain('sessionState.runtimeTransport');
   expect(source).not.toMatch(/runtimeTransport\s*===\s*['"]acp['"]/);
+  expect(sessionPageSource).toContain("searchParams.has('acp')");
+  expect(sessionPageSource).toContain("runtimeTransport: forceAcp ? 'acp' : undefined");
+  expect(sessionPageSource).not.toContain('experimental.acp_runtime');
 });
 
 test('the session page uses one SDK session hook for runtime session state', () => {

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -259,6 +259,7 @@ Single, self-contained changes. Anything multi-step earns a spec instead.
 | B28 | **Keep an explicit project-composer agent selection through asynchronous project-default hydration.**                                                                                                                                                                                                                                                                                                                                               | The deployed US two-test session suite clicked `memory-reflector`, then `useOpenCodeLocal()` changed its selection scope when `defaultAgentName` hydrated to `kortix`. The picker reset to `kortix` for 30 seconds.                                                                                          | **DONE 2026-07-27** — PR #5533, merge `ee45f55fa`; SDK tests `1283/0`, typecheck, packed-install smoke, and deployed US two-test suite `2/2` pass; both sessions returned exact `PONG`, and the mismatch fallback emitted no global error                                                                                                                                    |
 | B29 | **Preserve ACP upstream message boundaries in the projected transcript.**                                                                                                                                                                                                                                                                                                                                                                              | Dev session `ee41f742-9384-4f34-88e7-63ae3d765cae` emitted distinct `session/update.messageId` values for assistant steps, but `src/core/acp/projection.ts` discarded `messageId` and appended every text or reasoning chunk to one generated assistant message.                                                                                      | **DONE 2026-07-27** — implementation `60b06c6e4`; focused projection/controller tests `27/0`, full SDK tests `1299/0`, typecheck, packed-install smoke, supplied-transcript replay, and local ACP Chromium flow pass                                                                                                                                                                                          |
 | B30 | **Expose message-based session rewind and restore through both REST and ACP transports.** Editing an earlier user message must rewind the same canonical session instead of creating a fork. The removed path must remain recoverable until the replacement prompt commits.                                                                                                                                                                      | `apps/web/src/features/session/session-chat.tsx` contains `TODO(session-rewind)`. OpenCode exposes `/session/{sessionID}/revert` and `/unrevert`; ACP has no standard rewind method and needs a Kortix bridge extension plus transcript reload.                                                               | **DONE 2026-07-27** — implementation `eab4eef0f`; PR #5619 merged as `9e90e8ed7`. Deploy Dev run `30293660760` deployed source `e548c6a8fc9ee1d5a92db66d6feb912d4442ebeb`, which contains the merge. Dev session `7feb4e84-072f-4b71-987f-dc25dd542890` kept canonical OpenCode session `ses_05b075d25ffe7PBkZ632pcVAlW` across ACP and REST rewind, restore, replacement commit, reconnect, and file rollback. ACP produced `DEPLOYED_ACP_REPLACEMENT`; REST produced `DEPLOYED_REST_REPLACEMENT`; cleanup removed `26/26` probe sessions and restored ACP runtime overrides. SDK tests `1309/0`, daemon tests `306/0`, web source contract `5/0`, local ACP Playwright `1/0`, and local real ACP plus REST smoke pass. Shippable to production: **YES** for protocol behavior. Deployed UI interaction remains unverified because Browser discovery returned `[]`. |
+| B31 | **Allow a page-scoped ACP query override and settle completed ACP prompts that contain stale running tools.**                                                                                                                                                                                                                                                                                                                                     | `?acp` has no SDK transport override. Dev session `5322fa59-7a73-4fea-9f1a-9da59c2a0b5a` rendered the final assistant response while an older tool part remained `running`; `hasProjectionBlockers()` then kept the composer busy and blocked the queued prompt.                                                                 | **IN PROGRESS 2026-07-27** — session `acp-idle-query-override`; RED tests, SDK fix, web query wiring, full SDK gates, local Chromium proof, PR merge, Deploy Dev, deployed SHA proof, and deployed ACP-only proof required |
 
 > **Paths above are as of today (pre-Task-4).** After the restructure they move:
 > `platform/api/` → `core/http/api/`, `opencode/` → `core/runtime/`,
@@ -3444,3 +3445,23 @@ Live local REST and ACP proof used one disposable canonical OpenCode session:
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
 and deployed REST, ACP, and web verification remain.
+
+---
+
+### 2026-07-27 — session `acp-idle-query-override` (B31 claim)
+
+Claimed the ACP page override and stale-tool settlement defect.
+
+`?acp` will override the server-selected runtime transport for one session page.
+It will not mutate `experimental.acp_runtime`.
+The SDK will keep genuine active tools busy.
+The SDK will settle stale running tools after a newer assistant message and the
+final prompt result.
+Queued prompts will dispatch after settlement.
+
+Implementation will follow RED -> GREEN -> REFACTOR.
+Required gates are focused SDK and web tests, full SDK typecheck, full SDK suite,
+packed-install smoke, local Chromium ACP proof, PR merge, Deploy Dev, deployed SHA
+proof, and deployed ACP-only network proof.
+
+**Status:** IN PROGRESS.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -259,7 +259,7 @@ Single, self-contained changes. Anything multi-step earns a spec instead.
 | B28 | **Keep an explicit project-composer agent selection through asynchronous project-default hydration.**                                                                                                                                                                                                                                                                                                                                               | The deployed US two-test session suite clicked `memory-reflector`, then `useOpenCodeLocal()` changed its selection scope when `defaultAgentName` hydrated to `kortix`. The picker reset to `kortix` for 30 seconds.                                                                                          | **DONE 2026-07-27** — PR #5533, merge `ee45f55fa`; SDK tests `1283/0`, typecheck, packed-install smoke, and deployed US two-test suite `2/2` pass; both sessions returned exact `PONG`, and the mismatch fallback emitted no global error                                                                                                                                    |
 | B29 | **Preserve ACP upstream message boundaries in the projected transcript.**                                                                                                                                                                                                                                                                                                                                                                              | Dev session `ee41f742-9384-4f34-88e7-63ae3d765cae` emitted distinct `session/update.messageId` values for assistant steps, but `src/core/acp/projection.ts` discarded `messageId` and appended every text or reasoning chunk to one generated assistant message.                                                                                      | **DONE 2026-07-27** — implementation `60b06c6e4`; focused projection/controller tests `27/0`, full SDK tests `1299/0`, typecheck, packed-install smoke, supplied-transcript replay, and local ACP Chromium flow pass                                                                                                                                                                                          |
 | B30 | **Expose message-based session rewind and restore through both REST and ACP transports.** Editing an earlier user message must rewind the same canonical session instead of creating a fork. The removed path must remain recoverable until the replacement prompt commits.                                                                                                                                                                      | `apps/web/src/features/session/session-chat.tsx` contains `TODO(session-rewind)`. OpenCode exposes `/session/{sessionID}/revert` and `/unrevert`; ACP has no standard rewind method and needs a Kortix bridge extension plus transcript reload.                                                               | **DONE 2026-07-27** — implementation `eab4eef0f`; PR #5619 merged as `9e90e8ed7`. Deploy Dev run `30293660760` deployed source `e548c6a8fc9ee1d5a92db66d6feb912d4442ebeb`, which contains the merge. Dev session `7feb4e84-072f-4b71-987f-dc25dd542890` kept canonical OpenCode session `ses_05b075d25ffe7PBkZ632pcVAlW` across ACP and REST rewind, restore, replacement commit, reconnect, and file rollback. ACP produced `DEPLOYED_ACP_REPLACEMENT`; REST produced `DEPLOYED_REST_REPLACEMENT`; cleanup removed `26/26` probe sessions and restored ACP runtime overrides. SDK tests `1309/0`, daemon tests `306/0`, web source contract `5/0`, local ACP Playwright `1/0`, and local real ACP plus REST smoke pass. Shippable to production: **YES** for protocol behavior. Deployed UI interaction remains unverified because Browser discovery returned `[]`. |
-| B31 | **Allow a page-scoped ACP query override and settle completed ACP prompts that contain stale running tools.**                                                                                                                                                                                                                                                                                                                                     | `?acp` has no SDK transport override. Dev session `5322fa59-7a73-4fea-9f1a-9da59c2a0b5a` rendered the final assistant response while an older tool part remained `running`; `hasProjectionBlockers()` then kept the composer busy and blocked the queued prompt.                                                                 | **IN PROGRESS 2026-07-27** — session `acp-idle-query-override`; RED tests, SDK fix, web query wiring, full SDK gates, local Chromium proof, PR merge, Deploy Dev, deployed SHA proof, and deployed ACP-only proof required |
+| B31 | **Allow a page-scoped ACP query override and settle completed ACP prompts that contain stale running tools.**                                                                                                                                                                                                                                                                                                                                     | `?acp` has no SDK transport override. Dev session `5322fa59-7a73-4fea-9f1a-9da59c2a0b5a` rendered the final assistant response while an older tool part remained `running`; `hasProjectionBlockers()` then kept the composer busy and blocked the queued prompt.                                                                 | **IMPLEMENTATION COMPLETE 2026-07-27** — implementation `d3544ae14`; focused SDK `40/0`, full SDK `1312/0`, typecheck, packed-install smoke, web routing `5/0`, and touched web ESLint pass. PR #5636, Deploy Dev, deployed SHA proof, and deployed ACP-only proof remain |
 
 > **Paths above are as of today (pre-Task-4).** After the restructure they move:
 > `platform/api/` → `core/http/api/`, `opencode/` → `core/runtime/`,
@@ -3465,3 +3465,54 @@ packed-install smoke, local Chromium ACP proof, PR merge, Deploy Dev, deployed S
 proof, and deployed ACP-only network proof.
 
 **Status:** IN PROGRESS.
+
+---
+
+### 2026-07-27 — session `acp-idle-query-override` (B31 local completion)
+
+Implemented page-scoped ACP transport selection and stale-tool settlement in
+`d3544ae14`.
+
+`UseSessionOptions.runtimeTransport` is an additive per-hook override.
+The session page passes `acp` only when the URL contains `?acp`.
+The page does not mutate `experimental.acp_runtime`.
+The SDK policy keeps one AI transport mounted.
+The ACP policy disables OpenCode REST events, session listing, message sync, and
+`promptAsync`.
+
+A newer assistant message now closes unresolved tools from the previous assistant
+message.
+The 500-millisecond quiet period still blocks early idle while the current
+assistant message contains a genuine active tool.
+Queued prompts dispatch after stale tools settle.
+Transcript reload starts idle when an older assistant message contains a stale
+running tool.
+
+TDD evidence:
+
+- RED focused SDK: **36 pass / 4 fail**.
+- RED web routing contract: **4 pass / 1 fail**.
+- GREEN focused SDK: **40 pass / 0 fail**.
+- GREEN web routing contract: **5 pass / 0 fail**.
+
+Required gates:
+
+- `pnpm --filter @kortix/sdk typecheck`: exit 0.
+- `pnpm --filter @kortix/sdk test`: **1312 pass / 2 skip / 0 fail** with
+  **5785** assertions across **111** files.
+- `pnpm --filter @kortix/sdk run smoke:install`: packed install and Node ESM
+  import passed.
+- Touched web ESLint: exit 0.
+- Web `tsc --noEmit`: no errors reference the touched files. Existing unrelated
+  repository errors keep the full command at exit 1.
+- `git diff --check`: exit 0.
+
+The ACP browser canary now opens a server-selected REST session with `?acp`,
+asserts ACP-only AI traffic, then removes `?acp` and asserts REST rollback.
+The in-app browser runtime returned no available browsers.
+The local Chromium canary remains unexecuted.
+
+**Status:** IMPLEMENTATION COMPLETE.
+
+**Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
+and deployed UI verification remain.

--- a/packages/sdk/src/core/acp/projection.test.ts
+++ b/packages/sdk/src/core/acp/projection.test.ts
@@ -453,4 +453,42 @@ describe('ACP to Kortix session projection', () => {
     });
     expect(next).toBe(state);
   });
+
+  test('a newer assistant message terminalizes an unresolved tool from the previous message', () => {
+    let state = createAcpProjection('ses_1');
+    state = update(state, 'agent_thought_chunk', {
+      messageId: 'msg_assistant_1',
+      content: { type: 'text', text: 'Checking the files.' },
+    });
+    state = update(state, 'tool_call', {
+      toolCallId: 'call_stale',
+      title: 'bash',
+      kind: 'execute',
+      status: 'in_progress',
+      rawInput: { command: 'test -f deck.pptx' },
+    });
+    state = update(state, 'agent_message_chunk', {
+      messageId: 'msg_assistant_2',
+      content: { type: 'text', text: 'The deck is complete.' },
+    });
+
+    const previousAssistant = state.messages[0];
+    expect(previousAssistant?.info.role).toBe('assistant');
+    if (previousAssistant?.info.role !== 'assistant') {
+      throw new Error('Expected the first projected message to be an assistant message');
+    }
+    expect(previousAssistant.info.time.completed).toEqual(expect.any(Number));
+    expect(state.messages[0]?.parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool',
+        callID: 'call_stale',
+        state: expect.objectContaining({
+          status: 'completed',
+          output: '',
+          time: expect.objectContaining({ end: expect.any(Number) }),
+        }),
+      }),
+    );
+    expect(state.messages[1]?.info.id).toBe('msg_assistant_2');
+  });
 });

--- a/packages/sdk/src/core/acp/projection.ts
+++ b/packages/sdk/src/core/acp/projection.ts
@@ -153,6 +153,45 @@ function createAssistantMessage(
   return { info, parts: [] };
 }
 
+function completeAssistantMessage(
+  message: AcpMessageWithParts,
+  completed: number,
+): AcpMessageWithParts {
+  if (message.info.role !== 'assistant' || message.info.time.completed) return message;
+  const parts = message.parts.map((part) => {
+    if (
+      part.type !== 'tool' ||
+      (part.state.status !== 'pending' && part.state.status !== 'running')
+    ) {
+      return part;
+    }
+    const state = part.state;
+    const start = state.status === 'running' ? state.time.start : completed;
+    return {
+      ...part,
+      state: {
+        status: 'completed',
+        input: state.input,
+        output: '',
+        title:
+          state.status === 'running' && state.title
+            ? state.title
+            : toolInfo(part.tool).label,
+        metadata: state.status === 'running' ? (state.metadata ?? {}) : {},
+        time: { start, end: completed },
+      },
+    } satisfies ToolPart;
+  });
+  return {
+    ...message,
+    info: {
+      ...message.info,
+      time: { ...message.info.time, completed },
+    },
+    parts,
+  };
+}
+
 function withAssistant(
   state: AcpProjection,
   messageId: string | null,
@@ -183,15 +222,7 @@ function withAssistant(
 
   const completed = Date.now();
   const messages = state.messages.map((message) =>
-    message.info.role === 'assistant' && !message.info.time.completed
-      ? {
-          ...message,
-          info: {
-            ...message.info,
-            time: { ...message.info.time, completed },
-          },
-        }
-      : message,
+    completeAssistantMessage(message, completed),
   );
   const created = createAssistantMessage({ ...state, messages }, messageId);
   return {

--- a/packages/sdk/src/core/acp/session-controller.test.ts
+++ b/packages/sdk/src/core/acp/session-controller.test.ts
@@ -467,6 +467,211 @@ describe('ACP session controller', () => {
     ]);
   });
 
+  test('settles a final response after a stale running tool and dispatches the queued prompt', async () => {
+    const h = harness();
+    let promptCount = 0;
+    h.client.prompt = async (sessionId, prompt) => {
+      h.calls.push({ method: 'prompt', args: [sessionId, prompt] });
+      promptCount += 1;
+      if (promptCount === 1) {
+        h.emit({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: 'agent_thought_chunk',
+              messageId: 'msg_assistant_tool',
+              content: { type: 'text', text: 'Validating the deck.' },
+            },
+          },
+        });
+        h.emit({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId: 'call_stale',
+              title: 'bash',
+              kind: 'execute',
+              status: 'in_progress',
+              rawInput: { command: 'validate deck' },
+            },
+          },
+        });
+        h.emit({
+          jsonrpc: '2.0',
+          method: 'session/update',
+          params: {
+            sessionId,
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              messageId: 'msg_assistant_final',
+              content: { type: 'text', text: 'The deck is complete.' },
+            },
+          },
+        });
+      }
+      return { stopReason: 'end_turn' };
+    };
+    const controller = createAcpSessionController({
+      sessionId: 'ses_1',
+      client: h.client,
+    });
+    await controller.connect();
+
+    const first = controller.send([{ type: 'text', text: 'create deck' }]);
+    const queued = controller.send([{ type: 'text', text: 'export pptx' }]);
+    await Promise.all([first, queued]);
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+    expect(h.calls.filter((call) => call.method === 'prompt').map((call) => call.args[1])).toEqual([
+      [{ type: 'text', text: 'create deck' }],
+      [{ type: 'text', text: 'export pptx' }],
+    ]);
+    expect(controller.getSnapshot()).toMatchObject({
+      sending: false,
+      projection: { status: { type: 'idle' } },
+    });
+    expect(
+      controller
+        .getSnapshot()
+        .projection.messages.flatMap((message) => message.parts)
+        .find((part) => part.type === 'tool' && part.callID === 'call_stale'),
+    ).toMatchObject({
+      state: { status: 'completed' },
+    });
+  });
+
+  test('keeps a genuine active tool busy until its terminal update arrives', async () => {
+    const h = harness();
+    h.client.prompt = async (sessionId, prompt) => {
+      h.calls.push({ method: 'prompt', args: [sessionId, prompt] });
+      h.emit({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_thought_chunk',
+            messageId: 'msg_assistant_active',
+            content: { type: 'text', text: 'Running validation.' },
+          },
+        },
+      });
+      h.emit({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'call_active',
+            title: 'bash',
+            kind: 'execute',
+            status: 'in_progress',
+            rawInput: { command: 'validate deck' },
+          },
+        },
+      });
+      return { stopReason: 'end_turn' };
+    };
+    const controller = createAcpSessionController({
+      sessionId: 'ses_1',
+      client: h.client,
+    });
+    await controller.connect();
+
+    await controller.send([{ type: 'text', text: 'create deck' }]);
+    await new Promise((resolve) => setTimeout(resolve, 650));
+
+    expect(controller.getSnapshot()).toMatchObject({
+      sending: true,
+      projection: { status: { type: 'busy' } },
+    });
+
+    h.emit({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId: 'ses_1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'call_active',
+          status: 'completed',
+          rawOutput: { output: 'valid' },
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 650));
+
+    expect(controller.getSnapshot()).toMatchObject({
+      sending: false,
+      projection: { status: { type: 'idle' } },
+    });
+  });
+
+  test('loads a completed transcript with an older unresolved tool as idle', async () => {
+    const h = harness();
+    h.client.loadSession = async (input) => {
+      h.calls.push({ method: 'loadSession', args: [input] });
+      h.emit({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: input.sessionId,
+          update: {
+            sessionUpdate: 'agent_thought_chunk',
+            messageId: 'msg_assistant_tool',
+            content: { type: 'text', text: 'Validating.' },
+          },
+        },
+      });
+      h.emit({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: input.sessionId,
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'call_stale',
+            title: 'bash',
+            kind: 'execute',
+            status: 'in_progress',
+            rawInput: { command: 'validate deck' },
+          },
+        },
+      });
+      h.emit({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: input.sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            messageId: 'msg_assistant_final',
+            content: { type: 'text', text: 'Done.' },
+          },
+        },
+      });
+      return {};
+    };
+    const controller = createAcpSessionController({
+      sessionId: 'ses_1',
+      client: h.client,
+    });
+
+    await controller.connect();
+
+    expect(controller.getSnapshot()).toMatchObject({
+      ready: true,
+      sending: false,
+      projection: { status: { type: 'idle' } },
+    });
+  });
+
   test('answers ACP permission requests with the matching option id', async () => {
     const h = harness();
     const controller = createAcpSessionController({

--- a/packages/sdk/src/core/session/runtime-transport.test.ts
+++ b/packages/sdk/src/core/session/runtime-transport.test.ts
@@ -46,3 +46,15 @@ test('ACP transport disables OpenCode REST streaming, listing, sync, and send', 
     sendWith: 'acp',
   });
 });
+
+test('an explicit ACP override replaces a server-selected REST transport', () => {
+  expect(resolveSessionRuntimeTransport('rest', 'acp')).toBe('acp');
+  expect(createSessionRuntimePolicy('rest', 'acp')).toEqual({
+    transport: 'acp',
+    useAcp: true,
+    streamOpenCodeEvents: false,
+    listOpenCodeSessions: false,
+    syncOpenCodeMessages: false,
+    sendWith: 'acp',
+  });
+});

--- a/packages/sdk/src/core/session/runtime-transport.ts
+++ b/packages/sdk/src/core/session/runtime-transport.ts
@@ -2,7 +2,9 @@ export type SessionRuntimeTransport = 'acp' | 'rest';
 
 export function resolveSessionRuntimeTransport(
   value: SessionRuntimeTransport | undefined,
+  override?: SessionRuntimeTransport,
 ): SessionRuntimeTransport {
+  if (override) return override;
   return value === 'acp' ? 'acp' : 'rest';
 }
 
@@ -17,8 +19,9 @@ export interface SessionRuntimePolicy {
 
 export function createSessionRuntimePolicy(
   value: SessionRuntimeTransport | undefined,
+  override?: SessionRuntimeTransport,
 ): SessionRuntimePolicy {
-  const transport = resolveSessionRuntimeTransport(value);
+  const transport = resolveSessionRuntimeTransport(value, override);
   const useAcp = transport === 'acp';
   return {
     transport,

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -29,7 +29,10 @@ import {
   reconcileCommittedSessionRewind,
   type SessionRewindState,
 } from '../core/session/rewind';
-import { createSessionRuntimePolicy } from '../core/session/runtime-transport';
+import {
+  createSessionRuntimePolicy,
+  type SessionRuntimeTransport,
+} from '../core/session/runtime-transport';
 import { useOpenCodeCompactionStore } from '../browser/stores/opencode-compaction-store';
 import { useOpenCodePendingStore } from '../browser/stores/opencode-pending-store';
 import { setOpenCodeHealth, setSandboxStatus } from '../browser/stores/sandbox-connection-store';
@@ -323,6 +326,12 @@ export interface UseSessionOptions {
   /** Long-poll budget (ms) the client requests on `/start`; the server clamps it. */
   waitMs?: number;
   /**
+   * Override the server-selected AI transport for this hook instance.
+   * Hosts can use this for page-scoped diagnostics without changing project
+   * configuration. Omit it to use `/start.runtime_transport`.
+   */
+  runtimeTransport?: SessionRuntimeTransport;
+  /**
    * Replay a stashed first message (prompt + model + agent from the "new session"
    * screen) once the runtime is ready and the thread is empty. Default true. Hosts
    * with their own first-message hand-off (e.g. apps/web) set this false.
@@ -390,6 +399,7 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     enabled = true,
     chatEngine = true,
     initialOpenCodeSessionId = null,
+    runtimeTransport: runtimeTransportOverride,
   } = options;
 
   // 1. Drive /start until the runtime is ready (the server long-polls each tick).
@@ -414,7 +424,10 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
   const sandbox = startData?.sandbox ?? null;
   const startReady = stage === 'ready';
   const terminal = stage === 'failed' || stage === 'stopped';
-  const runtimePolicy = createSessionRuntimePolicy(startData?.runtime_transport);
+  const runtimePolicy = createSessionRuntimePolicy(
+    startData?.runtime_transport,
+    runtimeTransportOverride,
+  );
   const runtimeTransport = runtimePolicy.transport;
   const usesAcp = runtimePolicy.useAcp;
 

--- a/tests/e2e/specs/14-acp-runtime-canary.spec.ts
+++ b/tests/e2e/specs/14-acp-runtime-canary.spec.ts
@@ -199,7 +199,7 @@ test.describe.serial("14 — OpenCode ACP runtime canary", () => {
       auth.access_token,
       "PATCH",
       `/projects/${projectId}/experimental`,
-      { feature: "acp_runtime", enabled: true },
+      { feature: "acp_runtime", enabled: false },
     );
     const session = await api<{ session_id: string }>(
       auth.access_token,
@@ -216,7 +216,7 @@ test.describe.serial("14 — OpenCode ACP runtime canary", () => {
       auth.access_token,
       projectId,
       sessionId,
-      "acp",
+      "rest",
     );
   });
 
@@ -309,7 +309,7 @@ test.describe.serial("14 — OpenCode ACP runtime canary", () => {
     await installBrowserSession(
       page,
       auth,
-      `/projects/${projectId}/sessions/${sessionId}`,
+      `/projects/${projectId}/sessions/${sessionId}?acp`,
       password,
     );
     const input = page.getByRole("textbox", { name: "Message input" });
@@ -628,14 +628,9 @@ test.describe.serial("14 — OpenCode ACP runtime canary", () => {
       page.getByText("POST_RESTART_PONG", { exact: true }),
     ).toHaveCount(0);
 
-    await api(
-      auth.access_token,
-      "PATCH",
-      `/projects/${projectId}/experimental`,
-      { feature: "acp_runtime", enabled: false },
-    );
-    await waitForReadySession(auth.access_token, projectId, sessionId, "rest");
-    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.goto(`/projects/${projectId}/sessions/${sessionId}`, {
+      waitUntil: "domcontentloaded",
+    });
     await expect(input).toBeVisible({ timeout: 120_000 });
     const modelPicker = page.getByRole("button", { name: "Model picker" });
     await expect(modelPicker).toBeVisible({ timeout: 120_000 });


### PR DESCRIPTION
## Summary

- add a page-scoped `?acp` runtime override without changing project configuration
- terminalize unresolved tools when a newer ACP assistant message closes their message boundary
- preserve the 500 ms quiet-period guard for genuine active tools and late updates
- dispatch queued prompts after the final ACP response settles
- run the ACP canary against a server-selected REST session with `?acp`, then verify REST rollback without the query

## Verification

- `pnpm --filter @kortix/sdk typecheck` — pass
- `pnpm --filter @kortix/sdk test` — 1312 pass, 2 skip, 0 fail
- `pnpm --filter @kortix/sdk run smoke:install` — pass
- focused ACP SDK tests — 40 pass, 0 fail
- web routing contract — 5 pass, 0 fail
- touched web ESLint — pass
- web typecheck — no errors in touched files; the repository-wide command retains unrelated existing errors

## Browser status

The required in-app browser runtime returned no available browsers. The real local Chromium canary was not executed in this worktree.