### PR TITLE
fix(ci): give drift detection the Cloudflare token it needs to plan

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -158,6 +158,12 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
       - name: plan -detailed-exitcode
+        # The EKS roots declare a Cloudflare provider and fall back to a dummy
+        # token when none is supplied, which fails the plan with Cloudflare's
+        # auth error 10000 before any drift is reported. Read-only here: plan
+        # never writes DNS.
+        env:
+          TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -uo pipefail
           terraform -chdir="${{ matrix.root }}" init -input=false -no-color


### PR DESCRIPTION
Follow-up to #5760, which turned drift detection on for the first time.

The first real run proved the wiring: `infra/terraform/security-baseline` planned successfully (and the corrected matrix path worked). But all four EKS roots failed with Cloudflare's `Authentication error (10000)`.

Cause: those roots declare a `cloudflare` provider and fall back to a dummy token when none is supplied —

```hcl
api_token = var.cloudflare_api_token != "" ? var.cloudflare_api_token : (... : "0000000000000000000000000000000000000000")
```

so the plan dies on provider auth before it can report drift. Fix is to pass the `CLOUDFLARE_API_TOKEN` secret the repo already has as `TF_VAR_cloudflare_api_token`. Plan is read-only and never writes DNS.

Worth fixing rather than leaving: a job that goes red every night trains people to ignore it just as reliably as one that silently skips. Verified by dispatch after merge.