### PR TITLE
fix(release): pace managed repository provisioning

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -66,6 +66,11 @@ jobs:
       # Staging can provision managed repositories with the server credential.
       # CLI push flows also require repo-scoped token export from a GitHub App.
       KE2E_CAP_MANAGED_GIT_PUSH: ${{ vars.KE2E_CAP_MANAGED_GIT_PUSH || '0' }}
+      # GitHub applies a secondary content-creation limit independently of the
+      # REST core quota. Serialize and pace real managed-repository creation.
+      KE2E_PROVISION_CONCURRENCY: 1
+      KE2E_PROVISION_MIN_INTERVAL_MS: 5000
+      KE2E_PROVISION_RATE_LIMIT_DELAY_MS: 180000
       # staging.kortix.com sits behind Vercel deployment protection (SSO); the
       # Playwright configs send this as x-vercel-protection-bypass so the browser
       # suite can reach the app instead of the Vercel login wall.

--- a/tests/src/fixtures/provision.ts
+++ b/tests/src/fixtures/provision.ts
@@ -8,8 +8,12 @@ import { type Client, isKe2eRetryableError } from '../core/client';
 import { sleep } from '../core/poll';
 
 const MAX = Number(process.env.KE2E_PROVISION_CONCURRENCY ?? 2);
+const MIN_REQUEST_INTERVAL_MS = Number(process.env.KE2E_PROVISION_MIN_INTERVAL_MS ?? 0);
+const RATE_LIMIT_DELAY_MS = Number(process.env.KE2E_PROVISION_RATE_LIMIT_DELAY_MS ?? 120_000);
 let active = 0;
 const waiters: Array<() => void> = [];
+let nextRequestAt = 0;
+let pacingTail: Promise<void> = Promise.resolve();
 
 async function acquire(): Promise<void> {
   if (active < MAX) {
@@ -32,8 +36,22 @@ function isRetryableProvisionStatus(status: number): boolean {
   return status >= 500 && status <= 599;
 }
 
-function retryDelayMs(attempt: number): number {
+function retryDelayMs(attempt: number, rateLimited: boolean): number {
+  if (rateLimited) return RATE_LIMIT_DELAY_MS;
   return Math.min(5_000 * 2 ** attempt, 30_000);
+}
+
+export async function paceProvisionRequest(
+  minimumIntervalMs = MIN_REQUEST_INTERVAL_MS,
+): Promise<void> {
+  if (minimumIntervalMs <= 0) return;
+  const scheduled = pacingTail.then(async () => {
+    const delayMs = Math.max(0, nextRequestAt - Date.now());
+    if (delayMs > 0) await sleep(delayMs);
+    nextRequestAt = Date.now() + minimumIntervalMs;
+  });
+  pacingTail = scheduled.catch(() => undefined);
+  await scheduled;
 }
 
 /**
@@ -54,6 +72,7 @@ export async function provisionProject(
       attempts = attempt + 1;
       let r: Awaited<ReturnType<Client['post']>>;
       try {
+        await paceProvisionRequest();
         r = await client.post('/v1/projects/provision', body, {
           timeoutMs: PROVISION_REQUEST_TIMEOUT_MS,
         });
@@ -61,7 +80,7 @@ export async function provisionProject(
         if (!isKe2eRetryableError(error) || attempt === MAX_PROVISION_ATTEMPTS - 1) {
           throw error;
         }
-        await sleep(retryDelayMs(attempt));
+        await sleep(retryDelayMs(attempt, false));
         continue;
       }
 
@@ -69,10 +88,10 @@ export async function provisionProject(
       if (typeof id === 'string' && id.length > 0) return id;
       const responseText = r.text();
       lastFailure = `HTTP ${r.statusCode}: ${responseText}`;
-      const retryable =
-        isRetryableProvisionStatus(r.statusCode) || RATE_LIMIT_RE.test(responseText);
+      const rateLimited = RATE_LIMIT_RE.test(responseText);
+      const retryable = isRetryableProvisionStatus(r.statusCode) || rateLimited;
       if (!retryable || attempt === MAX_PROVISION_ATTEMPTS - 1) break;
-      await sleep(retryDelayMs(attempt));
+      await sleep(retryDelayMs(attempt, rateLimited));
     }
     throw new Error(
       `project provision returned no id after ${attempts} attempt(s): ${lastFailure}`,

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/core/client';
 import { waitFor } from '../src/core/poll';
 import type { Captured } from '../src/core/result';
-import { provisionProject } from '../src/fixtures/provision';
+import { paceProvisionRequest, provisionProject } from '../src/fixtures/provision';
 
 function response(statusCode: number, bodyText: string, json?: unknown) {
   return {
@@ -86,17 +86,36 @@ describe('release gate transient failure resilience', () => {
 
   it('retries an explicit HTTP 403 rate-limit response', async () => {
     vi.useFakeTimers();
+    const attempts: number[] = [];
     const post = vi
       .fn()
-      .mockResolvedValueOnce(response(403, '{"error":"secondary rate limit"}'))
-      .mockResolvedValueOnce(
-        response(200, '{"project_id":"project-3"}', { project_id: 'project-3' }),
-      );
+      .mockImplementationOnce(async () => {
+        attempts.push(Date.now());
+        return response(403, '{"error":"secondary rate limit"}');
+      })
+      .mockImplementationOnce(async () => {
+        attempts.push(Date.now());
+        return response(200, '{"project_id":"project-3"}', { project_id: 'project-3' });
+      });
 
     const result = provisionProject(clientWithPost(post), { name: 'release-gate-test' });
 
     await expect(settleTimers(result)).resolves.toBe('project-3');
     expect(post).toHaveBeenCalledTimes(2);
+    expect(attempts).toHaveLength(2);
+    expect((attempts.at(1) ?? 0) - (attempts.at(0) ?? 0)).toBeGreaterThanOrEqual(120_000);
+  });
+
+  it('paces concurrent managed repository creation attempts', async () => {
+    vi.useFakeTimers();
+    const starts: number[] = [];
+
+    const first = paceProvisionRequest(5_000).then(() => starts.push(Date.now()));
+    const second = paceProvisionRequest(5_000).then(() => starts.push(Date.now()));
+
+    await settleTimers(Promise.all([first, second]));
+    expect(starts).toHaveLength(2);
+    expect((starts.at(1) ?? 0) - (starts.at(0) ?? 0)).toBeGreaterThanOrEqual(5_000);
   });
 
   it('continues polling after a marked network error', async () => {


### PR DESCRIPTION
## Scope

Backport PR #5638 to the active v0.11.0 release candidate.

GitHub blocked the release gate with a secondary content-creation limit. This commit serializes repository provisioning, spaces attempts by 5 seconds, and applies a 180-second explicit rate-limit cooldown.

## Verification

- `bunx vitest run unit/release-gate-resilience.test.ts` -> 9 passed.
- Main PR #5638 passed 15 CI checks and merged as `8f8d00ac51790f52edd6f0d6465353b5e33bef5b`.