### PR TITLE
fix(sessions): sync runtime-generated titles

### DIFF
--- a/apps/api/src/__tests__/e2e-preview-proxy.test.ts
+++ b/apps/api/src/__tests__/e2e-preview-proxy.test.ts
@@ -51,6 +51,8 @@ let mockFetchCallCount = 0;
 let mockFetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body: string | null }> = [];
 let mockDbUpdateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
 let mockResolvedPreviewPorts: number[] = [];
+let mockAcpTitleCaptureCalls: Array<Record<string, unknown>> = [];
+let mockDeferredTitleCaptureCalls: Array<Record<string, unknown>> = [];
 
 function mockSandboxRows(): any[] {
   if (!mockDbSandbox) return [];
@@ -294,6 +296,15 @@ mock.module('../projects/secrets', () => {
   };
 });
 
+mock.module('../projects/opencode-title-capture', () => ({
+  scheduleTitleCaptureAfterPrompt: (input: Record<string, unknown>) => {
+    mockDeferredTitleCaptureCalls.push(input);
+  },
+  captureTitleAfterRuntimeEvent: async (input: Record<string, unknown>) => {
+    mockAcpTitleCaptureCalls.push(input);
+  },
+}));
+
 // Override global fetch for proxy requests
 const originalFetch = globalThis.fetch;
 function mockFetch(url: string | URL | Request, init?: RequestInit): Promise<Response> {
@@ -344,6 +355,7 @@ const { sandboxProxyApp } = await import('../sandbox-proxy/index');
 const { verifyKortixUserContext, KORTIX_USER_CONTEXT_HEADER } = await import('../shared/kortix-user-context');
 const { resolvePreviewWsUpstream } = await import('../sandbox-proxy/routes/preview');
 const { invalidateSandbox } = await import('../sandbox-proxy/backend');
+const { __resetPromptDedupe } = await import('../sandbox-proxy/prompt-dedupe');
 
 // ─── Test app factory ────────────────────────────────────────────────────────
 
@@ -381,6 +393,7 @@ function createProxyTestApp() {
 // ─── Reset ───────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
+  __resetPromptDedupe();
   invalidateSandbox(TEST_SANDBOX_ID);
   invalidateSandbox('platinum-oc-http');
   invalidateSandbox('daytona-oc-http');
@@ -403,6 +416,8 @@ beforeEach(() => {
   mockFetchCalls = [];
   mockDbUpdateCalls = [];
   mockResolvedPreviewPorts = [];
+  mockAcpTitleCaptureCalls = [];
+  mockDeferredTitleCaptureCalls = [];
 
   // Install mock fetch
   globalThis.fetch = mockFetch as any;
@@ -725,6 +740,133 @@ describe('Preview proxy: forwarding', () => {
     expect(mockFetchCalls[1].url).toBe(
       'https://preview.daytona.io/proxy-url/session/ses_123/prompt_async?directory=%2Fworkspace',
     );
+  });
+
+  test('captures ACP session_info_update titles before forwarding the SSE event', async () => {
+    const event =
+      'id: 7\n' +
+      'data: {"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_123","update":{"sessionUpdate":"session_info_update","title":"Research Marko Kraemer"}}}\n\n';
+    mockFetchResponses = [
+      {
+        status: 200,
+        body: event,
+        headers: { 'Content-Type': 'text/event-stream' },
+      },
+    ];
+    const app = createProxyTestApp();
+
+    const res = await app.request(
+      `/v1/p/${TEST_SANDBOX_ID}/8000/kortix/acp/ses_123`,
+      {
+        headers: {
+          Authorization: 'Bearer test',
+          Accept: 'text/event-stream',
+        },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(event);
+    expect(mockAcpTitleCaptureCalls).toEqual([
+      {
+        sessionId: mockDbSandbox.sessionId,
+        projectId: TEST_PROJECT_ID,
+        opencodeSessionId: 'ses_123',
+        title: 'Research Marko Kraemer',
+      },
+    ]);
+  });
+
+  test('captures an OpenCode REST session.updated title before forwarding the SSE event', async () => {
+    const event =
+      'data: {"directory":"/workspace","payload":{"type":"session.updated","properties":{"id":"ses_123","title":"REST title"}}}\n\n';
+    mockFetchResponses = [
+      {
+        status: 200,
+        body: event,
+        headers: { 'Content-Type': 'text/event-stream' },
+      },
+    ];
+    const app = createProxyTestApp();
+
+    const res = await app.request(`/v1/p/${TEST_SANDBOX_ID}/8000/global/event`, {
+      headers: {
+        Authorization: 'Bearer test',
+        Accept: 'text/event-stream',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(event);
+    expect(mockAcpTitleCaptureCalls).toEqual([
+      {
+        sessionId: mockDbSandbox.sessionId,
+        projectId: TEST_PROJECT_ID,
+        opencodeSessionId: 'ses_123',
+        title: 'REST title',
+      },
+    ]);
+  });
+
+  test('schedules deferred title capture after an accepted ACP session prompt', async () => {
+    mockFetchResponses = [{ status: 202, body: '' }];
+    const app = createProxyTestApp();
+
+    const res = await app.request(
+      `/v1/p/${TEST_SANDBOX_ID}/8000/kortix/acp/ses_123`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'prompt-1',
+          method: 'session/prompt',
+          params: { sessionId: 'ses_123', prompt: [{ type: 'text', text: 'Research Marko' }] },
+        }),
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(mockDeferredTitleCaptureCalls).toEqual([
+      {
+        sessionId: mockDbSandbox.sessionId,
+        projectId: TEST_PROJECT_ID,
+        externalId: TEST_SANDBOX_ID,
+        userId: TEST_USER_ID,
+      },
+    ]);
+  });
+
+  test('does not retry an ACP session prompt after an ambiguous upstream 502', async () => {
+    mockFetchResponses = [
+      { status: 502, body: 'bad gateway' },
+      { status: 202, body: '' },
+    ];
+    const app = createProxyTestApp();
+
+    const res = await app.request(
+      `/v1/p/${TEST_SANDBOX_ID}/8000/kortix/acp/ses_123`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'prompt-2',
+          method: 'session/prompt',
+          params: { sessionId: 'ses_123', prompt: [{ type: 'text', text: 'Research Marko' }] },
+        }),
+      },
+    );
+
+    expect(res.status).toBe(502);
+    expect(mockFetchCalls).toHaveLength(1);
+    expect(mockDeferredTitleCaptureCalls).toEqual([]);
   });
 
   test('allows prompt_async when requested agent matches the session-bound token agent', async () => {

--- a/apps/api/src/__tests__/unit-acp-session-title-stream.test.ts
+++ b/apps/api/src/__tests__/unit-acp-session-title-stream.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test';
+
+import { observeRuntimeSessionTitleStream } from '../projects/acp-session-title-stream';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function chunkedStream(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+describe('observeRuntimeSessionTitleStream', () => {
+  test('captures a real ACP session title across split SSE chunks and preserves the stream', async () => {
+    const raw =
+      'id: 7\n' +
+      'data: {"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_1","update":{"sessionUpdate":"session_info_update","title":"Research Marko Kraemer"}}}\n\n';
+    const titles: string[] = [];
+
+    const observed = observeRuntimeSessionTitleStream(
+      chunkedStream([raw.slice(0, 31), raw.slice(31, 79), raw.slice(79)]),
+      {
+        protocol: 'acp',
+        expectedSessionId: 'ses_1',
+        onTitle: async (event) => {
+          titles.push(event.title);
+        },
+      },
+    );
+
+    expect(decoder.decode(await new Response(observed).arrayBuffer())).toBe(raw);
+    expect(titles).toEqual(['Research Marko Kraemer']);
+  });
+
+  test('ignores placeholders, other sessions, and non-title updates', async () => {
+    const envelopes = [
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'ses_1',
+          update: {
+            sessionUpdate: 'session_info_update',
+            title: 'New session - 2026-07-28',
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'ses_other',
+          update: {
+            sessionUpdate: 'session_info_update',
+            title: 'Wrong session',
+          },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'ses_1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Hi' },
+          },
+        },
+      },
+    ];
+    const raw = envelopes
+      .map((envelope, index) => `id: ${index + 1}\ndata: ${JSON.stringify(envelope)}\n\n`)
+      .join('');
+    const titles: string[] = [];
+
+    const observed = observeRuntimeSessionTitleStream(chunkedStream([raw]), {
+      protocol: 'acp',
+      expectedSessionId: 'ses_1',
+      onTitle: async (event) => {
+        titles.push(event.title);
+      },
+    });
+
+    expect(decoder.decode(await new Response(observed).arrayBuffer())).toBe(raw);
+    expect(titles).toEqual([]);
+  });
+
+  test('captures an OpenCode REST session.updated title for the pinned root', async () => {
+    const raw =
+      'data: {"directory":"/workspace","payload":{"type":"session.updated","properties":{"id":"ses_root","title":"REST title"}}}\n\n';
+    const events: Array<{ sessionId: string; title: string }> = [];
+
+    const observed = observeRuntimeSessionTitleStream(chunkedStream([raw]), {
+      protocol: 'rest',
+      expectedSessionId: 'ses_root',
+      onTitle: async (event) => {
+        events.push(event);
+      },
+    });
+
+    expect(decoder.decode(await new Response(observed).arrayBuffer())).toBe(raw);
+    expect(events).toEqual([{ sessionId: 'ses_root', title: 'REST title' }]);
+  });
+});

--- a/apps/api/src/__tests__/unit-opencode-title-capture.test.ts
+++ b/apps/api/src/__tests__/unit-opencode-title-capture.test.ts
@@ -6,19 +6,24 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import {
+  captureTitleAfterRuntimeEvent,
   pendingTitleCaptures,
   scheduleTitleCaptureAfterPrompt,
 } from '../projects/opencode-title-capture';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-function row(metadata: Record<string, unknown> = {}) {
+function row(
+  metadata: Record<string, unknown> = {},
+  overrides: Record<string, unknown> = {},
+) {
   return {
     sessionId: 'session-1',
     projectId: 'project-1',
     accountId: 'account-1',
     opencodeSessionId: null,
     metadata,
+    ...overrides,
   } as any;
 }
 
@@ -111,5 +116,120 @@ describe('scheduleTitleCaptureAfterPrompt', () => {
     const h = harness({ loaded: null });
     scheduleTitleCaptureAfterPrompt({ sessionId: '', projectId: 'p', externalId: 'x' }, h.options);
     expect(pendingTitleCaptures()).toBe(0);
+  });
+});
+
+describe('captureTitleAfterRuntimeEvent', () => {
+  test('persists the exact runtime title without another sandbox read', async () => {
+    const persistCalls: unknown[] = [];
+    const options = {
+      loadRow: async () => row({}),
+      persistTitle: async (args: unknown) => {
+        persistCalls.push(args);
+      },
+    };
+
+    await captureTitleAfterRuntimeEvent(
+      {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        opencodeSessionId: 'opencode-root-1',
+        title: 'Research Marko Kraemer',
+      },
+      options,
+    );
+
+    expect(persistCalls).toEqual([
+      {
+        row: expect.objectContaining({ sessionId: 'session-1', projectId: 'project-1' }),
+        title: 'Research Marko Kraemer',
+      },
+    ]);
+  });
+
+  test('rejects a child-session title when the Kortix row pins another root', async () => {
+    const persistCalls: unknown[] = [];
+    await captureTitleAfterRuntimeEvent(
+      {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        opencodeSessionId: 'opencode-child-1',
+        title: 'Child task',
+      },
+      {
+        loadRow: async () => row({}, { opencodeSessionId: 'opencode-root-1' }),
+        persistTitle: async (args: unknown) => {
+          persistCalls.push(args);
+        },
+      },
+    );
+    expect(persistCalls).toEqual([]);
+  });
+
+  test('deduplicates concurrent runtime title events for one Kortix session', async () => {
+    let release = () => {};
+    const persistStarted = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const persistCalls: unknown[] = [];
+    const options = {
+      loadRow: async () => row({}),
+      persistTitle: async (args: unknown) => {
+        persistCalls.push(args);
+        await persistStarted;
+      },
+    };
+    const event = {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      opencodeSessionId: 'opencode-root-1',
+      title: 'Research Marko Kraemer',
+    };
+
+    const first = captureTitleAfterRuntimeEvent(event, options);
+    const second = captureTitleAfterRuntimeEvent(event, options);
+    await sleep(1);
+    expect(persistCalls).toHaveLength(1);
+    release();
+    await Promise.all([first, second]);
+  });
+
+  test('does not discard a distinct root title while another title persists', async () => {
+    let release = () => {};
+    const persistBlocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const persistCalls: Array<{ title: string }> = [];
+    const options = {
+      loadRow: async () => row({}, { opencodeSessionId: 'opencode-root-1' }),
+      persistTitle: async (args: { title: string }) => {
+        persistCalls.push(args);
+        if (args.title === 'First title') await persistBlocked;
+      },
+    };
+
+    const first = captureTitleAfterRuntimeEvent(
+      {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        opencodeSessionId: 'opencode-root-1',
+        title: 'First title',
+      },
+      options as Parameters<typeof captureTitleAfterRuntimeEvent>[1],
+    );
+    const second = captureTitleAfterRuntimeEvent(
+      {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        opencodeSessionId: 'opencode-root-1',
+        title: 'Second title',
+      },
+      options as Parameters<typeof captureTitleAfterRuntimeEvent>[1],
+    );
+
+    await sleep(1);
+    expect(persistCalls.map((call) => call.title)).toEqual(['First title', 'Second title']);
+    release();
+    await Promise.all([first, second]);
   });
 });

--- a/apps/api/src/projects/acp-session-title-stream.ts
+++ b/apps/api/src/projects/acp-session-title-stream.ts
@@ -1,0 +1,110 @@
+export type RuntimeSessionTitleEvent = {
+  sessionId: string;
+  title: string;
+};
+
+type RuntimeSessionTitleObserverOptions = {
+  protocol: 'acp' | 'rest';
+  expectedSessionId?: string;
+  onTitle(event: RuntimeSessionTitleEvent): Promise<void> | void;
+  onError?(error: unknown): void;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function realTitle(value: unknown): string | null {
+  const title = typeof value === 'string' ? value.trim() : '';
+  if (!title || /^new session\b/i.test(title)) return null;
+  return title;
+}
+
+function titleFromAcpEnvelope(
+  envelope: unknown,
+  expectedSessionId: string,
+): RuntimeSessionTitleEvent | null {
+  if (!isObject(envelope) || envelope.method !== 'session/update') return null;
+  const params = isObject(envelope.params) ? envelope.params : null;
+  if (!params || params.sessionId !== expectedSessionId) return null;
+  const update = isObject(params.update) ? params.update : null;
+  if (!update || update.sessionUpdate !== 'session_info_update') return null;
+  const title = realTitle(update.title);
+  return title ? { sessionId: expectedSessionId, title } : null;
+}
+
+function titleFromRestEnvelope(
+  envelope: unknown,
+  expectedSessionId?: string,
+): RuntimeSessionTitleEvent | null {
+  if (!isObject(envelope)) return null;
+  const event = isObject(envelope.payload) ? envelope.payload : envelope;
+  if (event.type !== 'session.updated') return null;
+  const properties = isObject(event.properties) ? event.properties : null;
+  if (!properties) return null;
+  const info = isObject(properties.info) ? properties.info : properties;
+  const sessionId = typeof info.id === 'string' ? info.id : '';
+  if (!sessionId || (expectedSessionId && sessionId !== expectedSessionId)) return null;
+  const title = realTitle(info.title);
+  return title ? { sessionId, title } : null;
+}
+
+function titleFromSseBlock(
+  block: string,
+  options: Pick<RuntimeSessionTitleObserverOptions, 'protocol' | 'expectedSessionId'>,
+): RuntimeSessionTitleEvent | null {
+  const data = block
+    .split('\n')
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice(5).trimStart())
+    .join('\n');
+  if (!data) return null;
+
+  const envelope = JSON.parse(data) as unknown;
+  return options.protocol === 'acp'
+    ? titleFromAcpEnvelope(envelope, options.expectedSessionId ?? '')
+    : titleFromRestEnvelope(envelope, options.expectedSessionId);
+}
+
+/**
+ * Observe runtime session-title updates without changing the proxied SSE bytes.
+ * The title callback finishes before the matching chunk reaches the client.
+ */
+export function observeRuntimeSessionTitleStream(
+  body: ReadableStream<Uint8Array>,
+  options: RuntimeSessionTitleObserverOptions,
+): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  let pending = '';
+
+  const processBlocks = async (flush = false): Promise<void> => {
+    const blocks = pending.split('\n\n');
+    pending = blocks.pop() ?? '';
+    if (flush && pending.trim()) {
+      blocks.push(pending);
+      pending = '';
+    }
+    for (const block of blocks) {
+      try {
+        const event = titleFromSseBlock(block, options);
+        if (event) await options.onTitle(event);
+      } catch (error) {
+        options.onError?.(error);
+      }
+    }
+  };
+
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      async transform(chunk, controller) {
+        pending += decoder.decode(chunk, { stream: true }).replaceAll('\r\n', '\n');
+        await processBlocks();
+        controller.enqueue(chunk);
+      },
+      async flush() {
+        pending += decoder.decode().replaceAll('\r\n', '\n');
+        await processBlocks(true);
+      },
+    }),
+  );
+}

