### PR TITLE
content(blog): differentiate agi-ready-architecture manifest from introducing-kortix

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -278,7 +278,7 @@ const agiReadyArchitecture: BlogPostEntry = {
 kortix_version: 2
 
 project:
-  name: acme-ops
+  name: acme-security-audit
 
 # A tool the agent can use. Credentials stay in the platform,
 # never in this file. The policy decides what needs a human.
@@ -290,10 +290,10 @@ connectors:
 
 # Run work on a schedule — nobody has to kick it off.
 triggers:
-  - slug: weekly-health-report
+  - slug: nightly-access-review
     type: cron
-    cron: "0 0 9 * * 1"
-    prompt: Draft the weekly customer health report for review.`,
+    cron: "0 0 2 * * *"
+    prompt: Audit last night's access logs and flag any out-of-policy connector calls for review.`,
     },
     {
       type: 'p',


### PR DESCRIPTION
## What & why

`agi-ready-architecture` and `introducing-kortix` both carried a **verbatim-identical** `kortix.yaml` code block — same project name (`acme-ops`), same trigger (`weekly-health-report`, cron `"0 0 9 * * 1"`), same prompt text, same slack connector with `require_approval`. This created a duplicate-content signal across two posts targeting overlapping architecture/manifest queries.

| Field | agi-ready (was) | agi-ready (now) | introducing (unchanged) |
| --- | --- | --- | --- |
| project name | `acme-ops` | `acme-security-audit` | `acme-ops` |
| trigger slug | `weekly-health-report` | `nightly-access-review` | `weekly-health-report` |
| cron | `0 0 9 * * 1` (weekly Mon 09:00) | `0 0 2 * * *` (nightly 02:00) | `0 0 9 * * 1` |
| prompt | health report | access-log audit | health report |

The new example is a thematically-appropriate **security/access-audit loop** — directly reinforcing agi-ready-architecture's thesis ("Every action has an identity", "more capability, not more authority"). `introducing-kortix` is unchanged.

## Scope

Pure content-only edit (4 lines, +4/-4) in `apps/web/src/lib/blog-posts.ts`. No renderer, route, import, type, or UI change. Both posts have 0 GSC impressions (no ranking equity at risk).

## Verification

- `grep 'weekly-health-report'` → 1 match (introducing-kortix only, was 2)
- `grep 'acme-ops'` → 1 match (introducing-kortix only, was 2)
- bun registry import: agi-ready code has `acme-security-audit` + `nightly-access-review`; introducing-kortix unchanged
- 0 `kortix.toml` / `black box` / `AI coworker` / `copilot` / `no-code` drift markers

## Experiment contract (SEO-CANNIBAL-007)

- **Hypothesis:** differentiating the manifest blocks removes the duplicate-content signal.
- **Baseline:** 2 verbatim-identical code blocks (L277-296 vs L474-506).
- **Target:** 0 verbatim overlap; agi-ready uses `acme-security-audit` + `nightly-access-review`.
- **Guardrails:** introducing-kortix unchanged; thematic alignment with AGI-readiness thesis; 0 GSC impressions on both posts (no equity at risk).
- **Rollback:** revert this PR.