### PR TITLE
fix(security): close public SSH/RDP exposure on the us-east-2 ACL and prevent its return

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -38,6 +38,8 @@ jobs:
           terraform_version: ${{ env.TF_VERSION }}
       - name: terraform fmt
         run: terraform fmt -check -recursive infra/terraform
+      - name: nacl auditor unit tests
+        run: python3 infra/terraform/scripts/test_audit_nacl_admin_ports.py
       - name: terraform validate (every root)
         run: |
           set -euo pipefail
@@ -95,6 +97,26 @@ jobs:
         with:
           sarif_file: checkov.sarif/results_sarif.sarif
           category: checkov-terraform
+
+  nacl-audit:
+    name: nacl admin-port audit
+    # Terraform governs the VPCs it creates; this checks what is actually
+    # deployed, so a hand-edited ACL or a new region cannot drift past the
+    # control. Hard gate — unlike drift detection, a finding is a real exposure.
+    if: github.event_name != 'pull_request' && vars.TF_PLAN_ROLE_ARN != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ vars.TF_PLAN_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
+      - name: audit every region for public SSH/RDP
+        run: python3 infra/terraform/scripts/audit-nacl-admin-ports.py
 
   drift:
     name: drift detection

--- a/infra/terraform/compliance-monitoring/use2-security.tf
+++ b/infra/terraform/compliance-monitoring/use2-security.tf
@@ -496,17 +496,34 @@ resource "aws_network_acl" "use2_restricted" {
     from_port  = 3390
     to_port    = 65535
   }
