### PR TITLE
fix(whitelabel-demo): make KaaB refusals reachable, and stop silent sends

### DIFF
--- a/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   useVisibleAgents,
   writeStartStash,
 } from '@kortix/sdk/react';
+import { serverErrorBody } from '@/lib/api-error-body';
 import { classifySessionStartFailure } from '@/lib/session-start-error';
 import type { BindableConnection } from '@/server/bindable-connections';
 import { getSessionToken } from '@/lib/session';
@@ -135,11 +136,10 @@ function ProjectHome() {
     onError: (err: unknown) => {
       // Two KaaB refusals need opposite responses, and a single generic toast
       // told the user to fix something they often could not fix.
-      const body =
-        err && typeof err === 'object' && 'body' in err
-          ? ((err as { body?: unknown }).body as Record<string, unknown> | null)
-          : null;
-      const failure = classifySessionStartFailure(body);
+      // The SDK's ApiError puts the parsed body on `data`/`details` and lifts
+      // `code` — it has no `body` field, so reading one made every KaaB refusal
+      // below unreachable.
+      const failure = classifySessionStartFailure(serverErrorBody(err));
       if (failure.kind === 'connector_connection_required') {
         setConnectPrompt({ connector: failure.connector, message: failure.message });
         return;

--- a/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker';
 import { Message } from '@/components/ui/message';
 import { SessionScope } from '@/components/workbench/session-scope';
+import { sendFailureTitle } from '@/lib/send-failure';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ChangesPanel } from '@/components/workbench/changes-panel';
 import { FilesPanel } from '@/components/workbench/files-panel';
@@ -241,6 +242,16 @@ function Thread({ session: c }: { session: UseSessionResult }) {
               <Button size="sm" variant="secondary" className="h-7 gap-1.5" onClick={c.cancel}>
                 Stop
               </Button>
+            </div>
+          ) : null}
+          {/* A rejected send used to be SILENT: the optimistic bubble vanished,
+              the typed text was gone, and nothing said why. useSession surfaces
+              a typed sendError — read it, and name the KaaB refusals the
+              generic message would otherwise swallow. */}
+          {c.sendError ? (
+            <div className="mx-4 mb-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm">
+              <div className="font-medium">{sendFailureTitle(c.sendError)}</div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{c.sendError.message}</p>
             </div>
           ) : null}
           <Composer

--- a/apps/whitelabel-demo/src/lib/api-error-body.ts
+++ b/apps/whitelabel-demo/src/lib/api-error-body.ts
@@ -1,0 +1,36 @@
+/**
+ * Pull the server's error body out of whatever the SDK threw.
+ *
+ * The SDK's `ApiError` carries the parsed body on `data` / `details`, lifts
+ * `code` to the top level, and has **no `body` field at all**
+ * (`core/http/api/errors.ts`). Demo code that read `err.body` therefore never
+ * fired: every Kortix-as-a-Backend refusal — the connector prompt, the agent
+ * switch conflict, the per-end-user cap — collapsed into one generic message,
+ * and the classifiers written to handle them were dead code.
+ *
+ * Reading through one function means the next classifier cannot get this wrong.
+ */
+export interface ServerErrorBody {
+  code?: unknown;
+  error?: unknown;
+  connector?: unknown;
+}
+
+export function serverErrorBody(err: unknown): ServerErrorBody | null {
+  if (!err || typeof err !== 'object') return null;
+  const e = err as Record<string, unknown>;
+
+  const candidate = [e.data, e.details, e.detail].find(
+    (v) => v && typeof v === 'object' && !Array.isArray(v),
+  ) as Record<string, unknown> | undefined;
+
+  // `code` is lifted onto the error itself, so it can be present even when the
+  // body did not parse. Prefer the body's own code, fall back to the lifted one.
+  const code = candidate?.code ?? e.code;
+  // ApiError.message is always coerced to a string and holds the server's
+  // `error`/`detail` text, so it is a usable fallback when the body is absent.
+  const error = candidate?.error ?? (typeof e.message === 'string' ? e.message : undefined);
+
+  if (code === undefined && error === undefined && !candidate) return null;
+  return { code, error, connector: candidate?.connector };
+}

--- a/apps/whitelabel-demo/src/lib/send-failure.ts
+++ b/apps/whitelabel-demo/src/lib/send-failure.ts
@@ -1,0 +1,30 @@
+import type { KortixSendError } from '@kortix/sdk/react';
+
+/**
+ * A short, human title for a failed send.
+ *
+ * `useSession` surfaces a typed `sendError`, but the demo never read it — so a
+ * rejected send was completely silent: the optimistic bubble vanished, the
+ * typed text was gone, and nothing said why. For a wrapper's end-user that is
+ * indistinguishable from the product being broken.
+ *
+ * The message itself is already formatted for display by the SDK; this only
+ * adds the one-line "what kind of problem is this", because the three kinds
+ * need different reactions from the user.
+ */
+export function sendFailureTitle(error: KortixSendError): string {
+  switch (error.kind) {
+    case 'billing':
+      // Not retryable by the end-user — the operator has to act.
+      return 'This session is out of credit';
+    case 'runtime-not-ready':
+      // Transient and self-healing; retrying is genuinely the right move.
+      return 'The runtime is still starting';
+    case 'runtime-error':
+      return error.gateway?.provider
+        ? `The ${error.gateway.provider} model failed`
+        : 'The agent could not run that';
+    default:
+      return 'Your message was not sent';
+  }
+}

--- a/apps/whitelabel-demo/tests/e2e/api-error-body.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/api-error-body.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { serverErrorBody } from '../../src/lib/api-error-body';
+
+describe('serverErrorBody', () => {
+  test('reads the parsed body the SDK puts on `data`', () => {
+    // The regression this exists for: demo code read `err.body`, which ApiError
+    // never sets, so every KaaB refusal collapsed to a generic message.
+    const body = serverErrorBody({
+      status: 409,
+      code: 'CONNECTOR_CONNECTION_REQUIRED',
+      data: { error: 'Connector "gmail" requires a personal connection', code: 'CONNECTOR_CONNECTION_REQUIRED', connector: 'gmail' },
+    });
+    expect(body?.code).toBe('CONNECTOR_CONNECTION_REQUIRED');
+    expect(body?.connector).toBe('gmail');
+  });
+
+  test('falls back to `details` and `detail`', () => {
+    expect(serverErrorBody({ details: { code: 'X' } })?.code).toBe('X');
+    expect(serverErrorBody({ detail: { code: 'Y' } })?.code).toBe('Y');
+  });
+
+  test('uses the lifted top-level code when the body did not parse', () => {
+    expect(serverErrorBody({ status: 403, code: 'REQUIRE_CONNECTORS_INTERACTIVE_ONLY' })?.code).toBe(
+      'REQUIRE_CONNECTORS_INTERACTIVE_ONLY',
+    );
+  });
+
+  test('uses ApiError.message as the text when the body has none', () => {
+    expect(serverErrorBody({ code: 'X', message: 'server said this' })?.error).toBe('server said this');
+  });
+
+  test('prefers the BODY code over the lifted one', () => {
+    // api-client lifts response.status.toString() as `code` when the body has
+    // none, so a numeric-looking lifted code must not shadow a real one.
+    expect(serverErrorBody({ code: '409', data: { code: 'REAL_CODE' } })?.code).toBe('REAL_CODE');
+  });
+
+  test('a non-object throw yields null rather than crashing the handler', () => {
+    expect(serverErrorBody(null)).toBeNull();
+    expect(serverErrorBody('boom')).toBeNull();
+    expect(serverErrorBody(undefined)).toBeNull();
+  });
+
+  test('an array body is not mistaken for an error object', () => {
+    expect(serverErrorBody({ data: [1, 2] })).toBeNull();
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { sendFailureTitle } from '../../src/lib/send-failure';
+
+describe('sendFailureTitle', () => {
+  test('billing reads as an operator problem, not a retry', () => {
+    expect(sendFailureTitle({ kind: 'billing', message: 'x' } as never)).toContain('credit');
+  });
+
+  test('a not-ready runtime reads as transient', () => {
+    expect(sendFailureTitle({ kind: 'runtime-not-ready', message: 'x' } as never)).toContain(
+      'starting',
+    );
+  });
+
+  test('a gateway failure names WHICH provider when the envelope carries it', () => {
+    expect(
+      sendFailureTitle({
+        kind: 'runtime-error',
+        message: 'x',
+        gateway: { provider: 'anthropic' },
+      } as never),
+    ).toBe('The anthropic model failed');
+  });
+
+  test('a gateway failure without a provider still reads sensibly', () => {
+    expect(sendFailureTitle({ kind: 'runtime-error', message: 'x' } as never)).toBe(
+      'The agent could not run that',
+    );
+  });
+
+  test('an unknown kind never produces an empty title', () => {
+    expect(sendFailureTitle({ kind: 'something-new', message: 'x' } as never).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Two dead paths, both mine.

## 1. The classifiers were unreachable

They read `err.body`. The SDK's `ApiError` has **no `body` field** — it puts the parsed body on `data`/`details`/`detail` and lifts `code` to the top (`core/http/api/errors.ts`, `api-client.ts:228-235`).

So every KaaB refusal collapsed into one generic message, and the code I wrote to handle them — the connector-connection prompt, the agent-switch conflict — **never ran**. I shipped classifiers and a UI for paths that could not fire.

`serverErrorBody()` now reads it correctly in one place, so the next classifier cannot get it wrong. Two details that matter:

- it **prefers the body's own `code`** over the lifted one, because `api-client` lifts `response.status.toString()` when the body has none — a numeric `"409"` would otherwise shadow a real code
- it falls back to `ApiError.message` for the text, which is always coerced to a string

## 2. A rejected send was silent

The optimistic bubble vanished, the typed text was gone, and nothing said why. `useSession` surfaces a typed `sendError` and the demo **never read it**. For a wrapper's end-user that is indistinguishable from the product being broken.

Now shown, with a title per kind, because the three need genuinely different reactions:

| Kind | Reads as |
| --- | --- |
| `billing` | an operator problem — not retryable by the end-user |
| `runtime-not-ready` | transient, retrying is right |
| `runtime-error` | names **which** provider failed when the gateway envelope carries it |

## Verification

- 12 unit cases
- `sdk-boundary`: 0 violations
- demo suite: 111 pass / 0 fail
- tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)