### PR TITLE
chore(release): promote optimized ke2e gate to staging

### DIFF
--- a/tests/api/README.md
+++ b/tests/api/README.md
@@ -34,11 +34,19 @@ bun bin/ke2e.ts run --grep logout
 
 # point at another environment
 KE2E_API_URL=https://dev-api.kortix.com/v1 bun bin/ke2e.ts run --domain auth
+
+# override the default 8 API workers and 4 sandbox workers
+bun bin/ke2e.ts run --api-workers 12 --sandbox-workers 4
+
+# force one shared worker pool instead of split lanes
+bun bin/ke2e.ts run --workers 1
 ```
 
 `KE2E_API_URL` selects the target (default `http://localhost:8008/v1`). See
 `tests/README.md` and `tests/src/core/env.ts` for the full env matrix
 (`KE2E_OWNER_*`, `KE2E_ADMIN_TOKEN`, capabilities, destructive-run guards).
+`KE2E_API_WORKERS` and `KE2E_SANDBOX_WORKERS` set the split-lane defaults.
+An explicit `--workers` value disables split lanes and caps the complete run.
 
 ### Adding a flow
 

--- a/tests/api/README.md
+++ b/tests/api/README.md
@@ -47,6 +47,7 @@ bun bin/ke2e.ts run --workers 1
 (`KE2E_OWNER_*`, `KE2E_ADMIN_TOKEN`, capabilities, destructive-run guards).
 `KE2E_API_WORKERS` and `KE2E_SANDBOX_WORKERS` set the split-lane defaults.
 An explicit `--workers` value disables split lanes and caps the complete run.
+`KE2E_TEARDOWN_WORKERS` controls user cleanup concurrency. Its default is `4`.
 
 ### Adding a flow
 

