### PR TITLE
refactor(infra): make Terraform the source of truth for the ECS envs

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -87,6 +87,13 @@ module "acm" {
 }
 
 # ── ECS Fargate API service (autoscaled) ──────────────────────────────────────
+# The env secret blob is the source of truth for which secrets exist:
+# ecs-deploy.sh wires every key in it into each task-def revision. Looked up by
+# name so the random ARN suffix is never hard-coded.
+data "aws_secretsmanager_secret" "env" {
+  name = "kortix-dev-env"
+}
+
 module "api" {
   source     = "../../modules/ecs-api"
   name       = local.name
@@ -101,11 +108,12 @@ module "api" {
   ]
   private_subnet_ids = module.network.private_subnet_ids
 
-  image           = var.api_image
-  container_port  = var.container_port
-  certificate_arn = one(module.acm[*].certificate_arn)
-  environment     = var.api_environment
-  secrets         = var.api_secrets
+  image            = var.api_image
+  container_port   = var.container_port
+  certificate_arn  = one(module.acm[*].certificate_arn)
+  environment      = var.api_environment
+  secrets          = var.api_secrets
+  secrets_blob_arn = data.aws_secretsmanager_secret.env.arn
 
   # Only Cloudflare's edge may reach the ALB (no direct-to-origin WAF bypass).
   alb_ingress_cidrs = local.cloudflare_ip_ranges
@@ -147,8 +155,9 @@ module "gateway" {
   certificate_arn = var.gateway_certificate_arn
   # PORT is auto-injected by the module; the gateway also needs to call back to
   # the API, which on Fargate is the public (Cloudflare-fronted) dev-api host.
-  environment = merge(var.gateway_environment, { KORTIX_API_URL = "https://dev-api.kortix.com" })
-  secrets     = var.api_secrets
+  environment      = merge(var.gateway_environment, { KORTIX_API_URL = "https://dev-api.kortix.com" })
+  secrets          = var.api_secrets
+  secrets_blob_arn = data.aws_secretsmanager_secret.env.arn
 
   alb_ingress_cidrs = local.cloudflare_ip_ranges
 

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -81,6 +81,13 @@ module "acm" {
   }
 }
 
+# The env secret blob is the source of truth for which secrets exist:
+# ecs-deploy.sh wires every key in it into each task-def revision. Looked up by
+# name so the random ARN suffix is never hard-coded.
+data "aws_secretsmanager_secret" "env" {
+  name = "kortix-prod-env"
+}
+
 module "api" {
   source     = "../../modules/ecs-api"
   name       = local.name
@@ -93,11 +100,12 @@ module "api" {
   ]
   private_subnet_ids = module.network.private_subnet_ids
 
-  image           = var.api_image
-  container_port  = var.container_port
-  certificate_arn = module.acm.certificate_arn
-  environment     = var.api_environment
-  secrets         = var.api_secrets
+  image            = var.api_image
+  container_port   = var.container_port
+  certificate_arn  = module.acm.certificate_arn
+  environment      = var.api_environment
+  secrets          = var.api_secrets
+  secrets_blob_arn = data.aws_secretsmanager_secret.env.arn
 
   # Only Cloudflare's edge may reach the ALB (no direct-to-origin WAF bypass).
   alb_ingress_cidrs = local.cloudflare_ip_ranges
@@ -155,6 +163,7 @@ module "gateway" {
   certificate_arn   = module.acm_gateway.certificate_arn
   environment       = merge(var.gateway_environment, { KORTIX_API_URL = "https://api.kortix.com" })
   secrets           = var.api_secrets
+  secrets_blob_arn  = data.aws_secretsmanager_secret.env.arn
 
   alb_ingress_cidrs = local.cloudflare_ip_ranges
 

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -18,7 +18,12 @@ variable "extra_api_hostnames" {
     canonical api.kortix.com record stays tunnel-locked on the old box.
   EOT
   type        = list(string)
-  default     = []
+  # This is a live SAN on the certificate currently serving api.kortix.com, so
+  # it belongs in version control rather than only in a gitignored tfvars. With
+  # the old default of [], any plan run without that local file — CI, or a
+  # second machine — proposed REPLACING the production certificate, because
+  # subject_alternative_names forces replacement.
+  default = ["api-ecs-fargate.kortix.com"]
 }
 
 variable "manage_dns" {

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -64,6 +64,13 @@ module "network" {
 }
 
 # ── ECS Fargate API service (autoscaled) ──────────────────────────────────────
+# The env secret blob is the source of truth for which secrets exist:
+# ecs-deploy.sh wires every key in it into each task-def revision. Looked up by
+# name so the random ARN suffix is never hard-coded.
+data "aws_secretsmanager_secret" "env" {
+  name = "kortix-staging-env"
+}
+
 module "api" {
   source     = "../../modules/ecs-api"
   name       = local.name
@@ -76,11 +83,12 @@ module "api" {
   ]
   private_subnet_ids = module.network.private_subnet_ids
 
-  image           = var.api_image
-  container_port  = var.container_port
-  certificate_arn = var.wildcard_certificate_arn
-  environment     = var.api_environment
-  secrets         = var.api_secrets
+  image            = var.api_image
+  container_port   = var.container_port
+  certificate_arn  = var.wildcard_certificate_arn
+  environment      = var.api_environment
+  secrets          = var.api_secrets
+  secrets_blob_arn = data.aws_secretsmanager_secret.env.arn
 
   alb_ingress_cidrs = local.cloudflare_ip_ranges
 
@@ -112,6 +120,7 @@ module "gateway" {
   certificate_arn   = var.wildcard_certificate_arn
   environment       = merge(var.gateway_environment, { KORTIX_API_URL = "https://staging-api.kortix.com" })
   secrets           = var.api_secrets
+  secrets_blob_arn  = data.aws_secretsmanager_secret.env.arn
 
   alb_ingress_cidrs = local.cloudflare_ip_ranges
 

--- a/infra/terraform/modules/ecs-api/main.tf
+++ b/infra/terraform/modules/ecs-api/main.tf
@@ -112,8 +112,19 @@ resource "aws_iam_role_policy_attachment" "execution" {
 }
 
 # Let the execution role pull the values behind any injected secrets.
+#
+# Prefer secrets_blob_arn. ecs-deploy.sh builds every task-def revision by
+# reading EVERY key out of the kortix-<env>-env blob, so the blob — not this
+# module — is the source of truth for which secrets exist. Enumerating them in
+# var.secrets as well means keeping a second copy by hand, and that copy is
+# already wrong: prod's blob holds 132 keys against 100 in tfvars, and staging
+# has 106 with no tfvars at all. Granting on the blob ARN covers every key
+# forever and deletes the drift rather than tracking it.
+#
+# var.secrets remains only as the fallback for callers that have not been
+# given a blob yet; it resolves to the same base ARNs.
 resource "aws_iam_role_policy" "secrets" {
-  count = length(var.secrets) > 0 ? 1 : 0
+  count = var.secrets_blob_arn != "" || length(var.secrets) > 0 ? 1 : 0
   name  = "${local.name}-secrets-read"
   role  = aws_iam_role.execution.id
   policy = jsonencode({
@@ -121,8 +132,10 @@ resource "aws_iam_role_policy" "secrets" {
     Statement = [{
       Effect = "Allow"
       Action = ["secretsmanager:GetSecretValue", "ssm:GetParameters"]
-      # Grant on the base secret/parameter ARN (strip any :json-key::version suffix from valueFrom).
-      Resource = distinct([for v in values(var.secrets) : join(":", slice(split(":", v), 0, 7))])
+      # Strip any :json-key::version suffix to reach the base secret ARN.
+      Resource = var.secrets_blob_arn != "" ? [var.secrets_blob_arn] : distinct([
+        for v in values(var.secrets) : join(":", slice(split(":", v), 0, 7))
+      ])
     }]
   })
 }
@@ -426,6 +439,18 @@ resource "aws_ecs_task_definition" "this" {
     # ALB target group health check (HTTP GET health_check_path) is the
     # authoritative gate for routing + the deployment circuit breaker.
   }])
+
+  # This resource only bootstraps the FIRST revision. Every later one is
+  # registered by ecs-deploy.sh, which rebuilds the container definition from
+  # the live service plus the secrets blob — so image, environment and secrets
+  # here go stale the moment anything deploys. The service already ignores
+  # task_definition, so re-registering from stale inputs on every apply
+  # produced an orphan revision nothing ran and a permanent "must be replaced"
+  # in the plan. Ceding the container definition removes the phantom diff and
+  # makes the deploy script the single owner of revisions.
+  lifecycle {
+    ignore_changes = [container_definitions]
+  }
 
   tags = {
     ManagedBy   = "terraform"

--- a/infra/terraform/modules/ecs-api/variables.tf
+++ b/infra/terraform/modules/ecs-api/variables.tf
@@ -172,3 +172,15 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "secrets_blob_arn" {
+  description = <<-EOT
+    ARN of the environment's Secrets Manager blob (kortix-<env>-env). The
+    execution role is granted GetSecretValue on it, which covers every key the
+    blob holds. Preferred over enumerating `secrets`, because ecs-deploy.sh
+    derives task-def secrets from the blob's keys — so the blob is the source
+    of truth and a second hand-maintained list can only drift from it.
+  EOT
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Makes Terraform an honest source of truth for the ECS environments. Code only — **no apply in this PR**.

## The problem

The prod root could not be planned reproducibly. With the gitignored, laptop-local `terraform.tfvars` it planned one thing; without it, on CI or any second machine, it planned to:

- **replace `module.acm.aws_acm_certificate.this`** — cert `efcbd970-…`, domain `api.kortix.com`, the cert currently on the `kortix-prod-alb` :443 listener
- **destroy both `aws_iam_role_policy.secrets`** — against a live task def injecting 132 secrets
- **replace both task definitions**

Same code, same state, wildly different result. So nobody applied it, so it drifted further.

## Three causes, all Terraform modelling something it doesn't own

**Secrets.** `ecs-deploy.sh` builds every revision by reading *every key* out of the `kortix-<env>-env` blob — the blob is the source of truth. `var.secrets` was a hand-maintained second copy, already rotted:

| env | keys in blob | in tfvars |
|---|---|---|
| prod | 132 | 100 |
| staging | 106 | none |
| dev | 105 | 67 |

Now the execution role is granted on the **blob ARN**, which covers every key permanently. The list can't drift because there is no list. (The old policy already collapsed to the same base ARN, so this is not a privilege change.)

**Task definitions.** Terraform re-registered a revision from stale `image`/`secrets` on every apply. The service already had `ignore_changes = [task_definition]`, so those revisions were orphans nothing ran — pure noise plus a permanent `must be replaced`. `container_definitions` now belongs to the deploy script.

**Certificate SANs.** `extra_api_hostnames` defaulted to `[]` while the live cert carries `api-ecs-fargate.kortix.com` (still live in DNS). `subject_alternative_names` forces replacement — that empty default is what armed the cert swap. It's a public hostname; it belongs in git.

## Result

```
prod, WITH local tfvars:     21 add, 26 change, 0 destroy
prod, WITHOUT local tfvars:  21 add, 26 change, 0 destroy   <- identical
```

Destroys went 1 → 0, and the plan is now machine-independent.

Verified the ALB security-group diff is **description-only** (`"Cloudflare origin traffic"` → `"HTTPS"`); the Cloudflare origin CIDRs are preserved, so the origin lock from #4121 is not affected.

## The 21 additions are SOC 2 controls that were never applied

KMS-encrypted CloudWatch log groups and ALB access-log S3 buckets (versioning, SSE, public-access-block, ownership controls, lifecycle, policy) for both api and gateway. Written in the module, never live.

## Not in this PR

Applying it. The plan is additive with zero destroys, but enabling ALB access logging touches a live production load balancer, so that should be a deliberate act — staging first, then prod. Also still open: 6 actively-used IAM roles absent from all state, 23 dead roles last used ~7 Apr 2026, and 7 orphaned customer-managed policies.
