### PR TITLE
test(ke2e): honor gateway Retry-After

### DIFF
--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -34,6 +34,20 @@ export function isKe2eRetryableError(error: unknown): boolean {
   );
 }
 
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+const MAX_RETRY_AFTER_MS = 60_000;
+
+/** Return the host-requested retry delay for a marked transient failure. */
+export function ke2eRetryDelayMs(
+  error: unknown,
+  fallbackMs = DEFAULT_RETRY_DELAY_MS,
+): number {
+  if (!isKe2eRetryableError(error)) return fallbackMs;
+  const delay = (error as { ke2eRetryAfterMs?: unknown }).ke2eRetryAfterMs;
+  if (typeof delay !== 'number' || !Number.isFinite(delay)) return fallbackMs;
+  return Math.min(MAX_RETRY_AFTER_MS, Math.max(fallbackMs, Math.trunc(delay)));
+}
+
 export interface ReqOpts {
   /** `:param` substitutions for the URL (template stays the coverage key). */
   params?: Record<string, string | number>;
@@ -136,6 +150,7 @@ export class Res {
         `transient gateway status ${this.statusCode}; expected [${codes.join(', ')}]`,
       );
       (error as any).ke2eRetryable = true;
+      (error as any).ke2eRetryAfterMs = retryAfterMs(this.header('retry-after'));
       throw error;
     }
     assert({
@@ -194,6 +209,15 @@ export function isKe2eTransientGatewayResponse(response: Res): boolean {
     response.header('retry-after') !== undefined ||
     response.header('content-type')?.includes('text/html') === true
   );
+}
+
+function retryAfterMs(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+  const at = Date.parse(value);
+  if (!Number.isFinite(at)) return undefined;
+  return Math.max(0, at - Date.now());
 }
 
 const TRANSIENT_GATEWAY_RETRY_DELAY_MS = 2_000;

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -13,6 +13,7 @@ import { loadEnv, type Env } from "./env";
 import { log } from "./log";
 import { partitionParallelFlows } from "./lanes";
 import { mapWithConcurrency } from "./concurrency";
+import { ke2eRetryDelayMs } from "./client";
 import {
   summarize,
   type Assertion,
@@ -145,7 +146,7 @@ async function runOneFlow(
       // Never retry assertion failures — only infra signals.
       const retryable = !(err instanceof AssertionError) && (err as any)?.ke2eRetryable === true;
       if (!retryable || attempt >= maxAttempts) break;
-      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      await new Promise((resolve) => setTimeout(resolve, ke2eRetryDelayMs(err)));
     }
   }
   const reason = (lastError as Error)?.message ?? String(lastError);

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -4,6 +4,7 @@ import {
   Res,
   isKe2eRetryableError,
   isKe2eTransientGatewayResponse,
+  ke2eRetryDelayMs,
 } from '../src/core/client';
 import { waitFor } from '../src/core/poll';
 import type { Captured } from '../src/core/result';
@@ -203,6 +204,16 @@ describe('release gate transient failure resilience', () => {
     }
 
     expect(isKe2eRetryableError(error)).toBe(true);
+    expect(ke2eRetryDelayMs(error)).toBe(30_000);
+  });
+
+  it('caps a host-requested retry delay at 60 seconds', () => {
+    const error = Object.assign(new Error('transient gateway status 503'), {
+      ke2eRetryable: true,
+      ke2eRetryAfterMs: 180_000,
+    });
+
+    expect(ke2eRetryDelayMs(error)).toBe(60_000);
   });
 
   it('does not mark an API contract 503 for retry', () => {


### PR DESCRIPTION
## Summary

- preserve one clean flow retry for host-level `502`/`503`/`504` responses
- honor the host `Retry-After` delay instead of retrying after two seconds
- cap the delay at 60 seconds
- keep API contract `5xx` responses non-retryable

## Evidence

- stable release QA `30326920663` completed `377/388` flows with only `CONN-5` failing after two host-level `503` responses
- the previous retry waited two seconds even when the response supplied `Retry-After`
- `bun run typecheck` passed
- `bun run test:unit` passed `34/34`
- `bun run coverage` passed `497/507`, `10` allowlisted, `0` uncovered