### PR TITLE
chore(release): include latest Pi runtime fix in staging

### DIFF
--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -223,7 +223,8 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // feature as a transient provider failure mid-call.
 // v34: bake exact Claude Code, Codex, and Pi ACP adapter versions. The sandbox
 // daemon can start all four harnesses without a request-time package download.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v34';
+// v35: pin Pi's internal 0.x packages to the same version as pi-coding-agent.
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v35';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -4,7 +4,7 @@
 
 # Immutable dev tag (CI bumps to dev-<sha8>). Bootstrap value until the first run.
 image:
-  tag: "dev-d87349a9"
+  tag: "dev-1b4db8f8"
 # Dev sizing (≤100 users): 1-replica floor, burst to 2.
 replicas: 1
 autoscaling:

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-d87349a9"
+  tag: "dev-1b4db8f8"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -90,7 +90,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -254,7 +254,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -419,7 +419,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -137,6 +137,15 @@ describe('runtime artifact integrity', () => {
     expect(rendered).toContain(
       `"@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"`,
     );
+    expect(rendered).toContain(
+      `"@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}"`,
+    );
+    expect(rendered).toContain(
+      `"@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}"`,
+    );
+    expect(rendered).toContain(
+      `"@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}"`,
+    );
     expect(rendered).toContain('command -v claude-agent-acp');
     expect(rendered).toContain('command -v codex-acp');
     expect(rendered).toContain('command -v pi-acp');

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -571,7 +571,10 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '',
     // Install every ACP adapter during image construction. Runtime requests
     // only start these pinned executables. They never download an npm package.
-    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \\`,
+    // pi-coding-agent declares caret ranges for its internal 0.x packages.
+    // Pin those root dependencies to prevent incompatible later 0.x releases
+    // from replacing the matching versions in pnpm's global dependency graph.
+    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}" \\`,
     '    && command -v claude-agent-acp \\',
     '    && command -v codex-acp \\',
     '    && command -v pi-acp \\',


### PR DESCRIPTION
Promote current `main` at `cb03942c8d7be83a7248ccdbc4c05e36a8c31cef` to staging.

This adds the Pi internal dependency pin from PR `#5671` to the release candidate.