--- a/apps/api/src/projects/opencode-title-capture.ts
+++ b/apps/api/src/projects/opencode-title-capture.ts
@@ -1,10 +1,10 @@
 import { and, eq } from 'drizzle-orm';
 
 import { projectSessions } from '@kortix/db';
-import { db } from '../shared/db';
 import { logger as appLogger } from '../lib/logger';
-import { isPlaceholderOpencodeTitle, syncRowFromSandbox } from './opencode-title-sync';
+import { db } from '../shared/db';
 import type { ProjectSessionRow } from './lib/serializers';
+import { isPlaceholderOpencodeTitle, syncRowFromSandbox } from './opencode-title-sync';
 
 // Deferred title capture, scheduled off the prompt proxy path.
 //
@@ -20,6 +20,7 @@ const FIRST_ATTEMPT_DELAY_MS = 20_000;
 const RETRY_DELAY_MS = 40_000;
 
 const pending = new Set<string>();
+const immediate = new Map<string, Promise<void>>();
 
 function hasRealTitle(row: ProjectSessionRow): boolean {
   const metadata = (row.metadata ?? {}) as Record<string, unknown>;
@@ -37,12 +38,34 @@ async function loadRow(sessionId: string, projectId: string): Promise<ProjectSes
   return (row as ProjectSessionRow | undefined) ?? null;
 }
 