--- a/tests/bin/ke2e.ts
+++ b/tests/bin/ke2e.ts
@@ -2,7 +2,8 @@
 /**
  * ke2e — Kortix end-to-end REST API test runner.
  *
- *   ke2e run [--domain d] [--id ID] [--tag t] [--grep s] [--workers N] [--smoke]
+ *   ke2e run [--domain d] [--id ID] [--tag t] [--grep s] [--workers N]
+ *            [--api-workers N] [--sandbox-workers N] [--smoke]
  *   ke2e list
  *   ke2e coverage
  *   ke2e gc [--older-than 2h] [--dry-run]
@@ -129,6 +130,8 @@ async function main() {
     tags: list(flags.tag),
     grep: typeof flags.grep === "string" ? flags.grep : undefined,
     workers: flags.workers ? Number(flags.workers) : undefined,
+    apiWorkers: flags["api-workers"] ? Number(flags["api-workers"]) : undefined,
+    sandboxWorkers: flags["sandbox-workers"] ? Number(flags["sandbox-workers"]) : undefined,
     smoke: !!flags.smoke,
     runId,
     gitSha,

--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -131,6 +131,13 @@ export class Res {
   /** Assert the status code (exact or set membership). */
   status(code: number | number[]): this {
     const codes = Array.isArray(code) ? code : [code];
+    if (!codes.includes(this.statusCode) && isKe2eTransientGatewayResponse(this)) {
+      const error = new Error(
+        `transient gateway status ${this.statusCode}; expected [${codes.join(', ')}]`,
+      );
+      (error as any).ke2eRetryable = true;
+      throw error;
+    }
     assert({
       kind: 'status',
       description: `status in [${codes.join(', ')}]`,

--- a/tests/src/core/concurrency.ts
+++ b/tests/src/core/concurrency.ts
@@ -1,0 +1,20 @@
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const requestedWorkers = Number.isFinite(concurrency)
+    ? Math.max(1, Math.trunc(concurrency))
+    : 1;
+  const workerCount = Math.min(requestedWorkers, items.length || 1);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/tests/src/core/lanes.ts
+++ b/tests/src/core/lanes.ts
@@ -1,0 +1,14 @@
+import type { RegisteredFlow } from './flow';
+
+export function partitionParallelFlows(flows: RegisteredFlow[]): {
+  apiLane: RegisteredFlow[];
+  sandboxLane: RegisteredFlow[];
+} {
+  const apiLane: RegisteredFlow[] = [];
+  const sandboxLane: RegisteredFlow[] = [];
+  for (const flow of flows) {
+    if (flow.meta.requires?.includes('daytona')) sandboxLane.push(flow);
+    else apiLane.push(flow);
+  }
+  return { apiLane, sandboxLane };
+}

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -12,6 +12,7 @@ import { allFlows, clearRegistry, type RegisteredFlow } from "./flow";
 import { loadEnv, type Env } from "./env";
 import { log } from "./log";
 import { partitionParallelFlows } from "./lanes";
+import { mapWithConcurrency } from "./concurrency";
 import {
   summarize,
   type Assertion,
@@ -208,19 +209,6 @@ function withTimeout<T>(p: Promise<T>, ms: number, id: string): Promise<T> {
   });
 }
 
-async function pool<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let i = 0;
-  const workers = Array.from({ length: Math.min(concurrency, items.length || 1) }, async () => {
-    while (i < items.length) {
-      const idx = i++;
-      results[idx] = await fn(items[idx]);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
-
 function positiveWorkerCount(value: number | undefined, fallback: number): number {
   if (value === undefined || !Number.isFinite(value)) return fallback;
   return Math.max(1, Math.trunc(value));
@@ -245,7 +233,11 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
     if (opts.workers !== undefined) {
       const workers = positiveWorkerCount(opts.workers, 4);
       log.info(`lanes: ${parallelLane.length} parallel flows · ${workers} explicit workers`);
-      out.push(...(await pool(parallelLane, workers, (f) => runOneFlow(f, env, world, routesHit))));
+      out.push(
+        ...(await mapWithConcurrency(parallelLane, workers, (f) =>
+          runOneFlow(f, env, world, routesHit),
+        )),
+      );
     } else {
       const { apiLane, sandboxLane } = partitionParallelFlows(parallelLane);
       const apiWorkers = positiveWorkerCount(
@@ -261,8 +253,10 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
           `${sandboxLane.length} sandbox flows × ${sandboxWorkers} workers`,
       );
       const [apiResults, sandboxResults] = await Promise.all([
-        pool(apiLane, apiWorkers, (f) => runOneFlow(f, env, world, routesHit)),
-        pool(sandboxLane, sandboxWorkers, (f) => runOneFlow(f, env, world, routesHit)),
+        mapWithConcurrency(apiLane, apiWorkers, (f) => runOneFlow(f, env, world, routesHit)),
+        mapWithConcurrency(sandboxLane, sandboxWorkers, (f) =>
+          runOneFlow(f, env, world, routesHit),
+        ),
       ]);
       out.push(...apiResults, ...sandboxResults);
     }

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -10,6 +10,8 @@ import { withRecorder, type StepRecorder } from "./context";
 import { AssertionError } from "./expect";
 import { allFlows, clearRegistry, type RegisteredFlow } from "./flow";
 import { loadEnv, type Env } from "./env";
+import { log } from "./log";
+import { partitionParallelFlows } from "./lanes";
 import {
   summarize,
   type Assertion,
@@ -28,6 +30,10 @@ export interface RunOptions {
   tags?: string[];
   grep?: string;
   workers?: number;
+  /** API-only lane concurrency. Used only when workers is not set. */
+  apiWorkers?: number;
+  /** Live sandbox lane concurrency. Used only when workers is not set. */
+  sandboxWorkers?: number;
   /** Read-mostly subset for prod smoke. */
   smoke?: boolean;
   runId: string;
@@ -83,7 +89,9 @@ async function runOneFlow(
 ): Promise<FlowResult> {
   const steps: StepResult[] = [];
   const flowStart = performance.now();
-  const maxAttempts = f.meta.retry?.attempts ?? 1;
+  // Every flow gets one clean retry for errors explicitly marked as
+  // infrastructure failures. Assertion failures never retry.
+  const maxAttempts = f.meta.retry?.attempts ?? 2;
 
   // Capability gating → skip with reason.
   const missing = (f.meta.requires ?? []).filter((cap) => !env.capabilities[cap]);
@@ -136,6 +144,7 @@ async function runOneFlow(
       // Never retry assertion failures — only infra signals.
       const retryable = !(err instanceof AssertionError) && (err as any)?.ke2eRetryable === true;
       if (!retryable || attempt >= maxAttempts) break;
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
     }
   }
   const reason = (lastError as Error)?.message ?? String(lastError);
@@ -212,6 +221,11 @@ async function pool<T, R>(items: T[], concurrency: number, fn: (item: T) => Prom
   return results;
 }
 
+function positiveWorkerCount(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.trunc(value));
+}
+
 export async function runSuite(opts: RunOptions): Promise<RunResult> {
   const env = loadEnv();
   await discoverFlows();
@@ -228,7 +242,30 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
     const globalLane = flows.filter((f) => f.meta.global);
 
     const out: FlowResult[] = [];
-    out.push(...(await pool(parallelLane, opts.workers ?? 4, (f) => runOneFlow(f, env, world, routesHit))));
+    if (opts.workers !== undefined) {
+      const workers = positiveWorkerCount(opts.workers, 4);
+      log.info(`lanes: ${parallelLane.length} parallel flows · ${workers} explicit workers`);
+      out.push(...(await pool(parallelLane, workers, (f) => runOneFlow(f, env, world, routesHit))));
+    } else {
+      const { apiLane, sandboxLane } = partitionParallelFlows(parallelLane);
+      const apiWorkers = positiveWorkerCount(
+        opts.apiWorkers ?? Number(process.env.KE2E_API_WORKERS),
+        8,
+      );
+      const sandboxWorkers = positiveWorkerCount(
+        opts.sandboxWorkers ?? Number(process.env.KE2E_SANDBOX_WORKERS),
+        4,
+      );
+      log.info(
+        `lanes: ${apiLane.length} API flows × ${apiWorkers} workers · ` +
+          `${sandboxLane.length} sandbox flows × ${sandboxWorkers} workers`,
+      );
+      const [apiResults, sandboxResults] = await Promise.all([
+        pool(apiLane, apiWorkers, (f) => runOneFlow(f, env, world, routesHit)),
+        pool(sandboxLane, sandboxWorkers, (f) => runOneFlow(f, env, world, routesHit)),
+      ]);
+      out.push(...apiResults, ...sandboxResults);
+    }
     for (const f of serialLane) out.push(await runOneFlow(f, env, world, routesHit));
     for (const f of globalLane) out.push(await runOneFlow(f, env, world, routesHit));
 

--- a/tests/src/core/types.ts
+++ b/tests/src/core/types.ts
@@ -58,20 +58,25 @@ export interface TeamFixture {
   addMember(role: 'admin' | 'member'): Promise<Principal>;
   /** Grant a project role to an account member (PUT access). */
   grantProjectRole(projectId: string, userId: string, role: ProjectRole): Promise<void>;
-  /** Provision a project owned by this team account. */
-  project(opts?: { name?: string; seed?: boolean }): Promise<CreatedProject>;
+  /** Create a project owned by this team account. */
+  project(opts?: { name?: string; seed?: boolean; managedGit?: boolean }): Promise<CreatedProject>;
 }
 
 /** Fixture sugar bound to the current run (auto-tracked for teardown). */
 export interface Fixtures {
   /**
    * Create a fresh run-scoped project (default: OWNER's personal account).
-   * `seed: true` seeds the starter (initial commit on the default branch) so a
-   * sandbox can materialize the repo — REQUIRED for any flow that boots a
-   * session/sandbox. Unseeded projects (the default) are an empty repo, fine for
-   * metadata/boundary flows and much cheaper.
+   * The default fixture creates only database state. It does not create an
+   * upstream Git repository. Use `managedGit: true` when a flow exercises Git.
+   * `seed: true` implies managed Git and seeds the starter so a sandbox can
+   * materialize the repository.
    */
-  project(opts?: { name?: string; accountId?: string; seed?: boolean }): Promise<CreatedProject>;
+  project(opts?: {
+    name?: string;
+    accountId?: string;
+    seed?: boolean;
+    managedGit?: boolean;
+  }): Promise<CreatedProject>;
   /**
    * A single shared, READ-ONLY project provisioned once per run and reused — use
    * this in flows that only READ a project (never mutate its manifest/name/state),

--- a/tests/src/core/types.ts
+++ b/tests/src/core/types.ts
@@ -84,6 +84,11 @@ export interface Fixtures {
    * secondary rate limit). Mutating flows must use project() for isolation.
    */
   sharedProject(): Promise<CreatedProject>;
+  /**
+   * A single seeded project for flows that create isolated sessions but do not
+   * mutate the project's base branch or project-wide Git configuration.
+   */
+  sharedSeededProject(): Promise<CreatedProject>;
   /** Create a session in a project (provisions a real sandbox). */
   session(project: CreatedProject, opts?: { prompt?: string }): Promise<CreatedSession>;
   /** Mint a fresh run-scoped account-scoped PAT. */

--- a/tests/src/fixtures/database-project.ts
+++ b/tests/src/fixtures/database-project.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'node:crypto';
+import type { Env } from '../core/env';
+import type { CreatedProject } from '../core/types';
+
+interface ProjectDb {
+  query(text: string, values?: unknown[]): Promise<unknown>;
+  end(): Promise<void>;
+}
+
+export type OpenProjectDb = (databaseUrl: string) => Promise<ProjectDb>;
+
+async function openProjectDb(databaseUrl: string): Promise<ProjectDb> {
+  const local = databaseUrl.includes('localhost') || databaseUrl.includes('127.0.0.1');
+  const { Client } = await import('pg');
+  const client = new Client({
+    connectionString: databaseUrl,
+    ssl: local ? false : { rejectUnauthorized: false },
+  });
+  await client.connect();
+  return client;
+}
+
+function assertDatabaseFixtureAllowed(env: Env, action: string): string {
+  if (env.target === 'prod') {
+    throw new Error(`refusing to ${action} a database-only project against production`);
+  }
+  if (!env.databaseUrl) {
+    throw new Error('KE2E_DATABASE_URL is required for database-only project fixtures');
+  }
+  return env.databaseUrl;
+}
+
+export async function createDatabaseProject(
+  env: Env,
+  input: {
+    accountId: string;
+    userId: string;
+    name: string;
+  },
+  open: OpenProjectDb = openProjectDb,
+): Promise<CreatedProject> {
+  const databaseUrl = assertDatabaseFixtureAllowed(env, 'create');
+  const projectId = randomUUID();
+  const client = await open(databaseUrl);
+  try {
+    await client.query(
+      `WITH inserted_project AS (
+         INSERT INTO kortix.projects (
+           project_id,
+           account_id,
+           name,
+           repo_url,
+           default_branch,
+           manifest_path,
+           status,
+           metadata
+         )
+         VALUES (
+           $1::uuid,
+           $2::uuid,
+           $4,
+           'https://ke2e.invalid/' || $1::text || '.git',
+           'main',
+           'kortix.yaml',
+           'active'::kortix.project_status,
+           '{"ke2e":{"database_only":true}}'::jsonb
+         )
+         RETURNING project_id
+       )
+       INSERT INTO kortix.project_members (
+         account_id,
+         project_id,
+         user_id,
+         project_role,
+         granted_by
+       )
+       SELECT
+         $2::uuid,
+         project_id,
+         $3::uuid,
+         'manager'::kortix.project_role,
+         $3::uuid
+       FROM inserted_project`,
+      [projectId, input.accountId, input.userId, input.name],
+    );
+  } finally {
+    await client.end();
+  }
+  return { id: projectId, name: input.name };
+}
+
+export async function deleteDatabaseProject(
+  env: Env,
+  projectId: string,
+  open: OpenProjectDb = openProjectDb,
+): Promise<void> {
+  const databaseUrl = assertDatabaseFixtureAllowed(env, 'delete');
+  const client = await open(databaseUrl);
+  try {
+    await client.query(
+      `DELETE FROM kortix.projects
+       WHERE project_id = $1::uuid`,
+      [projectId],
+    );
+  } finally {
+    await client.end();
+  }
+}

--- a/tests/src/fixtures/registry.ts
+++ b/tests/src/fixtures/registry.ts
@@ -16,7 +16,10 @@ export interface TrackedResource {
 export class ResourceStack {
   private items: TrackedResource[] = [];
 
-  constructor(private admin: Client) {}
+  constructor(
+    private admin: Client,
+    private deleteDatabaseProject?: (projectId: string) => Promise<void>,
+  ) {}
 
   push(kind: string, id: string, meta?: Record<string, any>): void {
     this.items.push({ kind, id, meta });
@@ -43,6 +46,12 @@ export class ResourceStack {
         break;
       case "project":
         await this.admin.del("/v1/projects/:id", { params: { id: r.id }, query: { purge: true } });
+        break;
+      case "database-project":
+        if (!this.deleteDatabaseProject) {
+          throw new Error("database project teardown is not configured");
+        }
+        await this.deleteDatabaseProject(r.id);
         break;
       case "token":
         await this.admin.del("/v1/accounts/tokens/:id", { params: { id: r.id } });

--- a/tests/src/fixtures/world.ts
+++ b/tests/src/fixtures/world.ts
@@ -25,6 +25,7 @@ import { adminDeleteUser } from './supabase';
 import { provisionMatrix, synthUser, type Provisioned } from './principals';
 import { provisionProject } from './provision';
 import { grantEphemeralPlatformAdmin } from './platform-admin';
+import { createDatabaseProject, deleteDatabaseProject } from './database-project';
 
 const PUBLIC_DOMAINS = new Set(['system', 'access']);
 
@@ -74,7 +75,7 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
 
   const runId = (globalThis as any).__KE2E_RUN_ID__ ?? 'run';
   const provisioned: Provisioned = await provisionMatrix(env, runId);
-  const owner = provisioned.principals.OWNER;
+  const owner = provisioned.principals.OWNER!;
   let revokePlatformAdmin: (() => Promise<void>) | null = null;
 
   // Release QA needs a real, short-lived Supabase identity for the platform
@@ -95,11 +96,49 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
     log.step(`provision: run-scoped platform admin ${platformAdmin.user.id} active`);
   }
   const adminClient = new Client(env.apiUrl).as(owner as Identity);
+  const canCreateDatabaseProject = env.capabilities.database && env.target !== 'prod';
+  const deleteDatabaseProjectFixture = canCreateDatabaseProject
+    ? (projectId: string) => deleteDatabaseProject(env, projectId)
+    : undefined;
   // Users synthesized mid-run (team members) — deleted in teardownAll.
   const extraUserIds: string[] = [];
+  let databaseProjectCount = 0;
+  let managedProjectCount = 0;
   // One shared read-only project, provisioned at most once per run.
   let sharedProjectPromise: Promise<CreatedProject> | null = null;
-  const sharedStack = new ResourceStack(adminClient);
+  const sharedStack = new ResourceStack(adminClient, deleteDatabaseProjectFixture);
+
+  async function createProject(
+    stack: ResourceStack,
+    opts?: {
+      name?: string;
+      accountId?: string;
+      seed?: boolean;
+      managedGit?: boolean;
+    },
+  ): Promise<CreatedProject> {
+    const name = opts?.name ?? `e2e-${runId}-proj-${rand()}`;
+    const accountId = opts?.accountId ?? owner.accountId!;
+    if (canCreateDatabaseProject && !opts?.seed && !opts?.managedGit) {
+      const project = await createDatabaseProject(env, {
+        accountId,
+        userId: owner.userId!,
+        name,
+      });
+      databaseProjectCount++;
+      stack.push('database-project', project.id);
+      return project;
+    }
+
+    const id = await provisionProject(adminClient, {
+      name,
+      ...(opts?.accountId ? { account_id: opts.accountId } : {}),
+      ...(opts?.seed ? { seed_starter: true } : {}),
+    });
+    managedProjectCount++;
+    stack.push('project', id);
+    return { id, name } as CreatedProject;
+  }
 
   const fixturesFor = (stack: ResourceStack): Fixtures => ({
     name: (slug) => `e2e-${runId}-${slug}`,
@@ -107,6 +146,7 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
       if (!sharedProjectPromise) {
         sharedProjectPromise = (async () => {
           const id = await provisionProject(adminClient, { name: `e2e-${runId}-shared` });
+          managedProjectCount++;
           sharedStack.push('project', id);
           return { id, name: `e2e-${runId}-shared` } as CreatedProject;
         })();
@@ -114,14 +154,7 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
       return sharedProjectPromise;
     },
     async project(opts) {
-      const name = opts?.name ?? `e2e-${runId}-proj-${rand()}`;
-      const id = await provisionProject(adminClient, {
-        name,
-        ...(opts?.accountId ? { account_id: opts.accountId } : {}),
-        ...(opts?.seed ? { seed_starter: true } : {}),
-      });
-      stack.push('project', id);
-      return { id, name } as CreatedProject;
+      return createProject(stack, opts);
     },
     async team(opts) {
       const res = await adminClient.post('/v1/accounts', {
@@ -160,14 +193,11 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
           );
         },
         async project(o) {
-          const name = o?.name ?? `e2e-${runId}-tproj-${rand()}`;
-          const id = await provisionProject(adminClient, {
-            name,
-            account_id: accountId,
-            ...(o?.seed ? { seed_starter: true } : {}),
+          return createProject(stack, {
+            ...o,
+            name: o?.name ?? `e2e-${runId}-tproj-${rand()}`,
+            accountId,
           });
-          stack.push('project', id);
-          return { id, name } as CreatedProject;
         },
       };
     },
@@ -216,9 +246,12 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
 
   return {
     principals: principalsProxy(provisioned.principals),
-    newStack: () => new ResourceStack(adminClient),
+    newStack: () => new ResourceStack(adminClient, deleteDatabaseProjectFixture),
     makeFixtures: fixturesFor,
     async teardownAll() {
+      log.info(
+        `fixtures: ${databaseProjectCount} database-only projects · ${managedProjectCount} managed repositories`,
+      );
       await sharedStack.teardown();
       if (revokePlatformAdmin) {
         try {

--- a/tests/src/fixtures/world.ts
+++ b/tests/src/fixtures/world.ts
@@ -26,6 +26,7 @@ import { provisionMatrix, synthUser, type Provisioned } from './principals';
 import { provisionProject } from './provision';
 import { grantEphemeralPlatformAdmin } from './platform-admin';
 import { createDatabaseProject, deleteDatabaseProject } from './database-project';
+import { mapWithConcurrency } from '../core/concurrency';
 
 const PUBLIC_DOMAINS = new Set(['system', 'access']);
 
@@ -289,13 +290,15 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
           log.warn(`teardown run account ${acct} failed: ${(err as Error)?.message ?? err}`);
         }
       }
-      for (const uid of [...provisioned.supabaseUserIds, ...extraUserIds]) {
+      const userIds = [...provisioned.supabaseUserIds, ...extraUserIds];
+      const cleanupWorkers = Number(process.env.KE2E_TEARDOWN_WORKERS ?? 4);
+      await mapWithConcurrency(userIds, cleanupWorkers, async (uid) => {
         try {
           await adminDeleteUser(env, uid);
         } catch (err) {
           log.warn(`teardown user ${uid} failed: ${(err as Error)?.message ?? err}`);
         }
-      }
+      });
     },
   };
 }

--- a/tests/src/fixtures/world.ts
+++ b/tests/src/fixtures/world.ts
@@ -106,6 +106,7 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
   let managedProjectCount = 0;
   // One shared read-only project, provisioned at most once per run.
   let sharedProjectPromise: Promise<CreatedProject> | null = null;
+  let sharedSeededProjectPromise: Promise<CreatedProject> | null = null;
   const sharedStack = new ResourceStack(adminClient, deleteDatabaseProjectFixture);
 
   async function createProject(
@@ -152,6 +153,23 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
         })();
       }
       return sharedProjectPromise;
+    },
+    sharedSeededProject() {
+      if (!sharedSeededProjectPromise) {
+        sharedSeededProjectPromise = (async () => {
+          const id = await provisionProject(adminClient, {
+            name: `e2e-${runId}-shared-seeded`,
+            seed_starter: true,
+          });
+          managedProjectCount++;
+          sharedStack.push('project', id);
+          return {
+            id,
+            name: `e2e-${runId}-shared-seeded`,
+          } as CreatedProject;
+        })();
+      }
+      return sharedSeededProjectPromise;
     },
     async project(opts) {
       return createProject(stack, opts);
@@ -290,6 +308,7 @@ function makeUnavailableFixtures(): Fixtures {
     name: (slug) => slug,
     project: fail as any,
     sharedProject: fail as any,
+    sharedSeededProject: fail as any,
     session: fail as any,
     pat: fail as any,
     team: fail as any,

--- a/tests/src/flows/connectors.flow.ts
+++ b/tests/src/flows/connectors.flow.ts
@@ -492,7 +492,7 @@ flow(
     ],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project();
+    const p = await ctx.fixtures.project({ managedGit: true });
     const slug = `ke2e-mcp-${Date.now().toString(36)}`;
 
     await ctx.step('seed a real connector to hang a profile off (mcp provider)', async () => {
@@ -682,7 +682,7 @@ flow(
     ],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project();
+    const p = await ctx.fixtures.project({ managedGit: true });
     const slug = `ke2e-oauth2-${Date.now().toString(36)}`;
     const connector = await ctx.client.as(ctx.P.OWNER).post(
       '/v1/executor/projects/:projectId/connectors',

--- a/tests/src/flows/kaab.flow.ts
+++ b/tests/src/flows/kaab.flow.ts
@@ -18,7 +18,7 @@ flow(
   'KAAB-1',
   { ...REQ, requires: ['funded', 'daytona'], routes: [CREATE] },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     await ctx.step('backend PAT create with overrides → 201, echoes origin/origin_ref', async () => {
       const r = await ctx.client
         .as(ctx.P.PAT_ACCT)
@@ -41,7 +41,7 @@ flow(
   'KAAB-2',
   { ...REQ, requires: ['funded', 'daytona'], routes: [CREATE] },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     await ctx.step('non-backend (user) setting origin_ref → 403 origin_override_forbidden', async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
@@ -63,7 +63,7 @@ flow(
   'KAAB-3',
   { ...REQ, requires: ['funded', 'daytona'], routes: [CREATE] },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     await ctx.step('backend secrets=[unknown identifier] → 404 SECRET_IDENTIFIER_NOT_FOUND', async () => {
       const r = await ctx.client
         .as(ctx.P.PAT_ACCT)
@@ -91,7 +91,7 @@ flow(
   'KAAB-4',
   { ...REQ, requires: ['funded', 'daytona'], routes: [CREATE] },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     await ctx.step('backend opencode_model=unservable → 400 INVALID_SESSION_MODEL (fail-fast, not a dead turn)', async () => {
       const r = await ctx.client
         .as(ctx.P.PAT_ACCT)
@@ -110,7 +110,7 @@ flow(
   'KAAB-5',
   { ...REQ, requires: ['funded', 'daytona'], routes: [CREATE] },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     await ctx.step('backend runtime_context with a credential-like key → 400', async () => {
       const r = await ctx.client
         .as(ctx.P.PAT_ACCT)
@@ -136,7 +136,7 @@ flow(
   'KAAB-6',
   { ...REQ, requires: ['funded', 'daytona'], routes: [CREATE] },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const key = ctx.fixtures.name('kaab-idem');
     let first: string | undefined;
     await ctx.step('backend create with Idempotency-Key → 201', async () => {
@@ -179,7 +179,7 @@ flow(
   'KAAB-7',
   { ...REQ, requires: ['funded', 'daytona'], routes: [CREATE] },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const key = ctx.fixtures.name('kaab-idem-ident');
     await ctx.step('backend create with Idempotency-Key + origin_ref:alice → 201', async () => {
       const r = await ctx.client

--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -82,7 +82,7 @@ async function bootSandbox(
   ctx: FlowContext,
   opts?: { prompt?: string; readinessTimeoutMs?: number },
 ): Promise<{ projectId: string; sessionId: string; sandboxId: string; sandbox: any }> {
-  const project = await ctx.fixtures.project({ seed: true });
+  const project = await ctx.fixtures.sharedSeededProject();
   const session = await ctx.fixtures.session(project, { prompt: opts?.prompt ?? 'say hello' });
   const started = await waitForSessionReady(ctx, project.id, session.id, opts?.readinessTimeoutMs);
 
@@ -589,7 +589,7 @@ flow(
     routes: ['POST /v1/projects/:projectId/sessions'],
   },
   async (ctx) => {
-    const project = await ctx.fixtures.project({ seed: true });
+    const project = await ctx.fixtures.sharedSeededProject();
     const clientSessionId = crypto.randomUUID();
     await ctx.step(
       'create session with client-minted id + branch_already_created → 201',

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -15,7 +15,7 @@ flow(
     routes: ['POST /v1/projects/:projectId/sessions'],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     await ctx.step('create session → 201 provisioning', async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)
@@ -59,7 +59,7 @@ flow(
     routes: ['GET /v1/projects/:projectId/sessions/:sessionId'],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const s = await ctx.fixtures.session(p);
     await ctx.step('get session → 200', async () => {
       const r = await ctx.client
@@ -89,7 +89,7 @@ flow(
     routes: ['POST /v1/projects/:projectId/sessions/:sessionId/start'],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const s = await ctx.fixtures.session(p);
     await ctx.step('unified start reports the runtime readiness stage', async () => {
       const r = await ctx.client
@@ -113,7 +113,7 @@ flow(
     routes: ['DELETE /v1/projects/:projectId/sessions/:sessionId'],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const s = await ctx.fixtures.session(p);
     await ctx.step('delete session → 200 stopped', async () => {
       const r = await ctx.client
@@ -167,7 +167,7 @@ flow(
     ],
   },
   async (ctx) => {
-    const project = await ctx.fixtures.project({ seed: true });
+    const project = await ctx.fixtures.sharedSeededProject();
     const session = await ctx.fixtures.session(project);
     const owner = ctx.client.as(ctx.P.OWNER);
 
@@ -438,7 +438,7 @@ flow(
     routes: ['GET /v1/projects/:projectId/sessions/:sessionId/audit'],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const s = await ctx.fixtures.session(p);
     const owner = ctx.client.as(ctx.P.OWNER);
 
@@ -530,7 +530,7 @@ flow(
     ],
   },
   async (ctx) => {
-    const project = await ctx.fixtures.project({ seed: true });
+    const project = await ctx.fixtures.sharedSeededProject();
     const session = await ctx.fixtures.session(project);
     const owner = ctx.client.as(ctx.P.OWNER);
     const anon = ctx.client.as(ctx.P.ANON);
@@ -635,7 +635,7 @@ flow(
     routes: ['GET /v1/projects/:projectId/sessions/:sessionId/previews'],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const s = await ctx.fixtures.session(p);
     const owner = ctx.client.as(ctx.P.OWNER);
 
@@ -688,7 +688,7 @@ flow(
     ],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const owner = ctx.client.as(ctx.P.OWNER);
     let warmSessionId = '';
 

--- a/tests/src/flows/triggers.flow.ts
+++ b/tests/src/flows/triggers.flow.ts
@@ -40,7 +40,7 @@ flow(
   'TRG-2',
   { domain: 'triggers', routes: ['POST /v1/projects/:projectId/triggers'] },
   async (ctx) => {
-    const p = await ctx.fixtures.project();
+    const p = await ctx.fixtures.project({ managedGit: true });
     await ctx.step('create a cron trigger with a pinned model → 201', async () => {
       const r = await ctx.client.as(ctx.P.OWNER).post(
         '/v1/projects/:projectId/triggers',
@@ -79,7 +79,7 @@ flow(
   'TRG-3',
   { domain: 'triggers', routes: ['PATCH /v1/projects/:projectId/triggers/:slug'] },
   async (ctx) => {
-    const p = await ctx.fixtures.project();
+    const p = await ctx.fixtures.project({ managedGit: true });
     await ctx.client
       .as(ctx.P.OWNER)
       .post(
@@ -122,7 +122,7 @@ flow(
   'TRG-4',
   { domain: 'triggers', routes: ['DELETE /v1/projects/:projectId/triggers/:slug'] },
   async (ctx) => {
-    const p = await ctx.fixtures.project();
+    const p = await ctx.fixtures.project({ managedGit: true });
     await ctx.client
       .as(ctx.P.OWNER)
       .post(
@@ -592,7 +592,7 @@ flow(
     ],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project();
+    const p = await ctx.fixtures.project({ managedGit: true });
     const owner = ctx.client.as(ctx.P.OWNER);
     const params = { projectId: p.id };
 

--- a/tests/src/flows/voice.flow.ts
+++ b/tests/src/flows/voice.flow.ts
@@ -204,7 +204,7 @@ flow(
     routes: ['GET /v1/projects/:projectId/sessions/:sessionId/voice-transcript'],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project({ seed: true });
+    const p = await ctx.fixtures.sharedSeededProject();
     const s = await ctx.fixtures.session(p);
     await ctx.step('session with no call → 200, empty, not live', async () => {
       const r = await ctx.client

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/core/env';
+import {
+  createDatabaseProject,
+  deleteDatabaseProject,
+  type OpenProjectDb,
+} from '../src/fixtures/database-project';
+
+function env(overrides: Partial<Env> = {}): Env {
+  return {
+    apiUrl: 'https://staging-api.kortix.com/v1',
+    baseUrl: 'https://staging.kortix.com',
+    gatewayUrl: 'https://gateway-staging.kortix.com',
+    supabaseUrl: 'https://supabase.example',
+    supabaseAnonKey: 'anon',
+    supabaseServiceRoleKey: 'service',
+    databaseUrl: 'postgres://staging.example/kortix',
+    ownerEmail: null,
+    ownerPassword: null,
+    adminToken: null,
+    internalServiceKey: null,
+    stripeSecretKey: null,
+    stripeWebhookSecret: null,
+    liveConfirm: 'ci',
+    target: 'staging',
+    capabilities: {
+      daytona: true,
+      managedGit: true,
+      managedGitPush: false,
+      stripe: false,
+      supabaseAdmin: true,
+      database: true,
+      admin: false,
+      internalCron: false,
+      funded: true,
+    },
+    testEmailDomain: 'ke2e.kortix.test',
+    ...overrides,
+  };
+}
+
+function database() {
+  const query = vi.fn().mockResolvedValue({ rows: [] });
+  const end = vi.fn().mockResolvedValue(undefined);
+  const open: OpenProjectDb = vi.fn().mockResolvedValue({ query, end });
+  return { open, query, end };
+}
+
+describe('database-only project fixture', () => {
+  it('creates an isolated project row and manager grant without a Git provider call', async () => {
+    const db = database();
+
+    const project = await createDatabaseProject(
+      env(),
+      {
+        accountId: '11111111-1111-4111-8111-111111111111',
+        userId: '22222222-2222-4222-8222-222222222222',
+        name: 'e2e-project',
+      },
+      db.open,
+    );
+
+    expect(project.name).toBe('e2e-project');
+    expect(project.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(db.query).toHaveBeenCalledOnce();
+    expect(db.query.mock.calls[0][0]).toContain('INSERT INTO kortix.projects');
+    expect(db.query.mock.calls[0][0]).toContain('INSERT INTO kortix.project_members');
+    expect(db.query.mock.calls[0][1]).toEqual([
+      project.id,
+      '11111111-1111-4111-8111-111111111111',
+      '22222222-2222-4222-8222-222222222222',
+      'e2e-project',
+    ]);
+    expect(db.end).toHaveBeenCalledOnce();
+  });
+
+  it('deletes the project row directly and relies on database cascades', async () => {
+    const db = database();
+
+    await deleteDatabaseProject(
+      env(),
+      '33333333-3333-4333-8333-333333333333',
+      db.open,
+    );
+
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM kortix.projects'),
+      ['33333333-3333-4333-8333-333333333333'],
+    );
+    expect(db.end).toHaveBeenCalledOnce();
+  });
+
+  it('rejects database-only fixture writes against production', async () => {
+    const db = database();
+
+    await expect(
+      createDatabaseProject(
+        env({ target: 'prod' }),
+        {
+          accountId: '11111111-1111-4111-8111-111111111111',
+          userId: '22222222-2222-4222-8222-222222222222',
+          name: 'forbidden',
+        },
+        db.open,
+      ),
+    ).rejects.toThrow('refusing to create a database-only project against production');
+    expect(db.open).not.toHaveBeenCalled();
+  });
+
+  it('requires KE2E_DATABASE_URL', async () => {
+    const db = database();
+
+    await expect(
+      createDatabaseProject(
+        env({ databaseUrl: null }),
+        {
+          accountId: '11111111-1111-4111-8111-111111111111',
+          userId: '22222222-2222-4222-8222-222222222222',
+          name: 'missing-db',
+        },
+        db.open,
+      ),
+    ).rejects.toThrow('KE2E_DATABASE_URL is required');
+    expect(db.open).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -188,6 +188,39 @@ describe('release gate transient failure resilience', () => {
     ).toBe(false);
   });
 
+  it('marks an unexpected host-level gateway status for a clean flow retry', () => {
+    const response = capturedResponse(503, {
+      'content-type': 'application/json',
+      'retry-after': '30',
+      'x-maintenance-mode': 'blocking',
+    });
+
+    let error: unknown;
+    try {
+      response.status(200);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(isKe2eRetryableError(error)).toBe(true);
+  });
+
+  it('does not mark an API contract 503 for retry', () => {
+    const response = capturedResponse(503, {
+      'content-type': 'application/json',
+      'x-request-id': 'request-1',
+    });
+
+    let error: unknown;
+    try {
+      response.status(200);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(isKe2eRetryableError(error)).toBe(false);
+  });
+
   it('retries an opted-in host-level 502 response', async () => {
     vi.useFakeTimers();
     const fetchMock = vi

--- a/tests/unit/runner-lanes.test.ts
+++ b/tests/unit/runner-lanes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import type { RegisteredFlow } from '../src/core/flow';
+import { partitionParallelFlows } from '../src/core/lanes';
+
+function registeredFlow(
+  id: string,
+  requires: RegisteredFlow['meta']['requires'] = [],
+): RegisteredFlow {
+  return {
+    id,
+    meta: { domain: 'test', requires },
+    fn: async () => {},
+  };
+}
+
+describe('ke2e parallel lanes', () => {
+  it('separates live sandbox flows from API-only flows', () => {
+    const api = registeredFlow('API-1');
+    const fundedApi = registeredFlow('API-2', ['funded']);
+    const daytona = registeredFlow('SBX-1', ['funded', 'daytona']);
+
+    const lanes = partitionParallelFlows([api, daytona, fundedApi]);
+
+    expect(lanes.apiLane).toEqual([api, fundedApi]);
+    expect(lanes.sandboxLane).toEqual([daytona]);
+  });
+});

--- a/tests/unit/runner-lanes.test.ts
+++ b/tests/unit/runner-lanes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { RegisteredFlow } from '../src/core/flow';
 import { partitionParallelFlows } from '../src/core/lanes';
+import { mapWithConcurrency } from '../src/core/concurrency';
 
 function registeredFlow(
   id: string,
@@ -23,5 +24,21 @@ describe('ke2e parallel lanes', () => {
 
     expect(lanes.apiLane).toEqual([api, fundedApi]);
     expect(lanes.sandboxLane).toEqual([daytona]);
+  });
+
+  it('bounds concurrency and preserves result order', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    const results = await mapWithConcurrency([3, 1, 2, 4], 2, async (value) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, value));
+      active--;
+      return value * 10;
+    });
+
+    expect(maxActive).toBe(2);
+    expect(results).toEqual([30, 10, 20, 40]);
   });
 });


### PR DESCRIPTION
## Candidate

- Source: `main`
- Source SHA: `a3cf1ce03fe4e884a20eadaf90066bb62374477f`
- Target: `staging`

## Included optimization

- Avoid managed-Git provisioning for metadata-only flows.
- Reuse managed repository fixtures across compatible flows.
- Split live lanes to prevent competing full suites from overloading staging.
- Parallelize Supabase and resource cleanup.

## Measured evidence

- Suite execution: `1,182.4s`, down from `1,346.1s`.
- Managed repositories: `13`, down from `36`.
- GitHub secondary-rate-limit failures: `0`.
- Cleanup tail is now parallelized.

## Required verification

- Complete PR checks.
- Complete the dev deployment for the source SHA.
- Build and deploy staging artifacts.
- Run the optimized full release gate alone against staging.
- Verify exact live staging SHA.