### PR TITLE
fix(ci): supply cloudflare_zone_id to the drift plan

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -164,6 +164,7 @@ jobs:
         # never writes DNS.
         env:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TF_VAR_cloudflare_zone_id: ${{ vars.CLOUDFLARE_ZONE_ID }}
         run: |
           set -uo pipefail
           terraform -chdir="${{ matrix.root }}" init -input=false -no-color


### PR DESCRIPTION
Last piece of the drift-detection chain (#5760 enabled it, #5763 gave it the Cloudflare token).

After #5763 the run went from 1/5 to 3/5 roots planning. The two EKS **platform** roots still failed, on a plainer problem:

```
Error: No value for required variable
  on variables.tf line 60:
  60: variable "cloudflare_zone_id" {
```

They declare `cloudflare_zone_id` with no default, so plan stopped before touching a single resource. The repo already exposes `CLOUDFLARE_ZONE_ID` as a variable — pass it as `TF_VAR_cloudflare_zone_id`.

Expected result: all five roots plan. Several will legitimately **report** drift — that is the control working, and reconciling that drift is separate work.