### PR TITLE
fix(release): block mismatched production Supabase auth

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -566,7 +566,7 @@ jobs:
   # `attach-desktop` job, best-effort — a desktop problem can never block a release.
   github-release:
     name: GitHub Release v${{ needs.version.outputs.version }}
-    needs: [version, retag-images, build-cli, deploy-ecs, deploy-api, verify-live-version]
+    needs: [version, retag-images, build-cli, deploy-ecs, deploy-api, verify-live-version, frontend-auth-proof]
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -1240,6 +1240,21 @@ jobs:
             echo "Vercel auto-deploys the \`prod\` branch (→ kortix.com). No action needed here."
           } >> "$GITHUB_STEP_SUMMARY"
 
+  frontend-auth-proof:
+    name: Prod frontend auth configuration
+    needs: [version, frontend-note]
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v7
+      - name: Wait for the released frontend and verify its EU Supabase configuration
+        run: |
+          node apps/web/scripts/validate-production-supabase-env.mjs \
+            --runtime-url https://kortix.com/api/runtime-config \
+            --expected-version "${{ needs.version.outputs.version }}" \
+            --attempts 30 \
+            --interval-ms 20000
+
   # ── Keep main's VERSION honest (post-publish, never premature) ──────────────
   # promote.yml does NOT bump main's VERSION (publishing is gated on the prod
   # merge). After a release publishes, advance main's VERSION to the NEXT dev
@@ -1353,7 +1368,7 @@ jobs:
   # rollout banner.
   maintenance-banner-off:
     name: Rollout banner (lower)
-    needs: [verify-live-version]
+    needs: [verify-live-version, frontend-auth-proof]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node scripts/copy-viewer-wasm.mjs && NODE_OPTIONS='--max-http-header-size=32768' dotenvx run --ignore=MISSING_ENV_FILE -f .env.local -f .env -- next dev --turbopack --port ${WEB_PORT:-3000}",
     "dev:staging-env": "NODE_OPTIONS='--max-http-header-size=32768' dotenvx run --overload -f .env.staging -- next dev --turbopack --port ${WEB_PORT:-3000}",
-    "build": "node scripts/copy-viewer-wasm.mjs && next build",
+    "build": "node scripts/validate-production-supabase-env.mjs && node scripts/copy-viewer-wasm.mjs && next build",
     "start": "next start",
     "lint": "next lint",
     "catalog:enrich": "bun scripts/enrich-llm-catalog-capabilities.ts",

