### PR TITLE
chore(release): final main cutoff for v0.11.0 staging

### DIFF
--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -224,7 +224,8 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // v34: bake exact Claude Code, Codex, and Pi ACP adapter versions. The sandbox
 // daemon can start all four harnesses without a request-time package download.
 // v35: pin Pi's internal 0.x packages to the same version as pi-coding-agent.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v35';
+// v36: install Pi with npm because pnpm 11 isolates each global root graph.
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v36';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { MID_SESSION_CAPABILITIES } from '@/lib/mid-session-change';
+import { Lock, RefreshCw, Repeat } from 'lucide-react';
+
+/**
+ * What this session may still change, stated honestly.
+ *
+ * The three overrides look alike and behave completely differently. Showing a
+ * secrets control that cannot work would be worse than showing none — so this
+ * shows the LIMIT, with the reason, instead of a disabled input the user will
+ * keep poking.
+ */
+const ROWS = [
+  {
+    key: 'model' as const,
+    label: 'Model',
+    icon: RefreshCw,
+    badge: 'Changeable now',
+    detail: 'Switching restarts the runtime, which ends the in-flight turn.',
+  },
+  {
+    key: 'agent' as const,
+    label: 'Agent',
+    icon: Repeat,
+    badge: 'Per message',
+    detail:
+      'Each message names the agent that runs it. Switching to an agent with different secret access needs a new session — re-scoping cannot un-read what this session already loaded.',
+  },
+  {
+    key: 'secrets' as const,
+    label: 'Secrets',
+    icon: Lock,
+    badge: 'Fixed at start',
+    detail:
+      'The secret allowlist is set once when the session starts and never changes. Narrowing it mid-flight could leave the session unable to boot. Start a new session to change it.',
+  },
+];
+
+export function SessionScope() {
+  return (
+    <div className="space-y-2">
+      {ROWS.map((row) => {
+        const Icon = row.icon;
+        const fixed = MID_SESSION_CAPABILITIES[row.key] === 'fixed_at_create';
+        return (
+          <div
+            key={row.key}
+            className="flex items-start gap-3 rounded-md border border-border bg-card px-3 py-2.5"
+          >
+            <Icon
+              className={`mt-0.5 size-4 shrink-0 ${fixed ? 'text-muted-foreground' : 'text-brand'}`}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{row.label}</span>
+                <Badge variant={fixed ? 'secondary' : 'outline'} className="text-xs">
+                  {row.badge}
+                </Badge>
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{row.detail}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
@@ -12,6 +12,7 @@ import { Bubble, BubbleContent } from '@/components/ui/bubble';
 import { Button } from '@/components/ui/button';
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker';
 import { Message } from '@/components/ui/message';
+import { SessionScope } from '@/components/workbench/session-scope';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ChangesPanel } from '@/components/workbench/changes-panel';
 import { FilesPanel } from '@/components/workbench/files-panel';
@@ -39,7 +40,7 @@ export function WorkbenchTabs({
     <Tabs defaultValue="chat" className="flex min-h-0 flex-1 flex-col gap-0">
       <div className="px-5 pt-3.5">
         <TabsList>
-          {(['chat', 'files', 'changes', 'preview'] as const).map((v) => (
+          {(['chat', 'files', 'changes', 'preview', 'scope'] as const).map((v) => (
             <TabsTrigger key={v} value={v} className="px-3.5 capitalize">
               {v}
             </TabsTrigger>
@@ -54,6 +55,18 @@ export function WorkbenchTabs({
       </TabsContent>
       <TabsContent value="files" className="min-h-0 flex-1 overflow-hidden p-4">
         <FilesPanel projectId={projectId} />
+      </TabsContent>
+      {/* What this session can still change. Shown as a first-class tab rather
+          than a settings footnote: 'can I switch the agent / secrets now?' is a
+          question people ask mid-session, and the answers genuinely differ. */}
+      <TabsContent value="scope" className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div className="mx-auto max-w-xl">
+          <h2 className="text-sm font-medium">What this session can change</h2>
+          <p className="mb-3 mt-0.5 text-xs text-muted-foreground">
+            Overrides are set when a session starts. These are the ones you can still move.
+          </p>
+          <SessionScope />
+        </div>
       </TabsContent>
       <TabsContent value="changes" className="min-h-0 flex-1 overflow-hidden p-4">
         <ChangesPanel projectId={projectId} sessionId={sessionId} />

--- a/apps/whitelabel-demo/src/lib/mid-session-change.ts
+++ b/apps/whitelabel-demo/src/lib/mid-session-change.ts
@@ -1,0 +1,64 @@
+/**
+ * What can actually change once a session is running — and what cannot.
+ *
+ * These three overrides look alike from the outside and behave completely
+ * differently, which is exactly the sort of thing a reference app should make
+ * legible rather than let people discover in production:
+ *
+ * - MODEL — changeable. `PUT /sessions/{id}/model` re-points the running runtime.
+ *   Restarts it, so the in-flight turn ends.
+ * - AGENT — changeable PER PROMPT: each message names the agent it runs. But a
+ *   switch to an agent with a DIFFERENT secrets grant is refused
+ *   (409 AGENT_SWITCH_REQUIRES_NEW_SESSION), because re-scoping now cannot
+ *   un-read what the session's original agent already pulled into the box.
+ * - SECRETS — NOT changeable, by design. `secrets_allowlist` is written once at
+ *   create and there is no update path anywhere. The server comments are blunt
+ *   about why: a mutable allowlist "would leave the session permanently
+ *   unbootable" if it were narrowed below what the box already needs.
+ */
+
+export type MidSessionCapability = 'changeable' | 'per_prompt' | 'fixed_at_create';
+
+export const MID_SESSION_CAPABILITIES = {
+  model: 'changeable',
+  agent: 'per_prompt',
+  secrets: 'fixed_at_create',
+} as const satisfies Record<string, MidSessionCapability>;
+
+export type AgentSwitchOutcome =
+  | { kind: 'ok' }
+  | { kind: 'needs_new_session'; message: string }
+  | { kind: 'grant_unresolved'; message: string }
+  | { kind: 'unknown'; message: string };
+
+interface UpstreamError {
+  code?: unknown;
+  error?: unknown;
+}
+
+/**
+ * Classify a prompt rejected because of the agent it asked to run.
+ *
+ * `AGENT_SWITCH_REQUIRES_NEW_SESSION` is not a failure to retry — retrying with
+ * the same agent will always fail. The only resolution is a new session, so the
+ * UI must offer that rather than a retry button.
+ *
+ * `AGENT_SECRET_GRANT_UNRESOLVED` is the opposite: the sandbox is fine and only
+ * our ability to VERIFY entitlement failed, so retrying IS correct (503).
+ */
+export function classifyAgentSwitch(body: UpstreamError | null): AgentSwitchOutcome {
+  const code = typeof body?.code === 'string' ? body.code : '';
+  const message =
+    typeof body?.error === 'string' && body.error.trim().length > 0
+      ? body.error
+      : 'The agent could not be switched.';
+
+  if (code === 'AGENT_SWITCH_REQUIRES_NEW_SESSION') {
+    return { kind: 'needs_new_session', message };
+  }
+  if (code === 'AGENT_SECRET_GRANT_UNRESOLVED') {
+    return { kind: 'grant_unresolved', message };
+  }
+  if (code) return { kind: 'unknown', message };
+  return { kind: 'ok' };
+}

--- a/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { MID_SESSION_CAPABILITIES, classifyAgentSwitch } from '../../src/lib/mid-session-change';
+
+describe('what can change mid-session', () => {
+  test('model changes, agent is per-prompt, secrets are fixed at create', () => {
+    // Encoded so the UI cannot drift from the server contract: offering a
+    // secrets control would be offering something that cannot work.
+    expect(MID_SESSION_CAPABILITIES.model).toBe('changeable');
+    expect(MID_SESSION_CAPABILITIES.agent).toBe('per_prompt');
+    expect(MID_SESSION_CAPABILITIES.secrets).toBe('fixed_at_create');
+  });
+});
+
+describe('classifyAgentSwitch', () => {
+  test('a grant-crossing switch needs a NEW SESSION, not a retry', () => {
+    // Retrying with the same agent fails forever — re-scoping cannot un-read
+    // what the session's original agent already pulled into the sandbox.
+    const result = classifyAgentSwitch({
+      code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION',
+      error: 'agent switch requires a new session',
+    });
+    expect(result.kind).toBe('needs_new_session');
+  });
+
+  test('an unresolved grant IS worth retrying — the sandbox is fine', () => {
+    const result = classifyAgentSwitch({ code: 'AGENT_SECRET_GRANT_UNRESOLVED', error: 'x' });
+    expect(result.kind).toBe('grant_unresolved');
+  });
+
+  test('the two are never conflated — one is terminal, the other transient', () => {
+    const terminal = classifyAgentSwitch({ code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION' });
+    const transient = classifyAgentSwitch({ code: 'AGENT_SECRET_GRANT_UNRESOLVED' });
+    expect(terminal.kind).not.toBe(transient.kind);
+  });
+
+  test('no code means the prompt was not rejected for the agent', () => {
+    expect(classifyAgentSwitch({}).kind).toBe('ok');
+    expect(classifyAgentSwitch(null).kind).toBe('ok');
+  });
+
+  test('an unrecognised code degrades to a readable message', () => {
+    expect(classifyAgentSwitch({ code: 'SOMETHING_ELSE', error: 'boom' })).toEqual({
+      kind: 'unknown',
+      message: 'boom',
+    });
+  });
+
+  test('a blank server message still yields something readable', () => {
+    const result = classifyAgentSwitch({ code: 'X', error: '  ' });
+    // Narrow first: only the non-'ok' variants carry a message.
+    expect(result.kind).toBe('unknown');
+    if (result.kind !== 'ok') {
+      expect(result.message).toBe('The agent could not be switched.');
+    }
+  });
+});

--- a/docs/KAAB_DEPTH_PLAN.md
+++ b/docs/KAAB_DEPTH_PLAN.md
@@ -53,8 +53,25 @@ priority list.
 - Two files (`unit-preview-auth-principal`, `e2e-preview-proxy`) failed to LOAD
   from incomplete `mock.module` factories — a SyntaxError, environment-independent.
   Fixed in #5583 (0 → 24 and 0 → 52 tests). That fix stands.
-- `e2e-preview-proxy` still shows 4 failures under CI's billing value, so those
-  are not explained by the env flag. Unresolved.
+- `e2e-preview-proxy` still shows 4 failures under CI's billing value. Narrowed
+  but **not resolved** — what I ruled out, so the next person does not repeat it:
+
+  | Hypothesis | Verdict |
+  | --- | --- |
+  | The `KORTIX_BILLING_INTERNAL_ENABLED` flag | **No** — fails under CI's value too |
+  | Incomplete `mock.module` (the sibling-file failure mode) | **No** — stubbing `projects/lib/secret-grant` fully changed nothing |
+  | Wrong sandbox id in the fixture | **No** — every prompt test uses `TEST_SANDBOX_ID`, and one env-sync test on that id PASSES |
+  | The retry classifier mis-ranks a 401 as transient | **No** — `isRetryableEnvSyncFailure` (preview.ts:71) matches only 502/503/504, then returns `false` for any `env sync failed:` prefix |
+
+  So the product's fail-closed path looks **correct**: a 401 env sync is
+  classified non-retryable and should surface as 502. The tests assert exactly
+  that and do not reach it. The remaining unknown is why the 401 never reaches
+  `postEnvToDaemon` — most likely the `mockFetchResponses` queue ordering, since
+  the passing sibling test supplies responses for BOTH the env-sync call and the
+  forward while these four supply one.
+
+  **Do not "fix" these by relaxing the assertions.** They encode the correct
+  intent; the harness is what is not delivering the failure.
 - A lint that fails a `mock.module` factory omitting exports the graph needs is
   still worth adding: that single class of bug zeroed two files silently.
 

--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -4,7 +4,7 @@
 
 # Immutable dev tag (CI bumps to dev-<sha8>). Bootstrap value until the first run.
 image:
-  tag: "dev-1b4db8f8"
+  tag: "dev-5762bcfc"
 # Dev sizing (≤100 users): 1-replica floor, burst to 2.
 replicas: 1
 autoscaling:

--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -4,7 +4,7 @@
 
 # Immutable dev tag (CI bumps to dev-<sha8>). Bootstrap value until the first run.
 image:
-  tag: "dev-5762bcfc"
+  tag: "dev-dda51b0b"
 # Dev sizing (≤100 users): 1-replica floor, burst to 2.
 replicas: 1
 autoscaling:

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-1b4db8f8"
+  tag: "dev-5762bcfc"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -90,7 +90,8 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" \\
+    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -254,7 +255,8 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" \\
+    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\
@@ -419,7 +421,8 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.17.11" \\
     && command -v opencode \\
     && opencode --version
 
-RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
+RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@0.58.1" "@agentclientprotocol/codex-acp@1.1.2" "pi-acp@0.0.31" \\
+    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@0.80.6" "@earendil-works/pi-ai@0.80.6" "@earendil-works/pi-tui@0.80.6" "@earendil-works/pi-agent-core@0.80.6" \\
     && command -v claude-agent-acp \\
     && command -v codex-acp \\
     && command -v pi-acp \\

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -146,6 +146,9 @@ describe('runtime artifact integrity', () => {
     expect(rendered).toContain(
       `"@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}"`,
     );
+    expect(rendered).toContain(
+      'npm install -g --prefix /home/kortix/.local',
+    );
     expect(rendered).toContain('command -v claude-agent-acp');
     expect(rendered).toContain('command -v codex-acp');
     expect(rendered).toContain('command -v pi-acp');

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -571,10 +571,10 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '',
     // Install every ACP adapter during image construction. Runtime requests
     // only start these pinned executables. They never download an npm package.
-    // pi-coding-agent declares caret ranges for its internal 0.x packages.
-    // Pin those root dependencies to prevent incompatible later 0.x releases
-    // from replacing the matching versions in pnpm's global dependency graph.
-    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}" \\`,
+    // pnpm 11 gives each global root package an isolated dependency graph.
+    // npm deduplicates Pi's exact internal versions into one compatible graph.
+    `RUN pnpm add -g "@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}" "@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}" "pi-acp@${PI_ACP_VERSION}" \\`,
+    `    && npm install -g --prefix /home/kortix/.local "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-ai@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-tui@${PI_CODING_AGENT_VERSION}" "@earendil-works/pi-agent-core@${PI_CODING_AGENT_VERSION}" \\`,
     '    && command -v claude-agent-acp \\',
     '    && command -v codex-acp \\',
     '    && command -v pi-acp \\',


### PR DESCRIPTION
Promote the final release cutoff from `main` at `dda51b0bdfb842529cd94453c8ae93071ba83f44` to staging.

This adds PR `#5676` mid-session controls and its sandbox-template updates. Release QA must run after this exact cutoff deploys.