### PR TITLE
chore(release): promote current main to staging

### DIFF
--- a/apps/web/src/lib/blog-posts.ts
+++ b/apps/web/src/lib/blog-posts.ts
@@ -278,7 +278,7 @@ const agiReadyArchitecture: BlogPostEntry = {
 kortix_version: 2
 
 project:
-  name: acme-ops
+  name: acme-security-audit
 
 # A tool the agent can use. Credentials stay in the platform,
 # never in this file. The policy decides what needs a human.
@@ -290,10 +290,10 @@ connectors:
 
 # Run work on a schedule — nobody has to kick it off.
 triggers:
-  - slug: weekly-health-report
+  - slug: nightly-access-review
     type: cron
-    cron: "0 0 9 * * 1"
-    prompt: Draft the weekly customer health report for review.`,
+    cron: "0 0 2 * * *"
+    prompt: Audit last night's access logs and flag any out-of-policy connector calls for review.`,
     },
     {
       type: 'p',

--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -54,7 +54,7 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
   const { Client } = await import("pg");
   const client = new Client({
     connectionString: conn,
-    ssl: local ? false : { rejectUnauthorized: false },
+    ssl: local ? false : true,
   });
   await client.connect();
   try {

--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -3,8 +3,8 @@
  * domain, so reclaiming those users (+ their cascade) is the primary leak guard.
  * Runs by email-domain prefix + age so it never touches an in-flight run.
  *
- * Uses the Supabase admin API (service-role). A DB/Daytona fallback for orphaned
- * sandboxes can be layered on later via KE2E_DATABASE_URL.
+ * Uses the direct database when available so cleanup selects only test users.
+ * Falls back to the paginated Supabase admin API when direct access is absent.
  */
 import { Client } from "../core/client";
 import { mapWithConcurrency } from "../core/concurrency";
@@ -52,7 +52,10 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
   const conn = env.databaseUrl!;
   const local = conn.includes("localhost") || conn.includes("127.0.0.1");
   const { Client } = await import("pg");
-  const client = new Client({ connectionString: conn, ssl: local ? false : true });
+  const client = new Client({
+    connectionString: conn,
+    ssl: local ? false : { rejectUnauthorized: false },
+  });
   await client.connect();
   try {
     const r = await client.query(
@@ -70,14 +73,8 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
 }
 
 async function listTestUsers(env: Env): Promise<SupaUser[]> {
-  let users: SupaUser[];
-  try {
-    users = await listTestUsersViaApi(env);
-  } catch (err) {
-    if (!env.databaseUrl) throw err;
-    log.warn(`admin list failed (${String((err as Error).message).slice(0, 90)}) — falling back to read-only DB query`);
-    users = await listTestUsersViaDb(env);
-  }
+  if (env.databaseUrl) return listTestUsersViaDb(env);
+  const users = await listTestUsersViaApi(env);
   return users.filter((u) => (u.email ?? "").endsWith(`@${env.testEmailDomain}`));
 }
 

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -168,6 +168,6 @@ describe('managed Git fixture selection', () => {
     expect(workflow).toContain('KE2E_GC_WORKERS: 8');
     expect(gc).toContain('mapWithConcurrency(stale, workers');
     expect(gc).toContain('if (env.databaseUrl) return listTestUsersViaDb(env)');
-    expect(gc).toContain("ssl: local ? false : { rejectUnauthorized: false }");
+    expect(gc).toContain('ssl: local ? false : true');
   });
 });

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -167,5 +167,7 @@ describe('managed Git fixture selection', () => {
     expect(workflow).toContain('timeout-minutes: 5');
     expect(workflow).toContain('KE2E_GC_WORKERS: 8');
     expect(gc).toContain('mapWithConcurrency(stale, workers');
+    expect(gc).toContain('if (env.databaseUrl) return listTestUsersViaDb(env)');
+    expect(gc).toContain("ssl: local ? false : { rejectUnauthorized: false }");
   });
 });


### PR DESCRIPTION
Promotes current `main` to `staging`.

Candidate SHA: `e4934dae575a1b6b9140637cf5dbf5537c3ad319`

Includes the database-first staging E2E cleanup optimization.

Production is unchanged.