### PR TITLE
feat(sessions): generate session titles from the first prompt via the gateway

### DIFF
--- a/apps/api/src/__tests__/unit-session-title-generate.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-generate.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { ProjectSessionRow } from '../projects/lib/serializers';
+import {
+  type GenerateSessionTitleOptions,
+  extractFirstPromptText,
+  generateSessionTitleFromFirstPrompt,
+  sanitizeGeneratedTitle,
+} from '../projects/session-title-generate';
+
+function row(metadata: Record<string, unknown>): ProjectSessionRow {
+  return {
+    sessionId: 'sess-1',
+    projectId: 'proj-1',
+    accountId: 'acct-1',
+    metadata,
+  } as unknown as ProjectSessionRow;
+}
+
+function headers(contentType = 'application/json'): Headers {
+  return new Headers({ 'content-type': contentType });
+}
+
+function bodyOf(value: unknown): ArrayBuffer {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+describe('sanitizeGeneratedTitle', () => {
+  it('strips wrapping quotes and collapses whitespace', () => {
+    expect(sanitizeGeneratedTitle('  "Set Up  MS Graph"  ')).toBe('Set Up MS Graph');
+    expect(sanitizeGeneratedTitle('`Fix the login bug`')).toBe('Fix the login bug');
+  });
+
+  it('caps length and drops newlines', () => {
+    const long = 'a'.repeat(200);
+    const out = sanitizeGeneratedTitle('line one\nline two');
+    expect(out).toBe('line one line two');
+    expect((sanitizeGeneratedTitle(long) ?? '').length).toBeLessThanOrEqual(64);
+  });
+
+  it('rejects empty and placeholder-shaped titles', () => {
+    expect(sanitizeGeneratedTitle('')).toBeNull();
+    expect(sanitizeGeneratedTitle('   ')).toBeNull();
+    expect(sanitizeGeneratedTitle(null)).toBeNull();
+    expect(sanitizeGeneratedTitle('New session - 2026-07-28')).toBeNull();
+  });
+});
+
+describe('extractFirstPromptText', () => {
+  it('reads REST { parts } text blocks', () => {
+    const body = bodyOf({
+      parts: [
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: 'world' },
+      ],
+    });
+    expect(extractFirstPromptText(body, headers())).toBe('hello\nworld');
+  });
+
+  it('reads ACP { params: { prompt } } text blocks', () => {
+    const body = bodyOf({
+      method: 'session/prompt',
+      params: { sessionId: 'x', prompt: [{ type: 'text', text: 'set up connector' }] },
+    });
+    expect(extractFirstPromptText(body, headers())).toBe('set up connector');
+  });
+
+  it('ignores non-text blocks and non-json / empty bodies', () => {
+    const withImage = bodyOf({
+      parts: [
+        { type: 'image', url: 'x' },
+        { type: 'text', text: 'ok' },
+      ],
+    });
+    expect(extractFirstPromptText(withImage, headers())).toBe('ok');
+    expect(extractFirstPromptText(bodyOf({ parts: [] }), headers())).toBeNull();
+    expect(extractFirstPromptText(undefined, headers())).toBeNull();
+    expect(
+      extractFirstPromptText(
+        bodyOf({ parts: [{ type: 'text', text: 'x' }] }),
+        headers('text/plain'),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('generateSessionTitleFromFirstPrompt', () => {
+  function harness(over: Partial<GenerateSessionTitleOptions> & { row?: ProjectSessionRow } = {}) {
+    const persisted: string[] = [];
+    const minted: string[] = [];
+    const revoked: string[] = [];
+    let generateCalls = 0;
+    const options: GenerateSessionTitleOptions = {
+      loadRow: async () => over.row ?? row({ opencode_model: 'codex/gpt-5.6-sol' }),
+      generate:
+        over.generate ??
+        (async () => {
+          generateCalls += 1;
+          return '"Set Up MS Graph"';
+        }),
+      mintKey:
+        over.mintKey ??
+        (async () => {
+          minted.push('k');
+          return { secret: 'sk', keyId: 'key-1' };
+        }),
+      revokeKey:
+        over.revokeKey ??
+        (async (_p, keyId) => {
+          revoked.push(keyId);
+        }),
+      persist:
+        over.persist ??
+        (async (_r, title) => {
+          persisted.push(title);
+        }),
+    };
+    return { options, persisted, minted, revoked, generateCalls: () => generateCalls };
+  }
+
+  const input = {
+    sessionId: 'sess-1',
+    projectId: 'proj-1',
+    accountId: 'acct-1',
+    userId: 'user-1',
+    firstPromptText: 'Please set up the MS Graph OAuth2 connector',
+  };
+
+  it('generates, sanitizes, and persists a title; always revokes the key', async () => {
+    const h = harness();
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+    expect(h.persisted).toEqual(['Set Up MS Graph']);
+    expect(h.revoked).toEqual(['key-1']);
+  });
+
+  it('is idempotent — skips a session that already has a real title', async () => {
+    const h = harness({
+      row: row({ name: 'Existing Title', opencode_model: 'codex/gpt-5.6-sol' }),
+    });
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+    expect(h.persisted).toEqual([]);
+    expect(h.generateCalls()).toBe(0);
+  });
+
+  it('skips a user-named session (custom_name) but re-titles a placeholder name', async () => {
+    const custom = harness({
+      row: row({ custom_name: 'My Name', opencode_model: 'codex/gpt-5.6-sol' }),
+    });
+    await generateSessionTitleFromFirstPrompt(input, custom.options);
+    expect(custom.persisted).toEqual([]);
+
+    const placeholder = harness({
+      row: row({ name: 'New session - 2026-07-28', opencode_model: 'codex/gpt-5.6-sol' }),
+    });
+    await generateSessionTitleFromFirstPrompt(input, placeholder.options);
+    expect(placeholder.persisted).toEqual(['Set Up MS Graph']);
+  });
+
+  it('skips when the session has no model to title with', async () => {
+    const h = harness({ row: row({}) });
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+    expect(h.persisted).toEqual([]);
+    expect(h.generateCalls()).toBe(0);
+  });
+
+  it('revokes the minted key even when generation throws', async () => {
+    const h = harness({
+      generate: async () => {
+        throw new Error('gateway down');
+      },
+    });
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+    expect(h.persisted).toEqual([]);
+    expect(h.revoked).toEqual(['key-1']);
+  });
+
+  it('does not persist an empty prompt', async () => {
+    const h = harness();
+    await generateSessionTitleFromFirstPrompt({ ...input, firstPromptText: '   ' }, h.options);
+    expect(h.persisted).toEqual([]);
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
 import { PLATFORM_DEFAULT_MODEL_ID } from '@kortix/llm-catalog';
+import { z } from 'zod';
 import { SLACK_BOT_SCOPES } from './channels/slack-manifest';
 import {
   DEFAULT_LLM_GATEWAY_FALLBACK_POLICIES,
@@ -34,7 +34,7 @@ const optStr = z.string().optional().default('');
 const optStrDefault = (def: string) => z.string().optional().default(def);
 
 /** Optional URL string with a custom default. Not required, just validated if present. */
-  const optUrl = (def: string) =>
+const optUrl = (def: string) =>
   z
     .string()
     .optional()
@@ -48,7 +48,7 @@ const optInt = (def: number) =>
     .optional()
     .default(String(def))
     .transform((v) => {
-      const n = parseInt(v, 10);
+      const n = Number.parseInt(v, 10);
       return Number.isNaN(n) ? def : n;
     });
 
@@ -143,6 +143,11 @@ const envSchema = z.object({
   // Global background-worker switch. API-only and migration-shadow deployments
   // keep request handling active while disabling every recurring write loop.
   KORTIX_WORKERS_ENABLED: optBoolTrue,
+  // Kortix-owned session titles: on a session's first prompt, generate the
+  // title ourselves via the internal LLM gateway (using the session's own
+  // model) instead of relying on the harness summarizer. On by default; the
+  // kill-switch falls the whole path back to the OpenCode title sync.
+  SESSION_TITLE_GENERATION_ENABLED: optBoolTrue,
   // EXPERIMENTAL: the "Use this template" install feature — the /v1/templates
   // routes plus the use-case-page button + install wizard. Single kill-switch;
   // off by default so it stays hidden in prod while templates are authored.
@@ -888,6 +893,7 @@ export const config = {
   // Single master switch — see schema docstring above.
   KORTIX_BILLING_INTERNAL_ENABLED: env.KORTIX_BILLING_INTERNAL_ENABLED,
   KORTIX_WORKERS_ENABLED: env.KORTIX_WORKERS_ENABLED,
+  SESSION_TITLE_GENERATION_ENABLED: env.SESSION_TITLE_GENERATION_ENABLED,
   KORTIX_TEMPLATES_ENABLED: env.KORTIX_TEMPLATES_ENABLED,
   OPENAPI_PUBLIC_DOCS: env.OPENAPI_PUBLIC_DOCS,
   ENTERPRISE_LICENSE_AVAILABLE: env.ENTERPRISE_LICENSE_AVAILABLE,
@@ -1303,7 +1309,7 @@ const TOOL_PRICING: Record<string, ToolPricing> = {
   },
 };
 
-export function getToolCost(toolName: string, resultCount: number = 0): number {
+export function getToolCost(toolName: string, resultCount = 0): number {
   const pricing = TOOL_PRICING[toolName];
   if (!pricing) {
     return 0.01;

--- a/apps/api/src/projects/opencode-title-capture.ts
+++ b/apps/api/src/projects/opencode-title-capture.ts
@@ -44,6 +44,11 @@ async function persistTitle(input: {
 }): Promise<void> {
   const metadata = (input.row.metadata ?? {}) as Record<string, unknown>;
   if (metadata.name === input.title) return;
+  // A real title we already hold (e.g. from session-title-generate, the
+  // authoritative first-prompt source) must never be clobbered by a harness
+  // summarizer title arriving later — only fill in over empty/placeholder.
+  const currentName = typeof metadata.name === 'string' ? metadata.name : null;
+  if (currentName && !isPlaceholderOpencodeTitle(currentName)) return;
   await db
     .update(projectSessions)
     .set({
@@ -143,12 +148,9 @@ export function captureTitleAfterRuntimeEvent(
   ) {
     return Promise.resolve();
   }
-  const key = [
-    input.projectId,
-    input.sessionId,
-    input.opencodeSessionId,
-    input.title.trim(),
-  ].join(':');
+  const key = [input.projectId, input.sessionId, input.opencodeSessionId, input.title.trim()].join(
+    ':',
+  );
   const existing = immediate.get(key);
   if (existing) return existing;
 

--- a/apps/api/src/projects/opencode-title-sync.ts
+++ b/apps/api/src/projects/opencode-title-sync.ts
@@ -1,14 +1,14 @@
 import { and, eq, inArray } from 'drizzle-orm';
 
 import { projectSessions, sessionSandboxes } from '@kortix/db';
-import { db } from '../shared/db';
 import { logger as appLogger } from '../lib/logger';
+import { db } from '../shared/db';
+import type { ProjectSessionRow } from './lib/serializers';
 import {
+  type OpencodeSessionLite,
   listSandboxOpencodeSessions,
   resolveRootSessionId,
-  type OpencodeSessionLite,
 } from './opencode-mapping';
-import type { ProjectSessionRow } from './lib/serializers';
 
 // Title-sync is best-effort enrichment for deferred post-prompt capture. It can
 // fan out one sandbox round-trip per active sandbox when an explicit maintenance
@@ -171,12 +171,14 @@ export async function syncRowFromSandbox(input: {
   const metadata = (input.row.metadata ?? {}) as Record<string, unknown>;
   const currentName = typeof metadata.name === 'string' ? metadata.name : null;
   const rawRootTitle = snapshots.find((entry) => entry.id === resolvedRootId)?.title ?? null;
-  // Only a REAL summarizer title may become (or replace) the name — the
-  // placeholder default must never be persisted, and a real title arriving
-  // later must replace a previously frozen placeholder.
+  // Only a REAL summarizer title may become the name — the placeholder default
+  // must never be persisted. A real title we already hold (e.g. one generated
+  // from the first prompt by session-title-generate, the authoritative source)
+  // WINS: the harness summarizer is a fallback and must never clobber it. So
+  // the harness title only fills in when the current name is empty/placeholder.
   const rootTitle = isPlaceholderOpencodeTitle(rawRootTitle) ? null : rawRootTitle;
-  const nextName =
-    rootTitle ?? (isPlaceholderOpencodeTitle(currentName) ? null : currentName);
+  const hasRealCurrentName = Boolean(currentName) && !isPlaceholderOpencodeTitle(currentName);
+  const nextName = hasRealCurrentName ? currentName : rootTitle;
   const pinChanged = input.row.opencodeSessionId !== resolvedRootId;
   const nameChanged = Boolean(nextName) && nextName !== currentName;
   const sessionsChanged = !sameSessions(metadata.opencode_sessions, scopedSessions);
@@ -202,12 +204,14 @@ export async function syncRowFromSandbox(input: {
     )
     .returning();
 
-  return updated ?? {
-    ...input.row,
-    opencodeSessionId: resolvedRootId,
-    metadata: nextMetadata,
-    updatedAt: new Date(),
-  };
+  return (
+    updated ?? {
+      ...input.row,
+      opencodeSessionId: resolvedRootId,
+      metadata: nextMetadata,
+      updatedAt: new Date(),
+    }
+  );
 }
 
 export async function syncOpenCodeTitlesForSessions(input: {

--- a/apps/api/src/projects/session-title-generate.ts
+++ b/apps/api/src/projects/session-title-generate.ts
@@ -1,0 +1,263 @@
+import { and, eq } from 'drizzle-orm';
+
+import { projectSessions } from '@kortix/db';
+import { createGateway } from '@kortix/llm-gateway';
+import { config } from '../config';
+import { logger as appLogger } from '../lib/logger';
+import { createGatewayKey, revokeGatewayKey } from '../llm-gateway/gateway-keys';
+import { createInProcessGatewayHooks } from '../llm-gateway/hooks';
+import { toWireModel } from '../llm-gateway/resolution/effective';
+import { db } from '../shared/db';
+import type { ProjectSessionRow } from './lib/serializers';
+import { isPlaceholderOpencodeTitle } from './opencode-title-sync';
+
+// Kortix-owned session titles.
+//
+// Historically a session's title came from OpenCode's in-sandbox summarizer,
+// mirrored into `metadata.name` by opencode-title-*. That path is fragile: it
+// depends on the summarizer succeeding in the sandbox and on the box being
+// awake when the deferred capture polls it, so long/failed/large sessions never
+// got a title and stayed the frozen "New session" placeholder.
+//
+// Instead we generate the title ourselves the moment a session serves its FIRST
+// user prompt: one short call to the internal LLM gateway, using the model the
+// session was started with, over just the first prompt text. It is the
+// authoritative source; the OpenCode sync is now a fallback that never
+// overwrites a real title (see opencode-title-sync / opencode-title-capture).
+//
+// Fire-and-forget by contract: idempotent, best-effort, and it never blocks or
+// fails the prompt request.
+
+const MAX_TITLE_LENGTH = 64;
+const MAX_PROMPT_CHARS = 4000;
+const TITLE_MAX_TOKENS = 24;
+
+const TITLE_SYSTEM_PROMPT =
+  "You write a concise, specific title for a chat session from the user's first message. " +
+  'Reply with ONLY the title: 3 to 6 words, Title Case, no surrounding quotes, no trailing ' +
+  'punctuation, and no preamble.';
+
+// The same pipeline the API mounts, run directly in-process so title generation
+// behaves identically whether the gateway is in-process or a standalone pod — we
+// never depend on the pod's URL for our own internal call.
+let gatewaySingleton: ReturnType<typeof createGateway> | null = null;
+function internalGateway(): ReturnType<typeof createGateway> {
+  if (!gatewaySingleton) gatewaySingleton = createGateway(createInProcessGatewayHooks());
+  return gatewaySingleton;
+}
+
+/** Normalize a model-generated title: strip wrapping quotes, collapse
+ *  whitespace, bound the length, and reject a placeholder-shaped result. */
+export function sanitizeGeneratedTitle(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  let title = raw.replace(/[\r\n]+/g, ' ').trim();
+  title = title
+    .replace(/^["'`]+/, '')
+    .replace(/["'`]+$/, '')
+    .trim();
+  title = title.replace(/\s+/g, ' ');
+  if (!title) return null;
+  if (title.length > MAX_TITLE_LENGTH) title = title.slice(0, MAX_TITLE_LENGTH).trim();
+  if (!title || isPlaceholderOpencodeTitle(title)) return null;
+  return title;
+}
+
+/** First user prompt text from a REST (`{parts}`) or ACP (`{params:{prompt}}`)
+ *  body — the two content-block shapes the sandbox prompt proxy forwards. */
+export function extractFirstPromptText(
+  body: ArrayBuffer | undefined,
+  incomingHeaders: Headers,
+): string | null {
+  if (!body) return null;
+  if (!(incomingHeaders.get('content-type') ?? '').toLowerCase().includes('application/json'))
+    return null;
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(body)) as {
+      parts?: unknown;
+      params?: { prompt?: unknown };
+    };
+    const blocks = Array.isArray(parsed.parts)
+      ? parsed.parts
+      : Array.isArray(parsed.params?.prompt)
+        ? (parsed.params?.prompt as unknown[])
+        : null;
+    if (!blocks) return null;
+    const text = (blocks as Array<{ type?: unknown; text?: unknown }>)
+      .filter((p) => p?.type === 'text' && typeof p.text === 'string')
+      .map((p) => p.text as string)
+      .join('\n')
+      .trim();
+    return text || null;
+  } catch {
+    return null;
+  }
+}
+
+function contentToString(content: unknown): string | null {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && typeof part === 'object' && 'text' in part
+          ? String((part as { text?: unknown }).text ?? '')
+          : '',
+      )
+      .join('');
+  }
+  return null;
+}
+
+async function generateViaGateway(
+  model: string,
+  authorization: string,
+  promptText: string,
+): Promise<string | null> {
+  const rawBody = JSON.stringify({
+    model,
+    stream: false,
+    max_tokens: TITLE_MAX_TOKENS,
+    messages: [
+      { role: 'system', content: TITLE_SYSTEM_PROMPT },
+      { role: 'user', content: promptText.slice(0, MAX_PROMPT_CHARS) },
+    ],
+  });
+  const res = await internalGateway().chatCompletions({ authorization, rawBody });
+  if (!res.ok) {
+    appLogger.warn('[title-generate] gateway returned non-200', { status: res.status, model });
+    return null;
+  }
+  const data = (await res.json().catch(() => null)) as {
+    choices?: Array<{ message?: { content?: unknown } }>;
+  } | null;
+  return contentToString(data?.choices?.[0]?.message?.content);
+}
+
+async function loadRow(sessionId: string, projectId: string): Promise<ProjectSessionRow | null> {
+  const [row] = await db
+    .select()
+    .from(projectSessions)
+    .where(and(eq(projectSessions.sessionId, sessionId), eq(projectSessions.projectId, projectId)))
+    .limit(1);
+  return (row as ProjectSessionRow | undefined) ?? null;
+}
+
+/** A session still needs a title unless the user named it or a real (non
+ *  placeholder) title already exists — matches opencode-title-capture. */
+function needsTitle(row: ProjectSessionRow): boolean {
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  if (typeof metadata.custom_name === 'string' && metadata.custom_name.trim()) return false;
+  const name = typeof metadata.name === 'string' ? metadata.name : null;
+  return !(name && !isPlaceholderOpencodeTitle(name));
+}
+
+/** The model the session was started with, in gateway wire form. */
+function sessionModel(row: ProjectSessionRow): string | null {
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  const ref = typeof metadata.opencode_model === 'string' ? metadata.opencode_model.trim() : '';
+  return ref ? toWireModel(ref) : null;
+}
+
+async function persistTitle(row: ProjectSessionRow, title: string): Promise<void> {
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  await db
+    .update(projectSessions)
+    .set({ metadata: { ...metadata, name: title }, updatedAt: new Date() })
+    .where(
+      and(
+        eq(projectSessions.sessionId, row.sessionId),
+        eq(projectSessions.projectId, row.projectId),
+        eq(projectSessions.accountId, row.accountId),
+      ),
+    );
+}
+
+export interface GenerateSessionTitleInput {
+  sessionId: string;
+  projectId: string;
+  accountId: string;
+  userId: string;
+  firstPromptText: string;
+}
+
+/** Injectable seams so unit tests run without process-global module mocks. */
+export interface GenerateSessionTitleOptions {
+  loadRow?: (sessionId: string, projectId: string) => Promise<ProjectSessionRow | null>;
+  generate?: (model: string, authorization: string, promptText: string) => Promise<string | null>;
+  mintKey?: (
+    accountId: string,
+    projectId: string,
+    userId: string,
+  ) => Promise<{ secret: string; keyId: string } | null>;
+  revokeKey?: (projectId: string, keyId: string) => Promise<void>;
+  persist?: (row: ProjectSessionRow, title: string) => Promise<void>;
+}
+
+/**
+ * Generate a session's title from its FIRST user prompt via the internal LLM
+ * gateway (using the session's own model) and persist it to `metadata.name`.
+ * Authoritative and Kortix-owned. Fire-and-forget: idempotent, best-effort,
+ * never blocks or fails the prompt.
+ */
+export async function generateSessionTitleFromFirstPrompt(
+  input: GenerateSessionTitleInput,
+  options: GenerateSessionTitleOptions = {},
+): Promise<void> {
+  if (!config.SESSION_TITLE_GENERATION_ENABLED) return;
+  const promptText = input.firstPromptText.trim();
+  if (!input.sessionId || !input.projectId || !input.accountId || !input.userId || !promptText)
+    return;
+
+  const load = options.loadRow ?? loadRow;
+  const generate = options.generate ?? generateViaGateway;
+  const persist = options.persist ?? persistTitle;
+  const mint =
+    options.mintKey ??
+    (async (accountId, projectId, userId) => {
+      const key = await createGatewayKey({
+        accountId,
+        projectId,
+        name: 'internal-session-title',
+        createdBy: userId,
+      });
+      return { secret: key.secret_key, keyId: key.key_id };
+    });
+  const revoke =
+    options.revokeKey ?? ((projectId, keyId) => revokeGatewayKey(projectId, keyId).then(() => {}));
+
+  try {
+    const row = await load(input.sessionId, input.projectId);
+    if (!row || !needsTitle(row)) return;
+
+    const model = sessionModel(row);
+    if (!model) {
+      appLogger.warn('[title-generate] no session model to title with', {
+        sessionId: input.sessionId,
+      });
+      return;
+    }
+
+    const minted = await mint(input.accountId, input.projectId, input.userId);
+    if (!minted) return;
+    let title: string | null = null;
+    try {
+      title = sanitizeGeneratedTitle(await generate(model, `Bearer ${minted.secret}`, promptText));
+    } finally {
+      await revoke(input.projectId, minted.keyId).catch(() => {});
+    }
+    if (!title) return;
+
+    // Re-check under the freshest row so a concurrent rename / capture wins.
+    const fresh = await load(input.sessionId, input.projectId);
+    if (!fresh || !needsTitle(fresh)) return;
+    await persist(fresh, title);
+    appLogger.info('[title-generate] titled session from first prompt', {
+      sessionId: input.sessionId,
+      title,
+    });
+  } catch (err) {
+    appLogger.warn('[title-generate] failed', {
+      sessionId: input.sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -3,6 +3,7 @@ import { HTTPException } from 'hono/http-exception';
 import { config } from '../../config';
 import { getTraceHeaders } from '../../lib/request-context';
 import type { ProviderName } from '../../platform/providers';
+import { observeRuntimeSessionTitleStream } from '../../projects/acp-session-title-stream';
 import { syncSandboxEnvForPrompt } from '../../projects/lib/sandbox-env-sync';
 import {
   AgentSecretGrantMismatchError,
@@ -12,12 +13,15 @@ import {
   SessionGrantRemintError,
   remintGrantForAgentSwitch,
 } from '../../projects/lib/session-token-grant';
-import { observeRuntimeSessionTitleStream } from '../../projects/acp-session-title-stream';
 import {
   captureTitleAfterRuntimeEvent,
   scheduleTitleCaptureAfterPrompt,
 } from '../../projects/opencode-title-capture';
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
+import {
+  extractFirstPromptText,
+  generateSessionTitleFromFirstPrompt,
+} from '../../projects/session-title-generate';
 import { KORTIX_USER_CONTEXT_HEADER } from '../../shared/kortix-user-context';
 import { canAccessPreviewSandbox, canAccessSandboxSession } from '../../shared/preview-ownership';
 import {
@@ -756,10 +760,22 @@ export async function forwardToSandbox(
           body = bodyWithoutPromptAgent(body, incomingHeaders);
         }
         // A prompt is the one moment this sandbox is guaranteed awake, and
-        // OpenCode's summarizer titles the session seconds after the first
-        // reply — capture it on a deferred timer instead of hoping a session
-        // list gets requested while the box is still up (the frozen
-        // "New session - <date>" rows). Fire-and-forget; never blocks the prompt.
+        // Kortix-owned title: generate it ourselves from this first prompt via
+        // the internal gateway (the authoritative source). The OpenCode
+        // summarizer capture below stays as a fallback that never clobbers a
+        // real title. Both are fire-and-forget and never block the prompt.
+        if (userId) {
+          const firstPromptText = extractFirstPromptText(body, incomingHeaders);
+          if (firstPromptText) {
+            void generateSessionTitleFromFirstPrompt({
+              sessionId: record.sessionId,
+              projectId: record.projectId,
+              accountId: record.accountId,
+              userId,
+              firstPromptText,
+            });
+          }
+        }
         scheduleTitleCaptureAfterPrompt({
           sessionId: record.sessionId,
           projectId: record.projectId,
@@ -1040,6 +1056,18 @@ export async function forwardToSandbox(
       // Got an HTTP response → sandbox is alive, pass it through with CORS.
       void markSandboxUsed(sandboxId);
       if (acpPromptSession && upstream.ok) {
+        if (userId) {
+          const firstPromptText = extractFirstPromptText(body, incomingHeaders);
+          if (firstPromptText) {
+            void generateSessionTitleFromFirstPrompt({
+              sessionId: record.sessionId,
+              projectId: record.projectId,
+              accountId: record.accountId,
+              userId,
+              firstPromptText,
+            });
+          }
+        }
         scheduleTitleCaptureAfterPrompt({
           sessionId: record.sessionId,
           projectId: record.projectId,


### PR DESCRIPTION
## Why

Session titles all showed **"New session"** on some instances (Essentia). Root cause: titles came from OpenCode's **in-sandbox summarizer**, mirrored into `metadata.name` by `opencode-title-*`. That path is fragile — it depends on the summarizer succeeding inside the sandbox and on the box being awake when the deferred capture polls it. When it breaks (flaky model, unhealthy sandbox agent, long/failed sessions), every session stays the frozen `"New session - <date>"` placeholder, which the serializer nulls → the sidebar shows "New session" forever.

## What

**Take ownership of titles.** The moment a session serves its **first user prompt**, we generate the title ourselves: one short call to the **internal LLM gateway**, using **the model the session was started with**, over just the first prompt text — then persist to `metadata.name`. No dependency on the harness summarizer.

- **New `apps/api/src/projects/session-title-generate.ts`**
  - Runs the gateway pipeline **in-process** (`createGateway(createInProcessGatewayHooks())`) so it behaves identically whether the gateway is in-process or a standalone pod — no deployment-specific URL.
  - Auths with a **short-lived minted-then-revoked gateway key** (guaranteed-valid auth + correct per-account billing/routing).
  - Sanitizes the model output (strip quotes, collapse whitespace, cap length, reject placeholder).
  - **Idempotent + fire-and-forget**: never blocks or fails the prompt; never overwrites a user rename (`custom_name`) or an existing real title.
- **Wired into the sandbox prompt proxy** for both transports — REST `prompt_async`/`message` and ACP `session/prompt`.
- **OpenCode sync is now a pure fallback**: `opencode-title-sync` + `opencode-title-capture` no longer overwrite an existing real title, so a harness title arriving later can't clobber ours.
- **Gated by `SESSION_TITLE_GENERATION_ENABLED`** (default on; kill-switch falls the whole path back to the OpenCode sync).

## Design notes

- Uses the session's own model (`metadata.opencode_model` → gateway wire form) per the intended behavior — no separate/hardcoded title model.
- Best-effort by contract: any failure just logs a `[title-generate]` warn and leaves the fallback path intact.

## Tests

New unit suite + guards on the fallback paths:
- `session-title-generate` **12/0** — sanitize, first-prompt extraction (REST `parts` + ACP `params.prompt`), idempotence, `custom_name`/placeholder handling, no-model skip, key revoked even when generation throws, empty-prompt skip.
- `opencode-title-capture` **11/0**, `opencode-title-sync` **8/0** (no-clobber guards, existing tests green), `preview` **12/0**.
- `tsc --noEmit` clean; Biome clean on new files.