### PR TITLE
chore(release): promote current main to staging

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -147,11 +147,21 @@ Docker running when Supabase needs to be reached or started.
 
 ```sh
 pnpm worktree stop <n>
+pnpm worktree stop --all      # every worktree at once
 ```
 
-Kills the web/api/gateway processes. Shared-DB mode leaves the primary Supabase
-running. Isolated-DB mode also stops the worktree's Supabase. Data (DB volume
-for isolated mode, branch, files) is preserved; `start` resumes it.
+Kills the web/api/gateway **process trees** — the dev servers plus the ~15 workers
+each one forks, the Cloudflare tunnel, and `stripe listen` — then verifies they are
+gone before recording the stop. Shared-DB mode leaves the primary Supabase running.
+Isolated-DB mode also stops the worktree's Supabase. Data (DB volume for isolated
+mode, branch, files) is preserved; `start` resumes it.
+
+**Stop what you are not using.** A stack holds ~19 processes and a few GB that
+Turbopack never gives back, so a handful of forgotten stacks will exhaust swap and
+get something OOM-killed. `stop --all` is the end-of-day sweep and the way back
+from stacks orphaned by an OOM kill (their supervisor is gone, so there is no
+`Ctrl+C` left to press). `pnpm worktree doctor` shows what is actually running,
+including worktrees whose recorded status has drifted from reality.
 
 ### `nuke` (alias `rm`) — tear down and free the slot
 

--- a/apps/api/src/executor/sync.ts
+++ b/apps/api/src/executor/sync.ts
@@ -30,7 +30,7 @@ import {
   extractConnectors,
   manifestHashForConnector,
 } from '../projects/connectors';
-import { type GitBackedProject, readRepoFile } from '../projects/git';
+import { type GitBackedProject, isRepoFileNotFoundError, readRepoFile } from '../projects/git';
 import { withProjectGitAuth } from '../projects/index';
 import { extractProjectPolicies } from '../projects/policies';
 import { extractTriggers, readManifest } from '../projects/triggers';
@@ -100,15 +100,37 @@ async function discoverConnectorAuthFromSource(
   }
   const spec = typeof draft.spec === 'string' ? draft.spec.trim() : '';
   if (provider === 'openapi') {
-    return spec ? discoverOpenApiAuth(await loadSpecDoc(project, spec), spec) : EMPTY_AUTH_DISCOVERY;
+    // The spec may not exist in the repo (e.g. the user supplied a path that
+    // isn't there). `loadSpecDoc`/`loadSourceText` throws a clean `Error` for
+    // that case (see `readRepoFile`/`RepoFileNotFoundError`/#3537) — there's no
+    // auth to discover from a missing spec, so degrade to the empty discovery
+    // instead of letting the throw propagate as an unhandled 500 (Better Stack
+    // `a8d20288…`).
+    if (!spec) return EMPTY_AUTH_DISCOVERY;
+    try {
+      return discoverOpenApiAuth(await loadSpecDoc(project, spec), spec);
+    } catch (e) {
+      if (isRepoFileNotFoundError(e) || String((e as Error).message).startsWith('connector spec not found in repository:')) {
+        return EMPTY_AUTH_DISCOVERY;
+      }
+      throw e;
+    }
   }
   if (provider === 'postman') {
     if (!spec) return EMPTY_AUTH_DISCOVERY;
-    const documents = await resolvePostmanSource(spec, (source) => loadSourceText(project, source), {
-      githubDefaultBranch: resolveGithubDefaultBranch,
-      postmanApiKey: config.POSTMAN_API_KEY,
-      resolveWorkspace: resolvePostmanWorkspace,
-    });
+    let documents: PostmanSourceDocument[];
+    try {
+      documents = await resolvePostmanSource(spec, (source) => loadSourceText(project, source), {
+        githubDefaultBranch: resolveGithubDefaultBranch,
+        postmanApiKey: config.POSTMAN_API_KEY,
+        resolveWorkspace: resolvePostmanWorkspace,
+      });
+    } catch (e) {
+      if (isRepoFileNotFoundError(e) || String((e as Error).message).startsWith('connector spec not found in repository:')) {
+        return EMPTY_AUTH_DISCOVERY;
+      }
+      throw e;
+    }
     return mergeAuthDiscoveries(documents.map((document) =>
       document.kind === 'openapi'
         ? discoverOpenApiAuth(document.doc, document.source)
@@ -712,7 +734,21 @@ async function loadSourceText(project: GitBackedProject, spec: string): Promise<
     }
     raw = await res.text();
   } else {
-    raw = await readRepoFile(project, spec, project.defaultBranch);
+    // `readRepoFile` throws a typed `RepoFileNotFoundError` when the path isn't
+    // in the repo at the ref (see #3537 / `isGitPathNotFoundError`) instead of
+    // letting the `GitOperationError` propagate as an unhandled 500. A
+    // connector spec pointing at a missing repo path is a user config error;
+    // rethrow it with the spec name so the best-effort
+    // `resolveCatalog`/`discoverConnectorAuthFromSource` wrappers can surface a
+    // clean message (Better Stack `a8d20288…`).
+    try {
+      raw = await readRepoFile(project, spec, project.defaultBranch);
+    } catch (err) {
+      if (isRepoFileNotFoundError(err)) {
+        throw new Error(`connector spec not found in repository: ${spec}`);
+      }
+      throw err;
+    }
   }
   return raw;
 }
