### PR TITLE
fix(kaab): gate opencode :4096 on session visibility, not just :8000

### DIFF
--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -1158,10 +1158,13 @@ export async function resolvePreviewWsUpstream(opts: {
   if (!(await canAccessPreviewSandbox({ previewSandboxId: sandboxId, userId }))) {
     return { ok: false, status: 403, message: 'not authorized' };
   }
-  // Daemon port (8000) carries session conversation data — gate on session
-  // visibility, not just account membership (see forwardToSandbox).
+  // Both session-data ports carry the conversation — gate on session visibility,
+  // not just account membership (see forwardToSandbox). This resolver forces
+  // opencode WebSockets to :4096 on Daytona, so keying on 8000 alone left the
+  // PTY/opencode WS leg ungated there — the same hole this PR closes on the HTTP
+  // side, one function further down the file.
   if (
-    upstreamPort === 8000 &&
+    carriesSessionData(upstreamPort) &&
     !(await canAccessSandboxSession({
       sessionId: record.sessionId,
       projectId: record.projectId,

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -36,6 +36,7 @@ import {
   proxyAttemptTimeoutMs,
 } from '../preview-retry-budget';
 import { claimPromptDelivery, promptDeliveryKey } from '../prompt-dedupe';
+import { carriesSessionData } from '../session-data-ports';
 
 // `userId` is set by combinedAuth (mounted in ../index.ts) before this route.
 const preview = new Hono<{
@@ -591,9 +592,10 @@ export async function forwardToSandbox(
     });
   }
   // Effective upstream port: Platinum opencode(4096) → the in-box agent on 8000.
-  // The 8000-keyed AUTH/CONTROL guards below (session-visibility gate + /kortix/env
-  // block) key on THIS, so rerouted opencode is gated exactly like a direct :8000
-  // request (sandbox ownership is already enforced unconditionally above). NOTE:
+  // The AUTH/CONTROL guards below (session-visibility gate + /kortix/env block)
+  // key on THIS via carriesSessionData(), which covers BOTH 8000 and opencode's
+  // 4096 — Platinum reroutes 4096→8000, Daytona does not, and gating on 8000
+  // alone left the direct-:4096 Daytona path ungated. NOTE:
   // redirectPrefix/X-Forwarded-Prefix and shouldSyncProjectEnvBeforeProxy stay on
   // the client-addressed `port` ON PURPOSE — the prefix must reflect the URL the
   // client actually used (/4096), and env-sync-before-prompt must behave identically
@@ -616,7 +618,7 @@ export async function forwardToSandbox(
   // whose access was revoked/downgraded replays captured ids on the data path.
   if (
     access.kind === 'principal' &&
-    upstreamPort === 8000 &&
+    carriesSessionData(upstreamPort) &&
     !(await canAccessSandboxSession({
       sessionId: record.sessionId,
       projectId: record.projectId,
@@ -631,7 +633,7 @@ export async function forwardToSandbox(
   // live secret env. The API reaches it server-to-server (postEnvToDaemon),
   // never through this user-facing proxy — block it so an account member can't
   // inject arbitrary env into a sandbox by POSTing /v1/p/<id>/8000/kortix/env.
-  if (upstreamPort === 8000 && /^\/kortix\/env(?:$|[/?#])/.test(remainingPath)) {
+  if (carriesSessionData(upstreamPort) && /^\/kortix\/env(?:$|[/?#])/.test(remainingPath)) {
     return jsonProxyError({ error: 'not found' }, 404, origin);
   }
   if (record.status !== 'active') {

--- a/apps/api/src/sandbox-proxy/session-data-ports.test.ts
+++ b/apps/api/src/sandbox-proxy/session-data-ports.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { PUBLIC_SHARE_BLOCKED_PORTS } from '../shared/session-public-shares';
+import { SESSION_DATA_PORTS, carriesSessionData } from './session-data-ports';
+
+describe('carriesSessionData', () => {
+  test('the daemon port is gated', () => {
+    expect(carriesSessionData(8000)).toBe(true);
+  });
+
+  test('opencode 4096 is gated — THE LEAK', () => {
+    // Daytona's routeIngress is a pass-through, so a client-addressed :4096 stays
+    // :4096. Gating on 8000 alone let a sandbox token reach ANOTHER end-user's
+    // conversation there, because ownership alone cannot separate end-users when
+    // every KaaB session shares one created_by.
+    expect(carriesSessionData(4096)).toBe(true);
+  });
+
+  test('ordinary user ports are NOT gated — dev servers must stay reachable', () => {
+    // Over-gating would break the product: a user's own app on :3000 has nothing
+    // to do with session visibility.
+    for (const port of [3000, 5173, 8080, 80, 443]) {
+      expect(carriesSessionData(port)).toBe(false);
+    }
+  });
+
+  test('agrees with the public-share block list, which already knew both ports', () => {
+    // shared/session-public-shares.ts blocks 4096 AND 8000 from public shares.
+    // The two lists encode the same judgement; if they ever disagree, one of them
+    // is wrong.
+    for (const port of SESSION_DATA_PORTS) {
+      expect(PUBLIC_SHARE_BLOCKED_PORTS.has(port)).toBe(true);
+    }
+  });
+});

--- a/apps/api/src/sandbox-proxy/session-data-ports.test.ts
+++ b/apps/api/src/sandbox-proxy/session-data-ports.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 import { PUBLIC_SHARE_BLOCKED_PORTS } from '../shared/session-public-shares';
 import { SESSION_DATA_PORTS, carriesSessionData } from './session-data-ports';
@@ -30,5 +32,25 @@ describe('carriesSessionData', () => {
     for (const port of SESSION_DATA_PORTS) {
       expect(PUBLIC_SHARE_BLOCKED_PORTS.has(port)).toBe(true);
     }
+  });
+});
+
+describe('no auth guard keys on a bare port number', () => {
+  test('preview.ts has no `=== 8000` gate left', () => {
+    // Strix caught the first cut of this fix: the HTTP proxy was updated and the
+    // WebSocket resolver in the SAME FILE still keyed on 8000, so the PTY/opencode
+    // WS leg stayed ungated on Daytona. Three call sites had to change, not one.
+    //
+    // A literal port comparison in an authorization decision is the shape of that
+    // bug, so it is banned here rather than left to the next reviewer to notice.
+    const source = readFileSync(
+      join(import.meta.dir, 'routes', 'preview.ts'),
+      'utf8',
+    );
+    const offenders = source
+      .split('\n')
+      .map((line, i) => [i + 1, line] as const)
+      .filter(([, line]) => /(?:upstreamPort|effectivePort)\s*===\s*8000/.test(line));
+    expect(offenders).toEqual([]);
   });
 });

--- a/apps/api/src/sandbox-proxy/session-data-ports.ts
+++ b/apps/api/src/sandbox-proxy/session-data-ports.ts
@@ -1,0 +1,31 @@
+/**
+ * Ports whose traffic is the SESSION's conversation, not arbitrary user code.
+ *
+ * Two ports carry it, and the difference between them is a provider detail:
+ *
+ *   - 8000 — the in-box agent daemon (OpenCode REST/SSE + owner-synced secrets)
+ *   - 4096 — opencode's own HTTP/SSE server, reached DIRECTLY on Daytona
+ *
+ * Platinum's `routeIngress` rewrites 4096 → 8000, so a Platinum request is gated
+ * as :8000 whatever the client addressed. Daytona's `routeIngress` is a
+ * pass-through (`{ effectivePort: request.port }`), so on Daytona — the primary
+ * provider — a request to :4096 stays :4096.
+ *
+ * That is why gating on `upstreamPort === 8000` alone was a cross-end-user leak.
+ * Sandbox ownership is still enforced unconditionally upstream of this, but in
+ * Kortix-as-a-Backend every session shares ONE `created_by` (the wrapper's
+ * credential), so an ownership check cannot separate end-users — the per-SESSION
+ * gate is what does that, via `callerSessionId`. Skipping it for :4096 handed
+ * end-user A's sandbox token a path to end-user B's conversation on Daytona.
+ *
+ * `PUBLIC_SHARE_BLOCKED_PORTS` (shared/session-public-shares.ts) already treats
+ * 4096 and 8000 as equally sensitive. This is the same judgement, applied to the
+ * gate that had drifted from it.
+ */
+export const SESSION_DATA_PORTS: ReadonlySet<number> = new Set([8000, 4096]);
+
+/** True when this EFFECTIVE upstream port serves the session's conversation and
+ *  must therefore pass the per-session visibility gate. */
+export function carriesSessionData(upstreamPort: number): boolean {
+  return SESSION_DATA_PORTS.has(upstreamPort);
+}


### PR DESCRIPTION
Cross-end-user leak on **Daytona — the primary provider**. Confirmed from the audit, then verified by hand.

## The hole

The preview proxy's per-session visibility gate keyed on `upstreamPort === 8000`. Two ports carry a session's conversation, and which one you hit is a provider detail:

- **Platinum** — `routeIngress` rewrites `4096 → AGENT_PORT (8000)`, so a Platinum request is gated as `:8000` whatever the client addressed.
- **Daytona** — `routeIngress` is a pass-through, literally `{ effectivePort: request.port }`. A request to `:4096` **stays** `:4096`, so `upstreamPort === 8000` was false and the gate was skipped entirely.

Sandbox ownership is still enforced unconditionally upstream of this. That is exactly why the gap matters: in Kortix-as-a-Backend every session shares **one `created_by`** — the wrapper's credential — so an ownership check cannot separate end-users. The per-session gate is the thing that does, via `callerSessionId`. Skipping it for `:4096` handed end-user A's sandbox token a path to end-user B's opencode conversation.

This defeated the `callerSessionId` narrowing threaded through the REST side earlier today, on the one provider that matters most.

## The fix

`carriesSessionData(upstreamPort)` — true for `8000` **and** `4096` — applied to the session-visibility gate and, defensively, to the `/kortix/env` control-endpoint block.

**The codebase already knew both ports were sensitive.** `PUBLIC_SHARE_BLOCKED_PORTS` in `shared/session-public-shares.ts` blocks `[22, 4096, 8000, …]` from public shares. The preview gate had simply drifted from that judgement. There's a test asserting the two lists agree, so a future divergence fails rather than silently re-opening this.

## Why not just make Daytona reroute like Platinum

Because the reroute exists for a *connectivity* reason (Platinum's edge can't reach loopback `:4096`), not a security one. Making authorization depend on a transport workaround is how this drifted in the first place — the gate should name the ports it means.

## Verification

- 4 tests: both gated ports; ordinary user ports (3000/5173/8080/80/443) explicitly **not** gated, because over-gating would break every user's dev server; and the cross-check against `PUBLIC_SHARE_BLOCKED_PORTS`.
- Full `apps/api` suite: **24 failures, zero new.**