### PR TITLE
test(ke2e): cover connector-profiles all/default/policies + session model (5 routes)

### DIFF
--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 507,
+  "count": 521,
   "routes": [
     {
       "method": "GET",
@@ -1275,6 +1275,10 @@
       "path": "/v1/projects/:projectId/connector-profiles/:profileId/credential"
     },
     {
+      "method": "PUT",
+      "path": "/v1/projects/:projectId/connector-profiles/:profileId/default"
+    },
+    {
       "method": "GET",
       "path": "/v1/projects/:projectId/connector-profiles/:profileId/oauth2/application"
     },
@@ -1303,8 +1307,20 @@
       "path": "/v1/projects/:projectId/connector-profiles/:profileId/oauth2/status"
     },
     {
+      "method": "GET",
+      "path": "/v1/projects/:projectId/connector-profiles/:profileId/policies"
+    },
+    {
+      "method": "PUT",
+      "path": "/v1/projects/:projectId/connector-profiles/:profileId/policies"
+    },
+    {
       "method": "PUT",
       "path": "/v1/projects/:projectId/connector-profiles/:profileId/revoke"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/projects/:projectId/connector-profiles/all"
     },
     {
       "method": "POST",
@@ -1635,6 +1651,10 @@
       "path": "/v1/projects/:projectId/sessions/:sessionId/mcp/voice"
     },
     {
+      "method": "PUT",
+      "path": "/v1/projects/:projectId/sessions/:sessionId/model"
+    },
+    {
       "method": "GET",
       "path": "/v1/projects/:projectId/sessions/:sessionId/previews"
     },
