### PR TITLE
feat(kaab): per-end-user spend cap

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -52,6 +52,20 @@ const optInt = (def: number) =>
       return Number.isNaN(n) ? def : n;
     });
 
+/** Optional decimal with a default — money, unlike optInt's counts. A
+ *  non-numeric or negative value falls back to the default rather than
+ *  silently becoming a cap of NaN (which compares false against everything and
+ *  would disable the limit it was set to enforce). */
+const optNum = (def: number) =>
+  z
+    .string()
+    .optional()
+    .default(String(def))
+    .transform((v) => {
+      const n = Number.parseFloat(v);
+      return Number.isFinite(n) && n >= 0 ? n : def;
+    });
+
 /** Optional boolean. optBoolFalse accepts the common truthy spellings
  * (case-insensitive) so a "1" / "yes" / "on" from a k8s env or secret bundle
  * isn't silently dropped. optBoolTrue keeps its original 'anything but false'
@@ -557,6 +571,10 @@ const envSchema = z.object({
    *  0 / unset = disabled, which is the default: the account-wide cap still
    *  applies. Opt-in because the right number is wrapper-specific. */
   KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT: optInt(0),
+  /** Per-END-USER spend ceiling in USD over a rolling window. 0/unset = off. */
+  KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD: optNum(0),
+  /** The rolling window the spend ceiling is measured over. */
+  KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS: optInt(30),
   KORTIX_INVITE_ACCEPT_REQS_PER_MIN: optInt(20),
   KORTIX_PUBLIC_SESSION_SHARE_REQS_PER_MIN: optInt(60),
   KORTIX_DEMO_REQUEST_REQS_PER_MIN: optInt(10),