--- a/apps/web/scripts/validate-production-supabase-env.mjs
+++ b/apps/web/scripts/validate-production-supabase-env.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+export const EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF = 'jbriwassebxdwoieikga';
+export const EXPECTED_PRODUCTION_SUPABASE_URL = 'https://supa.kortix.com';
+export const EXPECTED_PRODUCTION_BACKEND_URL = 'https://api.kortix.com/v1';
+
+const EXPECTED_NATIVE_URL = `https://${EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF}.supabase.co`;
+const ALLOWED_PRODUCTION_URLS = new Set([EXPECTED_PRODUCTION_SUPABASE_URL, EXPECTED_NATIVE_URL]);
+const URL_VARIABLES = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'KORTIX_PUBLIC_SUPABASE_URL',
+  'SUPABASE_PUBLIC_URL',
+  'SUPABASE_URL',
+  'SUPABASE_SERVER_URL',
+];
+const KEY_VARIABLES = [
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'KORTIX_PUBLIC_SUPABASE_ANON_KEY',
+  'SUPABASE_ANON_KEY',
+];
+
+function required(env, name) {
+  const value = env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required for a Vercel production build`);
+  }
+  return value;
+}
+
+function normalizeUrl(value) {
+  return value.replace(/\/+$/, '');
+}
+
+function decodeJwtPayload(value) {
+  const parts = value.split('.');
+  if (parts.length !== 3) return null;
+
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    throw new Error('production Supabase anon key has an invalid JWT payload');
+  }
+}
+
+async function assertSupabaseAcceptsKey(url, key, fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(`${url}/auth/v1/settings`, {
+      headers: {
+        apikey: key,
+        'user-agent': 'kortix-production-supabase-release-guard',
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (error) {
+    throw new Error(`Supabase validation request failed for ${url}: ${error.message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Supabase validation failed with HTTP ${response.status} for ${url}`);
+  }
+}
+
+export async function validateProductionSupabaseEnv(env, { fetchImpl = globalThis.fetch } = {}) {
+  if (env.VERCEL_ENV !== 'production') {
+    return { skipped: true };
+  }
+
+  const publicUrl = normalizeUrl(required(env, 'NEXT_PUBLIC_SUPABASE_URL'));
+  const publicKey = required(env, 'NEXT_PUBLIC_SUPABASE_ANON_KEY');
+
+  for (const name of URL_VARIABLES) {
+    const rawValue = env[name]?.trim();
+    if (!rawValue) continue;
+    const value = normalizeUrl(rawValue);
+    if (!ALLOWED_PRODUCTION_URLS.has(value)) {
+      throw new Error(
+        `${name} must be ${EXPECTED_PRODUCTION_SUPABASE_URL} or the native EU project URL`,
+      );
+    }
+  }
+
+  if (!ALLOWED_PRODUCTION_URLS.has(publicUrl)) {
+    throw new Error(
+      `NEXT_PUBLIC_SUPABASE_URL must be ${EXPECTED_PRODUCTION_SUPABASE_URL} or the native EU project URL`,
+    );
+  }
+
+  const configuredKeys = KEY_VARIABLES.map((name) => env[name]?.trim()).filter(Boolean);
+  if (new Set(configuredKeys).size !== 1) {
+    throw new Error('production Supabase anon-key variables must contain one identical value');
+  }
+
+  const payload = decodeJwtPayload(publicKey);
+  if (payload) {
+    if (payload.ref !== EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF) {
+      throw new Error(
+        `anon key project ref ${payload.ref ?? 'missing'} does not match required production ref ${EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF}`,
+      );
+    }
+    if (payload.role !== 'anon') {
+      throw new Error(
+        `Supabase public key role must be anon, received ${payload.role ?? 'missing'}`,
+      );
+    }
+  }
+
+  const validationUrls = [...new Set([publicUrl, EXPECTED_NATIVE_URL])];
+  for (const url of validationUrls) {
+    await assertSupabaseAcceptsKey(url, publicKey, fetchImpl);
+  }
+
+  return {
+    skipped: false,
+    projectRef: payload?.ref ?? EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF,
+    supabaseUrl: publicUrl,
+  };
+}
+
+export function parseRuntimeConfigScript(source) {
+  const startMarker = 'window.__KORTIX_RUNTIME_CONFIG=';
+  const endMarker = ';window.__RUNTIME_ENV=';
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  if (start === -1 || end === -1) {
+    throw new Error('runtime config response does not contain the expected bootstrap script');
+  }
+
+  try {
+    return JSON.parse(source.slice(start + startMarker.length, end));
+  } catch {
+    throw new Error('runtime config response contains invalid JSON');
+  }
+}
+
+export async function validateDeployedProductionSupabase(
+  runtimeUrl,
+  { expectedVersion, fetchImpl = globalThis.fetch } = {},
+) {
+  const response = await fetchImpl(runtimeUrl, {
+    headers: {
+      'cache-control': 'no-cache',
+      'user-agent': 'kortix-production-supabase-release-guard',
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(`runtime config returned HTTP ${response.status}`);
+  }
+
+  const config = parseRuntimeConfigScript(await response.text());
+  if (expectedVersion && config.VERSION !== expectedVersion) {
+    throw new Error(
+      `runtime config version ${config.VERSION ?? 'missing'} does not match release ${expectedVersion}`,
+    );
+  }
+  if (config.BACKEND_URL !== EXPECTED_PRODUCTION_BACKEND_URL) {
+    throw new Error(
+      `runtime config backend ${config.BACKEND_URL ?? 'missing'} does not match ${EXPECTED_PRODUCTION_BACKEND_URL}`,
+    );
+  }
+
+  return validateProductionSupabaseEnv(
+    {
+      VERCEL_ENV: 'production',
+      NEXT_PUBLIC_SUPABASE_URL: config.SUPABASE_URL,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: config.SUPABASE_ANON_KEY,
+    },
+    { fetchImpl },
+  );
+}
+
+function readArgument(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+async function validateDeployedWithRetry(runtimeUrl, expectedVersion) {
+  const attempts = Number(readArgument('--attempts') ?? 30);
+  const intervalMs = Number(readArgument('--interval-ms') ?? 20_000);
+  let lastError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const result = await validateDeployedProductionSupabase(runtimeUrl, {
+        expectedVersion,
+      });
+      console.log(
+        `Production frontend guard passed for ${result.projectRef} at ${result.supabaseUrl}.`,
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        console.log(
+          `Production frontend guard attempt ${attempt}/${attempts} is not ready: ${error.message}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+async function main() {
+  const runtimeUrl = readArgument('--runtime-url');
+  if (runtimeUrl) {
+    await validateDeployedWithRetry(runtimeUrl, readArgument('--expected-version'));
+    return;
+  }
+
+  const result = await validateProductionSupabaseEnv(process.env);
+  if (result.skipped) {
+    console.log('Production Supabase release guard skipped outside Vercel production.');
+    return;
+  }
+
+  console.log(
+    `Production Supabase release guard passed for ${result.projectRef} at ${result.supabaseUrl}.`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`Production Supabase release guard failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/web/scripts/validate-production-supabase-env.test.mjs
+++ b/apps/web/scripts/validate-production-supabase-env.test.mjs
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+import {
+  EXPECTED_PRODUCTION_BACKEND_URL,
+  EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF,
+  EXPECTED_PRODUCTION_SUPABASE_URL,
+  parseRuntimeConfigScript,
+  validateDeployedProductionSupabase,
+  validateProductionSupabaseEnv,
+} from './validate-production-supabase-env.mjs';
+
+function jwtFor(ref, role = 'anon') {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode({ ref, role })}.signature`;
+}
+
+function successfulFetch() {
+  return async () => new Response('{}', { status: 200 });
+}
+
+function productionEnv(overrides = {}) {
+  return {
+    VERCEL_ENV: 'production',
+    NEXT_PUBLIC_SUPABASE_URL: EXPECTED_PRODUCTION_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: jwtFor(EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF),
+    ...overrides,
+  };
+}
+
+describe('validateProductionSupabaseEnv', () => {
+  it('does not enforce the production project outside a Vercel production build', async () => {
+    const result = await validateProductionSupabaseEnv(
+      {
+        VERCEL_ENV: 'preview',
+        NEXT_PUBLIC_SUPABASE_URL: 'https://preview.supabase.co',
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: 'preview-key',
+      },
+      { fetchImpl: async () => assert.fail('preview validation must not call Supabase') },
+    );
+
+    assert.deepEqual(result, { skipped: true });
+  });
+
+  it('accepts the pinned EU project URL and anon key', async () => {
+    const calls = [];
+    const result = await validateProductionSupabaseEnv(productionEnv(), {
+      fetchImpl: async (url, init) => {
+        calls.push({ url, apikey: init.headers.apikey });
+        return new Response('{}', { status: 200 });
+      },
+    });
+
+    assert.equal(result.projectRef, EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF);
+    assert.deepEqual(
+      calls.map(({ url }) => url),
+      [
+        `${EXPECTED_PRODUCTION_SUPABASE_URL}/auth/v1/settings`,
+        `https://${EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF}.supabase.co/auth/v1/settings`,
+      ],
+    );
+    assert.ok(
+      calls.every(({ apikey }) => apikey === productionEnv().NEXT_PUBLIC_SUPABASE_ANON_KEY),
+    );
+  });
+
+  it('rejects a production anon key from another Supabase project', async () => {
+    await assert.rejects(
+      validateProductionSupabaseEnv(
+        productionEnv({
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: jwtFor('uhrwvisbqjfxhxjvoofd'),
+        }),
+        { fetchImpl: successfulFetch() },
+      ),
+      /anon key project ref uhrwvisbqjfxhxjvoofd does not match required production ref jbriwassebxdwoieikga/,
+    );
+  });
+
+  it('rejects a production URL outside the pinned EU project', async () => {
+    await assert.rejects(
+      validateProductionSupabaseEnv(
+        productionEnv({
+          NEXT_PUBLIC_SUPABASE_URL: 'https://uhrwvisbqjfxhxjvoofd.supabase.co',
+        }),
+        { fetchImpl: successfulFetch() },
+      ),
+      /NEXT_PUBLIC_SUPABASE_URL must be https:\/\/supa\.kortix\.com or the native EU project URL/,
+    );
+  });
+
+  it('rejects conflicting URL aliases before Next.js can select one', async () => {
+    await assert.rejects(
+      validateProductionSupabaseEnv(
+        productionEnv({
+          SUPABASE_URL: EXPECTED_PRODUCTION_SUPABASE_URL,
+          KORTIX_PUBLIC_SUPABASE_URL: 'https://uhrwvisbqjfxhxjvoofd.supabase.co',
+        }),
+        { fetchImpl: successfulFetch() },
+      ),
+      /KORTIX_PUBLIC_SUPABASE_URL must be https:\/\/supa\.kortix\.com or the native EU project URL/,
+    );
+  });
+
+  it('rejects conflicting anon-key aliases', async () => {
+    await assert.rejects(
+      validateProductionSupabaseEnv(
+        productionEnv({
+          SUPABASE_ANON_KEY: jwtFor(EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF),
+          KORTIX_PUBLIC_SUPABASE_ANON_KEY: `${jwtFor(EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF)}-rotated`,
+        }),
+        { fetchImpl: successfulFetch() },
+      ),
+      /production Supabase anon-key variables must contain one identical value/,
+    );
+  });
+
+  it('rejects a key that the pinned native project does not accept', async () => {
+    await assert.rejects(
+      validateProductionSupabaseEnv(productionEnv(), {
+        fetchImpl: async (url) =>
+          new Response('{}', {
+            status: url.includes(EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF) ? 401 : 200,
+          }),
+      }),
+      /Supabase validation failed with HTTP 401/,
+    );
+  });
+});
+
+describe('deployed production validation', () => {
+  const key = jwtFor(EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF);
+  const config = {
+    SUPABASE_URL: EXPECTED_PRODUCTION_SUPABASE_URL,
+    SUPABASE_ANON_KEY: key,
+    BACKEND_URL: EXPECTED_PRODUCTION_BACKEND_URL,
+    VERSION: '0.11.0',
+  };
+  const script =
+    `window.__KORTIX_RUNTIME_CONFIG=${JSON.stringify(config)};` +
+    'window.__RUNTIME_ENV=window.__KORTIX_RUNTIME_CONFIG;';
+
+  it('parses the public runtime bootstrap without evaluating JavaScript', () => {
+    assert.deepEqual(parseRuntimeConfigScript(script), config);
+  });
+
+  it('validates the deployed version, backend, custom domain, and native project', async () => {
+    const calls = [];
+    const result = await validateDeployedProductionSupabase(
+      'https://kortix.com/api/runtime-config',
+      {
+        expectedVersion: '0.11.0',
+        fetchImpl: async (url) => {
+          calls.push(url);
+          return url.endsWith('/api/runtime-config')
+            ? new Response(script, { status: 200 })
+            : new Response('{}', { status: 200 });
+        },
+      },
+    );
+
+    assert.equal(result.projectRef, EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF);
+    assert.deepEqual(calls, [
+      'https://kortix.com/api/runtime-config',
+      `${EXPECTED_PRODUCTION_SUPABASE_URL}/auth/v1/settings`,
+      `https://${EXPECTED_PRODUCTION_SUPABASE_PROJECT_REF}.supabase.co/auth/v1/settings`,
+    ]);
+  });
+
+  it('rejects a stale deployed frontend version', async () => {
+    await assert.rejects(
+      validateDeployedProductionSupabase('https://kortix.com/api/runtime-config', {
+        expectedVersion: '0.11.1',
+        fetchImpl: async () => new Response(script, { status: 200 }),
+      }),
+      /runtime config version 0\.11\.0 does not match release 0\.11\.1/,
+    );
+  });
+
+  it('rejects a deployed frontend that points at another backend', async () => {
+    const wrongBackendScript = `window.__KORTIX_RUNTIME_CONFIG=${JSON.stringify({
+      ...config,
+      BACKEND_URL: 'https://api-use2-shadow.kortix.com/v1',
+    })};window.__RUNTIME_ENV=window.__KORTIX_RUNTIME_CONFIG;`;
+
+    await assert.rejects(
+      validateDeployedProductionSupabase('https://kortix.com/api/runtime-config', {
+        expectedVersion: '0.11.0',
+        fetchImpl: async () => new Response(wrongBackendScript, { status: 200 }),
+      }),
+      /does not match https:\/\/api\.kortix\.com\/v1/,
+    );
+  });
+});
+
+describe('release wiring', () => {
+  it('runs the guard inside the frontend build command', async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+    );
+
+    assert.match(
+      packageJson.scripts.build,
+      /^node scripts\/validate-production-supabase-env\.mjs && /,
+    );
+  });
+
+  it('blocks the GitHub release and banner clear on deployed frontend proof', async () => {
+    const workflow = await readFile(
+      new URL('../../../.github/workflows/deploy-prod.yml', import.meta.url),
+      'utf8',
+    );
+
+    assert.match(workflow, /frontend-auth-proof:\n/);
+    assert.match(
+      workflow,
+      /needs: \[version, retag-images, build-cli, deploy-ecs, deploy-api, verify-live-version, frontend-auth-proof\]/,
+    );
+    assert.match(
+      workflow,
+      /maintenance-banner-off:[\s\S]*?needs: \[verify-live-version, frontend-auth-proof\]/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- pin Vercel production builds to EU Supabase project `jbriwassebxdwoieikga`
- fail the frontend build before Next.js when URL, key, alias, or live GoTrue validation disagrees
- verify the released frontend version, backend URL, custom Supabase domain, and native project before publishing the GitHub release
- keep the release banner active until the frontend auth proof passes

## Verification
- `node --test apps/web/scripts/validate-production-supabase-env.test.mjs` — 13 passed
- wrong-project production build exits 1 before `next build`
- production `.env.prod` guard passes for `jbriwassebxdwoieikga`
- live `https://kortix.com/api/runtime-config` guard passes for frontend `0.11.0`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter Kortix-Computer-Frontend build` — passed
- `actionlint -ignore SC2035 .github/workflows/deploy-prod.yml` — passed; ignored three pre-existing SC2035 findings