### PR TITLE
fix(security): make the NACL admin-port audit actually run

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -103,7 +103,11 @@ jobs:
     # Terraform governs the VPCs it creates; this checks what is actually
     # deployed, so a hand-edited ACL or a new region cannot drift past the
     # control. Hard gate — unlike drift detection, a finding is a real exposure.
-    if: github.event_name != 'pull_request' && vars.TF_PLAN_ROLE_ARN != ''
+    #
+    # Uses its own role rather than TF_PLAN_ROLE_ARN: this job needs two
+    # read-only EC2 describes, while drift detection needs broad read plus
+    # state access. See security-baseline/iam-gha-nacl-audit.tf.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -111,9 +115,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # An unset role would silently skip the audit, which reads as a pass.
+      # A control that cannot run must fail loudly instead.
+      - name: require audit role
+        run: |
+          if [ -z "${{ vars.NACL_AUDIT_ROLE_ARN }}" ]; then
+            echo "::error::NACL_AUDIT_ROLE_ARN is unset - the admin-port audit cannot run."
+            exit 1
+          fi
       - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
         with:
-          role-to-assume: ${{ vars.TF_PLAN_ROLE_ARN }}
+          role-to-assume: ${{ vars.NACL_AUDIT_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-west-2' }}
       - name: audit every region for public SSH/RDP
         run: python3 infra/terraform/scripts/audit-nacl-admin-ports.py

--- a/infra/terraform/security-baseline/iam-gha-nacl-audit.tf
+++ b/infra/terraform/security-baseline/iam-gha-nacl-audit.tf
@@ -1,0 +1,71 @@
+# ════════════════════════════════════════════════════════════════════════════
+# kortix-gha-nacl-audit — the OIDC role the scheduled NACL admin-port audit
+# assumes (terraform-ci.yml, job "nacl admin-port audit").
+#
+# WHY A DEDICATED ROLE: the audit only needs to list regions and read network
+# ACLs. It deliberately does NOT reuse TF_PLAN_ROLE_ARN, which the drift job
+# consumes — that job runs `terraform plan` against whole roots and needs broad
+# read plus state access. Pointing both at one narrow role would light up drift
+# detection with permissions it cannot work with; pointing both at one broad
+# role would hand a read-everything credential to a job that needs two calls.
+#
+# The audit reads deployed reality rather than Terraform state on purpose:
+# Terraform only governs the VPCs it creates, so hand-edited ACLs, imported
+# VPCs and newly-opened regions are exactly the cases that need catching. That
+# is why the permissions are account-wide but read-only.
+# ════════════════════════════════════════════════════════════════════════════
+
+resource "aws_iam_role" "gha_nacl_audit" {
+  name = "kortix-gha-nacl-audit"
+  # The audit runs on schedule from the default branch and on demand via
+  # workflow_dispatch, so the subject is not pinned to a single ref.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:kortix-ai/suna:*"
+        }
+      }
+    }]
+  })
+  tags = {
+    ManagedBy  = "terraform"
+    Name       = "kortix-gha-nacl-audit"
+    Stack      = "security-baseline"
+    Compliance = "soc2"
+  }
+}
+
+resource "aws_iam_role_policy" "gha_nacl_audit" {
+  # checkov:skip=CKV_AWS_355: DescribeRegions and DescribeNetworkAcls are
+  # account-wide describes; neither API supports resource-level permissions.
+  # checkov:skip=CKV_AWS_290: Read-only describes; the policy grants no writes.
+  name = "nacl-admin-port-audit"
+  role = aws_iam_role.gha_nacl_audit.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "ReadNetworkAcls"
+      Effect = "Allow"
+      Action = [
+        "ec2:DescribeRegions",
+        "ec2:DescribeNetworkAcls",
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+output "gha_nacl_audit_role_arn" {
+  description = "Set as the repo variable NACL_AUDIT_ROLE_ARN for terraform-ci.yml."
+  value       = aws_iam_role.gha_nacl_audit.arn
+}


### PR DESCRIPTION
Follow-up to #5755. The audit that PR added has never run.

## The problem

The `nacl admin-port audit` job was gated on `vars.TF_PLAN_ROLE_ARN`. That repo variable does not exist, so the job resolves to `skipping` — which renders as green in the checks list. The control meant to catch a publicly reachable SSH or RDP port was inert from the moment it merged. `drift detection` has been skipping for the same reason since it was written.

This is the same failure shape as the original finding: something that looks compliant because nobody checked the part that was actually load-bearing.

## Changes

- **`kortix-gha-nacl-audit`** — a GitHub OIDC role granting exactly `ec2:DescribeRegions` and `ec2:DescribeNetworkAcls`, nothing else. **Already applied**: `security-baseline` planned clean at 2 to add / 0 to change / 0 to destroy, and the repo variable `NACL_AUDIT_ROLE_ARN` is set to the resulting ARN.
- **The job uses its own variable.** Reusing `TF_PLAN_ROLE_ARN` would have been wrong in both directions: pointing it at this narrow role would start the drift job running with credentials too limited to plan a root, and pointing both at a role broad enough for drift would hand a read-everything credential to a job that makes two describe calls.
- **An unset role now fails the job** instead of skipping it. A control that cannot run should say so out loud.

The audit reads deployed reality rather than Terraform state on purpose — Terraform only governs the VPCs it creates, so hand-edited ACLs, imported VPCs and newly-opened regions are exactly the cases worth catching. That is why the permissions are account-wide but strictly read-only.

## Verification

- `terraform fmt -check -recursive` and `validate` clean.
- Role and inline policy exist in `935064898258`; `NACL_AUDIT_ROLE_ARN` reads back correctly.
- The job is triggered on `main` after merge to confirm it assumes the role and scans all regions, rather than assuming the wiring is right this time.

## Still outstanding, not addressed here

`drift detection` remains inert — `TF_PLAN_ROLE_ARN` is still unset and provisioning a plan role is a larger, broader-permission exercise. Flagging it rather than quietly leaving it looking green.
