### PR TITLE
Heal corrupt git mirror cache entries

### DIFF
--- a/apps/api/src/__tests__/unit-git-mirror-clone.test.ts
+++ b/apps/api/src/__tests__/unit-git-mirror-clone.test.ts
@@ -229,4 +229,42 @@ describe('refreshMirror — partial-clone cleanup on failure', () => {
       await rm(workdir, { recursive: true, force: true }).catch(() => {});
     }
   });
+
+  test('an existing non-git cache directory is removed and recloned', async () => {
+    const workdir = await mkdtemp(join(tmpdir(), 'mirror-corrupt-'));
+    const cacheDir = join(workdir, 'cache');
+    const upstream = join(workdir, 'upstream');
+    await mkdir(upstream, { recursive: true });
+    await mkdir(cacheDir, { recursive: true });
+    await git(['init', '-b', 'main'], upstream);
+    await writeFile(join(upstream, 'README.md'), '# hi\n');
+    await git(['add', '.'], upstream);
+    await git(['commit', '-m', 'init'], upstream);
+
+    const project = {
+      projectId: 'eeeeeeee-0000-0000-0000-000000000005',
+      repoUrl: upstream,
+      defaultBranch: 'main',
+      manifestPath: '',
+      gitAuthToken: 'caller-supplied-token',
+    } as never;
+
+    const prevCacheDir = process.env.KORTIX_GIT_CACHE_DIR;
+    process.env.KORTIX_GIT_CACHE_DIR = cacheDir;
+    try {
+      const repoPath = repoCachePath(project);
+      await mkdir(repoPath, { recursive: true });
+      await writeFile(join(repoPath, 'not-a-repo.txt'), 'poisoned cache entry\n');
+
+      const healedPath = await refreshMirror(project);
+
+      expect(healedPath).toBe(repoPath);
+      expect(existsSync(join(repoPath, 'HEAD'))).toBe(true);
+      expect(existsSync(join(repoPath, 'objects'))).toBe(true);
+      expect(existsSync(join(repoPath, 'not-a-repo.txt'))).toBe(false);
+    } finally {
+      process.env.KORTIX_GIT_CACHE_DIR = prevCacheDir;
+      await rm(workdir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
 });

--- a/apps/api/src/projects/git/mirror.ts
+++ b/apps/api/src/projects/git/mirror.ts
@@ -328,13 +328,31 @@ const BARE_CLONE_TIMEOUT_MS = bareCloneTimeoutMs();
 const BARE_CLONE_MAX_ATTEMPTS = 2;
 const BARE_CLONE_RETRY_DELAY_MS = 500;
 
+function looksLikeBareMirror(repoPath: string): boolean {
+  return (
+    existsSync(join(repoPath, 'HEAD')) &&
+    existsSync(join(repoPath, 'config')) &&
+    existsSync(join(repoPath, 'objects')) &&
+    existsSync(join(repoPath, 'refs'))
+  );
+}
+
 async function doRefreshMirror(project: GitBackedProject, force = false) {
   const repoPath = repoCachePath(project);
   await mkdir(dirname(repoPath), { recursive: true });
   if (existsSync(join(repoPath, 'shallow'))) {
     await rm(repoPath, { recursive: true, force: true });
   }
-  const needsClone = !existsSync(repoPath);
+  let needsClone = !existsSync(repoPath);
+  if (!needsClone && !looksLikeBareMirror(repoPath)) {
+    // Self-heal a poisoned cache entry. This can happen if a previous clone was
+    // killed before git wrote a bare repo, or if an external cleanup left the
+    // hashed cache path as a plain directory. Without this guard a warm read can
+    // surface "fatal: not a git repository" all the way up to session startup.
+    await rm(repoPath, { recursive: true, force: true });
+    lastRefreshAt.delete(project.projectId);
+    needsClone = true;
+  }
   const lastRefresh = lastRefreshAt.get(project.projectId) || 0;
   const needsFetch = !needsClone && (force || Date.now() - lastRefresh >= refreshIntervalMs());
   // Nothing to do over the network — serve the warm cache without touching git.


### PR DESCRIPTION
## Summary
- detect existing git mirror cache paths that are not actually bare repositories
- remove poisoned cache entries and reclone instead of surfacing `fatal: not a git repository` during manifest/session startup paths
- add a regression test for an existing non-git cache directory being healed

## Tests
- bun test apps/api/src/__tests__/unit-git-mirror-clone.test.ts