### PR TITLE
fix(kaab): two critical regressions in my own isolation work

### DIFF
--- a/apps/api/src/projects/lib/approval-authority.test.ts
+++ b/apps/api/src/projects/lib/approval-authority.test.ts
@@ -168,3 +168,47 @@ describe('a service-account bearer may still resolve — deliberately', () => {
     ).toBe(false);
   });
 });
+
+describe('the browser human (regression: the Supabase sessionId collision)', () => {
+  test('a manager whose caller session is null CAN resolve — this is the dashboard', () => {
+    // `supabaseAuth` sets c.get('sessionId') to the SUPABASE AUTH session, and
+    // threading that raw value in as callerSessionId made this branch
+    // unreachable: every logged-in human tripped the session-bound refusal
+    // above and got 403 "An agent cannot resolve its own approval" on every
+    // approval, forever. callerKortixSessionId() is what keeps it null here.
+    const result = mayResolveApproval({
+      isManager: true,
+      targetSessionOrigin: 'backend',
+      targetSessionCreatedBy: WRAPPER,
+      callerUserId: HUMAN,
+      callerSessionId: null,
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  test('a browser human still sees a session’s approvals when unbound', () => {
+    // Same collision: comparing a Supabase auth-session UUID to a Kortix session
+    // id made needs-input return 0 for every browser caller.
+    expect(
+      maySeeSessionApprovals({
+        isManager: true,
+        callerSessionId: null,
+        targetSessionId: 'sess-xyz',
+        targetSessionOrigin: 'backend',
+      }),
+    ).toBe(true);
+  });
+
+  test('but a genuinely session-bound caller is STILL refused', () => {
+    // The fix must not weaken the guard it was protecting.
+    expect(
+      mayResolveApproval({
+        isManager: true,
+        targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
+        callerUserId: WRAPPER,
+        callerSessionId: 'sess-real-kortix-session',
+      }).allowed,
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/projects/lib/approval-authority.test.ts
+++ b/apps/api/src/projects/lib/approval-authority.test.ts
@@ -193,8 +193,10 @@ describe('the browser human (regression: the Supabase sessionId collision)', () 
       maySeeSessionApprovals({
         isManager: true,
         callerSessionId: null,
+        callerUserId: HUMAN,
         targetSessionId: 'sess-xyz',
         targetSessionOrigin: 'backend',
+        targetSessionCreatedBy: WRAPPER,
       }),
     ).toBe(true);
   });

--- a/apps/api/src/projects/lib/caller-session.test.ts
+++ b/apps/api/src/projects/lib/caller-session.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import type { Context } from 'hono';
+
+import { callerKortixSessionId } from './caller-session';
+
+/** Minimal stand-in for the two context vars this reads. */
+const ctx = (authType?: string, sessionId?: string) =>
+  ({
+    get: (key: string) => (key === 'authType' ? authType : key === 'sessionId' ? sessionId : undefined),
+  }) as unknown as Context;
+
+describe('callerKortixSessionId', () => {
+  test('a browser Supabase JWT is NOT session-bound, whatever sessionId holds', () => {
+    // THE BUG. supabaseAuth sets sessionId to the SUPABASE AUTH session so the
+    // per-account gate can do idle/force-logout. Treating it as a Kortix session
+    // made every isolation guard classify a logged-in human as an agent:
+    // approvals 403'd, the needs-input badge read 0, and a KaaB operator could
+    // not see their own backend sessions in the dashboard.
+    expect(callerKortixSessionId(ctx('supabase', 'e2b1d6a0-supabase-auth-session'))).toBeNull();
+  });
+
+  test('a sandbox PAT keeps its real Kortix session id — the guards depend on it', () => {
+    // If this returned null, the cross-end-user isolation guard would stop
+    // firing and one end-user's sandbox could reach another's session again.
+    expect(callerKortixSessionId(ctx('pat', 'sess-123'))).toBe('sess-123');
+  });
+
+  test('a PAT with no session id is not session-bound', () => {
+    expect(callerKortixSessionId(ctx('pat', undefined))).toBeNull();
+  });
+
+  test('an api key / service account passes its session id through when present', () => {
+    expect(callerKortixSessionId(ctx('apiKey', 'sess-abc'))).toBe('sess-abc');
+    expect(callerKortixSessionId(ctx('service_account', undefined))).toBeNull();
+  });
+
+  test('an unknown future token kind is NOT silently unbound', () => {
+    // Excluding only 'supabase' (rather than allow-listing 'pat') means a new
+    // session-minting token kind keeps narrowing by default. Failing open here
+    // would quietly re-open cross-end-user access.
+    expect(callerKortixSessionId(ctx('some_future_kind', 'sess-xyz'))).toBe('sess-xyz');
+  });
+
+  test('no authType at all still yields null when there is no session id', () => {
+    expect(callerKortixSessionId(ctx(undefined, undefined))).toBeNull();
+  });
+});

--- a/apps/api/src/projects/lib/caller-session.ts
+++ b/apps/api/src/projects/lib/caller-session.ts
@@ -1,0 +1,45 @@
+import type { Context } from 'hono';
+
+/**
+ * The caller's KORTIX session id — or null when the caller is not session-bound.
+ *
+ * `c.get('sessionId')` is overloaded, and the two meanings are not
+ * interchangeable:
+ *
+ *   - `authType: 'pat'`      → a Kortix PROJECT SESSION id (a sandbox executor
+ *                              token; `middleware/auth.ts` sets it from the
+ *                              validated token row).
+ *   - `authType: 'supabase'` → the SUPABASE AUTH SESSION id, i.e. "which browser
+ *                              login is this", set purely so the per-account
+ *                              session gate can do idle/lifetime/force-logout.
+ *
+ * Reading the raw context var and calling it a Kortix session is a live bug, not
+ * a theoretical one. Every KaaB isolation guard treats a NON-NULL caller session
+ * as "a sandbox acting for one end-user, narrow it" — so handing it a browser's
+ * Supabase auth session made the platform treat every logged-in human as an
+ * agent:
+ *
+ *   - `mayResolveApproval` refuses a session-bound caller BEFORE the manager
+ *     check, so no human could resolve any approval from the dashboard — 403
+ *     "An agent cannot resolve its own approval" on every click.
+ *   - `maySeeSessionApprovals` compares it to the target session id, so the
+ *     needs-input count was 0 for every browser caller and the badge never lit.
+ *   - `isSessionVisibleTo` refuses a session-bound caller reaching a sibling
+ *     BACKEND session, so a KaaB operator could not see their own backend
+ *     sessions in the dashboard at all.
+ *
+ * The codebase already knew about this collision — `db-deps.ts`'s
+ * `projectSessionIdForProjectPrincipal` exists solely to keep the Supabase value
+ * out of connector-profile resolution, with the same reasoning. This is that
+ * guard, generalised, so the next caller cannot get it wrong by reaching for the
+ * obvious context var.
+ */
+export function callerKortixSessionId(c: Context): string | null {
+  // Anything that is not a Supabase browser JWT carries a real Kortix session id
+  // when it carries one at all. Allow-listing 'supabase' as the ONLY excluded
+  // kind (rather than allow-listing 'pat') keeps a future token kind that mints
+  // session-bound credentials working by default — the isolation guards are the
+  // things that must not be weakened, and they read this as "narrow me".
+  if (c.get('authType') === 'supabase') return null;
+  return c.get('sessionId') ?? null;
+}

--- a/apps/api/src/projects/lib/session-token-grant.test.ts
+++ b/apps/api/src/projects/lib/session-token-grant.test.ts
@@ -55,3 +55,34 @@ describe('remintDecisionFor', () => {
     ).toEqual({ action: 'skip' });
   });
 });
+
+describe('remintDecisionFor — the REVERT case (regression)', () => {
+  const grantFor = (agent: string, extra: Partial<AgentGrant> = {}): AgentGrant => ({
+    agent,
+    kortixCli: 'all',
+    connectors: 'all',
+    env: 'all',
+    ...extra,
+  });
+
+  test('switching BACK to the narrow agent must re-narrow the token', () => {
+    // The escalation this closes: create with `support` (connectors: [zendesk]),
+    // switch once to `ops` (connectors: all) — which correctly re-mints to ops —
+    // then switch back. The first version skipped whenever the requested agent
+    // equalled `project_sessions.agent_name`, which NEVER changes, so the token
+    // kept ops' grant while support ran. Every later call from that box passed
+    // agentMayUseConnector unconditionally.
+    const storedOps = grantFor('ops');
+    const runningSupport = grantFor('support', { connectors: ['zendesk'], kortixCli: [] });
+    expect(remintDecisionFor(storedOps, runningSupport)).toEqual({
+      action: 'write',
+      grant: runningSupport,
+    });
+  });
+
+  test('the grant carries WHICH agent it represents — that is what makes revert detectable', () => {
+    // agent_name is the create-time agent; the stored grant's own `agent` field
+    // is the only record of where the token currently points.
+    expect(grantFor('ops').agent).toBe('ops');
+  });
+});

--- a/apps/api/src/projects/lib/session-token-grant.ts
+++ b/apps/api/src/projects/lib/session-token-grant.ts
@@ -132,6 +132,14 @@ export function remintDecisionFor(
  * Throws `SessionGrantRemintError` if the grant cannot be resolved or written;
  * the caller must fail the prompt rather than run the new agent under the old
  * agent's grant.
+ *
+ * KNOWN LIMIT — concurrent prompts. Two prompts naming different agents on the
+ * SAME session race: both resolve, both write, last writer wins, and the loser's
+ * agent then runs under the winner's grant for the rest of that turn. The token
+ * is one row shared by one box, so this cannot be fixed by locking here — it
+ * needs either a per-turn credential or a serialised prompt path. Documented
+ * rather than papered over; the single-prompt path (every ordinary session) is
+ * correct.
  */
 export async function remintGrantForAgentSwitch(input: {
   projectId: string;
@@ -142,12 +150,45 @@ export async function remintGrantForAgentSwitch(input: {
   requestedAgent: string | null;
 }): Promise<RemintDecision> {
   const requested = input.requestedAgent?.trim();
-  if (!requested || requested === DEFAULT_AGENT_SENTINEL || requested === input.sessionAgent) {
-    return { action: 'skip' };
+  // The agent that will ACTUALLY run. `project_sessions.agent_name` is the
+  // create-time agent and nothing ever updates it, so it is the fallback, not
+  // the reference point.
+  const runningAgent =
+    requested && requested !== DEFAULT_AGENT_SENTINEL ? requested : input.sessionAgent;
+
+  let stored: AgentGrant | null;
+  try {
+    const [token] = await db
+      .select({ agentGrant: accountTokens.agentGrant })
+      .from(accountTokens)
+      .where(
+        and(
+          eq(accountTokens.sessionId, input.sessionId),
+          eq(accountTokens.status, 'active'),
+          isNull(accountTokens.revokedAt),
+        ),
+      )
+      .limit(1);
+    stored = token?.agentGrant ?? null;
+  } catch (err) {
+    throw new SessionGrantRemintError(input.sessionId, err);
   }
 
+  // Skip — and pay NO manifest read — only when the token already represents the
+  // agent about to run.
+  //
+  // The earlier version skipped whenever `requested === sessionAgent`, which was
+  // wrong the moment a re-mint had happened: switch to a broader agent once, then
+  // switch back (or simply omit `agent`), and the token kept the BROADER grant
+  // while the narrower agent ran. `agent_name` never changes, so it could not
+  // detect that the token had moved. The grant's own `agent` field can.
+  if (stored?.agent === runningAgent) return { action: 'skip' };
+  // A null stored grant means the project declares no per-agent governance, so
+  // boot minted null too. Nothing to revert unless a concrete DIFFERENT agent is
+  // named — which is the only case worth a manifest read.
+  if (stored === null && runningAgent === input.sessionAgent) return { action: 'skip' };
+
   let running: AgentGrant | null;
-  let stored: AgentGrant | null;
   try {
     const [project] = await db
       .select({
@@ -165,22 +206,9 @@ export async function remintGrantForAgentSwitch(input: {
       defaultBranch: project?.defaultBranch,
       manifestPath: project?.manifestPath,
       sessionAgent: input.sessionAgent,
-      requestedAgent: requested,
+      requestedAgent: runningAgent,
       enforceGrantLock: config.KORTIX_ENFORCE_AGENT_SECRET_GRANT_LOCK,
     });
-
-    const [token] = await db
-      .select({ agentGrant: accountTokens.agentGrant })
-      .from(accountTokens)
-      .where(
-        and(
-          eq(accountTokens.sessionId, input.sessionId),
-          eq(accountTokens.status, 'active'),
-          isNull(accountTokens.revokedAt),
-        ),
-      )
-      .limit(1);
-    stored = token?.agentGrant ?? null;
   } catch (err) {
     // A secret-boundary refusal is the env sync's error to report, not ours —
     // rethrow it unchanged so the proxy still answers 409, not 503.

--- a/apps/api/src/projects/routes/r7.ts
+++ b/apps/api/src/projects/routes/r7.ts
@@ -56,6 +56,7 @@ import {
 } from '../session-lifecycle';
 import { requireEntitlement } from '../../accounts/iam/helpers';
 import { accountHasEntitlement } from '../../billing/services/entitlements';
+import { callerKortixSessionId } from '../lib/caller-session';
 import { resolveEndUserRef } from '../lib/end-user-ref';
 import { selectSessionRowsForViewer, type ProjectSessionListScope } from '../lib/session-inventory';
 
@@ -758,7 +759,7 @@ projectsApp.openapi(
     subject,
     grantsBySession,
     runtimeStatusBySession,
-    callerSessionId: c.get('sessionId') ?? null,
+    callerSessionId: callerKortixSessionId(c),
   });
   if (!selected.authorized) {
     return c.json({ error: 'Project manager access is required to list every session' }, 403);
@@ -1258,7 +1259,7 @@ projectsApp.openapi(
           targetSessionOrigin: s.origin ?? null,
           targetSessionCreatedBy: s.createdBy,
           callerUserId: loaded.userId,
-          callerSessionId: c.get('sessionId') ?? null,
+          callerSessionId: callerKortixSessionId(c),
         })
       ) {
         continue;
@@ -1373,7 +1374,7 @@ projectsApp.openapi(
       targetSessionOrigin: targetOrigin,
       targetSessionCreatedBy: targetCreatedBy,
       callerUserId: loaded.userId,
-      callerSessionId: c.get('sessionId') ?? null,
+      callerSessionId: callerKortixSessionId(c),
     });
     if (!verdict.allowed) {
       return c.json(

--- a/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
+++ b/apps/api/src/sandbox-proxy/routes/forward-prompt-dedupe.test.ts
@@ -36,6 +36,16 @@ mock.module('../../shared/preview-ownership', () => ({
 mock.module('../../projects/lib/sandbox-env-sync', () => ({
   syncSandboxEnvForPrompt: async () => {},
 }));
+// Same reason as the env sync above: the pre-prompt grant re-mint reads the
+// session's token row, and this file is about DELIVERY dedupe, not grants. It
+// is deliberately NOT a no-op stub of convenience — the real function fails the
+// prompt CLOSED when it cannot read the token (a prompt must never run under an
+// unverified grant), so an unmocked db here turns every delivery test red for a
+// reason that has nothing to do with delivery.
+mock.module('../../projects/lib/session-token-grant', () => ({
+  remintGrantForAgentSwitch: async () => ({ action: 'skip' }),
+  SessionGrantRemintError: class SessionGrantRemintError extends Error {},
+}));
 mock.module('../../projects/opencode-title-capture', () => ({
   scheduleTitleCaptureAfterPrompt: () => {},
   captureTitleAfterRuntimeEvent: async () => {},


### PR DESCRIPTION
Both found by the 240-agent KaaB audit. Both are defects **I introduced** in earlier PRs this session, and neither was caught by the tests I wrote at the time.

---

## 1. A Supabase auth session was being treated as a Kortix session

`c.get('sessionId')` is overloaded and the two meanings are not interchangeable:

- `authType: 'pat'` → a Kortix **project session** id (a sandbox executor token)
- `authType: 'supabase'` → the **Supabase auth session** id — "which browser login is this" — set only so the per-account gate can do idle / force-logout

I threaded the raw context var in as `callerSessionId` at three sites in `r7.ts`. Every KaaB isolation guard reads a non-null caller session as *"a sandbox acting for one end-user — narrow it"*. So the platform classified **every logged-in human as an agent**:

- `mayResolveApproval` refuses a session-bound caller **before** the manager check → no human could resolve any approval from the dashboard. 403 *"An agent cannot resolve its own approval"* on every click, forever.
- `maySeeSessionApprovals` compares it to the target session id → needs-input returned `0` for every browser caller and the badge never lit.
- `isSessionVisibleTo` refuses a session-bound caller reaching a sibling **backend** session → a KaaB operator could not see their own backend sessions in the dashboard at all.

**The codebase already knew about this collision.** `db-deps.ts`'s `projectSessionIdForProjectPrincipal` exists solely to keep the Supabase value out of connector-profile resolution, with a comment saying exactly why. I reached for the obvious context var and didn't check.

Fixed with `callerKortixSessionId(c)` — that guard generalised, so the next caller can't get it wrong the same way. It excludes **only** `'supabase'` rather than allow-listing `'pat'`, so a future session-minting token kind keeps narrowing by default; failing open there would quietly re-open cross-end-user access.

**Why my own verification missed it:** I tested the live filter against dev with a **PAT**. The browser path was never exercised. A PAT has no `session_id`, so `callerSessionId` was null and every guard took the correct branch.

## 2. The agent-switch re-mint was one-way

From #5698. `remintGrantForAgentSwitch` skipped whenever the requested agent equalled `project_sessions.agent_name` — but that column records the **create-time** agent and *nothing ever updates it*. So:

```
create with `support` (connectors: [zendesk])
turn 1: {"agent":"ops"}      → re-mints to ops (connectors: all)   ✅
turn 2: {"agent":"support"}  → requested === agent_name → SKIP     ❌
        OpenCode runs support; the token still holds ops' grant.
```

Every later call from that box passed `agentMayUseConnector` / `agentMayPerform` unconditionally. A narrow agent permanently inherited a broad one's authority after a single switch — a privilege escalation in the very PR that was meant to close one.

Fixed by comparing against the **stored grant's own `agent` field**, which is the only record of where the token currently points. `agent_name` can't detect that the token has moved; the grant can.

The ordinary turn still pays no manifest read — it now costs one indexed `SELECT` on `session_id` to learn where the token points, and short-circuits when that already matches the running agent.

### Known limit, documented rather than papered over

Two concurrent prompts naming different agents on the same session still race: both resolve, both write, last writer wins. The token is one row shared by one box, so it can't be fixed by locking here — it needs a per-turn credential or a serialised prompt path. It's now stated in the function's doc comment.

---

## A test I had to fix, and why it wasn't just silenced

The re-mint now reads the token on every prompt, which turned `forward-prompt-dedupe.test.ts` red — it mocks `sandbox-env-sync` (the other DB-touching pre-prompt step) but not the grant module, so the real function hit an unmocked `db` and **failed the prompt closed**.

That fail-closed behaviour is correct and matches `SecretGrantResolutionError`: a prompt must never run under a grant we couldn't verify. So the fix is the mock, not the behaviour — and the mock carries a comment saying so, because "stub it to make the red go away" is exactly how that guarantee would get deleted later.

## Verification

- 6 tests for `callerKortixSessionId`, including that a real sandbox PAT **still** narrows (a fix that unbound everything would silently re-open the hole it was protecting).
- 3 tests for the browser-human approval path, plus one asserting a genuinely session-bound caller is **still** refused.
- 2 tests for the revert case.
- Full `apps/api` suite: **24 failures, zero new.**