### PR TITLE
fix(infra): capture the Cloudflare zone id so plans stop proposing DNS churn

### DIFF
--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -7,7 +7,12 @@ variable "aws_region" {
 variable "cloudflare_zone_id" {
   description = "Cloudflare zone ID for kortix.com. Supply via TF_VAR_cloudflare_zone_id."
   type        = string
-  default     = ""
+  # The kortix.com zone id. Not a secret — it is already exposed as the
+  # CLOUDFLARE_ZONE_ID repo variable and appears in every Cloudflare API URL.
+  # It defaults here because an empty value resolves zone_id to null on every
+  # cloudflare_record, and zone_id forces replacement: a plan run without the
+  # gitignored tfvars proposed destroying and recreating live production DNS.
+  default = "af378d3df4e4dd5052a1fcbf263b685d"
 }
 
 variable "cloudflare_api_token" {

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -7,7 +7,12 @@ variable "aws_region" {
 variable "cloudflare_zone_id" {
   description = "Cloudflare zone ID for kortix.com. Supply via TF_VAR_cloudflare_zone_id."
   type        = string
-  default     = ""
+  # The kortix.com zone id. Not a secret — it is already exposed as the
+  # CLOUDFLARE_ZONE_ID repo variable and appears in every Cloudflare API URL.
+  # It defaults here because an empty value resolves zone_id to null on every
+  # cloudflare_record, and zone_id forces replacement: a plan run without the
+  # gitignored tfvars proposed destroying and recreating live production DNS.
+  default = "af378d3df4e4dd5052a1fcbf263b685d"
 }
 
 variable "extra_api_hostnames" {

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -7,7 +7,12 @@ variable "aws_region" {
 variable "cloudflare_zone_id" {
   description = "Cloudflare zone ID for kortix.com. Supply via TF_VAR_cloudflare_zone_id."
   type        = string
-  default     = ""
+  # The kortix.com zone id. Not a secret — it is already exposed as the
+  # CLOUDFLARE_ZONE_ID repo variable and appears in every Cloudflare API URL.
+  # It defaults here because an empty value resolves zone_id to null on every
+  # cloudflare_record, and zone_id forces replacement: a plan run without the
+  # gitignored tfvars proposed destroying and recreating live production DNS.
+  default = "af378d3df4e4dd5052a1fcbf263b685d"
 }
 
 variable "cloudflare_api_token" {


### PR DESCRIPTION
Follow-up to #5771, and a correction to the evidence in it.

`cloudflare_zone_id` defaulted to `""`. That resolves `zone_id` to `null` on every `cloudflare_record`, and `zone_id` **forces replacement** — so a plan without the gitignored tfvars proposed destroying and recreating **live production DNS**:

- `module.acm.cloudflare_record.validation["api.kortix.com"]`
- `module.acm.cloudflare_record.validation["api-ecs-fargate.kortix.com"]`
- `module.acm_gateway.cloudflare_record.validation["gateway-ecs-fargate.kortix.com"]`
- `module.dns_extra[0].cloudflare_record.this["api-ecs-fargate"]`
- both `aws_acm_certificate_validation`

**Why #5771 reported 0 destroys and this doesn't contradict it:** every plan I ran there had the Cloudflare provider failing with `Authentication error (10000)`, so those resources were never evaluated. The `0 destroy` was real for the AWS resources and blind to the Cloudflare ones. Supplying a real token exposed the rest.

```
empty zone id + working CF token:     27 add, 28 change, 6 destroy
zone id captured + working CF token:  21 add, 28 change, 0 destroy
```

The zone id is not a secret — it is already the `CLOUDFLARE_ZONE_ID` repo variable and appears in every Cloudflare API URL. Applied to prod, staging and dev.

Same class as the empty `extra_api_hostnames` default: the value that describes production belongs in version control, not only in an ignored file on one laptop.