### PR TITLE
fix(api): preserve public-share permission status

### DIFF
--- a/apps/api/src/__tests__/unit-executor-share.test.ts
+++ b/apps/api/src/__tests__/unit-executor-share.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   intentToScope,
   isSecretUsableBy,
+  isSessionTargetVisibleToCaller,
   isSessionVisibleTo,
   parseSharingIntent,
   scopeToIntent,
@@ -249,5 +250,25 @@ describe('KaaB: sharing is not exempt from the isolation narrowing', () => {
         callerSessionId: 'session-a',
       }),
     ).toBe(true);
+  });
+
+  test('a human project member reaches the sharing permission check', () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        origin: 'user',
+        sessionId: 'private-session',
+        callerSessionId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("a session-bound backend credential cannot target another end-user's session", () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        origin: 'backend',
+        sessionId: 'session-of-end-user-b',
+        callerSessionId: 'session-of-end-user-a',
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/executor/share.ts
+++ b/apps/api/src/executor/share.ts
@@ -153,6 +153,20 @@ export interface SessionOwnershipContext {
   callerSessionId: string | null;
 }
 
+/**
+ * A session-bound sandbox credential may access only its own backend session.
+ *
+ * Human credentials and wrapper backend credentials have no session binding.
+ * Interactive sessions keep their human ownership semantics.
+ */
+export function isSessionTargetVisibleToCaller(ownership: SessionOwnershipContext): boolean {
+  return !(
+    ownership.origin === 'backend' &&
+    ownership.callerSessionId != null &&
+    ownership.callerSessionId !== ownership.sessionId
+  );
+}
+
 /** Pure: can this subject see/open the session? The owner always can. */
 export function isSessionVisibleTo(
   visibility: SessionVisibility,
@@ -165,11 +179,7 @@ export function isSessionVisibleTo(
   // session just because the wrapper credential created them both. Interactive
   // sessions are deliberately excluded: there created_by really is one person,
   // and narrowing would break `kortix sessions ls` from inside a normal sandbox.
-  const sharedCreatorIsMeaningless =
-    ownership.origin === 'backend' &&
-    ownership.callerSessionId != null &&
-    ownership.callerSessionId !== ownership.sessionId;
-  if (sharedCreatorIsMeaningless) return false;
+  if (!isSessionTargetVisibleToCaller(ownership)) return false;
 
   if (ownerId && ownerId === subject.userId) return true;
   if (visibility === 'project') return true;

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -1,4 +1,11 @@
-import { isSessionVisibleTo, loadSessionGrants, resolveShareSubject, type SecretGrant, type ShareSubject } from '../../executor/share';
+import {
+  isSessionTargetVisibleToCaller,
+  isSessionVisibleTo,
+  loadSessionGrants,
+  resolveShareSubject,
+  type SecretGrant,
+  type ShareSubject,
+} from '../../executor/share';
 import { authorize, assertAuthorized } from '../../iam';
 import { deriveRequestContext } from '../../iam/cache';
 import { invalidateIamCacheForUser, registerPrincipalScopedMemo } from '../../iam/cache-invalidation';
@@ -156,15 +163,14 @@ export async function loadSessionForSharing(
 } | null> {
   const row = await loadProjectSessionRow(loaded, sessionId);
   if (!row) return null;
-  // Same narrowing as the read path. In Kortix-as-a-Backend every session
-  // shares one `created_by`, so the ownership test below is meaningless across
-  // end-users and would hand A full sharing rights over B's session.
-  if (
-    !isSessionVisibleTo(row.visibility as 'private' | 'project' | 'restricted', row.createdBy, [], {
-      userId: loaded.userId,
-      groupIds: [],
-    }, { origin: row.origin ?? null, sessionId, callerSessionId })
-  ) {
+  // Apply only the session-bound KaaB narrowing here. Human project members
+  // must reach the sharing permission check and receive 403 when it rejects
+  // them. Session-content visibility does not govern share management.
+  if (!isSessionTargetVisibleToCaller({
+    origin: row.origin ?? null,
+    sessionId,
+    callerSessionId,
+  })) {
     return null;
   }
   const isOwner = row.createdBy === loaded.userId;

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -359,18 +359,18 @@ flow(
     });
 
     await ctx.step(
-      'a project EDITOR who did not create the session cannot list shares → 404',
+      'a project EDITOR who did not create the session cannot list shares → 403',
       async () => {
         const r = await ctx.client
           .as(editor)
           .get('/v1/projects/:projectId/sessions/:sessionId/public-shares', {
             params: { projectId: p.id, sessionId },
           });
-        r.status(404);
+        r.status(403);
       },
     );
     await ctx.step(
-      "a project EDITOR cannot create a share on someone else's session → 404",
+      "a project EDITOR cannot create a share on someone else's session → 403",
       async () => {
         const r = await ctx.client
           .as(editor)
@@ -379,16 +379,16 @@ flow(
             { preview: { port: 3000 } },
             { params: { projectId: p.id, sessionId } },
           );
-        r.status(404);
+        r.status(403);
       },
     );
-    await ctx.step("a project EDITOR cannot revoke someone else's share → 404", async () => {
+    await ctx.step("a project EDITOR cannot revoke someone else's share → 403", async () => {
       const r = await ctx.client
         .as(editor)
         .del('/v1/projects/:projectId/sessions/:sessionId/public-shares/:shareId', {
           params: { projectId: p.id, sessionId, shareId },
         });
-      r.status(404);
+      r.status(403);
     });
 
     await ctx.step(


### PR DESCRIPTION
## Summary

- return `403` for human project editors who cannot manage another session shares
- retain `404` isolation for session-bound KaaB credentials targeting a sibling backend session
- restore `SESS-14` assertions to the documented contract

## Verification

- `KORTIX_URL=http://localhost:8008 dotenvx run -- bun test --isolate src/__tests__/unit-executor-share.test.ts src/projects/lib/session-metadata-merge.test.ts` — 28 passed, 0 failed
- `pnpm --filter kortix-api typecheck` — passed
- `cd tests && bun bin/ke2e.ts coverage` — 497/507 routes, 10 allowlisted, 0 uncovered