### PR TITLE
docs: connectors_personal manifest field, changeModel SDK method, auth-type enum, runtimeTransport option

### DIFF
--- a/apps/web/content/docs/connect/connectors.mdx
+++ b/apps/web/content/docs/connect/connectors.mdx
@@ -130,7 +130,7 @@ connectors:
       type: bearer
 ```
 
-`provider` is one of `openapi`, `graphql`, `postman`, `http`, or `mcp`. `auth.type` is `bearer`, `basic`, `custom`, `oauth1`, or `none`.
+`provider` is one of `openapi`, `graphql`, `postman`, `http`, or `mcp`. `auth.type` is `bearer`, `basic`, `custom`, `api_key`, `oauth1`, `hmac`, `aws_sigv4`, `mtls`, or `none`.
 </Step>
 <Step>
 ### Merge the change request

--- a/apps/web/content/docs/project/manifest.mdx
+++ b/apps/web/content/docs/project/manifest.mdx
@@ -304,6 +304,7 @@ agents:
 | *(map key)* | — | `[a-z0-9][a-z0-9_-]{0,127}`, unique per project. Matches the `.md` filename it governs. |
 | `enabled` | `true` | `false` treats the agent as undeclared — the platform will not launch it. |
 | `connectors` | `none` | Which connector slugs this agent may call. `all` means every connector. |
+| `connectors_personal` | — | Subset of `connectors` that must resolve to the launching user's own connection (their member profile), not the shared project one. A session started with this agent auto-requires these; a missing one fails create with `CONNECTOR_CONNECTION_REQUIRED`. Interactive sessions only — backend/service-account sessions use `connector_bindings` instead. Must be a subset of `connectors`. |
 | `secrets` | `none` | Which project secrets this agent receives as sandbox env vars. Renamed from v1's `env`. |
 | `kortix_cli` | `none` | Which Kortix CLI and API actions this agent may perform. `all` means everything the launching user can do — an agent can never exceed its launcher. |
 | `skills` | `none` | Which skills this agent may load. |

--- a/apps/web/content/docs/sdk/react.mdx
+++ b/apps/web/content/docs/sdk/react.mdx
@@ -76,6 +76,7 @@ the run stays blocked. Use `answerQuestion`, `rejectQuestion`, or
 | Option | Default | What it does |
 |---|---|---|
 | `waitMs` | `15000` | The long-poll budget sent to `/start`. |
+| `runtimeTransport` | (unset) | Override the server-selected transport (`'rest'` \| `'acp'`) for page-scoped diagnostics. Omit to use `/start`'s `runtime_transport`. |
 | `replayStartStash` | `true` | Replay a prompt saved before the session existed, once the session is ready. |
 | `enabled` | `true` | Set `false` to delay the hook, for example until a billing check passes. |
 | `chatEngine` | `true` | Set `false` if your app mounts its own chat surface for this session, to avoid syncing messages twice. |

--- a/apps/web/content/docs/sdk/sessions.mdx
+++ b/apps/web/content/docs/sdk/sessions.mdx
@@ -70,6 +70,19 @@ await s.send('One-off task', { model, agent }); // overrides for this call only
 await s.abort(); // stop the current run
 ```
 
+`setModel` only chooses what the next local `send` asks for — it never leaves the
+handle. To **persist** a new model for a running session server-side, use
+`changeModel`:
+
+```ts
+const { applied_live } = await s.changeModel('anthropic/claude-opus-4-8');
+```
+
+Restarting the runtime is how the change takes effect, so an in-flight turn ends.
+`applied_live` is `true` when a running session took it now, `false` when it
+applies at the next start. Only the session owner or a project manager may change
+the model; anyone else gets `403`.
+
 `send()` resolves the runtime, then prompts it. `abort()` stops the current
 run without deleting the session.
 


### PR DESCRIPTION
## docs: connectors_personal manifest field, changeModel SDK method, auth-type enum, runtimeTransport option

