### PR TITLE
Fix release pacing unit-test environment

### DIFF
--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   Client,
   Res,
@@ -7,7 +7,9 @@ import {
 } from '../src/core/client';
 import { waitFor } from '../src/core/poll';
 import type { Captured } from '../src/core/result';
-import { paceProvisionRequest, provisionProject } from '../src/fixtures/provision';
+
+let paceProvisionRequest: typeof import('../src/fixtures/provision').paceProvisionRequest;
+let provisionProject: typeof import('../src/fixtures/provision').provisionProject;
 
 function response(statusCode: number, bodyText: string, json?: unknown) {
   return {
@@ -37,8 +39,17 @@ function capturedResponse(status: number, headers: Record<string, string>): Res 
 }
 
 describe('release gate transient failure resilience', () => {
+  beforeEach(async () => {
+    vi.stubEnv('KE2E_PROVISION_CONCURRENCY', '2');
+    vi.stubEnv('KE2E_PROVISION_MIN_INTERVAL_MS', '0');
+    vi.stubEnv('KE2E_PROVISION_RATE_LIMIT_DELAY_MS', '120000');
+    vi.resetModules();
+    ({ paceProvisionRequest, provisionProject } = await import('../src/fixtures/provision'));
+  });
+
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
The release workflow exports production pacing values into the unit-test process. Three fake-timer tests then exceed Vitest's 5-second timeout.

This change reloads the provision fixture per test with deterministic test pacing. It restores the process environment after each test.

Verification with release workflow environment:
- Targeted suite: 9/9
- Full unit suite: 25/25
- Coverage: 100%
- Typecheck: pass
- Biome: pass