@@ -1849,6 +1869,42 @@
     {
       "method": "POST",
       "path": "/v1/setup-links/secret/:token"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/bootstrap-owner"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/health"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/install-status"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/sandbox-providers"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/setup-complete"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/setup-status"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/setup-wizard-step"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/setup-wizard-step"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/status"
     },
     {
       "method": "GET",

--- a/tests/src/flows/connectors.flow.ts
+++ b/tests/src/flows/connectors.flow.ts
@@ -489,11 +489,16 @@ flow(
       'PUT /v1/projects/:projectId/connector-profiles/:profileId/credential',
       'PUT /v1/projects/:projectId/connector-profiles/:profileId/revoke',
       'POST /v1/projects/:projectId/connector-profiles/me',
+      'GET /v1/projects/:projectId/connector-profiles/all',
+      'PUT /v1/projects/:projectId/connector-profiles/:profileId/default',
+      'GET /v1/projects/:projectId/connector-profiles/:profileId/policies',
+      'PUT /v1/projects/:projectId/connector-profiles/:profileId/policies',
     ],
   },
   async (ctx) => {
     const p = await ctx.fixtures.project({ managedGit: true });
     const slug = `ke2e-mcp-${Date.now().toString(36)}`;
+    const ZERO_UUID = '00000000-0000-4000-a000-000000000000';
 
     await ctx.step('seed a real connector to hang a profile off (mcp provider)', async () => {
       // auth explicitly set (not omitted) so the create route skips its
@@ -532,18 +537,16 @@ flow(
 
     let profileId = '';
     await ctx.step('create (reconcile) a connection profile → 201 with a real shape', async () => {
-      const r = await ctx.client
-        .as(ctx.P.OWNER)
-        .post(
-          '/v1/projects/:projectId/connector-profiles',
-          {
-            connector_alias: slug,
-            owner_type: 'external',
-            owner_id: 'ke2e-external-owner-1',
-            label: 'KE2E connection',
-          },
-          { params: { projectId: p.id } },
-        );
+      const r = await ctx.client.as(ctx.P.OWNER).post(
+        '/v1/projects/:projectId/connector-profiles',
+        {
+          connector_alias: slug,
+          owner_type: 'external',
+          owner_id: 'ke2e-external-owner-1',
+          label: 'KE2E connection',
+        },
+        { params: { projectId: p.id } },
+      );
       r.status(201)
         .body()
         .has('$.connector_alias', slug)
@@ -581,6 +584,91 @@ flow(
         .exists('$.owner_id')
         .exists('$.profile_id');
       memberProfileId = r.json<any>().profile_id;
+    });
+
+    // ── /all roster (manage-gated) + /default + /policies ──────────────────
+    await ctx.step(
+      'GET /connector-profiles/all → 200 roster (manage-gated, narrow shape)',
+      async () => {
+        const r = await ctx.client
+          .as(ctx.P.OWNER)
+          .get('/v1/projects/:projectId/connector-profiles/all', { params: { projectId: p.id } });
+        r.status(200).body().exists('$.profiles');
+        // The roster deliberately excludes label/metadata (personal identifiers) —
+        // only identity + status. Pin that the narrow shape holds.
+        for (const row of r.json<{ profiles: Array<Record<string, unknown>> }>().profiles ?? []) {
+          if ('label' in row) throw new Error('roster leaked a `label` (personal annotation)');
+          if ('metadata' in row) throw new Error('roster leaked `metadata`');
+        }
+      },
+    );
+    await ctx.step(
+      'PUT /connector-profiles/:profileId/default → 200 ok (make member profile the default)',
+      async () => {
+        const r = await ctx.client
+          .as(ctx.P.OWNER)
+          .put(
+            '/v1/projects/:projectId/connector-profiles/:profileId/default',
+            {},
+            { params: { projectId: p.id, profileId: memberProfileId } },
+          );
+        r.status(200).body().has('$.ok', true);
+      },
+    );
+    await ctx.step(
+      'GET /connector-profiles/:profileId/policies → 200 with policies array',
+      async () => {
+        const r = await ctx.client
+          .as(ctx.P.OWNER)
+          .get('/v1/projects/:projectId/connector-profiles/:profileId/policies', {
+            params: { projectId: p.id, profileId: memberProfileId },
+          });
+        r.status(200).body().exists('$.policies');
+      },
+    );
+    await ctx.step(
+      'PUT /connector-profiles/:profileId/policies (replace with one allow rule) → 200 ok',
+      async () => {
+        const r = await ctx.client
+          .as(ctx.P.OWNER)
+          .put(
+            '/v1/projects/:projectId/connector-profiles/:profileId/policies',
+            { policies: [{ match: 'github.*', action: 'allow' }] },
+            { params: { projectId: p.id, profileId: memberProfileId } },
+          );
+        r.status(200).body().has('$.ok', true);
+      },
+    );
+    await ctx.step(
+      'PUT policies with an invalid match pattern → 400 (INVALID_MATCHER)',
+      async () => {
+        const r = await ctx.client
+          .as(ctx.P.OWNER)
+          .put(
+            '/v1/projects/:projectId/connector-profiles/:profileId/policies',
+            { policies: [{ match: '[unclosed', action: 'allow' }] },
+            { params: { projectId: p.id, profileId: memberProfileId } },
+          );
+        r.status(400);
+      },
+    );
+    await ctx.step('policies on an unknown profileId → 404', async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .get('/v1/projects/:projectId/connector-profiles/:profileId/policies', {
+          params: { projectId: p.id, profileId: ZERO_UUID },
+        });
+      r.status(404);
+    });
+    await ctx.step('default on an unknown profileId → 404', async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .put(
+          '/v1/projects/:projectId/connector-profiles/:profileId/default',
+          {},
+          { params: { projectId: p.id, profileId: ZERO_UUID } },
+        );
+      r.status(404);
     });
 
     await ctx.step('profile OAuth routes reject a non-Pipedream connector → 404/501', async () => {
@@ -695,11 +783,13 @@ flow(
       { params: { projectId: p.id } },
     );
     connector.status(200);
-    const defaultProfile = await ctx.client.as(ctx.P.OWNER).post(
-      '/v1/projects/:projectId/connectors/:slug/oauth2/profile',
-      {},
-      { params: { projectId: p.id, slug } },
-    );
+    const defaultProfile = await ctx.client
+      .as(ctx.P.OWNER)
+      .post(
+        '/v1/projects/:projectId/connectors/:slug/oauth2/profile',
+        {},
+        { params: { projectId: p.id, slug } },
+      );
     defaultProfile.status(200).body().exists('$.profile_id');
     const created = await ctx.client.as(ctx.P.OWNER).post(
       '/v1/projects/:projectId/connector-profiles',
@@ -727,10 +817,11 @@ flow(
         { params: { projectId: p.id, profileId } },
       );
       saved.status(200).body().has('$.ok', true);
-      const read = await ctx.client.as(ctx.P.OWNER).get(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/application',
-        { params: { projectId: p.id, profileId } },
-      );
+      const read = await ctx.client
+        .as(ctx.P.OWNER)
+        .get('/v1/projects/:projectId/connector-profiles/:profileId/oauth2/application', {
+          params: { projectId: p.id, profileId },
+        });
       read
         .status(200)
         .body()
@@ -739,35 +830,38 @@ flow(
     });
 
     await ctx.step('start Authorization Code with PKCE and read ready status', async () => {
-      const started = await ctx.client.as(ctx.P.OWNER).post(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/authorize',
-        {},
-        { params: { projectId: p.id, profileId } },
-      );
-      started
-        .status(200)
-        .body()
-        .exists('$.authorization_url')
-        .exists('$.expires_at');
-      const status = await ctx.client.as(ctx.P.OWNER).get(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/status',
-        { params: { projectId: p.id, profileId } },
-      );
+      const started = await ctx.client
+        .as(ctx.P.OWNER)
+        .post(
+          '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/authorize',
+          {},
+          { params: { projectId: p.id, profileId } },
+        );
+      started.status(200).body().exists('$.authorization_url').exists('$.expires_at');
+      const status = await ctx.client
+        .as(ctx.P.OWNER)
+        .get('/v1/projects/:projectId/connector-profiles/:profileId/oauth2/status', {
+          params: { projectId: p.id, profileId },
+        });
       status.status(200).body().has('$.status', 'ready');
     });
 
     await ctx.step('reject SSRF discovery and unavailable device endpoints', async () => {
-      const discovery = await ctx.client.as(ctx.P.OWNER).post(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/discover',
-        { discovery_url: 'https://127.0.0.1/.well-known/oauth-authorization-server' },
-        { params: { projectId: p.id, profileId } },
-      );
+      const discovery = await ctx.client
+        .as(ctx.P.OWNER)
+        .post(
+          '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/discover',
+          { discovery_url: 'https://127.0.0.1/.well-known/oauth-authorization-server' },
+          { params: { projectId: p.id, profileId } },
+        );
       discovery.status(400);
-      const device = await ctx.client.as(ctx.P.OWNER).post(
-        '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/device',
-        {},
-        { params: { projectId: p.id, profileId } },
-      );
+      const device = await ctx.client
+        .as(ctx.P.OWNER)
+        .post(
+          '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/device',
+          {},
+          { params: { projectId: p.id, profileId } },
+        );
       device.status(400);
       const poll = await ctx.client.as(ctx.P.OWNER).post(
         '/v1/projects/:projectId/connector-profiles/:profileId/oauth2/device/:sessionId',
@@ -805,11 +899,9 @@ flow(
   },
   async (ctx) => {
     await ctx.step('GET with a bogus token → 404 (invalid/unknown link)', async () => {
-      const r = await ctx.client
-        .as(ctx.P.ANON)
-        .get('/v1/setup-links/connector/:token', {
-          params: { token: 'bogus-connector-setup-link' },
-        });
+      const r = await ctx.client.as(ctx.P.ANON).get('/v1/setup-links/connector/:token', {
+        params: { token: 'bogus-connector-setup-link' },
+      });
       r.status(404).body().exists('$.error');
     });
     await ctx.step('POST .../start with a bogus token → 404 (invalid/unknown link)', async () => {

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -757,3 +757,73 @@ flow(
     });
   },
 );
+
+// SESS-MODEL — PUT /v1/projects/:projectId/sessions/:sessionId/model
+// (apps/api/src/projects/routes/r7.ts:1968-2098). Change a RUNNING session's
+// model. The full positive path needs a funded, live session (it restarts
+// opencode + re-points the agent); the BOUNDARIES are assertable without one:
+// an unknown session 404s, a malformed session id 400s, ANON 401s, and an
+// unknown project 404s — proving the route is mounted + its auth/shape gates
+// fire before any live-sandbox work. Covers the route for the coverage gate.
+flow(
+  'SESS-MODEL',
+  {
+    domain: 'sessions',
+    routes: ['PUT /v1/projects/:projectId/sessions/:sessionId/model'],
+  },
+  async (ctx) => {
+    const p = await ctx.fixtures.project();
+    const ZERO_UUID = '00000000-0000-4000-a000-000000000000';
+
+    await ctx.step('ANON → 401', async () => {
+      const r = await ctx.client
+        .as(ctx.P.ANON)
+        .put(
+          '/v1/projects/:projectId/sessions/:sessionId/model',
+          { opencode_model: 'anthropic/claude-sonnet-4-6' },
+          { params: { projectId: p.id, sessionId: ZERO_UUID } },
+        );
+      r.status(401);
+    });
+    await ctx.step('invalid (non-uuid) session id → 400', async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .put(
+          '/v1/projects/:projectId/sessions/:sessionId/model',
+          { opencode_model: 'anthropic/claude-sonnet-4-6' },
+          { params: { projectId: p.id, sessionId: 'not-a-uuid' } },
+        );
+      r.status(400);
+    });
+    await ctx.step('unknown projectId → 404 (project not loadable)', async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .put(
+          '/v1/projects/:projectId/sessions/:sessionId/model',
+          { opencode_model: 'anthropic/claude-sonnet-4-6' },
+          { params: { projectId: ZERO_UUID, sessionId: ZERO_UUID } },
+        );
+      r.status(404);
+    });
+    await ctx.step('unknown session (valid uuid) → 404 (session not found)', async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .put(
+          '/v1/projects/:projectId/sessions/:sessionId/model',
+          { opencode_model: 'anthropic/claude-sonnet-4-6' },
+          { params: { projectId: p.id, sessionId: ZERO_UUID } },
+        );
+      r.status(404);
+    });
+    await ctx.step('NONMEMBER → 403/404 (no project access)', async () => {
+      const r = await ctx.client
+        .as(ctx.P.NONMEMBER)
+        .put(
+          '/v1/projects/:projectId/sessions/:sessionId/model',
+          { opencode_model: 'anthropic/claude-sonnet-4-6' },
+          { params: { projectId: p.id, sessionId: ZERO_UUID } },
+        );
+      r.status([403, 404]);
+    });
+  },
+);


### PR DESCRIPTION
## What

Closes a **5-route coverage gate failure** that surfaced when main advanced to `0abd852a9`. The gate was red (`98% · 506/521 · 5 uncovered`); this PR closes all 5 gaps → gate green (`98.1% · 511/521 · 0 uncovered`).

## Why

5 new routes landed on main with no e2e coverage — exactly the failure mode the gate exists to catch. They are: the connector-profiles roster (`/all`), the per-profile default toggle (`/default`), the per-profile tool-call policies (`GET` + `PUT /policies`), and the running-session model change (`PUT /sessions/:sessionId/model`).

## Changes

**`COVD-1` extended** (`tests/src/flows/connectors.flow.ts`) — the existing connector-profile flow already seeds a real connector + profile, so the new routes fold in against that fixture:
- `GET /connector-profiles/all` → `200` roster (manage-gated; asserts `label`/`metadata` NOT leaked — only identity + status)
- `PUT /connector-profiles/:profileId/default` → `200 ok` (make the member profile the default)
- `GET /connector-profiles/:profileId/policies` → `200` with `policies` array
- `PUT /connector-profiles/:profileId/policies` (replace with one allow rule) → `200 ok`
- `PUT policies` with an invalid match pattern (`[unclosed`) → `400` (INVALID_MATCHER)
- `policies`/`default` on an unknown profileId → `404`

**`SESS-MODEL` new** (`tests/src/flows/sessions.flow.ts`) — `PUT /sessions/:sessionId/model`. The positive path needs a funded live session (it restarts opencode + re-points the agent), so this asserts the boundaries only:
- ANON → `401`
- invalid (non-uuid) session id → `400`
- unknown projectId → `404`
- unknown session (valid uuid) → `404`
- NONMEMBER → `403`/`404`

## Coverage

- Before: `98% · 506/521 routes · 10 allowlisted · 5 uncovered` — **gate FAILED**
- After:  `98.1% · 511/521 routes · 10 allowlisted · 0 uncovered` — **gate PASS**

This is **route-gap closure** (the gate was genuinely red), not edge-case depth.

## Verification

Static (sandbox has no live staging creds):
- `bun bin/ke2e.ts coverage` → gate passes (was failing), `COVD-1`/`SESS-MODEL` discovered
- `tsc --noEmit` → no errors in changed files
- `biome format` → clean

Live staging verification runs in CI `qa-release.yml` ke2e lane on merge. Both flows need no funded capability for the boundary assertions (COVD-1 uses a seeded connector/profile; SESS-MODEL asserts 4xx boundaries on unknown ids).

## Bugs filed

None — the route handlers behave as the code describes; this closes the coverage gaps and pins the auth/shape/lookup boundaries.