### PR TITLE
perf(ke2e): query stale users directly

### DIFF
--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -3,8 +3,8 @@
  * domain, so reclaiming those users (+ their cascade) is the primary leak guard.
  * Runs by email-domain prefix + age so it never touches an in-flight run.
  *
- * Uses the Supabase admin API (service-role). A DB/Daytona fallback for orphaned
- * sandboxes can be layered on later via KE2E_DATABASE_URL.
+ * Uses the direct database when available so cleanup selects only test users.
+ * Falls back to the paginated Supabase admin API when direct access is absent.
  */
 import { Client } from "../core/client";
 import { mapWithConcurrency } from "../core/concurrency";
@@ -52,7 +52,10 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
   const conn = env.databaseUrl!;
   const local = conn.includes("localhost") || conn.includes("127.0.0.1");
   const { Client } = await import("pg");
-  const client = new Client({ connectionString: conn, ssl: local ? false : true });
+  const client = new Client({
+    connectionString: conn,
+    ssl: local ? false : { rejectUnauthorized: false },
+  });
   await client.connect();
   try {
     const r = await client.query(
@@ -70,14 +73,8 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
 }
 
 async function listTestUsers(env: Env): Promise<SupaUser[]> {
-  let users: SupaUser[];
-  try {
-    users = await listTestUsersViaApi(env);
-  } catch (err) {
-    if (!env.databaseUrl) throw err;
-    log.warn(`admin list failed (${String((err as Error).message).slice(0, 90)}) — falling back to read-only DB query`);
-    users = await listTestUsersViaDb(env);
-  }
+  if (env.databaseUrl) return listTestUsersViaDb(env);
+  const users = await listTestUsersViaApi(env);
   return users.filter((u) => (u.email ?? "").endsWith(`@${env.testEmailDomain}`));
 }
 

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -167,5 +167,7 @@ describe('managed Git fixture selection', () => {
     expect(workflow).toContain('timeout-minutes: 5');
     expect(workflow).toContain('KE2E_GC_WORKERS: 8');
     expect(gc).toContain('mapWithConcurrency(stale, workers');
+    expect(gc).toContain('if (env.databaseUrl) return listTestUsersViaDb(env)');
+    expect(gc).toContain("ssl: local ? false : { rejectUnauthorized: false }");
   });
 });


### PR DESCRIPTION
The staging GC spent `4m45s` paging through all Supabase users before it found `548` stale test users.

Changes:
- query only `@ke2e.kortix.test` users through the configured staging database
- keep the Supabase API fallback for targets without database access
- use the same staging TLS mode as other database fixtures

Verification:
- staging GC dry run: `4.65s` including printing all stale users
- prior listing time: `4m45s`
- unit: 37/37 passed
- typecheck: passed
- coverage: 497/507 routes, 10 allowlisted, 0 uncovered