### PR TITLE
test(ke2e): cover the public file-share branch in SESS-13

### DIFF
--- a/tests/src/flows/sessions.flow.ts
+++ b/tests/src/flows/sessions.flow.ts
@@ -287,6 +287,86 @@ flow(
       );
       r.status(400);
     });
+
+    // The `file` branch of the same endpoint. Everything above exercises
+    // `preview`; a file share takes a different path through
+    // buildPublicShareInsert (normalizeWorkspaceFilePath, port forced null,
+    // mode forced 'view') and resolves to `.../file` rather than `.../:port`.
+    // It went uncovered while nothing in the product could create one — the
+    // frontend only regained that ability in #5751.
+    let fileShareId = '';
+    let fileToken = '';
+
+    await ctx.step('create a file public share → 201, portless, view-only', async () => {
+      const r = await owner.post(
+        '/v1/projects/:projectId/sessions/:sessionId/public-shares',
+        { file: { path: '/workspace/README.md', label: 'ke2e file' } },
+        { params: { projectId: project.id, sessionId: session.id } },
+      );
+      r.status(201)
+        .body()
+        .has('$.share.resource_type', 'file')
+        .has('$.share.file_path', '/workspace/README.md')
+        .has('$.share.port', null)
+        .has('$.share.mode', 'view')
+        .has('$.share.allow_websocket', false)
+        .matches('$.share.public_token', /^kps_[0-9a-f]{32}$/)
+        .matches('$.share.proxy_path', /^\/v1\/p\/public-share\/kps_[0-9a-f]{32}\/file$/);
+      const body = r.json<any>();
+      fileShareId = body.share.share_id;
+      fileToken = body.share.public_token;
+    });
+
+    await ctx.step('a workspace-relative path is normalized, not rejected', async () => {
+      const r = await owner.post(
+        '/v1/projects/:projectId/sessions/:sessionId/public-shares',
+        { file: { path: 'notes/report.md' } },
+        { params: { projectId: project.id, sessionId: session.id } },
+      );
+      // Not ctx.track'ed: public_share rows are FK'd to the session with ON
+      // DELETE CASCADE, so the session fixture's own teardown reclaims them.
+      r.status(201).body().has('$.share.file_path', '/workspace/notes/report.md');
+    });
+
+    await ctx.step('a traversing file path is refused → 400', async () => {
+      const r = await owner.post(
+        '/v1/projects/:projectId/sessions/:sessionId/public-shares',
+        { file: { path: '/workspace/../../etc/passwd' } },
+        { params: { projectId: project.id, sessionId: session.id } },
+      );
+      r.status(400);
+    });
+
+    await ctx.step(
+      'unauthenticated resolution of the file token → 200/503, and carries no public_url',
+      async () => {
+        const r = await ctx.client
+          .as(ctx.P.ANON)
+          .get('/v1/p/public-share/:token', { params: { token: fileToken } });
+        r.status([200, 503]);
+        if (r.statusCode === 200) {
+          // `public_url` is populated only for preview shares — a file share is
+          // reached through its proxy_path, never a bare origin URL.
+          r.body()
+            .has('$.share.resource_type', 'file')
+            .has('$.share.public_url', null)
+            .has('$.share.file_path', '/workspace/README.md');
+        }
+      },
+    );
+
+    await ctx.step('revoked file token → 410, same as a preview token', async () => {
+      const del = await owner.del(
+        '/v1/projects/:projectId/sessions/:sessionId/public-shares/:shareId',
+        { params: { projectId: project.id, sessionId: session.id, shareId: fileShareId } },
+      );
+      del.status(200);
+
+      const r = await ctx.client
+        .as(ctx.P.ANON)
+        .get('/v1/p/public-share/:token', { params: { token: fileToken } });
+      r.status(410);
+    });
   },
 );
 


### PR DESCRIPTION
## What

Adds e2e coverage for the **public file-share** branch, which had none.

`SESS-13` exercised only `preview` shares. The `file` branch takes a genuinely different path through `buildPublicShareInsert` — `normalizeWorkspaceFilePath`, port forced `null`, mode forced `'view'` — and resolves to `.../file` rather than `.../:port`. It went uncovered because **nothing in the product could create a file share** until #5751 restored the frontend's ability to.

Five new steps:

| Step | Asserts |
|---|---|
| create a file share | 201, `resource_type: 'file'`, `port: null`, `mode: 'view'`, `allow_websocket: false`, `proxy_path` matches `/v1/p/public-share/kps_…/file` |
| relative path | `notes/report.md` normalizes to `/workspace/notes/report.md` |
| traversal | `/workspace/../../etc/passwd` → 400 |
| anonymous resolve | 200/503, and `public_url` is `null` — that field is preview-only |
| revoked | → 410, same as a preview token |

## Verified live

Run against a live API (local stack + Cloudflare tunnel, real Daytona, real Supabase principals):

```
SESS-13  ✓  15/15 steps green   (10 pre-existing + 5 new)
SESS-14  ✓  access boundary (canManageSharing)
SESS-16  ✓  anonymous session-share viewing
ke2e coverage gate  ✓  98.1% · 507/517 routes · 0 uncovered
```

## Two gaps found while doing this

Neither is fixed here — flagging rather than silently expanding scope.

1. **SESS-13 has never actually run in CI.** It declares `requires: ['daytona', 'funded']`, but `e2e.yml` never sets `KE2E_CAP_FUNDED`, so the flow self-skips on every dispatch. That is why the file-share gap survived. Fixing it means deciding whether the shared e2e account should be funded.
2. **The public-share proxy's serving routes are outside the coverage gate.** `tests/spec/routes.generated.json` contains only `GET /v1/p/public-share/:token`. The routes that actually serve content — `/:token/file`, `/:token/file/*`, `/:token/:port`, `/:token/:port/*` — are absent, so they cannot be declared in `meta.routes` and are invisible to the gate.
