### PR TITLE
feat(whitelabel-demo): session scope controls, connector binding, and a testing guide

### DIFF
--- a/apps/whitelabel-demo/src/app/api/connections/route.ts
+++ b/apps/whitelabel-demo/src/app/api/connections/route.ts
@@ -1,20 +1,36 @@
 /**
- * Connections this wrapper may bind to a new session.
+ * Connections this wrapper may bind to a new session, grouped by connector
+ * alias.
  *
  * Provider-neutral and pre-filtered: a wrapper can only bind TEAM connections
  * (see `selectBindableConnections`), so the client is never shown an option that
- * would fail at session create.
+ * would fail at session create. Aliases with NOTHING bindable are still
+ * returned, carrying the reason — the client has to be able to say "a teammate
+ * has to share this one" instead of pretending the connector doesn't exist.
+ *
+ * The alias was hardcoded to one connector when this route only served the
+ * first-session screen. It is a request parameter now, and optional: a caller
+ * that doesn't know which connectors a project has (the new-session dialog)
+ * asks for all of them.
  */
-import { selectBindableConnections } from '@/server/bindable-connections';
+import { selectConnectorBindingChoices } from '@/server/bindable-connections';
 import { getRequestSession } from '@/server/auth';
 import { consumeRateLimit } from '@/server/rate-limit';
 import { isOwner, isValidProjectId } from '@/server/users';
 import { createScopedKortix } from '@kortix/sdk/server';
 import type { NextRequest } from 'next/server';
 
