### PR TITLE
Release candidate: sync test-only session title wait

### DIFF
--- a/tests/e2e/specs/17-acp-session-title-sync.spec.ts
+++ b/tests/e2e/specs/17-acp-session-title-sync.spec.ts
@@ -221,8 +221,13 @@ test.describe.serial('17 — ACP session title synchronization', () => {
       sessionLists.length = 0;
       const navigationsBeforePrompt = mainFrameNavigations;
       const marker = transport === 'acp' ? 'ACP_TITLE_SYNC_DONE' : 'REST_TITLE_SYNC_DONE';
+      const sendButton = page.getByRole('button', { name: 'Send message' });
+      await expect(page.getByText('Sandbox build running...', { exact: true })).toBeHidden({
+        timeout: 12 * 60_000,
+      });
       await input.fill(`Research the number 7 briefly. Then reply exactly ${marker}.`);
-      await page.getByRole('button', { name: 'Send message' }).click();
+      await expect(sendButton).toBeEnabled({ timeout: 30_000 });
+      await sendButton.click();
       await expect(page.getByText(marker, { exact: true }).last()).toBeVisible({
         timeout: 120_000,
       });


### PR DESCRIPTION
Sync test-only PR #5651 into staging.

The only changed file is tests/e2e/specs/17-acp-session-title-sync.spec.ts.

The merge commit will use [skip ci] because runtime source 4dbd2a59 is already built, deployed, and live-verified.