### PR TITLE
test(ke2e): bound release gate load

### DIFF
--- a/tests/api/README.md
+++ b/tests/api/README.md
@@ -35,7 +35,7 @@ bun bin/ke2e.ts run --grep logout
 # point at another environment
 KE2E_API_URL=https://dev-api.kortix.com/v1 bun bin/ke2e.ts run --domain auth
 
-# override the default 8 API workers and 4 sandbox workers
+# override the default 4 API workers and 4 sandbox workers
 bun bin/ke2e.ts run --api-workers 12 --sandbox-workers 4
 
 # force one shared worker pool instead of split lanes
@@ -47,7 +47,7 @@ bun bin/ke2e.ts run --workers 1
 (`KE2E_OWNER_*`, `KE2E_ADMIN_TOKEN`, capabilities, destructive-run guards).
 `KE2E_API_WORKERS` and `KE2E_SANDBOX_WORKERS` set the split-lane defaults.
 An explicit `--workers` value disables split lanes and caps the complete run.
-`KE2E_TEARDOWN_WORKERS` controls user cleanup concurrency. Its default is `4`.
+`KE2E_TEARDOWN_WORKERS` controls user cleanup concurrency. Its default is `2`.
 
 ### Adding a flow
 

--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -35,7 +35,7 @@ export function isKe2eRetryableError(error: unknown): boolean {
 }
 
 const DEFAULT_RETRY_DELAY_MS = 2_000;
-const MAX_RETRY_AFTER_MS = 60_000;
+const MAX_RETRY_AFTER_MS = 15_000;
 
 /** Return the host-requested retry delay for a marked transient failure. */
 export function ke2eRetryDelayMs(

--- a/tests/src/core/runner.ts
+++ b/tests/src/core/runner.ts
@@ -243,7 +243,7 @@ export async function runSuite(opts: RunOptions): Promise<RunResult> {
       const { apiLane, sandboxLane } = partitionParallelFlows(parallelLane);
       const apiWorkers = positiveWorkerCount(
         opts.apiWorkers ?? Number(process.env.KE2E_API_WORKERS),
-        8,
+        4,
       );
       const sandboxWorkers = positiveWorkerCount(
         opts.sandboxWorkers ?? Number(process.env.KE2E_SANDBOX_WORKERS),

--- a/tests/src/fixtures/world.ts
+++ b/tests/src/fixtures/world.ts
@@ -291,7 +291,7 @@ export async function buildWorld(env: Env, flows: RegisteredFlow[]): Promise<Wor
         }
       }
       const userIds = [...provisioned.supabaseUserIds, ...extraUserIds];
-      const cleanupWorkers = Number(process.env.KE2E_TEARDOWN_WORKERS ?? 4);
+      const cleanupWorkers = Number(process.env.KE2E_TEARDOWN_WORKERS ?? 2);
       await mapWithConcurrency(userIds, cleanupWorkers, async (uid) => {
         try {
           await adminDeleteUser(env, uid);

--- a/tests/unit/release-gate-resilience.test.ts
+++ b/tests/unit/release-gate-resilience.test.ts
@@ -204,16 +204,16 @@ describe('release gate transient failure resilience', () => {
     }
 
     expect(isKe2eRetryableError(error)).toBe(true);
-    expect(ke2eRetryDelayMs(error)).toBe(30_000);
+    expect(ke2eRetryDelayMs(error)).toBe(15_000);
   });
 
-  it('caps a host-requested retry delay at 60 seconds', () => {
+  it('caps a host-requested retry delay at 15 seconds', () => {
     const error = Object.assign(new Error('transient gateway status 503'), {
       ke2eRetryable: true,
       ke2eRetryAfterMs: 180_000,
     });
 
-    expect(ke2eRetryDelayMs(error)).toBe(60_000);
+    expect(ke2eRetryDelayMs(error)).toBe(15_000);
   });
 
   it('does not mark an API contract 503 for retry', () => {


### PR DESCRIPTION
## Summary

- run API and sandbox lanes in parallel with four workers each
- reduce Supabase teardown concurrency from four workers to two
- cap host-level `Retry-After` waits at 15 seconds
- keep one clean flow retry and keep API contract failures non-retryable

## Evidence

- QA `30329835492` at eight API workers triggered staging maintenance responses, sandbox readiness timeouts, and the 45-minute step timeout
- the run created 15 managed repositories because retries reprovisioned fixtures
- `bun run typecheck` passed
- `bun run test:unit` passed `34/34`
- `bun run coverage` passed `497/507`, `10` allowlisted, `0` uncovered