### PR TITLE
fix(web): stop ambient voice transcript polling

### DIFF
--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -12,16 +12,14 @@ import { useDeliverableReadiness } from '@/features/session/action-panel/shared/
 import { SessionAuditPanel } from '@/features/session/session-audit-panel';
 import { isPendingAction, useSessionAudit } from '@/features/session/session-audit-shared';
 import { SessionFilesExplorer } from '@/features/session/session-files-explorer';
-import { SessionVoiceTranscriptPanel } from '@/features/session/session-voice-transcript-panel';
-import { useVoiceTranscript } from '@/features/session/session-voice-transcript-shared';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { SessionTerminalPanel } from '@/features/session/session-terminal-panel';
+import { SessionVoiceTranscriptPanel } from '@/features/session/session-voice-transcript-panel';
+import { shouldPollVoiceTranscript } from '@/features/session/session-voice-transcript-shared';
 import { SessionWallpaperLayerContext } from '@/features/session/session-wallpaper-layer';
-import { useRuntimeMessages } from '@kortix/sdk/react';
 import { useIsMobile } from '@/hooks/utils';
 import { cn } from '@/lib/utils';
 import { useKortixComputerStore } from '@/stores/kortix-computer-store';
-import { useSessionStateStore } from '@kortix/sdk/react';
 import {
   SessionPanelView,
   sessionPreviewTabId,
@@ -30,6 +28,7 @@ import {
 import { useTabStore } from '@/stores/tab-store';
 import { useUserPreferencesStore } from '@/stores/user-preferences-store';
 import type { SessionStartStage } from '@kortix/sdk';
+import { useRuntimeMessages, useSessionStateStore } from '@kortix/sdk/react';
 import { PanelRight } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type React from 'react';
@@ -131,16 +130,6 @@ export const SessionLayout = memo(function SessionLayout({
     silent: true,
   });
   const auditPendingCount = (auditData?.actions ?? []).filter(isPendingAction).length;
-
-  // Whether a voice-agent worker is in this session's call right now — drives
-  // the "Voice" tab's live dot. Polled at the same cadence the panel itself
-  // uses (see session-voice-transcript-shared.ts) so the two never disagree;
-  // react-query dedupes this against the panel's own query when both mount.
-  const { data: voiceData } = useVoiceTranscript(projectId, projectSessionId, {
-    enabled: !transient && !booting && !!projectId && !!projectSessionId,
-    silent: true,
-  });
-  const voiceLive = voiceData?.live ?? false;
 
   useEffect(() => {
     if (shouldOpenPanel && !isSidePanelOpen) {
@@ -300,7 +289,6 @@ export const SessionLayout = memo(function SessionLayout({
       isSidePanelOpen={isSidePanelOpen}
       onTogglePanel={handleTogglePanel}
       auditBadge={auditPendingCount}
-      voiceLive={voiceLive}
       onToggleMode={togglePanelMode}
     />
   );
@@ -318,7 +306,17 @@ export const SessionLayout = memo(function SessionLayout({
   const swappableBody = showAudit ? (
     <SessionAuditPanel projectId={projectId} projectSessionId={projectSessionId} />
   ) : showVoice ? (
-    <SessionVoiceTranscriptPanel projectId={projectId} projectSessionId={projectSessionId} />
+    <SessionVoiceTranscriptPanel
+      projectId={projectId}
+      projectSessionId={projectSessionId}
+      pollingEnabled={shouldPollVoiceTranscript({
+        panelOpen: isSidePanelOpen,
+        voiceView: showVoice,
+        visibleLayout: isVisibleLayout,
+        booting,
+        transient,
+      })}
+    />
   ) : showExplorer ? (
     <SessionFilesExplorer
       chatSessionId={sessionId}
@@ -503,7 +501,6 @@ function PanelHeaderSwitcher({
   isSidePanelOpen,
   onTogglePanel,
   auditBadge = 0,
-  voiceLive = false,
   onToggleMode,
 }: {
   view: SessionPanelView;
@@ -512,9 +509,6 @@ function PanelHeaderSwitcher({
   onTogglePanel: () => void;
   /** Pending-approval count shown on the "Audit" tab; 0 hides the badge. */
   auditBadge?: number;
-  /** Whether a voice-agent worker is in this session's call right now —
-   *  shows a live dot on the "Voice" tab. */
-  voiceLive?: boolean;
   /** Flips `preferences.panelMode` back to 'easy'. Advanced-only — Easy mode
    *  renders no header at all, so it has no button to switch with. */
   onToggleMode: () => void;
@@ -582,9 +576,8 @@ function PanelHeaderSwitcher({
           <TabsTrigger size="xs" value="audit" variant="secondary" className="h-7 w-fit">
             Audit
           </TabsTrigger>
-          <TabsTrigger size="xs" value="voice" variant="secondary" className="h-7 w-fit gap-1.5">
+          <TabsTrigger size="xs" value="voice" variant="secondary" className="h-7 w-fit">
             Voice
-            {voiceLive && <span className="bg-kortix-green size-1.5 shrink-0 animate-pulse rounded-full" />}
           </TabsTrigger>
         </TabsList>
       </Tabs>

--- a/apps/web/src/features/session/session-voice-transcript-panel.tsx
+++ b/apps/web/src/features/session/session-voice-transcript-panel.tsx
@@ -34,11 +34,15 @@ import { useEffect, useRef } from 'react';
 export function SessionVoiceTranscriptPanel({
   projectId,
   projectSessionId,
+  pollingEnabled,
 }: {
   projectId?: string;
   projectSessionId?: string;
+  pollingEnabled: boolean;
 }) {
-  const { data, isLoading, isError, refetch } = useVoiceTranscript(projectId, projectSessionId);
+  const { data, isLoading, isError, refetch } = useVoiceTranscript(projectId, projectSessionId, {
+    enabled: pollingEnabled,
+  });
   const turns = data?.turns ?? [];
   const live = data?.live ?? false;
 
@@ -56,7 +60,7 @@ export function SessionVoiceTranscriptPanel({
 
   return (
     <div className="flex h-full w-full flex-col">
-      <div className="flex flex-shrink-0 items-center justify-between border-b border-border/60 px-6 py-3">
+      <div className="border-border/60 flex flex-shrink-0 items-center justify-between border-b px-6 py-3">
         <div>
           <h2 className="text-foreground text-sm font-semibold tracking-tight">Voice</h2>
           <p className="text-muted-foreground mt-0.5 text-xs">
@@ -110,7 +114,7 @@ export function SessionVoiceTranscriptPanel({
               <TranscriptRow key={turn.cursor} turn={turn} />
             ))}
             {!live && (
-              <li className="flex items-center justify-center gap-1.5 py-3 text-xs text-muted-foreground">
+              <li className="text-muted-foreground flex items-center justify-center gap-1.5 py-3 text-xs">
                 <PhoneOff className="size-3.5 shrink-0" />
                 Call ended
               </li>

--- a/apps/web/src/features/session/session-voice-transcript-shared.test.ts
+++ b/apps/web/src/features/session/session-voice-transcript-shared.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { relativeTurnTime, turnSpeakerLabel, voiceTranscriptKey } from './session-voice-transcript-shared';
+import {
+  relativeTurnTime,
+  shouldPollVoiceTranscript,
+  turnSpeakerLabel,
+  voiceTranscriptKey,
+} from './session-voice-transcript-shared';
 
 describe('turnSpeakerLabel', () => {
   test('a tool-role turn is labeled by its speaker (the tool name)', () => {
@@ -38,4 +43,30 @@ describe('voiceTranscriptKey', () => {
     expect(voiceTranscriptKey('P1', 'S1')).toEqual(['voice-transcript', 'P1', 'S1']);
     expect(voiceTranscriptKey(undefined, undefined)).toEqual(['voice-transcript', '', '']);
   });
+});
+
+describe('shouldPollVoiceTranscript', () => {
+  const visibleVoicePanel = {
+    panelOpen: true,
+    voiceView: true,
+    visibleLayout: true,
+    booting: false,
+    transient: false,
+  };
+
+  test('polls only when the active session Voice panel is visible', () => {
+    expect(shouldPollVoiceTranscript(visibleVoicePanel)).toBe(true);
+  });
+
+  for (const [name, override] of [
+    ['normal session chat', { voiceView: false }],
+    ['closed side panel', { panelOpen: false }],
+    ['inactive session tab', { visibleLayout: false }],
+    ['booting session', { booting: true }],
+    ['transient session', { transient: true }],
+  ] as const) {
+    test(`does not poll for ${name}`, () => {
+      expect(shouldPollVoiceTranscript({ ...visibleVoicePanel, ...override })).toBe(false);
+    });
+  }
 });

--- a/apps/web/src/features/session/session-voice-transcript-shared.ts
+++ b/apps/web/src/features/session/session-voice-transcript-shared.ts
@@ -34,32 +34,48 @@ export function voiceTranscriptKey(projectId: string | undefined, sessionId: str
 }
 
 interface UseVoiceTranscriptOptions {
-  /** Skip the query entirely (e.g. not the active session / missing ids). */
-  enabled?: boolean;
+  /** Poll only while the active session's Voice panel is visible. */
+  enabled: boolean;
   /** Poll cadence in ms. Default 2.5s; pass `false` to poll once. */
   refetchInterval?: number | false;
-  /** Suppress the global error toast (for an ambient/background mount). */
-  silent?: boolean;
 }
 
 export function useVoiceTranscript(
   projectId: string | undefined,
   sessionId: string | undefined,
-  options?: UseVoiceTranscriptOptions,
+  options: UseVoiceTranscriptOptions,
 ) {
-  const enabled = !!projectId && !!sessionId && (options?.enabled ?? true);
+  const enabled = !!projectId && !!sessionId && options.enabled;
   return useQuery<VoiceTranscript>({
     queryKey: voiceTranscriptKey(projectId, sessionId),
     // `enabled` guards presence, so the `?? ''` fallbacks are never exercised.
     queryFn: () =>
       getVoiceTranscript(projectId ?? '', sessionId ?? '', {
         limit: TRANSCRIPT_LIMIT,
-        showErrors: !options?.silent,
+        showErrors: true,
       }),
     enabled,
     staleTime: 2_000,
-    refetchInterval: options?.refetchInterval ?? VOICE_TRANSCRIPT_REFETCH_MS,
+    refetchInterval: options.refetchInterval ?? VOICE_TRANSCRIPT_REFETCH_MS,
   });
+}
+
+interface VoiceTranscriptVisibility {
+  panelOpen: boolean;
+  voiceView: boolean;
+  visibleLayout: boolean;
+  booting: boolean;
+  transient: boolean;
+}
+
+export function shouldPollVoiceTranscript({
+  panelOpen,
+  voiceView,
+  visibleLayout,
+  booting,
+  transient,
+}: VoiceTranscriptVisibility): boolean {
+  return panelOpen && voiceView && visibleLayout && !booting && !transient;
 }
 
 /** Display label for a turn's speaker column. 'tool' turns carry their own


### PR DESCRIPTION
## Cause

`SessionLayout` mounted `useVoiceTranscript` for every open session. The query fetched `voice-transcript?limit=500` every 2.5 seconds. The result only powered the Advanced Voice tab live dot.

## Change

- Remove the ambient layout query and live dot.
- Require an explicit `enabled` option for `useVoiceTranscript`.
- Poll only when the side panel is open, Voice is selected, the session layout is active, boot is complete, and the session is not transient.
- Add a regression matrix for every disabled state.

## Verification

- `bun test src/features/session/session-voice-transcript-shared.test.ts` -> 12 passed, 0 failed.
- `npx eslint src/features/session/session-layout.tsx src/features/session/session-voice-transcript-panel.tsx src/features/session/session-voice-transcript-shared.ts src/features/session/session-voice-transcript-shared.test.ts` -> exit 0.
- `pnpm exec prettier --check ...` -> all matched files pass.
- `npx tsc --noEmit` -> repository baseline exits 2; changed files report 0 errors.

## Demo

Real Chromium against the isolated local web/API stack:

```json
{
  "normalChatRequests": 0,
  "voicePanelRequests": 2,
  "requestsAfterLeavingVoice": 0,
  "requestSuffix": "/voice-transcript?limit=500"
}
```

The two positive requests occurred while the Voice panel was visible. The two 7.5-second negative windows produced zero transcript requests.