### PR TITLE
Repair marketplace tests missed by the starter slim-down

### DIFF
--- a/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
+++ b/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { mockIamEngineAllowAll, mockIamMembershipSyncNoop } from './helpers/iam-mocks';
-import { Hono } from 'hono';
-import { HTTPException } from 'hono/http-exception';
 import {
-  accountGithubInstallations,
   accountGithubInstallationStates,
+  accountGithubInstallations,
   accountMembers,
   projectGitConnections,
   projectMembers,
   projects,
 } from '@kortix/db';
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { mockIamEngineAllowAll, mockIamMembershipSyncNoop } from './helpers/iam-mocks';
 
 const USER_ID = '00000000-0000-4000-a000-000000000001';
 const ACCOUNT_ID = '00000000-0000-4000-a000-000000000101';
@@ -100,7 +100,9 @@ function setTestAuth(userId = USER_ID, userEmail = 'starter@example.test') {
 }
 
 function getTestAuth() {
-  return (globalThis as any)[TEST_AUTH_KEY] ?? { userId: USER_ID, userEmail: 'starter@example.test' };
+  return (
+    (globalThis as any)[TEST_AUTH_KEY] ?? { userId: USER_ID, userEmail: 'starter@example.test' }
+  );
 }
 
 // This repo's local `.env` (loaded automatically by `bun test`) sets real
@@ -130,18 +132,20 @@ function resetState() {
   ownerRepoListCalls = [];
   installationRepoListCalls = [];
   platformAdmin = false;
-  installationRows = [{
-    installationRowId: '00000000-0000-4000-a000-000000000041',
-    accountId: ACCOUNT_ID,
-    installationId: '42',
-    ownerLogin: 'kortix-org',
-    ownerType: 'Organization',
-    repositorySelection: 'all',
-    permissions: { contents: 'write' },
-    metadata: {},
-    createdAt: new Date('2026-01-01T00:00:00Z'),
-    updatedAt: new Date('2026-01-01T00:00:00Z'),
-  }];
+  installationRows = [
+    {
+      installationRowId: '00000000-0000-4000-a000-000000000041',
+      accountId: ACCOUNT_ID,
+      installationId: '42',
+      ownerLogin: 'kortix-org',
+      ownerType: 'Organization',
+      repositorySelection: 'all',
+      permissions: { contents: 'write' },
+      metadata: {},
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+    },
+  ];
 }
 
 mockIamEngineAllowAll();
