### PR TITLE
fix(kaab): revoke a session's executor tokens when its sandbox is gone

### DIFF
--- a/apps/api/src/__tests__/integration-token-revocation.test.ts
+++ b/apps/api/src/__tests__/integration-token-revocation.test.ts
@@ -8,12 +8,16 @@ import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import { accountTokens, accounts, projects } from '@kortix/db';
 import { db } from '../shared/db';
-import { revokeAllAccountTokensForUser } from '../repositories/account-tokens';
+import {
+  revokeAllAccountTokensForUser,
+  revokeSessionExecutorTokens,
+} from '../repositories/account-tokens';
 
 const ACCOUNT = crypto.randomUUID();
 const PROJECT = crypto.randomUUID();
 const USER = crypto.randomUUID();
 const OTHER = crypto.randomUUID();
+const OTHER_ACCOUNT = crypto.randomUUID();
 
 let n = 0;
 async function seedToken(userId: string, opts: { projectId?: string; sessionId?: string } = {}) {
@@ -36,12 +40,14 @@ const statusOf = async (tokenId: string) =>
 
 beforeAll(async () => {
   await db.insert(accounts).values({ accountId: ACCOUNT, name: 'tok-revoke-test' });
+  await db.insert(accounts).values({ accountId: OTHER_ACCOUNT, name: 'tok-revoke-test-other' });
   await db.insert(projects).values({ projectId: PROJECT, accountId: ACCOUNT, name: 'p', repoUrl: 'https://example.com/p.git' });
 });
 
 afterAll(async () => {
   await db.delete(projects).where(eq(projects.accountId, ACCOUNT));
   await db.delete(accounts).where(eq(accounts.accountId, ACCOUNT)); // cascades tokens
+  await db.delete(accounts).where(eq(accounts.accountId, OTHER_ACCOUNT));
 });
 
 describe('revokeAllAccountTokensForUser', () => {
@@ -83,5 +89,34 @@ describe('revokeAllAccountTokensForUser', () => {
     } finally {
       await db.delete(accounts).where(eq(accounts.accountId, otherAccount));
     }
+  });
+});
+
+describe('revokeSessionExecutorTokens', () => {
+  test('revokes every live token for ONE session, leaving other sessions alone', async () => {
+    // A session can hold several tokens — each re-provision mints another under
+    // the same session_id — so revoking "the" token is not enough.
+    const first = await seedToken(USER, { projectId: PROJECT, sessionId: 'sess-gone' });
+    const afterRestart = await seedToken(USER, { projectId: PROJECT, sessionId: 'sess-gone' });
+    const neighbour = await seedToken(USER, { projectId: PROJECT, sessionId: 'sess-alive' });
+
+    const revoked = await revokeSessionExecutorTokens('sess-gone', ACCOUNT);
+
+    expect(revoked).toBe(2);
+    expect(await statusOf(first)).toBe('revoked');
+    expect(await statusOf(afterRestart)).toBe('revoked');
+    expect(await statusOf(neighbour)).toBe('active');
+  });
+
+  test('will not reach across accounts on a session id', async () => {
+    const mine = await seedToken(USER, { projectId: PROJECT, sessionId: 'sess-shared-id' });
+    expect(await revokeSessionExecutorTokens('sess-shared-id', OTHER_ACCOUNT)).toBe(0);
+    expect(await statusOf(mine)).toBe('active');
+  });
+
+  test('is idempotent — a second call revokes nothing further', async () => {
+    await seedToken(USER, { projectId: PROJECT, sessionId: 'sess-twice' });
+    expect(await revokeSessionExecutorTokens('sess-twice', ACCOUNT)).toBe(1);
+    expect(await revokeSessionExecutorTokens('sess-twice', ACCOUNT)).toBe(0);
   });
 });

--- a/apps/api/src/projects/sandbox-reaper.ts
+++ b/apps/api/src/projects/sandbox-reaper.ts
@@ -43,6 +43,7 @@ import { ACTIVE_SESSION_STATUSES } from './lib/session-status';
 import { config } from '../config';
 import { hasActiveExecutionLease } from './execution-lease';
 import { preserveEstablishedRuntime } from './runtime-identity';
+import { revokeSessionExecutorTokens } from '../repositories/account-tokens';
 
 export const REAP_BATCH_SIZE = 100;
 const REAP_CONCURRENCY = 6;
