### PR TITLE
chore(release): promote current main to staging

### DIFF
--- a/apps/api/src/__tests__/unit-executor-share.test.ts
+++ b/apps/api/src/__tests__/unit-executor-share.test.ts
@@ -215,3 +215,39 @@ describe('session sharing — default private; team-wide or select-members', () 
     expect(visibilityToIntent('restricted', members.grants)).toEqual({ mode: 'members', memberIds: [BOB], groupIds: [SALES] });
   });
 });
+
+/**
+ * The SHARING path must obey the same KaaB narrowing as the read path.
+ *
+ * `loadSessionForSharing` is a separate helper from `loadVisibleSession`, and
+ * the commit that threaded `callerSessionId` through every visibility check
+ * enumerated the latter's call sites and missed this one. Sharing is the worst
+ * place to miss: a public share is UNAUTHENTICATED and its router is mounted
+ * before auth, so a mint against another end-user's session exposes their live
+ * app port and workspace files to anyone with the URL.
+ */
+describe('KaaB: sharing is not exempt from the isolation narrowing', () => {
+  const WRAPPER = 'wrapper-service-account';
+
+  test("one end-user's sandbox may not manage sharing on another's session", () => {
+    // Same shape as the read path: shared creator, backend origin, different
+    // caller session. If this returns true, A can mint a public URL onto B.
+    expect(
+      isSessionVisibleTo('private', WRAPPER, [], { userId: WRAPPER, groupIds: [] }, {
+        origin: 'backend',
+        sessionId: 'session-of-end-user-b',
+        callerSessionId: 'session-of-end-user-a',
+      }),
+    ).toBe(false);
+  });
+
+  test('a sandbox may still manage sharing on its OWN session', () => {
+    expect(
+      isSessionVisibleTo('private', WRAPPER, [], { userId: WRAPPER, groupIds: [] }, {
+        origin: 'backend',
+        sessionId: 'session-a',
+        callerSessionId: 'session-a',
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/iam/connector-alias-grant.test.ts
+++ b/apps/api/src/iam/connector-alias-grant.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { canonicalConnectorAlias } from '../projects/lib/session-connector-bindings';
 import { agentMayUseConnector, canonicalizeGrantConnectors } from './agent-scope';
+import { grantFromLoadedAgents } from '../projects/agents';
 
 /**
  * A grant is compared at THREE gates that historically used three different
@@ -55,5 +56,66 @@ describe('connector alias spelling must not decide the outcome', () => {
     expect(Array.isArray(normalized?.connectors) ? normalized.connectors : []).toEqual([
       'kortix_email',
     ]);
+  });
+});
+
+describe('the v2 default_agent grant must canonicalize too', () => {
+  // The concrete-agent branch canonicalizes with a comment saying it MUST, so
+  // all three gates compare the same spelling. The v2 default_agent branch
+  // returned `declared.connectors` raw — so a v2 project whose default agent
+  // grants `email` had that connector silently denied at the call gate, which
+  // compares the canonical `kortix_email`.
+  test('a public-spelling grant on the default agent still admits the connector', () => {
+    const loaded = {
+      specs: [
+        {
+          name: 'support',
+          enabled: true,
+          kortixCli: 'all' as const,
+          connectors: ['email', 'slack'],
+          env: 'all' as const,
+        },
+      ],
+      errors: [],
+      defaultAgent: 'support',
+    };
+    const grant = grantFromLoadedAgents('default', loaded as never);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('email'))).toBe(true);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('kortix_email'))).toBe(true);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('slack'))).toBe(true);
+  });
+
+  test('an ungranted connector is still refused on the default agent', () => {
+    const loaded = {
+      specs: [
+        { name: 'support', enabled: true, kortixCli: 'all' as const, connectors: ['email'], env: 'all' as const },
+      ],
+      errors: [],
+      defaultAgent: 'support',
+    };
+    const grant = grantFromLoadedAgents('default', loaded as never);
+    expect(agentMayUseConnector(grant, canonicalConnectorAlias('slack'))).toBe(false);
+  });
+});
+
+describe('a manifest that could not be READ must not widen a grant', () => {
+  // The mint resolves the grant with .catch(() => null), and null means NO
+  // RESTRICTION. Combined with a synthesized blank manifest whose agent is
+  // literally connectors:'all', a transient git blip could hand a governed
+  // project's session a fully unrestricted token.
+  test('errors present + default sentinel resolves DENY-ALL, never all-grant', () => {
+    const loaded = {
+      specs: [],
+      errors: [{ message: 'manifest unreadable' }],
+      defaultAgent: null,
+    };
+    const grant = grantFromLoadedAgents('default', loaded as never);
+    expect(grant).not.toBeNull();
+    expect(agentMayUseConnector(grant, 'kortix_email')).toBe(false);
+  });
+
+  test('a clean project with no agents section is still unrestricted (unchanged)', () => {
+    // No [[agents]] and no errors = the project never adopted governance.
+    expect(grantFromLoadedAgents('default', { specs: [], errors: [], defaultAgent: null } as never)).toBeNull();
   });
 });

--- a/apps/api/src/llm-gateway/routing/policy-config.test.ts
+++ b/apps/api/src/llm-gateway/routing/policy-config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 
-import { parseFallbackPolicies } from './policy-config';
+import {
+  DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES,
+  parseFallbackPolicies,
+} from './policy-config';
 
 describe('gateway fallback policy configuration', () => {
   test('accepts arbitrary operator-defined model ids and ordered fallbacks', () => {
@@ -42,5 +45,14 @@ describe('gateway fallback policy configuration', () => {
         fallbackOn: 'any-error',
       },
     ]))).toThrow('shared/model');
+  });
+
+  test('routes the platform default to an independent managed fallback', () => {
+    expect(parseFallbackPolicies(DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES)).toContainEqual({
+      id: 'platform-default-resilience',
+      models: ['glm-5.2'],
+      fallbackModels: ['deepseek-v4-flash'],
+      fallbackOn: 'transient',
+    });
   });
 });

--- a/apps/api/src/llm-gateway/routing/policy-config.ts
+++ b/apps/api/src/llm-gateway/routing/policy-config.ts
@@ -27,6 +27,12 @@ const fallbackPoliciesSchema = z.array(fallbackPolicySchema).superRefine((polici
 
 export const DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES = JSON.stringify([
   {
+    id: 'platform-default-resilience',
+    models: ['glm-5.2'],
+    fallbackModels: ['deepseek-v4-flash'],
+    fallbackOn: 'transient',
+  },
+  {
     id: 'platform-default-degrade',
     models: ['codex/gpt-5.6-sol'],
     fallbackModels: ['glm-5.2'],

--- a/apps/api/src/projects/agents.ts
+++ b/apps/api/src/projects/agents.ts
@@ -361,12 +361,16 @@ export function grantFromLoadedAgents(agentName: string, loaded: LoadedAgents): 
     if (loaded.defaultAgent) {
       const declared = loaded.specs.find((s) => s.name === loaded.defaultAgent && s.enabled);
       if (declared) {
-        return {
+        // Canonicalize here for the SAME reason the concrete-agent branch does
+        // (see above): catalog / call / create all compare canonical slugs, so
+        // a manifest that writes `email` rather than `kortix_email` would be
+        // silently denied at the call gate.
+        return canonicalizeGrantConnectors({
           agent: loaded.defaultAgent,
           kortixCli: declared.kortixCli,
           connectors: declared.connectors,
           env: declared.env,
-        };
+        });
       }
     }
     // A project locks down its default by setting `default_agent` to a
@@ -376,6 +380,17 @@ export function grantFromLoadedAgents(agentName: string, loaded: LoadedAgents): 
     // manifest-level default_agent to honor) or a v2 manifest whose declared
     // default_agent doesn't resolve to an enabled spec (a validation-time
     // error the CR-merge gate should already have caught).
+    //
+    // EXCEPT when the manifest could not be read or parsed. `null` here means
+    // NO RESTRICTION (agent-scope.ts), and the mint resolves this grant with
+    // `.catch(() => null)` — so an unreadable manifest on a GOVERNED project
+    // would hand the session a fully unrestricted token for the life of the
+    // sandbox. Never widen on an error: a session that cannot prove what it is
+    // allowed to use gets nothing, which is the same rule the secrets path
+    // already follows (secret-grant.ts passes rethrowReadErrors for this).
+    if (loaded.errors.length > 0) {
+      return { agent: agentName, kortixCli: [], connectors: [], env: [] };
+    }
     return null;
   }
 

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -140,6 +140,14 @@ export async function loadVisibleSession(
 export async function loadSessionForSharing(
   loaded: { row: ProjectRow; userId: string; effectiveRole: ProjectRole },
   sessionId: string,
+  /**
+   * The CALLER's own session when the credential is bound to one. REQUIRED —
+   * see loadVisibleSession. Sharing is the worst surface to leave unnarrowed:
+   * a public share is UNAUTHENTICATED and its router is mounted before auth,
+   * so minting one against another end-user's session exposes their live app
+   * port and workspace files to anyone holding the URL.
+   */
+  callerSessionId: string | null,
 ): Promise<{
   row: ProjectSessionRow;
   isOwner: boolean;
@@ -148,6 +156,17 @@ export async function loadSessionForSharing(
 } | null> {
   const row = await loadProjectSessionRow(loaded, sessionId);
   if (!row) return null;
+  // Same narrowing as the read path. In Kortix-as-a-Backend every session
+  // shares one `created_by`, so the ownership test below is meaningless across
+  // end-users and would hand A full sharing rights over B's session.
+  if (
+    !isSessionVisibleTo(row.visibility as 'private' | 'project' | 'restricted', row.createdBy, [], {
+      userId: loaded.userId,
+      groupIds: [],
+    }, { origin: row.origin ?? null, sessionId, callerSessionId })
+  ) {
+    return null;
+  }
   const isOwner = row.createdBy === loaded.userId;
   const canManageProject = roleAllows(loaded.effectiveRole, 'manage');
   return { row, isOwner, canManageProject, canManageSharing: isOwner || canManageProject };

--- a/apps/api/src/projects/lib/approval-authority.test.ts
+++ b/apps/api/src/projects/lib/approval-authority.test.ts
@@ -133,3 +133,38 @@ describe('maySeeSessionApprovals', () => {
     ).toBe(true);
   });
 });
+
+describe('a service-account bearer may still resolve — deliberately', () => {
+  test('the wrapper backend can relay its end-user approval decision', () => {
+    // In KaaB the end-user has no Kortix identity, so the ONLY path for their
+    // decision to reach this endpoint is relayed by the wrapper's backend.
+    // Refusing service accounts would make require_approval unusable for the
+    // exact product it exists to serve.
+    //
+    // Safe because an agent can never hold an SA bearer: the sandbox gets a
+    // session-bound PAT, the per-agent SA's secret is hashed and DISCARDED at
+    // creation, and /v1/accounts/* is refused for project-scoped tokens.
+    expect(
+      mayResolveApproval({
+        isManager: true,
+        targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
+        callerUserId: 'wrapper-service-account-id',
+        callerSessionId: null,
+      }).allowed,
+    ).toBe(true);
+  });
+
+  test('a service account WITHOUT manager rights still cannot resolve', () => {
+    // Allowing the operator is not the same as allowing every non-human caller.
+    expect(
+      mayResolveApproval({
+        isManager: false,
+        targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
+        callerUserId: 'some-service-account',
+        callerSessionId: null,
+      }).allowed,
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/approval-authority.test.ts
+++ b/apps/api/src/projects/lib/approval-authority.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+import { mayResolveApproval, maySeeSessionApprovals } from './approval-authority';
+
+const WRAPPER = 'wrapper-service-account';
+const HUMAN = 'human-1';
+
+describe('mayResolveApproval', () => {
+  test('an AGENT can never approve — not even its own session', () => {
+    // The whole point of require_approval is a human in the loop. An automated
+    // caller approving itself makes the gate decorative.
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'backend',
+      targetSessionCreatedBy: WRAPPER,
+      callerUserId: WRAPPER,
+      callerSessionId: 'my-own-session',
+    });
+    expect(result).toEqual({ allowed: false, reason: 'session_bound_caller' });
+  });
+
+  test("an agent cannot approve ANOTHER end-user's gated call", () => {
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'backend',
+      targetSessionCreatedBy: WRAPPER,
+      callerUserId: WRAPPER,
+      callerSessionId: 'some-other-session',
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  test('created_by does NOT confer launcher status on a backend session', () => {
+    // Every KaaB session shares one created_by, so this test would pass for
+    // every end-user against every other's approval.
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'backend',
+      targetSessionCreatedBy: WRAPPER,
+      callerUserId: WRAPPER,
+      callerSessionId: null,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'not_launcher_or_manager' });
+  });
+
+  test('an INTERACTIVE session keeps its launcher — created_by is one person there', () => {
+    const result = mayResolveApproval({
+      isManager: false,
+      targetSessionOrigin: 'user',
+      targetSessionCreatedBy: HUMAN,
+      callerUserId: HUMAN,
+      callerSessionId: null,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  test('a different human still cannot resolve an interactive session', () => {
+    expect(
+      mayResolveApproval({
+        isManager: false,
+        targetSessionOrigin: 'user',
+        targetSessionCreatedBy: HUMAN,
+        callerUserId: 'someone-else',
+        callerSessionId: null,
+      }).allowed,
+    ).toBe(false);
+  });
+
+  test('a project manager may resolve either way', () => {
+    for (const origin of ['backend', 'user']) {
+      expect(
+        mayResolveApproval({
+          isManager: true,
+          targetSessionOrigin: origin,
+          targetSessionCreatedBy: WRAPPER,
+          callerUserId: 'manager',
+          callerSessionId: null,
+        }).allowed,
+      ).toBe(true);
+    }
+  });
+
+  test('a session-bound caller is refused EVEN IF its token carries manager rights', () => {
+    // The critical ordering. An agent's token inherits the role of whoever
+    // minted it — in KaaB the wrapper's own account, which is usually a project
+    // owner. Checking isManager first would hand the agent exactly the
+    // authority this refusal exists to withhold, and the fix would be
+    // decorative.
+    expect(
+      mayResolveApproval({
+        isManager: true,
+        targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
+        callerUserId: WRAPPER,
+        callerSessionId: 's1',
+      }),
+    ).toEqual({ allowed: false, reason: 'session_bound_caller' });
+  });
+});
+
+describe('maySeeSessionApprovals', () => {
+  const base = {
+    isManager: false,
+    targetSessionId: 'session-b',
+    targetSessionOrigin: 'backend',
+    targetSessionCreatedBy: WRAPPER,
+    callerUserId: WRAPPER,
+  };
+
+  test("an agent sees only its OWN session's approvals", () => {
+    // This is the leak that feeds the resolve exploit: an execution_id is all
+    // the resolve route needs, and the old filter exposed every sibling's.
+    expect(maySeeSessionApprovals({ ...base, callerSessionId: 'session-b' })).toBe(true);
+    expect(maySeeSessionApprovals({ ...base, callerSessionId: 'session-a' })).toBe(false);
+  });
+
+  test('created_by does not expose backend sessions to a non-manager human', () => {
+    expect(maySeeSessionApprovals({ ...base, callerSessionId: null })).toBe(false);
+  });
+
+  test('a manager sees them', () => {
+    expect(maySeeSessionApprovals({ ...base, isManager: true, callerSessionId: null })).toBe(true);
+  });
+
+  test('an interactive session still shows to its real launcher', () => {
+    expect(
+      maySeeSessionApprovals({
+        ...base,
+        targetSessionOrigin: 'user',
+        targetSessionCreatedBy: HUMAN,
+        callerUserId: HUMAN,
+        callerSessionId: null,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/projects/lib/approval-authority.ts
+++ b/apps/api/src/projects/lib/approval-authority.ts
@@ -17,9 +17,26 @@
  *     writes a standing grant and injects continuation text into the victim's
  *     session.
  *
- * An automated caller must NEVER be its own approver. That is the whole point
- * of a human-in-the-loop gate, so a session-bound credential is refused
- * outright rather than being narrowed to "its own session".
+ * A SESSION-BOUND caller must never be its own approver. That is the whole
+ * point of a human-in-the-loop gate, so it is refused outright rather than
+ * narrowed to "its own session".
+ *
+ * A direct SERVICE-ACCOUNT bearer is deliberately still allowed, and that is a
+ * considered decision rather than an oversight:
+ *
+ *  - The agent can never hold one. The sandbox receives KORTIX_CLI_TOKEN, a PAT
+ *    carrying `sessionId` (session-sandbox.ts), and the per-agent service
+ *    account's secret is generated, hashed and DISCARDED at creation
+ *    ("plaintext `secret` intentionally discarded — identity-only",
+ *    repositories/service-accounts.ts). Service-account routes live under
+ *    /v1/accounts/*, which enforceTokenProjectScope refuses for a
+ *    project/session-scoped token. So there is no path from inside a sandbox to
+ *    an SA bearer.
+ *  - It is the WRAPPER'S OWN backend credential — the operator. In
+ *    Kortix-as-a-Backend the only way an end-user's approval decision can reach
+ *    this endpoint is relayed by that backend, because the end-user has no
+ *    Kortix identity. Refusing it would make require_approval unusable for the
+ *    exact product this exists to serve.
  */
 export type ApprovalRefusal = 'session_bound_caller' | 'not_launcher_or_manager';
 
@@ -42,7 +59,7 @@ export function mayResolveApproval(input: {
   // very often a project owner. Checking `isManager` first would hand the agent
   // exactly the authority this refusal exists to withhold.
   //
-  // No automated caller approves anything, whatever role its token carries.
+  // No session-bound caller approves anything, whatever role its token carries.
   if (input.callerSessionId !== null) {
     return { allowed: false, reason: 'session_bound_caller' };
   }

--- a/apps/api/src/projects/lib/approval-authority.ts
+++ b/apps/api/src/projects/lib/approval-authority.ts
@@ -1,0 +1,89 @@
+/**
+ * Who may resolve (approve / deny) a gated tool call.
+ *
+ * This is the THIRD surface with the same root cause: `created_by` was treated
+ * as "the person who launched this session". In Kortix-as-a-Backend every
+ * session is created by the wrapper's single credential, so `created_by`
+ * identifies nobody — and the in-sandbox token carries that exact `userId`.
+ *
+ * Two distinct failures followed:
+ *
+ *  1. SELF-APPROVAL. The agent holds its own `execution_id` from the 202
+ *     `pending_approval` body, and its token's `userId` equals `created_by`.
+ *     It could approve the very call `require_approval` exists to hold — which
+ *     makes the gate decorative rather than a control.
+ *
+ *  2. CROSS-END-USER. Sibling `execution_id`s are reachable, and resolving one
+ *     writes a standing grant and injects continuation text into the victim's
+ *     session.
+ *
+ * An automated caller must NEVER be its own approver. That is the whole point
+ * of a human-in-the-loop gate, so a session-bound credential is refused
+ * outright rather than being narrowed to "its own session".
+ */
+export type ApprovalRefusal = 'session_bound_caller' | 'not_launcher_or_manager';
+
+export function mayResolveApproval(input: {
+  /** True when the caller holds project-manager rights. */
+  isManager: boolean;
+  /** The session that owns the pending execution. */
+  targetSessionOrigin: string | null;
+  /** `created_by` of that session. */
+  targetSessionCreatedBy: string | null;
+  /** The acting user. */
+  callerUserId: string;
+  /** The caller's OWN session when its credential is bound to one (a sandbox
+   *  token). Non-null means an automated caller. */
+  callerSessionId: string | null;
+}): { allowed: true } | { allowed: false; reason: ApprovalRefusal } {
+  // ORDER MATTERS. The session-bound check runs FIRST, before the manager
+  // branch, because an agent's token inherits the role of the user who minted
+  // it — and in Kortix-as-a-Backend that is the wrapper's own account, which is
+  // very often a project owner. Checking `isManager` first would hand the agent
+  // exactly the authority this refusal exists to withhold.
+  //
+  // No automated caller approves anything, whatever role its token carries.
+  if (input.callerSessionId !== null) {
+    return { allowed: false, reason: 'session_bound_caller' };
+  }
+
+  // A manager is a human with project authority; that stands.
+  if (input.isManager) return { allowed: true };
+
+  // `created_by` only means "the launcher" for a session a single person
+  // actually started. For a wrapper-created session it is the wrapper, shared
+  // by every end-user, so it cannot confer launcher status.
+  const createdByIsMeaningful = input.targetSessionOrigin !== 'backend';
+  const isLauncher =
+    createdByIsMeaningful &&
+    input.targetSessionCreatedBy !== null &&
+    input.targetSessionCreatedBy === input.callerUserId;
+
+  return isLauncher ? { allowed: true } : { allowed: false, reason: 'not_launcher_or_manager' };
+}
+
+/**
+ * May this caller SEE a session's pending approvals?
+ *
+ * The counterpart to mayResolveApproval, and the leak that feeds it: the count
+ * endpoint filtered on `createdBy === callerUserId`, which is true for every
+ * KaaB session, so one end-user's sandbox could enumerate every other's pending
+ * gates — and an execution_id is all the resolve route needs.
+ *
+ * A session-bound caller may see ONLY its own session. Unlike resolving, this is
+ * a narrowing rather than a refusal: an agent legitimately needs to know its own
+ * call is waiting.
+ */
+export function maySeeSessionApprovals(input: {
+  isManager: boolean;
+  targetSessionId: string;
+  targetSessionOrigin: string | null;
+  targetSessionCreatedBy: string | null;
+  callerUserId: string;
+  callerSessionId: string | null;
+}): boolean {
+  if (input.callerSessionId !== null) return input.callerSessionId === input.targetSessionId;
+  if (input.isManager) return true;
+  if (input.targetSessionOrigin === 'backend') return false;
+  return input.targetSessionCreatedBy === input.callerUserId;
+}

--- a/apps/api/src/projects/lib/sandbox-token-session.test.ts
+++ b/apps/api/src/projects/lib/sandbox-token-session.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { sandboxTokenMayActOnSession } from './sandbox-token-session';
+
+describe('sandboxTokenMayActOnSession', () => {
+  test('a sandbox token may act on its OWN session', () => {
+    expect(sandboxTokenMayActOnSession('sess-a', 'sess-a')).toBe(true);
+  });
+
+  test("a sandbox token may NOT act on a sibling session in the same project", () => {
+    // The IDOR: same project, different session — turn-question let this through
+    // because it only scoped session_id to the project.
+    expect(sandboxTokenMayActOnSession('sess-a', 'sess-b')).toBe(false);
+  });
+
+  test('a missing sandbox binding is refused, never treated as a wildcard', () => {
+    expect(sandboxTokenMayActOnSession(null, 'sess-a')).toBe(false);
+    expect(sandboxTokenMayActOnSession(undefined, 'sess-a')).toBe(false);
+    expect(sandboxTokenMayActOnSession('', 'sess-a')).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/sandbox-token-session.ts
+++ b/apps/api/src/projects/lib/sandbox-token-session.ts
@@ -1,0 +1,20 @@
+/**
+ * A sandbox token acts for exactly one session.
+ *
+ * `sandbox_id == session_id` by construction (session-sandbox.ts mints the
+ * token bound to the sandbox it provisions), so any request carrying a
+ * caller-supplied `session_id` under a sandbox token must target that token's
+ * OWN session — never a sibling in the same project.
+ *
+ * `POST /turn-question` scoped the caller-supplied `session_id` to the project
+ * only, so one sandbox could finalize and repost another session's live turn.
+ * The sibling `turn-stream` already gets this right; this makes the invariant a
+ * named, tested function so no third route relearns it wrong.
+ */
+export function sandboxTokenMayActOnSession(
+  tokenSandboxId: string | null | undefined,
+  requestedSessionId: string,
+): boolean {
+  if (!tokenSandboxId) return false;
+  return tokenSandboxId === requestedSessionId;
+}

--- a/apps/api/src/projects/lib/serializer-redaction.test.ts
+++ b/apps/api/src/projects/lib/serializer-redaction.test.ts
@@ -46,6 +46,36 @@ describe('serializeSession redaction', () => {
     expect(out.secrets_allowlist).toBeNull();
   });
 
+  test('an inaccessible row leaks no CONVERSATION-DERIVED field either', () => {
+    // name / custom_name / opencode_sessions are all computed FROM metadata
+    // before the redaction, so redacting the metadata object alone left the
+    // OpenCode-synced title (which summarises the conversation) and the
+    // conversation-tree snapshot exposed.
+    const out = serializeSession(
+      row({
+        metadata: {
+          initial_prompt: 'secret',
+          name: 'Migrating the payroll database',
+          custom_name: 'Payroll migration',
+          opencode_sessions: [{ id: 'oc1', title: 'Migrating the payroll database' }],
+        },
+      }),
+      { canAccess: false },
+    ) as Record<string, unknown>;
+    expect(out.name).toBeNull();
+    expect(out.custom_name).toBeNull();
+    expect(out.opencode_sessions).toEqual([]);
+  });
+
+  test('an ACCESSIBLE row keeps its title and conversation tree', () => {
+    const out = serializeSession(
+      row({ metadata: { name: 'Migrating the payroll database', opencode_sessions: [{ id: 'oc1' }] } }),
+      { canAccess: true },
+    ) as Record<string, unknown>;
+    expect(out.name).toBe('Migrating the payroll database');
+    expect(out.opencode_sessions).toEqual([{ id: 'oc1' }]);
+  });
+
   test('an inaccessible row still carries what a listing legitimately needs', () => {
     // The point of scope=project is that a manager can SEE the session exists,
     // its status, and when it ran — redaction must not break that.

--- a/apps/api/src/projects/lib/serializer-redaction.test.ts
+++ b/apps/api/src/projects/lib/serializer-redaction.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { serializeSession } from './serializers';
+
+/**
+ * A row a caller cannot ACCESS must not carry that session's content.
+ *
+ * `GET /sessions?scope=project` deliberately lists rows the caller cannot open
+ * (so a manager sees the whole project), marking each `can_access: false`. The
+ * serializer redacted nothing, so those rows still carried `metadata` — which
+ * holds `initial_prompt`, the literal text an end-user typed — plus the
+ * end-user handle and the session's secret allowlist.
+ */
+const row = (over: Record<string, unknown> = {}) =>
+  ({
+    sessionId: '11111111-1111-4111-8111-111111111111',
+    accountId: 'a',
+    projectId: 'p',
+    branchName: 'b',
+    baseRef: 'main',
+    sandboxProvider: 'daytona',
+    sandboxId: 's',
+    sandboxUrl: null,
+    opencodeSessionId: null,
+    agentName: 'default',
+    status: 'running',
+    error: null,
+    createdBy: 'wrapper',
+    visibility: 'private',
+    origin: 'backend',
+    originRef: 'end-user-alice',
+    secretsAllowlist: ['STRIPE_KEY'],
+    connectorBindingsInheritUnbound: false,
+    metadata: { initial_prompt: 'my private prompt', source: 'backend' },
+    createdAt: new Date('2026-07-21T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-21T00:00:00.000Z'),
+    ...over,
+  }) as never;
+
+describe('serializeSession redaction', () => {
+  test('an inaccessible row carries no metadata, end-user handle, or allowlist', () => {
+    const out = serializeSession(row(), { canAccess: false }) as Record<string, unknown>;
+    expect(out.can_access).toBe(false);
+    expect(out.metadata).toEqual({});
+    expect(out.end_user_ref).toBeNull();
+    expect(out.origin_ref).toBeNull();
+    expect(out.secrets_allowlist).toBeNull();
+  });
+
+  test('an inaccessible row still carries what a listing legitimately needs', () => {
+    // The point of scope=project is that a manager can SEE the session exists,
+    // its status, and when it ran — redaction must not break that.
+    const out = serializeSession(row(), { canAccess: false }) as Record<string, unknown>;
+    expect(out.session_id).toBe('11111111-1111-4111-8111-111111111111');
+    expect(out.status).toBe('running');
+    expect(out.created_by).toBe('wrapper');
+  });
+
+  test('an ACCESSIBLE row is completely unchanged', () => {
+    const out = serializeSession(row(), { canAccess: true }) as Record<string, unknown>;
+    expect(out.metadata).toEqual({ initial_prompt: 'my private prompt', source: 'backend' });
+    expect(out.end_user_ref).toBe('end-user-alice');
+    expect(out.secrets_allowlist).toEqual(['STRIPE_KEY']);
+  });
+
+  test('the default (no ctx) stays accessible — single-session reads are already gated', () => {
+    const out = serializeSession(row()) as Record<string, unknown>;
+    expect(out.can_access).toBe(true);
+    expect(out.end_user_ref).toBe('end-user-alice');
+  });
+});

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -70,22 +70,29 @@ export function serializeSession(
     deletedBy?: string | null;
   },
 ): ProjectSession {
-  const opencodeSessions = Array.isArray(row.metadata?.opencode_sessions)
-    ? row.metadata.opencode_sessions
-    : [];
+  // Computed BEFORE the metadata-derived fields below, because name,
+  // custom_name and opencode_sessions are all derived FROM metadata — redacting
+  // the metadata object alone would still have leaked the OpenCode-synced title
+  // (which summarises the conversation) and the conversation-tree snapshot.
+  const canAccess = ctx?.canAccess ?? true;
+  const opencodeSessions =
+    canAccess && Array.isArray(row.metadata?.opencode_sessions)
+      ? row.metadata.opencode_sessions
+      : [];
   const isOwner = ctx?.viewerId ? row.createdBy === ctx.viewerId : false;
   // A user-set name (metadata.custom_name) is authoritative and ALWAYS wins
   // over the auto title (metadata.name) mirrored from OpenCode server-side
   // during session reads. `name` is the resolved display value;
   // `custom_name` is exposed separately so clients can tell an override apart
   // from the auto title.
-  const customName = typeof row.metadata?.custom_name === 'string' ? row.metadata.custom_name : null;
+  const customName =
+    canAccess && typeof row.metadata?.custom_name === 'string' ? row.metadata.custom_name : null;
   // Historic rows may carry OpenCode's frozen placeholder ("New session - …")
   // in metadata.name — expose it as untitled so clients fall back to their own
   // display chain instead of a junk title (heals old rows with no backfill).
-  const rawAutoName = typeof row.metadata?.name === 'string' ? row.metadata.name : null;
+  const rawAutoName =
+    canAccess && typeof row.metadata?.name === 'string' ? row.metadata.name : null;
   const autoName = isPlaceholderOpencodeTitle(rawAutoName) ? null : rawAutoName;
-  const canAccess = ctx?.canAccess ?? true;
   return {
     session_id: row.sessionId,
     account_id: row.accountId,

--- a/apps/api/src/projects/lib/serializers.ts
+++ b/apps/api/src/projects/lib/serializers.ts
@@ -85,6 +85,7 @@ export function serializeSession(
   // display chain instead of a junk title (heals old rows with no backfill).
   const rawAutoName = typeof row.metadata?.name === 'string' ? row.metadata.name : null;
   const autoName = isPlaceholderOpencodeTitle(rawAutoName) ? null : rawAutoName;
+  const canAccess = ctx?.canAccess ?? true;
   return {
     session_id: row.sessionId,
     account_id: row.accountId,
@@ -100,7 +101,10 @@ export function serializeSession(
     agent_name: row.agentName,
     status: row.status,
     error: row.error,
-    metadata: row.metadata ?? {},
+    // A row the caller cannot ACCESS is still listed (scope=project shows a
+    // manager the whole project) but must not carry the session's CONTENT.
+    // metadata holds initial_prompt — the literal text an end-user typed.
+    metadata: canAccess ? (row.metadata ?? {}) : {},
     opencode_sessions: opencodeSessions,
     // Ownership + org-visibility (Phase 2 session sharing).
     created_by: row.createdBy,
@@ -109,15 +113,17 @@ export function serializeSession(
     owner_type: ctx?.ownerType ?? (row.createdBy ? 'unknown' : null),
     visibility: row.visibility,
     origin: row.origin,
-    end_user_ref: row.originRef,
+    // Which END-USER a backend session acts for, and what it may read, are
+    // both session content — withheld on a row the caller cannot open.
+    end_user_ref: canAccess ? row.originRef : null,
     // Deprecated alias, echoed with the same value so wrappers written against
     // the old name keep working. The DB column keeps its original name.
-    origin_ref: row.originRef,
-    secrets_allowlist: row.secretsAllowlist ?? null,
+    origin_ref: canAccess ? row.originRef : null,
+    secrets_allowlist: canAccess ? (row.secretsAllowlist ?? null) : null,
     sharing: visibilityToIntent(row.visibility as 'private' | 'project' | 'restricted', ctx?.grants ?? []),
     is_owner: isOwner,
     can_manage_sharing: isOwner || Boolean(ctx?.canManageProject),
-    can_access: ctx?.canAccess ?? true,
+    can_access: canAccess,
     runtime_status: ctx?.runtimeStatus ?? null,
     deleted_at: ctx?.deletedAt ?? null,
     deleted_by: ctx?.deletedBy ?? null,

--- a/apps/api/src/projects/routes/public-shares.ts
+++ b/apps/api/src/projects/routes/public-shares.ts
@@ -73,7 +73,7 @@ projectsApp.openapi(
 
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const visible = await loadSessionForSharing(loaded, sessionId);
+    const visible = await loadSessionForSharing(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json({ error: 'Only the session owner or an editor can view public shares' }, 403);
@@ -109,7 +109,7 @@ projectsApp.openapi(
     const body = await readBody(c);
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const visible = await loadSessionForSharing(loaded, sessionId);
+    const visible = await loadSessionForSharing(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json({ error: 'Only the session owner or an editor can create public shares' }, 403);
@@ -168,7 +168,7 @@ projectsApp.openapi(
 
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
-    const visible = await loadSessionForSharing(loaded, sessionId);
+    const visible = await loadSessionForSharing(loaded, sessionId, c.get('sessionId') ?? null);
     if (!visible) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageSharing) {
       return c.json({ error: 'Only the session owner or an editor can revoke public shares' }, 403);

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -87,6 +87,7 @@ import {
 } from '../../repositories/model-preferences';
 import { getProjectRoutingPolicy } from '../../repositories/project-routing-policies';
 import { isValidMatcher } from '../../executor/policy';
+import { sandboxTokenMayActOnSession } from '../lib/sandbox-token-session';
 import { db } from '../../shared/db';
 import {
   acquireExecutionLease,
@@ -3006,6 +3007,10 @@ projectsApp.openapi(
   async (c: any) => {
     const projectId = c.req.param('projectId');
 
+    // The session this credential is BOUND to, when it is a sandbox token.
+    // Null for a human caller.
+    let callerSandboxSessionId: string | null = null;
+
     const authType = (c as any).get('authType') as string | undefined;
     if (authType === 'apiKey' && (c as any).get('apiKeyType') === 'sandbox') {
       const accountId = (c as any).get('accountId') as string | undefined;
@@ -3014,7 +3019,10 @@ projectsApp.openapi(
         return c.json({ error: 'turn-question requires a sandbox token' }, 403);
       }
       const [sandbox] = await db
-        .select({ sandboxId: sessionSandboxes.sandboxId })
+        .select({
+          sandboxId: sessionSandboxes.sandboxId,
+          sessionId: sessionSandboxes.sessionId,
+        })
         .from(sessionSandboxes)
         .where(
           and(
@@ -3028,8 +3036,12 @@ projectsApp.openapi(
       if (!sandbox) {
         return c.json({ error: 'sandbox token is not scoped to this project' }, 403);
       }
+      callerSandboxSessionId = sandbox.sessionId ?? sandbox.sandboxId;
     } else {
-      const loaded = await loadProjectForUser(c, projectId, 'read');
+      // A question card finalizes and re-posts a LIVE turn, so it is a
+      // mutation of that session — 'read' is too weak. The sibling turn-stream
+      // route already requires more than read for the same reason.
+      const loaded = await loadProjectForUser(c, projectId, 'session');
       if (!loaded) return c.json({ error: 'Not found' }, 404);
     }
 
@@ -3048,9 +3060,17 @@ projectsApp.openapi(
       return c.json({ error: 'session_id is required' }, 400);
     }
 
-    // session_id is caller-supplied — scope it back to :projectId so a caller
-    // authed for their own project can't relay a question into another
-    // tenant's live session (IDOR).
+    // session_id is caller-supplied. Scoping it to :projectId closes the
+    // cross-TENANT hole, but a sandbox token acts for exactly ONE session, so
+    // project scope still let sandbox A finalize and repost session B's live
+    // turn. sandbox_id == session_id by construction — bind to it.
+    if (
+      callerSandboxSessionId !== null &&
+      !sandboxTokenMayActOnSession(callerSandboxSessionId, sessionId)
+    ) {
+      return c.json({ error: 'sandbox token is not scoped to this session' }, 403);
+    }
+
     const [turnQuestionSession] = await db
       .select({ sessionId: projectSessions.sessionId })
       .from(projectSessions)

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -19,6 +19,7 @@ import { roleAllows } from '../access';
 import { createRoute, z } from '@hono/zod-openapi';
 import { accountGroupMembers, accountGroups, accountMembers, executorConnectors, executorExecutions, projectGroupGrants, projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, asc, desc, eq, inArray, isNull } from 'drizzle-orm';
+import { mayResolveApproval, maySeeSessionApprovals } from '../lib/approval-authority';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
 import { tierGrantsAllModels } from '../../billing/services/tiers';
 import { config } from '../../config';
@@ -1213,6 +1214,7 @@ projectsApp.openapi(
         sessionId: projectSessions.sessionId,
         opencodeSessionId: projectSessions.opencodeSessionId,
         createdBy: projectSessions.createdBy,
+        origin: projectSessions.origin,
       })
       .from(projectSessions)
       .where(and(eq(projectSessions.projectId, projectId), inArray(projectSessions.sessionId, kortixIds)));
@@ -1220,7 +1222,21 @@ projectsApp.openapi(
     const sessions: Record<string, number> = {};
     let total = 0;
     for (const s of sess) {
-      if (!isManager && s.createdBy !== loaded.userId) continue;
+      // created_by is shared across every KaaB session, so it cannot filter
+      // one end-user's pending gates from another's — and an execution_id is
+      // all the resolve route needs.
+      if (
+        !maySeeSessionApprovals({
+          isManager,
+          targetSessionId: s.sessionId,
+          targetSessionOrigin: s.origin ?? null,
+          targetSessionCreatedBy: s.createdBy,
+          callerUserId: loaded.userId,
+          callerSessionId: c.get('sessionId') ?? null,
+        })
+      ) {
+        continue;
+      }
       const n = byKortix[s.sessionId] ?? 0;
       if (n <= 0) continue;
       sessions[s.sessionId] = n;
@@ -1313,19 +1329,37 @@ projectsApp.openapi(
     } catch {
       isManager = false;
     }
-    let isLauncher = false;
-    if (!isManager && row.sessionId) {
+    let targetCreatedBy: string | null = null;
+    let targetOrigin: string | null = null;
+    if (row.sessionId) {
       const [session] = await db
-        .select({ createdBy: projectSessions.createdBy })
+        .select({ createdBy: projectSessions.createdBy, origin: projectSessions.origin })
         .from(projectSessions)
         // Scope to THIS project too — sessionId is a PK so it's globally unique,
         // but making the project bound explicit keeps the gate self-documenting.
         .where(and(eq(projectSessions.sessionId, row.sessionId), eq(projectSessions.projectId, projectId)))
         .limit(1);
-      isLauncher = Boolean(session && session.createdBy === loaded.userId);
+      targetCreatedBy = session?.createdBy ?? null;
+      targetOrigin = session?.origin ?? null;
     }
-    if (!isManager && !isLauncher) {
-      return c.json({ error: 'Only a project manager or the session launcher can resolve this' }, 403);
+    const verdict = mayResolveApproval({
+      isManager,
+      targetSessionOrigin: targetOrigin,
+      targetSessionCreatedBy: targetCreatedBy,
+      callerUserId: loaded.userId,
+      callerSessionId: c.get('sessionId') ?? null,
+    });
+    if (!verdict.allowed) {
+      return c.json(
+        verdict.reason === 'session_bound_caller'
+          ? {
+              error:
+                'An agent cannot resolve its own approval — a human must approve or deny this',
+              code: 'APPROVAL_REQUIRES_HUMAN',
+            }
+          : { error: 'Only a project manager or the session launcher can resolve this' },
+        403,
+      );
     }
 
     const detail = {

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -37,6 +37,9 @@ export const config = {
   // 0 = disabled. Set to a byte ceiling (e.g. 1048576 for 1 MiB) to reject
   // oversized requests with a 413 before they reach an upstream.
   maxRequestBytes: optionalInt('GATEWAY_MAX_REQUEST_BYTES', 0),
+  // A provider can return HTTP 200 and then send zero stream bytes. Cancel that
+  // candidate before the caller's 125-second transport deadline expires.
+  streamProbeTimeoutMs: optionalInt('GATEWAY_STREAM_PROBE_TIMEOUT_MS', 30_000),
   retry: {
     maxAttempts: optionalInt('GATEWAY_RETRY_MAX_ATTEMPTS', 3),
     baseDelayMs: optionalInt('GATEWAY_RETRY_BASE_MS', 300),

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -63,6 +63,7 @@ export function buildServer(): GatewayServer {
       captureBodies: config.captureBodies,
       maxCapturedBodyBytes: config.maxCapturedBodyBytes,
       maxRequestBytes: config.maxRequestBytes || undefined,
+      streamProbeTimeoutMs: config.streamProbeTimeoutMs,
     },
     { logger },
   );

--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -51,7 +51,7 @@ curl -X POST "$KORTIX_API_URL/projects/$KORTIX_PROJECT_ID/sessions" \
   -d '{
     "end_user_ref": "your-app-user-123",
     "agent_name": "support",
-    "opencode_model": "anthropic/claude-opus-4-8",
+    "opencode_model": "kortix/claude-opus-4.8",
     "connector_bindings": { "gmail": { "profile_id": "<profile-id>" } },
     "secrets": ["STRIPE_KEY"]
   }'
@@ -71,7 +71,7 @@ const kortix = createScopedKortix({
 const session = await kortix.project(projectId).sessions.create({
   end_user_ref: 'your-app-user-123',
   agent_name: 'support',
-  opencode_model: 'anthropic/claude-opus-4-8',
+  opencode_model: 'kortix/claude-opus-4.8',
   connector_bindings: { gmail: { profile_id } },
   secrets: ['STRIPE_KEY'],
 });
@@ -236,3 +236,70 @@ starting a second one. Replaying a key with a **different** body — different
 | `404` | `CONNECTOR_PROFILE_NOT_FOUND` | The bound `profile_id` doesn't exist for this project (or isn't yours). |
 | `409` | `CONNECTOR_PROFILE_INACTIVE` | The bound profile is revoked or the connector is disabled. |
 | `409` | `IDEMPOTENCY_*_CONFLICT` | An `Idempotency-Key` was replayed with a different body. Keep the body identical across retries. |
+| `403` | `CONNECTOR_NOT_ASSIGNED` | The session's agent isn't granted a connector you named. **The first error most wrappers hit** — list the alias under that agent's `connectors:` in your manifest. |
+| `403` | `REQUIRE_CONNECTORS_INTERACTIVE_ONLY` | `require_connectors` is interactive-only. A backend key acts for no single person — bind an explicit `profile_id` with `connector_bindings`. |
+| `403` | `origin_override_forbidden` | A non-backend caller tried to set `end_user_ref` or `secrets`. |
+| `409` | `CONNECTOR_CONNECTION_REQUIRED` | Interactive only: the user hasn't connected their own account. The body names which connector. |
+| `409` | `END_USER_REF_CONFLICT` | You sent `end_user_ref` and the deprecated `origin_ref` with different values. |
+| `409` | `IDEMPOTENCY_KEY_CONFLICT` | The key collided with a different operation. Unlike the other idempotency errors, the fix is a **higher-entropy key** — the uniqueness index is global. |
+| `429` | `concurrent_session_limit` / `per_origin_session_limit` | Account-wide, or per-end-user when the operator enables it. Retry with backoff. |
+| `402` | `subscription_required` / `insufficient_credits` | Billing — not retryable without operator action. |
+
+## What you can change once a session is running
+
+| Override | Mid-session |
+| --- | --- |
+| `opencode_model` | **Yes** — `PUT /projects/{id}/sessions/{sessionId}/model` |
+| `agent_name` | **Per message** — each prompt names the agent that runs it |
+| `secrets`, `connector_bindings`, `runtime_context`, `end_user_ref` | **No** — set once at create |
+
+### Changing the model
+
+```bash
+curl -sS -X PUT "$KORTIX_API_URL/projects/$PROJECT_ID/sessions/$SESSION_ID/model" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"opencode_model":"kortix/claude-opus-4.8"}'
+```
+
+The response carries `applied_live`. `true` means a running sandbox took it now;
+`false` means it applies at next start. **Tell your user which** — someone told
+"model changed" whose next answer comes from the old model has been misled.
+Applying it live restarts the runtime and ends the in-flight turn, so a no-op
+PUT deliberately does not restart.
+
+### Why secrets can't change
+
+`secrets_allowlist` is written once. A mutable allowlist could be narrowed below
+what the sandbox already needs and leave the session unbootable. Start a new
+session to change what it may read.
+
+### Switching agents
+
+Each message names the agent that runs it. A switch to an agent with a
+*different secrets grant* is refused `409 AGENT_SWITCH_REQUIRES_NEW_SESSION` —
+and **retrying cannot succeed**, because re-scoping cannot un-read what the
+session already loaded. Offer a new session, not a retry.
+
+Note the current limitation: a switch re-scopes *secrets* but not *connectors* —
+the sandbox token's connector grant is minted once from the create-time agent.
+
+## Isolation between your end-users
+
+Every session your backend creates shares one `created_by` — your wrapper
+credential — so ownership alone cannot tell your users apart. The platform
+narrows on the *caller's* session instead: a token bound to end-user A's sandbox
+cannot read, share, or approve on end-user B's session.
+
+Your backend credential is unaffected. It is the operator and still sees
+everything it created.
+
+<Callout type="warn">
+  **Inject `end_user_ref` server-side, from your authenticated session — never
+  accept it from a browser.** A client that can set it can bill another user, or
+  replay their session through a shared `Idempotency-Key`.
+</Callout>
+
+Listing with `?scope=project` includes rows the caller cannot open, marked
+`can_access: false`. Those are redacted — no `metadata` (which holds
+`initial_prompt`), no `end_user_ref`, no `secrets_allowlist`.

--- a/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
   useVisibleAgents,
   writeStartStash,
 } from '@kortix/sdk/react';
+import { serverErrorBody } from '@/lib/api-error-body';
 import { classifySessionStartFailure } from '@/lib/session-start-error';
 import type { BindableConnection } from '@/server/bindable-connections';
 import { getSessionToken } from '@/lib/session';
@@ -135,11 +136,10 @@ function ProjectHome() {
     onError: (err: unknown) => {
       // Two KaaB refusals need opposite responses, and a single generic toast
       // told the user to fix something they often could not fix.
-      const body =
-        err && typeof err === 'object' && 'body' in err
-          ? ((err as { body?: unknown }).body as Record<string, unknown> | null)
-          : null;
-      const failure = classifySessionStartFailure(body);
+      // The SDK's ApiError puts the parsed body on `data`/`details` and lifts
+      // `code` — it has no `body` field, so reading one made every KaaB refusal
+      // below unreachable.
+      const failure = classifySessionStartFailure(serverErrorBody(err));
       if (failure.kind === 'connector_connection_required') {
         setConnectPrompt({ connector: failure.connector, message: failure.message });
         return;

--- a/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker';
 import { Message } from '@/components/ui/message';
 import { SessionScope } from '@/components/workbench/session-scope';
+import { sendFailureTitle } from '@/lib/send-failure';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ChangesPanel } from '@/components/workbench/changes-panel';
 import { FilesPanel } from '@/components/workbench/files-panel';
@@ -241,6 +242,16 @@ function Thread({ session: c }: { session: UseSessionResult }) {
               <Button size="sm" variant="secondary" className="h-7 gap-1.5" onClick={c.cancel}>
                 Stop
               </Button>
+            </div>
+          ) : null}
+          {/* A rejected send used to be SILENT: the optimistic bubble vanished,
+              the typed text was gone, and nothing said why. useSession surfaces
+              a typed sendError — read it, and name the KaaB refusals the
+              generic message would otherwise swallow. */}
+          {c.sendError ? (
+            <div className="mx-4 mb-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm">
+              <div className="font-medium">{sendFailureTitle(c.sendError)}</div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{c.sendError.message}</p>
             </div>
           ) : null}
           <Composer

--- a/apps/whitelabel-demo/src/lib/api-error-body.ts
+++ b/apps/whitelabel-demo/src/lib/api-error-body.ts
@@ -1,0 +1,36 @@
+/**
+ * Pull the server's error body out of whatever the SDK threw.
+ *
+ * The SDK's `ApiError` carries the parsed body on `data` / `details`, lifts
+ * `code` to the top level, and has **no `body` field at all**
+ * (`core/http/api/errors.ts`). Demo code that read `err.body` therefore never
+ * fired: every Kortix-as-a-Backend refusal — the connector prompt, the agent
+ * switch conflict, the per-end-user cap — collapsed into one generic message,
+ * and the classifiers written to handle them were dead code.
+ *
+ * Reading through one function means the next classifier cannot get this wrong.
+ */
+export interface ServerErrorBody {
+  code?: unknown;
+  error?: unknown;
+  connector?: unknown;
+}
+
+export function serverErrorBody(err: unknown): ServerErrorBody | null {
+  if (!err || typeof err !== 'object') return null;
+  const e = err as Record<string, unknown>;
+
+  const candidate = [e.data, e.details, e.detail].find(
+    (v) => v && typeof v === 'object' && !Array.isArray(v),
+  ) as Record<string, unknown> | undefined;
+
+  // `code` is lifted onto the error itself, so it can be present even when the
+  // body did not parse. Prefer the body's own code, fall back to the lifted one.
+  const code = candidate?.code ?? e.code;
+  // ApiError.message is always coerced to a string and holds the server's
+  // `error`/`detail` text, so it is a usable fallback when the body is absent.
+  const error = candidate?.error ?? (typeof e.message === 'string' ? e.message : undefined);
+
+  if (code === undefined && error === undefined && !candidate) return null;
+  return { code, error, connector: candidate?.connector };
+}

--- a/apps/whitelabel-demo/src/lib/send-failure.ts
+++ b/apps/whitelabel-demo/src/lib/send-failure.ts
@@ -1,0 +1,30 @@
+import type { KortixSendError } from '@kortix/sdk/react';
+
+/**
+ * A short, human title for a failed send.
+ *
+ * `useSession` surfaces a typed `sendError`, but the demo never read it — so a
+ * rejected send was completely silent: the optimistic bubble vanished, the
+ * typed text was gone, and nothing said why. For a wrapper's end-user that is
+ * indistinguishable from the product being broken.
+ *
+ * The message itself is already formatted for display by the SDK; this only
+ * adds the one-line "what kind of problem is this", because the three kinds
+ * need different reactions from the user.
+ */
+export function sendFailureTitle(error: KortixSendError): string {
+  switch (error.kind) {
+    case 'billing':
+      // Not retryable by the end-user — the operator has to act.
+      return 'This session is out of credit';
+    case 'runtime-not-ready':
+      // Transient and self-healing; retrying is genuinely the right move.
+      return 'The runtime is still starting';
+    case 'runtime-error':
+      return error.gateway?.provider
+        ? `The ${error.gateway.provider} model failed`
+        : 'The agent could not run that';
+    default:
+      return 'Your message was not sent';
+  }
+}

--- a/apps/whitelabel-demo/tests/e2e/api-error-body.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/api-error-body.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { serverErrorBody } from '../../src/lib/api-error-body';
+
+describe('serverErrorBody', () => {
+  test('reads the parsed body the SDK puts on `data`', () => {
+    // The regression this exists for: demo code read `err.body`, which ApiError
+    // never sets, so every KaaB refusal collapsed to a generic message.
+    const body = serverErrorBody({
+      status: 409,
+      code: 'CONNECTOR_CONNECTION_REQUIRED',
+      data: { error: 'Connector "gmail" requires a personal connection', code: 'CONNECTOR_CONNECTION_REQUIRED', connector: 'gmail' },
+    });
+    expect(body?.code).toBe('CONNECTOR_CONNECTION_REQUIRED');
+    expect(body?.connector).toBe('gmail');
+  });
+
+  test('falls back to `details` and `detail`', () => {
+    expect(serverErrorBody({ details: { code: 'X' } })?.code).toBe('X');
+    expect(serverErrorBody({ detail: { code: 'Y' } })?.code).toBe('Y');
+  });
+
+  test('uses the lifted top-level code when the body did not parse', () => {
+    expect(serverErrorBody({ status: 403, code: 'REQUIRE_CONNECTORS_INTERACTIVE_ONLY' })?.code).toBe(
+      'REQUIRE_CONNECTORS_INTERACTIVE_ONLY',
+    );
+  });
+
+  test('uses ApiError.message as the text when the body has none', () => {
+    expect(serverErrorBody({ code: 'X', message: 'server said this' })?.error).toBe('server said this');
+  });
+
+  test('prefers the BODY code over the lifted one', () => {
+    // api-client lifts response.status.toString() as `code` when the body has
+    // none, so a numeric-looking lifted code must not shadow a real one.
+    expect(serverErrorBody({ code: '409', data: { code: 'REAL_CODE' } })?.code).toBe('REAL_CODE');
+  });
+
+  test('a non-object throw yields null rather than crashing the handler', () => {
+    expect(serverErrorBody(null)).toBeNull();
+    expect(serverErrorBody('boom')).toBeNull();
+    expect(serverErrorBody(undefined)).toBeNull();
+  });
+
+  test('an array body is not mistaken for an error object', () => {
+    expect(serverErrorBody({ data: [1, 2] })).toBeNull();
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { sendFailureTitle } from '../../src/lib/send-failure';
+
+describe('sendFailureTitle', () => {
+  test('billing reads as an operator problem, not a retry', () => {
+    expect(sendFailureTitle({ kind: 'billing', message: 'x' } as never)).toContain('credit');
+  });
+
+  test('a not-ready runtime reads as transient', () => {
+    expect(sendFailureTitle({ kind: 'runtime-not-ready', message: 'x' } as never)).toContain(
+      'starting',
+    );
+  });
+
+  test('a gateway failure names WHICH provider when the envelope carries it', () => {
+    expect(
+      sendFailureTitle({
+        kind: 'runtime-error',
+        message: 'x',
+        gateway: { provider: 'anthropic' },
+      } as never),
+    ).toBe('The anthropic model failed');
+  });
+
+  test('a gateway failure without a provider still reads sensibly', () => {
+    expect(sendFailureTitle({ kind: 'runtime-error', message: 'x' } as never)).toBe(
+      'The agent could not run that',
+    );
+  });
+
+  test('an unknown kind never produces an empty title', () => {
+    expect(sendFailureTitle({ kind: 'something-new', message: 'x' } as never).length).toBeGreaterThan(0);
+  });
+});

--- a/docs/KAAB_DEPTH_PLAN.md
+++ b/docs/KAAB_DEPTH_PLAN.md
@@ -9,28 +9,47 @@ could not verify is marked as such rather than asserted.
 
 **Corrected 2026-07-27 after I got this wrong twice. Read the correction.**
 
-### What is actually true
+### What is actually true — settled by a dispatch run, 2026-07-28
 
-`package-tests.yml` triggers on **`pull_request` only** (plus manual dispatch) —
-20 of the last 20 runs were `pull_request`. The `kortix-api` job materializes
-`DOTENV_PRIVATE_KEY` only when `github.event_name != 'pull_request'`, a
-deliberate control added by a pentest the same day:
+**`DOTENV_PRIVATE_KEY` is not configured as a repo secret at all.**
 
-> exposing DOTENV_PRIVATE_KEY would let a same-repo branch PR read all 80+ prod
-> secrets decryptable with that one key
+Proven, not inferred: dispatching `package-tests.yml` on `main`
+(run `30335178547`) is a `workflow_dispatch` event, which satisfies the job's
+`github.event_name != 'pull_request'` condition. The env-gated suite **still
+skipped**, logging "DOTENV_PRIVATE_KEY not configured for this context".
+`gh secret list` then confirmed the name is absent from the repository.
 
-Both halves are individually correct. Together they mean the condition can never
-be satisfied, so **the env-gated suite never runs anywhere**. This is not
-negligence — it is a security control colliding with a trigger list.
+So the ternary
 
-**The fix is small and preserves the security property:** add
-`push: branches: [main]`. PR-head code still never sees the key; the suite gains
-a post-merge venue.
+```yaml
+DOTENV_PRIVATE_KEY: ${{ github.event_name != 'pull_request' && secrets.DOTENV_PRIVATE_KEY || '' }}
+```
 
-**Risk to weigh first:** locally the suite shows failures under the real CI
-command, but my environment is provably not CI's (see below), so I cannot
-predict whether enabling this turns `main` red. Someone should dry-run it via
-`workflow_dispatch` before wiring the trigger.
+resolves to `''` on **every** event, and the ~1757-test suite runs nowhere.
+
+**Do NOT "fix" this by adding `push: branches: [main]`.** That was my earlier
+recommendation and it is wrong — it changes nothing while looking like a fix,
+which is worse than the current visible gap.
+
+**The actual fix is a human action:** provision `DOTENV_PRIVATE_KEY` as a
+repository secret. The workflow's shape is already correct — the pentest's
+condition rightly withholds the key from PR-head code — so once the secret
+exists, `workflow_dispatch` works immediately and adding a `push: [main]`
+trigger gives the suite a permanent venue where the key is safe to materialize.
+
+### How many times I got this wrong
+
+Recorded because the pattern is more useful than the answer:
+
+| Claim | Verdict |
+| --- | --- |
+| "the suite doesn't run in CI" | Right conclusion, no evidence behind it |
+| "it runs on push, just not PRs" | **Wrong** — I misread `gh run list --branch=main`, which lists PR-event runs |
+| "the trigger list is `pull_request`-only, so the condition can never hold" | True, but not the binding constraint |
+| "the secret is not configured" | **Confirmed** by a dispatch run + `gh secret list` |
+
+Each step was a confident answer built on the previous one's framing rather than
+on a measurement. The dispatch run cost two minutes and settled it.
 
 ### What I got wrong, and why it matters
 

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -38,7 +38,7 @@ curl -X POST https://api.kortix.com/v1/projects/<project-id>/sessions \
     "initial_prompt": "Summarize my new signups",
     "end_user_ref": "your-app-user-123",
     "agent_name": "support",
-    "opencode_model": "anthropic/claude-opus-4-8",
+    "opencode_model": "kortix/claude-opus-4.8",
     "connector_bindings": { "gmail": { "profile_id": "<profile-id>" } },
     "secrets": ["STRIPE_KEY"]
   }'
@@ -65,7 +65,7 @@ const session = await kortix.project(projectId).sessions.create({
   initial_prompt: 'Summarize my new signups',
   end_user_ref: 'your-app-user-123',
   agent_name: 'support',
-  opencode_model: 'anthropic/claude-opus-4-8',
+  opencode_model: 'kortix/claude-opus-4.8',
   connector_bindings: { gmail: { profile_id } },
   secrets: ['STRIPE_KEY'],
 });
@@ -189,8 +189,17 @@ both mintable with your API key:
    await kortix.project(projectId).connectors.profiles.activate(profile.profile_id);
    // → bind at session start: connector_bindings: { 'user-mcp': { profile_id: profile.profile_id } }
    ```
-   All of these are gated by `project.connector.write` (editor-tier and up) — a
-   dashboard API key rides that automatically.
+   All of these are gated by `project.connector_profiles.manage`, which is
+   **manager-only** (`iam/role-perms.ts` `MANAGER_ONLY`) — the built-in
+   **Manager** role, or owner/admin. An *editor* is NOT enough: `reconcile`
+   returns 403 and `updateCredential` / `activate` return **404**, deliberately
+   indistinguishable from "no such profile" so the endpoint never confirms a
+   profile exists to someone who may not touch it. If you hunt a nonexistent id
+   bug here, check the role first.
+
+   Binding an `external` profile at session create additionally needs
+   `project.session.bindings.write` — also manager-only. That is why the
+   override table below says "project manager" for `connector_bindings`.
 
    **OAuth apps (Gmail, Slack, Notion — `provider: 'pipedream'`).** There's no
    static token to paste; the end-user authorizes in their browser **once**, and
@@ -392,6 +401,16 @@ await s.send(prompt);
 | `409` | `IDEMPOTENCY_SECRETS_CONFLICT` / `IDEMPOTENCY_BINDING_CONFLICT` | An `Idempotency-Key` was replayed with a different `secrets` / `connector_bindings` body. Keep the body identical across retries. |
 | `400` | `INVALID_SESSION_MODEL` | `opencode_model` isn't servable for this account (retired, not entitled, or a typo), or isn't a valid model id. |
 | `400` | `INVALID_SESSION_SECRETS` / `INVALID_SESSION_CONNECTOR_BINDINGS` / `INVALID_SESSION_RUNTIME_CONTEXT` | Malformed `secrets` / `connector_bindings` / `runtime_context` (the last also rejects credential-like keys and enforces the 64-entry / 16 KiB caps). |
+| `403` | `CONNECTOR_NOT_ASSIGNED` | The session's agent isn't granted a connector you named in `connector_bindings` (or `require_connectors`). **The first error most wrappers hit** — any project with an `agents:` block must list the alias under that agent's `connectors:`. |
+| `403` | `REQUIRE_CONNECTORS_INTERACTIVE_ONLY` | A backend caller used `require_connectors`. A wrapper key acts for no single person, so "the current user's own connection" has no meaning — bind an explicit `profile_id` with `connector_bindings` instead. |
+| `409` | `CONNECTOR_CONNECTION_REQUIRED` | Interactive only: this user hasn't connected their own account for a required connector. The body names `connector` so you can prompt for exactly that one. |
+| `409` | `CONNECTOR_PROFILE_INACTIVE` | The bound connection is revoked or errored. Reconnect it; a revoked profile fails closed and never silently falls back. |
+| `409` | `IDEMPOTENCY_ORIGIN_CONFLICT` | An `Idempotency-Key` was replayed under a **different** `end_user_ref`. This is the guard that stops one end-user receiving another's session — do not work around it by reusing keys. |
+| `409` | `IDEMPOTENCY_KEY_CONFLICT` | The key collided with a different operation. Remediation is the **opposite** of the other idempotency errors: use a higher-entropy key. The uniqueness index is global. |
+| `409` | `END_USER_REF_CONFLICT` | You sent both `end_user_ref` and the deprecated `origin_ref` with **different** values. Send only `end_user_ref`. |
+| `409` | `SESSION_NOT_RUNNING` | You tried to change the model of a terminal session. Nothing would consume it. |
+| `429` | `concurrent_session_limit` / `per_origin_session_limit` | Account-wide, or per-end-user when `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` is set (defaults to 0 = off). Retry with backoff. |
+| `402` | `subscription_required` / `insufficient_credits` | Billing. Not retryable without operator action. |
 
 ---
 
@@ -427,3 +446,89 @@ wire field. Sending both is fine when they agree; disagreeing values are
 rejected `400 END_USER_REF_CONFLICT` rather than one silently winning. Sandboxes
 receive both `KORTIX_END_USER_REF` and `KORTIX_ORIGIN_REF`. The database column
 keeps its original name — that is internal and renaming it would buy nothing.
+
+## Changing a running session's model
+
+`opencode_model` is set at create, but a live session can be re-pointed:
+
+```bash
+curl -sS -X PUT "$KORTIX_API_URL/projects/$PROJECT_ID/sessions/$SESSION_ID/model" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"opencode_model":"kortix/claude-opus-4.8"}'
+```
+
+```jsonc
+{ "opencode_model": "kortix/claude-opus-4.8", "applied_live": true }
+```
+
+Three things worth knowing:
+
+- **`applied_live` is not decoration.** `true` means a running sandbox took it
+  now; `false` means it was stored and applies when the session next starts.
+  Report the difference to your user — someone told "model changed" whose next
+  answer comes from the old model has been misled.
+- **Applying it live restarts the runtime**, which ends the in-flight turn. A
+  no-op PUT (same model) deliberately does *not* restart, so re-sending is free.
+- Only the session owner or a project manager may change it. Being able to *see*
+  a shared session is not permission to re-point it.
+
+The model is validated against the same servability check as create, so an
+unentitled or retired id fails fast with `400 INVALID_SESSION_MODEL` rather than
+becoming a dead turn later.
+
+## Per-connection permissions
+
+One connector can hold several connections — `support@`, `sales@`, a member's
+own mailbox — and they often warrant different permissions. Policy resolves in
+this order:
+
+```
+project rules   → un-overridable (the admin guardrail)
+connection      → beats the connector default
+connector       → the fallback
+risk default    → read runs, write/destructive asks
+```
+
+So `support@` can be read-only while `sales@` may send, under one `gmail`
+connector. Set it in the dashboard: **Connections → ⋯ → Permissions for this
+connection**. A connector with no connection-level rule behaves exactly as
+before.
+
+## What a wrapper CANNOT change mid-session
+
+| Override | Mid-session | Why |
+| --- | --- | --- |
+| `opencode_model` | **yes** — see above | |
+| `agent_name` | **per message** — each prompt names the agent that runs it | A switch to an agent with a *different secrets grant* is refused `409 AGENT_SWITCH_REQUIRES_NEW_SESSION`; retrying cannot succeed, because re-scoping cannot un-read what the session already loaded. |
+| `secrets` | **no** | `secrets_allowlist` is written once at create. A mutable allowlist could be narrowed below what the sandbox already needs and leave it unbootable. |
+| `connector_bindings` | **no** | Create-only. Start a new session to bind differently. |
+| `runtime_context` | **no** | Create-only. |
+| `end_user_ref` | **no** | Create-only, and it is what usage attribution keys on. |
+
+**Known limitation.** A mid-session agent switch re-scopes *secrets* but not
+*connectors*: the in-sandbox token's grant is minted once from the create-time
+agent and is not re-minted. A switched agent therefore keeps the boot agent's
+connector authority. Operators who need per-agent connector governance enforced
+on switch can set `KORTIX_ENFORCE_SESSION_AGENT_LOCK=1`, which refuses the
+switch outright.
+
+## Session isolation between your end-users
+
+Sessions your backend creates all share one `created_by` — your wrapper
+credential — so ownership alone cannot separate them. The platform narrows on
+the *caller's* session instead: a token bound to end-user A's sandbox cannot
+read, share, or resolve approvals on end-user B's session, even though both were
+created by you.
+
+Your backend credential is unaffected: it is the operator and still sees every
+session it created. That asymmetry is deliberate.
+
+Two consequences for wrapper authors:
+
+- **`end_user_ref` must be injected server-side**, from your authenticated
+  session — never accepted from a browser. A client that can set it can bill
+  another user, or replay their session through a shared `Idempotency-Key`.
+- Listing with `?scope=project` shows rows the caller cannot open, marked
+  `can_access: false`. Those rows are **redacted**: no `metadata` (which holds
+  `initial_prompt`), no `end_user_ref`, no `secrets_allowlist`.

--- a/infra/k8s/envs/dev/gateway-values.yaml
+++ b/infra/k8s/envs/dev/gateway-values.yaml
@@ -4,7 +4,7 @@
 
 # Immutable dev tag (CI bumps to dev-<sha8>). Bootstrap value until the first run.
 image:
-  tag: "dev-dda51b0b"
+  tag: "dev-9ac237f1"
 # Dev sizing (≤100 users): 1-replica floor, burst to 2.
 replicas: 1
 autoscaling:

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-9ac237f1"
+  tag: "dev-57e081c0"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-dda51b0b"
+  tag: "dev-cb5bb899"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-8bfb1096"
+  tag: "dev-9ac237f1"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-cb5bb899"
+  tag: "dev-8bfb1096"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-5762bcfc"
+  tag: "dev-dda51b0b"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/packages/llm-gateway/src/domain/config.ts
+++ b/packages/llm-gateway/src/domain/config.ts
@@ -11,4 +11,10 @@ export interface GatewayConfig {
   maxRequestBytes?: number;
   /** Maximum number of fallback models after the primary. Defaults to 3, hard-capped at 8. */
   maxFallbackModels?: number;
+  /**
+   * Maximum silence while probing a newly opened streaming response.
+   * The gateway cancels the stalled candidate and tries the next model.
+   * Defaults to 30 seconds.
+   */
+  streamProbeTimeoutMs?: number;
 }

--- a/packages/llm-gateway/src/pipeline/handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/handler.test.ts
@@ -828,6 +828,57 @@ describe("gateway.chatCompletions — combined authorize hook", () => {
     });
   });
 
+  test("streaming model fallback bypasses a primary that opens but produces no bytes", async () => {
+    const calls: string[] = [];
+    const { hooks, traces } = makeHooks({
+      resolveRoute: async (_principal, input) => ({
+        policyId: "test-stalled-stream",
+        primaryModel: input.requestedModel,
+        fallbackModels: ["fallback"],
+        fallbackOn: "transient",
+      }),
+      resolveUpstream: async (_principal, model) => [{
+        ...managed,
+        provider: model,
+        baseUrl: `https://${model}.test/v1`,
+        resolvedModel: model,
+      }],
+    });
+    const fetchImpl: FetchImpl = async (url) => {
+      calls.push(String(url));
+      if (String(url).includes("primary.test")) {
+        return new Response(new ReadableStream<Uint8Array>(), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response(
+        'data: {"choices":[{"delta":{"content":"fallback ok"}}]}\n\n' +
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n' +
+        "data: [DONE]\n\n",
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    };
+
+    const res = await createGateway(hooks, {
+      retry: { ...fastRetry, maxAttempts: 1 },
+      streamProbeTimeoutMs: 20,
+    }, { fetchImpl }).chatCompletions({
+      authorization: "Bearer good",
+      rawBody: '{"model":"primary","stream":true,"messages":[{"role":"user","content":"ping"}]}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("fallback ok");
+    expect(calls).toHaveLength(2);
+    await flush();
+    expect(traces.at(-1)?.metadata.gatewayRouting).toEqual({
+      policy: "test-stalled-stream",
+      models: ["primary", "fallback"],
+      selected: "fallback",
+    });
+  });
+
   test("any-error model policy falls back on a deterministic primary 400", async () => {
     const calls: string[] = [];
     const { hooks } = makeHooks({

--- a/packages/llm-gateway/src/pipeline/handler.ts
+++ b/packages/llm-gateway/src/pipeline/handler.ts
@@ -772,7 +772,9 @@ export async function handleChatCompletions(
       continue;
     }
 
-    const probe = await probeStream(candidateUpstream.body);
+    const probe = await probeStream(candidateUpstream.body, {
+      inactivityTimeoutMs: config.streamProbeTimeoutMs,
+    });
     if (probe.hasContent) {
       upstream = candidateUpstream;
       descriptor = chosenDescriptor;

--- a/packages/llm-gateway/src/pipeline/streaming.test.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.test.ts
@@ -6,11 +6,16 @@ const dec = new TextDecoder();
 
 function controllableUpstream() {
   let controller!: ReadableStreamDefaultController<Uint8Array>;
-  const stream = new ReadableStream<Uint8Array>({ start(c) { controller = c; } });
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { controller = c; },
+    cancel() { cancelled = true; },
+  });
   return {
     stream,
     push: (s: string) => controller.enqueue(enc.encode(s)),
     close: () => controller.close(),
+    get cancelled() { return cancelled; },
   };
 }
 
@@ -154,6 +159,18 @@ describe('probeStream', () => {
     });
     const result = await probeStream(stream);
     expect(result.hasContent).toBe(false);
+  });
+
+  test('times out and cancels a stream that opens but produces no bytes', async () => {
+    const up = controllableUpstream();
+    const result = await probeStream(up.stream, { inactivityTimeoutMs: 20 });
+
+    expect(result.hasContent).toBe(false);
+    expect(result.readError).toEqual({
+      message: 'upstream stream probe timeout exceeded (20ms with no bytes)',
+      code: 'stream_probe_timeout',
+    });
+    expect(up.cancelled).toBe(true);
   });
 });
 

--- a/packages/llm-gateway/src/pipeline/streaming.ts
+++ b/packages/llm-gateway/src/pipeline/streaming.ts
@@ -80,11 +80,20 @@ class StreamInactivityTimeoutError extends Error {
 
 // A candidate that opens a stream, sends nothing usable, and closes cleanly (the
 // empty-completion bug) fails fast — real models produce their first token well
-// within this budget. Bounding the probe by chunk/byte count (not a wall-clock
-// timer racing the in-flight read) means we never abandon a pending read() and
-// risk silently dropping a chunk once real relaying resumes.
+// within this budget. The chunk/byte budget bounds valid but content-free
+// frames. The inactivity budget cancels a pending read before failover, so a
+// late chunk cannot reach the rejected candidate's relay.
 const PROBE_MAX_CHUNKS = 64;
 const PROBE_MAX_BYTES = 64 * 1024;
+const PROBE_INACTIVITY_TIMEOUT_MS = 30_000;
+
+export interface StreamProbeOptions {
+  /**
+   * Maximum time between upstream chunks while no usable output exists.
+   * The reader is cancelled when the timeout expires.
+   */
+  inactivityTimeoutMs?: number;
+}
 
 export interface StreamProbeResult {
   hasContent: boolean;
@@ -105,10 +114,14 @@ export interface StreamProbeResult {
 // budget is exhausted — whichever comes first. Every chunk consumed is captured
 // in `chunks` so the caller can replay them verbatim (via `primed`) without
 // losing a single byte, regardless of which outcome is reached.
-export async function probeStream(body: ReadableStream<Uint8Array>): Promise<StreamProbeResult> {
+export async function probeStream(
+  body: ReadableStream<Uint8Array>,
+  options: StreamProbeOptions = {},
+): Promise<StreamProbeResult> {
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   const decoder = new TextDecoder();
+  const inactivityTimeoutMs = options.inactivityTimeoutMs ?? PROBE_INACTIVITY_TIMEOUT_MS;
   let buffer = '';
   let bytes = 0;
 
@@ -116,11 +129,32 @@ export async function probeStream(body: ReadableStream<Uint8Array>): Promise<Str
     if (chunks.length >= PROBE_MAX_CHUNKS || bytes >= PROBE_MAX_BYTES) {
       return { hasContent: true, reader, chunks };
     }
-    let done: boolean;
-    let value: Uint8Array | undefined;
-    try {
-      ({ done, value } = await reader.read());
-    } catch (err) {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      reader.read().then(
+        (result) => ({ kind: 'read' as const, result }),
+        (error: unknown) => ({ kind: 'error' as const, error }),
+      ),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        timeout = setTimeout(() => resolve({ kind: 'timeout' }), inactivityTimeoutMs);
+      }),
+    ]);
+    if (timeout) clearTimeout(timeout);
+
+    if (outcome.kind === 'timeout') {
+      const message =
+        `upstream stream probe timeout exceeded (${inactivityTimeoutMs}ms with no bytes)`;
+      await reader.cancel(message).catch(() => undefined);
+      return {
+        hasContent: sseHasContent(buffer),
+        errorFrame: sseErrorFrame(buffer),
+        readError: { message, code: 'stream_probe_timeout' },
+        reader,
+        chunks,
+      };
+    }
+    if (outcome.kind === 'error') {
+      const err = outcome.error;
       const message = boundedErrorMessage(err);
       return {
         hasContent: sseHasContent(buffer),
@@ -130,6 +164,7 @@ export async function probeStream(body: ReadableStream<Uint8Array>): Promise<Str
         chunks,
       };
     }
+    const { done, value } = outcome.result;
     if (done)
       return {
         hasContent: sseHasContent(buffer),


### PR DESCRIPTION
Promotes the current `main` candidate to `staging`.

Candidate branch SHA: `987d0858c5a9be9d96223805c56180baf19dad58`
Runtime source SHA: `9ac237f1efca96ddb4449464b94f078f66585383`

Includes:
- zero-byte model stream timeout and fallback
- session isolation and agent grant security fixes
- dev GitOps image pins

Production is unchanged.