@@ -185,7 +189,11 @@ mock.module('../projects/git', () => ({
   resolveTreeOid: async () => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
   materializeRepoContext: async () => '/tmp/fake-snapshot-context',
   resolveBranchTip: async () => 'a'.repeat(40),
-  resolveBranchAheadState: async () => ({ ahead: false, baseSha: 'a'.repeat(40), headSha: 'a'.repeat(40) }),
+  resolveBranchAheadState: async () => ({
+    ahead: false,
+    baseSha: 'a'.repeat(40),
+    headSha: 'a'.repeat(40),
+  }),
   getBranchDiff: async () => ({ files: [], diff: '' }),
   getDiffBetweenShas: async () => ({ files: [], diff: '' }),
   previewMerge: async () => ({ canMerge: true, conflicts: [] }),
@@ -200,34 +208,50 @@ mock.module('../projects/git', () => ({
 // snapshots/builder imports from projects/git — once mocked, builder.ts
 // resolves cleanly. We stub the helpers projects/index calls so the
 // fire-and-forget snapshot kickoff in the create paths is a no-op here.
-mock.module("../snapshots/builder", () => ({
-  ensureSandboxImage: async () => ({ snapshotName: "kortix-default-test", slug: "default", contentHash: "a".repeat(64), built: false, isDefault: true }),
-  deleteSandboxImage: async () => ({ deleted: false, snapshotName: "kortix-default-test", slug: "default" }),
+mock.module('../snapshots/builder', () => ({
+  ensureSandboxImage: async () => ({
+    snapshotName: 'kortix-default-test',
+    slug: 'default',
+    contentHash: 'a'.repeat(64),
+    built: false,
+    isDefault: true,
+  }),
+  deleteSandboxImage: async () => ({
+    deleted: false,
+    snapshotName: 'kortix-default-test',
+    slug: 'default',
+  }),
   listSnapshotBuilds: async () => [],
   listSandboxTemplates: async () => [],
-  resolveTemplate: async () => ({ slug: "default", spec: {}, isDefault: true }),
+  resolveTemplate: async () => ({ slug: 'default', spec: {}, isDefault: true }),
   kickPreBuild: () => {},
   kickRoutedPreBuild: () => {},
   templateBuildProviders: () => ['daytona', 'platinum', 'e2b'],
   kickProjectTemplatePrebuilds: () => {},
   reconcileStaleBuilds: async () => ({ healed: 0 }),
   reconcileProjectTemplates: async () => {},
-  resolveCommitSha: async () => "a".repeat(40),
+  resolveCommitSha: async () => 'a'.repeat(40),
   ensurePerProjectWarmImage: async () => ({
-    snapshotName: "kortix-ppwarm-test",
-    tip: "a".repeat(40),
+    snapshotName: 'kortix-ppwarm-test',
+    tip: 'a'.repeat(40),
     built: false,
-    provider: "daytona",
+    provider: 'daytona',
   }),
-  DEFAULT_SANDBOX_SLUG: "default",
+  DEFAULT_SANDBOX_SLUG: 'default',
 }));
 
 mock.module('../projects/github', () => ({
   buildGitHubAppInstallUrl: () => 'https://github.com/apps/kortix-test/installations/new',
-  verifyGitHubAppInstallState: (state: string) => state === 'valid-install-state' ? ACCOUNT_ID : null,
-  verifyGitHubAppInstallStatePayload: (state: string) => state === 'valid-install-state'
-    ? { accountId: ACCOUNT_ID, nonce: 'valid-install-nonce', issuedAt: Math.floor(Date.now() / 1000) }
-    : null,
+  verifyGitHubAppInstallState: (state: string) =>
+    state === 'valid-install-state' ? ACCOUNT_ID : null,
+  verifyGitHubAppInstallStatePayload: (state: string) =>
+    state === 'valid-install-state'
+      ? {
+          accountId: ACCOUNT_ID,
+          nonce: 'valid-install-nonce',
+          issuedAt: Math.floor(Date.now() / 1000),
+        }
+      : null,
   deleteFile: async () => undefined,
   deleteRepo: async () => undefined,
   addCollaborator: async () => undefined,
@@ -289,17 +313,21 @@ mock.module('../projects/github', () => ({
   }),
   listInstallationRepositories: async (installationId: string, options?: any) => {
     installationRepoListCalls.push({ installationId, options });
-    return installationId === '84' ? [{
-        id: 84,
-        name: 'portal',
-        full_name: 'acme/portal',
-        private: true,
-        html_url: 'https://github.com/acme/portal',
-        clone_url: 'https://github.com/acme/portal.git',
-        ssh_url: 'git@github.com:acme/portal.git',
-        default_branch: 'trunk',
-        description: null,
-      }] : [];
+    return installationId === '84'
+      ? [
+          {
+            id: 84,
+            name: 'portal',
+            full_name: 'acme/portal',
+            private: true,
+            html_url: 'https://github.com/acme/portal',
+            clone_url: 'https://github.com/acme/portal.git',
+            ssh_url: 'git@github.com:acme/portal.git',
+            default_branch: 'trunk',
+            description: null,
+          },
+        ]
+      : [];
   },
   // Not exercised by this file's scenarios (App installations only, no
   // managed-git PAT fallback here) — stubbed so the mocked module still
@@ -357,26 +385,30 @@ async function selectRowsForTable(table: unknown) {
   }
   if (table === accountGithubInstallationStates) {
     return githubInstallationStateConsumed
-      ? [{
-          installationId: '42',
-          consumedAt: new Date('2026-01-01T00:00:00Z'),
-        }]
+      ? [
+          {
+            installationId: '42',
+            consumedAt: new Date('2026-01-01T00:00:00Z'),
+          },
+        ]
       : [];
   }
   if (table === projects) {
-    return [{
-      projectId: PROJECT_ID,
-      accountId: ACCOUNT_ID,
-      name: 'Company OS',
-      repoUrl: 'https://github.com/kortix-org/company-os.git',
-      defaultBranch: 'main',
-      manifestPath: 'kortix.yaml',
-      status: 'active',
-      metadata: {},
-      lastOpenedAt: null,
-      createdAt: new Date('2026-01-01T00:00:00Z'),
-      updatedAt: new Date('2026-01-01T00:00:00Z'),
-    }];
+    return [
+      {
+        projectId: PROJECT_ID,
+        accountId: ACCOUNT_ID,
+        name: 'Company OS',
+        repoUrl: 'https://github.com/kortix-org/company-os.git',
+        defaultBranch: 'main',
+        manifestPath: 'kortix.yaml',
+        status: 'active',
+        metadata: {},
+        lastOpenedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
   }
   if (table === projectGitConnections) {
     return gitConnectionRows;
@@ -402,137 +434,144 @@ function storedProject(values: any) {
 }
 
 const starterDbMock: any = {
-    select: () => ({
-      from: (table: unknown) => ({
-        where: () => {
-          const builder = {
+  select: () => ({
+    from: (table: unknown) => ({
+      where: () => {
+        const builder = {
+          limit: async () => (await selectRowsForTable(table)).slice(0, 1),
+          orderBy: () => ({
             limit: async () => (await selectRowsForTable(table)).slice(0, 1),
-            orderBy: () => ({
-              limit: async () => (await selectRowsForTable(table)).slice(0, 1),
-              then: (resolve: any, reject: any) =>
-                selectRowsForTable(table).then(resolve, reject),
-            }),
-            then: (resolve: any, reject: any) =>
-              selectRowsForTable(table).then(resolve, reject),
-          };
-          return builder;
-        },
-      }),
-    }),
-    insert: (table: unknown) => ({
-      values: (values: any) => ({
-        onConflictDoNothing: () => ({
-          returning: async () => table === projects ? [storedProject(values)] : [],
-        }),
-        onConflictDoUpdate: () => {
-          if (table === projectMembers) {
-            const persist = () => {
-              grantedProjectRole = values;
-              return [values];
-            };
-            return {
-              returning: async () => persist(),
-              then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
-                Promise.resolve(persist()).then(resolve, reject),
-            };
-          }
-          return {
-            returning: async () => {
-              if (table === accountGithubInstallations) {
-                const existingIndex = installationRows.findIndex((row) =>
-                  row.accountId === values.accountId &&
-                  row.installationId === values.installationId,
-                );
-                const row = {
-                  installationRowId: existingIndex >= 0
-                    ? installationRows[existingIndex]!.installationRowId
-                    : '00000000-0000-4000-a000-000000000042',
-                  accountId: values.accountId,
-                  installationId: values.installationId,
-                  ownerLogin: values.ownerLogin,
-                  ownerType: values.ownerType,
-                  repositorySelection: values.repositorySelection ?? null,
-                  permissions: values.permissions ?? {},
-                  metadata: values.metadata ?? {},
-                  createdAt: existingIndex >= 0
-                    ? installationRows[existingIndex]!.createdAt
-                    : new Date('2026-01-01T00:00:00Z'),
-                  updatedAt: values.updatedAt ?? new Date('2026-01-02T00:00:00Z'),
-                };
-                if (existingIndex >= 0) installationRows[existingIndex] = row;
-                else installationRows.push(row);
-                return [row];
-              }
-              if (table === projectGitConnections) {
-                const existingIndex = gitConnectionRows.findIndex((row) => row.projectId === values.projectId);
-                const row = {
-                  connectionId: existingIndex >= 0
-                    ? gitConnectionRows[existingIndex]!.connectionId
-                    : '00000000-0000-4000-a000-000000000501',
-                  accountId: values.accountId,
-                  projectId: values.projectId,
-                  provider: values.provider,
-                  repoUrl: values.repoUrl,
-                upstreamUrl: values.upstreamUrl ?? null,
-                managed: values.managed ?? false,
-                  repoOwner: values.repoOwner ?? null,
-                  repoName: values.repoName ?? null,
-                  externalRepoId: values.externalRepoId ?? null,
-                  defaultBranch: values.defaultBranch,
-                  authMethod: values.authMethod,
-                  installationId: values.installationId ?? null,
-                  credentialRef: values.credentialRef ?? null,
-                  permissions: values.permissions ?? {},
-                  visibility: values.visibility ?? null,
-                  webhookId: values.webhookId ?? null,
-                  status: values.status ?? 'connected',
-                  lastValidatedAt: values.lastValidatedAt ?? new Date('2026-01-01T00:00:00Z'),
-                  lastErrorCode: values.lastErrorCode ?? null,
-                  lastErrorMessage: values.lastErrorMessage ?? null,
-                  metadata: values.metadata ?? {},
-                  createdAt: existingIndex >= 0 ? gitConnectionRows[existingIndex]!.createdAt : new Date('2026-01-01T00:00:00Z'),
-                  updatedAt: values.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
-                } as typeof projectGitConnections.$inferSelect;
-                if (existingIndex >= 0) gitConnectionRows[existingIndex] = row;
-                else gitConnectionRows.push(row);
-                return [row];
-              }
-              if (table !== projects) return [];
-              return [storedProject(values)];
-            },
-          };
-        },
-        returning: async () => {
-          if (table === projectGitConnections) {
-            return starterDbMock.insert(table).values(values).onConflictDoUpdate({}).returning();
-          }
-          if (table === projectMembers) {
-            grantedProjectRole = values;
-            return [values];
-          }
-          if (table !== projects) return [];
-          return [storedProject(values)];
-        },
-      }),
-    }),
-    update: (table: unknown) => ({
-      set: () => ({
-        where: () => ({
-          returning: async () => {
-            if (table === accountGithubInstallationStates && !githubInstallationStateConsumed) {
-              githubInstallationStateConsumed = true;
-              return [{ stateNonce: 'valid-install-nonce' }];
-            }
-            return [];
-          },
-        }),
-      }),
-    }),
-    delete: (table: unknown) => ({
-      where: async () => {
-        if (table === accountGithubInstallations) installationRows = [];
+            then: (resolve: any, reject: any) => selectRowsForTable(table).then(resolve, reject),
+          }),
+          then: (resolve: any, reject: any) => selectRowsForTable(table).then(resolve, reject),
+        };
+        return builder;
       },
     }),
+  }),
+  insert: (table: unknown) => ({
+    values: (values: any) => ({
+      onConflictDoNothing: () => ({
+        returning: async () => (table === projects ? [storedProject(values)] : []),
+      }),
+      onConflictDoUpdate: () => {
+        if (table === projectMembers) {
+          const persist = () => {
+            grantedProjectRole = values;
+            return [values];
+          };
+          return {
+            returning: async () => persist(),
+            then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve(persist()).then(resolve, reject),
+          };
+        }
+        return {
+          returning: async () => {
+            if (table === accountGithubInstallations) {
+              const existingIndex = installationRows.findIndex(
+                (row) =>
+                  row.accountId === values.accountId &&
+                  row.installationId === values.installationId,
+              );
+              const row = {
+                installationRowId:
+                  existingIndex >= 0
+                    ? installationRows[existingIndex]!.installationRowId
+                    : '00000000-0000-4000-a000-000000000042',
+                accountId: values.accountId,
+                installationId: values.installationId,
+                ownerLogin: values.ownerLogin,
+                ownerType: values.ownerType,
+                repositorySelection: values.repositorySelection ?? null,
+                permissions: values.permissions ?? {},
+                metadata: values.metadata ?? {},
+                createdAt:
+                  existingIndex >= 0
+                    ? installationRows[existingIndex]!.createdAt
+                    : new Date('2026-01-01T00:00:00Z'),
+                updatedAt: values.updatedAt ?? new Date('2026-01-02T00:00:00Z'),
+              };
+              if (existingIndex >= 0) installationRows[existingIndex] = row;
+              else installationRows.push(row);
+              return [row];
+            }
+            if (table === projectGitConnections) {
+              const existingIndex = gitConnectionRows.findIndex(
+                (row) => row.projectId === values.projectId,
+              );
+              const row = {
+                connectionId:
+                  existingIndex >= 0
+                    ? gitConnectionRows[existingIndex]!.connectionId
+                    : '00000000-0000-4000-a000-000000000501',
+                accountId: values.accountId,
+                projectId: values.projectId,
+                provider: values.provider,
+                repoUrl: values.repoUrl,
+                upstreamUrl: values.upstreamUrl ?? null,
+                managed: values.managed ?? false,
+                repoOwner: values.repoOwner ?? null,
+                repoName: values.repoName ?? null,
+                externalRepoId: values.externalRepoId ?? null,
+                defaultBranch: values.defaultBranch,
+                authMethod: values.authMethod,
+                installationId: values.installationId ?? null,
+                credentialRef: values.credentialRef ?? null,
+                permissions: values.permissions ?? {},
+                visibility: values.visibility ?? null,
+                webhookId: values.webhookId ?? null,
+                status: values.status ?? 'connected',
+                lastValidatedAt: values.lastValidatedAt ?? new Date('2026-01-01T00:00:00Z'),
+                lastErrorCode: values.lastErrorCode ?? null,
+                lastErrorMessage: values.lastErrorMessage ?? null,
+                metadata: values.metadata ?? {},
+                createdAt:
+                  existingIndex >= 0
+                    ? gitConnectionRows[existingIndex]!.createdAt
+                    : new Date('2026-01-01T00:00:00Z'),
+                updatedAt: values.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
+              } as typeof projectGitConnections.$inferSelect;
+              if (existingIndex >= 0) gitConnectionRows[existingIndex] = row;
+              else gitConnectionRows.push(row);
+              return [row];
+            }
+            if (table !== projects) return [];
+            return [storedProject(values)];
+          },
+        };
+      },
+      returning: async () => {
+        if (table === projectGitConnections) {
+          return starterDbMock.insert(table).values(values).onConflictDoUpdate({}).returning();
+        }
+        if (table === projectMembers) {
+          grantedProjectRole = values;
+          return [values];
+        }
+        if (table !== projects) return [];
+        return [storedProject(values)];
+      },
+    }),
+  }),
+  update: (table: unknown) => ({
+    set: () => ({
+      where: () => ({
+        returning: async () => {
+          if (table === accountGithubInstallationStates && !githubInstallationStateConsumed) {
+            githubInstallationStateConsumed = true;
+            return [{ stateNonce: 'valid-install-nonce' }];
+          }
+          return [];
+        },
+      }),
+    }),
+  }),
+  delete: (table: unknown) => ({
+    where: async () => {
+      if (table === accountGithubInstallations) installationRows = [];
+    },
+  }),
 };
 starterDbMock.transaction = async (run: (tx: typeof starterDbMock) => Promise<unknown>) =>
   run(starterDbMock);
@@ -573,7 +612,9 @@ describe('create-repo starter scaffold contract', () => {
 
     // The full core ships as source (self-contained): tools, skills, agents.
     expect(files.find((file) => file.path === '.kortix/opencode/tools/show.ts')).toBeDefined();
-    expect(files.find((file) => file.path === '.kortix/opencode/skills/kortix-system/SKILL.md')).toBeDefined();
+    expect(
+      files.find((file) => file.path === '.kortix/opencode/skills/kortix-system/SKILL.md'),
+    ).toBeDefined();
     expect(files.find((file) => file.path === '.kortix/opencode/agents/kortix.md')).toBeDefined();
     // The manifest IS shipped and names the project.
     const manifest = files.find((file) => file.path === 'kortix.yaml');
@@ -618,7 +659,9 @@ describe('create-repo starter scaffold contract', () => {
   test('manages account GitHub App installation metadata through the project API', async () => {
     const app = createApp();
 
-    const installed = await app.request(`/v1/projects/github/installation?account_id=${ACCOUNT_ID}`);
+    const installed = await app.request(
+      `/v1/projects/github/installation?account_id=${ACCOUNT_ID}`,
+    );
     expect(installed.status).toBe(200);
     expect(await installed.json()).toMatchObject({
       account_id: ACCOUNT_ID,
@@ -663,14 +706,19 @@ describe('create-repo starter scaffold contract', () => {
       owner_login: 'kortix-org',
     });
 
-    const disconnect = await app.request(`/v1/projects/github/installation?account_id=${ACCOUNT_ID}`, {
-      method: 'DELETE',
-    });
+    const disconnect = await app.request(
+      `/v1/projects/github/installation?account_id=${ACCOUNT_ID}`,
+      {
+        method: 'DELETE',
+      },
+    );
     expect(disconnect.status).toBe(200);
     expect(await disconnect.json()).toEqual({ ok: true });
     expect(installationRows).toEqual([]);
 
-    const uninstalled = await app.request(`/v1/projects/github/installation?account_id=${ACCOUNT_ID}`);
+    const uninstalled = await app.request(
+      `/v1/projects/github/installation?account_id=${ACCOUNT_ID}`,
+    );
     expect(uninstalled.status).toBe(200);
     expect(await uninstalled.json()).toMatchObject({
       account_id: ACCOUNT_ID,
@@ -696,17 +744,21 @@ describe('create-repo starter scaffold contract', () => {
     });
 
     const app = createApp();
-    const installations = await app.request(`/v1/projects/github/installations?account_id=${ACCOUNT_ID}`);
+    const installations = await app.request(
+      `/v1/projects/github/installations?account_id=${ACCOUNT_ID}`,
+    );
     expect(installations.status).toBe(200);
     const installationsBody = await installations.json();
     expect(installationsBody).toMatchObject({
       account_id: ACCOUNT_ID,
       installed: true,
     });
-    expect(installationsBody.installations).toEqual(expect.arrayContaining([
-      expect.objectContaining({ installation_id: '42', owner_login: 'kortix-org' }),
-      expect.objectContaining({ installation_id: '84', owner_login: 'acme' }),
-    ]));
+    expect(installationsBody.installations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ installation_id: '42', owner_login: 'kortix-org' }),
+        expect.objectContaining({ installation_id: '84', owner_login: 'acme' }),
+      ]),
+    );
 
     const repos = await app.request(
       `/v1/projects/github/repositories?account_id=${ACCOUNT_ID}` +
@@ -773,7 +825,7 @@ describe('create-repo starter scaffold contract', () => {
     expect(gitConnectionRows).toContainEqual(
       expect.objectContaining({
         projectId: PROJECT_ID,
-        provider: "github",
+        provider: 'github',
         managed: false,
       }),
     );
@@ -892,7 +944,9 @@ describe('create-repo starter scaffold contract', () => {
     // on repo creation. Every other file is brand-new.
     const readmeIdx = committedPaths.indexOf('README.md');
     expect(commitCalls[readmeIdx]!.existingSha).toBe('existing-readme-sha');
-    expect(commitCalls.filter((_, i) => i !== readmeIdx).every((call) => call.existingSha === undefined)).toBe(true);
+    expect(
+      commitCalls.filter((_, i) => i !== readmeIdx).every((call) => call.existingSha === undefined),
+    ).toBe(true);
 
     expect(insertedProject).toMatchObject({
       accountId: ACCOUNT_ID,
@@ -910,19 +964,21 @@ describe('create-repo starter scaffold contract', () => {
         },
       },
     });
-    expect(gitConnectionRows).toContainEqual(expect.objectContaining({
-      projectId: PROJECT_ID,
-      provider: 'github',
-      repoUrl: 'https://github.com/kortix-org/company-os.git',
-      repoOwner: 'kortix-org',
-      repoName: 'company-os',
-      externalRepoId: '7',
-      authMethod: 'github_app',
-      installationId: '42',
-      managed: true,
-      visibility: 'private',
-      status: 'connected',
-    }));
+    expect(gitConnectionRows).toContainEqual(
+      expect.objectContaining({
+        projectId: PROJECT_ID,
+        provider: 'github',
+        repoUrl: 'https://github.com/kortix-org/company-os.git',
+        repoOwner: 'kortix-org',
+        repoName: 'company-os',
+        externalRepoId: '7',
+        authMethod: 'github_app',
+        installationId: '42',
+        managed: true,
+        visibility: 'private',
+        status: 'connected',
+      }),
+    );
     expect(grantedProjectRole).toMatchObject({
       accountId: ACCOUNT_ID,
       projectId: PROJECT_ID,
@@ -932,83 +988,55 @@ describe('create-repo starter scaffold contract', () => {
     });
   });
 
-  test("commits a selected marketplace project template into the new GitHub repository", async () => {
+  test('commits a selected marketplace project template into the new GitHub repository', async () => {
     const app = createApp();
-    const res = await app.request("/v1/projects/create-repo", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    const res = await app.request('/v1/projects/create-repo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         account_id: ACCOUNT_ID,
-        name: "company-os",
-        project_name: "Company OS",
+        name: 'company-os',
+        project_name: 'Company OS',
         private: true,
-        source_item_id: "kortix-projects:starter",
+        source_item_id: 'kortix-projects:starter',
       }),
     });
 
     expect(res.status).toBe(201);
     expect(commitCalls.map((call) => call.path)).toContain(
-      ".kortix/opencode/skills/account-research/SKILL.md",
+      '.kortix/opencode/skills/account-research/SKILL.md',
     );
-    expect(
-      commitCalls.find((call) => call.path === "kortix.yaml")?.content,
-    ).toContain('name: "Company OS"');
+    expect(commitCalls.find((call) => call.path === 'kortix.yaml')?.content).toContain(
+      'name: "Company OS"',
+    );
     expect(gitConnectionRows).toContainEqual(
       expect.objectContaining({
         projectId: PROJECT_ID,
-        provider: "github",
+        provider: 'github',
         managed: true,
       }),
     );
   });
 
-  test("commits the SEO Department marketplace project into the new GitHub repository", async () => {
+  test('rejects a retired bundled project id instead of committing a half-built repo', async () => {
     const app = createApp();
-    const res = await app.request("/v1/projects/create-repo", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    const res = await app.request('/v1/projects/create-repo', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         account_id: ACCOUNT_ID,
-        name: "seo-team",
-        project_name: "Acme SEO",
+        name: 'seo-team',
+        project_name: 'Acme SEO',
         private: true,
-        source_item_id: "kortix-projects:seo-department",
+        source_item_id: 'kortix-projects:seo-department',
       }),
     });
 
-    expect(res.status).toBe(201);
-    expect(commitCalls.map((call) => call.path)).toEqual(
-      expect.arrayContaining([
-        ".kortix/opencode/agents/seo-director.md",
-        ".kortix/opencode/agents/technical-seo.md",
-        ".kortix/opencode/agents/content-strategist.md",
-        ".kortix/opencode/agents/serp-analyst.md",
-        ".kortix/opencode/agents/seo-repo-watchdog.md",
-        ".kortix/opencode/skills/seo-operating-system/SKILL.md",
-        ".kortix/opencode/skills/technical-seo-audit/SKILL.md",
-        ".kortix/opencode/skills/seo-repo-monitoring/SKILL.md",
-        ".kortix/opencode/skills/content-seo-workflow/SKILL.md",
-        ".kortix/opencode/skills/serp-intelligence/SKILL.md",
-        ".kortix/memory/SEO.md",
-        "install.md",
-      ]),
-    );
-    const manifest = commitCalls.find((call) => call.path === "kortix.yaml")?.content;
-    expect(manifest).toContain('name: "Acme SEO"');
-    expect(manifest).toContain("default_agent: seo-director");
-    expect(manifest).toContain("daily-serp-watch");
-    expect(manifest).toContain("repo-seo-watch");
-    expect(manifest).toContain("daily-repo-seo-sweep");
-    expect(manifest).toContain("weekly-technical-audit");
-    expect(manifest).toContain("weekly-content-refresh");
-    expect(manifest).toContain("monthly-seo-growth-report");
-    expect(gitConnectionRows).toContainEqual(
-      expect.objectContaining({
-        projectId: PROJECT_ID,
-        provider: "github",
-        managed: true,
-      }),
-    );
+    // The department templates were retired; the marketplace now leads with the
+    // single Kortix Starter project. Asking for a gone id must fail outright
+    // rather than create a repo and commit a partial tree into it.
+    expect(res.status).not.toBe(201);
+    expect(commitCalls.length).toBe(0);
   });
 
   test('rejects hidden marketplace projects before creating a GitHub repository', async () => {

--- a/apps/api/src/__tests__/unit-marketplace.test.ts
+++ b/apps/api/src/__tests__/unit-marketplace.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'bun:test';
 process.env.KORTIX_DEFAULT_MARKETPLACES = '';
 import {
   DEFAULT_MARKETPLACES,
+  _resetExternalCache,
   assertAllowedSourceAddress,
   findCatalogEntryByName,
   getCatalogItemDetail,
@@ -14,7 +15,6 @@ import {
   listMarketplaces,
   marketplaceIdOf,
   registerMarketplaceSourceProvider,
-  _resetExternalCache,
 } from '../marketplace/catalog';
 
 describe('marketplace catalog', () => {
@@ -68,7 +68,11 @@ describe('marketplace catalog', () => {
     expect(agentBrowserDetail!.marketplaceId).toBe('kortix');
     expect(agentBrowserDetail!.type).toBe('registry:skill');
     expect(agentBrowserDetail!.managedBy).toBeUndefined();
-    expect(agentBrowserDetail!.defaultProjectInstall).toBe(true);
+    // `agent-browser` ships in the SCAFFOLD now (driving a browser is a floor
+    // capability), so it is no longer an opt-in default marketplace install —
+    // it arrives with the repo and is badged as part of the starter instead.
+    expect(agentBrowserDetail!.defaultProjectInstall).toBe(false);
+    expect(agentBrowserDetail!.partOfProject?.title).toBe('Kortix Starter');
 
     const starterDetail = await getCatalogItemDetail('kortix-projects:starter');
     expect(starterDetail!.dependencyItems.some((d) => d.name === 'agent-browser')).toBe(true);
@@ -93,20 +97,28 @@ describe('marketplace catalog', () => {
     const defaultInstallNames = new Set(
       depDetails.filter((d) => d?.defaultProjectInstall).map((d) => d!.name),
     );
+    // The artifact floor that carries `defaultProjectInstall`. `deep-research`,
+    // `document-review` and the GTM skills moved to the marketplace with the flag
+    // stripped (leaving it on would have silently re-installed exactly what the
+    // slim-down removed); `research-report` was deleted; `agent-browser` is
+    // scaffolded now, so it arrives with the repo rather than as a default install.
     for (const name of [
-      'agent-browser',
-      'deep-research',
-      'document-review',
+      'design-foundations',
       'docx',
       'pdf',
       'presentations',
-      'research-report',
+      'web-publishing-and-deployments',
+      'webapp',
       'website-building',
       'xlsx',
     ]) {
       expect(defaultInstallNames.has(name)).toBe(true);
       expect(all.find((i) => i.name === name)?.defaultProjectInstall).toBe(true);
     }
+    for (const name of ['deep-research', 'document-review', 'account-research', 'search']) {
+      expect(all.find((i) => i.name === name)?.defaultProjectInstall).toBe(false);
+    }
+    expect(all.find((i) => i.name === 'research-report')).toBeUndefined();
   });
 
   test('marks only kortix-* runtime skills as Kortix-managed', async () => {
@@ -152,115 +164,12 @@ describe('marketplace catalog', () => {
     expect(projects.every((i) => i.type === 'registry:project')).toBe(true);
     // `pdf` is browseable again — a query hit on its own tile.
     expect((await listCatalogItems({ query: 'pdf' })).some((i) => i.name === 'pdf')).toBe(true);
-    expect((await listCatalogItems({ query: 'starter' })).some((i) => i.id === 'kortix-projects:starter')).toBe(true);
+    expect(
+      (await listCatalogItems({ query: 'starter' })).some(
+        (i) => i.id === 'kortix-projects:starter',
+      ),
+    ).toBe(true);
     expect((await listCatalogItems({ query: 'zzzznotathing' })).length).toBe(0);
-  });
-
-  test('surfaces SEO Department as a full cloneable project with agents and schedules', async () => {
-    const projects = await listCatalogItems({ type: 'project', source: 'kortix' });
-    const seo = projects.find((i) => i.id === 'kortix-projects:seo-department');
-    expect(seo).toBeTruthy();
-    expect(seo!.title).toBe('SEO Department');
-    expect(seo!.categories).toEqual(expect.arrayContaining(['marketing', 'seo', 'automation']));
-    expect(seo!.dependencies).toEqual(
-      expect.arrayContaining(['deep-research', 'search', 'research-report', 'xlsx']),
-    );
-
-    const detail = await getCatalogItemDetail('kortix-projects:seo-department');
-    expect(detail).toBeTruthy();
-    expect(detail!.readme).toContain('# SEO Department');
-    expect(detail!.files.map((f) => f.target)).toEqual(
-      expect.arrayContaining([
-        'kortix.yaml',
-        'install.md',
-        '.kortix/memory/SEO.md',
-        '.kortix/opencode/agents/seo-director.md',
-        '.kortix/opencode/agents/technical-seo.md',
-        '.kortix/opencode/agents/content-strategist.md',
-        '.kortix/opencode/agents/serp-analyst.md',
-        '.kortix/opencode/agents/seo-repo-watchdog.md',
-        '.kortix/opencode/skills/seo-operating-system/SKILL.md',
-        '.kortix/opencode/skills/technical-seo-audit/SKILL.md',
-        '.kortix/opencode/skills/seo-repo-monitoring/SKILL.md',
-        '.kortix/opencode/skills/content-seo-workflow/SKILL.md',
-        '.kortix/opencode/skills/serp-intelligence/SKILL.md',
-      ]),
-    );
-    expect(detail!.projectAgents?.map((a) => a.name).sort()).toEqual([
-      'content-strategist',
-      'seo-director',
-      'seo-repo-watchdog',
-      'serp-analyst',
-      'technical-seo',
-    ]);
-    expect(detail!.projectTriggers?.map((t) => t.slug).sort()).toEqual([
-      'daily-repo-seo-sweep',
-      'daily-serp-watch',
-      'monthly-seo-growth-report',
-      'repo-seo-watch',
-      'seo-request-intake',
-      'weekly-content-refresh',
-      'weekly-technical-audit',
-    ]);
-  });
-
-  test('surfaces Marketing Department as a full cloneable project with agents and schedules', async () => {
-    const projects = await listCatalogItems({ type: 'project', source: 'kortix' });
-    const marketing = projects.find((i) => i.id === 'kortix-projects:marketing-department');
-    expect(marketing).toBeTruthy();
-    expect(marketing!.title).toBe('Marketing Department');
-    expect(marketing!.categories).toEqual(expect.arrayContaining(['marketing', 'growth', 'automation']));
-    expect(marketing!.dependencies).toEqual(
-      expect.arrayContaining(['deep-research', 'search', 'research-report', 'xlsx']),
-    );
-    expect(marketing!.dependencies).toEqual(
-      expect.arrayContaining(['ad-performance-review', 'brand-mention-monitor', 'social-post-drafting']),
-    );
-
-    const detail = await getCatalogItemDetail('kortix-projects:marketing-department');
-    expect(detail).toBeTruthy();
-    expect(detail!.readme).toContain('# Marketing Department');
-    expect(detail!.files.map((f) => f.target)).toEqual(
-      expect.arrayContaining([
-        'kortix.yaml',
-        'install.md',
-        '.kortix/memory/MARKETING.md',
-        '.kortix/opencode/agents/marketing-director.md',
-        '.kortix/opencode/agents/campaign-strategist.md',
-        '.kortix/opencode/agents/content-marketer.md',
-        '.kortix/opencode/agents/lifecycle-marketer.md',
-        '.kortix/opencode/agents/growth-analyst.md',
-        '.kortix/opencode/agents/brand-guardian.md',
-        '.kortix/opencode/agents/marketing-repo-watchdog.md',
-        '.kortix/opencode/skills/marketing-operating-system/SKILL.md',
-        '.kortix/opencode/skills/brand-positioning/SKILL.md',
-        '.kortix/opencode/skills/campaign-strategy/SKILL.md',
-        '.kortix/opencode/skills/content-engine/SKILL.md',
-        '.kortix/opencode/skills/lifecycle-growth/SKILL.md',
-        '.kortix/opencode/skills/marketing-analytics/SKILL.md',
-        '.kortix/opencode/skills/marketing-repo-awareness/SKILL.md',
-      ]),
-    );
-    expect(detail!.projectAgents?.map((a) => a.name).sort()).toEqual([
-      'brand-guardian',
-      'campaign-strategist',
-      'content-marketer',
-      'growth-analyst',
-      'lifecycle-marketer',
-      'marketing-director',
-      'marketing-repo-watchdog',
-    ]);
-    expect(detail!.projectTriggers?.map((t) => t.slug).sort()).toEqual([
-      'daily-marketing-performance-pulse',
-      'daily-marketing-repo-sweep',
-      'marketing-request-intake',
-      'monthly-marketing-report',
-      'repo-marketing-watch',
-      'weekly-brand-competitor-watch',
-      'weekly-campaign-planning',
-      'weekly-content-calendar',
-      'weekly-lifecycle-review',
-    ]);
   });
 
   test('source safety — rejects local + private/non-https URLs (LFI/SSRF guard)', () => {
@@ -321,7 +230,6 @@ describe('marketplace catalog', () => {
     expect(detail.files.every((f) => f.target.startsWith('@skills/'))).toBe(true);
     expect(detail.readme).toContain('---');
   });
-
 });
 
 describe('marketplace external registries (skills.sh / GitHub path)', () => {
@@ -331,7 +239,8 @@ describe('marketplace external registries (skills.sh / GitHub path)', () => {
 
   function stub(map: Record<string, string>) {
     const fetchStub = (async (url: unknown) => {
-      const key = typeof url === 'object' && url && 'url' in url ? String((url as Request).url) : String(url);
+      const key =
+        typeof url === 'object' && url && 'url' in url ? String((url as Request).url) : String(url);
       const body = map[key];
       if (body == null) return new Response('not found', { status: 404 });
       return new Response(body, { status: 200 });
@@ -354,7 +263,13 @@ describe('marketplace external registries (skills.sh / GitHub path)', () => {
             name: 'hello-ext',
             type: 'registry:skill',
             title: 'Hello (external)',
-            files: [{ path: 'hello/SKILL.md', type: 'registry:file', target: '@skills/hello-ext/SKILL.md' }],
+            files: [
+              {
+                path: 'hello/SKILL.md',
+                type: 'registry:file',
+                target: '@skills/hello-ext/SKILL.md',
+              },
+            ],
           },
         ],
       }),
@@ -375,7 +290,10 @@ describe('marketplace external registries (skills.sh / GitHub path)', () => {
       const skillFile = detail!.files.find((f) => f.target === '@skills/hello-ext/SKILL.md');
       expect(skillFile).toBeTruthy();
 
-      const fetched = await getCatalogItemFile('mock-skills:hello-ext', '@skills/hello-ext/SKILL.md');
+      const fetched = await getCatalogItemFile(
+        'mock-skills:hello-ext',
+        '@skills/hello-ext/SKILL.md',
+      );
       expect(fetched?.content).toContain('Hi from an external registry');
     } finally {
       restoreFetch();
@@ -393,7 +311,7 @@ describe('marketplace external registries (skills.sh / GitHub path)', () => {
       // Base intact — the starter project (browse now folds individual
       // kortix-starter skills like `pdf` inside it, so check by id/detail).
       expect(all.find((i) => i.id === 'kortix-projects:starter')).toBeTruthy();
-      expect((await getCatalogItemDetail('kortix-starter:pdf'))).toBeTruthy();
+      expect(await getCatalogItemDetail('kortix-starter:pdf')).toBeTruthy();
       expect(all.find((i) => i.name === 'hello-ext')).toBeUndefined();
     } finally {
       restoreFetch();
@@ -411,7 +329,9 @@ describe('marketplace external registries (skills.sh / GitHub path)', () => {
             name: 'db-ext',
             type: 'registry:skill',
             title: 'DB ext',
-            files: [{ path: 'db/SKILL.md', type: 'registry:file', target: '@skills/db-ext/SKILL.md' }],
+            files: [
+              { path: 'db/SKILL.md', type: 'registry:file', target: '@skills/db-ext/SKILL.md' },
+            ],
           },
         ],
       }),

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -200,7 +200,6 @@ const CAPABILITY_HINTS: Record<string, Partial<ItemCapabilities>> = {
     network: ["api.replicate.com"],
   },
   "deep-research": { tools: ["web_search"] },
-  "research-report": { tools: ["web_search"] },
   "account-research": { tools: ["web_search"] },
   "competitive-intelligence": { tools: ["web_search"] },
   "draft-outreach": { tools: ["web_search"] },


### PR DESCRIPTION
Follow-up to #5770.

Three assertions in `src/__tests__/unit-marketplace.test.ts` broke when the department templates were deleted and the skill floor was cut. I verified `src/marketplace/` but not `src/__tests__/`, so they landed on main red. My mistake.

The **catalog itself was correct** throughout — browse returns exactly one project (`Kortix Starter`), and no department/studio item is reachable. Only the tests were stale.

## Fixed

- Dropped the SEO Department and Marketing Department catalog tests — both templates were retired.
- `agent-browser` is scaffolded now, so it is no longer a default marketplace install; it arrives with the repo and is badged "Part of Kortix Starter".
- Corrected the `defaultProjectInstall` roster to the real artifact floor, and pinned the **inverse**: skills that moved to the marketplace must NOT carry the flag (leaving it on would silently re-install exactly what the slim-down removed), and `research-report` must be absent entirely.
- Replaced a **latent** e2e test that cloned the SEO Department. That file currently fails to load on an unrelated pre-existing Bun module-resolution error, so it never ran and never went red — it now asserts that a retired project id is rejected rather than creating a repo and committing a partial tree into it.
- Removed the dead `research-report` CAPABILITY_HINTS entry.

## Checked and deliberately left alone

- `components/home/interactive-demo/data.ts` lists `research-report` — but that list is marketing copy, not the catalog: `nda-triage`, `openalex-paper-search`, `pptx`, `remotion` and `sql-queries` are all in it and none exist in the catalog either.
- The two `scripts/e2e/*-smoke.ts` hits are a synthetic `marketplaceItem()` fixture behind mocked `page.route` — not real catalog reads.

## Tests

api (unit-marketplace, marketplace, skills, managed-skills, seed-files, install-prompts) 57/57. Typecheck clean.