### PR TITLE
fix(sessions): title with the live picked model, not the stale opencode_model

### DIFF
--- a/apps/api/src/__tests__/unit-session-title-generate.test.ts
+++ b/apps/api/src/__tests__/unit-session-title-generate.test.ts
@@ -4,6 +4,7 @@ import type { ProjectSessionRow } from '../projects/lib/serializers';
 import {
   type GenerateSessionTitleOptions,
   extractFirstPromptText,
+  extractPromptModel,
   generateSessionTitleFromFirstPrompt,
   sanitizeGeneratedTitle,
 } from '../projects/session-title-generate';
@@ -85,18 +86,52 @@ describe('extractFirstPromptText', () => {
   });
 });
 
+describe('extractPromptModel', () => {
+  it('reads the kortix-namespace pick as the bare wire id (REST body.model)', () => {
+    const body = bodyOf({
+      parts: [{ type: 'text', text: 'go' }],
+      model: { providerID: 'kortix', modelID: 'codex/gpt-5.6-sol' },
+    });
+    expect(extractPromptModel(body, headers())).toBe('codex/gpt-5.6-sol');
+  });
+
+  it('reads an ACP params.model and a BYOK provider pair', () => {
+    const acp = bodyOf({
+      method: 'session/prompt',
+      params: { model: { providerID: 'kortix', modelID: 'glm-5.2' } },
+    });
+    expect(extractPromptModel(acp, headers())).toBe('glm-5.2');
+    const byok = bodyOf({
+      parts: [],
+      model: { providerID: 'anthropic', modelID: 'claude-sonnet-4.6' },
+    });
+    expect(extractPromptModel(byok, headers())).toBe('anthropic/claude-sonnet-4.6');
+  });
+
+  it('accepts a string model and returns null when absent', () => {
+    expect(extractPromptModel(bodyOf({ model: 'kortix/glm-5.2' }), headers())).toBe('glm-5.2');
+    expect(
+      extractPromptModel(bodyOf({ parts: [{ type: 'text', text: 'x' }] }), headers()),
+    ).toBeNull();
+    expect(extractPromptModel(undefined, headers())).toBeNull();
+  });
+});
+
 describe('generateSessionTitleFromFirstPrompt', () => {
   function harness(over: Partial<GenerateSessionTitleOptions> & { row?: ProjectSessionRow } = {}) {
     const persisted: string[] = [];
     const minted: string[] = [];
     const revoked: string[] = [];
+    const models: string[] = [];
     let generateCalls = 0;
     const options: GenerateSessionTitleOptions = {
-      loadRow: async () => over.row ?? row({ opencode_model: 'codex/gpt-5.6-sol' }),
+      loadRow: async () =>
+        over.row ?? row({ opencode_model: 'amazon-bedrock/jp.anthropic.claude-opus-5' }),
       generate:
         over.generate ??
-        (async () => {
+        (async (model) => {
           generateCalls += 1;
+          models.push(model);
           return '"Set Up MS Graph"';
         }),
       mintKey:
@@ -116,7 +151,7 @@ describe('generateSessionTitleFromFirstPrompt', () => {
           persisted.push(title);
         }),
     };
-    return { options, persisted, minted, revoked, generateCalls: () => generateCalls };
+    return { options, persisted, minted, revoked, models, generateCalls: () => generateCalls };
   }
 
   const input = {
@@ -127,9 +162,28 @@ describe('generateSessionTitleFromFirstPrompt', () => {
     firstPromptText: 'Please set up the MS Graph OAuth2 connector',
   };
 
+  it('titles with the LIVE picked model (modelHint), not the stale opencode_model', async () => {
+    const h = harness(); // row.opencode_model is the stale/broken bedrock default
+    await generateSessionTitleFromFirstPrompt(
+      { ...input, modelHint: 'codex/gpt-5.6-sol' },
+      h.options,
+    );
+    expect(h.models).toEqual(['codex/gpt-5.6-sol']);
+    expect(h.persisted).toEqual(['Set Up MS Graph']);
+  });
+
+  it('falls back to opencode_model when the prompt carries no model', async () => {
+    const h = harness({ row: row({ opencode_model: 'kortix/glm-5.2' }) });
+    await generateSessionTitleFromFirstPrompt(input, h.options);
+    expect(h.models).toEqual(['glm-5.2']);
+  });
+
   it('generates, sanitizes, and persists a title; always revokes the key', async () => {
     const h = harness();
-    await generateSessionTitleFromFirstPrompt(input, h.options);
+    await generateSessionTitleFromFirstPrompt(
+      { ...input, modelHint: 'codex/gpt-5.6-sol' },
+      h.options,
+    );
     expect(h.persisted).toEqual(['Set Up MS Graph']);
     expect(h.revoked).toEqual(['key-1']);
   });

--- a/apps/api/src/projects/session-title-generate.ts
+++ b/apps/api/src/projects/session-title-generate.ts
@@ -93,6 +93,42 @@ export function extractFirstPromptText(
   }
 }
 
+/** The model the user picked for THIS turn, in gateway wire form, read from the
+ *  prompt body — REST `body.model` or ACP `body.params.model`, shaped
+ *  `{ providerID, modelID }` (opencode's per-send override) or a bare string.
+ *  This is the LIVE model actually used, unlike the session's stale boot-default
+ *  `opencode_model`. Returns null when the body carries no model. */
+export function extractPromptModel(
+  body: ArrayBuffer | undefined,
+  incomingHeaders: Headers,
+): string | null {
+  if (!body) return null;
+  if (!(incomingHeaders.get('content-type') ?? '').toLowerCase().includes('application/json'))
+    return null;
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(body)) as {
+      model?: unknown;
+      params?: { model?: unknown };
+    };
+    const raw = parsed.model ?? parsed.params?.model;
+    if (!raw) return null;
+    if (typeof raw === 'string') return toWireModel(raw.trim()) || null;
+    if (typeof raw === 'object') {
+      const m = raw as { providerID?: unknown; modelID?: unknown };
+      const modelId = typeof m.modelID === 'string' ? m.modelID.trim() : '';
+      const providerId = typeof m.providerID === 'string' ? m.providerID.trim() : '';
+      if (!modelId) return null;
+      // opencode's synthetic `kortix` provider already carries the full gateway
+      // wire id in modelID (e.g. `codex/gpt-5.6-sol`, `glm-5.2`); any other
+      // provider is a BYOK `provider/model` pair.
+      return providerId && providerId !== 'kortix' ? `${providerId}/${modelId}` : modelId;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 function contentToString(content: unknown): string | null {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
@@ -177,6 +213,10 @@ export interface GenerateSessionTitleInput {
   accountId: string;
   userId: string;
   firstPromptText: string;
+  /** The model the user actually picked for this turn (gateway wire form, from
+   *  the prompt body). Preferred over the session's stale boot-default
+   *  `opencode_model`, which goes out of date the moment the model is switched. */
+  modelHint?: string;
 }
 
 /** Injectable seams so unit tests run without process-global module mocks. */
@@ -228,9 +268,12 @@ export async function generateSessionTitleFromFirstPrompt(
     const row = await load(input.sessionId, input.projectId);
     if (!row || !needsTitle(row)) return;
 
-    const model = sessionModel(row);
+    // Prefer the model the user actually picked for this turn (from the prompt
+    // body); the session's stored `opencode_model` is only the boot default and
+    // goes stale the moment the model is switched.
+    const model = input.modelHint?.trim() || sessionModel(row);
     if (!model) {
-      appLogger.warn('[title-generate] no session model to title with', {
+      appLogger.warn('[title-generate] no model to title with', {
         sessionId: input.sessionId,
       });
       return;

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -20,6 +20,7 @@ import {
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
 import {
   extractFirstPromptText,
+  extractPromptModel,
   generateSessionTitleFromFirstPrompt,
 } from '../../projects/session-title-generate';
 import { KORTIX_USER_CONTEXT_HEADER } from '../../shared/kortix-user-context';
@@ -773,6 +774,7 @@ export async function forwardToSandbox(
               accountId: record.accountId,
               userId,
               firstPromptText,
+              modelHint: extractPromptModel(body, incomingHeaders) ?? undefined,
             });
           }
         }
@@ -1065,6 +1067,7 @@ export async function forwardToSandbox(
               accountId: record.accountId,
               userId,
               firstPromptText,
+              modelHint: extractPromptModel(body, incomingHeaders) ?? undefined,
             });
           }
         }


### PR DESCRIPTION
## Problem (found by deterministic verification on Essentia)

The first-prompt title generator read the model from `metadata.opencode_model` — but that's only the session's **boot default**, which goes **stale the moment the model is switched**. On a session where the picked model differs from the platform default, the title call used the *wrong* model.

Live evidence: session picked `codex/gpt-5.6-sol` (agent ran fine), but the title call used the stale `metadata.opencode_model` = `amazon-bedrock/jp.anthropic.claude-opus-5` — a **misconfigured platform default** (invalid `jp.` inference-profile id for `us-east-1`). Bedrock 400'd `"The provided model identifier is invalid"`, so the title never generated even though the session itself was fine.

`opencode_model` isn't removable (the boot path needs a starting model), but it's the wrong source for "the model in use right now."

## Fix

Read the model the user **actually picked for this turn** from the prompt body — `model: { providerID, modelID }` (opencode's per-send override, populated by the SDK and typed in `@opencode-ai/sdk`) — and prefer it over `opencode_model` (kept only as a fallback when the prompt carries no model).

- For the synthetic `kortix` provider, `modelID` **is** the gateway wire id (`codex/gpt-5.6-sol`, `glm-5.2`); other providers are BYOK `provider/model`.
- New `extractPromptModel(body, headers)` — REST `body.model` + ACP `params.model`, object or string — wired into both prompt-proxy call sites as `modelHint`.
- `generateSessionTitleFromFirstPrompt` prefers `modelHint`, falls back to `opencode_model`.

## Tests

**17/17** — live-model-wins-over-stale-opencode_model, opencode_model fallback when prompt has no model, REST/ACP/BYOK/string extraction, plus the existing suite. `tsc --noEmit` + Biome clean.

Follow-up (separate): Essentia's platform-default opus id `jp.anthropic.claude-opus-5` is itself invalid for us-east-1 and should be corrected to `us.anthropic.claude-opus-5` — that's a config issue, not code.