### PR TITLE
fix(ke2e): require strict TLS for GC database

### DIFF
--- a/tests/src/fixtures/gc.ts
+++ b/tests/src/fixtures/gc.ts
@@ -54,7 +54,7 @@ async function listTestUsersViaDb(env: Env): Promise<SupaUser[]> {
   const { Client } = await import("pg");
   const client = new Client({
     connectionString: conn,
-    ssl: local ? false : { rejectUnauthorized: false },
+    ssl: local ? false : true,
   });
   await client.connect();
   try {

--- a/tests/unit/database-project-fixture.test.ts
+++ b/tests/unit/database-project-fixture.test.ts
@@ -168,6 +168,6 @@ describe('managed Git fixture selection', () => {
     expect(workflow).toContain('KE2E_GC_WORKERS: 8');
     expect(gc).toContain('mapWithConcurrency(stale, workers');
     expect(gc).toContain('if (env.databaseUrl) return listTestUsersViaDb(env)');
-    expect(gc).toContain("ssl: local ? false : { rejectUnauthorized: false }");
+    expect(gc).toContain('ssl: local ? false : true');
   });
 });


### PR DESCRIPTION
## Summary
- require CA-validated TLS for remote PostgreSQL GC connections
- retain plaintext connections only for local database URLs
- update the focused workflow assertion

## Verification
- `cd tests && bun test unit/database-project-fixture.test.ts`
- 7 passed, 0 failed
- `git diff --check`