### PR TITLE
feat(whitelabel-demo): show what a running session can and cannot change

### DIFF
--- a/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { MID_SESSION_CAPABILITIES } from '@/lib/mid-session-change';
+import { Lock, RefreshCw, Repeat } from 'lucide-react';
+
+/**
+ * What this session may still change, stated honestly.
+ *
+ * The three overrides look alike and behave completely differently. Showing a
+ * secrets control that cannot work would be worse than showing none — so this
+ * shows the LIMIT, with the reason, instead of a disabled input the user will
+ * keep poking.
+ */
+const ROWS = [
+  {
+    key: 'model' as const,
+    label: 'Model',
+    icon: RefreshCw,
+    badge: 'Changeable now',
+    detail: 'Switching restarts the runtime, which ends the in-flight turn.',
+  },
+  {
+    key: 'agent' as const,
+    label: 'Agent',
+    icon: Repeat,
+    badge: 'Per message',
+    detail:
+      'Each message names the agent that runs it. Switching to an agent with different secret access needs a new session — re-scoping cannot un-read what this session already loaded.',
+  },
+  {
+    key: 'secrets' as const,
+    label: 'Secrets',
+    icon: Lock,
+    badge: 'Fixed at start',
+    detail:
+      'The secret allowlist is set once when the session starts and never changes. Narrowing it mid-flight could leave the session unable to boot. Start a new session to change it.',
+  },
+];
+
+export function SessionScope() {
+  return (
+    <div className="space-y-2">
+      {ROWS.map((row) => {
+        const Icon = row.icon;
+        const fixed = MID_SESSION_CAPABILITIES[row.key] === 'fixed_at_create';
+        return (
+          <div
+            key={row.key}
+            className="flex items-start gap-3 rounded-md border border-border bg-card px-3 py-2.5"
+          >
+            <Icon
+              className={`mt-0.5 size-4 shrink-0 ${fixed ? 'text-muted-foreground' : 'text-brand'}`}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{row.label}</span>
+                <Badge variant={fixed ? 'secondary' : 'outline'} className="text-xs">
+                  {row.badge}
+                </Badge>
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{row.detail}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
@@ -12,6 +12,7 @@ import { Bubble, BubbleContent } from '@/components/ui/bubble';
 import { Button } from '@/components/ui/button';
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker';
 import { Message } from '@/components/ui/message';
+import { SessionScope } from '@/components/workbench/session-scope';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ChangesPanel } from '@/components/workbench/changes-panel';
 import { FilesPanel } from '@/components/workbench/files-panel';
@@ -39,7 +40,7 @@ export function WorkbenchTabs({
     <Tabs defaultValue="chat" className="flex min-h-0 flex-1 flex-col gap-0">
       <div className="px-5 pt-3.5">
         <TabsList>
-          {(['chat', 'files', 'changes', 'preview'] as const).map((v) => (
+          {(['chat', 'files', 'changes', 'preview', 'scope'] as const).map((v) => (
             <TabsTrigger key={v} value={v} className="px-3.5 capitalize">
               {v}
             </TabsTrigger>
@@ -54,6 +55,18 @@ export function WorkbenchTabs({
       </TabsContent>
       <TabsContent value="files" className="min-h-0 flex-1 overflow-hidden p-4">
         <FilesPanel projectId={projectId} />
+      </TabsContent>
+      {/* What this session can still change. Shown as a first-class tab rather
+          than a settings footnote: 'can I switch the agent / secrets now?' is a
+          question people ask mid-session, and the answers genuinely differ. */}
+      <TabsContent value="scope" className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div className="mx-auto max-w-xl">
+          <h2 className="text-sm font-medium">What this session can change</h2>
+          <p className="mb-3 mt-0.5 text-xs text-muted-foreground">
+            Overrides are set when a session starts. These are the ones you can still move.
+          </p>
+          <SessionScope />
+        </div>
       </TabsContent>
       <TabsContent value="changes" className="min-h-0 flex-1 overflow-hidden p-4">
         <ChangesPanel projectId={projectId} sessionId={sessionId} />

--- a/apps/whitelabel-demo/src/lib/mid-session-change.ts
+++ b/apps/whitelabel-demo/src/lib/mid-session-change.ts
@@ -1,0 +1,64 @@
+/**
+ * What can actually change once a session is running — and what cannot.
+ *
+ * These three overrides look alike from the outside and behave completely
+ * differently, which is exactly the sort of thing a reference app should make
+ * legible rather than let people discover in production:
+ *
+ * - MODEL — changeable. `PUT /sessions/{id}/model` re-points the running runtime.
+ *   Restarts it, so the in-flight turn ends.
+ * - AGENT — changeable PER PROMPT: each message names the agent it runs. But a
+ *   switch to an agent with a DIFFERENT secrets grant is refused
+ *   (409 AGENT_SWITCH_REQUIRES_NEW_SESSION), because re-scoping now cannot
+ *   un-read what the session's original agent already pulled into the box.
+ * - SECRETS — NOT changeable, by design. `secrets_allowlist` is written once at
+ *   create and there is no update path anywhere. The server comments are blunt
+ *   about why: a mutable allowlist "would leave the session permanently
+ *   unbootable" if it were narrowed below what the box already needs.
+ */
+
+export type MidSessionCapability = 'changeable' | 'per_prompt' | 'fixed_at_create';
+
+export const MID_SESSION_CAPABILITIES = {
+  model: 'changeable',
+  agent: 'per_prompt',
+  secrets: 'fixed_at_create',
+} as const satisfies Record<string, MidSessionCapability>;
+
+export type AgentSwitchOutcome =
+  | { kind: 'ok' }
+  | { kind: 'needs_new_session'; message: string }
+  | { kind: 'grant_unresolved'; message: string }
+  | { kind: 'unknown'; message: string };
+
+interface UpstreamError {
+  code?: unknown;
+  error?: unknown;
+}
+
+/**
+ * Classify a prompt rejected because of the agent it asked to run.
+ *
+ * `AGENT_SWITCH_REQUIRES_NEW_SESSION` is not a failure to retry — retrying with
+ * the same agent will always fail. The only resolution is a new session, so the
+ * UI must offer that rather than a retry button.
+ *
+ * `AGENT_SECRET_GRANT_UNRESOLVED` is the opposite: the sandbox is fine and only
+ * our ability to VERIFY entitlement failed, so retrying IS correct (503).
+ */
+export function classifyAgentSwitch(body: UpstreamError | null): AgentSwitchOutcome {
+  const code = typeof body?.code === 'string' ? body.code : '';
+  const message =
+    typeof body?.error === 'string' && body.error.trim().length > 0
+      ? body.error
+      : 'The agent could not be switched.';
+
+  if (code === 'AGENT_SWITCH_REQUIRES_NEW_SESSION') {
+    return { kind: 'needs_new_session', message };
+  }
+  if (code === 'AGENT_SECRET_GRANT_UNRESOLVED') {
+    return { kind: 'grant_unresolved', message };
+  }
+  if (code) return { kind: 'unknown', message };
+  return { kind: 'ok' };
+}

--- a/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { MID_SESSION_CAPABILITIES, classifyAgentSwitch } from '../../src/lib/mid-session-change';
+
+describe('what can change mid-session', () => {
+  test('model changes, agent is per-prompt, secrets are fixed at create', () => {
+    // Encoded so the UI cannot drift from the server contract: offering a
+    // secrets control would be offering something that cannot work.
+    expect(MID_SESSION_CAPABILITIES.model).toBe('changeable');
+    expect(MID_SESSION_CAPABILITIES.agent).toBe('per_prompt');
+    expect(MID_SESSION_CAPABILITIES.secrets).toBe('fixed_at_create');
+  });
+});
+
+describe('classifyAgentSwitch', () => {
+  test('a grant-crossing switch needs a NEW SESSION, not a retry', () => {
+    // Retrying with the same agent fails forever — re-scoping cannot un-read
+    // what the session's original agent already pulled into the sandbox.
+    const result = classifyAgentSwitch({
+      code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION',
+      error: 'agent switch requires a new session',
+    });
+    expect(result.kind).toBe('needs_new_session');
+  });
+
+  test('an unresolved grant IS worth retrying — the sandbox is fine', () => {
+    const result = classifyAgentSwitch({ code: 'AGENT_SECRET_GRANT_UNRESOLVED', error: 'x' });
+    expect(result.kind).toBe('grant_unresolved');
+  });
+
+  test('the two are never conflated — one is terminal, the other transient', () => {
+    const terminal = classifyAgentSwitch({ code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION' });
+    const transient = classifyAgentSwitch({ code: 'AGENT_SECRET_GRANT_UNRESOLVED' });
+    expect(terminal.kind).not.toBe(transient.kind);
+  });
+
+  test('no code means the prompt was not rejected for the agent', () => {
+    expect(classifyAgentSwitch({}).kind).toBe('ok');
+    expect(classifyAgentSwitch(null).kind).toBe('ok');
+  });
+
+  test('an unrecognised code degrades to a readable message', () => {
+    expect(classifyAgentSwitch({ code: 'SOMETHING_ELSE', error: 'boom' })).toEqual({
+      kind: 'unknown',
+      message: 'boom',
+    });
+  });
+
+  test('a blank server message still yields something readable', () => {
+    const result = classifyAgentSwitch({ code: 'X', error: '  ' });
+    // Narrow first: only the non-'ok' variants carry a message.
+    expect(result.kind).toBe('unknown');
+    if (result.kind !== 'ok') {
+      expect(result.message).toBe('The agent could not be switched.');
+    }
+  });
+});


### PR DESCRIPTION
"Change the agent / secrets mid-session" has **three different answers**, and the
demo made none of them visible. I verified each against the server before
building, rather than assuming they were symmetric:

| Override | Mid-session | Why |
| --- | --- | --- |
| **Model** | changeable now | `PUT /sessions/{id}/model` re-points the running runtime; the restart ends the in-flight turn |
| **Agent** | per message | each prompt names the agent that runs it — `requestedAgent` drives secret-grant resolution |
| **Secrets** | **fixed at start** | `secrets_allowlist` is written once at create; there is **no update path anywhere** in `apps/api` |

## I deliberately did not build a secrets control

Offering one would be offering something that cannot work. The server comments
are explicit that a mutable allowlist *"would leave the session permanently
unbootable"* if narrowed below what the box already needs.

So the demo shows the **limit and the reason** rather than a disabled input
people keep poking at.

## The agent trap worth encoding

Switching to an agent with a **different secrets grant** is refused
`409 AGENT_SWITCH_REQUIRES_NEW_SESSION`, and **retrying can never succeed** —
re-scoping cannot un-read what the session's original agent already pulled into
the sandbox. That needs "start a new session", not a retry button.

`AGENT_SECRET_GRANT_UNRESOLVED` (503) is the exact opposite: the sandbox is
fine, only our ability to *verify* entitlement failed, so retrying is correct.

`classifyAgentSwitch` keeps them apart, with a test asserting they are never
conflated — one is terminal, the other transient, and treating them alike sends
the user in the wrong direction either way.

## Verification

- 7 unit cases
- `sdk-boundary`: 0 violations
- demo suite: 99 pass / 0 fail
- tsc clean

**Not covered:** the panel is informational. Actually *performing* an agent
switch from the UI (and surfacing the 409 inline) would need the send path to
carry an agent selector, which is a larger change to the chat composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
