### PR TITLE
fix(security): bind turn-question to the sandbox token's own session

### DIFF
--- a/apps/api/src/projects/lib/sandbox-token-session.test.ts
+++ b/apps/api/src/projects/lib/sandbox-token-session.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { sandboxTokenMayActOnSession } from './sandbox-token-session';
+
+describe('sandboxTokenMayActOnSession', () => {
+  test('a sandbox token may act on its OWN session', () => {
+    expect(sandboxTokenMayActOnSession('sess-a', 'sess-a')).toBe(true);
+  });
+
+  test("a sandbox token may NOT act on a sibling session in the same project", () => {
+    // The IDOR: same project, different session — turn-question let this through
+    // because it only scoped session_id to the project.
+    expect(sandboxTokenMayActOnSession('sess-a', 'sess-b')).toBe(false);
+  });
+
+  test('a missing sandbox binding is refused, never treated as a wildcard', () => {
+    expect(sandboxTokenMayActOnSession(null, 'sess-a')).toBe(false);
+    expect(sandboxTokenMayActOnSession(undefined, 'sess-a')).toBe(false);
+    expect(sandboxTokenMayActOnSession('', 'sess-a')).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/sandbox-token-session.ts
+++ b/apps/api/src/projects/lib/sandbox-token-session.ts
@@ -1,0 +1,20 @@
+/**
+ * A sandbox token acts for exactly one session.
+ *
+ * `sandbox_id == session_id` by construction (session-sandbox.ts mints the
+ * token bound to the sandbox it provisions), so any request carrying a
+ * caller-supplied `session_id` under a sandbox token must target that token's
+ * OWN session — never a sibling in the same project.
+ *
+ * `POST /turn-question` scoped the caller-supplied `session_id` to the project
+ * only, so one sandbox could finalize and repost another session's live turn.
+ * The sibling `turn-stream` already gets this right; this makes the invariant a
+ * named, tested function so no third route relearns it wrong.
+ */
+export function sandboxTokenMayActOnSession(
+  tokenSandboxId: string | null | undefined,
+  requestedSessionId: string,
+): boolean {
+  if (!tokenSandboxId) return false;
+  return tokenSandboxId === requestedSessionId;
+}

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -87,6 +87,7 @@ import {
 } from '../../repositories/model-preferences';
 import { getProjectRoutingPolicy } from '../../repositories/project-routing-policies';
 import { isValidMatcher } from '../../executor/policy';
+import { sandboxTokenMayActOnSession } from '../lib/sandbox-token-session';
 import { db } from '../../shared/db';
 import {
   acquireExecutionLease,
@@ -3006,6 +3007,10 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
 
+    // The session this credential is BOUND to, when it is a sandbox token.
+    // Null for a human caller.
+    let callerSandboxSessionId: string | null = null;
+
     const authType = (c as any).get('authType') as string | undefined;
     if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
       const accountId = (c as any).get('accountId') as string | undefined;
@@ -3014,7 +3019,10 @@ projectsApp.openapi(
         return c.json({ error: 'turn-question requires a sandbox token' }, 403);
       }
       const [sandbox] = await db
-        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .select({
+          sandboxId: sessionSandboxes.sandboxId,
+          sessionId: sessionSandboxes.sessionId,
+        })
         .from(sessionSandboxes)
         .where(
           and(
@@ -3028,8 +3036,12 @@ projectsApp.openapi(
       if (!sandbox) {
         return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
       }
+      callerSandboxSessionId = sandbox.sessionId ?? sandbox.sandboxId;
     } else {
-      const loaded = await loadProjectForUser(c, projectId, 'read');
+      // A question card finalizes and re-posts a LIVE turn, so it is a
+      // mutation of that session — 'read' is too weak. The sibling turn-stream
+      // route already requires more than read for the same reason.
+      const loaded = await loadProjectForUser(c, projectId, 'session');
       if (!loaded) return c.json({ error: 'Not found' }, 404);
     }
 
@@ -3048,9 +3060,17 @@ projectsApp.openapi(
       return c.json({ error: 'session_id is required' }, 400);
     }
 
-    // session_id is caller-supplied — scope it back to :projectId so a caller
-    // authed for their own project can't relay a question into another
-    // tenant's live session (IDOR).
+    // session_id is caller-supplied. Scoping it to :projectId closes the
+    // cross-TENANT hole, but a sandbox token acts for exactly ONE session, so
+    // project scope still let sandbox A finalize and repost session B's live
+    // turn. sandbox_id == session_id by construction — bind to it.
+    if (
+      callerSandboxSessionId !== null &&
+      !sandboxTokenMayActOnSession(callerSandboxSessionId, sessionId)
+    ) {
+      return c.json({ error: 'sandbox token is not scoped to this session' }, 403);
+    }
+
     const [turnQuestionSession] = await db
       .select({ sessionId: projectSessions.sessionId })
       .from(projectSessions)


### PR DESCRIPTION
`POST /turn-question` scoped the caller-supplied `session_id` to the **project** only. A sandbox token acts for exactly one session (`sandbox_id == session_id` by construction), so project scope still let sandbox A target session B inside the same project.

**Not a display bug.** `channels/slack/questions.ts:37-39` finalizes and **deletes** the victim's live turn before posting, and packs caller-supplied text into button values that route back as a follow-up turn.

## Already solved next door

The sibling `turn-stream` route binds correctly (`r4.ts:2264` — *"sandbox token is not scoped to this session"*). Git history: turn-question's project-scoping landed 2026-07-10, turn-stream's session binding 2026-07-11, never backported.

`sandboxTokenMayActOnSession` makes the invariant a named, tested function so a third route cannot relearn it wrong.

## Also raised the human branch

The non-sandbox path required only `'read'`. Posting a question card finalizes and re-posts a **live turn** — a mutation — so a read-only member should not be able to do it. Now `'session'`.

## Verification

- 3 unit cases, incl. that a missing binding is refused rather than treated as a wildcard
- `apps/api` tsc clean
- full suite vs clean `main` (own worktree at `origin/main`): 28 → 24 failures, **zero new**

🤖 Generated with [Claude Code](https://claude.com/claude-code)