### PR TITLE
fix(onboarding): bind the remembered-project cookie to its owner

### DIFF
--- a/apps/web/src/app/(app)/connectors/page.tsx
+++ b/apps/web/src/app/(app)/connectors/page.tsx
@@ -35,7 +35,7 @@ function ConnectorResult() {
   const connectorsEnabled = isConnectorsEnabled();
 
   useEffect(() => {
-    if (!connectorsEnabled) router.replace(latestProjectPath());
+    if (!connectorsEnabled) router.replace(latestProjectPath(null));
   }, [connectorsEnabled, router]);
 
   const ok = params.get('connected') === 'true';
@@ -71,7 +71,7 @@ function ConnectorResult() {
             <Plug className="h-4 w-4" />
             {tI18nHardcoded.raw('autoAppAppConnectorsPageJsxTextCloseWindowa183ed6a')}
           </Button>
-          <Button variant="ghost" onClick={() => router.replace(latestProjectPath())}>
+          <Button variant="ghost" onClick={() => router.replace(latestProjectPath(null))}>
             {tI18nHardcoded.raw('autoAppAppConnectorsPageJsxTextGoToProjectsfb39e5ad')}
           </Button>
         </div>

--- a/apps/web/src/app/(app)/invites/[inviteId]/page.tsx
+++ b/apps/web/src/app/(app)/invites/[inviteId]/page.tsx
@@ -110,7 +110,7 @@ export default function InvitePage() {
             {tHardcodedUi.raw('appInvitesInviteidPage.line98JsxTextInviteNotFound')}
           </StateHeading>
           <StateBody>{tHardcodedUi.raw('appInvitesInviteidPage.inviteInvalidOrRevoked')}</StateBody>
-          <GhostAction onClick={() => router.replace(latestProjectPath())}>
+          <GhostAction onClick={() => router.replace(latestProjectPath(null))}>
             {tHardcodedUi.raw('appInvitesInviteidPage.line105JsxTextBackToProjects')}
           </GhostAction>
         </InviteCard>
@@ -143,7 +143,7 @@ export default function InvitePage() {
           <p className="text-foreground/30 mt-4 text-xs">
             {tHardcodedUi.raw('appInvitesInviteidPage.line129JsxTextSignOutAndSignBackInWithThe')}
           </p>
-          <GhostAction onClick={() => router.replace(latestProjectPath())}>
+          <GhostAction onClick={() => router.replace(latestProjectPath(null))}>
             {tHardcodedUi.raw('appInvitesInviteidPage.line132JsxTextBackToProjects')}
           </GhostAction>
         </InviteCard>
@@ -165,7 +165,7 @@ export default function InvitePage() {
               'appInvitesInviteidPage.line145JsxTextAskThePersonWhoInvitedYouToSend',
             )}
           </StateBody>
-          <GhostAction onClick={() => router.replace(latestProjectPath())}>
+          <GhostAction onClick={() => router.replace(latestProjectPath(null))}>
             {tHardcodedUi.raw('appInvitesInviteidPage.line148JsxTextBackToProjects')}
           </GhostAction>
         </InviteCard>

--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -299,7 +299,7 @@ export default function ProjectsPage() {
     autoCreateAttempted.current.add(accountId);
     setAutoCreating(true);
     ensureFirstProject(accountId, {
-      preferredProjectId: readLastProjectId(),
+      preferredProjectId: readLastProjectId(user?.id),
       // Same CWE-352 gate as the landing door: a cross-site link must not be
       // able to mint a managed git repo just because the visitor is signed in.
       allowCreate: navigationMayCreateProject(),
@@ -309,7 +309,7 @@ export default function ProjectsPage() {
           setAutoCreating(false);
           return;
         }
-        writeLastProjectId(project.project_id);
+        writeLastProjectId(user?.id, project.project_id);
         queryClient.invalidateQueries({ queryKey: ['projects', accountId] });
         router.replace(`/projects/${project.project_id}`);
       })
@@ -351,7 +351,7 @@ export default function ProjectsPage() {
       if ((projectsQuery.data?.length ?? 0) <= 1) {
         suppressAutoProjectAfterDelete();
       }
-      if (readLastProjectId() === projectId) clearLastProjectId();
+      if (readLastProjectId(user?.id) === projectId) clearLastProjectId();
       queryClient.invalidateQueries({ queryKey: ['projects'] });
       const name = projectId === archiveTarget?.project_id ? archiveTarget?.name : undefined;
       successToast(name ? `"${name}" archived` : 'Project archived');

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -71,12 +71,12 @@ export default function ProjectStartPage() {
 
     try {
       const project = await ensureFirstProject(account.account_id, {
-        preferredProjectId: readLastProjectId(),
+        preferredProjectId: readLastProjectId(user?.id),
         allowCreate: canCreate && !isAutoProjectSuppressed() && navigationMayCreateProject(),
       });
 
       if (project) {
-        writeLastProjectId(project.project_id);
+        writeLastProjectId(user?.id, project.project_id);
         router.replace(`/projects/${project.project_id}`);
         return;
       }
@@ -103,7 +103,7 @@ export default function ProjectStartPage() {
     } finally {
       if (attempts.current >= MAX_RESOLVE_ATTEMPTS) resolving.current = false;
     }
-  }, [accountsQuery.data, selectedAccountId, router]);
+  }, [accountsQuery.data, selectedAccountId, router, user?.id]);
 
   useEffect(() => {
     if (attempts.current > 0) return;

--- a/apps/web/src/app/(auth)/auth/actions.ts
+++ b/apps/web/src/app/(auth)/auth/actions.ts
@@ -17,7 +17,8 @@ import {
   recordPlatformLogout,
   submitAccessRequest,
 } from '@kortix/sdk';
-import { headers } from 'next/headers';
+import { LAST_PROJECT_COOKIE } from '@/lib/onboarding/landing-destination';
+import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 function normalizeTrustedOrigin(value?: string | null): string | null {
@@ -482,6 +483,11 @@ export async function signOut() {
   if (error) {
     return { message: error.message || 'Could not sign out' };
   }
+
+  // Forget the remembered project. Ownership binding already stops the next
+  // account from following it, but leaving one user's project id sitting in a
+  // shared browser after they sign out is needless.
+  (await cookies()).delete(LAST_PROJECT_COOKIE);
 
   return redirect('/');
 }

--- a/apps/web/src/app/(auth)/auth/callback/route.ts
+++ b/apps/web/src/app/(auth)/auth/callback/route.ts
@@ -4,6 +4,7 @@ import { isInviteReturnUrl, resolveAuthRedirectBaseUrl, sanitizeAuthReturnUrl } 
 import {
   LAST_PROJECT_COOKIE,
   PROJECT_LANDING_PATH,
+  parseLastProjectForUser,
   projectPathFromId,
 } from '@/lib/onboarding/landing-destination';
 import { ACTIVE_INSTANCE_COOKIE } from '@kortix/sdk/instance-routes';
@@ -238,8 +239,15 @@ export async function GET(request: NextRequest) {
         // browser already told us which project they had open last. Reading a
         // cookie costs nothing, so this is a strictly free hop to remove.
         if (finalDestination === PROJECT_LANDING_PATH) {
+          // Scoped to THIS user. The cookie survives sign-out, so an unscoped
+          // read sent the next account to sign in on this browser straight into
+          // the previous account's project — i.e. onto "Request access to this
+          // project", on every login.
           const lastProjectPath = projectPathFromId(
-            request.cookies.get(LAST_PROJECT_COOKIE)?.value,
+            parseLastProjectForUser(
+              request.cookies.get(LAST_PROJECT_COOKIE)?.value,
+              data.user.id,
+            ),
           );
           if (lastProjectPath) finalDestination = lastProjectPath;
         }

--- a/apps/web/src/app/(auth)/auth/github-popup/page.tsx
+++ b/apps/web/src/app/(auth)/auth/github-popup/page.tsx
@@ -30,7 +30,7 @@ export default function GitHubOAuthPopup() {
     let cancelled = false;
 
     // Get return URL from sessionStorage (set by parent component)
-    const returnUrl = sessionStorage.getItem('github-returnUrl') || latestProjectPath();
+    const returnUrl = sessionStorage.getItem('github-returnUrl') || latestProjectPath(null);
 
     const postMessage = (message: AuthMessage) => {
       try {

--- a/apps/web/src/app/(auth)/auth/phone-verification/page.tsx
+++ b/apps/web/src/app/(auth)/auth/phone-verification/page.tsx
@@ -167,7 +167,7 @@ export default function PhoneVerificationPage() {
       // Wait a bit for cache invalidation, then redirect. Track the timer so a
       // pre-redirect unmount doesn't fire router.push/onSuccess after unmount.
       redirectTimerRef.current = setTimeout(() => {
-        router.push(latestProjectPath());
+        router.push(latestProjectPath(null));
       }, 2000);
     } catch (err) {
       console.error('❌ OTP verification failed:', err);

--- a/apps/web/src/app/(auth)/github/setup/page.tsx
+++ b/apps/web/src/app/(auth)/github/setup/page.tsx
@@ -67,7 +67,7 @@ function GitHubSetup() {
     if (setupAction === 'uninstall') {
       setState('done');
       setMessage('GitHub App removed from your account.');
-      redirectTimer.current = window.setTimeout(() => router.replace(latestProjectPath()), 900);
+      redirectTimer.current = window.setTimeout(() => router.replace(latestProjectPath(null)), 900);
       return;
     }
 
@@ -268,7 +268,7 @@ function GitHubSetup() {
                 size="lg"
                 variant="outline"
                 className="w-full"
-                onClick={() => router.replace(consumeGitHubSetupReturn() ?? latestProjectPath())}
+                onClick={() => router.replace(consumeGitHubSetupReturn() ?? latestProjectPath(null))}
               >
                 Back
               </Button>
@@ -276,7 +276,7 @@ function GitHubSetup() {
           </Rise>
         ) : state === 'error' ? (
           <Rise delay={0.06}>
-            <Button size="lg" className="w-full" onClick={() => router.replace(latestProjectPath())}>
+            <Button size="lg" className="w-full" onClick={() => router.replace(latestProjectPath(null))}>
               Back to Kortix
             </Button>
           </Rise>

--- a/apps/web/src/app/(public)/(marketing)/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/page.tsx
@@ -18,8 +18,7 @@ import Security from '@/features/marketing/security/security';
 import WhyKortix from '@/features/marketing/why-kortix';
 import { useAuth } from '@/features/providers/auth-provider';
 import { trackCtaSignup } from '@/lib/analytics/gtm';
-import { resolveDefaultLandingPath } from '@/lib/onboarding/landing-destination';
-import { readLastProjectId } from '@/lib/onboarding/last-project-cookie';
+import { latestProjectPath } from '@/lib/onboarding/last-project-cookie';
 import { useTranslations } from 'next-intl';
 import { useCallback } from 'react';
 import { HiArrowRight } from 'react-icons/hi2';
@@ -43,7 +42,7 @@ export default function Home() {
 
   const handleLaunch = useCallback(() => {
     trackCtaSignup();
-    window.location.href = user ? resolveDefaultLandingPath(readLastProjectId()) : '/auth';
+    window.location.href = user ? latestProjectPath(user?.id) : '/auth';
   }, [user]);
 
   return (

--- a/apps/web/src/app/(system)/p/[port]/page.tsx
+++ b/apps/web/src/app/(system)/p/[port]/page.tsx
@@ -35,7 +35,7 @@ export default function PreviewPage({
     if (tabs[tabId]) {
       setActiveTab(tabId);
     } else {
-      router.replace(latestProjectPath());
+      router.replace(latestProjectPath(null));
     }
   }, [port, tabs, setActiveTab, router]);
 

--- a/apps/web/src/components/blog/blog-cta.tsx
+++ b/apps/web/src/components/blog/blog-cta.tsx
@@ -15,7 +15,7 @@ export function BlogCta() {
 
   const handleStart = useCallback(() => {
     trackCtaSignup();
-    window.location.href = user ? latestProjectPath() : '/auth';
+    window.location.href = user ? latestProjectPath(user?.id) : '/auth';
   }, [user]);
 
   return (

--- a/apps/web/src/components/dashboard/connecting-screen.tsx
+++ b/apps/web/src/components/dashboard/connecting-screen.tsx
@@ -76,7 +76,7 @@ export function ConnectingScreen({
   const runtimeSummary = 'Runtime services degraded';
 
   const handleSwitch = () => {
-    router.push(backHref || latestProjectPath());
+    router.push(backHref || latestProjectPath(null));
   };
 
   const serverLabel = labelOverride?.trim() || 'workspace';

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -31,6 +31,7 @@ import { KortixHyperLogo } from '@/components/ui/marketing/kortix-hyper-logo';
 import { Textarea } from '@/components/ui/textarea';
 import { WallpaperBackground } from '@/components/ui/wallpaper-background';
 import { useAuth } from '@/features/providers/auth-provider';
+import { clearLastProjectId, readLastProjectId } from '@/lib/onboarding/last-project-cookie';
 import { useAdminRole } from '@/hooks/admin/use-admin-role';
 import { getProject, requestProjectAccess, setAdminBypass } from '@kortix/sdk';
 import { cn } from '@/lib/utils';
@@ -133,6 +134,16 @@ function ForbiddenProjectState({ projectId }: { projectId: string }) {
   const [sent, setSent] = useState(false);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [bypassError, setBypassError] = useState<string | null>(null);
+
+  // Stop this screen from becoming the user's permanent landing page. If the
+  // remembered project is one they cannot read, every `/` hit and every sign-in
+  // would redirect straight back here. The shell's self-heal does not fire for
+  // this case: a private project is a legitimate 403 surface, not a failed
+  // fetch. Forget it and let the landing door resolve a project they can open.
+  useEffect(() => {
+    if (readLastProjectId(user?.id) !== projectId) return;
+    clearLastProjectId();
+  }, [projectId, user?.id]);
 
   const requestMutation = useMutation({
     mutationFn: () => requestProjectAccess(projectId, message),

--- a/apps/web/src/features/marketing/cli-install-section.tsx
+++ b/apps/web/src/features/marketing/cli-install-section.tsx
@@ -31,7 +31,7 @@ export function CliInstallSection() {
 
   const handleLaunch = useCallback(() => {
     trackCtaSignup();
-    window.location.href = user ? latestProjectPath() : '/auth';
+    window.location.href = user ? latestProjectPath(user?.id) : '/auth';
   }, [user]);
 
   const copyInstallCommand = useCallback(() => {

--- a/apps/web/src/features/marketing/hero.tsx
+++ b/apps/web/src/features/marketing/hero.tsx
@@ -22,7 +22,7 @@ const Hero = () => {
 
   const handleLaunch = useCallback(() => {
     trackCtaSignup();
-    window.location.href = user ? latestProjectPath() : '/auth';
+    window.location.href = user ? latestProjectPath(user?.id) : '/auth';
   }, [user]);
 
   return (

--- a/apps/web/src/features/workspace/project-layout/project-shell.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-shell.tsx
@@ -85,8 +85,8 @@ export function ProjectShell({ projectId, initialSidebarOpen, children }: Projec
   // would send them into a 404 bounce loop on their next visit.
   useEffect(() => {
     if (!projectDetail) return;
-    writeLastProjectId(projectId);
-  }, [projectDetail, projectId]);
+    writeLastProjectId(user?.id, projectId);
+  }, [projectDetail, projectId, user?.id]);
 
   // Self-heal a stale remembered project. The cookie outlives the project it
   // names (deleted project, signed into a different account on the same
@@ -97,10 +97,10 @@ export function ProjectShell({ projectId, initialSidebarOpen, children }: Projec
     if (!projectDetailError) return;
     const status = (projectDetailError as { status?: number }).status;
     if (status !== 403 && status !== 404) return;
-    if (readLastProjectId() !== projectId) return;
+    if (readLastProjectId(user?.id) !== projectId) return;
     clearLastProjectId();
     router.replace(PROJECT_LANDING_PATH);
-  }, [projectDetailError, projectId, router]);
+  }, [projectDetailError, projectId, router, user?.id]);
 
   useEffect(() => {
     // Files graduated out of Customize into its own page — send legacy

--- a/apps/web/src/lib/onboarding/landing-destination.test.ts
+++ b/apps/web/src/lib/onboarding/landing-destination.test.ts
@@ -46,16 +46,34 @@ describe('projectPathFromId', () => {
 });
 
 describe('resolveDefaultLandingPath', () => {
-  test('sends a remembered project straight to its page', () => {
-    expect(resolveDefaultLandingPath(VALID)).toBe(`/projects/${VALID}`);
+  const USER_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const USER_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const cookie = (userId: string, projectId: string) => `${userId}:${projectId}`;
+
+  test('sends a remembered project straight to its page for its OWNER', () => {
+    expect(resolveDefaultLandingPath(cookie(USER_A, VALID), USER_A)).toBe(`/projects/${VALID}`);
+  });
+
+  test('REGRESSION: a different user never inherits the previous account\'s project', () => {
+    // The shipped bug: sign out of A, sign in as B in the same browser, and the
+    // post-auth redirect followed A's cookie straight into A's project — so B
+    // landed on "Request access to this project" on every single login.
+    expect(resolveDefaultLandingPath(cookie(USER_A, VALID), USER_B)).toBe(PROJECT_LANDING_PATH);
+  });
+
+  test('a legacy unowned cookie (bare project id) is never trusted', () => {
+    // Cookies written before the binding existed carry no owner, so they could
+    // belong to anyone who used this browser.
+    expect(resolveDefaultLandingPath(VALID, USER_A)).toBe(PROJECT_LANDING_PATH);
   });
 
   test('falls back to the landing door, never to the projects list', () => {
-    // The regression this guards: the default destination silently reverting to
-    // the `/projects` list, which is the manual-selection step we removed.
-    expect(resolveDefaultLandingPath(null)).toBe(PROJECT_LANDING_PATH);
-    expect(resolveDefaultLandingPath('nonsense')).toBe(PROJECT_LANDING_PATH);
-    expect(resolveDefaultLandingPath(PROJECT_LANDING_PATH)).toBe(PROJECT_LANDING_PATH);
+    expect(resolveDefaultLandingPath(null, USER_A)).toBe(PROJECT_LANDING_PATH);
+    expect(resolveDefaultLandingPath('nonsense', USER_A)).toBe(PROJECT_LANDING_PATH);
+    expect(resolveDefaultLandingPath(cookie(USER_A, VALID), null)).toBe(PROJECT_LANDING_PATH);
+    expect(resolveDefaultLandingPath(cookie(USER_A, 'not-a-uuid'), USER_A)).toBe(
+      PROJECT_LANDING_PATH,
+    );
   });
 
   test('a tampered cookie can never produce an off-origin redirect', () => {
@@ -64,8 +82,10 @@ describe('resolveDefaultLandingPath', () => {
       '//evil.example.com',
       '/admin',
       '../admin',
+      `${USER_A}://evil.example.com`,
+      `${USER_A}:../../admin`,
     ]) {
-      expect(resolveDefaultLandingPath(hostile)).toBe(PROJECT_LANDING_PATH);
+      expect(resolveDefaultLandingPath(hostile, USER_A)).toBe(PROJECT_LANDING_PATH);
     }
   });
 });

--- a/apps/web/src/lib/onboarding/landing-destination.ts
+++ b/apps/web/src/lib/onboarding/landing-destination.ts
@@ -24,11 +24,47 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * The cookie is written by the browser, so treat it as untrusted input. Only a
  * well-formed UUID is ever interpolated into a redirect path — that keeps a
  * tampered cookie from turning the `/` redirect into an open redirect or a
- * path-traversal. A cookie naming a project the user cannot read still fails
- * closed: the project page 404s and bounces back to `PROJECT_LANDING_PATH`.
+ * path-traversal.
  */
 export function isValidProjectId(value: string | null | undefined): value is string {
   return typeof value === 'string' && UUID_RE.test(value);
+}
+
+/**
+ * The cookie stores `<userId>:<projectId>`, NOT a bare project id.
+ *
+ * One browser outlives one session. Signing out of account A and into account B
+ * left A's cookie in place, and a bare project id gave B a redirect straight
+ * into A's project — landing on "Request access to this project" on EVERY
+ * login, because an access-denied screen is a legitimate 403 surface and not an
+ * error the stale-cookie self-heal catches.
+ *
+ * Binding the id to its owner makes that state unrepresentable: a cookie whose
+ * user does not match the authenticated user is ignored. That holds for
+ * sign-out, session expiry, a closed tab, and two accounts sharing a browser —
+ * none of which "clear it on sign-out" covers on its own.
+ */
+export function serializeLastProject(userId: string, projectId: string): string | null {
+  if (!isValidProjectId(userId) || !isValidProjectId(projectId)) return null;
+  return `${userId}:${projectId}`;
+}
+
+/**
+ * The project id in the cookie, but ONLY when it belongs to `currentUserId`.
+ * Returns null for a mismatch, a malformed value, or a legacy bare-project-id
+ * cookie written before this binding existed.
+ */
+export function parseLastProjectForUser(
+  cookieValue: string | null | undefined,
+  currentUserId: string | null | undefined,
+): string | null {
+  if (!cookieValue || !isValidProjectId(currentUserId)) return null;
+  const separator = cookieValue.indexOf(':');
+  if (separator === -1) return null; // legacy bare id — unowned, so never trusted
+  const ownerId = cookieValue.slice(0, separator);
+  const projectId = cookieValue.slice(separator + 1);
+  if (ownerId !== currentUserId) return null;
+  return isValidProjectId(projectId) ? projectId : null;
 }
 
 /** `/projects/<id>` for a trusted-shaped id, else null. */
@@ -39,7 +75,15 @@ export function projectPathFromId(projectId: string | null | undefined): string 
 /**
  * The default destination for an authenticated user, given whatever the browser
  * remembered. Falls back to the instant landing door, never to the list.
+ *
+ * `currentUserId` is required for the remembered project to be used at all —
+ * callers without it get the door, which re-resolves correctly.
  */
-export function resolveDefaultLandingPath(lastProjectId: string | null | undefined): string {
-  return projectPathFromId(lastProjectId) ?? PROJECT_LANDING_PATH;
+export function resolveDefaultLandingPath(
+  cookieValue: string | null | undefined,
+  currentUserId: string | null | undefined,
+): string {
+  return (
+    projectPathFromId(parseLastProjectForUser(cookieValue, currentUserId)) ?? PROJECT_LANDING_PATH
+  );
 }

--- a/apps/web/src/lib/onboarding/last-project-cookie.ts
+++ b/apps/web/src/lib/onboarding/last-project-cookie.ts
@@ -1,8 +1,9 @@
 import {
   LAST_PROJECT_COOKIE,
   LAST_PROJECT_COOKIE_MAX_AGE,
-  isValidProjectId,
+  parseLastProjectForUser,
   resolveDefaultLandingPath,
+  serializeLastProject,
 } from '@/lib/onboarding/landing-destination';
 
 /**
@@ -10,25 +11,36 @@ import {
  *
  * Deliberately a cookie and not localStorage: middleware has to read it to send
  * `/` and post-auth redirects straight to a project, and middleware cannot see
- * localStorage. It holds a project id only — never a token — and every consumer
- * re-validates it, because the browser can write anything here.
+ * localStorage. It holds `<userId>:<projectId>` — never a token — and every
+ * consumer re-validates it, because the browser can write anything here.
+ *
+ * EVERY read and write is scoped to a user id. A browser outlives a session, so
+ * an unscoped cookie sent the next person to sign in on this machine straight
+ * into the previous person's project. Callers that cannot supply the current
+ * user id get null / the landing door, which re-resolves correctly.
  */
-export function readLastProjectId(): string | null {
+export function readRawLastProjectCookie(): string | null {
   if (typeof document === 'undefined') return null;
   const match = document.cookie
     .split('; ')
     .find((entry) => entry.startsWith(`${LAST_PROJECT_COOKIE}=`));
   if (!match) return null;
-  const value = decodeURIComponent(match.slice(LAST_PROJECT_COOKIE.length + 1));
-  return isValidProjectId(value) ? value : null;
+  return decodeURIComponent(match.slice(LAST_PROJECT_COOKIE.length + 1));
 }
 
-export function writeLastProjectId(projectId: string): void {
+/** The remembered project, but only if it belongs to `userId`. */
+export function readLastProjectId(userId: string | null | undefined): string | null {
+  return parseLastProjectForUser(readRawLastProjectCookie(), userId);
+}
+
+export function writeLastProjectId(userId: string | null | undefined, projectId: string): void {
   if (typeof document === 'undefined') return;
-  if (!isValidProjectId(projectId)) return;
+  if (!userId) return;
+  const value = serializeLastProject(userId, projectId);
+  if (!value) return;
   const secure = window.location.protocol === 'https:' ? '; Secure' : '';
   document.cookie =
-    `${LAST_PROJECT_COOKIE}=${encodeURIComponent(projectId)}` +
+    `${LAST_PROJECT_COOKIE}=${encodeURIComponent(value)}` +
     `; Path=/; Max-Age=${LAST_PROJECT_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
 }
 
@@ -38,17 +50,18 @@ export function clearLastProjectId(): void {
 }
 
 /**
- * Where "take me into the app" goes from client code: the latest project the
+ * Where "take me into the app" goes from client code: the latest project this
  * user had open, else the landing door that resolves one.
  *
  * Use this for every implicit destination — post-flow returns, the logo, the
  * marketing "launch app" CTA. Never send those to `/projects`: the list is a
  * place the user chooses to visit, not a place the app drops them.
  *
- * Do NOT use this after an account switch. The cookie names a project in the
- * account the user just left, so those callers must use `PROJECT_LANDING_PATH`
- * and let the landing door re-resolve against the new account.
+ * Pass the CURRENT user's id. Omitting it is safe (you get the door) but loses
+ * the direct hop. Do NOT use this after an account switch — the cookie names a
+ * project in the account the user just left, which is still theirs and so still
+ * passes the ownership check. Those callers must use `PROJECT_LANDING_PATH`.
  */
-export function latestProjectPath(): string {
-  return resolveDefaultLandingPath(readLastProjectId());
+export function latestProjectPath(userId: string | null | undefined): string {
+  return resolveDefaultLandingPath(readRawLastProjectCookie(), userId);
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -3,6 +3,7 @@ import { getMaintenanceConfig } from '@/lib/maintenance-store';
 import { MAINTENANCE_BYPASS_COOKIE, verifyBypassToken } from '@/lib/maintenance-bypass';
 import {
   LAST_PROJECT_COOKIE,
+  PROJECT_LANDING_PATH,
   resolveDefaultLandingPath,
 } from '@/lib/onboarding/landing-destination';
 import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
@@ -270,9 +271,11 @@ export async function middleware(request: NextRequest) {
     if (!isAllowed) {
       // Into the latest project, not the list — the desktop shell has no
       // marketing surface, so this bounce IS the user's default destination.
-      return NextResponse.redirect(
-        new URL(resolveDefaultLandingPath(request.cookies.get(LAST_PROJECT_COOKIE)?.value), request.url),
-      );
+      // The landing door, not the remembered project: this gate runs BEFORE the
+      // Supabase user is fetched below, so there is no identity here to check
+      // the cookie against — and an unowned cookie read is exactly the bug that
+      // sent one account into another account's project. The door re-resolves.
+      return NextResponse.redirect(new URL(PROJECT_LANDING_PATH, request.url));
     }
   }
 
@@ -417,6 +420,7 @@ export async function middleware(request: NextRequest) {
   // only accepts a well-formed project id and falls back to the door.
   const defaultLandingPath = resolveDefaultLandingPath(
     request.cookies.get(LAST_PROJECT_COOKIE)?.value,
+    user?.id,
   );
 
   // FAST PATH: authenticated users hitting the homepage go straight to a project.


### PR DESCRIPTION
## The bug

Signing out of one account and signing in with another **in the same browser** dropped the second user on **"Request access to this project"** — on every login. Reported with a screenshot from dev.

`kortix_last_project` held a bare project id with no owner, and `signOut` never cleared it. The post-auth hop in `/auth/callback` therefore read a cookie written by the *previous* user and redirected the new one straight into a project they cannot read.

My stale-cookie self-heal from #5758 did not catch it. That fires on a 403/404 from the project-detail fetch in `project-shell`, but a private project renders `project-access-boundary` instead — a legitimate 403 surface, not a failed fetch. So the cookie survived and re-trapped the user on every visit.

## The fix

The cookie is now `<userId>:<projectId>`, honoured only when the owner matches the authenticated user.

Clearing on sign-out alone would not have been enough — session expiry, a closed tab, and two accounts sharing a browser all leave the cookie behind with no sign-out to hook. Binding makes the bad state **unrepresentable** rather than racing to clean it up. A legacy bare-id cookie carries no owner and is never trusted; those users fall through to the landing door, which re-resolves correctly.

Supporting changes:
- `signOut` deletes the cookie (belt and braces, not the mechanism).
- The access-request boundary clears it when it names the project being denied, so that screen can never become a permanent landing page.
- Every read/write is scoped to a user id. Call sites without one pass `null` and degrade to the landing door — safe by construction, so no site can leak another user's project.
- The desktop-shell allowlist bounce uses the door instead: that gate runs **before** the Supabase user is fetched, so there is no identity to check against there. Reading the cookie unowned would have reintroduced the same bug — and referencing `user` there is a TDZ crash.

## Verification

Two real signups in one browser profile, with A's cookie carried into B's session:

```
cookie after A:  3b538732-…:1c6c7ad4-…      (userId:projectId)
carried into B:  3b538732-…:1c6c7ad4-…
A project:       1c6c7ad4-6822-49ba-86ef-2c25ea18b9e5
B project:       5b1f86a1-4ec1-4fba-893b-d0352cff66de
B saw "Request access": false
✅ B landed on their own distinct project
```

2289 tests pass. Adds a named `REGRESSION` case for the exact scenario (`resolveDefaultLandingPath` with A's cookie and B's id → the door), plus legacy unowned-cookie and `<uuid>:../../admin` tampering cases.