### PR TITLE
fix(ci): scope drift detection to roots CI can actually plan

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -141,11 +141,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The */platform roots are deliberately absent. They drive the helm and
+        # kubernetes providers, and Helm keeps release state in Kubernetes
+        # Secrets — so planning them from CI would mean granting this role
+        # secret-read inside the production cluster. That is a bigger grant
+        # than drift reporting justifies. Plan them from an operator session.
         root:
           - infra/terraform/environments/prod-eks/cluster
-          - infra/terraform/environments/prod-eks/platform
           - infra/terraform/environments/dev-eks/cluster
-          - infra/terraform/environments/dev-eks/platform
           # Not under environments/ — the stack lives at the terraform root.
           - infra/terraform/security-baseline
     steps:


### PR DESCRIPTION
Final piece of the drift chain (#5760 enabled it, #5763 token, #5765 zone id).

Progression across those fixes: 1/5 roots planning → 3/5 → and the last two are a different class of problem.

The `prod-eks/platform` and `dev-eks/platform` roots drive the `helm` and `kubernetes` providers against the EKS clusters. `kortix-gha-tf-plan` is not an access entry on either cluster, so they fail with `Error: Unauthorized`.

**Why I did not just grant the access:** Helm stores release state in Kubernetes **Secrets**. A plan of these roots has to read them. So making this work means giving the CI principal secret-read inside the production cluster — a much larger grant than a nightly drift report justifies, and squarely against the point of the deny list added in #5760.

So: drop the two roots from the matrix, with the reasoning recorded inline. The remaining three (`prod-eks/cluster`, `dev-eks/cluster`, `security-baseline`) plan cleanly.

The alternative — leaving them red every night — degrades the signal exactly the way the silent `skipping` did. A check people learn to ignore is not a control. Plan those two from an operator session instead.