### PR TITLE
fix(security): session sharing was exempt from the KaaB isolation narrowing

### DIFF
--- a/apps/api/src/__tests__/unit-executor-share.test.ts
+++ b/apps/api/src/__tests__/unit-executor-share.test.ts
@@ -215,3 +215,39 @@ describe('session sharing — default private; team-wide or select-members', () 
     expect(visibilityToIntent('restricted', members.grants)).toEqual({ mode: 'members', memberIds: [BOB], groupIds: [SALES] });
   });
 });
+
+/**
+ * The SHARING path must obey the same KaaB narrowing as the read path.
+ *
+ * `loadSessionForSharing` is a separate helper from `loadVisibleSession`, and
+ * the commit that threaded `callerSessionId` through every visibility check
+ * enumerated the latter's call sites and missed this one. Sharing is the worst
+ * place to miss: a public share is UNAUTHENTICATED and its router is mounted
+ * before auth, so a mint against another end-user's session exposes their live
+ * app port and workspace files to anyone with the URL.
+ */
+describe('KaaB: sharing is not exempt from the isolation narrowing', () => {
+  const WRAPPER = 'wrapper-service-account';
+
+  test("one end-user's sandbox may not manage sharing on another's session", () => {
+    // Same shape as the read path: shared creator, backend origin, different
+    // caller session. If this returns true, A can mint a public URL onto B.
+    expect(
+      isSessionVisibleTo('private', WRAPPER, [], { userId: WRAPPER, groupIds: [] }, {
+        origin: 'backend',
+        sessionId: 'session-of-end-user-b',
+        callerSessionId: 'session-of-end-user-a',
+      }),
+    ).toBe(false);
+  });
+
+  test('a sandbox may still manage sharing on its OWN session', () => {
+    expect(
+      isSessionVisibleTo('private', WRAPPER, [], { userId: WRAPPER, groupIds: [] }, {
+        origin: 'backend',
+        sessionId: 'session-a',
+        callerSessionId: 'session-a',
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -140,6 +140,14 @@ export async function loadVisibleSession(
 export async function loadSessionForSharing(
   loaded: { row: ProjectRow; userId: string; effectiveRole: ProjectRole },
   sessionId: string,
+  /**
+   * The CALLER's own session when the credential is bound to one. REQUIRED —
+   * see loadVisibleSession. Sharing is the worst surface to leave unnarrowed:
+   * a public share is UNAUTHENTICATED and its router is mounted before auth,
+   * so minting one against another end-user's session exposes their live app
+   * port and workspace files to anyone holding the URL.
+   */
+  callerSessionId: string | null,
 ): Promise<{
   row: ProjectSessionRow;
   isOwner: boolean;
@@ -148,6 +156,17 @@ export async function loadSessionForSharing(
 } | null> {
   const row = await loadProjectSessionRow(loaded, sessionId);
   if (!row) return null;
+  // Same narrowing as the read path. In Kortix-as-a-Backend every session
+  // shares one `created_by`, so the ownership test below is meaningless across
+  // end-users and would hand A full sharing rights over B's session.
+  if (
+    !isSessionVisibleTo(row.visibility as 'private' | 'project' | 'restricted', row.createdBy, [], {
+      userId: loaded.userId,
+      groupIds: [],
+    }, { origin: row.origin ?? null, sessionId, callerSessionId })
+  ) {
+    return null;
+  }
   const isOwner = row.createdBy === loaded.userId;
   const canManageProject = roleAllows(loaded.effectiveRole, 'manage');
   return { row, isOwner, canManageProject, canManageSharing: isOwner || canManageProject };

--- a/apps/api/src/projects/routes/public-shares.ts
+++ b/apps/api/src/projects/routes/public-shares.ts
@@ -73,7 +73,7 @@ projectsApp.openapi(
 
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const visible = await loadSessionForSharing(loaded, sessionId);
+    const visible = await loadSessionForSharing(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json({ error: 'Only the session owner or an editor can view public shares' }, 403);
@@ -109,7 +109,7 @@ projectsApp.openapi(
     const body = await readBody(c);
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const visible = await loadSessionForSharing(loaded, sessionId);
+    const visible = await loadSessionForSharing(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json({ error: 'Only the session owner or an editor can create public shares' }, 403);
@@ -168,7 +168,7 @@ projectsApp.openapi(
 
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const visible = await loadSessionForSharing(loaded, sessionId);
+    const visible = await loadSessionForSharing(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json({ error: 'Only the session owner or an editor can revoke public shares' }, 403);


### PR DESCRIPTION
## My own miss

Commit `c4b93bc560` ("thread caller session into every KaaB visibility check") enumerated `loadVisibleSession`'s call sites and threaded `callerSessionId` through all twelve.

`loadSessionForSharing` is a **separate helper in the same file** and was never touched. It took no `callerSessionId`, never called `isSessionVisibleTo`, and computed `isOwner` from `row.createdBy` alone.

In KaaB every session shares one `created_by` — so that ownership test is **true for every end-user against every other end-user's session**, and `canManageSharing = isOwner || canManageProject` inherits it.

## Why sharing is the worst place to miss it

A public share is **unauthenticated**, and its router mounts **before auth** (`sandbox-proxy/index.ts:28`). So end-user A could mint a publicly resolvable URL onto end-user B's live app port or workspace files (`resourceType: 'file'` has no port gate), and list or revoke B's shares.

## The fix

`loadSessionForSharing` now takes a **required** `callerSessionId` and applies the same predicate before computing `isOwner`.

Required, not optional — optional is precisely how the *first* isolation fix defaulted open, which Strix caught earlier today. The compiler now names any new caller that must decide.

## Verification

- `apps/api` tsc clean
- share / inventory / share-endpoint / public-session-share: 55 pass / 0 fail
- full suite vs **current** clean main (own worktree at `origin/main`): 28 → 24 failures, **zero new**

Found by an adversarial completeness audit (74 agents, 38 findings surviving refutation), then verified line by line before I touched anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)