@@ -800,9 +836,23 @@ async function loadHttpRoutes(
 ): Promise<HttpRouteSpec[]> {
   if (!spec) return [];
   if (/^https?:\/\//i.test(spec)) assertAllowedSourceAddress(spec);
-  const raw = /^https?:\/\//i.test(spec)
-    ? await (await safeEgressFetch(spec)).text()
-    : await readRepoFile(project, spec, project.defaultBranch);
+  let raw: string;
+  if (/^https?:\/\//i.test(spec)) {
+    raw = await (await safeEgressFetch(spec)).text();
+  } else {
+    // `readRepoFile` throws a typed `RepoFileNotFoundError` when the path isn't
+    // in the repo (see #3537). A missing http-routes spec is a user config
+    // error surfaced as a clean message via the `resolveCatalog` best-effort
+    // wrapper, not an unhandled 500 (Better Stack `a8d20288…`).
+    try {
+      raw = await readRepoFile(project, spec, project.defaultBranch);
+    } catch (err) {
+      if (isRepoFileNotFoundError(err)) {
+        throw new Error(`http routes spec not found in repository: ${spec}`);
+      }
+      throw err;
+    }
+  }
   const parsed = /\.toml$/i.test(spec) ? (parseToml(raw) as any) : JSON.parse(raw);
   const routes = Array.isArray(parsed?.routes) ? parsed.routes : [];
   return routes as HttpRouteSpec[];

--- a/apps/api/src/projects/git.ts
+++ b/apps/api/src/projects/git.ts
@@ -52,6 +52,8 @@ export {
   archiveRepoSubtree,
   getFileAtRef,
   getFileHistory,
+  RepoFileNotFoundError,
+  isRepoFileNotFoundError,
 } from './git/files';
 
 export {

--- a/apps/api/src/projects/git/files.test.ts
+++ b/apps/api/src/projects/git/files.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GitOperationError, isGitPathNotFoundError, runGit as realRunGit } from './mirror';
+import { isRepoFileNotFoundError, RepoFileNotFoundError } from './files';
+
+// `readRepoFile` imports `runGit` + `refreshMirror` from `./mirror`. We mock the
+// module so `runGit` is controllable per-test (returns stdout, throws a
+// path-not-found GitOperationError, or throws a real git failure) and
+// `refreshMirror` short-circuits to a temp dir without touching the network.
+const mirrorModule = await import('./mirror');
+
+let runGitImpl: (...args: Parameters<typeof realRunGit>) => Promise<{ stdout: string; stderr: string }>;
+let repoPath = '';
+
+mock.module('./mirror', () => ({
+  ...mirrorModule,
+  runGit: async (...args: Parameters<typeof realRunGit>) => runGitImpl(...args),
+  refreshMirror: async () => repoPath,
+}));
+
+const { readRepoFile } = await import('./files');
+
+const project = {
+  projectId: 'test-project',
+  defaultBranch: 'main',
+  repoUrl: 'https://github.com/kortix-ai/test.git',
+  gitAuthToken: null,
+  gitAuthHeaders: {},
+} as any;
+
+beforeEach(async () => {
+  repoPath = await mkdtemp(join(tmpdir(), 'kortix-readrepofile-test-'));
+  runGitImpl = realRunGit;
+});
+
+afterEach(async () => {
+  if (repoPath) await rm(repoPath, { recursive: true, force: true });
+});
+
+describe('isGitPathNotFoundError', () => {
+  test('returns true for the EXACT prod message (Windows path, quoted)', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `Command failed: git show main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"\nfatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+      gitArgs: ['show', 'main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"'],
+      stderr: `fatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(true);
+  });
+
+  test('returns true for a plain missing-path git message', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: path 'postcss.config.js' does not exist in 'my-change'`,
+      gitArgs: ['show', 'my-change:postcss.config.js'],
+      stderr: `fatal: path 'postcss.config.js' does not exist in 'my-change'`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(true);
+  });
+
+  test('returns true when the wording is only in the message (stderr empty)', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: path 'openapi.yaml' does not exist in 'main'`,
+      gitArgs: ['show', 'main:openapi.yaml'],
+      stderr: '',
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(true);
+  });
+
+  test('returns false for a real git failure (not a git repository)', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: not a git repository (or any of the parent directories): .git`,
+      gitArgs: ['show', 'main:file.txt'],
+      stderr: `fatal: not a git repository (or any of the parent directories): .git`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(false);
+  });
+
+  test('returns false for an auth failure', () => {
+    const err = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: could not read Username for 'https://github.com': No such device or address`,
+      gitArgs: ['fetch', 'origin'],
+      stderr: `fatal: could not read Username for 'https://github.com': No such device or address`,
+      exitCode: 128,
+    });
+    expect(isGitPathNotFoundError(err)).toBe(false);
+  });
+
+  test('returns false for a timeout (transient, must still page)', () => {
+    const err = new GitOperationError({
+      kind: 'timeout',
+      message: `git show timed out after 30000ms (signal SIGTERM)`,
+      gitArgs: ['show', 'main:openapi.yaml'],
+      signal: 'SIGTERM',
+      stderr: '',
+    });
+    expect(isGitPathNotFoundError(err)).toBe(false);
+  });
+
+  test('returns false for a non-GitOperationError', () => {
+    expect(isGitPathNotFoundError(new Error('does not exist in main'))).toBe(false);
+    expect(isGitPathNotFoundError(null)).toBe(false);
+    expect(isGitPathNotFoundError(undefined)).toBe(false);
+  });
+});
+
+describe('readRepoFile', () => {
+  test('throws a RepoFileNotFoundError for a path that does not exist in the repo (the prod failure shape)', async () => {
+    runGitImpl = async () => {
+      throw new GitOperationError({
+        kind: 'failed',
+        message: `Command failed: git show main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"\nfatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+        gitArgs: ['show', 'main:"C:\\Users\\bibon\\Desktop\\Fortnite.url"'],
+        stderr: `fatal: path '"C:\\Users\\bibon\\Desktop\\Fortnite.url"' does not exist in 'main'`,
+        exitCode: 128,
+      });
+    };
+    const promise = readRepoFile(project, 'C:\\Users\\bibon\\Desktop\\Fortnite.url', 'main');
+    await expect(promise).rejects.toBeInstanceOf(RepoFileNotFoundError);
+    await expect(promise).rejects.toMatchObject({
+      name: 'RepoFileNotFoundError',
+      filePath: 'C:\\Users\\bibon\\Desktop\\Fortnite.url',
+      ref: 'main',
+    });
+    // And the typed guard recognizes it.
+    try {
+      await readRepoFile(project, 'C:\\Users\\bibon\\Desktop\\Fortnite.url', 'main');
+    } catch (err) {
+      expect(isRepoFileNotFoundError(err)).toBe(true);
+    }
+  });
+
+  test('throws a RepoFileNotFoundError for a plain missing path', async () => {
+    runGitImpl = async () => {
+      throw new GitOperationError({
+        kind: 'failed',
+        message: `fatal: path 'openapi.yaml' does not exist in 'main'`,
+        gitArgs: ['show', 'main:openapi.yaml'],
+        stderr: `fatal: path 'openapi.yaml' does not exist in 'main'`,
+        exitCode: 128,
+      });
+    };
+    await expect(readRepoFile(project, 'openapi.yaml', 'main')).rejects.toBeInstanceOf(RepoFileNotFoundError);
+  });
+
+  test('still throws the original GitOperationError for a real git failure (genuine bugs propagate)', async () => {
+    const realErr = new GitOperationError({
+      kind: 'failed',
+      message: `fatal: not a git repository (or any of the parent directories): .git`,
+      gitArgs: ['show', 'main:file.txt'],
+      stderr: `fatal: not a git repository (or any of the parent directories): .git`,
+      exitCode: 128,
+    });
+    runGitImpl = async () => {
+      throw realErr;
+    };
+    await expect(readRepoFile(project, 'file.txt', 'main')).rejects.toBe(realErr);
+    // And the typed guard does NOT misclassify a genuine git failure.
+    try {
+      await readRepoFile(project, 'file.txt', 'main');
+    } catch (err) {
+      expect(isRepoFileNotFoundError(err)).toBe(false);
+    }
+  });
+
+  test('still throws for a timeout (transient failures must page)', async () => {
+    const timeoutErr = new GitOperationError({
+      kind: 'timeout',
+      message: `git show timed out after 30000ms (signal SIGTERM)`,
+      gitArgs: ['show', 'main:openapi.yaml'],
+      signal: 'SIGTERM',
+      stderr: '',
+    });
+    runGitImpl = async () => {
+      throw timeoutErr;
+    };
+    await expect(readRepoFile(project, 'openapi.yaml', 'main')).rejects.toBe(timeoutErr);
+  });
+
+  test('returns the content for a valid path (happy path, unchanged)', async () => {
+    runGitImpl = async () => ({ stdout: 'openapi: 3.0.0\n', stderr: '' });
+    const content = await readRepoFile(project, 'openapi.yaml', 'main');
+    expect(content).toBe('openapi: 3.0.0\n');
+  });
+
+  test('throws "File path is required" for an empty/normalized-null path', async () => {
+    await expect(readRepoFile(project, '', 'main')).rejects.toThrow('File path is required');
+    await expect(readRepoFile(project, '/', 'main')).rejects.toThrow('File path is required');
+  });
+
+  test('throws "Invalid path" for a path traversal attempt', async () => {
+    await expect(readRepoFile(project, '../etc/passwd', 'main')).rejects.toThrow('Invalid path');
+  });
+
+  test('uses the default branch when no ref is given', async () => {
+    let capturedArgs: readonly string[] = [];
+    runGitImpl = async (args) => {
+      capturedArgs = args;
+      return { stdout: 'content', stderr: '' };
+    };
+    await readRepoFile(project, 'file.txt');
+    expect(capturedArgs).toEqual(['show', 'main:file.txt']);
+  });
+});
+
+describe('RepoFileNotFoundError', () => {
+  test('is a typed Error with filePath/ref + a cause', () => {
+    const cause = new Error('underlying');
+    const err = new RepoFileNotFoundError('openapi.yaml', 'main', cause);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('RepoFileNotFoundError');
+    expect(err.filePath).toBe('openapi.yaml');
+    expect(err.ref).toBe('main');
+    expect(err.message).toBe(`file not found in repository at 'main:openapi.yaml'`);
+    expect((err as any).cause).toBe(cause);
+  });
+
+  test('isRepoFileNotFoundError narrows the type', () => {
+    const err = new RepoFileNotFoundError('x', 'main');
+    expect(isRepoFileNotFoundError(err)).toBe(true);
+    expect(isRepoFileNotFoundError(new Error('x'))).toBe(false);
+    expect(isRepoFileNotFoundError(null)).toBe(false);
+    expect(isRepoFileNotFoundError(undefined)).toBe(false);
+  });
+});

--- a/apps/api/src/projects/git/files.ts
+++ b/apps/api/src/projects/git/files.ts
@@ -3,7 +3,7 @@
 
 import { validateRef } from '../git-ref';
 import { listCommits } from './commits';
-import { normalizeTreePath, refreshMirror, runGit, runGitCapture, spawn } from './mirror';
+import { isGitPathNotFoundError, normalizeTreePath, refreshMirror, runGit, runGitCapture, spawn } from './mirror';
 import type {
   GetFileAtRefResult,
   GetFileHistoryOptions,
@@ -105,13 +105,51 @@ export async function grepRepoFiles(
   return matches;
 }
 
-export async function readRepoFile(project: GitBackedProject, filePath: string, ref?: string) {
+export async function readRepoFile(project: GitBackedProject, filePath: string, ref?: string): Promise<string> {
   const normalized = normalizeTreePath(filePath);
   if (!normalized) throw new Error('File path is required');
   const treeRef = validateRef(ref || project.defaultBranch);
   const repoPath = await refreshMirror(project);
-  const result = await runGit(['show', `${treeRef}:${normalized}`], repoPath, false);
-  return result.stdout;
+  try {
+    const result = await runGit(['show', `${treeRef}:${normalized}`], repoPath, false);
+    return result.stdout;
+  } catch (err) {
+    // A "path does not exist in '<ref>'" `git show` failure is an expected
+    // client condition (the path simply isn't in the repo at this ref), not a
+    // server bug — convert it into a typed `RepoFileNotFoundError` instead of
+    // letting the `GitOperationError` propagate as an unhandled 500 (Better
+    // Stack pattern `a8d20288…`). Mirrors `getFileAtRef`'s `{ found: false }`
+    // sentinel from #3537, but as a typed throw so existing callers that wrap
+    // `readRepoFile` in try/catch (config/agent-config/compile-agent-config)
+    // keep working unchanged. Genuine git failures (auth, corrupt repo,
+    // timeout) still throw the original `GitOperationError`.
+    if (isGitPathNotFoundError(err)) {
+      throw new RepoFileNotFoundError(normalized, treeRef, err);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Typed error for the expected "file not in the repo at this ref" condition.
+ * Distinct from `GitOperationError` so callers can branch on the expected case
+ * (skip/empty/discover-no-auth) without swallowing genuine git failures
+ * (auth, timeout, corrupt repo) that must still surface.
+ */
+export class RepoFileNotFoundError extends Error {
+  readonly filePath: string;
+  readonly ref: string;
+  constructor(filePath: string, ref: string, cause?: unknown) {
+    super(`file not found in repository at '${ref}:${filePath}'`);
+    this.name = 'RepoFileNotFoundError';
+    this.filePath = filePath;
+    this.ref = ref;
+    if (cause !== undefined) (this as any).cause = cause;
+  }
+}
+
+export function isRepoFileNotFoundError(err: unknown): err is RepoFileNotFoundError {
+  return err instanceof RepoFileNotFoundError;
 }
 
 /**

--- a/apps/api/src/projects/git/mirror.ts
+++ b/apps/api/src/projects/git/mirror.ts
@@ -249,6 +249,24 @@ export function isGitOperationError(err: unknown): err is GitOperationError {
   return err instanceof GitOperationError;
 }
 
+/**
+ * A "path does not exist" failure from `git show <ref>:<path>` is an EXPECTED
+ * client condition (the user supplied a path that isn't in the repo), NOT a
+ * server bug — it must not page Sentry as an unhandled 500 the way a real git
+ * failure (auth, corrupt repo, timeout) would. Git emits the stable wording
+ * `fatal: path '<path>' does not exist in '<ref>'` on stderr (which becomes the
+ * `GitOperationError` message/`stderr` via `classifyGitError`). Anchor on the
+ * stable `does not exist in` substring; the path + ref are variable. Used by
+ * `readRepoFile` to convert this single class into a null sentinel (mirroring
+ * `getFileAtRef`'s `{ found: false }` from #3537) while letting genuine git
+ * failures still throw (Better Stack pattern `a8d20288…`).
+ */
+export function isGitPathNotFoundError(err: unknown): boolean {
+  if (!isGitOperationError(err)) return false;
+  const text = `${err.message}\n${err.stderr}`;
+  return text.includes('does not exist in');
+}
+
 export async function runGit(
   args: string[],
   cwd?: string,

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-b8e1e75b"
+  tag: "dev-985b7db0"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/scripts/worktree/README.md
+++ b/scripts/worktree/README.md
@@ -24,7 +24,8 @@ pnpm worktree create --name migration-fix --db --yes
 | `pnpm worktree create --name <n> [--branch b] [--from main] [--db] [--no-start] [--yes]` | From a fresh clone: install missing deps, create the worktree, allocate a port block, `pnpm install`, build runtime artifacts, then boot the stack against the shared primary Supabase DB. Add `--db` to render/start/migrate a separate Supabase project. Idempotent — re-run to resume. |
 | `pnpm worktree new <n>` | Alias of `create` (positional name). |
 | `pnpm worktree start <n>` | Boot an existing worktree's app stack on its ports. Shared mode uses primary Supabase; isolated mode starts/migrates its own Supabase. Streams logs; `Ctrl+C` stops the dev servers. |
-| `pnpm worktree stop <n>` | Stop the dev servers. Isolated mode also stops that worktree's Supabase containers. **Data is preserved.** |
+| `pnpm worktree stop <n>` | Stop the dev servers — the whole process tree, verified dead before the registry records it. Isolated mode also stops that worktree's Supabase containers. **Data is preserved.** |
+| `pnpm worktree stop --all` | Stop every worktree in one pass. The end-of-day sweep, and the way back from stacks orphaned by an OOM kill. |
 | `pnpm worktree nuke <n> [--force]` | Tear down the app worktree: stop, `git worktree remove`, delete the slot's store, free the port slot. Isolated mode also drops its Supabase containers **and volumes**. Shared mode leaves primary Supabase untouched. |
 | `pnpm worktree list` | All worktrees with their slot, branch, status, and ports. |
 | `pnpm worktree status [n]` | Live health (🟢/⚪) of web/api/Supabase per worktree. |
@@ -79,6 +80,40 @@ bumps the slot rather than colliding silently.
   committed encrypted `.env` — **no committed file is ever edited.**
 
 The only in-worktree artifact is the gitignored `.kortix-worktree.json` marker.
+
+## Stopping: why it kills trees, not ports
+
+A running stack is not three processes, it is three trees — `pnpm … dev` forks a
+dotenvx wrapper, which forks the dev server, which forks a worker pool. Next dev
+alone leaves ~15 (`webpack-loaders`, `postcss`, an esbuild service), and **only
+the leaf holds the port**.
+
+Stopping by "kill whatever listens on the port" therefore reclaimed 3 of ~19
+processes and leaked the rest. Leaked workers reparent to launchd, keep their
+1–3 GB Turbopack heap, lose their terminal, and can no longer be reached by
+`Ctrl+C` or by `stop` — so they survive until reboot. Enough of them exhausts
+swap; the OOM kill then takes a supervisor with it, orphaning another stack.
+That loop is why this is tree-based:
+
+- **Roots come from observable state**, never stored pids — a stale pid file plus
+  pid reuse means signalling a stranger. Three probes, because no one of them
+  sees everything: processes whose **cwd** is in the worktree (the servers and
+  their workers), processes **listening** on a slot port (anything that outlived
+  its parent), and `cloudflared` / `stripe listen` matched by the **slot's API
+  port** in their command line (they run from the CLI's cwd, so the cwd probe
+  misses them).
+- **A cwd match alone is not enough to be a root.** A shell pipeline, an editor,
+  or an agent working in the worktree shares its cwd; only argv[0] looking like
+  the toolchain (`node`/`bun`/`pnpm`/`next`/`esbuild`/…) promotes it. Everything
+  else dies only by being a descendant of something that does.
+- **The reaper never descends through itself** or its ancestors, so `stop` run
+  from inside the worktree cannot kill the shell it was typed into.
+- **Every kill is verified** (SIGTERM → SIGKILL → re-check). `stopped` is only
+  recorded when nothing survived; an unverified write is what used to make `list`
+  report stacks as stopped while 20 of their processes were resident.
+
+`pnpm worktree doctor` counts what is actually alive per worktree and reports
+registry drift in both directions; `pnpm worktree stop --all` clears the lot.
 
 ## The two enabling changes (default to primary behavior)
 

--- a/scripts/worktree/__tests__/contract.test.ts
+++ b/scripts/worktree/__tests__/contract.test.ts
@@ -43,7 +43,10 @@ describe('dependency contract — every external binary the worktree spawns is d
   });
 
   test('every bin spawned in lib.ts is either declared in DEPS or a shell builtin', () => {
-    const allowed = new Set([...depBins, 'bash', 'git', 'node', 'stripe', 'cloudflared', 'dotenvx']);
+    // `ps` joins bash/git as a POSIX base utility the reaper relies on: it is present
+    // on every macOS and Linux box, so declaring it in DEPS would only add a check
+    // that can never fail. `lsof` is reached through `bash -lc` and needs no entry.
+    const allowed = new Set([...depBins, 'bash', 'git', 'node', 'ps', 'stripe', 'cloudflared', 'dotenvx']);
     const spawned = new Set(
       [...libSrc.matchAll(/(?:run|sh|spawn)\(\s*\[\s*'([a-z][a-z0-9-]*)'/g)].map((m) => m[1]),
     );

--- a/scripts/worktree/__tests__/procs.test.ts
+++ b/scripts/worktree/__tests__/procs.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type ProcRow,
+  ancestorsOf,
+  executableOf,
+  expandTree,
+  isDevStackProcess,
+  isUnder,
+  parseLsofCwd,
+  parsePsTable,
+  planKill,
+  sidecarPids,
+  stackPids,
+} from '../lib';
+
+/**
+ * A real stack, as `ps` sees it: `pnpm dev` forks a dotenvx wrapper, which forks the
+ * dev server, which forks its worker pool. Only the LEAF binds the port — which is
+ * why "kill whatever holds the port" reclaimed 3 of ~19 processes and leaked the rest.
+ */
+const WT = '/Users/dev/Projects/kortix/suna-featurex';
+const STACK: ProcRow[] = [
+  { pid: 100, ppid: 1, command: 'bun scripts/worktree/cli.ts start featurex' },
+  { pid: 200, ppid: 100, command: 'pnpm --filter kortix-api dev' },
+  { pid: 201, ppid: 200, command: 'node dotenvx.js run -- bun run --hot src/index.ts' },
+  { pid: 202, ppid: 201, command: 'bun run --hot src/index.ts' },
+  { pid: 300, ppid: 100, command: 'pnpm --filter Kortix-Computer-Frontend dev' },
+  { pid: 301, ppid: 300, command: 'node next dev' },
+  { pid: 302, ppid: 301, command: 'node next-server' },
+  { pid: 303, ppid: 302, command: 'node .next/webpack-loaders.js 1' },
+  { pid: 304, ppid: 302, command: 'node .next/webpack-loaders.js 2' },
+  { pid: 305, ppid: 302, command: 'node .next/postcss.js' },
+  { pid: 306, ppid: 301, command: 'esbuild --service' },
+  { pid: 400, ppid: 1, command: 'cloudflared tunnel --no-autoupdate --url http://localhost:18508' },
+  {
+    pid: 401,
+    ppid: 1,
+    command: 'stripe listen --forward-to http://localhost:18508/v1/billing/webhooks/stripe',
+  },
+  { pid: 999, ppid: 1, command: '/Applications/Ghostty.app/Contents/MacOS/ghostty' },
+];
+
+describe('parsePsTable', () => {
+  test('splits pid/ppid off a command that itself contains spaces and digits', () => {
+    const rows = parsePsTable(
+      '  501   1 /usr/bin/foo --port 8008 --x 2\n 502 501 bun run --hot src/index.ts\n',
+    );
+    expect(rows).toEqual([
+      { pid: 501, ppid: 1, command: '/usr/bin/foo --port 8008 --x 2' },
+      { pid: 502, ppid: 501, command: 'bun run --hot src/index.ts' },
+    ]);
+  });
+
+  test('ignores header junk and blank lines', () => {
+    expect(parsePsTable('\n  PID PPID COMMAND\n\n 7 1 x\n')).toEqual([
+      { pid: 7, ppid: 1, command: 'x' },
+    ]);
+  });
+});
+
+describe('parseLsofCwd', () => {
+  test('pairs each -Fp pid record with the -Fn path that follows it', () => {
+    expect(parseLsofCwd('p100\nn/a/b\np200\nn/c\n')).toEqual([
+      { pid: 100, cwd: '/a/b' },
+      { pid: 200, cwd: '/c' },
+    ]);
+  });
+
+  test('drops path records that arrive before any pid', () => {
+    expect(parseLsofCwd('n/orphaned\np5\nn/real\n')).toEqual([{ pid: 5, cwd: '/real' }]);
+  });
+});
+
+describe('isUnder', () => {
+  test('matches the directory itself and anything beneath it', () => {
+    expect(isUnder('/w/suna-x', '/w/suna-x')).toBe(true);
+    expect(isUnder('/w/suna-x/apps/web', '/w/suna-x')).toBe(true);
+  });
+
+  test('respects segment boundaries so one worktree never reaps another', () => {
+    expect(isUnder('/w/suna-xyz', '/w/suna-x')).toBe(false);
+    expect(isUnder('/w/suna-x-old/apps/api', '/w/suna-x')).toBe(false);
+  });
+
+  test('tolerates a trailing slash on the directory', () => {
+    expect(isUnder('/w/suna-x/apps', '/w/suna-x/')).toBe(true);
+  });
+});
+
+describe('expandTree', () => {
+  test('a supervisor root reaches every descendant, not just its direct children', () => {
+    expect(expandTree([100], STACK).sort((a, b) => a - b)).toEqual([
+      100, 200, 201, 202, 300, 301, 302, 303, 304, 305, 306,
+    ]);
+  });
+
+  test('THE REGRESSION: the port-holding leaf is not the tree — killing it leaves the rest alive', () => {
+    const portHolder = 302;
+    const fromLeaf = expandTree([portHolder], STACK);
+    const fromRoot = expandTree([100], STACK);
+    expect(fromLeaf).not.toContain(300);
+    expect(fromLeaf).not.toContain(202);
+    expect(fromRoot.length).toBeGreaterThan(fromLeaf.length);
+  });
+
+  test('never escapes into unrelated processes', () => {
+    expect(expandTree([100], STACK)).not.toContain(999);
+  });
+
+  test('is cycle-safe against a self-parenting or looping ps snapshot', () => {
+    const looped: ProcRow[] = [
+      { pid: 1, ppid: 1, command: 'launchd' },
+      { pid: 2, ppid: 3, command: 'a' },
+      { pid: 3, ppid: 2, command: 'b' },
+    ];
+    expect(expandTree([2], looped).sort()).toEqual([2, 3]);
+  });
+
+  test('deduplicates overlapping roots', () => {
+    expect(expandTree([100, 300, 302], STACK).filter((p) => p === 302)).toHaveLength(1);
+  });
+});
+
+describe('ancestorsOf', () => {
+  test('walks the parent chain and stops at init', () => {
+    expect(ancestorsOf(303, STACK)).toEqual([302, 301, 300, 100]);
+  });
+
+  test('returns nothing for a process parented by init', () => {
+    expect(ancestorsOf(100, STACK)).toEqual([]);
+  });
+});
+
+describe('planKill — the safety envelope', () => {
+  test('expands roots to the whole tree', () => {
+    expect(planKill({ roots: [100], rows: STACK, selfPid: 999 })).toContain(303);
+  });
+
+  test('refuses to sweep a tree it is running inside — self-preservation beats completeness', () => {
+    expect(planKill({ roots: [100], rows: STACK, selfPid: 302 })).toEqual([]);
+  });
+
+  test('sparing that tree does not spare unrelated roots in the same sweep', () => {
+    expect(planKill({ roots: [100, 400], rows: STACK, selfPid: 302 })).toEqual([400]);
+  });
+
+  test('never signals an ancestor of the reaper — that would kill the shell it was typed into', () => {
+    const plan = planKill({ roots: [100], rows: STACK, selfPid: 303 });
+    for (const pid of [302, 301, 300, 100]) expect(plan).not.toContain(pid);
+  });
+
+  test('never descends through the reaper into its own subprocesses', () => {
+    const rows: ProcRow[] = [
+      { pid: 500, ppid: 1, command: 'bun scripts/worktree/cli.ts stop featurex' },
+      { pid: 501, ppid: 500, command: 'ps -Ao pid=,ppid=,command=' },
+    ];
+    expect(planKill({ roots: [500], rows, selfPid: 500 })).toEqual([]);
+  });
+
+  test('but a supervisor CAN kill the servers it spawned, passed in as explicit roots', () => {
+    const plan = planKill({ roots: [200, 300], rows: STACK, selfPid: 100 });
+    expect(plan).toContain(202);
+    expect(plan).toContain(303);
+    expect(plan).not.toContain(100);
+  });
+
+  test('never signals init or pid 0', () => {
+    const rows: ProcRow[] = [
+      { pid: 1, ppid: 0, command: 'launchd' },
+      { pid: 2, ppid: 1, command: 'x' },
+    ];
+    const plan = planKill({ roots: [1, 0, 2], rows, selfPid: 500 });
+    expect(plan).toEqual([2]);
+  });
+});
+
+describe('sidecarPids', () => {
+  test('finds the tunnel and stripe forwarder, which run from the CLI cwd and so evade the cwd probe', () => {
+    expect(sidecarPids(STACK, 18508).sort()).toEqual([400, 401]);
+  });
+
+  test('a shorter port is not a prefix match for a longer one', () => {
+    expect(sidecarPids(STACK, 1850)).toEqual([]);
+  });
+
+  test('ignores non-sidecar processes that merely mention the port', () => {
+    const rows: ProcRow[] = [{ pid: 5, ppid: 1, command: 'curl http://localhost:18508/health' }];
+    expect(sidecarPids(rows, 18508)).toEqual([]);
+  });
+});
+
+describe('isDevStackProcess', () => {
+  test('recognises the toolchain a stack is actually made of', () => {
+    for (const cmd of [
+      'pnpm --filter kortix-api dev',
+      'bun run --hot src/index.ts',
+      `node ${WT}/apps/web/.next/webpack-loaders.js 42`,
+      'esbuild --service',
+      'node dotenvx.js run -- x',
+    ])
+      expect(isDevStackProcess(cmd), cmd).toBe(true);
+  });
+
+  test('THE PIPELINE BUG: things that merely share the worktree cwd are not stack roots', () => {
+    for (const cmd of [
+      'grep -v ^>',
+      'tail -20',
+      '/bin/zsh',
+      'git status',
+      'vim src/x.ts',
+      'claude --resume',
+      'codex exec',
+    ])
+      expect(isDevStackProcess(cmd), cmd).toBe(false);
+  });
+
+  test('only argv[0] counts — a shell whose ARGUMENTS mention node is still just a shell', () => {
+    expect(isDevStackProcess('/bin/zsh -c cd /w/suna-x && nohup node fake.js 18508')).toBe(false);
+    expect(isDevStackProcess('bash -lc "pnpm dev"')).toBe(false);
+  });
+});
+
+describe('executableOf', () => {
+  test('strips the directory and the arguments', () => {
+    expect(executableOf('/Users/dev/.nvm/versions/node/v22/bin/node -e code')).toBe('node');
+    expect(executableOf('  pnpm --filter x dev  ')).toBe('pnpm');
+    expect(executableOf('')).toBe('');
+  });
+});
+
+describe('stackPids', () => {
+  const cwds = [
+    { pid: 200, cwd: `${WT}/apps/api` },
+    { pid: 302, cwd: `${WT}/apps/web` },
+    { pid: 999, cwd: '/Users/dev/Projects/kortix/suna' },
+  ];
+
+  test('reports the full footprint — cwd owners, their descendants, and the sidecars', () => {
+    expect(stackPids(WT, 18508, { rows: STACK, cwds }, 500).sort((a, b) => a - b)).toEqual([
+      200, 201, 202, 302, 303, 304, 305, 400, 401,
+    ]);
+  });
+
+  test('counts what `stop` would actually reap, not just the roots', () => {
+    const roots = [200, 302, 400, 401];
+    expect(stackPids(WT, 18508, { rows: STACK, cwds }, 500).length).toBeGreaterThan(roots.length);
+  });
+
+  test('leaves the primary checkout alone', () => {
+    expect(stackPids(WT, 18508, { rows: STACK, cwds }, 500)).not.toContain(999);
+  });
+
+  test('does not count a shell pipeline running inside the worktree', () => {
+    const rows: ProcRow[] = [...STACK, { pid: 700, ppid: 1, command: 'grep -v ^>' }];
+    const withPipeline = [...cwds, { pid: 700, cwd: WT }];
+    expect(stackPids(WT, 18508, { rows, cwds: withPipeline }, 500)).not.toContain(700);
+  });
+
+  test('excludes the caller and its ancestors, so `doctor` run inside a worktree never counts itself', () => {
+    const pids = stackPids(WT, 18508, { rows: STACK, cwds }, 302);
+    expect(pids).not.toContain(302);
+    expect(pids).toContain(200);
+  });
+
+  test('reports nothing for a stack that is genuinely down', () => {
+    expect(stackPids('/w/suna-idle', 19999, { rows: STACK, cwds }, 500)).toEqual([]);
+  });
+});

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -21,8 +21,9 @@ import {
   writeMarker, ensureDeps, checkDeps, supaWorkdir, slotDir, startTunnel, startStripeListen, WT_HOME, REGISTRY_PATH,
   startSupabaseDb, startSupabaseFullStack, hasKortixSchema, ensureRuntimeArtifacts, dbModeOf,
   ensurePrimarySupabase, primaryCredsFromStatus, SHARED_SUPABASE_PORTS,
+  killTree, stackRoots, stackPids, listenersOn, psTable, cwdTable,
   type Registry, type SlotEntry, type Ports, type Tunnel, type StripeListen,
-  type DbMode,
+  type DbMode, type KillResult,
 } from './lib';
 import { existsSync, rmSync } from 'node:fs';
 import * as clack from '@clack/prompts';
@@ -54,16 +55,60 @@ const link = (href: string, text: string) =>
 // can't see it — so the API would silently fall back to the single-model
 // passthrough. We only ever touch this worktree's own slot ports.
 async function freeSlotPorts(ports: Ports): Promise<void> {
-  let freed = 0;
+  const roots: number[] = [];
   for (const [label, port] of [['web', ports.web], ['api', ports.api], ['gateway', ports.gateway]] as const) {
-    const u = portInUse(port);
-    if (u.inUse && u.pid) {
-      sub(`freeing stale ${label} process on :${port} (pid ${u.pid})`);
-      sh(['bash', '-lc', `kill ${u.pid} 2>/dev/null || true`]);
-      freed++;
+    const pids = listenersOn(port);
+    if (pids.length) {
+      sub(`freeing stale ${label} process on :${port} (pid ${pids.join(', ')})`);
+      roots.push(...pids);
     }
   }
-  if (freed) await Bun.sleep(400);
+  if (!roots.length) return;
+  const res = await killTree(roots);
+  if (res.survived.length) warn(`could not free ${plural(res.survived.length, 'process', 'processes')} still holding this slot's ports (${res.survived.join(', ')})`);
+}
+
+const plural = (n: number, one: string, many: string) => `${n} ${n === 1 ? one : many}`;
+
+async function setStatus(name: string, status: SlotEntry['status']): Promise<void> {
+  await withLock(() => {
+    const r = loadRegistry();
+    if (r.slots[name]) { r.slots[name].status = status; saveRegistry(r); }
+  });
+}
+
+/**
+ * Tear down one worktree's whole stack and report what survived.
+ *
+ * Callers MUST gate the registry write on `survived` being empty. Recording
+ * "stopped" for a kill that did not happen is precisely what made `list` report
+ * stacks as stopped while 20 of their processes were still resident.
+ */
+/**
+ * A stack costs ~19 processes, and Next dev under Turbopack climbs to 1–3 GB and
+ * never gives it back, so a handful of forgotten stacks is enough to exhaust swap
+ * on a developer laptop. Warn before adding to the pile rather than letting the
+ * OOM killer deliver the news.
+ */
+const CROWDED_STACKS = 3;
+function warnOnStackPressure(current: string, reg: Registry): void {
+  const tables = { rows: psTable(), cwds: cwdTable() };
+  const live = Object.entries(reg.slots)
+    .filter(([n, e]) => n !== current && stackPids(e.path, e.ports.api, tables).length > 0)
+    .map(([n]) => n);
+  if (live.length < CROWDED_STACKS) return;
+  warn(`${live.length} other worktree stacks are already running (${live.join(', ')})`);
+  sub(`each holds ~19 processes and a few GB — free them with ${pc.cyan('pnpm worktree stop --all')}`);
+}
+
+async function stopStack(e: SlotEntry, opts: { quiet?: boolean } = {}): Promise<KillResult> {
+  const roots = stackRoots(e.path, e.ports);
+  const res = await killTree(roots);
+  if (!opts.quiet) {
+    if (!res.targeted.length) sub('no stack processes running');
+    else sub(`killed ${plural(res.targeted.length, 'process', 'processes')} ${pc.dim(`(${plural(roots.length, 'root', 'roots')} + descendants)`)}`);
+  }
+  return res;
 }
 
 // Gate on the gateway actually listening. The API proxies sandbox LLM traffic to
@@ -121,7 +166,7 @@ ${pc.bgCyan(pc.black(' pnpm worktree '))}  ${pc.dim('isolated multi-instance dev
 
   ${pc.cyan('pnpm worktree')}                 ${pc.dim('interactive menu')}
   ${pc.cyan('pnpm worktree create')}          ${pc.dim('guided wizard (or --name <n> --from <branch> [--db] [--no-tunnel])')}
-  ${pc.cyan('start')} ${pc.dim('<n> [--stripe] [--no-tunnel]')}   ${pc.cyan('stop')} ${pc.dim('<n>')}   ${pc.cyan('nuke')} ${pc.dim('<n> [--force]')}
+  ${pc.cyan('start')} ${pc.dim('<n> [--stripe] [--no-tunnel]')}   ${pc.cyan('stop')} ${pc.dim('<n> | --all')}   ${pc.cyan('nuke')} ${pc.dim('<n> [--force]')}
   ${pc.cyan('pr')} ${pc.dim('<n> [--title … --base main --draft --web]')}
   ${pc.cyan('list')}        ${pc.cyan('status')} ${pc.dim('[n]')}   ${pc.cyan('doctor')} ${pc.dim('[--yes]')}
 
@@ -392,6 +437,7 @@ async function cmdStart(a: Args) {
   if (!sh(['docker', 'info']).ok) die('Docker daemon not running — start Docker and retry');
   const e = entry!;
   const dbMode = dbModeOf(e);
+  warnOnStackPressure(name, reg);
 
   // Heal a stale ports cache. The registry stores a denormalized copy of
   // computePorts(slot), so a worktree created before a port was added to BASE
@@ -470,17 +516,28 @@ async function cmdStart(a: Args) {
   const gateway = Bun.spawn(['pnpm', '--filter', GATEWAY_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...gatewayLaunchEnv(e.ports) }, stdout: 'inherit', stderr: 'inherit' });
   const web = Bun.spawn(['pnpm', '--filter', WEB_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...webLaunchEnv(e.ports, creds, { billing: !!stripe }) }, stdout: 'inherit', stderr: 'inherit' });
   void waitForGateway(e.ports.gateway, gateway);
-  const killListeners = (sig: string) => { for (const port of [e.ports.web, e.ports.api, e.ports.gateway]) { const u = portInUse(port); if (u.inUse && u.pid) sh(['bash', '-lc', `kill ${sig} ${u.pid} 2>/dev/null || true`]); } };
   let stopping = false;
   const shutdown = async () => {
     if (stopping) return; stopping = true;
     console.log(`\n${pc.yellow('▸')} stopping…`);
+    // Snapshot the process table BEFORE signalling anything: the moment a parent
+    // dies its children reparent to launchd and the tree can no longer be
+    // reconstructed from ppid. Killing the port holder alone is what used to leak
+    // the ~15 Next workers behind it.
+    const rows = psTable();
+    const spawned = [api.pid, gateway.pid, web.pid, tunnel?.proc.pid, stripe?.proc.pid]
+      .filter((p): p is number => typeof p === 'number');
+    const roots = [...new Set([...spawned, ...stackRoots(e.path, e.ports, { rows })])];
     try { api.kill(); } catch {} try { gateway.kill(); } catch {} try { web.kill(); } catch {} try { tunnel?.proc.kill(); } catch {} try { stripe?.proc.kill(); } catch {}
-    killListeners('');
-    await Promise.race([Promise.all([api.exited, gateway.exited, web.exited]), Bun.sleep(6000)]);
-    killListeners('-9');
-    await withLock(() => { const r = loadRegistry(); if (r.slots[name]) { r.slots[name].status = 'stopped'; saveRegistry(r); } });
-    ok('stopped.');
+    await Promise.race([Promise.all([api.exited, gateway.exited, web.exited]), Bun.sleep(4000)]);
+    const res = await killTree(roots, { rows });
+    if (res.survived.length) {
+      await setStatus(name, 'running');
+      warn(`${plural(res.survived.length, 'process', 'processes')} survived SIGKILL (${res.survived.join(', ')}) — "${name}" left marked running`);
+    } else {
+      await setStatus(name, 'stopped');
+      ok(`stopped — ${plural(res.targeted.length, 'process', 'processes')} reaped.`);
+    }
     process.exit(0);
   };
   process.on('SIGINT', () => { void shutdown(); });
@@ -490,16 +547,48 @@ async function cmdStart(a: Args) {
 }
 
 async function cmdStop(a: Args) {
+  if (a.flags.all) return cmdStopAll();
   const name = need(a.name);
   const reg = loadRegistry();
   const e = reg.slots[name];
   if (!e) die(`unknown worktree "${name}"`);
   step(`Stopping "${name}"`);
-  for (const port of [e!.ports.web, e!.ports.api, e!.ports.gateway]) { const u = portInUse(port); if (u.inUse && u.pid) sh(['bash', '-lc', `kill ${u.pid} 2>/dev/null || true`]); }
+  const res = await stopStack(e!);
   if (dbModeOf(e!) === 'isolated') sh(['supabase', '--workdir', supaWorkdir(name), 'stop']);
   else sub('shared primary Supabase left running');
-  await withLock(() => { const r = loadRegistry(); if (r.slots[name]) { r.slots[name].status = 'stopped'; saveRegistry(r); } });
+  if (res.survived.length) {
+    await setStatus(name, 'running');
+    warn(`${plural(res.survived.length, 'process', 'processes')} survived SIGKILL (${res.survived.join(', ')}) — "${name}" left marked running.`);
+    sub(`inspect with ${pc.cyan(`ps -p ${res.survived.join(',')}`)}`);
+    return;
+  }
+  await setStatus(name, 'stopped');
   ok(`stopped (data preserved). Restart with ${pc.cyan('pnpm worktree start ' + name)}.`);
+}
+
+/**
+ * Stop every worktree in one pass — the end-of-day sweep, and the recovery path
+ * when stacks have been orphaned by an OOM kill (their supervisor is gone, so
+ * there is no Ctrl+C left to press and nothing else will ever reclaim them).
+ */
+async function cmdStopAll() {
+  const reg = loadRegistry();
+  const names = Object.keys(reg.slots);
+  if (!names.length) { console.log(`\n  ${pc.dim('No worktrees.')}`); return; }
+  step(`Stopping ${plural(names.length, 'worktree', 'worktrees')}`);
+  let reaped = 0;
+  const stubborn: string[] = [];
+  for (const n of names) {
+    const e = reg.slots[n];
+    const res = await stopStack(e, { quiet: true });
+    if (res.targeted.length) console.log(`  ${res.survived.length ? pc.red('✗') : pc.green('✓')} ${n} ${pc.dim(`${plural(res.targeted.length, 'process', 'processes')}`)}`);
+    reaped += res.targeted.length - res.survived.length;
+    if (res.survived.length) stubborn.push(n);
+    else if (res.targeted.length) await setStatus(n, 'stopped');
+  }
+  if (stubborn.length) warn(`could not fully stop: ${stubborn.join(', ')}`);
+  ok(`reaped ${plural(reaped, 'process', 'processes')} across ${plural(names.length, 'worktree', 'worktrees')}.`);
+  sub('isolated-DB Supabase containers are left running — stop one with `pnpm worktree stop <n>`');
 }
 
 async function cmdNuke(a: Args) {
@@ -510,7 +599,10 @@ async function cmdNuke(a: Args) {
   const pid = e!.projectId;
   const dbMode = dbModeOf(e!);
   step(`Nuking "${name}" ${pc.dim(dbMode === 'isolated' ? '(project ' + pid + ')' : '(shared DB mode)')}`);
-  for (const port of [e!.ports.web, e!.ports.api, e!.ports.gateway]) { const u = portInUse(port); if (u.inUse && u.pid) sh(['bash', '-lc', `kill ${u.pid} 2>/dev/null || true`]); }
+  const stopped = await stopStack(e!);
+  // A process whose cwd is still inside the checkout keeps the directory busy, so
+  // an unverified kill here surfaces later as a confusing `git worktree remove` failure.
+  if (stopped.survived.length) warn(`${plural(stopped.survived.length, 'process', 'processes')} survived (${stopped.survived.join(', ')}) — removal may fail`);
   if (dbMode === 'isolated') {
     await spin('Stopping Supabase containers', ['supabase', '--workdir', supaWorkdir(name), 'stop', '--no-backup']);
     await spin('Removing Docker containers', ['bash', '-lc', `docker rm -f $(docker ps -aq --filter "name=_${pid}$") 2>/dev/null || true`]);
@@ -575,6 +667,7 @@ function cmdStatus(a: Args) {
   const reg = loadRegistry();
   const names = a.name ? [sanitizeName(a.name)] : Object.keys(reg.slots);
   if (!names.length) { console.log(`\n  ${pc.dim('No worktrees.')}`); return; }
+  const procTables = { rows: psTable(), cwds: cwdTable() };
   for (const n of names) {
     const e = reg.slots[n];
     if (!e) { warn(`${n}: unknown`); continue; }
@@ -582,7 +675,9 @@ function cmdStatus(a: Args) {
     const sb = dbMode === 'isolated'
       ? sh(['supabase', '--workdir', supaWorkdir(n), 'status']).ok
       : portInUse(SHARED_SUPABASE_PORTS.sbApi).inUse;
+    const procs = stackPids(e.path, e.ports.api, procTables).length;
     console.log(`\n${pc.bold(n)}  ${pc.dim(`(slot ${e.slot} · ${e.status} · ${dbMode})`)}  ${pc.dim(e.path)}`);
+    console.log(`  procs  ${dot(procs > 0)} ${procs ? plural(procs, 'process', 'processes') : pc.dim('none')}`);
     console.log(`  web    ${dot(portInUse(e.ports.web).inUse)} :${e.ports.web}    api ${dot(portInUse(e.ports.api).inUse)} :${e.ports.api}`);
     if (dbMode === 'isolated') console.log(`  supa   ${dot(sb)} db :${e.ports.sbDb}  studio :${e.ports.sbStudio}  inbucket :${e.ports.sbInbucket}`);
     else console.log(`  supa   ${dot(sb)} shared db :${SHARED_SUPABASE_PORTS.sbDb}  studio :${SHARED_SUPABASE_PORTS.sbStudio}  inbucket :${SHARED_SUPABASE_PORTS.sbInbucket}`);
@@ -607,6 +702,33 @@ async function cmdDoctor(a: Args) {
       : '';
     console.log(`  ${issues.length ? pc.red('✗') : pc.green('✓')} ${n} ${pc.dim('(' + dbMode + ')')}${issues.length ? ' ' + pc.red(issues.join('; ')) : ''}${orphan ? pc.dim(' (containers present)') : ''}`);
   }
+
+  // Memory pressure is the failure mode that actually bites here, and the registry
+  // cannot be trusted to report it: a stack whose supervisor was OOM-killed stays
+  // recorded however it was last written while its processes run on forever. Count
+  // what is actually alive.
+  step('Stack processes');
+  const rows = psTable();
+  const cwds = cwdTable();
+  const drift: string[] = [];
+  let live = 0;
+  for (const [n, e] of Object.entries(reg.slots)) {
+    const pids = stackPids(e.path, e.ports.api, { rows, cwds });
+    if (!pids.length) {
+      if (e.status === 'running') drift.push(`${n}: recorded running, nothing alive`);
+      continue;
+    }
+    live += pids.length;
+    if (e.status !== 'running') drift.push(`${n}: recorded ${e.status}, ${plural(pids.length, 'process', 'processes')} alive`);
+    console.log(`  ${pc.yellow('●')} ${n} ${pc.dim(`${plural(pids.length, 'process', 'processes')} · recorded ${e.status}`)}`);
+  }
+  if (!live) ok('no worktree stacks running');
+  else {
+    warn(`${plural(live, 'process', 'processes')} held by worktree stacks`);
+    sub(`free them all with ${pc.cyan('pnpm worktree stop --all')}`);
+  }
+  for (const d of drift) sub(pc.yellow('drift: ') + d);
+
   console.log(`\n  ${pc.dim('registry: ' + REGISTRY_PATH)}`);
 }
 

--- a/scripts/worktree/lib.ts
+++ b/scripts/worktree/lib.ts
@@ -19,6 +19,7 @@
  */
 export * from './lib/ports';
 export * from './lib/exec';
+export * from './lib/procs';
 export * from './lib/registry';
 export * from './lib/git';
 export * from './lib/supabase';

--- a/scripts/worktree/lib/procs.ts
+++ b/scripts/worktree/lib/procs.ts
@@ -1,0 +1,310 @@
+/**
+ * Process-tree reaping for worktree stacks.
+ *
+ * A running stack is not three processes, it is three TREES. `pnpm --filter … dev`
+ * forks a package-manager shim, which forks a dotenvx wrapper, which forks the dev
+ * server, which forks a worker pool — Next dev alone leaves ~15 (`webpack-loaders`,
+ * `postcss`, an esbuild service). Only the leaf holds the port.
+ *
+ * Stopping by "kill whatever listens on the port" therefore reclaimed 3 of ~19
+ * processes and silently leaked the rest. Leaked workers reparent to launchd, keep
+ * their (1–3 GB, Turbopack never shrinks) heap, lose their terminal, and can no
+ * longer be reached by Ctrl+C or by `stop` — so they live until reboot. A few of
+ * those and the machine dies of swap exhaustion; the OOM kill then takes the
+ * supervisor with it, orphaning yet another stack. That is the loop this closes.
+ *
+ * Design notes:
+ * - Roots are discovered from OBSERVABLE state only (cwd, port listeners, command
+ *   line). We deliberately do NOT persist pids at start: a stale pid file plus pid
+ *   reuse means signalling a stranger, and the registry has already proven it
+ *   drifts from reality.
+ * - Every kill is VERIFIED. Callers use the survivor list to decide what to record,
+ *   because a status written on an unverified kill is what made `list` lie.
+ * - `process.kill` is used directly rather than shelling out to kill(1), so a
+ *   failure surfaces as an exception instead of a swallowed non-zero exit.
+ */
+import { sh } from './exec';
+
+export interface ProcRow {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+export interface KillResult {
+  /** Every pid we signalled, roots and descendants alike. */
+  targeted: number[];
+  /** Targets still alive after SIGTERM → SIGKILL. Non-empty means DO NOT record "stopped". */
+  survived: number[];
+}
+
+/** Parse `ps -Ao pid=,ppid=,command=`. Tolerates leading pad and spaces in the command. */
+export function parsePsTable(stdout: string): ProcRow[] {
+  const rows: ProcRow[] = [];
+  for (const line of stdout.split('\n')) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/);
+    if (m) rows.push({ pid: Number(m[1]), ppid: Number(m[2]), command: m[3].trim() });
+  }
+  return rows;
+}
+
+/** Parse `lsof -a -d cwd -Fpn` — alternating `p<pid>` / `n<path>` records. */
+export function parseLsofCwd(stdout: string): Array<{ pid: number; cwd: string }> {
+  const out: Array<{ pid: number; cwd: string }> = [];
+  let pid = 0;
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('p')) pid = Number(line.slice(1)) || 0;
+    else if (line.startsWith('n') && pid) out.push({ pid, cwd: line.slice(1) });
+  }
+  return out;
+}
+
+/**
+ * Path containment that respects segment boundaries — `…/suna-web` must never be
+ * treated as living inside `…/suna-w`, or one worktree's stop would reap another's.
+ */
+export function isUnder(path: string, dir: string): boolean {
+  const d = dir.replace(/\/+$/, '');
+  return path === d || path.startsWith(`${d}/`);
+}
+
+/** Roots plus every descendant, breadth-first. Cycle-safe (a bad ps snapshot can self-parent). */
+export function expandTree(roots: number[], rows: ProcRow[]): number[] {
+  const children = new Map<number, number[]>();
+  for (const r of rows) {
+    if (r.ppid === r.pid) continue;
+    const list = children.get(r.ppid);
+    if (list) list.push(r.pid);
+    else children.set(r.ppid, [r.pid]);
+  }
+  const seen = new Set<number>();
+  const queue = [...roots];
+  for (let i = 0; i < queue.length; i++) {
+    const pid = queue[i];
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    for (const child of children.get(pid) ?? []) if (!seen.has(child)) queue.push(child);
+  }
+  return [...seen];
+}
+
+/** The pid's parent chain up to init. Used to keep a reaper from killing its own shell. */
+export function ancestorsOf(pid: number, rows: ProcRow[]): number[] {
+  const byPid = new Map(rows.map((r) => [r.pid, r]));
+  const out: number[] = [];
+  let cur = byPid.get(pid);
+  const seen = new Set<number>([pid]);
+  while (cur && cur.ppid > 1 && !seen.has(cur.ppid)) {
+    out.push(cur.ppid);
+    seen.add(cur.ppid);
+    cur = byPid.get(cur.ppid);
+  }
+  return out;
+}
+
+/**
+ * Expand roots to full trees, then remove everything we must not signal: pid 0/1,
+ * ourselves, and our own ancestors. The self-exclusion is load-bearing — `stop` run
+ * from a shell whose cwd is inside the worktree matches its own cwd probe, and
+ * without this the reaper would kill the terminal it was typed into.
+ */
+export function planKill(opts: { roots: number[]; rows: ProcRow[]; selfPid: number }): number[] {
+  const { roots, rows, selfPid } = opts;
+  const protectedPids = new Set<number>([0, 1, selfPid, ...ancestorsOf(selfPid, rows)]);
+  // Prune protected pids from the SEEDS, not just the result. The reaper's own cwd
+  // is inside the worktree and its argv[0] is `bun`, so discovery legitimately
+  // returns it as a root; expanding through it would then sweep up the very `ps`
+  // child that produced this table. Seeds handed in explicitly (the start
+  // supervisor passing its own spawned servers) are unaffected — they are not the
+  // reaper itself.
+  const seeds = roots.filter((pid) => !protectedPids.has(pid));
+  return expandTree(seeds, rows).filter((pid) => pid > 1 && !protectedPids.has(pid));
+}
+
+/**
+ * Command shapes that belong to a dev stack.
+ *
+ * The cwd probe on its own is too broad: a shell pipeline, an editor, `git`, or a
+ * coding agent working in the worktree all share its working directory. An early
+ * version of this reaper took cwd as sufficient and killed the `grep` on the other
+ * end of its own output pipe — the stop ran, but silently, because its reader was
+ * dead. So a cwd match only makes something a ROOT if it also looks like the
+ * toolchain; anything else dies only by being a descendant of something that does.
+ */
+const DEV_BINARIES = new Set([
+  'node',
+  'bun',
+  'pnpm',
+  'npm',
+  'yarn',
+  'next',
+  'next-server',
+  'esbuild',
+  'dotenvx',
+]);
+const SIDECAR_BINARIES = new Set(['cloudflared', 'stripe']);
+
+/**
+ * The binary being executed, ignoring its arguments.
+ *
+ * Matching anywhere in the command line is not good enough: `zsh -c '… node foo.js'`
+ * mentions node, and treating that as a stack root would reap the user's shell. Only
+ * argv[0] decides — every real stack process runs the toolchain binary directly.
+ */
+export function executableOf(command: string): string {
+  const argv0 = command.trim().split(/\s+/)[0] ?? '';
+  return argv0.slice(argv0.lastIndexOf('/') + 1);
+}
+
+export function isDevStackProcess(command: string): boolean {
+  return DEV_BINARIES.has(executableOf(command));
+}
+
+/** pids whose command line targets `http://localhost:<port>` — the tunnel and stripe forwarder. */
+export function sidecarPids(rows: ProcRow[], apiPort: number): number[] {
+  const target = new RegExp(`localhost:${apiPort}(?![0-9])`);
+  return rows
+    .filter((r) => SIDECAR_BINARIES.has(executableOf(r.command)) && target.test(r.command))
+    .map((r) => r.pid);
+}
+
+export interface CwdRow {
+  pid: number;
+  cwd: string;
+}
+
+export function psTable(): ProcRow[] {
+  return parsePsTable(sh(['ps', '-Ao', 'pid=,ppid=,command=']).stdout);
+}
+
+/**
+ * Working directory of every process on the box, in one shot. Callers that scan
+ * many worktrees fetch this once and pass it down — a per-worktree lsof would be
+ * ~55 full scans on this machine.
+ */
+export function cwdTable(): CwdRow[] {
+  return parseLsofCwd(sh(['bash', '-lc', 'lsof -a -d cwd -Fpn 2>/dev/null || true']).stdout);
+}
+
+/** Every process whose working directory is inside `dir`. */
+export function cwdOwners(dir: string, rows?: CwdRow[]): number[] {
+  return (rows ?? cwdTable()).filter((r) => isUnder(r.cwd, dir)).map((r) => r.pid);
+}
+
+/** All pids listening on a port — `portInUse` returns only the first, which hid siblings. */
+export function listenersOn(port: number): number[] {
+  const out = sh([
+    'bash',
+    '-lc',
+    `lsof -nP -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`,
+  ]).stdout;
+  return out
+    .split('\n')
+    .map((s) => Number(s.trim()))
+    .filter((n) => n > 1);
+}
+
+export function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means it exists but belongs to someone else; only ESRCH proves it is gone.
+    return (e as NodeJS.ErrnoException)?.code === 'EPERM';
+  }
+}
+
+/**
+ * Every process belonging to a worktree's stack, found three independent ways
+ * because no single probe sees all of it:
+ *  - cwd inside the worktree → the dev servers and their whole worker pool;
+ *  - listening on a slot port → anything that outlived its parent and still binds;
+ *  - command line pointing at the slot's API port → cloudflared / `stripe listen`,
+ *    which run from the CLI's own cwd and so are invisible to the cwd probe.
+ */
+export function stackRoots(
+  worktreePath: string,
+  ports: { web: number; api: number; gateway: number },
+  tables: { rows?: ProcRow[]; cwds?: CwdRow[] } = {},
+): number[] {
+  const rows = tables.rows ?? psTable();
+  const roots = new Set<number>([
+    ...devCwdOwners(worktreePath, rows, tables.cwds),
+    ...listenersOn(ports.web),
+    ...listenersOn(ports.api),
+    ...listenersOn(ports.gateway),
+    ...sidecarPids(rows, ports.api),
+  ]);
+  return [...roots];
+}
+
+/** cwd owners that also look like the dev toolchain — see DEV_PROCESS. */
+function devCwdOwners(worktreePath: string, rows: ProcRow[], cwds?: CwdRow[]): number[] {
+  const commands = new Map(rows.map((r) => [r.pid, r.command]));
+  return cwdOwners(worktreePath, cwds).filter((pid) => isDevStackProcess(commands.get(pid) ?? ''));
+}
+
+/**
+ * Cheap liveness probe for reporting across every registered worktree: cwd and
+ * sidecars only, from tables the caller already fetched. Skips the per-port lsof
+ * that `stackRoots` does, which would be 3 scans per worktree.
+ *
+ * Reports the same set `stop` would kill (roots plus descendants, minus the caller
+ * and its ancestors) so the count reflects the real footprint — counting roots
+ * alone understated a stack by ~60%, which is the number that matters when the
+ * question is "what is eating my memory".
+ */
+export function stackPids(
+  worktreePath: string,
+  apiPort: number,
+  tables: { rows: ProcRow[]; cwds: CwdRow[] },
+  selfPid = process.pid,
+): number[] {
+  const roots = [
+    ...devCwdOwners(worktreePath, tables.rows, tables.cwds),
+    ...sidecarPids(tables.rows, apiPort),
+  ];
+  return planKill({ roots, rows: tables.rows, selfPid });
+}
+
+function signalAll(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already gone, or not ours — the verification pass is what decides.
+    }
+  }
+}
+
+async function waitGone(pids: number[], ms: number): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (!pids.some(alive)) return;
+    await Bun.sleep(100);
+  }
+}
+
+/**
+ * Signal a whole tree and prove it died: SIGTERM, wait out the grace period, then
+ * SIGKILL whatever ignored it. Survivors are returned rather than thrown so the
+ * caller can refuse to record a stop that did not happen.
+ */
+export async function killTree(
+  roots: number[],
+  opts: { rows?: ProcRow[]; graceMs?: number } = {},
+): Promise<KillResult> {
+  const rows = opts.rows ?? psTable();
+  const targeted = planKill({ roots, rows, selfPid: process.pid });
+  if (!targeted.length) return { targeted: [], survived: [] };
+
+  signalAll(targeted, 'SIGTERM');
+  await waitGone(targeted, opts.graceMs ?? 3000);
+
+  const stubborn = targeted.filter(alive);
+  if (stubborn.length) {
+    signalAll(stubborn, 'SIGKILL');
+    await waitGone(stubborn, 1500);
+  }
+  return { targeted, survived: targeted.filter(alive) };
+}


### PR DESCRIPTION
## Candidate

- Source: `main`
- Source SHA: `f211a31d1f5c2f7d1870c8224cf153f7536269fb`
- Target: `staging`

## Included changes

- Return `404` when `readRepoFile` cannot find a Git path.
- Stop complete worktree process trees during shutdown.
- Include the current dev GitOps pin so both branches reach exact equality.

## Required verification

- Complete all pull request checks.
- Build staging artifacts.
- Apply staging database migrations.
- Deploy EKS, ECS API, ECS gateway, Cloudflare routing, and Vercel.
- Verify live staging SHA and health.
- Confirm `main` and `staging` have identical remote SHAs before release.