### PR TITLE
Fix CodeQL secure temporary file gate

### DIFF
--- a/apps/api/src/__tests__/unit-git-mirror-clone.test.ts
+++ b/apps/api/src/__tests__/unit-git-mirror-clone.test.ts
@@ -254,7 +254,10 @@ describe('refreshMirror — partial-clone cleanup on failure', () => {
     try {
       const repoPath = repoCachePath(project);
       await mkdir(repoPath, { recursive: true });
-      await writeFile(join(repoPath, 'not-a-repo.txt'), 'poisoned cache entry\n');
+      await writeFile(join(repoPath, 'not-a-repo.txt'), 'poisoned cache entry\n', {
+        flag: 'wx',
+        mode: 0o600,
+      });
 
       const healedPath = await refreshMirror(project);
 


### PR DESCRIPTION
Fix the high-severity CodeQL finding that blocks staging PR #5643.

- Create the test poison file with exclusive wx mode.
- Restrict file permissions to 0600.

Verification: bun test apps/api/src/__tests__/unit-git-mirror-clone.test.ts returned 9 pass, 0 fail.