### PR TITLE
fix(prod): preserve API deployment selector

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -814,6 +814,8 @@ jobs:
       ARGO_APP: kortix-prod
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-eks-deploy
     steps:
+      - uses: actions/checkout@v7
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -864,6 +866,13 @@ jobs:
               -p '{"spec":{"source":{"targetRevision":"prod"}}}'
           fi
           kubectl -n argocd annotate application "$ARGO_APP" argocd.argoproj.io/refresh=hard --overwrite || true
+
+      - name: Reconcile Argo CD Application from repo (code is source of truth)
+        if: steps.guard.outputs.exists == 'true'
+        run: |
+          kubectl apply -f infra/k8s/argocd/applications/prod.yaml
+          kubectl -n argocd annotate application "$ARGO_APP" \
+            argocd.argoproj.io/refresh=hard --overwrite
 
       # Wait for Argo CD to reconcile the promote bump and the Deployment to finish
       # rolling out exactly :VERSION — Argo applied the new spec (observedGeneration
@@ -917,6 +926,8 @@ jobs:
       ARGO_APP: kortix-gateway-prod
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-eks-deploy
     steps:
+      - uses: actions/checkout@v7
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,9 +16,9 @@ name: Deploy Prod
 #        blob, stamped with the clean KORTIX_VERSION.
 #      - EKS (standby): the promote PR merge already bumped infra/k8s/envs/prod,
 #        so Argo CD rolls the prod Deployment — deploy-api WATCHES it reach vX.Y.Z.
-#      - US East 2 ECS shadow: deploy-us-shadow applies the same database
-#        migrations, refreshes logical replication, and rolls the US API and
-#        gateway. It does not change production routing or enable writers.
+#      - US East 2 ECS shadow: deploy-us-shadow rolls the US API and gateway
+#        without changing database replication. The cutover workflow owns the
+#        final database migration and reconciliation.
 #   3. verify-live-version curls the PUBLIC endpoints (router + each origin) and
 #      asserts the live reported version == X.Y.Z. Nothing that announces
 #      success — the GitHub Release, the Slack announce, the banner-lower — runs
@@ -774,9 +774,10 @@ jobs:
 
   # ── Deploy the pre-cutover US East 2 production shadow ──────────────────────
   # The shadow uses the native US East 2 Supabase project and separate ECS
-  # services. This job keeps its database schema, logical publication, API, and
-  # gateway on the same release as production. It does not change Cloudflare
-  # routing, production DNS, desired counts, or worker flags.
+  # services. This job keeps its API and gateway on the same release as
+  # production. Database synchronization remains an explicit cutover action.
+  # This job does not change Cloudflare routing, production DNS, database
+  # replication, desired counts, or worker flags.
   deploy-us-shadow:
     name: Deploy API + gateway to US East 2 shadow
     needs: [version, retag-images, verify-image-commits, migrate-db]
@@ -787,7 +788,7 @@ jobs:
     with:
       version: ${{ needs.version.outputs.version }}
       source_sha: ${{ needs.version.outputs.source_sha }}
-      synchronize_database: true
+      synchronize_database: false
     secrets: inherit
 
   # ── Deploy API to prod EKS (the standby backend, kept in perfect parity) ─────

--- a/infra/k8s/argocd/applications/prod.yaml
+++ b/infra/k8s/argocd/applications/prod.yaml
@@ -23,7 +23,9 @@ spec:
     targetRevision: prod
     path: infra/k8s/charts/kortix-api
     helm:
-      releaseName: kortix-api
+      # Keep the original Helm release name. The live Deployment selector uses
+      # app.kubernetes.io/instance=kortix-prod, and selectors are immutable.
+      releaseName: kortix-prod
       valueFiles:
         - ../../envs/prod/values.yaml
   destination:


### PR DESCRIPTION
## Problems

1. `Deploy Prod` cannot roll the EKS standby API. The live Deployment selector uses `app.kubernetes.io/instance=kortix-prod`. The Argo CD Application renders `app.kubernetes.io/instance=kortix-api`. Kubernetes rejects the immutable selector change.
2. The regular release path tries to refresh a disabled US shadow subscription. Database synchronization belongs to the final cutover workflow.

## Fix

- Restore the original Helm release name `kortix-prod`.
- Check out the repository in both EKS deployment jobs.
- Reconcile the API Argo CD Application from the committed manifest before rollout verification.
- Deploy and verify US shadow images without changing database replication.
- Keep final database migration and reconciliation in the explicit cutover workflow.

## Verification

- `git diff --check` passes.
- Ruby parses `.github/workflows/deploy-prod.yml`.
- `helm template kortix-prod ...` renders Deployment `kortix-api`.
- The rendered selector is `app.kubernetes.io/instance: kortix-prod`.
- The rendered image is `kortix/kortix-api:0.11.0`.
- Live EKS rollout reached image `0.11.0`, generation `837/837`, updated `3/3`, and available `3/3`.

This PR does not change Cloudflare, DNS, database writers, or traffic routing.