### PR TITLE
fix(api): return 404 for readRepoFile git-show path-not-found (BS a8d20288)

### DIFF
--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -30,7 +30,7 @@ import {
   extractConnectors,
   manifestHashForConnector,
 } from '../projects/connectors';
-import { type GitBackedProject, readRepoFile } from '../projects/git';
+import { type GitBackedProject, isRepoFileNotFoundError, readRepoFile } from '../projects/git';
 import { withProjectGitAuth } from '../projects/index';
 import { extractProjectPolicies } from '../projects/policies';
 import { extractTriggers, readManifest } from '../projects/triggers';
@@ -100,15 +100,37 @@ async function discoverConnectorAuthFromSource(
   }
   const spec = typeof draft.spec === 'string' ? draft.spec.trim() : '';
   if (provider === 'openapi') {
-    return spec ? discoverOpenApiAuth(await loadSpecDoc(project, spec), spec) : EMPTY_AUTH_DISCOVERY;
+    // The spec may not exist in the repo (e.g. the user supplied a path that
+    // isn't there). `loadSpecDoc`/`loadSourceText` throws a clean `Error` for
+    // that case (see `readRepoFile`/`RepoFileNotFoundError`/#3537) — there's no
+    // auth to discover from a missing spec, so degrade to the empty discovery
+    // instead of letting the throw propagate as an unhandled 500 (Better Stack
+    // `a8d20288…`).
+    if (!spec) return EMPTY_AUTH_DISCOVERY;
+    try {
+      return discoverOpenApiAuth(await loadSpecDoc(project, spec), spec);
+    } catch (e) {
+      if (isRepoFileNotFoundError(e) || String((e as Error).message).startsWith('connector spec not found in repository:')) {
+        return EMPTY_AUTH_DISCOVERY;
+      }
+      throw e;
+    }
   }
   if (provider === 'postman') {
     if (!spec) return EMPTY_AUTH_DISCOVERY;
-    const documents = await resolvePostmanSource(spec, (source) => loadSourceText(project, source), {
-      githubDefaultBranch: resolveGithubDefaultBranch,
-      postmanApiKey: config.POSTMAN_API_KEY,
-      resolveWorkspace: resolvePostmanWorkspace,
-    });
+    let documents: PostmanSourceDocument[];
+    try {
+      documents = await resolvePostmanSource(spec, (source) => loadSourceText(project, source), {
+        githubDefaultBranch: resolveGithubDefaultBranch,
+        postmanApiKey: config.POSTMAN_API_KEY,
+        resolveWorkspace: resolvePostmanWorkspace,
+      });
+    } catch (e) {
+      if (isRepoFileNotFoundError(e) || String((e as Error).message).startsWith('connector spec not found in repository:')) {
+        return EMPTY_AUTH_DISCOVERY;
+      }
+      throw e;
+    }
     return mergeAuthDiscoveries(documents.map((document) =>
       document.kind === 'openapi'
         ? discoverOpenApiAuth(document.doc, document.source)
@@ -712,7 +734,21 @@ async function loadSourceText(project: GitBackedProject, spec: string): Promise<
     }
     raw = await res.text();
   } else {
-    raw = await readRepoFile(project, spec, project.defaultBranch);
+    // `readRepoFile` throws a typed `RepoFileNotFoundError` when the path isn't
+    // in the repo at the ref (see #3537 / `isGitPathNotFoundError`) instead of
+    // letting the `GitOperationError` propagate as an unhandled 500. A
+    // connector spec pointing at a missing repo path is a user config error;
+    // rethrow it with the spec name so the best-effort
+    // `resolveCatalog`/`discoverConnectorAuthFromSource` wrappers can surface a
+    // clean message (Better Stack `a8d20288…`).
+    try {
+      raw = await readRepoFile(project, spec, project.defaultBranch);
+    } catch (err) {
+      if (isRepoFileNotFoundError(err)) {
+        throw new Error(`connector spec not found in repository: ${spec}`);
+      }
+      throw err;
+    }
   }
   return raw;
 }