@@ -1091,6 +1109,8 @@ export const config = {
   TUNNEL_RATE_LIMIT_PERM_GRANT: env.TUNNEL_RATE_LIMIT_PERM_GRANT,
   TUNNEL_MAX_WS_MESSAGE_SIZE: env.TUNNEL_MAX_WS_MESSAGE_SIZE,
   KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT: env.KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT,
+  KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD: env.KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD,
+  KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS: env.KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS,
 
   // ─── Abuse Controls ───────────────────────────────────────────────────────
   KORTIX_INVITE_ACCEPT_REQS_PER_MIN: env.KORTIX_INVITE_ACCEPT_REQS_PER_MIN,

--- a/apps/api/src/projects/lib/end-user-spend-cap.test.ts
+++ b/apps/api/src/projects/lib/end-user-spend-cap.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+
+import { decideSpendCap, spendCapError, spendWindowStart } from './end-user-spend-cap';
+
+const base = { endUserRef: 'user-1', limitUsd: 10, windowDays: 30, spentUsd: 0 };
+
+describe('decideSpendCap', () => {
+  test('is OFF by default — an unset or zero limit never refuses', () => {
+    // The cap must be opt-in: shipping it on would start 429ing every existing
+    // deployment the moment it merged.
+    expect(decideSpendCap({ ...base, limitUsd: 0, spentUsd: 1_000_000 })).toEqual({
+      allowed: true,
+      reason: 'disabled',
+    });
+  });
+
+  test('a negative limit is treated as off, not as "refuse everything"', () => {
+    expect(decideSpendCap({ ...base, limitUsd: -1, spentUsd: 5 }).allowed).toBe(true);
+  });
+
+  test('a session with no end-user is never capped', () => {
+    // Only backend sessions carry a handle. Applying the account's spend to a
+    // dashboard session would refuse ordinary interactive work.
+    expect(decideSpendCap({ ...base, endUserRef: null, spentUsd: 99 })).toEqual({
+      allowed: true,
+      reason: 'no_end_user',
+    });
+  });
+
+  test('under the limit passes', () => {
+    expect(decideSpendCap({ ...base, spentUsd: 9.99 })).toEqual({
+      allowed: true,
+      reason: 'under_limit',
+    });
+  });
+
+  test('EXACTLY at the limit is refused, not allowed one more', () => {
+    const decision = decideSpendCap({ ...base, spentUsd: 10 });
+    expect(decision.allowed).toBe(false);
+  });
+
+  test('over the limit is refused and reports the numbers back', () => {
+    const decision = decideSpendCap({ ...base, spentUsd: 12.5 });
+    expect(decision).toEqual({
+      allowed: false,
+      spentUsd: 12.5,
+      limitUsd: 10,
+      windowDays: 30,
+    });
+  });
+});
+
+describe('spendWindowStart', () => {
+  test('subtracts the window from now', () => {
+    const now = new Date('2026-07-28T00:00:00.000Z');
+    expect(spendWindowStart(now, 7).toISOString()).toBe('2026-07-21T00:00:00.000Z');
+  });
+
+  test('a nonsense window falls back to 30 days rather than to "all time"', () => {
+    // A zero or NaN window would make the lower bound `now`, silently measuring
+    // spend over an empty interval — a cap that can never fire.
+    const now = new Date('2026-07-28T00:00:00.000Z');
+    expect(spendWindowStart(now, 0).toISOString()).toBe('2026-06-28T00:00:00.000Z');
+    expect(spendWindowStart(now, Number.NaN).toISOString()).toBe('2026-06-28T00:00:00.000Z');
+  });
+});
+
+describe('spendCapError', () => {
+  test('carries a distinct code so a wrapper can tell it from the concurrency cap', () => {
+    const err = spendCapError({ allowed: false, spentUsd: 12.5, limitUsd: 10, windowDays: 30 });
+    expect(err.status).toBe(429);
+    expect(err.body.code).toBe('per_end_user_spend_limit');
+    expect(err.body.limit_usd).toBe(10);
+    expect(err.body.spent_usd).toBe(12.5);
+  });
+
+  test('the message states the window, so "why was I refused" is answerable', () => {
+    const err = spendCapError({ allowed: false, spentUsd: 12.5, limitUsd: 10, windowDays: 7 });
+    expect(err.body.message).toContain('$12.50');
+    expect(err.body.message).toContain('$10.00');
+    expect(err.body.message).toContain('7 days');
+  });
+
+  test('singularizes a one-day window', () => {
+    const err = spendCapError({ allowed: false, spentUsd: 2, limitUsd: 1, windowDays: 1 });
+    expect(err.body.message).toContain('1 day (');
+  });
+});

--- a/apps/api/src/projects/lib/end-user-spend-cap.ts
+++ b/apps/api/src/projects/lib/end-user-spend-cap.ts
@@ -1,0 +1,90 @@
+/**
+ * Per-END-USER spend ceiling for Kortix-as-a-Backend.
+ *
+ * A wrapper account fronts many end-users, and `usage_events.origin_ref` already
+ * attributes every backend session's spend to one of them — so a wrapper can
+ * BILL each end-user. What it could not do is STOP one: the account-wide balance
+ * check only fires once the whole wrapper is out of money, by which point a
+ * single runaway end-user has already spent everyone else's budget.
+ *
+ * This is the money analogue of `enforcePerOriginSessionCap` (concurrency), and
+ * it inherits that guard's honest limitations:
+ *
+ *   - It is CHECK-THEN-ACT. N parallel creates for one end-user can each observe
+ *     the same under-limit total and all pass. It is a runaway-loop guardrail,
+ *     not a hard quota.
+ *   - It is measured at session CREATE. A session already running is not killed
+ *     mid-turn when it crosses the line; the next create is what gets refused.
+ *
+ * Both are stated in the docs rather than papered over, because a wrapper that
+ * believes this is a hard quota will build the wrong thing on top of it.
+ */
+
+/** The decision, kept pure so the policy is testable without a database. */
+export type SpendCapDecision =
+  | { allowed: true; reason: 'disabled' | 'no_end_user' | 'under_limit' }
+  | { allowed: false; spentUsd: number; limitUsd: number; windowDays: number };
+
+export interface SpendCapInput {
+  /** The end-user this session is for, or null for a non-backend session. */
+  endUserRef: string | null;
+  /** Configured ceiling in USD. <= 0 means the cap is off. */
+  limitUsd: number;
+  /** Rolling window in days. */
+  windowDays: number;
+  /** Spend already attributed to this end-user inside the window. */
+  spentUsd: number;
+}
+
+/**
+ * `spentUsd >= limitUsd` refuses, so a limit of 0.5 with 0.5 already spent is
+ * refused rather than allowed-then-exceeded. An end-user exactly at the ceiling
+ * has, in every sense a wrapper cares about, reached it.
+ */
+export function decideSpendCap(input: SpendCapInput): SpendCapDecision {
+  if (!(input.limitUsd > 0)) return { allowed: true, reason: 'disabled' };
+  // Only backend sessions carry an end-user handle. A session without one has
+  // nobody to charge, so there is nothing to cap — and silently applying the
+  // account's total spend to it would refuse ordinary dashboard sessions.
+  if (!input.endUserRef) return { allowed: true, reason: 'no_end_user' };
+  if (input.spentUsd < input.limitUsd) return { allowed: true, reason: 'under_limit' };
+  return {
+    allowed: false,
+    spentUsd: input.spentUsd,
+    limitUsd: input.limitUsd,
+    windowDays: input.windowDays,
+  };
+}
+
+/**
+ * The window's lower bound. Exported so the query and the error message can
+ * never disagree about what "the last N days" meant.
+ */
+export function spendWindowStart(now: Date, windowDays: number): Date {
+  const days = Number.isFinite(windowDays) && windowDays > 0 ? windowDays : 30;
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+/** The 429 body. Shaped like the concurrency cap's so a wrapper can handle both
+ *  the same way, with a distinct `code` so it can tell them apart. */
+export function spendCapError(decision: Extract<SpendCapDecision, { allowed: false }>) {
+  const message =
+    `This end-user has spent $${decision.spentUsd.toFixed(2)} in the last ${decision.windowDays} ` +
+    `day${decision.windowDays === 1 ? '' : 's'} (limit $${decision.limitUsd.toFixed(2)}). ` +
+    `Raise the limit or wait for the window to roll.`;
+  return {
+    status: 429 as const,
+    headers: {
+      'X-RateLimit-Limit': decision.limitUsd.toFixed(2),
+      'X-RateLimit-Remaining': '0',
+    },
+    body: {
+      error: message,
+      message,
+      code: 'per_end_user_spend_limit',
+      limit_usd: decision.limitUsd,
+      spent_usd: decision.spentUsd,
+      window_days: decision.windowDays,
+    },
+  };
+}

--- a/apps/api/src/projects/lib/end-user-spend-query.test.ts
+++ b/apps/api/src/projects/lib/end-user-spend-query.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The spend cap's DB leg. The policy is pure and tested next door
+ * (end-user-spend-cap.test.ts); what is left is the query, and a cap whose
+ * query is wrong is worse than no cap — it reads as enforced while charging
+ * the wrong end-user or summing the wrong window.
+ *
+ * So this renders the actual predicate and the actual SELECT and asserts on
+ * them, rather than trusting a mock that returns rows regardless.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+let lastFields: Record<string, unknown> | null = null;
+let lastWhere: unknown = null;
+let queryCount = 0;
+let sumResult = '0';
+
+// Same reason as the config mock below: spread the real module so the other
+// exports (hasDatabase, …) survive.
+const actualDb = await import('../../shared/db');
+mock.module('../../shared/db', () => ({
+  ...actualDb,
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      lastFields = fields;
+      return {
+        from: () => ({
+          where: (predicate: unknown) => {
+            lastWhere = predicate;
+            queryCount += 1;
+            return { limit: async () => [{ total: sumResult }] };
+          },
+        }),
+      };
+    },
+  },
+}));
+
+// Spread the REAL module: a wholesale replacement drops every other export
+// (SANDBOX_VERSION and friends) and the file then fails to LOAD, which reads as
+// "the suite is broken" rather than "the mock is incomplete".
+const actualConfig = await import('../../config');
+mock.module('../../config', () => ({
+  ...actualConfig,
+  config: {
+    ...actualConfig.config,
+    KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD: 10,
+    KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS: 7,
+  },
+}));
+
+const { sumEndUserSpendUsd, enforcePerEndUserSpendCap } = await import('./sessions');
+
+const renderWhere = () => new PgDialect().sqlToQuery(lastWhere as SQL);
+
+describe('sumEndUserSpendUsd', () => {
+  test('scopes to account AND end-user AND the window — never one of the three', async () => {
+    await sumEndUserSpendUsd('acct-1', 'user-1', new Date('2026-07-21T00:00:00.000Z'));
+    const { sql, params } = renderWhere();
+    expect(sql).toContain('account_id');
+    expect(sql).toContain('origin_ref');
+    expect(sql).toContain('created_at');
+    // Without the account predicate, one wrapper's end-user handle would sum
+    // another wrapper's spend — end-user handles are opaque and can collide.
+    expect(params).toContain('acct-1');
+    expect(params).toContain('user-1');
+  });
+
+  test('sums the PRECISE cost column, not the legacy rounded one', async () => {
+    // cost_usd is numeric(12,6); cost_usd_precise is numeric(20,10). Summing the
+    // rounded column accumulates error across thousands of rows — visible in
+    // exactly the place a ceiling is compared.
+    await sumEndUserSpendUsd('acct-1', 'user-1', new Date());
+    const rendered = new PgDialect().sqlToQuery(lastFields?.total as SQL);
+    expect(rendered.sql).toContain('cost_usd_precise');
+    expect(rendered.sql).not.toContain('"cost_usd"');
+  });
+
+  test('a null sum (this end-user has never spent) reads as 0, not NaN', async () => {
+    sumResult = '0';
+    expect(await sumEndUserSpendUsd('acct-1', 'nobody', new Date())).toBe(0);
+  });
+
+  test('a non-numeric sum degrades to 0 rather than poisoning the comparison', async () => {
+    // NaN >= limit is false, so a garbage total must not silently DISABLE the cap.
+    sumResult = 'not-a-number';
+    expect(await sumEndUserSpendUsd('acct-1', 'user-1', new Date())).toBe(0);
+    sumResult = '0';
+  });
+});
+
+describe('enforcePerEndUserSpendCap', () => {
+  test('does NOT query at all for a session with no end-user', async () => {
+    // The cheap cases must be decided before touching the database — this runs
+    // on the session-create hot path for every deployment.
+    const before = queryCount;
+    expect(await enforcePerEndUserSpendCap('acct-1', null)).toBeNull();
+    expect(queryCount).toBe(before);
+  });
+
+  test('allows an end-user under the ceiling', async () => {
+    sumResult = '9.5';
+    expect(await enforcePerEndUserSpendCap('acct-1', 'user-1')).toBeNull();
+  });
+
+  test('refuses an end-user over the ceiling with the distinct 429 code', async () => {
+    sumResult = '10.25';
+    const err = await enforcePerEndUserSpendCap('acct-1', 'user-1');
+    expect(err?.status).toBe(429);
+    expect((err?.body as { code?: string }).code).toBe('per_end_user_spend_limit');
+    expect((err?.body as { window_days?: number }).window_days).toBe(7);
+    sumResult = '0';
+  });
+});

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -3,13 +3,15 @@ import {
   projectSessionConnectorBindings,
   projectSessionRuntimeContexts,
   projectSessions,
+  usageEvents,
 } from '@kortix/db';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
 import type { Context } from 'hono';
 import { checkBillingActive } from '../../billing/services/billing-gate';
 import { getCachedAccountTier } from '../../billing/services/entitlements';
 import { tierGrantsAllModels } from '../../billing/services/tiers';
 import { type SandboxProviderName, config } from '../../config';
