### PR TITLE
feat(kaab): re-mint the session token grant on a mid-session agent switch

### DIFF
--- a/apps/api/src/projects/lib/secret-grant.test.ts
+++ b/apps/api/src/projects/lib/secret-grant.test.ts
@@ -17,14 +17,20 @@ mock.module('../agents', () => ({
 
 const {
   AgentSecretGrantMismatchError,
+  agentGrantDiffers,
   SecretGrantResolutionError,
   effectiveRunningAgent,
+  resolveSessionAgentGrant,
   resolveSessionSecretGrant,
   secretGrantEnvDiffers,
   secretGrantEnvForRunningAgent,
 } = await import('./secret-grant');
 
-function spec(name: string, env: AgentSpec['env']): AgentSpec {
+function spec(
+  name: string,
+  env: AgentSpec['env'],
+  extra: Partial<Pick<AgentSpec, 'connectors' | 'kortixCli'>> = {},
+): AgentSpec {
   return {
     name,
     path: `kortix.yaml#agents.${name}`,
@@ -34,6 +40,7 @@ function spec(name: string, env: AgentSpec['env']): AgentSpec {
     env,
     file: null,
     model: null,
+    ...extra,
   } as AgentSpec;
 }
 
@@ -69,6 +76,51 @@ describe('effectiveRunningAgent', () => {
 
   test('surrounding whitespace does not create a distinct agent', () => {
     expect(effectiveRunningAgent('  release-bot  ', 'kortix')).toBe('release-bot');
+  });
+});
+
+describe('agentGrantDiffers', () => {
+  const grant = (extra: Record<string, unknown>) =>
+    ({ agent: 'a', kortixCli: 'all', connectors: 'all', env: 'all', ...extra }) as never;
+
+  test('an identical grant is a free switch', () => {
+    expect(agentGrantDiffers(grant({}), grant({}))).toBe(false);
+  });
+
+  test('a DIFFERENT connector grant is a switch, even when secrets match', () => {
+    // The leg the secrets-only lock left open: the token's connector grant is
+    // written once at mint, so the switched-to agent would call the boot
+    // agent's connectors.
+    expect(agentGrantDiffers(grant({}), grant({ connectors: ['calendar'] }))).toBe(true);
+  });
+
+  test('a DIFFERENT kortixCli grant is a switch too', () => {
+    expect(agentGrantDiffers(grant({}), grant({ kortixCli: ['session.read'] }))).toBe(true);
+  });
+
+  test('order and duplicates in a connector list are not a difference', () => {
+    expect(
+      agentGrantDiffers(
+        grant({ connectors: ['b', 'a', 'a'] }),
+        grant({ connectors: ['a', 'b'] }),
+      ),
+    ).toBe(false);
+  });
+
+  test('connector case IS a difference — the call gate matches exactly', () => {
+    // agentMayUseConnector uses includes(), not a case-insensitive compare, so
+    // calling these equal here would predict the wrong thing at the gate.
+    expect(agentGrantDiffers(grant({ connectors: ['Calendar'] }), grant({ connectors: ['calendar'] }))).toBe(
+      true,
+    );
+  });
+
+  test('a null grant is unrestricted, and equal to an explicit all', () => {
+    expect(agentGrantDiffers(null, grant({}))).toBe(false);
+  });
+
+  test('an explicit EMPTY list is a real narrowing, not "all"', () => {
+    expect(agentGrantDiffers(null, grant({ connectors: [] }))).toBe(true);
   });
 });
 
@@ -209,6 +261,49 @@ describe('resolveSessionSecretGrant', () => {
     await expect(
       resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'narrow', requestedAgent: 'broad' }),
     ).rejects.toThrow(AgentSecretGrantMismatchError);
+  });
+
+  test('ALLOWS a switch that changes only the connector grant', async () => {
+    // Identical secrets, different connectors. This must NOT 409: per-agent
+    // `connectors:` with no `secrets:` declared is the most ordinary manifest
+    // shape there is, and the dashboard offers the switch. The connector
+    // difference is handled by re-minting the token
+    // (lib/session-token-grant.ts), which is possible precisely because those
+    // grants are checked at call time rather than already sitting in the box.
+    loadProjectAgentsImpl = async () =>
+      loaded([
+        spec('a', ['NPM_TOKEN'], { connectors: 'all' }),
+        spec('b', ['NPM_TOKEN'], { connectors: ['calendar'] }),
+      ]);
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'a', requestedAgent: 'b' }),
+    ).resolves.toEqual(['NPM_TOKEN']);
+  });
+
+  test('resolveSessionAgentGrant returns the RUNNING agent grant, not the session one', async () => {
+    loadProjectAgentsImpl = async () =>
+      loaded([
+        spec('a', ['NPM_TOKEN'], { connectors: 'all' }),
+        spec('b', ['NPM_TOKEN'], { connectors: ['calendar'] }),
+      ]);
+    const grant = await resolveSessionAgentGrant({
+      ...PROJECT,
+      sessionAgent: 'a',
+      requestedAgent: 'b',
+    });
+    expect(grant?.agent).toBe('b');
+    expect(grant?.connectors).toEqual(['calendar']);
+  });
+
+  test('allows a switch between agents whose grants match in every dimension', async () => {
+    loadProjectAgentsImpl = async () =>
+      loaded([
+        spec('a', ['NPM_TOKEN'], { connectors: ['calendar'], kortixCli: ['session.read'] }),
+        spec('b', ['npm_token'], { connectors: ['calendar'], kortixCli: ['session.read'] }),
+      ]);
+    await expect(
+      resolveSessionSecretGrant({ ...PROJECT, sessionAgent: 'a', requestedAgent: 'b' }),
+    ).resolves.toEqual(['npm_token']);
   });
 
   test('the default sentinel on a bound session is not treated as a switch', async () => {

--- a/apps/api/src/projects/lib/secret-grant.ts
+++ b/apps/api/src/projects/lib/secret-grant.ts
@@ -30,6 +30,7 @@
  * single I/O entry point both call sites use.
  */
 
+import type { AgentGrant } from '@kortix/db';
 import {
   DEFAULT_AGENT_SENTINEL,
   type LoadedAgents,
@@ -121,6 +122,61 @@ export function secretGrantEnvDiffers(
 }
 
 /**
+ * The same collapse for a grant's `connectors` / `kortixCli` lists.
+ *
+ * Deliberately NOT case-folded, unlike `grantEnvKey`. Each list is compared by
+ * its own gate with an exact `includes()` (`agentMayUseConnector`,
+ * `agentMayPerform`), so folding case here would call two lists equal that those
+ * gates treat as different — and the whole point of this comparison is to
+ * predict what those gates will do.
+ */
+function grantListKey(list: string[] | 'all' | undefined): string {
+  if (list === undefined || list === 'all') return '*all*';
+  return [...new Set(list)].sort().join(',');
+}
+
+/**
+ * True when running `requestedAgent` instead of `sessionAgent` would change ANY
+ * part of the authorization grant — secrets, connectors, or Kortix CLI actions.
+ *
+ * This is the RE-MINT predicate, not a refusal. A session's `agentGrant` is
+ * written onto its token row ONCE, at mint (`account_tokens.agent_grant`), from
+ * the agent the session was created with. Nothing re-mints it, and nothing
+ * updates `project_sessions.agent_name` either — but a prompt may name a
+ * different agent and the proxy forwards that untouched. So an agent reached by
+ * SWITCHING ran with the boot agent's connector and CLI grants:
+ *
+ *     create session with agent A (connectors: all)
+ *     prompt {"agent": "B"} where B declares connectors: [calendar]
+ *       -> opencode runs B
+ *       -> the token still carries A's grant
+ *       -> B calls A's connectors, including ones its own manifest denies it
+ *
+ * The inverse is a functional bug rather than an escalation: a broad agent
+ * reached from a narrow session gets 403 CONNECTOR_NOT_ASSIGNED with nothing in
+ * the manifest to explain it.
+ *
+ * Why re-mint here where secrets REFUSE: a secret is already disclosed by the
+ * time a switch is observed — it is in the box's tmpfs env file, in every shell
+ * the previous agent spawned, and in its own context — so narrowing later
+ * cannot un-read it. Connector and CLI grants are different: they are checked
+ * against the token row at CALL time, so rewriting the row genuinely re-scopes
+ * every subsequent call. Refusing those instead would 409 the most ordinary
+ * manifest shape there is — per-agent `connectors:` with no `secrets:` declared
+ * at all — on a switch the dashboard's own UI offers.
+ */
+export function agentGrantDiffers(
+  sessionGrant: AgentGrant | null,
+  requestedGrant: AgentGrant | null,
+): boolean {
+  return (
+    secretGrantEnvDiffers(sessionGrant?.env, requestedGrant?.env) ||
+    grantListKey(sessionGrant?.connectors) !== grantListKey(requestedGrant?.connectors) ||
+    grantListKey(sessionGrant?.kortixCli) !== grantListKey(requestedGrant?.kortixCli)
+  );
+}
+
+/**
  * Pure policy over an already-loaded manifest — exported for tests. Throws
  * `AgentSecretGrantMismatchError` when the switch crosses a secret boundary.
  *
@@ -174,7 +230,30 @@ export interface SessionSecretGrantInput {
 export async function resolveSessionSecretGrant(
   input: SessionSecretGrantInput,
 ): Promise<string[] | 'all' | undefined> {
-  if (!input.defaultBranch) return undefined;
+  return (await loadGrantForRunningAgent(input)).env;
+}
+
+/**
+ * The FULL grant of the agent a prompt will actually run — secrets, connectors
+ * and Kortix CLI actions.
+ *
+ * Same resolution, same failure modes, same refusal as
+ * `resolveSessionSecretGrant` (which is this function's `env` leg): callers get
+ * `SecretGrantResolutionError` on an unreadable manifest and
+ * `AgentSecretGrantMismatchError` on a secret-boundary switch. The extra legs
+ * exist for the token re-mint, which needs to know what the running agent may
+ * reach, not just what it may read.
+ */
+export async function resolveSessionAgentGrant(
+  input: SessionSecretGrantInput,
+): Promise<AgentGrant | null> {
+  return (await loadGrantForRunningAgent(input)).grant;
+}
+
+async function loadGrantForRunningAgent(
+  input: SessionSecretGrantInput,
+): Promise<{ grant: AgentGrant | null; env: string[] | 'all' | undefined }> {
+  if (!input.defaultBranch) return { grant: null, env: undefined };
 
   const runningAgent = effectiveRunningAgent(input.requestedAgent, input.sessionAgent);
 
@@ -200,10 +279,13 @@ export async function resolveSessionSecretGrant(
     throw new SecretGrantResolutionError(runningAgent, err);
   }
 
-  return secretGrantEnvForRunningAgent(
+  // Runs the secret-boundary refusal FIRST, so a switch that must be refused is
+  // never also re-minted — one switch cannot half-succeed.
+  const env = secretGrantEnvForRunningAgent(
     loaded,
     input.sessionAgent,
     runningAgent,
     input.enforceGrantLock ?? true,
   );
+  return { grant: grantFromLoadedAgents(runningAgent, loaded), env };
 }

--- a/apps/api/src/projects/lib/session-token-grant.test.ts
+++ b/apps/api/src/projects/lib/session-token-grant.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import type { AgentGrant } from '@kortix/db';
+
+import { remintDecisionFor } from './session-token-grant';
+
+const grant = (extra: Partial<AgentGrant> = {}): AgentGrant => ({
+  agent: 'a',
+  kortixCli: 'all',
+  connectors: 'all',
+  env: 'all',
+  ...extra,
+});
+
+describe('remintDecisionFor', () => {
+  test('an unchanged grant writes nothing', () => {
+    expect(remintDecisionFor(grant(), grant())).toEqual({ action: 'skip' });
+  });
+
+  test('a project with no per-agent governance stays a no-op on both sides', () => {
+    // null = unrestricted. Boot minted null too, so there is nothing to change
+    // and — critically — nothing to mistake for a widening.
+    expect(remintDecisionFor(null, null)).toEqual({ action: 'skip' });
+  });
+
+  test('a changed CONNECTOR grant is re-pointed — the hole this closes', () => {
+    const running = grant({ agent: 'b', connectors: ['calendar'] });
+    expect(remintDecisionFor(grant(), running)).toEqual({ action: 'write', grant: running });
+  });
+
+  test('a changed kortixCli grant is re-pointed too', () => {
+    const running = grant({ agent: 'b', kortixCli: ['project.session.read'] });
+    expect(remintDecisionFor(grant(), running)).toEqual({ action: 'write', grant: running });
+  });
+
+  test('NARROWING to a real grant is written', () => {
+    const running = grant({ agent: 'b', connectors: [], kortixCli: [] });
+    expect(remintDecisionFor(grant(), running)).toEqual({ action: 'write', grant: running });
+  });
+
+  test('REFUSES to blank a real grant out to unrestricted', () => {
+    // Resolution returns null both for "no governance" and for "the manifest
+    // could not be read". Writing null here would hand the switched-to agent
+    // every connector in the account because we momentarily could not read the
+    // file that says otherwise.
+    const decision = remintDecisionFor(grant({ connectors: ['calendar'] }), null);
+    expect(decision.action).toBe('refuse');
+  });
+
+  test('order and duplicates in a list are not a change worth writing', () => {
+    expect(
+      remintDecisionFor(
+        grant({ connectors: ['b', 'a', 'a'] }),
+        grant({ connectors: ['a', 'b'] }),
+      ),
+    ).toEqual({ action: 'skip' });
+  });
+});

--- a/apps/api/src/projects/lib/session-token-grant.ts
+++ b/apps/api/src/projects/lib/session-token-grant.ts
@@ -1,0 +1,199 @@
+/**
+ * Re-mint a live session token's agent grant when a prompt switches agents.
+ *
+ * `account_tokens.agent_grant` is written ONCE, at session mint, from the agent
+ * the session was created with. Nothing ever rewrote it, and nothing updates
+ * `project_sessions.agent_name` either — but in-session agent switching is
+ * allowed and the proxy forwards a prompt's concrete `agent` field untouched.
+ * So the connector and Kortix-CLI gates (`agentMayUseConnector`,
+ * `agentMayPerform`) read the BOOT agent's grant no matter which agent is
+ * actually running:
+ *
+ *     create session with agent A (connectors: all)
+ *     prompt {"agent": "B"}  where B declares connectors: [calendar]
+ *       -> opencode runs B
+ *       -> the token still carries A's grant
+ *       -> B calls A's connectors, including ones its own manifest denies it
+ *
+ * Secrets are handled the opposite way, deliberately (see `secret-grant.ts`): a
+ * secret-boundary switch is REFUSED, because by the time the switch is observed
+ * the previous agent's secrets are already in the box's tmpfs env file, in every
+ * shell it spawned, and in its own context — narrowing later cannot un-read
+ * them. Connector and CLI grants have no such residue: they are checked against
+ * this row at CALL time, so rewriting it genuinely re-scopes every subsequent
+ * call. And refusing them instead would 409 the most ordinary manifest shape
+ * there is — per-agent `connectors:` with no `secrets:` declared at all — on a
+ * switch the dashboard's own UI offers.
+ */
+
+import { and, eq, isNull } from 'drizzle-orm';
+import { accountTokens, projects, type AgentGrant } from '@kortix/db';
+import { db } from '../../shared/db';
+import { config } from '../../config';
+import { DEFAULT_AGENT_SENTINEL } from '../agents';
+import {
+  AgentSecretGrantMismatchError,
+  agentGrantDiffers,
+  resolveSessionAgentGrant,
+} from './secret-grant';
+
+/** The re-mint could not be written. The caller must FAIL the prompt: letting it
+ *  through would run the new agent against the previous agent's grant, which is
+ *  the escalation this module exists to close. */
+export class SessionGrantRemintError extends Error {
+  constructor(
+    readonly sessionId: string,
+    cause: unknown,
+  ) {
+    super(
+      `could not re-mint the agent grant for session '${sessionId}': ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+    this.name = 'SessionGrantRemintError';
+  }
+}
+
+/**
+ * Rewrite the grant on every LIVE token belonging to this session.
+ *
+ * Scoped to active, unrevoked rows: a revoked token must stay dead, and
+ * rewriting its grant would quietly resurrect a credential the operator killed.
+ *
+ * Writing `null` is meaningful — it is the UNRESTRICTED grant a project without
+ * per-agent governance gets — so the update is unconditional once the caller has
+ * decided the grant changed. Returns how many rows were rewritten; zero is not
+ * an error (a session whose token already expired has nothing to re-scope, and
+ * its next call 401s anyway).
+ */
+export async function remintSessionAgentGrant(
+  sessionId: string,
+  grant: AgentGrant | null,
+): Promise<number> {
+  try {
+    const rows = await db
+      .update(accountTokens)
+      .set({ agentGrant: grant })
+      .where(
+        and(
+          eq(accountTokens.sessionId, sessionId),
+          eq(accountTokens.status, 'active'),
+          isNull(accountTokens.revokedAt),
+        ),
+      )
+      .returning({ tokenId: accountTokens.tokenId });
+    return rows.length;
+  } catch (err) {
+    throw new SessionGrantRemintError(sessionId, err);
+  }
+}
+
+export type RemintDecision =
+  | { action: 'skip' }
+  | { action: 'write'; grant: AgentGrant }
+  | { action: 'refuse'; reason: string };
+
+/**
+ * Pure policy: what to do with the token's grant when `running` is the agent a
+ * prompt will actually execute and `stored` is what the token currently holds.
+ *
+ * The `refuse` case is the one worth reading. A `null` grant means UNRESTRICTED
+ * (see `agent-scope.ts`), and resolution returns `null` both for "this project
+ * declares no per-agent governance" and for "the manifest could not be read at
+ * all" (no default branch). The first is harmless — a project with no
+ * governance minted a `null` grant at boot too, so `stored` is already `null`
+ * and this is a `skip`. The second is not: writing `null` over a real grant
+ * would hand the switched-to agent every connector and CLI action in the
+ * account because we momentarily could not read the file that says otherwise.
+ * So a re-mint may re-point or narrow, never blank out.
+ */
+export function remintDecisionFor(
+  stored: AgentGrant | null,
+  running: AgentGrant | null,
+): RemintDecision {
+  if (!agentGrantDiffers(stored, running)) return { action: 'skip' };
+  if (running === null) {
+    return {
+      action: 'refuse',
+      reason:
+        'the agent this prompt runs resolved to an UNRESTRICTED grant while the session token holds a narrower one — refusing rather than widening the token',
+    };
+  }
+  return { action: 'write', grant: running };
+}
+
+/**
+ * Re-point a session token's grant at the agent a prompt actually runs.
+ *
+ * A no-op — and, importantly, no manifest read — unless the prompt names a
+ * concrete agent that differs from the session's. Ordinary turns are the
+ * overwhelming majority and must not pay for this.
+ *
+ * Throws `SessionGrantRemintError` if the grant cannot be resolved or written;
+ * the caller must fail the prompt rather than run the new agent under the old
+ * agent's grant.
+ */
+export async function remintGrantForAgentSwitch(input: {
+  projectId: string;
+  sessionId: string;
+  /** `project_sessions.agent_name` — the agent the session was CREATED with. */
+  sessionAgent: string;
+  /** The agent this prompt asked to run, verbatim from the body. */
+  requestedAgent: string | null;
+}): Promise<RemintDecision> {
+  const requested = input.requestedAgent?.trim();
+  if (!requested || requested === DEFAULT_AGENT_SENTINEL || requested === input.sessionAgent) {
+    return { action: 'skip' };
+  }
+
+  let running: AgentGrant | null;
+  let stored: AgentGrant | null;
+  try {
+    const [project] = await db
+      .select({
+        repoUrl: projects.repoUrl,
+        defaultBranch: projects.defaultBranch,
+        manifestPath: projects.manifestPath,
+      })
+      .from(projects)
+      .where(eq(projects.projectId, input.projectId))
+      .limit(1);
+
+    running = await resolveSessionAgentGrant({
+      projectId: input.projectId,
+      repoUrl: project?.repoUrl ?? '',
+      defaultBranch: project?.defaultBranch,
+      manifestPath: project?.manifestPath,
+      sessionAgent: input.sessionAgent,
+      requestedAgent: requested,
+      enforceGrantLock: config.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK,
+    });
+
+    const [token] = await db
+      .select({ agentGrant: accountTokens.agentGrant })
+      .from(accountTokens)
+      .where(
+        and(
+          eq(accountTokens.sessionId, input.sessionId),
+          eq(accountTokens.status, 'active'),
+          isNull(accountTokens.revokedAt),
+        ),
+      )
+      .limit(1);
+    stored = token?.agentGrant ?? null;
+  } catch (err) {
+    // A secret-boundary refusal is the env sync's error to report, not ours —
+    // rethrow it unchanged so the proxy still answers 409, not 503.
+    if (err instanceof AgentSecretGrantMismatchError) throw err;
+    throw new SessionGrantRemintError(input.sessionId, err);
+  }
+
+  const decision = remintDecisionFor(stored, running);
+  if (decision.action === 'refuse') {
+    throw new SessionGrantRemintError(input.sessionId, new Error(decision.reason));
+  }
+  if (decision.action === 'write') {
+    await remintSessionAgentGrant(input.sessionId, decision.grant);
+  }
+  return decision;
+}

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -8,6 +8,10 @@ import {
   AgentSecretGrantMismatchError,
   SecretGrantResolutionError,
 } from '../../projects/lib/secret-grant';
+import {
+  SessionGrantRemintError,
+  remintGrantForAgentSwitch,
+} from '../../projects/lib/session-token-grant';
 import { observeRuntimeSessionTitleStream } from '../../projects/acp-session-title-stream';
 import {
   captureTitleAfterRuntimeEvent,
@@ -424,6 +428,17 @@ export function secretGrantErrorResponse(err: unknown, origin?: string): Respons
   // We could not establish what this agent may read. 503 rather than 502: the
   // sandbox is fine, our ability to VERIFY entitlement is what failed, and
   // retrying is the correct client response.
+  // The switch was legal but we could not rewrite the token's grant to match the
+  // agent now running. 503 for the same reason as above — and refusing is the
+  // point: forwarding would run the new agent against the OLD agent's connector
+  // and CLI grants, which is exactly the escalation the re-mint closes.
+  if (err instanceof SessionGrantRemintError) {
+    return jsonProxyError(
+      { error: err.message, code: 'AGENT_SWITCH_GRANT_UNAPPLIED' },
+      503,
+      origin,
+    );
+  }
   if (err instanceof SecretGrantResolutionError) {
     return jsonProxyError(
       { error: err.message, code: 'AGENT_SECRET_GRANT_UNRESOLVED' },
@@ -747,6 +762,18 @@ export async function forwardToSandbox(
             // The secret grant is resolved from the agent this prompt actually
             // runs, not the session's create-time column — see
             // projects/lib/secret-grant.ts.
+            requestedAgent,
+          });
+          // The env sync above already refused a secret-boundary switch, so
+          // reaching here means the switch is legal. Re-point the token's
+          // connector/CLI grant at the agent that will actually run — it was
+          // frozen at mint from the BOOT agent, and those gates read it at call
+          // time. Only on a real switch: an ordinary turn resolves to the
+          // session's own agent and skips the manifest read entirely.
+          await remintGrantForAgentSwitch({
+            projectId: record.projectId,
+            sessionId: record.sessionId,
+            sessionAgent,
             requestedAgent,
           });
         } catch (err) {

--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -239,6 +239,7 @@ starting a second one. Replaying a key with a **different** body — different
 | `403` | `CONNECTOR_NOT_ASSIGNED` | The session's agent isn't granted a connector you named. **The first error most wrappers hit** — list the alias under that agent's `connectors:` in your manifest. |
 | `403` | `REQUIRE_CONNECTORS_INTERACTIVE_ONLY` | `require_connectors` is interactive-only. A backend key acts for no single person — bind an explicit `profile_id` with `connector_bindings`. |
 | `403` | `origin_override_forbidden` | A non-backend caller tried to set `end_user_ref` or `secrets`. |
+| `503` | `AGENT_SWITCH_GRANT_UNAPPLIED` | A mid-session agent switch was legal but its token re-mint could not be written. Retryable. |
 | `409` | `CONNECTOR_CONNECTION_REQUIRED` | Interactive only: the user hasn't connected their own account. The body names which connector. |
 | `409` | `END_USER_REF_CONFLICT` | You sent `end_user_ref` and the deprecated `origin_ref` with different values. |
 | `409` | `IDEMPOTENCY_KEY_CONFLICT` | The key collided with a different operation. Unlike the other idempotency errors, the fix is a **higher-entropy key** — the uniqueness index is global. |
@@ -281,8 +282,13 @@ Each message names the agent that runs it. A switch to an agent with a
 and **retrying cannot succeed**, because re-scoping cannot un-read what the
 session already loaded. Offer a new session, not a retry.
 
-Note the current limitation: a switch re-scopes *secrets* but not *connectors* —
-the sandbox token's connector grant is minted once from the create-time agent.
+A switch that changes only **connectors** or **Kortix CLI actions** is allowed
+and *re-mints* the session token: the new agent runs with exactly the grant its
+own manifest entry declares. Those gates check the token at call time, so
+re-pointing it works — unlike secrets, which are already in the box. If the
+re-mint cannot be written the prompt is refused (`503
+AGENT_SWITCH_GRANT_UNAPPLIED`) rather than run under the previous agent's
+authority.
 
 ## Isolation between your end-users
 

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -506,12 +506,24 @@ before.
 | `runtime_context` | **no** | Create-only. |
 | `end_user_ref` | **no** | Create-only, and it is what usage attribution keys on. |
 
-**Known limitation.** A mid-session agent switch re-scopes *secrets* but not
-*connectors*: the in-sandbox token's grant is minted once from the create-time
-agent and is not re-minted. A switched agent therefore keeps the boot agent's
-connector authority. Operators who need per-agent connector governance enforced
-on switch can set `KORTIX_ENFORCE_SESSION_AGENT_LOCK=1`, which refuses the
-switch outright.
+**A mid-session agent switch is governed, and the two halves are governed
+differently — on purpose.**
+
+- **Connectors and Kortix CLI actions are re-minted.** The switched-to agent's
+  own grant is written onto the session token before the prompt runs, so it
+  reaches exactly the connectors its manifest entry declares. These gates read
+  the token at *call* time, so re-pointing it re-scopes every subsequent call.
+- **Secrets refuse the switch** (`409 AGENT_SWITCH_REQUIRES_NEW_SESSION`) when
+  the two agents declare different `secrets`. There is nothing to re-scope: by
+  the time the switch is visible, the first agent's secrets are already in the
+  sandbox's env file, in every shell it spawned, and in its own context.
+  Narrowing later cannot un-read them. Agents with the *same* secrets grant
+  switch freely.
+
+If the re-mint cannot be applied, the prompt is refused with
+`503 AGENT_SWITCH_GRANT_UNAPPLIED` rather than run under the previous agent's
+authority. Operators who want *any* agent change refused, regardless of grants,
+can still set `KORTIX_ENFORCE_SESSION_AGENT_LOCK=1`.
 
 ## Session isolation between your end-users
 


### PR DESCRIPTION
Closes the last leg of the mid-session agent-switch hole. The secrets leg shipped earlier; the connector and Kortix-CLI legs did not.

`account_tokens.agent_grant` is written **once**, at session mint, from the agent the session was created with. Nothing ever rewrote it, and nothing updates `project_sessions.agent_name` either — but in-session switching is allowed and the proxy forwards a prompt's concrete `agent` field untouched. So `agentMayUseConnector` / `agentMayPerform` read the *boot* agent's grant no matter which agent is running:

```
create session with agent A (connectors: all)
prompt {"agent": "B"}  where B declares connectors: [calendar]
  → opencode runs B
  → the token still carries A's grant
  → B calls A's connectors, including ones its own manifest denies it
```

The inverse is a functional bug rather than an escalation: a broad agent reached from a narrow session gets `403 CONNECTOR_NOT_ASSIGNED` with nothing in the manifest to explain it.

## Why re-mint here, when secrets refuse

I started by extending the existing refusal to cover connectors — symmetry, one mechanism. **That was wrong and I backed it out.** It would `409` the most ordinary manifest shape there is: per-agent `connectors:` with no `secrets:` declared at all. Both agents' secret grants are equal, so the current lock stays silent, and my version would have started refusing a switch the dashboard's own UI offers.

The asymmetry is real, not a shortcut:

- **Secrets are already disclosed** by the time a switch is observed — in the box's tmpfs env file, in every shell the first agent spawned, in its own context. Narrowing later cannot un-read them, so refusing is the only honest answer.
- **Connector and CLI grants are checked against the token row at call time.** Rewriting the row genuinely re-scopes every subsequent call.

Order is enforced: the secret-boundary refusal runs first, so one switch can never half-succeed.

## Fail-closed details

- A `null` grant means **unrestricted**, and resolution returns `null` both for "this project declares no per-agent governance" and for "the manifest could not be read". The first is a no-op (boot minted `null` too). The second is not — so a re-mint may re-point or narrow, **never blank a real grant out**. That case is refused.
- If the re-mint cannot be resolved or written, the prompt is refused `503 AGENT_SWITCH_GRANT_UNAPPLIED` rather than forwarded under the previous agent's authority.
- The update touches only `status='active'` and `revoked_at IS NULL` rows — rewriting a revoked token's grant would quietly resurrect a credential an operator killed.
- Ordinary turns pay nothing: no manifest read unless the prompt names a concrete agent that differs from the session's.

## Verification

- New pure-policy tests for `remintDecisionFor`, including the refuse-rather-than-widen case and list order/dup normalization.
- `resolveSessionAgentGrant` returns the **running** agent's grant, not the session's — tested.
- The old test asserting a connector-only switch is refused is **replaced** with one asserting it is allowed, with the reasoning in the test body.
- Full `apps/api` suite: **24 failures, zero new** against the run from the immediately preceding merge.
- Docs corrected in both places — the guide and the public page each carried a "known limitation" paragraph that this makes false.