### PR TITLE
fix(runtime): pin Pi internal dependencies

### DIFF
--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -223,7 +223,8 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // feature as a transient provider failure mid-call.
 // v34: bake exact Claude Code, Codex, and Pi ACP adapter versions. The sandbox
 // daemon can start all four harnesses without a request-time package download.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v34';
+// v35: pin Pi's internal 0.x packages to the same version as pi-coding-agent.
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v35';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -90,7 +90,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -254,7 +254,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -419,7 +419,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -137,6 +137,15 @@ describe('runtime artifact integrity', () => {
     expect(rendered).toContain(
       `"@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"`,
     );
+    expect(rendered).toContain(
+      `"@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}"`,
+    );
+    expect(rendered).toContain(
+      `"@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}"`,
+    );
+    expect(rendered).toContain(
+      `"@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}"`,
+    );
     expect(rendered).toContain('command -v claude-agent-acp');
     expect(rendered).toContain('command -v codex-acp');
     expect(rendered).toContain('command -v pi-acp');

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -571,7 +571,10 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '',
     // Install every ACP adapter during image construction. Runtime requests
     // only start these pinned executables. They never download an npm package.
-    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \\`,
+    // pi-coding-agent declares caret ranges for its internal 0.x packages.
+    // Pin those root dependencies to prevent incompatible later 0.x releases
+    // from replacing the matching versions in pnpm's global dependency graph.
+    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}" \\`,
     '    && command -v claude-agent-acp \\',
     '    && command -v codex-acp \\',
     '    && command -v pi-acp \\',


### PR DESCRIPTION
## Summary

- Pin `pi-ai`, `pi-tui`, and `pi-agent-core` to `0.80.6`.
- Prevent pnpm from resolving incompatible later `0.x` releases.
- Bump the runtime layer identity to v35.

## Provider evidence

Daytona resolved `pi-coding-agent@0.80.6` with `pi-ai@0.82.1`. The image probe failed with:

```text
SyntaxError: The requested module '@earendil-works/pi-ai/oauth' does not provide an export named 'getOAuthApiKey'
```

An isolated global install with all Pi packages pinned to `0.80.6` returned `pi --version` as `0.80.6`.

## Verification

- `bun test packages/shared/src/sandbox`: 55 pass, 0 fail.
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/snapshots`: 252 pass, 1 skip, 0 fail.
- `pnpm --filter kortix-api typecheck`: passed.
- `git diff --check`: passed.