### PR TITLE
fix(runtime): install Pi with npm

### DIFF
--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -224,7 +224,8 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // v34: bake exact Claude Code, Codex, and Pi ACP adapter versions. The sandbox
 // daemon can start all four harnesses without a request-time package download.
 // v35: pin Pi's internal 0.x packages to the same version as pi-coding-agent.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v35';
+// v36: install Pi with npm because pnpm 11 isolates each global root graph.
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v36';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -90,7 +90,8 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" \\
+    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -254,7 +255,8 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" \\
+    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -419,7 +421,8 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" \\
+    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -146,6 +146,9 @@ describe('runtime artifact integrity', () => {
     expect(rendered).toContain(
       `"@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}"`,
     );
+    expect(rendered).toContain(
+      'npm install -g --prefix /home/kortix/.local',
+    );
     expect(rendered).toContain('command -v claude-agent-acp');
     expect(rendered).toContain('command -v codex-acp');
     expect(rendered).toContain('command -v pi-acp');

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -571,10 +571,10 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '',
     // Install every ACP adapter during image construction. Runtime requests
     // only start these pinned executables. They never download an npm package.
-    // pi-coding-agent declares caret ranges for its internal 0.x packages.
-    // Pin those root dependencies to prevent incompatible later 0.x releases
-    // from replacing the matching versions in pnpm's global dependency graph.
-    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}" \\`,
+    // pnpm 11 gives each global root package an isolated dependency graph.
+    // npm deduplicates Pi's exact internal versions into one compatible graph.
+    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" \\`,
+    `    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}" \\`,
     '    && command -v claude-agent-acp \\',
     '    && command -v codex-acp \\',
     '    && command -v pi-acp \\',


### PR DESCRIPTION
## Summary

- Keep Claude, Codex, and Pi ACP adapters under pnpm.
- Install `pi-coding-agent` and its internal packages with npm.
- Pin all Pi package versions to `0.80.6`.
- Bump the runtime layer identity to v36.

## Provider evidence

`pnpm@11.15.1` gives each global root package an isolated dependency graph. `pi-coding-agent@0.80.6` therefore retained `pi-ai@0.82.1` despite exact root pins. Both local pnpm 11 reproduction and Daytona failed with:

```text
SyntaxError: The requested module '@earendil-works/pi-ai/oauth' does not provide an export named 'getOAuthApiKey'
```

The exact combined install now passes:

```text
claude-agent-acp --version -> 0.58.1
codex-acp --version -> @agentclientprotocol/codex-acp 1.1.2
pi-acp --help -> exit 0
pi --version -> 0.80.6
```

## Verification

- `bun test packages/shared/src/sandbox`: 55 pass, 0 fail.
- `KORTIX_URL=http://localhost:8008 dotenvx run -f apps/api/.env -- bun test apps/api/src/snapshots`: 252 pass, 1 skip, 0 fail.
- `pnpm --filter kortix-api typecheck`: passed.
- `git diff --check`: passed.