### PR TITLE
chore(release): promote current main to staging

### DIFF
--- a/apps/api/src/__tests__/unit-executor-share.test.ts
+++ b/apps/api/src/__tests__/unit-executor-share.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   intentToScope,
   isSecretUsableBy,
+  isSessionTargetVisibleToCaller,
   isSessionVisibleTo,
   parseSharingIntent,
   scopeToIntent,
@@ -249,5 +250,25 @@ describe('KaaB: sharing is not exempt from the isolation narrowing', () => {
         callerSessionId: 'session-a',
       }),
     ).toBe(true);
+  });
+
+  test('a human project member reaches the sharing permission check', () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        origin: 'user',
+        sessionId: 'private-session',
+        callerSessionId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("a session-bound backend credential cannot target another end-user's session", () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        origin: 'backend',
+        sessionId: 'session-of-end-user-b',
+        callerSessionId: 'session-of-end-user-a',
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/executor/share.ts
+++ b/apps/api/src/executor/share.ts
@@ -153,6 +153,20 @@ export interface SessionOwnershipContext {
   callerSessionId: string | null;
 }
 
+/**
+ * A session-bound sandbox credential may access only its own backend session.
+ *
+ * Human credentials and wrapper backend credentials have no session binding.
+ * Interactive sessions keep their human ownership semantics.
+ */
+export function isSessionTargetVisibleToCaller(ownership: SessionOwnershipContext): boolean {
+  return !(
+    ownership.origin === 'backend' &&
+    ownership.callerSessionId != null &&
+    ownership.callerSessionId !== ownership.sessionId
+  );
+}
+
 /** Pure: can this subject see/open the session? The owner always can. */
 export function isSessionVisibleTo(
   visibility: SessionVisibility,
@@ -165,11 +179,7 @@ export function isSessionVisibleTo(
   // session just because the wrapper credential created them both. Interactive
   // sessions are deliberately excluded: there created_by really is one person,
   // and narrowing would break `kortix sessions ls` from inside a normal sandbox.
-  const sharedCreatorIsMeaningless =
-    ownership.origin === 'backend' &&
-    ownership.callerSessionId != null &&
-    ownership.callerSessionId !== ownership.sessionId;
-  if (sharedCreatorIsMeaningless) return false;
+  if (!isSessionTargetVisibleToCaller(ownership)) return false;
 
   if (ownerId && ownerId === subject.userId) return true;
   if (visibility === 'project') return true;

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -1,4 +1,11 @@
-import { isSessionVisibleTo, loadSessionGrants, resolveShareSubject, type SecretGrant, type ShareSubject } from '../../executor/share';
+import {
+  isSessionTargetVisibleToCaller,
+  isSessionVisibleTo,
+  loadSessionGrants,
+  resolveShareSubject,
+  type SecretGrant,
+  type ShareSubject,
+} from '../../executor/share';
 import { authorize, assertAuthorized } from '../../iam';
 import { deriveRequestContext } from '../../iam/cache';
 import { invalidateIamCacheForUser, registerPrincipalScopedMemo } from '../../iam/cache-invalidation';
@@ -156,15 +163,14 @@ export async function loadSessionForSharing(
 } | null> {
   const row = await loadProjectSessionRow(loaded, sessionId);
   if (!row) return null;
-  // Same narrowing as the read path. In Kortix-as-a-Backend every session
-  // shares one `created_by`, so the ownership test below is meaningless across
-  // end-users and would hand A full sharing rights over B's session.
-  if (
-    !isSessionVisibleTo(row.visibility as 'private' | 'project' | 'restricted', row.createdBy, [], {
-      userId: loaded.userId,
-      groupIds: [],
-    }, { origin: row.origin ?? null, sessionId, callerSessionId })
-  ) {
+  // Apply only the session-bound KaaB narrowing here. Human project members
+  // must reach the sharing permission check and receive 403 when it rejects
+  // them. Session-content visibility does not govern share management.
+  if (!isSessionTargetVisibleToCaller({
+    origin: row.origin ?? null,
+    sessionId,
+    callerSessionId,
+  })) {
     return null;
   }
   const isOwner = row.createdBy === loaded.userId;

--- a/apps/api/src/projects/lib/session-metadata-merge.test.ts
+++ b/apps/api/src/projects/lib/session-metadata-merge.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { projectSessionMetadataMerge } from './session-metadata-merge';
+
+describe('project session metadata merge', () => {
+  test('merges telemetry into the current database value', () => {
+    const query = new PgDialect().sqlToQuery(
+      projectSessionMetadataMerge({
+        session_start_timeline: { totalMs: 42 },
+      }),
+    );
+
+    expect(query.sql).toContain('"project_sessions"."metadata"');
+    expect(query.sql).toContain('coalesce(');
+    expect(query.sql).toContain('||');
+    expect(query.params).toEqual([
+      JSON.stringify({
+        session_start_timeline: { totalMs: 42 },
+      }),
+    ]);
+  });
+});

--- a/apps/api/src/projects/lib/session-metadata-merge.ts
+++ b/apps/api/src/projects/lib/session-metadata-merge.ts
@@ -1,0 +1,13 @@
+import { projectSessions } from '@kortix/db';
+import { type SQL, sql } from 'drizzle-orm';
+
+/**
+ * Merge top-level session metadata in the UPDATE statement.
+ *
+ * The expression reads the current row value after PostgreSQL acquires the row
+ * lock. A detached telemetry writer cannot overwrite a concurrent warm-session
+ * claim with metadata that it read before the claim.
+ */
+export function projectSessionMetadataMerge(patch: Record<string, unknown>): SQL {
+  return sql`coalesce(${projectSessions.metadata}, '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb`;
+}

--- a/apps/api/src/projects/lib/session-runtime-allocator.ts
+++ b/apps/api/src/projects/lib/session-runtime-allocator.ts
@@ -1,15 +1,16 @@
 import { eq } from 'drizzle-orm';
 
 import { projectSessions } from '@kortix/db';
+import type { SandboxProviderName } from '../../config';
 import { logger } from '../../lib/logger';
 import { ProvisionTimeline } from '../../platform/services/provision-timeline';
 import { provisionSessionSandbox } from '../../platform/services/session-sandbox';
 import { db } from '../../shared/db';
-import type { SandboxProviderName } from '../../config';
-import type { ProjectRow } from './serializers';
-import { RuntimeIdentityConflictError } from '../runtime-identity-error';
-import { mergeSessionSandboxEnv } from './session-runtime-context';
 import type { GitBackedProject } from '../git';
+import { RuntimeIdentityConflictError } from '../runtime-identity-error';
+import type { ProjectRow } from './serializers';
+import { projectSessionMetadataMerge } from './session-metadata-merge';
+import { mergeSessionSandboxEnv } from './session-runtime-context';
 
 type RuntimeProject = Pick<ProjectRow, 'repoUrl' | 'defaultBranch' | 'manifestPath' | 'metadata'>;
 
@@ -125,19 +126,10 @@ async function mergeSessionMetadata(
   sessionId: string,
   extra: Record<string, unknown>,
 ): Promise<void> {
-  const [current] = await db
-    .select({ metadata: projectSessions.metadata })
-    .from(projectSessions)
-    .where(eq(projectSessions.sessionId, sessionId))
-    .limit(1);
-  const currentMetadata =
-    current?.metadata && typeof current.metadata === 'object'
-      ? (current.metadata as Record<string, unknown>)
-      : {};
   await db
     .update(projectSessions)
     .set({
-      metadata: { ...currentMetadata, ...extra },
+      metadata: projectSessionMetadataMerge(extra),
       updatedAt: new Date(),
     })
     .where(eq(projectSessions.sessionId, sessionId));

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -77,6 +77,7 @@ import {
 import { canOverride, resolveSessionOrigin } from './session-origin';
 import { resolveEndUserRef } from './end-user-ref';
 import { resolveSessionSandboxSlug } from './session-sandbox-metadata';
+import { projectSessionMetadataMerge } from './session-metadata-merge';
 import {
   buildSessionRuntimeContextEnv,
   mergeSessionSandboxEnv,
@@ -1309,19 +1310,10 @@ export async function createProjectSession(input: {
       });
 
       const mergeSessionMetadata = async (extra: Record<string, unknown>) => {
-        const [current] = await db
-          .select({ metadata: projectSessions.metadata })
-          .from(projectSessions)
-          .where(eq(projectSessions.sessionId, sessionId))
-          .limit(1);
-        const currentMetadata =
-          current?.metadata && typeof current.metadata === 'object'
-            ? (current.metadata as Record<string, unknown>)
-            : {};
         await db
           .update(projectSessions)
           .set({
-            metadata: { ...currentMetadata, ...extra },
+            metadata: projectSessionMetadataMerge(extra),
             updatedAt: new Date(),
           })
           .where(eq(projectSessions.sessionId, sessionId));

--- a/infra/k8s/envs/dev/values.yaml
+++ b/infra/k8s/envs/dev/values.yaml
@@ -6,7 +6,7 @@
 # Immutable dev tag (CI bumps to dev-<sha8> on each main push). Bootstrap value
 # is :dev-latest until the first deploy-dev-eks run pins an immutable sha.
 image:
-  tag: "dev-0f390c6c"
+  tag: "dev-fe9c7bfe"
 kortixVersion: ""
 env:
   internalKortixEnv: dev

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -359,18 +359,18 @@ flow(
     });
 
     await ctx.step(
-      'a project EDITOR who did not create the session cannot list shares → 403',
+      'a project EDITOR who did not create the session cannot list shares → 404',
       async () => {
         const r = await ctx.client
           .as(editor)
           .get('/v1/projects/:projectId/sessions/:sessionId/public-shares', {
             params: { projectId: p.id, sessionId },
           });
-        r.status(403);
+        r.status(404);
       },
     );
     await ctx.step(
-      "a project EDITOR cannot create a share on someone else's session → 403",
+      "a project EDITOR cannot create a share on someone else's session → 404",
       async () => {
         const r = await ctx.client
           .as(editor)
@@ -379,16 +379,16 @@ flow(
             { preview: { port: 3000 } },
             { params: { projectId: p.id, sessionId } },
           );
-        r.status(403);
+        r.status(404);
       },
     );
-    await ctx.step("a project EDITOR cannot revoke someone else's share → 403", async () => {
+    await ctx.step("a project EDITOR cannot revoke someone else's share → 404", async () => {
       const r = await ctx.client
         .as(editor)
         .del('/v1/projects/:projectId/sessions/:sessionId/public-shares/:shareId', {
           params: { projectId: p.id, sessionId, shareId },
         });
-      r.status(403);
+      r.status(404);
     });
 
     await ctx.step(

--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -359,18 +359,18 @@ flow(
     });
 
     await ctx.step(
-      'a project EDITOR who did not create the session cannot list shares → 404',
+      'a project EDITOR who did not create the session cannot list shares → 403',
       async () => {
         const r = await ctx.client
           .as(editor)
           .get('/v1/projects/:projectId/sessions/:sessionId/public-shares', {
             params: { projectId: p.id, sessionId },
           });
-        r.status(404);
+        r.status(403);
       },
     );
     await ctx.step(
-      "a project EDITOR cannot create a share on someone else's session → 404",
+      "a project EDITOR cannot create a share on someone else's session → 403",
       async () => {
         const r = await ctx.client
           .as(editor)
@@ -379,16 +379,16 @@ flow(
             { preview: { port: 3000 } },
             { params: { projectId: p.id, sessionId } },
           );
-        r.status(404);
+        r.status(403);
       },
     );
-    await ctx.step("a project EDITOR cannot revoke someone else's share → 404", async () => {
+    await ctx.step("a project EDITOR cannot revoke someone else's share → 403", async () => {
       const r = await ctx.client
         .as(editor)
         .del('/v1/projects/:projectId/sessions/:sessionId/public-shares/:shareId', {
           params: { projectId: p.id, sessionId, shareId },
         });
-      r.status(404);
+      r.status(403);
     });
 
     await ctx.step(


### PR DESCRIPTION
## Candidate

Promote current `main` at `efa3c793fc8b664bd1d91aed9d4d4912435863bb` to `staging`.

Includes:

- PR #5716 atomic warm-session metadata merge
- PR #5717 public-share permission contract fix
- PR #5658 managed Git fixture reuse and split live lanes
- strict PostgreSQL TLS for the QA garbage collector

Production remains unchanged.