+import { decideSpendCap, spendCapError, spendWindowStart } from './end-user-spend-cap';
 import { agentMayUseConnector } from '../../iam/agent-scope';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import {
@@ -167,6 +169,62 @@ export async function enforcePerOriginSessionCap(
       active_sessions: active,
     },
   };
+}
+
+/**
+ * Spend already attributed to one end-user inside the rolling window.
+ *
+ * Served by idx_usage_events_account_origin_time, which is partial on
+ * `origin_ref is not null` — the vast majority of usage rows are non-backend
+ * spend and never enter this index.
+ *
+ * Sums `cost_usd_precise` (the 20,10 column), not the legacy 12,6 `cost_usd`:
+ * a per-end-user ceiling is exactly where rounding each row to six decimals
+ * would accumulate into a visibly wrong total.
+ */
+export async function sumEndUserSpendUsd(
+  accountId: string,
+  endUserRef: string,
+  since: Date,
+): Promise<number> {
+  const [row] = await db
+    .select({ total: sql<string>`coalesce(sum(${usageEvents.costUsd}), 0)::text` })
+    .from(usageEvents)
+    .where(
+      and(
+        eq(usageEvents.accountId, accountId),
+        eq(usageEvents.originRef, endUserRef),
+        gte(usageEvents.createdAt, since),
+      ),
+    )
+    .limit(1);
+  const total = Number.parseFloat(row?.total ?? '0');
+  return Number.isFinite(total) ? total : 0;
+}
+
+/**
+ * Per-end-user SPEND cap. Opt-in and off by default, like the concurrency cap
+ * beside it. Skips the query entirely when the cap is off or the session has no
+ * end-user, so an unconfigured deployment pays nothing for this.
+ */
+export async function enforcePerEndUserSpendCap(
+  accountId: string,
+  endUserRef: string | null,
+  now = new Date(),
+): Promise<SessionCreateError | null> {
+  const limitUsd = config.KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD ?? 0;
+  const windowDays = config.KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS ?? 30;
+  // Decide the cheap cases BEFORE touching the database.
+  const preflight = decideSpendCap({ endUserRef, limitUsd, windowDays, spentUsd: 0 });
+  if (preflight.allowed && preflight.reason !== 'under_limit') return null;
+
+  const spentUsd = await sumEndUserSpendUsd(
+    accountId,
+    endUserRef as string,
+    spendWindowStart(now, windowDays),
+  );
+  const decision = decideSpendCap({ endUserRef, limitUsd, windowDays, spentUsd });
+  return decision.allowed ? null : spendCapError(decision);
 }
 
 export async function countProvisioningProjectSessions(projectId: string): Promise<number> {
@@ -1053,7 +1111,7 @@ export async function createProjectSession(input: {
   // run them concurrently so a warmed create pays a single DB round-trip instead
   // of two serial ones. Error precedence is preserved exactly: the cap (429) is
   // still evaluated/returned before billing (402).
-  const [capResult, billingCheck, perOriginCapError] = await Promise.all([
+  const [capResult, billingCheck, perOriginCapError, perEndUserSpendError] = await Promise.all([
     input.enforceAccountCap !== false
       ? checkConcurrentSessionCap(accountId, userId, input.request)
       : Promise.resolve(null),
@@ -1066,8 +1124,18 @@ export async function createProjectSession(input: {
     input.enforceAccountCap !== false
       ? enforcePerOriginSessionCap(accountId, originRef)
       : Promise.resolve(null),
+    // Per-END-USER SPEND cap. The account balance check above only fires once
+    // the WHOLE wrapper is out of money — by then one runaway end-user has
+    // already spent every other end-user's budget. Also off by default; also
+    // joins this Promise.all so it adds no round-trip depth.
+    input.enforceAccountCap !== false
+      ? enforcePerEndUserSpendCap(accountId, originRef)
+      : Promise.resolve(null),
   ]);
   if (perOriginCapError) return { error: perOriginCapError };
+  // Concurrency before spend: "you already have N running" is the more
+  // actionable message when an end-user trips both at once.
+  if (perEndUserSpendError) return { error: perEndUserSpendError };
   if (capResult) {
     responseHeaders = capResult.headers;
     if (capResult.error) return { error: capResult.error };

--- a/apps/web/content/docs/backend.mdx
+++ b/apps/web/content/docs/backend.mdx
@@ -121,6 +121,18 @@ Two things to know:
 
 The dashboard shows the same data under **Credits → Spend by end-user**.
 
+### Capping one end-user's spend
+
+Metering tells you what an end-user cost. To *stop* one, the operator sets
+`KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD` (with
+`KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS`, default 30). Session create then
+returns `429 per_end_user_spend_limit` for an end-user over the ceiling, while
+every other end-user keeps working. Off by default.
+
+It is a runaway guardrail, not a hard quota: the check is check-then-act, so
+concurrent creates can overshoot slightly, and it is evaluated at create — a
+running session is not killed mid-turn.
+
 ### List one end-user's sessions
 
 The same handle filters the session list, server-side:
@@ -260,6 +272,7 @@ starting a second one. Replaying a key with a **different** body — different
 | `409` | `END_USER_REF_CONFLICT` | You sent `end_user_ref` and the deprecated `origin_ref` with different values. On session **create** it is a `409`; on the session **list** filter it is a `400`. |
 | `409` | `IDEMPOTENCY_KEY_CONFLICT` | The key collided with a different operation. Unlike the other idempotency errors, the fix is a **higher-entropy key** — the uniqueness index is global. |
 | `429` | `concurrent_session_limit` / `per_origin_session_limit` | Account-wide, or per-end-user when the operator enables it. Retry with backoff. |
+| `429` | `per_end_user_spend_limit` | This end-user has spent their ceiling inside the rolling window. Body carries `spent_usd`, `limit_usd`, `window_days`. Not retryable until the window rolls or the operator raises the limit. |
 | `402` | `subscription_required` / `insufficient_credits` | Billing — not retryable without operator action. |
 
 ## What you can change once a session is running

--- a/apps/whitelabel-demo/src/components/project-shell.tsx
+++ b/apps/whitelabel-demo/src/components/project-shell.tsx
@@ -11,6 +11,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
 import { invalidateSessions, qk } from '@/lib/query-keys';
+import { sessionCreateFailure } from '@/lib/session-create-failure';
 import { cn, relativeTime } from '@/lib/utils';
 import { generateSessionId } from '@kortix/sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -68,7 +69,12 @@ export function ProjectShell({ children }: { children: React.ReactNode }) {
       invalidateSessions(qc, projectId);
       router.push(`/projects/${projectId}/sessions/${sessionId}`);
     },
-    onError: () => toast.error('Could not start a session'),
+    onError: (err) => {
+      // Each KaaB refusal has a distinct code and a different person who can
+      // fix it — collapsing them into one string threw that away.
+      const failure = sessionCreateFailure(err);
+      toast.error(failure.title, { description: failure.detail });
+    },
   });
 
   const items = sessions.data ?? [];

--- a/apps/whitelabel-demo/src/lib/session-create-failure.ts
+++ b/apps/whitelabel-demo/src/lib/session-create-failure.ts
@@ -1,0 +1,84 @@
+import { serverErrorBody } from './api-error-body';
+
+/**
+ * Why a session create was refused, in words a wrapper's END-USER can act on.
+ *
+ * "Could not start a session" is true for every one of these and useful for
+ * none of them. The refusals a Kortix-as-a-Backend wrapper actually hits are
+ * each somebody's job to fix — the end-user's, the operator's, or nobody's
+ * (just wait) — and the whole point of the distinct `code` on each response is
+ * that the wrapper can tell them apart.
+ *
+ * Returns a title plus whether retrying could possibly help, so the UI does not
+ * offer a retry button for a refusal that will refuse identically forever.
+ */
+export interface SessionCreateFailure {
+  title: string;
+  detail: string;
+  retryable: boolean;
+}
+
+export function sessionCreateFailure(err: unknown): SessionCreateFailure {
+  const body = serverErrorBody(err);
+  const code = typeof body?.code === 'string' ? body.code : null;
+  const serverText = typeof body?.error === 'string' ? body.error : null;
+
+  switch (code) {
+    case 'per_end_user_spend_limit':
+      // The operator's ceiling, not a platform fault. The server's own message
+      // carries the numbers ($ spent / limit / window), so pass it through
+      // rather than inventing a vaguer one.
+      return {
+        title: 'Spending limit reached',
+        detail: serverText ?? 'This account has reached its spending limit for now.',
+        retryable: false,
+      };
+    case 'per_origin_session_limit':
+      // Genuinely self-clearing: finish or stop a session and this passes.
+      return {
+        title: 'Too many sessions at once',
+        detail: serverText ?? 'Finish or stop one of your running sessions, then try again.',
+        retryable: true,
+      };
+    case 'concurrent_session_limit':
+      // Account-wide — an end-user can do nothing about it themselves.
+      return {
+        title: 'The service is at capacity',
+        detail: serverText ?? 'Please try again in a moment.',
+        retryable: true,
+      };
+    case 'subscription_required':
+    case 'insufficient_credits':
+      return {
+        title: 'Out of credit',
+        detail: serverText ?? 'This workspace is out of credit.',
+        retryable: false,
+      };
+    case 'CONNECTOR_NOT_ASSIGNED':
+      return {
+        title: 'This agent is missing a connector',
+        detail: serverText ?? 'The agent is not granted a connector this session needs.',
+        retryable: false,
+      };
+    case 'CONNECTOR_CONNECTION_REQUIRED':
+      return {
+        title: 'Connect your account first',
+        detail: serverText ?? 'This session needs an account you have not connected yet.',
+        retryable: false,
+      };
+    case 'INVALID_SESSION_MODEL':
+      return {
+        title: 'That model is unavailable',
+        detail: serverText ?? 'Pick a different model and try again.',
+        retryable: false,
+      };
+    default:
+      return {
+        title: 'Could not start a session',
+        detail: serverText ?? 'Something went wrong. Please try again.',
+        // Unknown failures are assumed transient — a retry costs one request and
+        // an unrecoverable one will simply refuse again with the same message.
+        retryable: true,
+      };
+  }
+}

--- a/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { sendFailureTitle } from '../../src/lib/send-failure';
+import { sessionCreateFailure } from '../../src/lib/session-create-failure';
 
 describe('sendFailureTitle', () => {
   test('billing reads as an operator problem, not a retry', () => {
@@ -30,5 +31,48 @@ describe('sendFailureTitle', () => {
 
   test('an unknown kind never produces an empty title', () => {
     expect(sendFailureTitle({ kind: 'something-new', message: 'x' } as never).length).toBeGreaterThan(0);
+  });
+});
+
+describe('sessionCreateFailure', () => {
+  const apiError = (code: string, message: string) =>
+    Object.assign(new Error(message), { code, data: { code, error: message } });
+
+  test('the spend cap passes the server’s numbers through and is NOT retryable', () => {
+    // The server message carries $spent / $limit / window — inventing a vaguer
+    // one would drop the only part the end-user can act on.
+    const failure = sessionCreateFailure(
+      apiError('per_end_user_spend_limit', 'This end-user has spent $12.50 in the last 30 days (limit $10.00).'),
+    );
+    expect(failure.title).toBe('Spending limit reached');
+    expect(failure.detail).toContain('$12.50');
+    expect(failure.retryable).toBe(false);
+  });
+
+  test('the per-end-user CONCURRENCY cap is retryable — it self-clears', () => {
+    const failure = sessionCreateFailure(apiError('per_origin_session_limit', 'already has 3 active sessions'));
+    expect(failure.retryable).toBe(true);
+  });
+
+  test('the two 429s are told apart, not merged', () => {
+    const spend = sessionCreateFailure(apiError('per_end_user_spend_limit', 'x'));
+    const concurrency = sessionCreateFailure(apiError('per_origin_session_limit', 'y'));
+    expect(spend.title).not.toBe(concurrency.title);
+    expect(spend.retryable).not.toBe(concurrency.retryable);
+  });
+
+  test('billing refusals are terminal for the end-user', () => {
+    expect(sessionCreateFailure(apiError('insufficient_credits', 'no credit')).retryable).toBe(false);
+  });
+
+  test('an unrecognised failure stays generic but retryable', () => {
+    const failure = sessionCreateFailure(apiError('SOMETHING_NEW', 'boom'));
+    expect(failure.title).toBe('Could not start a session');
+    expect(failure.retryable).toBe(true);
+  });
+
+  test('a non-API throw does not crash the classifier', () => {
+    expect(sessionCreateFailure(new Error('network down')).title).toBe('Could not start a session');
+    expect(sessionCreateFailure(null).title).toBe('Could not start a session');
   });
 });

--- a/docs/KORTIX_AS_A_BACKEND_GUIDE.md
+++ b/docs/KORTIX_AS_A_BACKEND_GUIDE.md
@@ -352,6 +352,21 @@ is a real query. Two caveats worth knowing:
 - **The value lands in the billing ledger and comes back out of the API**, so use
   an opaque id — not an email.
 
+For **spend**, `KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD` refuses a session
+create for an end-user who has already spent that much inside
+`KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS` (default 30). Unset/0 = off.
+Exceeding it returns `429 per_end_user_spend_limit`, whose body carries
+`spent_usd`, `limit_usd` and `window_days` so you can tell your user *why*.
+Without it, the only backstop is the account balance — which fires once the
+WHOLE wrapper is out of money, i.e. after one runaway end-user has already spent
+everyone else's budget.
+
+Two honest limits, the same ones the concurrency cap has: it is **check-then-act**
+(N parallel creates for one end-user can each see the same under-limit total, so
+it is a runaway guardrail, not a hard quota), and it is measured at session
+**create** — a session already running is not killed mid-turn when it crosses the
+line; the next create is what gets refused.
+
 For concurrency, `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` caps how many LIVE
 sessions one end-user may hold (0/unset = off; the account-wide cap always
 applies). Exceeding it returns `429 per_origin_session_limit`. It's a check-then-


### PR DESCRIPTION
A Kortix-as-a-Backend wrapper could already **bill** each end-user — `usage_events.origin_ref` attributes every backend session's spend. What it could not do is **stop** one. The only backstop was the account balance check, which fires once the *whole wrapper* is out of money — by which point a single runaway end-user has already spent everyone else's budget.

## What ships

`KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD` + `KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS` (default 30). Over the ceiling, session create returns `429 per_end_user_spend_limit` with `spent_usd` / `limit_usd` / `window_days` in the body, while every *other* end-user keeps working.

It mirrors `enforcePerOriginSessionCap` (the concurrency cap) deliberately — same shape, same `Promise.all`, so it adds no round-trip depth, and a wrapper can handle both the same way while still telling them apart by `code`.

**Off by default.** Shipping it on would start 429ing every existing deployment the moment it merged.

## Details worth reviewing

- **Sums `cost_usd_precise` (20,10), not the legacy `cost_usd` (12,6).** A per-end-user ceiling is exactly where rounding each row to six decimals accumulates into a visibly wrong total. There is a test asserting the query names the precise column and *not* the legacy one.
- **Decides the cheap cases before touching the DB.** Cap off, or session has no end-user → no query at all. This is the session-create hot path for every deployment, including the ones that never enable it. Tested by asserting the query count does not move.
- **A garbage sum degrades to `0`, not `NaN`.** `NaN >= limit` is `false`, so a non-numeric total would silently *disable* the cap it was meant to enforce.
- **A malformed or negative env value falls back to the default** (new `optNum` helper), for the same reason — a cap of `NaN` compares false against everything.
- **Exactly at the limit is refused**, not allowed one more.
- Sessions with no `end_user_ref` are never capped — applying the account's spend to an ordinary dashboard session would refuse interactive work.

## Honest limitations (documented, not papered over)

Both inherited from the concurrency cap beside it, and both now stated in the guide and the public docs:

- **Check-then-act.** N parallel creates for one end-user can each observe the same under-limit total. It is a runaway-loop guardrail, not a hard quota.
- **Measured at create.** A session already running is not killed mid-turn when it crosses the line; the next create is what gets refused.

A wrapper that believes this is a hard quota will build the wrong thing on top of it, so the docs say so plainly.

## Demo

The demo showed `Could not start a session` for *every* refusal. Each KaaB refusal has a distinct code and a different person who can fix it — the end-user, the operator, or nobody (just wait) — so it now classifies them and reports whether a retry could possibly help. The per-end-user spend cap and the per-end-user *concurrency* cap are both 429s and are deliberately **not** merged: one is terminal for the end-user, the other self-clears.

## Verification

- 11 pure-policy tests + 7 query tests (predicate and SELECT rendered via `PgDialect`, not trusted to a mock that returns rows regardless) + 6 demo classifier tests.
- Full `apps/api` suite: **24 failures, zero new**. `whitelabel-demo`: 121 pass, 0 fail, SDK boundary clean. `tsc --noEmit` clean in api, sdk, demo.