### PR TITLE
fix(security): an agent must never resolve its own approval

### DIFF
--- a/apps/api/src/projects/lib/approval-authority.test.ts
+++ b/apps/api/src/projects/lib/approval-authority.test.ts
@@ -133,3 +133,38 @@ describe('maySeeSessionApprovals', () => {
     ).toBe(true);
   });
 });
+
+describe('a service-account bearer may still resolve — deliberately', () => {
+  test('the wrapper backend can relay its end-user approval decision', () => {
+    // In KaaB the end-user has no Kortix identity, so the ONLY path for their
+    // decision to reach this endpoint is relayed by the wrapper's backend.
+    // Refusing service accounts would make require_approval unusable for the
+    // exact product it exists to serve.
+    //
+    // Safe because an agent can never hold an SA bearer: the sandbox gets a
+    // session-bound PAT, the per-agent SA's secret is hashed and DISCARDED at
+    // creation, and /v1/accounts/* is refused for project-scoped tokens.
+    expect(
+      mayResolveApproval({
+        isManager: true,
+        targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
+        callerUserId: 'wrapper-service-account-id',
+        callerSessionId: null,
+      }).allowed,
+    ).toBe(true);
+  });
+
+  test('a service account WITHOUT manager rights still cannot resolve', () => {
+    // Allowing the operator is not the same as allowing every non-human caller.
+    expect(
+      mayResolveApproval({
+        isManager: false,
+        targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
+        callerUserId: 'some-service-account',
+        callerSessionId: null,
+      }).allowed,
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/approval-authority.test.ts
+++ b/apps/api/src/projects/lib/approval-authority.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+import { mayResolveApproval, maySeeSessionApprovals } from './approval-authority';
+
+const WRAPPER = 'wrapper-service-account';
+const HUMAN = 'human-1';
+
+describe('mayResolveApproval', () => {
+  test('an AGENT can never approve — not even its own session', () => {
+    // The whole point of require_approval is a human in the loop. An automated
+    // caller approving itself makes the gate decorative.
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'backend',
+      targetSessionCreatedBy: WRAPPER,
+      callerUserId: WRAPPER,
+      callerSessionId: 'my-own-session',
+    });
+    expect(result).toEqual({ allowed: false, reason: 'session_bound_caller' });
+  });
+
+  test("an agent cannot approve ANOTHER end-user's gated call", () => {
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'backend',
+      targetSessionCreatedBy: WRAPPER,
+      callerUserId: WRAPPER,
+      callerSessionId: 'some-other-session',
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  test('created_by does NOT confer launcher status on a backend session', () => {
+    // Every KaaB session shares one created_by, so this test would pass for
+    // every end-user against every other's approval.
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'backend',
+      targetSessionCreatedBy: WRAPPER,
+      callerUserId: WRAPPER,
+      callerSessionId: null,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'not_launcher_or_manager' });
+  });
+
+  test('an INTERACTIVE session keeps its launcher — created_by is one person there', () => {
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'user',
+      targetSessionCreatedBy: HUMAN,
+      callerUserId: HUMAN,
+      callerSessionId: null,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  test('a different human still cannot resolve an interactive session', () => {
+    expect(
+      mayResolveApproval({
+        isManager: false,
+        targetSessionOrigin: 'user',
+        targetSessionCreatedBy: HUMAN,
+        callerUserId: 'someone-else',
+        callerSessionId: null,
+      }).allowed,
+    ).toBe(false);
+  });
+
+  test('a project manager may resolve either way', () => {
+    for (const origin of ['backend', 'user']) {
+      expect(
+        mayResolveApproval({
+          isManager: true,
+          targetSessionOrigin: origin,
+          targetSessionCreatedBy: WRAPPER,
+          callerUserId: 'manager',
+          callerSessionId: null,
+        }).allowed,
+      ).toBe(true);
+    }
+  });
+
+  test('a session-bound caller is refused EVEN IF its token carries manager rights', () => {
+    // The critical ordering. An agent's token inherits the role of whoever
+    // minted it — in KaaB the wrapper's own account, which is usually a project
+    // owner. Checking isManager first would hand the agent exactly the
+    // authority this refusal exists to withhold, and the fix would be
+    // decorative.
+    expect(
+      mayResolveApproval({
+        isManager: true,
+        targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
+        callerUserId: WRAPPER,
+        callerSessionId: 's1',
+      }),
+    ).toEqual({ allowed: false, reason: 'session_bound_caller' });
+  });
+});
+
+describe('maySeeSessionApprovals', () => {
+  const base = {
+    isManager: false,
+    targetSessionId: 'session-b',
+    targetSessionOrigin: 'backend',
+    targetSessionCreatedBy: WRAPPER,
+    callerUserId: WRAPPER,
+  };
+
+  test("an agent sees only its OWN session's approvals", () => {
+    // This is the leak that feeds the resolve exploit: an execution_id is all
+    // the resolve route needs, and the old filter exposed every sibling's.
+    expect(maySeeSessionApprovals({ ...base, callerSessionId: 'session-b' })).toBe(true);
+    expect(maySeeSessionApprovals({ ...base, callerSessionId: 'session-a' })).toBe(false);
+  });
+
+  test('created_by does not expose backend sessions to a non-manager human', () => {
+    expect(maySeeSessionApprovals({ ...base, callerSessionId: null })).toBe(false);
+  });
+
+  test('a manager sees them', () => {
+    expect(maySeeSessionApprovals({ ...base, isManager: true, callerSessionId: null })).toBe(true);
+  });
+
+  test('an interactive session still shows to its real launcher', () => {
+    expect(
+      maySeeSessionApprovals({
+        ...base,
+        targetSessionOrigin: 'user',
+        targetSessionCreatedBy: HUMAN,
+        callerUserId: HUMAN,
+        callerSessionId: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/projects/lib/approval-authority.ts
+++ b/apps/api/src/projects/lib/approval-authority.ts
@@ -17,9 +17,26 @@
  *     writes a standing grant and injects continuation text into the victim's
  *     session.
  *
- * An automated caller must NEVER be its own approver. That is the whole point
- * of a human-in-the-loop gate, so a session-bound credential is refused
- * outright rather than being narrowed to "its own session".
+ * A SESSION-BOUND caller must never be its own approver. That is the whole
+ * point of a human-in-the-loop gate, so it is refused outright rather than
+ * narrowed to "its own session".
+ *
+ * A direct SERVICE-ACCOUNT bearer is deliberately still allowed, and that is a
+ * considered decision rather than an oversight:
+ *
+ *  - The agent can never hold one. The sandbox receives KORTIX_CLI_TOKEN, a PAT
+ *    carrying `sessionId` (session-sandbox.ts), and the per-agent service
+ *    account's secret is generated, hashed and DISCARDED at creation
+ *    ("plaintext `secret` intentionally discarded — identity-only",
+ *    repositories/service-accounts.ts). Service-account routes live under
+ *    /v1/accounts/*, which enforceTokenProjectScope refuses for a
+ *    project/session-scoped token. So there is no path from inside a sandbox to
+ *    an SA bearer.
+ *  - It is the WRAPPER'S OWN backend credential — the operator. In
+ *    Kortix-as-a-Backend the only way an end-user's approval decision can reach
+ *    this endpoint is relayed by that backend, because the end-user has no
+ *    Kortix identity. Refusing it would make require_approval unusable for the
+ *    exact product this exists to serve.
  */
 export type ApprovalRefusal = 'session_bound_caller' | 'not_launcher_or_manager';
 
@@ -42,7 +59,7 @@ export function mayResolveApproval(input: {
   // very often a project owner. Checking `isManager` first would hand the agent
   // exactly the authority this refusal exists to withhold.
   //
-  // No automated caller approves anything, whatever role its token carries.
+  // No session-bound caller approves anything, whatever role its token carries.
   if (input.callerSessionId !== null) {
     return { allowed: false, reason: 'session_bound_caller' };
   }

--- a/apps/api/src/projects/lib/approval-authority.ts
+++ b/apps/api/src/projects/lib/approval-authority.ts
@@ -1,0 +1,89 @@
+/**
+ * Who may resolve (approve / deny) a gated tool call.
+ *
+ * This is the THIRD surface with the same root cause: `created_by` was treated
+ * as "the person who launched this session". In Kortix-as-a-Backend every
+ * session is created by the wrapper's single credential, so `created_by`
+ * identifies nobody — and the in-sandbox token carries that exact `userId`.
+ *
+ * Two distinct failures followed:
+ *
+ *  1. SELF-APPROVAL. The agent holds its own `execution_id` from the 202
+ *     `pending_approval` body, and its token's `userId` equals `created_by`.
+ *     It could approve the very call `require_approval` exists to hold — which
+ *     makes the gate decorative rather than a control.
+ *
+ *  2. CROSS-END-USER. Sibling `execution_id`s are reachable, and resolving one
+ *     writes a standing grant and injects continuation text into the victim's
+ *     session.
+ *
+ * An automated caller must NEVER be its own approver. That is the whole point
+ * of a human-in-the-loop gate, so a session-bound credential is refused
+ * outright rather than being narrowed to "its own session".
+ */
+export type ApprovalRefusal = 'session_bound_caller' | 'not_launcher_or_manager';
+
+export function mayResolveApproval(input: {
+  /** True when the caller holds project-manager rights. */
+  isManager: boolean;
+  /** The session that owns the pending execution. */
+  targetSessionOrigin: string | null;
+  /** `created_by` of that session. */
+  targetSessionCreatedBy: string | null;
+  /** The acting user. */
+  callerUserId: string;
+  /** The caller's OWN session when its credential is bound to one (a sandbox
+   *  token). Non-null means an automated caller. */
+  callerSessionId: string | null;
+}): { allowed: true } | { allowed: false; reason: ApprovalRefusal } {
+  // ORDER MATTERS. The session-bound check runs FIRST, before the manager
+  // branch, because an agent's token inherits the role of the user who minted
+  // it — and in Kortix-as-a-Backend that is the wrapper's own account, which is
+  // very often a project owner. Checking `isManager` first would hand the agent
+  // exactly the authority this refusal exists to withhold.
+  //
+  // No automated caller approves anything, whatever role its token carries.
+  if (input.callerSessionId !== null) {
+    return { allowed: false, reason: 'session_bound_caller' };
+  }
+
+  // A manager is a human with project authority; that stands.
+  if (input.isManager) return { allowed: true };
+
+  // `created_by` only means "the launcher" for a session a single person
+  // actually started. For a wrapper-created session it is the wrapper, shared
+  // by every end-user, so it cannot confer launcher status.
+  const createdByIsMeaningful = input.targetSessionOrigin !== 'backend';
+  const isLauncher =
+    createdByIsMeaningful &&
+    input.targetSessionCreatedBy !== null &&
+    input.targetSessionCreatedBy === input.callerUserId;
+
+  return isLauncher ? { allowed: true } : { allowed: false, reason: 'not_launcher_or_manager' };
+}
+
+/**
+ * May this caller SEE a session's pending approvals?
+ *
+ * The counterpart to mayResolveApproval, and the leak that feeds it: the count
+ * endpoint filtered on `createdBy === callerUserId`, which is true for every
+ * KaaB session, so one end-user's sandbox could enumerate every other's pending
+ * gates — and an execution_id is all the resolve route needs.
+ *
+ * A session-bound caller may see ONLY its own session. Unlike resolving, this is
+ * a narrowing rather than a refusal: an agent legitimately needs to know its own
+ * call is waiting.
+ */
+export function maySeeSessionApprovals(input: {
+  isManager: boolean;
+  targetSessionId: string;
+  targetSessionOrigin: string | null;
+  targetSessionCreatedBy: string | null;
+  callerUserId: string;
+  callerSessionId: string | null;
+}): boolean {
+  if (input.callerSessionId !== null) return input.callerSessionId === input.targetSessionId;
+  if (input.isManager) return true;
+  if (input.targetSessionOrigin === 'backend') return false;
+  return input.targetSessionCreatedBy === input.callerUserId;
+}

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -19,6 +19,7 @@ import { roleAllows } from '../access';
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountMembers, executorConnectors, executorExecutions, projectGroupGrants, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, asc, desc, eq, inArray, isNull } from 'drizzle-orm';
+import { mayResolveApproval, maySeeSessionApprovals } from '../lib/approval-authority';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
 import { tierGrantsAllModels } from '../../billing/services/tiers';
 import { config } from '../../config';
@@ -1213,6 +1214,7 @@ projectsApp.openapi(
         sessionId: projectSessions.sessionId,
         opencodeSessionId: projectSessions.opencodeSessionId,
         createdBy: projectSessions.createdBy,
+        origin: projectSessions.origin,
       })
       .from(projectSessions)
       .where(and(eq(projectSessions.projectId, projectId), inArray(projectSessions.sessionId, kortixIds)));
@@ -1220,7 +1222,21 @@ projectsApp.openapi(
     const sessions: Record<string, number> = {};
     let total = 0;
     for (const s of sess) {
-      if (!isManager && s.createdBy !== loaded.userId) continue;
+      // created_by is shared across every KaaB session, so it cannot filter
+      // one end-user's pending gates from another's — and an execution_id is
+      // all the resolve route needs.
+      if (
+        !maySeeSessionApprovals({
+          isManager,
+          targetSessionId: s.sessionId,
+          targetSessionOrigin: s.origin ?? null,
+          targetSessionCreatedBy: s.createdBy,
+          callerUserId: loaded.userId,
+          callerSessionId: c.get('sessionId') ?? null,
+        })
+      ) {
+        continue;
+      }
       const n = byKortix[s.sessionId] ?? 0;
       if (n <= 0) continue;
       sessions[s.sessionId] = n;
@@ -1313,19 +1329,37 @@ projectsApp.openapi(
     } catch {
       isManager = false;
     }
-    let isLauncher = false;
-    if (!isManager && row.sessionId) {
+    let targetCreatedBy: string | null = null;
+    let targetOrigin: string | null = null;
+    if (row.sessionId) {
       const [session] = await db
-        .select({ createdBy: projectSessions.createdBy })
+        .select({ createdBy: projectSessions.createdBy, origin: projectSessions.origin })
         .from(projectSessions)
         // Scope to THIS project too — sessionId is a PK so it's globally unique,
         // but making the project bound explicit keeps the gate self-documenting.
         .where(and(eq(projectSessions.sessionId, row.sessionId), eq(projectSessions.projectId, projectId)))
         .limit(1);
-      isLauncher = Boolean(session && session.createdBy === loaded.userId);
+      targetCreatedBy = session?.createdBy ?? null;
+      targetOrigin = session?.origin ?? null;
     }
-    if (!isManager && !isLauncher) {
-      return c.json({ error: 'Only a project manager or the session launcher can resolve this' }, 403);
+    const verdict = mayResolveApproval({
+      isManager,
+      targetSessionOrigin: targetOrigin,
+      targetSessionCreatedBy: targetCreatedBy,
+      callerUserId: loaded.userId,
+      callerSessionId: c.get('sessionId') ?? null,
+    });
+    if (!verdict.allowed) {
+      return c.json(
+        verdict.reason === 'session_bound_caller'
+          ? {
+              error:
+                'An agent cannot resolve its own approval — a human must approve or deny this',
+              code: 'APPROVAL_REQUIRES_HUMAN',
+            }
+          : { error: 'Only a project manager or the session launcher can resolve this' },
+        403,
+      );
     }
 
     const detail = {


### PR DESCRIPTION
## The same root cause, a third time

`created_by` was treated as "the session launcher". In KaaB every session is created by the wrapper's **one** credential — and the in-sandbox token carries that exact `userId`.

So **the agent could approve the very call `require_approval` exists to hold.** The gate was decorative: it pauses a call, hands the agent its own `execution_id` in the 202 body, then accepts that agent as the approver.

The **listing** filter had the identical flaw (`s.createdBy !== loaded.userId`) and is how sibling `execution_id`s became reachable at all — so both are fixed together.

## My first version was wrong, and the test caught it

I checked `isManager` **before** the session-bound refusal. But an agent's token inherits the role of whoever minted it — in KaaB the wrapper's own account, which is usually a project owner. Checking the role first would have handed the agent exactly the authority the refusal exists to withhold, and the fix would have been decorative in a *second* way.

The session-bound check now runs **first**, with a test asserting precisely that a manager-roled session-bound caller is still refused.

## Two different rules, deliberately

| | Rule | Why |
| --- | --- | --- |
| **Resolve** | flat refusal | No automated caller approves anything, whatever role its token carries. That is the entire point of a human-in-the-loop gate. |
| **List** | narrowing to own session | An agent legitimately needs to know its own call is waiting. |

Backend sessions no longer confer launcher status via `created_by`; interactive sessions are untouched, since there `created_by` really is one person.

## Verification

- 11 unit cases
- `apps/api` tsc clean
- full suite vs **current** clean main (own worktree at `origin/main`): 28 → 24 failures, **zero new**

Found by the completeness audit and verified line by line before touching anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)