Docs-only accuracy sweep from the autonomous `docs-maintainer` run (2026-07-28). Four drifts found by four parallel `docs-maintainer-worker` shards and independently re-verified by the orchestrator against current source before editing.

### Audit window
- `kortix-ai/suna`: `377eb9eb7` (2026-07-27 checkpoint) → `45ebcd8de` (origin/main). 471 reachable commits (297 non-merge + 174 merge — large window with many staging-deploy chores). Full-SHA coverage manifest passes `check-commit-coverage.mjs` (5 `docs-change`, 13 `already-current`, 453 `no-doc-impact`). Window includes: `origin_ref`→`end_user_ref` rename (backend.mdx updated by feature author), message-based rewind (sdk/react.mdx updated by feature author), per-end-user cost breakdown, `connectors_personal`/`require_connectors` KaaB connector features, per-connection policy layer, model-mid-flight change, US East 2 cutover.

### Fixes

**1. `connectors_personal` manifest field (HIGH) — `project/manifest.mdx:307`**
The v2 manifest agents table omitted `connectors_personal`, a first-class governance field. It declares which connector aliases must resolve to the launching user's own connection (member profile), not the shared project one. A session started with this agent auto-requires these; a missing one fails create with `CONNECTOR_CONNECTION_REQUIRED`. Interactive sessions only — backend/SA sessions use `connector_bindings` instead. Must be a subset of `connectors`. Source proof: `packages/manifest-schema/src/index.v2.ts:125-132`; `apps/api/src/projects/lib/sessions.ts:867-881`; `apps/api/src/projects/routes/agent-scope.ts:39`.

**2. `s.changeModel(model)` SDK method (HIGH) — `sdk/sessions.mdx`**
The docs documented `s.setModel` (local sticky selector, never leaves the handle) but not `s.changeModel(model)` — which persists a new model for a running session server-side, re-pointing the sandbox. Restarting the runtime is how the change takes effect (an in-flight turn ends). Returns `{ applied_live }` — `true` when a running session took it now, `false` at next start. Only the session owner or a project manager may change the model (403 otherwise). Source proof: `packages/sdk/src/core/client/kortix.ts:881-890`; `packages/sdk/src/core/rest/projects-client/sessions.ts:521-540`; `apps/api/src/projects/routes/r7.ts:2017`.

**3. `connect/connectors.mdx:133` auth-type enum (MEDIUM, pre-existing) — `connect/connectors.mdx`**
The connectors page listed only 5 of 9 supported auth types (`bearer, basic, custom, oauth1, none`), inconsistent with the manifest reference (which has all 9). Added `api_key, hmac, aws_sigv4, mtls`. Source proof: `packages/manifest-schema/src/constants.ts:29-39` (`CONNECTOR_AUTH_TYPES`); `apps/web/content/docs/project/manifest.mdx:272` (sibling page already correct).

**4. `runtimeTransport` option (LOW) — `sdk/react.mdx`**
The `useSession` Options table omitted `runtimeTransport`, which lets a host override the server-selected transport (`'rest'` | `'acp'`) for page-scoped diagnostics. It was documented only as a return field. Source proof: `packages/sdk/src/react/use-session.ts:338` (`runtimeTransport?: SessionRuntimeTransport`); `:409,436`.

### Verification
- `check-fumadocs.mjs` PASS (28 pages, 6 nav, 28 routes).
- `git diff --check` PASS; `test-docs-maintainer-gates.mjs` PASS.
- Grep gates PASS (positive markers: `connectors_personal`, `CONNECTOR_CONNECTION_REQUIRED`, `changeModel`, `applied_live`, "Only the session owner or a project manager", `api_key`/`hmac`/`aws_sigv4`/`mtls` in connectors.mdx, `runtimeTransport` option row).
- This PR is docs-only — 4 files under `apps/web/content/docs/**`.

