### PR TITLE
fix(ke2e): bound stale-user cleanup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,9 +120,11 @@ jobs:
       - name: GC leaked resources from prior runs
         if: github.event_name != 'pull_request'
         continue-on-error: true
+        timeout-minutes: 5
         run: bun bin/ke2e.ts gc --older-than 2h
         working-directory: tests
         env:
+          KE2E_GC_WORKERS: 8
           KE2E_API_URL: ${{ steps.target.outputs.base }}
           KE2E_OWNER_EMAIL: ${{ secrets.KE2E_OWNER_EMAIL }}
           KE2E_OWNER_PASSWORD: ${{ secrets.KE2E_OWNER_PASSWORD }}

--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -7,6 +7,7 @@
  * sandboxes can be layered on later via KE2E_DATABASE_URL.
  */
 import { Client } from "../core/client";
+import { mapWithConcurrency } from "../core/concurrency";
 import { loadEnv, type Env } from "../core/env";
 import { log } from "../core/log";
 import { adminDeleteUser, passwordGrant } from "./supabase";
@@ -97,10 +98,16 @@ export async function runGc(opts: GcOptions): Promise<void> {
   log.info(`gc: ${users.length} test user(s) found, ${stale.length} older than ${opts.olderThan}`);
   let removed = 0;
   let failed = 0;
-  for (const u of stale) {
+  const configuredWorkers = Number(process.env.KE2E_GC_WORKERS ?? 8);
+  const workers =
+    Number.isFinite(configuredWorkers) && configuredWorkers > 0
+      ? Math.min(32, Math.trunc(configuredWorkers))
+      : 8;
+  log.info(`gc: reclaiming with ${workers} workers`);
+  await mapWithConcurrency(stale, workers, async (u) => {
     if (opts.dryRun) {
       log.info(`  would delete ${u.email} (${u.id})`);
-      continue;
+      return;
     }
     try {
       await reclaimUser(env, u);
@@ -109,7 +116,7 @@ export async function runGc(opts: GcOptions): Promise<void> {
       failed++;
       log.warn(`  could not reclaim ${u.email}: ${String((err as Error).message).slice(0, 120)}`);
     }
-  }
+  });
   if (!opts.dryRun) {
     log.pass(`gc: reclaimed ${removed} stale test user(s)`);
     if (failed) log.fail(`gc: ${failed} could not be reclaimed (see warnings)`);

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -156,4 +156,16 @@ describe('managed Git fixture selection', () => {
     expect(workflow).toContain('secrets.STAGING_DATABASE_URL');
     expect(workflow).toContain('secrets.STAGING_STRIPE_SECRET_KEY');
   });
+
+  it('bounds stale-user GC with parallel workers and a workflow timeout', () => {
+    const workflow = readFileSync(
+      resolve(import.meta.dirname, '../../.github/workflows/e2e.yml'),
+      'utf8',
+    );
+    const gc = readFileSync(resolve(import.meta.dirname, '../src/fixtures/gc.ts'), 'utf8');
+
+    expect(workflow).toContain('timeout-minutes: 5');
+    expect(workflow).toContain('KE2E_GC_WORKERS: 8');
+    expect(gc).toContain('mapWithConcurrency(stale, workers');
+  });
 });


### PR DESCRIPTION
The corrected staging E2E workflow found `548` stale test users. Serial cleanup blocked the selected flow for more than three minutes.

Changes:
- reclaim stale users with `8` workers
- cap configured GC workers at `32`
- bound workflow GC to `5` minutes
- keep cleanup advisory so the selected flow starts after the timeout

Verification:
- tests unit: 37/37 passed
- tests typecheck: passed
- ke2e coverage: 497/507 routes, 10 allowlisted, 0 uncovered