### PR TITLE
fix(acp): refresh ingress credentials after restart

### DIFF
--- a/apps/api/src/projects/routes/acp-proxy.test.ts
+++ b/apps/api/src/projects/routes/acp-proxy.test.ts
@@ -11,6 +11,11 @@ let syncedProviderHeaders: Record<string, string> | null = null;
 let accessActions: string[] = [];
 let capabilityActions: string[] = [];
 let canManageSharing = true;
+let endpointCalls = 0;
+let invalidatedSandboxIds: string[] = [];
+let upstreamStatuses: number[] = [];
+let upstreamFetchCount = 0;
+let envSyncStatuses: number[] = [];
 
 mock.module('../lib/access', () => ({
   assertProjectCapability: async (
@@ -57,18 +62,29 @@ mock.module('../../shared/db', () => ({
 }));
 
 mock.module('../runtime-inspection', () => ({
-  sandboxRuntimeEndpoint: async () => ({
-    url: 'https://sandbox.test',
-    headers: { 'x-kortix-user-context': 'signed' },
-    providerHeaders: { 'x-daytona-preview-token': 'preview' },
-    serviceKey: 'service-key',
-  }),
+  sandboxRuntimeEndpoint: async () => {
+    endpointCalls += 1;
+    return {
+      url: 'https://sandbox.test',
+      headers: { 'x-kortix-user-context': 'signed' },
+      providerHeaders: { 'x-daytona-preview-token': 'preview' },
+      serviceKey: 'service-key',
+    };
+  },
+}));
+
+mock.module('../../sandbox-proxy/backend', () => ({
+  invalidateSandbox: (externalId: string) => {
+    invalidatedSandboxIds.push(externalId);
+  },
 }));
 
 mock.module('../lib/sandbox-env-sync', () => ({
   syncSandboxEnvForPrompt: async (input: {
     providerHeaders: Record<string, string>;
   }) => {
+    const status = envSyncStatuses.shift();
+    if (status) throw new Error(`env sync failed: ${status}`);
     syncedProviderHeaders = input.providerHeaders;
   },
 }));
@@ -87,10 +103,21 @@ mock.module('../lib/acp-sse-proxy', () => ({
 
 const realFetch = globalThis.fetch;
 globalThis.fetch = (async (input, init) => {
+  upstreamFetchCount += 1;
   upstreamUrl = String(input);
   upstreamHeaders = new Headers(init?.headers);
+  const status = upstreamStatuses.shift();
+  if (status && status !== 200) {
+    return Response.json({ error: 'stale ingress credential' }, { status });
+  }
   if (init?.method === 'DELETE') {
     return new Response(null, { status: 204 });
+  }
+  if (init?.method === 'GET') {
+    return new Response('id: 1\ndata: {"jsonrpc":"2.0","method":"kortix/cursor"}\n\n', {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
   }
   const request = JSON.parse(String(init?.body)) as Record<string, unknown>;
   return Response.json({
@@ -111,6 +138,11 @@ beforeEach(() => {
   accessActions = [];
   capabilityActions = [];
   canManageSharing = true;
+  endpointCalls = 0;
+  invalidatedSandboxIds = [];
+  upstreamStatuses = [];
+  upstreamFetchCount = 0;
+  envSyncStatuses = [];
 });
 
 afterAll(() => {
@@ -171,6 +203,64 @@ test('session/prompt syncs env with provider headers and no user context', async
   expect(syncedProviderHeaders).toEqual({
     'x-daytona-preview-token': 'preview',
   });
+});
+
+test('session/prompt refreshes stale ingress credentials when env sync rejects authentication', async () => {
+  envSyncStatuses = [401];
+
+  const response = await projectsApp.request(`/${PROJECT_ID}/sessions/${SESSION_ID}/acp`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'rpc-prompt-retry',
+      method: 'session/prompt',
+      params: { sessionId: 'native-session', prompt: [] },
+    }),
+  });
+
+  expect(response.status).toBe(200);
+  expect(endpointCalls).toBe(2);
+  expect(invalidatedSandboxIds).toEqual(['sandbox-external-1']);
+  expect(syncedProviderHeaders).toEqual({
+    'x-daytona-preview-token': 'preview',
+  });
+});
+
+test('POST .../acp refreshes stale ingress credentials once after an auth rejection', async () => {
+  upstreamStatuses = [401, 200];
+  const request = {
+    jsonrpc: '2.0',
+    id: 'rpc-retry',
+    method: 'initialize',
+    params: { protocolVersion: 1 },
+  };
+
+  const response = await projectsApp.request(`/${PROJECT_ID}/sessions/${SESSION_ID}/acp`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  expect(response.status).toBe(200);
+  expect(endpointCalls).toBe(2);
+  expect(upstreamFetchCount).toBe(2);
+  expect(invalidatedSandboxIds).toEqual(['sandbox-external-1']);
+  expect(appended.map((entry) => (entry as { direction: string }).direction)).toEqual([
+    'client_to_agent',
+    'agent_to_client',
+  ]);
+});
+
+test('GET .../acp refreshes stale ingress credentials once after an auth rejection', async () => {
+  upstreamStatuses = [401, 200];
+
+  const response = await projectsApp.request(`/${PROJECT_ID}/sessions/${SESSION_ID}/acp`);
+
+  expect(response.status).toBe(200);
+  expect(endpointCalls).toBe(2);
+  expect(upstreamFetchCount).toBe(2);
+  expect(invalidatedSandboxIds).toEqual(['sandbox-external-1']);
 });
 
 test('GET transcript retains project read access', async () => {

--- a/apps/api/src/projects/routes/acp.ts
+++ b/apps/api/src/projects/routes/acp.ts
@@ -5,6 +5,7 @@ import type { Context } from 'hono';
 
 import { PROJECT_ACTIONS } from '../../iam';
 import type { ProviderName } from '../../platform/providers';
+import { invalidateSandbox } from '../../sandbox-proxy/backend';
 import { db } from '../../shared/db';
 import type { AppEnv } from '../../types';
 import { assertProjectCapability, loadProjectForUser, loadVisibleSession } from '../lib/access';
@@ -87,9 +88,66 @@ async function resolveAcpTarget(
   if (!endpoint) return null;
   return {
     ...binding,
+    externalId: sandbox.externalId,
     provider: sandbox.provider as ProviderName,
     endpoint,
   };
+}
+
+type AcpTarget = NonNullable<Awaited<ReturnType<typeof resolveAcpTarget>>>;
+
+function acpUpstreamUrl(target: AcpTarget): string {
+  return (
+    `${target.endpoint.url}/kortix/acp/${encodeURIComponent(target.acpServerId)}` +
+    `?agent=${encodeURIComponent(target.runtimeHarness)}`
+  );
+}
+
+async function refreshAcpTargetIngress(target: AcpTarget): Promise<AcpTarget | null> {
+  invalidateSandbox(target.externalId);
+  const endpoint = await sandboxRuntimeEndpoint(target.externalId, target.userId);
+  return endpoint ? { ...target, endpoint } : null;
+}
+
+async function fetchAcpUpstreamWithIngressRefresh(
+  target: AcpTarget,
+  createInit: (target: AcpTarget) => RequestInit,
+): Promise<{ target: AcpTarget; upstream: Response }> {
+  let activeTarget = target;
+  let upstream = await fetch(acpUpstreamUrl(activeTarget), createInit(activeTarget));
+  if (upstream.status !== 401 && upstream.status !== 403) {
+    return { target: activeTarget, upstream };
+  }
+
+  const refreshed = await refreshAcpTargetIngress(activeTarget);
+  if (!refreshed) return { target: activeTarget, upstream };
+  activeTarget = refreshed;
+  upstream = await fetch(acpUpstreamUrl(activeTarget), createInit(activeTarget));
+  return { target: activeTarget, upstream };
+}
+
+async function syncPromptEnvWithIngressRefresh(target: AcpTarget): Promise<AcpTarget> {
+  const sync = (activeTarget: AcpTarget) =>
+    syncSandboxEnvForPrompt({
+      projectId: activeTarget.projectId,
+      sessionId: activeTarget.sessionId,
+      serviceKey: activeTarget.endpoint.serviceKey,
+      previewUrl: activeTarget.endpoint.url,
+      providerHeaders: activeTarget.endpoint.providerHeaders,
+      providerName: activeTarget.provider,
+    });
+
+  try {
+    await sync(target);
+    return target;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/\benv sync failed: (?:401|403)\b/.test(message)) throw error;
+    const refreshed = await refreshAcpTargetIngress(target);
+    if (!refreshed) throw error;
+    await sync(refreshed);
+    return refreshed;
+  }
 }
 
 projectsApp.get('/:projectId/sessions/:sessionId/acp/transcript', async (c) => {
@@ -113,7 +171,7 @@ projectsApp.get('/:projectId/sessions/:sessionId/acp/transcript', async (c) => {
 
 projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp', async (c) => {
   const method = c.req.method.toUpperCase();
-  const target = await resolveAcpTarget(
+  let target = await resolveAcpTarget(
     c,
     method === 'GET' ? 'read' : 'session',
     method === 'GET'
@@ -123,10 +181,6 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
         : PROJECT_ACTIONS.PROJECT_SESSION_START,
   );
   if (!target) return c.json({ error: 'ACP session runtime not found' }, 404);
-  const upstreamUrl =
-    `${target.endpoint.url}/kortix/acp/${encodeURIComponent(target.acpServerId)}` +
-    `?agent=${encodeURIComponent(target.runtimeHarness)}`;
-  const headers = new Headers(target.endpoint.headers);
 
   if (method === 'POST') {
     let envelope: Record<string, unknown>;
@@ -142,14 +196,7 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
 
     if (envelope.method === 'session/prompt') {
       try {
-        await syncSandboxEnvForPrompt({
-          projectId: target.projectId,
-          sessionId: target.sessionId,
-          serviceKey: target.endpoint.serviceKey,
-          previewUrl: target.endpoint.url,
-          providerHeaders: target.endpoint.providerHeaders,
-          providerName: target.provider,
-        });
+        target = await syncPromptEnvWithIngressRefresh(target);
       } catch (error) {
         return c.json(
           {
@@ -168,12 +215,16 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
       direction: 'client_to_agent',
       envelope,
     });
-    headers.set('Content-Type', 'application/json');
-    const upstream = await fetch(upstreamUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(envelope),
-      signal: c.req.raw.signal,
+    const body = JSON.stringify(envelope);
+    const { upstream } = await fetchAcpUpstreamWithIngressRefresh(target, (activeTarget) => {
+      const headers = new Headers(activeTarget.endpoint.headers);
+      headers.set('Content-Type', 'application/json');
+      return {
+        method: 'POST',
+        headers,
+        body,
+        signal: c.req.raw.signal,
+      };
     });
     if (upstream.ok && upstream.status !== 202 && upstream.status !== 204) {
       const body = await upstream.text();
@@ -210,15 +261,18 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
     if (!Number.isSafeInteger(afterOrdinal) || afterOrdinal < 0) {
       return c.json({ error: 'Last-Event-ID must be a non-negative integer' }, 400);
     }
-    headers.set('Accept', 'text/event-stream');
-    // Always replay the active process from its first event. The durable
-    // unique key removes duplicates and the DB ordinal remains monotonic
-    // when a restarted harness begins a new upstream sequence.
-    headers.set('Last-Event-ID', '0');
-    const upstream = await fetch(upstreamUrl, {
-      method: 'GET',
-      headers,
-      signal: c.req.raw.signal,
+    const { upstream } = await fetchAcpUpstreamWithIngressRefresh(target, (activeTarget) => {
+      const headers = new Headers(activeTarget.endpoint.headers);
+      headers.set('Accept', 'text/event-stream');
+      // Always replay the active process from its first event. The durable
+      // unique key removes duplicates and the DB ordinal remains monotonic
+      // when a restarted harness begins a new upstream sequence.
+      headers.set('Last-Event-ID', '0');
+      return {
+        method: 'GET',
+        headers,
+        signal: c.req.raw.signal,
+      };
     });
     if (!upstream.ok || !upstream.body) {
       return new Response(upstream.body, {
@@ -262,11 +316,11 @@ projectsApp.on(['GET', 'POST', 'DELETE'], '/:projectId/sessions/:sessionId/acp',
       403,
     );
   }
-  const upstream = await fetch(upstreamUrl, {
+  const { upstream } = await fetchAcpUpstreamWithIngressRefresh(target, (activeTarget) => ({
     method: 'DELETE',
-    headers,
+    headers: activeTarget.endpoint.headers,
     signal: c.req.raw.signal,
-  });
+  }));
   return new Response(upstream.body, {
     status: upstream.status,
     headers: decodedResponseHeaders(upstream),

--- a/tests/README.md
+++ b/tests/README.md
@@ -94,6 +94,30 @@ pnpm --filter @kortix/tests test:shell:vps               # VPS checks
 | `E2E_API_URL` | `http://localhost:13738/v1` | API URL |
 | `E2E_SUPABASE_URL` | `http://localhost:13740` | Supabase URL |
 
+## ACP Multi-Harness Protocol Smoke
+
+Run `tests/e2e/scripts/acp-multi-harness-smoke.ts` against a live API. The
+script verifies session creation, the headless prompt, a follow-up prompt,
+transcript reload, immutable runtime identity, restart, and a post-restart
+prompt. The default harness set is `opencode,claude,codex,pi`.
+
+```bash
+E2E_ACP_MULTI_HARNESS_HARNESSES=codex,pi \
+E2E_ACP_MULTI_HARNESS_PROVIDER=daytona \
+bun tests/e2e/scripts/acp-multi-harness-smoke.ts
+```
+
+The script creates a disposable user and project. It stops every created
+session and archives the project in `finally`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `E2E_ACP_MULTI_HARNESS_HARNESSES` | All four harnesses | Comma-separated harness subset |
+| `E2E_ACP_MULTI_HARNESS_PROVIDER` | Project default | Sandbox provider |
+| `E2E_ACP_MULTI_HARNESS_MODEL` | Harness default | Explicit session model |
+| `E2E_ACP_MULTI_HARNESS_OPENAI_API_KEY` | Unset | Temporary direct key for the disposable project |
+| `E2E_KEEP_ACP_MULTI_HARNESS_FIXTURE` | `0` | Set to `1` to preserve the fixture for debugging |
+
 ## Note on Unit Tests
 
 Unit tests that live with their packages (e.g. `apps/api/src/__tests__/`,

--- a/tests/e2e/scripts/acp-multi-harness-smoke.ts
+++ b/tests/e2e/scripts/acp-multi-harness-smoke.ts
@@ -68,6 +68,8 @@ const reuseProjectId = process.env.E2E_ACP_MULTI_HARNESS_REUSE_PROJECT_ID?.trim(
 const reuseUserEmail = process.env.E2E_ACP_MULTI_HARNESS_REUSE_EMAIL?.trim() || '';
 const sandboxProvider =
   (process.env.E2E_ACP_MULTI_HARNESS_PROVIDER?.trim() as SandboxProvider | undefined) || undefined;
+const runtimeModel = process.env.E2E_ACP_MULTI_HARNESS_MODEL?.trim() || '';
+const directOpenAiKey = process.env.E2E_ACP_MULTI_HARNESS_OPENAI_API_KEY?.trim() || '';
 const manifest = readFileSync(
   resolve(repoRoot, 'packages/starter/examples/acp-multi-harness/kortix.yaml'),
   'utf8',
@@ -322,6 +324,7 @@ async function verifyHarness(token: string, harness: Harness): Promise<void> {
       agent_name: harness,
       initial_prompt: `Reply with exactly ${firstMarker}`,
       ...(sandboxProvider ? { provider: sandboxProvider } : {}),
+      ...(runtimeModel ? { opencode_model: runtimeModel } : {}),
     },
     201,
   );
@@ -417,7 +420,7 @@ async function verifyHarness(token: string, harness: Harness): Promise<void> {
 async function main(): Promise<void> {
   log(
     'target',
-    `${apiBase} with ${harnesses.join(', ')} on ${sandboxProvider ?? 'the project default provider'}`,
+    `${apiBase} with ${harnesses.join(', ')} on ${sandboxProvider ?? 'the project default provider'} using ${runtimeModel || 'each harness default model'}`,
   );
   assert(
     (reuseProjectId && reuseUserEmail) || (!reuseProjectId && !reuseUserEmail),
@@ -486,6 +489,13 @@ async function main(): Promise<void> {
       `manifest validation failed: ${JSON.stringify(validation.issues)}`,
     );
     await api(token, 'POST', `/executor/projects/${projectId}/connectors/sync`, {});
+    if (directOpenAiKey) {
+      await api(token, 'POST', `/projects/${projectId}/secrets`, {
+        name: 'OPENAI_API_KEY',
+        value: directOpenAiKey,
+      });
+      log('credential', 'seeded temporary OPENAI_API_KEY for this disposable fixture');
+    }
   }
 
   const detail = await waitFor(


### PR DESCRIPTION
## Summary
- retry ACP upstream requests once after a 401 or 403
- invalidate the replica-local sandbox ingress cache before the retry
- retry prompt env sync when stale ingress credentials reject authentication
- add model and temporary OpenAI credential inputs to the multi-harness smoke runner
- document the deployed protocol smoke command

## Evidence
- `bun test apps/api/src/projects/routes/acp-proxy.test.ts` -> 8 pass, 0 fail
- `bunx biome check apps/api/src/projects/routes/acp.ts apps/api/src/projects/routes/acp-proxy.test.ts tests/e2e/scripts/acp-multi-harness-smoke.ts` -> clean
- `pnpm --filter kortix-api typecheck` -> exit 0
- dev Pi transcript completed initial prompt, follow-up, and reload before restart returned 401 through a stale Daytona ingress credential
