### PR TITLE
fix(ke2e): preserve claimed warm-session metadata

### DIFF
--- a/apps/api/src/projects/lib/session-metadata-merge.test.ts
+++ b/apps/api/src/projects/lib/session-metadata-merge.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { projectSessionMetadataMerge } from './session-metadata-merge';
+
+describe('project session metadata merge', () => {
+  test('merges telemetry into the current database value', () => {
+    const query = new PgDialect().sqlToQuery(
+      projectSessionMetadataMerge({
+        session_start_timeline: { totalMs: 42 },
+      }),
+    );
+
+    expect(query.sql).toContain('"project_sessions"."metadata"');
+    expect(query.sql).toContain('coalesce(');
+    expect(query.sql).toContain('||');
+    expect(query.params).toEqual([
+      JSON.stringify({
+        session_start_timeline: { totalMs: 42 },
+      }),
+    ]);
+  });
+});

--- a/apps/api/src/projects/lib/session-metadata-merge.ts
+++ b/apps/api/src/projects/lib/session-metadata-merge.ts
@@ -1,0 +1,13 @@
+import { projectSessions } from '@kortix/db';
+import { type SQL, sql } from 'drizzle-orm';
+
+/**
+ * Merge top-level session metadata in the UPDATE statement.
+ *
+ * The expression reads the current row value after PostgreSQL acquires the row
+ * lock. A detached telemetry writer cannot overwrite a concurrent warm-session
+ * claim with metadata that it read before the claim.
+ */
+export function projectSessionMetadataMerge(patch: Record<string, unknown>): SQL {
+  return sql`coalesce(${projectSessions.metadata}, '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb`;
+}

--- a/apps/api/src/projects/lib/session-runtime-allocator.ts
+++ b/apps/api/src/projects/lib/session-runtime-allocator.ts
@@ -1,15 +1,16 @@
 import { eq } from 'drizzle-orm';
 
 import { projectSessions } from '@kortix/db';
+import type { SandboxProviderName } from '../../config';
 import { logger } from '../../lib/logger';
 import { ProvisionTimeline } from '../../platform/services/provision-timeline';
 import { provisionSessionSandbox } from '../../platform/services/session-sandbox';
 import { db } from '../../shared/db';
-import type { SandboxProviderName } from '../../config';
-import type { ProjectRow } from './serializers';
-import { RuntimeIdentityConflictError } from '../runtime-identity-error';
-import { mergeSessionSandboxEnv } from './session-runtime-context';
 import type { GitBackedProject } from '../git';
+import { RuntimeIdentityConflictError } from '../runtime-identity-error';
+import type { ProjectRow } from './serializers';
+import { projectSessionMetadataMerge } from './session-metadata-merge';
+import { mergeSessionSandboxEnv } from './session-runtime-context';
 
 type RuntimeProject = Pick<ProjectRow, 'repoUrl' | 'defaultBranch' | 'manifestPath' | 'metadata'>;
 
@@ -125,19 +126,10 @@ async function mergeSessionMetadata(
   sessionId: string,
   extra: Record<string, unknown>,
 ): Promise<void> {
-  const [current] = await db
-    .select({ metadata: projectSessions.metadata })
-    .from(projectSessions)
-    .where(eq(projectSessions.sessionId, sessionId))
-    .limit(1);
-  const currentMetadata =
-    current?.metadata && typeof current.metadata === 'object'
-      ? (current.metadata as Record<string, unknown>)
-      : {};
   await db
     .update(projectSessions)
     .set({
-      metadata: { ...currentMetadata, ...extra },
+      metadata: projectSessionMetadataMerge(extra),
       updatedAt: new Date(),
     })
     .where(eq(projectSessions.sessionId, sessionId));

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -77,6 +77,7 @@ import {
 import { canOverride, resolveSessionOrigin } from './session-origin';
 import { resolveEndUserRef } from './end-user-ref';
 import { resolveSessionSandboxSlug } from './session-sandbox-metadata';
+import { projectSessionMetadataMerge } from './session-metadata-merge';
 import {
   buildSessionRuntimeContextEnv,
   mergeSessionSandboxEnv,
@@ -1309,19 +1310,10 @@ export async function createProjectSession(input: {
       });
 
       const mergeSessionMetadata = async (extra: Record<string, unknown>) => {
-        const [current] = await db
-          .select({ metadata: projectSessions.metadata })
-          .from(projectSessions)
-          .where(eq(projectSessions.sessionId, sessionId))
-          .limit(1);
-        const currentMetadata =
-          current?.metadata && typeof current.metadata === 'object'
-            ? (current.metadata as Record<string, unknown>)
-            : {};
         await db
           .update(projectSessions)
           .set({
-            metadata: { ...currentMetadata, ...extra },
+            metadata: projectSessionMetadataMerge(extra),
             updatedAt: new Date(),
           })
           .where(eq(projectSessions.sessionId, sessionId));

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -359,18 +359,18 @@ flow(
     });
 
     await ctx.step(
-      'a project EDITOR who did not create the session cannot list shares → 403',
+      'a project EDITOR who did not create the session cannot list shares → 404',
       async () => {
         const r = await ctx.client
           .as(editor)
           .get('/v1/projects/:projectId/sessions/:sessionId/public-shares', {
             params: { projectId: p.id, sessionId },
           });
-        r.status(403);
+        r.status(404);
       },
     );
     await ctx.step(
-      "a project EDITOR cannot create a share on someone else's session → 403",
+      "a project EDITOR cannot create a share on someone else's session → 404",
       async () => {
         const r = await ctx.client
           .as(editor)
@@ -379,16 +379,16 @@ flow(
             { preview: { port: 3000 } },
             { params: { projectId: p.id, sessionId } },
           );
-        r.status(403);
+        r.status(404);
       },
     );
-    await ctx.step("a project EDITOR cannot revoke someone else's share → 403", async () => {
+    await ctx.step("a project EDITOR cannot revoke someone else's share → 404", async () => {
       const r = await ctx.client
         .as(editor)
         .del('/v1/projects/:projectId/sessions/:sessionId/public-shares/:shareId', {
           params: { projectId: p.id, sessionId, shareId },
         });
-      r.status(403);
+      r.status(404);
     });
 
     await ctx.step(


### PR DESCRIPTION
## Failure evidence

Release gate `30355456801` failed `SESS-18`. The first warm-session claim returned `200`. Detached session-start telemetry then restored stale `warm_session.state=available`. A second claim returned `200`; the contract requires `409 WARM_SESSION_ALREADY_CLAIMED`.

The same gate failed `SESS-14` because the flow expected `403`. Current KaaB isolation intentionally hides inaccessible sessions with `404`.

## Changes

- Merge session telemetry into the current `project_sessions.metadata` value inside the SQL update.
- Apply the atomic merge to both session runtime allocation paths.
- Update all three `SESS-14` public-share assertions to the current `404` contract.

## Verification

- `bun test apps/api/src/projects/lib/session-metadata-merge.test.ts apps/api/src/projects/lib/warm-sessions.test.ts` -> `7 pass, 0 fail`.
- `pnpm --filter kortix-api typecheck` -> exit `0`.
- `bun run test:unit -- --run unit/release-gate-resilience.test.ts` in `tests/` -> `12 pass, 0 fail`.
- `pnpm exec biome check apps/api/src/projects/lib/session-metadata-merge.ts apps/api/src/projects/lib/session-metadata-merge.test.ts apps/api/src/projects/lib/session-runtime-allocator.ts` -> clean.

## Live proof after merge

Run `SESS-14,SESS-18` against deployed dev. Then promote the merged SHA to staging and rerun the full release gate.