@@ -710,6 +711,7 @@ export async function reconcileSandboxRemovedByExternalId(externalId: string, no
     .select({
       sandboxId: sessionSandboxes.sandboxId,
       sessionId: sessionSandboxes.sessionId,
+      accountId: sessionSandboxes.accountId,
       externalId: sessionSandboxes.externalId,
       metadata: sessionSandboxes.metadata,
       status: sessionSandboxes.status,
@@ -720,6 +722,15 @@ export async function reconcileSandboxRemovedByExternalId(externalId: string, no
   if (!row) return false;
   if (!row.externalId) return false;
   await preserveEstablishedRuntime(row, 'provider_webhook_removed', now);
+  // The box is GONE at the provider — unlike an idle stop, nothing can wake it,
+  // so its executor token is now a bearer credential with no owner. Nothing
+  // else ever expires these (no expiresAt, exempt from PAT idle-revoke).
+  await revokeSessionExecutorTokens(row.sessionId, row.accountId).catch((err) =>
+    console.error(
+      `[reaper] FAILED to revoke executor tokens for removed sandbox ${externalId} (session ${row.sessionId}):`,
+      err,
+    ),
+  );
   invalidateProviderCache(externalId);
   return true;
 }

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -5,6 +5,7 @@ import { getProvider } from '../../platform/providers';
 import { db } from '../../shared/db';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, eq } from 'drizzle-orm';
+import { revokeSessionExecutorTokens } from '../../repositories/account-tokens';
 import { withProjectGitAuth } from '../lib/git';
 import { allocateSessionRuntime } from '../lib/session-runtime-allocator';
 import { sandboxSlugFromSessionMetadata } from '../lib/session-sandbox-metadata';
@@ -103,6 +104,18 @@ export async function deleteSession(input: {
   void pauseComputeSession(sessionId).catch((err) =>
     console.warn(`[projects] compute pause failed for ${sessionId}:`, err),
   );
+
+  // The provider sandbox is being removed above, so this session's executor
+  // token can never be used legitimately again — but nothing expired it, so it
+  // stayed a valid bearer forever. Awaited (not fire-and-forget) so the
+  // credential is dead before we report the session gone; a failure is logged at
+  // error level rather than failing the delete, since the box is already going.
+  await revokeSessionExecutorTokens(sessionId, accountId).catch((err) => {
+    console.error(
+      `[projects] FAILED to revoke executor tokens for deleted session ${sessionId} — a valid token may outlive its sandbox:`,
+      err,
+    );
+  });
 
   return { ok: true };
 }

--- a/apps/api/src/repositories/account-tokens.ts
+++ b/apps/api/src/repositories/account-tokens.ts
@@ -262,6 +262,44 @@ export async function revokeAllAccountTokensForUser(
   return result.length;
 }
 
+/**
+ * Revoke every live executor token minted for ONE session.
+ *
+ * Session tokens are minted with no `expiresAt` and are deliberately exempt from
+ * the PAT idle-revoke sweep ("lifetime tied to the sandbox" — see
+ * `validateAccountToken`). Nothing else expired them, so until this existed the
+ * only thing that ever revoked one was offboarding the whole USER: every session
+ * a Kortix-as-a-Backend wrapper ever ran left behind a permanently-valid,
+ * project-scoped bearer carrying that agent's grant.
+ *
+ * Call this only where the sandbox can never legitimately come back — session
+ * delete and provider-removed reconciliation. NOT on an idle stop: `wakeSandbox`
+ * restarts the SAME container, whose env still holds the token it was born with,
+ * so revoking there would brick a box the user is entitled to resume.
+ *
+ * A session may hold several tokens (each re-provision mints another for the
+ * same `session_id`), so this revokes all of them. Scoped by account: a
+ * session id must never reach across tenants.
+ */
+export async function revokeSessionExecutorTokens(
+  sessionId: string,
+  accountId: string,
+): Promise<number> {
+  const result = await db
+    .update(accountTokens)
+    .set({ status: 'revoked', revokedAt: new Date() })
+    .where(
+      and(
+        eq(accountTokens.sessionId, sessionId),
+        eq(accountTokens.accountId, accountId),
+        eq(accountTokens.status, 'active'),
+      ),
+    )
+    .returning({ tokenId: accountTokens.tokenId });
+
+  return result.length;
+}
+
 // ─── Validation ──────────────────────────────────────────────────────────────
 
 /**

--- a/apps/api/src/repositories/session-token-revocation.test.ts
+++ b/apps/api/src/repositories/session-token-revocation.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `revokeSessionExecutorTokens` is one UPDATE, so the whole of its correctness
+ * is in the SET and the WHERE. This renders both and asserts on them, which is
+ * what the real-DB integration test in `__tests__/integration-token-revocation`
+ * cannot do in CI (integration tests need a live Postgres and are excluded from
+ * `scripts/test.sh`).
+ *
+ * The scoping is not incidental: dropping the account predicate would let one
+ * tenant's session id revoke another's tokens, and dropping `status='active'`
+ * would rewrite already-revoked rows' `revoked_at`, destroying the audit trail
+ * of when a credential actually died.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+let lastSet: Record<string, unknown> | null = null;
+let lastWhere: unknown = null;
+
+mock.module('../shared/db', () => ({
+  db: {
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        lastSet = values;
+        return {
+          where: (predicate: unknown) => {
+            lastWhere = predicate;
+            return { returning: async () => [{ tokenId: 't1' }, { tokenId: 't2' }] };
+          },
+        };
+      },
+    }),
+  },
+}));
+
+const { revokeSessionExecutorTokens } = await import('./account-tokens');
+
+describe('revokeSessionExecutorTokens', () => {
+  test('revokes by session AND account AND active-only, and reports the count', async () => {
+    const revoked = await revokeSessionExecutorTokens('sess-1', 'acct-1');
+    expect(revoked).toBe(2);
+
+    const { sql, params } = new PgDialect().sqlToQuery(lastWhere as SQL);
+    expect(sql).toContain('session_id');
+    expect(sql).toContain('account_id');
+    expect(sql).toContain('status');
+    // A session id alone must never be enough — it would reach across tenants.
+    expect(params).toContain('sess-1');
+    expect(params).toContain('acct-1');
+    expect(params).toContain('active');
+  });
+
+  test('marks the row revoked AND stamps when — status alone loses the audit trail', async () => {
+    await revokeSessionExecutorTokens('sess-1', 'acct-1');
+    expect(lastSet?.status).toBe('revoked');
+    expect(lastSet?.revokedAt).toBeInstanceOf(Date);
+  });
+});

--- a/docs/KAAB_DEPTH_PLAN.md
+++ b/docs/KAAB_DEPTH_PLAN.md
@@ -139,6 +139,18 @@ Remaining, in order of what teaches the most:
 6. **Per-end-user concurrency cap** — currently `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT`
    defaults to 0 (off) and is set in no chart, so it is dark everywhere.
 
+## Shipped since this plan was written
+
+- **Session list filters by `end_user_ref`** (indexed, server-side), so a wrapper
+  no longer pulls the whole project to find one customer — and the demo scopes
+  its list to the signed-in end-user rather than showing everyone's.
+- **Mid-session agent switch re-mints the token grant.** Connectors and Kortix
+  CLI actions now follow the agent that actually runs; secrets keep refusing the
+  switch, for the reason that difference exists (secrets are already in the box).
+- **Executor tokens are revoked when their sandbox is gone.** They had no
+  expiry and were exempt from idle-revoke, so every session ever run left a live
+  bearer behind.
+
 ## Phase 3 — prove it, don't assert it
 
 The two security fixes shipped today are covered by unit tests of their decision

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -444,6 +444,11 @@ await s.send(prompt);
 - **Nothing widens.** `secrets` only narrows within the agent's grant;
   `connector_bindings` credentials are broker-resolved server-side and never
   enter the sandbox.
+- **A session's token dies with its sandbox.** The executor token injected into a
+  sandbox is revoked when the session is deleted or the provider reports the box
+  removed — so an exfiltrated token stops working instead of outliving the
+  session that justified it. An *idle stop* deliberately does not revoke: the box
+  can be woken and is still the same container, holding the same token.
 
 See also the runnable, end-to-end version of this flow —
 [`packages/sdk/examples/09-kaab-backend-wrapper.ts`](../packages/sdk/examples/09-kaab-backend-wrapper.ts)


### PR DESCRIPTION
Every session Kortix has ever run left behind a permanently-valid bearer token.

The executor token minted for a sandbox (`account_tokens` with `session_id` set) is created with **no `expiresAt`**, is deliberately **exempt from the PAT idle-revoke sweep** — `validateAccountToken` skips project-scoped tokens because their "lifetime is tied to the sandbox" — and is only ever revoked by `revokeAllAccountTokensForUser`, i.e. when the whole **user** is offboarded. Nothing tied it to the sandbox at all. For a Kortix-as-a-Backend wrapper, where one account fronts many end-users and sessions are created and discarded constantly, that is an ever-growing pile of live, project-scoped credentials, each carrying an agent grant.

## Where it revokes — and where it deliberately does not

Revoked at the two points where the container can never legitimately return:

- `deleteSession` — the provider sandbox is being removed.
- `reconcileSandboxRemovedByExternalId` — the provider reports the box destroyed/deleted/lost (webhook + reaper).

**Not** on an idle stop. I checked the wake path before touching this: `wakeSandbox` calls `provider.ensureRunning(externalId)`, which restarts the *same container* — whose env still holds the token it was born with. Revoking on stop would brick every box a user is entitled to resume. That distinction is written into the function's doc comment so the next person doesn't "fix" the inconsistency.

## Details

- A session can hold **several** tokens — each re-provision mints another under the same `session_id` — so this revokes all of them, not "the" token.
- Scoped by `account_id` as well as `session_id`: a session id must never reach across tenants.
- Scoped to `status='active'`, so re-revoking doesn't rewrite an already-revoked row's `revoked_at` and destroy the record of when the credential actually died.
- In `deleteSession` it is **awaited**, so the credential is dead before we report the session gone — but a failure is logged at error level rather than failing the delete, since the sandbox removal is already in flight.

## Verification

- Unit test (runs in CI) renders the UPDATE's `SET` and `WHERE` and asserts on both — the account predicate, the active-only predicate, and that `revoked_at` is stamped, not just `status`. A one-statement repository function's entire correctness is in those clauses.
- Integration test extended against a real DB for the multi-token, cross-account, and idempotency cases. Note: that file **cannot run in CI** (integration tests need live Postgres and are excluded from `scripts/test.sh`), and it also fails on clean `main` on my machine because the local DB predates a schema column — I verified that failure is pre-existing by stashing and re-running, not introduced here.
- Full `apps/api` suite: **24 failures, zero new**.