+  # Permit public UDP except SSH (22) and RDP (3389), mirroring the TCP carve-out.
   ingress {
     protocol   = "udp"
     rule_no    = 130
     action     = "allow"
     cidr_block = "0.0.0.0/0"
     from_port  = 0
+    to_port    = 21
+  }
+  ingress {
+    protocol   = "udp"
+    rule_no    = 140
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 23
+    to_port    = 3388
+  }
+  ingress {
+    protocol   = "udp"
+    rule_no    = 150
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3390
     to_port    = 65535
   }
   ingress {
     protocol   = "icmp"
-    rule_no    = 140
+    rule_no    = 160
     action     = "allow"
     cidr_block = "0.0.0.0/0"
     from_port  = 0

--- a/infra/terraform/environments/prod-us-east-2-shadow/main.tf
+++ b/infra/terraform/environments/prod-us-east-2-shadow/main.tf
@@ -38,6 +38,11 @@ module "network" {
   az_count           = 2
   single_nat_gateway = false
   tags               = local.tags
+
+  # compliance-monitoring owns this VPC's default NACL (aws_default_network_acl.use2)
+  # and points its subnets at aws_network_acl.use2_restricted. Adopting it here too
+  # would make the two roots overwrite each other on every apply.
+  manage_default_network_acl = false
 }
 
 module "certificate" {

--- a/infra/terraform/modules/network/main.tf
+++ b/infra/terraform/modules/network/main.tf
@@ -58,6 +58,102 @@ resource "aws_internet_gateway" "this" {
   tags   = local.internet_gateway_tags
 }
 
+# ── Default network ACL baseline ──────────────────────────────────────────────
+# Public TCP/UDP is allowed as 1024-3388 + 3390-65535 rather than 1024-65535, so
+# RDP (3389) is excluded; SSH (22) sits below 1024 and is excluded by the
+# ephemeral floor. Rule numbers match the ACLs already deployed in every region
+# so adopting an existing VPC is a no-op rather than a rewrite. Return traffic
+# still flows because NACLs are stateless and ephemeral source ports land inside
+# the permitted ranges.
+resource "aws_default_network_acl" "this" {
+  count = var.manage_default_network_acl ? 1 : 0
+
+  default_network_acl_id = aws_vpc.this.default_network_acl_id
+
+  # Unrestricted traffic inside the VPC.
+  ingress {
+    protocol   = -1
+    rule_no    = 1
+    action     = "allow"
+    cidr_block = aws_vpc.this.cidr_block
+    from_port  = 0
+    to_port    = 0
+  }
+
+  # Individually published public TCP ports (80/443 by default).
+  dynamic "ingress" {
+    for_each = { for i, p in var.public_ingress_tcp_ports : i => p }
+    content {
+      protocol   = "tcp"
+      rule_no    = 110 + (ingress.key * 10)
+      action     = "allow"
+      cidr_block = "0.0.0.0/0"
+      from_port  = ingress.value
+      to_port    = ingress.value
+    }
+  }
+
+  # Ephemeral return ranges, split around RDP (3389).
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 130
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 3388
+  }
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 140
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3390
+    to_port    = 65535
+  }
+  ingress {
+    protocol   = "udp"
+    rule_no    = 150
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 3388
+  }
+  ingress {
+    protocol   = "udp"
+    rule_no    = 160
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3390
+    to_port    = 65535
+  }
+  ingress {
+    protocol   = "icmp"
+    rule_no    = 170
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+    icmp_type  = -1
+    icmp_code  = -1
+  }
+
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = merge({ ManagedBy = "terraform" }, var.tags, { Name = "${var.name}-default-nacl" })
+
+  # Subnet membership follows subnet creation/deletion, not this resource.
+  lifecycle {
+    ignore_changes = [subnet_ids]
+  }
+}
+
 # ── Public subnets ────────────────────────────────────────────────────────────
 resource "aws_subnet" "public" {
   count             = var.az_count

--- a/infra/terraform/modules/network/variables.tf
+++ b/infra/terraform/modules/network/variables.tf
@@ -27,6 +27,32 @@ variable "tags" {
   default     = {}
 }
 
+# ── Default network ACL ───────────────────────────────────────────────────────
+# A VPC's AWS-created default NACL permits every protocol from 0.0.0.0/0, which
+# leaves SSH (22) and RDP (3389) publicly reachable at the subnet boundary. This
+# module adopts that default NACL and replaces its rules with a baseline that
+# carves both admin ports out of the public ranges, so every VPC is compliant by
+# construction instead of by hand-editing each one after the fact.
+#
+# Set false ONLY when another Terraform root already owns this VPC's default
+# NACL (owning the same resource from two states makes them fight on apply).
+variable "manage_default_network_acl" {
+  description = "Adopt the VPC's default NACL and enforce the restricted baseline. Set false if another root owns it."
+  type        = bool
+  default     = true
+}
+
+variable "public_ingress_tcp_ports" {
+  description = "Public TCP ports opened individually below the ephemeral range (e.g. 80, 443)."
+  type        = list(number)
+  default     = [80, 443]
+
+  validation {
+    condition     = !contains(var.public_ingress_tcp_ports, 22) && !contains(var.public_ingress_tcp_ports, 3389)
+    error_message = "public_ingress_tcp_ports must not contain 22 (SSH) or 3389 (RDP); these must never be reachable from 0.0.0.0/0."
+  }
+}
+
 # ── EKS subnet discovery tags (optional; empty = no-op for the ECS envs) ───────
 # EKS needs subnets tagged so the AWS Load Balancer Controller can auto-discover
 # where to place ALBs (`kubernetes.io/role/elb` on public, `.../internal-elb` on

--- a/infra/terraform/scripts/audit-nacl-admin-ports.py
+++ b/infra/terraform/scripts/audit-nacl-admin-ports.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Fail if any network ACL exposes SSH (22) or RDP (3389) to the internet.
+
+Terraform only governs the VPCs it creates. This audits what is actually
+deployed, so a hand-edited ACL, an imported VPC, or a brand-new region cannot
+drift past the control unnoticed.
+
+Rules are evaluated the way AWS evaluates them: ascending rule number, first
+match wins. A permissive rule that sits behind an explicit deny is therefore
+not a finding, and a rule is only checked against the protocol it applies to
+("all protocols" applies to both TCP and UDP).
+
+  ./audit-nacl-admin-ports.py                       # current credentials
+  ./audit-nacl-admin-ports.py --profile essentia    # a specific account
+  ./audit-nacl-admin-ports.py --region us-east-2    # one region
+  ./audit-nacl-admin-ports.py --json                # machine-readable
+
+Exit codes: 0 clean, 1 findings, 2 the scan itself failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+ADMIN_PORTS = {22: "SSH", 3389: "RDP"}
+# NACL protocol numbers. "-1" means every protocol.
+PROTOCOLS = {"6": "tcp", "17": "udp"}
+OPEN_CIDRS = {"0.0.0.0/0", "::/0"}
+
+
+def aws(args: list[str], profile: str | None) -> dict:
+    cmd = ["aws", *args, "--output", "json"]
+    if profile:
+        cmd += ["--profile", profile]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"{' '.join(cmd)} failed")
+    return json.loads(proc.stdout)
+
+
+def regions(profile: str | None) -> list[str]:
+    data = aws(["ec2", "describe-regions"], profile)
+    return sorted(r["RegionName"] for r in data["Regions"])
+
+
+def rule_matches(entry: dict, port: int, protocol: str) -> bool:
+    """True if this entry is the one AWS applies to (port, protocol)."""
+    entry_protocol = entry["Protocol"]
+    if entry_protocol not in ("-1", protocol):
+        return False
+    # "All protocols" entries carry no port range and cover every port.
+    port_range = entry.get("PortRange")
+    if entry_protocol != "-1" and port_range:
+        if not port_range["From"] <= port <= port_range["To"]:
+            return False
+    return True
+
+
+def audit_acl(acl: dict, region: str) -> list[dict]:
+    inbound = sorted(
+        (e for e in acl["Entries"] if not e["Egress"]),
+        key=lambda e: e["RuleNumber"],
+    )
+    findings = []
+    for port, service in ADMIN_PORTS.items():
+        for protocol, protocol_name in PROTOCOLS.items():
+            for entry in inbound:
+                if not rule_matches(entry, port, protocol):
+                    continue
+                cidr = entry.get("CidrBlock") or entry.get("Ipv6CidrBlock")
+                # Narrower sources are fine; only an internet-wide rule decides
+                # the outcome, and only the first matching one applies.
+                if cidr not in OPEN_CIDRS:
+                    continue
+                if entry["RuleAction"] == "allow":
+                    findings.append(
+                        {
+                            "region": region,
+                            "network_acl_id": acl["NetworkAclId"],
+                            "vpc_id": acl["VpcId"],
+                            "is_default": acl["IsDefault"],
+                            "port": port,
+                            "service": service,
+                            "protocol": protocol_name,
+                            "rule_number": entry["RuleNumber"],
+                            "cidr": cidr,
+                            "subnets": [a["SubnetId"] for a in acl.get("Associations", [])],
+                        }
+                    )
+                break  # first match wins, allow or deny
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", help="AWS profile (default: ambient credentials)")
+    parser.add_argument("--region", action="append", help="Region to scan; repeatable")
+    parser.add_argument("--json", action="store_true", help="Emit findings as JSON")
+    args = parser.parse_args()
+
+    try:
+        targets = args.region or regions(args.profile)
+    except Exception as exc:  # noqa: BLE001 - surfaced verbatim to the operator
+        print(f"error: could not list regions: {exc}", file=sys.stderr)
+        return 2
+
+    findings: list[dict] = []
+    scanned = 0
+    for region in targets:
+        try:
+            data = aws(["ec2", "describe-network-acls", "--region", region], args.profile)
+        except Exception as exc:  # noqa: BLE001
+            print(f"error: {region}: {exc}", file=sys.stderr)
+            return 2
+        scanned += 1
+        for acl in data["NetworkAcls"]:
+            findings.extend(audit_acl(acl, region))
+
+    if args.json:
+        print(json.dumps(findings, indent=2))
+    else:
+        account = args.profile or "default credentials"
+        for f in findings:
+            scope = "default VPC ACL" if f["is_default"] else "custom ACL"
+            print(
+                f"FAIL {f['region']} {f['network_acl_id']} ({scope}, {f['vpc_id']}): "
+                f"rule {f['rule_number']} allows {f['service']} "
+                f"({f['protocol']}/{f['port']}) from {f['cidr']} "
+                f"-> {len(f['subnets'])} subnet(s)"
+            )
+        if findings:
+            print(f"\n{len(findings)} finding(s) across {scanned} region(s) [{account}]")
+        else:
+            print(f"clean: no ACL exposes SSH or RDP across {scanned} region(s) [{account}]")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/terraform/scripts/test_audit_nacl_admin_ports.py
+++ b/infra/terraform/scripts/test_audit_nacl_admin_ports.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Regression tests for audit-nacl-admin-ports.
+
+Dependency-free on purpose: `python3 test_audit_nacl_admin_ports.py`.
+
+The case that matters most is `test_udp_hole_is_caught`. The ACL that failed
+the Drata control had SSH and RDP correctly carved out of its TCP rules but
+left UDP wide open, so a TCP-only reading of the ruleset called it compliant.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "audit", Path(__file__).with_name("audit-nacl-admin-ports.py")
+)
+audit = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(audit)
+
+
+def acl(entries: list[dict], acl_id: str = "acl-test") -> dict:
+    return {
+        "NetworkAclId": acl_id,
+        "VpcId": "vpc-test",
+        "IsDefault": False,
+        "Entries": entries,
+        "Associations": [{"SubnetId": "subnet-test"}],
+    }
+
+
+def allow(rule_no, protocol, from_port=None, to_port=None, cidr="0.0.0.0/0"):
+    entry = {
+        "RuleNumber": rule_no,
+        "Protocol": protocol,
+        "RuleAction": "allow",
+        "Egress": False,
+        "CidrBlock": cidr,
+    }
+    if from_port is not None:
+        entry["PortRange"] = {"From": from_port, "To": to_port}
+    return entry
+
+
+def deny(rule_no, protocol, from_port=None, to_port=None, cidr="0.0.0.0/0"):
+    entry = allow(rule_no, protocol, from_port, to_port, cidr)
+    entry["RuleAction"] = "deny"
+    return entry
+
+
+DENY_ALL = deny(32767, "-1")
+
+
+def ports(findings) -> set:
+    return {(f["protocol"], f["port"]) for f in findings}
+
+
+def test_udp_hole_is_caught():
+    """The exact pre-fix us-east-2 ruleset: TCP carved, UDP wide open."""
+    entries = [
+        allow(50, "-1", cidr="10.40.0.0/16"),
+        allow(100, "6", 0, 21),
+        allow(110, "6", 23, 3388),
+        allow(120, "6", 3390, 65535),
+        allow(130, "17", 0, 65535),  # the hole
+        DENY_ALL,
+    ]
+    found = ports(audit.audit_acl(acl(entries), "us-east-2"))
+    assert found == {("udp", 22), ("udp", 3389)}, found
+
+
+def test_fixed_ruleset_is_clean():
+    """The same ACL after splitting the UDP range."""
+    entries = [
+        allow(50, "-1", cidr="10.40.0.0/16"),
+        allow(100, "6", 0, 21),
+        allow(110, "6", 23, 3388),
+        allow(120, "6", 3390, 65535),
+        allow(130, "17", 0, 21),
+        allow(140, "17", 23, 3388),
+        allow(150, "17", 3390, 65535),
+        DENY_ALL,
+    ]
+    assert audit.audit_acl(acl(entries), "us-east-2") == []
+
+
+def test_module_baseline_is_clean():
+    """The baseline modules/network writes: ephemeral ranges split around RDP."""
+    entries = [
+        allow(1, "-1", cidr="10.20.0.0/16"),
+        allow(110, "6", 80, 80),
+        allow(120, "6", 443, 443),
+        allow(130, "6", 1024, 3388),
+        allow(140, "6", 3390, 65535),
+        allow(150, "17", 1024, 3388),
+        allow(160, "17", 3390, 65535),
+        allow(170, "1"),
+        DENY_ALL,
+    ]
+    assert audit.audit_acl(acl(entries), "eu-west-2") == []
+
+
+def test_default_vpc_acl_is_caught():
+    """An untouched AWS default NACL allows everything from anywhere."""
+    found = ports(audit.audit_acl(acl([allow(100, "-1"), DENY_ALL]), "us-west-1"))
+    assert found == {("tcp", 22), ("udp", 22), ("tcp", 3389), ("udp", 3389)}, found
+
+
+def test_deny_before_allow_wins():
+    """Explicit denies ahead of a broad allow are compliant: first match wins."""
+    entries = [
+        deny(90, "6", 22, 22),
+        deny(91, "6", 3389, 3389),
+        deny(92, "17", 22, 22),
+        deny(93, "17", 3389, 3389),
+        allow(100, "-1"),
+        DENY_ALL,
+    ]
+    assert audit.audit_acl(acl(entries), "us-west-2") == []
+
+
+def test_allow_before_deny_still_fails():
+    """Ordering is real: a deny placed after the allow never applies."""
+    entries = [allow(100, "-1"), deny(200, "6", 22, 22), DENY_ALL]
+    assert ("tcp", 22) in ports(audit.audit_acl(acl(entries), "us-west-2"))
+
+
+def test_narrow_source_is_not_a_finding():
+    """SSH from the corporate range is not internet exposure."""
+    entries = [allow(100, "6", 22, 22, cidr="10.0.0.0/8"), DENY_ALL]
+    assert audit.audit_acl(acl(entries), "us-west-2") == []
+
+
+def test_egress_is_ignored():
+    entries = [dict(allow(100, "-1"), Egress=True), DENY_ALL]
+    assert audit.audit_acl(acl(entries), "us-west-2") == []
+
+
+def test_ipv6_open_source_is_caught():
+    entries = [
+        {
+            "RuleNumber": 100,
+            "Protocol": "6",
+            "RuleAction": "allow",
+            "Egress": False,
+            "Ipv6CidrBlock": "::/0",
+            "PortRange": {"From": 22, "To": 22},
+        },
+        DENY_ALL,
+    ]
+    assert ("tcp", 22) in ports(audit.audit_acl(acl(entries), "us-west-2"))
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"ok   {test.__name__}")
+        except AssertionError as exc:
+            print(f"FAIL {test.__name__}: {exc}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes the Drata failure **AWS Network ACLs Public Remote Server Administration Access Restricted** (failing since 2026-07-25) and removes the conditions that let it happen.

## The failing resource

`acl-0e2cae3e6f710ee7d` — us-east-2, `kortix-prod-use2-restricted`, attached to 4 production subnets.

Its TCP rules correctly carved SSH and RDP out of the public ranges (`0-21`, `23-3388`, `3390-65535`), but rule 130 allowed **UDP `0-65535` from `0.0.0.0/0`** — so both admin ports stayed reachable over UDP. Reading only the TCP rules makes the ACL look compliant, which is why this sat unnoticed.

Fixed by splitting the UDP allow into the same three ranges as TCP (ICMP renumbered 140 → 160). **Already applied** via targeted `terraform apply` on the `compliance-monitoring` root: 1 changed, 0 destroyed, in place, `prevent_destroy` untouched.

## Why it could happen at all

The account's other eight ACLs are all compliant — but every one of them was **hand-edited, in two different styles** (some carve the ranges, some use explicit denies at rule 90/91), and none are in Terraform. `modules/network` creates VPCs and never touched their default ACL, which AWS ships allowing every protocol from `0.0.0.0/0`. Any VPC rebuild or new environment would have landed exposed again.

## Changes

- **`modules/network`** adopts each VPC's default ACL and writes one baseline: public TCP/UDP as `1024-3388` + `3390-65535`, so RDP is excluded and SSH sits below the ephemeral floor. Rule numbers match the ACLs already deployed, so adopting an existing VPC is a no-op rather than a rewrite — `staging`'s plan confirms it targets `acl-08e0de4ddfa6aacda` and writes rules identical to the live ones.
- **`public_ingress_tcp_ports`** rejects 22 and 3389 at `terraform validate` time.
- **`prod-us-east-2-shadow`** opts out — `compliance-monitoring` already owns that VPC's default ACL, and two roots owning one resource would fight on every apply.
- **`scripts/audit-nacl-admin-ports.py`** reads what is actually deployed in every region and evaluates rules the way AWS does (ascending rule number, first match wins), because Terraform only governs the VPCs it creates. Hand-edits, imported VPCs and new regions are all in scope.
- **CI** — auditor unit tests run on PRs; the live audit runs as a hard gate on the schedule that already has AWS credentials.

## Verification

- All 17 regions re-scanned post-apply: no ACL exposes SSH or RDP.
- Both prod ECS services still 2/2 running, all ALB targets healthy. No traffic impact — rule 50 already allows all VPC-internal traffic, so in-VPC DNS was never in the rule-churn path.
- 9 auditor tests pass, including the exact ruleset that failed (TCP carved, UDP open) and rule-ordering cases in both directions.
- `terraform fmt -check -recursive` and `validate` clean across all 11 roots.

## Not in this PR

The module baseline is **code-only for now**. Every environment root carries heavy pre-existing drift (staging alone plans 23 add / 24 change / 4 destroy of unrelated tag and listener changes), so applying the baseline would sweep that in. Nothing is exposed meanwhile: all eight ACLs are compliant today and the auditor now guards them. The baseline lands on each root's next deliberate apply, after that drift is reconciled separately.