+function upstreamBase(): string {
+  return (
+    process.env.KORTIX_UPSTREAM ??
+    process.env.KORTIX_API_URL ??
+    'https://api.kortix.com/v1'
+  ).replace(/\/+$/, '');
+}
+
 export async function GET(req: NextRequest) {
   const apiKey = process.env.KORTIX_API_KEY;
-  if (!apiKey) return Response.json({ connections: [] });
+  if (!apiKey) return Response.json({ connectors: [] });
 
   const session = getRequestSession(req);
   if (!session) return Response.json({ error: 'Not authenticated' }, { status: 401 });
@@ -25,7 +41,7 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const projectId = url.searchParams.get('projectId') ?? '';
   const connector = url.searchParams.get('connector') ?? '';
-  if (!isValidProjectId(projectId) || !connector) {
+  if (!isValidProjectId(projectId)) {
     return Response.json({ error: 'Invalid identifiers' }, { status: 400 });
   }
   if (!isOwner(session.userId, projectId)) {
@@ -33,17 +49,22 @@ export async function GET(req: NextRequest) {
   }
 
   const kortix = createScopedKortix({
-    backendUrl: process.env.KORTIX_API_URL ?? 'https://api.kortix.com/v1',
+    // KORTIX_UPSTREAM first, like the proxy and every other server route: a
+    // deployment that only sets it (the documented setup) was silently sending
+    // this lookup to the PUBLIC api, whose failure this route swallows as "no
+    // connections" — an empty picker with no error anywhere.
+    backendUrl: upstreamBase(),
     getToken: async () => apiKey,
   });
 
   try {
     const result = await kortix.project(projectId).connectors.profiles.list();
-    return Response.json({
-      connections: selectBindableConnections(result?.profiles, connector),
-    });
+    const connectors = selectConnectorBindingChoices(result?.profiles).filter(
+      (choice) => !connector || choice.alias === connector,
+    );
+    return Response.json({ connectors });
   } catch {
     // A project with no connectors is the common case, not an error state.
-    return Response.json({ connections: [] });
+    return Response.json({ connectors: [] });
   }
 }

--- a/apps/whitelabel-demo/src/app/api/session-model/route.ts
+++ b/apps/whitelabel-demo/src/app/api/session-model/route.ts
@@ -20,7 +20,14 @@ import type { NextRequest } from 'next/server';
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function upstreamBase(): string {
-  return process.env.KORTIX_API_URL ?? 'https://api.kortix.com/v1';
+  // KORTIX_UPSTREAM first, like the proxy and every other server route. Reading
+  // only KORTIX_API_URL sent the model control to the PUBLIC api on any
+  // deployment that configures the documented variable, so every change 404'd.
+  return (
+    process.env.KORTIX_UPSTREAM ??
+    process.env.KORTIX_API_URL ??
+    'https://api.kortix.com/v1'
+  ).replace(/\/+$/, '');
 }
 
 async function scoped(req: NextRequest) {

--- a/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
+++ b/apps/whitelabel-demo/src/app/projects/[id]/page.tsx
@@ -4,6 +4,11 @@ import Loading from '@/components/ui/loading';
 
 import { AgentPicker } from '@/components/chat/agent-picker';
 import { ModelPicker } from '@/components/chat/model-picker';
+import {
+  ConnectorBindingFields,
+  bindingLabels,
+  useConnectorBindingChoices,
+} from '@/components/connector-bindings';
 import { ProjectShell } from '@/components/project-shell';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -26,8 +31,7 @@ import {
 } from '@kortix/sdk/react';
 import { serverErrorBody } from '@/lib/api-error-body';
 import { classifySessionStartFailure } from '@/lib/session-start-error';
-import type { BindableConnection } from '@/server/bindable-connections';
-import { getSessionToken } from '@/lib/session';
+import { NO_OVERRIDES, buildSessionCreateInput } from '@/lib/session-overrides';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowUp, Sparkles } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
@@ -67,26 +71,16 @@ function ProjectHome() {
     connector: string;
     message: string;
   } | null>(null);
-  // Which shared connection this session should run as. Unset = the connector's
-  // default, which is what an unbound alias resolves to server-side anyway.
-  const [boundConnection, setBoundConnection] = useState<string | null>(null);
+  // Which shared connection each connector should run as. An alias absent from
+  // this map keeps the connector's default, which is what an unbound alias
+  // resolves to server-side anyway.
+  const [bindings, setBindings] = useState<Record<string, string>>({});
 
   // Only TEAM connections are offered: a wrapper has no personal identity
-  // upstream, so a member's private connection cannot be bound at all.
-  const connections = useQuery({
-    queryKey: ['bindable-connections', projectId],
-    queryFn: async () => {
-      const token = getSessionToken();
-      const res = await fetch(
-        `/api/connections?projectId=${encodeURIComponent(projectId)}&connector=gmail`,
-        { headers: token ? { Authorization: `Bearer ${token}` } : undefined },
-      );
-      if (!res.ok) return { connections: [] as BindableConnection[] };
-      return (await res.json()) as { connections: BindableConnection[] };
-    },
-    staleTime: 60_000,
-    retry: false,
-  });
+  // upstream, so a member's private connection cannot be bound at all. The
+  // alias used to be hardcoded here, which meant exactly one connector could
+  // ever be bound from this screen.
+  const connectors = useConnectorBindingChoices(projectId);
   const [template, setTemplate] = useState('default');
   const [agent, setAgent] = useState<string | null>(null);
   const [model, setModel] = useState<ModelKey | null>(null);
@@ -108,20 +102,20 @@ function ProjectHome() {
   const start = useMutation({
     mutationFn: async (text: string) => {
       const sessionId = generateSessionId();
-      // Template + agent are create-time; the prompt + model + agent flow into
-      // the first message (stashed) so the chosen model applies at start.
-      await kortix.project(projectId).sessions.create({
-        session_id: sessionId,
-        name: text.slice(0, 60),
-        ...(template && template !== 'default' ? { sandbox_slug: template } : {}),
-        ...(agent ? { agent_name: agent } : {}),
-        // connector_bindings names the exact connection this session runs as.
-        // Omitted entirely when unset, so the server's default resolution applies
-        // rather than us guessing at it.
-        ...(boundConnection
-          ? { connector_bindings: { gmail: { profile_id: boundConnection } } }
-          : {}),
-      });
+      // Template + agent + bindings are create-time; the prompt + model + agent
+      // flow into the first message (stashed) so the chosen model applies at
+      // start. Unset overrides are omitted by the builder rather than guessed.
+      await kortix.project(projectId).sessions.create(
+        buildSessionCreateInput(
+          { ...NO_OVERRIDES, agent, bindings },
+          {
+            sessionId,
+            name: text.slice(0, 60),
+            sandboxSlug: template,
+            connectionLabels: bindingLabels(connectors.data?.connectors ?? [], bindings),
+          },
+        ),
+      );
       writeStartStash(sessionId, { prompt: text, model, agent });
       kortix
         .project(projectId)
@@ -169,29 +163,16 @@ function ProjectHome() {
           </p>
         </div>
 
-        {/* Which shared connection this session runs as. Only shown when there
-            is a genuine choice — one connection means the default is the only
-            answer, and a picker with a single option is noise. */}
-        {(connections.data?.connections.length ?? 0) > 1 && (
-          <div className="mb-3 flex items-center gap-2 text-left">
-            <span className="text-xs text-muted-foreground">Run as</span>
-            <Select
-              value={boundConnection ?? 'default'}
-              onValueChange={(v) => setBoundConnection(v === 'default' ? null : v)}
-            >
-              <SelectTrigger className="h-7 w-auto gap-1.5 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="default">Default connection</SelectItem>
-                {connections.data?.connections.map((connection) => (
-                  <SelectItem key={connection.profileId} value={connection.profileId}>
-                    {connection.label}
-                    {connection.isDefault ? ' (default)' : ''}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+        {/* Which shared account each connector runs as — every alias the
+            project has connections for, including the ones where the honest
+            answer is "a teammate has to share this first". */}
+        {(connectors.data?.connectors.length ?? 0) > 0 && (
+          <div className="mb-3 text-left">
+            <ConnectorBindingFields
+              choices={connectors.data?.connectors ?? []}
+              value={bindings}
+              onChange={setBindings}
+            />
           </div>
         )}
 

--- a/apps/whitelabel-demo/src/components/connector-bindings.tsx
+++ b/apps/whitelabel-demo/src/components/connector-bindings.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+/**
+ * "Which account does this session act as?" — for every connector the project
+ * has connections for, not one hardcoded alias.
+ *
+ * Two states, and the difference between them is the thing people get wrong:
+ *  - team connections exist → pick one (or leave it on the project default)
+ *  - none do → say so, and say that a TEAMMATE is the one who can change it.
+ *    There is deliberately no "connect it yourself" button; a wrapper has no
+ *    personal upstream identity, and the interactive flow that would connect
+ *    one is refused for a wrapper credential (see `connectorBindingNotice`).
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { connectorBindingNotice } from '@/lib/connector-binding';
+import { getSessionToken } from '@/lib/session';
+import type { ConnectorBindingChoice } from '@/server/bindable-connections';
+import { useQuery } from '@tanstack/react-query';
+import { Users } from 'lucide-react';
+
+const DEFAULT_VALUE = 'default';
+
+/** Every alias the project has connections for, with what may be bound. */
+export function useConnectorBindingChoices(projectId: string, enabled = true) {
+  return useQuery({
+    queryKey: ['connector-binding-choices', projectId],
+    queryFn: async () => {
+      const token = getSessionToken();
+      const res = await fetch(`/api/connections?projectId=${encodeURIComponent(projectId)}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      });
+      if (!res.ok) return { connectors: [] as ConnectorBindingChoice[] };
+      return (await res.json()) as { connectors: ConnectorBindingChoice[] };
+    },
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
+export function ConnectorBindingFields({
+  choices,
+  value,
+  onChange,
+}: {
+  choices: ConnectorBindingChoice[];
+  /** Alias -> profile id. An alias absent from this map stays on the default. */
+  value: Record<string, string>;
+  onChange: (next: Record<string, string>) => void;
+}) {
+  if (choices.length === 0) return null;
+
+  const set = (alias: string, profileId: string | null) => {
+    const next = { ...value };
+    // Unbinding REMOVES the alias rather than storing an empty string: the
+    // create body must omit it entirely so the server resolves its own default.
+    if (profileId) next[alias] = profileId;
+    else delete next[alias];
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-2">
+      {choices.map((choice) => {
+        const notice = connectorBindingNotice(choice);
+        if (notice) {
+          return (
+            <div
+              key={choice.alias}
+              className="flex items-start gap-2.5 rounded-md border border-border bg-muted/30 px-3 py-2.5"
+            >
+              <Users className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <div className="text-sm">{notice.title}</div>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                  {notice.detail}
+                </p>
+              </div>
+            </div>
+          );
+        }
+
+        return (
+          <div key={choice.alias} className="flex items-center justify-between gap-3">
+            <span className="truncate font-mono text-xs text-muted-foreground">{choice.alias}</span>
+            <Select
+              value={value[choice.alias] ?? DEFAULT_VALUE}
+              onValueChange={(v) => set(choice.alias, v === DEFAULT_VALUE ? null : v)}
+            >
+              <SelectTrigger
+                className="h-8 w-56 text-xs"
+                aria-label={`Connection for ${choice.alias}`}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={DEFAULT_VALUE}>Project default</SelectItem>
+                {choice.connections.map((connection) => (
+                  <SelectItem key={connection.profileId} value={connection.profileId}>
+                    {connection.label}
+                    {connection.isDefault ? ' (default)' : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Labels for the chosen connections, keyed by alias — recorded in session
+ *  metadata so the workbench can name what a running session is bound to. */
+export function bindingLabels(
+  choices: ConnectorBindingChoice[],
+  bindings: Record<string, string>,
+): Record<string, string> {
+  const labels: Record<string, string> = {};
+  for (const [alias, profileId] of Object.entries(bindings)) {
+    const match = choices
+      .find((choice) => choice.alias === alias)
+      ?.connections.find((connection) => connection.profileId === profileId);
+    if (match) labels[alias] = match.label;
+  }
+  return labels;
+}

--- a/apps/whitelabel-demo/src/components/new-session-dialog.tsx
+++ b/apps/whitelabel-demo/src/components/new-session-dialog.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+/**
+ * Start a session with its create-only overrides chosen up front.
+ *
+ * The sidebar used to create sessions with nothing but an id, which quietly
+ * made "the project default agent, the agent's full secret grant, the default
+ * connection for every connector" the only session shape this app could
+ * produce — even though all three are settable exactly once, at create, and
+ * never again (`mid-session-change.ts`). This is where that choice happens.
+ *
+ * Everything is optional and every unset field is OMITTED from the create body
+ * rather than sent as a guess (`buildSessionCreateInput`), so the default
+ * behaviour is byte-for-byte what it was before this dialog existed.
+ */
+
+import Loading from '@/components/ui/loading';
+
+import { AgentPicker } from '@/components/chat/agent-picker';
+import {
+  ConnectorBindingFields,
+  bindingLabels,
+  useConnectorBindingChoices,
+} from '@/components/connector-bindings';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { kortix } from '@/lib/kortix';
+import { invalidateSessions, qk } from '@/lib/query-keys';
+import { sessionCreateFailure } from '@/lib/session-create-failure';
+import {
+  NO_OVERRIDES,
+  type SessionOverrides,
+  buildSessionCreateInput,
+} from '@/lib/session-overrides';
+import { generateSessionId } from '@kortix/sdk';
+import { useProjectConfig, useVisibleAgents } from '@kortix/sdk/react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+export function NewSessionDialog({
+  projectId,
+  trigger,
+  initialAgent = null,
+}: {
+  projectId: string;
+  trigger: React.ReactNode;
+  /** Pre-picked agent — used when a refused agent switch sends someone here. */
+  initialAgent?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="max-h-[85dvh] overflow-y-auto scrollbar-thin sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New session</DialogTitle>
+          <DialogDescription>
+            These are set once, when the session starts. Leave anything untouched to keep this
+            project&apos;s defaults.
+          </DialogDescription>
+        </DialogHeader>
+        {/* Mounted only while open so the pickers' fetches don't run on every
+            page that renders the sidebar. */}
+        {open && (
+          <NewSessionForm
+            projectId={projectId}
+            initialAgent={initialAgent}
+            onDone={() => setOpen(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function NewSessionForm({
+  projectId,
+  initialAgent,
+  onDone,
+}: {
+  projectId: string;
+  initialAgent: string | null;
+  onDone: () => void;
+}) {
+  const router = useRouter();
+  const qc = useQueryClient();
+
+  const [agent, setAgent] = useState<string | null>(initialAgent);
+  const [bindings, setBindings] = useState<Record<string, string>>({});
+  // Off = send no allowlist at all, which is today's behaviour and the honest
+  // default: the agent's own grant already narrows what the sandbox receives.
+  const [narrowSecrets, setNarrowSecrets] = useState(false);
+  const [allowed, setAllowed] = useState<string[] | null>(null);
+
+  const agents = useVisibleAgents({ projectId });
+  const config = useProjectConfig(projectId);
+  const connectors = useConnectorBindingChoices(projectId);
+  const secrets = useQuery({
+    queryKey: qk.secrets(projectId),
+    queryFn: () => kortix.project(projectId).secrets.list(),
+    retry: false,
+  });
+
+  // The allowlist is by IDENTIFIER, not by env KEY: two identifiers can inject
+  // the same key, which is exactly the collision the server rejects (409).
+  const identifiers = (secrets.data?.items ?? []).map((secret) => ({
+    identifier: secret.identifier,
+    name: secret.name,
+  }));
+  // Default to NOTHING checked rather than everything.
+  //
+  // Pre-checking every listed row looks helpful and makes create fail on two
+  // ordinary projects. `GET /secrets` lists rows of every scope, but create
+  // validates the allowlist against runtime-scoped rows only — so a project with
+  // a Teams/Slack install (whose install rows are `scope:'connector'`) gets
+  // 404 SECRET_IDENTIFIER_NOT_FOUND. And two identifiers may legally share one
+  // env KEY, which is exactly the 409 SECRET_IDENTIFIER_KEY_COLLISION the server
+  // rejects — so pre-checking both guarantees it.
+  //
+  // An empty allowlist is also the honest default for a control whose whole
+  // point is narrowing: the user picks what to expose, rather than un-picking
+  // from a set the server may refuse.
+  const checked = allowed ?? [];
+
+  const overrides: SessionOverrides = {
+    ...NO_OVERRIDES,
+    agent,
+    bindings,
+    secrets: narrowSecrets ? checked : null,
+  };
+
+  const start = useMutation({
+    mutationFn: async () => {
+      const sessionId = generateSessionId();
+      await kortix
+        .project(projectId)
+        .sessions.create(
+          buildSessionCreateInput(overrides, {
+            sessionId,
+            connectionLabels: bindingLabels(connectors.data?.connectors ?? [], bindings),
+          }),
+        );
+      return sessionId;
+    },
+    onSuccess: (sessionId) => {
+      invalidateSessions(qc, projectId);
+      onDone();
+      router.push(`/projects/${projectId}/sessions/${sessionId}`);
+    },
+    onError: (err) => {
+      // Each KaaB refusal has a distinct code and a different person who can
+      // fix it — collapsing them into one string threw that away.
+      const failure = sessionCreateFailure(err);
+      toast.error(failure.title, { description: failure.detail });
+    },
+  });
+
+  const toggle = (identifier: string, on: boolean) => {
+    const next = on
+      ? [...new Set([...checked, identifier])]
+      : checked.filter((id) => id !== identifier);
+    setAllowed(next);
+  };
+
+  return (
+    <div className="space-y-5">
+      <section className="space-y-1.5">
+        <Label>Agent</Label>
+        <div className="flex items-center gap-2">
+          <AgentPicker
+            agents={agents}
+            value={agent}
+            onChange={setAgent}
+            defaultName={config?.default_agent}
+          />
+          {agents.length === 0 && (
+            <span className="text-xs text-muted-foreground">
+              This project runs its default agent.
+            </span>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <Label htmlFor="narrow-secrets">Limit which secrets this session can read</Label>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Off, the session gets the agent&apos;s full secret grant. An allowlist only ever
+              narrows it, and it cannot be changed once the session starts.
+            </p>
+          </div>
+          <Switch
+            id="narrow-secrets"
+            checked={narrowSecrets}
+            onCheckedChange={setNarrowSecrets}
+            disabled={secrets.isLoading || identifiers.length === 0}
+          />
+        </div>
+        {secrets.isLoading && <Skeleton className="h-8 w-full" />}
+        {narrowSecrets && (
+          <div className="space-y-1.5 rounded-md border border-border bg-muted/30 p-3">
+            {identifiers.map((secret) => (
+              <div key={secret.identifier} className="flex items-center justify-between gap-3">
+                <Label
+                  htmlFor={`secret-${secret.identifier}`}
+                  className="min-w-0 font-mono text-xs font-normal"
+                >
+                  <span className="truncate">{secret.identifier}</span>
+                  {secret.name !== secret.identifier && (
+                    <span className="truncate text-muted-foreground">→ {secret.name}</span>
+                  )}
+                </Label>
+                <Switch
+                  id={`secret-${secret.identifier}`}
+                  checked={checked.includes(secret.identifier)}
+                  onCheckedChange={(on) => toggle(secret.identifier, on)}
+                />
+              </div>
+            ))}
+            {checked.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                This session will receive no project secrets at all.
+              </p>
+            )}
+          </div>
+        )}
+      </section>
+
+      {(connectors.data?.connectors.length ?? 0) > 0 && (
+        <section className="space-y-2">
+          <div>
+            <Label>Connections</Label>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Which shared account each connector acts as. Sessions started here can only use
+              connections shared with the team.
+            </p>
+          </div>
+          <ConnectorBindingFields
+            choices={connectors.data?.connectors ?? []}
+            value={bindings}
+            onChange={setBindings}
+          />
+        </section>
+      )}
+
+      <DialogFooter>
+        <Button variant="ghost" onClick={onDone} disabled={start.isPending}>
+          Cancel
+        </Button>
+        <Button onClick={() => start.mutate()} disabled={start.isPending}>
+          {start.isPending && <Loading className="size-4" />}
+          Start session
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/apps/whitelabel-demo/src/components/project-shell.tsx
+++ b/apps/whitelabel-demo/src/components/project-shell.tsx
@@ -6,19 +6,17 @@
  * workbench, and project settings so navigation stays consistent.
  */
 
+import { NewSessionDialog } from '@/components/new-session-dialog';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { kortix } from '@/lib/kortix';
-import { invalidateSessions, qk } from '@/lib/query-keys';
-import { sessionCreateFailure } from '@/lib/session-create-failure';
+import { qk } from '@/lib/query-keys';
 import { cn, relativeTime } from '@/lib/utils';
-import { generateSessionId } from '@kortix/sdk';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, FolderX, Plus, Settings } from 'lucide-react';
 import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
-import { toast } from 'sonner';
+import { useParams } from 'next/navigation';
 
 const STATUS_DOT: Record<string, string> = {
   running: 'bg-emerald-500',
@@ -41,8 +39,6 @@ export function ProjectShell({ children }: { children: React.ReactNode }) {
   const params = useParams();
   const projectId = String(params.id);
   const activeSessionId = params.sessionId ? String(params.sessionId) : null;
-  const router = useRouter();
-  const qc = useQueryClient();
 
   const project = useQuery({
     queryKey: qk.project(projectId),
@@ -57,24 +53,6 @@ export function ProjectShell({ children }: { children: React.ReactNode }) {
     refetchInterval: denied ? false : 5_000,
     enabled: !denied,
     retry: (count, err) => !isAccessError(err) && count < 2,
-  });
-
-  const newSession = useMutation({
-    mutationFn: async () => {
-      const sessionId = generateSessionId();
-      await kortix.project(projectId).sessions.create({ session_id: sessionId });
-      return sessionId;
-    },
-    onSuccess: (sessionId) => {
-      invalidateSessions(qc, projectId);
-      router.push(`/projects/${projectId}/sessions/${sessionId}`);
-    },
-    onError: (err) => {
-      // Each KaaB refusal has a distinct code and a different person who can
-      // fix it — collapsing them into one string threw that away.
-      const failure = sessionCreateFailure(err);
-      toast.error(failure.title, { description: failure.detail });
-    },
   });
 
   const items = sessions.data ?? [];
@@ -105,14 +83,17 @@ export function ProjectShell({ children }: { children: React.ReactNode }) {
         </div>
 
         <div className="px-3 pb-2">
-          <Button
-            className="w-full justify-start gap-2"
-            variant="secondary"
-            disabled={newSession.isPending}
-            onClick={() => newSession.mutate()}
-          >
-            <Plus className="size-4" /> New session
-          </Button>
+          {/* Every session used to be created with an id and nothing else. The
+              overrides behind this dialog are create-only, so this is the only
+              moment they can be chosen at all. */}
+          <NewSessionDialog
+            projectId={projectId}
+            trigger={
+              <Button className="w-full justify-start gap-2" variant="secondary">
+                <Plus className="size-4" /> New session
+              </Button>
+            }
+          />
         </div>
 
         <ScrollArea className="flex-1 px-2">

--- a/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/session-scope.tsx
@@ -1,49 +1,80 @@
 'use client';
 
-import { Badge } from '@/components/ui/badge';
-import { MID_SESSION_CAPABILITIES } from '@/lib/mid-session-change';
-import { Lock, RefreshCw, Repeat } from 'lucide-react';
-
 /**
- * What this session may still change, stated honestly.
+ * What THIS session is scoped to, and what it can still change.
  *
- * The three overrides look alike and behave completely differently. Showing a
- * secrets control that cannot work would be worse than showing none — so this
- * shows the LIMIT, with the reason, instead of a disabled input the user will
- * keep poking.
+ * This panel used to print the same three paragraphs for every session. The
+ * rules were right and the answers were missing: "can I switch the agent?"
+ * depends on which agent this session booted with, and "what can it read?" is
+ * a list that exists on the session. So every row shows the session's real
+ * state, the model row carries the real control, and the frozen rows explain
+ * why THIS session cannot move rather than restating the rule in the abstract.
  */
-const ROWS = [
-  {
-    key: 'model' as const,
-    label: 'Model',
-    icon: RefreshCw,
-    badge: 'Changeable now',
-    detail: 'Switching restarts the runtime, which ends the in-flight turn.',
-  },
-  {
-    key: 'agent' as const,
-    label: 'Agent',
-    icon: Repeat,
-    badge: 'Per message',
-    detail:
-      'Each message names the agent that runs it. Switching to an agent with different secret access needs a new session — re-scoping cannot un-read what this session already loaded.',
-  },
-  {
-    key: 'secrets' as const,
-    label: 'Secrets',
-    icon: Lock,
-    badge: 'Fixed at start',
-    detail:
-      'The secret allowlist is set once when the session starts and never changes. Narrowing it mid-flight could leave the session unable to boot. Start a new session to change it.',
-  },
-];
 
-export function SessionScope() {
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ModelSwitcher } from '@/components/workbench/model-switcher';
+import { kortix } from '@/lib/kortix';
+import { qk } from '@/lib/query-keys';
+import { isFixedAtStart, readBoundConnections, sessionScopeIsReadable, sessionScopeRows, type ScopeRowKey } from '@/lib/session-scope';
+import { useQuery } from '@tanstack/react-query';
+import { Lock, Plug, RefreshCw, Repeat } from 'lucide-react';
+
+const ICONS: Record<ScopeRowKey, typeof Lock> = {
+  model: RefreshCw,
+  agent: Repeat,
+  secrets: Lock,
+  connections: Plug,
+};
+
+export function SessionScope({ projectId, sessionId }: { projectId: string; sessionId: string }) {
+  const session = useQuery({
+    queryKey: qk.session(projectId, sessionId),
+    queryFn: () => kortix.session(projectId, sessionId).get({ showErrors: false }),
+    retry: false,
+  });
+
+  if (session.isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-16 rounded-md" />
+        ))}
+      </div>
+    );
+  }
+
+  // "Couldn't read it" must not render as "it isn't narrowed": every row below
+  // is a claim about what this session may reach, and a wrong one here is
+  // worse than none.
+  //
+  // A REDACTED row is the trap here, and it arrives as a perfectly good HTTP 200:
+  // the serializer blanks an inaccessible session to `metadata: {}` and
+  // `secrets_allowlist: null` — and `null` is precisely the value this panel
+  // reads as "everything the agent grant allows". So a session the caller may
+  // NOT open would render as LESS restricted than one they may. `can_access` is
+  // on the payload for exactly this; not reading it turns a redaction into a
+  // false reassurance.
+  if (!sessionScopeIsReadable(session.data)) {
+    return (
+      <p className="rounded-md border border-border bg-card px-3 py-2.5 text-xs text-muted-foreground">
+        This session&apos;s scope could not be read just now. Reopen the session to try again.
+      </p>
+    );
+  }
+
+  const rows = sessionScopeRows({
+    agentName: session.data.agent_name,
+    // null = never narrowed, which is the opposite of an empty allowlist.
+    secretsAllowlist: session.data.secrets_allowlist ?? null,
+    boundConnections: readBoundConnections(session.data.metadata),
+  });
+
   return (
     <div className="space-y-2">
-      {ROWS.map((row) => {
-        const Icon = row.icon;
-        const fixed = MID_SESSION_CAPABILITIES[row.key] === 'fixed_at_create';
+      {rows.map((row) => {
+        const Icon = ICONS[row.key];
+        const fixed = isFixedAtStart(row.key);
         return (
           <div
             key={row.key}
@@ -59,7 +90,15 @@ export function SessionScope() {
                   {row.badge}
                 </Badge>
               </div>
-              <p className="mt-0.5 text-xs text-muted-foreground">{row.detail}</p>
+              {row.control === 'model' && (
+                <div className="-ml-2 mt-0.5">
+                  <ModelSwitcher projectId={projectId} sessionId={sessionId} />
+                </div>
+              )}
+              {row.value !== null && (
+                <div className="mt-0.5 break-words font-mono text-xs">{row.value}</div>
+              )}
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{row.detail}</p>
             </div>
           </div>
         );

--- a/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
+++ b/apps/whitelabel-demo/src/components/workbench/workbench-tabs.tsx
@@ -12,7 +12,9 @@ import { Bubble, BubbleContent } from '@/components/ui/bubble';
 import { Button } from '@/components/ui/button';
 import { Marker, MarkerContent, MarkerIcon } from '@/components/ui/marker';
 import { Message } from '@/components/ui/message';
+import { NewSessionDialog } from '@/components/new-session-dialog';
 import { SessionScope } from '@/components/workbench/session-scope';
+import { agentSwitchRefusal } from '@/lib/mid-session-change';
 import { sendFailureTitle } from '@/lib/send-failure';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ChangesPanel } from '@/components/workbench/changes-panel';
@@ -23,7 +25,7 @@ import { qk } from '@/lib/query-keys';
 import { cn } from '@/lib/utils';
 import type { UseSessionResult } from '@kortix/sdk/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AlertTriangle, RotateCw, Sparkles } from 'lucide-react';
+import { AlertTriangle, Plus, RotateCw, Sparkles } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -66,7 +68,7 @@ export function WorkbenchTabs({
           <p className="mb-3 mt-0.5 text-xs text-muted-foreground">
             Overrides are set when a session starts. These are the ones you can still move.
           </p>
-          <SessionScope />
+          <SessionScope projectId={projectId} sessionId={sessionId} />
         </div>
       </TabsContent>
       <TabsContent value="changes" className="min-h-0 flex-1 overflow-hidden p-4">
@@ -105,6 +107,11 @@ function Thread({ session: c }: { session: UseSessionResult }) {
     },
     onError: () => toast.error('Could not reconnect the runtime'),
   });
+
+  // A send refused because the message named an agent this session cannot run.
+  // It arrives as an ordinary runtime error, so it has to be recognised before
+  // the generic failure panel swallows the one refusal with a real remedy.
+  const agentSwitch = agentSwitchRefusal(c.sendError);
 
   const runtimeReady = c.runtimePhase === 'ready';
   // "Down" = was connected, now confirmed unreachable (a drop, not the initial boot).
@@ -248,7 +255,35 @@ function Thread({ session: c }: { session: UseSessionResult }) {
               the typed text was gone, and nothing said why. useSession surfaces
               a typed sendError — read it, and name the KaaB refusals the
               generic message would otherwise swallow. */}
-          {c.sendError ? (
+          {agentSwitch ? (
+            // The one refusal where retrying is guaranteed to fail: this
+            // sandbox's env is provisioned for the agent it booted with, and
+            // re-scoping now cannot un-read what that agent already loaded.
+            // Offer the only thing that works instead of an error.
+            <div className="mx-4 mb-2 rounded-lg border border-brand/40 bg-brand/5 px-3 py-2.5">
+              <div className="text-sm font-medium">
+                {agentSwitch.requestedAgent
+                  ? `${agentSwitch.requestedAgent} needs its own session`
+                  : 'That agent needs its own session'}
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {agentSwitch.expectedAgent
+                  ? `This session is running as ${agentSwitch.expectedAgent}, and the two have different secret access. Start a new session to use it.`
+                  : 'It has different secret access than the agent this session started with. Start a new session to use it.'}
+              </p>
+              <div className="mt-2">
+                <NewSessionDialog
+                  projectId={c.projectId}
+                  initialAgent={agentSwitch.requestedAgent}
+                  trigger={
+                    <Button size="sm" variant="secondary" className="h-7 gap-1.5">
+                      <Plus className="size-3.5" /> Start a new session
+                    </Button>
+                  }
+                />
+              </div>
+            </div>
+          ) : c.sendError ? (
             <div className="mx-4 mb-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm">
               <div className="font-medium">{sendFailureTitle(c.sendError)}</div>
               <p className="mt-0.5 text-xs text-muted-foreground">{c.sendError.message}</p>

--- a/apps/whitelabel-demo/src/lib/api-error-body.ts
+++ b/apps/whitelabel-demo/src/lib/api-error-body.ts
@@ -14,6 +14,10 @@ export interface ServerErrorBody {
   code?: unknown;
   error?: unknown;
   connector?: unknown;
+  /** The parsed body itself. Refusals carry fields specific to their code —
+   *  `requested_agent`, `expected_agent`, … — and a classifier that needs one
+   *  should read it here instead of re-parsing the error. */
+  raw?: Record<string, unknown>;
 }
 
 export function serverErrorBody(err: unknown): ServerErrorBody | null {
@@ -32,5 +36,5 @@ export function serverErrorBody(err: unknown): ServerErrorBody | null {
   const error = candidate?.error ?? (typeof e.message === 'string' ? e.message : undefined);
 
   if (code === undefined && error === undefined && !candidate) return null;
-  return { code, error, connector: candidate?.connector };
+  return { code, error, connector: candidate?.connector, raw: candidate };
 }

--- a/apps/whitelabel-demo/src/lib/connector-binding.ts
+++ b/apps/whitelabel-demo/src/lib/connector-binding.ts
@@ -1,0 +1,41 @@
+import type { ConnectorBindingChoice } from '@/server/bindable-connections';
+
+/**
+ * What to tell someone about a connector they cannot bind.
+ *
+ * "Your own account" vs "a teammate's team-shared account" is the thing people
+ * get wrong about connectors in wrapper mode, so the copy names the distinction
+ * instead of saying "no connections available".
+ *
+ * `selfServiceAction` is typed `null` on purpose. A wrapper acts under one
+ * credential for many end-users, so there is no personal upstream identity to
+ * connect WITH — the interactive flow that would do it (`require_connectors`)
+ * is refused for a wrapper credential outright
+ * (403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY). A "connect it yourself" button
+ * here could only ever lead to that refusal, so the type forbids one existing.
+ */
+export interface ConnectorBindingNotice {
+  title: string;
+  detail: string;
+  selfServiceAction: null;
+}
+
+export function connectorBindingNotice(
+  choice: ConnectorBindingChoice,
+): ConnectorBindingNotice | null {
+  if (choice.connections.length > 0) return null;
+
+  if (choice.unavailable === 'team_connection_inactive') {
+    return {
+      title: `${choice.alias} needs reconnecting`,
+      detail: `The team's ${choice.alias} connection is revoked or failing, so it cannot be used. A teammate has to reconnect it — it becomes available here as soon as they do.`,
+      selfServiceAction: null,
+    };
+  }
+
+  return {
+    title: `No shared ${choice.alias} account yet`,
+    detail: `${choice.alias} is only connected to people's own accounts, which sessions started here cannot use. Once a teammate shares a ${choice.alias} connection with the team, it appears in this list.`,
+    selfServiceAction: null,
+  };
+}

--- a/apps/whitelabel-demo/src/lib/mid-session-change.ts
+++ b/apps/whitelabel-demo/src/lib/mid-session-change.ts
@@ -17,6 +17,8 @@
  *   unbootable" if it were narrowed below what the box already needs.
  */
 
+import { serverErrorBody } from './api-error-body';
+
 export type MidSessionCapability = 'changeable' | 'per_prompt' | 'fixed_at_create';
 
 export const MID_SESSION_CAPABILITIES = {
@@ -61,4 +63,72 @@ export function classifyAgentSwitch(body: UpstreamError | null): AgentSwitchOutc
   }
   if (code) return { kind: 'unknown', message };
   return { kind: 'ok' };
+}
+
+/** A refused agent switch, with the agents the server named. */
+export interface AgentSwitchRefusal {
+  message: string;
+  /** The agent the message asked for — the one that needs a new session. */
+  requestedAgent: string | null;
+  /** The agent this session's sandbox is provisioned for. */
+  expectedAgent: string | null;
+}
+
+/** The `{...}` payload embedded in a runtime error's message text.
+ *
+ *  The refusal is raised by the sandbox proxy on the prompt itself, so it
+ *  reaches a host as a generic runtime error whose message carries the JSON
+ *  body rather than as a structured API error. Read both shapes, or the one
+ *  refusal that CANNOT be retried renders as an ordinary "send failed". */
+function embeddedErrorBody(text: unknown): { code?: unknown; error?: unknown } | null {
+  if (typeof text !== 'string') return null;
+  const start = text.indexOf('{');
+  if (start < 0) return null;
+  try {
+    const parsed: unknown = JSON.parse(text.slice(start));
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Recognise a send that was refused because the message named an agent whose
+ * secret grant differs from the one this session booted with.
+ *
+ * Returns null for every other failure: the caller offers "start a new session"
+ * ONLY here, because that is the only resolution — retrying the same send fails
+ * identically, forever.
+ */
+export function agentSwitchRefusal(
+  error: { message?: string; cause?: unknown } | null | undefined,
+): AgentSwitchRefusal | null {
+  if (!error) return null;
+  const cause = error.cause as { message?: unknown } | undefined;
+
+  // Same refusal, two envelopes: a structured API error, or the JSON body
+  // carried inside a runtime error's message text. `fields` is the body
+  // itself, which is where the agent names live.
+  const candidates: Array<{ code?: unknown; error?: unknown; fields: Record<string, unknown> }> =
+    [];
+  const structured = serverErrorBody(cause);
+  if (structured) candidates.push({ ...structured, fields: structured.raw ?? {} });
+  for (const text of [cause?.message, error.message]) {
+    const parsed = embeddedErrorBody(text);
+    if (parsed) candidates.push({ ...parsed, fields: parsed as Record<string, unknown> });
+  }
+
+  for (const candidate of candidates) {
+    if (classifyAgentSwitch(candidate).kind !== 'needs_new_session') continue;
+    return {
+      message: stringOrNull(candidate.error) ?? 'That agent needs a new session.',
+      requestedAgent: stringOrNull(candidate.fields.requested_agent),
+      expectedAgent: stringOrNull(candidate.fields.expected_agent),
+    };
+  }
+  return null;
 }

--- a/apps/whitelabel-demo/src/lib/session-create-failure.ts
+++ b/apps/whitelabel-demo/src/lib/session-create-failure.ts
@@ -66,6 +66,56 @@ export function sessionCreateFailure(err: unknown): SessionCreateFailure {
         detail: serverText ?? 'This session needs an account you have not connected yet.',
         retryable: false,
       };
+    // The three the new overrides dialog makes reachable. Each is terminal:
+    // the allowlist is create-only, so "try again" with the same selection
+    // refuses identically.
+    case 'SECRET_IDENTIFIER_NOT_FOUND':
+      return {
+        title: 'A selected secret is not available to sessions',
+        detail:
+          serverText ??
+          'One of the secrets you picked is owned by an integration rather than the project runtime. Deselect it and start again.',
+        retryable: false,
+      };
+    case 'SECRET_IDENTIFIER_KEY_COLLISION':
+      return {
+        title: 'Two selected secrets use the same variable name',
+        detail:
+          serverText ??
+          'Two of the secrets you picked inject the same environment variable, so the session cannot tell them apart. Pick one of them.',
+        retryable: false,
+      };
+    case 'INVALID_SESSION_SECRETS':
+      return {
+        title: 'That secret selection is not valid',
+        detail: serverText ?? 'Adjust the selected secrets and start again.',
+        retryable: false,
+      };
+    case 'CONNECTOR_PROFILE_NOT_FOUND':
+      return {
+        title: 'That connection no longer exists',
+        detail:
+          serverText ??
+          'The connection you picked has been removed. Pick another, or ask a teammate to reconnect it.',
+        retryable: false,
+      };
+    case 'CONNECTOR_PROFILE_INACTIVE':
+      return {
+        title: 'That connection needs reconnecting',
+        detail:
+          serverText ??
+          'The connection you picked is revoked or disabled. A teammate needs to reconnect it before a session can use it.',
+        retryable: false,
+      };
+    case 'origin_override_forbidden':
+      // Direct mode: `secrets` is a backend-origin field, so a browser PAT is
+      // refused. Developer-facing upstream copy would be meaningless here.
+      return {
+        title: 'Secret narrowing needs wrapper mode',
+        detail:
+          'This deployment is talking to Kortix directly, where the per-session secret allowlist is not available.',
+        retryable: false,
+      };
     case 'INVALID_SESSION_MODEL':
       return {
         title: 'That model is unavailable',

--- a/apps/whitelabel-demo/src/lib/session-overrides.ts
+++ b/apps/whitelabel-demo/src/lib/session-overrides.ts
@@ -1,0 +1,90 @@
+import type { CreateProjectSessionInput } from '@kortix/sdk';
+
+/**
+ * The overrides a new session can be started with, and the exact create body
+ * they turn into.
+ *
+ * Every one of these is CREATE-ONLY (see `mid-session-change.ts`), which is why
+ * they are chosen in a dialog before the session exists rather than adjusted in
+ * the workbench afterwards. The builder is pure so what the demo sends can be
+ * asserted without booting anything.
+ *
+ * The rule throughout: an unset override is OMITTED, never sent as a guess.
+ * A guessed `secrets: []` would boot a sandbox with no secrets at all, and a
+ * guessed binding would pin the session to a connection nobody chose.
+ */
+
+/** Which project secrets a session may read. `null` = don't narrow at all. */
+export type SecretsAllowlist = string[] | null;
+
+export interface SessionOverrides {
+  /** Agent name; null = the project's default agent. */
+  agent: string | null;
+  /** Secret IDENTIFIERS (not env keys — several identifiers can share a key). */
+  secrets: SecretsAllowlist;
+  /** Connector alias -> connection profile id. Empty = bind nothing. */
+  bindings: Record<string, string>;
+}
+
+export const NO_OVERRIDES: SessionOverrides = { agent: null, secrets: null, bindings: {} };
+
+/** Labels for the connections that were bound, keyed by alias — see
+ *  `BOUND_CONNECTIONS_KEY`. */
+export type BoundConnectionLabels = Record<string, string>;
+
+/**
+ * Where this wrapper records WHICH connections it bound.
+ *
+ * The platform has no read-back for a session's connector bindings — they are
+ * accepted at create and never serialized onto the session — so a wrapper that
+ * wants to show a running session's bindings has to remember them itself.
+ * Session metadata is the session-scoped place to do that, and it is withheld
+ * from viewers who can't open the session, same as the allowlist.
+ */
+export const BOUND_CONNECTIONS_KEY = 'lumen_bound_connections';
+
+export interface SessionCreateExtras {
+  sessionId: string;
+  name?: string;
+  sandboxSlug?: string;
+  /** Display labels for the bound connections, recorded in session metadata. */
+  connectionLabels?: BoundConnectionLabels;
+}
+
+export function buildSessionCreateInput(
+  overrides: SessionOverrides,
+  extras: SessionCreateExtras,
+): CreateProjectSessionInput {
+  const aliases = Object.keys(overrides.bindings);
+
+  return {
+    session_id: extras.sessionId,
+    ...(extras.name ? { name: extras.name } : {}),
+    ...(extras.sandboxSlug && extras.sandboxSlug !== 'default'
+      ? { sandbox_slug: extras.sandboxSlug }
+      : {}),
+    ...(overrides.agent ? { agent_name: overrides.agent } : {}),
+    // An empty allowlist is a real choice (inject zero project secrets), so the
+    // "don't narrow" signal has to be null rather than an empty array.
+    ...(overrides.secrets ? { secrets: overrides.secrets } : {}),
+    ...(aliases.length > 0
+      ? {
+          connector_bindings: Object.fromEntries(
+            aliases.map((alias) => [alias, { profile_id: overrides.bindings[alias]! }]),
+          ),
+          // Binding ANY alias otherwise switches every other alias off its
+          // project default ("all-or-nothing"). Picking one connection in this
+          // dialog must not silently unplug the connectors nobody touched.
+          inherit_unbound: true,
+          metadata: {
+            [BOUND_CONNECTIONS_KEY]: Object.fromEntries(
+              aliases.map((alias) => [
+                alias,
+                extras.connectionLabels?.[alias] ?? overrides.bindings[alias]!,
+              ]),
+            ),
+          },
+        }
+      : {}),
+  };
+}

--- a/apps/whitelabel-demo/src/lib/session-scope.ts
+++ b/apps/whitelabel-demo/src/lib/session-scope.ts
@@ -1,0 +1,157 @@
+import { MID_SESSION_CAPABILITIES } from './mid-session-change';
+import { BOUND_CONNECTIONS_KEY } from './session-overrides';
+
+/**
+ * What THIS session is actually scoped to, and what can still move.
+ *
+ * The scope panel used to print generic prose about the three overrides. Prose
+ * cannot answer the question people actually have mid-session — "what can this
+ * session read, right now?" — so every row here carries the session's real
+ * value, and the "can I change it?" line explains the reason for THIS session
+ * rather than restating the rule.
+ *
+ * Pure: the workbench passes what it read off the session, so the wording can
+ * be asserted without a runtime.
+ */
+
+export type ScopeRowKey = 'model' | 'agent' | 'secrets' | 'connections';
+
+export interface SessionScopeRow {
+  key: ScopeRowKey;
+  label: string;
+  /** The short "can I change this now?" badge. */
+  badge: string;
+  /** This session's real state, in one line. null when the row's own control
+   *  already shows it — duplicating the model next to the model switcher would
+   *  just give the two places to disagree. */
+  value: string | null;
+  detail: string;
+  /** Whether a live control belongs on this row — only the model has one. */
+  control: 'model' | null;
+}
+
+export interface SessionScopeInput {
+  /** `session.agent_name` — null when the project default agent runs. */
+  agentName: string | null | undefined;
+  /** `session.secrets_allowlist` — null/undefined = never narrowed. */
+  secretsAllowlist: string[] | null | undefined;
+  /** Connections bound at create, alias -> label (see `BOUND_CONNECTIONS_KEY`). */
+  boundConnections: Record<string, string>;
+}
+
+const ALL_SECRETS = 'Everything the agent is granted';
+
+/**
+ * The connections this wrapper recorded when it created the session.
+ *
+ * The platform accepts `connector_bindings` at create and never serializes
+ * them back onto the session, so metadata is the only place a running
+ * session's bindings survive. Anything else in there is ignored — it is
+ * free-form, and a session created before this existed simply has none.
+ */
+export function readBoundConnections(
+  metadata: Record<string, unknown> | null | undefined,
+): Record<string, string> {
+  const raw = metadata?.[BOUND_CONNECTIONS_KEY];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  return Object.fromEntries(
+    Object.entries(raw as Record<string, unknown>).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
+}
+
+export function describeSecretsAllowlist(
+  allowlist: string[] | null | undefined,
+  agentName: string | null | undefined,
+): string {
+  if (allowlist === null || allowlist === undefined) {
+    return agentName ? `Everything ${agentName} is granted` : ALL_SECRETS;
+  }
+  // `secrets: []` is a deliberate choice, not an empty state — saying "none"
+  // where the UI says "all" for null is the whole point of the distinction.
+  if (allowlist.length === 0) return 'No project secrets';
+  return allowlist.join(', ');
+}
+
+export function sessionScopeRows(input: SessionScopeInput): SessionScopeRow[] {
+  const agent = input.agentName ?? null;
+  const agentLabel = agent ?? 'The project default agent';
+  const bound = Object.entries(input.boundConnections);
+
+  return [
+    {
+      key: 'model',
+      label: 'Model',
+      badge: 'Changeable now',
+      value: null,
+      detail:
+        'Switching restarts the runtime, which ends the in-flight turn. If it cannot be applied live the change is saved and takes effect the next time this session starts — the switcher says which happened.',
+      control: 'model',
+    },
+    {
+      key: 'agent',
+      label: 'Agent',
+      badge: 'Per message',
+      value: agentLabel,
+      detail: agent
+        ? `Messages run as ${agent} unless another agent is picked in the composer. An agent whose SECRET access differs from ${agent}'s is refused — re-scoping now cannot un-read what ${agent} already loaded — and only a new session can run it.`
+        : "Messages run as the project's default agent unless another is picked in the composer. An agent with different SECRET access is refused and needs a new session; different connector or CLI access is fine.",
+      control: null,
+    },
+    {
+      key: 'secrets',
+      label: 'Secrets',
+      badge: 'Fixed at start',
+      value: describeSecretsAllowlist(input.secretsAllowlist, agent),
+      detail:
+        input.secretsAllowlist === null || input.secretsAllowlist === undefined
+          ? 'This session was started without a narrower allowlist, so it gets the agent’s full secret grant. An allowlist can only be set when a session starts — narrowing one mid-flight could leave the session unable to boot.'
+          : 'This allowlist was set when the session started and cannot be widened or narrowed now. Start a new session to change it.',
+      control: null,
+    },
+    {
+      key: 'connections',
+      label: 'Connections',
+      badge: 'Fixed at start',
+      value:
+        bound.length === 0
+          ? 'The project default for every connector'
+          : bound.map(([alias, label]) => `${alias}: ${label}`).join(', '),
+      detail:
+        bound.length === 0
+          ? 'Every connector this agent uses resolves to the project’s default connection. Bind a specific team connection when starting a session to run as that account instead.'
+          : 'Bound when the session started. Connectors not listed here still use the project default. Sessions started from here can only run as a TEAM connection — never a teammate’s private one.',
+      control: null,
+    },
+  ];
+}
+
+/** The scope rows the mid-session capability map says are frozen. Keeps the
+ *  badges from drifting away from the contract they describe. */
+export function isFixedAtStart(key: ScopeRowKey): boolean {
+  if (key === 'connections') return true;
+  return MID_SESSION_CAPABILITIES[key] === 'fixed_at_create';
+}
+
+/**
+ * Is this session's scope safe to RENDER as fact?
+ *
+ * A redacted session arrives as a perfectly good HTTP 200: the serializer blanks
+ * an inaccessible row to `metadata: {}` and `secrets_allowlist: null`, and
+ * `null` is exactly what `sessionScopeRows` reads as "everything the agent grant
+ * allows". So a session the caller may NOT open would render as LESS restricted
+ * than one they may — a redaction turned into a false reassurance.
+ *
+ * Lives here rather than inline in the component so it can be tested: the panel
+ * is prose about what a session may reach, and prose that is wrong is worse than
+ * absent.
+ */
+export function sessionScopeIsReadable<T extends { can_access?: boolean }>(
+  session: T | null | undefined,
+): session is T {
+  if (!session) return false;
+  // Only an explicit false hides it. `undefined` means the field was not
+  // serialized for this shape at all, which is the ordinary accessible case.
+  return session.can_access !== false;
+}

--- a/apps/whitelabel-demo/src/server/bindable-connections.ts
+++ b/apps/whitelabel-demo/src/server/bindable-connections.ts
@@ -21,6 +21,22 @@ export interface BindableConnection {
   isDefault: boolean;
 }
 
+/**
+ * Why an alias the project HAS connections for still has nothing to bind.
+ *
+ * Both answers are "ask a teammate", never "connect it yourself": a wrapper
+ * credential cannot connect on an end-user's behalf, and `require_connectors`
+ * — the interactive flow that would — is refused for it outright.
+ */
+export type ConnectorBindingUnavailable = 'private_only' | 'team_connection_inactive';
+
+export interface ConnectorBindingChoice {
+  alias: string;
+  /** Everything a wrapper may bind for this alias. Empty ⇒ see `unavailable`. */
+  connections: BindableConnection[];
+  unavailable: ConnectorBindingUnavailable | null;
+}
+
 export function selectBindableConnections(
   profiles: ConnectionProfile[] | undefined,
   connectorAlias: string,
@@ -47,4 +63,47 @@ export function selectBindableConnections(
       if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
       return a.label.localeCompare(b.label);
     });
+}
+
+/**
+ * Every connector alias the project has connections for, each with what this
+ * wrapper may actually bind — including the aliases where the answer is
+ * "nothing".
+ *
+ * The empty ones matter most. An alias whose only connections are members'
+ * PRIVATE ones looks connected from the inside (a teammate connected it, in
+ * their own account) and is unbindable from here, which is the single most
+ * confusing thing about connectors in wrapper mode. Grouping is done over ALL
+ * profiles, not just the bindable ones, precisely so that case can be named
+ * rather than silently disappearing from the picker.
+ */
+export function selectConnectorBindingChoices(
+  profiles: ConnectionProfile[] | undefined,
+): ConnectorBindingChoice[] {
+  const aliases = [...new Set((profiles ?? []).map((profile) => profile.connector_alias))].sort(
+    (a, b) => a.localeCompare(b),
+  );
+
+  return aliases.map((alias) => {
+    const connections = selectBindableConnections(profiles, alias);
+    if (connections.length > 0) return { alias, connections, unavailable: null };
+    // A revoked/errored TEAM connection is a different ask than a private one:
+    // the team connection exists and needs reconnecting, rather than never
+    // having been shared. Same actor either way — a teammate.
+    // `member` is the only owner type a wrapper genuinely cannot reach — it is
+    // one person's private connection. Everything else (`project`, `agent`,
+    // `subject`, `external`) is a shared/system profile that the platform WILL
+    // bind for a caller who may manage system profiles, so calling those
+    // "only connected to people's own accounts" tells the user something false
+    // AND names an action — "ask a teammate to share it" — that resolves
+    // nothing. Channel/inbox installs mint `external` profiles, so this is a
+    // shape that really occurs, not a hypothetical.
+    const forAlias = (profiles ?? []).filter((p) => p.connector_alias === alias);
+    const hasNonMemberProfile = forAlias.some((p) => p.owner_type !== 'member');
+    return {
+      alias,
+      connections,
+      unavailable: hasNonMemberProfile ? 'team_connection_inactive' : 'private_only',
+    };
+  });
 }

--- a/apps/whitelabel-demo/tests/e2e/connector-binding-choices.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/connector-binding-choices.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test';
+import { connectorBindingNotice } from '../../src/lib/connector-binding';
+import { selectConnectorBindingChoices } from '../../src/server/bindable-connections';
+
+const profile = (over: Record<string, unknown> = {}) =>
+  ({
+    profile_id: 'p1',
+    connector_alias: 'gmail',
+    owner_type: 'project',
+    owner_id: null,
+    label: 'Support',
+    status: 'active',
+    is_default: false,
+    metadata: {},
+    ...over,
+  }) as never;
+
+describe('selectConnectorBindingChoices', () => {
+  test('groups by alias, so no connector is privileged over another', () => {
+    const choices = selectConnectorBindingChoices([
+      profile({ connector_alias: 'slack', profile_id: 'a' }),
+      profile({ connector_alias: 'gmail', profile_id: 'b' }),
+    ]);
+    expect(choices.map((c) => c.alias)).toEqual(['gmail', 'slack']);
+    expect(choices.every((c) => c.connections.length === 1)).toBe(true);
+  });
+
+  test('an alias only PRIVATE connections exist for is still listed, as unavailable', () => {
+    // This is the confusing case: a teammate connected it — to their own
+    // account — so it looks connected and cannot be bound. Dropping the alias
+    // from the list would leave nothing to explain.
+    const [choice] = selectConnectorBindingChoices([
+      profile({ owner_type: 'member', owner_id: 'u1' }),
+    ]);
+    expect(choice!.connections).toEqual([]);
+    expect(choice!.unavailable).toBe('private_only');
+  });
+
+  test('a revoked TEAM connection is a different ask than a private one', () => {
+    const [choice] = selectConnectorBindingChoices([profile({ status: 'revoked' })]);
+    expect(choice!.unavailable).toBe('team_connection_inactive');
+  });
+
+  test('a bindable connection wins over any unbindable sibling on the same alias', () => {
+    const [choice] = selectConnectorBindingChoices([
+      profile({ profile_id: 'mine', owner_type: 'member', owner_id: 'u1' }),
+      profile({ profile_id: 'team', label: 'Team inbox' }),
+    ]);
+    expect(choice!.unavailable).toBeNull();
+    expect(choice!.connections.map((c) => c.profileId)).toEqual(['team']);
+  });
+
+  test('no profiles is no connectors, not a crash', () => {
+    expect(selectConnectorBindingChoices(undefined)).toEqual([]);
+  });
+});
+
+describe('connectorBindingNotice', () => {
+  const choiceFor = (over: Record<string, unknown>) =>
+    ({ alias: 'gmail', connections: [], unavailable: 'private_only', ...over }) as never;
+
+  test('a bindable alias has no notice — the picker speaks for itself', () => {
+    expect(
+      connectorBindingNotice(
+        choiceFor({
+          unavailable: null,
+          connections: [
+            { profileId: 'p', connectorAlias: 'gmail', label: 'Support', isDefault: true },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test('the private-only case points at a TEAMMATE, not at the reader', () => {
+    const notice = connectorBindingNotice(choiceFor({}))!;
+    expect(notice.detail).toContain('teammate');
+    expect(notice.detail).toContain('own accounts');
+  });
+
+  test('a revoked team connection asks for a reconnect, not a first-time share', () => {
+    const notice = connectorBindingNotice(choiceFor({ unavailable: 'team_connection_inactive' }))!;
+    expect(notice.detail).toContain('reconnect');
+  });
+
+  test('neither case offers a self-connect action', () => {
+    // A wrapper credential has no personal upstream identity, and the
+    // interactive flow that would connect one is refused for it outright
+    // (403 REQUIRE_CONNECTORS_INTERACTIVE_ONLY) — so a "connect it yourself"
+    // button could only ever lead to that refusal.
+    for (const unavailable of ['private_only', 'team_connection_inactive']) {
+      expect(connectorBindingNotice(choiceFor({ unavailable }))!.selfServiceAction).toBeNull();
+    }
+  });
+
+  test('no notice ever tells the reader to connect the account themselves', () => {
+    for (const unavailable of ['private_only', 'team_connection_inactive']) {
+      const notice = connectorBindingNotice(choiceFor({ unavailable }))!;
+      expect(`${notice.title} ${notice.detail}`.toLowerCase()).not.toContain('connect your');
+    }
+  });
+});
+
+describe('unavailable reason must not mislabel a shared connection (F4)', () => {
+  const profile = (owner: string, status = 'active') =>
+    ({ profile_id: `p-${owner}`, connector_alias: 'gmail', label: owner, owner_type: owner, status, is_default: false }) as never;
+
+  test('an EXTERNAL profile is not "private only" — channel installs mint those', () => {
+    // executor/sync.ts inserts owner_type:'external' profiles for channel/inbox
+    // installs, and the platform WILL bind them for a caller who may manage
+    // system profiles. Calling that "only connected to people's own accounts"
+    // is false AND names an action — ask a teammate to share it — that fixes
+    // nothing.
+    const choices = selectConnectorBindingChoices([profile('external', 'revoked')], ['gmail']);
+    expect(choices[0]?.unavailable).toBe('team_connection_inactive');
+  });
+
+  test('only a MEMBER-owned connection is genuinely private to one person', () => {
+    const choices = selectConnectorBindingChoices([profile('member', 'revoked')], ['gmail']);
+    expect(choices[0]?.unavailable).toBe('private_only');
+  });
+
+  test('an active team connection is offered, not reported unavailable', () => {
+    const choices = selectConnectorBindingChoices([profile('project')], ['gmail']);
+    expect(choices[0]?.unavailable).toBeNull();
+    expect(choices[0]?.connections).toHaveLength(1);
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/mid-session-change.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { MID_SESSION_CAPABILITIES, classifyAgentSwitch } from '../../src/lib/mid-session-change';
+import {
+  MID_SESSION_CAPABILITIES,
+  agentSwitchRefusal,
+  classifyAgentSwitch,
+} from '../../src/lib/mid-session-change';
 
 describe('what can change mid-session', () => {
   test('model changes, agent is per-prompt, secrets are fixed at create', () => {
@@ -52,5 +56,58 @@ describe('classifyAgentSwitch', () => {
     if (result.kind !== 'ok') {
       expect(result.message).toBe('The agent could not be switched.');
     }
+  });
+});
+
+describe('agentSwitchRefusal', () => {
+  // The refusal is raised by the sandbox proxy on the prompt itself, so a host
+  // sees a generic runtime error whose message carries the 409 body.
+  const runtimeError = (body: Record<string, unknown>) => ({
+    kind: 'runtime-error' as const,
+    message: JSON.stringify(body),
+    cause: new Error(`Failed to perform action: ${JSON.stringify(body)}`),
+  });
+
+  const REFUSAL = {
+    error: 'agent switch requires a new session',
+    code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION',
+    expected_agent: 'support',
+    requested_agent: 'finance',
+  };
+
+  test('a refused switch names both agents, so the UI can say which is which', () => {
+    const refusal = agentSwitchRefusal(runtimeError(REFUSAL))!;
+    expect(refusal.requestedAgent).toBe('finance');
+    expect(refusal.expectedAgent).toBe('support');
+  });
+
+  test('it is recognised from a STRUCTURED error body too', () => {
+    // Same refusal, different envelope depending on which layer rejected it.
+    const refusal = agentSwitchRefusal({
+      message: 'x',
+      cause: Object.assign(new Error('x'), { data: REFUSAL }),
+    })!;
+    expect(refusal.requestedAgent).toBe('finance');
+  });
+
+  test('an ordinary send failure is NOT offered a new session', () => {
+    // Offering "start a new session" for a transient failure would throw away
+    // the session over something a retry fixes.
+    expect(agentSwitchRefusal({ message: 'the model timed out', cause: new Error('boom') })).toBeNull();
+    expect(agentSwitchRefusal(null)).toBeNull();
+  });
+
+  test('the RETRYABLE grant failure is never mistaken for it', () => {
+    expect(
+      agentSwitchRefusal(runtimeError({ code: 'AGENT_SECRET_GRANT_UNRESOLVED', error: 'x' })),
+    ).toBeNull();
+  });
+
+  test('a refusal without agent names still surfaces, with a usable message', () => {
+    const refusal = agentSwitchRefusal(
+      runtimeError({ code: 'AGENT_SWITCH_REQUIRES_NEW_SESSION', error: 'nope' }),
+    )!;
+    expect(refusal.requestedAgent).toBeNull();
+    expect(refusal.message).toBe('nope');
   });
 });

--- a/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
+++ b/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
@@ -48,6 +48,19 @@ export interface GatewaySessionRow {
   [key: string]: unknown;
 }
 
+/** One `/connector-profiles` row — the shape `selectConnectorBindingChoices`
+ *  filters. Deliberately the raw upstream shape, not the app's view of it. */
+export interface MockConnectionProfile {
+  profile_id: string;
+  connector_alias: string;
+  owner_type: 'project' | 'agent' | 'member' | 'subject' | 'external';
+  owner_id: string | null;
+  label: string;
+  status: 'active' | 'revoked' | 'error';
+  is_default: boolean;
+  metadata: Record<string, unknown>;
+}
+
 export interface MockUpstream {
   /** Base URL WITHOUT `/v1` — pass `${url}/v1` as `KORTIX_UPSTREAM`. */
   url: string;
@@ -62,6 +75,8 @@ export interface MockUpstream {
    *  never provisioned, to prove per-user filtering actually filters. */
   seedProject(overrides?: Partial<MockProject>): MockProject;
   seedGatewaySessions(projectId: string, rows: GatewaySessionRow[]): void;
+  /** Seed the connection profiles `/connector-profiles` returns for a project. */
+  seedConnectionProfiles(projectId: string, profiles: MockConnectionProfile[]): void;
   /** Make GET /v1/projects/:id/gateway/sessions fail (500) for this project id. */
   failGatewayFor(projectId: string): void;
   /** Make POST /v1/projects/:id/cli-token return HTTP 200 with a body MISSING
@@ -78,6 +93,7 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
   const projects = new Map<string, MockProject>();
   const secrets = new Map<string, Array<{ name: string; value?: string }>>();
   const gatewaySessions = new Map<string, GatewaySessionRow[]>();
+  const connectionProfiles = new Map<string, MockConnectionProfile[]>();
   const failingGatewayProjects = new Set<string>();
   const malformedCliTokenProjects = new Set<string>();
   const activeIntervals = new Set<ReturnType<typeof setInterval>>();
@@ -172,6 +188,12 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
           secrets.set(id, list);
           return Response.json({ ok: true });
         }
+      }
+
+      const profilesMatch = p.match(/^projects\/([^/]+)\/connector-profiles$/);
+      if (profilesMatch && method === 'GET') {
+        const [, id] = profilesMatch;
+        return Response.json({ profiles: connectionProfiles.get(id) ?? [] });
       }
 
       const gatewayMatch = p.match(/^projects\/([^/]+)\/gateway\/sessions$/);
@@ -346,6 +368,9 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
     },
     seedGatewaySessions(projectId, rows) {
       gatewaySessions.set(projectId, rows);
+    },
+    seedConnectionProfiles(projectId, profiles) {
+      connectionProfiles.set(projectId, profiles);
     },
     failGatewayFor(projectId) {
       failingGatewayProjects.add(projectId);

--- a/apps/whitelabel-demo/tests/e2e/new-session-overrides.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/new-session-overrides.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The create-only overrides, end to end through the wrapper.
+ *
+ * This boots the real app against the MOCK upstream, so it proves what the
+ * demo SENDS and how it handles what comes back — not that the platform
+ * enforces any of it. The refusals these overrides can produce
+ * (SECRET_IDENTIFIER_NOT_FOUND, CONNECTOR_PROFILE_INACTIVE, …) are the real
+ * API's job and are tested there.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import {
+  type AppInstance,
+  createTestKortix,
+  loginUser,
+  resetUsersStore,
+  startApp,
+  uniqueEmail,
+} from './harness';
+import { type MockConnectionProfile, type MockUpstream, createMockUpstream } from './mock-upstream';
+import { DEMO_PASSWORD, WRAPPER_KEY, wrapperEnv } from './env';
+import { NO_OVERRIDES, buildSessionCreateInput } from '../../src/lib/session-overrides';
+import type { ConnectorBindingChoice } from '../../src/server/bindable-connections';
+
+const profile = (over: Partial<MockConnectionProfile>): MockConnectionProfile => ({
+  profile_id: 'p1',
+  connector_alias: 'slack',
+  owner_type: 'project',
+  owner_id: null,
+  label: 'Support',
+  status: 'active',
+  is_default: false,
+  metadata: {},
+  ...over,
+});
+
+describe('starting a session with overrides', () => {
+  let mock: MockUpstream;
+  let app: AppInstance;
+  let token: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    resetUsersStore();
+    mock = createMockUpstream(WRAPPER_KEY);
+    app = await startApp(wrapperEnv({ KORTIX_UPSTREAM: `${mock.url}/v1` }));
+    token = await loginUser(app, uniqueEmail('overrides'), DEMO_PASSWORD);
+    const project = await createTestKortix(app, token).projects.provision({ name: 'Overrides' });
+    projectId = project.project_id;
+    mock.seedConnectionProfiles(projectId, [
+      profile({ profile_id: 'slack_team', connector_alias: 'slack', is_default: true }),
+      // Connected, but to a person's own account — unbindable from a wrapper.
+      profile({
+        profile_id: 'gmail_mine',
+        connector_alias: 'gmail',
+        owner_type: 'member',
+        owner_id: 'u1',
+        label: 'My inbox',
+      }),
+    ]);
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.stop();
+    mock?.stop();
+    resetUsersStore();
+  });
+
+  async function connectorChoices(): Promise<ConnectorBindingChoice[]> {
+    const res = await fetch(
+      `${app.baseUrl}/api/connections?projectId=${encodeURIComponent(projectId)}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    expect(res.status).toBe(200);
+    return ((await res.json()) as { connectors: ConnectorBindingChoice[] }).connectors;
+  }
+
+  async function lastSessionCreate() {
+    const create = mock.requests.filter(
+      (r) => r.method === 'POST' && r.path === `/v1/projects/${projectId}/sessions`,
+    );
+    expect(create.length).toBe(1);
+    return create[0]!.body as Record<string, unknown>;
+  }
+
+  test('a narrowed allowlist reaches the API as `secrets`', async () => {
+    mock.reset();
+    const kortix = createTestKortix(app, token);
+    await kortix
+      .project(projectId)
+      .sessions.create(
+        buildSessionCreateInput(
+          { ...NO_OVERRIDES, secrets: ['STRIPE_KEY'] },
+          { sessionId: '00000000-0000-4000-8000-00000000a001' },
+        ),
+      );
+
+    expect(await lastSessionCreate()).toMatchObject({ secrets: ['STRIPE_KEY'] });
+  });
+
+  test('a binding reaches the API keyed by the alias that was chosen', async () => {
+    mock.reset();
+    const kortix = createTestKortix(app, token);
+    await kortix
+      .project(projectId)
+      .sessions.create(
+        buildSessionCreateInput(
+          { ...NO_OVERRIDES, bindings: { slack: 'slack_team' } },
+          { sessionId: '00000000-0000-4000-8000-00000000a002' },
+        ),
+      );
+
+    const body = await lastSessionCreate();
+    expect(body.connector_bindings).toEqual({ slack: { profile_id: 'slack_team' } });
+    expect(body.inherit_unbound).toBe(true);
+  });
+
+  test('an untouched dialog adds nothing to the create the wrapper already sent', async () => {
+    mock.reset();
+    const kortix = createTestKortix(app, token);
+    await kortix
+      .project(projectId)
+      .sessions.create(
+        buildSessionCreateInput(NO_OVERRIDES, {
+          sessionId: '00000000-0000-4000-8000-00000000a003',
+        }),
+      );
+
+    // `end_user_ref` is injected by the proxy from the signed-in user and is
+    // never accepted from the browser — so the ONLY thing the dialog itself
+    // contributed here is the session id.
+    const body = await lastSessionCreate();
+    expect(Object.keys(body).sort()).toEqual(['end_user_ref', 'session_id']);
+    expect(body.session_id).toBe('00000000-0000-4000-8000-00000000a003');
+  });
+
+  test('the picker offers the team connection and only the team connection', async () => {
+    const slack = (await connectorChoices()).find((c) => c.alias === 'slack')!;
+    expect(slack.connections.map((c) => c.profileId)).toEqual(['slack_team']);
+  });
+
+  test('an alias with no team connection is offered as "ask a teammate"', async () => {
+    // The private connection exists upstream; it must never appear as an
+    // option, and the alias must not silently vanish either.
+    const gmail = (await connectorChoices()).find((c) => c.alias === 'gmail')!;
+    expect(gmail.connections).toEqual([]);
+    expect(gmail.unavailable).toBe('private_only');
+  });
+
+  test('the wrapper key is what talks to the API, never the end-user token', async () => {
+    await connectorChoices();
+    expect(mock.authViolations).toHaveLength(0);
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/send-failure.test.ts
@@ -76,3 +76,42 @@ describe('sessionCreateFailure', () => {
     expect(sessionCreateFailure(null).title).toBe('Could not start a session');
   });
 });
+
+describe('the overrides dialog makes new refusals reachable (F3)', () => {
+  const apiError = (code: string, message = 'x') =>
+    Object.assign(new Error(message), { code, data: { code, error: message } });
+
+  test('every code the secrets/connector overrides can produce is TERMINAL, not retryable', () => {
+    // Each of these refuses identically on retry: the allowlist and the bindings
+    // are create-only, so offering "try again" sends the user in a loop.
+    for (const code of [
+      'SECRET_IDENTIFIER_NOT_FOUND',
+      'SECRET_IDENTIFIER_KEY_COLLISION',
+      'INVALID_SESSION_SECRETS',
+      'CONNECTOR_PROFILE_NOT_FOUND',
+      'CONNECTOR_PROFILE_INACTIVE',
+      'origin_override_forbidden',
+    ]) {
+      const failure = sessionCreateFailure(apiError(code));
+      expect(failure.retryable).toBe(false);
+      expect(failure.title).not.toBe('Could not start a session');
+    }
+  });
+
+  test('the key-collision refusal names the actual problem', () => {
+    // "Two identifiers inject the same env var" is legal in the project and
+    // illegal in one session — the user cannot guess that from a generic error.
+    const failure = sessionCreateFailure(apiError('SECRET_IDENTIFIER_KEY_COLLISION'));
+    expect(failure.title.toLowerCase()).toContain('same variable name');
+  });
+
+  test('direct mode gets its own copy, not upstream developer text', () => {
+    // `secrets` is backend-origin-only, so in direct mode the server's own
+    // message is about token kinds — meaningless to an end user.
+    const failure = sessionCreateFailure(apiError('origin_override_forbidden', 'origin override forbidden'));
+    expect(failure.title).toContain('wrapper mode');
+    // and it must NOT pass the upstream sentence through, unlike the cases where
+    // the server's message carries numbers the user needs.
+    expect(failure.detail).not.toContain('origin override forbidden');
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/session-overrides.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-overrides.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  BOUND_CONNECTIONS_KEY,
+  NO_OVERRIDES,
+  buildSessionCreateInput,
+} from '../../src/lib/session-overrides';
+
+const SESSION_ID = '00000000-0000-4000-8000-000000000001';
+
+describe('buildSessionCreateInput', () => {
+  test('an untouched dialog sends exactly what the bare create sent before', () => {
+    // The overrides are opt-in. If this ever grows a field, every existing
+    // session shape changes silently — which is the failure this test exists
+    // to catch.
+    expect(buildSessionCreateInput(NO_OVERRIDES, { sessionId: SESSION_ID })).toEqual({
+      session_id: SESSION_ID,
+    });
+  });
+
+  test('a narrowed allowlist is sent as `secrets`', () => {
+    const input = buildSessionCreateInput(
+      { ...NO_OVERRIDES, secrets: ['STRIPE_KEY', 'GMAIL_TOKEN'] },
+      { sessionId: SESSION_ID },
+    );
+    expect(input.secrets).toEqual(['STRIPE_KEY', 'GMAIL_TOKEN']);
+  });
+
+  test('an EMPTY allowlist is sent — "zero secrets" is a choice, not an absence', () => {
+    const input = buildSessionCreateInput(
+      { ...NO_OVERRIDES, secrets: [] },
+      { sessionId: SESSION_ID },
+    );
+    expect(input.secrets).toEqual([]);
+  });
+
+  test('no allowlist means the field is absent, not an empty array', () => {
+    // `secrets: []` would boot a sandbox with no project secrets at all — the
+    // opposite of "leave it alone".
+    const input = buildSessionCreateInput(NO_OVERRIDES, { sessionId: SESSION_ID });
+    expect('secrets' in input).toBe(false);
+  });
+
+  test('a binding is keyed by the alias that was chosen', () => {
+    const input = buildSessionCreateInput(
+      { ...NO_OVERRIDES, bindings: { slack: 'prof_9' } },
+      { sessionId: SESSION_ID },
+    );
+    // The alias used to be hardcoded to one connector, so binding anything
+    // else silently bound the wrong one.
+    expect(input.connector_bindings).toEqual({ slack: { profile_id: 'prof_9' } });
+    expect(Object.keys(input.connector_bindings ?? {})).not.toContain('gmail');
+  });
+
+  test('several aliases can be bound in one create', () => {
+    const input = buildSessionCreateInput(
+      { ...NO_OVERRIDES, bindings: { slack: 'prof_9', notion: 'prof_3' } },
+      { sessionId: SESSION_ID },
+    );
+    expect(input.connector_bindings).toEqual({
+      slack: { profile_id: 'prof_9' },
+      notion: { profile_id: 'prof_3' },
+    });
+  });
+
+  test('binding one alias keeps the project default for every other one', () => {
+    // Without inherit_unbound, binding ANY alias switches all the others off
+    // their project default — picking one connection would unplug the rest.
+    const input = buildSessionCreateInput(
+      { ...NO_OVERRIDES, bindings: { slack: 'prof_9' } },
+      { sessionId: SESSION_ID },
+    );
+    expect(input.inherit_unbound).toBe(true);
+  });
+
+  test('no bindings means no connector fields at all', () => {
+    const input = buildSessionCreateInput(NO_OVERRIDES, { sessionId: SESSION_ID });
+    expect('connector_bindings' in input).toBe(false);
+    expect('inherit_unbound' in input).toBe(false);
+    expect('metadata' in input).toBe(false);
+  });
+
+  test('what was bound is recorded in metadata — the platform never reads it back', () => {
+    const input = buildSessionCreateInput(
+      { ...NO_OVERRIDES, bindings: { slack: 'prof_9' } },
+      { sessionId: SESSION_ID, connectionLabels: { slack: 'Support' } },
+    );
+    expect(input.metadata?.[BOUND_CONNECTIONS_KEY]).toEqual({ slack: 'Support' });
+  });
+
+  test('a missing label falls back to the profile id rather than dropping the row', () => {
+    const input = buildSessionCreateInput(
+      { ...NO_OVERRIDES, bindings: { slack: 'prof_9' } },
+      { sessionId: SESSION_ID },
+    );
+    expect(input.metadata?.[BOUND_CONNECTIONS_KEY]).toEqual({ slack: 'prof_9' });
+  });
+
+  test('the agent is sent only when one was picked', () => {
+    expect(
+      buildSessionCreateInput({ ...NO_OVERRIDES, agent: 'support' }, { sessionId: SESSION_ID })
+        .agent_name,
+    ).toBe('support');
+    expect('agent_name' in buildSessionCreateInput(NO_OVERRIDES, { sessionId: SESSION_ID })).toBe(
+      false,
+    );
+  });
+
+  test('the "default" sandbox template is not a template override', () => {
+    const input = buildSessionCreateInput(NO_OVERRIDES, {
+      sessionId: SESSION_ID,
+      sandboxSlug: 'default',
+    });
+    expect('sandbox_slug' in input).toBe(false);
+  });
+
+  test('everything at once composes into one body', () => {
+    const input = buildSessionCreateInput(
+      { agent: 'support', secrets: ['STRIPE_KEY'], bindings: { slack: 'prof_9' } },
+      { sessionId: SESSION_ID, name: 'Refund a customer', sandboxSlug: 'python' },
+    );
+    expect(input).toEqual({
+      session_id: SESSION_ID,
+      name: 'Refund a customer',
+      sandbox_slug: 'python',
+      agent_name: 'support',
+      secrets: ['STRIPE_KEY'],
+      connector_bindings: { slack: { profile_id: 'prof_9' } },
+      inherit_unbound: true,
+      metadata: { [BOUND_CONNECTIONS_KEY]: { slack: 'prof_9' } },
+    });
+  });
+});

--- a/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/session-scope.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test';
+import { BOUND_CONNECTIONS_KEY, buildSessionCreateInput } from '../../src/lib/session-overrides';
+import {
+  isFixedAtStart,
+  readBoundConnections,
+  sessionScopeIsReadable,
+  sessionScopeRows,
+} from '../../src/lib/session-scope';
+
+const rows = (over: Partial<Parameters<typeof sessionScopeRows>[0]> = {}) =>
+  sessionScopeRows({ agentName: null, secretsAllowlist: null, boundConnections: {}, ...over });
+
+const row = (key: string, over: Parameters<typeof rows>[0] = {}) =>
+  rows(over).find((r) => r.key === key)!;
+
+describe('sessionScopeRows', () => {
+  test("a real allowlist is shown, not a description of what an allowlist is", () => {
+    expect(row('secrets', { secretsAllowlist: ['STRIPE_KEY', 'GMAIL_TOKEN'] }).value).toBe(
+      'STRIPE_KEY, GMAIL_TOKEN',
+    );
+  });
+
+  test('no allowlist reads as "everything the agent is granted", never as empty', () => {
+    // null (never narrowed) and [] (narrowed to nothing) are opposite states;
+    // rendering both as an empty list would claim a session can read nothing.
+    expect(row('secrets', { secretsAllowlist: null, agentName: 'support' }).value).toBe(
+      'Everything support is granted',
+    );
+    expect(row('secrets', { secretsAllowlist: [] }).value).toBe('No project secrets');
+  });
+
+  test('the allowlist reason is specific to whether THIS session has one', () => {
+    expect(row('secrets', { secretsAllowlist: null }).detail).toContain('without a narrower');
+    expect(row('secrets', { secretsAllowlist: ['A'] }).detail).toContain('cannot be widened');
+  });
+
+  test("the agent row names this session's agent, in both directions", () => {
+    const scoped = row('agent', { agentName: 'support' });
+    expect(scoped.value).toBe('support');
+    // The refusal is about SECRET access specifically — connector and CLI
+    // grants may differ freely — so the row has to say which.
+    expect(scoped.detail).toContain('SECRET access');
+    expect(scoped.detail).toContain('support');
+    expect(row('agent').value).toBe('The project default agent');
+  });
+
+  test('the model row carries the control instead of a duplicated value', () => {
+    const model = row('model');
+    expect(model.control).toBe('model');
+    expect(model.value).toBeNull();
+    // "applied_live: false" is a real outcome, so the row must not promise the
+    // change always takes effect immediately.
+    expect(model.detail).toContain('next time this session starts');
+  });
+
+  test('bound connections are listed by alias', () => {
+    expect(row('connections', { boundConnections: { slack: 'Support', gmail: 'Team inbox' } }).value).toBe(
+      'slack: Support, gmail: Team inbox',
+    );
+  });
+
+  test('nothing bound reads as the project default, not as "no connectors"', () => {
+    expect(row('connections').value).toBe('The project default for every connector');
+  });
+
+  test('a bound session is told unbound connectors still fall back to the default', () => {
+    expect(row('connections', { boundConnections: { slack: 'Support' } }).detail).toContain(
+      'still use the project default',
+    );
+  });
+
+  test('only the model is changeable now — the badges match the contract', () => {
+    expect(isFixedAtStart('model')).toBe(false);
+    expect(isFixedAtStart('secrets')).toBe(true);
+    expect(isFixedAtStart('connections')).toBe(true);
+    // Per-message, so not frozen — but it has no control on this panel.
+    expect(isFixedAtStart('agent')).toBe(false);
+    expect(rows().filter((r) => r.control !== null).map((r) => r.key)).toEqual(['model']);
+  });
+});
+
+describe('readBoundConnections', () => {
+  test('round-trips what the create wrote — the panel reads its own record', () => {
+    // The platform never serializes a session's bindings back, so the create
+    // body and the scope panel have to agree on one metadata key or the
+    // Connections row silently reads empty forever.
+    const created = buildSessionCreateInput(
+      { agent: null, secrets: null, bindings: { slack: 'prof_9' } },
+      { sessionId: 's', connectionLabels: { slack: 'Support' } },
+    );
+    expect(readBoundConnections(created.metadata)).toEqual({ slack: 'Support' });
+  });
+
+  test('a session created before this existed reads as unbound, not as broken', () => {
+    expect(readBoundConnections({})).toEqual({});
+    expect(readBoundConnections(null)).toEqual({});
+    expect(readBoundConnections({ name: 'Some session' })).toEqual({});
+  });
+
+  test('junk in metadata is ignored rather than rendered', () => {
+    expect(readBoundConnections({ [BOUND_CONNECTIONS_KEY]: 'nope' })).toEqual({});
+    expect(readBoundConnections({ [BOUND_CONNECTIONS_KEY]: { slack: 7, gmail: 'Team' } })).toEqual({
+      gmail: 'Team',
+    });
+  });
+});
+
+describe('a redacted session must not read as permissive (F1)', () => {
+  test('can_access:false is treated as unreadable, not as "not narrowed"', () => {
+    // The serializer blanks an inaccessible session to `metadata: {}` and
+    // `secrets_allowlist: null` and still returns HTTP 200. `null` is exactly
+    // what this panel reads as "everything the agent grant allows", so without
+    // the can_access check a session the caller may NOT open renders as LESS
+    // restricted than one they may — a false reassurance about a security fact.
+    expect(sessionScopeIsReadable({ can_access: false })).toBe(false);
+    // ...while an accessible session, or one whose shape omits the field, renders.
+    expect(sessionScopeIsReadable({ can_access: true })).toBe(true);
+    expect(sessionScopeIsReadable({})).toBe(true);
+    expect(sessionScopeIsReadable(null)).toBe(false);
+    expect(sessionScopeIsReadable(undefined)).toBe(false);
+  });
+
+  test('a null allowlist on an ACCESSIBLE session still means "everything granted"', () => {
+    // Guard the other direction: the fix must not make a legitimately
+    // un-narrowed session look restricted.
+    const rows = sessionScopeRows({ agentName: 'kortix', secretsAllowlist: null, boundConnections: {} });
+    const secrets = rows.find((r) => r.key === 'secrets');
+    expect(secrets?.detail ?? '').not.toContain('0 secret');
+  });
+});

--- a/docs/KAAB_TESTING_GUIDE.md
+++ b/docs/KAAB_TESTING_GUIDE.md
@@ -1,0 +1,879 @@
+# Testing Kortix-as-a-Backend by hand
+
+A sit-down testing script. Every capability KaaB ships today, as a numbered
+recipe: the exact command, and the exact result that means it worked.
+
+Two vantage points, and the difference matters:
+
+- **The Lumen demo UI** (`apps/whitelabel-demo`) — what a wrapper's *end-user*
+  sees. Lumen holds ONE Kortix credential and fronts many users.
+- **curl against the API** — what the *operator* sees. This is the only place
+  you can look across end-users, because Lumen deliberately narrows every
+  read to the signed-in one.
+
+Several capabilities have **no UI at all** (the per-session `secrets` allowlist
+is the big one). Those recipes are curl-only, and say so.
+
+Reference docs, not this file, for the contract itself:
+[`KORTIX_AS_A_BACKEND_GUIDE.md`](KORTIX_AS_A_BACKEND_GUIDE.md).
+
+> **Which Lumen this describes.** Every UI claim below was read off committed
+> code. A new-session dialog that chooses agent + secrets + per-connector
+> bindings up front is **in flight in the working tree** (`new-session-dialog.tsx`,
+> `connector-bindings.tsx`, `lib/session-overrides.ts`, `lib/session-scope.ts`).
+> When that lands, the curl-only recipes in C and the "hardcoded to gmail" caveat
+> in F stop being true — the platform behaviour they exercise does not change,
+> only where you click. The curl recipes stay valid either way; run them if a
+> UI result surprises you.
+
+---
+
+## A. Setup — Lumen in wrapper mode against dev
+
+### A1. Get an ACCOUNT-scoped API key
+
+Dashboard → **Settings → Tokens → Create API key**. Do **not** use a
+project-scoped token.
+
+Verify before you go further:
+
+```bash
+export KORTIX_API_KEY=kortix_pat_...
+curl -s -o /dev/null -w '%{http_code}\n' \
+  https://dev-api.kortix.com/v1/projects \
+  -H "Authorization: Bearer $KORTIX_API_KEY"
+```
+
+- `200` → account-scoped. Good.
+- `403` → project-scoped. The body reads
+  `{"message":"Project-scoped token cannot list projects"}`
+  (`apps/api/src/middleware/auth.ts:737`).
+
+**Why this one matters more than it looks.** Lumen's home page lists projects
+through `GET /projects`. With a project-scoped key that call 403s, and the UI
+renders *"Couldn't load projects — try signing in again"*
+(`apps/whitelabel-demo/src/app/page.tsx:126`). Signing in again cannot possibly
+fix it. If the project list is broken, check the key's scope first.
+
+### A2. Write `.env.local`
+
+`apps/whitelabel-demo/.env.local`:
+
+```dotenv
+KORTIX_API_KEY=kortix_pat_...
+KORTIX_UPSTREAM=https://dev-api.kortix.com/v1
+KORTIX_API_URL=https://dev-api.kortix.com/v1
+SESSION_SECRET=any-long-random-string
+# optional
+# DEMO_PASSWORD=
+COST_MARKUP=1.2
+```
+
+**Set BOTH upstream variables to the same value.** They are not aliases:
+
+| Route | Reads |
+|---|---|
+| `/api/kortix/*` (the BFF proxy), `/api/usage`, `/api/preview-url` | `KORTIX_UPSTREAM` |
+| `/api/connections` (the connector picker), `/api/session-model` | `KORTIX_API_URL` |
+
+`/api/connections` and `/api/session-model` fall back to
+`https://api.kortix.com/v1` — **production** — when `KORTIX_API_URL` is unset
+(`src/app/api/connections/route.ts:36`, `src/app/api/session-model/route.ts:23`).
+Set only `KORTIX_UPSTREAM` and the connector picker and the model switcher
+silently talk to the wrong deployment while everything else talks to dev.
+
+### A3. Build and start
+
+```bash
+cd apps/whitelabel-demo
+lsof -ti :3010 | xargs -r kill      # gotcha 1, below
+rm -rf .next                         # gotcha 2, below
+pnpm build
+WHITELABEL_PORT=3010 pnpm start
+```
+
+**Gotcha 1 — a stale process on the port keeps answering.** `next start` fails
+with `EADDRINUSE` when 3010 is taken, and if you miss that line in the scroll,
+every curl you run afterwards hits the *old* server and you will spend an hour
+testing code you did not build. Kill the port first, every time.
+
+**Gotcha 2 — the e2e harness skips the build when `.next/BUILD_ID` exists.**
+So does your muscle memory. After any source change, `rm -rf .next`. This has
+already burned us once.
+
+### A4. Verify wrapper mode is on
+
+```bash
+curl -s localhost:3010/api/mode
+```
+
+Expected, exactly:
+
+```json
+{"wrapperMode":true}
+```
+
+`{"wrapperMode":false}` means `KORTIX_API_KEY` was not visible to the server
+process — Lumen is in direct mode and none of the rest of this guide applies.
+
+### A5. Log in
+
+Open <http://localhost:3010> and sign in with **any email-shaped string and any
+non-empty password**. There is no user directory; the email *is* the user id
+(`src/server/auth.ts#checkDemoCredentials`). Set `DEMO_PASSWORD` in `.env.local`
+to require one specific password instead.
+
+For curl, mint a token the same way the browser does:
+
+```bash
+export LUMEN=http://localhost:3010
+export TOKEN_A=$(curl -s -X POST $LUMEN/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"alice@example.com","password":"x"}' | jq -r .token)
+
+curl -s $LUMEN/api/auth/me -H "Authorization: Bearer $TOKEN_A"
+```
+
+Expected: `{"userId":"alice@example.com"}`. Note the email is **lowercased** —
+that lowercased string is the `end_user_ref` for everything that follows.
+
+### A6. Create a project, and know where ownership lives
+
+Click **New project** in the UI (this hits `POST /projects/provision`).
+
+Lumen's whole isolation model is a JSON file: `.lumen-data/users.json` under the
+app's cwd, mapping login email → the project ids that user provisioned
+(`src/server/users.ts`). A user who does not own a project id gets `403` from
+the proxy for every route under it.
+
+That file is also your test rig. To put **two** logins on the **same** project
+(needed for the connector and isolation recipes), stop the server and edit it:
+
+```json
+{
+  "alice@example.com": ["<project-uuid>"],
+  "bob@example.com":   ["<project-uuid>"]
+}
+```
+
+Restart. This is a demo store, not a security boundary — it is meant to be
+edited by hand.
+
+Export the ids you will reuse:
+
+```bash
+export API=https://dev-api.kortix.com/v1
+export PROJECT_ID=<project-uuid>
+```
+
+---
+
+## B. The usage label (`end_user_ref`)
+
+### B1. What it is, and why the browser cannot set it
+
+In wrapper mode every upstream call carries **one** credential — Lumen's
+`KORTIX_API_KEY`. Upstream therefore cannot tell Lumen's users apart on its own.
+`end_user_ref` is how Lumen tells it, and it drives per-end-user usage
+attribution, idempotency-replay protection, the per-end-user session filter, and
+the optional caps in section H.
+
+Lumen injects it **server-side** in the BFF proxy, from the verified session
+token (`src/server/end-user.ts`). The browser cannot supply it. A client that
+could set it could:
+
+- **bill another user** — every usage row for the session is attributed to the
+  string it sent; and
+- **replay another user's session** — session create is idempotent on
+  `Idempotency-Key`, so a shared key under a *different* end-user would hand the
+  original session back to the wrong person. (Upstream refuses that pairing with
+  `409 IDEMPOTENCY_ORIGIN_CONFLICT`, but the wrapper must not be the thing
+  offering the attempt.)
+
+A browser that *names somebody else* is rejected rather than silently corrected,
+so the attempt surfaces instead of looking like it worked:
+
+```bash
+curl -s -X POST "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $TOKEN_A" -H 'Content-Type: application/json' \
+  -d '{"end_user_ref":"bob@example.com"}'
+```
+
+Expected: HTTP `403`, body
+`{"error":"end_user_ref must not be set by the client — it is derived from your session"}`.
+
+Echoing your *own* id is fine (it agrees) and passes through.
+
+### B2. Produce spend under two labels
+
+Sign in as `alice@example.com` in one browser profile and `bob@example.com` in
+another (or just use two `TOKEN_*` values plus the UI once each). Start a
+session as each and run **one real turn** — a turn, not just a session create;
+usage rows come from model calls.
+
+### B3. Read the spend back, grouped
+
+```bash
+curl -s "$API/usage?group_by=end_user_ref" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" | jq .
+```
+
+Expected: `data` (account totals) plus a `breakdown` array with one entry per
+end-user. Each entry carries **both** spellings with the same value:
+
+```json
+{
+  "end_user_ref": "alice@example.com",
+  "origin_ref":   "alice@example.com",
+  "input_tokens": 1234, "output_tokens": 567, "cost": 0.0181, "count": 2
+}
+```
+
+Rows with no `end_user_ref` (ordinary dashboard sessions) are excluded from this
+grouping — that is deliberate, not a gap.
+
+### B4. Narrow to one end-user
+
+```bash
+curl -s "$API/usage?end_user_ref=alice@example.com" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" | jq .data
+```
+
+Expected: `data` shows **Alice's** totals, not the account's. The filter applies
+to the totals, not just the breakdown — a wrapper asking for one user's spend
+never gets account-wide numbers back (`router/routes/usage.ts`).
+
+### B5. List one end-user's sessions
+
+```bash
+curl -s "$API/projects/$PROJECT_ID/sessions?end_user_ref=alice@example.com" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" | jq '.[] | {session_id, end_user_ref, agent_name, status}'
+```
+
+Expected: only Alice's sessions. The filter is applied **in the SQL**, not after
+— you are not pulling the whole project and filtering client-side.
+
+### B6. The deprecated spelling, and the 400
+
+`origin_ref` still works everywhere `end_user_ref` does, and is echoed back with
+the same value:
+
+```bash
+curl -s "$API/usage?group_by=origin_ref" -H "Authorization: Bearer $KORTIX_API_KEY" | jq '.breakdown[0]'
+```
+
+Sending **both with different values** is a `400`, on session create, on the
+session list, and on usage:
+
+```bash
+curl -s "$API/usage?end_user_ref=alice@example.com&origin_ref=bob@example.com" \
+  -H "Authorization: Bearer $KORTIX_API_KEY"
+```
+
+Expected: HTTP `400`, message
+`end_user_ref and its deprecated alias origin_ref disagree — send only end_user_ref`.
+On session create/list the same conflict comes back as
+`{"code":"END_USER_REF_CONFLICT"}`. Picking a winner would misattribute every
+usage row for that session, so nothing picks one.
+
+### B7. What Lumen's own `/usage` page shows
+
+`http://localhost:3010/usage` shows **your own line only**. `/api/usage`
+narrows the rollup to the caller (`endUserRef: session.userId`) on purpose: the
+account-wide rollup would otherwise let any signed-in Lumen user read every
+other end-user's id and spend from the main nav. A real operator dashboard would
+gate the unnarrowed view behind an operator role; the demo has no such role.
+
+**So: cross-user comparison is a curl-with-the-API-key exercise (B3), not a UI
+one.** That is the correct product behaviour, not a missing feature.
+
+---
+
+## C. Secrets — the per-session allowlist
+
+**No UI exists for the allowlist** in committed code — secrets CRUD has one,
+narrowing a session to a subset of them does not, so recipes C3 onward are curl.
+(A new-session dialog that offers the allowlist is in flight; see the note at the
+top. The curl recipes exercise the same create body either way.)
+
+### C1. Add two secrets
+
+Project → **Settings → Secrets**. Add:
+
+| Name | Value |
+|---|---|
+| `ALPHA_KEY` | `alpha-value` |
+| `BETA_KEY` | `beta-value` |
+
+The name is uppercased and must be a valid env var name. `KORTIX_*` is reserved
+(`400`). The **identifier** — the handle a grant and an allowlist reference —
+defaults to the name.
+
+### C2. Confirm they exist
+
+```bash
+curl -s "$API/projects/$PROJECT_ID/secrets" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" | jq '.items[] | {identifier, name, configured}'
+```
+
+Values are never returned. Expected: `ALPHA_KEY` and `BETA_KEY`.
+
+### C3. Start a session narrowed to a subset
+
+Through Lumen's proxy, so `end_user_ref` is stamped for you:
+
+```bash
+curl -s -X POST "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $TOKEN_A" -H 'Content-Type: application/json' \
+  -d '{"secrets":["ALPHA_KEY"]}' | jq '{session_id, end_user_ref, secrets_allowlist}'
+```
+
+Expected:
+
+```json
+{
+  "session_id": "…",
+  "end_user_ref": "alice@example.com",
+  "secrets_allowlist": ["ALPHA_KEY"]
+}
+```
+
+`secrets_allowlist` echoing back is the proof it was accepted. If it is `null`,
+the field did not take.
+
+It is a **pure narrowing**: the sandbox receives *(the agent's `secrets` grant)
+∩ (your allowlist)*. It can never widen. `[]` means zero project secrets. Omit
+the field entirely and the agent's normal set applies.
+
+> `secrets` is backend-only. Sending it from a non-backend caller (a human web
+> session, an in-sandbox agent token) is `403 origin_override_forbidden`. It
+> works here because Lumen forwards under an API key, which resolves to
+> `origin: backend`.
+
+### C4. Prove it inside the sandbox
+
+```bash
+export SESSION_ID=<from C3>
+curl -s -X POST "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions/$SESSION_ID/start" \
+  -H "Authorization: Bearer $TOKEN_A" | jq '{stage, agent_name, retriable}'
+```
+
+Poll it until `stage` reports the runtime is up — a cold sandbox takes tens of
+seconds. `retriable: false` means it is terminal and polling will not help.
+
+Then open the session in the UI and ask the agent, in chat:
+
+> Run `echo "$KORTIX_PROJECT_SECRET_NAMES"` and `env | cut -d= -f1 | sort` and
+> paste the output. Do not print any values.
+
+Expected: `KORTIX_PROJECT_SECRET_NAMES` contains `ALPHA_KEY` and **not**
+`BETA_KEY`, and the env-name list agrees. Ask for names only — the values are
+genuinely there (see the last section), and there is no reason to put them in a
+transcript.
+
+Repeat C3 with `"secrets":[]` and the same probe: expected, neither name is
+present.
+
+### C5. The two create-time validations
+
+```bash
+# unknown identifier
+curl -s -X POST "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $TOKEN_A" -H 'Content-Type: application/json' \
+  -d '{"secrets":["NOPE_KEY"]}'
+```
+
+Expected: HTTP `404`, `{"code":"SECRET_IDENTIFIER_NOT_FOUND", …}` naming the
+missing identifier. A typo fails fast rather than silently injecting nothing.
+
+If two allowlisted identifiers resolve to the **same env KEY**, create fails
+`409 SECRET_IDENTIFIER_KEY_COLLISION`. This is checked at create precisely
+*because* the allowlist is immutable — an ambiguous grant would throw at boot
+and leave the session permanently unbootable with no way to fix it.
+
+### C6. Prove it cannot be changed mid-session
+
+There is no route. `secrets_allowlist` is written once at create and nothing
+anywhere updates it — try `PATCH`ing the session metadata and you will find
+`opencode_model` and friends are server-managed keys too.
+
+**What to do instead: start a new session.** That is not a workaround, it is the
+design. Narrowing later cannot un-read what an earlier turn already pulled into
+the box — the secret is in the sandbox's env file, in every shell the agent
+spawned, and in its own context.
+
+Lumen states this in the UI: session workbench → **Scope** panel, the *Secrets:
+Fixed at start* row (`src/components/workbench/session-scope.tsx`). That panel
+is informational only — there is nothing to click, by design.
+
+---
+
+## D. Agent — switching per message
+
+### D1. Prerequisite: a manifest where the switch means something
+
+**Do this first or the whole recipe is a no-op.** If both agents have the same
+grants, every switch is legal and proves nothing. Commit a `kortix.yaml` on the
+project's default branch with two agents whose grants genuinely differ:
+
+```yaml
+kortix_version: 2
+default_agent: kortix
+
+agents:
+  kortix:
+    connectors: all
+    secrets: all
+    kortix_cli: all
+    skills: all
+
+  # Same SECRETS as narrow-b, different CONNECTORS → switching is ALLOWED
+  # and re-mints the token onto this agent's connector/CLI grant.
+  narrow-a:
+    secrets: [ALPHA_KEY]
+    connectors: [github]
+
+  # Different SECRETS from narrow-a → switching is REFUSED.
+  narrow-b:
+    secrets: [BETA_KEY]
+    connectors: [github]
+```
+
+Each agent also needs its behaviour file at
+`.kortix/opencode/agents/<name>.md` — the manifest map is governance only.
+Grants are read from the **default branch**, so this must be merged, not just
+pushed to a side branch.
+
+v2 is deny-by-default: an agent declared without a `secrets:` key gets none.
+Note also that `secrets: all` and *no `secrets:` key at all* are the **same**
+authority downstream and compare equal — so a switch between two agents that
+both omit `secrets:` is a free switch, not a mismatch.
+
+### D2. The allowed switch (same secrets, different connectors)
+
+Start a session on `narrow-a`:
+
+```bash
+curl -s -X POST "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $TOKEN_A" -H 'Content-Type: application/json' \
+  -d '{"agent_name":"narrow-a"}' | jq '{session_id, agent_name}'
+```
+
+Open it in the UI, then use the **agent picker in the composer** to pick an
+agent with the *same* `secrets:` list but a different `connectors:` list, and
+send a message.
+
+Expected: the message runs. Behind it, the session's executor token is
+**re-minted** onto the new agent's connector and CLI grant. That re-mint is the
+point — without it the new agent would run against the *old* agent's connector
+grant, calling integrations its own manifest denies it.
+
+If the re-mint itself fails you get `503 AGENT_SWITCH_GRANT_UNAPPLIED`. That one
+**is** retryable: the sandbox is fine, only the re-scope failed, and forwarding
+the prompt anyway is exactly the escalation the re-mint closes.
+
+### D3. The refused switch (different secrets)
+
+Same session (`narrow-a`), now switch to `narrow-b` and send.
+
+Expected: the turn is refused with HTTP `409`:
+
+```json
+{
+  "error": "agent switch requires a new session",
+  "code": "AGENT_SWITCH_REQUIRES_NEW_SESSION",
+  "expected_agent": "narrow-a",
+  "requested_agent": "narrow-b"
+}
+```
+
+**Retrying cannot succeed.** Retrying with the same agent will 409 identically,
+forever. The only resolution is a new session started on `narrow-b`. Secrets are
+disclosed by the time a switch is observed, so re-scoping now cannot un-read
+them — which is why this refuses where connectors merely re-mint.
+
+### D4. Reading the code in the UI
+
+Lumen classifies this correctly in `src/lib/mid-session-change.ts`
+(`classifyAgentSwitch` → `needs_new_session`, "offer a new session, not a
+retry"), but that helper **is not wired into any component today**. What you will
+actually see in the workbench is the generic send-failure banner — *"The agent
+could not run that"* — with the server's message underneath.
+
+So read the exact code from **DevTools → Network**, or reproduce it against the
+SDK. Do not conclude from the banner alone that it was a different failure.
+
+### D5. The `default` sentinel is non-binding, both ways
+
+A session stored as `default`, or a prompt naming `default`, never counts as a
+switch. The client resolves "the default" to a concrete name for display and
+echoes it back on later turns; comparing that echo against the stored sentinel
+used to 409 the most ordinary flow there is. If you see a switch refusal on a
+session you never switched, check whether the session's `agent_name` is
+`default`.
+
+---
+
+## E. Model — changing it mid-session
+
+### E1. In the UI
+
+Open a session; the **model switcher** sits in the session header. Change it.
+The runtime restarts, which ends the in-flight turn — expected, not a bug.
+
+### E2. Through Lumen's route
+
+Lumen's `/api/session-model` is the provider-neutral seam: the browser speaks
+`{ model }` and the runtime's field name stays server-side.
+
+```bash
+curl -s -X PUT \
+  "$LUMEN/api/session-model?projectId=$PROJECT_ID&sessionId=$SESSION_ID" \
+  -H "Authorization: Bearer $TOKEN_A" -H 'Content-Type: application/json' \
+  -d '{"model":"kortix/claude-opus-4-8"}'
+```
+
+Expected: `{"model":"kortix/claude-opus-4-8","appliedLive":true}` on a live
+session.
+
+### E3. Directly upstream
+
+```bash
+curl -s -X PUT "$API/projects/$PROJECT_ID/sessions/$SESSION_ID/model" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"opencode_model":"kortix/claude-opus-4-8"}' | jq .
+```
+
+Expected: `{"opencode_model": "...", "applied_live": true|false, "detail": "..."}`.
+
+### E4. Read `applied_live` — it is the whole point of the endpoint
+
+`applied_live: false` means **stored, but the running box did not take it — it
+applies at the next start.** These are genuinely different outcomes and the
+caller cannot otherwise tell them apart, which is why `detail` says which:
+
+| `applied_live` | `detail` | What it means |
+|---|---|---|
+| `true` | *(absent)* | The live sandbox took it now. |
+| `false` | `already set to this model` | No change was needed. |
+| `false` | `stored — applies when the sandbox next starts` | The session has no live box (not started yet, or stopped). |
+| `false` | `stored, but not pushed: <reason>` | There was a live box and the push failed. |
+
+Any UI showing this must **say** "applies at next start" for the false cases.
+Reporting a bare success is a lie the user discovers one turn later.
+
+### E5. The two refusals
+
+- Terminal session → `409 SESSION_NOT_RUNNING`. Nothing would consume the value.
+- Model not servable for the account (retired, not entitled, typo) →
+  `400 INVALID_SESSION_MODEL`. Validated against the same resolver session
+  create uses, so a bad model fails here rather than as a dead turn later.
+
+Use `kortix/<id>` for managed models; `<provider>/<id>` for bring-your-own-key.
+
+---
+
+## F. Connectors — binding a session to a specific connection
+
+### F1. See what exists
+
+```bash
+curl -s "$API/projects/$PROJECT_ID/connector-profiles" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" \
+  | jq '.profiles[] | {label, connector_alias, owner_type, status, is_default, profile_id}'
+```
+
+`owner_type` is the field that decides everything below:
+
+- `project` → **team-shared**. A wrapper may bind it.
+- `member` → somebody's **private** connection. A wrapper may not.
+- `external` → owned by *your app's* end-user, minted by your backend.
+
+Lumen's picker shows only `owner_type: "project"` **and** `status: "active"`,
+default first (`src/server/bindable-connections.ts`). Offering anything else
+would produce a session-create failure the end-user cannot act on.
+
+### F2. Nobody has connected gmail yet
+
+Open a project page in Lumen. The connection picker offers only **Default** —
+Lumen queried `/api/connections?connector=gmail` and got nothing bindable.
+
+Now try to make the wrapper connect on the user's behalf. It cannot, and the
+refusal is explicit:
+
+```bash
+curl -s -X POST "$API/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"require_connectors":["gmail"]}'
+```
+
+Expected: HTTP `403`
+
+```json
+{
+  "error": "require_connectors is interactive-only — a backend/service-account session has no single current user; use connector_bindings instead",
+  "code": "REQUIRE_CONNECTORS_INTERACTIVE_ONLY"
+}
+```
+
+**A wrapper credential acts for no single person.** `require_connectors` means
+"resolve *the current user's own* connection", and there is no current user
+behind an API key fronting a thousand of them. Lumen never sends this field; the
+curl above is how you see the platform enforce it.
+
+### F3. A team connection exists — now it is bindable
+
+`owner_type` is chosen when the profile is **created** and there is no
+convert-a-private-one-to-team flip. A private connection stays private:
+`POST …/connector-profiles/me` always mints `owner_type: "member"`. A **team**
+connection is a separate profile created through the manager-gated route:
+
+```bash
+# 1. mint the TEAM profile (no owner_id — it belongs to the whole project)
+curl -s -X POST "$API/projects/$PROJECT_ID/connector-profiles" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"connector_alias":"gmail","owner_type":"project","label":"Support inbox"}' | jq .
+```
+
+Then a human authorizes it once. For an OAuth connector like Gmail
+(`provider: pipedream`) that is `…/connect` → consent in the browser →
+`…/connect/finalize`; for a static-credential connector it is
+`…/credential` → `…/activate`. Both flows, with runnable SDK snippets, are in
+[`KORTIX_AS_A_BACKEND_GUIDE.md` §3](KORTIX_AS_A_BACKEND_GUIDE.md).
+
+> Creating and authorizing profiles needs `project.connector_profiles.manage`,
+> which is **manager-only**. As an editor, `reconcile` 403s and
+> `credential`/`activate` return `404` — deliberately indistinguishable from
+> "no such profile". If you are chasing a phantom missing-id bug here, check the
+> role first.
+
+Re-run F1. Expected: the profile reads `owner_type: "project"`,
+`status: "active"`.
+
+Reload the Lumen project page. Expected: the connection now appears in the
+picker by label, with the project default pre-selected. Pick it and start a
+session.
+
+Lumen sends (`src/app/projects/[id]/page.tsx`):
+
+```json
+{ "connector_bindings": { "gmail": { "profile_id": "<the id you picked>" } } }
+```
+
+Expected: the session runs **as that connection**. The credential is resolved
+server-side by the broker at tool-call time and never enters the sandbox env.
+
+Two things to know before you read too much into a green run:
+
+- **The alias is hardcoded to `gmail`** in the demo's project page, and this
+  path only runs for the **first** session started from the project page. Every
+  other session Lumen creates (`src/components/project-shell.tsx`) sends only
+  `{ session_id }` — no agent, no bindings, no secrets. So a second session
+  started from the sidebar silently loses the binding you picked. (Both are what
+  the in-flight new-session dialog exists to fix — see the note at the top. Until
+  it lands, bind by curl if you need it on a later session.)
+- **All-or-nothing binding.** If a session binds *any* alias, every *unbound*
+  alias resolves to null for that session. Pass `inherit_unbound: true` to keep
+  the project-default fallback for the rest. It can only ever inherit the
+  project default, never another owner's profile, so it is safe for any caller.
+
+### F4. The error table — and what to actually do
+
+| Status | Code | What happened | What to do |
+|---|---|---|---|
+| `403` | `CONNECTOR_NOT_ASSIGNED` | The session's **agent** is not granted the alias you bound. The first error most wrappers hit. | Add the alias under that agent's `connectors:` in `kortix.yaml` on the default branch. In a v2 manifest an agent with no `connectors:` key gets **none**. |
+| `409` | `CONNECTOR_CONNECTION_REQUIRED` | Interactive path: the acting user has not connected their own account for a required connector. The body names the `connector` so you can prompt for exactly that one. | Prompt *that* user to connect. A wrapper cannot do it for them — see F2. Lumen surfaces this as the "Connect *X* to continue" prompt. |
+| `403` | `REQUIRE_CONNECTORS_INTERACTIVE_ONLY` | A backend caller used `require_connectors`. | Bind an explicit `profile_id` with `connector_bindings` instead. |
+| `404` | `CONNECTOR_PROFILE_NOT_FOUND` | The `profile_id` does not exist **or** it is somebody's `member`-private connection, which your credential may not bind. Deliberately indistinguishable, so an id cannot be used to probe who connected what. | Re-list profiles (F1) and bind one with `owner_type: "project"` or `"external"`. If a backend needs a particular mailbox, add it as a **team** connection. Also check your role: profile management is manager-only. |
+| `409` | `CONNECTOR_PROFILE_INACTIVE` | The bound connection is revoked or errored. | Reconnect it. A revoked profile fails **closed** — it never silently falls back to a shared default, mid-session included. |
+
+---
+
+## G. Isolation between end-users
+
+### G1. In the browser
+
+Sign in as `alice@example.com` in one browser profile and `bob@example.com` in
+another (a private window is enough). Start a session as each.
+
+Expected: each sees only their own sessions in the project's session list, even
+though both are the same Kortix project under the same Kortix credential.
+
+### G2. Prove the filter is server-side, not client-side
+
+The session list is scoped in the BFF proxy, not in the browser
+(`src/server/end-user.ts#scopeSessionListToEndUser`). Upstream would happily
+list every session in the project — it sees one wrapper credential and cannot
+tell Lumen's users apart — so passing the browser's query string through
+unchanged would show everyone everything.
+
+Ask, as Alice, for Bob's sessions:
+
+```bash
+curl -s "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions?end_user_ref=bob@example.com" \
+  -H "Authorization: Bearer $TOKEN_A"
+```
+
+Expected: HTTP `403`,
+`{"error":"end_user_ref must not be set by the client — it is derived from your session"}`.
+Rejected rather than quietly corrected, so the attempt surfaces instead of
+looking like it worked.
+
+Now ask for nothing at all:
+
+```bash
+curl -s "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $TOKEN_A" | jq '[.[] | .end_user_ref] | unique'
+```
+
+Expected: `["alice@example.com"]`. The proxy stamped the filter for you.
+
+### G3. The operator vantage
+
+The same list with the account API key shows **both**, which is correct — the
+operator owns the account:
+
+```bash
+curl -s "$API/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $KORTIX_API_KEY" | jq '[.[] | .end_user_ref] | unique'
+```
+
+Expected: `["alice@example.com","bob@example.com"]`.
+
+### G4. Project-level isolation is separate
+
+Section B/G isolation is per-**end-user within a project**. Lumen *also* isolates
+per-**project**: a user only sees projects they provisioned through the wrapper
+(`.lumen-data/users.json`, A6). Sign in as a third email and the project list is
+empty — a `403` from the policy table, not a filtered view.
+
+---
+
+## H. Caps
+
+Both caps are **off by default** and are set on the **API deployment**, not in
+Lumen. Exact spellings from `apps/api/src/config.ts:573-577`:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT` | `0` (off) | Max **live** sessions one end-user may hold. |
+| `KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD` | `0` (off) | Spend ceiling per end-user, in USD, over a rolling window. |
+| `KORTIX_BACKEND_PER_END_USER_SPEND_WINDOW_DAYS` | `30` | The window the ceiling is measured over. |
+
+Note the window variable is `…_SPEND_WINDOW_DAYS`, not `…_SPEND_LIMIT_WINDOW_DAYS`.
+
+### H1. Trip the concurrency cap
+
+Set `KORTIX_BACKEND_PER_ORIGIN_SESSION_LIMIT=1` on the API and restart it. As
+Alice, start one session, leave it running, and start a second:
+
+```bash
+curl -si -X POST "$LUMEN/api/kortix/projects/$PROJECT_ID/sessions" \
+  -H "Authorization: Bearer $TOKEN_A" -H 'Content-Type: application/json' -d '{}'
+```
+
+Use `-i`: the interesting part is in the headers, and the proxy passes upstream
+response headers straight through. Expected: HTTP `429`, headers
+`X-RateLimit-Limit: 1` and `X-RateLimit-Remaining: 0`, body:
+
+```json
+{
+  "error": "This end-user already has 1 active session (limit 1). Finish or stop one before starting another.",
+  "message": "…",
+  "code": "per_origin_session_limit",
+  "limit": 1,
+  "active_sessions": 1
+}
+```
+
+In Lumen this surfaces as **"Too many sessions at once"**, marked *retryable* —
+correctly, since stopping a session clears it
+(`src/lib/session-create-failure.ts`).
+
+### H2. Trip the spend cap
+
+Set `KORTIX_BACKEND_PER_END_USER_SPEND_LIMIT_USD` to just under what Alice has
+already spent in the window (read it from B4), restart the API, and create a
+session as Alice.
+
+Expected: HTTP `429`, body:
+
+```json
+{
+  "error": "This end-user has spent $12.50 in the last 30 days (limit $10.00). Raise the limit or wait for the window to roll.",
+  "code": "per_end_user_spend_limit",
+  "limit_usd": 10, "spent_usd": 12.5, "window_days": 30
+}
+```
+
+The comparison is `spent >= limit`, so an end-user exactly at the ceiling is
+refused rather than allowed-then-exceeded. Lumen shows **"Spending limit
+reached"**, marked *not* retryable, and passes the server's own numbers through
+rather than inventing a vaguer message.
+
+Sessions with **no** `end_user_ref` (ordinary dashboard sessions) are exempt from
+both caps — there is nobody to charge, and applying the account's total spend to
+them would refuse normal work.
+
+### H3. The honest caveat — read this before building on either
+
+Both are **check-then-act guardrails measured at session CREATE**, not hard
+quotas:
+
+- **Racy.** N parallel creates for one end-user can each observe the same
+  under-limit state and all pass. Treat them as protection against a runaway
+  loop, not as a billing boundary.
+- **Create-time only.** A session already running is not killed mid-turn when it
+  crosses the line. The *next* create is what gets refused.
+
+The code says this about itself, in both files, on purpose: "a wrapper that
+believes this is a hard quota will build the wrong thing on top of it."
+
+---
+
+## What you cannot test yet
+
+### Secret DELIVERY strategy (the env-var refactor) is not wired
+
+Designed, with a pure policy layer merged — and **not connected to anything**.
+Today every granted secret still enters the sandbox environment exactly as it
+always has: readable by any command the agent runs, present in the box's env
+file and in every shell the agent spawned, and re-pushed on every prompt.
+
+The LLM gateway's deny-list narrows what **OpenCode** sees, to protect gateway
+routing (spend, budgets, logs) — not what the **box** holds.
+
+So there is no per-secret delivery mode to test, and no test that would
+distinguish "delivered as env" from anything else, because env is the only
+delivery there is. The measured baseline, anchored line-by-line to code on
+`main`, is [`ENV_SECRET_EXPOSURE_BASELINE.md`](ENV_SECRET_EXPOSURE_BASELINE.md);
+the design is [`SECRET_DELIVERY_STRATEGY_PLAN.md`](SECRET_DELIVERY_STRATEGY_PLAN.md).
+
+What you *can* test today is which secrets are **present** (section C) — the
+narrowing works and is enforced at both boot and hot-push. What you cannot test
+is how they are handed over.
+
+### Lumen's e2e suite proves Lumen, not the platform
+
+```bash
+cd apps/whitelabel-demo && pnpm test
+```
+
+runs the SDK boundary lint plus the bun tests in `tests/e2e`, which boot a real
+`next start` against a **mock upstream** (`tests/e2e/mock-upstream.ts`).
+
+That proves the demo **sends the right calls and handles the responses
+correctly**. It does **not** prove the platform enforces anything — the mock
+returns whatever the test tells it to. Green there and a green run of the
+recipes above are two different claims. Only the recipes touch real enforcement.
+
+(The harness skips the build when `.next/BUILD_ID` exists — `rm -rf .next` after
+changing source, or you will test stale output.)
+
+### Not covered here
+
+- **Turn delivery by curl.** Prompts go through the sandbox proxy transport, not
+  a plain REST route. Drive turns from the UI, or from the SDK — the runnable
+  end-to-end wrapper is `packages/sdk/examples/09-kaab-backend-wrapper.ts`.
+- **`AGENT_SWITCH_REQUIRES_NEW_SESSION` as UI copy.** The classifier exists and
+  is tested; no component renders it yet (D4).


### PR DESCRIPTION
Makes the demo able to actually *exercise* the KaaB per-session overrides instead of describing them, plus `docs/KAAB_TESTING_GUIDE.md`.

Built by agents, then attacked by an independent reviewer. **Four of its findings were things that would have made the UI lie to you**, which is worse than not having it — I fixed all four before landing.

## What ships

- **New-session dialog** — agent, per-session secrets allowlist, connector binding. Previously `sessions.create({ session_id })` and nothing else.
- **Generalized connector binding** — the alias was hardcoded to `gmail` in two places and only ran for the first session from the project page.
- **Live Scope tab** — this session's real allowlist, agent, model and bound connections, instead of 69 lines of generic prose with no `onClick`.
- **`docs/KAAB_TESTING_GUIDE.md`** — numbered recipes for every capability, curl and UI, including how the usage label works.

## The four fixes the review forced

**F1 — the Scope tab read a redacted session as maximally permissive.** The serializer blanks an inaccessible row to `metadata: {}` / `secrets_allowlist: null` and still returns **HTTP 200** — and `null` is exactly what the panel reads as *"everything the agent grant allows."* So a session you may **not** open rendered as **less** restricted than one you may. `can_access` was on the payload and unread.

Fixed with a `sessionScopeIsReadable()` type guard. I deliberately extracted it into the pure lib rather than leaving the check inline: the demo has no testing-library, so an inline condition would have been untestable, and this panel is prose about what a session can reach — prose that is wrong is worse than absent.

**F2 — enabling the secrets switch broke create on ordinary projects.** It pre-checked every row `secrets.list()` returned, but create validates the allowlist against **runtime-scoped rows only**. Any project with a Teams/Slack install has `scope:'connector'` rows → `404 SECRET_IDENTIFIER_NOT_FOUND`. And two identifiers may legally share one env KEY → `409 SECRET_IDENTIFIER_KEY_COLLISION`, guaranteed by pre-checking both. Now defaults to **nothing checked**, which is also the honest default for a control whose entire purpose is narrowing.

**F3 — the failure classifier didn't know the codes this diff makes reachable.** Six of them fell through to *"Could not start a session"* with `retryable: true` — on refusals that are create-only and will refuse identically forever. All six now have specific copy and are marked terminal.

**F4 — `private_only` mislabelled shared connections.** The filter tested `owner_type === 'project'`, but channel/inbox installs mint `owner_type: 'external'` profiles that the platform **will** bind. Users were told *"only connected to people's own accounts"* and *"once a teammate shares a connection"* — both false, with no action that resolves it. Now only `member`-owned counts as genuinely private.

## One claim in the build report I had to retract

It said an untouched dialog producing `{session_id}` was *"proven by test."* No test imports the dialog at all — the reviewer mutated the default `useState(false)` → `true` and the suite stayed green. What is actually proven is `buildSessionCreateInput(NO_OVERRIDES, …)`. I left the claim out of the code comments rather than restate it.

## Verification

184 pass, 0 fail, SDK boundary clean, `tsc --noEmit` clean. New tests cover each fix, including the direction that matters for F1 — a null allowlist on an **accessible** session must still read as "everything granted", so the fix cannot make a legitimately un-narrowed session look restricted.

## Still open (from the same review, not blocking)

The Connections row renders `lumen_bound_connections`, which is browser-authored metadata and client-mutable via PATCH — it's presented alongside server-sourced rows and overstates itself. And `/api/connections` still swallows a lookup failure as "no connectors". Both worth a follow-up.