### PR TITLE
fix(ke2e): reuse managed project on staging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,20 @@ on:
         required: false
       KE2E_DATABASE_URL:
         required: false
+      STAGING_SUPABASE_URL:
+        required: false
+      STAGING_SUPABASE_ANON_KEY:
+        required: false
+      STAGING_SUPABASE_SERVICE_ROLE_KEY:
+        required: false
+      STAGING_DATABASE_URL:
+        required: false
+      STAGING_INTERNAL_SERVICE_KEY:
+        required: false
+      STAGING_STRIPE_SECRET_KEY:
+        required: false
+      STAGING_STRIPE_WEBHOOK_SECRET:
+        required: false
 
 concurrency:
   group: ke2e-${{ inputs.base_url || 'dev' }}
@@ -112,10 +126,10 @@ jobs:
           KE2E_API_URL: ${{ steps.target.outputs.base }}
           KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}
           KE2E_OWNER_PASSWORD: ${{ secrets.KE2E_OWNER_PASSWORD }}
-          KE2E_SUPABASE_URL: ${{ secrets.KE2E_SUPABASE_URL }}
-          KE2E_SUPABASE_ANON_KEY: ${{ secrets.KE2E_SUPABASE_ANON_KEY }}
-          KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.KE2E_SUPABASE_SERVICE_ROLE_KEY }}
-          KE2E_DATABASE_URL: ${{ secrets.KE2E_DATABASE_URL }}
+          KE2E_SUPABASE_URL: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_SUPABASE_URL || secrets.KE2E_SUPABASE_URL }}
+          KE2E_SUPABASE_ANON_KEY: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_SUPABASE_ANON_KEY || secrets.KE2E_SUPABASE_ANON_KEY }}
+          KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY || secrets.KE2E_SUPABASE_SERVICE_ROLE_KEY }}
+          KE2E_DATABASE_URL: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_DATABASE_URL || secrets.KE2E_DATABASE_URL }}
 
       - name: Run ke2e
         run: |
@@ -129,11 +143,14 @@ jobs:
           KE2E_LIVE_CONFIRM: "ci"
           KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}
           KE2E_OWNER_PASSWORD: ${{ secrets.KE2E_OWNER_PASSWORD }}
-          KE2E_SUPABASE_URL: ${{ secrets.KE2E_SUPABASE_URL }}
-          KE2E_SUPABASE_ANON_KEY: ${{ secrets.KE2E_SUPABASE_ANON_KEY }}
-          KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.KE2E_SUPABASE_SERVICE_ROLE_KEY }}
+          KE2E_SUPABASE_URL: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_SUPABASE_URL || secrets.KE2E_SUPABASE_URL }}
+          KE2E_SUPABASE_ANON_KEY: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_SUPABASE_ANON_KEY || secrets.KE2E_SUPABASE_ANON_KEY }}
+          KE2E_SUPABASE_SERVICE_ROLE_KEY: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY || secrets.KE2E_SUPABASE_SERVICE_ROLE_KEY }}
           KE2E_ADMIN_TOKEN: ${{ secrets.KE2E_ADMIN_TOKEN }}
-          KE2E_DATABASE_URL: ${{ secrets.KE2E_DATABASE_URL }}
+          KE2E_DATABASE_URL: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_DATABASE_URL || secrets.KE2E_DATABASE_URL }}
+          KE2E_INTERNAL_SERVICE_KEY: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_INTERNAL_SERVICE_KEY || '' }}
+          KE2E_STRIPE_SECRET_KEY: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_STRIPE_SECRET_KEY || '' }}
+          KE2E_STRIPE_WEBHOOK_SECRET: ${{ startsWith(inputs.base_url, 'https://staging-api.kortix.com/') && secrets.STAGING_STRIPE_WEBHOOK_SECRET || '' }}
 
       - name: Secret-leak guard on artifacts
         if: always()

--- a/tests/src/flows/connectors.flow.ts
+++ b/tests/src/flows/connectors.flow.ts
@@ -82,13 +82,16 @@ flow(
   'CONN-5',
   {
     domain: 'connectors',
+    // This flow mutates kortix.yaml. Run it after the parallel lanes so it can
+    // reuse the shared managed repository without racing read-only flows.
+    global: true,
     routes: [
       'GET /v1/executor/projects/:projectId/policies',
       'PUT /v1/executor/projects/:projectId/policies',
     ],
   },
   async (ctx) => {
-    const p = await ctx.fixtures.project();
+    const p = await ctx.fixtures.sharedProject();
     await ctx.step('read policies → 200', async () => {
       const r = await ctx.client
         .as(ctx.P.OWNER)

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { Env } from '../src/core/env';
 import {
@@ -122,5 +124,36 @@ describe('database-only project fixture', () => {
       ),
     ).rejects.toThrow('KE2E_DATABASE_URL is required');
     expect(db.open).not.toHaveBeenCalled();
+  });
+});
+
+describe('managed Git fixture selection', () => {
+  it('runs CONN-5 last against the shared managed repository', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, '../src/flows/connectors.flow.ts'),
+      'utf8',
+    );
+    const start = source.indexOf("'CONN-5'");
+    const end = source.indexOf("\nflow(", start);
+    const conn5 = source.slice(start, end);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(conn5).toContain('global: true');
+    expect(conn5).toContain('ctx.fixtures.sharedProject()');
+    expect(conn5).not.toContain('ctx.fixtures.project()');
+  });
+
+  it('uses staging credentials for manual E2E runs against staging', () => {
+    const workflow = readFileSync(
+      resolve(import.meta.dirname, '../../.github/workflows/e2e.yml'),
+      'utf8',
+    );
+
+    expect(workflow).toContain('secrets.STAGING_SUPABASE_URL');
+    expect(workflow).toContain('secrets.STAGING_SUPABASE_ANON_KEY');
+    expect(workflow).toContain('secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY');
+    expect(workflow).toContain('secrets.STAGING_DATABASE_URL');
+    expect(workflow).toContain('secrets.STAGING_STRIPE_SECRET_KEY');
   });
 });


### PR DESCRIPTION
Fixes two staging E2E defects.

- `CONN-5` runs in the global lane against the shared managed repository.
- Manual staging E2E dispatches use staging Supabase, database, internal-service, and Stripe secrets.
- Full-suite managed repository count does not increase.

Verification:
- tests unit: 36/36 passed
- tests typecheck: passed
- ke2e coverage: 497/507 routes, 10 allowlisted, 0 uncovered
- live staging `CONN-5`: 1/1 passed in 14.38s, 1 managed repository