### PR TITLE
fix(security): never widen an agent grant on a manifest error; canonicalize the v2 default

### DIFF
--- a/apps/api/src/iam/connector-alias-grant.test.ts
+++ b/apps/api/src/iam/connector-alias-grant.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { canonicalConnectorAlias } from '../projects/lib/session-connector-bindings';
 import { agentMayUseConnector, canonicalizeGrantConnectors } from './agent-scope';
+import { grantFromLoadedAgents } from '../projects/agents';
 
 /**
  * A grant is compared at THREE gates that historically used three different
@@ -55,5 +56,66 @@ describe('connector alias spelling must not decide the outcome', () => {
     expect(Array.isArray(normalized?.connectors) ? normalized.connectors : []).toEqual([
       'kortix_email',
     ]);
+  });
+});
+
+describe('the v2 default_agent grant must canonicalize too', () => {
+  // The concrete-agent branch canonicalizes with a comment saying it MUST, so
+  // all three gates compare the same spelling. The v2 default_agent branch
+  // returned `declared.connectors` raw — so a v2 project whose default agent
+  // grants `email` had that connector silently denied at the call gate, which
+  // compares the canonical `kortix_email`.
+  test('a public-spelling grant on the default agent still admits the connector', () => {
+    const loaded = {
+      specs: [
+        {
+          name: 'support',
+          enabled: true,
+          kortixCli: 'all' as const,
+          connectors: ['email', 'slack'],
+          env: 'all' as const,
+        },
+      ],
+      errors: [],
+      defaultAgent: 'support',
+    };
+    const grant = grantFromLoadedAgents('default', loaded as never);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('email'))).toBe(true);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('kortix_email'))).toBe(true);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('slack'))).toBe(true);
+  });
+
+  test('an ungranted connector is still refused on the default agent', () => {
+    const loaded = {
+      specs: [
+        { name: 'support', enabled: true, kortixCli: 'all' as const, connectors: ['email'], env: 'all' as const },
+      ],
+      errors: [],
+      defaultAgent: 'support',
+    };
+    const grant = grantFromLoadedAgents('default', loaded as never);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('slack'))).toBe(false);
+  });
+});
+
+describe('a manifest that could not be READ must not widen a grant', () => {
+  // The mint resolves the grant with .catch(() => null), and null means NO
+  // RESTRICTION. Combined with a synthesized blank manifest whose agent is
+  // literally connectors:'all', a transient git blip could hand a governed
+  // project's session a fully unrestricted token.
+  test('errors present + default sentinel resolves DENY-ALL, never all-grant', () => {
+    const loaded = {
+      specs: [],
+      errors: [{ message: 'manifest unreadable' }],
+      defaultAgent: null,
+    };
+    const grant = grantFromLoadedAgents('default', loaded as never);
+    expect(grant).not.toBeNull();
+    expect(agentMayUseConnector(grant, 'kortix_email')).toBe(false);
+  });
+
+  test('a clean project with no agents section is still unrestricted (unchanged)', () => {
+    // No [[agents]] and no errors = the project never adopted governance.
+    expect(grantFromLoadedAgents('default', { specs: [], errors: [], defaultAgent: null } as never)).toBeNull();
   });
 });

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -361,12 +361,16 @@ export function grantFromLoadedAgents(agentName: string, loaded: LoadedAgents): 
     if (loaded.defaultAgent) {
       const declared = loaded.specs.find((s) => s.name === loaded.defaultAgent && s.enabled);
       if (declared) {
-        return {
+        // Canonicalize here for the SAME reason the concrete-agent branch does
+        // (see above): catalog / call / create all compare canonical slugs, so
+        // a manifest that writes `email` rather than `kortix_email` would be
+        // silently denied at the call gate.
+        return canonicalizeGrantConnectors({
           agent: loaded.defaultAgent,
           kortixCli: declared.kortixCli,
           connectors: declared.connectors,
           env: declared.env,
-        };
+        });
       }
     }
     // A project locks down its default by setting `default_agent` to a
@@ -376,6 +380,17 @@ export function grantFromLoadedAgents(agentName: string, loaded: LoadedAgents): 
     // manifest-level default_agent to honor) or a v2 manifest whose declared
     // default_agent doesn't resolve to an enabled spec (a validation-time
     // error the CR-merge gate should already have caught).
+    //
+    // EXCEPT when the manifest could not be read or parsed. `null` here means
+    // NO RESTRICTION (agent-scope.ts), and the mint resolves this grant with
+    // `.catch(() => null)` — so an unreadable manifest on a GOVERNED project
+    // would hand the session a fully unrestricted token for the life of the
+    // sandbox. Never widen on an error: a session that cannot prove what it is
+    // allowed to use gets nothing, which is the same rule the secrets path
+    // already follows (secret-grant.ts passes rethrowReadErrors for this).
+    if (loaded.errors.length > 0) {
+      return { agent: agentName, kortixCli: [], connectors: [], env: [] };
+    }
     return null;
   }
 


### PR DESCRIPTION
Two fail-open holes in grant resolution. Both found by the completeness audit, both verified line by line before fixing, both with tests that failed first.

## G6 — an unreadable manifest could mint an all-grant token

The mint resolves the grant with `.catch(() => null)` (`session-sandbox.ts:143`), and `null` means **no restriction** (`agent-scope.ts`).

For the `default` sentinel, an unreadable manifest collapses to `synthesizeBlankManifest`, whose synthesized agent is literally `connectors: 'all', kortix_cli: 'all'`. So on a project that **has** adopted `agents:` governance, one transient git/mirror blip during provisioning could mint a session token holding every project connector — for the whole life of that sandbox, with only a `console.warn`.

A **concrete** agent name already failed closed (`agents.ts:385`). The hole was exactly the sentinel.

Now the sentinel returns deny-all whenever `loaded.errors` is non-empty — the same rule the secrets path already follows (`secret-grant.ts` passes `rethrowReadErrors` for precisely this: *a session that cannot prove what it is allowed to read gets nothing, loudly*). A clean project with no `[[agents]]` section is untouched and still unrestricted.

## G8 — the v2 `default_agent` grant skipped canonicalization

The concrete-agent branch canonicalizes connectors **with a comment saying it must**, so catalog / call / create compare the same spelling. The v2 `default_agent` branch returned `declared.connectors` raw.

So a v2 project whose default agent grants `email` had that connector **silently denied** at the call gate, which compares `kortix_email`. A one-line asymmetry the code's own comment forbade — and `db-deps.ts:858` even asserts the invariant this branch violated.

## Verification

- 4 new cases; **2 failed before the fix**
- `apps/api` tsc clean
- full suite vs clean `main` (own worktree at `origin/main`): 28 → 24 failures, **zero new**

🤖 Generated with [Claude Code](https://claude.com/claude-code)