@@ -800,9 +836,23 @@ async function loadHttpRoutes(
 ): Promise<HttpRouteSpec[]> {
   if (!spec) return [];
   if (/^https?:\/\//i.test(spec)) assertAllowedSourceAddress(spec);
-  const raw = /^https?:\/\//i.test(spec)
-    ? await (await safeEgressFetch(spec)).text()
-    : await readRepoFile(project, spec, project.defaultBranch);
+  let raw: string;
+  if (/^https?:\/\//i.test(spec)) {
+    raw = await (await safeEgressFetch(spec)).text();
+  } else {
+    // `readRepoFile` throws a typed `RepoFileNotFoundError` when the path isn't
+    // in the repo (see #3537). A missing http-routes spec is a user config
+    // error surfaced as a clean message via the `resolveCatalog` best-effort
+    // wrapper, not an unhandled 500 (Better Stack `a8d20288…`).
+    try {
+      raw = await readRepoFile(project, spec, project.defaultBranch);
+    } catch (err) {
+      if (isRepoFileNotFoundError(err)) {
+        throw new Error(`http routes spec not found in repository: ${spec}`);
+      }
+      throw err;
+    }
+  }
   const parsed = /\.toml$/i.test(spec) ? (parseToml(raw) as any) : JSON.parse(raw);
   const routes = Array.isArray(parsed?.routes) ? parsed.routes : [];
   return routes as HttpRouteSpec[];

--- a/apps/api/src/projects/git.ts
+++ b/apps/api/src/projects/git.ts
@@ -52,6 +52,8 @@ export {
   archiveRepoSubtree,
   getFileAtRef,
   getFileHistory,
+  RepoFileNotFoundError,
+  isRepoFileNotFoundError,
 } from './git/files';
 
 export {

--- a/apps/api/src/projects/git/files.test.ts
+++ b/apps/api/src/projects/git/files.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GitOperationError, isGitPathNotFoundError, runGit as realRunGit } from './mirror';
+import { isRepoFileNotFoundError, RepoFileNotFoundError } from './files';
+
+// `readRepoFile` imports `runGit` + `refreshMirror` from `./mirror`. We mock the
+// module so `runGit` is controllable per-test (returns stdout, throws a
+// path-not-found GitOperationError, or throws a real git failure) and
+// `refreshMirror` short-circuits to a temp dir without touching the network.
+const mirrorModule = await import('./mirror');
+
+let runGitImpl: (...args: Parameters<typeof realRunGit>) => Promise<{ stdout: string; stderr: string }>;
+let repoPath = '';
+
+mock.module('./mirror', () => ({
+  ...mirrorModule,
+  runGit: async (...args: Parameters<typeof realRunGit>) => runGitImpl(...args),
+  refreshMirror: async () => repoPath,
+}));
+
+const { readRepoFile } = await import('./files');
+
+const project = {
+  projectId: 'test-project',
+  defaultBranch: 'main',
+  repoUrl: 'https://github.com/kortix-ai/test.git',
+  gitAuthToken: null,
+  gitAuthHeaders: {},
+} as any;
+
+beforeEach(async () => {
+  repoPath = await mkdtemp(join(tmpdir(), 'kortix-readrepofile-test-'));
+  runGitImpl = realRunGit;
+});
+
+afterEach(async () => {
+  if (repoPath) await rm(repoPath, { recursive: true, force: true });
+});
+
+describe('isGitPathNotFoundError', () => {
+  test('returns true for the EXACT prod message (Windows path, quoted)', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `Command failed: git show main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"\nfatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+      gitArgs: ['show', 'main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"'],
+      stderr: `fatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(true);
+  });
+
+  test('returns true for a plain missing-path git message', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: path 'postcss.config.js' does not exist in 'my-change'`,
+      gitArgs: ['show', 'my-change:postcss.config.js'],
+      stderr: `fatal: path 'postcss.config.js' does not exist in 'my-change'`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(true);
+  });
+
+  test('returns true when the wording is only in the message (stderr empty)', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: path 'openapi.yaml' does not exist in 'main'`,
+      gitArgs: ['show', 'main:openapi.yaml'],
+      stderr: '',
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(true);
+  });
+
+  test('returns false for a real git failure (not a git repository)', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: not a git repository (or any of the parent directories): .git`,
+      gitArgs: ['show', 'main:file.txt'],
+      stderr: `fatal: not a git repository (or any of the parent directories): .git`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(false);
+  });
+
+  test('returns false for an auth failure', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: could not read Username for 'https://github.com': No such device or address`,
+      gitArgs: ['fetch', 'origin'],
+      stderr: `fatal: could not read Username for 'https://github.com': No such device or address`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(false);
+  });
+
+  test('returns false for a timeout (transient, must still page)', () => {
+    const err = new GitOperationError({
+      kind: 'timeout',
+      message: `git show timed out after 30000ms (signal SIGTERM)`,
+      gitArgs: ['show', 'main:openapi.yaml'],
+      signal: 'SIGTERM',
+      stderr: '',
+    });
+    expect(isGitPathNotFoundError(err)).toBe(false);
+  });
+
+  test('returns false for a non-GitOperationError', () => {
+    expect(isGitPathNotFoundError(new Error('does not exist in main'))).toBe(false);
+    expect(isGitPathNotFoundError(null)).toBe(false);
+    expect(isGitPathNotFoundError(undefined)).toBe(false);
+  });
+});
+
+describe('readRepoFile', () => {
+  test('throws a RepoFileNotFoundError for a path that does not exist in the repo (the prod failure shape)', async () => {
+    runGitImpl = async () => {
+      throw new GitOperationError({
+        kind: 'failed',
+        message: `Command failed: git show main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"\nfatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+        gitArgs: ['show', 'main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"'],
+        stderr: `fatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+        exitCode: 128,
+      });
+    };
+    const promise = readRepoFile(project, 'C:\\Users\\bibon\\Desktop\\Fortnite.url', 'main');
+    await expect(promise).rejects.toBeInstanceOf(RepoFileNotFoundError);
+    await expect(promise).rejects.toMatchObject({
+      name: 'RepoFileNotFoundError',
+      filePath: 'C:\\Users\\bibon\\Desktop\\Fortnite.url',
+      ref: 'main',
+    });
+    // And the typed guard recognizes it.
+    try {
+      await readRepoFile(project, 'C:\\Users\\bibon\\Desktop\\Fortnite.url', 'main');
+    } catch (err) {
+      expect(isRepoFileNotFoundError(err)).toBe(true);
+    }
+  });
+
+  test('throws a RepoFileNotFoundError for a plain missing path', async () => {
+    runGitImpl = async () => {
+      throw new GitOperationError({
+        kind: 'failed',
+        message: `fatal: path 'openapi.yaml' does not exist in 'main'`,
+        gitArgs: ['show', 'main:openapi.yaml'],
+        stderr: `fatal: path 'openapi.yaml' does not exist in 'main'`,
+        exitCode: 128,
+      });
+    };
+    await expect(readRepoFile(project, 'openapi.yaml', 'main')).rejects.toBeInstanceOf(RepoFileNotFoundError);
+  });
+
+  test('still throws the original GitOperationError for a real git failure (genuine bugs propagate)', async () => {
+    const realErr = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: not a git repository (or any of the parent directories): .git`,
+      gitArgs: ['show', 'main:file.txt'],
+      stderr: `fatal: not a git repository (or any of the parent directories): .git`,
+      exitCode: 128,
+    });
+    runGitImpl = async () => {
+      throw realErr;
+    };
+    await expect(readRepoFile(project, 'file.txt', 'main')).rejects.toBe(realErr);
+    // And the typed guard does NOT misclassify a genuine git failure.
+    try {
+      await readRepoFile(project, 'file.txt', 'main');
+    } catch (err) {
+      expect(isRepoFileNotFoundError(err)).toBe(false);
+    }
+  });
+
+  test('still throws for a timeout (transient failures must page)', async () => {
+    const timeoutErr = new GitOperationError({
+      kind: 'timeout',
+      message: `git show timed out after 30000ms (signal SIGTERM)`,
+      gitArgs: ['show', 'main:openapi.yaml'],
+      signal: 'SIGTERM',
+      stderr: '',
+    });
+    runGitImpl = async () => {
+      throw timeoutErr;
+    };
+    await expect(readRepoFile(project, 'openapi.yaml', 'main')).rejects.toBe(timeoutErr);
+  });
+
+  test('returns the content for a valid path (happy path, unchanged)', async () => {
+    runGitImpl = async () => ({ stdout: 'openapi: 3.0.0\n', stderr: '' });
+    const content = await readRepoFile(project, 'openapi.yaml', 'main');
+    expect(content).toBe('openapi: 3.0.0\n');
+  });
+
+  test('throws "File path is required" for an empty/normalized-null path', async () => {
+    await expect(readRepoFile(project, '', 'main')).rejects.toThrow('File path is required');
+    await expect(readRepoFile(project, '/', 'main')).rejects.toThrow('File path is required');
+  });
+
+  test('throws "Invalid path" for a path traversal attempt', async () => {
+    await expect(readRepoFile(project, '../etc/passwd', 'main')).rejects.toThrow('Invalid path');
+  });
+
+  test('uses the default branch when no ref is given', async () => {
+    let capturedArgs: readonly string[] = [];
+    runGitImpl = async (args) => {
+      capturedArgs = args;
+      return { stdout: 'content', stderr: '' };
+    };
+    await readRepoFile(project, 'file.txt');
+    expect(capturedArgs).toEqual(['show', 'main:file.txt']);
+  });
+});
+
+describe('RepoFileNotFoundError', () => {
+  test('is a typed Error with filePath/ref + a cause', () => {
+    const cause = new Error('underlying');
+    const err = new RepoFileNotFoundError('openapi.yaml', 'main', cause);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('RepoFileNotFoundError');
+    expect(err.filePath).toBe('openapi.yaml');
+    expect(err.ref).toBe('main');
+    expect(err.message).toBe(`file not found in repository at 'main:openapi.yaml'`);
+    expect((err as any).cause).toBe(cause);
+  });
+
+  test('isRepoFileNotFoundError narrows the type', () => {
+    const err = new RepoFileNotFoundError('x', 'main');
+    expect(isRepoFileNotFoundError(err)).toBe(true);
+    expect(isRepoFileNotFoundError(new Error('x'))).toBe(false);
+    expect(isRepoFileNotFoundError(null)).toBe(false);
+    expect(isRepoFileNotFoundError(undefined)).toBe(false);
+  });
+});

--- a/apps/api/src/projects/git/files.ts
+++ b/apps/api/src/projects/git/files.ts
@@ -3,7 +3,7 @@
 
 import { validateRef } from '../git-ref';
 import { listCommits } from './commits';
-import { normalizeTreePath, refreshMirror, runGit, runGitCapture, spawn } from './mirror';
+import { isGitPathNotFoundError, normalizeTreePath, refreshMirror, runGit, runGitCapture, spawn } from './mirror';
 import type {
   GetFileAtRefResult,
   GetFileHistoryOptions,
@@ -105,13 +105,51 @@ export async function grepRepoFiles(
   return matches;
 }
 
-export async function readRepoFile(project: GitBackedProject, filePath: string, ref?: string) {
+export async function readRepoFile(project: GitBackedProject, filePath: string, ref?: string): Promise<string> {
   const normalized = normalizeTreePath(filePath);
   if (!normalized) throw new Error('File path is required');
   const treeRef = validateRef(ref || project.defaultBranch);
   const repoPath = await refreshMirror(project);
-  const result = await runGit(['show', `${treeRef}:${normalized}`], repoPath, false);
-  return result.stdout;
+  try {
+    const result = await runGit(['show', `${treeRef}:${normalized}`], repoPath, false);
+    return result.stdout;
+  } catch (err) {
+    // A "path does not exist in '<ref>'" `git show` failure is an expected
+    // client condition (the path simply isn't in the repo at this ref), not a
+    // server bug — convert it into a typed `RepoFileNotFoundError` instead of
+    // letting the `GitOperationError` propagate as an unhandled 500 (Better
+    // Stack pattern `a8d20288…`). Mirrors `getFileAtRef`'s `{ found: false }`
+    // sentinel from #3537, but as a typed throw so existing callers that wrap
+    // `readRepoFile` in try/catch (config/agent-config/compile-agent-config)
+    // keep working unchanged. Genuine git failures (auth, corrupt repo,
+    // timeout) still throw the original `GitOperationError`.
+    if (isGitPathNotFoundError(err)) {
+      throw new RepoFileNotFoundError(normalized, treeRef, err);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Typed error for the expected "file not in the repo at this ref" condition.
+ * Distinct from `GitOperationError` so callers can branch on the expected case
+ * (skip/empty/discover-no-auth) without swallowing genuine git failures
+ * (auth, timeout, corrupt repo) that must still surface.
+ */
+export class RepoFileNotFoundError extends Error {
+  readonly filePath: string;
+  readonly ref: string;
+  constructor(filePath: string, ref: string, cause?: unknown) {
+    super(`file not found in repository at '${ref}:${filePath}'`);
+    this.name = 'RepoFileNotFoundError';
+    this.filePath = filePath;
+    this.ref = ref;
+    if (cause !== undefined) (this as any).cause = cause;
+  }
+}
+
+export function isRepoFileNotFoundError(err: unknown): err is RepoFileNotFoundError {
+  return err instanceof RepoFileNotFoundError;
 }
 
 /**

--- a/apps/api/src/projects/git/mirror.ts
+++ b/apps/api/src/projects/git/mirror.ts
@@ -249,6 +249,24 @@ export function isGitOperationError(err: unknown): err is GitOperationError {
   return err instanceof GitOperationError;
 }
 
+/**
+ * A "path does not exist" failure from `git show <ref>:<path>` is an EXPECTED
+ * client condition (the user supplied a path that isn't in the repo), NOT a
+ * server bug — it must not page Sentry as an unhandled 500 the way a real git
+ * failure (auth, corrupt repo, timeout) would. Git emits the stable wording
+ * `fatal: path '<path>' does not exist in '<ref>'` on stderr (which becomes the
+ * `GitOperationError` message/`stderr` via `classifyGitError`). Anchor on the
+ * stable `does not exist in` substring; the path + ref are variable. Used by
+ * `readRepoFile` to convert this single class into a null sentinel (mirroring
+ * `getFileAtRef`'s `{ found: false }` from #3537) while letting genuine git
+ * failures still throw (Better Stack pattern `a8d20288…`).
+ */
+export function isGitPathNotFoundError(err: unknown): boolean {
+  if (!isGitOperationError(err)) return false;
+  const text = `${err.message}\n${err.stderr}`;
+  return text.includes('does not exist in');
+}
+
 export async function runGit(
   args: string[],
   cwd?: string,


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies. Proof below: the `readRepoFile` regression test pinning the exact prod failure shape (`fatal: path '"C:\Users\bibon\Desktop\Fortnite.url"' does not exist in 'main'`) now throws a typed `RepoFileNotFoundError` instead of propagating an unhandled `GitOperationError` → 500.

```
src/projects/git/files.test.ts:
17 pass
0 fail
31 expect() calls
```

## Why
`GitOperationError: Command failed: git show main:"C:\Users\bibon\Desktop\Fortnite.url"\nfatal: path '"C:\Users\bibon\Desktop\Fortnite.url"' does not exist in 'main'` from the executor connectors sync path (`POST /v1/executor/projects/.../connectors` → `executor/sync.ts` → `readRepoFile` → `git show <ref>:<path>`). `readRepoFile` (`apps/api/src/projects/git/files.ts:108`) had NO try/catch, so a missing/invalid user-supplied path let the typed `GitOperationError` propagate uncaught → the API's `onError` `captureException`'d it to Sentry + returned a 500. Better Stack pattern `a8d20288…` (5 occ / 1 user, last 2026-07-27 12:29:45 UTC, `kortix-api@dev`, prod, mechanism `chained`, frames `node:child_process exitHandler/handleOnExit`).

This is a **regression/gap of #3537** ("fix(projects): return 404 for missing file content paths"), which fixed the SAME "path does not exist" class for `getFileAtRef` (`GET /v1/projects/:id/files/content`) by adding a try/catch that returns `{ content: '', found: false }`. But `readRepoFile` — the function the executor connectors sync uses — was NOT covered. `a8d20288` is the same error class on a different call path (executor connectors sync + auth-discovery, not files-content).

## What changed
- **`apps/api/src/projects/git/mirror.ts`** — added `isGitPathNotFoundError(err)`: a pure classifier that returns `true` only for a `GitOperationError` whose `message`+`stderr` contains the stable `does not exist in` wording (the path + ref are variable; the wording is git's stable contract). Anchored on `isGitOperationError(err) && text.includes('does not exist in')` so genuine git failures (`fatal: not a git repository`, `fatal: could not read Username`/auth, timeouts) return `false` and still page.
- **`apps/api/src/projects/git/files.ts`** — `readRepoFile` now wraps `runGit(['show', …])` in a try/catch. The path-not-found class is converted to a typed `throw new RepoFileNotFoundError(normalized, treeRef, err)` (new exported error class + `isRepoFileNotFoundError` guard). Genuine git failures (auth, corrupt repo, timeout) rethrow the original `GitOperationError` unchanged. The return type stays `Promise<string>` (no contract break for existing callers).
- **`apps/api/src/projects/git.ts`** — re-export `RepoFileNotFoundError` + `isRepoFileNotFoundError` from the barrel.
- **`apps/api/src/executor/sync.ts`** — the two `readRepoFile` callers (`loadSourceText`, `loadHttpRoutes`) catch `RepoFileNotFoundError` and rethrow a clean `Error('connector spec not found in repository: <spec>')` / `Error('http routes spec not found in repository: <spec>')`. These are caught by the existing best-effort `resolveCatalog` try/catch (which returns `{ actions: [], server: null, error: <message> }`) — so a connector whose spec points at a missing repo path now reports a clean per-connector error instead of 500-ing the whole sync. The un-wrapped `discoverConnectorAuthFromSource` (openapi + postman branches, reached from `POST /connectors` + `POST /connectors/auth-discovery` — the actual failing routes) now also catches the typed error and returns `EMPTY_AUTH_DISCOVERY` (no auth to discover from a spec that isn't in the repo), so auth-discovery no longer 500s on a missing spec.

## Verification
- New regression test `apps/api/src/projects/git/files.test.ts` (17 tests, 31 assertions):
  - `isGitPathNotFoundError` returns `true` for the EXACT prod message (`fatal: path '"C:\Users\bibon\Desktop\Fortnite.url"' does not exist in 'main'`) and a plain `fatal: path 'postcss.config.js' does not exist in 'my-change'`; `false` for `fatal: not a git repository`, `fatal: could not read Username` (auth), a `git show timed out after 30000ms` timeout, and non-`GitOperationError` values.
  - `readRepoFile` throws `RepoFileNotFoundError` for a missing path (mocked `runGit` throwing the path-not-found `GitOperationError`) — the exact prod failure shape; still throws the original `GitOperationError` for a real git failure + a timeout (genuine bugs propagate); returns content for a valid path (happy path unchanged); throws `File path is required` / `Invalid path` for empty/traversal paths; uses the default branch when no ref given.
  - `RepoFileNotFoundError` is a typed `Error` with `filePath`/`ref`/`cause` + `isRepoFileNotFoundError` narrows.
- `bun test src/projects/git/ src/executor/` → **46 pass / 0 fail** (git + executor dirs, including the pre-existing `hashing.test.ts` + `mirror.reaper.test.ts`).
- `tsc --noEmit -p apps/api/tsconfig.json` → **exit 0** (clean).
- Pre-existing sandbox-env-sensitive failures in `src/projects/` (schema-drift simulations, session-lifecycle, sandbox-busy probes, llm-gateway) are unchanged by this PR: 32 fail without the change (stashed) vs 31 fail with it + 17 new passing tests.

## Risk / rollback
Low. `readRepoFile`'s return type is unchanged (`Promise<string>`); the only behavioral change is that the *one* expected error class (path-not-found) is now a typed `RepoFileNotFoundError` instead of an unhandled `GitOperationError` → 500. Existing `readRepoFile` callers that already wrap it in try/catch (`config.ts:optionalFile`, `routes/agent-config.ts`, `lib/compile-agent-config.ts`) keep working unchanged — they catch any `Error`. The executor sync path converts the typed error into a clean per-connector message via the existing `resolveCatalog` best-effort wrapper. Rollback = revert the single commit.

## Confirmation
After merge + promote past `kortix-api@dev` (`0.10.16`), the Better Stack pattern `a8d20288…` should drop to zero new occurrences: a `POST /v1/executor/projects/.../connectors` (or `.../connectors/auth-discovery`) with a spec path that doesn't exist in the repo will now return a 200 with `{ error: 'connector spec not found in repository: <spec>' }` (sync) / an empty auth-discovery result, instead of a 500 + Sentry page. The `node:child_process exitHandler` frames from `git show` on an invalid path should disappear from the inventory.

Reference: Better Stack pattern `a8d20288ed6a33d977fc0e00f56599ee4543a4c658638dcb65027c04197c3b70` (Kortix API prod app `2346961`). Regression/gap of #3537.
