### PR TITLE
fix(gateway): fail over stalled model streams

### DIFF
--- a/apps/api/src/llm-gateway/routing/policy-config.test.ts
+++ b/apps/api/src/llm-gateway/routing/policy-config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 
-import { parseFallbackPolicies } from './policy-config';
+import {
+  DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES,
+  parseFallbackPolicies,
+} from './policy-config';
 
 describe('gateway fallback policy configuration', () => {
   test('accepts arbitrary operator-defined model ids and ordered fallbacks', () => {
@@ -42,5 +45,14 @@ describe('gateway fallback policy configuration', () => {
         fallbackOn: 'any-error',
       },
     ]))).toThrow('shared/model');
+  });
+
+  test('routes the platform default to an independent managed fallback', () => {
+    expect(parseFallbackPolicies(DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES)).toContainEqual({
+      id: 'platform-default-resilience',
+      models: ['glm-5.2'],
+      fallbackModels: ['deepseek-v4-flash'],
+      fallbackOn: 'transient',
+    });
   });
 });

--- a/apps/api/src/llm-gateway/routing/policy-config.ts
+++ b/apps/api/src/llm-gateway/routing/policy-config.ts
@@ -27,6 +27,12 @@ const fallbackPoliciesSchema = z.array(fallbackPolicySchema).superRefine((polici
 
 export const DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES = JSON.stringify([
   {
+    id: 'platform-default-resilience',
+    models: ['glm-5.2'],
+    fallbackModels: ['deepseek-v4-flash'],
+    fallbackOn: 'transient',
+  },
+  {
     id: 'platform-default-degrade',
     models: ['codex/gpt-5.6-sol'],
     fallbackModels: ['glm-5.2'],

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -37,6 +37,9 @@ export const config = {
   // 0 = disabled. Set to a byte ceiling (e.g. 1048576 for 1 MiB) to reject
   // oversized requests with a 413 before they reach an upstream.
   maxRequestBytes: optionalInt('GATEWAY_MAX_REQUEST_BYTES', 0),
+  // A provider can return HTTP 200 and then send zero stream bytes. Cancel that
+  // candidate before the caller's 125-second transport deadline expires.
+  streamProbeTimeoutMs: optionalInt('GATEWAY_STREAM_PROBE_TIMEOUT_MS', 30_000),
   retry: {
     maxAttempts: optionalInt('GATEWAY_RETRY_MAX_ATTEMPTS', 3),
     baseDelayMs: optionalInt('GATEWAY_RETRY_BASE_MS', 300),

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -63,6 +63,7 @@ export function buildServer(): GatewayServer {
       captureBodies: config.captureBodies,
       maxCapturedBodyBytes: config.maxCapturedBodyBytes,
       maxRequestBytes: config.maxRequestBytes || undefined,
+      streamProbeTimeoutMs: config.streamProbeTimeoutMs,
     },
     { logger },
   );

--- a/packages/llm-gateway/src/domain/config.ts
+++ b/packages/llm-gateway/src/domain/config.ts
@@ -11,4 +11,10 @@ export interface GatewayConfig {
   maxRequestBytes?: number;
   /** Maximum number of fallback models after the primary. Defaults to 3, hard-capped at 8. */
   maxFallbackModels?: number;
+  /**
+   * Maximum silence while probing a newly opened streaming response.
+   * The gateway cancels the stalled candidate and tries the next model.
+   * Defaults to 30 seconds.
+   */
+  streamProbeTimeoutMs?: number;
 }

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -828,6 +828,57 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     });
   });
 
+  test("streaming model fallback bypasses a primary that opens but produces no bytes", async () => {
+    const calls: string[] = [];
+    const { hooks, traces } = makeHooks({
+      resolveRoute: async (_principal, input) => ({
+        policyId: "test-stalled-stream",
+        primaryModel: input.requestedModel,
+        fallbackModels: ["fallback"],
+        fallbackOn: "transient",
+      }),
+      resolveUpstream: async (_principal, model) => [{
+        ...managed,
+        provider: model,
+        baseUrl: `https://${model}.test/v1`,
+        resolvedModel: model,
+      }],
+    });
+    const fetchImpl: FetchImpl = async (url) => {
+      calls.push(String(url));
+      if (String(url).includes("primary.test")) {
+        return new Response(new ReadableStream<Uint8Array>(), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response(
+        'data: {"choices":[{"delta":{"content":"fallback ok"}}]}\n\n' +
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n' +
+        "data: [DONE]\n\n",
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    };
+
+    const res = await createGateway(hooks, {
+      retry: { ...fastRetry, maxAttempts: 1 },
+      streamProbeTimeoutMs: 20,
+    }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"primary","stream":true,"messages":[{"role":"user","content":"ping"}]}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("fallback ok");
+    expect(calls).toHaveLength(2);
+    await flush();
+    expect(traces.at(-1)?.metadata.gatewayRouting).toEqual({
+      policy: "test-stalled-stream",
+      models: ["primary", "fallback"],
+      selected: "fallback",
+    });
+  });
+
   test("any-error model policy falls back on a deterministic primary 400", async () => {
     const calls: string[] = [];
     const { hooks } = makeHooks({

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -772,7 +772,9 @@ export async function handleChatCompletions(
       continue;
     }
 
-    const probe = await probeStream(candidateUpstream.body);
+    const probe = await probeStream(candidateUpstream.body, {
+      inactivityTimeoutMs: config.streamProbeTimeoutMs,
+    });
     if (probe.hasContent) {
       upstream = candidateUpstream;
       descriptor = chosenDescriptor;

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -6,11 +6,16 @@ const dec = new TextDecoder();
 
 function controllableUpstream() {
   let controller!: ReadableStreamDefaultController<Uint8Array>;
-  const stream = new ReadableStream<Uint8Array>({ start(c) { controller = c; } });
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { controller = c; },
+    cancel() { cancelled = true; },
+  });
   return {
     stream,
     push: (s: string) => controller.enqueue(enc.encode(s)),
     close: () => controller.close(),
+    get cancelled() { return cancelled; },
   };
 }
 
@@ -154,6 +159,18 @@ describe('probeStream', () => {
     });
     const result = await probeStream(stream);
     expect(result.hasContent).toBe(false);
+  });
+
+  test('times out and cancels a stream that opens but produces no bytes', async () => {
+    const up = controllableUpstream();
+    const result = await probeStream(up.stream, { inactivityTimeoutMs: 20 });
+
+    expect(result.hasContent).toBe(false);
+    expect(result.readError).toEqual({
+      message: 'upstream stream probe timeout exceeded (20ms with no bytes)',
+      code: 'stream_probe_timeout',
+    });
+    expect(up.cancelled).toBe(true);
   });
 });
 

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -80,11 +80,20 @@ class StreamInactivityTimeoutError extends Error {
 
 // A candidate that opens a stream, sends nothing usable, and closes cleanly (the
 // empty-completion bug) fails fast — real models produce their first token well
-// within this budget. Bounding the probe by chunk/byte count (not a wall-clock
-// timer racing the in-flight read) means we never abandon a pending read() and
-// risk silently dropping a chunk once real relaying resumes.
+// within this budget. The chunk/byte budget bounds valid but content-free
+// frames. The inactivity budget cancels a pending read before failover, so a
+// late chunk cannot reach the rejected candidate's relay.
 const PROBE_MAX_CHUNKS = 64;
 const PROBE_MAX_BYTES = 64 * 1024;
+const PROBE_INACTIVITY_TIMEOUT_MS = 30_000;
+
+export interface StreamProbeOptions {
+  /**
+   * Maximum time between upstream chunks while no usable output exists.
+   * The reader is cancelled when the timeout expires.
+   */
+  inactivityTimeoutMs?: number;
+}
 
 export interface StreamProbeResult {
   hasContent: boolean;
@@ -105,10 +114,14 @@ export interface StreamProbeResult {
 // budget is exhausted — whichever comes first. Every chunk consumed is captured
 // in `chunks` so the caller can replay them verbatim (via `primed`) without
 // losing a single byte, regardless of which outcome is reached.
-export async function probeStream(body: ReadableStream<Uint8Array>): Promise<StreamProbeResult> {
+export async function probeStream(
+  body: ReadableStream<Uint8Array>,
+  options: StreamProbeOptions = {},
+): Promise<StreamProbeResult> {
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   const decoder = new TextDecoder();
+  const inactivityTimeoutMs = options.inactivityTimeoutMs ?? PROBE_INACTIVITY_TIMEOUT_MS;
   let buffer = '';
   let bytes = 0;
 
@@ -116,11 +129,32 @@ export async function probeStream(body: ReadableStream<Uint8Array>): Promise<Str
     if (chunks.length >= PROBE_MAX_CHUNKS || bytes >= PROBE_MAX_BYTES) {
       return { hasContent: true, reader, chunks };
     }
-    let done: boolean;
-    let value: Uint8Array | undefined;
-    try {
-      ({ done, value } = await reader.read());
-    } catch (err) {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      reader.read().then(
+        (result) => ({ kind: 'read' as const, result }),
+        (error: unknown) => ({ kind: 'error' as const, error }),
+      ),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        timeout = setTimeout(() => resolve({ kind: 'timeout' }), inactivityTimeoutMs);
+      }),
+    ]);
+    if (timeout) clearTimeout(timeout);
+
+    if (outcome.kind === 'timeout') {
+      const message =
+        `upstream stream probe timeout exceeded (${inactivityTimeoutMs}ms with no bytes)`;
+      await reader.cancel(message).catch(() => undefined);
+      return {
+        hasContent: sseHasContent(buffer),
+        errorFrame: sseErrorFrame(buffer),
+        readError: { message, code: 'stream_probe_timeout' },
+        reader,
+        chunks,
+      };
+    }
+    if (outcome.kind === 'error') {
+      const err = outcome.error;
       const message = boundedErrorMessage(err);
       return {
         hasContent: sseHasContent(buffer),
@@ -130,6 +164,7 @@ export async function probeStream(body: ReadableStream<Uint8Array>): Promise<Str
         chunks,
       };
     }
+    const { done, value } = outcome.result;
     if (done)
       return {
         hasContent: sseHasContent(buffer),


### PR DESCRIPTION
## Summary

- cancel a streaming candidate after 30 seconds with no upstream bytes
- fail over the platform default from `glm-5.2` to managed `deepseek-v4-flash`
- cover stream cancellation and model fallback with regression tests

## Evidence

- `bun test packages/llm-gateway/src` -> 344 passed
- focused gateway and routing tests -> 88 passed
- `pnpm --filter @kortix/llm-gateway typecheck` -> passed
- `pnpm --filter @kortix/llm-gateway-server typecheck` -> passed
- `pnpm --filter kortix-api typecheck` -> passed
- direct Aster `glm-5.2` probe: four requests timed out after 30 seconds with zero bytes
- direct OpenRouter `deepseek-v4-flash` probe: HTTP 200, four content bytes, zero error frames, 2.1 seconds