+async function persistTitle(input: {
+  row: ProjectSessionRow;
+  title: string;
+}): Promise<void> {
+  const metadata = (input.row.metadata ?? {}) as Record<string, unknown>;
+  if (metadata.name === input.title) return;
+  await db
+    .update(projectSessions)
+    .set({
+      metadata: { ...metadata, name: input.title },
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(projectSessions.sessionId, input.row.sessionId),
+        eq(projectSessions.projectId, input.row.projectId),
+        eq(projectSessions.accountId, input.row.accountId),
+      ),
+    );
+}
+
 /** Injectable seams so unit tests run without process-global module mocks. */
 export interface TitleCaptureOptions {
   firstMs?: number;
   retryMs?: number;
   loadRow?: (sessionId: string, projectId: string) => Promise<ProjectSessionRow | null>;
   sync?: typeof syncRowFromSandbox;
+  persistTitle?: typeof persistTitle;
 }
 
 /**
@@ -84,7 +107,7 @@ export function scheduleTitleCaptureAfterPrompt(
       await attempt();
     } catch (err) {
       // Best-effort enrichment: a failed capture must never surface — the
-      // The next prompt schedules another capture attempt.
+      // next prompt schedules another capture attempt.
       appLogger.warn('[title-capture] deferred capture failed', {
         sessionId: input.sessionId,
         projectId: input.projectId,
@@ -98,7 +121,60 @@ export function scheduleTitleCaptureAfterPrompt(
   setTimeout(() => void run(), firstMs);
 }
 
+/**
+ * Persist a title supplied by ACP session_info_update or OpenCode
+ * session.updated before the API proxy forwards that event to the browser.
+ */
+export function captureTitleAfterRuntimeEvent(
+  input: {
+    sessionId: string;
+    projectId: string;
+    opencodeSessionId: string;
+    title: string;
+  },
+  options: TitleCaptureOptions = {},
+): Promise<void> {
+  if (
+    !input.sessionId ||
+    !input.projectId ||
+    !input.opencodeSessionId ||
+    !input.title.trim() ||
+    isPlaceholderOpencodeTitle(input.title)
+  ) {
+    return Promise.resolve();
+  }
+  const key = [
+    input.projectId,
+    input.sessionId,
+    input.opencodeSessionId,
+    input.title.trim(),
+  ].join(':');
+  const existing = immediate.get(key);
+  if (existing) return existing;
+
+  const load = options.loadRow ?? loadRow;
+  const persist = options.persistTitle ?? persistTitle;
+  const run = (async () => {
+    try {
+      const row = await load(input.sessionId, input.projectId);
+      if (!row) return;
+      if (row.opencodeSessionId && row.opencodeSessionId !== input.opencodeSessionId) return;
+      await persist({ row, title: input.title.trim() });
+    } catch (err) {
+      appLogger.warn('[title-capture] runtime title synchronization failed', {
+        sessionId: input.sessionId,
+        projectId: input.projectId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  })().finally(() => {
+    immediate.delete(key);
+  });
+  immediate.set(key, run);
+  return run;
+}
+
 /** Test hook: number of sessions with a capture in flight. */
 export function pendingTitleCaptures(): number {
-  return pending.size;
+  return pending.size + immediate.size;
 }

--- a/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
@@ -38,6 +38,7 @@ mock.module('../../projects/lib/sandbox-env-sync', () => ({
 }));
 mock.module('../../projects/opencode-title-capture', () => ({
   scheduleTitleCaptureAfterPrompt: () => {},
+  captureTitleAfterRuntimeEvent: async () => {},
 }));
 mock.module('../../projects/routes/shared', () => ({
   resumeStoppedSandboxByExternalId: async () => true,

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -8,7 +8,11 @@ import {
   AgentSecretGrantMismatchError,
   SecretGrantResolutionError,
 } from '../../projects/lib/secret-grant';
-import { scheduleTitleCaptureAfterPrompt } from '../../projects/opencode-title-capture';
+import { observeRuntimeSessionTitleStream } from '../../projects/acp-session-title-stream';
+import {
+  captureTitleAfterRuntimeEvent,
+  scheduleTitleCaptureAfterPrompt,
+} from '../../projects/opencode-title-capture';
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
 import { KORTIX_USER_CONTEXT_HEADER } from '../../shared/kortix-user-context';
 import { canAccessPreviewSandbox, canAccessSandboxSession } from '../../shared/preview-ownership';
@@ -305,13 +309,53 @@ function shouldSyncProjectEnvBeforeProxy(port: number, method: string, path: str
   return /^\/session\/[^/]+\/(?:prompt_async|message)(?:$|[/?#])/.test(path);
 }
 
-// A prompt-delivery POST is the ONE mutating, non-idempotent call on this proxy
-// (POST /session/:id/prompt_async|message on the daemon port). opencode has no
-// idempotency of its own, so re-POSTing the same body enqueues the user's
-// message a second time (the 3x-queued bug). This is exactly the set the
-// env-sync-before-prompt gate already recognises, so delegate to it.
-function isPromptDelivery(method: string, port: number, path: string): boolean {
-  return shouldSyncProjectEnvBeforeProxy(port, method, path);
+// ACP prompt delivery shares the runtime URL with its GET event stream.
+// Inspect the JSON-RPC envelope before applying prompt deduplication.
+function acpPromptSessionId(
+  method: string,
+  upstreamPort: number,
+  path: string,
+  incomingHeaders: Headers,
+  body: ArrayBuffer | undefined,
+): string | null {
+  if (method.toUpperCase() !== 'POST' || upstreamPort !== SANDBOX_AGENT_PORT || !body) {
+    return null;
+  }
+  if (!incomingHeaders.get('content-type')?.toLowerCase().includes('application/json')) {
+    return null;
+  }
+  const match = path.match(/^\/kortix\/acp\/([^/?#]+)(?:$|[/?#])/);
+  if (!match) return null;
+  try {
+    const routeSessionId = decodeURIComponent(match[1]);
+    const envelope = JSON.parse(new TextDecoder().decode(body)) as {
+      method?: unknown;
+      params?: { sessionId?: unknown };
+    };
+    return envelope.method === 'session/prompt' && envelope.params?.sessionId === routeSessionId
+      ? routeSessionId
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function runtimeTitleStream(
+  method: string,
+  upstreamPort: number,
+  path: string,
+  contentType: string | null,
+): { protocol: 'acp' | 'rest'; expectedSessionId?: string } | null {
+  if (method.toUpperCase() !== 'GET' || upstreamPort !== SANDBOX_AGENT_PORT) return null;
+  if (!contentType?.toLowerCase().includes('text/event-stream')) return null;
+  if (/^\/global\/event(?:$|[/?#])/.test(path)) return { protocol: 'rest' };
+  const match = path.match(/^\/kortix\/acp\/([^/?#]+)(?:$|[/?#])/);
+  if (!match) return null;
+  try {
+    return { protocol: 'acp', expectedSessionId: decodeURIComponent(match[1]) };
+  } catch {
+    return null;
+  }
 }
 
 // True only when a fetch failure PROVES nothing reached the box: the upstream
@@ -541,6 +585,15 @@ export async function forwardToSandbox(
   // to Daytona, which likewise skips it on the direct 4096 opencode path.
   const ingressRequest = { port, path: remainingPath, transport: 'http' as const };
   const upstreamPort = routeSandboxIngress(record, ingressRequest).effectivePort;
+  const acpPromptSession = acpPromptSessionId(
+    method,
+    upstreamPort,
+    remainingPath,
+    incomingHeaders,
+    body,
+  );
+  const promptDelivery =
+    shouldSyncProjectEnvBeforeProxy(port, method, remainingPath) || acpPromptSession !== null;
 
   // The daemon port serves the session's OpenCode conversation + owner-synced
   // secrets; gate it on SESSION visibility (mirrors loadVisibleSession on the
@@ -599,14 +652,10 @@ export async function forwardToSandbox(
   }
   const serviceKey = record.serviceKey;
 
-  // Dedupe prompt delivery up-front. Prompt POSTs are the only mutating,
-  // non-idempotent calls here, and the CLI mints one Idempotency-Key per logical
-  // prompt. Claim a stable key (the inbound Idempotency-Key, else a content hash
-  // of sandbox+session+body) BEFORE the retry loop so a duplicate inbound prompt
-  // — a client resend, or the other proxy edge (subdomain.ts also calls this) —
-  // short-circuits to a 200 no-op instead of re-POSTing and enqueueing the user's
-  // message twice. First claim within the TTL proceeds; a repeat is deduped.
-  if (isPromptDelivery(method, port, remainingPath)) {
+  // Dedupe prompt delivery up-front. REST and ACP prompt POSTs are the only
+  // mutating, non-idempotent calls here. Claim a stable key before the retry
+  // loop so a duplicate inbound prompt cannot enqueue the user message twice.
+  if (promptDelivery) {
     const dedupeKey = promptDeliveryKey({
       idempotencyKey: incomingHeaders.get('idempotency-key'),
       sandboxId,
@@ -635,6 +684,9 @@ export async function forwardToSandbox(
   // providers there is no such signal, so the preview proxy never errors the row;
   // liveness is owned by the health-check loop + reconciler, not a port request.
   let sawDeadSignal = false;
+  // False until this request reaches the non-idempotent upstream prompt fetch.
+  // Pre-prompt failures, such as env synchronization, are safe to retry.
+  let promptDeliveryMayHaveReachedUpstream = false;
   // A blocking session-turn (`POST /session/:id/message`) whose single attempt
   // (it gets ~the whole remaining budget, see proxyAttemptTimeoutMs) still hit
   // the connect-timer. That's a legitimately long-running, healthy turn, not a
@@ -810,6 +862,7 @@ export async function forwardToSandbox(
       );
       let upstream: Response;
       try {
+        if (promptDelivery) promptDeliveryMayHaveReachedUpstream = true;
         upstream = await fetch(targetUrl, {
           method,
           headers,
@@ -873,7 +926,6 @@ export async function forwardToSandbox(
         // the response), so re-POSTing would enqueue it twice. Pass the upstream
         // response straight through to the passthrough below. GET/idempotent
         // requests retry as before.
-        const promptDelivery = isPromptDelivery(method, port, remainingPath);
         if (!promptDelivery && attempt < MAX_RETRIES) {
           // Port not ready yet — sandbox is booting (container running, port down).
           console.warn(
@@ -931,8 +983,41 @@ export async function forwardToSandbox(
 
       // Got an HTTP response → sandbox is alive, pass it through with CORS.
       void markSandboxUsed(sandboxId);
+      if (acpPromptSession && upstream.ok) {
+        scheduleTitleCaptureAfterPrompt({
+          sessionId: record.sessionId,
+          projectId: record.projectId,
+          externalId: record.externalId,
+          userId: userId || undefined,
+        });
+      }
       const respHeaders = clientResponseHeaders(upstream.headers, origin);
-      return new Response(upstream.body, {
+      const titleStream = runtimeTitleStream(
+        method,
+        upstreamPort,
+        remainingPath,
+        upstream.headers.get('content-type'),
+      );
+      const responseBody =
+        upstream.body && titleStream
+          ? observeRuntimeSessionTitleStream(upstream.body, {
+              ...titleStream,
+              onTitle: async (event) => {
+                await captureTitleAfterRuntimeEvent({
+                  sessionId: record.sessionId,
+                  projectId: record.projectId,
+                  opencodeSessionId: event.sessionId,
+                  title: event.title,
+                });
+              },
+              onError: (error) => {
+                console.warn(
+                  `[title-capture] failed to inspect ACP stream for ${record.sessionId}: ${errorMessage(error, 'unknown error')}`,
+                );
+              },
+            })
+          : upstream.body;
+      return new Response(responseBody, {
         status: upstream.status,
         statusText: upstream.statusText,
         headers: respHeaders,
@@ -968,7 +1053,11 @@ export async function forwardToSandbox(
       // the friendly unreachable response below. (The Daytona "no IP / no runner"
       // 400 branch — a rejection before opencode — retries in the response path
       // above, which is safe.)
-      if (isPromptDelivery(method, port, remainingPath) && !isConnectionRefusedError(err)) {
+      if (
+        promptDeliveryMayHaveReachedUpstream &&
+        promptDelivery &&
+        !isConnectionRefusedError(err)
+      ) {
         break;
       }
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -260,6 +260,7 @@ Single, self-contained changes. Anything multi-step earns a spec instead.
 | B29 | **Preserve ACP upstream message boundaries in the projected transcript.**                                                                                                                                                                                                                                                                                                                                                                              | Dev session `ee41f742-9384-4f34-88e7-63ae3d765cae` emitted distinct `session/update.messageId` values for assistant steps, but `src/core/acp/projection.ts` discarded `messageId` and appended every text or reasoning chunk to one generated assistant message.                                                                                      | **DONE 2026-07-27** — implementation `60b06c6e4`; focused projection/controller tests `27/0`, full SDK tests `1299/0`, typecheck, packed-install smoke, supplied-transcript replay, and local ACP Chromium flow pass                                                                                                                                                                                          |
 | B30 | **Expose message-based session rewind and restore through both REST and ACP transports.** Editing an earlier user message must rewind the same canonical session instead of creating a fork. The removed path must remain recoverable until the replacement prompt commits.                                                                                                                                                                      | `apps/web/src/features/session/session-chat.tsx` contains `TODO(session-rewind)`. OpenCode exposes `/session/{sessionID}/revert` and `/unrevert`; ACP has no standard rewind method and needs a Kortix bridge extension plus transcript reload.                                                               | **DONE 2026-07-27** — implementation `eab4eef0f`; PR #5619 merged as `9e90e8ed7`. Deploy Dev run `30293660760` deployed source `e548c6a8fc9ee1d5a92db66d6feb912d4442ebeb`, which contains the merge. Dev session `7feb4e84-072f-4b71-987f-dc25dd542890` kept canonical OpenCode session `ses_05b075d25ffe7PBkZ632pcVAlW` across ACP and REST rewind, restore, replacement commit, reconnect, and file rollback. ACP produced `DEPLOYED_ACP_REPLACEMENT`; REST produced `DEPLOYED_REST_REPLACEMENT`; cleanup removed `26/26` probe sessions and restored ACP runtime overrides. SDK tests `1309/0`, daemon tests `306/0`, web source contract `5/0`, local ACP Playwright `1/0`, and local real ACP plus REST smoke pass. Shippable to production: **YES** for protocol behavior. Deployed UI interaction remains unverified because Browser discovery returned `[]`. |
 | B31 | **Allow a page-scoped ACP query override and settle completed ACP prompts that contain stale running tools.**                                                                                                                                                                                                                                                                                                                                     | `?acp` has no SDK transport override. Dev session `5322fa59-7a73-4fea-9f1a-9da59c2a0b5a` rendered the final assistant response while an older tool part remained `running`; `hasProjectionBlockers()` then kept the composer busy and blocked the queued prompt.                                                                 | **IMPLEMENTATION COMPLETE 2026-07-27** — implementation `d3544ae14`; focused SDK `40/0`, full SDK `1312/0`, typecheck, packed-install smoke, web routing `5/0`, and touched web ESLint pass. PR #5636, Deploy Dev, deployed SHA proof, and deployed ACP-only proof remain |
+| B32 | **Synchronize generated Kortix session names from both ACP and OpenCode REST runtimes without navigation or refresh.**                                                                                                                                                                                                                                                                                                                           | ACP emits `session_info_update`; OpenCode `/global/event` emits a wrapped `session.updated`. Neither path reliably persisted `metadata.name`, and the sidebar query could stay stale after a completed prompt.                                                                                              | **IMPLEMENTATION COMPLETE 2026-07-28** — ACP and REST title events persist server-side; the SDK refetches list and detail queries through a bounded post-send loop; focused API `78/0`, full SDK `1318/0`, API and SDK typechecks, packed-install smoke, test-harness typecheck, and local ACP plus REST Chromium `1/0` pass. Full API has `3` pre-existing failures reproduced in the primary checkout. PR, Deploy Dev, deployed SHA proof, and deployed UI proof remain. |
 
 > **Paths above are as of today (pre-Task-4).** After the restructure they move:
 > `platform/api/` → `core/http/api/`, `opencode/` → `core/runtime/`,
@@ -833,6 +834,37 @@ default names and behavior remain unchanged. SDK work will follow RED → GREEN 
 REFACTOR and finish on the full typecheck, test, and packed-install smoke gates.
 
 **Status:** IN PROGRESS.
+
+---
+
+### 2026-07-28 — session `acp-session-name-sync` (B32 implementation)
+
+ACP `session_info_update` and OpenCode REST `session.updated` events now persist
+the generated root-session title in `project_sessions.metadata.name`.
+
+The REST parser handles the real `/global/event` envelope:
+`{ directory, payload: { type, properties } }`.
+
+`useSession` refetches the active Kortix session list and detail queries after
+runtime title events. It also runs a bounded refresh after each send.
+
+Verification:
+
+- Focused API: **78 pass / 0 fail / 178 assertions**.
+- API typecheck: exit `0`.
+- SDK typecheck: exit `0`.
+- Full SDK: **1318 pass / 0 fail / 5797 assertions / 111 files**.
+- SDK packed-install smoke: passed.
+- Test-harness typecheck: exit `0`.
+- Local ACP and REST Chromium: **1 pass / 0 fail**.
+- Full API: **3 pre-existing failures**. The same failures reproduce in the
+  primary checkout in `maintenance.test.ts` and
+  `unit-hosted-deployment-vendor-removal.test.ts`.
+
+**Status:** IMPLEMENTATION COMPLETE.
+
+**Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
+and deployed ACP plus REST UI verification remain.
 
 ---
 
@@ -3516,3 +3548,20 @@ The local Chromium canary remains unexecuted.
 
 **Shippable to production: NOT YET.** PR merge, Deploy Dev, deployed SHA proof,
 and deployed UI verification remain.
+
+---
+
+### 2026-07-28 — session `acp-session-name-sync` (B32 claim)
+
+Claimed the Kortix session-name synchronization defect for ACP-backed sessions.
+
+The investigation will trace the authoritative server-side title mirror,
+ACP runtime session metadata, project-session reads, SDK query invalidation,
+and sidebar rendering.
+
+Implementation will follow RED -> GREEN -> REFACTOR.
+Required gates are focused API, SDK, and web tests, API and SDK typechecks,
+the full SDK suite, packed-install smoke, local browser proof, PR merge,
+Deploy Dev, deployed SHA proof, and deployed session-name synchronization.
+
+**Status:** IN PROGRESS.

--- a/packages/sdk/src/react/session-title-sync.ts
+++ b/packages/sdk/src/react/session-title-sync.ts
@@ -1,0 +1,109 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+type SessionTitleQueryClient = Pick<QueryClient, 'getQueryData' | 'refetchQueries'>;
+
+interface SessionTitleRefreshOptions {
+  delaysMs?: number[];
+  signal?: AbortSignal;
+  sleep?: (delayMs: number, signal?: AbortSignal) => Promise<void>;
+}
+
+const DEFAULT_TITLE_REFRESH_DELAYS_MS = [0, 5_000, 5_000, 10_000, 10_000, 15_000, 20_000];
+
+function readRealTitle(value: unknown): string | null {
+  const title = typeof value === 'string' ? value.trim() : '';
+  if (!title || /^new session\b/i.test(title)) return null;
+  return title;
+}
+
+export function readAcpSessionTitle(sessionInfo: Record<string, unknown> | null): string | null {
+  return readRealTitle(sessionInfo?.title);
+}
+
+function cachedSessionHasTitle(
+  queryClient: Pick<QueryClient, 'getQueryData'>,
+  projectId: string,
+  sessionId: string,
+): boolean {
+  const list = queryClient.getQueryData<unknown>(['project-sessions', projectId]);
+  const detail = queryClient.getQueryData<unknown>(['project-session', projectId, sessionId]);
+  const candidates = [...(Array.isArray(list) ? list : []), detail];
+  return candidates.some((candidate) => {
+    if (!candidate || typeof candidate !== 'object') return false;
+    const session = candidate as Record<string, unknown>;
+    const candidateId =
+      typeof session.session_id === 'string'
+        ? session.session_id
+        : typeof session.sessionId === 'string'
+          ? session.sessionId
+          : null;
+    if (candidateId !== sessionId) return false;
+    return Boolean(readRealTitle(session.custom_name) || readRealTitle(session.name));
+  });
+}
+
+function refetchSessionTitleQueries(
+  queryClient: Pick<QueryClient, 'refetchQueries'>,
+  projectId: string,
+  sessionId: string,
+): Promise<unknown[]> {
+  return Promise.all([
+    queryClient.refetchQueries({
+      queryKey: ['project-sessions', projectId],
+      type: 'active',
+    }),
+    queryClient.refetchQueries({
+      queryKey: ['project-session', projectId, sessionId],
+      type: 'active',
+    }),
+  ]);
+}
+
+function sleep(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (delayMs <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, delayMs);
+    signal?.addEventListener('abort', finish, { once: true });
+  });
+}
+
+/**
+ * Refetch the authoritative Kortix session until its generated title appears.
+ *
+ * OpenCode generates titles asynchronously. ACP does not guarantee a
+ * session_info_update notification, so runtime events are only a fast path.
+ * This bounded loop covers both ACP and REST without permanent sidebar polling.
+ */
+export async function refreshSessionTitleQueryUntilResolved(
+  queryClient: SessionTitleQueryClient,
+  projectId: string,
+  sessionId: string,
+  options: SessionTitleRefreshOptions = {},
+): Promise<boolean> {
+  const delays = options.delaysMs ?? DEFAULT_TITLE_REFRESH_DELAYS_MS;
+  const wait = options.sleep ?? sleep;
+
+  for (const delayMs of delays) {
+    await wait(delayMs, options.signal);
+    if (options.signal?.aborted) return false;
+    if (cachedSessionHasTitle(queryClient, projectId, sessionId)) return true;
+    await refetchSessionTitleQueries(queryClient, projectId, sessionId);
+    if (cachedSessionHasTitle(queryClient, projectId, sessionId)) return true;
+  }
+  return false;
+}
+
+export function syncAcpSessionTitleQuery(
+  queryClient: Pick<QueryClient, 'refetchQueries'>,
+  projectId: string,
+  sessionId: string,
+  sessionInfo: Record<string, unknown> | null,
+): void {
+  if (!readAcpSessionTitle(sessionInfo)) return;
+  void refetchSessionTitleQueries(queryClient, projectId, sessionId);
+}

--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -75,6 +75,10 @@ import {
   sendStateOnError,
   shouldRetrySessionStart,
 } from './use-session';
+import {
+  refreshSessionTitleQueryUntilResolved,
+  syncAcpSessionTitleQuery,
+} from './session-title-sync';
 import { clearSessionFresh, markSessionFresh } from '../core/http/fresh-sessions';
 import { SessionStartError } from '../core/rest/projects-client';
 import { useSyncStore } from '../browser/stores/sync-store';
@@ -143,6 +147,119 @@ describe('OpenCode session rewind', () => {
     await expect(rewindOpenCodeSession('oc-session', 'missing')).rejects.toThrow(
       'message not found',
     );
+  });
+});
+
+describe('ACP session title synchronization', () => {
+  test('refetches the matching Kortix list and detail queries for a real title', async () => {
+    const calls: unknown[] = [];
+    const queryClient = {
+      refetchQueries: (input: unknown) => {
+        calls.push(input);
+        return Promise.resolve();
+      },
+    };
+
+    syncAcpSessionTitleQuery(
+      queryClient as Parameters<typeof syncAcpSessionTitleQuery>[0],
+      'project-1',
+      'session-1',
+      { title: 'Research Marko Kraemer' },
+    );
+    await Promise.resolve();
+
+    expect(calls).toEqual([
+      { queryKey: ['project-sessions', 'project-1'], type: 'active' },
+      { queryKey: ['project-session', 'project-1', 'session-1'], type: 'active' },
+    ]);
+  });
+
+  test('does not refetch for missing or placeholder ACP titles', async () => {
+    const calls: unknown[] = [];
+    const queryClient = {
+      refetchQueries: (input: unknown) => {
+        calls.push(input);
+        return Promise.resolve();
+      },
+    };
+
+    const titleQueryClient = queryClient as Parameters<typeof syncAcpSessionTitleQuery>[0];
+    syncAcpSessionTitleQuery(titleQueryClient, 'project-1', 'session-1', null);
+    syncAcpSessionTitleQuery(titleQueryClient, 'project-1', 'session-1', {
+      title: 'New session - 2026-07-28',
+    });
+    await Promise.resolve();
+
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('bounded session title refresh', () => {
+  test('refetches authoritative session queries until a generated title appears', async () => {
+    const calls: Array<{ queryKey: string[]; type: string }> = [];
+    let title: string | null = null;
+    const queryClient = {
+      getQueryData: (queryKey: string[]) => {
+        if (queryKey[0] === 'project-sessions') {
+          return [{ session_id: 'session-1', name: title, custom_name: null }];
+        }
+        return { session_id: 'session-1', name: title, custom_name: null };
+      },
+      refetchQueries: (input: { queryKey: string[]; type: string }) => {
+        calls.push(input);
+        if (
+          input.queryKey[0] === 'project-sessions' &&
+          calls.filter((call) => call.queryKey[0] === 'project-sessions').length === 2
+        ) {
+          title = 'Research Marko Kraemer';
+        }
+        return Promise.resolve();
+      },
+    };
+
+    const resolved = await refreshSessionTitleQueryUntilResolved(
+      queryClient as Parameters<typeof refreshSessionTitleQueryUntilResolved>[0],
+      'project-1',
+      'session-1',
+      {
+        delaysMs: [0, 0],
+        sleep: async () => {},
+      },
+    );
+
+    expect(resolved).toBe(true);
+    expect(calls).toEqual([
+      { queryKey: ['project-sessions', 'project-1'], type: 'active' },
+      { queryKey: ['project-session', 'project-1', 'session-1'], type: 'active' },
+      { queryKey: ['project-sessions', 'project-1'], type: 'active' },
+      { queryKey: ['project-session', 'project-1', 'session-1'], type: 'active' },
+    ]);
+  });
+
+  test('does not refetch when the cache already contains a generated title', async () => {
+    const calls: unknown[] = [];
+    const queryClient = {
+      getQueryData: () => [
+        { session_id: 'session-1', name: 'Research Marko Kraemer', custom_name: null },
+      ],
+      refetchQueries: (input: unknown) => {
+        calls.push(input);
+        return Promise.resolve();
+      },
+    };
+
+    const resolved = await refreshSessionTitleQueryUntilResolved(
+      queryClient as Parameters<typeof refreshSessionTitleQueryUntilResolved>[0],
+      'project-1',
+      'session-1',
+      {
+        delaysMs: [0],
+        sleep: async () => {},
+      },
+    );
+
+    expect(resolved).toBe(true);
+    expect(calls).toEqual([]);
   });
 });
 

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -19,7 +19,7 @@
  * and the `/start` poll for `(projectId, sessionId)`.
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { getClient, RuntimeNotReadyError } from '../core/runtime/client';
@@ -67,6 +67,11 @@ import { useRuntimePhase } from './use-runtime-phase';
 import { clearStartStash, readStartStash } from './session-start-stash';
 import { useSessionPicks } from './use-session-picks';
 import { useSessionSync } from './use-session-sync';
+import {
+  readAcpSessionTitle,
+  refreshSessionTitleQueryUntilResolved,
+  syncAcpSessionTitleQuery,
+} from './session-title-sync';
 import { useVisibleAgents } from './use-visible-agents';
 import {
   rejectQuestion as rejectQuestionApi,
@@ -393,6 +398,8 @@ const DISABLED_CHAT_ENGINE_SYNC = {
 };
 
 export function useSession(projectId: string, sessionId: string, options: UseSessionOptions = {}) {
+  const queryClient = useQueryClient();
+  const titleRefreshAbortRef = useRef<AbortController | null>(null);
   const {
     waitMs = 15_000,
     replayStartStash = true,
@@ -488,6 +495,18 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     sessionId: rootSessionId,
     enabled: enabled && switched && usesAcp,
   });
+  const acpSessionTitle = readAcpSessionTitle(acpRuntime.projection.sessionInfo);
+  useEffect(() => {
+    if (!usesAcp || !acpSessionTitle) return;
+    syncAcpSessionTitleQuery(queryClient, projectId, sessionId, { title: acpSessionTitle });
+  }, [queryClient, projectId, sessionId, usesAcp, acpSessionTitle]);
+  useEffect(
+    () => () => {
+      titleRefreshAbortRef.current?.abort();
+      titleRefreshAbortRef.current = null;
+    },
+    [projectId, sessionId],
+  );
   // Always call the hook (rules-of-hooks) so it stays in the same position
   // every render, but starve it with an empty session id when the chat engine
   // is off — `useSessionSync('')` fetches/polls nothing (its effects no-op on
@@ -618,6 +637,16 @@ export function useSession(projectId: string, sessionId: string, options: UseSes
     },
   ): Promise<void> => {
     if (!ocSessionId) throw new RuntimeNotReadyError();
+    titleRefreshAbortRef.current?.abort();
+    const titleRefreshAbort = new AbortController();
+    titleRefreshAbortRef.current = titleRefreshAbort;
+    void refreshSessionTitleQueryUntilResolved(queryClient, projectId, sessionId, {
+      signal: titleRefreshAbort.signal,
+    }).finally(() => {
+      if (titleRefreshAbortRef.current === titleRefreshAbort) {
+        titleRefreshAbortRef.current = null;
+      }
+    });
     const model = override?.model ?? picks.model;
     const agent = override?.agent ?? picks.agent;
     const variant = override?.variant;

--- a/tests/e2e/specs/17-acp-session-title-sync.spec.ts
+++ b/tests/e2e/specs/17-acp-session-title-sync.spec.ts
@@ -1,0 +1,254 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+
+import { createApiJsonClient } from '../helpers/http';
+import {
+  type AuthSession,
+  type AuthUser,
+  createAuthUser,
+  deleteAuthUser,
+  installBrowserSession,
+  signIn,
+} from '../helpers/session-auth';
+
+const enabled = process.env.E2E_ENABLE_ACP_TITLE_SYNC === '1';
+const apiBase = process.env.E2E_API_URL || 'http://localhost:8008/v1';
+const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
+const databaseUrl =
+  process.env.E2E_DATABASE_URL || 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+const password = 'AcpTitleSync123!';
+const api = createApiJsonClient(apiBase);
+const authOptions = { supabaseUrl, password };
+
+interface ReadySession {
+  externalId: string;
+  opencodeSessionId: string;
+}
+
+interface ProjectSession {
+  session_id: string;
+  name: string | null;
+}
+
+async function waitForReadySession(
+  token: string,
+  projectId: string,
+  sessionId: string,
+  expectedTransport: 'acp' | 'rest',
+): Promise<ReadySession> {
+  const deadline = Date.now() + 12 * 60_000;
+  let last = '';
+  while (Date.now() < deadline) {
+    const result = await api<{
+      stage: string;
+      runtime_transport?: 'acp' | 'rest';
+      opencode_session_id?: string | null;
+      sandbox?: { status?: string; external_id?: string | null } | null;
+    }>(token, 'POST', `/projects/${projectId}/sessions/${sessionId}/start?wait_ms=8000`, {});
+    last = [
+      result.stage,
+      result.sandbox?.status ?? 'none',
+      result.runtime_transport ?? 'none',
+      result.opencode_session_id ?? 'none',
+    ].join(':');
+    if (result.stage === 'failed' || result.sandbox?.status === 'failed') {
+      throw new Error(`session failed before readiness: ${last}`);
+    }
+    if (
+      result.stage === 'ready' &&
+      result.sandbox?.status === 'active' &&
+      result.sandbox.external_id &&
+      result.runtime_transport === expectedTransport &&
+      result.opencode_session_id
+    ) {
+      return {
+        externalId: result.sandbox.external_id,
+        opencodeSessionId: result.opencode_session_id,
+      };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`session did not become ready: ${last}`);
+}
+
+test.describe.serial('17 — ACP session title synchronization', () => {
+  test.skip(!enabled, 'Set E2E_ENABLE_ACP_TITLE_SYNC=1 for the real sandbox flow.');
+  test.setTimeout(20 * 60_000);
+
+  let user: AuthUser;
+  let auth: AuthSession;
+  let projectId = '';
+  const sessionIds: string[] = [];
+
+  test.beforeAll(async ({ browser: _browser }, testInfo) => {
+    testInfo.setTimeout(20 * 60_000);
+    const email = `acp-title-${Date.now()}-${randomUUID().slice(0, 8)}@example.test`;
+    user = await createAuthUser(email, authOptions);
+    auth = await signIn(email, authOptions);
+
+    const accounts = await api<Array<{ account_id: string; personal_account?: boolean }>>(
+      auth.access_token,
+      'GET',
+      '/accounts',
+    );
+    const account = accounts.find((item) => item.personal_account) ?? accounts[0];
+    expect(account?.account_id).toBeTruthy();
+    execFileSync(
+      'psql',
+      [
+        databaseUrl,
+        '-v',
+        'ON_ERROR_STOP=1',
+        '-c',
+        `INSERT INTO kortix.credit_accounts (account_id, balance, tier)
+         VALUES ('${account.account_id}', 1000, 'tier_2_20')
+         ON CONFLICT (account_id)
+         DO UPDATE SET balance = 1000, tier = 'tier_2_20'`,
+      ],
+      { stdio: 'ignore' },
+    );
+
+    const project = await api<{ project_id: string }>(
+      auth.access_token,
+      'POST',
+      '/projects/provision',
+      {
+        account_id: account.account_id,
+        name: `ACP title sync ${Date.now()}`,
+        seed_starter: true,
+      },
+      201,
+    );
+    projectId = project.project_id;
+    await api(auth.access_token, 'PATCH', `/projects/${projectId}/onboarding`, {
+      completed: true,
+    });
+    await api(auth.access_token, 'PUT', `/projects/${projectId}/model-defaults`, {
+      scope: 'project',
+      model: 'claude-sonnet-4.6',
+    });
+  });
+
+  test.afterAll(async ({ browser: _browser }, testInfo) => {
+    testInfo.setTimeout(2 * 60_000);
+    if (projectId) {
+      for (const sessionId of sessionIds) {
+        await api(
+          auth.access_token,
+          'DELETE',
+          `/projects/${projectId}/sessions/${sessionId}`,
+        ).catch(() => {});
+      }
+    }
+    if (projectId) {
+      await api(auth.access_token, 'DELETE', `/projects/${projectId}`).catch(() => {});
+    }
+    if (user?.id) {
+      await deleteAuthUser(user.id, {
+        supabaseUrl,
+        envFiles: ['apps/api/.env', 'apps/web/.env'],
+      });
+    }
+  });
+
+  test('updates the sidebar from ACP and REST titles without a refresh', async ({ page }) => {
+    const acpPrompts: string[] = [];
+    const restPrompts: string[] = [];
+    const sessionLists: ProjectSession[][] = [];
+    let mainFrameNavigations = 0;
+
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) mainFrameNavigations += 1;
+    });
+    page.on('request', (request) => {
+      if (request.method() === 'POST' && request.url().includes('/kortix/acp/')) {
+        const body = request.postData() ?? '';
+        if (body.includes('"method":"session/prompt"')) acpPrompts.push(body);
+      }
+      if (request.url().includes('/prompt_async')) restPrompts.push(request.url());
+    });
+    page.on('response', async (response) => {
+      const url = new URL(response.url());
+      if (
+        response.request().method() !== 'GET' ||
+        url.pathname !== `/v1/projects/${projectId}/sessions`
+      ) {
+        return;
+      }
+      const body = await response.json().catch(() => null);
+      if (Array.isArray(body)) sessionLists.push(body as ProjectSession[]);
+    });
+
+    for (const transport of ['acp', 'rest'] as const) {
+      await api(auth.access_token, 'PATCH', `/projects/${projectId}/experimental`, {
+        feature: 'acp_runtime',
+        enabled: transport === 'acp',
+      });
+      const session = await api<{ session_id: string }>(
+        auth.access_token,
+        'POST',
+        `/projects/${projectId}/sessions`,
+        { opencode_model: 'kortix/claude-sonnet-4.6' },
+        201,
+      );
+      const sessionId = session.session_id;
+      sessionIds.push(sessionId);
+      await waitForReadySession(auth.access_token, projectId, sessionId, transport);
+
+      const path = `/projects/${projectId}/sessions/${sessionId}${
+        transport === 'acp' ? '?acp' : ''
+      }`;
+      await installBrowserSession(page, auth, path, password);
+      const input = page.getByRole('textbox', { name: 'Message input' });
+      await expect(input).toBeVisible({ timeout: 120_000 });
+      const sessionTitle = page.locator(
+        `a[href="/projects/${projectId}/sessions/${sessionId}"] span[title]`,
+      );
+      await expect(sessionTitle).toHaveAttribute('title', 'New session', {
+        timeout: 30_000,
+      });
+
+      const welcomeCard = page.getByRole('complementary', {
+        name: /Welcome from Marko/i,
+      });
+      if (await welcomeCard.isVisible().catch(() => false)) {
+        await welcomeCard.getByRole('button', { name: 'Dismiss' }).click();
+      }
+
+      acpPrompts.length = 0;
+      restPrompts.length = 0;
+      sessionLists.length = 0;
+      const navigationsBeforePrompt = mainFrameNavigations;
+      const marker = transport === 'acp' ? 'ACP_TITLE_SYNC_DONE' : 'REST_TITLE_SYNC_DONE';
+      await input.fill(`Research the number 7 briefly. Then reply exactly ${marker}.`);
+      await page.getByRole('button', { name: 'Send message' }).click();
+      await expect(page.getByText(marker, { exact: true }).last()).toBeVisible({
+        timeout: 120_000,
+      });
+      await expect
+        .poll(() => sessionTitle.getAttribute('title'), { timeout: 120_000 })
+        .not.toBe('New session');
+
+      const renderedTitle = await sessionTitle.getAttribute('title');
+      expect(renderedTitle).toBeTruthy();
+      if (!renderedTitle) throw new Error('sidebar did not render the generated session title');
+      expect(mainFrameNavigations).toBe(navigationsBeforePrompt);
+      expect(acpPrompts).toHaveLength(transport === 'acp' ? 1 : 0);
+      expect(restPrompts).toHaveLength(transport === 'rest' ? 1 : 0);
+      expect(sessionLists.length).toBeGreaterThan(0);
+
+      const browserSnapshot = sessionLists
+        .flat()
+        .find((item) => item.session_id === sessionId && item.name === renderedTitle);
+      expect(browserSnapshot?.name).toBe(renderedTitle);
+
+      const persisted = await api<ProjectSession[]>(
+        auth.access_token,
+        'GET',
+        `/projects/${projectId}/sessions`,
+      );
+      expect(persisted.find((item) => item.session_id === sessionId)?.name).toBe(renderedTitle);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- persist generated root-session titles from ACP `session_info_update` and OpenCode REST `session.updated` events
- refetch active Kortix session list and detail queries after title events and through a bounded post-send loop
- deduplicate ACP prompt delivery and preserve retry safety before the upstream prompt fetch
- add a real Chromium flow for ACP and REST title updates without navigation or refresh

## Verification

- `78 pass / 0 fail` focused API tests
- `pnpm --filter kortix-api typecheck`
- `1318 pass / 0 fail` full SDK suite
- `pnpm --filter @kortix/sdk typecheck`
- `pnpm --filter @kortix/sdk run smoke:install`
- test-harness TypeScript: exit 0
- real local Chromium ACP + REST flow: `1 passed`

## Existing API suite failures

The full API suite reports 3 unrelated failures. The same failures reproduce in the primary checkout:

- `src/projects/maintenance.test.ts`
- 2 assertions in `src/__tests__/unit-hosted-deployment-vendor-removal.test.ts`